### PR TITLE
Serve a query-only MCP profile and bring a deep trace inside its ceiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1309,6 +1309,13 @@ jobs:
 
   # The served MCP surface, graded on the pull request that moves it.
   #
+  # It grades two profiles now: `agent-default`, which is what `kin setup`
+  # writes and what the five main-only assertions below read, and `agent-query`,
+  # the query-only list a client that never writes can serve instead. The second
+  # is here rather than in an acceptance suite because its whole claim is a
+  # size, and a size that is only graded on `main` moves for four landings
+  # before anyone sees it (FIR-3107).
+  #
   # Five assertions in this repository read the served surface, and every one of
   # them runs only on `main`'s push: install-proof.yml's "Graph query and MCP
   # tool-call proof" step, which throws `MCP tools/list omitted semantic_search`
@@ -1377,7 +1384,7 @@ jobs:
       # failed, 2 when one could not be read, 3 when the fixture could not be
       # built. None of the three is a pass, and an unreadable surface says
       # nothing about whether the surface moved, so all three fail this job.
-      - name: Grade the served agent-default MCP surface
+      - name: Grade the served MCP surfaces
         env:
           KIN_SURFACE_LABEL: ${{ github.event_name }}-${{ github.sha }}
         run: |
@@ -1402,7 +1409,7 @@ jobs:
             echo "::error title=The served MCP surface moved::the assertions that grade it on main are skipped on every pull request; this is the same set, on this pull request's own binaries"
             exit 1
           fi
-          echo "the served agent-default surface still satisfies every main-only assertion"
+          echo "the served surfaces still satisfy every main-only assertion"
 
   # A skipped matrix job never expands, so the required per-platform contexts
   # would go missing instead of reporting skipped, and a required context nobody

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -2574,6 +2574,18 @@ fn evaluate_mcp_client_against(
                         path.display()
                     ),
                 ),
+                // `kin setup` writes `agent-default`, and an operator who
+                // narrowed the entry to the query half of that same belt
+                // made a supported choice rather than a mistake. Reporting it
+                // as misconfigured would tell someone who deliberately dropped
+                // the transaction contracts from every prompt to put them back.
+                Some("agent-query") => (
+                    HealthStatus::Healthy,
+                    format!(
+                        "{servers_key}.kin present with the query-only agent-query profile ({})",
+                        path.display()
+                    ),
+                ),
                 // An entry that names no profile is served the curated
                 // agent-default surface by `kin mcp start` itself, so it is
                 // correctly wired even though `kin setup` would have stated it.
@@ -2590,7 +2602,7 @@ fn evaluate_mcp_client_against(
                 Some(other) => (
                     HealthStatus::Misconfigured,
                     format!(
-                        "{servers_key}.kin present but KIN_MCP_TOOL_PROFILE is {other} (expected agent-default, or unset to take it as the default) in {}",
+                        "{servers_key}.kin present but KIN_MCP_TOOL_PROFILE is {other} (expected agent-default, agent-query, or unset to take agent-default as the default) in {}",
                         path.display()
                     ),
                 ),
@@ -10124,6 +10136,40 @@ mod tests {
         assert!(
             detail.contains("defaults to the agent-default profile"),
             "the reader must be told which surface an unset profile resolves to: {detail}"
+        );
+    }
+
+    /// The query-only surface is a supported choice, not a fault.
+    ///
+    /// `kin setup` writes `agent-default`, and an operator who narrowed the
+    /// entry to the same belt without its session and transaction tools stopped
+    /// paying for contracts a query-only client never calls (FIR-3107). Doctor
+    /// telling them to put those back would be doctor arguing with a product
+    /// decision.
+    #[test]
+    fn mcp_config_on_the_query_profile_is_healthy() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("claude.json");
+        std::fs::write(
+            &path,
+            serde_json::to_string_pretty(&serde_json::json!({
+                "mcpServers": {
+                    "kin": {
+                        "command": "kin",
+                        "args": ["mcp", "start"],
+                        "env": { "KIN_MCP_TOOL_PROFILE": "agent-query" }
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let (status, detail) = evaluate_mcp_client_against(&path, "claude", "kin");
+        assert!(matches!(status, HealthStatus::Healthy), "detail: {detail}");
+        assert!(
+            detail.contains("agent-query"),
+            "the reader must be told which surface is wired: {detail}"
         );
     }
 

--- a/crates/kin-cli/src/commands/mcp.rs
+++ b/crates/kin-cli/src/commands/mcp.rs
@@ -263,6 +263,11 @@ async fn run_startup_binding(
 pub(crate) enum McpToolProfile {
     /// The curated belt every configured agent gets. The default.
     AgentDefault,
+    /// The same belt with its write half removed: discovery and retrieval
+    /// tools, no session and no transaction tools. A second served list for a
+    /// client that only queries, not a mode: `AgentDefault` is unchanged and
+    /// still serves every write tool.
+    AgentQuery,
     /// The retrieval belt the benchmark arm drives.
     Benchmark,
     /// Read-only graph-native ContextBench belt: no write-side session or
@@ -276,6 +281,7 @@ pub(crate) enum McpToolProfile {
 /// `--tool-profile` accept, in the order a help message should list them.
 const TOOL_PROFILE_TOKENS: &[(&str, McpToolProfile)] = &[
     ("agent-default", McpToolProfile::AgentDefault),
+    ("agent-query", McpToolProfile::AgentQuery),
     ("full", McpToolProfile::Full),
     ("benchmark", McpToolProfile::Benchmark),
     ("context-bench", McpToolProfile::ContextBench),
@@ -286,6 +292,7 @@ impl McpToolProfile {
     pub(crate) fn allowed_tool_names(self) -> Option<&'static [&'static str]> {
         match self {
             Self::AgentDefault => Some(kin_mcp::agent_default_tool_names()),
+            Self::AgentQuery => Some(kin_mcp::agent_query_tool_names()),
             Self::Benchmark => Some(kin_mcp::benchmark_tool_names()),
             Self::ContextBench => Some(kin_mcp::context_bench_tool_names()),
             Self::Full => None,
@@ -295,13 +302,14 @@ impl McpToolProfile {
     /// Whether this profile IS the curated agent belt: short descriptions,
     /// trimmed input schemas, and the compact `semantic_locate` shape.
     ///
-    /// `agent-default` only. `full` is the whole documented surface by
-    /// definition. `benchmark` and `context-bench` keep the long forms and the
-    /// shared payload because their bytes are an input to a citable result, and
-    /// a benchmark number must not move because a description was rewritten or a
-    /// payload was narrowed.
+    /// `agent-default` and `agent-query`, which is that belt with its write half
+    /// removed and therefore the same short forms. `full` is the whole
+    /// documented surface by definition. `benchmark` and `context-bench` keep
+    /// the long forms and the shared payload because their bytes are an input to
+    /// a citable result, and a benchmark number must not move because a
+    /// description was rewritten or a payload was narrowed.
     pub(crate) fn is_agent_belt(self) -> bool {
-        matches!(self, Self::AgentDefault)
+        matches!(self, Self::AgentDefault | Self::AgentQuery)
     }
 
     pub(crate) fn token(self) -> &'static str {
@@ -364,8 +372,12 @@ impl ResolvedToolProfile {
             ),
             ToolProfileSource::Default => format!(
                 "Kin MCP: serving the default '{token}' tool profile ({count} tools). Set \
-                 KIN_MCP_TOOL_PROFILE=full (or --tool-profile full) for the complete {} tool \
-                 surface; accepted profiles: {}.",
+                 KIN_MCP_TOOL_PROFILE=agent-query (or --tool-profile agent-query) for the same \
+                 belt without the session and transaction tools ({} tools), which a \
+                 query-only client re-sends in every prompt and never calls, or \
+                 KIN_MCP_TOOL_PROFILE=full for the complete {} tool surface; accepted \
+                 profiles: {}.",
+                McpToolProfile::AgentQuery.tool_count(),
                 McpToolProfile::Full.tool_count(),
                 accepted_tool_profiles()
             ),
@@ -885,7 +897,7 @@ mod tests {
         bind_daemon_for_repo_dir, bind_first_kin_repo_against, build_mcp_start_config,
         registry_should_resolve, registry_startup_choice, resolve_repo_override,
         resolve_tool_profile, session_authority_notice, BindRefusal, DaemonBindMode,
-        McpToolProfile, RegistryStartupChoice, ToolProfileSource,
+        McpToolProfile, RegistryStartupChoice, ToolProfileSource, TOOL_PROFILE_TOKENS,
     };
     use kin_core::registry::{KinRegistry, RegisteredRepo};
     use kin_core::test_env::EnvVarGuard;
@@ -986,12 +998,22 @@ mod tests {
 
     #[test]
     fn every_named_profile_resolves_to_its_own_surface() {
-        for (token, expected) in [
+        let rows = [
             ("agent-default", McpToolProfile::AgentDefault),
+            ("agent-query", McpToolProfile::AgentQuery),
             ("benchmark", McpToolProfile::Benchmark),
             ("context-bench", McpToolProfile::ContextBench),
             ("full", McpToolProfile::Full),
-        ] {
+        ];
+        // Written out AND counted. Without the count a profile added to
+        // `TOOL_PROFILE_TOKENS` would ride in unnamed, and this loop would
+        // report every token it happened to list.
+        assert_eq!(
+            rows.len(),
+            TOOL_PROFILE_TOKENS.len(),
+            "a profile joined the token table without a row here"
+        );
+        for (token, expected) in rows {
             let resolved = resolve_tool_profile(None, Some(token));
             assert_eq!(resolved.profile, expected, "for token {token}");
             assert_eq!(resolved.source, ToolProfileSource::Env);
@@ -1033,20 +1055,35 @@ mod tests {
         );
     }
 
-    /// The startup line is the only channel this change has — stdout belongs to
-    /// the protocol — so an unconfigured server must announce both what it is
-    /// serving and how to ask for the rest.
+    /// The startup line is the only channel this change has, since stdout
+    /// belongs to the protocol, so an unconfigured server must announce what it
+    /// is serving and both ways to ask for something else.
     #[test]
-    fn the_default_startup_notice_names_the_surface_and_the_opt_in() {
+    fn the_default_startup_notice_names_the_surface_and_the_opt_ins() {
         let notice = resolve_tool_profile(None, None).startup_notice();
         assert!(notice.contains("agent-default"), "notice: {notice}");
         assert!(
             notice.contains("KIN_MCP_TOOL_PROFILE=full"),
             "notice: {notice}"
         );
+        // The lighter surface is the one a query-only client wants and the one
+        // nobody would guess exists. The default profile was invisible until
+        // this line said so, and a second profile nobody is told about is the
+        // same defect one profile along.
+        assert!(
+            notice.contains("KIN_MCP_TOOL_PROFILE=agent-query"),
+            "notice must name the query-only surface: {notice}"
+        );
         assert!(
             notice.contains(&kin_mcp::agent_default_tool_names().len().to_string()),
             "notice must state the served count: {notice}"
+        );
+        assert!(
+            notice.contains(&format!(
+                "({} tools)",
+                kin_mcp::agent_query_tool_names().len()
+            )),
+            "notice must state what the query surface costs: {notice}"
         );
     }
 

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -2083,10 +2083,11 @@ enum McpAction {
         /// never repointed by the client's workspace roots.
         #[arg(long, value_name = "PATH")]
         repo: Option<PathBuf>,
-        /// Tool surface to serve: `agent-default` (the curated agent belt, and
-        /// the default), `full` (every tool, roughly 12k extra tokens of
-        /// schemas per session), `benchmark`, or `context-bench`. Overrides
-        /// KIN_MCP_TOOL_PROFILE.
+        /// Tool surface to serve: `agent-default` (the curated agent belt,
+        /// and the default), `agent-query` (that belt without the session and
+        /// transaction tools, for a client that only queries), `full` (every
+        /// tool, roughly 12k extra tokens of schemas per session), `benchmark`,
+        /// or `context-bench`. Overrides KIN_MCP_TOOL_PROFILE.
         #[arg(long = "tool-profile", value_name = "PROFILE")]
         tool_profile: Option<String>,
         /// Never start or revive a daemon from this server: bind only a daemon

--- a/crates/kin-core/src/env_registry.rs
+++ b/crates/kin-core/src/env_registry.rs
@@ -309,7 +309,7 @@ pub const OPERATIONAL: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_ALLOW_PARENT_STORE", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Operational, summary: "allow discovering a store in a parent directory" },
     EnvVarSpec { name: "KIN_BINARY_PATH", kind: Kind::Path, default: "", sensitivity: Sensitivity::Operational, summary: "override the kin binary path for bench dispatch" },
     EnvVarSpec { name: "KIN_BUILD_GRAPH_TIMEOUT_SECS", kind: Kind::Secs, default: "60", sensitivity: Sensitivity::Operational, summary: "timeout for building a historical ref-view graph" },
-    EnvVarSpec { name: "KIN_MCP_TOOL_PROFILE", kind: Kind::Str, default: "agent-default", sensitivity: Sensitivity::Operational, summary: "MCP tool surface: agent-default (curated, the default), full (every tool), benchmark, context-bench" },
+    EnvVarSpec { name: "KIN_MCP_TOOL_PROFILE", kind: Kind::Str, default: "agent-default", sensitivity: Sensitivity::Operational, summary: "MCP tool surface: agent-default (curated, the default), agent-query (the same belt with no session or transaction tools), full (every tool), benchmark, context-bench" },
     EnvVarSpec { name: "KIN_MCP_REPO", kind: Kind::Path, default: "", sensitivity: Sensitivity::Operational, summary: "bind `kin mcp start` to this repository instead of the launch directory" },
     EnvVarSpec { name: "KIN_MCP_CACHE_DIR", kind: Kind::Path, default: "", sensitivity: Sensitivity::Operational, summary: "cache directory override for the npm MCP wrapper's managed Kin binary" },
     EnvVarSpec { name: "KIN_MCP_KIN_BINARY", kind: Kind::Path, default: "", sensitivity: Sensitivity::Operational, summary: "explicit native Kin binary used by the @kinlab/kin-mcp wrapper" },

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -773,8 +773,18 @@ fn shape_for(tool: &str) -> Option<ResponseShape> {
             bulk_keys: &[],
             narrow_param: "limit",
         },
+        // `clipped_steps` sheds before `chain`, because the ladder trims from
+        // the end of this list. A clip is a note about breadth the walk gave
+        // up; the chain is the answer, and `spine_clipped_steps` beside it
+        // keeps the count when the detail goes.
+        //
+        // Naming only `chain` was FIR-2602's shape on this tool. A deep walk
+        // measured on 2026-09-02 spent 758 characters on six clips that the
+        // table could not count, and shipped 15,875 characters against a
+        // 12,000 ceiling (FIR-3107). A key the table does not name is a key
+        // the bounder cannot cut.
         "trace_data_flow" => ResponseShape {
-            collections: &["chain"],
+            collections: &["chain", "clipped_steps"],
             body_keys: &["body"],
             explain_keys: &[],
             top_explain_keys: &[],
@@ -1277,6 +1287,41 @@ fn run_ladder(
             break;
         }
     }
+    // Before the floor goes, the cheapest bytes in the response: the verbatim
+    // restatements of one sentence.
+    //
+    // Measured on 2026-09-02 (FIR-3107) on a `trace_data_flow` at depth, at the
+    // agent belt's 12,000-character ceiling. The part of that response the
+    // budget never trims was 9,210 characters, and roughly 7,700 of it was FOUR
+    // copies of one 1,900-character limiting-factor sentence:
+    // `_kin.verdict.limiting_factor`, `_kin.verdict.note`, `negative.advice`
+    // and `negative.trust_reason`. No rung above could reach the ceiling
+    // because the answer rows were not what was over it.
+    //
+    // This drops two of the three restatements and leaves a pointer. It never
+    // touches `limiting_factor`, which is the canonical copy every reader is
+    // sent to first, nor `trust_reason`, which is the sentence `negative`
+    // publishes in its own right. Nothing is lost: the statement survives, and
+    // the two places that repeated it now name where it lives.
+    // Applied here so the floor guard below measures the response after the
+    // pointer rather than before it, and applied AGAIN by the envelope
+    // finalizer once its loop settles, because a pass of that loop can rebuild
+    // the verdict and write the long form back over this.
+    point_restated_limiting_factor(payload, budget);
+
+    // The floor of one entry per list is absolute, and a response that cannot
+    // reach its ceiling with it says so rather than giving it up.
+    //
+    // A rung that released the floor when releasing it was what fit was written
+    // for FIR-3107 and taken out again: `response_budget_elisions.py` check 4
+    // went red on it locally, because at a tight ceiling an `impact_analysis`
+    // then emptied `entity_impacts`, `affected_callers`, `affected_tests` and
+    // `changed_ids` all at once. That is FIR-2602 exactly, and an empty array
+    // reading as "the walk found none" is a worse answer than a response that
+    // ships over its ceiling and discloses it. The rungs above are what bring
+    // the measured case inside its ceiling; `the_entry_floor_holds_even_when_    // releasing_it_would_fit` is what keeps this decision from being undone by
+    // the next person who reads the arithmetic and not the history.
+
     if withheld_any {
         let kept = primary
             .and_then(|key| payload.get(key))
@@ -1302,6 +1347,151 @@ fn run_ladder(
 
     disclose(payload, budget, started_at, &cuts, &remediations);
 }
+
+/// The join every restatement of the limiting factor is built with.
+///
+/// One literal, so this reads exactly what [`crate::verdict`] and
+/// [`crate::negative`] wrote rather than a pattern that resembles it.
+const LIMITING_FACTOR_JOIN: &str = " Limiting factor: ";
+
+/// Point the restatements at the canonical sentence and say so, on a response
+/// over its ceiling. Returns how many fields were pointed.
+///
+/// Called twice on the stdio path: once inside the ladder, so the floor rung
+/// below it measures the smaller response, and once by the envelope finalizer
+/// after its loop settles, because that loop rebuilds the verdict and would
+/// otherwise write the long form back over the pointer. Both the rewrite and
+/// its disclosure are idempotent, so the second call is free when the first
+/// already held.
+pub(crate) fn point_restated_limiting_factor(
+    payload: &mut Value,
+    budget: &ResponseBudget,
+) -> usize {
+    let pointed = shed_restated_limiting_factor(payload, budget);
+    if pointed > 0 {
+        disclose_restatements_pointed(payload, pointed);
+    }
+    pointed
+}
+
+/// Replace a verbatim restatement of the limiting factor with a pointer to it,
+/// in the two fields that carry one, and only on a response over its ceiling.
+///
+/// Returns how many fields were pointed.
+///
+/// The rewrite fires only when the tail after the join IS the canonical
+/// sentence, ignoring a trailing full stop. A field whose tail says anything
+/// else is left alone, which is what keeps this from turning a field that had
+/// something of its own to say into a pointer at something else.
+fn shed_restated_limiting_factor(payload: &mut Value, budget: &ResponseBudget) -> usize {
+    if measure(payload) <= budget.max_chars {
+        return 0;
+    }
+    // Each row is one field that ends by restating another, and the field it
+    // restates. `_kin.verdict.limiting_factor` and `negative.trust_reason` are
+    // both left whole: the first is the canonical sentence the server tells
+    // every reader to consult first, the second is what `negative` publishes in
+    // its own right and what the acceptance suite grades.
+    const RESTATEMENTS: [(&str, &str, &str, &str); 2] = [
+        (
+            crate::envelope::ENVELOPE_KEY,
+            "verdict",
+            "note",
+            "limiting_factor",
+        ),
+        (crate::negative::NEGATIVE_KEY, "", "advice", "trust_reason"),
+    ];
+    let mut pointed = 0usize;
+    for (root, section, field, canonical_field) in RESTATEMENTS {
+        fn block<'a>(value: &'a Value, root: &str, section: &str) -> Option<&'a Value> {
+            let block = value.get(root)?;
+            if section.is_empty() {
+                Some(block)
+            } else {
+                block.get(section)
+            }
+        }
+        let Some(canonical) = block(payload, root, section)
+            .and_then(|block| block.get(canonical_field))
+            .and_then(Value::as_str)
+            .map(|text| text.trim_end_matches('.').to_string())
+            .filter(|text| !text.is_empty())
+        else {
+            continue;
+        };
+        let Some(text) = block(payload, root, section)
+            .and_then(|block| block.get(field))
+            .and_then(Value::as_str)
+            .map(str::to_string)
+        else {
+            continue;
+        };
+        let Some(at) = text.rfind(LIMITING_FACTOR_JOIN) else {
+            continue;
+        };
+        // Word for word, or not at all. A tail that says anything of its own is
+        // left alone, which is what keeps this from turning a field with
+        // something to say into a pointer at something else.
+        if text[at + LIMITING_FACTOR_JOIN.len()..].trim_end_matches('.') != canonical {
+            continue;
+        }
+        let mut shortened = text[..at].to_string();
+        let owner = if section.is_empty() {
+            format!("{root}.{canonical_field}")
+        } else {
+            format!("{root}.{section}.{canonical_field}")
+        };
+        shortened.push_str(&format!("{LIMITING_FACTOR_JOIN}see `{owner}`."));
+        let target = if section.is_empty() {
+            payload.get_mut(root).and_then(|block| block.get_mut(field))
+        } else {
+            payload
+                .get_mut(root)
+                .and_then(|block| block.get_mut(section))
+                .and_then(|block| block.get_mut(field))
+        };
+        if let Some(target) = target {
+            *target = Value::String(shortened);
+            pointed += 1;
+        }
+    }
+    pointed
+}
+
+/// Say that a restatement was replaced by a pointer.
+///
+/// Its own entry rather than a clause inside [`BOUNDED_REASON`], because that
+/// reason code means answer rows were withheld and `prior_bound` reads it on
+/// the second arm to decide whether the response was bounded. Nothing was
+/// withheld here.
+fn disclose_restatements_pointed(payload: &mut Value, pointed: usize) {
+    let entry = json!({
+        "component": "response_budget",
+        "reason": RESTATEMENT_POINTED_REASON,
+        "detail": format!(
+            "this response was over its ceiling, so {pointed} field(s) that restated \
+             another field word for word now point at it instead. Nothing was dropped: \
+             `_kin.verdict.limiting_factor` and `negative.trust_reason` carry the statement \
+             in full, and each pointer names the field it points at"
+        ),
+    });
+    match payload
+        .get_mut("degradations")
+        .and_then(Value::as_array_mut)
+    {
+        Some(existing) => {
+            existing.retain(|prior| {
+                prior.get("reason").and_then(Value::as_str) != Some(RESTATEMENT_POINTED_REASON)
+            });
+            existing.push(entry);
+        }
+        None => payload["degradations"] = Value::Array(vec![entry]),
+    }
+}
+
+/// The reason code a response whose restatements were replaced by a pointer
+/// carries.
+pub const RESTATEMENT_POINTED_REASON: &str = "qualification_restatement_pointed";
 
 /// The reason code a response the budget cut carries.
 pub const BOUNDED_REASON: &str = "response_bounded";
@@ -2276,6 +2466,151 @@ mod tests {
         assert!(cuts
             .iter()
             .all(|cut| cut["component"] == json!("response_budget")));
+    }
+
+    /// A trace payload whose fixed part is a fixed size, so a test can put the
+    /// ceiling on either side of it.
+    ///
+    /// `fixed_chars` stands for the part of a real response the budget never
+    /// trims: the `_kin` envelope, the `negative` object and the fields that
+    /// qualify the walk. Measured on 2026-09-02 that part was 9,210 characters
+    /// of a 12,000-character ceiling (FIR-3107), which is the whole reason the
+    /// rung below exists.
+    fn floor_case_payload(steps: usize, step_chars: usize, fixed_chars: usize) -> Value {
+        let chain: Vec<Value> = (1..=steps)
+            .map(|step| {
+                json!({
+                    "step": step,
+                    "parent_step": step - 1,
+                    "entity_id": format!("id-{step}"),
+                    "entity_name": format!("hop_{step}"),
+                    "signature": "s".repeat(step_chars),
+                })
+            })
+            .collect();
+        json!({
+            "focal_name": "Session.send",
+            "untrimmable": "f".repeat(fixed_chars),
+            "total_steps": steps,
+            "chain": chain,
+        })
+    }
+
+    /// The floor of one entry per list holds even when giving it up is exactly
+    /// what would fit.
+    ///
+    /// This fixture is the tempting case: one surviving row does not fit and no
+    /// rows do, so releasing the floor would put the response inside its
+    /// ceiling. A rung that did that was written for FIR-3107 and taken out
+    /// again, because `response_budget_elisions.py` check 4 went red on it: at a
+    /// tight ceiling an `impact_analysis` emptied `entity_impacts`,
+    /// `affected_callers`, `affected_tests` and `changed_ids` in one pass, which
+    /// is FIR-2602 reappearing. An empty array reads as "the walk found none",
+    /// and no counter beside it outranks that reading, so a response that cannot
+    /// reach its ceiling says so in `response_over_budget` instead.
+    #[test]
+    fn the_entry_floor_holds_even_when_releasing_it_would_fit() {
+        const BUDGET: usize = 8_000;
+        let mut payload = floor_case_payload(4, 2_400, 6_000);
+        let budget = ResponseBudget {
+            max_chars: BUDGET,
+            ..ResponseBudget::default()
+        };
+        // Both controls, because the case is defined by the gap between them.
+        let mut one_row = payload.clone();
+        one_row["chain"] = json!([payload["chain"][0].clone()]);
+        assert!(
+            measure(&one_row) > BUDGET,
+            "the fixture fits at the floor, so it is not the tempting case"
+        );
+        let mut none = payload.clone();
+        none["chain"] = json!([]);
+        assert!(
+            measure(&none) <= BUDGET,
+            "the fixture does not fit even empty, so releasing the floor was never on offer"
+        );
+
+        enforce(&mut payload, "trace_data_flow", &budget).expect("trace_data_flow is budgeted");
+        assert_eq!(
+            payload["chain"].as_array().map(Vec::len),
+            Some(1),
+            "the budget emptied a walk that reached four steps to make a ceiling: {payload}"
+        );
+        let reasons: Vec<&str> = payload["degradations"]
+            .as_array()
+            .expect("a cut is disclosed")
+            .iter()
+            .filter_map(|entry| entry["reason"].as_str())
+            .collect();
+        assert!(
+            reasons.contains(&OVER_BUDGET_REASON),
+            "a response that stayed over its ceiling has to say so: {reasons:?}"
+        );
+    }
+
+    /// `clipped_steps` is an array a trace answer carries and the shape table
+    /// did not name, which is FIR-2602's shape: a key the table does not name
+    /// is a key the bounder cannot cut. Six clips were 758 characters of a
+    /// 12,000-character ceiling in the measured case (FIR-3107).
+    ///
+    /// It sheds before the chain, because a clip is a note about breadth the
+    /// walk gave up and the chain is the answer.
+    #[test]
+    fn clipped_steps_shed_before_the_chain_they_annotate() {
+        const BUDGET: usize = 6_000;
+        let mut payload = floor_case_payload(4, 400, 0);
+        payload["clipped_steps"] = Value::Array(
+            (0..20)
+                .map(|index| {
+                    json!({
+                        "step": index,
+                        "limit_per_step": 12,
+                        "dropped_callees": 7,
+                        "dropped_crossing_file": 3,
+                        "note": "n".repeat(300),
+                    })
+                })
+                .collect(),
+        );
+        assert!(
+            measure(&payload) > BUDGET,
+            "the fixture must overflow or nothing is trimmed"
+        );
+        let budget = ResponseBudget {
+            max_chars: BUDGET,
+            ..ResponseBudget::default()
+        };
+        enforce(&mut payload, "trace_data_flow", &budget).expect("trace_data_flow is budgeted");
+
+        let clips = payload["clipped_steps"]
+            .as_array()
+            .expect("clips survive")
+            .len();
+        assert!(
+            clips < 20,
+            "the bounder still cannot count `clipped_steps`, so it cannot cut them: {payload}"
+        );
+        let chain = payload["chain"].as_array().expect("a chain survives").len();
+        // The order is the assertion, not the survival: the ladder keeps going
+        // until the response fits, so the chain can lose a row too. What must
+        // not happen is the annotation outliving the answer it annotates.
+        assert!(
+            20 - clips > 4 - chain,
+            "the chain gave up {} rows while the clips gave up {}, so the annotation is \
+             outranking the answer: {payload}",
+            4 - chain,
+            20 - clips
+        );
+        assert!(
+            chain > 1,
+            "the clips were shed and the answer went with them anyway: {payload}"
+        );
+        assert_eq!(
+            payload["elisions"]["clipped_steps"]["elided"],
+            json!(20 - clips),
+            "the clips went without appearing in the one map that answers what was lost: \
+             {payload}"
+        );
     }
 
     /// One `trace_data_flow` chain, wide and shallow, with `target_name` echoing

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -2716,6 +2716,14 @@ fn apply_response_budget(annotated: &mut Value, tool_name: &str, budget: &Respon
         }
     }
 
+    // The loop above rebuilds the verdict on any pass that marked the response
+    // bounded, so a pointer the ladder wrote inside the loop is overwritten by
+    // the long form on the next pass. It is applied here, after the loop has
+    // settled, where nothing rewrites those fields again.
+    if crate::budget::point_restated_limiting_factor(annotated, budget) > 0 {
+        settle_response_accounting(annotated, &mut accounting);
+    }
+
     // The last accounting rewrite is itself part of the response. Reconcile
     // the residual marker against that exact shape, then settle its size once
     // more because adding or removing the marker changes the measured bytes.
@@ -3547,6 +3555,277 @@ mod tests {
 
     /// A daemon envelope over a graph that reports itself ready, which is the
     /// state every one of these fixtures answers from.
+    /// One `trace_data_flow` answer at depth, in the shape the demo measured on
+    /// hiredis on 2026-09-02: eleven hops, most of them reached by name alone,
+    /// six clipped nodes, a two-candidate focal and partial C edge coverage.
+    ///
+    /// Sized to overflow the agent belt's own 12,000-character ceiling, which is
+    /// what the case is about.
+    fn deep_trace_payload() -> Value {
+        let steps: Vec<Value> = (1..=11)
+            .map(|index| {
+                json!({
+                    "step": index,
+                    "role": "callee",
+                    "relation_kind": "Calls",
+                    "resolution": if index > 4 { "name_only" } else { "type_resolved" },
+                    "parent_step": index - 1,
+                    "depth": (index + 1) / 2,
+                    "reference_lines": [120 + index, 340 + index],
+                    "reference_lines_absent_reason": null,
+                    "fanout_truncated": false,
+                    "fanout_dropped": 0,
+                    "terminal": null,
+                    "entity_id": format!("6f1c9b0e-{index:04}-4a21-9d33-2b7e5c8a10{index:02}"),
+                    "entity_name": format!("redisAsyncCommand_stage_{index}"),
+                    "entity_kind": "Function",
+                    "entity_role": "source",
+                    "entity_file": format!("src/async_stage_{index}.c"),
+                    "external": false,
+                    "start_line": 100 + index * 7,
+                    "end_line": 160 + index * 7,
+                    "signature": "int redisAsyncCommand(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, const char *format, ...)",
+                    "body": null,
+                    "span_coherence": null,
+                    "crossing": null,
+                })
+            })
+            .collect();
+        let clips: Vec<Value> = (0..6)
+            .map(|index| {
+                json!({
+                    "step": index,
+                    "limit_per_step": 12,
+                    "dropped_callees": 7,
+                    "dropped_crossing_file": 3,
+                    "spine": true,
+                })
+            })
+            .collect();
+        json!({
+            "focal_id": "6f1c9b0e-0000-4a21-9d33-2b7e5c8a1000",
+            "focal_name": "redisAsyncCommand",
+            "focal_kind": "Function",
+            "focal_file": "src/async.c",
+            "focal_entity": {
+                "entity_id": "6f1c9b0e-0000-4a21-9d33-2b7e5c8a1000",
+                "entity_name": "redisAsyncCommand",
+                "entity_kind": "Function",
+                "entity_role": "source",
+                "entity_file": "src/async.c",
+                "external": false,
+                "start_line": 700,
+                "end_line": 760,
+                "signature": "int redisAsyncCommand(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, const char *format, ...)",
+                "body": null,
+                "span_coherence": null,
+                "crossing": null,
+            },
+            "direction": "calls",
+            "depth": 6,
+            "limit_per_step": 12,
+            "bodies_included": false,
+            "include_type_edges": false,
+            "chain": steps,
+            "total_steps": 11,
+            "truncated": true,
+            "focal_resolution": { "addressed_by": "name", "same_name_candidates": 2 },
+            "edge_coverage": {
+                "language": "C",
+                "classes": { "calls": "present", "imports": "absent", "references": "partial" },
+                "cross_file_classes": ["calls"],
+                "budget_exhausted": false,
+                "reference_enrichment": "build_only",
+                "scope_entities": 6160,
+            },
+            "clipped_steps": clips,
+            "spine_clipped_steps": 4,
+            "max_response_chars": 45000,
+            "fanout_narrowed": 0,
+            "terminal_external_steps": 0,
+            "terminal_annotation_steps": 0,
+            "terminal_leaf_steps": 2,
+            "terminal_bound_steps": 3,
+            "terminal_coverage_gap_steps": 0,
+        })
+    }
+
+    fn belt_bounded_deep_trace() -> Value {
+        let budget = ResponseBudget {
+            max_chars: crate::agent_belt::AGENT_DEFAULT_RESPONSE_MAX_CHARS as usize,
+            ..ResponseBudget::default()
+        };
+        let annotated = finalize_bounded(
+            ToolCallResult::text(deep_trace_payload().to_string()),
+            ready_daemon_envelope(),
+            "trace_data_flow",
+            &budget,
+        );
+        annotated_value(&annotated)
+    }
+
+    /// The measured case, and the one the belt advertises a number for.
+    ///
+    /// `trace_data_flow` on `agent-default` is injected `max_chars: 12,000` and
+    /// advertises the same number, and on 2026-09-02 the demo's run against
+    /// hiredis received 15,875 characters, 32 percent over (FIR-3107). It had
+    /// bounded everything it could reach: the chain was already at its floor of
+    /// one entry, and what was over the ceiling was the part of the response the
+    /// budget never trims.
+    ///
+    /// Measured here on this fixture, that part was 9,210 characters against a
+    /// 12,000 ceiling, and roughly 7,700 of it was four verbatim copies of one
+    /// 1,900-character limiting-factor sentence. So the answer fits now by
+    /// writing that sentence once and pointing at it, rather than by giving up
+    /// the walk it was asked for.
+    #[test]
+    fn a_deep_trace_answers_inside_the_ceiling_the_belt_advertises() {
+        const CEILING: usize = crate::agent_belt::AGENT_DEFAULT_RESPONSE_MAX_CHARS as usize;
+        // The control. A fixture that fits on its own grades nothing, because
+        // every rung below returns at its first line.
+        let raw = crate::budget::measure(&deep_trace_payload());
+        assert!(
+            raw > CEILING / 2,
+            "the fixture is {raw} characters, too small to reach the ceiling with an envelope"
+        );
+
+        let final_payload = belt_bounded_deep_trace();
+        let shipped = crate::budget::measure(&final_payload);
+        println!("deep trace ships {shipped} characters against a {CEILING} ceiling");
+        assert!(
+            shipped <= CEILING,
+            "the answer ships {shipped} characters against the {CEILING} it advertises: \
+             {final_payload}"
+        );
+        assert_eq!(
+            final_payload["_kin"]["response"]["chars_after_budget"],
+            json!(shipped),
+            "the accounting has to name the size that ships"
+        );
+
+        // It fit by shedding restatement, not by giving up the walk.
+        let chain = final_payload["chain"]
+            .as_array()
+            .expect("a chain survives")
+            .len();
+        assert!(
+            chain > 0,
+            "the answer gave up every step to fit: {final_payload}"
+        );
+
+        let degradations = final_payload["degradations"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        let reasons: Vec<&str> = degradations
+            .iter()
+            .filter_map(|entry| entry["reason"].as_str())
+            .collect();
+        assert!(
+            reasons.contains(&crate::budget::RESTATEMENT_POINTED_REASON),
+            "nothing disclosed what was shortened: {reasons:?}"
+        );
+        assert!(
+            !reasons.contains(&crate::budget::OVER_BUDGET_REASON),
+            "the answer fits and still says it did not: {reasons:?}"
+        );
+        let detail = degradations
+            .iter()
+            .find(|entry| entry["reason"] == json!(crate::budget::RESTATEMENT_POINTED_REASON))
+            .and_then(|entry| entry["detail"].as_str())
+            .expect("the disclosure carries a detail")
+            .to_string();
+        // Printed, not merely asserted: the sentence a caller reads is the
+        // artifact.
+        println!("composed disclosure: {detail}");
+        assert!(
+            detail.contains("_kin.verdict.limiting_factor")
+                && detail.contains("negative.trust_reason"),
+            "the disclosure does not name where the statement still lives: {detail}"
+        );
+
+        // Nothing was lost. The canonical copies are whole and the two fields
+        // that restated them point at them by name.
+        let factor = final_payload["_kin"]["verdict"]["limiting_factor"]
+            .as_str()
+            .expect("a bounded trace names a limiting factor");
+        assert!(
+            factor.len() > 400,
+            "the canonical sentence was shortened, which is the one thing this must not do: \
+             {factor}"
+        );
+        let note = final_payload["_kin"]["verdict"]["note"]
+            .as_str()
+            .expect("the verdict carries a note");
+        assert!(
+            note.contains("see `_kin.verdict.limiting_factor`"),
+            "the note does not point at the sentence it used to repeat: {note}"
+        );
+        assert!(
+            !note.contains(factor),
+            "the note still carries the whole sentence verbatim: {note}"
+        );
+        let trust_reason = final_payload["negative"]["trust_reason"]
+            .as_str()
+            .expect("the negative carries its own reason");
+        assert!(
+            trust_reason.len() > 400,
+            "negative.trust_reason was shortened; the acceptance suite reads it whole: \
+             {trust_reason}"
+        );
+        let advice = final_payload["negative"]["advice"]
+            .as_str()
+            .expect("the negative carries advice");
+        assert!(
+            advice.contains("see `negative.trust_reason`"),
+            "the advice does not point at the reason it used to repeat: {advice}"
+        );
+    }
+
+    /// The direction that makes the test above mean something: a response INSIDE
+    /// its ceiling keeps every word, restatements included.
+    ///
+    /// Without this, a pointer written unconditionally would pass everything
+    /// above while quietly shortening every trace answer Kin serves.
+    #[test]
+    fn a_trace_that_fits_keeps_every_restatement() {
+        let budget = ResponseBudget {
+            max_chars: 60_000,
+            ..ResponseBudget::default()
+        };
+        let annotated = finalize_bounded(
+            ToolCallResult::text(deep_trace_payload().to_string()),
+            ready_daemon_envelope(),
+            "trace_data_flow",
+            &budget,
+        );
+        let payload = annotated_value(&annotated);
+        assert!(
+            crate::budget::measure(&payload) <= 60_000,
+            "the roomy arm has to fit, or it is grading the same case as the tight one"
+        );
+        let note = payload["_kin"]["verdict"]["note"]
+            .as_str()
+            .expect("the verdict carries a note");
+        assert!(
+            !note.contains("see `_kin.verdict.limiting_factor`"),
+            "a response with room to spare was shortened anyway: {note}"
+        );
+        let reasons: Vec<&str> = payload["degradations"]
+            .as_array()
+            .map(|entries| {
+                entries
+                    .iter()
+                    .filter_map(|entry| entry["reason"].as_str())
+                    .collect()
+            })
+            .unwrap_or_default();
+        assert!(
+            !reasons.contains(&crate::budget::RESTATEMENT_POINTED_REASON),
+            "nothing was shortened and the response says it was: {reasons:?}"
+        );
+    }
+
     fn ready_daemon_envelope() -> Envelope {
         Envelope::daemon().with_health(&json!({
             "initialized": true,

--- a/crates/kin-mcp/src/lib.rs
+++ b/crates/kin-mcp/src/lib.rs
@@ -45,7 +45,8 @@ pub use session::{
 };
 pub use startup_binding::{StartupBindingState, StartupDaemonBinding};
 pub use tools::{
-    agent_default_tool_names, benchmark_tool_names, context_bench_tool_names, tool_definitions,
+    agent_default_tool_names, agent_query_tool_names, benchmark_tool_names,
+    context_bench_tool_names, name_set as tool_name_set, served_tools_list, tool_definitions,
 };
 pub use types::{
     ContentBlock, JsonRpcRequest, JsonRpcResponse, ToolCallParams, ToolCallResult, ToolDefinition,

--- a/crates/kin-mcp/src/server.rs
+++ b/crates/kin-mcp/src/server.rs
@@ -19,7 +19,6 @@ use crate::error::{McpError, Result};
 use crate::handlers::{handle_tool_call, RequestRepositoryAuthority};
 use crate::session::SessionRegistry;
 use crate::startup_binding::{StartupBindingState, StartupDaemonBinding};
-use crate::tools::tool_definitions;
 use crate::types::*;
 
 /// MCP server configuration.
@@ -1184,29 +1183,10 @@ fn handle_initialize(
 }
 
 fn handle_tools_list(id: Option<serde_json::Value>, config: &McpServerConfig) -> JsonRpcResponse {
-    let mut tools = tool_definitions();
-    if let Some(allowed) = &config.allowed_tools {
-        // Captured before the filter, because the annotation below has to tell a
-        // registered tool this profile withholds from a phrase that is simply
-        // prose. After the retain, the withheld ones are gone and that
-        // distinction is unrecoverable.
-        let registered: Vec<String> = tools.tools.iter().map(|tool| tool.name.clone()).collect();
-        tools.tools.retain(|tool| allowed.contains(&tool.name));
-        // A served description that sends the reader to a tool this profile does
-        // not serve is a surface contradicting itself, and it is not rare: the
-        // default profile has five of them naming seven withheld tools
-        // (FIR-3031). Answered here rather than in any description, because this
-        // is the one place the served set is known.
-        crate::tools::annotate_unserved_cross_references(&mut tools, &registered, allowed);
-    }
-    // After the filter and the annotation, so the short forms are the last word
-    // and cannot be re-lengthened by a note computed from the long ones. The
-    // annotation is a no-op on this profile anyway, because a short form names
-    // only tools the profile serves, but the ORDER is what guarantees that
-    // rather than the current wording.
-    if config.agent_belt {
-        crate::agent_belt::compact_for_agent_default(&mut tools);
-    }
+    // The filter, the withheld-tool annotation and the belt compaction live in
+    // one function, so a test that measures the served bytes measures what this
+    // writes to the client rather than its own copy of the recipe.
+    let tools = crate::tools::served_tools_list(config.allowed_tools.as_ref(), config.agent_belt);
     JsonRpcResponse::success(id, serde_json::to_value(&tools).unwrap_or_default())
 }
 

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -395,6 +395,51 @@ pub fn annotate_unserved_cross_references(
     }
 }
 
+/// The tool listing one profile serves, exactly as a client receives it.
+///
+/// `allowed` is the profile's name set, or `None` for the unfiltered surface;
+/// `agent_belt` is whether the short descriptions and trimmed schemas apply.
+///
+/// One function rather than a body inside the stdio handler, because the size of
+/// this listing is now a number checks assert. A test that rebuilt the listing
+/// by restating the filter, the annotation and the compaction would be measuring
+/// its own restatement, and would keep reporting a saving after the server had
+/// stopped producing one.
+pub fn served_tools_list(
+    allowed: Option<&std::collections::HashSet<String>>,
+    agent_belt: bool,
+) -> ToolsListResult {
+    let mut tools = tool_definitions();
+    if let Some(allowed) = allowed {
+        // Captured before the filter, because the annotation below has to tell a
+        // registered tool this profile withholds from a phrase that is simply
+        // prose. After the retain, the withheld ones are gone and that
+        // distinction is unrecoverable.
+        let registered: Vec<String> = tools.tools.iter().map(|tool| tool.name.clone()).collect();
+        tools.tools.retain(|tool| allowed.contains(&tool.name));
+        // A served description that sends the reader to a tool this profile does
+        // not serve is a surface contradicting itself, and it is not rare: the
+        // default profile has five of them naming seven withheld tools
+        // (FIR-3031). Answered here rather than in any description, because this
+        // is the one place the served set is known.
+        annotate_unserved_cross_references(&mut tools, &registered, allowed);
+    }
+    // After the filter and the annotation, so the short forms are the last word
+    // and cannot be re-lengthened by a note computed from the long ones. The
+    // annotation is a no-op on the default profile anyway, because a short form
+    // names only tools that profile serves, but the ORDER is what guarantees
+    // that rather than the current wording.
+    if agent_belt {
+        crate::agent_belt::compact_for_agent_default(&mut tools);
+    }
+    tools
+}
+
+/// The name set for one profile, in the shape [`served_tools_list`] takes.
+pub fn name_set(names: &[&str]) -> std::collections::HashSet<String> {
+    names.iter().map(|name| (*name).to_string()).collect()
+}
+
 /// Build the list of all MCP tools that Kin exposes, in name order.
 ///
 /// The order is part of the contract. A client caches the prompt it builds from
@@ -1617,6 +1662,56 @@ pub fn agent_default_tool_names() -> &'static [&'static str] {
     ]
 }
 
+/// Tool names for the query half of the agent belt.
+///
+/// [`agent_default_tool_names`] minus the session and transaction tools. Same
+/// tools, same served names, same short descriptions and trimmed schemas: this
+/// is that profile with its write half removed, not a second belt to keep in
+/// step with it.
+///
+/// Native tool calling re-sends the whole `tools` array on every turn, so the
+/// served list is a per-turn cost rather than a per-session one. Measured on
+/// 2026-09-02 by the demo's MCP executor against a real `kin mcp start` on
+/// `agent-default`: `tools/list` was 30,194 bytes and 8,627 tokens on
+/// google/gemma-4-e4b, 36 percent of that run's 24,000-token ceiling before the
+/// model had asked anything, and the run bought two tool calls. Across six runs
+/// the model called `semantic_locate`, `trace_data_flow` and
+/// `graph_neighborhood` and never once reached for a session or a transaction
+/// tool, while `kin_transaction_stage` and `kin_transaction_commit` alone were
+/// 11,245 of those bytes (FIR-3107).
+///
+/// So a client that only queries should not carry the write contracts in every
+/// prompt. This is that surface, and
+/// `the_query_profile_costs_far_fewer_bytes_than_agent_default` holds the saving
+/// on the served schemas a client actually receives.
+///
+/// A second served list, not a mode. `agent-default` is unchanged and still
+/// serves every write tool, and nothing here makes Kin itself read-only.
+///
+/// `get_entity_source` stays. It joined `agent-default` because staging a body
+/// update means restating the current source, which is a write-side argument,
+/// but it is also the tool that turns an id into the exact graph-owned body,
+/// and a querying belt whose discovery tools hand back bounded snippets needs
+/// that door as much as a writing one does.
+pub fn agent_query_tool_names() -> &'static [&'static str] {
+    &[
+        "kin_artifact_list",
+        "kin_artifact_read",
+        "kin_graph_status",
+        "semantic_locate",
+        "semantic_search",
+        "get_context_pack",
+        "impact_analysis",
+        "get_entity_source",
+        "trace_data_flow",
+        crate::handlers::path::TOOL_NAME,
+        "find_references",
+        "graph_neighborhood",
+        crate::handlers::file_entities::TOOL_NAME,
+        "kin_provenance_query",
+    ]
+}
+
 /// Tool names for the READ-ONLY graph-native ContextBench profile.
 ///
 /// This is the belt the graph-native benchmark agent arm drives: purely
@@ -2610,6 +2705,164 @@ The Kin MCP server exposes 2 semantic tools to AI assistants.
             visible,
             profile.len(),
             "every profile tool should be listable"
+        );
+    }
+
+    /// The query profile is `agent-default` with its write half removed, and the
+    /// removed half is exactly the session and transaction tools.
+    ///
+    /// The exact names are written out rather than derived, because deriving
+    /// them from `agent_default_tool_names()` by the same rule the profile is
+    /// built with would be a check that cannot fail: any name added to the
+    /// default belt would silently join the query one, which is the decision this
+    /// test exists to make somebody take.
+    #[test]
+    fn agent_query_serves_the_query_half_of_the_agent_belt() {
+        let query: Vec<&str> = agent_query_tool_names().to_vec();
+        let mut sorted = query.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(
+            sorted.len(),
+            query.len(),
+            "agent-query lists a name twice: {query:?}"
+        );
+        assert_eq!(
+            sorted,
+            vec![
+                "find_references",
+                "get_context_pack",
+                "get_entity_source",
+                "graph_neighborhood",
+                "impact_analysis",
+                "kin_artifact_list",
+                "kin_artifact_read",
+                "kin_graph_status",
+                "kin_provenance_query",
+                "list_file_entities",
+                "semantic_locate",
+                "semantic_search",
+                "trace_data_flow",
+                "trace_path",
+            ],
+            "the query profile's served names moved; a name here is a public surface"
+        );
+
+        // Every one of them is a tool the registry defines, and every one is
+        // annotated read-only. The annotation is the structural half: a tool
+        // that mutates artifacts, sessions or the graph cannot join this list
+        // without this failing, whatever its name suggests.
+        let list = tool_definitions();
+        for name in &query {
+            let tool = list
+                .tools
+                .iter()
+                .find(|tool| tool.name == *name)
+                .unwrap_or_else(|| {
+                    panic!("agent-query tool '{name}' is not in tool_definitions()")
+                });
+            assert!(
+                tool.annotations.read_only_hint && !tool.annotations.destructive_hint,
+                "agent-query serves '{name}', which the registry does not annotate read-only"
+            );
+        }
+
+        let default: BTreeSet<&str> = agent_default_tool_names().iter().copied().collect();
+        let query_set: BTreeSet<&str> = query.iter().copied().collect();
+        assert!(
+            query_set.is_subset(&default),
+            "agent-query serves a name agent-default does not, so the two belts have drifted: {:?}",
+            query_set.difference(&default).collect::<Vec<_>>()
+        );
+        let removed: Vec<&str> = default.difference(&query_set).copied().collect();
+        assert_eq!(
+            removed,
+            vec![
+                "kin_session_end",
+                "kin_session_heartbeat",
+                "kin_session_start",
+                "kin_transaction_abort",
+                "kin_transaction_begin",
+                "kin_transaction_commit",
+                "kin_transaction_stage",
+            ],
+            "the query profile removed something other than the write half"
+        );
+    }
+
+    /// The saving, measured on the listing a client receives.
+    ///
+    /// This is the finding the profile exists for. Native tool calling re-sends
+    /// the whole `tools` array on every turn, so the served list is a per-turn
+    /// cost: measured on 2026-09-02 against a real `kin mcp start`,
+    /// `agent-default`'s `tools/list` was 30,194 bytes and 8,627 tokens on
+    /// google/gemma-4-e4b, 36 percent of that run's 24,000-token ceiling before
+    /// the model had asked anything (FIR-3107).
+    ///
+    /// The assertion is in BYTES, because bytes are what this process can
+    /// measure. Tokens are a property of somebody else's tokenizer, and a test
+    /// that pretended to count them would be asserting a number it made up. The
+    /// demo measured 3.5 bytes per token on that model, so the ratio held here
+    /// is the ratio of the token cost on it too; the absolute token number is
+    /// the demo's to report, not this test's.
+    ///
+    /// Driven through `served_tools_list`, which is the function the stdio
+    /// handler calls, so this measures the bytes written to a client rather than
+    /// a restatement of the filter, the annotation and the compaction.
+    #[test]
+    fn the_query_profile_costs_far_fewer_bytes_than_agent_default() {
+        // No more than 65 percent of the default belt's listing. A ceiling
+        // rather than the measured number: the point is that the write
+        // contracts are gone, and pinning the exact byte count would fail on
+        // every description edit while saying nothing about that.
+        const CEILING_PERCENT: usize = 65;
+
+        let default = served_tools_list(Some(&name_set(agent_default_tool_names())), true);
+        let query = served_tools_list(Some(&name_set(agent_query_tool_names())), true);
+        assert_eq!(default.tools.len(), agent_default_tool_names().len());
+        assert_eq!(query.tools.len(), agent_query_tool_names().len());
+
+        let bytes = |list: &ToolsListResult| {
+            serde_json::to_string(list)
+                .expect("a tool listing serializes")
+                .len()
+        };
+        let (default_bytes, query_bytes) = (bytes(&default), bytes(&query));
+        // Printed, not merely asserted: the number is the artifact, and the next
+        // person to move a description should be able to read what it cost.
+        println!(
+            "tools/list bytes: agent-default {default_bytes} over {} tools, agent-query \
+             {query_bytes} over {} tools ({}%)",
+            default.tools.len(),
+            query.tools.len(),
+            query_bytes * 100 / default_bytes.max(1),
+        );
+        assert!(
+            query_bytes * 100 <= default_bytes * CEILING_PERCENT,
+            "agent-query's tools/list is {query_bytes} bytes against agent-default's \
+             {default_bytes}, over the {CEILING_PERCENT}% ceiling this profile exists to buy"
+        );
+
+        // The control. A ratio under a ceiling proves nothing if the listing it
+        // measured was empty, or if the two profiles were served the same bytes.
+        assert!(
+            query_bytes > 5_000,
+            "the query listing is {query_bytes} bytes, which is too small to be a real surface"
+        );
+        let serialized = serde_json::to_string(&query).expect("a tool listing serializes");
+        for withheld in [
+            "kin_transaction_stage",
+            "kin_transaction_commit",
+            "kin_session_start",
+        ] {
+            assert!(
+                !serialized.contains(withheld),
+                "the query listing still carries `{withheld}`, so the saving is not what it looks"
+            );
+        }
+        assert!(
+            serialized.contains("semantic_locate") && serialized.contains("trace_data_flow"),
+            "the query listing lost the retrieval tools it exists to serve"
         );
     }
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1412,7 +1412,7 @@ kin mcp start [options]
 | --- | --- | --- |
 | `--global` |  | Run in global mode, serving every repo in this home's registry (KIN_REGISTRY_PATH, else <KIN_HOME>/registry.toml, else ~/.kin/registry.toml) |
 | `--repo <path>` |  | Bind this server to a specific Kin repository instead of relying on the launching process's working directory. Overrides KIN_MCP_REPO. Use this for a global agent-CLI MCP entry that may launch outside any Kin repository (e.g. an umbrella workspace root). |
-| `--tool-profile <profile>` |  | Tool surface to serve: `agent-default` (the curated agent belt, and the default), `full` (every tool, roughly 12k extra tokens of schemas per session), `benchmark`, or `context-bench`. Overrides KIN_MCP_TOOL_PROFILE. |
+| `--tool-profile <profile>` |  | Tool surface to serve: `agent-default` (the curated agent belt, and the default), `agent-query` (that belt without the session and transaction tools, for a client that only queries), `full` (every tool, roughly 12k extra tokens of schemas per session), `benchmark`, or `context-bench`. Overrides KIN_MCP_TOOL_PROFILE. |
 | `--no-spawn` |  | Never start or revive a daemon from this server: bind only a daemon that is already running, and answer graph tool calls with an honest "no daemon is running" error otherwise. This is the probe mode for watchdogs and boot-time checks (equivalent to KIN_NO_DAEMON=1): the MCP handshake and tool list are served in full, and nothing heavy is ever spawned by the check itself. |
 
 ### `kin assistant`

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -39,7 +39,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_MCP_KIN_BINARY` | path | *(unset)* | operational | explicit native Kin binary used by the @kinlab/kin-mcp wrapper |
 | `KIN_MCP_RELEASE_BASE_URL` | url | GitHub Releases | operational | release mirror base URL used by the @kinlab/kin-mcp wrapper |
 | `KIN_MCP_REPO` | path | *(unset)* | operational | bind `kin mcp start` to this repository instead of the launch directory |
-| `KIN_MCP_TOOL_PROFILE` | string | agent-default | operational | MCP tool surface: agent-default (curated, the default), full (every tool), benchmark, context-bench |
+| `KIN_MCP_TOOL_PROFILE` | string | agent-default | operational | MCP tool surface: agent-default (curated, the default), agent-query (the same belt with no session or transaction tools), full (every tool), benchmark, context-bench |
 | `KIN_NO_PROVISION` | bool | false | operational | forbid network provisioning by the @kinlab/kin launcher |
 | `KIN_NO_SETUP` | bool | false | operational | skip the installer's post-install setup wizard when set truthy |
 | `KIN_REGISTRY_REPAIR` | bool | false | operational | allow the POSIX installer to repair safe registry ownership modes |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -159,6 +159,7 @@ command line (the flag wins):
 | profile | surface |
 | -- | -- |
 | `agent-default` | the curated agent belt, **the default** |
+| `agent-query` | the same belt with no session and no transaction tools, for a client that only queries |
 | `full` | every tool this reference documents |
 | `benchmark` | the retrieval belt the benchmark arm drives |
 | `context-bench` | read-only graph-native retrieval, no write-side session or transaction tools |
@@ -185,6 +186,30 @@ This is a context budget, measured. On 2026-09-02 the profile's `tools/list` was
 over 20 tools, 47,739 of it descriptions and 30,456 input schemas, spent before the model
 asked anything. `full`, `benchmark` and `context-bench` keep the long forms: the last two
 because their `tools/list` bytes are an input to a citable benchmark result.
+
+#### `agent-query` is that belt without its write half
+
+Native tool calling re-sends the whole `tools` array on every turn, so the served list is a
+per-turn cost, not a per-session one. Measured on 2026-09-02 against a real `kin mcp start`,
+`agent-default`'s `tools/list` was 30,194 bytes and 8,627 tokens on google/gemma-4-e4b: 36
+percent of that run's 24,000-token ceiling before the model had asked anything, and the run
+bought two tool calls. `kin_transaction_stage` and `kin_transaction_commit` alone were 11,245
+of those bytes, and across six runs the model never reached for a session or a transaction
+tool (FIR-3107).
+
+`agent-query` is `agent-default` minus the three session tools and the four transaction tools.
+Same served names, same short descriptions, same trimmed schemas, so nothing an agent learned
+on one profile is wrong on the other. Point a query-only client at it:
+
+```sh
+KIN_MCP_TOOL_PROFILE=agent-query kin mcp start --repo /path/to/repo
+```
+
+This is a second served list, not a mode. `agent-default` is unchanged, every write tool is
+still served on it, and nothing here makes Kin read-only. What `agent-query` buys is context:
+a client that never stages or commits stops paying for those contracts in every prompt. Like
+every profile it is a context budget rather than a permission boundary, so the paragraph above
+applies: a local process holding your daemon's credentials can still write.
 
 `agent-default` serves the declaration filter under its registered name, `semantic_search`,
 like every other profile. It also accepts **`find_declarations`** on a `tools/call`, which is

--- a/scripts/acceptance/mcp_surface_contract.py
+++ b/scripts/acceptance/mcp_surface_contract.py
@@ -71,6 +71,41 @@ UNREADABLE = "UNREADABLE"
 # a default that moves would otherwise quietly re-point this whole suite.
 AGENT_DEFAULT_PROFILE = "agent-default"
 
+# The query profile and the exact names it serves, read out of
+# crates/kin-mcp/src/tools.rs::agent_query_tool_names on 2026-09-02. Written out
+# rather than derived: the served set is a public surface, and a check that
+# derived it from the binary under test would agree with any surface that
+# binary happened to serve.
+AGENT_QUERY_PROFILE = "agent-query"
+AGENT_QUERY_NAMES = (
+    "find_references",
+    "get_context_pack",
+    "get_entity_source",
+    "graph_neighborhood",
+    "impact_analysis",
+    "kin_artifact_list",
+    "kin_artifact_read",
+    "kin_graph_status",
+    "kin_provenance_query",
+    "list_file_entities",
+    "semantic_locate",
+    "semantic_search",
+    "trace_data_flow",
+    "trace_path",
+)
+
+# The share of agent-default's tools/list the query profile may cost.
+#
+# Native tool calling re-sends the whole tools array on every turn, so this is a
+# per-turn cost. Measured on 2026-09-02 by the demo's MCP executor against a
+# real `kin mcp start`: agent-default's tools/list was 30,194 bytes and 8,627
+# tokens on google/gemma-4-e4b, 36 percent of that run's 24,000-token ceiling
+# before the model had asked anything (FIR-3107). The assertion is in BYTES,
+# because bytes are what this process can measure; the demo measured 3.5 bytes
+# per token on that model, so the ratio held here is the ratio of the token cost
+# on it too.
+AGENT_QUERY_LIST_CEILING_PERCENT = 65
+
 # The tool names the two shipped proofs assert literally. Read out of
 # .github/workflows/install-proof.yml and scripts/prove-windows-npm-first-run.mjs
 # on 2026-09-02; both assert this one name and no other. Adding a name to either
@@ -175,6 +210,46 @@ def grade_served_names_are_registered(listing, registry):
             "agent-default serves %s under a name the registry does not carry" % unregistered
         ]
     return []
+
+
+def grade_query_profile(query, default):
+    """The query profile serves its exact set, no write tool, and far fewer bytes."""
+    tools = query.get("tools")
+    if not isinstance(tools, list) or not tools:
+        return ["the agent-query profile listed no tools"]
+    served = sorted(name for name in (tool.get("name") for tool in tools) if name)
+    problems = []
+    if served != sorted(AGENT_QUERY_NAMES):
+        problems.append(
+            "agent-query serves %s, not the set this suite grades (%s)"
+            % (served, sorted(AGENT_QUERY_NAMES))
+        )
+    write_side = [
+        name
+        for name in served
+        if name.startswith("kin_session_") or name.startswith("kin_transaction_")
+    ]
+    if write_side:
+        problems.append("agent-query serves the write tools %s" % write_side)
+
+    baseline = default.get("tools")
+    if not isinstance(baseline, list) or not baseline:
+        problems.append("agent-default listed no tools, so there is nothing to measure against")
+        return problems
+    query_bytes = len(json.dumps(query, sort_keys=True))
+    default_bytes = len(json.dumps(default, sort_keys=True))
+    if query_bytes * 100 > default_bytes * AGENT_QUERY_LIST_CEILING_PERCENT:
+        problems.append(
+            "agent-query's tools/list is %d bytes against agent-default's %d (%d%%), over "
+            "the %d%% ceiling the profile exists to buy"
+            % (
+                query_bytes,
+                default_bytes,
+                query_bytes * 100 // max(default_bytes, 1),
+                AGENT_QUERY_LIST_CEILING_PERCENT,
+            )
+        )
+    return problems
 
 
 def grade_search_call(payload):
@@ -518,10 +593,38 @@ def run_checks(suite, verbose=False):
     )
 
     try:
+        query, _, query_stderr = suite.serve(AGENT_QUERY_PROFILE, [])
+    except McpError as error:
+        query, query_stderr, query_error = None, "", error
+    if query is None:
+        res = Result(*[entry for entry in CHECK_TITLES if entry[0] == "7"][0])
+        res.unknown(
+            "the agent-query profile was unreadable, so its surface is unknown: %s" % query_error
+        )
+        results.append(res)
+    else:
+        record(
+            "7", "FIR-3107", "the query profile serves its exact set and costs far fewer bytes",
+            grade_query_profile(query, served),
+            "agent-query served %d tools in %d bytes against agent-default's %d in %d"
+            % (
+                len(query.get("tools") or []),
+                len(json.dumps(query, sort_keys=True)),
+                len(served.get("tools") or []),
+                len(json.dumps(served, sort_keys=True)),
+            ),
+        )
+        if AGENT_QUERY_PROFILE not in (query_stderr or ""):
+            results[-1].unknown(
+                "the server printed no notice naming %r, so which surface was measured is "
+                "unknown" % AGENT_QUERY_PROFILE
+            )
+
+    try:
         registry, _, _ = suite.serve("full", [])
     except McpError as error:
         registry = None
-        for ident, source, title in CHECK_TITLES[5:]:
+        for ident, source, title in [entry for entry in CHECK_TITLES if entry[0] in ("5", "6")]:
             res = Result(ident, source, title)
             res.unknown("the full profile was unreadable, so the registry is unknown: %s" % error)
             results.append(res)
@@ -557,6 +660,7 @@ CHECK_TITLES = [
     ("4", "magic:14", "the kin_graph_status description names the as-of-earlier shape"),
     ("5", "response_budget:2", "every advertised budget is one a client accepts"),
     ("6", "the general form", "no name is served that the registry does not carry"),
+    ("7", "FIR-3107", "the query profile serves its exact set and costs far fewer bytes"),
 ]
 
 
@@ -638,6 +742,34 @@ def self_test():
     expect("call on a good result",
            grade_search_call({"result": {"content": [{"text": "hello in probe.py"}]}}), False)
 
+    def profile_listing(names, padding=0):
+        return {
+            "tools": [
+                {
+                    "name": name,
+                    "description": "d" * (40 + padding),
+                    "inputSchema": {"properties": {"query": {}}},
+                }
+                for name in names
+            ]
+        }
+
+    default_listing = profile_listing(
+        list(AGENT_QUERY_NAMES)
+        + [
+            "kin_session_start",
+            "kin_session_heartbeat",
+            "kin_session_end",
+            "kin_transaction_begin",
+            "kin_transaction_stage",
+            "kin_transaction_commit",
+            "kin_transaction_abort",
+        ],
+        padding=400,
+    )
+    expect("query profile on a good pair",
+           grade_query_profile(profile_listing(AGENT_QUERY_NAMES), default_listing), False)
+
     # And one break per grader.
     expect("control on the full profile",
            grade_profile_notice("Kin MCP: serving the 'full' tool profile (66 tools) from --tool-profile."),
@@ -676,11 +808,28 @@ def self_test():
            grade_search_call({"result": {"content": [{"text": "nothing here"}]}}), True)
     expect("call on no frame at all", grade_search_call(None), True)
 
+    moved = profile_listing(AGENT_QUERY_NAMES)
+    moved["tools"][0]["name"] = "find_declarations"
+    expect("query profile when a served name moved",
+           grade_query_profile(moved, default_listing), True)
+
+    writeful = profile_listing(list(AGENT_QUERY_NAMES) + ["kin_transaction_commit"])
+    expect("query profile when a write tool joined it",
+           grade_query_profile(writeful, default_listing), True)
+
+    # The whole point of the profile, and the break that would make it
+    # pointless: a query listing that costs what the default costs.
+    expect("query profile when it saves nothing",
+           grade_query_profile(profile_listing(AGENT_QUERY_NAMES, padding=400), default_listing),
+           True)
+
     # An empty listing must never read as a clean surface.
     expect("names on an empty listing", grade_proof_asserted_names({"tools": []}), True)
     expect("knob on an empty listing", grade_trace_shape_knob({"tools": []}), True)
     expect("description on an empty listing", grade_graph_status_description({"tools": []}), True)
     expect("budgets on an empty listing", grade_advertised_budgets({"tools": []}, registry), True)
+    expect("query profile on an empty listing",
+           grade_query_profile({"tools": []}, default_listing), True)
 
     for problem in problems:
         print("SELF-TEST FAIL %s" % problem)


### PR DESCRIPTION
## What

Two things FIR-3107 measured on Kin's real MCP server, on the same run.

**A query-only served list.** Native tool calling re-sends the whole `tools` array on every turn, so `tools/list` is a per-turn cost, not a per-session one. On 2026-09-02 the demo's MCP executor drove `kin mcp start` on `agent-default` against hiredis with google/gemma-4-e4b: 21 tools, 30,194 bytes, 8,627 tokens. That is 36 percent of the run's 24,000-token ceiling spent before the model asked anything, and the run bought two tool calls before it hit total-budget at 40,471. Across six runs the model called `semantic_locate`, `trace_data_flow` and `graph_neighborhood` and never once reached for a session or a transaction tool, while `kin_transaction_stage` and `kin_transaction_commit` alone were 11,245 of those bytes.

`agent-query` is `agent-default` minus the three session tools and the four transaction tools. Same served names, same short descriptions, same trimmed schemas, so nothing an agent learned on one profile is wrong on the other. **It is a second served list, not a mode.** `agent-default` is unchanged, every write tool is still served on it, and nothing here makes Kin read-only.

Measured on the wire by the new per-PR check, on this branch's own binaries:

```
CHECK 7 FIR-3107 PASS agent-query served 14 tools in 17922 bytes against agent-default's 21 in 34470
```

52 percent. At the 3.5 bytes per token the demo measured on that model, that is roughly 4,700 tokens back per turn.

**A deep trace that honours its ceiling.** The same run's `trace_data_flow` shipped 15,875 bytes against the 12,000 its own schema advertises, and disclosed it honestly in three degradations. It had already bounded everything it could reach: the chain was at its floor of one entry. What was over the ceiling was the part of the response the budget never trims.

That premise is where the ticket's mechanism and the measurement part company, so I measured before writing the fix. On a fixture of that shape at the belt's 12,000 ceiling:

| block | chars |
|---|---|
| `_kin` | 5,070 |
| `negative` | 4,140 |
| `degradations` | 922 |
| `chain` (already at its floor of one row) | 793 |
| `clipped_steps` | 758 |
| everything else | ~1,996 |
| **total shipped** | **13,679** |

Trimming steps could not have reached 12,000: one row was 793 of it. And roughly 7,700 of the 9,210 untrimmable characters were four verbatim copies of one 1,900-character limiting-factor sentence, in `_kin.verdict.limiting_factor`, `_kin.verdict.note`, `negative.trust_reason` and inside `negative.advice`.

Two rungs answer it:

1. **`clipped_steps` joins the trace shape's collections**, ranked to shed before the chain it annotates. FIR-2602's lesson, one tool along: a key the table does not name is a key the bounder cannot cut.
2. **A response over its ceiling writes the limiting factor once and points at it.** The two fields that restated another field word for word now carry `Limiting factor: see \`_kin.verdict.limiting_factor\`.` and `see \`negative.trust_reason\`.`. `limiting_factor` and `trust_reason` are left whole, the rewrite fires only when the tail IS the canonical sentence, and it fires only over the ceiling. Disclosed as `qualification_restatement_pointed`.

That fixture ships **9,947** characters now, against 13,679 before, with the chain intact.

### A third rung was written and taken out again

The brief asked for the floor of one entry per list to go when releasing it is what fits. I built it, with a guard that fired only when emptying would actually reach the ceiling, and then ran `scripts/acceptance/response_budget_elisions.py` against this branch's own binaries before landing:

```
CHECK 4 FIR-2602 FAIL `entity_impacts` held 63 entries at the ceiling and [] at the floor, so the
budget emptied it; `affected_callers` ... `affected_tests` ... `changed_ids` was cut to an empty
array, which reads as 'the walk found none'
response budget elisions: 11 PASS, 1 FAIL, 0 UNREADABLE
```

That is FIR-2602 reappearing. At a tight ceiling an `impact_analysis` emptied all four of its lists at once, and my guard could not tell that case from the trace one. An empty array reading as "the walk found none" is a worse answer than a response that ships over its ceiling and discloses it, which is the fleet's recorded decision from FIR-2600 and FIR-2602 both.

So the rung is out, the floor is absolute, and `the_entry_floor_holds_even_when_releasing_it_would_fit` holds that decision against the next person who reads the arithmetic and not the history. It costs nothing on the measured case: the two rungs above bring it to 9,947 and the release never fired there anyway.

After removing it, on this branch's binaries:

```
response budget elisions: 12 PASS, 0 FAIL, 0 UNREADABLE
```

`handle_tools_list` also moves into one `crate::tools::served_tools_list`, so a test that measures the served bytes measures what the server writes to a client rather than its own restatement of the filter, the annotation and the compaction.

## Where a profile had to be registered

`agent_query_tool_names` and `served_tools_list` in `kin-mcp`; `McpToolProfile::AgentQuery`, the `TOOL_PROFILE_TOKENS` row, `allowed_tool_names`, `is_agent_belt` and the startup notice in `kin-cli`; `kin doctor`, which reads `agent-query` as healthy rather than misconfigured; the clap help, `docs/cli-reference.md`, `docs/env-vars.md` with `crates/kin-core/src/env_registry.rs` beside it, and `docs/mcp-tools.md`. No served tool name moves.

The per-PR **MCP surface contract** job now grades two profiles, and its step is renamed accordingly. The query profile's whole claim is a size, and a size graded only on `main` moves for four landings before anyone sees it, which is the shape that took five assertions red on 2026-09-02.

## Falsification

Every new test, broken at the behaviour it guards, with the red line it printed. Ten mutants.

**1. Add `kin_transaction_commit` to `agent_query_tool_names`:**
```
tools::tests::agent_query_serves_the_query_half_of_the_agent_belt panicked at crates/kin-mcp/src/tools.rs:2731:
assertion `left == right` failed: the query profile's served names moved; a name here is a public surface
  left: [..., "kin_provenance_query", "kin_transaction_commit", "list_file_entities", ...]
 right: [..., "kin_provenance_query", "list_file_entities", ...]
```

**2. Serve `agent_default_tool_names()` under the query profile:**
```
tools::tests::the_query_profile_costs_far_fewer_bytes_than_agent_default panicked at crates/kin-mcp/src/tools.rs:2838:
agent-query's tools/list is 32976 bytes against agent-default's 32976, over the 65% ceiling this profile exists to buy
```

**3. Stop pointing restatements after the finalizer loop (`if false && point_restated_limiting_factor(...)`):**
```
envelope::tests::a_deep_trace_answers_inside_the_ceiling_the_belt_advertises panicked at crates/kin-mcp/src/envelope.rs:3695:
the answer ships 13594 characters against the 12000 it advertises
```
That is FIR-3107's symptom reproduced. It also shows why the post-loop call is load-bearing: the in-ladder call fires, then a pass of the loop rebuilds the verdict and writes the long form back.

**4. Remove the over-ceiling guard on the pointer (`if false && measure(payload) <= budget.max_chars`):**
```
envelope::tests::a_trace_that_fits_keeps_every_restatement panicked at crates/kin-mcp/src/envelope.rs:3810:
a response with room to spare was shortened anyway
```

**5. Release the floor (`trim_collection(payload, key, target, 0)`), which is the rung this PR removed:**
```
budget::tests::the_entry_floor_holds_even_when_releasing_it_would_fit panicked at crates/kin-mcp/src/budget.rs:2534:
assertion `left == right` failed: the budget emptied a walk that reached four steps to make a ceiling
  left: Some(0)
 right: Some(1)
```

**6. Return the trace shape's collections to `&["chain"]`:**
```
budget::tests::clipped_steps_shed_before_the_chain_they_annotate panicked at crates/kin-mcp/src/budget.rs:2741:
the bounder still cannot count `clipped_steps`, so it cannot cut them
```

**7. Drop the `Some("agent-query")` arm from doctor:**
```
commands::health::tests::mcp_config_on_the_query_profile_is_healthy panicked at crates/kin-cli/src/commands/health.rs:10162:
detail: mcpServers.kin present but KIN_MCP_TOOL_PROFILE is agent-query (expected agent-default, agent-query, or unset ...)
```

**8. Drop the `agent-query` row from the profile-resolution table in the test:**
```
commands::mcp::tests::every_named_profile_resolves_to_its_own_surface panicked at crates/kin-cli/src/commands/mcp.rs:1006:
assertion `left == right` failed: a profile joined the token table without a row here
  left: 4
 right: 5
```

**9. Drop the `agent-query` clause from the startup notice:**
```
commands::mcp::tests::the_default_startup_notice_names_the_surface_and_the_opt_ins panicked at crates/kin-cli/src/commands/mcp.rs:1068:
notice must name the query-only surface: Kin MCP: serving the default 'agent-default' tool profile (21 tools). Set KIN_MCP_TOOL_PROFILE=full ...
```

**10. The Python grader** carries its own falsification, run first in CI by `--self-test`: `grade_query_profile` is driven against a correct pair and against a moved served name, a write tool joining the list, a listing that saves nothing, and an empty listing.

## Verification

- `bin/kin-precheck kin` through `heavy-slot`: **16 gates ran, 16 passed, 0 failed**, on kin 59c2239c234254058b8ac4acf79716805c493fe1, worktree `.kin-coord/worktrees/kin-mcp-readonly-kin`, branch `chore/lane-kin-mcp-readonly-kin`.
- `cargo test -p kin-mcp`: 865 passed, 0 failed.
- `cargo test -p kin-cli --lib`: 2094 passed, 0 failed.
- `cargo test -p kin-core --lib -- env_registry`: 34 passed, including the `docs/env-vars.md` drift check.
- `scripts/acceptance/mcp_surface_contract.py --self-test`: every grader passed its correct case and failed each break.
- Against this branch's own `kin` and `kin-daemon`: `mcp_surface_contract.py` **8 PASS, 0 FAIL, 0 UNREADABLE**; `response_budget_elisions.py` **12 PASS, 0 FAIL**; `verdict_limits_repro.py` **4 pass, 0 FAIL**; `working_copy_freshness_repro.py` all four checks PASS. The last three are the main-graded suites that read the fields the pointer rewrites.

## The three byte counts, reconciled

Three numbers for one listing, and they differ for two reasons rather than one.

| number | what it counts |
|---:|---|
| 32,976 | the `result` object serialized compactly, the way serde writes it to the wire |
| 33,010 | the whole JSON-RPC frame, compact, which is what a client reads off the pipe |
| 34,470 | the same object through Python's `json.dumps(..., sort_keys=True)`, which inserts `", "` and `": "` separators the wire never carries |
| 30,194 | what the demo measured on 2026-09-02, on kin 0.6.4+local.8600fc67 |

The check in this PR prints 34,470 because it measures with Python's default separators. The **ratio is 52.1 percent either way**, because both profiles are counted the same way, so the assertion and the claim are unaffected. The remaining gap to the demo's 30,194 is build drift, not counting: it measured main at 8600fc67c, and today's main carries #1384, #1386 and #1387 on top. The follow-up trim PR touches exactly this code and will switch the check to compact bytes.

## Claims not made

The token numbers are the demo's, from its tokenizer; every assertion in this PR is in bytes, because bytes are what CI can count.

The trace numbers are from a fixture built to the measured shape, not from a replay of the hiredis call. The mechanism it exposes, four copies of one sentence in the untrimmable part, is a property of the response shape rather than of that store.

Closes FIR-3107
