### PR TITLE
Rejoin a persisted receipt with the operation it names, and pin kin-db 0.7.89

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3289,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.88"
+version = "0.7.89"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "1ef5edb19fa49df56cff01d73fd5b2e1f573e5060e06bff1dcb5b427be1b18be"
+checksum = "8360c983f0f93148ae19bb0976dfe71fc88755bd6c33e6d3cc23d555b87f4f62"
 dependencies = [
  "bincode",
  "bstr",
@@ -6671,7 +6671,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ kin-lsp = { version = "=0.7.12", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.88", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.89", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.23", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-cli/src/commands/commit.rs
+++ b/crates/kin-cli/src/commands/commit.rs
@@ -509,11 +509,22 @@ fn landed_commit_for_operation(
     else {
         return Ok(None);
     };
+    // A persisted receipt names its operation record rather than repeating it
+    // (kin-db 0.7.89, FIR-3064), so the record comes from the log the same
+    // envelope holds.
+    let Some(operation) = lease
+        .metadata()
+        .operation_log
+        .iter()
+        .find(|operation| operation.operation_id == receipt.operation_id)
+    else {
+        return Ok(None);
+    };
     // The daemon's own recovery asks this of the same record, so the rule lives
     // in kin-core rather than once in each crate. A second copy is only ever
     // wrong in a way that looks like a passing run: both suites stay green while
     // one side writes a shape the other stopped reading.
-    let Some(published) = kin_core::published_change(&receipt.operation) else {
+    let Some(published) = kin_core::published_change(operation) else {
         return Ok(None);
     };
     let (branch, change_id) = (

--- a/crates/kin-cli/src/commands/reconcile.rs
+++ b/crates/kin-cli/src/commands/reconcile.rs
@@ -411,8 +411,20 @@ fn validate_base_authority_preflight(
                  its exact authority lease"
             )
         })?;
+    // A persisted receipt names its operation record rather than repeating it
+    // (kin-db 0.7.89, FIR-3064), so it is validated against the log entry it
+    // names rather than against an embedded copy of it. That is the same set of
+    // comparisons `RepositoryCommitReceipt::validate` made.
+    let operation = lease
+        .metadata()
+        .operation_log
+        .iter()
+        .find(|operation| operation.operation_id == receipt.operation_id)
+        .ok_or_else(|| {
+            anyhow!("session base names an operation this repository's log does not hold")
+        })?;
     receipt
-        .validate()
+        .validate_against(operation)
         .context("validate exact session recovery receipt")?;
     if receipt.repository_id != base.repository_id
         || receipt.roots_before != base.authority_roots

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -130,7 +130,7 @@ pub use ref_view::{
 };
 pub use repository_authority::{
     authority_opens, durable_semantic_enrichment_summary,
-    open_persisted_local_repository_authority, published_change, revalidate_pinned_local_namespace,
-    DurableSemanticEnrichmentSummary, LocalRepositoryAuthorityBinding, PinnedNamespaceRefusal,
-    PublishedChange,
+    open_persisted_local_repository_authority, published_change, rejoined_receipt,
+    revalidate_pinned_local_namespace, DurableSemanticEnrichmentSummary,
+    LocalRepositoryAuthorityBinding, PinnedNamespaceRefusal, PublishedChange,
 };

--- a/crates/kin-core/src/repository_authority.rs
+++ b/crates/kin-core/src/repository_authority.rs
@@ -68,6 +68,56 @@ pub struct PublishedChange {
 /// inference: it moves when and only when a transaction publishes into history,
 /// so an operation that left it standing published nothing, whatever its ref and
 /// head look like.
+/// The whole commit receipt for `operation_id`, rejoined with the operation
+/// record it names.
+///
+/// A persisted receipt stopped repeating its operation record in kin-db 0.7.89:
+/// the log and the receipt held the same record and together they were 41.8
+/// percent of a full VS Code store (FIR-3064). Everything above storage still
+/// wants a whole `RepositoryCommitReceipt`, so this is the one place that puts
+/// the two halves back together.
+///
+/// One place rather than one per crate, because the alternative was fifteen
+/// copies of the same pairing across kin-core, kin-cli, kin-remote and
+/// kin-daemon, and a second copy of a rule is only ever wrong in a way that
+/// looks like a passing run.
+///
+/// `None` when no receipt names that operation, when the log holds no entry for
+/// it, or when the two do not validate as a pair. The last is a defect rather
+/// than a state and is logged: a receipt reunited with the wrong operation is
+/// worse than one that cannot be found.
+pub fn rejoined_receipt(
+    metadata: &kin_db::PersistedRepositoryAuthority,
+    operation_id: kin_model::OperationId,
+) -> Option<kin_model::RepositoryCommitReceipt> {
+    let persisted = metadata
+        .receipts
+        .iter()
+        .find(|receipt| receipt.operation_id == operation_id)?;
+    let Some(record) = metadata
+        .operation_log
+        .iter()
+        .find(|record| record.operation_id == operation_id)
+    else {
+        tracing::error!(
+            operation_id = %operation_id,
+            "a durable receipt names an operation the log does not hold"
+        );
+        return None;
+    };
+    match persisted.rejoin(record) {
+        Ok(receipt) => Some(receipt),
+        Err(error) => {
+            tracing::error!(
+                operation_id = %operation_id,
+                error = %error,
+                "a durable receipt does not match the operation it names"
+            );
+            None
+        }
+    }
+}
+
 pub fn published_change(record: &RepositoryOperationRecord) -> Option<PublishedChange> {
     if record.roots_before.history == record.roots_after.history {
         return None;

--- a/crates/kin-core/src/tree.rs
+++ b/crates/kin-core/src/tree.rs
@@ -3556,19 +3556,39 @@ fn installed_repository_receipt(
     operation_id: OperationId,
     transaction_hash: Hash256,
 ) -> Option<RepositoryCommitReceipt> {
-    authority
-        .read_authority()
-        .metadata()
-        .receipts
+    let lease = authority.read_authority();
+    let metadata = lease.metadata();
+    let persisted = metadata.receipts.iter().find(|receipt| {
+        receipt.operation_id == operation_id && receipt.transaction_hash == transaction_hash
+    })?;
+    // A persisted receipt names its operation record rather than repeating it
+    // (kin-db 0.7.89, FIR-3064), so it is rejoined here with the log entry it
+    // names. `rejoin` revalidates the pair, so a receipt reunited with the
+    // wrong operation is refused rather than returned as if it were whole.
+    let operation = metadata
+        .operation_log
         .iter()
-        .find(|receipt| {
-            receipt.operation_id == operation_id && receipt.transaction_hash == transaction_hash
-        })
-        .cloned()
-        .map(|mut receipt| {
-            receipt.outcome = RepositoryCommitOutcome::IdempotentReplay;
-            receipt
-        })
+        .find(|operation| operation.operation_id == persisted.operation_id)
+        .or_else(|| {
+            tracing::error!(
+                operation_id = %persisted.operation_id,
+                "a durable receipt names an operation the log does not hold"
+            );
+            None
+        })?;
+    let mut receipt = match persisted.rejoin(operation) {
+        Ok(receipt) => receipt,
+        Err(error) => {
+            tracing::error!(
+                operation_id = %persisted.operation_id,
+                error = %error,
+                "a durable receipt does not match the operation it names"
+            );
+            return None;
+        }
+    };
+    receipt.outcome = RepositoryCommitOutcome::IdempotentReplay;
+    Some(receipt)
 }
 
 fn repository_commit_error_is_definitely_prepublication(error: &kin_db::KinDbError) -> bool {

--- a/crates/kin-daemon/src/repository_branch.rs
+++ b/crates/kin-daemon/src/repository_branch.rs
@@ -520,7 +520,7 @@ fn create(
 ) -> Result<BranchExecution> {
     require_branch_ref(name)?;
     let lease = authority.manager.read_authority();
-    if let Some(receipt) = operation_receipt(lease.metadata().receipts.as_slice(), operation_id) {
+    if let Some(receipt) = operation_receipt(lease.metadata(), operation_id) {
         let roots = lease.roots().clone();
         drop(lease);
         return replay_ref_operation(
@@ -623,7 +623,7 @@ fn delete(
 ) -> Result<BranchExecution> {
     require_branch_ref(name)?;
     let lease = authority.manager.read_authority();
-    if let Some(receipt) = operation_receipt(lease.metadata().receipts.as_slice(), operation_id) {
+    if let Some(receipt) = operation_receipt(lease.metadata(), operation_id) {
         let roots = lease.roots().clone();
         drop(lease);
         return replay_ref_operation(
@@ -800,7 +800,7 @@ fn switch(
 ) -> Result<BranchCommandOutcome> {
     require_branch_ref(name)?;
     let lease = authority.manager.read_authority();
-    if let Some(receipt) = operation_receipt(lease.metadata().receipts.as_slice(), operation_id) {
+    if let Some(receipt) = operation_receipt(lease.metadata(), operation_id) {
         let roots = lease.roots().clone();
         drop(lease);
         return replay_switch(state, authority, &roots, receipt, name, actor)
@@ -1460,14 +1460,18 @@ fn validate_identical_replay(
     Ok(())
 }
 
+/// The whole receipt for `operation_id`.
+///
+/// Delegates to kin-core, because a persisted receipt names its operation
+/// record rather than repeating it (kin-db 0.7.89, FIR-3064) and the pairing
+/// that puts the two halves back together belongs in one place. This crate had
+/// two copies of the old lookup, in this file and in `repository_stash.rs`,
+/// which is exactly the drift a shared rule prevents.
 fn operation_receipt(
-    receipts: &[RepositoryCommitReceipt],
+    metadata: &kin_db::PersistedRepositoryAuthority,
     operation_id: OperationId,
 ) -> Option<RepositoryCommitReceipt> {
-    receipts
-        .iter()
-        .find(|receipt| receipt.operation_id == operation_id)
-        .cloned()
+    kin_core::rejoined_receipt(metadata, operation_id)
 }
 
 fn local_workspace<'a>(

--- a/crates/kin-daemon/src/repository_checkout.rs
+++ b/crates/kin-daemon/src/repository_checkout.rs
@@ -256,12 +256,12 @@ fn plan_and_commit(
     };
     let actor = request.actor.clone();
     let reason = checkout_reason(&selected, &target_change_id);
-    let existing_receipt = lease
-        .metadata()
-        .receipts
-        .iter()
-        .find(|receipt| receipt.operation_id == request.operation_id)
-        .cloned();
+    // Whole rather than as persisted: a persisted receipt names its operation
+    // record rather than repeating it (kin-db 0.7.89, FIR-3064), and the replay
+    // below needs that record's workspace mutation. `rejoined_receipt`
+    // revalidates the pair, so the `validate` this used to call is already done
+    // by the time it returns.
+    let existing_receipt = kin_core::rejoined_receipt(lease.metadata(), request.operation_id);
     // Materialized only on the planning path. A replay returns before the
     // authority transition is planned, so demanding a workspace authority
     // graph there would fail a recovery that can otherwise complete.
@@ -299,9 +299,6 @@ fn plan_and_commit(
     let target_tree = target_state.tree.clone();
 
     if let Some(receipt) = existing_receipt {
-        receipt
-            .validate()
-            .context("validate persisted checkout receipt")?;
         let replay_transaction = RepositoryTransaction {
             schema_version: REPOSITORY_TRANSACTION_SCHEMA_VERSION,
             operation_id: request.operation_id,

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -395,19 +395,17 @@ pub(crate) fn plan_session_workspace_admission(
     let recovered_receipt = if exact_base_is_current {
         None
     } else {
-        let receipt = lease
-            .metadata()
-            .receipts
-            .iter()
-            .find(|receipt| receipt.operation_id == base.reconcile_operation_id)
-            .cloned()
+        // Whole rather than as persisted, and already validated against the
+        // operation it names: a persisted receipt stopped repeating that record
+        // in kin-db 0.7.89 (FIR-3064), and `rejoined_receipt` does the pairing
+        // and the validation the `validate` here used to do.
+        let receipt = kin_core::rejoined_receipt(lease.metadata(), base.reconcile_operation_id)
             .ok_or_else(|| {
                 invalid(
                     "repository authority moved after session materialization; exact reconcile \
                      does not silently rebase",
                 )
             })?;
-        receipt.validate()?;
         if receipt.transaction_hash != transaction_hash || current_workspace.tree != *desired_tree {
             return Err(invalid(
                 "session operation already names a different authority transition",
@@ -1134,13 +1132,7 @@ pub(crate) fn recover_native_commit(
 ) -> Result<Option<NativeCommitResult>> {
     let authority = authority_context.open().map_err(DaemonError::Graph)?;
     let lease = authority.read_authority();
-    let Some(receipt) = lease
-        .metadata()
-        .receipts
-        .iter()
-        .find(|receipt| receipt.operation_id == operation_id)
-        .cloned()
-    else {
+    let Some(receipt) = kin_core::rejoined_receipt(lease.metadata(), operation_id) else {
         return Ok(None);
     };
     // Reading the record's two shapes belongs to kin-core, because the CLI's own

--- a/crates/kin-daemon/src/repository_rollback.rs
+++ b/crates/kin-daemon/src/repository_rollback.rs
@@ -151,12 +151,10 @@ fn plan_and_commit(
     // than replanned. Replanning would compare the restored head against the
     // same target, find nothing left to restore, and report a false failure for
     // an operation that succeeded.
-    if let Some(receipt) = metadata
-        .receipts
-        .iter()
-        .find(|receipt| receipt.operation_id == request.operation_id)
-        .cloned()
-    {
+    //
+    // Whole rather than as persisted: a receipt names its operation record
+    // rather than repeating it (kin-db 0.7.89, FIR-3064).
+    if let Some(receipt) = kin_core::rejoined_receipt(metadata, request.operation_id) {
         let roots = roots.clone();
         drop(lease);
         return report_already_committed(

--- a/crates/kin-daemon/src/repository_stash.rs
+++ b/crates/kin-daemon/src/repository_stash.rs
@@ -277,7 +277,7 @@ fn push(
     actor: &AuthorId,
 ) -> Result<StashOutcome> {
     let lease = authority.manager.read_authority();
-    if let Some(receipt) = operation_receipt(lease.metadata().receipts.as_slice(), operation_id) {
+    if let Some(receipt) = operation_receipt(lease.metadata(), operation_id) {
         drop(lease);
         return recover(authority, receipt);
     }
@@ -710,7 +710,7 @@ fn pop(
     actor: &AuthorId,
 ) -> Result<StashOutcome> {
     let lease = authority.manager.read_authority();
-    if let Some(receipt) = operation_receipt(lease.metadata().receipts.as_slice(), operation_id) {
+    if let Some(receipt) = operation_receipt(lease.metadata(), operation_id) {
         drop(lease);
         return recover(authority, receipt);
     }
@@ -1178,14 +1178,18 @@ fn resolved_admission_policy(
         })
 }
 
+/// The whole receipt for `operation_id`.
+///
+/// Delegates to kin-core, because a persisted receipt names its operation
+/// record rather than repeating it (kin-db 0.7.89, FIR-3064) and the pairing
+/// that puts the two halves back together belongs in one place. This crate had
+/// two copies of the old lookup, in this file and in `repository_stash.rs`,
+/// which is exactly the drift a shared rule prevents.
 fn operation_receipt(
-    receipts: &[RepositoryCommitReceipt],
+    metadata: &kin_db::PersistedRepositoryAuthority,
     operation_id: OperationId,
 ) -> Option<RepositoryCommitReceipt> {
-    receipts
-        .iter()
-        .find(|receipt| receipt.operation_id == operation_id)
-        .cloned()
+    kin_core::rejoined_receipt(metadata, operation_id)
 }
 
 fn local_workspace<'a>(

--- a/crates/kin-daemon/src/repository_tag.rs
+++ b/crates/kin-daemon/src/repository_tag.rs
@@ -125,13 +125,10 @@ fn publish(
 ) -> Result<TagExecution> {
     require_tag_ref(&request.name)?;
     let lease = authority.manager.read_authority();
-    if let Some(receipt) = lease
-        .metadata()
-        .receipts
-        .iter()
-        .find(|receipt| receipt.operation_id == request.operation_id)
-        .cloned()
-    {
+    // Whole rather than as persisted: a receipt names its operation record
+    // rather than repeating it (kin-db 0.7.89, FIR-3064), and the replay below
+    // reads that record.
+    if let Some(receipt) = kin_core::rejoined_receipt(lease.metadata(), request.operation_id) {
         let roots = lease.roots().clone();
         drop(lease);
         return replay(authority, &roots, receipt, request);

--- a/crates/kin-remote/src/repository_transfer.rs
+++ b/crates/kin-remote/src/repository_transfer.rs
@@ -1311,21 +1311,42 @@ where
     let transaction = transfer_transaction(pack, actor)?;
     let transaction_hash = transaction.transaction_hash().map_err(model)?;
     let lease = authority.read_authority();
-    if let Some(receipt) = lease
+    if let Some(persisted) = lease
         .authority_metadata()
         .receipts
         .iter()
         .find(|receipt| receipt.operation_id == pack.operation_id)
     {
-        if receipt.transaction_hash != transaction_hash {
+        if persisted.transaction_hash != transaction_hash {
             return Err(RepositoryTransferError::Conflict(format!(
                 "operation {} was already committed with a different exact transaction",
                 pack.operation_id
             )));
         }
+        // A persisted receipt names its operation record rather than repeating
+        // it (kin-db 0.7.89, FIR-3064), so it is rejoined with the log entry it
+        // names. `rejoin` revalidates the pair, so a receipt reunited with the
+        // wrong operation is refused here rather than replayed as a whole one.
+        let operation = lease
+            .authority_metadata()
+            .operation_log
+            .iter()
+            .find(|operation| operation.operation_id == persisted.operation_id)
+            .ok_or_else(|| {
+                RepositoryTransferError::Conflict(format!(
+                    "operation {} has a durable receipt and no log entry",
+                    persisted.operation_id
+                ))
+            })?;
+        let receipt = persisted.rejoin(operation).map_err(|error| {
+            RepositoryTransferError::Conflict(format!(
+                "durable receipt for operation {} does not match the operation it names: {error}",
+                persisted.operation_id
+            ))
+        })?;
         return Ok(transfer_receipt(
             pack,
-            receipt.clone(),
+            receipt,
             RepositoryTransferApplyOutcome::IdempotentReplay,
         ));
     }


### PR DESCRIPTION
## What broke, and what said so

kin-db 0.7.89 stopped repeating the operation record inside every commit
receipt. The log and the receipt held the same record, and together they were
**41.8 percent of a full VS Code store**, 1,425,399,123 bytes of it resident
(FIR-3064).

That PR's body said its in-memory API did not move for any consumer. **It was
wrong in four crates.** What said so was the registry receiver's verify step on
the 0.7.89 refresh, run `33647602488`, failing at `kin-core/src/tree.rs:3559`.

Building kin against the published 0.7.89 walks through **kin-core, kin-remote,
kin-cli and kin-daemon, about fifteen sites**. Everything above storage still
wants a whole `RepositoryCommitReceipt`, so the two halves have to be put back
together somewhere.

## One place, not fifteen

`kin_core::rejoined_receipt(metadata, operation_id)` finds the receipt, finds
the log entry it names, and rejoins them through the accessor kin-db documents,
which revalidates the pair.

Fifteen hand-written pairings would have been fifteen chances to pair a receipt
with the wrong operation. `commit.rs` already carried a comment saying this rule
belongs in kin-core rather than once per crate, because a second copy is only
ever wrong in a way that looks like a passing run. kin-daemon had **two copies**
of the old lookup, in `repository_branch.rs` and `repository_stash.rs`, which is
that drift already realized. Both now delegate.

The helper **refuses rather than guesses**. No receipt, no log entry, or a pair
that does not validate all return `None`, and the last two are logged, because a
receipt reunited with the wrong operation is worse than one that cannot be
found.

Three call sites that used to call `receipt.validate()` no longer do. The rejoin
validates the same fields against the log entry rather than against an embedded
copy of it, which is the comparison the embedded copy existed to allow.

## The pin is in the same commit

Either half alone leaves the tree unbuildable or the defect unfixed, so
`kin-db = "=0.7.89"` lands with the fix.

## Verified against the real crate

0.7.89 is tagged and on the index, so this builds against the published crate
rather than a path override, which is a truer check than a patch would have
been.

- `cargo build --workspace --all-targets` clean
- `cargo test -p kin-core -p kin-remote` green, 800 and 102 tests plus every
  integration binary
- `bin/kin-precheck kin` 16 gates ran, 16 passed, 0 failed

## One lock line that is not the pin

The lock diff is three lines: kin-db's version, kin-db's checksum, and one edge
under `winapi-util 0.1.11` moving from `windows-sys 0.61.2` to `0.48.0`. Both
windows-sys versions were already in the lock; this is one edge resolving
differently, not a shared crate being downgraded.

It is a consequence of the version bump rather than a hand edit, and the control
says so: with main's own `Cargo.toml` and main's own `Cargo.lock`, a plain build
rewrites nothing, so main's lock is not stale and the difference appears only
with 0.7.89 resolved in. It survives a minimal `cargo update -p kin-db --precise
0.7.89` too, so it is not an artefact of how the lock was regenerated. Flagged
rather than smoothed over, and the Windows legs grade it.

## Provenance

The kin-db side landed under lane `kin-kernel-memory`; this PR is under lane
`kin-kernel-memory-2`, from a fresh worktree, so the earlier lane's tree stays
untouched.

One thing that tree was holding is now answered: the stranded one-line
`.clone().into()` fix at `crates/kin-remote/src/repository_transfer.rs:890` is
**obsolete**. kin main compiles that call site unchanged against 0.7.89, so the
dead worktree can be reaped without losing anything.

Related: FIR-3064
