### PR TITLE
Bind the registry wave to protected main history and land it when green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,7 @@ jobs:
           bash ./scripts/test-publish-dev-container.sh
           bash ./scripts/kin-dev-image.test.sh
           python3 ./scripts/test-kin-registry-release-receiver.py
+          python3 ./scripts/test-kin-registry-wave-landing.py
           python3 ./scripts/test_install_optional_vfs.py
           python3 ./scripts/test_installer_parity.py
           # Every install surface builds a release asset name; the release

--- a/.github/workflows/kin-registry-release.yml
+++ b/.github/workflows/kin-registry-release.yml
@@ -57,47 +57,48 @@ jobs:
       BASE_BRANCH: main
       WAVE_BRANCH: automation/kin-registry-dependency-wave
     steps:
-      - name: Bind early disarm to the queued workflow policy
-        id: base
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          base_sha="$(gh api \
-            "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BASE_BRANCH}" \
-            --jq .object.sha)"
-          if [[ ! "$base_sha" =~ ^[0-9a-f]{40}$ ]] ||
-             [ "$base_sha" != "$GITHUB_SHA" ]; then
-            echo "::error::early disarm is not bound to exact queued protected main"
-            exit 1
-          fi
-          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
-
-      # github.sha, not steps.base.outputs.base_sha: the step above already
-      # refuses unless that computed value equals github.sha, so the checkout
-      # ref and the assertion target are the same commit either way. A
-      # step-output expression reads as attacker-influenceable to a static
-      # checker with no view of the shell assertion that pins it, so this
-      # checkout uses the literal trusted context value instead. CodeQL rule
-      # actions/cache-poisoning/poisonable-step named this exact expression.
+      # The literal trusted context value, never a step output: a step-output
+      # expression reads as attacker-influenceable to a static checker with no
+      # view of the shell assertion that pins it (CodeQL rule
+      # actions/cache-poisoning/poisonable-step named exactly that shape).
+      # github.sha is what the binding step below proves to be protected
+      # main's history before anything reads it as policy.
       - name: Checkout exact policy for early disarm
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.sha }}
           persist-credentials: false
 
-      - name: Refuse protected-main movement before early-disarm token mint
+      # Bound to the sha this run checked out, proven to be an ancestor of the
+      # protected tip rather than equal to it. Equality cannot hold while lanes
+      # land every few minutes: four receiver runs refused on 2026-09-02 with
+      # "queued receiver policy <sha> is not protected main <sha>" while main
+      # moved under them. The property that matters is that the policy running
+      # here is main's own history: a commit still reachable from the protected
+      # tip is unrewritten, and GitHub resolved github.sha from the default
+      # branch, so it is neither a branch nor a fork. A behind or diverged
+      # answer is exactly what a force-push looks like, and both refuse.
+      - name: Bind early disarm to the queued workflow policy
+        id: base
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          current_base="$(gh api \
-            "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BASE_BRANCH}" \
-            --jq .object.sha)"
-          if [ "$current_base" != "$GITHUB_SHA" ]; then
-            echo "::error::protected main moved before early disarm"
-            exit 1
-          fi
+          python3 scripts/verify-protected-main-history.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --policy-sha "$GITHUB_SHA" \
+            --branch "$BASE_BRANCH"
+          echo "base_sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Refuse protected-main rewrite before early-disarm token mint
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python3 scripts/verify-protected-main-history.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --policy-sha "$GITHUB_SHA" \
+            --branch "$BASE_BRANCH"
 
       - name: Mint repository-scoped early-disarm token
         id: app-token
@@ -149,35 +150,28 @@ jobs:
       KIN_ACTIONS_SHA: 398595fa14ba1eaebca6eb176facd8a57ce9db05 # v0.1.33
       BASE_BRANCH: main
     steps:
-      - name: Bind preparation to the queued workflow policy
-        id: base
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          base_sha="$(gh api \
-            "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BASE_BRANCH}" \
-            --jq .object.sha)"
-          if [[ ! "$base_sha" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::error::protected main returned invalid object id $base_sha"
-            exit 1
-          fi
-          if [ "$base_sha" != "$GITHUB_SHA" ]; then
-            echo "::error::queued receiver policy $GITHUB_SHA is not protected main $base_sha"
-            exit 1
-          fi
-          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
-
-      # github.sha, not steps.base.outputs.base_sha: see the comment on the
-      # same substitution in disarm-wave above. The step directly above this
-      # one already refuses the job unless the computed value equals
-      # github.sha, so this checks out the same commit either way.
+      # github.sha, the literal trusted context value: see the comment on the
+      # same checkout in disarm-wave above. The binding step below proves this
+      # exact commit is protected main's history before anything reads it as
+      # policy, and it is the admitted base every later job binds to.
       - name: Checkout exact queued protected main
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Bind preparation to the queued workflow policy
+        id: base
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python3 scripts/verify-protected-main-history.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --policy-sha "$GITHUB_SHA" \
+            --branch "$BASE_BRANCH"
+          echo "base_sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Checkout exact Kin dependency updater
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -354,28 +348,10 @@ jobs:
       WAVE_BRANCH: automation/kin-registry-dependency-wave
       ADMITTED_BASE: ${{ needs.prepare-wave.outputs.base_sha }}
     steps:
-      - name: Rebind the fresh mutation runner to queued policy
-        id: base
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          base_sha="$(gh api \
-            "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BASE_BRANCH}" \
-            --jq .object.sha)"
-          if [[ ! "$base_sha" =~ ^[0-9a-f]{40}$ ]] ||
-             [ "$base_sha" != "$GITHUB_SHA" ] ||
-             [ "$base_sha" != "$ADMITTED_BASE" ]; then
-            echo "::error::fresh mutation runner is not bound to exact queued protected main"
-            exit 1
-          fi
-          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
-
-      # github.sha, not steps.base.outputs.base_sha: see the comment on the
-      # same substitution in disarm-wave above. The step directly above this
-      # one already refuses the job unless the computed value equals both
-      # github.sha and prepare-wave's admitted base, so this checks out the
-      # same commit either way.
+      # github.sha, the literal trusted context value: see the comment on the
+      # same checkout in disarm-wave above. The rebind step below refuses
+      # unless this exact commit is prepare-wave's admitted base and proves it
+      # is protected main's history.
       - name: Checkout exact protected main for trusted mutation code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -383,19 +359,32 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Refuse protected-main movement immediately before token mint
+      - name: Rebind the fresh mutation runner to queued policy
+        id: base
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          current_base="$(gh api \
-            "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BASE_BRANCH}" \
-            --jq .object.sha)"
-          if [ "$current_base" != "$GITHUB_SHA" ] ||
-             [ "$current_base" != "$ADMITTED_BASE" ]; then
-            echo "::error::protected main moved before dependency-wave token mint"
+          if [[ ! "$ADMITTED_BASE" =~ ^[0-9a-f]{40}$ ]] ||
+             [ "$ADMITTED_BASE" != "$GITHUB_SHA" ]; then
+            echo "::error::fresh mutation runner is not bound to the admitted queued policy"
             exit 1
           fi
+          python3 scripts/verify-protected-main-history.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --policy-sha "$GITHUB_SHA" \
+            --branch "$BASE_BRANCH"
+          echo "base_sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Refuse protected-main rewrite immediately before token mint
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python3 scripts/verify-protected-main-history.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --policy-sha "$ADMITTED_BASE" \
+            --branch "$BASE_BRANCH"
 
       - name: Mint repository-scoped dependency-wave token
         id: app-token
@@ -454,19 +443,16 @@ jobs:
             echo "workspace_version=$(jq -r .workspace_version <<<"$candidate")"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Refuse protected-main movement before repository mutation
+      - name: Refuse protected-main rewrite before repository mutation
         if: needs.prepare-wave.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
-          current_base="$(gh api \
-            "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BASE_BRANCH}" \
-            --jq .object.sha)"
-          if [ "$current_base" != "$ADMITTED_BASE" ]; then
-            echo "::error::protected main moved before the fixed PR write"
-            exit 1
-          fi
+          python3 scripts/verify-protected-main-history.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --policy-sha "$ADMITTED_BASE" \
+            --branch "$BASE_BRANCH"
 
       - name: Ensure dependency-wave labels exist
         if: needs.prepare-wave.outputs.changed == 'true'
@@ -554,12 +540,19 @@ jobs:
              [ "$(jq -r .head.repo.full_name <<<"$pull")" != "$GITHUB_REPOSITORY" ] ||
              [ "$(jq -r .head.ref <<<"$pull")" != "$WAVE_BRANCH" ] ||
              [ "$(jq -r .base.ref <<<"$pull")" != "$BASE_BRANCH" ] ||
-             [ "$(jq -r .base.sha <<<"$pull")" != "$ADMITTED_BASE" ] ||
              ! jq -e '.auto_merge == null' >/dev/null <<<"$pull" ||
              [ "$api_head" != "$ACTION_HEAD" ]; then
             echo "::error::dependency PR is not the exact first-party automation branch"
             exit 1
           fi
+          # The pull base is main's tip at the moment the action pushed, which
+          # may be ahead of the admitted base. It has to be protected main at
+          # or after that base; anything else descends from something else.
+          python3 scripts/verify-protected-main-history.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --policy-sha "$ADMITTED_BASE" \
+            --descendant "$(jq -r .base.sha <<<"$pull")" \
+            --branch "$BASE_BRANCH"
           api_tree="$(gh api \
             "repos/${GITHUB_REPOSITORY}/git/commits/${api_head}" --jq .tree.sha)"
           if [ "$api_tree" != "$EXPECTED_TREE" ]; then

--- a/.github/workflows/kin-registry-wave-land.yml
+++ b/.github/workflows/kin-registry-wave-land.yml
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+name: Kin Registry Wave Landing
+
+# Lands the receiver's dependency-wave pull request by itself, the moment every
+# check-run on its head has concluded green. Two arms: every completion of a
+# check-producing workflow on the wave branch, and a sweep four times an hour
+# for producers that are not workflows of this repository (CodeQL's default
+# setup) or that concluded while a judgment was already running. Both events
+# resolve this workflow from the default branch, and the judge proves
+# github.sha is protected main history before reading it as policy.
+#
+# The judgment is scripts/land-kin-registry-wave.py, whose rule is the fleet's
+# landing rule: the FULL check-run set on the head, read by name with
+# per_page=100 and the listed length asserted against total_count, every run
+# concluded, none failed, skipped and neutral green, the six ruleset contexts
+# present, one bot commit carrying the reserved marker, a diff inside the
+# receiver's write set, and the release-App attestation verified. GitHub's own
+# auto-merge is not the mechanism: it merges on the six ruleset contexts alone,
+# and the admission chain refuses any server-owned landing state on the wave.
+# There is no manual dispatch arm, because this workflow reaches a
+# release-capable secret.
+on:
+  workflow_run:
+    workflows:
+      - CI
+      - SAST
+      - Secret Scan
+      - DCO
+      - PR Text Hygiene
+      - Daemon Smoke
+      - Docker
+      - Fuzz
+      - Acceptance
+      - Install Proof Canary
+      - Link Check
+      - CodeQL
+    types: [completed]
+  schedule:
+    - cron: "5,20,35,50 * * * *"
+
+permissions:
+  contents: read
+
+env:
+  BASE_BRANCH: main
+  WAVE_BRANCH: automation/kin-registry-dependency-wave
+
+jobs:
+  judge-wave:
+    name: Judge the open Kin registry wave
+    # A completion on any other branch is not news about the wave, and a head
+    # repository other than this one is never the wave.
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event.workflow_run.head_branch == 'automation/kin-registry-dependency-wave' &&
+       github.event.workflow_run.head_repository.full_name == github.repository)
+    concurrency:
+      group: kin-registry-wave-judge-${{ github.repository }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      issues: read
+      pull-requests: read
+    outputs:
+      decision: ${{ steps.judge.outputs.decision || 'wait' }}
+      pull: ${{ steps.judge.outputs.pull }}
+      head: ${{ steps.judge.outputs.head }}
+    env:
+      # The GitHub-side landing hold, the wave's equivalent of the fleet's
+      # kin_main_frozen gate. A captain sets it with
+      #   gh variable set KIN_MAIN_FROZEN --repo firelock-ai/kin --body "<why>"
+      # and lifts it with `gh variable delete KIN_MAIN_FROZEN`. Any non-empty
+      # value holds every wave landing and is reported in the judgment.
+      KIN_MAIN_FROZEN: ${{ vars.KIN_MAIN_FROZEN }}
+    steps:
+      - name: Find the open dependency wave
+        id: find
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          count="$(gh api --method GET "repos/${GITHUB_REPOSITORY}/pulls" \
+            -f state=open \
+            -f "head=${GITHUB_REPOSITORY_OWNER}:${WAVE_BRANCH}" \
+            -f "base=${BASE_BRANCH}" \
+            -f per_page=100 \
+            --jq 'length')"
+          if [[ ! "$count" =~ ^[0-9]+$ ]]; then
+            echo "::error::open wave listing did not answer with a count: $count"
+            exit 1
+          fi
+          echo "open=$count" >> "$GITHUB_OUTPUT"
+          if [ "$count" = 0 ]; then
+            echo "::notice::no open pull request from ${WAVE_BRANCH}; nothing to judge"
+          fi
+
+      # The literal trusted context value: see the same checkout in
+      # kin-registry-release.yml. The binding step below proves github.sha is
+      # protected main's history before the judgment reads it as policy.
+      - name: Checkout the queued landing policy
+        if: steps.find.outputs.open != '0'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Bind the judgment to protected main history
+        if: steps.find.outputs.open != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python3 scripts/verify-protected-main-history.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --policy-sha "$GITHUB_SHA" \
+            --branch "$BASE_BRANCH"
+
+      - name: Judge the wave against its full check set
+        id: judge
+        if: steps.find.outputs.open != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          verdict="$(python3 scripts/land-kin-registry-wave.py judge \
+            --repository "$GITHUB_REPOSITORY" \
+            --workspace "$GITHUB_WORKSPACE" \
+            --freeze "$KIN_MAIN_FROZEN")"
+          printf '%s\n' "$verdict"
+          {
+            echo "decision=$(jq -r .decision <<<"$verdict")"
+            echo "pull=$(jq -r '.pull // ""' <<<"$verdict")"
+            echo "head=$(jq -r '.head // ""' <<<"$verdict")"
+          } >> "$GITHUB_OUTPUT"
+
+  land-wave:
+    name: Land the green Kin registry wave
+    needs: judge-wave
+    if: needs.judge-wave.outputs.decision == 'land'
+    concurrency:
+      group: kin-registry-wave-land-${{ github.repository }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: release-tag
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      issues: read
+      pull-requests: read
+    env:
+      KIN_MAIN_FROZEN: ${{ vars.KIN_MAIN_FROZEN }}
+      JUDGED_PULL: ${{ needs.judge-wave.outputs.pull }}
+      JUDGED_HEAD: ${{ needs.judge-wave.outputs.head }}
+    steps:
+      - name: Checkout the queued landing policy for the merge
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Bind the landing to protected main history
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$JUDGED_PULL" =~ ^[1-9][0-9]*$ ]] ||
+             [[ ! "$JUDGED_HEAD" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::judgment handed over no exact pull and head"
+            exit 1
+          fi
+          python3 scripts/verify-protected-main-history.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --policy-sha "$GITHUB_SHA" \
+            --branch "$BASE_BRANCH"
+
+      - name: Mint repository-scoped landing token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.KIN_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.KIN_RELEASE_BOT_PRIVATE_KEY }}
+          owner: firelock-ai
+          repositories: kin
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Verify exact landing App identity and scope
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+          python3 scripts/verify-kin-release-app-token.py \
+            --app-slug "$APP_SLUG" \
+            --repository "$GITHUB_REPOSITORY"
+
+      # Every read goes through the workflow token; only the merge call and
+      # its read-back use the App token, the way the attester keeps the App
+      # away from Actions reads.
+      - name: Squash the green wave onto protected main
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KIN_LAND_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          python3 scripts/land-kin-registry-wave.py land \
+            --repository "$GITHUB_REPOSITORY" \
+            --workspace "$GITHUB_WORKSPACE" \
+            --freeze "$KIN_MAIN_FROZEN" \
+            --pull "$JUDGED_PULL" \
+            --head "$JUDGED_HEAD" \
+            --merge-token-env KIN_LAND_TOKEN

--- a/docs/release-bot.md
+++ b/docs/release-bot.md
@@ -373,3 +373,44 @@ A clean refusal with no tag created proves the untrusted input and head guards.
 It deliberately stops before App-token minting, so verify the Environment
 policy and secret placement independently during setup; the first admitted
 release proves the complete token-and-ruleset path.
+
+## Registry dependency wave
+
+`.github/workflows/kin-registry-release.yml` receives a typed
+`kin-registry-release` dispatch from a registry publish, reconciles the full
+pin set hourly, prepares the new Cargo pins on a credential-free runner, and
+writes the admitted bytes to one pull request on
+`automation/kin-registry-dependency-wave` through the release App. Every job
+binds to the commit it checked out, `github.sha`, and proves it is protected
+main's history with `scripts/verify-protected-main-history.py`: the commit must
+be the tip of `main` or an ancestor of it, read through the compare API. A lane
+landing while the receiver runs no longer refuses the wave; a force-pushed or
+foreign ref still does. The wave's pull base is proven to be protected main at
+or after the admitted base for the same reason, in the receiver, the attester
+and the CI gate alike.
+
+`.github/workflows/kin-registry-release-attest.yml` then binds the exact wave
+head to a release-App attestation that the required CI gate revalidates.
+
+`.github/workflows/kin-registry-wave-land.yml` lands the wave. It runs when a
+check-producing workflow completes on the wave branch and on a sweep four times
+an hour, and `scripts/land-kin-registry-wave.py` decides `land`, `wait` or
+`refuse`: one open first-party wave opened by the release App with no
+auto-merge armed, one bot commit carrying the reserved marker, a diff inside
+`Cargo.toml` and `Cargo.lock`, every check-run on the head concluded and none
+failed over the full set (`per_page=100`, the listed length asserted against
+`total_count`, the newest run per check name, skipped and neutral green, the
+six ruleset contexts present), the pull mergeable, and the attestation
+verified. Only then does the land job mint the App token, squash-merge with the
+pull title and body and never the marker line, and prove the squash is on
+`main`. A failed check, a foreign commit, an off-scope file or an unreadable
+listing refuses loudly; checks still running, a missing attestation or an open
+hold wait quietly. GitHub's own auto-merge is not the mechanism, because it
+merges on the six ruleset contexts alone and the admission chain refuses any
+server-owned landing state on the wave.
+
+The hold is the repository variable `KIN_MAIN_FROZEN`, the wave's equivalent
+of the fleet's `kin_main_frozen` gate. Set it with
+`gh variable set KIN_MAIN_FROZEN --repo firelock-ai/kin --body "<why>"` and
+lift it with `gh variable delete KIN_MAIN_FROZEN --repo firelock-ai/kin`. Any
+non-empty value holds every wave landing and is named in the judgment.

--- a/scripts/attest-kin-registry-wave.py
+++ b/scripts/attest-kin-registry-wave.py
@@ -51,6 +51,10 @@ landing = _load(
     "kin_registry_wave_attester_landing",
     SCRIPT_DIR / "ensure-kin-registry-wave-no-automerge.py",
 )
+history = _load(
+    "kin_registry_wave_attester_history",
+    SCRIPT_DIR / "verify-protected-main-history.py",
+)
 
 
 def run_gh(arguments: Sequence[str]) -> str:
@@ -72,6 +76,47 @@ def gh_json(arguments: Sequence[str]) -> Any:
         return json.loads(run_gh(arguments))
     except json.JSONDecodeError as exc:
         raise AttesterError("GitHub returned malformed JSON") from exc
+
+
+def _history_fetch(endpoint: str) -> Any:
+    return gh_json(["api", endpoint])
+
+
+def _require_protected_history(repository: str, policy_sha: str) -> None:
+    """Refuse unless the receiver's policy sha is still protected main history.
+
+    Equality with the live tip was the old test, and it refused every
+    attestation that arrived while lanes were landing. What the attestation
+    needs is that the policy which produced the admission was main's own
+    history and has not been rewritten: an ancestor of the current tip.
+    """
+    try:
+        history.require_protected_history(
+            repository,
+            policy_sha,
+            branch=guard.EXPECTED_BASE,
+            fetch=_history_fetch,
+        )
+    except history.HistoryError as exc:
+        raise AttesterError(
+            f"receiver policy is not protected main history: {exc}"
+        ) from exc
+
+
+def _require_descendant_base(repository: str, admitted_base: str, pull_base: str) -> None:
+    """Refuse unless a pull base is protected main at or after the admitted base."""
+    try:
+        history.require_descendant(
+            repository,
+            admitted_base,
+            pull_base,
+            branch=guard.EXPECTED_BASE,
+            fetch=_history_fetch,
+        )
+    except history.HistoryError as exc:
+        raise AttesterError(
+            f"pull base is not protected main at or after the admitted base: {exc}"
+        ) from exc
 
 
 def _event(path: Path) -> dict[str, Any]:
@@ -310,12 +355,7 @@ def validate_live_admission(
     pull_number = int(admission["pull"])
     head = str(admission["head"])
     policy_sha = str(admission["policy_sha"])
-    current_ref = gh_json(
-        ["api", f"repos/{repository}/git/ref/heads/{guard.EXPECTED_BASE}"]
-    )
-    ref_object = current_ref.get("object") if isinstance(current_ref, dict) else None
-    if not isinstance(ref_object, dict) or ref_object.get("sha") != policy_sha:
-        raise AttesterError("protected main moved after the completed receiver")
+    _require_protected_history(repository, policy_sha)
 
     pull = gh_json(["api", f"repos/{repository}/pulls/{pull_number}"])
     try:
@@ -327,8 +367,7 @@ def validate_live_admission(
         )
     except guard.AdmissionError as exc:
         raise AttesterError(str(exc)) from exc
-    if pull_evidence.base != admission["base"]:
-        raise AttesterError("live pull base differs from the completed admission")
+    _require_descendant_base(repository, str(admission["base"]), pull_evidence.base)
 
     graphql_pull = landing._graphql_pull(repository, pull_number)
     try:
@@ -675,7 +714,7 @@ def _validate_recheck_pull(
         or head_repo.get("url") != repository_url
         or not isinstance(base, dict)
         or base.get("ref") != guard.EXPECTED_BASE
-        or base.get("sha") != admission["base"]
+        or not isinstance(base.get("sha"), str)
         or not isinstance(base_repo, dict)
         or base_repo.get("name") != repository_name
         or base_repo.get("url") != repository_url
@@ -683,6 +722,7 @@ def _validate_recheck_pull(
         raise AttesterError(
             "post-attestation CI run is not bound to the exact admitted pull"
         )
+    _require_descendant_base(repository, str(admission["base"]), str(base["sha"]))
 
 
 def _validate_recheck_job(
@@ -979,10 +1019,11 @@ def _exact_pull_state(
         or not isinstance(head.get("repo"), dict)
         or head["repo"].get("full_name") != repository
         or not isinstance(base, dict)
-        or base.get("sha") != admission["base"]
+        or not isinstance(base.get("sha"), str)
         or base.get("ref") != guard.EXPECTED_BASE
     ):
         raise AttesterError(f"pull {state} response differs from the exact admission")
+    _require_descendant_base(repository, str(admission["base"]), str(base["sha"]))
 
 
 def _reopen_pull(

--- a/scripts/land-kin-registry-wave.py
+++ b/scripts/land-kin-registry-wave.py
@@ -1,0 +1,782 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Land the Kin registry dependency wave once its full check set is green.
+
+The receiver opens and updates the wave pull request on
+`automation/kin-registry-dependency-wave` and the attester binds its exact head
+to a release-App attestation. Nothing landed it: `bin/kin-lane merge land`
+refuses every automation/ head by design, GitHub auto-merge merges on the six
+ruleset contexts alone while the fleet's rule is the FULL check set read by
+name, and the v2 admission chain refuses any server-owned landing state on the
+wave. So a captain squashed the wave by hand, or rebuilt its bytes in a lane
+branch without the reserved marker.
+
+This script is the landing. `judge` reads everything the verdict rests on and
+decides `land`, `wait` or `refuse` with the reason; `land` re-judges and then
+squash-merges through the release App, verifying the merge landed on protected
+main. The judgment itself is a pure function over one snapshot document, so the
+test feeds it fixture check-run sets and asserts the verdict without GitHub.
+
+The landing rule, in the order it is applied:
+
+1. A non-empty `KIN_MAIN_FROZEN` repository variable holds every landing.
+2. Exactly one open pull request from the wave branch to main, opened by the
+   release App, not a draft, with no auto-merge armed, whose branch tip on
+   origin is still the head under judgment.
+3. Its only commit is the receiver's bot commit: authored and committed by
+   github-actions[bot] and carrying the reserved marker exactly once.
+4. Its diff touches only the paths the receiver writes (Cargo.toml and
+   Cargo.lock), as modifications, never an add, delete or rename.
+5. Every check-run on the head has concluded and none failed, read over the
+   full set with `per_page=100` and the listed length asserted against
+   `total_count`, deduplicated per check name keeping the newest run (the
+   attester's close-and-reopen retrigger leaves a cancelled first suite beside
+   the green one), with skipped and neutral counted as green, and the six
+   contexts the main ruleset requires all present.
+6. GitHub reports the pull mergeable (a conflict refuses; an answer still being
+   computed waits).
+7. The release-App attestation for this exact head verifies.
+
+The squash message is the pull title with its number and the pull body. It never
+carries the marker line: the marker is the authorization to land, reserved for
+receiver heads, and a marker on main without its pull is what the CI gate
+refuses. It never carries a Co-authored-by line either, which the fleet's
+history audit flags.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Sequence
+
+
+EXPECTED_REPOSITORY = "firelock-ai/kin"
+BOT_LOGIN = "github-actions[bot]"
+BOT_ID = 41898282
+BOT_EMAIL = "41898282+github-actions[bot]@users.noreply.github.com"
+LOWER_SHA = re.compile(r"^[0-9a-f]{40}$")
+GREEN_CONCLUSIONS = frozenset({"success", "skipped", "neutral"})
+# Ruleset 19746451 "Require status checks on main", read on 2026-09-02 through
+# repos/firelock-ai/kin/rules/branches/main. These have to be PRESENT on the
+# head before a landing so an empty or half-arrived check set never reads as
+# green. release-tag.yml's RULESET_REQUIRED_CHECKS mirror is a superset of this
+# list by contract, and scripts/test-kin-registry-wave-landing.py holds the two
+# together.
+RULESET_REQUIRED_CONTEXTS = (
+    "DCO Sign-off",
+    "PR text hygiene",
+    "cargo-deny",
+    "gitleaks (full history)",
+    "Fast gate lint and policy",
+    "Fast gate build and tests",
+)
+# Pull states GitHub reports in `mergeable_state`. `dirty` is a conflict and
+# terminal until the receiver rebuilds the wave; the rest resolve on their own.
+CONFLICT_STATES = frozenset({"dirty"})
+SETTLING_STATES = frozenset({"unknown", "blocked", "behind", "draft"})
+LAND = "land"
+WAIT = "wait"
+REFUSE = "refuse"
+ATTESTATION_VERIFIED = "verified"
+ATTESTATION_PENDING = "pending"
+
+
+class LandingError(RuntimeError):
+    """The wave could not be judged or landed on a trustworthy reading."""
+
+
+def _load(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise LandingError(f"cannot load trusted helper {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+guard = _load(
+    "kin_registry_wave_landing_guard",
+    SCRIPT_DIR / "verify-kin-registry-wave-head.py",
+)
+history = _load(
+    "kin_registry_wave_landing_history",
+    SCRIPT_DIR / "verify-protected-main-history.py",
+)
+WAVE_BRANCH = guard.WAVE_BRANCH
+BASE_BRANCH = guard.EXPECTED_BASE
+ALLOWED_PATHS = guard.ALLOWED_PATHS
+COMMIT_MARKER = guard.COMMIT_MARKER
+APP_LOGIN = guard.ATTESTATION_CREATOR
+APP_ID = guard.ATTESTATION_CREATOR_ID
+
+
+@dataclass(frozen=True)
+class Verdict:
+    decision: str
+    reason: str
+    pull: int | None = None
+    head: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def document(self) -> dict[str, Any]:
+        return {
+            "decision": self.decision,
+            "reason": self.reason,
+            "pull": self.pull,
+            "head": self.head,
+            "details": self.details,
+        }
+
+
+def run_gh(arguments: Sequence[str], *, token: str | None = None) -> str:
+    env = os.environ.copy()
+    if token is not None:
+        env["GH_TOKEN"] = token
+    result = subprocess.run(
+        ["gh", *arguments],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "no output"
+        raise LandingError(f"gh {' '.join(arguments)} failed: {detail}")
+    return result.stdout
+
+
+def gh_json(arguments: Sequence[str], *, token: str | None = None) -> Any:
+    try:
+        return json.loads(run_gh(arguments, token=token))
+    except json.JSONDecodeError as exc:
+        raise LandingError("GitHub returned malformed JSON") from exc
+
+
+def _history_fetch(endpoint: str) -> Any:
+    return gh_json(["api", endpoint])
+
+
+def _flatten_pages(value: Any, label: str) -> list[Any]:
+    """Flatten a `gh api --paginate --slurp` answer for a list endpoint."""
+
+    if not isinstance(value, list):
+        raise LandingError(f"{label} listing is not an array")
+    if value and all(isinstance(page, list) for page in value):
+        return [item for page in value for item in page]
+    return value
+
+
+def _check_run_pages(value: Any) -> list[dict[str, Any]]:
+    """Normalize the check-runs answer into its page objects."""
+
+    if isinstance(value, dict):
+        return [value]
+    if isinstance(value, list) and all(isinstance(page, dict) for page in value):
+        return value
+    raise LandingError("check-run listing is neither a page nor a list of pages")
+
+
+# ---------------------------------------------------------------------------
+# The pure judgment.
+# ---------------------------------------------------------------------------
+
+
+def _sha(value: Any) -> str | None:
+    if isinstance(value, str) and LOWER_SHA.fullmatch(value) is not None:
+        return value
+    return None
+
+
+def _count(value: Any) -> int | None:
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        return value
+    return None
+
+
+def judge_check_runs(pages: Any) -> dict[str, Any]:
+    """Judge the full check-run set on one head.
+
+    Returns the deduplicated set with the names still running, the names that
+    failed and the required names not present. Raises LandingError when the
+    listing cannot be trusted: a page count that disagrees with `total_count`
+    is the paging trap that fails toward green, and a run without a name or an
+    id cannot be keyed.
+    """
+
+    if not isinstance(pages, list) or not pages:
+        raise LandingError("check-run listing is empty or not a list of pages")
+    totals: set[int] = set()
+    runs: list[dict[str, Any]] = []
+    for page in pages:
+        if not isinstance(page, dict):
+            raise LandingError("check-run page is not an object")
+        total = _count(page.get("total_count"))
+        page_runs = page.get("check_runs")
+        if total is None or not isinstance(page_runs, list):
+            raise LandingError("check-run page lacks total_count or check_runs")
+        totals.add(total)
+        runs.extend(page_runs)
+    if len(totals) != 1:
+        raise LandingError(f"check-run pages disagree on total_count: {sorted(totals)}")
+    total = totals.pop()
+    if len(runs) != total:
+        raise LandingError(
+            f"check-run listing is incomplete: {len(runs)} listed of {total} reported"
+        )
+
+    newest: dict[str, dict[str, Any]] = {}
+    for run in runs:
+        if not isinstance(run, dict):
+            raise LandingError("check-run entry is not an object")
+        name = run.get("name")
+        run_id = _count(run.get("id"))
+        if not isinstance(name, str) or not name or run_id is None:
+            raise LandingError("check-run entry lacks a name or an id")
+        started = run.get("started_at") or run.get("completed_at") or ""
+        if not isinstance(started, str):
+            raise LandingError(f"check-run {name!r} has a malformed timestamp")
+        key = (started, run_id)
+        current = newest.get(name)
+        if current is None or key > current["_key"]:
+            newest[name] = {**run, "_key": key}
+
+    pending: list[str] = []
+    failed: list[str] = []
+    for name in sorted(newest):
+        run = newest[name]
+        conclusion = run.get("conclusion")
+        if conclusion is None or conclusion == "":
+            pending.append(name)
+        elif conclusion not in GREEN_CONCLUSIONS:
+            failed.append(f"{name}={conclusion}")
+    missing = [name for name in RULESET_REQUIRED_CONTEXTS if name not in newest]
+    return {
+        "total": total,
+        "distinct": len(newest),
+        "pending": pending,
+        "failed": failed,
+        "missing_required": missing,
+    }
+
+
+def compose_squash_message(pull: dict[str, Any]) -> tuple[str, str]:
+    """The squash title and message, refusing text main's history must not carry."""
+
+    number = _count(pull.get("number"))
+    title = pull.get("title")
+    body = pull.get("body")
+    if number is None or not isinstance(title, str) or not title.strip():
+        raise LandingError("pull has no usable number or title for the squash")
+    if body is None:
+        body = ""
+    if not isinstance(body, str):
+        raise LandingError("pull body is not text")
+    lines = [line.rstrip() for line in body.strip().splitlines()]
+    if any(line.strip() == COMMIT_MARKER for line in lines):
+        raise LandingError(
+            "pull body carries the reserved dependency-wave marker; main's "
+            "history must not"
+        )
+    if any(re.match(r"(?i)^\s*co-authored-by\s*:", line) for line in lines):
+        raise LandingError("pull body carries a Co-authored-by line")
+    if any(line.strip() == COMMIT_MARKER for line in title.splitlines()):
+        raise LandingError("pull title carries the reserved dependency-wave marker")
+    return f"{title.strip()} (#{number})", "\n".join(lines).strip()
+
+
+def _pull_identity(pull: Any, expected_number: int) -> str | None:
+    """The reason the pull is not the exact open first-party wave, or None."""
+
+    if not isinstance(pull, dict):
+        return "pull response is not an object"
+    head = pull.get("head")
+    base = pull.get("base")
+    user = pull.get("user")
+    if not isinstance(head, dict) or not isinstance(base, dict):
+        return "pull response has no head or base"
+    head_repo = head.get("repo")
+    if pull.get("number") != expected_number:
+        return f"pull number moved from {expected_number} to {pull.get('number')!r}"
+    if pull.get("state") != "open":
+        return f"pull is {pull.get('state')!r}, not open"
+    if pull.get("draft") is True:
+        return "pull is a draft"
+    if pull.get("merged_at") is not None:
+        return "pull already carries a merge"
+    if "auto_merge" not in pull:
+        return "pull response omitted server-side auto-merge state"
+    if pull.get("auto_merge") is not None:
+        return "pull has auto-merge armed, which the wave never carries"
+    if head.get("ref") != WAVE_BRANCH:
+        return f"pull head ref {head.get('ref')!r} is not {WAVE_BRANCH}"
+    if not isinstance(head_repo, dict) or head_repo.get("full_name") != EXPECTED_REPOSITORY:
+        return "pull head is not first-party"
+    if base.get("ref") != BASE_BRANCH:
+        return f"pull base ref {base.get('ref')!r} is not {BASE_BRANCH}"
+    if _sha(head.get("sha")) is None or _sha(base.get("sha")) is None:
+        return "pull head or base sha is malformed"
+    if (
+        not isinstance(user, dict)
+        or user.get("login") != APP_LOGIN
+        or user.get("id") != APP_ID
+        or user.get("type") != "Bot"
+    ):
+        return "pull was not opened by the release App"
+    return None
+
+
+def _commit_identity(commit: Any, head: str) -> str | None:
+    """The reason a pull commit is not the receiver's bot commit, or None."""
+
+    if not isinstance(commit, dict):
+        return "pull commit entry is not an object"
+    if commit.get("sha") != head:
+        return f"pull commit {commit.get('sha')!r} is not the head {head}"
+    for role in ("author", "committer"):
+        actor = commit.get(role)
+        if (
+            not isinstance(actor, dict)
+            or actor.get("login") != BOT_LOGIN
+            or actor.get("id") != BOT_ID
+        ):
+            return f"pull commit {role} is not {BOT_LOGIN}"
+    inner = commit.get("commit")
+    if not isinstance(inner, dict):
+        return "pull commit lacks its git commit"
+    for role in ("author", "committer"):
+        actor = inner.get(role)
+        if not isinstance(actor, dict) or actor.get("email") != BOT_EMAIL:
+            return f"pull commit git {role} email is not the bot's"
+    message = inner.get("message")
+    if not isinstance(message, str):
+        return "pull commit has no message"
+    marker_lines = [line for line in message.splitlines() if line.strip() == COMMIT_MARKER]
+    if len(marker_lines) != 1:
+        return f"pull commit carries the reserved marker {len(marker_lines)} times, not once"
+    return None
+
+
+def judge(snapshot: dict[str, Any]) -> Verdict:
+    """Decide land, wait or refuse from one snapshot. Pure."""
+
+    freeze = snapshot.get("freeze")
+    if isinstance(freeze, str) and freeze.strip():
+        return Verdict(WAIT, f"landings are frozen by KIN_MAIN_FROZEN: {freeze.strip()}")
+    if freeze not in (None, "") and not isinstance(freeze, str):
+        return Verdict(REFUSE, "freeze value is not text")
+
+    open_pulls = snapshot.get("open_pulls")
+    if not isinstance(open_pulls, list):
+        return Verdict(REFUSE, "open wave listing is not an array")
+    if not open_pulls:
+        return Verdict(WAIT, f"no open pull request from {WAVE_BRANCH}")
+    if len(open_pulls) != 1:
+        return Verdict(REFUSE, f"{len(open_pulls)} open pull requests from {WAVE_BRANCH}")
+    listed = open_pulls[0]
+    number = _count(listed.get("number")) if isinstance(listed, dict) else None
+    if number is None or number < 1:
+        return Verdict(REFUSE, "open wave listing has no valid pull number")
+
+    pull = snapshot.get("pull")
+    problem = _pull_identity(pull, number)
+    if problem is not None:
+        return Verdict(REFUSE, problem, pull=number)
+    head = str(pull["head"]["sha"])
+    base = str(pull["base"]["sha"])
+
+    branch_tip = snapshot.get("branch_tip")
+    if _sha(branch_tip) is None:
+        return Verdict(REFUSE, f"origin carries no readable {WAVE_BRANCH} tip", number, head)
+    if branch_tip != head:
+        return Verdict(
+            REFUSE,
+            f"origin/{WAVE_BRANCH} is at {branch_tip}, not the pull head {head}",
+            number,
+            head,
+        )
+
+    commits = snapshot.get("commits")
+    if not isinstance(commits, list):
+        return Verdict(REFUSE, "pull commit listing is not an array", number, head)
+    if pull.get("commits") != 1 or len(commits) != 1:
+        return Verdict(
+            REFUSE,
+            f"pull carries {pull.get('commits')!r} commits ({len(commits)} listed); "
+            "the receiver writes exactly one",
+            number,
+            head,
+        )
+    problem = _commit_identity(commits[0], head)
+    if problem is not None:
+        return Verdict(REFUSE, problem, number, head)
+
+    files = snapshot.get("files")
+    if not isinstance(files, list):
+        return Verdict(REFUSE, "pull file listing is not an array", number, head)
+    if pull.get("changed_files") != len(files) or not files:
+        return Verdict(
+            REFUSE,
+            f"pull reports {pull.get('changed_files')!r} changed files, {len(files)} listed",
+            number,
+            head,
+        )
+    for entry in files:
+        if not isinstance(entry, dict):
+            return Verdict(REFUSE, "pull file entry is not an object", number, head)
+        filename = entry.get("filename")
+        if filename not in ALLOWED_PATHS:
+            return Verdict(
+                REFUSE,
+                f"pull touches {filename!r}, outside the receiver's write set "
+                f"{sorted(ALLOWED_PATHS)}",
+                number,
+                head,
+            )
+        if entry.get("status") != "modified" or entry.get("previous_filename"):
+            return Verdict(
+                REFUSE,
+                f"pull {entry.get('status')!r} {filename!r}; the receiver only modifies",
+                number,
+                head,
+            )
+
+    try:
+        checks = judge_check_runs(snapshot.get("check_run_pages"))
+    except LandingError as exc:
+        return Verdict(REFUSE, f"check-runs unreadable: {exc}", number, head)
+    if checks["failed"]:
+        return Verdict(
+            REFUSE,
+            "checks failed: " + ", ".join(checks["failed"]),
+            number,
+            head,
+            checks,
+        )
+    if checks["pending"]:
+        return Verdict(
+            WAIT,
+            "checks still running: " + ", ".join(checks["pending"]),
+            number,
+            head,
+            checks,
+        )
+    if checks["missing_required"]:
+        return Verdict(
+            WAIT,
+            "required contexts not yet reported: "
+            + ", ".join(checks["missing_required"]),
+            number,
+            head,
+            checks,
+        )
+
+    state = pull.get("mergeable_state")
+    if state in CONFLICT_STATES or pull.get("mergeable") is False:
+        return Verdict(
+            REFUSE,
+            f"GitHub reports the pull {state!r}; the next receiver run rebuilds the wave",
+            number,
+            head,
+            checks,
+        )
+    if state in SETTLING_STATES or state is None or pull.get("mergeable") is None:
+        return Verdict(
+            WAIT,
+            f"GitHub reports the pull mergeable_state {state!r}",
+            number,
+            head,
+            checks,
+        )
+
+    attestation = snapshot.get("attestation")
+    if attestation == ATTESTATION_PENDING:
+        return Verdict(
+            WAIT, "release-App attestation for this head has not arrived", number, head, checks
+        )
+    if attestation != ATTESTATION_VERIFIED:
+        return Verdict(REFUSE, f"attestation: {attestation}", number, head, checks)
+
+    try:
+        compose_squash_message(pull)
+    except LandingError as exc:
+        return Verdict(REFUSE, str(exc), number, head, checks)
+
+    return Verdict(
+        LAND,
+        f"every check on {head} concluded green ({checks['distinct']} distinct of "
+        f"{checks['total']} check-runs) and the attestation verifies",
+        number,
+        head,
+        {**checks, "base": base},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gathering the snapshot from GitHub.
+# ---------------------------------------------------------------------------
+
+
+def _open_wave_pulls(repository: str) -> Any:
+    owner = repository.split("/", 1)[0]
+    return gh_json(
+        [
+            "api",
+            "--method",
+            "GET",
+            f"repos/{repository}/pulls",
+            "-f",
+            "state=open",
+            "-f",
+            f"head={owner}:{WAVE_BRANCH}",
+            "-f",
+            f"base={BASE_BRANCH}",
+            "-f",
+            "per_page=100",
+        ]
+    )
+
+
+def _branch_tip(repository: str) -> str | None:
+    try:
+        document = gh_json(["api", f"repos/{repository}/git/ref/heads/{WAVE_BRANCH}"])
+    except LandingError:
+        return None
+    ref_object = document.get("object") if isinstance(document, dict) else None
+    return _sha(ref_object.get("sha")) if isinstance(ref_object, dict) else None
+
+
+def _attestation_state(
+    workspace: Path,
+    repository: str,
+    number: int,
+    head: str,
+    base: str,
+) -> str:
+    try:
+        guard.ensure_pull_head(workspace, number, head)
+        guard.verify_attestation(
+            workspace,
+            repository,
+            number,
+            head,
+            wait_seconds=0,
+            expected_base=base,
+        )
+    except guard.PendingAttestation:
+        return ATTESTATION_PENDING
+    except guard.AdmissionError as exc:
+        return f"refused: {exc}"
+    return ATTESTATION_VERIFIED
+
+
+def gather(repository: str, workspace: Path, freeze: str) -> dict[str, Any]:
+    """Read everything `judge` decides on, in the order it decides."""
+
+    snapshot: dict[str, Any] = {
+        "freeze": freeze,
+        "open_pulls": _open_wave_pulls(repository),
+        "pull": None,
+        "branch_tip": None,
+        "commits": [],
+        "files": [],
+        "check_run_pages": [],
+        "attestation": ATTESTATION_PENDING,
+    }
+    open_pulls = snapshot["open_pulls"]
+    if not isinstance(open_pulls, list) or len(open_pulls) != 1:
+        return snapshot
+    listed = open_pulls[0]
+    number = _count(listed.get("number")) if isinstance(listed, dict) else None
+    if number is None or number < 1:
+        return snapshot
+    pull = gh_json(["api", f"repos/{repository}/pulls/{number}"])
+    snapshot["pull"] = pull
+    if _pull_identity(pull, number) is not None:
+        return snapshot
+    head = str(pull["head"]["sha"])
+    base = str(pull["base"]["sha"])
+    snapshot["branch_tip"] = _branch_tip(repository)
+    snapshot["commits"] = _flatten_pages(
+        gh_json(
+            [
+                "api",
+                "--paginate",
+                "--slurp",
+                f"repos/{repository}/pulls/{number}/commits?per_page=100",
+            ]
+        ),
+        "pull commit",
+    )
+    snapshot["files"] = _flatten_pages(
+        gh_json(
+            [
+                "api",
+                "--paginate",
+                "--slurp",
+                f"repos/{repository}/pulls/{number}/files?per_page=100",
+            ]
+        ),
+        "pull file",
+    )
+    snapshot["check_run_pages"] = _check_run_pages(
+        gh_json(
+            [
+                "api",
+                "--paginate",
+                "--slurp",
+                f"repos/{repository}/commits/{head}/check-runs?per_page=100",
+            ]
+        )
+    )
+    snapshot["attestation"] = _attestation_state(workspace, repository, number, head, base)
+    return snapshot
+
+
+def squash(
+    repository: str,
+    pull: dict[str, Any],
+    head: str,
+    *,
+    merge_token: str,
+) -> dict[str, Any]:
+    """Squash the judged head onto main through the release App and prove it."""
+
+    number = int(pull["number"])
+    title, message = compose_squash_message(pull)
+    response = gh_json(
+        [
+            "api",
+            "--method",
+            "PUT",
+            f"repos/{repository}/pulls/{number}/merge",
+            "-f",
+            "merge_method=squash",
+            "-f",
+            f"sha={head}",
+            "-f",
+            f"commit_title={title}",
+            "-f",
+            f"commit_message={message}",
+        ],
+        token=merge_token,
+    )
+    if not isinstance(response, dict) or response.get("merged") is not True:
+        raise LandingError(f"merge call did not report a merge: {response!r}")
+    merged_sha = _sha(response.get("sha"))
+    if merged_sha is None:
+        raise LandingError("merge call returned no commit sha")
+    after = gh_json(["api", f"repos/{repository}/pulls/{number}"], token=merge_token)
+    if (
+        not isinstance(after, dict)
+        or after.get("merged") is not True
+        or after.get("merge_commit_sha") != merged_sha
+    ):
+        raise LandingError("pull read back after the merge does not carry the squash")
+    try:
+        on_main = history.require_protected_history(
+            repository, merged_sha, branch=BASE_BRANCH, fetch=_history_fetch
+        )
+    except history.HistoryError as exc:
+        raise LandingError(f"squash {merged_sha} is not on protected main: {exc}") from exc
+    return {
+        "merged_sha": merged_sha,
+        "title": title,
+        "main_tip": on_main["tip"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Command line.
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    fixture = subparsers.add_parser("judge-fixture", help="judge one snapshot document")
+    fixture.add_argument("--fixture", type=Path, required=True)
+    for name in ("judge", "land"):
+        command = subparsers.add_parser(name)
+        command.add_argument("--repository", required=True)
+        command.add_argument("--workspace", type=Path, required=True)
+        command.add_argument("--freeze", default="")
+        if name == "land":
+            command.add_argument("--pull", type=int, required=True)
+            command.add_argument("--head", required=True)
+            command.add_argument(
+                "--merge-token-env",
+                required=True,
+                help="environment variable holding the release-App token for the merge",
+            )
+    return parser.parse_args(argv)
+
+
+def _emit(verdict: Verdict) -> int:
+    document = verdict.document()
+    print(json.dumps(document, sort_keys=True))
+    if verdict.decision == REFUSE:
+        print(f"::error title=Kin registry wave refused::{verdict.reason}", file=sys.stderr)
+        return 1
+    if verdict.decision == WAIT:
+        print(f"::notice::wave landing waits: {verdict.reason}", file=sys.stderr)
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    try:
+        if args.command == "judge-fixture":
+            with args.fixture.open(encoding="utf-8") as stream:
+                snapshot = json.load(stream)
+            if not isinstance(snapshot, dict):
+                raise LandingError("fixture is not an object")
+            return _emit(judge(snapshot))
+        if args.repository != EXPECTED_REPOSITORY:
+            raise LandingError(f"repository must be {EXPECTED_REPOSITORY}")
+        snapshot = gather(args.repository, args.workspace, args.freeze)
+        verdict = judge(snapshot)
+        if args.command == "judge" or verdict.decision != LAND:
+            return _emit(verdict)
+        if verdict.pull != args.pull or verdict.head != args.head:
+            return _emit(
+                Verdict(
+                    WAIT,
+                    f"the wave moved since it was judged: pull {verdict.pull} head "
+                    f"{verdict.head} is not the judged pull {args.pull} head {args.head}",
+                    verdict.pull,
+                    verdict.head,
+                )
+            )
+        merge_token = os.environ.get(args.merge_token_env, "")
+        if not merge_token:
+            raise LandingError(f"{args.merge_token_env} is unset; no token to merge with")
+        landed = squash(args.repository, snapshot["pull"], verdict.head, merge_token=merge_token)
+        return _emit(
+            Verdict(
+                LAND,
+                f"landed pull {verdict.pull} head {verdict.head} as {landed['merged_sha']}",
+                verdict.pull,
+                verdict.head,
+                {**verdict.details, **landed},
+            )
+        )
+    except (LandingError, OSError, json.JSONDecodeError) as exc:
+        return _emit(Verdict(REFUSE, str(exc)))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-kin-registry-release-receiver.py
+++ b/scripts/test-kin-registry-release-receiver.py
@@ -1038,7 +1038,12 @@ class HeadAdmissionTests(unittest.TestCase):
                     require_open=True,
                 )
 
-    def test_rejects_attested_base_that_is_not_the_current_pull_base(self) -> None:
+    def test_accepts_a_descendant_pull_base_and_rejects_an_unrelated_one(self) -> None:
+        # The pull base is main's tip at the pull's last push, so it moves past
+        # the attested base whenever a lane lands between the receiver's
+        # checkout and its push. Protected main at or after the attested base
+        # is what the attestation needs; a base the attested base does not
+        # reach descends from something else.
         with tempfile.TemporaryDirectory() as directory:
             repo = Path(directory)
             base = initialize_repo(repo)
@@ -1048,8 +1053,27 @@ class HeadAdmissionTests(unittest.TestCase):
             (repo / "README.md").write_text("advanced\n", encoding="utf-8")
             run_git(repo, "add", "README.md")
             run_git(repo, "commit", "-q", "-m", "advance main")
-            current_base = run_git(repo, "rev-parse", "HEAD")
-            with self.assertRaisesRegex(head_guard.AdmissionError, "not current"):
+            advanced_base = run_git(repo, "rev-parse", "HEAD")
+            evidence = head_guard.validate_attestation(
+                repo,
+                head_guard.EXPECTED_REPOSITORY,
+                77,
+                head,
+                reviews,
+                comments,
+                expected_base=advanced_base,
+            )
+            self.assertEqual(evidence.base, base)
+            run_git(repo, "switch", "-q", "--orphan", "unrelated")
+            (repo / "Cargo.toml").write_text(manifest(), encoding="utf-8")
+            (repo / "Cargo.lock").write_text(
+                "version = 4\nkin-db 0.7.67\n", encoding="utf-8"
+            )
+            (repo / "README.md").write_text("unrelated\n", encoding="utf-8")
+            run_git(repo, "add", "-A")
+            run_git(repo, "commit", "-q", "-m", "unrelated root")
+            unrelated_base = run_git(repo, "rev-parse", "HEAD")
+            with self.assertRaisesRegex(head_guard.AdmissionError, "not an ancestor"):
                 head_guard.validate_attestation(
                     repo,
                     head_guard.EXPECTED_REPOSITORY,
@@ -1057,7 +1081,7 @@ class HeadAdmissionTests(unittest.TestCase):
                     head,
                     reviews,
                     comments,
-                    expected_base=current_base,
+                    expected_base=unrelated_base,
                 )
 
     def test_rejects_server_side_auto_merge(self) -> None:
@@ -1519,6 +1543,76 @@ class PostCompletionAttesterTests(unittest.TestCase):
                 workflow_run=workflow_run_document(base),
             )
             self.assertEqual(evidence.head, head)
+
+    def test_attestation_survives_main_advancing_and_refuses_a_rewrite(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, _, result_file, base, head = self._changed(directory)
+            run = workflow_run_document(base)
+            event_file = Path(directory) / "event.json"
+            event_file.write_text(
+                json.dumps({"action": "completed", "workflow_run": run}),
+                encoding="utf-8",
+            )
+            pull = pull_document(head, base)
+            reviews, comments = attestation_documents(repo, base, head)
+            tip = "9" * 40
+
+            def fake(relation: str):
+                compare = {
+                    "status": relation,
+                    "ahead_by": 2 if relation == "ahead" else 1,
+                    "behind_by": 0 if relation == "ahead" else 1,
+                    "merge_base_commit": {"sha": base},
+                }
+
+                def answer(arguments: list[str]) -> object:
+                    endpoint = next(
+                        (item for item in arguments if item.startswith("repos/")), ""
+                    )
+                    if "/actions/runs/331/attempts/2" in endpoint:
+                        return run
+                    if endpoint.endswith("/git/ref/heads/main"):
+                        return {"object": {"sha": tip}}
+                    if endpoint.endswith(f"/compare/{base}...{tip}"):
+                        return compare
+                    if endpoint == f"repos/{head_guard.EXPECTED_REPOSITORY}/pulls/77":
+                        return pull
+                    if endpoint.endswith("/reviews?per_page=100"):
+                        return [reviews]
+                    if endpoint.endswith("/comments?per_page=100"):
+                        return [comments]
+                    raise AssertionError(f"unexpected mocked GitHub request: {arguments}")
+
+                return answer
+
+            with mock.patch.object(
+                attester, "gh_json", side_effect=fake("ahead")
+            ), mock.patch.object(
+                attester.guard, "gh_json", return_value=workflow_run_document(base)
+            ), self._live_graphql(head):
+                result = attester.validate_for_attestation(
+                    event_file=event_file,
+                    admission_file=result_file,
+                    workspace=repo,
+                    repository=attester.EXPECTED_REPOSITORY,
+                )
+            self.assertIs(result["changed"], True)
+            self.assertIs(result["needs_attestation"], False)
+
+            with mock.patch.object(
+                attester, "gh_json", side_effect=fake("diverged")
+            ), mock.patch.object(
+                attester.guard, "gh_json", return_value=workflow_run_document(base)
+            ), self._live_graphql(head):
+                with self.assertRaisesRegex(
+                    attester.AttesterError, "not protected main history"
+                ):
+                    attester.validate_for_attestation(
+                        event_file=event_file,
+                        admission_file=result_file,
+                        workspace=repo,
+                        repository=attester.EXPECTED_REPOSITORY,
+                    )
 
     def test_recheck_filters_irrelevant_same_sha_runs(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -2290,7 +2384,7 @@ class WorkflowContractTests(unittest.TestCase):
             "Clear inherited landing state before candidate handling",
             "Download the compiled data-only candidate",
             "Revalidate and apply only the admitted manifest bytes",
-            "Refuse protected-main movement before repository mutation",
+            "Refuse protected-main rewrite before repository mutation",
             "Open or update the dependency bump PR",
             "Clear and verify landing state on the generated PR",
             "Verify exact first-party generated PR",
@@ -2309,18 +2403,24 @@ class WorkflowContractTests(unittest.TestCase):
         resolve = step_block(self.workflow, "Bind preparation to the queued workflow policy")
         checkout = step_block(self.workflow, "Checkout exact queued protected main")
         mutation_fence = step_block(
-            self.workflow, "Refuse protected-main movement immediately before token mint"
+            self.workflow, "Refuse protected-main rewrite immediately before token mint"
         )
         admission = step_block(
             self.workflow, "Revalidate and apply only the admitted manifest bytes"
         )
         writer = step_block(self.workflow, "Open or update the dependency bump PR")
         verifier = step_block(self.workflow, "Verify exact first-party generated PR")
-        self.assertIn("base_sha=", resolve)
-        self.assertIn('!= "$GITHUB_SHA"', early_resolve)
-        self.assertIn('!= "$GITHUB_SHA"', resolve)
+        # Bound to github.sha and proven protected main history rather than
+        # equal to the live tip; scripts/test-kin-registry-wave-landing.py
+        # pins the proof itself.
+        self.assertIn("base_sha=$GITHUB_SHA", resolve)
+        history_call = "python3 scripts/verify-protected-main-history.py"
+        for block in (early_resolve, resolve):
+            self.assertIn(history_call, block)
+            self.assertIn('--policy-sha "$GITHUB_SHA"', block)
         self.assertIn("ref: ${{ github.sha }}", checkout)
-        self.assertIn('!= "$GITHUB_SHA"', mutation_fence)
+        self.assertIn(history_call, mutation_fence)
+        self.assertIn('--policy-sha "$ADMITTED_BASE"', mutation_fence)
         self.assertIn("kin-registry-wave-artifact.py apply", admission)
         self.assertIn("branch: ${{ env.WAVE_BRANCH }}", writer)
         self.assertIn("base: ${{ env.BASE_BRANCH }}", writer)

--- a/scripts/test-kin-registry-wave-landing.py
+++ b/scripts/test-kin-registry-wave-landing.py
@@ -1,0 +1,1020 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Deterministic contract tests for the Kin registry wave landing and binding.
+
+Two scripts are under test. `verify-protected-main-history.py` proves a
+workflow's policy sha is protected main's history through the compare API, and
+`land-kin-registry-wave.py` judges the wave pull request against the fleet's
+landing rule from one snapshot document. Both judgments are pure functions, so
+every case here is a fixture and a verdict, with no GitHub in the loop. The
+workflow contract tests pin the shape of the receiver's binding steps and the
+landing workflow's two jobs, because a step that stops calling the proof reads
+exactly like one that never needed it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import copy
+import importlib.util
+import io
+import itertools
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HISTORY_PATH = ROOT / "scripts" / "verify-protected-main-history.py"
+LANDING_PATH = ROOT / "scripts" / "land-kin-registry-wave.py"
+HEAD_GUARD_PATH = ROOT / "scripts" / "verify-kin-registry-wave-head.py"
+ATTESTER_PATH = ROOT / "scripts" / "attest-kin-registry-wave.py"
+RECEIVER_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "kin-registry-release.yml"
+ATTEST_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "kin-registry-release-attest.yml"
+LANDING_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "kin-registry-wave-land.yml"
+RELEASE_TAG_PATH = ROOT / ".github" / "workflows" / "release-tag.yml"
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+REPO = "firelock-ai/kin"
+POLICY = "a" * 40
+TIP = "b" * 40
+HEAD = "c" * 40
+BASE = "d" * 40
+OTHER = "e" * 40
+BETWEEN = "f" * 40
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+history = load_module("kin_wave_history_tests", HISTORY_PATH)
+landing = load_module("kin_wave_landing_tests", LANDING_PATH)
+
+
+def job_block(workflow: str, job_id: str) -> str:
+    match = re.search(
+        rf"(?ms)^  {re.escape(job_id)}:\n.*?(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+        workflow,
+    )
+    if match is None:
+        raise AssertionError(f"workflow job {job_id!r} is missing")
+    return match.group(0)
+
+
+def step_block(workflow: str, step_name: str) -> str:
+    match = re.search(
+        rf"(?ms)^      - name: {re.escape(step_name)}\n.*?"
+        r"(?=^      - (?:name|uses):|^  [A-Za-z0-9_-]+:\n|\Z)",
+        workflow,
+    )
+    if match is None:
+        raise AssertionError(f"workflow step {step_name!r} is missing")
+    return match.group(0)
+
+
+# ---------------------------------------------------------------------------
+# Protected-history proof.
+# ---------------------------------------------------------------------------
+
+
+def ref_endpoint(branch: str = "main") -> str:
+    return f"repos/{REPO}/git/ref/heads/{branch}"
+
+
+def compare_endpoint(base: str, head: str) -> str:
+    return f"repos/{REPO}/compare/{base}...{head}"
+
+
+def ref_document(sha: Any) -> dict[str, Any]:
+    return {"object": {"sha": sha}}
+
+
+def compare_document(
+    status: Any,
+    ahead_by: Any = 0,
+    behind_by: Any = 0,
+    *,
+    merge_base: Any = POLICY,
+) -> dict[str, Any]:
+    return {
+        "status": status,
+        "ahead_by": ahead_by,
+        "behind_by": behind_by,
+        "merge_base_commit": {"sha": merge_base},
+    }
+
+
+class Fetch:
+    """Serve fixture documents by endpoint and record every read."""
+
+    def __init__(self, answers: dict[str, Any]) -> None:
+        self.answers = answers
+        self.calls: list[str] = []
+
+    def __call__(self, endpoint: str) -> Any:
+        self.calls.append(endpoint)
+        if endpoint not in self.answers:
+            raise AssertionError(f"unexpected GitHub read: {endpoint}")
+        return copy.deepcopy(self.answers[endpoint])
+
+
+class ProtectedHistoryTests(unittest.TestCase):
+    def test_identical_tip_is_proven_without_a_compare(self) -> None:
+        fetch = Fetch({ref_endpoint(): ref_document(POLICY)})
+        verdict = history.require_protected_history(REPO, POLICY, fetch=fetch)
+        self.assertEqual(verdict["relation"], "identical")
+        self.assertEqual(verdict["tip"], POLICY)
+        self.assertEqual(fetch.calls, [ref_endpoint()])
+
+    def test_tip_ahead_of_the_policy_is_protected_history(self) -> None:
+        fetch = Fetch(
+            {
+                ref_endpoint(): ref_document(TIP),
+                compare_endpoint(POLICY, TIP): compare_document("ahead", 3),
+            }
+        )
+        verdict = history.require_protected_history(REPO, POLICY, fetch=fetch)
+        self.assertEqual(verdict["relation"], "ancestor")
+        self.assertEqual(verdict["ahead_by"], 3)
+        self.assertEqual(verdict["tip"], TIP)
+        self.assertEqual(fetch.calls, [ref_endpoint(), compare_endpoint(POLICY, TIP)])
+
+    def test_behind_and_diverged_are_rewrites_and_refuse(self) -> None:
+        for status, behind in (("behind", 2), ("diverged", 1)):
+            with self.subTest(status=status):
+                fetch = Fetch(
+                    {
+                        ref_endpoint(): ref_document(TIP),
+                        compare_endpoint(POLICY, TIP): compare_document(status, 0, behind),
+                    }
+                )
+                with self.assertRaisesRegex(history.HistoryError, status):
+                    history.require_protected_history(REPO, POLICY, fetch=fetch)
+
+    def test_ahead_with_a_foreign_merge_base_refuses(self) -> None:
+        fetch = Fetch(
+            {
+                ref_endpoint(): ref_document(TIP),
+                compare_endpoint(POLICY, TIP): compare_document(
+                    "ahead", 1, merge_base=OTHER
+                ),
+            }
+        )
+        with self.assertRaisesRegex(history.HistoryError, "merge base"):
+            history.require_protected_history(REPO, POLICY, fetch=fetch)
+
+    def test_ahead_with_a_behind_count_refuses(self) -> None:
+        fetch = Fetch(
+            {
+                ref_endpoint(): ref_document(TIP),
+                compare_endpoint(POLICY, TIP): compare_document("ahead", 1, 1),
+            }
+        )
+        with self.assertRaisesRegex(history.HistoryError, "behind"):
+            history.require_protected_history(REPO, POLICY, fetch=fetch)
+
+    def test_malformed_compare_answers_refuse(self) -> None:
+        cases = {
+            "not an object": ["ahead"],
+            "count": compare_document("ahead", "3"),
+            "status": compare_document(None, 1),
+            "identical": compare_document("identical", 1),
+            "zero ahead": compare_document("ahead", 0),
+        }
+        for label, document in cases.items():
+            with self.subTest(label=label):
+                with self.assertRaisesRegex(history.HistoryError, label):
+                    history.judge_relation(POLICY, TIP, document)
+
+    def test_malformed_shas_refuse(self) -> None:
+        fetch = Fetch({ref_endpoint(): ref_document("not-a-sha")})
+        with self.assertRaisesRegex(history.HistoryError, "tip must be"):
+            history.require_protected_history(REPO, POLICY, fetch=fetch)
+        with self.assertRaisesRegex(history.HistoryError, "policy sha must be"):
+            history.require_protected_history(REPO, "abc", fetch=fetch)
+
+    def test_descendant_needs_both_the_forward_and_the_branch_proof(self) -> None:
+        on_branch = Fetch(
+            {
+                compare_endpoint(POLICY, BETWEEN): compare_document("ahead", 1),
+                ref_endpoint(): ref_document(TIP),
+                compare_endpoint(BETWEEN, TIP): compare_document(
+                    "ahead", 2, merge_base=BETWEEN
+                ),
+            }
+        )
+        verdict = history.require_descendant(REPO, POLICY, BETWEEN, fetch=on_branch)
+        self.assertEqual(verdict["relation"], "ancestor")
+        self.assertEqual(verdict["tip"], TIP)
+        self.assertEqual(
+            on_branch.calls,
+            [
+                compare_endpoint(POLICY, BETWEEN),
+                ref_endpoint(),
+                compare_endpoint(BETWEEN, TIP),
+            ],
+        )
+
+        off_branch = Fetch(
+            {
+                compare_endpoint(POLICY, BETWEEN): compare_document("ahead", 1),
+                ref_endpoint(): ref_document(TIP),
+                compare_endpoint(BETWEEN, TIP): compare_document(
+                    "diverged", 2, 1, merge_base=POLICY
+                ),
+            }
+        )
+        with self.assertRaisesRegex(history.HistoryError, "diverged"):
+            history.require_descendant(REPO, POLICY, BETWEEN, fetch=off_branch)
+
+        not_forward = Fetch(
+            {
+                compare_endpoint(POLICY, BETWEEN): compare_document("behind", 0, 1),
+            }
+        )
+        with self.assertRaisesRegex(history.HistoryError, "behind"):
+            history.require_descendant(REPO, POLICY, BETWEEN, fetch=not_forward)
+
+        same = Fetch({ref_endpoint(): ref_document(POLICY)})
+        verdict = history.require_descendant(REPO, POLICY, POLICY, fetch=same)
+        self.assertEqual(verdict["relation"], "identical")
+
+    def test_cli_exit_codes_follow_the_proof(self) -> None:
+        quiet = contextlib.ExitStack()
+        quiet.enter_context(contextlib.redirect_stdout(io.StringIO()))
+        quiet.enter_context(contextlib.redirect_stderr(io.StringIO()))
+        self.addCleanup(quiet.close)
+        green = Fetch(
+            {
+                ref_endpoint(): ref_document(TIP),
+                compare_endpoint(POLICY, TIP): compare_document("ahead", 1),
+            }
+        )
+        with mock.patch.object(history, "gh_json", side_effect=green):
+            self.assertEqual(
+                history.main(["--repository", REPO, "--policy-sha", POLICY]), 0
+            )
+        red = Fetch(
+            {
+                ref_endpoint(): ref_document(TIP),
+                compare_endpoint(POLICY, TIP): compare_document("diverged", 1, 1),
+            }
+        )
+        with mock.patch.object(history, "gh_json", side_effect=red):
+            self.assertEqual(
+                history.main(["--repository", REPO, "--policy-sha", POLICY]), 1
+            )
+        with mock.patch.object(history, "gh_json", side_effect=green):
+            self.assertEqual(
+                history.main(
+                    ["--repository", "not-a-repository", "--policy-sha", POLICY]
+                ),
+                1,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Wave landing judgment.
+# ---------------------------------------------------------------------------
+
+
+_ids = itertools.count(1000)
+EARLY = "2026-09-02T09:20:00Z"
+LATE = "2026-09-02T09:31:00Z"
+
+
+def check_run(
+    name: str,
+    conclusion: str | None = "success",
+    *,
+    status: str = "completed",
+    started: str = LATE,
+    app: str = "github-actions",
+) -> dict[str, Any]:
+    return {
+        "id": next(_ids),
+        "name": name,
+        "status": status,
+        "conclusion": conclusion,
+        "started_at": started,
+        "completed_at": started if conclusion else None,
+        "head_sha": HEAD,
+        "app": {"slug": app},
+    }
+
+
+EXTRA_GREEN_NAMES = (
+    "Check & Test (ubuntu-latest)",
+    "Windows installer + vector release build",
+    "CodeQL",
+)
+
+
+def green_runs() -> list[dict[str, Any]]:
+    runs = [check_run(name) for name in landing.RULESET_REQUIRED_CONTEXTS]
+    runs.extend(check_run(name) for name in EXTRA_GREEN_NAMES)
+    runs.append(check_run("Product Acceptance", "skipped"))
+    runs.append(check_run("Code Coverage", "neutral"))
+    return runs
+
+
+def pages(runs: list[dict[str, Any]], total: int | None = None) -> list[dict[str, Any]]:
+    return [{"total_count": len(runs) if total is None else total, "check_runs": runs}]
+
+
+def bot_commit(
+    sha: str = HEAD,
+    *,
+    login: str = landing.BOT_LOGIN,
+    user_id: int = landing.BOT_ID,
+    email: str = landing.BOT_EMAIL,
+    marker_count: int = 1,
+) -> dict[str, Any]:
+    message = "chore(deps): refresh Kin registry pins after kin-db@0.7.85\n\n"
+    message += "".join(f"{landing.COMMIT_MARKER}\n" for _ in range(marker_count))
+    message += f"Signed-off-by: {landing.BOT_LOGIN} <{landing.BOT_EMAIL}>\n"
+    return {
+        "sha": sha,
+        "author": {"login": login, "id": user_id},
+        "committer": {"login": login, "id": user_id},
+        "commit": {
+            "author": {"email": email},
+            "committer": {"email": email},
+            "message": message,
+        },
+    }
+
+
+def wave_file(name: str, status: str = "modified") -> dict[str, Any]:
+    return {"filename": name, "status": status}
+
+
+def wave_pull(**overrides: Any) -> dict[str, Any]:
+    pull: dict[str, Any] = {
+        "number": 1360,
+        "state": "open",
+        "draft": False,
+        "merged_at": None,
+        "auto_merge": None,
+        "mergeable": True,
+        "mergeable_state": "clean",
+        "commits": 1,
+        "changed_files": 2,
+        "title": "chore(deps): refresh Kin registry pins after kin-db@0.7.85",
+        "body": (
+            "Automated Kin registry dependency wave.\n\n"
+            "This PR updates the allowed root-manifest registry pins."
+        ),
+        "user": {"login": landing.APP_LOGIN, "id": landing.APP_ID, "type": "Bot"},
+        "head": {"sha": HEAD, "ref": landing.WAVE_BRANCH, "repo": {"full_name": REPO}},
+        "base": {"sha": BASE, "ref": "main"},
+    }
+    pull.update(overrides)
+    return pull
+
+
+def green_snapshot(**overrides: Any) -> dict[str, Any]:
+    snapshot: dict[str, Any] = {
+        "freeze": "",
+        "open_pulls": [{"number": 1360}],
+        "pull": wave_pull(),
+        "branch_tip": HEAD,
+        "commits": [bot_commit()],
+        "files": [wave_file("Cargo.toml"), wave_file("Cargo.lock")],
+        "check_run_pages": pages(green_runs()),
+        "attestation": landing.ATTESTATION_VERIFIED,
+    }
+    snapshot.update(overrides)
+    return snapshot
+
+
+class WaveJudgeTests(unittest.TestCase):
+    def assertVerdict(
+        self,
+        snapshot: dict[str, Any],
+        decision: str,
+        reason: str,
+    ) -> landing.Verdict:
+        verdict = landing.judge(snapshot)
+        self.assertEqual(
+            (verdict.decision, decision),
+            (decision, decision),
+            f"expected {decision}, got {verdict.decision}: {verdict.reason}",
+        )
+        self.assertRegex(verdict.reason, reason)
+        return verdict
+
+    def test_all_green_lands(self) -> None:
+        verdict = self.assertVerdict(green_snapshot(), landing.LAND, "concluded green")
+        self.assertEqual(verdict.pull, 1360)
+        self.assertEqual(verdict.head, HEAD)
+        self.assertEqual(verdict.details["pending"], [])
+        self.assertEqual(verdict.details["failed"], [])
+        self.assertEqual(verdict.details["base"], BASE)
+
+    def test_one_failure_refuses(self) -> None:
+        runs = green_runs() + [check_run("cargo-fuzz (parse_adapter)", "failure")]
+        verdict = self.assertVerdict(
+            green_snapshot(check_run_pages=pages(runs)),
+            landing.REFUSE,
+            r"checks failed: cargo-fuzz \(parse_adapter\)=failure",
+        )
+        self.assertEqual(verdict.pull, 1360)
+        for conclusion in ("cancelled", "timed_out", "action_required", "stale"):
+            with self.subTest(conclusion=conclusion):
+                runs = green_runs() + [check_run("Linux Daemon Smoke", conclusion)]
+                self.assertVerdict(
+                    green_snapshot(check_run_pages=pages(runs)),
+                    landing.REFUSE,
+                    f"checks failed: Linux Daemon Smoke={conclusion}",
+                )
+
+    def test_one_pending_waits(self) -> None:
+        runs = green_runs() + [check_run("Linux Daemon Smoke", None, status="in_progress")]
+        self.assertVerdict(
+            green_snapshot(check_run_pages=pages(runs)),
+            landing.WAIT,
+            "checks still running: Linux Daemon Smoke",
+        )
+        runs = green_runs() + [check_run("Linux Daemon Smoke", None, status="queued")]
+        self.assertVerdict(
+            green_snapshot(check_run_pages=pages(runs)),
+            landing.WAIT,
+            "checks still running: Linux Daemon Smoke",
+        )
+
+    def test_incomplete_listing_refuses(self) -> None:
+        runs = green_runs()
+        self.assertVerdict(
+            green_snapshot(check_run_pages=pages(runs, total=len(runs) + 5)),
+            landing.REFUSE,
+            f"incomplete: {len(runs)} listed of {len(runs) + 5} reported",
+        )
+        two_pages = [
+            {"total_count": len(runs), "check_runs": runs[:3]},
+            {"total_count": len(runs) + 1, "check_runs": runs[3:]},
+        ]
+        self.assertVerdict(
+            green_snapshot(check_run_pages=two_pages),
+            landing.REFUSE,
+            "disagree on total_count",
+        )
+        self.assertVerdict(
+            green_snapshot(check_run_pages=[]), landing.REFUSE, "empty or not a list"
+        )
+        self.assertVerdict(
+            green_snapshot(check_run_pages=[{"total_count": 1}]),
+            landing.REFUSE,
+            "lacks total_count or check_runs",
+        )
+
+    def test_paged_listing_that_adds_up_lands(self) -> None:
+        runs = green_runs()
+        two_pages = [
+            {"total_count": len(runs), "check_runs": runs[:4]},
+            {"total_count": len(runs), "check_runs": runs[4:]},
+        ]
+        self.assertVerdict(
+            green_snapshot(check_run_pages=two_pages), landing.LAND, "concluded green"
+        )
+
+    def test_non_bot_commit_refuses(self) -> None:
+        human = bot_commit(login="troyjr4103", user_id=63249686)
+        self.assertVerdict(
+            green_snapshot(commits=[human]),
+            landing.REFUSE,
+            "pull commit author is not github-actions",
+        )
+        bot_by_login_only = bot_commit(user_id=1)
+        self.assertVerdict(
+            green_snapshot(commits=[bot_by_login_only]),
+            landing.REFUSE,
+            "pull commit author is not github-actions",
+        )
+        foreign_email = bot_commit(email="someone@example.com")
+        self.assertVerdict(
+            green_snapshot(commits=[foreign_email]),
+            landing.REFUSE,
+            "git author email is not the bot",
+        )
+
+    def test_marker_must_appear_exactly_once(self) -> None:
+        for count in (0, 2):
+            with self.subTest(count=count):
+                self.assertVerdict(
+                    green_snapshot(commits=[bot_commit(marker_count=count)]),
+                    landing.REFUSE,
+                    f"reserved marker {count} times",
+                )
+
+    def test_second_commit_refuses(self) -> None:
+        snapshot = green_snapshot(
+            commits=[bot_commit(sha=OTHER), bot_commit()],
+            pull=wave_pull(commits=2),
+        )
+        self.assertVerdict(snapshot, landing.REFUSE, "exactly one")
+        snapshot = green_snapshot(commits=[bot_commit(sha=OTHER)])
+        self.assertVerdict(snapshot, landing.REFUSE, "is not the head")
+
+    def test_off_scope_file_refuses(self) -> None:
+        files = [wave_file("Cargo.toml"), wave_file("Cargo.lock"), wave_file("README.md")]
+        self.assertVerdict(
+            green_snapshot(files=files, pull=wave_pull(changed_files=3)),
+            landing.REFUSE,
+            "touches 'README.md', outside the receiver's write set",
+        )
+        self.assertVerdict(
+            green_snapshot(files=files),
+            landing.REFUSE,
+            "reports 2 changed files, 3 listed",
+        )
+        added = [wave_file("Cargo.toml"), wave_file("Cargo.lock", "added")]
+        self.assertVerdict(
+            green_snapshot(files=added), landing.REFUSE, "the receiver only modifies"
+        )
+        renamed = [wave_file("Cargo.toml"), {**wave_file("Cargo.lock"), "previous_filename": "x"}]
+        self.assertVerdict(
+            green_snapshot(files=renamed), landing.REFUSE, "the receiver only modifies"
+        )
+
+    def test_superseded_cancelled_suite_lands_on_the_newest_run(self) -> None:
+        # The attester's close-and-reopen retrigger leaves the first CI suite
+        # cancelled beside the green one: kin#1360's head carried 87 check-runs
+        # in exactly this shape. Newest per name is the fleet's rule.
+        runs = green_runs()
+        runs.append(check_run("Fast gate build and tests", "cancelled", started=EARLY))
+        runs.append(check_run("Fast gate lint and policy", "cancelled", started=EARLY))
+        self.assertVerdict(
+            green_snapshot(check_run_pages=pages(runs)), landing.LAND, "concluded green"
+        )
+
+    def test_newer_failure_after_an_older_success_refuses(self) -> None:
+        runs = green_runs()
+        runs.append(check_run("cargo-deny", "failure", started="2026-09-02T09:40:00Z"))
+        self.assertVerdict(
+            green_snapshot(check_run_pages=pages(runs)),
+            landing.REFUSE,
+            "checks failed: cargo-deny=failure",
+        )
+
+    def test_missing_required_context_waits(self) -> None:
+        runs = [run for run in green_runs() if run["name"] != "cargo-deny"]
+        self.assertVerdict(
+            green_snapshot(check_run_pages=pages(runs)),
+            landing.WAIT,
+            "required contexts not yet reported: cargo-deny",
+        )
+
+    def test_empty_check_set_never_lands(self) -> None:
+        self.assertVerdict(
+            green_snapshot(check_run_pages=pages([])),
+            landing.WAIT,
+            "required contexts not yet reported",
+        )
+
+    def test_freeze_holds_every_landing(self) -> None:
+        verdict = self.assertVerdict(
+            green_snapshot(freeze="release window, captain holds main"),
+            landing.WAIT,
+            "frozen by KIN_MAIN_FROZEN: release window",
+        )
+        self.assertIsNone(verdict.pull)
+        self.assertVerdict(green_snapshot(freeze="   "), landing.LAND, "concluded green")
+
+    def test_no_wave_waits_and_two_waves_refuse(self) -> None:
+        self.assertVerdict(green_snapshot(open_pulls=[]), landing.WAIT, "no open pull")
+        self.assertVerdict(
+            green_snapshot(open_pulls=[{"number": 1360}, {"number": 1361}]),
+            landing.REFUSE,
+            "2 open pull requests",
+        )
+        self.assertVerdict(
+            green_snapshot(open_pulls={"number": 1360}), landing.REFUSE, "not an array"
+        )
+
+    def test_pull_identity_refusals(self) -> None:
+        cases = {
+            "not open": wave_pull(state="closed"),
+            "draft": wave_pull(draft=True),
+            "auto-merge armed": wave_pull(auto_merge={"enabled_by": {"login": "x"}}),
+            "omitted server-side auto-merge": {
+                key: value for key, value in wave_pull().items() if key != "auto_merge"
+            },
+            "is not automation/kin-registry-dependency-wave": wave_pull(
+                head={"sha": HEAD, "ref": "chore/lane-x", "repo": {"full_name": REPO}}
+            ),
+            "not first-party": wave_pull(
+                head={"sha": HEAD, "ref": landing.WAVE_BRANCH, "repo": {"full_name": "fork/kin"}}
+            ),
+            "base ref 'release' is not main": wave_pull(base={"sha": BASE, "ref": "release"}),
+            "not opened by the release App": wave_pull(
+                user={"login": "troyjr4103", "id": 63249686, "type": "User"}
+            ),
+            "moved from 1360": wave_pull(number=1359),
+            "already carries a merge": wave_pull(merged_at="2026-09-02T10:00:00Z"),
+        }
+        for reason, pull in cases.items():
+            with self.subTest(reason=reason):
+                self.assertVerdict(green_snapshot(pull=pull), landing.REFUSE, re.escape(reason))
+
+    def test_branch_tip_must_be_the_judged_head(self) -> None:
+        self.assertVerdict(
+            green_snapshot(branch_tip=OTHER), landing.REFUSE, "not the pull head"
+        )
+        self.assertVerdict(
+            green_snapshot(branch_tip=None), landing.REFUSE, "no readable"
+        )
+
+    def test_conflict_refuses_and_a_settling_state_waits(self) -> None:
+        self.assertVerdict(
+            green_snapshot(pull=wave_pull(mergeable=False, mergeable_state="dirty")),
+            landing.REFUSE,
+            "'dirty'",
+        )
+        for state in ("unknown", "blocked", "behind"):
+            with self.subTest(state=state):
+                self.assertVerdict(
+                    green_snapshot(pull=wave_pull(mergeable_state=state)),
+                    landing.WAIT,
+                    f"mergeable_state '{state}'",
+                )
+        self.assertVerdict(
+            green_snapshot(pull=wave_pull(mergeable=None, mergeable_state="clean")),
+            landing.WAIT,
+            "mergeable_state",
+        )
+
+    def test_attestation_pending_waits_and_refused_refuses(self) -> None:
+        self.assertVerdict(
+            green_snapshot(attestation=landing.ATTESTATION_PENDING),
+            landing.WAIT,
+            "attestation for this head has not arrived",
+        )
+        self.assertVerdict(
+            green_snapshot(attestation="refused: dependency head tree differs"),
+            landing.REFUSE,
+            "attestation: refused: dependency head tree differs",
+        )
+
+    def test_squash_message_never_carries_the_marker(self) -> None:
+        title, message = landing.compose_squash_message(wave_pull())
+        self.assertEqual(
+            title, "chore(deps): refresh Kin registry pins after kin-db@0.7.85 (#1360)"
+        )
+        self.assertNotIn(landing.COMMIT_MARKER, message)
+        self.assertNotIn(landing.COMMIT_MARKER, title)
+        self.assertIn("Automated Kin registry dependency wave.", message)
+        body_with_marker = wave_pull(body=f"Automated wave.\n\n{landing.COMMIT_MARKER}\n")
+        with self.assertRaisesRegex(landing.LandingError, "reserved dependency-wave marker"):
+            landing.compose_squash_message(body_with_marker)
+        self.assertVerdict(
+            green_snapshot(pull=body_with_marker),
+            landing.REFUSE,
+            "reserved dependency-wave marker",
+        )
+        co_authored = wave_pull(body="wave\n\nCo-authored-by: github-actions[bot] <x@y>")
+        with self.assertRaisesRegex(landing.LandingError, "Co-authored-by"):
+            landing.compose_squash_message(co_authored)
+        _, empty = landing.compose_squash_message(wave_pull(body=None))
+        self.assertEqual(empty, "")
+
+    def test_judge_fixture_cli_reports_the_verdict_and_exit_code(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory) / "green.json"
+            fixture.write_text(json.dumps(green_snapshot()), encoding="utf-8")
+            result = subprocess.run(
+                [sys.executable, str(LANDING_PATH), "judge-fixture", "--fixture", str(fixture)],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(json.loads(result.stdout)["decision"], landing.LAND)
+
+            red = Path(directory) / "red.json"
+            runs = green_runs() + [check_run("cargo-deny", "failure")]
+            red.write_text(
+                json.dumps(green_snapshot(check_run_pages=pages(runs))), encoding="utf-8"
+            )
+            result = subprocess.run(
+                [sys.executable, str(LANDING_PATH), "judge-fixture", "--fixture", str(red)],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertEqual(json.loads(result.stdout)["decision"], landing.REFUSE)
+            self.assertIn("::error title=Kin registry wave refused::", result.stderr)
+
+            waiting = Path(directory) / "wait.json"
+            waiting.write_text(json.dumps(green_snapshot(open_pulls=[])), encoding="utf-8")
+            result = subprocess.run(
+                [sys.executable, str(LANDING_PATH), "judge-fixture", "--fixture", str(waiting)],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(json.loads(result.stdout)["decision"], landing.WAIT)
+            self.assertIn("::notice::wave landing waits", result.stderr)
+
+    def test_land_refuses_when_the_wave_moved_since_judgment(self) -> None:
+        stdout = io.StringIO()
+        with mock.patch.object(landing, "gather", return_value=green_snapshot()):
+            with mock.patch.dict("os.environ", {"KIN_LAND_TOKEN": "t"}), \
+                    contextlib.redirect_stdout(stdout), \
+                    contextlib.redirect_stderr(io.StringIO()):
+                code = landing.main(
+                    [
+                        "land",
+                        "--repository",
+                        REPO,
+                        "--workspace",
+                        ".",
+                        "--pull",
+                        "1360",
+                        "--head",
+                        OTHER,
+                        "--merge-token-env",
+                        "KIN_LAND_TOKEN",
+                    ]
+                )
+        self.assertEqual(code, 0)
+        verdict = json.loads(stdout.getvalue())
+        self.assertEqual(verdict["decision"], landing.WAIT)
+        self.assertIn("moved since it was judged", verdict["reason"])
+
+    def test_land_squashes_only_the_judged_head_and_proves_it_landed(self) -> None:
+        merged = "9" * 40
+        calls: list[tuple[list[str], str | None]] = []
+
+        def fake_gh(arguments: list[str], *, token: str | None = None) -> Any:
+            calls.append((list(arguments), token))
+            endpoint = next((item for item in arguments if item.startswith("repos/")), "")
+            if endpoint.endswith("/merge"):
+                return {"merged": True, "sha": merged, "message": "Pull Request successfully merged"}
+            if endpoint == f"repos/{REPO}/pulls/1360":
+                return {"merged": True, "merge_commit_sha": merged}
+            if endpoint == ref_endpoint():
+                return ref_document(merged)
+            raise AssertionError(f"unexpected GitHub call: {arguments}")
+
+        with mock.patch.object(landing, "gh_json", side_effect=fake_gh):
+            landed = landing.squash(REPO, wave_pull(), HEAD, merge_token="app-token")
+        self.assertEqual(landed["merged_sha"], merged)
+        merge_call = next(args for args, _ in calls if any(a.endswith("/merge") for a in args))
+        merge_token = next(token for args, token in calls if any(a.endswith("/merge") for a in args))
+        self.assertEqual(merge_token, "app-token")
+        self.assertIn("merge_method=squash", merge_call)
+        self.assertIn(f"sha={HEAD}", merge_call)
+        self.assertTrue(any(a.startswith("commit_title=") and a.endswith("(#1360)") for a in merge_call))
+        self.assertFalse(any(landing.COMMIT_MARKER in a for a in merge_call))
+
+        def disagreeing_gh(arguments: list[str], *, token: str | None = None) -> Any:
+            endpoint = next((item for item in arguments if item.startswith("repos/")), "")
+            if endpoint.endswith("/merge"):
+                return {"merged": True, "sha": merged}
+            if endpoint == f"repos/{REPO}/pulls/1360":
+                return {"merged": True, "merge_commit_sha": OTHER}
+            raise AssertionError(f"unexpected GitHub call: {arguments}")
+
+        with mock.patch.object(landing, "gh_json", side_effect=disagreeing_gh):
+            with self.assertRaisesRegex(landing.LandingError, "does not carry the squash"):
+                landing.squash(REPO, wave_pull(), HEAD, merge_token="app-token")
+
+    def test_ruleset_contexts_are_names_this_repository_produces(self) -> None:
+        # The six live ruleset contexts have to be display names some workflow
+        # here publishes, or the landing waits forever on a name nobody
+        # produces. The mint's RULESET_REQUIRED_CHECKS mirror is a different
+        # reviewed list (a superset of its release-critical set) and predates
+        # the fast-gate contexts, so the producers are the authority here.
+        produced: set[str] = set()
+        for workflow in sorted((ROOT / ".github" / "workflows").glob("*.yml")):
+            produced.update(
+                re.findall(r"(?m)^    name: (.+?)\s*$", workflow.read_text(encoding="utf-8"))
+            )
+        missing = sorted(set(landing.RULESET_REQUIRED_CONTEXTS) - produced)
+        self.assertEqual(missing, [], f"no workflow job publishes {missing}")
+        self.assertEqual(len(landing.RULESET_REQUIRED_CONTEXTS), 6)
+        release_tag = RELEASE_TAG_PATH.read_text(encoding="utf-8")
+        mint_required = re.search(
+            r"(?m)^          REQUIRED_CHECKS: \|\n((?:            .+\n)+)", release_tag
+        )
+        self.assertIsNotNone(mint_required, "release-tag.yml no longer declares REQUIRED_CHECKS")
+        mint = {line.strip() for line in mint_required.group(1).splitlines() if line.strip()}
+        # Every context the mint vetoes on that a pull request produces is
+        # also one the landing insists on; the rest of the mint's set is
+        # main-push evidence the wave head cannot carry.
+        for context in ("DCO Sign-off", "cargo-deny", "gitleaks (full history)"):
+            self.assertIn(context, mint)
+            self.assertIn(context, landing.RULESET_REQUIRED_CONTEXTS)
+
+    def test_allowed_paths_are_exactly_the_receivers_write_set(self) -> None:
+        writer = step_block(
+            RECEIVER_WORKFLOW_PATH.read_text(encoding="utf-8"),
+            "Open or update the dependency bump PR",
+        )
+        match = re.search(r"(?m)add-paths: \|\n((?:            .+\n)+)", writer)
+        self.assertIsNotNone(match)
+        written = {line.strip() for line in match.group(1).splitlines() if line.strip()}
+        self.assertEqual(written, set(landing.ALLOWED_PATHS))
+
+
+# ---------------------------------------------------------------------------
+# Workflow contracts.
+# ---------------------------------------------------------------------------
+
+
+HISTORY_CALL = "python3 scripts/verify-protected-main-history.py"
+
+
+class ReceiverBindingContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = RECEIVER_WORKFLOW_PATH.read_text(encoding="utf-8")
+        cls.disarm_job = job_block(cls.workflow, "disarm-wave")
+        cls.prepare_job = job_block(cls.workflow, "prepare-wave")
+        cls.mutation_job = job_block(cls.workflow, "mutate-wave")
+
+    def test_every_binding_proves_ancestry_instead_of_equality(self) -> None:
+        policy_steps = (
+            "Bind early disarm to the queued workflow policy",
+            "Refuse protected-main rewrite before early-disarm token mint",
+            "Bind preparation to the queued workflow policy",
+            "Rebind the fresh mutation runner to queued policy",
+        )
+        admitted_steps = (
+            "Refuse protected-main rewrite immediately before token mint",
+            "Refuse protected-main rewrite before repository mutation",
+        )
+        for name in policy_steps:
+            block = step_block(self.workflow, name)
+            self.assertIn(HISTORY_CALL, block, name)
+            self.assertIn('--policy-sha "$GITHUB_SHA"', block, name)
+            self.assertIn('--branch "$BASE_BRANCH"', block, name)
+        for name in admitted_steps:
+            block = step_block(self.workflow, name)
+            self.assertIn(HISTORY_CALL, block, name)
+            self.assertIn('--policy-sha "$ADMITTED_BASE"', block, name)
+        for name in ("Bind early disarm to the queued workflow policy",
+                     "Bind preparation to the queued workflow policy",
+                     "Rebind the fresh mutation runner to queued policy"):
+            self.assertIn('echo "base_sha=$GITHUB_SHA"', step_block(self.workflow, name))
+        # The one equality that stays: the mutation runner must be the admitted
+        # base. Main's tip is never compared to github.sha by equality again.
+        self.assertEqual(self.workflow.count('!= "$GITHUB_SHA"'), 1)
+        self.assertIn(
+            '[ "$ADMITTED_BASE" != "$GITHUB_SHA" ]',
+            step_block(self.workflow, "Rebind the fresh mutation runner to queued policy"),
+        )
+        self.assertNotIn("protected-main movement", self.workflow)
+        self.assertNotIn("git/ref/heads/${BASE_BRANCH}", self.workflow)
+
+    def test_checkout_precedes_each_binding(self) -> None:
+        pairs = (
+            (self.disarm_job, "Checkout exact policy for early disarm",
+             "Bind early disarm to the queued workflow policy"),
+            (self.prepare_job, "Checkout exact queued protected main",
+             "Bind preparation to the queued workflow policy"),
+            (self.mutation_job, "Checkout exact protected main for trusted mutation code",
+             "Rebind the fresh mutation runner to queued policy"),
+        )
+        for job, checkout, binding in pairs:
+            self.assertLess(job.index(f"- name: {checkout}"), job.index(f"- name: {binding}"))
+            self.assertIn("ref: ${{ github.sha }}", step_block(self.workflow, checkout))
+            self.assertIn("persist-credentials: false", step_block(self.workflow, checkout))
+
+    def test_generated_pull_base_is_proven_a_descendant(self) -> None:
+        verifier = step_block(self.workflow, "Verify exact first-party generated PR")
+        self.assertIn(HISTORY_CALL, verifier)
+        self.assertIn('--policy-sha "$ADMITTED_BASE"', verifier)
+        self.assertIn('--descendant "$(jq -r .base.sha <<<"$pull")"', verifier)
+        self.assertNotIn('.base.sha <<<"$pull")" != "$ADMITTED_BASE"', verifier)
+
+    def test_attester_and_gate_accept_a_descendant_base(self) -> None:
+        attester = ATTESTER_PATH.read_text(encoding="utf-8")
+        self.assertIn('SCRIPT_DIR / "verify-protected-main-history.py"', attester)
+        self.assertIn("history.require_protected_history(", attester)
+        self.assertIn("history.require_descendant(", attester)
+        self.assertNotIn("protected main moved after the completed receiver", attester)
+        self.assertNotIn('base.get("sha") != admission["base"]', attester)
+        guard = HEAD_GUARD_PATH.read_text(encoding="utf-8")
+        self.assertIn("is_ancestor(workspace, base, expected_base)", guard)
+        self.assertIn("ensure_commit(workspace, expected_base)", guard)
+        self.assertNotIn("is not current pull base", guard)
+        self.assertIn("is_ancestor(workspace, admitted.base, base)", guard)
+
+
+class LandingWorkflowContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = LANDING_WORKFLOW_PATH.read_text(encoding="utf-8")
+        cls.judge_job = job_block(cls.workflow, "judge-wave")
+        cls.land_job = job_block(cls.workflow, "land-wave")
+
+    def test_triggers_are_completions_and_a_sweep_with_no_dispatch(self) -> None:
+        trigger = self.workflow.split("\njobs:", 1)[0]
+        self.assertIn("workflow_run:", trigger)
+        self.assertIn("types: [completed]", trigger)
+        for workflow in ("CI", "SAST", "Secret Scan", "DCO", "PR Text Hygiene", "CodeQL"):
+            self.assertIn(f"      - {workflow}\n", trigger)
+        self.assertIn('cron: "5,20,35,50 * * * *"', trigger)
+        self.assertNotIn("workflow_dispatch", self.workflow)
+        self.assertNotIn("pull_request", trigger)
+        self.assertRegex(trigger, r"(?m)^permissions:\n  contents: read$")
+
+    def test_judge_reads_only_the_wave_and_binds_to_protected_history(self) -> None:
+        self.assertIn(
+            "github.event.workflow_run.head_branch == 'automation/kin-registry-dependency-wave'",
+            self.judge_job,
+        )
+        self.assertIn(
+            "github.event.workflow_run.head_repository.full_name == github.repository",
+            self.judge_job,
+        )
+        self.assertIn("github.event_name == 'schedule'", self.judge_job)
+        self.assertIn("cancel-in-progress: false", self.judge_job)
+        self.assertIn("kin-registry-wave-judge-${{ github.repository }}", self.judge_job)
+        self.assertIn("checks: read", self.judge_job)
+        self.assertNotIn("write", self.judge_job)
+        self.assertNotIn("environment:", self.judge_job)
+        self.assertNotIn("create-github-app-token", self.judge_job)
+        self.assertIn("KIN_MAIN_FROZEN: ${{ vars.KIN_MAIN_FROZEN }}", self.judge_job)
+        bind = step_block(self.workflow, "Bind the judgment to protected main history")
+        self.assertIn(HISTORY_CALL, bind)
+        self.assertIn('--policy-sha "$GITHUB_SHA"', bind)
+        judge = step_block(self.workflow, "Judge the wave against its full check set")
+        self.assertIn("land-kin-registry-wave.py judge", judge)
+        self.assertIn('--freeze "$KIN_MAIN_FROZEN"', judge)
+        self.assertIn("GH_TOKEN: ${{ github.token }}", judge)
+        checkout = step_block(self.workflow, "Checkout the queued landing policy")
+        self.assertIn("ref: ${{ github.sha }}", checkout)
+        self.assertIn("persist-credentials: false", checkout)
+        self.assertIn("fetch-depth: 0", checkout)
+        self.assertLess(self.judge_job.index("- name: Checkout the queued landing policy"),
+                        self.judge_job.index("- name: Bind the judgment"))
+        self.assertLess(self.judge_job.index("- name: Bind the judgment"),
+                        self.judge_job.index("- name: Judge the wave"))
+        self.assertIn("decision: ${{ steps.judge.outputs.decision || 'wait' }}", self.judge_job)
+
+    def test_land_runs_only_on_a_land_verdict_through_the_release_app(self) -> None:
+        self.assertIn("needs: judge-wave", self.land_job)
+        self.assertIn("if: needs.judge-wave.outputs.decision == 'land'", self.land_job)
+        self.assertIn("environment: release-tag", self.land_job)
+        self.assertIn("kin-registry-wave-land-${{ github.repository }}", self.land_job)
+        self.assertIn("cancel-in-progress: false", self.land_job)
+        token = step_block(self.workflow, "Mint repository-scoped landing token")
+        self.assertIn("permission-contents: write", token)
+        self.assertIn("permission-pull-requests: write", token)
+        self.assertNotIn("permission-issues", token)
+        self.assertNotIn("permission-actions", token)
+        self.assertNotIn("permission-statuses", token)
+        identity = step_block(self.workflow, "Verify exact landing App identity and scope")
+        self.assertIn("verify-kin-release-app-token.py", identity)
+        squash = step_block(self.workflow, "Squash the green wave onto protected main")
+        self.assertIn("land-kin-registry-wave.py land", squash)
+        self.assertIn("--merge-token-env KIN_LAND_TOKEN", squash)
+        self.assertIn("KIN_LAND_TOKEN: ${{ steps.app-token.outputs.token }}", squash)
+        self.assertIn("GH_TOKEN: ${{ github.token }}", squash)
+        self.assertIn('--pull "$JUDGED_PULL"', squash)
+        self.assertIn('--head "$JUDGED_HEAD"', squash)
+        self.assertIn('--freeze "$KIN_MAIN_FROZEN"', squash)
+        bind = step_block(self.workflow, "Bind the landing to protected main history")
+        self.assertIn(HISTORY_CALL, bind)
+        self.assertIn('[[ ! "$JUDGED_PULL" =~ ^[1-9][0-9]*$ ]]', bind)
+        self.assertIn('[[ ! "$JUDGED_HEAD" =~ ^[0-9a-f]{40}$ ]]', bind)
+        order = [
+            self.land_job.index(f"- name: {name}")
+            for name in (
+                "Checkout the queued landing policy for the merge",
+                "Bind the landing to protected main history",
+                "Mint repository-scoped landing token",
+                "Verify exact landing App identity and scope",
+                "Squash the green wave onto protected main",
+            )
+        ]
+        self.assertEqual(order, sorted(order))
+        self.assertNotIn("gh pr merge", self.workflow)
+        self.assertNotIn("--auto", self.workflow)
+
+    def test_ci_runs_this_test(self) -> None:
+        ci = CI_PATH.read_text(encoding="utf-8")
+        self.assertIn("python3 ./scripts/test-kin-registry-wave-landing.py", ci)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -800,6 +800,14 @@ EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
     ".github/workflows/kin-registry-release-attest.yml": {
         "attest-completed-receiver": "Attest completed Kin registry receiver",
     },
+    # The wave's own landing. The judge reads every check-run on the wave head
+    # by name and the land job squash-merges through the release App only when
+    # that full set has concluded green. Both run on workflow_run and schedule,
+    # so neither publishes a pull-request or merge-group context.
+    ".github/workflows/kin-registry-wave-land.yml": {
+        "judge-wave": "Judge the open Kin registry wave",
+        "land-wave": "Land the green Kin registry wave",
+    },
     ".github/workflows/link-check.yml": {
         "link-check": "Check public documentation links",
     },

--- a/scripts/verify-kin-registry-wave-head.py
+++ b/scripts/verify-kin-registry-wave-head.py
@@ -170,6 +170,27 @@ def is_ancestor(workspace: Path, base: str, head: str) -> bool:
     )
 
 
+def ensure_commit(workspace: Path, sha: str) -> None:
+    """Fetch `sha` from origin when the checkout does not hold it yet.
+
+    A pull base that moved past the checkout's knowledge of main is still main
+    history on origin, and GitHub serves any reachable commit by sha. The fetch
+    is allowed to fail: `is_ancestor` on a commit the checkout still lacks
+    answers no, which is the fail-closed direction.
+    """
+
+    present = _run(
+        ["git", "-C", str(workspace), "cat-file", "-e", f"{sha}^{{commit}}"],
+        check=False,
+    ).returncode
+    if present == 0:
+        return
+    _run(
+        ["git", "-C", str(workspace), "fetch", "--no-tags", "origin", sha],
+        check=False,
+    )
+
+
 def ensure_pull_head(workspace: Path, pull_number: int, head: str) -> None:
     present = _run(
         ["git", "-C", str(workspace), "cat-file", "-e", f"{head}^{{commit}}"],
@@ -411,9 +432,9 @@ def verify_merge_group_dependency_tree(
 ) -> None:
     """Reject any queued peer that changes the admitted dependency paths."""
 
-    if admitted.base != base:
+    if admitted.base != base and not is_ancestor(workspace, admitted.base, base):
         raise AdmissionError(
-            "merge group base differs from the admitted dependency base"
+            "merge group base does not descend from the admitted dependency base"
         )
     expected_tree = git(
         workspace,
@@ -762,10 +783,18 @@ def validate_attestation(
         validate_workflow_run(repository, latest, workflow_run)
     expected_tree = str(latest["tree"])
     base = str(latest["base"])
+    # The pull base is main's tip at the pull's last push and moves past the
+    # attested base whenever a lane lands between the receiver's checkout and
+    # its push. Protected main at or after the attested base is what the
+    # attestation needs; a base that is not an ancestor of it descends from
+    # something other than the policy that produced the admission.
     if expected_base is not None and base != expected_base:
-        raise AdmissionError(
-            f"dependency admission base {base} is not current pull base {expected_base}"
-        )
+        ensure_commit(workspace, expected_base)
+        if not is_ancestor(workspace, base, expected_base):
+            raise AdmissionError(
+                f"dependency admission base {base} is not an ancestor of "
+                f"current pull base {expected_base}"
+            )
     evidence = validate_delta(workspace, base, head, require_marker=True)
     if evidence.tree != expected_tree:
         raise AdmissionError(
@@ -1054,9 +1083,12 @@ def verify_merge_group(
         expected_head=candidate_head,
         require_open=True,
     )
-    if pull_evidence.base != base:
+    if pull_evidence.base != base and not is_ancestor(
+        workspace, pull_evidence.base, base
+    ):
         raise AdmissionError(
-            "merge group base differs from the current dependency pull base"
+            "merge group base is not protected main at or after the current "
+            "dependency pull base"
         )
     admitted = verify_attestation(
         workspace,

--- a/scripts/verify-protected-main-history.py
+++ b/scripts/verify-protected-main-history.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Prove that a workflow's policy commit is protected main's own history.
+
+A queued workflow runs the workflow file and scripts of GITHUB_SHA, the default
+branch tip at the moment GitHub created the run. The receiver, the attester and
+the wave landing used to require that sha to still EQUAL the tip of main at every
+step, which is a property main cannot hold while lanes are landing every few
+minutes: four receiver runs failed on 2026-09-02 between 05:30Z and 06:12Z on
+"queued receiver policy <sha> is not protected main <sha>" while the branch
+moved under them, and the pins only arrived once main happened to stand still.
+
+The property those steps protect is narrower than equality: the policy that runs
+must be protected main's, not a branch, a fork or a rewritten ref. That holds
+whenever the policy sha is an ancestor of main's current tip, because a commit
+that is still reachable from the protected tip cannot have been rewritten, and a
+sha that GitHub resolved as the default branch tip cannot be a branch or a fork.
+So this module reads the tip, and when the two differ it asks the compare API
+for the relation between the policy sha and the tip. `identical` and `ahead`
+(the tip is ahead of the policy sha, with nothing behind and the policy sha as
+the merge base) are the two shapes that prove ancestry. `behind` and `diverged`
+are exactly what a force-push or a wrong branch looks like, and both refuse.
+
+The same proof serves a second question: whether a pull request's base sha is
+protected main at or after an admitted base. That is `require_descendant`,
+which proves the admitted base is an ancestor of the pull base and the pull base
+is an ancestor of the tip.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from typing import Any, Callable, Sequence
+
+
+LOWER_SHA = re.compile(r"^[0-9a-f]{40}$")
+DEFAULT_BRANCH = "main"
+# The two compare statuses that prove the compared base is an ancestor of the
+# compared head. `behind` and `diverged` are the rewrite and wrong-branch shapes.
+ANCESTOR_STATUSES = frozenset({"identical", "ahead"})
+
+Fetch = Callable[[str], Any]
+# `fetch` defaults resolve to gh_json at call time rather than at definition
+# time, so a caller (or a test) that replaces the module's gh_json is honoured.
+
+
+class HistoryError(RuntimeError):
+    """The policy sha could not be proven to be protected main's history."""
+
+
+def require_sha(label: str, value: Any) -> str:
+    if not isinstance(value, str) or LOWER_SHA.fullmatch(value) is None:
+        raise HistoryError(f"{label} must be 40-character lowercase hex, got {value!r}")
+    return value
+
+
+def judge_relation(base: str, head: str, compare: Any) -> dict[str, Any]:
+    """Judge one compare document as proof that `base` is an ancestor of `head`.
+
+    Pure: the caller fetched `compare` from `repos/<repo>/compare/<base>...<head>`
+    and this decides. Every field the proof rests on is checked, so a truncated
+    or malformed answer refuses instead of reading as green.
+    """
+
+    base = require_sha("compare base", base)
+    head = require_sha("compare head", head)
+    if not isinstance(compare, dict):
+        raise HistoryError("compare response is not an object")
+    status = compare.get("status")
+    ahead_by = compare.get("ahead_by")
+    behind_by = compare.get("behind_by")
+    merge_base = compare.get("merge_base_commit")
+    merge_base_sha = merge_base.get("sha") if isinstance(merge_base, dict) else None
+    for label, value in (("ahead_by", ahead_by), ("behind_by", behind_by)):
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise HistoryError(f"compare {label} is not a count: {value!r}")
+    if status not in ANCESTOR_STATUSES:
+        raise HistoryError(
+            f"{base} is not protected history of {head}: compare status is "
+            f"{status!r} (ahead_by={ahead_by}, behind_by={behind_by})"
+        )
+    if behind_by != 0:
+        raise HistoryError(
+            f"{base} is not protected history of {head}: {behind_by} commit(s) "
+            "behind, which is what a rewritten ref looks like"
+        )
+    if status == "identical" and ahead_by != 0:
+        raise HistoryError("compare reports identical with a non-zero ahead count")
+    if status == "ahead" and ahead_by == 0:
+        raise HistoryError("compare reports ahead with a zero ahead count")
+    if merge_base_sha != base:
+        raise HistoryError(
+            f"compare merge base {merge_base_sha!r} is not {base}, so the "
+            "ancestry claim does not rest on this sha"
+        )
+    return {
+        "base": base,
+        "head": head,
+        "relation": "identical" if status == "identical" else "ancestor",
+        "ahead_by": ahead_by,
+    }
+
+
+def gh_json(endpoint: str) -> Any:
+    result = subprocess.run(
+        ["gh", "api", endpoint],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "no output"
+        raise HistoryError(f"gh api {endpoint} failed: {detail}")
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise HistoryError("GitHub returned malformed JSON") from exc
+
+
+def _resolve(fetch: Fetch | None) -> Fetch:
+    return gh_json if fetch is None else fetch
+
+
+def read_tip(repository: str, branch: str, fetch: Fetch | None = None) -> str:
+    document = _resolve(fetch)(f"repos/{repository}/git/ref/heads/{branch}")
+    ref_object = document.get("object") if isinstance(document, dict) else None
+    sha = ref_object.get("sha") if isinstance(ref_object, dict) else None
+    return require_sha(f"protected {branch} tip", sha)
+
+
+def prove_ancestor(
+    repository: str,
+    base: str,
+    head: str,
+    fetch: Fetch | None = None,
+) -> dict[str, Any]:
+    """Prove `base` is an ancestor of `head` (or the same commit)."""
+
+    base = require_sha("ancestor", base)
+    head = require_sha("descendant", head)
+    if base == head:
+        return {"base": base, "head": head, "relation": "identical", "ahead_by": 0}
+    compare = _resolve(fetch)(f"repos/{repository}/compare/{base}...{head}")
+    return judge_relation(base, head, compare)
+
+
+def require_protected_history(
+    repository: str,
+    policy_sha: str,
+    *,
+    branch: str = DEFAULT_BRANCH,
+    fetch: Fetch | None = None,
+) -> dict[str, Any]:
+    """Prove `policy_sha` is the tip of `branch` or reachable from it."""
+
+    policy_sha = require_sha("policy sha", policy_sha)
+    tip = read_tip(repository, branch, fetch)
+    verdict = prove_ancestor(repository, policy_sha, tip, fetch)
+    verdict["branch"] = branch
+    verdict["tip"] = tip
+    return verdict
+
+
+def require_descendant(
+    repository: str,
+    ancestor: str,
+    descendant: str,
+    *,
+    branch: str = DEFAULT_BRANCH,
+    fetch: Fetch | None = None,
+) -> dict[str, Any]:
+    """Prove `descendant` is protected `branch` history at or after `ancestor`."""
+
+    ancestor = require_sha("admitted base", ancestor)
+    descendant = require_sha("pull base", descendant)
+    forward = prove_ancestor(repository, ancestor, descendant, fetch)
+    on_branch = require_protected_history(
+        repository, descendant, branch=branch, fetch=fetch
+    )
+    return {
+        "ancestor": ancestor,
+        "descendant": descendant,
+        "relation": forward["relation"],
+        "ahead_by": forward["ahead_by"],
+        "branch": branch,
+        "tip": on_branch["tip"],
+    }
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--repository", required=True)
+    parser.add_argument(
+        "--policy-sha",
+        required=True,
+        help="the sha whose membership in protected history is being proven",
+    )
+    parser.add_argument("--branch", default=DEFAULT_BRANCH)
+    parser.add_argument(
+        "--descendant",
+        help=(
+            "prove this sha is protected history at or after --policy-sha "
+            "instead of proving --policy-sha against the branch tip"
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    try:
+        if args.repository.count("/") != 1:
+            raise HistoryError("repository must be owner/name")
+        if args.descendant is None:
+            verdict = require_protected_history(
+                args.repository, args.policy_sha, branch=args.branch
+            )
+        else:
+            verdict = require_descendant(
+                args.repository,
+                args.policy_sha,
+                args.descendant,
+                branch=args.branch,
+            )
+    except HistoryError as exc:
+        print(f"::error title=Policy is not protected main history::{exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(verdict, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The registry dependency wave no longer refuses while main is moving, and it lands itself once every check on its head is green.

## What was wrong

The receiver bound each job to protected main by requiring `git/ref/heads/main` to equal `GITHUB_SHA`, in four places, and required the wave pull base to equal the admitted base. Tonight kin landed a PR every few minutes, so four dispatch runs (33594947728, 33595151461, 33595481589 and 33597817211, 05:30Z to 06:12Z) failed at "Bind preparation to the queued workflow policy" with `queued receiver policy <sha> is not protected main <sha>`, and the pins only arrived at 08:24Z once main held still. The attester (`validate_live_admission`) and the CI gate (`validate_attestation(expected_base=...)`) carried the same equality one hop downstream, so a receiver-only fix would have moved the failure rather than removed it.

Nothing landed the wave either: `merge land` refuses every `automation/*` head by design, and the reserved marker on the bot commit is refused on any non-wave PR, so a captain rebuilt #1344 by hand.

## The fix, and which option

Ancestry proof, not retry. Every binding keeps binding to `GITHUB_SHA`, the commit the run checked out, and proves it is protected main's history with the new `scripts/verify-protected-main-history.py`: the tip of `main`, or an ancestor of it through the compare API (`identical` or `ahead`, `behind_by` 0, merge base equal to the policy sha). `behind` and `diverged` are what a force-push or a foreign ref looks like, and both refuse. A bounded retry inside the run could not have worked: the receiver compiles for minutes and the equality never holds during a wave. The property the old check protected, that the policy which runs is protected main's under the App token, is kept whole: a commit still reachable from the protected tip is unrewritten, and GitHub resolved `GITHUB_SHA` from the default branch.

The wave pull base is proven to be protected main at or after the admitted base (`--descendant`) in the receiver's generated-PR check, the attester's live admission, its recheck and close/reopen paths, and the CI gate, which reads it with `git merge-base --is-ancestor` after fetching the sha when the checkout lacks it. Evidence that a pull base only moves on a head push: #1360 sat at base ec0f0d06a while main moved on to 19d646e48.

## Self-landing

`kin-registry-wave-land.yml` runs on the completion of CI, SAST, Secret Scan, DCO, PR Text Hygiene, Daemon Smoke, Docker, Fuzz, Acceptance, Install Proof Canary, Link Check and CodeQL on the wave branch, plus a sweep at :05, :20, :35 and :50. `scripts/land-kin-registry-wave.py judge` decides `land`, `wait` or `refuse` from one snapshot: one open first-party wave opened by the release App with no auto-merge armed and its origin tip equal to the head; exactly one commit, authored and committed by github-actions[bot], carrying the marker once; a diff that only modifies Cargo.toml and Cargo.lock (the receiver's add-paths; the updater writes no fuzz/Cargo.lock); every check-run on the head read with `per_page=100` and the listed length asserted against `total_count`, deduplicated per name keeping the newest run (the attester's close and reopen retrigger leaves a cancelled first suite beside the green one, and #1360 carried 87 check-runs in exactly that shape), none failed, skipped and neutral green, the six ruleset contexts present; the pull mergeable; the release-App attestation verified. Only then does the land job (environment `release-tag`) mint the App token with contents and pull-requests write, verify its identity, re-judge, and `PUT /pulls/N/merge` with `merge_method=squash`, `sha=<head>`, the pull title with its number and the pull body. The squash never carries the marker line (reserved for receiver heads, and a marker on main without its pull is what the CI gate refuses) and never carries a Co-authored-by line, which the fleet's history audit flags; the script then proves the squash is on `main`.

GitHub's own auto-merge is not the mechanism, for two reasons read from the repo: ruleset 19746451 requires six contexts while the wave head carries 45 or more distinct checks, so auto-merge would land on the six alone, and the v2 admission chain (the receiver's disarm job, the attester and the CI gate) refuses any server-owned landing state on the wave.

Refusals are loud (exit 1, `::error`): a failed check, a foreign commit, an off-scope file, an incomplete listing, a conflict. Waits are quiet (exit 0, `::notice`): checks still running, a required context not yet reported, an attestation not yet posted, and the new GitHub-side hold, repository variable `KIN_MAIN_FROZEN`, any non-empty value, set with `gh variable set KIN_MAIN_FROZEN --repo firelock-ai/kin --body "<why>"`. Mirroring `bin/kin-lane gate set kin_main_frozen` into that variable is a kin-ecosystem follow-up.

## Verification

- `scripts/test-kin-registry-wave-landing.py`: 42 tests over fixture check-run sets (all green, one failure, one pending, a paged listing whose total_count exceeds the listed runs, a non-bot commit, an off-scope file, a superseded cancelled suite, a newer failure, a missing required context, a freeze) and the proof's identical, ahead, behind, diverged and merge-base cases. Wired into ci.yml beside the receiver test.
- `scripts/test-kin-registry-release-receiver.py`: 59 tests, three rewritten for the ancestry rule, one added for main advancing under a completed receiver and a diverged main refusing.
- `scripts/test-release-workflow-authority.py` green with the census entry for the two new jobs.
- Falsified: 26 mutations applied one at a time, each turning its named test red; the table is in the lane report.
- Live, read-only: the proof accepts the 09:35Z receiver policy sha (four behind the tip) and refuses the wave head as `diverged`; the judge on live #1360 answered `wait` on `Analyze (rust)` still running, 86 check-runs, 47 distinct, none failed.
- Gates run: actionlint on both workflows, check-quarantine, the docker feature guard and its test, the release-policy node validators (187), node --check, assertion reachability, zero-file-search, runtime boundaries, private repo coupling. No Rust changed, so fmt and clippy have nothing new to grade; hosted CI is the gate of record.

Related: FIR-3084
