### PR TITLE
Bound the Windows cargo cache so its save cannot outlive the job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -664,21 +664,36 @@ jobs:
         with:
           tool: sccache
 
+      # This was a hand-rolled `actions/cache` carrying `target` and the sccache
+      # directory under a `hashFiles('Cargo.lock')` key, the only Windows leg in
+      # this file that did not use `rust-cache`. A cache key is immutable, so
+      # every main push that repinned a dependency asked for a key nothing had
+      # written and the post step tarred the whole Windows release tree to mint
+      # it. On 59c2239c2 that save started
+      # `tar --posix -cf cache.tzst ... --use-compress-program "zstd -T0"` at
+      # 17:36:59Z and had emitted nothing further at 18:04:28Z, when the
+      # 60-minute job timeout cancelled it. The job's own work had finished at
+      # 17:36:31Z: the build was green and the admission contract had passed, and
+      # the run still lost its Windows evidence to an archive nobody was waiting
+      # on. The same shape cost the prior sha 2m18s and the dispatch-only
+      # vector proof 5 minutes, so the ceiling was never bounded, only lucky.
+      #
+      # `rust-cache` bounds it by construction: it prunes the workspace's own
+      # artifacts out of `target` before saving, and it writes at most one entry
+      # per key. The three sibling Windows legs above already carry exactly this
+      # block, so this removes a bespoke shape rather than adding one.
+      #
+      # `${{ runner.temp }}/sccache` is deliberately not carried over.
+      # `sccache --show-stats` reported "Compile requests 0" at the end of both
+      # sampled runs (59c2239c2 and 39d3f481a), so what that path archived was a
+      # directory the build never read. The wrapper itself is left alone.
       - name: Cache cargo registry and build
-        uses: actions/cache@v6
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-            ${{ runner.temp }}/sccache
-          # Cache key renamed with the feature set. The vectorless key indexed a
-          # dependency graph with no ndarray, tokenizers, hnsw or onig in it, so
-          # restoring from it would warm almost nothing and would report a hit
-          # while doing so.
-          key: windows-vector-cargo-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            windows-vector-cargo-
+          # FIR-2744, and see the note on the first cache step in this file.
+          add-rust-environment-hash-key: false
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-on-failure: true
 
       # Windows ships native vector search, so this asserts the feature graph in
       # both directions rather than only forbidding features. `vector` and

--- a/.github/workflows/windows-vector-proof.yml
+++ b/.github/workflows/windows-vector-proof.yml
@@ -71,17 +71,25 @@ jobs:
         with:
           tool: sccache
 
+      # Same bound as the `windows-installer` leg in ci.yml, and for the same
+      # reason. This carried `target` under a lockfile-keyed `actions/cache`, so
+      # every dispatch against a repinned lock minted a fresh entry by tarring
+      # the whole Windows release tree. The header note above measures what that
+      # cost on run 30969196206: 5 of the 36 minutes went to the post-job save.
+      # ci.yml's Windows installer leg ran the identical shape into its 60-minute
+      # timeout on 59c2239c2, which is the failure this workflow's larger budget
+      # had been hiding rather than avoiding. `rust-cache` prunes the workspace's
+      # own artifacts out of `target` before saving and writes one entry per key.
+      #
+      # `${{ runner.temp }}/sccache` is still set as the wrapper's directory by
+      # the build step below; it is simply no longer archived.
       - name: Cache cargo registry and build
-        uses: actions/cache@v6
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-            ${{ runner.temp }}/sccache
-          key: windows-vector-proof-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            windows-vector-proof-
+          # FIR-2744, and see the note on the first cache step in ci.yml.
+          add-rust-environment-hash-key: false
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-on-failure: true
 
       # Keyed on the model id rather than the lock: the download is invariant
       # across source changes, and a cold fetch is most of this job's wall clock.

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -16329,11 +16329,18 @@ def main() -> None:
     # save-if does not create that boundary. Do not reason about a related
     # change as though it did.
     #
-    # Scope: this covers Swatinem/rust-cache uses only. Three actions/cache
-    # uses remain deliberately outside it: the windows-installer and coverage
-    # jobs are admitted only from main, while fuzz may still write a cache on a
-    # qualifying pull request. This is not a repository-wide no-PR-writes
-    # invariant.
+    # Scope: this covers Swatinem/rust-cache uses only. Two cargo actions/cache
+    # uses remain deliberately outside it: coverage is admitted only from main,
+    # while fuzz may still write a cache on a qualifying pull request. This is
+    # not a repository-wide no-PR-writes invariant.
+    #
+    # windows-installer used to be the third. It hand-rolled an actions/cache
+    # whose key carried hashFiles('Cargo.lock') over a path that included
+    # `target`, so every repin minted a fresh multi-GB Windows entry, and on
+    # 59c2239c2 the post-step archive ran past the job's 60-minute timeout and
+    # cancelled a run whose work had already finished. It now carries the same
+    # rust-cache block as the three sibling Windows legs, which is why this
+    # assertion covers it.
     assert_rust_cache_steps(workflow_sources)
     assert_required_context_action_pins(workflow_sources)
     assert_tag_readback_retries(release_tag)


### PR DESCRIPTION
## What broke

kin main's tip `59c2239c2` lost its CI run to a cache save. The `Windows installer + vector release build` job ran 17:04:11Z to 18:04:35Z and was cancelled at exactly its 60-minute timeout. Its work had finished 28 minutes earlier:

```
10  Build Windows release binaries with vector features  success  17:06:02Z -> 17:35:39Z
11  Verify Windows build provenance and feature set      success  17:35:39Z -> 17:35:54Z
12  Assert the Windows admission contract                success  17:35:54Z -> 17:36:31Z
23  Post Cache cargo registry and build                  CANCELLED 17:36:31Z -> 18:04:28Z
```

The job log names the mechanism. The post step started

```
17:36:59.7Z [command]"C:\Program Files\Git\usr\bin\tar.exe" --posix -cf cache.tzst ... --use-compress-program "zstd -T0"
18:04:28.1Z ##[error]The operation was canceled.
```

and emitted nothing in between. It spent 27m28s compressing a Windows release `target/` tree, and the run's Windows evidence died with it.

## Why it happened, and why it was not a one-off

That job was the only Windows leg in `ci.yml` still hand-rolling `actions/cache`. Its path carried `target` and `${{ runner.temp }}/sccache` under `key: windows-vector-cargo-${{ hashFiles('Cargo.lock') }}`. A cache key is immutable, so every main push that repins a dependency asks for a key nothing has written, restores an older one by prefix, and then mints a fresh multi-GB archive.

`59c2239c2` is the "pin kin-db 0.7.89" landing, so its lock hash was new. Its restore was a prefix hit, not a primary one:

```
17:05:12Z Cache hit for restore-key: windows-vector-cargo-36d32e20...
17:05:20Z Cache Size: ~1411 MB (1479876352 B)
```

The prior sha paid the same tax and only escaped because it lost a race: `Failed to save: Unable to reserve cache with key windows-vector-cargo-36d32e20..., another job may be creating this cache` at 2m18s. The dispatch-only vector proof records its own number in its header: 5 of 36 minutes on the post-job save. The ceiling was never bounded, only lucky.

Repo cache usage is currently 9.29 GiB across 47 entries, and the largest single entry is this job's 1.38 GiB.

## The change

Both Windows jobs now use the `rust-cache` block the three sibling Windows legs in `ci.yml` already carry, byte for byte:

```yaml
      - name: Cache cargo registry and build
        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
        with:
          add-rust-environment-hash-key: false
          save-if: ${{ github.ref == 'refs/heads/main' }}
          cache-on-failure: true
```

`rust-cache` prunes the workspace's own artifacts out of `target` before saving and writes at most one entry per key, so the save is bounded by construction. This keeps compile reuse rather than trading the hang for a cold dependency graph, which matters because the job's own comment measures it at 20 to 25 minutes per round and its budget is 60. No timeout change was needed.

`${{ runner.temp }}/sccache` is no longer archived. `sccache --show-stats` printed `Compile requests 0` at the end of both sampled runs (`59c2239c2` and `39d3f481a`), so that path was archiving a directory the build never read. The wrapper itself is untouched.

Three `actions/cache` uses are deliberately left alone, and none is this class: coverage is already registry-only with a comment explaining why, the brownfield corpora and the Hugging Face hub are keyed on pinned content rather than on a lockfile, and `fuzz` caches a small `fuzz/target` on Linux under a toolchain-pinned key.

## Falsification

Moving the step brings it inside `assert_rust_cache_steps`, whose scope note had named `windows-installer` as deliberately outside it. That note is corrected in the same commit.

Both new steps were proved to be genuinely covered. Mutating `ci.yml`'s save-if to `${{ github.ref != 'refs/heads/nope' }}`:

```
AssertionError: ci.yml rust-cache save-if must be the exact main-only scalar or the exact restore-only scalar
rc=1
```

Mutating `windows-vector-proof.yml`'s to `save-if: true`:

```
AssertionError: windows-vector-proof.yml rust-cache save-if must be the exact main-only scalar or the exact restore-only scalar
rc=1
```

Both lines were restored and the guard returns rc=0.

## Local gates

Run against `.kin-coord/worktrees/ci-hygiene-kin` at `55c332dac`, branch `chore/lane-ci-hygiene-kin`:

- `python3 scripts/test-release-workflow-authority.py` rc=0
- `python3 scripts/test-assertion-reachability.py` rc=0
- `bash scripts/test-windows-authority-legs.sh` rc=0
- `bash scripts/test-release-policy-gate.sh` rc=0
- `actionlint` on both changed workflows rc=0

## What this PR cannot show

No Windows leg runs on kin pull requests, so nothing here exercises the changed step. The effect is visible only on main's push run after this lands. I will read that run's `Windows installer + vector release build` job by step and report the post-cache time.
