### PR TITLE
Extract abstract classes, namespace bodies and ambient declarations in TypeScript (FIR-3100)

### DIFF
--- a/crates/kin-parser/src/languages/typescript.rs
+++ b/crates/kin-parser/src/languages/typescript.rs
@@ -546,8 +546,44 @@ fn extract_ts_class_like(
 
     // Recurse into class body for methods
     if let Some(body) = node.child_by_field_name("body") {
+        // TypeScript writes an overload set as N bodiless signatures followed by
+        // one implementation, and all N+1 are one method. `TextModel.applyEdits`
+        // is written five times in `textModel.ts` and `GridView.getView` three
+        // times. Emitting per node would leave the file holding six entities
+        // under one name, so the signatures collapse onto the implementation,
+        // and a `declare class`'s repeated signature with no implementation
+        // collapses onto its own first occurrence.
+        //
+        // Collected before the walk, because the implementation follows its
+        // signatures in the source and a check made as each member is reached
+        // would not yet have seen it.
+        let implemented: std::collections::HashSet<String> = {
+            let mut cursor = body.walk();
+            body.children(&mut cursor)
+                .filter(|m| m.kind() == "method_definition")
+                .filter_map(|m| m.child_by_field_name("name"))
+                .filter_map(|n| n.utf8_text(source).ok())
+                .map(str::to_string)
+                .collect()
+        };
+        let mut signatures_seen: std::collections::HashSet<String> = Default::default();
         let mut cursor = body.walk();
         for member in body.children(&mut cursor) {
+            if matches!(
+                member.kind(),
+                "method_signature" | "abstract_method_signature"
+            ) {
+                let Some(member_name) = member
+                    .child_by_field_name("name")
+                    .and_then(|n| n.utf8_text(source).ok())
+                    .map(str::to_string)
+                else {
+                    continue;
+                };
+                if implemented.contains(&member_name) || !signatures_seen.insert(member_name) {
+                    continue;
+                }
+            }
             extract_ts_class_member(&member, source, file_id, name, entities, relations);
         }
     }
@@ -1848,6 +1884,55 @@ declare module ambientWithNoBody;
             modules.contains(&"ambientWithNoBody"),
             "the body-less ambient module is missing: {modules:?}"
         );
+    }
+
+    /// An overload set is one method, however many times it is written.
+    /// `src/vs/editor/common/model/textModel.ts` declares `applyEdits` five
+    /// times as a signature and once with a body; `GridView.getView` three
+    /// times. Emitting per node put 144 duplicate `(file, name)` pairs across
+    /// 40 files into the VS Code graph before this collapsed them.
+    #[test]
+    fn an_overload_set_is_one_method_however_many_signatures_it_carries() {
+        let adapter = TypeScriptAdapter;
+        let source = br#"
+export class TextModel {
+    public applyEdits(operations: readonly IIdentifiedSingleEditOperation[]): void;
+    public applyEdits(operations: readonly IIdentifiedSingleEditOperation[], computeUndoEdits: false): void;
+    public applyEdits(operations: readonly IIdentifiedSingleEditOperation[], computeUndoEdits: true): IValidEditOperation[];
+    public applyEdits(operations: readonly IIdentifiedSingleEditOperation[], computeUndoEdits: boolean = false): void | IValidEditOperation[] {
+        return this._doApplyEdits(operations);
+    }
+    public getLineContent(lineNumber: number): string { return ''; }
+}
+
+declare class AmbientOnly {
+    lex(src: string): Token[];
+    lex(src: string, options: Options): Token[];
+    inlineTokens(src: string): Token[];
+}
+"#;
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("textModel.ts");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let names: Vec<&str> = output.entities.iter().map(|e| e.name.as_str()).collect();
+
+        let count = |needle: &str| names.iter().filter(|n| **n == needle).count();
+        assert_eq!(
+            count("TextModel.applyEdits"),
+            1,
+            "an overload set became {} entities: {names:?}",
+            count("TextModel.applyEdits")
+        );
+        assert_eq!(
+            count("AmbientOnly.lex"),
+            1,
+            "a signature with no implementation was emitted {} times: {names:?}",
+            count("AmbientOnly.lex")
+        );
+        // The controls: the collapse must not eat a method that is written once,
+        // whether it carries a body or not.
+        assert_eq!(count("TextModel.getLineContent"), 1, "{names:?}");
+        assert_eq!(count("AmbientOnly.inlineTokens"), 1, "{names:?}");
     }
 
     /// TypeScript merges a namespace with a same-named class, interface, enum,

--- a/crates/kin-parser/src/languages/typescript.rs
+++ b/crates/kin-parser/src/languages/typescript.rs
@@ -121,6 +121,26 @@ pub(super) fn extract_typescript_tree(
     // copies of this rule and drifted anyway: the TypeScript index predicate
     // never matched `index.d.ts`. Sharing the helper is what the header
     // comment above already says the shared surface exists for.
+    // TypeScript merges a namespace with a class, interface, enum, function or
+    // type alias of the same name in the same file: `interface Event {}` beside
+    // `namespace Event {}` is ONE symbol, and 24 of the 70 namespaces in VS
+    // Code's editor and base subtree are written that way. Minting a Module for
+    // the namespace half leaves the file holding two entities under one name,
+    // which is the exact collision `owners.finish` warns about below and which
+    // the linker's (file, name) index cannot tell apart.
+    //
+    // Run over the finished list rather than checking as each header is pushed,
+    // because the merge is order-free in the source: `type Sizing` precedes its
+    // namespace in `grid.ts` and `namespace Tokens` precedes its interface in
+    // `marked.d.ts`. Every Module in `entities` at this point is a namespace
+    // header; the file's own module is pushed below.
+    let merged: std::collections::HashSet<String> = entities
+        .iter()
+        .filter(|e| e.kind != EntityKind::Module)
+        .map(|e| e.name.clone())
+        .collect();
+    entities.retain(|e| e.kind != EntityKind::Module || !merged.contains(&e.name));
+
     let (module_name, is_package) = js_module_identity(&file_id.0, suffixes);
     if !module_name.is_empty() {
         entities.push(ExtractedEntity {
@@ -201,7 +221,14 @@ fn extract_ts_node(
                 extract_calls_from_context(node, source, &name, None, relations);
             }
         }
-        "class_declaration" => {
+        // `abstract class Foo {}` is `abstract_class_declaration` in the
+        // grammar, a sibling of `class_declaration` carrying the identical
+        // field set (decorators, name, type_parameters, class_heritage, body).
+        // Matching only `class_declaration` dropped every abstract class and
+        // every method on it: 99 of the 102 abstract classes in VS Code's
+        // editor and base subtree, with 1,248 members inside them, against 14
+        // of 1,979 plain classes missed for unrelated reasons.
+        "class_declaration" | "abstract_class_declaration" => {
             if let Some(name_node) = node.child_by_field_name("name") {
                 let name = name_node.utf8_text(source).unwrap_or("").to_string();
                 extract_ts_class_like(node, &name, source, file_id, entities, relations);
@@ -431,6 +458,63 @@ fn extract_ts_node(
                 }
             }
         }
+        // `namespace X { ... }` is `internal_module` and `module X { ... }` is
+        // `module`; both carry a `name` and an optional `statement_block` body.
+        // Neither had an arm, so every declaration written inside a namespace
+        // was dropped along with the namespace itself. VS Code's
+        // `coreCommands.ts` declares 117 names and the graph held ten: the ten
+        // that sit at column zero outside all four of its namespaces.
+        //
+        // The body's children go back through `extract_ts_node` with their own
+        // plain names, which is what the Rust adapter's `mod_item` arm does in
+        // this same crate and what the call extractor can resolve: a call
+        // written `CoreNavigationCommands.MoveTo.runEditorCommand(x)` is a
+        // `member_expression`, and `extract_calls_from_context` collapses those
+        // to the bare property name. An entity named `CoreNavigationCommands.MoveTo`
+        // would be a name no call site in the repository ever writes.
+        "internal_module" | "module" => {
+            if let Some(name_node) = node.child_by_field_name("name") {
+                // `declare module "marked"` names the module with a string
+                // literal; the quotes are syntax, not part of the name.
+                let name = name_node
+                    .utf8_text(source)
+                    .unwrap_or("")
+                    .trim_matches(|c| c == '"' || c == '\'')
+                    .to_string();
+                if !name.is_empty() {
+                    entities.push(ExtractedEntity {
+                        kind: EntityKind::Module,
+                        name,
+                        signature: node_signature(node, source),
+                        visibility: detect_ts_visibility(node, source),
+                        doc_summary: extract_preceding_comment(node, source),
+                        fingerprint: compute_fingerprint(node, source),
+                        span: span_from_node(node, file_id),
+                    });
+                }
+            }
+            // `declare module foo;` has no body to descend into.
+            if let Some(body) = node.child_by_field_name("body") {
+                let mut cursor = body.walk();
+                for child in body.children(&mut cursor) {
+                    extract_ts_node(
+                        &child, source, file_id, entities, relations, owners, definers,
+                    );
+                }
+            }
+        }
+        // `declare` wraps a plain declaration in the grammar, so a `.d.ts`
+        // file's `declare class`, `declare const`, `declare function` and
+        // `declare namespace` all reached the walk as `ambient_declaration` and
+        // matched nothing. Unwrap it and the arms above do the work.
+        "ambient_declaration" => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                extract_ts_node(
+                    &child, source, file_id, entities, relations, owners, definers,
+                );
+            }
+        }
         "import_statement" => {}
         _ => {}
     }
@@ -478,7 +562,19 @@ fn extract_ts_class_member(
     relations: &mut Vec<ExtractedRelation>,
 ) {
     match node.kind() {
-        "method_definition" | "public_field_definition" => {
+        // The pinned grammar gives `class_body` six child kinds and a member
+        // written without a body is not `method_definition`: `public abstract
+        // runCoreEditorCommand(...): void;` is `abstract_method_signature` and
+        // a `declare class`'s `space(token): string;` is `method_signature`.
+        // Matching only the two with bodies meant every abstract method was
+        // dropped even once its class was extracted, which is how the demo's
+        // `runCoreEditorCommand` stayed missing through the first arm.
+        // `index_signature` and `class_static_block`, the other two, carry no
+        // name and stay out.
+        "method_definition"
+        | "method_signature"
+        | "abstract_method_signature"
+        | "public_field_definition" => {
             if let Some(name_node) = node.child_by_field_name("name") {
                 let name = name_node.utf8_text(source).unwrap_or("").to_string();
                 let qualified = format!("{}.{}", class_name, name);
@@ -1626,5 +1722,237 @@ function registerHandler(target: EventTarget, event: string, handler: () => void
             .map(|e| e.name.as_str())
             .collect();
         assert!(invented.is_empty(), "got {invented:?}");
+    }
+
+    /// A faithful reduction of `src/vs/editor/browser/coreCommands.ts`, which
+    /// declares 117 names and whose graph held ten before this change: an
+    /// `export abstract class` with an abstract method on it, a second bare
+    /// `abstract class`, and the column-zero declarations between the
+    /// namespaces that were the only ones an unqualified `class_declaration`
+    /// arm could reach.
+    #[test]
+    fn an_abstract_class_and_the_methods_on_it_become_entities() {
+        let adapter = TypeScriptAdapter;
+        let source = br#"
+export abstract class CoreEditorCommand<T> extends EditorCommand {
+    public runEditorCommand(accessor: ServicesAccessor, editor: ICodeEditor): void {
+        this.runCoreEditorCommand(editor, {});
+    }
+    public abstract runCoreEditorCommand(viewModel: IViewModel, args: Partial<T>): void;
+}
+
+abstract class EditorOrNativeTextInputCommand {
+    constructor(target: MultiCommand) {}
+    public runDOMCommand(activeElement: Element): void {}
+}
+
+function registerCommand<T extends Command>(command: T): T { return command; }
+"#;
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("coreCommands.ts");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        assert!(matches!(output.parse_state, ParseState::Valid));
+        let named = entities_besides_the_files_own_module(&output.entities);
+
+        assert!(
+            named.contains(&(EntityKind::Class, "CoreEditorCommand")),
+            "the exported abstract class is missing: {named:?}"
+        );
+        assert!(
+            named.contains(&(EntityKind::Class, "EditorOrNativeTextInputCommand")),
+            "the bare abstract class is missing: {named:?}"
+        );
+        assert!(
+            named.contains(&(EntityKind::Method, "CoreEditorCommand.runCoreEditorCommand")),
+            "the abstract method the demo named is missing: {named:?}"
+        );
+        assert!(
+            named.contains(&(EntityKind::Method, "CoreEditorCommand.runEditorCommand")),
+            "a concrete method on an abstract class is missing: {named:?}"
+        );
+        // The control: the plain function beside them was never dropped, so a
+        // suite that only asserted "some entities exist" would pass with the
+        // abstract arm deleted.
+        assert!(
+            named.contains(&(EntityKind::Function, "registerCommand")),
+            "the plain function is missing: {named:?}"
+        );
+    }
+
+    /// The `CoreNavigationCommands` shape: a namespace whose body holds the
+    /// classes an editor question routes to. Their names stay unqualified,
+    /// because `extract_calls_from_context` collapses a
+    /// `CoreNavigationCommands.MoveTo.runEditorCommand(x)` member expression to
+    /// the bare property, so a qualified entity would be a name no call site
+    /// writes.
+    #[test]
+    fn a_namespace_body_is_walked_like_the_files_own_top_level() {
+        let adapter = TypeScriptAdapter;
+        let source = br#"
+export namespace CoreNavigationCommands {
+    export interface BaseCommandOptions { source?: string; }
+
+    export class BaseMoveToCommand extends CoreEditorCommand<MoveCommandOptions> {
+        public runCoreEditorCommand(viewModel: IViewModel, args: Partial<MoveCommandOptions>): void {}
+    }
+
+    export const MoveTo = registerCommand(new BaseMoveToCommand());
+
+    function parse(args: RawArguments): ParsedArguments { return args; }
+}
+
+module LegacyNames {
+    export class Renamed {}
+}
+
+declare module ambientWithNoBody;
+"#;
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("coreCommands.ts");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let named = entities_besides_the_files_own_module(&output.entities);
+        let modules: Vec<&str> = output
+            .entities
+            .iter()
+            .filter(|e| e.kind == EntityKind::Module && e.name != "coreCommands")
+            .map(|e| e.name.as_str())
+            .collect();
+
+        assert!(
+            named.contains(&(EntityKind::Class, "BaseMoveToCommand")),
+            "a class inside a namespace is missing: {named:?}"
+        );
+        assert!(
+            named.contains(&(EntityKind::Method, "BaseMoveToCommand.runCoreEditorCommand")),
+            "a method on a class inside a namespace is missing: {named:?}"
+        );
+        assert!(
+            named.contains(&(EntityKind::Interface, "BaseCommandOptions")),
+            "an interface inside a namespace is missing: {named:?}"
+        );
+        assert!(
+            named.contains(&(EntityKind::Function, "parse")),
+            "a function inside a namespace is missing: {named:?}"
+        );
+        assert!(
+            named.contains(&(EntityKind::Class, "Renamed")),
+            "a class inside a `module` block is missing: {named:?}"
+        );
+        assert!(
+            modules.contains(&"CoreNavigationCommands") && modules.contains(&"LegacyNames"),
+            "the namespace headers are missing: {modules:?}"
+        );
+        // A body-less `declare module foo;` has nothing to descend into and
+        // must not panic or invent a member.
+        assert!(
+            modules.contains(&"ambientWithNoBody"),
+            "the body-less ambient module is missing: {modules:?}"
+        );
+    }
+
+    /// TypeScript merges a namespace with a same-named class, interface, enum,
+    /// function or type alias. `src/vs/base/common/event.ts` writes
+    /// `interface Event` beside `namespace Event`, and 24 of VS Code's 70
+    /// namespaces are written that way. One symbol, one entity.
+    #[test]
+    fn a_namespace_merged_with_a_same_name_declaration_mints_no_second_entity() {
+        let adapter = TypeScriptAdapter;
+        let source = br#"
+export interface Event<T> { (listener: (e: T) => void): IDisposable; }
+
+export namespace Event {
+    export const None: Event<any> = () => Disposable.None;
+    export function once<T>(event: Event<T>): Event<T> { return event; }
+}
+
+export namespace Schemas {
+    export const file = 'file';
+}
+
+export namespace Tokens { }
+export interface Tokens { space: boolean; }
+"#;
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("event.ts");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let modules: Vec<&str> = output
+            .entities
+            .iter()
+            .filter(|e| e.kind == EntityKind::Module && e.name != "event")
+            .map(|e| e.name.as_str())
+            .collect();
+
+        assert!(
+            !modules.contains(&"Event"),
+            "the merged namespace minted a second entity under the interface's name: {modules:?}"
+        );
+        // Written the other way round in the source, which is why the merge is
+        // resolved over the finished list rather than as each header is pushed.
+        assert!(
+            !modules.contains(&"Tokens"),
+            "the merge is order-dependent: {modules:?}"
+        );
+        // The control: a namespace nothing merges with keeps its entity.
+        assert!(
+            modules.contains(&"Schemas"),
+            "a standalone namespace lost its entity: {modules:?}"
+        );
+        let named = entities_besides_the_files_own_module(&output.entities);
+        assert!(
+            named.contains(&(EntityKind::Function, "once")),
+            "the merged namespace's own members are missing: {named:?}"
+        );
+    }
+
+    /// A `.d.ts` file's declarations reach the walk wrapped in
+    /// `ambient_declaration`, which matched nothing. `marked.d.ts` and
+    /// `semver.d.ts` between them lost 105 of their 135 declared names.
+    #[test]
+    fn an_ambient_declaration_is_unwrapped_to_the_declaration_inside_it() {
+        let adapter = TypeScriptAdapter;
+        let source = br#"
+declare class _Renderer {
+    space(token: Tokens.Space): string;
+}
+
+declare namespace Tokens {
+    interface Space { type: 'space'; }
+}
+
+declare function marked(src: string): string;
+
+export declare const MAX_LENGTH = 256;
+"#;
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("marked.d.ts");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let named = entities_besides_the_files_own_module(&output.entities);
+
+        assert!(
+            named.contains(&(EntityKind::Class, "_Renderer")),
+            "the ambient class is missing: {named:?}"
+        );
+        assert!(
+            named.contains(&(EntityKind::Method, "_Renderer.space")),
+            "the ambient class's method is missing: {named:?}"
+        );
+        assert!(
+            named.contains(&(EntityKind::Interface, "Space")),
+            "a declaration inside an ambient namespace is missing: {named:?}"
+        );
+        // `declare function marked(...): string;` is `function_signature`, not
+        // `function_declaration`, and it stays out of this change on purpose.
+        // A bare signature is also how TypeScript writes an overload set, so
+        // the arm cannot be added until overloads collapse onto their
+        // implementation: `src/vs/base/browser/dom.ts` writes `h` five times
+        // and `svgElem` five times, and matching the kind alone would mint five
+        // entities for one function. The fixture keeps the line so a reader can
+        // see what is still missing.
+        assert!(
+            named
+                .iter()
+                .any(|(kind, name)| *kind == EntityKind::Constant && *name == "MAX_LENGTH"),
+            "the exported ambient const is missing: {named:?}"
+        );
     }
 }


### PR DESCRIPTION
## Coverage, before and after

`kin init --json --no-enrich` on a fresh admission of VS Code's `src/vs/editor` and `src/vs/base`
at `1f625adb84abf41cdff31f40f66e58a222f033f6`, 1,837 files, under a scratch `KIN_HOME` with
`KIN_EMBED_BACKEND=cpu`. Same bytes on both sides: 1,837 files each and a 40-file hash sample with
an identical digest. BEFORE is `origin/main`'s parser, whose `typescript.rs` blob is identical to
this branch's parent.

| # | file | top-level names in source | graph entities before | after | delta |
|---:|---|---:|---:|---:|---:|
| 1 | `src/vs/editor/browser/coreCommands.ts` | 117 | 10 | 177 | +167 |
| 2 | `src/vs/base/common/marked/marked.d.ts` | 92 | 25 | 191 | +166 |
| 3 | `src/vs/editor/common/editorContextKeys.ts` | 61 | 1 | 62 | +61 |
| 4 | `src/vs/editor/common/standaloneStrings.ts` | 60 | 1 | 61 | +60 |
| 5 | `src/vs/base/common/network.ts` | 70 | 39 | 96 | +57 |
| 6 | `src/vs/base/common/event.ts` | 88 | 144 | 192 | +48 |
| 7 | `src/vs/base/common/semver/semver.d.ts` | 43 | 1 | 48 | +47 |
| 8 | `src/vs/base/common/platform.ts` | 65 | 30 | 36 | +6 |
| 9 | `src/vs/base/common/semver/semver.js` | 39 | 1 | 1 | +0 |
| 10 | `src/vs/base/browser/performance.ts` | 28 | 1 | 23 | +22 |
| 11 | `src/vs/editor/test/node/diffing/fixtures/difficult-move/1.js` | 34 | 12 | 12 | +0 |
| 12 | `src/vs/editor/test/node/diffing/fixtures/difficult-move/2.js` | 35 | 13 | 13 | +0 |
| 13 | `src/vs/editor/contrib/snippet/browser/snippetParser.ts` | 26 | 105 | 120 | +15 |
| 14 | `src/vs/base/common/iterator.ts` | 18 | 1 | 17 | +16 |
| 15 | `src/vs/base/common/themables.ts` | 25 | 6 | 24 | +18 |
| 16 | `src/vs/editor/editor.api.ts` | 19 | 5 | 5 | +0 |
| 17 | `src/vs/base/common/color.ts` | 20 | 76 | 90 | +14 |
| 18 | `src/vs/editor/common/languages.ts` | 195 | 239 | 254 | +15 |
| 19 | `src/vs/base/common/marked/marked.js` | 24 | 156 | 156 | +0 |
| 20 | `src/vs/editor/common/cursor/cursorMoveCommands.ts` | 14 | 44 | 75 | +31 |

| control file, which must not move | before | after |
|---|---:|---:|
| `src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts` | 358 | 358 |
| `src/vs/editor/common/model/textModel.ts` | 343 | 343 |
| `src/vs/base/browser/ui/tree/asyncDataTree.ts` | 241 | 241 |
| `src/vs/editor/browser/viewParts/minimap/minimap.ts` | 196 | 196 |
| `src/vs/editor/common/viewModelEventDispatcher.ts` | 156 | 156 |

All five control files identical to the entity: **True**.

| whole store | before | after | delta |
|---|---:|---:|---:|
| entities | 29392 | 31554 | +2162 |
| relations | 55807 | 62541 | +6734 |
| files carrying entities | 1355 | 1355 | +0 |
| duplicate (file, name) pairs | 210 in 117 files | 244 in 128 files | +34 |

**Entity names present before and absent after: 0.** Nothing was displaced.

`kin graph status`, which counts only definitions this repository owns and so excludes the 74
external reference targets the export carries, reads **29,318 to 31,477**. Repository coverage is
1,355 of 1,837 on both sides and does not move, which is the point: coverage is counted per file,
so a file yielding ten of its 117 declarations already counted as covered.

The "top-level names in source" column is a simple source count of declarations at file scope or
one level inside a namespace. It is not the entity denominator, because the graph also holds every
method and field inside those declarations, which is why a file can end with more entities than
that column shows.

The 34 new duplicate `(file, name)` pairs, classified rather than waved past:

| kind | count | what it is |
|---|---:|---|
| `get x()` beside `set x()` | 16 | two `method_definition` nodes under one name, a shape the graph already carried: 101 of the 210 before this change are the same thing, on classes that were already visible |
| cross-scope reuse of a plain name | 13 | `marked.d.ts` declares `setOptions`, `walkTokens`, `lexer`, `options`, `use`, `parser`, `parseInline` and `parse` both inside `declare namespace marked` and at file top level; `coreCommands.ts` writes `interface RawArguments` in both `EditorScroll_` and `RevealLine_`; plus `languages.ts` 3 and `dom.ts` 1. This is the measured price of plain names |
| a declaration sharing its file's module name | 5 | `performance`, `process`, `equals`, `semver`, `marked`. 41 files in the BEFORE store already carry this shape, `rename.ts` holding `function rename` beside module `rename` among them |

`runCoreEditorCommand`, the one real gap of the three the verifier named:

- before: 0 entities
- after: 15 entities, each qualified by its own owner: ['BaseMoveToCommand.runCoreEditorCommand', 'BottomCommand.runCoreEditorCommand', 'ColumnSelectCommand.runCoreEditorCommand', 'CoreEditorCommand.runCoreEditorCommand', 'CursorMoveBasedCommand.runCoreEditorCommand', 'CursorMoveImpl.runCoreEditorCommand'] ...

## What was wrong

`extract_typescript_tree` walks `root.children()` one level and `extract_ts_node` dispatches on
twelve node kinds. Four the pinned grammar emits (tree-sitter-typescript 0.23.2, tree-sitter
0.26.10) had no arm, so every declaration written inside them was dropped while the file still
counted as covered.

`abstract_class_declaration` is a sibling of `class_declaration` with the identical field set.
`internal_module` and `module` are `namespace X {}` and `module X {}`, both carrying a name and an
optional `statement_block` body. `ambient_declaration` is the `declare` wrapper every `.d.ts`
declaration arrives in. And a class member written without a body is neither `method_definition`
nor `public_field_definition`: it is `abstract_method_signature` or `method_signature`, two of the
six kinds `class_body` can hold.

Measured across the 1,355 code files in that subtree: the source declares 9,044 top-level names and
the graph was missing 1,241, 13.7 percent, plus 1,461 methods and fields inside the class bodies
that went with them.

| cause | grammar node kind | declarations | members | total |
|---|---|---:|---:|---:|
| `abstract class X {}` | `abstract_class_declaration` | 99 | 1,248 | 1,347 |
| `namespace X {}` and `module X {}` bodies | `internal_module`, `module` | 665 | 115 | 780 |
| `declare ...` in a `.d.ts` | `ambient_declaration` | 36 | 85 | 121 |
| a member written without a body | `abstract_method_signature`, `method_signature` | in the rows above | | |

The falsification that ranked it, with a control that had to hit: 102 distinct column-zero
`abstract class` names in the checkout, 6 in the graph, 96 absent (94 percent), against 1,979
column-zero plain `class` names of which 1,965 are present (0.7 percent absent).

This is what cost the demo its VS Code rows. `runCoreEditorCommand`, which the raw side named and
the verifier marked as a name the graph lacks, has 31 declaration sites in `coreCommands.ts`: one
on the abstract class `CoreEditorCommand` and 30 on classes inside the `CoreNavigationCommands` and
`CoreEditingCommands` namespaces. Every one was dropped, by two independent causes at once.

The other two names the verifier flagged are not declarations. `createEditor` appears only in a
JSDoc example in `dom.ts` and as a helper nested inside a test body; `Handling` is a `//` comment
and a test title string.

## Two design calls, decided by evidence

**Namespace members keep their plain names.** `extract_calls_from_context` collapses a
`member_expression` callee to the bare property, so a call written
`CoreNavigationCommands.MoveTo.runEditorCommand(x)` records `runEditorCommand` and a reference to
`CoreNavigationCommands.MoveTo` records `MoveTo`. A qualified entity would carry a name no call
site in the repository ever writes. The Rust adapter's `mod_item` arm in this crate already emits
module members unqualified for the same reason.

**A namespace merged with a same-named declaration mints one entity, not two.** TypeScript merges
`interface Event {}` with `namespace Event {}` into one symbol, and 24 of this subtree's 70
namespaces are written that way. The guard runs over the finished entity list rather than as each
header is pushed, because the source writes the merge in both orders: `type Sizing` precedes its
namespace in `grid.ts`, `namespace Tokens` precedes its interface in `marked.d.ts`. The other 46
namespaces are standalone and keep their entity.

## Deliberately not in this change

`function_signature`. A bare signature is an ambient function in a `.d.ts` but an overload set in a
`.ts`, and `dom.ts` writes `h` five times and `svgElem` five times before their implementations.
Matching on kind alone would mint five entities for one function, so overloads have to collapse
onto their implementation first. FIR-3101 carries it with the measurement: 91 within-file duplicate
names across 52 files.

The 431 top-level consts the graph also lacks are `is_trivial_reexport` doing its documented job.

## The overload collapse, which the proof run found

The first proof run raised duplicates from 210 to 372, and two control files moved. The cause was
this PR's own `method_signature` arm: TypeScript writes an overload set as N bodiless signatures
followed by one implementation, and `TextModel.applyEdits` is written five times as a signature and
once with a body. 144 of the 162 new duplicates were method overload sets across 40 files.

The second commit collapses them. The body's `method_definition` names are collected before the
walk, because the implementation follows its signatures in the source and a check made as each
member is reached has not seen it yet. A signature whose name is implemented in the same body emits
nothing; a repeated signature with no implementation, which is how a `declare class` writes
overloads, collapses onto its own first occurrence. With that in, all five control files come back
identical to the entity and duplicates land at 244.

This is the same shape that keeps `function_signature` out of the PR, now proved at class scope
rather than argued.

## Falsification

Eight mutations, each chosen to compile clean so the assertion fails rather than rustc, applied
against committed state with the tree asserted clean between them. No survivors.

| mutation | tests red |
|---|---|
| `abstract_class_declaration` removed from the class arm | 1 |
| the `internal_module \| module` arm can never match | 3 |
| `method_signature` and `abstract_method_signature` removed from the member arm | 2 |
| the `ambient_declaration` arm can never match | 2 |
| the declaration-merging guard can never fire | 1 |
| the implementation set can never suppress a signature | 1 |
| repeated signatures are no longer deduplicated | 1 |
| the overload collapse can never fire | 1 |

Three mutations redden more than their own test, and the coupling is real: the namespace fixture
carries a `declare module` that reaches the ambient arm, and the ambient fixture carries a
`declare namespace` that reaches the namespace arm. Each test also carries a control that was never
dropped, so a suite asserting only "some entities exist" would pass with the arm deleted.

## Reach beyond TypeScript files, stated as read rather than measured

`JavaScriptAdapter::extract` (`javascript.rs:32`) is the only extract entry a `.js` file has, and
its first act is `if tree_is_typescript_family(tree) { return
super::typescript::extract_typescript_tree(...) }` (`javascript.rs:42-48`).
`tree_is_typescript_family` is true exactly when the winning tree came from a TypeScript or TSX
grammar, since it tests the tree's language for a `type_annotation` node kind. There is no second
path. So a `.js` file whose Flow content the TSX grammar reads returns through every arm in this
diff, `ambient_declaration` included.

That matters for React. The lane measuring `javascript.rs` reports that nine of its worst files,
the `flow-typed/environments/*.js` library definitions and `scripts/flow/environment.js`, parse
under TSX with under two percent unparsed and still lose roughly 480 top-level declarations,
because a Flow libdef writes `declare class` and friends and the walk never descended into the
`ambient_declaration` wrapper. This arm is the one that unwraps it.

**No number for that is claimed here, and this corpus cannot supply one.** VS Code's editor and
base subtree holds eight `.js` files and not one of them carries a `declare` or a `namespace` line,
so nothing in the table above exercises the `.js` route. The React figure is read on the next demo
build, by the lane that measured it, not asserted by this PR. What this PR establishes is that the
route exists and lands in these arms.

The lane working in `javascript.rs` touches no line of this diff.

Ticket FIR-3100. Follow-up FIR-3101.
