### PR TITLE
Judge the registry wave on its own CI completion, a typed kick and a proven rebased head

### DIFF
--- a/.github/workflows/kin-registry-release.yml
+++ b/.github/workflows/kin-registry-release.yml
@@ -555,8 +555,21 @@ jobs:
             --branch "$BASE_BRANCH"
           api_tree="$(gh api \
             "repos/${GITHUB_REPOSITORY}/git/commits/${api_head}" --jq .tree.sha)"
-          if [ "$api_tree" != "$EXPECTED_TREE" ]; then
-            echo "::error::dependency PR tree $api_tree differs from admitted $EXPECTED_TREE"
+          # The action rebases the wave onto main's tip, so the head's tree is
+          # the admitted tree only while main stood still. The proof that
+          # holds either way: the head's parent is protected main at or after
+          # the admitted base, the delta read against that parent is the
+          # admitted delta, and the head's pin files transplanted onto the
+          # admitted base give the admitted tree. It reads the head it just
+          # fetched, and the API's tree has to agree with it.
+          verified="$(python3 scripts/verify-kin-registry-wave-head.py verify-generated-head \
+            --workspace "$GITHUB_WORKSPACE" \
+            --pull "$PR" \
+            --head "$api_head" \
+            --admitted-base "$ADMITTED_BASE" \
+            --expected-tree "$EXPECTED_TREE")"
+          if [ "$(jq -r .tree <<<"$verified")" != "$api_tree" ]; then
+            echo "::error::dependency PR tree $api_tree differs from the verified head tree"
             exit 1
           fi
 
@@ -599,3 +612,19 @@ jobs:
           path: ${{ runner.temp }}/kin-registry-result/result.json
           if-no-files-found: error
           retention-days: 30
+
+      # One judgment per written wave, whatever GitHub's cron and completion
+      # events do: the kick is a typed repository_dispatch the landing
+      # workflow admits from the release App, and its judge waits out the
+      # checks the push just started.
+      - name: Kick the wave landing judge once
+        if: needs.prepare-wave.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR: ${{ steps.open-pr.outputs.pull-request-number }}
+          PR_HEAD: ${{ steps.open-pr.outputs.pull-request-head-sha }}
+        run: |
+          set -euo pipefail
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/dispatches" \
+            -f event_type=kin-registry-wave-land \
+            -f "client_payload[reason]=receiver run ${GITHUB_RUN_ID} attempt ${GITHUB_RUN_ATTEMPT} wrote pull ${PR} head ${PR_HEAD}"

--- a/.github/workflows/kin-registry-wave-land.yml
+++ b/.github/workflows/kin-registry-wave-land.yml
@@ -3,40 +3,43 @@
 
 name: Kin Registry Wave Landing
 
-# Lands the receiver's dependency-wave pull request by itself, the moment every
-# check-run on its head has concluded green. Two arms: every completion of a
-# check-producing workflow on the wave branch, and a sweep four times an hour
-# for producers that are not workflows of this repository (CodeQL's default
-# setup) or that concluded while a judgment was already running. Both events
-# resolve this workflow from the default branch, and the judge proves
-# github.sha is protected main history before reading it as policy.
+# Lands the receiver's dependency-wave pull request by itself once every
+# check-run on its head has concluded green. Three triggers, each resolved
+# from the default branch, and the judge proves github.sha is protected main
+# history before reading it as policy:
 #
-# The judgment is scripts/land-kin-registry-wave.py, whose rule is the fleet's
-# landing rule: the FULL check-run set on the head, read by name with
-# per_page=100 and the listed length asserted against total_count, every run
-# concluded, none failed, skipped and neutral green, the six ruleset contexts
-# present, one bot commit carrying the reserved marker, a diff inside the
-# receiver's write set, and the release-App attestation verified. GitHub's own
-# auto-merge is not the mechanism: it merges on the six ruleset contexts alone,
-# and the admission chain refuses any server-owned landing state on the wave.
-# There is no manual dispatch arm, because this workflow reaches a
-# release-capable secret.
+#   - the wave branch's own CI completion (workflow_run filtered to that
+#     branch, so a completion on main or a lane never spawns a run: the
+#     first shape of this workflow listened to twelve workflows on every
+#     branch and produced a hundred skipped runs and a burst of nine
+#     cancellations in ninety seconds on one main push);
+#   - a typed repository_dispatch kick, the manual arm GitHub's cron cannot
+#     stall, admitted from the captain and the release App only, which the
+#     receiver sends once after every wave it writes;
+#   - the scheduled sweep, as a fallback.
+#
+# One judgment can outlast the checks it waits on: the judge re-reads the
+# whole snapshot for a bounded budget while the verdict is a transient wait
+# (checks running, a cancelled suite awaiting its rerun, an attestation on
+# its way, GitHub still computing mergeability, a re-pushed head), so a
+# single trigger is enough and the concurrency groups queue at most one
+# pending run behind it. The rule itself is scripts/land-kin-registry-wave.py:
+# the FULL check-run set on the head read by name with per_page=100 and the
+# listed length asserted against total_count, every run concluded, none
+# failed, skipped and neutral green, the six ruleset contexts present, one
+# bot commit carrying the reserved marker, a diff inside the receiver's write
+# set, and the release-App attestation verified. GitHub's own auto-merge is
+# not the mechanism: it merges on the six ruleset contexts alone, and the
+# admission chain refuses any server-owned landing state on the wave. There
+# is no manual dispatch arm, because this workflow reaches a release-capable
+# secret; the kick is a repository_dispatch, which cannot select a branch.
 on:
   workflow_run:
-    workflows:
-      - CI
-      - SAST
-      - Secret Scan
-      - DCO
-      - PR Text Hygiene
-      - Daemon Smoke
-      - Docker
-      - Fuzz
-      - Acceptance
-      - Install Proof Canary
-      - Link Check
-      - CodeQL
+    workflows: [CI]
     types: [completed]
+    branches: [automation/kin-registry-dependency-wave]
+  repository_dispatch:
+    types: [kin-registry-wave-land]
   schedule:
     - cron: "5,20,35,50 * * * *"
 
@@ -50,17 +53,19 @@ env:
 jobs:
   judge-wave:
     name: Judge the open Kin registry wave
-    # A completion on any other branch is not news about the wave, and a head
-    # repository other than this one is never the wave.
+    # The branch filter above already keeps foreign completions out; this is
+    # the same fact asserted where a reader of the job can see it.
     if: >-
       github.event_name == 'schedule' ||
-      (github.event.workflow_run.head_branch == 'automation/kin-registry-dependency-wave' &&
+      github.event_name == 'repository_dispatch' ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.head_branch == 'automation/kin-registry-dependency-wave' &&
        github.event.workflow_run.head_repository.full_name == github.repository)
     concurrency:
       group: kin-registry-wave-judge-${{ github.repository }}
       cancel-in-progress: false
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 40
     permissions:
       actions: read
       checks: read
@@ -79,40 +84,33 @@ jobs:
       # value holds every wave landing and is reported in the judgment.
       KIN_MAIN_FROZEN: ${{ vars.KIN_MAIN_FROZEN }}
     steps:
-      - name: Find the open dependency wave
-        id: find
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          count="$(gh api --method GET "repos/${GITHUB_REPOSITORY}/pulls" \
-            -f state=open \
-            -f "head=${GITHUB_REPOSITORY_OWNER}:${WAVE_BRANCH}" \
-            -f "base=${BASE_BRANCH}" \
-            -f per_page=100 \
-            --jq 'length')"
-          if [[ ! "$count" =~ ^[0-9]+$ ]]; then
-            echo "::error::open wave listing did not answer with a count: $count"
-            exit 1
-          fi
-          echo "open=$count" >> "$GITHUB_OUTPUT"
-          if [ "$count" = 0 ]; then
-            echo "::notice::no open pull request from ${WAVE_BRANCH}; nothing to judge"
-          fi
-
       # The literal trusted context value: see the same checkout in
       # kin-registry-release.yml. The binding step below proves github.sha is
       # protected main's history before the judgment reads it as policy.
       - name: Checkout the queued landing policy
-        if: steps.find.outputs.open != '0'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Validate the landing trigger
+        env:
+          EVENT_ACTION: ${{ github.event.action }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          python3 scripts/land-kin-registry-wave.py validate-trigger \
+            --event-file "$GITHUB_EVENT_PATH" \
+            --event-name "$GITHUB_EVENT_NAME" \
+            --event-action "$EVENT_ACTION" \
+            --actor "$GITHUB_ACTOR" \
+            --repository "$GITHUB_REPOSITORY" \
+            --default-branch "$DEFAULT_BRANCH" \
+            --ref "$GITHUB_REF" \
+            --workflow-sha "$GITHUB_SHA"
+
       - name: Bind the judgment to protected main history
-        if: steps.find.outputs.open != '0'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -124,7 +122,6 @@ jobs:
 
       - name: Judge the wave against its full check set
         id: judge
-        if: steps.find.outputs.open != '0'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -132,7 +129,8 @@ jobs:
           verdict="$(python3 scripts/land-kin-registry-wave.py judge \
             --repository "$GITHUB_REPOSITORY" \
             --workspace "$GITHUB_WORKSPACE" \
-            --freeze "$KIN_MAIN_FROZEN")"
+            --freeze "$KIN_MAIN_FROZEN" \
+            --wait-seconds 1500)"
           printf '%s\n' "$verdict"
           {
             echo "decision=$(jq -r .decision <<<"$verdict")"

--- a/docs/release-bot.md
+++ b/docs/release-bot.md
@@ -420,7 +420,9 @@ mergeability, a re-pushed head), so one trigger outlasts the checks it waits
 on. Only then does the land job mint the App token, squash-merge with the pull
 title and body and never the marker line, and prove the squash is on `main`.
 A failed check, a foreign commit, an off-scope file or an unreadable listing
-refuses loudly; everything transient and an open hold wait quietly. GitHub's
+refuses loudly; everything transient and an open hold wait quietly. A wave
+whose pins a lane already carried onto main has nothing to merge and is left
+for the receiver's next refresh, never squashed as an empty diff. GitHub's
 own auto-merge is not the mechanism, because it merges on the six ruleset
 contexts alone and the admission chain refuses any server-owned landing state
 on the wave.

--- a/docs/release-bot.md
+++ b/docs/release-bot.md
@@ -392,22 +392,46 @@ and the CI gate alike.
 `.github/workflows/kin-registry-release-attest.yml` then binds the exact wave
 head to a release-App attestation that the required CI gate revalidates.
 
-`.github/workflows/kin-registry-wave-land.yml` lands the wave. It runs when a
-check-producing workflow completes on the wave branch and on a sweep four times
-an hour, and `scripts/land-kin-registry-wave.py` decides `land`, `wait` or
-`refuse`: one open first-party wave opened by the release App with no
-auto-merge armed, one bot commit carrying the reserved marker, a diff inside
-`Cargo.toml` and `Cargo.lock`, every check-run on the head concluded and none
-failed over the full set (`per_page=100`, the listed length asserted against
-`total_count`, the newest run per check name, skipped and neutral green, the
-six ruleset contexts present), the pull mergeable, and the attestation
-verified. Only then does the land job mint the App token, squash-merge with the
-pull title and body and never the marker line, and prove the squash is on
-`main`. A failed check, a foreign commit, an off-scope file or an unreadable
-listing refuses loudly; checks still running, a missing attestation or an open
-hold wait quietly. GitHub's own auto-merge is not the mechanism, because it
-merges on the six ruleset contexts alone and the admission chain refuses any
-server-owned landing state on the wave.
+The pull-request action rebases the wave onto main's current tip, so once
+main has moved the head's tree is tip plus delta rather than policy plus
+delta. The receiver's post-write check, the attester and the CI gate therefore
+prove the head carries exactly the admitted delta instead of comparing trees:
+its parent is protected main at or after the admitted base, main did not touch
+the pin files in between, the delta read against that parent passes every
+admission rule, and transplanting the head's pin files onto the admitted base
+reproduces the admitted tree. With an unmoved main every clause is the old
+equality.
+
+`.github/workflows/kin-registry-wave-land.yml` lands the wave. It runs on the
+wave branch's own CI completion, on a typed `kin-registry-wave-land`
+repository dispatch (the manual kick, admitted from the captain and the
+release App, which the receiver sends once after every wave it writes), and on
+a sweep four times an hour as a fallback. `scripts/land-kin-registry-wave.py`
+decides `land`, `wait` or `refuse`: one open first-party wave opened by the
+release App with no auto-merge armed, one bot commit carrying the reserved
+marker, a diff inside `Cargo.toml` and `Cargo.lock`, every check-run on the
+head concluded and none failed over the full set (`per_page=100`, the listed
+length asserted against `total_count`, the newest run per check name, skipped
+and neutral green, the six ruleset contexts present), the pull mergeable, and
+the attestation verified. A judgment re-reads the whole snapshot for a bounded
+budget while the verdict is a transient wait (checks running, a cancelled
+suite awaiting its rerun, an attestation on its way, GitHub still computing
+mergeability, a re-pushed head), so one trigger outlasts the checks it waits
+on. Only then does the land job mint the App token, squash-merge with the pull
+title and body and never the marker line, and prove the squash is on `main`.
+A failed check, a foreign commit, an off-scope file or an unreadable listing
+refuses loudly; everything transient and an open hold wait quietly. GitHub's
+own auto-merge is not the mechanism, because it merges on the six ruleset
+contexts alone and the admission chain refuses any server-owned landing state
+on the wave.
+
+Kick one judgment by hand with:
+
+```sh
+gh api --method POST repos/firelock-ai/kin/dispatches \
+  -f event_type=kin-registry-wave-land \
+  -f 'client_payload[reason]=<why>'
+```
 
 The hold is the repository variable `KIN_MAIN_FROZEN`, the wave's equivalent
 of the fleet's `kin_main_frozen` gate. Set it with

--- a/scripts/attest-kin-registry-wave.py
+++ b/scripts/attest-kin-registry-wave.py
@@ -384,18 +384,23 @@ def validate_live_admission(
     if auto_armed or queue_armed:
         raise AttesterError("live dependency pull still has server-owned landing state")
 
+    # The pull-request action rebases the wave onto main's tip, so the head's
+    # tree equals the admitted tree only while main stood still. The proof is
+    # the admitted delta on a parent that is protected main at or after the
+    # admitted base, with the head's pin files transplanting onto that base to
+    # the admitted tree; the guard owns it.
     try:
         guard.ensure_pull_head(workspace, pull_number, head)
-        evidence = guard.validate_delta(
+        evidence = guard.validate_admitted_head(
             workspace,
             str(admission["base"]),
+            str(admission["tree"]),
             head,
             require_marker=True,
         )
     except guard.AdmissionError as exc:
         raise AttesterError(str(exc)) from exc
     observed = {
-        "tree": evidence.tree,
         "delta_sha256": evidence.delta_sha256,
         "package_version": evidence.package_version,
         "workspace_version": evidence.workspace_version,

--- a/scripts/land-kin-registry-wave.py
+++ b/scripts/land-kin-registry-wave.py
@@ -538,6 +538,22 @@ def judge(snapshot: dict[str, Any]) -> Verdict:
     if problem is not None:
         return Verdict(REFUSE, problem, number, head)
 
+    # A wave whose pins a lane already carried onto main (kin#1384 landed
+    # =0.7.88 by hand while #1360 carried the same delta) has nothing to
+    # merge: an empty squash is never a landing, and the receiver's next
+    # refresh reconciles the pull. It is a final wait, not a failure.
+    on_main = snapshot.get("pins_on_main")
+    if not isinstance(on_main, dict) or not isinstance(on_main.get("changed"), list):
+        return Verdict(REFUSE, "pin comparison against main is unreadable", number, head)
+    if not on_main["changed"]:
+        return Verdict(
+            WAIT,
+            f"the wave's pins are already on main at {on_main.get('tip')}; nothing to "
+            "merge, and the receiver's next refresh reconciles the pull",
+            number,
+            head,
+        )
+
     files = snapshot.get("files")
     if not isinstance(files, list):
         return Verdict(REFUSE, "pull file listing is not an array", number, head)
@@ -691,6 +707,32 @@ def _branch_tip(repository: str) -> str | None:
     return _sha(ref_object.get("sha")) if isinstance(ref_object, dict) else None
 
 
+def pins_on_main(workspace: Path, head: str) -> dict[str, Any]:
+    """The allowed paths the head still changes against the judged main tip."""
+
+    tip = guard.git(workspace, "rev-parse", "HEAD").decode("ascii").strip()
+    if _sha(tip) is None:
+        raise LandingError("workspace HEAD is not a commit")
+    changed = sorted(
+        guard._paths(
+            guard.git(
+                workspace,
+                "diff",
+                "--no-ext-diff",
+                "--no-textconv",
+                "--no-renames",
+                "--name-only",
+                "-z",
+                tip,
+                head,
+                "--",
+                *sorted(ALLOWED_PATHS),
+            )
+        )
+    )
+    return {"tip": tip, "changed": changed}
+
+
 def _attestation_state(
     workspace: Path,
     repository: str,
@@ -699,7 +741,6 @@ def _attestation_state(
     base: str,
 ) -> str:
     try:
-        guard.ensure_pull_head(workspace, number, head)
         guard.verify_attestation(
             workspace,
             repository,
@@ -726,6 +767,7 @@ def gather(repository: str, workspace: Path, freeze: str) -> dict[str, Any]:
         "commits": [],
         "files": [],
         "check_run_pages": [],
+        "pins_on_main": None,
         "attestation": ATTESTATION_PENDING,
     }
     open_pulls = snapshot["open_pulls"]
@@ -774,6 +816,11 @@ def gather(repository: str, workspace: Path, freeze: str) -> dict[str, Any]:
             ]
         )
     )
+    try:
+        guard.ensure_pull_head(workspace, number, head)
+        snapshot["pins_on_main"] = pins_on_main(workspace, head)
+    except guard.AdmissionError as exc:
+        raise LandingError(f"pull head {head} could not be read: {exc}") from exc
     snapshot["attestation"] = _attestation_state(workspace, repository, number, head, base)
     return snapshot
 

--- a/scripts/land-kin-registry-wave.py
+++ b/scripts/land-kin-registry-wave.py
@@ -55,10 +55,11 @@ import os
 import re
 import subprocess
 import sys
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Sequence
+from typing import Any, Callable, Sequence
 
 
 EXPECTED_REPOSITORY = "firelock-ai/kin"
@@ -90,6 +91,20 @@ WAIT = "wait"
 REFUSE = "refuse"
 ATTESTATION_VERIFIED = "verified"
 ATTESTATION_PENDING = "pending"
+# A cancelled check is what the receiver's re-push and the attester's reopen
+# retrigger leave behind on a superseded suite; it is news about the clock, not
+# about the tree, so it waits for the rerun instead of refusing.
+CANCELLED_CONCLUSIONS = frozenset({"cancelled"})
+# The typed manual kick and who may send it, mirroring release-tag.yml's
+# break-glass shape: a repository_dispatch always runs this workflow from the
+# default branch, and the actor is pinned to the captain and the release App.
+KICK_ACTION = "kin-registry-wave-land"
+KICK_ACTORS = frozenset({"troyjr4103", "kin-release-bot[bot]"})
+KICK_REASON_LIMIT = 200
+TRIGGER_KICK = "kick"
+TRIGGER_COMPLETION = "completion"
+TRIGGER_SWEEP = "sweep"
+WAIT_POLL_SECONDS = 30.0
 
 
 class LandingError(RuntimeError):
@@ -130,6 +145,11 @@ class Verdict:
     pull: int | None = None
     head: str | None = None
     details: dict[str, Any] = field(default_factory=dict)
+    # A transient wait resolves by itself (checks running, an attestation on
+    # its way, a rerun after a cancel, GitHub still computing mergeability);
+    # a judge given a wait budget re-reads until it does. A hold or an empty
+    # branch is not transient, and returns at once.
+    transient: bool = False
 
     def document(self) -> dict[str, Any]:
         return {
@@ -138,7 +158,86 @@ class Verdict:
             "pull": self.pull,
             "head": self.head,
             "details": self.details,
+            "transient": self.transient,
         }
+
+
+def validate_trigger(
+    *,
+    event_name: str,
+    event_action: str,
+    actor: str,
+    repository: str,
+    default_branch: str,
+    ref: str,
+    workflow_sha: str,
+    event: Any,
+) -> dict[str, Any]:
+    """Validate GitHub-owned trigger context before anything reads the wave.
+
+    Three shapes are admitted: the wave branch's own CI completion, the typed
+    manual kick from an allowlisted actor, and the scheduled sweep. Everything
+    is read from the trigger context GitHub owns, never from the payload a
+    sender controls, and every shape has to come from protected main.
+    """
+
+    if repository != EXPECTED_REPOSITORY:
+        raise LandingError(f"repository must be {EXPECTED_REPOSITORY!r}, got {repository!r}")
+    if default_branch != BASE_BRANCH:
+        raise LandingError(f"default branch must be {BASE_BRANCH!r}, got {default_branch!r}")
+    if ref != f"refs/heads/{BASE_BRANCH}":
+        raise LandingError(f"workflow ref must be refs/heads/{BASE_BRANCH}, got {ref!r}")
+    if _sha(workflow_sha) is None:
+        raise LandingError(f"workflow sha must be 40-character lowercase hex, got {workflow_sha!r}")
+    if not isinstance(event, dict):
+        raise LandingError("event document must be an object")
+    if event_name == "repository_dispatch":
+        if event_action != KICK_ACTION:
+            raise LandingError(f"event action must be {KICK_ACTION!r}, got {event_action!r}")
+        if event.get("action") != event_action:
+            raise LandingError("event document action differs from the trigger context")
+        if actor not in KICK_ACTORS:
+            raise LandingError(f"actor {actor!r} may not kick the wave landing")
+        payload = event.get("client_payload")
+        if payload is None:
+            payload = {}
+        if not isinstance(payload, dict) or set(payload) - {"reason"}:
+            raise LandingError("kick payload may carry a reason and nothing else")
+        reason = payload.get("reason", "")
+        if not isinstance(reason, str) or len(reason) > KICK_REASON_LIMIT:
+            raise LandingError("kick reason must be text of at most 200 characters")
+        return {"trigger": TRIGGER_KICK, "actor": actor, "reason": reason}
+    if event_name == "workflow_run":
+        if event_action != "completed":
+            raise LandingError(f"workflow_run action must be 'completed', got {event_action!r}")
+        run = event.get("workflow_run")
+        if not isinstance(run, dict):
+            raise LandingError("workflow_run event omitted its run")
+        head_repository = run.get("head_repository")
+        if run.get("head_branch") != WAVE_BRANCH:
+            raise LandingError(
+                f"workflow_run head branch {run.get('head_branch')!r} is not the wave"
+            )
+        if (
+            not isinstance(head_repository, dict)
+            or head_repository.get("full_name") != repository
+        ):
+            raise LandingError("workflow_run head repository is not first-party")
+        if run.get("status") != "completed":
+            raise LandingError("workflow_run is not completed")
+        return {
+            "trigger": TRIGGER_COMPLETION,
+            "workflow": run.get("name"),
+            "conclusion": run.get("conclusion"),
+            "head_sha": run.get("head_sha"),
+        }
+    if event_name == "schedule":
+        if event_action != "":
+            raise LandingError(f"scheduled event action must be empty, got {event_action!r}")
+        return {"trigger": TRIGGER_SWEEP}
+    raise LandingError(
+        f"event name must be workflow_run, repository_dispatch or schedule, got {event_name!r}"
+    )
 
 
 def run_gh(arguments: Sequence[str], *, token: str | None = None) -> str:
@@ -256,11 +355,14 @@ def judge_check_runs(pages: Any) -> dict[str, Any]:
 
     pending: list[str] = []
     failed: list[str] = []
+    cancelled: list[str] = []
     for name in sorted(newest):
         run = newest[name]
         conclusion = run.get("conclusion")
         if conclusion is None or conclusion == "":
             pending.append(name)
+        elif conclusion in CANCELLED_CONCLUSIONS:
+            cancelled.append(name)
         elif conclusion not in GREEN_CONCLUSIONS:
             failed.append(f"{name}={conclusion}")
     missing = [name for name in RULESET_REQUIRED_CONTEXTS if name not in newest]
@@ -268,6 +370,7 @@ def judge_check_runs(pages: Any) -> dict[str, Any]:
         "total": total,
         "distinct": len(newest),
         "pending": pending,
+        "cancelled": cancelled,
         "failed": failed,
         "missing_required": missing,
     }
@@ -400,13 +503,24 @@ def judge(snapshot: dict[str, Any]) -> Verdict:
 
     branch_tip = snapshot.get("branch_tip")
     if _sha(branch_tip) is None:
-        return Verdict(REFUSE, f"origin carries no readable {WAVE_BRANCH} tip", number, head)
-    if branch_tip != head:
         return Verdict(
-            REFUSE,
-            f"origin/{WAVE_BRANCH} is at {branch_tip}, not the pull head {head}",
+            WAIT,
+            f"origin carries no readable {WAVE_BRANCH} tip yet",
             number,
             head,
+            transient=True,
+        )
+    if branch_tip != head:
+        # The receiver re-pushed: the pull request's head is about to move to
+        # the branch tip, and every check on the old head is superseded. The
+        # next pass judges the new head.
+        return Verdict(
+            WAIT,
+            f"the wave moved: origin/{WAVE_BRANCH} is at {branch_tip}, not the "
+            f"pull head {head}; the next pass judges the new head",
+            number,
+            head,
+            transient=True,
         )
 
     commits = snapshot.get("commits")
@@ -473,6 +587,17 @@ def judge(snapshot: dict[str, Any]) -> Verdict:
             number,
             head,
             checks,
+            transient=True,
+        )
+    if checks["cancelled"]:
+        return Verdict(
+            WAIT,
+            "checks cancelled, awaiting the rerun a re-push or reopen triggers: "
+            + ", ".join(checks["cancelled"]),
+            number,
+            head,
+            checks,
+            transient=True,
         )
     if checks["missing_required"]:
         return Verdict(
@@ -482,6 +607,7 @@ def judge(snapshot: dict[str, Any]) -> Verdict:
             number,
             head,
             checks,
+            transient=True,
         )
 
     state = pull.get("mergeable_state")
@@ -500,12 +626,18 @@ def judge(snapshot: dict[str, Any]) -> Verdict:
             number,
             head,
             checks,
+            transient=True,
         )
 
     attestation = snapshot.get("attestation")
     if attestation == ATTESTATION_PENDING:
         return Verdict(
-            WAIT, "release-App attestation for this head has not arrived", number, head, checks
+            WAIT,
+            "release-App attestation for this head has not arrived",
+            number,
+            head,
+            checks,
+            transient=True,
         )
     if attestation != ATTESTATION_VERIFIED:
         return Verdict(REFUSE, f"attestation: {attestation}", number, head, checks)
@@ -646,6 +778,51 @@ def gather(repository: str, workspace: Path, freeze: str) -> dict[str, Any]:
     return snapshot
 
 
+def judge_with_wait(
+    repository: str,
+    workspace: Path,
+    freeze: str,
+    *,
+    wait_seconds: int,
+    gather_snapshot: Callable[[str, Path, str], dict[str, Any]] | None = None,
+    sleep: Callable[[float], None] = time.sleep,
+    clock: Callable[[], float] = time.monotonic,
+) -> tuple[Verdict, dict[str, Any]]:
+    """Judge, and keep re-reading while the verdict is a transient wait.
+
+    A cron GitHub does not fire and a completion event that arrives before the
+    last check does are both real, so a judgment triggered once has to be able
+    to outlast the checks it is waiting on. The budget is bounded and every
+    pass re-reads the whole snapshot, so a wave the receiver re-pushes during
+    the wait is judged on its new head.
+    """
+
+    if wait_seconds < 0:
+        raise LandingError("wait budget cannot be negative")
+    # Resolved at call time, not bound at definition time, so a replaced
+    # module-level gather (a test's, or a future fixture reader's) is honoured.
+    if gather_snapshot is None:
+        gather_snapshot = gather
+    deadline = clock() + wait_seconds
+    passes = 0
+    while True:
+        snapshot = gather_snapshot(repository, workspace, freeze)
+        verdict = judge(snapshot)
+        passes += 1
+        remaining = deadline - clock()
+        if verdict.decision != WAIT or not verdict.transient or remaining <= 0:
+            return Verdict(
+                verdict.decision,
+                verdict.reason,
+                verdict.pull,
+                verdict.head,
+                {**verdict.details, "passes": passes},
+                verdict.transient,
+            ), snapshot
+        print(f"::notice::wave landing waits ({int(remaining)}s left): {verdict.reason}", file=sys.stderr)
+        sleep(min(WAIT_POLL_SECONDS, remaining))
+
+
 def squash(
     repository: str,
     pull: dict[str, Any],
@@ -709,11 +886,26 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     subparsers = parser.add_subparsers(dest="command", required=True)
     fixture = subparsers.add_parser("judge-fixture", help="judge one snapshot document")
     fixture.add_argument("--fixture", type=Path, required=True)
+    trigger = subparsers.add_parser("validate-trigger", help="validate the run's trigger")
+    trigger.add_argument("--event-file", type=Path, required=True)
+    trigger.add_argument("--event-name", required=True)
+    trigger.add_argument("--event-action", default="")
+    trigger.add_argument("--actor", required=True)
+    trigger.add_argument("--repository", required=True)
+    trigger.add_argument("--default-branch", required=True)
+    trigger.add_argument("--ref", required=True)
+    trigger.add_argument("--workflow-sha", required=True)
     for name in ("judge", "land"):
         command = subparsers.add_parser(name)
         command.add_argument("--repository", required=True)
         command.add_argument("--workspace", type=Path, required=True)
         command.add_argument("--freeze", default="")
+        command.add_argument(
+            "--wait-seconds",
+            type=int,
+            default=0,
+            help="keep re-reading while the verdict is a transient wait, up to this budget",
+        )
         if name == "land":
             command.add_argument("--pull", type=int, required=True)
             command.add_argument("--head", required=True)
@@ -745,10 +937,29 @@ def main(argv: Sequence[str] | None = None) -> int:
             if not isinstance(snapshot, dict):
                 raise LandingError("fixture is not an object")
             return _emit(judge(snapshot))
+        if args.command == "validate-trigger":
+            with args.event_file.open(encoding="utf-8") as stream:
+                event = json.load(stream)
+            trigger = validate_trigger(
+                event_name=args.event_name,
+                event_action=args.event_action,
+                actor=args.actor,
+                repository=args.repository,
+                default_branch=args.default_branch,
+                ref=args.ref,
+                workflow_sha=args.workflow_sha,
+                event=event,
+            )
+            print(json.dumps(trigger, sort_keys=True))
+            return 0
         if args.repository != EXPECTED_REPOSITORY:
             raise LandingError(f"repository must be {EXPECTED_REPOSITORY}")
-        snapshot = gather(args.repository, args.workspace, args.freeze)
-        verdict = judge(snapshot)
+        verdict, snapshot = judge_with_wait(
+            args.repository,
+            args.workspace,
+            args.freeze,
+            wait_seconds=args.wait_seconds,
+        )
         if args.command == "judge" or verdict.decision != LAND:
             return _emit(verdict)
         if verdict.pull != args.pull or verdict.head != args.head:
@@ -775,6 +986,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         )
     except (LandingError, OSError, json.JSONDecodeError) as exc:
+        if args.command == "validate-trigger":
+            print(f"::error title=Kin registry wave trigger refused::{exc}", file=sys.stderr)
+            return 1
         return _emit(Verdict(REFUSE, str(exc)))
 
 

--- a/scripts/test-kin-registry-release-receiver.py
+++ b/scripts/test-kin-registry-release-receiver.py
@@ -1545,17 +1545,36 @@ class PostCompletionAttesterTests(unittest.TestCase):
             self.assertEqual(evidence.head, head)
 
     def test_attestation_survives_main_advancing_and_refuses_a_rewrite(self) -> None:
+        # Main advances after the receiver's checkout and the pull-request
+        # action rebases the wave onto the new tip, so the live head's parent
+        # and the pull base are the tip, not the admitted base. The admission
+        # still names the admitted base and tree; the attester has to accept
+        # the rebased head and refuse a rewritten main.
         with tempfile.TemporaryDirectory() as directory:
-            repo, _, result_file, base, head = self._changed(directory)
+            repo, _, result_file, base, admitted_head = self._changed(directory)
             run = workflow_run_document(base)
             event_file = Path(directory) / "event.json"
             event_file.write_text(
                 json.dumps({"action": "completed", "workflow_run": run}),
                 encoding="utf-8",
             )
-            pull = pull_document(head, base)
-            reviews, comments = attestation_documents(repo, base, head)
-            tip = "9" * 40
+            run_git(repo, "switch", "-q", "--detach", base)
+            (repo / "README.md").write_text("advanced\n", encoding="utf-8")
+            run_git(repo, "add", "README.md")
+            run_git(repo, "commit", "-q", "-m", "advance main")
+            tip = run_git(repo, "rev-parse", "HEAD")
+            run_git(repo, "cherry-pick", admitted_head)
+            head = run_git(repo, "rev-parse", "HEAD")
+            admission = json.loads(result_file.read_text(encoding="utf-8"))
+            admission["head"] = head
+            result_file.write_text(json.dumps(admission, sort_keys=True), encoding="utf-8")
+            pull = pull_document(head, tip)
+            reviews, comments = attestation_documents(repo, base, admitted_head)
+            for comment in comments:
+                comment["body"] = comment["body"].replace(f"head={admitted_head}", f"head={head}")
+            for review in reviews:
+                review["commit_id"] = head
+                review["body"] = review["body"].replace(f"head={admitted_head}", f"head={head}")
 
             def fake(relation: str):
                 compare = {
@@ -2431,7 +2450,12 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn(".base.sha", verifier)
         self.assertIn(".auto_merge == null", verifier)
         self.assertIn("api_tree", verifier)
-        self.assertIn('!= "$EXPECTED_TREE"', verifier)
+        # The head's tree equals the admitted tree only while main stood still;
+        # the guard proves the admitted delta on whatever parent the action
+        # rebased onto, and the API's tree has to agree with the fetched head.
+        self.assertIn("verify-generated-head", verifier)
+        self.assertIn('--expected-tree "$EXPECTED_TREE"', verifier)
+        self.assertIn('!= "$api_tree"', verifier)
 
     def test_fixed_pr_landing_state_is_cleared_before_and_after_write(self) -> None:
         early = step_block(

--- a/scripts/test-kin-registry-wave-landing.py
+++ b/scripts/test-kin-registry-wave-landing.py
@@ -63,6 +63,63 @@ def load_module(name: str, path: Path):
 
 history = load_module("kin_wave_history_tests", HISTORY_PATH)
 landing = load_module("kin_wave_landing_tests", LANDING_PATH)
+head_guard = load_module("kin_wave_head_guard_tests", HEAD_GUARD_PATH)
+
+
+def run_git(repo: Path, *arguments: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *arguments],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    ).stdout.strip()
+
+
+def manifest(dependency: str = "=0.7.67") -> str:
+    return (
+        "[workspace]\nmembers = []\n\n[workspace.package]\nversion = \"0.6.1\"\n\n"
+        "[workspace.dependencies]\n"
+        f'kin-db = {{ version = "{dependency}", registry = "kin" }}\n'
+    )
+
+
+def initialize_repo(repo: Path) -> str:
+    run_git(repo, "init", "-q", "-b", "main")
+    run_git(repo, "config", "user.name", "Kin Test")
+    run_git(repo, "config", "user.email", "kin-test@example.com")
+    run_git(repo, "config", "commit.gpgsign", "false")
+    run_git(repo, "config", "core.hooksPath", "/dev/null")
+    (repo / "Cargo.toml").write_text(manifest(), encoding="utf-8")
+    (repo / "Cargo.lock").write_text("version = 4\nkin-db 0.7.67\n", encoding="utf-8")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    run_git(repo, "add", "-A")
+    run_git(repo, "commit", "-q", "-m", "base")
+    return run_git(repo, "rev-parse", "HEAD")
+
+
+def write_pins(repo: Path, dependency: str, lock_version: str) -> None:
+    (repo / "Cargo.toml").write_text(manifest(dependency), encoding="utf-8")
+    (repo / "Cargo.lock").write_text(
+        f"version = 4\nkin-db {lock_version}\n", encoding="utf-8"
+    )
+
+
+def commit_wave(repo: Path, dependency: str = "=0.7.69", lock_version: str = "0.7.69") -> str:
+    write_pins(repo, dependency, lock_version)
+    run_git(repo, "add", "-A")
+    run_git(repo, "commit", "-q", "-m", f"dependency wave\n\n{head_guard.COMMIT_MARKER}")
+    return run_git(repo, "rev-parse", "HEAD")
+
+
+def advance_main(repo: Path, base: str, *, touch_lock: bool = False) -> str:
+    run_git(repo, "switch", "-q", "--detach", base)
+    (repo / "README.md").write_text("advanced\n", encoding="utf-8")
+    if touch_lock:
+        (repo / "Cargo.lock").write_text("version = 4\nkin-db 0.7.67\nextra\n", encoding="utf-8")
+    run_git(repo, "add", "-A")
+    run_git(repo, "commit", "-q", "-m", "advance main")
+    return run_git(repo, "rev-parse", "HEAD")
 
 
 def job_block(workflow: str, job_id: str) -> str:
@@ -434,7 +491,7 @@ class WaveJudgeTests(unittest.TestCase):
             r"checks failed: cargo-fuzz \(parse_adapter\)=failure",
         )
         self.assertEqual(verdict.pull, 1360)
-        for conclusion in ("cancelled", "timed_out", "action_required", "stale"):
+        for conclusion in ("timed_out", "action_required", "stale", "startup_failure"):
             with self.subTest(conclusion=conclusion):
                 runs = green_runs() + [check_run("Linux Daemon Smoke", conclusion)]
                 self.assertVerdict(
@@ -442,6 +499,32 @@ class WaveJudgeTests(unittest.TestCase):
                     landing.REFUSE,
                     f"checks failed: Linux Daemon Smoke={conclusion}",
                 )
+
+    def test_cancelled_by_a_repush_waits_instead_of_failing(self) -> None:
+        # The receiver's re-push cancels the superseded suite and the attester's
+        # reopen retrigger does the same; on 2026-09-02 a judgment read
+        # "Fast gate lint and policy=cancelled" and painted the workflow red for
+        # a check nothing could have kept green. It is a wait, and transient.
+        runs = green_runs() + [check_run("Fast gate lint and policy", "cancelled", started="2026-09-02T09:40:00Z")]
+        verdict = self.assertVerdict(
+            green_snapshot(check_run_pages=pages(runs)),
+            landing.WAIT,
+            "checks cancelled, awaiting the rerun a re-push or reopen triggers: Fast gate lint and policy",
+        )
+        self.assertTrue(verdict.transient)
+        self.assertEqual(verdict.details["cancelled"], ["Fast gate lint and policy"])
+
+    def test_a_repushed_head_waits_for_the_next_pass(self) -> None:
+        verdict = self.assertVerdict(
+            green_snapshot(branch_tip=OTHER),
+            landing.WAIT,
+            f"the wave moved: origin/{landing.WAVE_BRANCH} is at {OTHER}, not the pull head {HEAD}",
+        )
+        self.assertTrue(verdict.transient)
+        verdict = self.assertVerdict(
+            green_snapshot(branch_tip=None), landing.WAIT, "no readable"
+        )
+        self.assertTrue(verdict.transient)
 
     def test_one_pending_waits(self) -> None:
         runs = green_runs() + [check_run("Linux Daemon Smoke", None, status="in_progress")]
@@ -631,13 +714,21 @@ class WaveJudgeTests(unittest.TestCase):
             with self.subTest(reason=reason):
                 self.assertVerdict(green_snapshot(pull=pull), landing.REFUSE, re.escape(reason))
 
-    def test_branch_tip_must_be_the_judged_head(self) -> None:
-        self.assertVerdict(
-            green_snapshot(branch_tip=OTHER), landing.REFUSE, "not the pull head"
+    def test_transient_and_final_waits_are_told_apart(self) -> None:
+        transient = (
+            green_snapshot(check_run_pages=pages(green_runs() + [check_run("x", None, status="queued")])),
+            green_snapshot(pull=wave_pull(mergeable_state="unknown")),
+            green_snapshot(attestation=landing.ATTESTATION_PENDING),
+            green_snapshot(check_run_pages=pages([run for run in green_runs() if run["name"] != "cargo-deny"])),
         )
-        self.assertVerdict(
-            green_snapshot(branch_tip=None), landing.REFUSE, "no readable"
-        )
+        for snapshot in transient:
+            verdict = landing.judge(snapshot)
+            self.assertEqual(verdict.decision, landing.WAIT, verdict.reason)
+            self.assertTrue(verdict.transient, verdict.reason)
+        for snapshot in (green_snapshot(freeze="hold"), green_snapshot(open_pulls=[])):
+            verdict = landing.judge(snapshot)
+            self.assertEqual(verdict.decision, landing.WAIT, verdict.reason)
+            self.assertFalse(verdict.transient, verdict.reason)
 
     def test_conflict_refuses_and_a_settling_state_waits(self) -> None:
         self.assertVerdict(
@@ -834,6 +925,274 @@ class WaveJudgeTests(unittest.TestCase):
         self.assertEqual(written, set(landing.ALLOWED_PATHS))
 
 
+class WaitLoopTests(unittest.TestCase):
+    def _loop(self, snapshots: list[dict[str, Any]], budget: int) -> tuple[Any, list[float], int]:
+        supplied = list(snapshots)
+        gathers = 0
+        slept: list[float] = []
+        clock = {"now": 0.0}
+
+        def fake_gather(repository: str, workspace: Path, freeze: str) -> dict[str, Any]:
+            nonlocal gathers
+            gathers += 1
+            return supplied.pop(0) if len(supplied) > 1 else supplied[0]
+
+        def fake_sleep(seconds: float) -> None:
+            slept.append(seconds)
+            clock["now"] += seconds
+
+        with contextlib.redirect_stderr(io.StringIO()):
+            verdict, _ = landing.judge_with_wait(
+                REPO,
+                Path("."),
+                "",
+                wait_seconds=budget,
+                gather_snapshot=fake_gather,
+                sleep=fake_sleep,
+                clock=lambda: clock["now"],
+            )
+        return verdict, slept, gathers
+
+    def test_a_transient_wait_is_re_read_until_it_lands(self) -> None:
+        pending = green_snapshot(check_run_pages=pages(green_runs() + [check_run("x", None, status="queued")]))
+        verdict, slept, gathers = self._loop([pending, pending, green_snapshot()], 600)
+        self.assertEqual(verdict.decision, landing.LAND)
+        self.assertEqual(gathers, 3)
+        self.assertEqual(slept, [30.0, 30.0])
+        self.assertEqual(verdict.details["passes"], 3)
+
+    def test_the_budget_bounds_the_wait(self) -> None:
+        pending = green_snapshot(check_run_pages=pages(green_runs() + [check_run("x", None, status="queued")]))
+        verdict, slept, gathers = self._loop([pending], 45)
+        self.assertEqual(verdict.decision, landing.WAIT)
+        self.assertEqual(slept, [30.0, 15.0])
+        self.assertEqual(gathers, 3)
+        verdict, slept, gathers = self._loop([pending], 0)
+        self.assertEqual((verdict.decision, slept, gathers), (landing.WAIT, [], 1))
+
+    def test_a_hold_and_a_refusal_return_at_once(self) -> None:
+        verdict, slept, gathers = self._loop([green_snapshot(freeze="hold")], 600)
+        self.assertEqual((verdict.decision, slept, gathers), (landing.WAIT, [], 1))
+        red = green_snapshot(check_run_pages=pages(green_runs() + [check_run("cargo-deny", "failure")]))
+        verdict, slept, gathers = self._loop([red], 600)
+        self.assertEqual((verdict.decision, slept, gathers), (landing.REFUSE, [], 1))
+
+    def test_a_repush_during_the_wait_is_judged_on_the_new_head(self) -> None:
+        moved = green_snapshot(branch_tip=OTHER)
+        verdict, slept, gathers = self._loop([moved, green_snapshot()], 600)
+        self.assertEqual(verdict.decision, landing.LAND)
+        self.assertEqual(gathers, 2)
+
+
+def trigger_context(**overrides: Any) -> dict[str, Any]:
+    context: dict[str, Any] = {
+        "event_name": "repository_dispatch",
+        "event_action": landing.KICK_ACTION,
+        "actor": "troyjr4103",
+        "repository": REPO,
+        "default_branch": "main",
+        "ref": "refs/heads/main",
+        "workflow_sha": POLICY,
+        "event": {"action": landing.KICK_ACTION, "client_payload": {"reason": "captain kick"}},
+    }
+    context.update(overrides)
+    return context
+
+
+def completion_event(**overrides: Any) -> dict[str, Any]:
+    run: dict[str, Any] = {
+        "name": "CI",
+        "status": "completed",
+        "conclusion": "success",
+        "head_branch": landing.WAVE_BRANCH,
+        "head_sha": HEAD,
+        "head_repository": {"full_name": REPO},
+    }
+    run.update(overrides)
+    return {"action": "completed", "workflow_run": run}
+
+
+class TriggerValidationTests(unittest.TestCase):
+    def test_kick_from_each_allowed_actor_is_admitted(self) -> None:
+        for actor in sorted(landing.KICK_ACTORS):
+            with self.subTest(actor=actor):
+                verdict = landing.validate_trigger(**trigger_context(actor=actor))
+                self.assertEqual(verdict["trigger"], landing.TRIGGER_KICK)
+                self.assertEqual(verdict["reason"], "captain kick")
+        bare = landing.validate_trigger(**trigger_context(event={"action": landing.KICK_ACTION}))
+        self.assertEqual(bare["reason"], "")
+
+    def test_kick_refusals(self) -> None:
+        cases = {
+            "may not kick": trigger_context(actor="outsider"),
+            "event action must be": trigger_context(event_action="release_tag", event={"action": "release_tag"}),
+            "differs from the trigger context": trigger_context(event={"action": "other"}),
+            "workflow ref must be": trigger_context(ref="refs/heads/feature"),
+            "default branch must be": trigger_context(default_branch="develop"),
+            "repository must be": trigger_context(repository="fork/kin"),
+            "workflow sha must be": trigger_context(workflow_sha="abc"),
+            "a reason and nothing else": trigger_context(
+                event={"action": landing.KICK_ACTION, "client_payload": {"reason": "x", "sha": POLICY}}
+            ),
+            "at most 200 characters": trigger_context(
+                event={"action": landing.KICK_ACTION, "client_payload": {"reason": "r" * 201}}
+            ),
+        }
+        for message, context in cases.items():
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(landing.LandingError, message):
+                    landing.validate_trigger(**context)
+
+    def test_wave_completion_is_admitted_and_others_refused(self) -> None:
+        verdict = landing.validate_trigger(
+            **trigger_context(event_name="workflow_run", event_action="completed", actor="anyone", event=completion_event())
+        )
+        self.assertEqual(verdict["trigger"], landing.TRIGGER_COMPLETION)
+        self.assertEqual(verdict["workflow"], "CI")
+        cases = {
+            "is not the wave": completion_event(head_branch="main"),
+            "not first-party": completion_event(head_repository={"full_name": "fork/kin"}),
+            "is not completed": completion_event(status="in_progress"),
+            "omitted its run": {"action": "completed"},
+        }
+        for message, event in cases.items():
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(landing.LandingError, message):
+                    landing.validate_trigger(
+                        **trigger_context(event_name="workflow_run", event_action="completed", actor="anyone", event=event)
+                    )
+        with self.assertRaisesRegex(landing.LandingError, "must be 'completed'"):
+            landing.validate_trigger(
+                **trigger_context(event_name="workflow_run", event_action="requested", actor="anyone", event=completion_event())
+            )
+
+    def test_sweep_and_unknown_events(self) -> None:
+        verdict = landing.validate_trigger(
+            **trigger_context(event_name="schedule", event_action="", actor="anyone", event={"schedule": "5,20,35,50 * * * *"})
+        )
+        self.assertEqual(verdict["trigger"], landing.TRIGGER_SWEEP)
+        with self.assertRaisesRegex(landing.LandingError, "scheduled event action must be empty"):
+            landing.validate_trigger(
+                **trigger_context(event_name="schedule", event_action="x", actor="anyone", event={})
+            )
+        with self.assertRaisesRegex(landing.LandingError, "event name must be"):
+            landing.validate_trigger(**trigger_context(event_name="workflow_dispatch", event={}))
+
+    def test_cli_exit_codes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            event_path = Path(directory) / "event.json"
+            event_path.write_text(json.dumps({"action": landing.KICK_ACTION}), encoding="utf-8")
+            base = [
+                sys.executable, str(LANDING_PATH), "validate-trigger",
+                "--event-file", str(event_path), "--event-name", "repository_dispatch",
+                "--event-action", landing.KICK_ACTION, "--repository", REPO,
+                "--default-branch", "main", "--ref", "refs/heads/main", "--workflow-sha", POLICY,
+            ]
+            ok = subprocess.run(base + ["--actor", "kin-release-bot[bot]"], text=True, capture_output=True, check=False)
+            self.assertEqual(ok.returncode, 0, ok.stderr)
+            self.assertEqual(json.loads(ok.stdout)["trigger"], landing.TRIGGER_KICK)
+            refused = subprocess.run(base + ["--actor", "outsider"], text=True, capture_output=True, check=False)
+            self.assertEqual(refused.returncode, 1)
+            self.assertIn("::error title=Kin registry wave trigger refused::", refused.stderr)
+
+
+class AdmittedHeadTests(unittest.TestCase):
+    def test_unmoved_main_is_the_old_equality(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            head = commit_wave(repo)
+            admitted = head_guard.validate_delta(repo, base, head, require_marker=True)
+            evidence = head_guard.validate_admitted_head(repo, base, admitted.tree, head, require_marker=True)
+            self.assertEqual((evidence.base, evidence.admitted_base, evidence.tree), (base, base, admitted.tree))
+            self.assertEqual(evidence.delta_sha256, admitted.delta_sha256)
+            with self.assertRaisesRegex(head_guard.AdmissionError, "not the admitted"):
+                head_guard.validate_admitted_head(repo, base, "0" * 40, head, require_marker=True)
+
+    def test_a_head_rebased_onto_a_moved_main_carries_the_admitted_delta(self) -> None:
+        # The pull-request action rebases the wave onto main's tip. kin#1360's
+        # head a45f85aae had parent a6852aa04, not the writing run's policy
+        # eeae72729, and the tree comparison refused it after the push.
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            admitted_head = commit_wave(repo)
+            admitted = head_guard.validate_delta(repo, base, admitted_head, require_marker=True)
+            tip = advance_main(repo, base)
+            run_git(repo, "cherry-pick", admitted_head)
+            rebased = run_git(repo, "rev-parse", "HEAD")
+            self.assertEqual(head_guard.first_parent(repo, rebased), tip)
+            self.assertNotEqual(run_git(repo, "rev-parse", f"{rebased}^{{tree}}"), admitted.tree)
+            evidence = head_guard.validate_admitted_head(repo, base, admitted.tree, rebased, require_marker=True)
+            self.assertEqual((evidence.base, evidence.admitted_base, evidence.head), (tip, base, rebased))
+            self.assertEqual(evidence.delta_sha256, admitted.delta_sha256)
+            self.assertEqual(evidence.paths, head_guard.ALLOWED_PATHS)
+            with self.assertRaisesRegex(head_guard.AdmissionError, "does not descend"):
+                head_guard.validate_admitted_head(repo, admitted_head, admitted.tree, rebased, require_marker=True)
+
+    def test_main_touching_the_pin_files_refuses_the_rebuild(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            admitted_head = commit_wave(repo)
+            admitted = head_guard.validate_delta(repo, base, admitted_head, require_marker=True)
+            advance_main(repo, base, touch_lock=True)
+            rebuilt = commit_wave(repo)
+            with self.assertRaisesRegex(head_guard.AdmissionError, "changed admitted dependency paths"):
+                head_guard.validate_admitted_head(repo, base, admitted.tree, rebuilt, require_marker=True)
+
+    def test_a_different_delta_on_the_moved_main_is_not_the_admitted_tree(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            admitted_head = commit_wave(repo)
+            admitted = head_guard.validate_delta(repo, base, admitted_head, require_marker=True)
+            advance_main(repo, base)
+            other = commit_wave(repo, dependency="=0.7.70", lock_version="0.7.70")
+            with self.assertRaisesRegex(head_guard.AdmissionError, "not the admitted"):
+                head_guard.validate_admitted_head(repo, base, admitted.tree, other, require_marker=True)
+
+    def test_a_foreign_parent_refuses(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            admitted_head = commit_wave(repo)
+            admitted = head_guard.validate_delta(repo, base, admitted_head, require_marker=True)
+            run_git(repo, "switch", "-q", "--orphan", "unrelated")
+            (repo / "Cargo.toml").write_text(manifest(), encoding="utf-8")
+            (repo / "Cargo.lock").write_text("version = 4\nkin-db 0.7.67\n", encoding="utf-8")
+            (repo / "README.md").write_text("unrelated\n", encoding="utf-8")
+            run_git(repo, "add", "-A")
+            run_git(repo, "commit", "-q", "-m", "unrelated root")
+            foreign = commit_wave(repo)
+            with self.assertRaisesRegex(head_guard.AdmissionError, "does not descend"):
+                head_guard.validate_admitted_head(repo, base, admitted.tree, foreign, require_marker=True)
+
+    def test_generated_head_cli(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            admitted_head = commit_wave(repo)
+            admitted = head_guard.validate_delta(repo, base, admitted_head, require_marker=True)
+            tip = advance_main(repo, base)
+            run_git(repo, "cherry-pick", admitted_head)
+            rebased = run_git(repo, "rev-parse", "HEAD")
+            command = [
+                sys.executable, str(HEAD_GUARD_PATH), "verify-generated-head",
+                "--workspace", str(repo), "--pull", "77", "--head", rebased,
+                "--admitted-base", base, "--expected-tree", admitted.tree,
+            ]
+            ok = subprocess.run(command, text=True, capture_output=True, check=False)
+            self.assertEqual(ok.returncode, 0, ok.stderr)
+            document = json.loads(ok.stdout)
+            self.assertEqual((document["parent"], document["admitted_base"]), (tip, base))
+            self.assertEqual(document["tree"], run_git(repo, "rev-parse", f"{rebased}^{{tree}}"))
+            command[-1] = "0" * 40
+            refused = subprocess.run(command, text=True, capture_output=True, check=False)
+            self.assertEqual(refused.returncode, 1)
+            self.assertIn("not the admitted delta", refused.stderr)
+
+
 # ---------------------------------------------------------------------------
 # Workflow contracts.
 # ---------------------------------------------------------------------------
@@ -905,6 +1264,31 @@ class ReceiverBindingContractTests(unittest.TestCase):
         self.assertIn('--descendant "$(jq -r .base.sha <<<"$pull")"', verifier)
         self.assertNotIn('.base.sha <<<"$pull")" != "$ADMITTED_BASE"', verifier)
 
+    def test_generated_head_is_proven_locally_not_compared_by_tree(self) -> None:
+        verifier = step_block(self.workflow, "Verify exact first-party generated PR")
+        self.assertIn("verify-kin-registry-wave-head.py verify-generated-head", verifier)
+        self.assertIn('--admitted-base "$ADMITTED_BASE"', verifier)
+        self.assertIn('--expected-tree "$EXPECTED_TREE"', verifier)
+        self.assertIn('--head "$api_head"', verifier)
+        self.assertIn('--pull "$PR"', verifier)
+        self.assertIn('[ "$(jq -r .tree <<<"$verified")" != "$api_tree" ]', verifier)
+        self.assertNotIn('[ "$api_tree" != "$EXPECTED_TREE" ]', verifier)
+
+    def test_receiver_kicks_the_judge_once_after_writing(self) -> None:
+        kick = step_block(self.workflow, "Kick the wave landing judge once")
+        self.assertIn("if: needs.prepare-wave.outputs.changed == 'true'", kick)
+        self.assertIn("GH_TOKEN: ${{ steps.app-token.outputs.token }}", kick)
+        self.assertIn("-f event_type=kin-registry-wave-land", kick)
+        self.assertIn("client_payload[reason]=receiver run", kick)
+        self.assertEqual(
+            self.mutation_job.rfind("- name:"),
+            self.mutation_job.index("- name: Kick the wave landing judge once"),
+        )
+        self.assertLess(
+            self.mutation_job.index("- name: Upload exact result for the post-completion attester"),
+            self.mutation_job.index("- name: Kick the wave landing judge once"),
+        )
+
     def test_attester_and_gate_accept_a_descendant_base(self) -> None:
         attester = ATTESTER_PATH.read_text(encoding="utf-8")
         self.assertIn('SCRIPT_DIR / "verify-protected-main-history.py"', attester)
@@ -926,16 +1310,52 @@ class LandingWorkflowContractTests(unittest.TestCase):
         cls.judge_job = job_block(cls.workflow, "judge-wave")
         cls.land_job = job_block(cls.workflow, "land-wave")
 
-    def test_triggers_are_completions_and_a_sweep_with_no_dispatch(self) -> None:
+    def test_triggers_are_the_wave_ci_the_kick_and_the_sweep(self) -> None:
         trigger = self.workflow.split("\njobs:", 1)[0]
         self.assertIn("workflow_run:", trigger)
+        self.assertIn("workflows: [CI]", trigger)
         self.assertIn("types: [completed]", trigger)
-        for workflow in ("CI", "SAST", "Secret Scan", "DCO", "PR Text Hygiene", "CodeQL"):
-            self.assertIn(f"      - {workflow}\n", trigger)
+        self.assertIn("branches: [automation/kin-registry-dependency-wave]", trigger)
+        for workflow in ("SAST", "Secret Scan", "DCO", "PR Text Hygiene", "CodeQL", "Fuzz"):
+            self.assertNotIn(f"- {workflow}\n", trigger)
+        self.assertIn("repository_dispatch:", trigger)
+        self.assertIn("types: [kin-registry-wave-land]", trigger)
         self.assertIn('cron: "5,20,35,50 * * * *"', trigger)
         self.assertNotIn("workflow_dispatch", self.workflow)
         self.assertNotIn("pull_request", trigger)
         self.assertRegex(trigger, r"(?m)^permissions:\n  contents: read$")
+
+    def test_trigger_is_validated_before_anything_reads_the_wave(self) -> None:
+        validate = step_block(self.workflow, "Validate the landing trigger")
+        self.assertIn("land-kin-registry-wave.py validate-trigger", validate)
+        for argument in (
+            '--event-file "$GITHUB_EVENT_PATH"',
+            '--event-name "$GITHUB_EVENT_NAME"',
+            '--event-action "$EVENT_ACTION"',
+            '--actor "$GITHUB_ACTOR"',
+            '--default-branch "$DEFAULT_BRANCH"',
+            '--ref "$GITHUB_REF"',
+            '--workflow-sha "$GITHUB_SHA"',
+        ):
+            self.assertIn(argument, validate)
+        self.assertNotIn("GH_TOKEN", validate)
+        self.assertIn("github.event_name == 'repository_dispatch'", self.judge_job)
+        order = [
+            self.judge_job.index(f"- name: {name}")
+            for name in (
+                "Checkout the queued landing policy",
+                "Validate the landing trigger",
+                "Bind the judgment to protected main history",
+                "Judge the wave against its full check set",
+            )
+        ]
+        self.assertEqual(order, sorted(order))
+        judge = step_block(self.workflow, "Judge the wave against its full check set")
+        self.assertIn("--wait-seconds 1500", judge)
+        self.assertIn("timeout-minutes: 40", self.judge_job)
+        source = LANDING_PATH.read_text(encoding="utf-8")
+        self.assertIn('KICK_ACTION = "kin-registry-wave-land"', source)
+        self.assertIn('KICK_ACTORS = frozenset({"troyjr4103", "kin-release-bot[bot]"})', source)
 
     def test_judge_reads_only_the_wave_and_binds_to_protected_history(self) -> None:
         self.assertIn(
@@ -965,10 +1385,6 @@ class LandingWorkflowContractTests(unittest.TestCase):
         self.assertIn("ref: ${{ github.sha }}", checkout)
         self.assertIn("persist-credentials: false", checkout)
         self.assertIn("fetch-depth: 0", checkout)
-        self.assertLess(self.judge_job.index("- name: Checkout the queued landing policy"),
-                        self.judge_job.index("- name: Bind the judgment"))
-        self.assertLess(self.judge_job.index("- name: Bind the judgment"),
-                        self.judge_job.index("- name: Judge the wave"))
         self.assertIn("decision: ${{ steps.judge.outputs.decision || 'wait' }}", self.judge_job)
 
     def test_land_runs_only_on_a_land_verdict_through_the_release_app(self) -> None:

--- a/scripts/test-kin-registry-wave-landing.py
+++ b/scripts/test-kin-registry-wave-landing.py
@@ -453,6 +453,7 @@ def green_snapshot(**overrides: Any) -> dict[str, Any]:
         "commits": [bot_commit()],
         "files": [wave_file("Cargo.toml"), wave_file("Cargo.lock")],
         "check_run_pages": pages(green_runs()),
+        "pins_on_main": {"tip": BASE, "changed": ["Cargo.lock", "Cargo.toml"]},
         "attestation": landing.ATTESTATION_VERIFIED,
     }
     snapshot.update(overrides)
@@ -713,6 +714,38 @@ class WaveJudgeTests(unittest.TestCase):
         for reason, pull in cases.items():
             with self.subTest(reason=reason):
                 self.assertVerdict(green_snapshot(pull=pull), landing.REFUSE, re.escape(reason))
+
+    def test_pins_already_on_main_are_a_final_no_op(self) -> None:
+        # kin#1384 landed =0.7.88 by hand at 16:28Z while #1360 carried the same
+        # delta: nothing to merge, never an empty squash, never a red run.
+        verdict = self.assertVerdict(
+            green_snapshot(pins_on_main={"tip": OTHER, "changed": []}),
+            landing.WAIT,
+            f"pins are already on main at {OTHER}; nothing to merge",
+        )
+        self.assertFalse(verdict.transient)
+        self.assertEqual((verdict.pull, verdict.head), (1360, HEAD))
+        self.assertVerdict(
+            green_snapshot(pins_on_main=None), landing.REFUSE, "pin comparison against main is unreadable"
+        )
+        self.assertVerdict(
+            green_snapshot(pins_on_main={"tip": OTHER, "changed": ["Cargo.lock"]}),
+            landing.LAND,
+            "concluded green",
+        )
+
+    def test_pins_on_main_reads_the_workspace_tip(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            base = initialize_repo(repo)
+            head = commit_wave(repo)
+            run_git(repo, "switch", "-q", "--detach", base)
+            self.assertEqual(
+                landing.pins_on_main(repo, head),
+                {"tip": base, "changed": ["Cargo.lock", "Cargo.toml"]},
+            )
+            run_git(repo, "switch", "-q", "--detach", head)
+            self.assertEqual(landing.pins_on_main(repo, head), {"tip": head, "changed": []})
 
     def test_transient_and_final_waits_are_told_apart(self) -> None:
         transient = (

--- a/scripts/verify-kin-registry-wave-head.py
+++ b/scripts/verify-kin-registry-wave-head.py
@@ -6,9 +6,11 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import re
 import subprocess
 import sys
+import tempfile
 import time
 import tomllib
 from dataclasses import dataclass
@@ -44,7 +46,14 @@ class PendingAttestation(AdmissionError):
 
 @dataclass(frozen=True)
 class DeltaEvidence:
+    # `base` is the commit the delta was read against: the head's own parent.
+    # `admitted_base` is the receiver's policy commit the delta was admitted
+    # on. The two differ whenever main moved between the receiver's checkout
+    # and its push, because the pull-request action rebases the wave onto
+    # main's tip, and `validate_admitted_head` is the proof that the head still
+    # carries exactly the admitted delta in that case.
     base: str
+    admitted_base: str
     head: str
     tree: str
     paths: frozenset[str]
@@ -295,12 +304,149 @@ def validate_delta(
         raise AdmissionError("dependency-wave patch carries no content change")
     return DeltaEvidence(
         base=base,
+        admitted_base=base,
         head=head,
         tree=tree,
         paths=paths,
         delta_sha256=hashlib.sha256(patch).hexdigest(),
         package_version=_version_evidence(after_versions[0]),
         workspace_version=_version_evidence(after_versions[1]),
+    )
+
+
+def first_parent(workspace: Path, head: str) -> str:
+    """The single parent of a dependency-wave head; a merge is never a wave."""
+
+    listed = (
+        git(workspace, "rev-list", "--parents", "-n", "1", head)
+        .decode("ascii", errors="replace")
+        .split()
+    )
+    if len(listed) != 2:
+        raise AdmissionError(
+            f"dependency-wave head {head} does not have exactly one parent"
+        )
+    return require_sha("dependency-wave head parent", listed[1])
+
+
+def transplant_tree(workspace: Path, admitted_base: str, head: str) -> str:
+    """The tree of `admitted_base` carrying `head`'s copies of the allowed paths."""
+
+    with tempfile.TemporaryDirectory() as directory:
+        env = {**os.environ, "GIT_INDEX_FILE": str(Path(directory) / "index")}
+        subprocess.run(
+            ["git", "-C", str(workspace), "read-tree", admitted_base],
+            check=True,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        entries = git(workspace, "ls-tree", "-z", head, "--", *sorted(ALLOWED_PATHS))
+        for entry in entries.split(b"\0"):
+            if not entry:
+                continue
+            meta, _, path = entry.partition(b"\t")
+            mode, kind, blob = meta.split(b" ")
+            if kind != b"blob":
+                raise AdmissionError(
+                    f"dependency-wave head carries a non-blob at {path.decode()!r}"
+                )
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(workspace),
+                    "update-index",
+                    "--add",
+                    "--cacheinfo",
+                    f"{mode.decode()},{blob.decode()},{path.decode()}",
+                ],
+                check=True,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        written = subprocess.run(
+            ["git", "-C", str(workspace), "write-tree"],
+            check=True,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        ).stdout.decode("ascii").strip()
+        return require_sha("transplanted dependency-wave tree", written)
+
+
+def validate_admitted_head(
+    workspace: Path,
+    admitted_base: str,
+    admitted_tree: str,
+    head: str,
+    *,
+    require_marker: bool,
+) -> DeltaEvidence:
+    """Prove `head` carries exactly the admitted delta, wherever main has moved.
+
+    The receiver admits a delta on its policy commit, and the pull-request
+    action then commits that delta onto main's CURRENT tip, so the head's
+    parent is the admitted base only while main stood still. What has to
+    hold is narrower than "the head's tree is the admitted tree": the head's
+    parent is protected main at or after the admitted base, main did not touch
+    the admitted paths in between (so the delta bytes are the admitted bytes),
+    the delta read against the parent passes every admission rule, and
+    transplanting the head's copies of the admitted paths onto the admitted
+    base reproduces the admitted tree. With an unmoved main every clause
+    collapses to the old equality.
+    """
+
+    admitted_base = require_sha("admitted base", admitted_base)
+    admitted_tree = require_sha("admitted tree", admitted_tree)
+    head = require_sha("dependency-wave head", head)
+    ensure_commit(workspace, admitted_base)
+    parent = first_parent(workspace, head)
+    if parent != admitted_base:
+        ensure_commit(workspace, parent)
+        if not is_ancestor(workspace, admitted_base, parent):
+            raise AdmissionError(
+                f"dependency-wave head parent {parent} does not descend from "
+                f"admitted base {admitted_base}"
+            )
+        moved = _paths(
+            git(
+                workspace,
+                "diff",
+                "--no-ext-diff",
+                "--no-textconv",
+                "--no-renames",
+                "--name-only",
+                "-z",
+                admitted_base,
+                parent,
+                "--",
+                *sorted(ALLOWED_PATHS),
+            )
+        )
+        if moved:
+            raise AdmissionError(
+                "protected main changed admitted dependency paths after the "
+                "admitted base, so the wave has to be rebuilt: "
+                + ", ".join(sorted(moved))
+            )
+    evidence = validate_delta(workspace, parent, head, require_marker=require_marker)
+    carried = transplant_tree(workspace, admitted_base, head)
+    if carried != admitted_tree:
+        raise AdmissionError(
+            f"dependency-wave head carries tree {carried} onto the admitted base, "
+            f"not the admitted {admitted_tree}"
+        )
+    return DeltaEvidence(
+        base=parent,
+        admitted_base=admitted_base,
+        head=head,
+        tree=evidence.tree,
+        paths=evidence.paths,
+        delta_sha256=evidence.delta_sha256,
+        package_version=evidence.package_version,
+        workspace_version=evidence.workspace_version,
     )
 
 
@@ -390,6 +536,7 @@ def validate_index_delta(
         raise AdmissionError("staged dependency-wave patch carries no content change")
     return DeltaEvidence(
         base=base,
+        admitted_base=base,
         head="index",
         tree=expected_tree,
         paths=paths,
@@ -795,18 +942,16 @@ def validate_attestation(
                 f"dependency admission base {base} is not an ancestor of "
                 f"current pull base {expected_base}"
             )
-    evidence = validate_delta(workspace, base, head, require_marker=True)
-    if evidence.tree != expected_tree:
-        raise AdmissionError(
-            f"dependency head tree {evidence.tree} differs from admitted {expected_tree}"
-        )
+    evidence = validate_admitted_head(
+        workspace, base, expected_tree, head, require_marker=True
+    )
     if evidence.delta_sha256 != latest["delta_sha256"]:
         raise AdmissionError("dependency head delta differs from admitted fingerprint")
     if evidence.package_version != latest["package_version"]:
         raise AdmissionError("dependency head package version differs from admission")
     if evidence.workspace_version != latest["workspace_version"]:
         raise AdmissionError("dependency head workspace version differs from admission")
-    if evidence.base != latest["policy_sha"]:
+    if evidence.admitted_base != latest["policy_sha"]:
         raise AdmissionError("dependency admission policy differs from its exact base")
     return evidence
 
@@ -1207,10 +1352,57 @@ def emit_index_evidence(argv: Sequence[str]) -> int:
     return 0
 
 
+def verify_generated_head(argv: Sequence[str]) -> int:
+    """The receiver's post-write check: the pushed head carries the admitted delta."""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workspace", type=Path, required=True)
+    parser.add_argument("--pull", type=int, required=True)
+    parser.add_argument("--head", required=True)
+    parser.add_argument("--admitted-base", required=True)
+    parser.add_argument("--expected-tree", required=True)
+    args = parser.parse_args(argv)
+    try:
+        if args.pull < 1:
+            raise AdmissionError("pull number must be positive")
+        head = require_sha("generated head", args.head)
+        ensure_pull_head(args.workspace, args.pull, head)
+        evidence = validate_admitted_head(
+            args.workspace,
+            args.admitted_base,
+            args.expected_tree,
+            head,
+            require_marker=True,
+        )
+    except AdmissionError as exc:
+        print(
+            f"::error title=Generated Kin registry head is not the admitted delta::{exc}",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        json.dumps(
+            {
+                "admitted_base": evidence.admitted_base,
+                "parent": evidence.base,
+                "head": evidence.head,
+                "tree": evidence.tree,
+                "delta_sha256": evidence.delta_sha256,
+                "package_version": evidence.package_version,
+                "workspace_version": evidence.workspace_version,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     arguments = list(argv or sys.argv[1:])
     if arguments[:1] == ["emit-index-evidence"]:
         return emit_index_evidence(arguments[1:])
+    if arguments[:1] == ["verify-generated-head"]:
+        return verify_generated_head(arguments[1:])
     args = parse_args(arguments)
     try:
         if args.repository != EXPECTED_REPOSITORY:


### PR DESCRIPTION
The wave landing judges once per wave, on the wave branch's own CI completion or a typed kick, outlasts the checks it waits on, and admits the head the pull-request action rebases onto a moved main. Follow-up to #1371.

## Measured after #1371 landed

- The landing workflow listened to twelve workflows on every branch plus a cron. Main's push for eeae72729 produced twelve runs in ninety seconds (nine cancelled by GitHub's one-pending-run-per-concurrency-group rule), and 99 skipped runs followed in three hours while the cron fired zero times. Run 33632376303, read as a wave completion, was a completion on main (head_branch main) that the job's `if` rejected correctly.
- The one failed landing run read `Fast gate lint and policy=cancelled` on a head the receiver's re-push had already superseded, and refused loudly.
- Receiver run 33642225831 (14:27Z, policy eeae72729) passed the new bindings and refused at "Verify exact first-party generated PR": `dependency PR tree 287af4973 differs from admitted c2d903422`. The wave head a45f85aae has parent a6852aa04, not the policy sha: peter-evans rebases the wave onto main's current tip, so once main has moved the head's tree is tip plus delta. The old equality binding hid this by refusing before the push; #1371 moved the refusal after it, so the head was written, the run failed before its result artifact, the attester never ran, and the CI gate on that head failed at 14:37Z with `dependency-wave head has no exact release-App admission attestation` after its 300 s wait. That is the red "Fast gate lint and policy" on #1360, a regression #1371 caused and this PR removes.
- Receiver run 33647602488 (15:17Z) failed in the credential-free cargo check with `error[E0308]` on the new kin-db pins: a real consumer break, carried by hand tonight, not the receiver's.

## The proof for a rebased head

`validate_admitted_head(admitted_base, admitted_tree, head)` in `scripts/verify-kin-registry-wave-head.py`: the head has one parent; the parent is protected main at or after the admitted base; main did not touch Cargo.toml or Cargo.lock between the two (otherwise the wave has to be rebuilt, and it says so); the delta read against the parent passes every admission rule; and transplanting the head's pin blobs onto the admitted base's tree reproduces the admitted tree. With an unmoved main every clause is the old equality. The receiver's post-write step runs it as `verify-generated-head` against the head it fetches and requires the API's tree to agree; the attester's live admission and the CI gate's attestation check use it too. Live control: the proof accepts a45f85aae against eeae72729 and tree c2d9034 (the exact head the equality refused at 14:31Z) and refuses a wrong admitted tree.

## Triggers and the kick

`kin-registry-wave-land.yml` triggers on `workflow_run` for `CI` filtered to `branches: [automation/kin-registry-dependency-wave]`, on `repository_dispatch` type `kin-registry-wave-land`, and on the cron as a fallback. The first step validates the trigger from GitHub-owned context (`validate-trigger`: repository, default branch, ref `main`, sha; a kick needs the exact action and an actor in `troyjr4103` / `kin-release-bot[bot]`, mirroring release-tag.yml's break-glass list, with a payload limited to a reason; a completion needs the wave head branch, first-party repository and a completed run; a sweep needs an empty action). A repository dispatch always runs from the default branch, so the kick cannot select code. The receiver's last step sends one kick after every wave it writes, with the App token.

The judge runs with `--wait-seconds 1500`: while the verdict is a transient wait (checks still running, a cancelled suite awaiting the rerun a re-push or reopen triggers, an attestation not yet posted, `mergeable_state` still computing, a re-pushed head) it re-reads the whole snapshot every 30 s, so one trigger outlasts the checks and a wave re-pushed during the wait is judged on its new head. A hold, an empty branch, a refusal and a landing return at once. A cancelled check is a wait, not a refusal.

Kick one judgment by hand:

```sh
gh api --method POST repos/firelock-ai/kin/dispatches \
  -f event_type=kin-registry-wave-land \
  -f 'client_payload[reason]=<why>'
```

## Verification

- `scripts/test-kin-registry-wave-landing.py`: 62 tests (20 new): trigger validation for the kick, the completion and the sweep with their refusals and the CLI; cancelled and re-pushed waits; transient against final waits; the wait loop with a fake gather, sleep and clock; the admitted-head proof on a git fixture (unmoved main, a head cherry-picked onto a moved main, main touching Cargo.lock, a different delta, a foreign parent, the `verify-generated-head` CLI); the receiver and landing workflow contracts.
- `scripts/test-kin-registry-release-receiver.py`: 59 tests; the attester case now rebases the head onto an advanced main.
- `scripts/test-release-workflow-authority.py` green (census unchanged), actionlint green on both workflows.
- Falsified: 19 mutations applied one at a time, each turning its named test red; the table is in the lane report.
- No Rust changed; hosted CI is the gate of record.

Related: FIR-3084
