### PR TITLE
Register the MCP spawn-admission suite with the step visibility rule

### DIFF
--- a/scripts/acceptance/test_workflow_step_visibility.py
+++ b/scripts/acceptance/test_workflow_step_visibility.py
@@ -113,6 +113,11 @@ EXPECTED_SUITES = (
         "acceptance/first_query.json",
     ),
     ExpectedSuite(
+        "scripts/acceptance/mcp_spawn_admission_repro.py",
+        "mcp_spawn",
+        "acceptance/mcp_spawn.json",
+    ),
+    ExpectedSuite(
         "scripts/acceptance/verdict_limits_repro.py",
         "verdict_limits",
         "acceptance/verdict_limits.json",


### PR DESCRIPTION
**Acceptance is red on main at `a6852aa04` and this is the fix.** It graded
nothing: every suite in that run reported UNREADABLE, and not one of them was
about the product.

`scripts/acceptance/test_workflow_step_visibility.py` pins the exact inventory
and order of the report-producing suites in `acceptance.yml` and of the reports
the verdict step reads. #1377 added a suite to the workflow and not to that
list, so the guard raised

```
VIOLATION: report-producing suite inventory or order changed
VIOLATION: Acceptance verdict report inventory or order changed
```

That step runs **eleventh**, before `Build kin + kin-daemon (release)`, and the
build does not carry `if: always()`. So the build never ran, and every suite
after it failed for want of `target/release/kin`:

```
CHECK suite FIR-3099 UNREADABLE could not start:
  [Errno 2] No such file or directory: '.../target/release/kin'
```

The suite is entered where it actually runs, between `first_query` and
`verdict_limits`, so the pinned order still matches the workflow's.

Verified on this branch: the guard passes against the real workflow (`workflow
authority holds: 27 suite reports reach one always-running verdict in order`)
and its own `--self-test` still catches every mutant (`all 2 controls clean, all
24 adversarial mutants caught`). Falsified by reverting the five added lines,
which reproduces both VIOLATION messages exactly.
