### PR TITLE
Bump kin-db to 0.7.88

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3289,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.84"
+version = "0.7.88"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "7f72d12b426a54d459e31d1834b9e23eaf84d5a5c110ea23cce959b861ec1c90"
+checksum = "1ef5edb19fa49df56cff01d73fd5b2e1f573e5060e06bff1dcb5b427be1b18be"
 dependencies = [
  "bincode",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ kin-lsp = { version = "=0.7.12", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.84", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.88", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.23", registry = "kin" }
 
 [profile.release]


### PR DESCRIPTION
Takes kin-db 0.7.88 from the kin registry, beside the kin-model 0.7.23 pin already on main.

## What it carries since 0.7.84

0.7.85: FIR-3096 salvage fix B, a reopen no longer retires every persisted vector when the index holds no revision vectors. 0.7.86: the mapped snapshot read. 0.7.87: the streamed snapshot frame (no wire-format change). 0.7.88: kin-db #270.

## Why not 0.7.89

The registry receiver's own verify step on the 0.7.89 refresh (run 33647602488, 15:19Z) fails compiling kin-core: E0308 at `crates/kin-core/src/tree.rs:3559`, where the receipt trim with a schema range changed the shape `metadata.receipts` hands back. That pin pairs with a kin-side change from the lane that made kin-db #271, and this PR takes the newest version that compiles.

## Shape

Cargo.toml and Cargo.lock only; no new environment names. Carried by hand because the receiver's wave PR (#1360, at 0.7.88) is stalled behind its landing workflow's trigger storm, which lane wavebot is fixing.

Related: FIR-3096
