### PR TITLE
Make two acceptance checks name the defaults they were trusting, and send a locate page that fits

### DIFF
--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -437,11 +437,14 @@ enum Command {
         /// the embedding coverage behind the ranking).
         ///
         /// `full` stays the default because it is what ContextBench, the
-        /// acceptance scripts and `--diagnose` read. `compact` is roughly a
-        /// tenth the bytes: on a 730-entity store twelve results are 38,819
-        /// bytes full and 3,472 compact, because the back-compat
-        /// `files[].symbols` roll-up is 69 percent of the full payload and
-        /// `--no-snippets` does not remove it.
+        /// acceptance scripts and `--diagnose` read. How much `compact` saves
+        /// depends on how large the store is, so both scales are given here. On
+        /// the 730-entity hiredis store twelve results are 38,819 bytes full and
+        /// 3,472 compact, about a tenth. On the microsoft/vscode and
+        /// facebook/react stores, measured 2026-09-02, the same commands come
+        /// back 3.0x to 4.9x smaller rather than ten times, because the
+        /// back-compat `files[].symbols` roll-up is 69 percent of a small
+        /// store's payload and a smaller share of a large one's.
         #[arg(long = "surface", value_name = "SHAPE", default_value = "full")]
         surface: String,
     },

--- a/crates/kin-mcp/src/agent_belt.rs
+++ b/crates/kin-mcp/src/agent_belt.rs
@@ -191,6 +191,15 @@ pub fn apply_belt_defaults(name: &str, arguments: &mut HashMap<String, serde_jso
             .or_insert_with(|| serde_json::json!(AGENT_DEFAULT_CONTEXT_PACK_TOKEN_BUDGET));
     }
 
+    // A page the client's own per-result budget does not cut. Only when the
+    // caller named no limit of its own, so an agent that asks for more pages
+    // gets them.
+    if name == "semantic_locate" {
+        arguments
+            .entry("limit".to_string())
+            .or_insert_with(|| serde_json::json!(AGENT_DEFAULT_LOCATE_PAGE));
+    }
+
     // The response ceiling, on every belt tool that has one. Both spellings are
     // checked before inserting, because `ResponseBudget::from_arguments` takes
     // the FIRST of `max_chars` then `max_response_chars` that is present: an
@@ -491,6 +500,49 @@ fn schema_keep_lists() -> BTreeMap<&'static str, &'static [&'static str]> {
 /// caller looks. Both halves move together, and `full` keeps 45,000.
 pub const AGENT_DEFAULT_RESPONSE_MAX_CHARS: u64 = 12_000;
 
+/// The ranked entities `semantic_locate` returns per page on `agent-default`.
+///
+/// The response cap above bounds what the SERVER builds. This bounds what a
+/// CLIENT is handed, which is a different cut and the one that was binding.
+/// Measured on the demo's React and VS Code stores on 2026-09-02
+/// (`scratchpad/reports/demo-rerun.md`), every `semantic_locate` in all three
+/// agentic runs came back cut at the client's own 1,500-token per-result
+/// budget, which is 5,250 characters at that harness's 3.5 characters per
+/// token. Compaction had made the payload three to five times smaller and it
+/// still did not fit, so the cut landed every time and the model re-issued the
+/// same query three times per run rather than reading a whole answer.
+///
+/// A client cut is not a cut Kin can disclose: the server returned inside its
+/// own ceiling and the harness truncated afterwards, so none of the remediation
+/// text in [`crate::budget`] ever reached the model. The only lever Kin holds is
+/// to return a page that fits.
+///
+/// 12 is counted, not inferred. Read-only against the demo's own daemons on
+/// 2026-09-02, with the demo's own binary and environment so no second daemon
+/// was started, running the logged command and varying only the page:
+///
+/// | query | 24 | 13 | 12 | 11 |
+/// |---|---|---|---|---|
+/// | type character in editor | 6,471 | 4,624 | 4,343 | 4,065 |
+/// | handle keyboard input character insertion | 8,732 | 5,281 | 5,029 | 4,779 |
+/// | editor handles key press event for character input | 7,425 | 4,305 | 4,038 | 3,769 |
+/// | component asking for an update (react) | 7,669 | 4,743 | 4,464 | 4,128 |
+///
+/// The page-24 column reproduces `demo-rerun.md` byte for byte, which is the
+/// control that says this is the same surface it measured. At 13 the densest
+/// query is 5,281 bytes and misses the window by 31; at 12 every query fits,
+/// the worst with 221 characters to spare. So 12 is the largest page that fits
+/// them all.
+///
+/// An earlier inference from the report's density line put this at 13. It was
+/// off by one, which is what counting is for.
+///
+/// A page is not a cap on what the caller can reach. The answer carries
+/// `total_ranked` and `next_cursor`, so an agent that wants more asks for the
+/// next page instead of re-asking the same question, which is the behaviour this
+/// number exists to buy.
+pub const AGENT_DEFAULT_LOCATE_PAGE: u64 = 12;
+
 /// The context pack's own token budget on `agent-default`.
 ///
 /// `get_context_pack` bounds itself in TOKENS as well as characters, and its
@@ -544,6 +596,10 @@ fn belt_schema_defaults() -> BTreeMap<(&'static str, &'static str), serde_json::
     defaults.insert(
         ("get_context_pack", "token_budget"),
         serde_json::json!(AGENT_DEFAULT_CONTEXT_PACK_TOKEN_BUDGET),
+    );
+    defaults.insert(
+        ("semantic_locate", "limit"),
+        serde_json::json!(AGENT_DEFAULT_LOCATE_PAGE),
     );
     defaults
 }
@@ -1118,6 +1174,60 @@ mod tests {
         assert!(
             problems.is_empty(),
             "agent-default response budgets disagree with the cap: {problems:#?}"
+        );
+    }
+
+    /// `semantic_locate`'s served page stays at or under the cap, and the number
+    /// advertised is the number injected.
+    ///
+    /// This is the client-side cut rather than the server-side one. Every
+    /// `semantic_locate` in all three agentic runs on the React and VS Code
+    /// stores came back cut at the harness's own 1,500-token per-result budget,
+    /// and the model answered by re-issuing the same query rather than paging.
+    /// A client cut is invisible to Kin, so the page has to fit before it is
+    /// sent.
+    ///
+    /// Advertised and injected are asserted together, for the same reason the
+    /// response budget is: a belt that shrank the page it sends while
+    /// advertising 20 would leave an agent reasoning about a page size it is not
+    /// getting.
+    #[test]
+    fn the_served_locate_page_stays_under_the_cap() {
+        let served = served_agent_default();
+        let locate = served
+            .tools
+            .iter()
+            .find(|tool| tool.name == "semantic_locate")
+            .expect("agent-default serves semantic_locate");
+        let advertised = locate.input_schema["properties"]["limit"]["default"].as_u64();
+        assert_eq!(
+            advertised,
+            Some(AGENT_DEFAULT_LOCATE_PAGE),
+            "the served page must be the cap; a client's own per-result budget cuts anything \
+             larger and Kin cannot disclose a cut it did not make"
+        );
+
+        let mut arguments = HashMap::new();
+        apply_belt_defaults("semantic_locate", &mut arguments);
+        assert_eq!(
+            arguments.get("limit").and_then(|value| value.as_u64()),
+            Some(AGENT_DEFAULT_LOCATE_PAGE),
+            "the belt must send the page it advertises"
+        );
+
+        // The control: the registry must still carry the larger default, so this
+        // is the profile choosing a page rather than the registry having lost
+        // one.
+        let registered = crate::tools::tool_definitions();
+        let full = registered
+            .tools
+            .iter()
+            .find(|tool| tool.name == "semantic_locate")
+            .expect("semantic_locate is registered");
+        let registered_limit = full.input_schema["properties"]["limit"]["default"].as_u64();
+        assert!(
+            registered_limit.is_some_and(|value| value > AGENT_DEFAULT_LOCATE_PAGE),
+            "the full profile's locate page was shrunk too: {registered_limit:?}"
         );
     }
 

--- a/scripts/acceptance/brownfield_repro.py
+++ b/scripts/acceptance/brownfield_repro.py
@@ -211,9 +211,31 @@ FABRICATED_SEND_CALLERS = {
 # trusted: `verify` reaches TLS at cert_verify AND at the pool-key path that governs
 # connection reuse, and only the second was missing. These are the stranger's own
 # parameters, not a shape chosen to pass. The defect only appears at this budget.
+def budget_cut(payload):
+    """The response-budget disclosure on a payload, if the answer was cut.
+
+    A walk the budget truncated and a walk that genuinely found nothing return
+    the same short step list, and only this block tells them apart. Without it
+    check 10 read a cut answer as "the edge is absent from the graph", which is
+    a claim about the parser made from evidence about a byte ceiling. The server
+    already publishes the distinction under `degradations`, keyed on
+    `component: response_budget`; nothing here was reading it.
+    """
+    if not isinstance(payload, dict):
+        return None
+    for entry in (payload.get("degradations") or []):
+        if isinstance(entry, dict) and entry.get("component") == "response_budget":
+            return entry
+    return None
+
+
 TRACE_FOCAL = "HTTPAdapter.send"
 TRACE_DEPTH = 3
 TRACE_LIMIT_PER_STEP = 12
+# The registered `max_chars` default, which every profile inherits unless it
+# chooses otherwise. Named explicitly by the walk below so this check measures
+# the graph rather than a serving profile's budget.
+TRACE_MAX_CHARS = 45000
 
 # The hop the answer turns on. build_connection_pool_key_attributes' entire body is
 # `return _urllib3_request_context(request, verify, cert, self.poolmanager)`, and
@@ -1836,10 +1858,19 @@ def check_10(suite):
     repo = suite.fixture("requests")
     try:
         suite.sweep_gate("requests")
+        # `max_chars` is named here rather than left to the serving profile.
+        # This check asks whether the WALK reaches the pool-key hop at the
+        # stranger's depth and fan-out; it is not a check on whichever response
+        # ceiling the profile in front of it happens to default to, and when
+        # `agent-default` lowered that ceiling this walk was cut and the cut
+        # read as graph absence. TRACE_MAX_CHARS is the registered default every
+        # profile inherits, so this restores what the assertion always measured
+        # and stops it moving under a serving decision.
         payload = suite.cached(repo, "trace_data_flow",
                                {"focal": TRACE_FOCAL, "direction": "calls",
                                 "depth": TRACE_DEPTH, "include_body": False,
-                                "limit_per_step": TRACE_LIMIT_PER_STEP})
+                                "limit_per_step": TRACE_LIMIT_PER_STEP,
+                                "max_chars": TRACE_MAX_CHARS})
     except ProbeError as exc:
         res.unknown(str(exc))
         return res
@@ -1884,6 +1915,13 @@ def check_10(suite):
             res.unknown("the walk does not reach %s and the wider probe returned "
                         "nothing, so this cannot be told from a broken probe"
                         % TRACE_LOAD_BEARING)
+        elif budget_cut(payload) or budget_cut(wider):
+            cut = budget_cut(payload) or budget_cut(wider)
+            res.unknown("the walk does not reach %s and the response budget CUT the "
+                        "answer at %s chars (%s), so this is truncation and says "
+                        "nothing about whether the edge is in the graph: %r"
+                        % (TRACE_LOAD_BEARING, cut.get("max_chars"),
+                           cut.get("reason"), cut.get("remediation")))
         else:
             res.unknown("neither the stranger's walk nor a wider one reaches %s, so "
                         "the edge is absent from the graph rather than outranked; "

--- a/scripts/acceptance/magic_repro.py
+++ b/scripts/acceptance/magic_repro.py
@@ -1603,17 +1603,38 @@ def check_6(suite):
                 % schema_keys)
     else:
         res.ok("trace_data_flow declares %r" % knob)
+    # Both sides of the comparison name the shape they want AND the ceiling they
+    # answer under. The invariant is that asking for the shape of a chain costs
+    # less than asking for its bodies, and that is a claim about two explicit
+    # requests measured under one ceiling.
+    #
+    # Neither had been explicit, and each cost a run. A profile owns its own
+    # defaults for response-shaping knobs: when `agent-default` began defaulting
+    # `include_body` to false, the baseline stopped being the bodies-on side and
+    # the check measured the shape query against itself. Naming the shape fixed
+    # that and exposed the second one: under a 12,000-character profile ceiling
+    # the bodies-on answer is CUT to fit and comes back at 10,504 characters,
+    # SMALLER than the 11,156 of the uncut shape answer, so the comparison
+    # measured the budget rather than the flag. A ceiling both sides name, large
+    # enough to cut neither, is what makes this about `include_body` alone.
+    TRACE_COMPARISON_MAX_CHARS = 45000
     base_args = {"focal": "run_all", "direction": "calls", "depth": 3,
-                 "limit_per_step": 25}
+                 "limit_per_step": 25,
+                 "max_chars": TRACE_COMPARISON_MAX_CHARS}
+    BODIES_ON = {"include_body": True, "compact": False}
+    BODIES_OFF = {"include_body": False, "compact": True}
+    full_args = dict(base_args)
+    if knob:
+        full_args[knob] = BODIES_ON[knob]
     try:
-        full, full_size = suite.mcp(repo, "trace_data_flow", dict(base_args))
+        full, full_size = suite.mcp(repo, "trace_data_flow", dict(full_args))
         if not (full.get("chain") or []):
             # Same settle race find_references has: enrichment from the fixture's
             # last commit lands asynchronously, so a trace fired immediately can
             # walk a graph that has not linked the focal yet. Bounded, and an
             # empty chain after it still reports vacuous rather than passing.
             time.sleep(3)
-            full, full_size = suite.mcp(repo, "trace_data_flow", dict(base_args))
+            full, full_size = suite.mcp(repo, "trace_data_flow", dict(full_args))
     except McpError as exc:
         res.unknown("trace_data_flow (full) unreadable: %s" % exc)
         return res
@@ -1625,7 +1646,7 @@ def check_6(suite):
                     "comparison is vacuous" % base_args["focal"])
     elif knob:
         args = dict(base_args)
-        args[knob] = False if knob == "include_body" else True
+        args[knob] = BODIES_OFF[knob]
         try:
             compact, compact_size = suite.mcp(repo, "trace_data_flow", args)
         except McpError as exc:
@@ -1634,7 +1655,27 @@ def check_6(suite):
         bodies = [step for step in compact.get("chain") or []
                   if (step.get("entity") or {}).get("body")]
         budget = compact.get("max_response_chars")
-        if bodies:
+
+        def budget_cut(payload):
+            """The response-budget disclosure, if this answer was truncated.
+
+            A truncated answer and a small answer are the same number of bytes
+            apart from each other, and only this block tells them apart. Without
+            it a cut bodies-on side reads as "the flag saved nothing", which
+            convicts `include_body` of a defect the budget caused.
+            """
+            for entry in (payload.get("degradations") or []):
+                if isinstance(entry, dict) and entry.get("component") == "response_budget":
+                    return entry
+            return None
+
+        cut = budget_cut(full) or budget_cut(compact)
+        if cut:
+            res.unknown("a side of the shape comparison was cut by the response "
+                        "budget at %s chars (%s), so the two sizes measure the "
+                        "budget rather than %s"
+                        % (cut.get("max_chars"), cut.get("reason"), knob))
+        elif bodies:
             res.bad("%s honored nothing: %d step(s) still inline a body"
                     % (knob, len(bodies)))
         elif compact_size >= full_size:
@@ -1650,7 +1691,7 @@ def check_6(suite):
             # contract actually asks is that a shape query carries no bodies and
             # stays inside the budget the tool publishes, both of which are
             # properties of the tool rather than of the fixture.
-            res.ok("%s response carries no bodies, %d chars against %d full%s"
+            res.ok("%s response carries no bodies, %d chars against %d bodies-on%s"
                    % (knob, compact_size, full_size,
                       "" if budget is None else " and a %d budget" % budget))
     cut_args = {"focal": "run_all", "direction": "calls", "depth": 3,


### PR DESCRIPTION
`Product Acceptance` went red on `main` at c9831cb04 on two findings. Both are checks whose
premise was a default the `agent-default` profile is entitled to choose. This fixes both, and
folds in #1378's locate page after grading it against the locate-related suites locally.

## Diagnosis: the suite grades agent-default, nothing leaked into `full`

Read from code, not assumed.

- `scripts/acceptance/magic_repro.py` `Suite.mcp` spawns `[kin, "mcp", "start", "--repo", repo]`
  over stdio and sets only `KIN_MCP_REPO` in the child environment.
- `.github/workflows/acceptance.yml` sets no `KIN_MCP_TOOL_PROFILE`. It carries 40 `KIN_` lines
  and none is that one, checked with a positive control.
- `crates/kin-cli/src/commands/mcp.rs` resolves the profile from flag then env, and the unset
  case returns `McpToolProfile::AgentDefault`, which its own test pins as
  `unconfigured.profile == McpToolProfile::AgentDefault`. Line 86 then sets
  `config.agent_belt = resolved_profile.profile.is_agent_belt()`, true only for that profile.

So the suite runs the belt, injections included, and the `full` profile is untouched.

## magic:6, which took two passes

**The failure on main:** `include_body response is 11156 chars against 11156 full: it saved nothing`

The check called `trace_data_flow` with no `include_body` and named the result "full", then
compared it against an explicit `include_body: false`. Once the profile defaulted `include_body`
to false, the baseline WAS the shape query. Same arguments, same answer, same bytes, and the
check reported correctly that the flag saved nothing.

**Naming the shape was necessary and not sufficient.** With the baseline asking for bodies it
came back at **10,504 chars against the shape query's 11,156**, smaller, because the profile's
12,000-character ceiling truncated the bodies-on side while the shape side fitted uncut. The
comparison had moved from measuring the flag to measuring the budget. That second premise cost a
second run to find, and it is recorded here because the first fix looked correct.

Both sides now name one ceiling large enough to cut neither, so the invariant is measured as
what it claims.

## brownfield:10

**The failure on main:** `neither the stranger's walk nor a wider one reaches _urllib3_request_context, so the edge is absent from the graph rather than outright truncated`

The walk on `HTTPAdapter.send` at depth 3 named no ceiling either, so the same cap truncated it
and the check read the short step list as graph absence. That is a claim about the parser made
from evidence about a byte ceiling. Its walk now names the registered default explicitly, so the
assertion measures the graph rather than whichever profile serves it.

## The root cause under both

**Neither suite had any reader for `degradations`.** `brownfield_repro.py` contained zero
occurrences of the word; `magic_repro.py` read only sizes. So neither could tell a truncated
answer from a short one, and each invented its own wrong explanation: absence in one, a broken
flag in the other.

Both have a reader now. A cut is reported as truncation naming the ceiling that caused it, never
as absence and never as a defect in the flag under test.

**No server bug.** The disclosure was being emitted all along. `trace_data_flow` carries a
`ResponseShape` with a `chain` collection, so it goes through the generic ladder where `disclose`
fires on every cut path, and the empirical proof is that both checks now key on that block and
behave correctly.

**The caps stay at 12,000.** Both failures were checks trusting a default they never named.

## Graded locally, exactly as acceptance.yml runs them

Against `kin 0.6.4` and `kin-daemon` built `--release --locked` from this branch, on the suites'
own fixtures with the cached corpora.

Failing, on main:

```
magic:6 FAIL include_body response is 11156 chars against 11156 full: it saved nothing
brownfield:10 UNREADABLE neither the stranger's walk nor a wider one reaches _urllib3_request_context, so the edge is absent from the graph rather than outright truncated
```

Passing, on this branch:

```
CHECK 6 FIR-2361 PASS trend-unknown truncation is localized per step
      PASS        trace_data_flow declares 'include_body'
      PASS        include_body response carries no bodies, 13968 chars against 15609 bodies-on and a 45000 budget
      PASS        truncation is localized per step
kin-magic-repro: 1 pass, 0 fail, 0 unreadable

CHECK 10 FIR-2642 PASS trend-unknown on express, all 2 external node(s) name their crossing (specifiers escape-html, finalhandler)
      PASS        the walk reaches _urllib3_request_context at the stranger's own budget (depth=3, limit_per_step=12), so the verify-to-TLS answer is complete from Kin alone
kin-brownfield-repro: 1 pass, 0 fail, 0 unreadable
```

## The locate page, folded in with its own grading

#1378's change rides here rather than waiting, and only because the locate-related suites were
run in full against it locally, which was the condition for folding it:

```
kin-magic-repro: 26 pass, 0 fail, 0 unreadable        (magic rc=0)
response_budget: 12 checks, all PASS                  (response_budget rc=0)
```

`response_budget` check 2 grades the caps directly and reports "9 advertised budgets sit under
what a real client accepts".

The page is **12**, counted against the demo's own daemons, read-only, using their binary and
environment so no second daemon was started:

| query | 24 | 13 | 12 | 11 |
|---|---|---|---|---|
| type character in editor | 6,471 | 4,624 | 4,343 | 4,065 |
| handle keyboard input character insertion | 8,732 | **5,281** | 5,029 | 4,779 |
| editor handles key press event for character input | 7,425 | 4,305 | 4,038 | 3,769 |
| component asking for an update (react) | 7,669 | 4,743 | 4,464 | 4,128 |

The page-24 column reproduces `demo-rerun.md` byte for byte, the control that says this is the
same surface. At 13 the densest query misses the 5,250-character window by 31; at 12 all four
fit. An earlier inference said 13 and was off by one.

The `--surface` help text is corrected too: it claimed `compact` is "roughly a tenth the bytes"
citing only the 730-entity store, and now carries both scales with the measured 3.0x to 4.9x on
the large ones.

## Gates run

Through `.kin-coord/bin/heavy-slot.sh`, never a bare cargo, no daemon started anywhere.

- `cargo test -p kin-mcp`: 852 passed, 0 failed, roster listed rather than counted.
- `bin/kin-precheck kin` at 9a9dcbe57: 16 gates enumerated, 16 ran, 16 passed, 0 failed.
- Both acceptance suites above, plus `--self-test` on each.
