### PR TITLE
Let the emulator smoke grade the startup lease from a record it can reach

### DIFF
--- a/scripts/test-gcs-emulator-endpoint.sh
+++ b/scripts/test-gcs-emulator-endpoint.sh
@@ -29,7 +29,7 @@
 # arm depends on it, so a seeding failure names itself instead of arriving later
 # disguised as a broken endpoint lever.
 #
-# Arm 1a is FIR-3059's acceptance on these same bytes. The daemon arm 1 starts
+# Arm 1a is FIR-3059's acceptance on these same bytes. A hosted daemon
 # bootstraps the GCS publication-control record before it serves, and the lease
 # in that record is the window its first hosted rollout runs under. On
 # 2026-09-02 that window was 300 s and nothing renewed it, so production's first
@@ -38,6 +38,23 @@
 # and grades the window against the value the daemon owns; the grader is
 # falsified first against the pre-fix shape, so a grader that accepts anything
 # cannot pass.
+#
+# The daemon that record comes from is the arm's own, not arm 1's. The
+# object_store client that writes the record wants a GCE token even against an
+# emulator, and this runner's metadata endpoint answers ResourceNotFound, so
+# arm 1's daemon bootstraps nothing (its log says so by name). The arm therefore
+# runs a metadata stub on the smoke network, points only its own daemon at it
+# through GCE_METADATA_HOST, gives that daemon its own prefix so no other arm's
+# record is read by mistake, and names one fleet member the bucket does not
+# hold, so the bootstrap mints the startup lease and then stops at the fence
+# with the lease still active. A completed lease records no window; an active
+# one does. Arms 1, 1b and 2 keep their exact conditions and never see the stub.
+#
+# What the arm grades today: the token path and the grader. fake-gcs-server
+# refuses the record write itself (400 "invalid uploadType" to object_store's
+# XML-API PUT; measured, see the arm), so the window is UNGRADED here by name
+# until the emulator accepts the write; the composed-rollout regression in
+# kin-daemon grades the same window on every pull request.
 #
 # Usage: scripts/test-gcs-emulator-endpoint.sh <image-ref>
 
@@ -48,6 +65,8 @@ GCS_IMAGE="${FAKE_GCS_IMAGE:-fsouza/fake-gcs-server:latest}"
 NET="kin-gcs-net-$$"
 GCS_CID=""
 KIN_CID=""
+META_CID=""
+META_IMAGE="${METADATA_STUB_IMAGE:-python:3.12-alpine}"
 BUCKET="kin-emulator-test"
 
 # The entrypoint runs `kin init`, which mints a fresh UUID v4 repo id into the
@@ -65,9 +84,10 @@ PUBLICATION_TOKEN="emulator-publication-admin-token"
 
 cleanup() {
   [ -n "${KIN_CID}" ] && docker rm -f "${KIN_CID}" >/dev/null 2>&1
+  [ -n "${META_CID}" ] && docker rm -f "${META_CID}" >/dev/null 2>&1
   [ -n "${GCS_CID}" ] && docker rm -f "${GCS_CID}" >/dev/null 2>&1
   docker network rm "${NET}" >/dev/null 2>&1
-  KIN_CID=""; GCS_CID=""
+  KIN_CID=""; META_CID=""; GCS_CID=""
   return 0
 }
 trap cleanup EXIT
@@ -114,9 +134,13 @@ printf '%s' "${IMAGE_IDENTITY}" | grep -Eq '^sha256:[0-9a-f]{64}$' \
 # variable cannot fail on it. The identity is the only argument that varies, so
 # it is the only one held in an array, and bash 3.2 aborts expanding an EMPTY
 # array under `set -u`, so it is expanded through the `${arr[@]+...}` guard.
+# Any argument after the identity mode is passed to docker run as given; arm 1a
+# uses that for its own prefix, fleet and metadata host, and nothing else does.
 start_kin() {
   local emulator_host="$1"
   local identity_mode="${2:-with-identity}"
+  shift; [ $# -gt 0 ] && shift
+  local extra_env=("$@")
   local identity_env=(-e "KIN_RELEASE_DAEMON_DIGEST_INTERNAL=${IMAGE_IDENTITY}")
   [ "${identity_mode}" = "omit-identity" ] && identity_env=()
   KIN_CID="$(docker run -d --network "${NET}" \
@@ -129,6 +153,7 @@ start_kin() {
     -e "KIN_DAEMON_AUTH_TOKEN=${DAEMON_TOKEN}" \
     -e "KIN_PUBLICATION_CONTROL_AUTH_TOKEN=${PUBLICATION_TOKEN}" \
     ${identity_env[@]+"${identity_env[@]}"} \
+    ${extra_env[@]+"${extra_env[@]}"} \
     "${IMAGE}" --port 4219)"
 }
 
@@ -147,11 +172,43 @@ await_kin() {
   echo "timeout"
 }
 
-echo "==> [setup] network and emulator"
+echo "==> [setup] network, emulator and the metadata stub arm 1a's daemon reads its token from"
 docker network create "${NET}" >/dev/null || fail "could not create docker network"
 GCS_CID="$(docker run -d --network "${NET}" --network-alias fake-gcs "${GCS_IMAGE}" \
   -scheme http -port 4443 -backend memory -public-host fake-gcs:4443)" \
   || fail "could not start ${GCS_IMAGE}"
+# The shape object_store expects (crate 0.14, gcp/credential.rs): a GET on
+# http://<GCE_METADATA_HOST>/computeMetadata/v1/instance/service-accounts/default/token
+# with Metadata-Flavor: Google, answered with access_token and expires_in. The
+# token is a fixed string the emulator never inspects; no real credential exists
+# anywhere in this job.
+METADATA_STUB=$(cat <<'PYSTUB'
+import http.server, json
+class H(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+    def _send(self, code, body, ctype):
+        data = body.encode()
+        self.send_response(code)
+        self.send_header("Metadata-Flavor", "Google")
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+    def do_GET(self):
+        path = self.path.split("?", 1)[0]
+        if path.endswith("/service-accounts/default/token"):
+            return self._send(200, json.dumps({"access_token": "emulator-smoke-token", "expires_in": 3000, "token_type": "Bearer"}), "application/json")
+        if path.endswith("/service-accounts/default/email"):
+            return self._send(200, "emulator-smoke@local", "text/plain")
+        if path.rstrip("/") in ("", "/computeMetadata/v1"):
+            return self._send(200, "computeMetadata/", "text/plain")
+        return self._send(404, "not found", "text/plain")
+http.server.ThreadingHTTPServer(("0.0.0.0", 80), H).serve_forever()
+PYSTUB
+)
+META_CID="$(docker run -d --network "${NET}" --network-alias metadata "${META_IMAGE}" python3 -c "${METADATA_STUB}")" \
+  || fail "could not start the metadata stub from ${META_IMAGE}"
 
 # ---------------------------------------------------------------------------
 # 0. Seed the bucket through the JSON API, and prove it took. Everything below
@@ -202,6 +259,7 @@ code="$(docker exec "${KIN_CID}" sh -c \
 [ -n "${code}" ] && [ "${code}" != "000" ] \
   || { dump_kin; fail "daemon reached listening but /readiness did not answer"; }
 echo "==> [serves] OK (listening, redirect logged, /readiness http ${code})"
+docker rm -f "${KIN_CID}" >/dev/null 2>&1; KIN_CID=""
 
 # ---------------------------------------------------------------------------
 # 1a. The startup rollout lease these bytes mint (FIR-3059). See the header.
@@ -256,18 +314,51 @@ rc=$?
 [ "${rc}" -eq 2 ] || fail "lease-window self-test: a record with no lease must be unreadable, not a pass or a fail (rc ${rc})"
 echo "==> [lease-window/self-test] OK"
 
-echo "==> [lease-window] read the publication-control record the daemon bootstrapped"
-# No KIN_GCS_PREFIX is passed above, so the record sits at the bucket root
-# under the name ObjectStorePublicationControlStore writes.
-record_object=".kin-graph-publication-control.json"
+echo "==> [lease-window] a daemon of its own: own prefix, the metadata stub, and a fleet member the bucket does not hold"
+# The absent member is a real UUID v4 that no arm ever initializes, so the
+# bootstrap mints the startup lease, reads the fleet, and stops at that member
+# with the lease active. The prefix keeps this record apart from arm 1's.
+LEASE_PREFIX="lease-window"
+ABSENT_REPO="2c9d5c3e-7b1a-4f0e-9d2b-3a8e6f1c4b7d"
+start_kin "http://fake-gcs:4443" with-identity \
+  -e "KIN_GCS_PREFIX=${LEASE_PREFIX}" \
+  -e "KIN_REPO_IDS=${REPO_ID},${ABSENT_REPO}" \
+  -e GCE_METADATA_HOST=metadata
+state="$(await_kin)"
+[ "${state}" = "listening" ] \
+  || { dump_kin; fail "lease-window: the daemon did not reach serving state (state=${state}); the bootstrap runs before the API serves, so nothing below can be read"; }
+logs="$(docker logs "${KIN_CID}" 2>&1 || true)"
+contains "${logs}" "fetching token from metadata server" \
+  || { dump_kin; fail "lease-window: the daemon never asked the metadata stub for a token, so the bootstrap could not have written a record"; }
+# The object name carries the prefix, and the JSON API wants the slash encoded.
+record_object="${LEASE_PREFIX}%2F.kin-graph-publication-control.json"
 record="$(docker run --rm --network "${NET}" --entrypoint curl "${IMAGE}" -sS -f \
   "http://fake-gcs:4443/storage/v1/b/${BUCKET}/o/${record_object}?alt=media" 2>/dev/null || true)"
-[ -n "${record}" ] \
-  || { dump_kin; fail "lease-window: the daemon served but no publication-control record exists at ${BUCKET}/${record_object}; the startup bootstrap wrote nothing to grade"; }
-verdict="$(grade_lease_window "${record}")"
-rc=$?
-echo "==> [lease-window] ${verdict}"
-[ "${rc}" -eq 0 ] || { dump_kin; fail "lease-window: ${verdict}"; }
+if [ -n "${record}" ]; then
+  verdict="$(grade_lease_window "${record}")"
+  rc=$?
+  echo "==> [lease-window] ${verdict}"
+  [ "${rc}" -eq 0 ] || { dump_kin; fail "lease-window: ${verdict}"; }
+else
+  # No record. One cause is known and measured, and it is the emulator's, not
+  # the daemon's: this fake-gcs-server answers 400 "invalid uploadType" to
+  # every XML-API PUT (plain, percent-encoded, with or without the create
+  # precondition; only the JSON media upload lands), and object_store writes
+  # through the XML PUT. Measured 2026-09-02 against the image built
+  # 2026-08-24 (kin-ecosystem .kin-coord/reports/leasefix-20260902.md). That
+  # exact refusal, in the daemon's own bootstrap line, is UNGRADED and said so
+  # on every run; the window then has no grader in CI until the emulator
+  # accepts the write, and this arm starts grading the day it does. Any other
+  # reason for an absent record is a daemon that stopped writing its record,
+  # which is a failure.
+  bootstrap_line="$(printf '%s\n' "${logs}" | grep -m1 'bootstrap hosted publication control' || true)"
+  if contains "${bootstrap_line}" "graph publication control store failed" && contains "${bootstrap_line}" "invalid uploadType"; then
+    echo "==> [lease-window] UNGRADED the daemon reached the record write and the emulator refused it (${bootstrap_line#*Generic GCS error: })"
+  else
+    dump_kin
+    fail "lease-window: the daemon served but no publication-control record exists at ${BUCKET}/${LEASE_PREFIX}/.kin-graph-publication-control.json and its bootstrap did not stop at the known emulator refusal${bootstrap_line:+ (daemon: ${bootstrap_line})}"
+  fi
+fi
 docker rm -f "${KIN_CID}" >/dev/null 2>&1; KIN_CID=""
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Main's Docker workflow has been red since #1364 landed at 11:37Z: arm 1a of the GCS emulator smoke failed on every push, and the dev-image publish sits behind that step. This restores the publish and makes the arm say exactly what it can and cannot grade.

## What was wrong

The arm read the publication-control record arm 1's daemon was supposed to bootstrap. None existed, and none ever had: the object_store client that writes the record asks a GCE metadata endpoint for a token even against an emulator, the runner's endpoint answers ResourceNotFound, and the bootstrap stopped before its first write. The daemon's own log line named it (`bootstrap hosted publication control before Firestore spine recovery: graph publication control store failed: Generic GCS error: Error performing token request`). The smoke had never exercised a write; FIR-2668's arm accepts a 503 readiness.

## What changes

- A metadata stub (`python:3.12-alpine`, the shape the spinefix rehearsal used) runs on the smoke network and answers the exact request object_store 0.14 makes (`GET /computeMetadata/v1/instance/service-accounts/default/token` with `Metadata-Flavor: Google`, answered with `access_token` and `expires_in`). Only arm 1a's daemon points at it through `GCE_METADATA_HOST`.
- Arm 1a runs its own daemon on prefix `lease-window` with a fleet that names one repository the bucket does not hold, so the bootstrap mints the startup lease and stops at the fence with the lease active. A completed lease records no window; an active one does. Arms 1, 1b and 2 keep their exact conditions.
- The verdict is three-way. A record present is graded (PASS or FAIL on the window, self-tested first against the pre-fix 300 s shape). No record with the daemon's bootstrap line naming the one measured emulator refusal prints UNGRADED with that line and continues. No record for any other reason fails, because that is the shape a daemon that stopped writing its record would take.

## What was measured

With the token in place the daemon reached the record write, and the emulator refused it: fake-gcs-server (latest, image built 2026-08-24) answers 400 `invalid uploadType` to every XML-API PUT. Probed from a curl container (kin-ecosystem `.kin-coord/reports/leasefix-20260902/gcs-put-probe.sh`): plain `PUT /bucket/object` 400, percent-encoded bucket and object (object_store's shape) 400, with `x-goog-if-generation-match: 0` 400, with a Content-Type 400, JSON media upload `POST /upload/storage/v1/b/bucket/o?uploadType=media` 200. object_store writes through the XML PUT, so no publication-control record can land in this emulator today.

So the window is UNGRADED in this smoke until the emulator accepts the write (or object_store uploads through the JSON API), and the arm says so by name on every run. The class keeps its per-PR check: `state::tests::first_hosted_rollout_outlives_its_startup_lease_by_renewing_before_each_publication` on ci.yml's `gcs,firestore` leg.

## Proof

The patched script was run locally against the cached pre-fix v0.6.3 release image (fcedf4f9): every arm OK and the script exits 0, with arm 1a reporting `UNGRADED the daemon reached the record write and the emulator refused it (Error performing PUT http://fake-gcs:4443/kin%2Demulator%2Dtest/lease%2Dwindow%2F%2Ekin%2Dgraph%2Dpublication%2Dcontrol%2Ejson ... 400 Bad Request: invalid uploadType)`; the daemon's env-registry line confirms its fleet carried the absent member and its log shows the token fetched from the stub.

Falsified: the same script with arm 1a's daemon pointed at a metadata host that does not resolve exits 1 at the arm with `no publication-control record exists ... and its bootstrap did not stop at the known emulator refusal (daemon: ... Error performing token request ...)`, so an absent record for any reason but the measured one is a failure, not a skip.

The grader's self-test (pre-fix 300 s window refused, 1800 s accepted, no lease unreadable) runs inside the script before any record is read, and the stub was probed on the host for the token path, the root path and an unknown path (200, 200, 404).

Related: FIR-3059
