### PR TITLE
Cut what a small model reads before its first question, and what it pays per answer

### DIFF
--- a/crates/kin-mcp/src/agent_belt.rs
+++ b/crates/kin-mcp/src/agent_belt.rs
@@ -138,7 +138,8 @@ pub fn canonicalize_tool_name(name: &mut String) {
     }
 }
 
-/// Ask `semantic_locate` for the compact shape on this belt's behalf.
+/// Ask, on this belt's agents' behalf, for the answer shape and the size a
+/// small model can afford.
 ///
 /// The compact response is opt-in on the wire, and deliberately so: the fused
 /// `semantic_locate` payload IS the `LocateResult` schema `kin locate --json`
@@ -154,14 +155,56 @@ pub fn canonicalize_tool_name(name: &mut String) {
 /// at twelve results.
 ///
 /// Only when the caller named no `surface` of its own. An agent that asks for
-/// `full` gets full, which is what makes this a default rather than an override.
+/// `full` gets full, which is what makes this a default rather than an override,
+/// and every insertion below follows the same rule.
+///
+/// The rest is the response size. The registered ceiling of 45,000 characters is
+/// right for a client with room and wrong for this belt: it is roughly 10,500
+/// tokens, so two default answers exhaust a 24,000-token run. Each budget tool
+/// therefore gets [`AGENT_DEFAULT_RESPONSE_MAX_CHARS`], the walker gets the
+/// shape rather than the bodies, and the context pack gets a token budget that
+/// fits inside the same answer. Every one of these is advertised on the served
+/// schema by [`apply_belt_schema_defaults`], so a caller reading `tools/list`
+/// sees the number the belt actually sends and can raise it with the same
+/// `max_chars` it always could.
 pub fn apply_belt_defaults(name: &str, arguments: &mut HashMap<String, serde_json::Value>) {
-    if name != "semantic_locate" {
-        return;
+    if name == "semantic_locate" {
+        arguments
+            .entry("surface".to_string())
+            .or_insert_with(|| serde_json::Value::String("compact".to_string()));
     }
-    arguments
-        .entry("surface".to_string())
-        .or_insert_with(|| serde_json::Value::String("compact".to_string()));
+
+    // Shape before bodies on the walker. Not inserted when the caller named
+    // either spelling, because `compact` is the alias for `include_body: false`
+    // and overriding a caller who asked for one of them would be the belt
+    // answering a question it was not asked.
+    if name == "trace_data_flow"
+        && !arguments.contains_key("include_body")
+        && !arguments.contains_key("compact")
+    {
+        arguments.insert("include_body".to_string(), serde_json::Value::Bool(false));
+    }
+
+    if name == "get_context_pack" {
+        arguments
+            .entry("token_budget".to_string())
+            .or_insert_with(|| serde_json::json!(AGENT_DEFAULT_CONTEXT_PACK_TOKEN_BUDGET));
+    }
+
+    // The response ceiling, on every belt tool that has one. Both spellings are
+    // checked before inserting, because `ResponseBudget::from_arguments` takes
+    // the FIRST of `max_chars` then `max_response_chars` that is present: an
+    // unconditional insert would silently outrank a caller who had passed
+    // `max_response_chars` and hand them a ceiling they never asked for.
+    if BUDGET_TOOLS.contains(&name)
+        && !arguments.contains_key("max_chars")
+        && !arguments.contains_key("max_response_chars")
+    {
+        arguments.insert(
+            "max_chars".to_string(),
+            serde_json::json!(AGENT_DEFAULT_RESPONSE_MAX_CHARS),
+        );
+    }
 }
 
 /// The short description for each tool the `agent-default` profile serves, by
@@ -426,6 +469,111 @@ fn schema_keep_lists() -> BTreeMap<&'static str, &'static [&'static str]> {
     ])
 }
 
+/// The response ceiling `agent-default` asks for on its agents' behalf.
+///
+/// Derived from one rule rather than taste: an agent must be able to make at
+/// least six tool calls at default answer size inside a 24,000-token run and
+/// still have room to answer. That puts one answer at about 2,800 tokens, and at
+/// the 4.28 bytes per token measured on this profile's own JSON against
+/// `google/gemma-4-e4b` that is about 12,000 characters.
+///
+/// The registered default is 45,000, which is [`crate::budget::
+/// RESPONSE_DEFAULT_MAX_CHARS`] and right for a client with room. On this belt
+/// it is catastrophic for the case the belt exists for: 45,000 characters is
+/// roughly 10,500 tokens, so TWO default answers exhaust a 24,000-token run
+/// before the model has reasoned about either. That is read from source rather
+/// than guessed, because `apply_belt_defaults` shaped only `semantic_locate`'s
+/// `surface` and every other tool fell through to the registered default.
+///
+/// Advertised AND injected, deliberately the same number. The acceptance suite
+/// treats the served schema as the contract an agent reads, so a belt that
+/// injected 12,000 while advertising 45,000 would be lying in the one place a
+/// caller looks. Both halves move together, and `full` keeps 45,000.
+pub const AGENT_DEFAULT_RESPONSE_MAX_CHARS: u64 = 12_000;
+
+/// The context pack's own token budget on `agent-default`.
+///
+/// `get_context_pack` bounds itself in TOKENS as well as characters, and its
+/// registered default of 16,000 is larger than the whole answer this belt now
+/// asks for. 2,500 sits under the roughly 2,800 tokens
+/// [`AGENT_DEFAULT_RESPONSE_MAX_CHARS`] buys, leaving the envelope its room.
+pub const AGENT_DEFAULT_CONTEXT_PACK_TOKEN_BUDGET: u64 = 2_500;
+
+/// The belt tools whose registered schema advertises a response budget.
+///
+/// Held as a list because [`apply_belt_defaults`] runs on every call and
+/// building the registry there to rediscover eight names would cost more than
+/// it saves. `the_budget_tool_list_matches_the_registry` fails if the registry
+/// and this list ever disagree, so it cannot go stale quietly.
+const BUDGET_TOOLS: [&str; 8] = [
+    "semantic_locate",
+    DECLARATION_FILTER_CANONICAL,
+    "find_references",
+    "trace_data_flow",
+    crate::handlers::path::TOOL_NAME,
+    "graph_neighborhood",
+    "impact_analysis",
+    "get_context_pack",
+];
+
+/// The properties whose advertised `default` this belt rewrites, by tool.
+///
+/// A number the profile injects has to be the number the profile advertises, or
+/// the served schema stops being the contract the acceptance suite grades it as.
+fn belt_schema_defaults() -> BTreeMap<(&'static str, &'static str), serde_json::Value> {
+    let mut defaults: BTreeMap<(&'static str, &'static str), serde_json::Value> = BTreeMap::new();
+    for tool in BUDGET_TOOLS {
+        defaults.insert(
+            (tool, "max_chars"),
+            serde_json::json!(AGENT_DEFAULT_RESPONSE_MAX_CHARS),
+        );
+    }
+    // `trace_data_flow` registers the same budget under both spellings, and a
+    // caller reading either one has to see the same ceiling.
+    defaults.insert(
+        ("trace_data_flow", "max_response_chars"),
+        serde_json::json!(AGENT_DEFAULT_RESPONSE_MAX_CHARS),
+    );
+    // Shape first. The tool's own belt description tells a model to pass false
+    // when it wants the shape of a chain, and then the registered default handed
+    // it bodies anyway.
+    defaults.insert(
+        ("trace_data_flow", "include_body"),
+        serde_json::Value::Bool(false),
+    );
+    defaults.insert(
+        ("get_context_pack", "token_budget"),
+        serde_json::json!(AGENT_DEFAULT_CONTEXT_PACK_TOKEN_BUDGET),
+    );
+    defaults
+}
+
+/// Rewrite one tool's advertised property defaults for `agent-default`.
+///
+/// Only a property the schema already carries is touched, so this can never
+/// invent a knob, and only its `default` moves: `minimum` and `maximum` are the
+/// server's real limits and stay as registered, which is also what keeps
+/// `response_budget_elisions.py` `check_2` satisfied, since it requires
+/// `minimum < default <= maximum`.
+fn apply_belt_schema_defaults(tool: &str, schema: &mut serde_json::Value) {
+    let defaults = belt_schema_defaults();
+    let Some(properties) = schema
+        .get_mut("properties")
+        .and_then(|value| value.as_object_mut())
+    else {
+        return;
+    };
+    for (name, property) in properties.iter_mut() {
+        let (Some(value), Some(property)) = (
+            defaults.get(&(tool, name.as_str())),
+            property.as_object_mut(),
+        ) else {
+            continue;
+        };
+        property.insert("default".to_string(), value.clone());
+    }
+}
+
 /// The most characters one `agent-default` PROPERTY description may carry.
 ///
 /// The tool descriptions were the visible half of the belt's cost and 1353 cut
@@ -580,6 +728,7 @@ pub fn compact_for_agent_default(list: &mut ToolsListResult) {
             trim_schema(&mut tool.input_schema, keep);
         }
         shorten_property_descriptions(&tool.name, &mut tool.input_schema);
+        apply_belt_schema_defaults(&tool.name, &mut tool.input_schema);
     }
     // No name is rewritten here, so the name order `tools::tool_definitions`
     // built survives untouched. A client caches the prompt it builds from
@@ -836,6 +985,214 @@ mod tests {
             unregistered.is_empty(),
             "agent-default serves {unregistered:?} under a name the registry does not carry, \
              which is a public rename no per-PR check but this one can see"
+        );
+    }
+
+    /// No served property description may run past its budget.
+    ///
+    /// Property prose was 10,153 bytes of the served schemas outside the two
+    /// exempt transaction tools, and one clause, `max_chars`, carried the same
+    /// 649 characters on seven tools. The shape, bounds and default of a
+    /// property are already machine-readable beside its description, so prose
+    /// that restates them is paid for on every `tools/list` a small model reads.
+    ///
+    /// Top-level properties only, and the two tools in [`PROSE_EXEMPT_TOOLS`]
+    /// are skipped, because the earlier compaction kept their nested mutation
+    /// contracts whole and this test is not the place to reopen that.
+    ///
+    /// Nothing in the acceptance suite reads a property description, checked
+    /// rather than assumed: `magic_repro.py` `check_6` tests for the presence of
+    /// the `include_body` or `compact` KEY, `check_14` arm 3 reads the TOOL
+    /// description, and `response_budget_elisions.py` `grade_advertised_budget`
+    /// reads only `maximum`, `default` and `minimum`. So this budget binds
+    /// without moving a check.
+    #[test]
+    fn no_agent_default_property_description_exceeds_its_budget() {
+        let over: Vec<(String, String, usize)> = served_agent_default()
+            .tools
+            .into_iter()
+            .filter(|tool| !PROSE_EXEMPT_TOOLS.contains(&tool.name.as_str()))
+            .flat_map(|tool| {
+                let properties = tool
+                    .input_schema
+                    .get("properties")
+                    .and_then(|value| value.as_object())
+                    .cloned()
+                    .unwrap_or_default();
+                properties
+                    .into_iter()
+                    .filter_map(|(name, property)| {
+                        let length = property.get("description")?.as_str()?.chars().count();
+                        (length > AGENT_DEFAULT_PROPERTY_DESCRIPTION_BUDGET).then_some((
+                            tool.name.clone(),
+                            name,
+                            length,
+                        ))
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        assert!(
+            over.is_empty(),
+            "over the {AGENT_DEFAULT_PROPERTY_DESCRIPTION_BUDGET}-character property budget: \
+             {over:?}; give each one a single clause in shared_property_descriptions or \
+             tool_property_descriptions"
+        );
+    }
+
+    /// The control for the budget above: the registered schemas must still carry
+    /// the long forms, or the profile is passing because the registry lost them.
+    #[test]
+    fn the_full_profile_keeps_the_long_property_descriptions() {
+        let full = crate::tools::tool_definitions();
+        let locate = full
+            .tools
+            .iter()
+            .find(|tool| tool.name == "semantic_locate")
+            .expect("semantic_locate is registered");
+        let budget = locate.input_schema["properties"]["max_chars"]["description"]
+            .as_str()
+            .expect("max_chars carries a description");
+        assert!(
+            budget.chars().count() > AGENT_DEFAULT_PROPERTY_DESCRIPTION_BUDGET,
+            "the full profile's max_chars prose was shortened too: {} chars",
+            budget.chars().count()
+        );
+    }
+
+    /// Every advertised response budget on `agent-default` stays at or under the
+    /// cap, and the number advertised is the number injected.
+    ///
+    /// The registered ceiling is 45,000 characters, about 10,500 gemma-4-e4b
+    /// tokens, so two default answers exhaust the 24,000-token run this belt
+    /// exists to fit. The cap is derived from one rule: six calls at default
+    /// size inside that run with room left to answer.
+    ///
+    /// Both halves are asserted together on purpose. A belt that injected the
+    /// cap while advertising 45,000 would pass any check that reads only one
+    /// side, and the served schema is what an agent reads before it decides
+    /// whether to narrow its own request. `minimum` and `maximum` are left as
+    /// registered, which is also what keeps
+    /// `response_budget_elisions.py` `check_2` satisfied, since it requires
+    /// `minimum < default <= maximum`.
+    #[test]
+    fn no_agent_default_response_budget_is_advertised_above_the_cap() {
+        let served = served_agent_default();
+        let mut problems: Vec<String> = Vec::new();
+        for tool in &served.tools {
+            let properties = tool
+                .input_schema
+                .get("properties")
+                .and_then(|value| value.as_object());
+            let Some(properties) = properties else {
+                continue;
+            };
+            for key in ["max_chars", "max_response_chars"] {
+                let Some(property) = properties.get(key) else {
+                    continue;
+                };
+                let advertised = property.get("default").and_then(|value| value.as_u64());
+                match advertised {
+                    None => problems.push(format!("{}.{key} advertises no default", tool.name)),
+                    Some(value) if value > AGENT_DEFAULT_RESPONSE_MAX_CHARS => {
+                        problems.push(format!(
+                            "{}.{key} advertises {value}, over the \
+                             {AGENT_DEFAULT_RESPONSE_MAX_CHARS}-character cap",
+                            tool.name
+                        ))
+                    }
+                    Some(_) => {}
+                }
+                // The number advertised has to be the number the belt sends.
+                let mut arguments = HashMap::new();
+                apply_belt_defaults(&tool.name, &mut arguments);
+                let injected = arguments.get("max_chars").and_then(|value| value.as_u64());
+                if injected != Some(AGENT_DEFAULT_RESPONSE_MAX_CHARS) {
+                    problems.push(format!(
+                        "{} advertises a budget and the belt injects {injected:?}",
+                        tool.name
+                    ));
+                }
+            }
+        }
+        assert!(
+            problems.is_empty(),
+            "agent-default response budgets disagree with the cap: {problems:#?}"
+        );
+    }
+
+    /// The belt must never outrank a caller who named a budget itself.
+    ///
+    /// `ResponseBudget::from_arguments` takes the FIRST of `max_chars` then
+    /// `max_response_chars` that is present, so an unconditional insert of
+    /// `max_chars` would silently override a caller who had passed
+    /// `max_response_chars` and answer under a ceiling they never asked for.
+    #[test]
+    fn the_belt_never_overrides_a_budget_the_caller_named() {
+        for key in ["max_chars", "max_response_chars"] {
+            let mut arguments = HashMap::from([(key.to_string(), serde_json::json!(58_000u64))]);
+            apply_belt_defaults("trace_data_flow", &mut arguments);
+            assert_eq!(
+                arguments.get(key).and_then(|value| value.as_u64()),
+                Some(58_000),
+                "the belt moved a {key} the caller named"
+            );
+            assert!(
+                !(key == "max_response_chars" && arguments.contains_key("max_chars")),
+                "the belt added max_chars beside a caller's max_response_chars, which \
+                 from_arguments would then prefer"
+            );
+        }
+        // Same rule on the walker's shape.
+        for key in ["include_body", "compact"] {
+            let mut arguments = HashMap::from([(key.to_string(), serde_json::json!(true))]);
+            apply_belt_defaults("trace_data_flow", &mut arguments);
+            assert_eq!(
+                arguments.get(key).and_then(|value| value.as_bool()),
+                Some(true),
+                "the belt moved a {key} the caller named"
+            );
+        }
+        // And a caller that names nothing gets the belt's shape.
+        let mut bare = HashMap::new();
+        apply_belt_defaults("trace_data_flow", &mut bare);
+        assert_eq!(
+            bare.get("include_body").and_then(|value| value.as_bool()),
+            Some(false),
+            "the walker's default shape on this belt is the chain, not the bodies"
+        );
+    }
+
+    /// [`BUDGET_TOOLS`] must name exactly the belt tools the REGISTRY gives a
+    /// budget property, or the belt caps a subset and nothing says so.
+    #[test]
+    fn the_budget_tool_list_matches_the_registry() {
+        let full = crate::tools::tool_definitions();
+        let belt: std::collections::HashSet<&str> = crate::tools::agent_default_tool_names()
+            .iter()
+            .copied()
+            .collect();
+        let mut registered: Vec<String> = full
+            .tools
+            .into_iter()
+            .filter(|tool| belt.contains(tool.name.as_str()))
+            .filter(|tool| {
+                tool.input_schema
+                    .get("properties")
+                    .and_then(|value| value.as_object())
+                    .is_some_and(|properties| {
+                        properties.contains_key("max_chars")
+                            || properties.contains_key("max_response_chars")
+                    })
+            })
+            .map(|tool| tool.name)
+            .collect();
+        registered.sort();
+        let mut listed: Vec<String> = BUDGET_TOOLS.iter().map(|name| name.to_string()).collect();
+        listed.sort();
+        assert_eq!(
+            listed, registered,
+            "BUDGET_TOOLS and the registry disagree about which belt tools carry a budget"
         );
     }
 
@@ -1113,18 +1470,58 @@ mod tests {
         }
     }
 
-    /// And it touches nothing else. A default that leaked onto another tool
-    /// would be sending an argument its handler never advertised.
+    /// Every argument the belt inserts is one the tool's registered schema
+    /// advertises, with one named exception, and a tool the belt has no default
+    /// for is left exactly as the caller sent it.
+    ///
+    /// This replaces a form that asserted the belt touched `semantic_locate`
+    /// alone. That held while `surface` was the only injection and stopped being
+    /// the point once the response ceiling moved onto every budget tool. The
+    /// durable invariant is the one that test's own comment named: a default
+    /// that leaked onto a tool would be sending an argument its handler never
+    /// advertised. That is what this asserts, against the registry rather than
+    /// against a list of names that has to be remembered.
+    ///
+    /// The exception is `semantic_locate`'s `surface`, which the registry
+    /// advertises on no profile. The compact shape is opt-in on the wire by
+    /// design, the handler reads the argument by name, and no tool in this
+    /// profile sets `additionalProperties: false`. It is named here so the
+    /// exception stays a decision on the record rather than a hole in the test.
     #[test]
-    fn the_belt_defaults_apply_to_locate_alone() {
-        for tool in ["semantic_search", "find_references", "get_context_pack"] {
-            let mut args: HashMap<String, serde_json::Value> = HashMap::new();
-            apply_belt_defaults(tool, &mut args);
-            assert!(
-                args.is_empty(),
-                "{tool} must be left exactly as the caller sent it"
-            );
+    fn the_belt_only_injects_arguments_the_tool_advertises() {
+        const UNADVERTISED_BY_DESIGN: [(&str, &str); 1] = [("semantic_locate", "surface")];
+        let full = crate::tools::tool_definitions();
+        let mut untouched = 0usize;
+        for tool in &full.tools {
+            let mut arguments: HashMap<String, serde_json::Value> = HashMap::new();
+            apply_belt_defaults(&tool.name, &mut arguments);
+            if arguments.is_empty() {
+                untouched += 1;
+                continue;
+            }
+            let properties = tool
+                .input_schema
+                .get("properties")
+                .and_then(|value| value.as_object());
+            for key in arguments.keys() {
+                if UNADVERTISED_BY_DESIGN.contains(&(tool.name.as_str(), key.as_str())) {
+                    continue;
+                }
+                assert!(
+                    properties.is_some_and(|properties| properties.contains_key(key)),
+                    "the belt injected {key} into {}, whose registered schema does not \
+                     advertise it",
+                    tool.name
+                );
+            }
         }
+        // The control. Without it the loop above is satisfied by a belt that
+        // injects into everything, since every assertion would then be about a
+        // tool that has defaults rather than about one that must not.
+        assert!(
+            untouched > 0,
+            "every registered tool received a belt default, so this test proved nothing"
+        );
     }
 
     /// Same for the keep-lists: a keep-list naming a property the tool does not

--- a/crates/kin-mcp/src/agent_belt.rs
+++ b/crates/kin-mcp/src/agent_belt.rs
@@ -426,10 +426,144 @@ fn schema_keep_lists() -> BTreeMap<&'static str, &'static [&'static str]> {
     ])
 }
 
-/// Rewrite one served tool list for the `agent-default` profile: short
-/// descriptions and trimmed schemas. Tool names are left exactly as
-/// registered, because two proofs that run only on `main` read `tools/list` and
-/// assert a name literally.
+/// The most characters one `agent-default` PROPERTY description may carry.
+///
+/// The tool descriptions were the visible half of the belt's cost and 1353 cut
+/// them from 47,739 characters to 6,188. Measured on 2026-09-02 against
+/// `google/gemma-4-e4b`, the model the demo actually runs, that left the served
+/// list at 7,747 tokens of which 6,380 are input schema and only 1,367 are
+/// description. The schemas are where the budget goes now, and inside them the
+/// bytes are property prose: thirteen property descriptions ran past 200
+/// characters, and one of them, `max_chars`, carried the same 649 characters on
+/// seven different tools.
+///
+/// 200 is one plain clause. A property description exists to tell a model what
+/// to pass, and the shape, bounds and default are already machine-readable
+/// beside it in `type`, `enum`, `minimum`, `maximum` and `default`, so prose
+/// that restates them is paid for twice.
+/// `no_agent_default_property_description_exceeds_its_budget` fails on any
+/// property over it.
+pub const AGENT_DEFAULT_PROPERTY_DESCRIPTION_BUDGET: usize = 200;
+
+/// The tools whose schemas this module does not rewrite at all.
+///
+/// 1353 left the nested transaction contracts whole, and they stay whole: a
+/// staged mutation's shape is the thing a caller gets wrong, and it is the one
+/// place on this belt where the schema IS the documentation. They cost 11,245
+/// bytes and 2,423 tokens between them, which is 31 percent of every token in
+/// the served list, and that number belongs in a product decision about which
+/// tools a read-only agent is served rather than in a prose trim.
+const PROSE_EXEMPT_TOOLS: [&str; 2] = ["kin_transaction_stage", "kin_transaction_commit"];
+
+/// Short property descriptions that read the same on every tool carrying them.
+///
+/// Keyed by property name alone, because these properties mean one thing across
+/// the belt and the long forms said that one thing seven times.
+/// [`tool_property_descriptions`] overrides this per tool where the meaning
+/// genuinely differs.
+fn shared_property_descriptions() -> BTreeMap<&'static str, &'static str> {
+    BTreeMap::from([
+        (
+            "max_chars",
+            "Serialized characters this response may occupy. What the budget cut is named under \
+             `elisions` and `_kin.response`, and a list it cut keeps one entry, so an empty list \
+             means none were found.",
+        ),
+        (
+            "max_response_chars",
+            "Serialized characters this response may occupy. `max_chars` is the same parameter \
+             under the other retrieval tools' name. A cut chain keeps one step and reports the \
+             rest under `elisions.chain`.",
+        ),
+        (
+            "cursor",
+            "Opaque token from a prior result's `next_cursor`, returning the next page of the \
+             same collection. Pass it back unedited, and omit it for a fresh query.",
+        ),
+    ])
+}
+
+/// Short property descriptions for one tool's property, overriding
+/// [`shared_property_descriptions`] where a name means different things.
+///
+/// Keyed by `(tool, property)`. `direction` is the reason this table exists: it
+/// walks callees on `trace_data_flow` and dependencies on `graph_neighborhood`,
+/// and one clause cannot honestly say both.
+fn tool_property_descriptions() -> BTreeMap<(&'static str, &'static str), &'static str> {
+    BTreeMap::from([
+        (
+            ("semantic_locate", "include_tests"),
+            "Rank test-role entities alongside source. Off by default unless your query itself \
+             reads as being about tests; what it withheld is counted under \
+             `semantic_coverage.graph_bodies`.",
+        ),
+        (
+            ("list_file_entities", "path"),
+            "Repository-relative path of the file to enumerate, such as \"lib/express.js\". No \
+             leading slash, no \"..\", no Kin or Git control component. Optional only when \
+             `cursor` names the file.",
+        ),
+        (
+            ("trace_data_flow", "target"),
+            "A symbol you are trying to reach, by exact name or UUID. Neighbours it stays \
+             reachable from survive the per-step cap first. Optional; one resolving to nothing \
+             is reported in degradations.",
+        ),
+        (
+            ("trace_data_flow", "include_body"),
+            "Inline each step's source body. Pass false for the SHAPE of the chain, which is a \
+             fraction of the size and is what you want unless you mean to read the code.",
+        ),
+        (
+            ("trace_data_flow", "direction"),
+            "Which way to walk: `calls` for callees, `callers` for callers, `both` merges.",
+        ),
+        (
+            ("graph_neighborhood", "direction"),
+            "Which way to walk: `out` for what the focal depends on, `in` for what depends on it \
+             (blast radius), `both` merges.",
+        ),
+    ])
+}
+
+/// Replace one tool's top-level property descriptions with their short forms.
+///
+/// Top-level only. A nested schema below a property belongs to whatever
+/// contract that property describes, and on this belt the only deep ones are
+/// the transaction mutations that [`PROSE_EXEMPT_TOOLS`] keeps whole anyway.
+fn shorten_property_descriptions(tool: &str, schema: &mut serde_json::Value) {
+    if PROSE_EXEMPT_TOOLS.contains(&tool) {
+        return;
+    }
+    let shared = shared_property_descriptions();
+    let per_tool = tool_property_descriptions();
+    let Some(properties) = schema
+        .get_mut("properties")
+        .and_then(|value| value.as_object_mut())
+    else {
+        return;
+    };
+    for (name, property) in properties.iter_mut() {
+        let short = per_tool
+            .get(&(tool, name.as_str()))
+            .or_else(|| shared.get(name.as_str()));
+        let (Some(short), Some(property)) = (short, property.as_object_mut()) else {
+            continue;
+        };
+        if property.contains_key("description") {
+            property.insert(
+                "description".to_string(),
+                serde_json::Value::String((*short).to_string()),
+            );
+        }
+    }
+}
+
+/// Rewrite one served tool list for the `agent-default` profile: short tool
+/// descriptions, trimmed schemas, and short property descriptions inside the
+/// schemas that survive. Tool names are left exactly as registered, because two
+/// proofs that run only on `main` read `tools/list` and assert a name
+/// literally.
 ///
 /// A tool with no short form keeps its registered description, so adding a tool
 /// to the profile is never silently a tool with no description. The
@@ -445,6 +579,7 @@ pub fn compact_for_agent_default(list: &mut ToolsListResult) {
         if let Some(keep) = keeps.get(tool.name.as_str()) {
             trim_schema(&mut tool.input_schema, keep);
         }
+        shorten_property_descriptions(&tool.name, &mut tool.input_schema);
     }
     // No name is rewritten here, so the name order `tools::tool_definitions`
     // built survives untouched. A client caches the prompt it builds from


### PR DESCRIPTION
Founder ask: make the compaction work well. Measured first, then changed.

## What the belt costs, before and after

The served `agent-default` `tools/list` was dumped from the exact path the belt's own budget
tests use, and tokens are real counts from `google/gemma-4-e4b`, the model the demo runs, served
by LM Studio. There is no tokenize endpoint, so the count is `usage.prompt_tokens` from
`POST /v1/completions` with `max_tokens: 1` less the empty-prompt baseline of 1. The method was
controlled before use: empty costs 1 token, a 70-character string costs 15, the same string
doubled costs exactly 30, so it is additive.

| | before | after | delta |
|---|---|---|---|
| description bytes | 6,188 | 6,188 | 0 |
| schema bytes | 27,276 | 22,713 | -4,563 |
| **tools/list bytes** | **33,464** | **28,901** | **-4,563** |
| description tokens | 1,367 | 1,367 | 0 |
| schema tokens | 6,380 | 5,316 | -1,064 |
| **tools/list tokens** | **7,747** | **6,683** | **-1,064, 13.7 percent** |
| **default answer chars** | **45,000** | **12,000** | **-33,000** |
| **default answer tokens** | **~10,514** | **~2,804** | **-73 percent** |
| **calls per 24,000-token run** | **~2.3** | **~8.6** | |

Outside the two exempt transaction tools the schemas fall from 16,031 bytes to 11,468, a 28
percent cut of the addressable part.

**The prose work more than paid for the knobs #1368 restored.** Those knobs cost 2,919 bytes
across eleven property entries. Take them back out and the schema total would be 19,794, which
is 1,131 BELOW the 20,925 the original trim reached. The belt is smaller now than it was when
the knobs were missing, with every knob present.

## Where the bytes were

Two findings decided the work, both read rather than assumed.

`kin_transaction_stage` and `kin_transaction_commit` carry 11,245 bytes and 2,423 tokens between
them, 31 percent of every token in the list. Those are the nested transaction contracts the
original compaction left whole, and they stay whole here. See the note at the end.

One property description was repeated verbatim on seven tools: `max_chars` carried the same 649
characters on `semantic_locate`, `semantic_search`, `trace_path`, `find_references`,
`get_context_pack`, `impact_analysis` and `graph_neighborhood`. Thirteen non-frozen property
descriptions ran past 200 characters.

## Part one: property prose

`agent-default` now gets short property descriptions the way it already gets short tool
descriptions, in the belt rather than the registry, so `full` still serves every word. A
property whose meaning is the same everywhere is written once and shared; `direction` is written
per tool, because it walks callees on `trace_data_flow` and dependencies on `graph_neighborhood`
and one clause cannot honestly say both. The budget is 200 characters, stated in the module,
because the shape, bounds and default of a property are already machine-readable beside its
description and prose that restates them is paid for on every `tools/list`.

Nothing in the acceptance suite reads a property description, checked rather than assumed:
`magic_repro.py` `check_6` tests for the presence of the `include_body` or `compact` KEY,
`check_14` arm 3 reads the TOOL description, and `response_budget_elisions.py`
`grade_advertised_budget` reads only `maximum`, `default` and `minimum`.

## Part two: the response budget

This is the larger lever. `apply_belt_defaults` shaped only `semantic_locate`'s `surface` and
returned, so every other tool answered at its registered ceiling of 45,000 characters. At the
4.28 bytes per token measured on this profile's own JSON that is roughly 10,500 tokens for ONE
answer, so two default answers exhaust a 24,000-token run before the model has reasoned about
either. The default was catastrophic for exactly the case the belt exists for.

The new default is derived from one rule rather than taste: an agent must be able to make at
least six tool calls at default answer size inside a 24,000-token run and still have room to
answer. That puts one answer at about 2,800 tokens, which is about 12,000 characters.

So `agent-default` asks for 12,000 on the eight belt tools that register a budget,
`trace_data_flow` gets the SHAPE of a chain rather than its bodies as its own description
already recommends, and `get_context_pack`'s token budget comes down to 2,500 to fit inside the
same answer. The `full` profile keeps every registered default.

**Advertised and injected as the same number, deliberately.** The acceptance suite treats the
served schema as the contract an agent reads, so a belt that injected 12,000 while advertising
45,000 would be lying in the one place a caller looks. Only `default` moves; `minimum` and
`maximum` stay as registered, which is also what keeps `check_2` satisfied, since it requires
`minimum < default <= maximum`.

**The belt never outranks a caller.** `ResponseBudget::from_arguments` takes the FIRST of
`max_chars` then `max_response_chars` that is present, so an unconditional insert of `max_chars`
would silently override a caller who had passed `max_response_chars` and answer under a ceiling
they never asked for. Both spellings are checked before inserting, and the same rule applies to
`include_body` and its `compact` alias.

**No truncation line was needed.** Both disclosure paths already say the answer was cut and name
`max_chars` as the way to widen it: `disclose` carries "or raise max_chars, up to the 60000 this
server will build" plus a `max_chars` field, and `disclose_residual` carries "narrow the request,
or raise max_chars". Checked before writing anything, so nothing redundant was added.

## Why a derived default rather than a measured one

The empirical arm was not available. The demo daemons had exited, so measuring meant STARTING a
daemon on a 1.5 GB store; the `gpu` lock was held live by another lane mid-run with a
reservation already waiting; and swap was 13,083 MB of 14,336 MB, 91 percent consumed, at load
average 26. Starting that daemon would have been an authority-contention refusal on a live demo
store. None was started.

The derivation stands on its own: the current default is measured to be catastrophic for the
case the belt exists for, the new default is advertised on the served schema, and it is
overridable by the same `max_chars` every caller already sees. A derived default that ships
today with its arithmetic beside it beats a measured one that ships tomorrow.

One independent corroboration exists already, from another lane and not commissioned for this.
`scratchpad/reports/measure-react-vscode-sep02.md` records the agentic angle on the complete
facebook/react store with "budgets left at their defaults in every angle": the Kin side consumed
**24,557 tokens** and "produced no visible answer after 464 completion tokens of thinking",
ending in an error state with no verified block rendered. That is the failure this cap addresses,
observed at full store scale. It reports no per-call breakdown, so it corroborates the direction
rather than the number.

## Guards, each falsified

| guard | falsification | result |
|---|---|---|
| `no_agent_default_property_description_exceeds_its_budget` | lengthened one property description | 21 passed, 1 failed, naming `("trace_data_flow", "direction", 242)` |
| `no_agent_default_response_budget_is_advertised_above_the_cap` | left one tool at the registered 45,000 | 21 passed, 1 failed, naming `impact_analysis.max_chars advertises 45000, over the 12000-character cap` |

It asserts the advertised default and the injected value TOGETHER, because a belt that moved one
and not the other would pass any check reading a single side.

Two more guards carry no mutation because they are structural:
`the_belt_never_overrides_a_budget_the_caller_named`, and `the_budget_tool_list_matches_the_registry`,
which fails if the registry and the belt's list ever disagree about which tools carry a budget.

`the_belt_defaults_apply_to_locate_alone` is rewritten rather than deleted. Its durable
invariant, stated in its own comment, was that the belt may not inject an argument a tool does
not advertise; that now holds for every registered tool, against the registry rather than a list
of names, with `semantic_locate`'s `surface` named as the one unadvertised-by-design exception
and a control asserting some tool was left untouched.

## One number for the founder, not implemented here

`kin_transaction_stage` and `kin_transaction_commit` are 31 percent of the tokens an agent reads
before it can ask its first question, and an agent session that only reads never calls either of
them. The demo's session is one of those, and so is most discovery work. A read-only profile
that omits the mutation tools, or a served list split between read and mutate, would take that
31 percent off the belt for those sessions. That is a product decision with a number beside it,
and it is deliberately not implemented in this PR.

## Gates run

Both through `.kin-coord/bin/heavy-slot.sh`, never a bare cargo, no daemon started anywhere.

- `cargo test -p kin-mcp`: 851 passed, 0 failed.
- `bin/kin-precheck kin` on this tree at e2679a64d: 16 gates enumerated from ci.yml's own check
  job, 16 ran, 16 passed, 0 failed.
