### PR TITLE
Keep the knobs the shipped acceptance checks read on agent-default

### DIFF
--- a/crates/kin-mcp/src/agent_belt.rs
+++ b/crates/kin-mcp/src/agent_belt.rs
@@ -18,6 +18,14 @@
 //! and `context-bench` profiles, whose payload bytes are part of a citable
 //! result and must not move because a description was rewritten.
 //!
+//! Measured the same way afterwards, with the acceptance exception below in
+//! place, the served profile is 33,464 bytes over 21 tools: 6,188 characters of
+//! description and 27,276 bytes of input schema. The descriptions are where the
+//! win is, 6,188 against 47,739. The schemas keep most of their bytes on
+//! purpose, because a property the shipped proofs or the acceptance suite grade
+//! has to stay advertised; [`schema_keep_lists`] names that exception and the
+//! checks that own it.
+//!
 //! Every short form answers two questions in one or two sentences: when to call
 //! this, and what comes back. Where two tools are easy to confuse, the one a
 //! caller reaches for by mistake names the other.

--- a/crates/kin-mcp/src/agent_belt.rs
+++ b/crates/kin-mcp/src/agent_belt.rs
@@ -193,7 +193,10 @@ fn short_descriptions() -> BTreeMap<&'static str, &'static str> {
             "kin_graph_status",
             "Report the graph this call is answered from: entity and relation counts, and how many \
              entities are embedded, pending or unindexed. Call it first when a search returns less \
-             than you expect, since an unembedded graph cannot rank by meaning.",
+             than you expect, since an unembedded graph cannot rank by meaning. On a store under \
+             continuous reconcile it can answer `sampling=last_settled_selected_graph` instead of a \
+             live one: the same counters as of the last settled reading, with a `stale` block \
+             giving that reading's age. Read `sampling` to tell the two apart.",
         ),
         // ── Walking: the chain question, and where it is answered ──
         (
@@ -317,11 +320,27 @@ fn short_descriptions() -> BTreeMap<&'static str, &'static str> {
 /// The input properties `agent-default` advertises for each tool, by registered
 /// name. A tool absent from this table keeps its full schema.
 ///
-/// Two rules decided every list. A property that changes WHICH entities come
-/// back stays. A property that only reshapes the response (`compact`,
-/// `max_chars`, `explain`, `snippet_alias`, `pipeline`) goes, because the
-/// profile now picks those defaults itself and every one of them is another line
-/// the model reads before it can ask its question.
+/// Two rules decided every list, and one exception overrides the second.
+///
+/// A property that changes WHICH entities come back stays. A property that only
+/// reshapes the response (`explain`, `snippet_alias`, `pipeline`) goes, because
+/// the profile picks those defaults itself and every one of them is another
+/// line the model reads before it can ask its question.
+///
+/// The exception: a response-shaping property the shipped proofs or the
+/// acceptance suite assert stays anyway, because those checks read the served
+/// schema as the contract an agent discovers the knob from. Trimming
+/// `include_body` and `compact` off `trace_data_flow` and `max_chars` off every
+/// tool that registered one took three acceptance findings red for four
+/// landings, and an agent that cannot see the knob cannot ask for bodies or
+/// bound a response. Three checks own that contract:
+/// `scripts/acceptance/magic_repro.py` `check_6`, which requires `include_body`
+/// or `compact` on `trace_data_flow`; `check_14` arm 3, which requires the
+/// literal `last_settled_selected_graph` in the served `kin_graph_status`
+/// description; and `scripts/acceptance/response_budget_elisions.py` `check_2`,
+/// which grades every advertised `max_chars` or `max_response_chars` and
+/// reports UNREADABLE when it finds none. Do not trim these again without
+/// moving those checks in the same change.
 fn schema_keep_lists() -> BTreeMap<&'static str, &'static [&'static str]> {
     BTreeMap::from([
         // Thirteen properties down to five. `cursor` and `page_size` stay
@@ -330,22 +349,38 @@ fn schema_keep_lists() -> BTreeMap<&'static str, &'static [&'static str]> {
         // all, and a caller asking about a test cannot otherwise find one.
         (
             "semantic_locate",
-            &["query", "limit", "granularity", "cursor", "include_tests"] as &[&str],
+            &[
+                "query",
+                "limit",
+                "granularity",
+                "cursor",
+                "include_tests",
+                "max_chars",
+            ] as &[&str],
         ),
         (
             DECLARATION_FILTER_CANONICAL,
-            &["query", "kind", "language", "limit"] as &[&str],
+            &["query", "kind", "language", "limit", "max_chars"] as &[&str],
         ),
         // `query` stays beside `entity_id`: this tool resolves an exact symbol
         // name to its canonical definition, and dropping it would take away the
         // path a caller uses when it has a name and no id.
         (
             "find_references",
-            &["entity_id", "query", "relation_kinds"] as &[&str],
+            &["entity_id", "query", "relation_kinds", "max_chars"] as &[&str],
         ),
         (
             "trace_data_flow",
-            &["focal", "target", "direction", "depth"] as &[&str],
+            &[
+                "focal",
+                "target",
+                "direction",
+                "depth",
+                "include_body",
+                "compact",
+                "max_response_chars",
+                "max_chars",
+            ] as &[&str],
         ),
         (
             crate::handlers::path::TOOL_NAME,
@@ -357,19 +392,27 @@ fn schema_keep_lists() -> BTreeMap<&'static str, &'static [&'static str]> {
                 "direction",
                 "max_depth",
                 "limit",
+                "max_chars",
             ] as &[&str],
         ),
         (
             "graph_neighborhood",
-            &["entity_id", "depth", "direction", "limit"] as &[&str],
+            &["entity_id", "depth", "direction", "limit", "max_chars"] as &[&str],
         ),
         (
             "impact_analysis",
-            &["entity_ids", "files", "base", "head", "change_ids"] as &[&str],
+            &[
+                "entity_ids",
+                "files",
+                "base",
+                "head",
+                "change_ids",
+                "max_chars",
+            ] as &[&str],
         ),
         (
             "get_context_pack",
-            &["entity_id", "depth", "token_budget"] as &[&str],
+            &["entity_id", "depth", "token_budget", "max_chars"] as &[&str],
         ),
         ("kin_provenance_query", &["entity_id", "limit"] as &[&str]),
     ])
@@ -653,6 +696,93 @@ mod tests {
         );
     }
 
+    /// The knobs the shipped acceptance checks read out of the served surface.
+    ///
+    /// `agent-default` trims response-shaping properties, and three acceptance
+    /// checks read exactly those properties as the contract an agent discovers
+    /// a knob from. Trimming them took `Product Acceptance` red on `main` for
+    /// four landings, as `magic:6`, `magic:14` and `response_budget:2`, while
+    /// every pull request stayed green, because that job is `skipped` on a pull
+    /// request and graded only on `main`'s push run.
+    ///
+    /// The three checks, so the next person can find them.
+    /// `scripts/acceptance/magic_repro.py` `check_6` requires `include_body` or
+    /// `compact` on `trace_data_flow`. Its `check_14` arm 3 requires the literal
+    /// `last_settled_selected_graph` in the served `kin_graph_status`
+    /// description. `scripts/acceptance/response_budget_elisions.py` `check_2`
+    /// grades every advertised `max_chars` or `max_response_chars` and reports
+    /// UNREADABLE when it finds none, so the served profile has to advertise a
+    /// budget wherever the registry does.
+    ///
+    /// Every arm collects rather than panics, so one trimmed knob reports itself
+    /// and the other two arms still run.
+    #[test]
+    fn agent_default_serves_every_knob_the_shipped_checks_assert() {
+        const BUDGET_KEYS: [&str; 2] = ["max_chars", "max_response_chars"];
+        let served = served_agent_default();
+        let full = crate::tools::tool_definitions();
+        let properties = |list: &ToolsListResult, name: &str| -> Vec<String> {
+            list.tools
+                .iter()
+                .find(|tool| tool.name == name)
+                .and_then(|tool| tool.input_schema.get("properties"))
+                .and_then(|value| value.as_object())
+                .map(|object| object.keys().cloned().collect())
+                .unwrap_or_default()
+        };
+        let has_budget =
+            |keys: &[String]| keys.iter().any(|key| BUDGET_KEYS.contains(&key.as_str()));
+        let mut problems: Vec<String> = Vec::new();
+
+        // magic_repro.py check_6.
+        let trace = properties(&served, "trace_data_flow");
+        if !trace
+            .iter()
+            .any(|key| key == "include_body" || key == "compact")
+        {
+            problems.push(format!(
+                "trace_data_flow advertises neither include_body nor compact, which \
+                 magic_repro.py check_6 requires: {trace:?}"
+            ));
+        }
+
+        // response_budget_elisions.py check_2, graded against the registry's own set.
+        for tool in &served.tools {
+            if !has_budget(&properties(&full, &tool.name)) {
+                continue;
+            }
+            let keys = properties(&served, &tool.name);
+            if !has_budget(&keys) {
+                problems.push(format!(
+                    "{} registers a budget parameter and agent-default advertises none, so \
+                     response_budget_elisions.py check_2 grades a smaller set than it did: \
+                     {keys:?}",
+                    tool.name
+                ));
+            }
+        }
+
+        // magic_repro.py check_14, arm 3.
+        let status = served
+            .tools
+            .iter()
+            .find(|tool| tool.name == "kin_graph_status")
+            .map(|tool| tool.description.as_str())
+            .unwrap_or_default();
+        if !status.contains("last_settled_selected_graph") {
+            problems.push(
+                "the kin_graph_status short description does not carry \
+                 last_settled_selected_graph, which magic_repro.py check_14 arm 3 requires"
+                    .to_string(),
+            );
+        }
+
+        assert!(
+            problems.is_empty(),
+            "agent-default trimmed a knob a shipped acceptance check reads: {problems:#?}"
+        );
+    }
+
     /// The in-place form the dispatchers call must agree with the borrowing one,
     /// or a call under the alias reaches a different place than a test asserts.
     #[test]
@@ -703,20 +833,23 @@ mod tests {
             properties.contains_key("query"),
             "the question must survive"
         );
-        for shaping in [
-            "max_chars",
-            "compact",
-            "explain",
-            "snippet_alias",
-            "pipeline",
-        ] {
+        // `max_chars` is the exception the keep-list doc names. It shapes the
+        // response like the four below, and it stays advertised because
+        // response_budget_elisions.py check_2 grades the advertised budget and
+        // reports UNREADABLE when no tool carries one. An agent that cannot see
+        // it cannot bound a response either.
+        assert!(
+            properties.contains_key("max_chars"),
+            "max_chars is graded off the served schema and must stay advertised"
+        );
+        for shaping in ["compact", "explain", "snippet_alias", "pipeline"] {
             assert!(
                 !properties.contains_key(shaping),
                 "{shaping} shapes the response and should not be advertised here"
             );
         }
-        // The control: the registered schema still has them, so the profile is
-        // hiding them rather than the registry having lost them.
+        // The control: the registered schema still has them all, so the profile
+        // is hiding the four rather than the registry having lost them.
         let registered = crate::tools::tool_definitions();
         let full = registered
             .tools


### PR DESCRIPTION
## The cause

`Product Acceptance` has been red on `main` for four landings, since ea25db6d8 (#1353), on
three findings. Issue #1365 tracks them. They are a different cause from the CI red on the
same shas, which #1366 fixed by reverting the served tool name.

Read from run 33614254660 on ec0f0d06a, job `Product Acceptance`, step "Acceptance verdict,
gated on the suite reports": `acceptance gate FAILED on 3 finding(s)`.

```
magic:6 FAIL trace_data_flow declares no compact/include_body parameter: ['depth', 'direction', 'focal', 'target']
magic:14 FAIL the kin_graph_status description does not tell a caller a reading as of an earlier instant is possible, so an agent cannot know to read `stale`
response_budget:2 UNREADABLE no tool advertised a budget parameter, so nothing was graded
```

All three come from the `agent-default` belt's schema trimming and short descriptions. Three
acceptance checks read exactly those properties and that description text off the served
surface:

- `scripts/acceptance/magic_repro.py` `check_6` reads `tools/list` and requires `include_body`
  or `compact` on `trace_data_flow`. The keep list gave it exactly
  `["focal", "target", "direction", "depth"]`, which is the printed list sorted.
- `check_14` arm 3 requires the literal token `last_settled_selected_graph` in the served
  `kin_graph_status` description. The short form did not carry it.
- `scripts/acceptance/response_budget_elisions.py` `check_2` scans every advertised schema for
  `max_chars` or `max_response_chars` and grades zero, so it reports UNREADABLE. The keep lists
  dropped `max_chars` from all eight belt tools that register one.

`Product Acceptance` is `skipped` on a pull request and graded only on main's push run, so
nothing per-PR could see any of this.

## The decision

These knobs are not decoration. An agent that cannot see `include_body` on `trace_data_flow`
cannot ask for the shape of a chain instead of its bodies. One that cannot see `max_chars`
cannot bound a response. One whose `kin_graph_status` description never says a settled reading
is possible cannot know to read the `stale` block. The served schema is the contract an agent
discovers a knob from, and the three checks are asserting exactly that.

So the belt's stated rule gains an exception rather than the checks moving.

- `schema_keep_lists` regains `include_body`, `compact`, `max_response_chars` and `max_chars`
  on `trace_data_flow`, all four of which its registered schema carries.
- It regains `max_chars` on the seven other belt tools whose registered schema advertises one:
  `semantic_search`, `semantic_locate`, `get_context_pack`, `trace_path`, `find_references`,
  `impact_analysis` and `graph_neighborhood`. That is every tool `response_budget` `check_2`
  graded before the trim.
- The `kin_graph_status` short description carries `last_settled_selected_graph` in one
  sentence saying a settled reading is possible and to read `sampling` to tell the two apart,
  drawn from the registered description's own wording.
- The keep-list doc comment now states the exception and names all three checks beside it, so
  nobody trims them again without moving them in the same change.
- `the_trimmed_schemas_drop_the_response_shaping_properties` now asserts `max_chars` IS
  advertised and that `compact`, `explain`, `snippet_alias` and `pipeline` still are not, with
  the registry control kept.

## The new guard

`agent_default_serves_every_knob_the_shipped_checks_assert` in
`crates/kin-mcp/src/agent_belt.rs` fails per pull request on all three findings. It collects
problems rather than panicking on the first, so one trimmed knob reports itself and the other
two arms still run. The budget arm grades the served profile against the registry's own set
rather than a hardcoded list, so a tool that gains a budget parameter later is covered without
anyone editing the test.

**Falsified, one arm at a time.** Each mutation left exactly one test red with exactly one
problem, and the other sixteen belt tests green:

| Mutation | Result |
|---|---|
| drop `include_body` and `compact` from the `trace_data_flow` keep list | 16 passed, 1 failed: `trace_data_flow advertises neither include_body nor compact, which magic_repro.py check_6 requires: ["depth", "direction", "focal", "max_chars", "max_response_chars", "target"]` |
| drop `max_chars` from the `semantic_search` keep list | 16 passed, 1 failed: `semantic_search registers a budget parameter and agent-default advertises none, so response_budget_elisions.py check_2 grades a smaller set than it did: ["kind", "language", "limit", "query"]` |
| remove the token from the `kin_graph_status` short form | 16 passed, 1 failed: `the kin_graph_status short description does not carry last_settled_selected_graph, which magic_repro.py check_14 arm 3 requires` |

## What this costs, measured

Measured by summing the served `agent-default` `tools/list` before and after this change, on
the same 21 tools:

| | before | after | delta |
|---|---|---|---|
| descriptions | 5,937 | 6,188 | +251 |
| input schemas | 20,925 | 27,276 | +6,351 |
| total | 26,862 | 33,464 | +6,602 |

The descriptions stay well inside `AGENT_DEFAULT_PROFILE_DESCRIPTION_BUDGET`, which is 10,000,
with 3,812 characters of headroom, and no tool moves past the 520-character per-tool cap.

The schema growth is real and worth stating plainly. The module's own recorded pre-compaction
measurement was 82,262 bytes over 20 tools, 47,739 of it descriptions and 30,456 input
schemas. After this change the schemas are 27,276 against that 30,456, so the schema trim is
now a small saving rather than a large one. The descriptions are where the win is: 6,188
against 47,739. The module doc is updated to carry those after-numbers, so its claim about
what the compaction bought stays honest rather than resting on the before-figure alone.

## Gates run

Both through `.kin-coord/bin/heavy-slot.sh`, never a bare cargo.

- `cargo test -p kin-mcp`: 846 passed, 0 failed.
- `bin/kin-precheck kin` against this worktree at abfc0448: 16 gates enumerated from ci.yml's
  own check job, 16 ran, 16 passed, 0 failed. That is fmt, clippy and every guard script the
  check job names.

## Relationship to the other cause

#1366 landed as 19d646e4 and fixed the CI half of the same landing: the `agent-default` profile
had served `semantic_search` under the alias `find_declarations`, which took the install proof
and the Windows npm proof red. This change is the Acceptance half. Both jobs are `skipped` on a
pull request, so each needed its own per-PR guard, and both now have one.
