### PR TITLE
Start no repo daemon until an MCP caller asks for a graph answer

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -270,6 +270,18 @@ jobs:
       - name: Falsify the first-query readiness graders
         run: python3 scripts/acceptance/first_query_readiness_repro.py --self-test
 
+      # FIR-3099. A daemon that starts opens the store and schedules the
+      # embedding pass, so a session that asked Kin nothing was paying for a
+      # full embed of the repository it happened to be launched in: 1.80 GiB
+      # and 99 percent of a core sixty seconds after a handshake, on a 657.8
+      # KiB store. The grader that decides it reads the process table, and a
+      # careless substring match there counts the suite's own driver, which
+      # carries both the daemon path and the repository path in its argv. Each
+      # case is paired with the input that must produce the opposite count,
+      # including that driver and another lane's daemon.
+      - name: Falsify the MCP spawn-admission graders
+        run: python3 scripts/acceptance/mcp_spawn_admission_repro.py --self-test
+
       # FIR-2781. The v0.6.0 stranger walked Session.send with limit_per_step 4
       # and got a chain that stops two hops short of where verify goes: the cap
       # discarded eleven of fifteen callees, HTTPAdapter.send among them, and
@@ -924,6 +936,32 @@ jobs:
             echo "::warning title=First-query readiness suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
           fi
 
+      - name: MCP spawn-admission suite (verdict comes from the gate step)
+        id: mcpspawn
+        if: always()
+        env:
+          KIN_ACCEPTANCE_LABEL: ${{ github.event_name }}-${{ github.sha }}
+        run: |
+          set -uo pipefail
+          mkdir -p acceptance
+          rc=0
+          python3 scripts/acceptance/mcp_spawn_admission_repro.py \
+            --kin target/release/kin \
+            --daemon target/release/kin-daemon \
+            --json acceptance/mcp_spawn.json >acceptance/mcp_spawn.log 2>&1 || rc=$?
+          cat acceptance/mcp_spawn.log
+          {
+            echo "### MCP spawn-admission suite (exit $rc)"
+            echo ''
+            echo '```'
+            grep -E '^CHECK ' acceptance/mcp_spawn.log || echo '(no CHECK line was printed)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning title=MCP spawn-admission suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
+          fi
+
       - name: Verdict-limits acceptance suite (verdict comes from the gate step)
         id: verdictlimits
         if: always()
@@ -1279,6 +1317,7 @@ jobs:
             --report first_contact=acceptance/first_contact.json \
             --report eject_journal=acceptance/eject_journal.json \
             --report first_query=acceptance/first_query.json \
+            --report mcp_spawn=acceptance/mcp_spawn.json \
             --report verdict_limits=acceptance/verdict_limits.json \
             --report working_copy_freshness=acceptance/working_copy_freshness.json \
             --report vcs_read_surfaces=acceptance/vcs_read_surfaces.json \

--- a/crates/kin-cli/src/commands/mcp.rs
+++ b/crates/kin-cli/src/commands/mcp.rs
@@ -31,6 +31,19 @@ use std::pin::Pin;
 /// immediately, and a `tools/call` that arrives before the binding settles is
 /// answered honestly that the daemon is still starting.
 ///
+/// Attach early, start on request (FIR-3099). Answering early moved the wait
+/// off the handshake; it did not make the work free. Resolving a repo daemon
+/// STARTS one when none is serving, and a daemon that starts opens the store
+/// and schedules the background embedding pass, so a session that made no Kin
+/// call at all was paying for a full embed of that repository: measured at 1.80
+/// GiB resident and 99 percent of a core sixty seconds after the handshake, on
+/// a 657.8 KiB store, with the fleet's gpu lock held by somebody else. Every
+/// bind this process performs before a caller asks for a graph answer therefore
+/// attaches to a daemon that is already serving and starts none, which keeps a
+/// warm session exactly as fast as it was; the first `tools/call` admits the
+/// spawn, and the binding task waiting on that admission then starts the daemon
+/// and settles as before.
+///
 /// `--no-spawn` is the probe contract (FIR-2341): this server binds only a
 /// daemon that is already serving and never starts one, neither in the
 /// startup binding nor through tool-call revival. It is carried as the
@@ -107,7 +120,12 @@ pub async fn start(
         move |roots: Vec<PathBuf>| -> Pin<Box<dyn Future<Output = kin_mcp::WorkspaceBinding> + Send>> {
             let startup = std::sync::Arc::clone(&binder_startup);
             Box::pin(async move {
-                bind_first_kin_repo(roots, startup.pinned_by_operator()).await
+                bind_first_kin_repo(
+                    roots,
+                    startup.pinned_by_operator(),
+                    DaemonBindMode::for_admission(startup.daemon_spawn_admitted()),
+                )
+                .await
             })
         },
     ));
@@ -157,6 +175,15 @@ async fn run_startup_binding(
     // later: once `kin init` has run, nothing on disk still says what the
     // launch directory looked like before it.
     kin_mcp::note_startup_repository(discovered.is_some());
+    // Publish the operator pin now rather than when its daemon binds. The
+    // workspace-roots binder reads it from this handle on the client's
+    // `roots/list` answer, which on a cold repository now always arrives before
+    // the bind settles, and a binder reading `false` would follow the client off
+    // the repository `--repo`/`KIN_MCP_REPO` named. A pin that resolves to no
+    // repository is still not a pin, which is why this is gated on discovery.
+    if repo_override.is_some() && discovered.is_some() {
+        startup.note_operator_pin();
+    }
     if let Some(layout) = &discovered {
         let kin_root = layout.root().to_path_buf();
         startup.set_phase_probe(Box::new(move || {
@@ -164,7 +191,7 @@ async fn run_startup_binding(
         }));
     }
 
-    let unbound_reason = match bind_daemon_for_repo_dir(&cwd).await {
+    let unbound_reason = match bind_daemon_when_asked(&cwd, &startup).await {
         Ok(daemon_url) => {
             eprintln!("{}", session_authority_notice());
             eprintln!("Kin MCP: forwarding graph tools to repo daemon at {daemon_url}");
@@ -486,7 +513,7 @@ async fn bind_from_registry(startup: &kin_mcp::StartupDaemonBinding) -> Option<k
                     crate::daemon_client::daemon_startup_phase(&kin_root)
                 }));
             }
-            match bind_daemon_for_repo_dir(&path).await {
+            match bind_daemon_when_asked(&path, startup).await {
                 Ok(daemon_url) => {
                     // Match the roots path: the daemon delegate reads the
                     // per-install loopback token from <root>/.kin/daemon.token
@@ -550,8 +577,9 @@ async fn bind_from_registry(startup: &kin_mcp::StartupDaemonBinding) -> Option<k
 async fn bind_first_kin_repo(
     roots: Vec<PathBuf>,
     pinned_by_operator: bool,
+    mode: DaemonBindMode,
 ) -> kin_mcp::WorkspaceBinding {
-    bind_first_kin_repo_against(roots, bound_repo_working_dir(), pinned_by_operator).await
+    bind_first_kin_repo_against(roots, bound_repo_working_dir(), pinned_by_operator, mode).await
 }
 
 /// Core of [`bind_first_kin_repo`] with the currently bound repository as an
@@ -562,6 +590,7 @@ async fn bind_first_kin_repo_against(
     roots: Vec<PathBuf>,
     bound_repo: Option<PathBuf>,
     pinned_by_operator: bool,
+    mode: DaemonBindMode,
 ) -> kin_mcp::WorkspaceBinding {
     // `KinLayout::discover` is filesystem-rooted: it walks up from each root and
     // finds a `.kin/` or nothing, regardless of which daemon this process is
@@ -625,7 +654,14 @@ async fn bind_first_kin_repo_against(
     }
 
     for working_dir in candidates.iter() {
-        let Ok(url) = bind_daemon_for_repo_dir(working_dir).await else {
+        // `mode` is the whole of this loop's part in FIR-3099. This binder runs
+        // inline in the stdio loop, on the client's `roots/list` answer, which
+        // arrives before the client has asked Kin anything. Attaching to a
+        // daemon that is already serving is free; starting one is not, so
+        // before the first `tools/call` a candidate with no running daemon is
+        // skipped and reported as `OtherRepository`, which the server keeps and
+        // puts through this binder again on that first call.
+        let Ok(url) = bind_daemon_for_repo_dir(working_dir, mode).await else {
             continue;
         };
         // Point the process at the bound repo so the daemon delegate resolves
@@ -719,22 +755,128 @@ fn resolve_repo_override(repo_arg: Option<PathBuf>) -> Option<PathBuf> {
 /// hard error: `kin mcp start` must always reach the stdio loop so
 /// `initialize`/`tools/list` succeed even when no repository is bound yet,
 /// with individual `tools/call` requests failing loud instead.
-async fn bind_daemon_for_repo_dir(dir: &Path) -> std::result::Result<String, String> {
+async fn bind_daemon_for_repo_dir(
+    dir: &Path,
+    mode: DaemonBindMode,
+) -> std::result::Result<String, BindRefusal> {
     if let Ok(url) = std::env::var("KIN_DAEMON_URL") {
         if !url.trim().is_empty() {
             return Ok(url);
         }
     }
     let layout = crate::commands::require_repository_layout_at(dir)
-        .map_err(|refusal| format!("{refusal:#}"))?;
+        .map_err(|refusal| BindRefusal::Reason(format!("{refusal:#}")))?;
+    if mode == DaemonBindMode::AttachOnly {
+        // Deliberately the resolver `kin doctor` reads from, not a second
+        // opinion: it answers for a daemon that is already serving and starts
+        // nothing. `None` here is not a failure, it is "a repository is here and
+        // nobody is serving it yet", which is the state a session that has asked
+        // for nothing is supposed to be left in.
+        return match crate::daemon_client::resolve_daemon_url_if_running_async(&layout).await {
+            Some(url) => {
+                std::env::set_var("KIN_DAEMON_URL", &url);
+                Ok(url)
+            }
+            None => Err(BindRefusal::SpawnNotAdmitted),
+        };
+    }
     let url = crate::daemon_client::resolve_daemon_url_for_mcp(&layout)
         .await
-        .map_err(|e| format!("{e:#}"))?
+        .map_err(|e| BindRefusal::Reason(format!("{e:#}")))?
         .ok_or_else(|| {
-            crate::daemon_client::daemon_required_error("MCP startup", &layout).to_string()
+            BindRefusal::Reason(
+                crate::daemon_client::daemon_required_error("MCP startup", &layout).to_string(),
+            )
         })?;
     std::env::set_var("KIN_DAEMON_URL", &url);
     Ok(url)
+}
+
+/// Whether a bind may START a repo daemon or may only attach to one that is
+/// already serving.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DaemonBindMode {
+    /// Bind a daemon already serving this repository. Start none.
+    AttachOnly,
+    /// Start a daemon when none is serving.
+    SpawnIfNeeded,
+}
+
+impl DaemonBindMode {
+    /// The mode a bind runs in, from whether a `tools/call` has admitted a
+    /// spawn. Pure, so the rule is readable without a server.
+    pub(crate) fn for_admission(spawn_admitted: bool) -> Self {
+        if spawn_admitted {
+            Self::SpawnIfNeeded
+        } else {
+            Self::AttachOnly
+        }
+    }
+}
+
+/// Why a bind produced no daemon URL.
+///
+/// The two are kept apart because they mean opposite things to a caller. A
+/// reason is final for this bind's inputs and is what the operator is told. A
+/// spawn that was not admitted is a state, not a failure: the repository is
+/// there, nothing is serving it, and the same bind will succeed the moment
+/// somebody asks Kin a question.
+#[derive(Debug)]
+pub(crate) enum BindRefusal {
+    /// No daemon, and none can be had here. Carries the sentence to report.
+    Reason(String),
+    /// A Kin repository is here with no daemon serving it, and no caller has
+    /// asked for a graph answer yet.
+    SpawnNotAdmitted,
+}
+
+impl BindRefusal {
+    /// The sentence a caller reports for this refusal.
+    pub(crate) fn reason(self) -> String {
+        match self {
+            Self::Reason(reason) => reason,
+            Self::SpawnNotAdmitted => {
+                "no daemon is serving this repository yet and no tool call has asked for one"
+                    .to_string()
+            }
+        }
+    }
+}
+
+/// Bind the daemon for `dir`, attaching to a running one now and starting one
+/// only once a `tools/call` has asked for a graph answer.
+///
+/// For the launcher's background binding task, which is the one place that has
+/// somewhere to wait: the stdio loop keeps serving `initialize` and
+/// `tools/list` the whole time this is parked. The workspace-roots binder runs
+/// inside that loop and so cannot wait here; it asks the admission instead and
+/// leaves its roots for the first tool call to retry.
+async fn bind_daemon_when_asked(
+    dir: &Path,
+    startup: &kin_mcp::StartupDaemonBinding,
+) -> std::result::Result<String, String> {
+    match bind_daemon_for_repo_dir(dir, DaemonBindMode::AttachOnly).await {
+        Ok(url) => return Ok(url),
+        // Not a repository, or a repository whose daemon this process cannot
+        // reach for a reason of its own. Neither improves by waiting.
+        Err(BindRefusal::Reason(reason)) => return Err(reason),
+        Err(BindRefusal::SpawnNotAdmitted) => {}
+    }
+    if crate::daemon_client::daemon_spawns_are_disabled() {
+        // The probe contract. No tool call will ever start a daemon here, so
+        // waiting for one to ask would leave this binding pending forever and
+        // every call answered "the daemon is still starting" about a daemon
+        // nothing will start. Settle now and let each call fail loud instead.
+        return Err(
+            "KIN_NO_DAEMON is set (or --no-spawn was passed) and no daemon is already \
+             serving this repository, so this server binds none"
+                .to_string(),
+        );
+    }
+    startup.await_daemon_spawn_admission().await;
+    bind_daemon_for_repo_dir(dir, DaemonBindMode::SpawnIfNeeded)
+        .await
+        .map_err(BindRefusal::reason)
 }
 
 #[cfg(test)]
@@ -742,8 +884,8 @@ mod tests {
     use super::{
         bind_daemon_for_repo_dir, bind_first_kin_repo_against, build_mcp_start_config,
         registry_should_resolve, registry_startup_choice, resolve_repo_override,
-        resolve_tool_profile, session_authority_notice, McpToolProfile, RegistryStartupChoice,
-        ToolProfileSource,
+        resolve_tool_profile, session_authority_notice, BindRefusal, DaemonBindMode,
+        McpToolProfile, RegistryStartupChoice, ToolProfileSource,
     };
     use kin_core::registry::{KinRegistry, RegisteredRepo};
     use kin_core::test_env::EnvVarGuard;
@@ -1010,9 +1152,10 @@ mod tests {
         // propagated out of `start`.
         let _daemon_guard = EnvVarGuard::unset("KIN_DAEMON_URL");
         let tmp = tempfile::tempdir().unwrap();
-        let reason = bind_daemon_for_repo_dir(tmp.path())
+        let reason = bind_daemon_for_repo_dir(tmp.path(), DaemonBindMode::SpawnIfNeeded)
             .await
-            .expect_err("a directory with no .kin/ must not resolve a daemon");
+            .expect_err("a directory with no .kin/ must not resolve a daemon")
+            .reason();
         assert!(
             reason.contains("not a Kin repository"),
             "unexpected reason: {reason}"
@@ -1052,6 +1195,7 @@ mod tests {
                 vec![repo.path().to_path_buf()],
                 Some(repo_dir.clone()),
                 false,
+                DaemonBindMode::SpawnIfNeeded,
             )
             .await,
             "the bound repository still being open must stay bound",
@@ -1083,6 +1227,7 @@ mod tests {
             vec![switched_to.path().to_path_buf()],
             Some(std::fs::canonicalize(previous.path()).unwrap()),
             false,
+            DaemonBindMode::SpawnIfNeeded,
         )
         .await;
 
@@ -1114,6 +1259,7 @@ mod tests {
                 vec![other.path().to_path_buf(), bound.path().to_path_buf()],
                 Some(bound_dir.clone()),
                 false,
+                DaemonBindMode::SpawnIfNeeded,
             )
             .await,
             "the bound repository being open anywhere must keep the binding",
@@ -1139,6 +1285,7 @@ mod tests {
             vec![other.path().to_path_buf()],
             Some(std::fs::canonicalize(pinned.path()).unwrap()),
             true,
+            DaemonBindMode::SpawnIfNeeded,
         )
         .await;
 
@@ -1166,6 +1313,7 @@ mod tests {
                 vec![pinned.path().to_path_buf()],
                 Some(pinned_dir.clone()),
                 true,
+                DaemonBindMode::SpawnIfNeeded,
             )
             .await,
             "roots naming the pinned repository must stay bound",
@@ -1183,7 +1331,13 @@ mod tests {
         let _no_daemon_guard = EnvVarGuard::set("KIN_NO_DAEMON", "1");
         let plain = tempfile::tempdir().unwrap();
         assert_eq!(
-            bind_first_kin_repo_against(vec![plain.path().to_path_buf()], None, false).await,
+            bind_first_kin_repo_against(
+                vec![plain.path().to_path_buf()],
+                None,
+                false,
+                DaemonBindMode::SpawnIfNeeded,
+            )
+            .await,
             kin_mcp::WorkspaceBinding::Unresolvable,
         );
     }
@@ -1212,7 +1366,13 @@ mod tests {
         );
 
         assert_eq!(
-            bind_first_kin_repo_against(vec![host_only], Some(served_dir.clone()), false).await,
+            bind_first_kin_repo_against(
+                vec![host_only],
+                Some(served_dir.clone()),
+                false,
+                DaemonBindMode::SpawnIfNeeded,
+            )
+            .await,
             kin_mcp::WorkspaceBinding::Unresolvable,
             "a root that resolves to no Kin repository here must not be reported as a switch"
         );
@@ -1222,9 +1382,13 @@ mod tests {
         // verdict tracks what the filesystem says rather than always answering
         // `Unresolvable`.
         let other = kin_repo_fixture();
-        let moved =
-            bind_first_kin_repo_against(vec![other.path().to_path_buf()], Some(served_dir), false)
-                .await;
+        let moved = bind_first_kin_repo_against(
+            vec![other.path().to_path_buf()],
+            Some(served_dir),
+            false,
+            DaemonBindMode::SpawnIfNeeded,
+        )
+        .await;
         assert!(
             matches!(moved, kin_mcp::WorkspaceBinding::OtherRepository(_)),
             "a visible second repository must be reported as another repository: {moved:?}"
@@ -1240,9 +1404,51 @@ mod tests {
         // survive the lazy-binding rework unchanged.
         let _guard = EnvVarGuard::set("KIN_DAEMON_URL", "http://127.0.0.1:4242");
         let tmp = tempfile::tempdir().unwrap();
-        let url = bind_daemon_for_repo_dir(tmp.path())
+        let url = bind_daemon_for_repo_dir(tmp.path(), DaemonBindMode::SpawnIfNeeded)
             .await
             .expect("an explicit KIN_DAEMON_URL must be trusted without repo discovery");
         assert_eq!(url, "http://127.0.0.1:4242");
+    }
+
+    /// FIR-3099, at the seam that decides it. Whether a bind may start a daemon
+    /// is a function of one thing: whether a caller has asked for a graph
+    /// answer. Both directions, because a mode that is always `SpawnIfNeeded`
+    /// would pass a test that only checked the admitted case.
+    #[test]
+    fn only_an_admitted_spawn_lets_a_bind_start_a_daemon() {
+        assert_eq!(
+            DaemonBindMode::for_admission(false),
+            DaemonBindMode::AttachOnly,
+            "before a tool call a bind must attach to a running daemon and start none"
+        );
+        assert_eq!(
+            DaemonBindMode::for_admission(true),
+            DaemonBindMode::SpawnIfNeeded,
+            "once a caller has asked for a graph answer the bind must be able to start one"
+        );
+    }
+
+    /// A repository with no daemon yet is a state, not a failure, and the two
+    /// must not collapse into one message. The operator-facing sentence belongs
+    /// to a bind that genuinely cannot produce a daemon.
+    #[tokio::test]
+    #[serial]
+    async fn an_unadmitted_spawn_refuses_without_claiming_the_repository_is_broken() {
+        let _daemon_guard = EnvVarGuard::unset("KIN_DAEMON_URL");
+        let repo = kin_repo_fixture();
+        let refusal = bind_daemon_for_repo_dir(repo.path(), DaemonBindMode::AttachOnly)
+            .await
+            .expect_err("no daemon is running for a fresh fixture, and none may be started");
+        assert!(
+            matches!(refusal, BindRefusal::SpawnNotAdmitted),
+            "an attach-only bind over a real repository with no daemon must report the \
+             unadmitted spawn, not a reason: {refusal:?}"
+        );
+        assert!(
+            std::env::var("KIN_DAEMON_URL")
+                .map(|url| url.trim().is_empty())
+                .unwrap_or(true),
+            "an attach-only bind that found no daemon must not pin a daemon URL"
+        );
     }
 }

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -7823,6 +7823,18 @@ pub fn resolve_daemon_url_if_running(layout: &KinLayout) -> Option<String> {
     None
 }
 
+/// Whether this process is forbidden to start daemons at all.
+///
+/// `KIN_NO_DAEMON` is the variable behind `kin mcp start --no-spawn`, and the
+/// MCP launcher needs the answer to tell two states apart that otherwise look
+/// identical from a bind that found no daemon: "nobody has asked for one yet",
+/// which is worth waiting on, and "this process will never start one", which
+/// settles now so every tool call fails loud with the remedy instead of being
+/// told a daemon is on its way.
+pub(crate) fn daemon_spawns_are_disabled() -> bool {
+    is_transient_bool_env("KIN_NO_DAEMON")
+}
+
 pub async fn resolve_daemon_url_if_running_async(layout: &KinLayout) -> Option<String> {
     if let Ok(url) = std::env::var("KIN_DAEMON_URL") {
         if url.trim().is_empty() {

--- a/crates/kin-mcp/src/server.rs
+++ b/crates/kin-mcp/src/server.rs
@@ -340,6 +340,14 @@ where
             // remedy-flavored "no daemon" error while one is on its way up.
             if method == Some("tools/call") {
                 if let Some(startup) = startup.as_ref() {
+                    // The first ask for a graph answer, and the only thing that
+                    // admits starting a daemon (FIR-3099). Before this line
+                    // every bind path attaches to a daemon that is already
+                    // serving and starts none, so a session that never calls a
+                    // tool never opens the store and never runs an embedding
+                    // pass. Set before the wait, because the wait is what the
+                    // launcher's binding task is sitting on.
+                    startup.admit_daemon_spawn();
                     if !startup
                         .wait_until_settled(TOOLS_CALL_STARTUP_BIND_GRACE)
                         .await
@@ -354,6 +362,24 @@ where
                     if !binding.is_bound() {
                         if let StartupBindingState::Bound(bound) = startup.snapshot() {
                             binding.bind(bound, BindingOrigin::Server);
+                        }
+                    }
+                    // Roots the pre-call binder resolved to a Kin repository it
+                    // was not yet allowed to start a daemon for. Put them
+                    // through the binder again now that it is. This is the
+                    // editor-launched-from-$HOME shape, where the client's roots
+                    // are the only thing naming a repository and the launch
+                    // directory settles unbound at once, so nothing was waited
+                    // for above. After the settle, not before it, so a startup
+                    // binding that is about to bind the same repository wins and
+                    // no second daemon is raced for it.
+                    if !binding.is_bound() {
+                        let deferred = binding.deferred_roots();
+                        if !deferred.is_empty() {
+                            if let Some(binder) = repo_binder.as_ref() {
+                                apply_workspace_roots(binder, deferred, &mut binding, repo_pinned)
+                                    .await;
+                            }
                         }
                     }
                 }
@@ -509,7 +535,20 @@ async fn apply_workspace_roots(
                  can resolve; keeping the repository this server was started with"
             );
         }
-        WorkspaceBinding::OtherRepository(_) | WorkspaceBinding::Unresolvable => {
+        // Nothing is bound and the client named Kin repositories this server can
+        // see. Before FIR-3099 that could only mean their daemons refused to
+        // start, so there was nothing to retry. Now it is also what a bind that
+        // is not yet allowed to start one looks like, so the roots are kept for
+        // the first `tools/call` to put through the binder again.
+        WorkspaceBinding::OtherRepository(repos) => {
+            tracing::info!(
+                repositories = ?repos,
+                "kin-mcp: the client's workspace roots name a Kin repository with no daemon bound \
+                 yet; the first tool call binds it"
+            );
+            binding.defer_roots(roots);
+        }
+        WorkspaceBinding::Unresolvable => {
             tracing::info!("kin-mcp: no Kin repository among the client's workspace roots");
         }
     }
@@ -552,6 +591,11 @@ struct RepoBindingState {
     /// Set when the client's workspace moved somewhere this server could not
     /// follow. Cleared by the next successful bind.
     mismatch: Option<WorkspaceMismatch>,
+    /// Roots that named a Kin repository this server can see while nothing was
+    /// bound. Kept so the first `tools/call` can put them through the binder
+    /// again once starting a daemon is admitted. Cleared by the next successful
+    /// bind.
+    deferred_roots: Vec<PathBuf>,
 }
 
 /// A workspace change the server could not follow: it is still bound to
@@ -596,6 +640,22 @@ impl RepoBindingState {
         self.repo_root = Some(bound.root);
         self.origin = Some(origin);
         self.mismatch = None;
+        self.deferred_roots.clear();
+    }
+
+    /// Remember roots that resolved to a Kin repository nothing is serving yet.
+    fn defer_roots(&mut self, roots: Vec<PathBuf>) {
+        self.deferred_roots = roots;
+    }
+
+    /// The roots waiting for a tool call to admit starting their daemon.
+    ///
+    /// Cloned rather than taken, so a call whose bind still fails leaves them
+    /// for the next one. That costs a bind attempt per refused call, which is
+    /// the same trade the mismatch retry above already makes and for the same
+    /// reason: every call in this state is being refused anyway.
+    fn deferred_roots(&self) -> Vec<PathBuf> {
+        self.deferred_roots.clone()
     }
 
     fn mark_mismatch(&mut self, requested_roots: Vec<PathBuf>, repo_pinned: bool) {
@@ -2692,6 +2752,122 @@ mod tests {
                 tool["name"]
             );
         }
+    }
+
+    /// FIR-3099. The whole handshake, and a workspace-roots answer beside it,
+    /// must leave the launcher's binding task still waiting: none of them is a
+    /// caller asking Kin for a graph answer, and starting a daemon for one costs
+    /// the store open and a full embedding pass.
+    ///
+    /// The roots answer is in the script on purpose. It is the second spawn
+    /// door and the only one that fires when the server was launched outside a
+    /// repository, so a fix that closed the startup binding alone would pass a
+    /// version of this test that omitted it.
+    #[tokio::test]
+    async fn a_handshake_and_a_roots_answer_admit_no_daemon_spawn() {
+        let startup = StartupDaemonBinding::new();
+        let seen_roots = std::sync::Arc::new(std::sync::Mutex::new(Vec::<PathBuf>::new()));
+        let recorder = std::sync::Arc::clone(&seen_roots);
+        let binder: RepoBinder = Box::new(move |roots: Vec<PathBuf>| {
+            let recorder = std::sync::Arc::clone(&recorder);
+            Box::pin(async move {
+                recorder.lock().unwrap().extend(roots);
+                // What an attach-only bind reports for a repository this server
+                // can see with no daemon serving it yet.
+                WorkspaceBinding::OtherRepository(vec![PathBuf::from("/work/repo")])
+            })
+        });
+
+        drive_daemon_loop_with_startup(
+            &[
+                initialize_with_roots_capability(),
+                serde_json::json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+                serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+                roots_response(&["/work/repo"]),
+            ],
+            Some(binder),
+            None,
+            Some(std::sync::Arc::clone(&startup)),
+        )
+        .await;
+
+        assert!(
+            !startup.daemon_spawn_admitted(),
+            "initialize, initialized, tools/list and a roots answer must not admit starting a \
+             daemon: every one of them arrives before a caller has asked Kin anything"
+        );
+        assert!(
+            !seen_roots.lock().unwrap().is_empty(),
+            "the binder must still have been consulted, or this test would pass on a server \
+             that ignores workspace roots entirely"
+        );
+    }
+
+    /// The other direction, which is what keeps the test above from passing on
+    /// a server that can never start a daemon at all.
+    #[tokio::test]
+    async fn the_first_tool_call_admits_the_daemon_spawn() {
+        let startup = StartupDaemonBinding::new();
+        startup.resolve_unbound("no repository at the launch directory");
+
+        drive_daemon_loop_with_startup(
+            &[
+                initialize_with_roots_capability(),
+                tool_call(3, "semantic_locate"),
+            ],
+            None,
+            None,
+            Some(std::sync::Arc::clone(&startup)),
+        )
+        .await;
+
+        assert!(
+            startup.daemon_spawn_admitted(),
+            "a tools/call is a caller asking for a graph answer, and must admit the spawn the \
+             answer needs"
+        );
+    }
+
+    /// Roots a pre-call bind could not follow are kept, not discarded, so the
+    /// first tool call binds the repository the client named instead of
+    /// reporting no daemon for a repository Kin can see.
+    #[tokio::test]
+    async fn deferred_roots_are_rebound_on_the_first_tool_call() {
+        let startup = StartupDaemonBinding::new();
+        startup.resolve_unbound("no repository at the launch directory");
+        let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counter = std::sync::Arc::clone(&calls);
+        let binder: RepoBinder = Box::new(move |_roots: Vec<PathBuf>| {
+            let counter = std::sync::Arc::clone(&counter);
+            Box::pin(async move {
+                // First pass is the attach-only bind, which found no daemon.
+                // Second pass runs with the spawn admitted and binds.
+                if counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                    WorkspaceBinding::OtherRepository(vec![PathBuf::from("/work/repo")])
+                } else {
+                    WorkspaceBinding::Bound(bound_repo("/work/repo", "http://127.0.0.1:4311"))
+                }
+            })
+        });
+
+        drive_daemon_loop_with_startup(
+            &[
+                initialize_with_roots_capability(),
+                roots_response(&["/work/repo"]),
+                tool_call(3, "semantic_locate"),
+            ],
+            Some(binder),
+            None,
+            Some(std::sync::Arc::clone(&startup)),
+        )
+        .await;
+
+        assert_eq!(
+            calls.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "the tool call must put the deferred roots through the binder again, now that \
+             starting their daemon is admitted"
+        );
     }
 
     async fn drive_daemon_loop(

--- a/crates/kin-mcp/src/startup_binding.rs
+++ b/crates/kin-mcp/src/startup_binding.rs
@@ -17,6 +17,18 @@
 //! daemon is still starting instead of hanging or failing as if no daemon
 //! could ever exist.
 //!
+//! The handle carries a second gate for the same reason it carries the first.
+//! Moving the bind behind the loop made the handshake fast; it did not make it
+//! free. A bind that resolves cold STARTS a daemon, and a daemon that starts
+//! opens the store and schedules the background embedding pass, so a session
+//! that asked Kin nothing was paying minutes of CPU or GPU and gigabytes of
+//! resident memory for a repository nobody had queried (FIR-3099: 1.80 GiB and
+//! 99 percent of a core sixty seconds after a handshake, on a 657.8 KiB store).
+//! So spawning is admitted rather than assumed: the launcher may attach to a
+//! daemon that is already serving, which costs nothing, and waits here for the
+//! server to admit a spawn. The server admits it on the first `tools/call`,
+//! which is the first moment a caller has actually asked for a graph answer.
+//!
 //! This crate is an answer surface under the zero-file-search rule and carries
 //! no filesystem primitive. The startup-phase detail in the still-starting
 //! report comes from a probe the launcher injects; the daemon-lifecycle IO
@@ -67,6 +79,10 @@ pub struct StartupDaemonBinding {
     /// The workspace-roots binder must not repoint such a binding, and with the
     /// bind running behind the loop this is only known once it settles.
     pinned_by_operator: AtomicBool,
+    /// Whether a caller has asked for a graph answer yet, which is what admits
+    /// starting a daemon for this repository. A watch channel rather than a
+    /// flag because the launcher's binding task waits on it.
+    spawn_admitted: tokio::sync::watch::Sender<bool>,
     began: Instant,
 }
 
@@ -75,6 +91,7 @@ impl std::fmt::Debug for StartupDaemonBinding {
         f.debug_struct("StartupDaemonBinding")
             .field("state", &*self.state.borrow())
             .field("pinned_by_operator", &self.pinned_by_operator())
+            .field("daemon_spawn_admitted", &self.daemon_spawn_admitted())
             .finish_non_exhaustive()
     }
 }
@@ -86,6 +103,7 @@ impl StartupDaemonBinding {
             state,
             phase_probe: Mutex::new(None),
             pinned_by_operator: AtomicBool::new(false),
+            spawn_admitted: tokio::sync::watch::channel(false).0,
             began: Instant::now(),
         })
     }
@@ -98,6 +116,21 @@ impl StartupDaemonBinding {
         if let Ok(mut guard) = self.phase_probe.lock() {
             *guard = Some(probe);
         }
+    }
+
+    /// Record that `--repo`/`KIN_MCP_REPO` names a repository this process can
+    /// see, before its daemon has been resolved.
+    ///
+    /// The pin used to be published only by `resolve_bound`, which meant it was
+    /// unknown until the daemon bound. That was already a race with the
+    /// client's `roots/list` answer, and deferring the daemon start until the
+    /// first `tools/call` would have widened it into the normal case: on a cold
+    /// repository the roots answer ALWAYS arrives first, and a binder reading
+    /// `false` here is free to follow the client off the repository the
+    /// operator pinned. A pin that names no repository still does not count,
+    /// which is the distinction this keeps.
+    pub fn note_operator_pin(&self) {
+        self.pinned_by_operator.store(true, Ordering::Release);
     }
 
     /// Settle the binding with a bound daemon. `pinned_by_operator` marks a
@@ -119,6 +152,48 @@ impl StartupDaemonBinding {
         self.state.send_replace(StartupBindingState::Unbound {
             reason: reason.into(),
         });
+    }
+
+    /// Record that a caller has asked for a graph answer, which admits starting
+    /// a daemon for this repository.
+    ///
+    /// Called by the stdio loop on `tools/call` and by nothing else: the
+    /// handshake, the tool list and the client's workspace roots are all things
+    /// a client sends before it has asked Kin anything, and none of them is a
+    /// reason to open a store and start an embedding pass. Idempotent, and
+    /// `send_replace` rather than `send` for the same reason the state channel
+    /// uses it: there is usually no subscriber, because the launcher's binding
+    /// task subscribes only while it is actually waiting.
+    pub fn admit_daemon_spawn(&self) {
+        self.spawn_admitted.send_replace(true);
+    }
+
+    /// Whether a `tools/call` has admitted starting a daemon.
+    ///
+    /// Read by every bind path that could start one, including the
+    /// workspace-roots binder, which runs inline in the stdio loop and so must
+    /// ask rather than wait.
+    pub fn daemon_spawn_admitted(&self) -> bool {
+        *self.spawn_admitted.borrow()
+    }
+
+    /// Resolve once a `tools/call` has admitted starting a daemon.
+    ///
+    /// For the launcher's background binding task, which has somewhere to wait.
+    /// Returns immediately when admission already happened.
+    pub async fn await_daemon_spawn_admission(&self) {
+        let mut receiver = self.spawn_admitted.subscribe();
+        loop {
+            if *receiver.borrow_and_update() {
+                return;
+            }
+            if receiver.changed().await.is_err() {
+                // The sender lives in this same struct, so this arm is
+                // unreachable while `self` is alive. Returning rather than
+                // spinning keeps a future refactor from wedging the binder.
+                return;
+            }
+        }
     }
 
     pub fn pinned_by_operator(&self) -> bool {
@@ -239,6 +314,87 @@ mod tests {
         assert!(
             began.elapsed() < Duration::from_secs(5),
             "a settled binding must answer immediately, not sit out the grace"
+        );
+    }
+
+    /// The whole of FIR-3099 in one assertion: nothing about creating a
+    /// binding, settling it, or pinning it admits starting a daemon. Only a
+    /// `tools/call` does, and the stdio loop is the only caller of
+    /// `admit_daemon_spawn`.
+    /// A pin is known as soon as the launch directory resolves, not when its
+    /// daemon does, because the workspace-roots binder asks before then.
+    #[test]
+    fn an_operator_pin_is_published_before_its_daemon_binds() {
+        let binding = StartupDaemonBinding::new();
+        assert!(!binding.pinned_by_operator());
+        binding.note_operator_pin();
+        assert!(
+            binding.pinned_by_operator(),
+            "a pin must be readable while the binding is still pending, or a roots answer that \
+             arrives first repoints the repository the operator named"
+        );
+        assert!(matches!(binding.snapshot(), StartupBindingState::Pending));
+        // Settling later must not unset it.
+        binding.resolve_bound(
+            BoundRepo {
+                root: PathBuf::from("/repo"),
+                daemon_url: "http://127.0.0.1:4242".to_string(),
+            },
+            true,
+        );
+        assert!(binding.pinned_by_operator());
+    }
+
+    #[test]
+    fn a_fresh_binding_does_not_admit_starting_a_daemon() {
+        let binding = StartupDaemonBinding::new();
+        assert!(
+            !binding.daemon_spawn_admitted(),
+            "a server that has been asked nothing must not admit starting a daemon"
+        );
+        binding.resolve_bound(
+            BoundRepo {
+                root: PathBuf::from("/repo"),
+                daemon_url: "http://127.0.0.1:4242".to_string(),
+            },
+            true,
+        );
+        assert!(
+            !binding.daemon_spawn_admitted(),
+            "attaching to a daemon that was already serving is not a caller asking for one"
+        );
+        binding.admit_daemon_spawn();
+        assert!(binding.daemon_spawn_admitted());
+        binding.admit_daemon_spawn();
+        assert!(
+            binding.daemon_spawn_admitted(),
+            "admission is idempotent: a second tool call must not unset it"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn the_binder_waits_for_admission_and_wakes_on_it() {
+        let binding = StartupDaemonBinding::new();
+        let waiter = std::sync::Arc::clone(&binding);
+        let wait = tokio::spawn(async move { waiter.await_daemon_spawn_admission().await });
+        tokio::time::sleep(Duration::from_secs(3600)).await;
+        assert!(
+            !wait.is_finished(),
+            "with no tool call the binding task must still be waiting an hour later,              not have started a daemon"
+        );
+        binding.admit_daemon_spawn();
+        wait.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn admission_that_already_happened_is_not_waited_for() {
+        let binding = StartupDaemonBinding::new();
+        binding.admit_daemon_spawn();
+        let began = Instant::now();
+        binding.await_daemon_spawn_admission().await;
+        assert!(
+            began.elapsed() < Duration::from_secs(5),
+            "an already-admitted spawn must not make the binder wait for a second call"
         );
     }
 

--- a/docs/session-runtime.md
+++ b/docs/session-runtime.md
@@ -244,6 +244,32 @@ The authoritative list of behavior-relevant variables is defined once in
 `kin-core` (`behavior_env`) and shared by both the daemon (which reports them)
 and the CLI (which compares them), so the two sides cannot drift apart.
 
+## When an MCP session starts a daemon
+
+`kin mcp start` starts no daemon until a caller asks for a graph answer. The
+first `tools/call` is that ask, and it is the only one: `initialize`, the tool
+list and the client's `roots/list` answer all arrive before anything has been
+asked of Kin, so none of them starts a daemon.
+
+Before that first call, every bind the server performs attaches to a daemon that
+is already serving the repository and starts none. A session opened beside a
+warm daemon is therefore exactly as fast as it ever was; a session opened on a
+repository nothing is serving stays at the cost of the stdio process until it is
+used.
+
+The reason is what a daemon start costs. Starting one opens the store and
+schedules the background embedding pass, which on a repository of any size is
+minutes of CPU or GPU and gigabytes of resident memory. Measured on 2026-09-02
+against a 657.8 KiB fixture store, the old behavior reached 1.80 GiB resident and
+99 percent of a core sixty seconds after a handshake, in a session that made no
+Kin call at all.
+
+The first call on a cold repository still pays for the start it needs. When the
+daemon is not ready inside the server's brief grace, that call is answered with
+the honest still-starting report naming the phase and the elapsed seconds, and
+the remedy is to retry rather than to restart anything. `KIN_DAEMON_AUTO_EMBED=0`
+remains the way to keep a daemon from embedding at all once it is running.
+
 ## Supervisor scope: what `KIN_HOME` does and does not bound
 
 Kin runs one worker daemon per repository and one **supervisor** per machine.

--- a/scripts/acceptance/mcp_spawn_admission_repro.py
+++ b/scripts/acceptance/mcp_spawn_admission_repro.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""What an MCP session costs a repository it has asked nothing about.
+
+FIR-3099. `kin mcp start` used to resolve its repo daemon from a task it
+started beside the stdio loop, and the workspace-roots binder resolved one
+again from the client's `roots/list` answer. Resolving a daemon STARTS one when
+none is serving, and a daemon that starts opens the store and schedules the
+background embedding pass. So an agent session that made no Kin call at all was
+paying for a full embed of that repository. Measured on 2026-09-02 against a
+24-file fixture whose store is 657.8 KiB: a daemon appeared 0.1 s after the
+handshake and held 1.80 GiB resident and 99 percent of a core at sixty seconds,
+with `sample` putting every frame in `run_background_embedding_batch`. On the
+kin checkout the same shape reached 17.7 GiB on Metal, beside a measured run
+that held the fleet's gpu lock.
+
+Both doors are graded here, because closing one leaves the other open:
+
+* the launcher's own startup binding, which fires whatever the client sends;
+* the workspace-roots binder, which fires on the `roots/list` answer and is the
+  only door when the server was launched outside a repository.
+
+**The control is the point of the suite.** A server that answered nothing at
+all would pass "no daemon appeared" perfectly. So the last check makes one
+`semantic_locate` call and requires the daemon AND its embedding worker to
+appear. Without it, deleting the MCP server would score four passes.
+
+    CHECK <id> <ticket> PASS|FAIL|UNREADABLE <detail>
+
+Exit 0 when every check graded, 3 when the suite could not start. The verdict
+belongs to `scripts/acceptance/gate.py`, which reads the `--json` report rather
+than the exit code.
+
+**What this does NOT cover, said here so a green run is not over-read.** It
+grades one repository per arm on a fixture whose daemon opens in seconds, so it
+says nothing about a store whose open outlasts the observation window, and it
+does not measure Metal: every arm forces `KIN_EMBED_BACKEND=cpu` so the suite
+never contends for the GPU on the fleet host. What it proves is that a
+handshake, a tool list and a workspace-roots answer start no daemon, and that a
+tool call still does.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+TICKET = "FIR-3099"
+
+# The daemon's own line for "my embedding worker is past the init wait and
+# running", emitted by `kin_daemon::daemon` immediately before it queues or
+# defers the pass. Named once so neither side can reword it and disarm this.
+EMBED_WORKER_MARKER = "embedding worker started"
+
+# How long to watch after the handshake. The reproduction saw the daemon at
+# 0.1 s and its embedding worker inside ten, so this is many times the window
+# in which the old behavior was visible.
+WATCH_SECONDS = 45.0
+
+
+def emit(check_id: str, verdict: str, detail: str) -> dict:
+    print(f"CHECK {check_id} {TICKET} {verdict} {detail}", flush=True)
+    return {"id": check_id, "ticket": TICKET, "verdict": verdict, "detail": detail}
+
+
+# ── graders ──────────────────────────────────────────────────────────────
+# Pure over their inputs so `--self-test` can put each one against the case it
+# must call the other way.
+
+
+def daemon_lines(ps_output: str, repo: str, daemon_bin: str) -> list[tuple[str, str]]:
+    """`(pid, argv)` for every `kin-daemon` serving `repo`.
+
+    Both needles are required, and the daemon binary must be the executable
+    rather than merely somewhere in the line: on a shared host another lane's
+    daemon must not be counted as this arm's, and neither must the driver that
+    carries both paths in its own argv.
+
+    The pid comes back with the line because the watch samples repeatedly, and a
+    caller that counted lines rather than pids would report one daemon seen
+    twenty-two times as twenty-two daemons.
+    """
+    found = []
+    for line in ps_output.splitlines():
+        parts = line.split(None, 5)
+        if len(parts) < 6:
+            continue
+        args = parts[5]
+        if args.split(None, 1)[0] != daemon_bin:
+            continue
+        if repo not in args:
+            continue
+        found.append((parts[0], args))
+    return found
+
+
+def embed_worker_ran(daemon_log: str) -> bool:
+    """Whether a daemon log records its embedding worker starting."""
+    return EMBED_WORKER_MARKER in daemon_log
+
+
+# ── fixture and session ──────────────────────────────────────────────────
+
+
+def build_fixture(root: Path, kin: str, env: dict) -> Path:
+    """A committed repository with entities and no vectors."""
+    repo = root / "repo"
+    repo.mkdir(parents=True)
+    for i in range(24):
+        (repo / f"mod_{i:02d}.py").write_text(
+            f'"""Module {i}."""\n\n\n'
+            f"class Handler{i}:\n"
+            f"    def dispatch(self, payload):\n"
+            f"        return self.transform(payload)\n\n"
+            f"    def transform(self, payload):\n"
+            f'        return {{"shard": {i}, "value": payload}}\n\n\n'
+            f"def build_handler_{i}() -> Handler{i}:\n"
+            f"    return Handler{i}()\n"
+        )
+    # The identity is passed with `-c` as well as through the environment, and
+    # the commit is signed off, so this works on a bare CI runner with no git
+    # config AND on a workstation whose hooks require a DCO line. A fixture the
+    # suite cannot commit reports UNREADABLE for every check, which is a broken
+    # grader rather than a product verdict.
+    git = {**env, "GIT_AUTHOR_NAME": "Kin CI", "GIT_AUTHOR_EMAIL": "ci@kinlab.ai",
+           "GIT_COMMITTER_NAME": "Kin CI", "GIT_COMMITTER_EMAIL": "ci@kinlab.ai"}
+    ident = ["-c", "user.name=Kin CI", "-c", "user.email=ci@kinlab.ai"]
+    for argv in (["git", "init", "-q", "."],
+                 ["git", *ident, "add", "-A"],
+                 ["git", *ident, "commit", "-qsm", "Add the spawn-admission fixture"]):
+        done = subprocess.run(argv, cwd=repo, env=git, capture_output=True, text=True)
+        if done.returncode != 0:
+            raise RuntimeError(
+                f"{' '.join(argv)} failed ({done.returncode}): "
+                f"{(done.stderr or done.stdout).strip()[:400]}")
+    done = subprocess.run([kin, "init", "--no-enrich", "."], cwd=repo, env=env,
+                          capture_output=True, text=True)
+    if done.returncode != 0:
+        raise RuntimeError(f"kin init failed ({done.returncode}): "
+                           f"{(done.stderr or done.stdout).strip()[-400:]}")
+    return repo
+
+
+def session(kin: str, daemon_bin: str, repo: Path, kin_home: Path, cwd: Path,
+            roots_answer: Path | None, tool_call: str | None,
+            watch_seconds: float, stop_when: str = "never") -> dict:
+    """One MCP server, one handshake, and what appeared in the process table.
+
+    Drives the server exactly as an agent CLI does: newline-delimited JSON-RPC
+    on stdin, `initialize`, `notifications/initialized`, `tools/list`, then
+    `tools/call` only when this arm is the control. stdin stays open the whole
+    time, because a client that closed it would end the session before the
+    window this suite is watching.
+    """
+    env = dict(os.environ)
+    env["KIN_HOME"] = str(kin_home)
+    env["KIN_EMBED_BACKEND"] = "cpu"
+    env["KIN_MCP_TOOL_PROFILE"] = "agent-default"
+    for leaked in ("KIN_DAEMON_URL", "KIN_NO_DAEMON", "KIN_MCP_REPO"):
+        env.pop(leaked, None)
+
+    proc = subprocess.Popen([kin, "mcp", "start"], cwd=str(cwd), env=env,
+                            stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE, text=True, bufsize=1)
+    stdout_lines: list[str] = []
+
+    def pump() -> None:
+        for line in proc.stdout:
+            stdout_lines.append(line)
+            try:
+                message = json.loads(line)
+            except ValueError:
+                continue
+            if message.get("method") == "roots/list" and roots_answer is not None:
+                proc.stdin.write(json.dumps({
+                    "jsonrpc": "2.0", "id": message.get("id"),
+                    "result": {"roots": [{"uri": f"file://{roots_answer}",
+                                          "name": "fixture"}]},
+                }) + "\n")
+                proc.stdin.flush()
+
+    threading.Thread(target=pump, daemon=True).start()
+
+    caps = {"roots": {"listChanged": True}} if roots_answer is not None else {}
+    messages = [
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize",
+         "params": {"protocolVersion": "2024-11-05", "capabilities": caps,
+                    "clientInfo": {"name": "fir3099-acceptance", "version": "0"}}},
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+    ]
+    if tool_call:
+        messages.append({"jsonrpc": "2.0", "id": 3, "method": "tools/call",
+                         "params": {"name": tool_call,
+                                    "arguments": {"query": "where is a handler dispatched"}}})
+    for message in messages:
+        proc.stdin.write(json.dumps(message) + "\n")
+        proc.stdin.flush()
+        time.sleep(0.3)
+
+    # `stop_when` ends the watch early for the control arms, which have already
+    # proved their point once the thing they are waiting for appears. The
+    # no-daemon arms never stop early: their claim is about the whole window, so
+    # ending it as soon as nothing has happened would be no claim at all.
+    log_path = repo / ".kin" / "daemon.log"
+    seen: dict[str, str] = {}
+    deadline = time.time() + watch_seconds
+    while time.time() < deadline:
+        ps = subprocess.run(["ps", "-Ao", "pid=,ppid=,rss=,pcpu=,etime=,args="],
+                            capture_output=True, text=True).stdout
+        seen.update(dict(daemon_lines(ps, str(repo), daemon_bin)))
+        if stop_when == "daemon" and seen:
+            break
+        if stop_when == "embed" and log_path.exists() and embed_worker_ran(
+                log_path.read_text(errors="replace")):
+            break
+        time.sleep(2)
+
+    try:
+        proc.stdin.close()
+    except OSError:
+        pass
+    try:
+        proc.wait(timeout=20)
+    except subprocess.TimeoutExpired:
+        proc.terminate()
+        proc.wait(timeout=10)
+
+    result = {
+        "daemons": [f"pid {pid}: {args}" for pid, args in sorted(seen.items())],
+        "daemon_log": log_path.read_text(errors="replace") if log_path.exists() else "",
+        "stderr": (proc.stderr.read() or "")[-4000:],
+        "stdout": "".join(stdout_lines)[-4000:],
+    }
+    subprocess.run([kin, "daemon", "stop"], cwd=str(repo), env=env,
+                   capture_output=True, text=True)
+    return result
+
+
+# ── checks ───────────────────────────────────────────────────────────────
+
+
+def check_handshake_starts_no_daemon(kin, daemon_bin, workdir) -> dict:
+    """The launcher's own startup binding, which fires whatever the client sends."""
+    root = workdir / "startup-door"
+    home = root / "kin-home"
+    home.mkdir(parents=True)
+    env = {**os.environ, "KIN_HOME": str(home), "KIN_EMBED_BACKEND": "cpu"}
+    repo = build_fixture(root, kin, env)
+    outcome = session(kin, daemon_bin, repo, home, repo, None, None, WATCH_SECONDS)
+    if outcome["daemons"]:
+        return emit("startup_binding_starts_no_daemon", "FAIL",
+                    f"the handshake started {len(outcome['daemons'])} daemon(s) with no tool "
+                    f"call: {outcome['daemons'][0][:160]}")
+    if embed_worker_ran(outcome["daemon_log"]):
+        return emit("startup_binding_starts_no_daemon", "FAIL",
+                    "no daemon was in the process table but the daemon log records an "
+                    "embedding worker starting")
+    return emit("startup_binding_starts_no_daemon", "PASS",
+                f"initialize, initialized and tools/list started no daemon in "
+                f"{WATCH_SECONDS:.0f}s and dispatched no embedding")
+
+
+def check_roots_answer_starts_no_daemon(kin, daemon_bin, workdir) -> dict:
+    """The workspace-roots binder, which is the only door outside a repository."""
+    root = workdir / "roots-door"
+    home = root / "kin-home"
+    home.mkdir(parents=True)
+    outside = root / "not-a-repo"
+    outside.mkdir(parents=True)
+    env = {**os.environ, "KIN_HOME": str(home), "KIN_EMBED_BACKEND": "cpu"}
+    repo = build_fixture(root, kin, env)
+    outcome = session(kin, daemon_bin, repo, home, outside, repo, None, WATCH_SECONDS)
+    if outcome["daemons"]:
+        return emit("workspace_roots_start_no_daemon", "FAIL",
+                    f"the client's roots answer started {len(outcome['daemons'])} daemon(s) "
+                    f"with no tool call: {outcome['daemons'][0][:160]}")
+    if embed_worker_ran(outcome["daemon_log"]):
+        return emit("workspace_roots_start_no_daemon", "FAIL",
+                    "no daemon was in the process table but the daemon log records an "
+                    "embedding worker starting")
+    return emit("workspace_roots_start_no_daemon", "PASS",
+                f"a roots/list answer naming the repository started no daemon in "
+                f"{WATCH_SECONDS:.0f}s")
+
+
+def check_a_tool_call_still_starts_the_daemon(kin, daemon_bin, workdir) -> dict:
+    """The control. Without it the two checks above pass on a server that does nothing."""
+    root = workdir / "control"
+    home = root / "kin-home"
+    home.mkdir(parents=True)
+    env = {**os.environ, "KIN_HOME": str(home), "KIN_EMBED_BACKEND": "cpu"}
+    repo = build_fixture(root, kin, env)
+    outcome = session(kin, daemon_bin, repo, home, repo, None, "semantic_locate",
+                      WATCH_SECONDS * 2, stop_when="daemon")
+    if not outcome["daemons"]:
+        return emit("a_tool_call_still_starts_the_daemon", "FAIL",
+                    "a semantic_locate call produced no daemon, so the two no-daemon checks "
+                    f"above prove nothing; server stderr: {outcome['stderr'][-400:]}")
+    return emit("a_tool_call_still_starts_the_daemon", "PASS",
+                f"the first semantic_locate produced the daemon: "
+                f"{outcome['daemons'][0][:160]}")
+
+
+def check_a_tool_call_still_dispatches_the_embed(kin, daemon_bin, workdir) -> dict:
+    """The other half of the control: the daemon a call produces still embeds."""
+    root = workdir / "control-embed"
+    home = root / "kin-home"
+    home.mkdir(parents=True)
+    env = {**os.environ, "KIN_HOME": str(home), "KIN_EMBED_BACKEND": "cpu"}
+    repo = build_fixture(root, kin, env)
+    outcome = session(kin, daemon_bin, repo, home, repo, None, "semantic_locate",
+                      WATCH_SECONDS * 2, stop_when="embed")
+    if not outcome["daemon_log"]:
+        return emit("a_tool_call_still_dispatches_the_embed", "UNREADABLE",
+                    "the daemon wrote no log for this store, so the embedding marker "
+                    "cannot be read either way")
+    if not embed_worker_ran(outcome["daemon_log"]):
+        return emit("a_tool_call_still_dispatches_the_embed", "FAIL",
+                    "the daemon a tool call produced never started its embedding worker, so "
+                    "a cold store would answer without vectors forever")
+    return emit("a_tool_call_still_dispatches_the_embed", "PASS",
+                f"the daemon a tool call produced logged '{EMBED_WORKER_MARKER}'")
+
+
+# ── self-test ────────────────────────────────────────────────────────────
+
+
+def self_test() -> int:
+    """Every grader against the case it must call the other way.
+
+    A suite whose graders cannot tell their own cases apart reports a clean
+    product on a broken one, so these run before any binary is built.
+    """
+    failures = []
+    daemon_bin = "/opt/kin/bin/kin-daemon"
+    repo = "/work/fixture"
+    present = (
+        f"  101   100  55000  39.1 00:01 {daemon_bin} --repo {repo} --port 0\n"
+    )
+    absent = "  102   100  20000   0.1 00:02 /usr/bin/python3 driver.py\n"
+    other_lane = f"  103   100  55000  10.0 00:03 {daemon_bin} --repo /work/other --port 0\n"
+    # The driver carries both needles in its own argv; a substring match would
+    # count it as a daemon, which is the bug this shape exists to avoid.
+    driver = f"  104   100  20000   0.1 00:04 /usr/bin/python3 repro.py --daemon {daemon_bin} --repo {repo}\n"
+
+    cases = [
+        ("a daemon for this repo is found", present + absent, 1),
+        ("no daemon is not invented", absent, 0),
+        ("another lane's daemon is not counted", other_lane + absent, 0),
+        ("the driver's own argv is not a daemon", driver, 0),
+    ]
+    for name, ps_output, expected in cases:
+        rows = daemon_lines(ps_output, repo, daemon_bin)
+        got = len(rows)
+        if got and any(not pid.isdigit() for pid, _ in rows):
+            failures.append(f"daemon_lines: {name}: a row came back without a pid")
+        if got != expected:
+            failures.append(f"daemon_lines: {name}: expected {expected}, got {got}")
+
+    # One daemon sampled twice is one daemon. A watch that counted lines would
+    # report the same process as many, which is what the pid key prevents.
+    repeated = present + present
+    if len(dict(daemon_lines(repeated, repo, daemon_bin))) != 1:
+        failures.append("daemon_lines: one daemon sampled twice must key to one pid")
+
+    if not embed_worker_ran(f"INFO kin_daemon: {EMBED_WORKER_MARKER}\n"):
+        failures.append("embed_worker_ran: missed the marker it exists to find")
+    if embed_worker_ran("INFO kin_daemon: reconcile complete\n"):
+        failures.append("embed_worker_ran: reported an embedding worker from a log with none")
+    if embed_worker_ran(""):
+        failures.append("embed_worker_ran: reported an embedding worker from an empty log")
+
+    for failure in failures:
+        print(f"SELFTEST FAIL {failure}", flush=True)
+    if failures:
+        return 1
+    print(f"SELFTEST {TICKET} OK: {len(cases) + 4} grader cases, each against its inverse",
+          flush=True)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kin", help="path to the kin binary under test")
+    parser.add_argument("--daemon", help="path to the kin-daemon binary under test")
+    parser.add_argument("--json", dest="json_out", help="write the report here")
+    parser.add_argument("--self-test", action="store_true",
+                        help="falsify this suite's graders and exit")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.kin or not args.daemon:
+        print(f"CHECK suite {TICKET} UNREADABLE --kin and --daemon are required", flush=True)
+        return 3
+
+    kin = str(Path(args.kin).resolve())
+    daemon_bin = str(Path(args.daemon).resolve())
+    workdir = Path(tempfile.mkdtemp(prefix="kin-fir3099-"))
+    try:
+        results = [
+            check_handshake_starts_no_daemon(kin, daemon_bin, workdir),
+            check_roots_answer_starts_no_daemon(kin, daemon_bin, workdir),
+            check_a_tool_call_still_starts_the_daemon(kin, daemon_bin, workdir),
+            check_a_tool_call_still_dispatches_the_embed(kin, daemon_bin, workdir),
+        ]
+    except Exception as err:  # noqa: BLE001  (the suite reports rather than traces)
+        print(f"CHECK suite {TICKET} UNREADABLE could not start: {err}", flush=True)
+        return 3
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+    if args.json_out:
+        with open(args.json_out, "w", encoding="utf-8") as handle:
+            json.dump({"ticket": TICKET, "checks": results}, handle, indent=2)
+
+    print(
+        f"SUITE {TICKET} graded={sum(1 for r in results if r['verdict'] in ('PASS', 'FAIL'))}"
+        f"/{len(results)} pass={sum(1 for r in results if r['verdict'] == 'PASS')} "
+        f"fail={sum(1 for r in results if r['verdict'] == 'FAIL')} "
+        f"unreadable={sum(1 for r in results if r['verdict'] == 'UNREADABLE')}",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
An MCP session start spawned a `kin-daemon` for the repository it was launched
in, before the client had asked Kin anything, and that daemon opened the store
and began embedding it. Measured on a 24-file fixture whose store is 657.8 KiB:
a daemon appeared **0.1 s after the handshake** and held **1.80 GiB resident and
99 percent of a core at sixty seconds**, with `sample` putting 294 of 294 frames
in `run_background_embedding_batch` into `BertEmbedder::process_chunk`. No
`tools/call` was ever made. On the kin checkout the same shape reached 17.7 GiB
on Metal beside a measured run that held the fleet's gpu lock, which is FIR-3099.

## Where it came from

Two doors, and closing one leaves the other open.

* `crates/kin-cli/src/commands/mcp.rs:117` spawned `run_startup_binding` on a
  task before the stdio loop, whatever the client sends. It reaches
  `bind_daemon_for_repo_dir` → `resolve_daemon_url_for_mcp` →
  `daemon_client.rs:7933` `ensure_daemon_running_with_idle_timeout`, which
  starts the process. FIR-2316 moved this off the handshake's critical path; it
  moved the wait, not the work.
* `crates/kin-mcp/src/server.rs:416` asks the client for `roots/list` right
  after `initialize`, and the answer runs `bind_first_kin_repo` into the same
  call. Measured on its own with a launch directory that is no repository: the
  startup bind refused and a daemon still appeared at 0.1 s, reaching 1864 MiB.

Once a daemon exists the embed schedules itself at `crates/kin-daemon/src/daemon.rs:4443`,
braked only by the operator opt-out `KIN_DAEMON_AUTO_EMBED`.

## The fix

**No daemon is started until the first `tools/call`.** Every bind performed
before that call may ATTACH to a daemon already serving the repository, which
costs nothing and keeps a warm session exactly as fast as it is today, and may
start none. The first `tools/call` is the first moment a caller has asked for a
graph answer, and it admits the spawn.

* `crates/kin-mcp/src/startup_binding.rs`: the handle the launcher's binding
  task and the stdio loop already share gains the admission gate, a
  `tokio::sync::watch` beside the one it carries. No process global.
* `crates/kin-mcp/src/server.rs`: the loop admits the spawn on `tools/call`,
  before the wait the binding task is sitting on. Roots that a pre-call bind
  resolved to a Kin repository it could not yet start a daemon for are kept and
  put through the binder again on that call, after the startup binding settles
  so no second daemon is raced for the same repository.
* `crates/kin-cli/src/commands/mcp.rs`: `bind_daemon_for_repo_dir` takes a
  `DaemonBindMode`. `AttachOnly` resolves through the same
  `resolve_daemon_url_if_running_async` that `kin doctor` reads from and reports
  `SpawnNotAdmitted`, which is a state rather than a failure. The two background
  bind paths attach now and wait for the admission before starting anything.
* `crates/kin-cli/src/daemon_client.rs`: one predicate so `--no-spawn`
  short-circuits that wait: a probe session must never be told a daemon is
  starting when nothing in the process will ever start one.
* `docs/session-runtime.md`: the lifecycle, the measured reason, and the fact
  that the first call on a cold repository still pays for the start it needs.

The first `semantic_locate` on a cold store still works. It admits the spawn,
and a call that arrives while the daemon is coming up already has an honest
answer that names the phase and the elapsed seconds and says to retry. That is
today's cold-start experience, unchanged. Nothing here changes daemon or embed
semantics, so `KIN_DAEMON_AUTO_EMBED`, the `--no-spawn` probe contract and
`docs/mcp-tools.md`'s promise that `semantic_locate` needs the running daemon
all stand.

## Checks

Per PR, in `cargo test -p kin-mcp --lib`:

* `a_handshake_and_a_roots_answer_admit_no_daemon_spawn` drives the whole
  handshake plus a `roots/list` answer through the real stdio loop and requires
  the admission to stay unset, with a second assertion that the binder was
  consulted so it cannot pass on a server that ignores roots.
* `the_first_tool_call_admits_the_daemon_spawn` is the other direction.
* `deferred_roots_are_rebound_on_the_first_tool_call` covers the
  editor-launched-from-`$HOME` shape.
* Three more on the gate itself in `startup_binding.rs`, including one that
  requires the binding task to still be waiting an hour of virtual time later.

End to end, `scripts/acceptance/mcp_spawn_admission_repro.py`, wired into the
`Product Acceptance` job in `acceptance.yml` with a `--self-test` step beside
the other grader falsifications. **That job carries `if: github.event_name != 'pull_request'`,
so it is graded on main's own push run and not here.** It starts the real server
against a repository with no vectors, completes `initialize`, `initialized` and
`tools/list`, waits 45 s past the point where the old build had already embedded,
and asserts no daemon in the process table and no embedding worker in the daemon
log; it grades the roots door the same way from outside a repository; and its
control makes one `semantic_locate` and requires both the daemon and its
embedding worker to appear, so the three no-daemon checks cannot pass on a server
that answers nothing.

## Falsified

Every check was driven against the behavior it guards, with `server.rs` restored
from a byte copy rather than `git checkout` after each arm, and verified
`diff`-identical.

| mutation | test that must go red | result |
|---|---|---|
| remove `startup.admit_daemon_spawn()` | `the_first_tool_call_admits_the_daemon_spawn` | FAILED |
| admit on `initialize` instead | `a_handshake_and_a_roots_answer_admit_no_daemon_spawn` | FAILED |
| remove the deferred-roots rebind | `deferred_roots_are_rebound_on_the_first_tool_call` | FAILED |
| intact tree | all three | 3 passed |

Each mutation reddened exactly its own test and left the others green.

End to end, the suite was run against binaries built from this branch's base sha
`a62a10d64` (the unfixed product; their own `--version` stamp names it) and
against the same tree with the fix:

| check | with the fix | unfixed |
|---|---|---|
| `startup_binding_starts_no_daemon` | PASS | **FAIL** |
| `workspace_roots_start_no_daemon` | PASS | **FAIL** |
| `a_tool_call_still_starts_the_daemon` | PASS | PASS |
| `a_tool_call_still_dispatches_the_embed` | PASS | PASS |

The two controls pass on both builds, which is what gives the two failures their
force: the unfixed server answers `semantic_locate` and embeds exactly as it
should. It also starts a daemon nobody asked for.

## One thing this changes beyond the spawn

An operator pin (`--repo` / `KIN_MCP_REPO`) used to be published on the shared
handle only when its daemon bound, which was already a race with the client's
`roots/list` answer and would have become the normal case here: on a cold
repository the roots answer now always arrives first, and a binder reading
`false` is free to follow the client off the pinned repository. The pin is
published as soon as the launch directory resolves to a Kin repository instead.
A pin naming no repository still does not count.

## Gates

`cargo test -p kin-mcp --lib`, `cargo test -p kin-cli --lib commands::mcp::` and
`daemon_client::`, then `bin/kin-precheck kin --repo-dir kin=<lane worktree>`,
which reads its 16 gates out of this workflow's own check job: clippy with
`-D warnings` and every guard including `zero_file_search_guard.sh` passed.


Closes FIR-3099.
