### PR TITLE
Select and preflight the release candidate with nobody at the keyboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1112,7 +1112,10 @@ jobs:
         run: |
           bash scripts/release-policy-gate.sh <<'RELEASE_POLICY'
           python3 scripts/test-release-workflow-authority.py
+          python3 scripts/test-select-release-candidate.py
           node --test \
+            scripts/release-proof/merge-preflight-records.test.mjs \
+            scripts/release-proof/vendored.test.mjs \
             scripts/check-glibc-floor.test.mjs \
             scripts/check-kin-vfs-compat.test.mjs \
             scripts/check-rc-build-drift.test.mjs \
@@ -1673,7 +1676,10 @@ jobs:
         run: |
           bash scripts/release-policy-gate.sh <<'RELEASE_POLICY'
           python3 scripts/test-release-workflow-authority.py
+          python3 scripts/test-select-release-candidate.py
           node --test \
+            scripts/release-proof/merge-preflight-records.test.mjs \
+            scripts/release-proof/vendored.test.mjs \
             scripts/check-glibc-floor.test.mjs \
             scripts/check-kin-vfs-compat.test.mjs \
             scripts/check-rc-build-drift.test.mjs \

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -1,0 +1,598 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+name: Release Cut
+
+# Selects the release candidate and proves half of it, with nobody at a keyboard.
+#
+# release-tag.yml mints a tag for the newest reviewed main commit in the staged
+# version's range carrying BOTH proof records, and release.yml refuses to
+# promote a tag that has none. Nothing produced those records automatically: a
+# captain picked the sha, pushed release/v<version>-candidate, dispatched
+# rc-build.yml, ran bin/kin-release-preflight on the archives and drove
+# bin/kin-stranger, then published both records by hand. On 2026-09-02 that
+# procedure cost a day. A rerun of a flaky required job made the first candidate
+# unmintable, because the mint reads a duplicated required context as ambiguous
+# authority; the stranger ran the tool's default two arms while the gate
+# required three; the account limit cut the driver mid-arm three times; and the
+# shared Mac ran out of memory under the host leg.
+#
+# This workflow owns the mechanical half. It selects the candidate itself,
+# arms the candidate branch, dispatches the archive build, and judges those
+# archives on hosted runners, publishing preflight.json exactly as the local
+# run does. What it does NOT do is run the stranger: see "The stranger is still
+# local" below, which is a measured limit rather than a gap left open.
+#
+# Trigger authority, and why there is no workflow_dispatch. Every arm here
+# resolves its workflow code from protected main, and the publish job reaches
+# the release App's key. A workflow_dispatch takes a ref, so it would let a
+# branch select the code that runs beside that credential. The typed
+# repository_dispatch cannot: GitHub always runs it from the default branch and
+# only when the workflow exists there. This mirrors release-tag.yml.
+on:
+  workflow_run:
+    workflows: [CI, RC Build]
+    types: [completed]
+  repository_dispatch:
+    types: [release_cut]
+  schedule:
+    # Offset from the mint (:11,:26,:41,:56) and the train (:07,:22,:37,:52) so
+    # a cycle selects, arms and proves between two mint evaluations rather than
+    # racing one. GitHub's cron stalled for most of 2026-09-02, so the schedule
+    # is the fallback here and never the only path.
+    - cron: "3,18,33,48 * * * *"
+
+permissions:
+  contents: read
+
+# Never two cuts at once, and never cancel one mid-flight: a cancelled preflight
+# leaves an armed candidate with no record, which the next cycle then re-arms.
+concurrency:
+  group: kin-release-cut
+  cancel-in-progress: false
+
+jobs:
+  select:
+    name: Select the release candidate
+    # The branch filters live in the selector's own trigger validation, which
+    # reads GitHub-owned context rather than a payload, so this condition is
+    # the cheap half: it keeps the job from starting on the CI and RC Build
+    # completions that are obviously not occasions. `workflow_run` fires on
+    # every completion of both workflows, which on a busy main is most of the
+    # day.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (
+        github.event.workflow_run.head_repository.full_name == github.repository &&
+        (
+          (
+            github.event.workflow_run.name == 'CI' &&
+            github.event.workflow_run.event == 'push' &&
+            github.event.workflow_run.head_branch == 'main'
+          ) ||
+          (
+            github.event.workflow_run.name == 'RC Build' &&
+            github.event.workflow_run.event == 'workflow_dispatch' &&
+            startsWith(github.event.workflow_run.head_branch, 'release/v')
+          )
+        )
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+    outputs:
+      decision: ${{ steps.select.outputs.decision || 'stand-down' }}
+      version: ${{ steps.select.outputs.version }}
+      branch: ${{ steps.select.outputs.branch }}
+      candidate: ${{ steps.select.outputs.candidate }}
+      rc_run: ${{ steps.select.outputs.rc_run }}
+      move: ${{ steps.select.outputs.move }}
+      reason: ${{ steps.select.outputs.reason }}
+    steps:
+      # The literal trusted context value, as in kin-registry-wave-land.yml.
+      # The binding step below proves github.sha is protected main's history
+      # before the judgment reads it as policy.
+      - name: Checkout the queued cut policy
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate the cut trigger
+        env:
+          EVENT_ACTION: ${{ github.event.action }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          python3 scripts/select-release-candidate.py validate-trigger \
+            --event-file "$GITHUB_EVENT_PATH" \
+            --event-name "$GITHUB_EVENT_NAME" \
+            --event-action "$EVENT_ACTION" \
+            --actor "$GITHUB_ACTOR" \
+            --repository "$GITHUB_REPOSITORY" \
+            --default-branch "$DEFAULT_BRANCH" \
+            --ref "$GITHUB_REF" \
+            --workflow-sha "$GITHUB_SHA"
+
+      - name: Bind the cut to protected main history
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python3 scripts/verify-protected-main-history.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --policy-sha "$GITHUB_SHA" \
+            --branch main
+
+      # The range is read from a freshly fetched protected main rather than
+      # from the checkout this run started with, for the reason release-tag.yml
+      # gives: a rerun of an older run carries that run's sha, which resolves
+      # the version main carried then rather than the version it carries now.
+      - name: Select the candidate
+        id: select
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          git update-ref refs/remotes/origin/main FETCH_HEAD
+          python3 scripts/select-release-candidate.py select \
+            --repository "$GITHUB_REPOSITORY" \
+            --workspace "$GITHUB_WORKSPACE" \
+            | tee "$RUNNER_TEMP/release-cut-decision.json"
+
+      # Uploaded on every path, including the ones that stood down and the ones
+      # that refused, so what a cycle decided is readable from outside it
+      # without a session reading a log.
+      - name: Publish this cycle's decision
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: release-cut-decision
+          path: ${{ runner.temp }}/release-cut-decision.json
+          if-no-files-found: ignore
+          retention-days: 7
+
+  arm:
+    name: Arm the release candidate
+    needs: select
+    if: needs.select.outputs.decision == 'arm'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # The same main-only Environment that protects the release App key
+    # everywhere else it is used. A job only resolves it by declaring it;
+    # without the binding the job silently falls back to repository-scoped
+    # copies of the same secret names, so a key rotation applied to the
+    # environment never reaches this arm.
+    environment: release-tag
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Checkout the queued cut policy
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Re-bind the arm to protected main history
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE: ${{ needs.select.outputs.candidate }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$CANDIDATE" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::selection handed over no exact candidate sha"
+            exit 1
+          fi
+          python3 scripts/verify-protected-main-history.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --policy-sha "$GITHUB_SHA" \
+            --branch main
+          # The candidate itself has to be main's own history too. The selector
+          # read it out of a first-parent log, and this proves the same thing
+          # against the API immediately before the branch moves.
+          python3 scripts/verify-protected-main-history.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --policy-sha "$CANDIDATE" \
+            --branch main
+
+      - name: Mint repository-scoped candidate-branch token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.KIN_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.KIN_RELEASE_BOT_PRIVATE_KEY }}
+          # owner plus repositories narrows the installation token to this one
+          # repository; owner alone would widen it to every repo the org-wide
+          # install can reach.
+          owner: firelock-ai
+          repositories: kin
+          permission-contents: write
+
+      - name: Move the candidate branch to the selected sha
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BRANCH: ${{ needs.select.outputs.branch }}
+          CANDIDATE: ${{ needs.select.outputs.candidate }}
+          MOVE: ${{ needs.select.outputs.move }}
+        run: |
+          set -euo pipefail
+          case "$MOVE" in
+            create|fast-forward|reset|none) ;;
+            *) echo "::error::unsupported branch move '$MOVE'"; exit 1 ;;
+          esac
+          if [ "$MOVE" = none ]; then
+            echo "::notice::${BRANCH} already points at ${CANDIDATE}"
+          elif [ "$MOVE" = create ]; then
+            gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/heads/${BRANCH}" \
+              -f sha="$CANDIDATE" >/dev/null
+          else
+            # A reset is deliberate and named by the selector: the newest green
+            # sha can be OLDER than a candidate that has since died, and a
+            # candidate branch is scratch that no ruleset protects, so moving it
+            # backwards is correct rather than a rewrite of anything reviewed.
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/git/refs/heads/${BRANCH}" \
+              -f sha="$CANDIDATE" \
+              -F force=true >/dev/null
+          fi
+          got="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BRANCH}" -q '.object.sha')"
+          if [ "$got" != "$CANDIDATE" ]; then
+            echo "::error::${BRANCH} reads back at ${got}, not ${CANDIDATE}"
+            exit 1
+          fi
+          echo "${BRANCH} -> ${CANDIDATE} (${MOVE})"
+
+      # The dispatch goes out on the workflow token, not the App's. rc-build.yml
+      # holds no credential by design and needs none to start, and keeping the
+      # App token off this call keeps its blast radius to the branch write above.
+      - name: Dispatch the candidate archive build
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ needs.select.outputs.branch }}
+          CANDIDATE: ${{ needs.select.outputs.candidate }}
+        run: |
+          set -euo pipefail
+          before="$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/rc-build.yml/runs?branch=${BRANCH}&per_page=1" -q '.workflow_runs[0].id // 0')"
+          gh workflow run rc-build.yml --repo "$GITHUB_REPOSITORY" --ref "$BRANCH"
+          # Read the run back rather than trusting the dispatch's exit code: the
+          # API answers 204 before the run exists, so a dispatch that produced
+          # nothing is silent otherwise and the next cycle would arm again.
+          run_id=""
+          attempt=0
+          while [ "$attempt" -lt 10 ]; do
+            attempt=$((attempt + 1))
+            sleep 6
+            run_id="$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/rc-build.yml/runs?branch=${BRANCH}&event=workflow_dispatch&per_page=5" \
+              -q "[.workflow_runs[] | select(.head_sha == \"${CANDIDATE}\" and (.id | tonumber) > ${before})] | sort_by(.id) | last | .id // empty")"
+            if [ -n "$run_id" ]; then
+              echo "rc-build run ${run_id} appeared on attempt ${attempt}"
+              break
+            fi
+          done
+          if [ -z "$run_id" ]; then
+            echo "::error::rc-build.yml was dispatched on ${BRANCH} but no run for ${CANDIDATE} appeared within a minute"
+            exit 1
+          fi
+          {
+            echo "## Release candidate armed"
+            echo ""
+            echo "| field | value |"
+            echo "| --- | --- |"
+            echo "| candidate | \`${CANDIDATE}\` |"
+            echo "| branch | \`${BRANCH}\` |"
+            echo "| rc-build | [${run_id}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${run_id}) |"
+            echo ""
+            echo "The RC Build's completion is itself a trigger for this workflow, so the"
+            echo "preflight follows without another occasion."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "rc-build run ${run_id} building ${CANDIDATE}"
+
+  # The host leg of the proof, on runners that can execute each archive.
+  #
+  # The local tool judges every archive in one run because that Mac can run a
+  # macOS archive natively and the Linux ones under emulation. Hosted, each
+  # archive runs on the runner whose architecture matches it, which is strictly
+  # better evidence: the emulated legs the local run marks out of scope (the
+  # daemon starves its own enrichment under qemu) execute natively here.
+  #
+  # This job reads no secret and declares no environment. It downloads
+  # artifacts, runs the proof and uploads a leg record; publishing is the next
+  # job's job, and keeping the App token away from the runner that executes
+  # candidate bytes is the whole reason the two are separate.
+  preflight:
+    name: Preflight ${{ matrix.artifact }}
+    needs: [select, arm]
+    # `always()` because `arm` is skipped on the proof path: the RC Build
+    # completion that triggers this cycle arrives when the branch is already
+    # armed, so requiring `arm` to have succeeded would skip the very job the
+    # trigger exists to start.
+    if: >-
+      always() &&
+      needs.select.outputs.decision == 'proof' &&
+      needs.select.result == 'success'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    permissions:
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # One row per archive rc-build.yml produces, each on the runner that
+          # executes it natively. The rows are the same three artifacts
+          # scripts/select-release-candidate.py requires of a usable rc-build,
+          # and the merge refuses a record whose legs do not cover them.
+          - os: macos-latest
+            artifact: kin-macos-aarch64
+          - os: ubuntu-24.04-arm
+            artifact: kin-linux-aarch64
+          - os: ubuntu-latest
+            artifact: kin-linux-x86_64
+    steps:
+      - name: Checkout the queued proof tooling
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Prove the vendored proof tooling is the bytes its manifest names
+        run: node --test scripts/release-proof/vendored.test.mjs
+
+      - name: Download the candidate archive
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RC_RUN: ${{ needs.select.outputs.rc_run }}
+          ARTIFACT: ${{ matrix.artifact }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$RC_RUN" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::selection handed over no rc-build run id"
+            exit 1
+          fi
+          mkdir -p "$RUNNER_TEMP/rc"
+          gh run download "$RC_RUN" --repo "$GITHUB_REPOSITORY" \
+            --name "$ARTIFACT" --dir "$RUNNER_TEMP/rc/$ARTIFACT"
+          archive="$RUNNER_TEMP/rc/$ARTIFACT/$ARTIFACT.tar.gz"
+          test -f "$archive"
+          test -f "$archive.sha256"
+          # The sidecar is checked before anything runs the bytes; the preflight
+          # checks it again, and both are cheap against an artifact store.
+          want="$(cut -d' ' -f1 < "$archive.sha256")"
+          have="$(shasum -a 256 "$archive" | cut -d' ' -f1)"
+          if [ "$want" != "$have" ]; then
+            echo "::error::${ARTIFACT}.tar.gz sidecar says ${want}, bytes are ${have}"
+            exit 1
+          fi
+          echo "KIN_RC_ARCHIVE=$archive" >> "$GITHUB_ENV"
+          echo "$ARTIFACT sha256 $have"
+
+      - name: Judge the archive with the release preflight
+        env:
+          CANDIDATE: ${{ needs.select.outputs.candidate }}
+          ARTIFACT: ${{ matrix.artifact }}
+          # The publisher lives in the next job. A leg record published from
+          # here would be one of three answers under one candidate sha, and the
+          # evidence branch is append-only, so the first to land would win and
+          # the mint would read a one-leg proof as the whole thing.
+          KIN_PREFLIGHT_NO_PUBLISH: "1"
+          # Hosted runners carry no Metal accelerator and no gpu lock table, and
+          # the verdict records that the CPU path is what ran.
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: |
+          set -euo pipefail
+          if [[ ! "$CANDIDATE" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::selection handed over no exact candidate sha"
+            exit 1
+          fi
+          # coreutils gives the preflight the GNU timeout its leg bound needs;
+          # without one it warns and runs unbounded, which on a hosted runner
+          # means a hung leg burns the whole job timeout with no verdict.
+          if ! timeout --version >/dev/null 2>&1; then
+            if [ "$RUNNER_OS" = macOS ]; then brew install coreutils; fi
+          fi
+          set +e
+          scripts/release-proof/bin/kin-release-preflight \
+            --archive "$KIN_RC_ARCHIVE" \
+            --kin-repo "$GITHUB_WORKSPACE" \
+            --kin-ref "$GITHUB_SHA" \
+            --expect-commit "$CANDIDATE" \
+            --cpu-embed \
+            --no-linux \
+            --lane release-proof \
+            --run-root "$RUNNER_TEMP/kpf" \
+            --leg-timeout 3600
+          rc=$?
+          set -e
+          # 0 PASS, 1 a leg FAILED, 2 UNREADABLE, 65 refused before any leg ran.
+          # Only PASS may produce a leg record: an UNREADABLE run is not a pass
+          # and must not reach the merge as one.
+          echo "preflight exit ${rc}"
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::the preflight did not pass for ${ARTIFACT} (exit ${rc})"
+            exit "$rc"
+          fi
+          record="$(ls -1 "$RUNNER_TEMP/kpf"/preflight.json 2>/dev/null || true)"
+          if [ -z "$record" ]; then
+            echo "::error::the preflight passed but wrote no preflight.json under $RUNNER_TEMP/kpf"
+            exit 1
+          fi
+          mkdir -p "$RUNNER_TEMP/leg"
+          cp "$record" "$RUNNER_TEMP/leg/preflight.json"
+
+      - name: Upload this leg's record
+        if: success()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: kin-release-preflight-${{ matrix.artifact }}
+          path: ${{ runner.temp }}/leg/preflight.json
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish the candidate's preflight record
+    needs: [select, preflight]
+    if: needs.select.outputs.decision == 'proof' && needs.preflight.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: release-tag
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout the queued proof tooling
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Re-bind the publish to protected main history
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE: ${{ needs.select.outputs.candidate }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$CANDIDATE" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::selection handed over no exact candidate sha"
+            exit 1
+          fi
+          python3 scripts/verify-protected-main-history.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --policy-sha "$GITHUB_SHA" \
+            --branch main
+          python3 scripts/verify-protected-main-history.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --policy-sha "$CANDIDATE" \
+            --branch main
+
+      - name: Collect every leg record
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
+        with:
+          pattern: kin-release-preflight-*
+          path: ${{ runner.temp }}/legs
+
+      - name: Merge the leg records into the candidate's preflight record
+        env:
+          CANDIDATE: ${{ needs.select.outputs.candidate }}
+        run: |
+          set -euo pipefail
+          legs=()
+          while IFS= read -r record; do
+            legs+=("$record")
+          done < <(find "$RUNNER_TEMP/legs" -name preflight.json -type f | sort)
+          if [ "${#legs[@]}" -eq 0 ]; then
+            echo "::error::no leg records were downloaded, so there is nothing to publish"
+            exit 1
+          fi
+          echo "merging ${#legs[@]} leg record(s)"
+          node scripts/release-proof/merge-preflight-records.mjs \
+            --candidate "$CANDIDATE" \
+            --out "$RUNNER_TEMP/preflight.json" \
+            "${legs[@]}"
+
+      - name: Mint repository-scoped evidence token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.KIN_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.KIN_RELEASE_BOT_PRIVATE_KEY }}
+          owner: firelock-ai
+          repositories: kin
+          permission-contents: write
+
+      # The publisher refuses to overwrite: a record is created without a blob
+      # sha, which GitHub rejects when the path exists, so a re-publish of
+      # identical bytes is a no-op success and a re-publish of different bytes
+      # is a loud refusal. That is why the merge above has to be deterministic.
+      - name: Publish preflight.json for the candidate
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          CANDIDATE: ${{ needs.select.outputs.candidate }}
+        run: |
+          set -euo pipefail
+          scripts/release-proof/bin/kin-evidence-publish \
+            --sha "$CANDIDATE" \
+            --name preflight.json \
+            --file "$RUNNER_TEMP/preflight.json" \
+            --repo "$GITHUB_REPOSITORY"
+
+      # The stranger is still local, and this is where a captain reads what to
+      # run. Three arms at 12 GiB each do not fit a 16 GiB hosted runner beside
+      # a Docker daemon, and the driver is a Claude Code session: on the account
+      # login it shares the founder's subscription limit, which cut three arms
+      # on 2026-09-02, and there is no repository secret carrying an API key for
+      # it yet. bin/kin-stranger already passes ANTHROPIC_API_KEY through on the
+      # account endpoint (it scrubs that variable only for --local-model), so
+      # the remaining work is a runner with the memory and a key, not a change
+      # to the tool. Until then this prints the exact command, and the mint
+      # stays refused for the missing stranger.env rather than fed a fake one.
+      - name: Say what the stranger still has to run
+        env:
+          CANDIDATE: ${{ needs.select.outputs.candidate }}
+          VERSION: ${{ needs.select.outputs.version }}
+          RC_RUN: ${{ needs.select.outputs.rc_run }}
+        run: |
+          set -euo pipefail
+          run_id="rc${VERSION//./}-${CANDIDATE:0:7}"
+          download="/tmp/kin-rc-${CANDIDATE:0:12}"
+          {
+            echo "## Preflight recorded for \`${CANDIDATE}\`"
+            echo ""
+            echo "\`evidence/${CANDIDATE}/preflight.json\` is on the \`release-evidence\` branch."
+            echo "The mint needs \`stranger.env\` beside it, which is still a local step:"
+            echo ""
+            echo '```'
+            echo "gh run download ${RC_RUN} --repo ${GITHUB_REPOSITORY} --dir ${download}"
+            echo "bin/kin-stranger prepare --run ${run_id} --arms green,brown,vcs"
+            echo "bin/kin-stranger run --run ${run_id} \\"
+            echo "  --archive ${download}/kin-linux-aarch64/kin-linux-aarch64.tar.gz \\"
+            echo "  --candidate-sha ${CANDIDATE}"
+            echo '```'
+            echo ""
+            echo "Name all three arms: the coverage gate refuses a record missing one, and"
+            echo "the evidence branch is append-only, so a two-arm record cannot be replaced."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice::preflight.json published for ${CANDIDATE}; the stranger run is still local"
+
+  # A refusal is a real outcome and has to be loud. The selector exits 1 and
+  # names the contexts that disqualified the newest sha, which fails the select
+  # job; this job exists so the refusal reaches the run's conclusion even when
+  # the selector stood down for a reason worth reading.
+  report:
+    name: Report the cut's decision
+    needs: select
+    if: always() && needs.select.result != 'skipped'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Summarize
+        env:
+          DECISION: ${{ needs.select.outputs.decision }}
+          REASON: ${{ needs.select.outputs.reason }}
+          CANDIDATE: ${{ needs.select.outputs.candidate }}
+          RESULT: ${{ needs.select.result }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Release cut: ${DECISION:-unreadable}"
+            echo ""
+            echo "${REASON:-the selector produced no reason, which is itself the finding}"
+            echo ""
+            [ -n "$CANDIDATE" ] && echo "Candidate: \`${CANDIDATE}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$RESULT" != success ]; then
+            echo "::error::the selection job concluded ${RESULT}; the cut did not decide"
+            exit 1
+          fi
+          echo "release cut decision: ${DECISION} (${REASON})"

--- a/docs/release-bot.md
+++ b/docs/release-bot.md
@@ -7,15 +7,18 @@ Kin's release front door is automatic and fail closed:
 2. The PR moves Cargo, npm, the explicit `kin-spine` path pin, `Cargo.lock`,
    and `CHANGELOG.md` together, then uses normal protected-main checks and
    GitHub auto-merge.
-3. `.github/workflows/release-tag.yml` finds the exact reviewed commit where
+3. `.github/workflows/release-cut.yml` selects the candidate that version will
+   be proven at, arms `release/vX.Y.Z-candidate`, dispatches the archive build,
+   and publishes `preflight.json` for it.
+4. `.github/workflows/release-tag.yml` finds the exact reviewed commit where
    the coherent untagged version first appeared and creates `vX.Y.Z` with the
    scoped release App.
-4. The existing tag-only `.github/workflows/release.yml` publishes and proves
+5. The existing tag-only `.github/workflows/release.yml` publishes and proves
    the release. `.github/workflows/release-recovery.yml` retries only failed or
    timed-out jobs, at most twice, while preserving the same immutable tag. Its
    final job publishes and attests deterministic `release-promotion.json`
    only after every stable-release capstone succeeds.
-5. Installer and hosted reconcilers take over afterward.
+6. Installer and hosted reconcilers take over afterward.
 
 The typed `repository_dispatch` remains a break-glass recovery path. It lets
 the release captain create a tag **without holding the founder credential**,
@@ -86,6 +89,56 @@ by `GITHUB_TOKEN`, whereas the App-owned merge emits the `main` push that starts
 CI and automatic tag admission. Main must require up-to-date checks so new
 merges cause the train to coalesce and re-test rather than release an older
 changelog against newer code.
+
+## Automatic release cut
+
+The mint tags the newest reviewed `main` commit in the staged version's range
+that carries both proof records under `evidence/<sha>/` on the `release-evidence`
+branch. `release-cut.yml` is what puts a record there without a captain.
+
+It runs on a completed CI run for a `main` push, on a completed RC Build for a
+`release/v*-candidate` branch, on the typed `release_cut` repository dispatch
+from the same allowlist the mint admits, and on a fifteen-minute sweep offset
+from the mint's and the train's. There is deliberately **no**
+`workflow_dispatch`: a dispatch takes a ref, and the publish job reaches the
+release App's key, so a branch must never be able to select the code running
+beside it. `scripts/select-release-candidate.py` decides, and both of its
+judgments are pure functions over one snapshot:
+
+1. `vX.Y.Z` already exists, so the cut is done.
+2. A sha in the range carries both records, so the mint owns it.
+3. The current candidate is kept until it is proven or dead. With `preflight.json`
+   recorded it waits for the stranger; alive with a usable RC Build it is proven;
+   alive with none it is armed again, twice at most.
+4. Otherwise the newest `main` commit in the range whose CI **and** Acceptance
+   push runs concluded success, and whose required contexts each appear exactly
+   once under push provenance, becomes the candidate.
+
+A sha still being graded is skipped rather than waited for, because on a busy
+`main` the newest sha is always pending and a selector that waits never
+converges. A sha whose required context is red, duplicated by a rerun, or
+claimed by another App is named and skipped: the mint reads a duplicated
+required context as ambiguous authority, so answering a flaky required job with
+a rerun is what kills the sha, and the next first-pass-green commit becomes the
+candidate instead.
+
+The proof runs on hosted runners, one per archive on the runner that executes it
+natively, using the tooling vendored under `scripts/release-proof/` from the
+private `kin-ecosystem` umbrella. `VENDORED.json` records each file's sha256 and
+`scripts/release-proof/vendored.test.mjs` refuses one that drifted. The three
+leg records are merged by `scripts/release-proof/merge-preflight-records.mjs`,
+which judges its own output with the mint's gate before anything is published;
+the merge is deterministic because the evidence branch is append-only and a
+re-publish of differing bytes is refused as tampering.
+
+**The stranger is still a local step.** Three arms at 12 GiB each do not fit a
+16 GiB hosted runner beside a Docker daemon, and the driver is a Claude Code
+session that on the account login shares the founder's subscription limit, which
+cut three arms on 2026-09-02. `bin/kin-stranger` already passes
+`ANTHROPIC_API_KEY` through on the account endpoint, so what is missing is a
+runner with the memory and a key, not a change to the tool. The publish job
+prints the exact command with all three arms named, and the mint stays refused
+for the missing `stranger.env` rather than being fed a partial one.
 
 ## Tag admission (fail-closed checks, in order)
 

--- a/scripts/release-proof/.gitignore
+++ b/scripts/release-proof/.gitignore
@@ -1,0 +1,1 @@
+.kin-coord/

--- a/scripts/release-proof/VENDORED.json
+++ b/scripts/release-proof/VENDORED.json
@@ -1,0 +1,13 @@
+{
+  "source_repository": "firelock-ai/kin-ecosystem",
+  "source_commit": "3ace010dbe6d3db43d8da2c38fa6290d0834a180",
+  "note": "Byte-identical copies of the umbrella proof tooling so the hosted preflight runs from kin alone; bin/kin-lane is a single-host lock shim written for this tree, not a copy. scripts/release-proof/vendored.test.mjs refuses a file whose sha256 left this manifest.",
+  "files": {
+    "bin/kin-release-preflight": {"source": "bin/kin-release-preflight", "sha256": "d42617e79966bf6d3548e00a9d303c38cf4689f6ff33610b6d9526019a028854"},
+    "bin/kin-release-preflight.d/Dockerfile": {"source": "bin/kin-release-preflight.d/Dockerfile", "sha256": "e6c0e30c2bf46fc889484fb7e32c73163c3cf315d60351be3acd2428d22d12f6"},
+    "bin/kin-release-preflight.d/proof-flow.sh": {"source": "bin/kin-release-preflight.d/proof-flow.sh", "sha256": "3a44e377a8c6bfcdfb688608ae5b9ba64293e3a955b711afe20ee237e2516b2b"},
+    "bin/kin-release-preflight.d/validate.mjs": {"source": "bin/kin-release-preflight.d/validate.mjs", "sha256": "53badad40150ee0a4d8c817af77f48f04ad2ae89616dce33686532b82afa35b9"},
+    "bin/kin-evidence-publish": {"source": "bin/kin-evidence-publish", "sha256": "38ae34733b38feb3344ed8cecfa9ab52219e463b4beb99d3f9c39889dd662d46"},
+    "bin/kin-acceptance-suite": {"source": "bin/kin-acceptance-suite", "sha256": "7ce214e6563e227695cf02411762ca5e8d01edf8898634db465ee30f455918f7"}
+  }
+}

--- a/scripts/release-proof/bin/kin-acceptance-suite
+++ b/scripts/release-proof/bin/kin-acceptance-suite
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""Resolve one product acceptance suite from the tree under test, and prove it.
+
+kin owns the acceptance suites. `kin/scripts/acceptance/magic_repro.py` and
+`brownfield_repro.py` are the only copies, and every umbrella caller executes
+one of them rather than a duplicate of its own. This tool is what turns "the
+tree under test" into an absolute path, prints that path with its sha256 and the
+sha and branch it came from, and refuses when the copy it resolved is a stranger.
+
+Why it exists. The umbrella carried its own copies for a while, and within two
+days of the port they had drifted six checks apart: kin's magic suite ran 0
+through 20 while the umbrella ran 0 through 9 and 12 through 16, and the
+umbrella's check 15 was the pre-fix flaky version, `time.sleep(3)` plus one
+retry where kin had already moved to `read_until_enriched`. Nothing detected
+either, because a second copy is only ever wrong in a way that looks like a
+passing run. The byte-consistency rule that was supposed to hold the two
+together was a rule for a human to remember, which is a rule doing a tool's job.
+
+Two ways to resolve, decided by what the caller is testing.
+
+    --checkout DIR    the tree under test IS a kin checkout, so the suite comes
+                      out of its own working tree. This is bin/kin-parity: it
+                      builds that checkout's bytes, so it runs that checkout's
+                      checks, and a lane that adds a check has it exercised by
+                      the same command that builds the binary it guards.
+
+    --kin-repo DIR --ref REF
+                      the tree under test carries no suite and cannot. A release
+                      archive holds kin, kin-daemon, kin-vfs, the shim, README
+                      and INSTALL and no scripts directory; the npm package
+                      ships `bin/`, `lib/` and `README.md`. Those callers pin to
+                      the kin checkout they already resolve, at a named ref, and
+                      never to a third copy: bin/kin-release-preflight at its
+                      existing KIN_REPO @ KIN_REF, bin/kin-shipped-gate at the
+                      tag whose bytes npm served.
+
+The drift tripwire runs either way and is the point of the tool. It compares the
+resolved bytes against `origin/main:scripts/acceptance/<suite>.py` in the kin
+checkout and reports one of four verdicts:
+
+    none        byte-identical to kin origin/main
+    tracked     differs, and is exactly the committed blob at the ref the caller
+                named. A lane branch that adds a check, or a release tag whose
+                suite is older than main, both land here. This is the ordinary
+                case for work in flight and it passes.
+    worktree    differs, and is an uncommitted edit to that tracked path inside
+                the checkout under test. Also passes, loudly, because testing
+                what you are holding is what --checkout is for.
+    unexplained matches none of the above, which means the bytes came from
+                somewhere that is not the tree under test and is not kin. That
+                is the class this tool exists to end, so it fails the run.
+
+`KIN_ACCEPTANCE_ALLOW_DRIFT="<reason>"` turns an unexplained verdict into a
+loud allowance. The reason is required and it prints on every run, the same
+contract kin's own `scripts/acceptance/gate.py` puts on `--allow-unreadable`,
+because an allowance nobody can see is an allowance nobody removes.
+
+A reference that cannot be read fails too. If `origin/main:<path>` is missing or
+unreadable the tripwire has no baseline, so it cannot fire, and a check that
+cannot fail is not evidence: it refuses instead of passing quietly.
+
+There is a third way in, and it is the one that lets the tripwire fire at all.
+Every caller keeps an environment override so its behavioral suite can inject a
+stub, and an override is also exactly how a stale copy gets executed for real.
+`--verify PATH` judges a file the caller already holds instead of resolving one,
+so an override is graded rather than trusted. Without it the tool would only
+ever grade bytes it had just extracted itself, which can differ from the ref
+they came from in no way at all: a guard that cannot reach its own failing case
+is not a guard.
+
+Usage:
+    bin/kin-acceptance-suite <magic|brownfield> --checkout DIR
+    bin/kin-acceptance-suite <magic|brownfield> --kin-repo DIR --ref REF --dest PATH
+    bin/kin-acceptance-suite <magic|brownfield> --verify PATH --kin-repo DIR [--ref REF]
+
+Options:
+    --checkout DIR    kin checkout that is the tree under test
+    --kin-repo DIR    kin checkout to read the suite out of by ref
+    --ref REF         ref to read from --kin-repo (required with it)
+    --dest PATH       write the resolved suite here, executable, and print that
+                      path instead of the in-tree one. Required with --kin-repo,
+                      optional with --checkout.
+    --verify PATH     grade this file instead of resolving one, against the tree
+                      named by --checkout or --kin-repo
+    --label TEXT      prefix for the printed lines (default: the suite name)
+    --no-fetch        do not fetch origin/main before reading the baseline
+    --json PATH       write the resolution and its verdict here
+
+Exit status:
+    0   resolved, and the tripwire passed or its allowance was named
+    1   the tripwire failed
+    3   the suite could not be resolved at all
+    64  usage
+"""
+
+from __future__ import print_function
+
+import argparse
+import functools
+import hashlib
+import json
+import os
+import subprocess
+import sys
+
+print = functools.partial(print, flush=True)
+
+SUITES = {
+    "magic": "scripts/acceptance/magic_repro.py",
+    "brownfield": "scripts/acceptance/brownfield_repro.py",
+}
+
+BASELINE_REF = "origin/main"
+ALLOW_ENV = "KIN_ACCEPTANCE_ALLOW_DRIFT"
+
+
+def git(args, cwd=None, timeout=120):
+    try:
+        proc = subprocess.run(["git"] + list(args), cwd=cwd, timeout=timeout,
+                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return 1, "", str(exc)
+    return (proc.returncode,
+            proc.stdout.decode("utf-8", "replace").strip(),
+            proc.stderr.decode("utf-8", "replace").strip())
+
+
+def sha256_of(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for block in iter(lambda: handle.read(65536), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def blob_of(path):
+    """git's own hash of the file, so a comparison against a ref is exact.
+
+    Computed with `git hash-object`, which needs no repository, so a suite
+    already extracted into a scratch directory hashes the same way the tree it
+    came from hashes it.
+    """
+    rc, out, _err = git(["hash-object", "--", path])
+    return out if rc == 0 else ""
+
+
+def blob_at(repo, ref, rel):
+    rc, out, _err = git(["rev-parse", "--verify", "--quiet", "%s:%s" % (ref, rel)], cwd=repo)
+    return out if rc == 0 else ""
+
+
+def describe(repo, ref):
+    """The sha and branch behind a resolution, printed so it can be disbelieved."""
+    if ref:
+        rc, sha, _err = git(["rev-parse", "--verify", "--quiet", ref], cwd=repo)
+        return (sha if rc == 0 else ""), ref
+    rc, sha, _err = git(["rev-parse", "HEAD"], cwd=repo)
+    _rc, branch, _e = git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=repo)
+    return (sha if rc == 0 else ""), (branch or "(detached)")
+
+
+def umbrella_kin():
+    """The umbrella's own kin checkout, found through git rather than by path.
+
+    Not `dirname(dirname(__file__))/kin`. These tools are meant to run from a
+    lane worktree, and there that path is the worktree, which has no kin
+    checkout inside it, so the default silently pointed at nothing. git's
+    common-dir is the same for a worktree and for the main checkout, which is
+    the property this needs, and bin/kin-parity resolves its own primary the
+    same way for the same reason.
+    """
+    here = os.path.dirname(os.path.abspath(__file__))
+    for args in (["rev-parse", "--path-format=absolute", "--git-common-dir"],
+                 ["rev-parse", "--git-common-dir"]):
+        rc, out, _err = git(args, cwd=here)
+        if rc != 0 or not out:
+            continue
+        common = out if os.path.isabs(out) else os.path.abspath(os.path.join(here, out))
+        candidate = os.path.join(os.path.dirname(common), "kin")
+        if os.path.isdir(candidate):
+            return candidate
+    fallback = os.path.join(os.path.dirname(here), "kin")
+    return fallback if os.path.isdir(fallback) else ""
+
+
+def is_kin_checkout(path):
+    return os.path.isfile(os.path.join(path, "crates", "kin-cli", "Cargo.toml"))
+
+
+def write_executable(dest, data):
+    """Write the extracted suite and leave it executable.
+
+    The mode is set explicitly and read back. A freshly created file takes the
+    process umask, so 0755 asked for is not 0755 granted, and a suite that lands
+    at 0644 dies at exec with no output and an empty diff, which is a failure
+    that looks like nothing at all.
+    """
+    parent = os.path.dirname(os.path.abspath(dest))
+    if parent and not os.path.isdir(parent):
+        os.makedirs(parent)
+    with open(dest, "wb") as handle:
+        handle.write(data)
+    os.chmod(dest, 0o755)
+    if not os.access(dest, os.X_OK):
+        return "wrote %s but it is not executable afterwards" % dest
+    return None
+
+
+def resolve(opts):
+    """(path, repo, ref, error). `ref` is None when the working tree answered."""
+    rel = SUITES[opts.suite]
+    if opts.verify:
+        path = os.path.abspath(opts.verify)
+        if not os.path.isfile(path):
+            return None, None, None, "--verify %s does not exist" % path
+        tree = os.path.abspath(opts.checkout or opts.kin_repo)
+        if not os.path.isdir(tree):
+            return None, None, None, "%s is not a directory" % tree
+        rc, _out, err = git(["rev-parse", "--show-toplevel"], cwd=tree)
+        if rc != 0:
+            return None, None, None, "%s is not a git checkout (%s)" % (tree, err)
+        return path, tree, opts.ref, None
+    if opts.checkout:
+        checkout = os.path.abspath(opts.checkout)
+        if not os.path.isdir(checkout):
+            return None, None, None, "--checkout %s is not a directory" % checkout
+        if not is_kin_checkout(checkout):
+            return None, None, None, (
+                "--checkout %s is not a kin checkout: it carries no "
+                "crates/kin-cli/Cargo.toml" % checkout)
+        path = os.path.join(checkout, rel)
+        if not os.path.isfile(path):
+            return None, None, None, (
+                "%s carries no %s. That tree predates the in-repo acceptance "
+                "suites; pass --kin-repo with a --ref that has them rather than "
+                "running a copy from anywhere else." % (checkout, rel))
+        if opts.dest:
+            with open(path, "rb") as handle:
+                problem = write_executable(opts.dest, handle.read())
+            if problem:
+                return None, None, None, problem
+            return os.path.abspath(opts.dest), checkout, None, None
+        return path, checkout, None, None
+
+    repo = os.path.abspath(opts.kin_repo)
+    if not os.path.isdir(repo):
+        return None, None, None, "--kin-repo %s is not a directory" % repo
+    rc, _out, err = git(["rev-parse", "--show-toplevel"], cwd=repo)
+    if rc != 0:
+        return None, None, None, "--kin-repo %s is not a git checkout (%s)" % (repo, err)
+    if not blob_at(repo, opts.ref, rel) and not opts.no_fetch:
+        # A release tag is the ordinary ref here and a checkout that has not
+        # fetched since the cut simply does not have it. One bounded fetch is
+        # the difference between "that tag has no suite" and "this clone has
+        # not heard of that tag", and those are different answers.
+        git(["fetch", "-q", "--tags", "origin"], cwd=repo, timeout=180)
+    if not blob_at(repo, opts.ref, rel):
+        return None, None, None, (
+            "%s has no %s at %s. A tag older than the in-repo suites cannot "
+            "supply one, and no other copy may stand in for it; pass --ref with "
+            "a ref that carries the suite." % (repo, rel, opts.ref))
+    proc = subprocess.run(["git", "-C", repo, "show", "%s:%s" % (opts.ref, rel)],
+                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if proc.returncode != 0:
+        return None, None, None, ("could not read %s:%s out of %s (%s)"
+                                  % (opts.ref, rel, repo,
+                                     proc.stderr.decode("utf-8", "replace").strip()))
+    problem = write_executable(opts.dest, proc.stdout)
+    if problem:
+        return None, None, None, problem
+    return os.path.abspath(opts.dest), repo, opts.ref, None
+
+
+def tripwire(path, repo, ref, rel, fetch):
+    """(verdict, detail, ok). The one guard that can fail in this tool."""
+    if fetch:
+        git(["fetch", "-q", "origin", "main"], cwd=repo, timeout=90)
+    baseline = blob_at(repo, BASELINE_REF, rel)
+    local = blob_of(path)
+    if not local:
+        return "unreadable", "git could not hash the resolved suite at %s" % path, False
+    if not baseline:
+        return ("unreadable",
+                "no baseline: %s:%s could not be read in %s, so the tripwire had "
+                "nothing to compare against and could not have failed"
+                % (BASELINE_REF, rel, repo), False)
+    if local == baseline:
+        return "none", "byte-identical to %s:%s" % (BASELINE_REF, rel), True
+    pinned = blob_at(repo, ref or "HEAD", rel)
+    if pinned and local == pinned:
+        return ("tracked",
+                "differs from %s and is exactly %s:%s (blob %s)"
+                % (BASELINE_REF, ref or "HEAD", rel, pinned[:12]), True)
+    # The worktree verdict is only available to bytes that ARE the tree's own
+    # copy of that path. A file merely sitting near the tree, or handed in by an
+    # override, has no claim on "this is what the checkout is holding", and
+    # letting it borrow one would forgive exactly the case the tool is for.
+    in_tree = os.path.realpath(path) == os.path.realpath(os.path.join(repo, rel))
+    if ref is None and in_tree:
+        rc, status, _err = git(["status", "--porcelain", "--", rel], cwd=repo)
+        if rc == 0 and status:
+            return ("worktree",
+                    "differs from %s and from HEAD, and is an uncommitted edit "
+                    "to %s in the checkout under test (%s)"
+                    % (BASELINE_REF, rel, status.splitlines()[0].strip()), True)
+    pin_ref = ref or "HEAD"
+    if pin_ref == BASELINE_REF:
+        against = "%s:%s (blob %s)" % (BASELINE_REF, rel, baseline[:12])
+    else:
+        against = ("%s:%s (blob %s) nor %s:%s (blob %s)"
+                   % (BASELINE_REF, rel, baseline[:12], pin_ref, rel,
+                      pinned[:12] if pinned else "absent"))
+    return ("unexplained",
+            "the executed suite matches neither %s, nor any edit tracked in %s, "
+            "so it came from outside the tree under test" % (against, repo), False)
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(add_help=True, description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("suite", choices=sorted(SUITES))
+    parser.add_argument("--checkout")
+    parser.add_argument("--kin-repo", dest="kin_repo")
+    parser.add_argument("--ref")
+    parser.add_argument("--dest")
+    parser.add_argument("--verify")
+    parser.add_argument("--label", default="")
+    parser.add_argument("--no-fetch", action="store_true")
+    parser.add_argument("--json", dest="json_out")
+    opts = parser.parse_args(argv[1:])
+
+    tag = "kin-acceptance-suite: %s" % (opts.label or opts.suite)
+    if opts.checkout and opts.kin_repo:
+        print("%s --checkout and --kin-repo name two different trees; pass one"
+              % tag, file=sys.stderr)
+        return 64
+    if not opts.checkout and not opts.kin_repo:
+        # No tree named, so take the umbrella's own kin checkout at origin/main.
+        # That clone is a standing one nothing keeps current, so its working
+        # tree is not trusted and the ref is, which is the same call
+        # bin/kin-release-preflight already makes for install.sh.
+        opts.kin_repo = umbrella_kin()
+        if not opts.kin_repo:
+            print("%s no tree named and no kin checkout found beside this "
+                  "repository; pass --checkout or --kin-repo" % tag, file=sys.stderr)
+            return 64
+        opts.ref = opts.ref or BASELINE_REF
+    if opts.verify and opts.dest:
+        print("%s --verify grades a file in place, so it takes no --dest" % tag, file=sys.stderr)
+        return 64
+    if not opts.verify and opts.kin_repo and not opts.ref:
+        print("%s --kin-repo needs --ref" % tag, file=sys.stderr)
+        return 64
+    if not opts.verify and opts.kin_repo and not opts.dest:
+        print("%s --kin-repo needs --dest to write the resolved suite to" % tag, file=sys.stderr)
+        return 64
+
+    rel = SUITES[opts.suite]
+    path, repo, ref, error = resolve(opts)
+    if error:
+        print("%s UNRESOLVED %s" % (tag, error), file=sys.stderr)
+        return 3
+
+    sha, branch = describe(repo, ref)
+    verdict, detail, ok = tripwire(path, repo, ref, rel, not opts.no_fetch)
+    allowance = (os.environ.get(ALLOW_ENV) or "").strip()
+    allowed = False
+    if not ok and allowance:
+        allowed = True
+        ok = True
+
+    print("%s source %s" % (tag, path), file=sys.stderr)
+    print("%s sha256 %s" % (tag, sha256_of(path)), file=sys.stderr)
+    print("%s tree %s ref %s sha %s branch %s"
+          % (tag, repo, ref or "(working tree)", sha or "(unknown)", branch),
+          file=sys.stderr)
+    print("%s drift %s: %s" % (tag, verdict, detail), file=sys.stderr)
+    if allowed:
+        # Printed on every run, never once at the point it was granted, because
+        # the whole failure mode here is an exception nobody sees again.
+        print("%s ALLOWANCE %s=%s admits the drift above" % (tag, ALLOW_ENV, allowance),
+              file=sys.stderr)
+
+    if opts.json_out:
+        parent = os.path.dirname(os.path.abspath(opts.json_out))
+        if parent and not os.path.isdir(parent):
+            os.makedirs(parent)
+        with open(opts.json_out, "w") as handle:
+            json.dump({"suite": opts.suite, "path": path, "relative": rel,
+                       "sha256": sha256_of(path), "tree": repo,
+                       "ref": ref, "tree_sha": sha, "branch": branch,
+                       "drift": verdict, "detail": detail,
+                       "allowance": allowance if allowed else "",
+                       "ok": bool(ok)}, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+
+    if not ok:
+        print("%s REFUSING: set %s=\"<reason>\" to run anyway, and the reason "
+              "prints on every run" % (tag, ALLOW_ENV), file=sys.stderr)
+        return 1
+    print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/release-proof/bin/kin-evidence-publish
+++ b/scripts/release-proof/bin/kin-evidence-publish
@@ -1,0 +1,361 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+// Publishes one proof-loop record to the release-evidence branch, where the
+// release train's gate can read it.
+//
+// The gate lives in the train (kin's scripts/check-release-proof-artifacts.mjs,
+// called by release-train.yml before it arms auto-merge and by release.yml
+// before it promotes). It reads evidence/<candidate-sha>/preflight.json and
+// evidence/<candidate-sha>/stranger.env off an orphan branch. Nothing wrote
+// those records until this tool: bin/kin-release-preflight and bin/kin-stranger
+// both wrote only to the operator's local .kin-coord, which no Actions job can
+// see, which is why v0.5.44 could ship with no captain and no evidence.
+//
+// Three disciplines are structural here rather than conventional.
+//
+// The token is resolved and proven before anything else happens. An
+// unauthenticated read of a private repo returns 404, which is also what an
+// absent record returns, so a publisher with no token reads "nothing here yet"
+// off every route and fails at the write, after the proof run it was recording
+// has already passed. That is how the v0.5.46 preflight failed at 05:15:12Z on
+// 2026-08-21. So the token is read from the environment or from gh, and it is
+// checked against the repo for push access at the door, in one line an operator
+// can act on.
+//
+// Append-only. A record is created through the contents API WITHOUT a blob sha,
+// and GitHub refuses that call when the path already exists. So overwriting is
+// not something this tool declines to do, it is something it cannot do. A
+// re-publish of byte-identical content is a no-op success, because a proof run
+// repeated after an interrupted publish must not be made to look like
+// tampering. A re-publish of DIFFERENT content under a sha that already has a
+// record is refused loudly: two different answers for one candidate is exactly
+// the ambiguity the gate exists to prevent, and the fix is a human reading both,
+// never a machine picking one.
+//
+// Never fatal to a verdict. This tool exits non-zero and says why, but its
+// callers run it after their verdict is decided and do not let it change that
+// verdict. A proof run that passed and failed to publish is a passed run whose
+// record can be posted again; a proof run failed by its own bookkeeping would
+// teach operators to skip the bookkeeping.
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const API = process.env.KIN_EVIDENCE_API || 'https://api.github.com';
+const BRANCH = process.env.KIN_EVIDENCE_BRANCH || 'release-evidence';
+const DEFAULT_REPO = 'firelock-ai/kin';
+const COMMIT_SHA = /^[0-9a-f]{40}$/;
+const PREFLIGHT_RECORD = 'preflight.json';
+const STRANGER_RECORD = 'stranger.env';
+const RECORDS = new Set([PREFLIGHT_RECORD, STRANGER_RECORD]);
+
+function usage(message) {
+  process.stderr.write(
+    `${message}\n\n` +
+    'usage: kin-evidence-publish --sha <40-hex commit> --name <preflight.json|stranger.env> --file <path>\n' +
+    '                            [--repo owner/name] [--require-archive <64-hex sha256>]\n' +
+    'the token comes from GH_TOKEN, else GITHUB_TOKEN, else "gh auth token", and must have push\n',
+  );
+  process.exit(2);
+}
+
+function parseArgs(argv) {
+  const args = { repo: DEFAULT_REPO };
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    const value = argv[i + 1];
+    switch (flag) {
+      case '--sha': args.sha = value; i += 1; break;
+      case '--name': args.name = value; i += 1; break;
+      case '--file': args.file = value; i += 1; break;
+      case '--repo': args.repo = value; i += 1; break;
+      case '--require-archive': args.requireArchive = value; i += 1; break;
+      default: usage(`unknown argument: ${flag}`);
+    }
+  }
+  if (!args.sha || !COMMIT_SHA.test(args.sha)) {
+    usage(`--sha must be a 40-character commit sha, got "${args.sha ?? ''}"`);
+  }
+  // The gate looks up exactly these two names. A typo would publish a record
+  // nothing ever reads, which is indistinguishable from never publishing.
+  if (!RECORDS.has(args.name)) {
+    usage(`--name must be one of ${[...RECORDS].join(', ')}, got "${args.name ?? ''}"`);
+  }
+  if (!args.file) usage('--file is required');
+  if (args.requireArchive !== undefined && !/^[0-9a-f]{64}$/.test(args.requireArchive)) {
+    usage(`--require-archive must be a 64-character sha256, got "${args.requireArchive}"`);
+  }
+  return args;
+}
+
+async function call(token, method, route, body) {
+  const headers = {
+    accept: 'application/vnd.github+json',
+    'user-agent': 'kin-evidence-publish',
+    'x-github-api-version': '2022-11-28',
+  };
+  if (token) headers.authorization = `Bearer ${token}`;
+  if (body !== undefined) headers['content-type'] = 'application/json';
+  const response = await fetch(`${API}${route}`, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await response.text();
+  let parsed = null;
+  try { parsed = text ? JSON.parse(text) : null; } catch { parsed = null; }
+  return { status: response.status, ok: response.ok, body: parsed, text };
+}
+
+async function readExisting(token, repo, route) {
+  const existing = await call(token, 'GET', route);
+  if (existing.status === 404) return null;
+  if (!existing.ok) {
+    throw new Error(
+      `could not read ${route} on ${BRANCH} of ${repo}: HTTP ${existing.status} ${existing.text.slice(0, 200)}`,
+    );
+  }
+  return existing.body;
+}
+
+// The branch has no history to share with main on purpose: these records
+// describe commits, they are not part of any commit's tree, and putting them on
+// main would make every proof run into drift the train then wants to release.
+async function createOrphanBranch(token, repo, filePath, content, message) {
+  const blob = await call(token, 'POST', `/repos/${repo}/git/blobs`, {
+    content, encoding: 'base64',
+  });
+  if (!blob.ok) throw new Error(`could not create blob: HTTP ${blob.status} ${blob.text.slice(0, 200)}`);
+  const tree = await call(token, 'POST', `/repos/${repo}/git/trees`, {
+    tree: [{ path: filePath, mode: '100644', type: 'blob', sha: blob.body.sha }],
+  });
+  if (!tree.ok) throw new Error(`could not create tree: HTTP ${tree.status} ${tree.text.slice(0, 200)}`);
+  const commit = await call(token, 'POST', `/repos/${repo}/git/commits`, {
+    message, tree: tree.body.sha, parents: [],
+  });
+  if (!commit.ok) throw new Error(`could not create commit: HTTP ${commit.status} ${commit.text.slice(0, 200)}`);
+  const ref = await call(token, 'POST', `/repos/${repo}/git/refs`, {
+    ref: `refs/heads/${BRANCH}`, sha: commit.body.sha,
+  });
+  if (!ref.ok) throw new Error(`could not create ${BRANCH}: HTTP ${ref.status} ${ref.text.slice(0, 200)}`);
+  return commit.body.sha;
+}
+
+// The chain, enforced at write time as well as read time. A stranger record is
+// only meaningful under a candidate whose preflight judged the very archive the
+// stranger ran, so publishing one under any other candidate is refused here
+// rather than discovered by the gate at release time. It also turns an
+// operator's mistyped candidate sha into an immediate, named failure instead of
+// a record that sits unread until a release is held by it.
+async function assertArchiveJudged(token, repo, sha, archive) {
+  const route = `/repos/${repo}/contents/evidence/${sha}/preflight.json?ref=${BRANCH}`;
+  const record = await readExisting(token, repo, route);
+  if (!record) {
+    throw new Error(
+      `cannot file a stranger record under ${sha}: no preflight record is ` +
+      `published there yet, so nothing establishes that archive ${archive} ` +
+      'belongs to this candidate. Publish the preflight record first.',
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(record.content ?? '', 'base64').toString());
+  } catch (cause) {
+    throw new Error(`the published preflight record for ${sha} is not valid JSON: ${cause.message}`);
+  }
+  const judged = (Array.isArray(parsed.legs) ? parsed.legs : [])
+    .map((leg) => leg?.result?.archive?.sha256)
+    .filter(Boolean);
+  if (!judged.includes(archive)) {
+    throw new Error(
+      `archive ${archive} is not one the published preflight for ${sha} judged ` +
+      `(${judged.join(', ') || 'none'}). Either the candidate sha is wrong or ` +
+      'the stranger ran on a different build; both need a human, not a retry.',
+    );
+  }
+}
+
+// Name what is being filed, before filing it.
+//
+// Three stranger run roots for one release carried the same archive sha256 and
+// names differing by one trailing character (rc0545, rc0545b, rc0545c), and one
+// of them was still running. Picking the wrong one under time pressure at a
+// release window is silent otherwise: the publish succeeds and the record reads
+// plausible. Echoing the record's own identifying fields makes a wrong pick
+// visible at the moment it happens rather than months later in a provenance
+// question.
+function describeRecord(name, raw) {
+  if (name === STRANGER_RECORD) {
+    const env = {};
+    for (const line of raw.toString().split('\n')) {
+      const eq = line.indexOf('=');
+      if (eq > 0) env[line.slice(0, eq).trim()] = line.slice(eq + 1);
+    }
+    return `arms=${env.arms ?? '<none>'} started_at=${env.started_at ?? '<none>'} ` +
+      `finished_at=${env.finished_at ?? '<none>'} archive=${(env.archive_sha256 ?? '').slice(0, 16)}`;
+  }
+  try {
+    const record = JSON.parse(raw.toString());
+    const commits = [...new Set((record.legs ?? [])
+      .map((leg) => leg?.result?.expected?.commit).filter(Boolean))];
+    return `run=${record.run ?? '<none>'} verdict=${record.verdict ?? '<none>'} ` +
+      `legs=${(record.legs ?? []).length} commit=${commits.join(',') || '<none>'}`;
+  } catch {
+    return 'unparseable';
+  }
+}
+
+// A stranger record with no finished_at describes a run that had not finished
+// when it was read. Refusing it is not fussiness: this branch is append-only by
+// construction, so filing the in-flight version means the completed version can
+// NEVER replace it, and the candidate is left permanently evidenced by a record
+// of a run whose outcome nobody had yet. The one case that produced this rule
+// was live at the moment it would have been published.
+function refuseUnfinished(name, raw, where) {
+  if (name !== STRANGER_RECORD) return;
+  const text = raw.toString();
+  const finished = text.split('\n').find((line) => line.startsWith('finished_at='));
+  if (!finished || !finished.slice('finished_at='.length).trim()) {
+    const started = text.split('\n').find((line) => line.startsWith('started_at='));
+    throw new Error(
+      `${where} carries no finished_at, so this run had not finished when the ` +
+      `file was read${started ? ` (${started.trim()})` : ''}. Evidence is ` +
+      'append-only, so filing it now would permanently evidence this candidate ' +
+      'with a run whose outcome nobody has yet. Wait for the run to land.',
+    );
+  }
+}
+
+// The token, resolved the way the operator's own shell resolves it.
+//
+// Reading only the environment is what broke the v0.5.46 preflight at 05:15:12Z
+// on 2026-08-21: an operator whose gh is logged in has no GH_TOKEN exported, so
+// the publisher sent every request unauthenticated and failed at the write with
+// HTTP 401 Requires authentication, after all three legs had already passed.
+// The back-fill runbook resolved it this way hours earlier and did not fail.
+function resolveToken() {
+  const fromEnv = (process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '').trim();
+  if (fromEnv) return fromEnv;
+  try {
+    return execFileSync('gh', ['auth', 'token'], {
+      // Bounded on purpose. A credential helper that stalls would otherwise
+      // hang the publish forever, at a release window, with nothing printed. A
+      // timeout throws, which lands in the no-token refusal below, and a
+      // refusal an operator can read beats a hang they have to guess at.
+      encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 10_000,
+    }).trim();
+  } catch {
+    // gh absent, logged out, or refusing. Either way there is no token, and
+    // that is the caller's answer, not an error to report from here.
+    return '';
+  }
+}
+
+// One line, never a raw body. gh and the API both answer a refusal with JSON,
+// and a refusal that spills JSON at a release window is one nobody reads to the
+// end of.
+function apiReason(response) {
+  const message = typeof response.body?.message === 'string' ? response.body.message : '';
+  const text = message.replace(/\s+/g, ' ').trim();
+  // Deliberately NOT falling back to the raw body. A response from something
+  // other than GitHub, or from a proxy in front of it, carries HTML or JSON
+  // that would arrive here as the "reason" and put a wall of it on the line an
+  // operator is meant to read.
+  return text ? text.slice(0, 120) : 'the response carried no message field';
+}
+
+// Prove the token reaches the repo BEFORE anything is read or written.
+//
+// This has to come first because a missing token does not announce itself: an
+// unauthenticated read of a private repo returns 404, the same answer an absent
+// path gives, so an empty environment makes every read here say "no record yet"
+// and "no branch yet" and walks the run all the way to the write before failing
+// there. The read side wears the costume of a normal first run. Asking for the
+// repo and requiring push turns that into one named refusal at the door.
+async function assertCanWrite(token, repo) {
+  if (!token) {
+    throw new Error(
+      `no GitHub token: GH_TOKEN and GITHUB_TOKEN are unset and "gh auth token" returned nothing, so nothing can be recorded on ${repo}. Run "gh auth login" or export GH_TOKEN.`,
+    );
+  }
+  const info = await call(token, 'GET', `/repos/${repo}`);
+  if (info.status === 404) {
+    throw new Error(
+      `this token cannot see ${repo} (HTTP 404, which is what a private repo returns to a token that cannot read it), so it cannot record evidence there.`,
+    );
+  }
+  if (!info.ok) {
+    throw new Error(`this token was refused by ${repo}: HTTP ${info.status} ${apiReason(info)}`);
+  }
+  if (info.body?.permissions?.push !== true) {
+    throw new Error(
+      `this token can read ${repo} but has no push permission, so the record would be refused at the write. Use a token with write access to ${repo}.`,
+    );
+  }
+}
+
+async function publish({ sha, name, file, repo, requireArchive }, { token = resolveToken(), log = console.log } = {}) {
+  await assertCanWrite(token, repo);
+  if (requireArchive) {
+    await assertArchiveJudged(token, repo, sha, requireArchive);
+  }
+  const raw = fs.readFileSync(file);
+  log(`filing ${name} for ${sha} from ${file}: ${describeRecord(name, raw)}`);
+  refuseUnfinished(name, raw, file);
+  const content = raw.toString('base64');
+  const filePath = `evidence/${sha}/${name}`;
+  const route = `/repos/${repo}/contents/${filePath}`;
+  const message = `Record ${name} for candidate ${sha}`;
+
+  const existing = await readExisting(token, repo, `${route}?ref=${BRANCH}`);
+  if (existing) {
+    const already = Buffer.from(existing.content ?? '', 'base64');
+    if (already.equals(raw)) {
+      log(`already recorded, identical: ${filePath} on ${BRANCH}`);
+      return { published: false, identical: true, path: filePath };
+    }
+    throw new Error(
+      `${filePath} already exists on ${BRANCH} with DIFFERENT content. This ` +
+      'candidate already has a record and evidence is append-only, so nothing ' +
+      'here will overwrite it. Two different answers for one candidate needs a ' +
+      'human to read both, not a machine to pick one.',
+    );
+  }
+
+  const branch = await call(token, 'GET', `/repos/${repo}/branches/${BRANCH}`);
+  if (branch.status === 404) {
+    const created = await createOrphanBranch(token, repo, filePath, content, message);
+    log(`created ${BRANCH} as an orphan branch and recorded ${filePath} (${created})`);
+    return { published: true, created: true, path: filePath };
+  }
+  if (!branch.ok) {
+    throw new Error(`could not read branch ${BRANCH}: HTTP ${branch.status} ${branch.text.slice(0, 200)}`);
+  }
+
+  // No `sha` field, so this cannot be an update. GitHub refuses the call if the
+  // path exists, which is what makes append-only structural here.
+  const put = await call(token, 'PUT', route, { message, content, branch: BRANCH });
+  if (!put.ok) {
+    throw new Error(
+      `could not record ${filePath} on ${BRANCH}: HTTP ${put.status} ${put.text.slice(0, 200)}`,
+    );
+  }
+  log(`recorded ${filePath} on ${BRANCH}`);
+  return { published: true, created: false, path: filePath };
+}
+
+module.exports = { parseArgs, publish, resolveToken, BRANCH };
+
+if (require.main === module) {
+  publish(parseArgs(process.argv.slice(2)))
+    .then(() => process.exit(0))
+    .catch((error) => {
+      process.stderr.write(`kin-evidence-publish: ${error.message}\n`);
+      process.exit(1);
+    });
+}

--- a/scripts/release-proof/bin/kin-lane
+++ b/scripts/release-proof/bin/kin-lane
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+#
+# A single-host lock table with the three verbs bin/kin-release-preflight
+# calls on the fleet's bin/kin-lane: acquire, holder and release. The fleet's
+# tool arbitrates one shared Mac between many sessions and is 4,500 lines
+# because of it. A hosted runner is one job on one machine, so the preflight's
+# daemon and gpu locks have nobody to contend with; what the preflight still
+# needs is the contract, because it refuses to run a leg under a lease it
+# cannot read back. This shim keeps that contract honest on its own table under
+# scripts/release-proof/.kin-coord/locks: a resource held by another lane is
+# refused, a holder is read back from disk, and a release by a lane that does
+# not hold the resource is refused.
+#
+# Not a copy of the fleet tool, and not a substitute for it on the shared box:
+# the umbrella's bin/kin-release-preflight keeps calling the real one there.
+set -euo pipefail
+
+SELF_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOCKS="${KIN_RELEASE_PROOF_LOCKS:-$SELF_DIR/../.kin-coord/locks}"
+
+die() { printf 'kin-lane (release-proof shim): %s\n' "$*" >&2; exit 1; }
+
+holder_of() { # <resource> -> the lane holding it, or nothing
+  [ -f "$LOCKS/$1/lane" ] && cat "$LOCKS/$1/lane" || true
+}
+
+cmd_acquire() { # <resource> <lane> [--pid <pid>] [reason...]
+  local res="${1:?resource}" lane="${2:?lane}" held
+  mkdir -p "$LOCKS"
+  held="$(holder_of "$res")"
+  if [ -n "$held" ] && [ "$held" != "$lane" ]; then
+    printf '%s is held by %s\n' "$res" "$held" >&2
+    return 1
+  fi
+  mkdir -p "$LOCKS/$res"
+  printf '%s\n' "$lane" > "$LOCKS/$res/lane"
+  printf '%s\n' "$*" > "$LOCKS/$res/argv"
+  printf 'acquired %s for %s\n' "$res" "$lane"
+}
+
+cmd_holder() { # <resource>
+  holder_of "${1:?resource}"
+}
+
+cmd_release() { # <resource> <lane>
+  local res="${1:?resource}" lane="${2:?lane}" held
+  held="$(holder_of "$res")"
+  [ -n "$held" ] || { printf '%s not held\n' "$res"; return 0; }
+  [ "$held" = "$lane" ] || die "'$res' is held by '$held', not '$lane', so this release is refused"
+  rm -rf -- "$LOCKS/$res"
+  printf 'released %s\n' "$res"
+}
+
+case "${1:-}" in
+  acquire) shift; cmd_acquire "$@" ;;
+  holder) shift; cmd_holder "$@" ;;
+  release) shift; cmd_release "$@" ;;
+  *) die "usage: kin-lane acquire <resource> <lane> [--pid <pid>] [reason] | holder <resource> | release <resource> <lane>" ;;
+esac

--- a/scripts/release-proof/bin/kin-release-preflight
+++ b/scripts/release-proof/bin/kin-release-preflight
@@ -1,0 +1,1012 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+#
+# kin-release-preflight: run the release's own proofs against local bytes,
+# before anything is tagged.
+#
+# The release proves a tag with the Install Proof (install, first run, MCP,
+# VFS projection, embedding, semantic retrieval, and a block of assertions on
+# what it captured) and the fleet gates shipped bytes with the same kin suite.
+# Both of those ran only after a tag existed, which is how v0.5.38 was built,
+# published, and then failed `semantic_coverage.complete` on every platform
+# with nothing local having ever asked the question. This tool asks it here:
+# the same flow, the same assertions, the same repro suite, against a build
+# from a worktree or an archive as shipped, on this host and inside a Debian 12
+# container for a Linux archive, with the glibc floor read off the packaged
+# kin-vfs and shim exactly as the release does.
+#
+# DEV-LOCAL. NON-CITABLE. The publish-fetch surface (get.kinlab.dev, the
+# attestation, the tag binding, the provenance manifest) is not exercised, and
+# the bytes are whatever this machine built or was handed. A pass here is what
+# lets a landing be submitted; it is never release, proof, or investor evidence.
+#
+# See --help for the runbook. Exit: 0 every leg PASS; 1 a leg FAILED; 2 nothing
+# failed but a leg or assertion was UNREADABLE; 64 usage; 65 refused before any
+# leg ran (stamp mismatch, missing tool, missing input); 66 a lane lock could
+# not be taken.
+set -uo pipefail
+
+SELF="${BASH_SOURCE[0]}"
+while [ -L "$SELF" ]; do
+  d="$(cd -P "$(dirname "$SELF")" && pwd)"
+  SELF="$(readlink "$SELF")"
+  case "$SELF" in /*) ;; *) SELF="$d/$SELF" ;; esac
+done
+# Bash reads a script incrementally, so a save to this file while a run is in
+# flight makes the interpreter resume mid-token and die on a syntax error the
+# file no longer contains. Every run therefore executes a private copy of itself
+# and records that copy's sha256; the helpers are copied into the run root the
+# same way before anything executes them.
+if [ -z "${KIN_PREFLIGHT_ORIGIN:-}" ]; then
+  origin="$(cd -P "$(dirname "$SELF")" && pwd)/$(basename "$SELF")"
+  copy="$(mktemp "${TMPDIR:-/tmp}/kin-release-preflight.XXXXXX")" || exit 65
+  cp "$origin" "$copy" || exit 65
+  KIN_PREFLIGHT_ORIGIN="$origin" KIN_PREFLIGHT_COPY="$copy" exec bash "$copy" "$@"
+fi
+BIN_DIR="$(cd -P "$(dirname "$KIN_PREFLIGHT_ORIGIN")" && pwd)"
+WS="$(cd -P "$BIN_DIR/.." && pwd)"
+HELPERS="$BIN_DIR/kin-release-preflight.d"
+KIN_LANE="$BIN_DIR/kin-lane"
+SUITE_RESOLVER="${KIN_PREFLIGHT_SUITE_RESOLVER:-$BIN_DIR/kin-acceptance-suite}"
+
+usage() {
+  cat <<'USAGE'
+usage:
+  kin-release-preflight --build <kin-checkout> [options]
+  kin-release-preflight --bin <kin> --daemon <kin-daemon> [options]
+  kin-release-preflight --archive <kin-<os>-<arch>.tar.gz> [--archive ...] [options]
+  kin-release-preflight --rc-run <run-id> [options]
+
+What it judges, and where:
+  --build DIR         release-build kin-cli and kin-daemon in DIR (a kin-lane worktree
+                      builds through `bin/kin-lane run <lane> kin -- cargo build`, any
+                      other checkout builds in place with --locked --release), then
+                      overlay them onto the newest published archive for this host
+                      (kin-vfs, the shim and KinNotifier.app come from that base) and
+                      prove the result on the host
+  --bin/--daemon      the same, from binaries you already built
+  --archive FILE      a release-shaped archive as shipped. The host's own target runs
+                      on the host; a Linux archive runs inside a Debian 12 container
+                      of its architecture (linux/arm64 for kin-linux-aarch64), where the
+                      glibc floor guard also runs on kin-vfs and the shim. Repeat the
+                      flag to judge several archives in one run
+  --rc-run ID         download every kin-<os>-<arch>.tar.gz a kin rc-build.yml run
+                      produced and judge each one as --archive would. This is how
+                      the Linux leg runs before a tag exists: a macOS host cannot
+                      cross-build a linux-aarch64 archive, and rc-build.yml builds
+                      release-shaped archives for a branch or tag without cutting
+                      one. Dispatch it ON the candidate branch, which is how the run
+                      resolves its workflow and its cache scope from the candidate:
+                      `gh workflow run rc-build.yml --repo firelock-ai/kin --ref <branch>`
+  Every leg runs kin scripts/acceptance/magic_repro.py against the installed binaries and requires
+  every check to pass.
+
+Options:
+  --base-archive FILE archive to overlay --build/--bin binaries onto (default: the newest
+                      GitHub release's archive for this host, cached under
+                      .kin-coord/preflight/base/<tag>/)
+  --kin-repo DIR      kin checkout supplying scripts/install.sh, check-glibc-floor.mjs
+                      and the workflow the assertions were ported from (default: the
+                      --build checkout, else <umbrella>/kin)
+  --kin-ref REF       git ref of --kin-repo to take those files from (default: the
+                      working tree for --build, else origin/main after a bounded fetch)
+  --expect-commit SHA the 40-hex commit both binaries must report (default: the --build
+                      checkout's HEAD, else the binaries' own stamp, which must agree)
+  --allow-dirty       waive the clean-source assertions (dirty, commit, lock provenance)
+                      for a build from uncommitted changes; the verdict says so
+  --lane NAME         lane name for the gpu/daemon locks (default: the --build worktree's
+                      lane, else preflight)
+  --lock-wait SECS    how long to wait for the locks before refusing (default 900)
+  --embed-seconds N   kin embed --max-seconds (default 300, the workflow's)
+  --cpu-embed         embed on the CPU (KIN_EMBED_BACKEND=cpu) in the host leg and take
+                      no gpu lock; the flow and its assertions are unchanged, the
+                      macOS accelerator path is not what ran, and the verdict says so
+  --leg-timeout SECS  wall-clock bound per leg (default 2700; the workflow's own job
+                      backstop is 90 minutes)
+  --no-linux          skip container legs even for Linux archives
+  --no-repro          skip the kin acceptance suite
+  --linux-image IMG   use this Docker image for the Linux legs instead of building
+                      the bundled Debian 12 image (it must carry node, git, python3,
+                      a C compiler, readelf, and run as a non-root user)
+  --run-root DIR      where the run's scratch, log and report go
+                      (default: /private/tmp/kpf/<stamp> on macOS, /tmp/kpf/<stamp>
+                      elsewhere, kept short because the flow binds Unix sockets under
+                      it; the log and JSON report are also copied to
+                      .kin-coord/preflight/<stamp>/)
+  --keep              keep the installed trees and probe repositories after the run
+  -h, --help          this text
+
+Verdict:
+  One block at the end: PASS, FAIL or UNREADABLE per leg with the literal failing
+  assertion, the magic repro tally, and a FINAL line. UNREADABLE means an assertion
+  could not be evaluated (a capture missing, an expected value unresolved) and is
+  never reported as PASS. Every line carries NON-CITABLE, because it is.
+
+Runbook:
+  before you enqueue a kin PR:
+    bin/kin-release-preflight --build .kin-coord/worktrees/<lane>-kin
+  before a tag, or on release-candidate bytes, or on a shipped archive:
+    bin/kin-release-preflight --archive dist/kin-macos-aarch64.tar.gz --archive dist/kin-linux-aarch64.tar.gz
+  on a release candidate that has no tag yet, which is the only form that runs
+  the Linux leg before the cut:
+    gh workflow run rc-build.yml --repo firelock-ai/kin --ref <candidate-branch>
+    bin/kin-release-preflight --rc-run <run-id>
+  read the FINAL line and the report path it names; nothing is tagged without PASS.
+USAGE
+}
+
+ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+say() { printf '[%s] preflight: %s\n' "$(ts)" "$*"; }
+warn() { printf '[%s] preflight: WARNING: %s\n' "$(ts)" "$*" >&2; }
+die() { printf '[%s] preflight: REFUSED: %s\n' "$(ts)" "$*" >&2; exit "${2:-65}"; }
+sha256_of() {
+  if command -v shasum >/dev/null 2>&1; then shasum -a 256 "$1" | cut -d' ' -f1
+  else sha256sum "$1" | cut -d' ' -f1; fi
+}
+bounded() { # <secs> <cmd...>: run under coreutils timeout when present
+  local secs="$1"; shift
+  if [ -n "${TIMEOUT_BIN:-}" ]; then "$TIMEOUT_BIN" -k 30 "$secs" "$@"; else "$@"; fi
+}
+
+# Quote the publisher's own reason, not the bare fact that it failed.
+#
+# On 2026-08-21 at 05:15:12Z the v0.5.46 preflight passed all three legs and
+# then printed "kin-evidence-publish: could not record evidence/a621321a.../
+# preflight.json on release-evidence: HTTP 401 Requires authentication". The
+# warning under it said only that the publisher had failed, so the reason lived
+# one line up in the scrollback and the retry command carried no hint that it
+# needed a token. The publisher's full output is printed either way; this lifts
+# its reason into the warning so the two are never separated.
+publish_reason() { # <file holding the publisher's output>
+  local line
+  line="$(sed -n 's/^kin-evidence-publish: //p' "$1" | tail -n 1)"
+  [ -n "$line" ] || line="$(command grep -v '^[[:space:]]*$' "$1" | tail -n 1)"
+  [ -n "$line" ] || line="the publisher printed no reason."
+  printf '%s' "$line"
+}
+
+# Never fatal to the verdict, and never silent about why. Returns 0 always: the
+# caller's verdict was decided before this ran and bookkeeping does not change
+# it.
+publish_record() { # <candidate sha> <report path>
+  local candidate="$1" report="$2" log rc
+  log="$(mktemp "${TMPDIR:-/tmp}/kin-preflight-publish.XXXXXX")" || return 0
+  "$BIN_DIR/kin-evidence-publish" --sha "$candidate" --name preflight.json --file "$report" > "$log" 2>&1
+  rc=$?
+  cat "$log"
+  if [ "$rc" -eq 0 ]; then
+    say "preflight record published for candidate $candidate"
+  else
+    warn "NOT PUBLISHED: $(publish_reason "$log") The verdict above stands and the record can be posted again with: $BIN_DIR/kin-evidence-publish --sha $candidate --name preflight.json --file $report"
+  fi
+  rm -f "$log"
+  return 0
+}
+
+# Print the exact interpreter that proved it can import tomllib. Do not return
+# only its directory: Homebrew's framework directory can contain python3.13 but
+# no python3 entry, which lets a later PATH lookup fall through to Apple's
+# Python 3.9 even though this probe passed with a newer interpreter.
+resolve_tomllib_python() {
+  local candidate real
+  for candidate in "$(command -v python3 2>/dev/null)" /opt/homebrew/bin/python3 /usr/local/bin/python3 /usr/bin/python3; do
+    [ -n "$candidate" ] && [ -x "$candidate" ] || continue
+    real="$("$candidate" -c 'import sys,os; print(os.path.realpath(sys.executable))' 2>/dev/null)" || continue
+    [ -n "$real" ] && [ -x "$real" ] || continue
+    if "$real" -c 'import tomllib' >/dev/null 2>&1; then
+      printf '%s\n' "$real"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Sourcing this file with KIN_PREFLIGHT_DEFINITIONS_ONLY=1 stops here, with the
+# helpers defined and nothing run, so the behavioral suite can drive
+# publish_record against a stub publisher. Set KIN_PREFLIGHT_ORIGIN too, or the
+# self-copy above execs a real run over the caller.
+if [ "${KIN_PREFLIGHT_DEFINITIONS_ONLY:-0}" = 1 ]; then return 0 2>/dev/null || exit 0; fi
+
+# ------------------------------------------------------------------ arguments
+BUILD_DIR=""; BIN_KIN=""; BIN_DAEMON=""; BASE_ARCHIVE=""; KIN_REPO=""; KIN_REF=""
+EXPECT_COMMIT=""; ALLOW_DIRTY=0; LANE=""; LOCK_WAIT=900; EMBED_SECONDS=300; LEG_TIMEOUT=2700
+NO_LINUX=0; NO_REPRO=0; LINUX_IMAGE=""; RUN_ROOT=""; KEEP=0; CPU_EMBED=0
+RC_RUN=""; RC_REPO="firelock-ai/kin"
+ARCHIVES=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --build) BUILD_DIR="${2:?--build needs a directory}"; shift 2 ;;
+    --bin) BIN_KIN="${2:?--bin needs a path}"; shift 2 ;;
+    --daemon) BIN_DAEMON="${2:?--daemon needs a path}"; shift 2 ;;
+    --archive) ARCHIVES+=("${2:?--archive needs a file}"); shift 2 ;;
+    --rc-run) RC_RUN="${2:?--rc-run needs a run id}"; shift 2 ;;
+    --rc-repo) RC_REPO="${2:?--rc-repo needs owner/name}"; shift 2 ;;
+    --base-archive) BASE_ARCHIVE="${2:?--base-archive needs a file}"; shift 2 ;;
+    --kin-repo) KIN_REPO="${2:?--kin-repo needs a directory}"; shift 2 ;;
+    --kin-ref) KIN_REF="${2:?--kin-ref needs a ref}"; shift 2 ;;
+    --expect-commit) EXPECT_COMMIT="${2:?--expect-commit needs a sha}"; shift 2 ;;
+    --allow-dirty) ALLOW_DIRTY=1; shift ;;
+    --lane) LANE="${2:?--lane needs a name}"; shift 2 ;;
+    --lock-wait) LOCK_WAIT="${2:?--lock-wait needs seconds}"; shift 2 ;;
+    --embed-seconds) EMBED_SECONDS="${2:?--embed-seconds needs a number}"; shift 2 ;;
+    --cpu-embed) CPU_EMBED=1; shift ;;
+    --leg-timeout) LEG_TIMEOUT="${2:?--leg-timeout needs seconds}"; shift 2 ;;
+    --no-linux) NO_LINUX=1; shift ;;
+    --no-repro) NO_REPRO=1; shift ;;
+    --linux-image) LINUX_IMAGE="${2:?--linux-image needs an image}"; shift 2 ;;
+    --run-root) RUN_ROOT="${2:?--run-root needs a directory}"; shift 2 ;;
+    --keep) KEEP=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) printf 'kin-release-preflight: unknown argument %s\n\n' "$1" >&2; usage >&2; exit 64 ;;
+  esac
+done
+if [ -n "$BUILD_DIR" ] && { [ -n "$BIN_KIN" ] || [ -n "$BIN_DAEMON" ]; }; then
+  printf 'kin-release-preflight: --build and --bin/--daemon are exclusive\n' >&2; exit 64
+fi
+if { [ -n "$BIN_KIN" ] && [ -z "$BIN_DAEMON" ]; } || { [ -z "$BIN_KIN" ] && [ -n "$BIN_DAEMON" ]; }; then
+  printf 'kin-release-preflight: --bin and --daemon go together\n' >&2; exit 64
+fi
+if [ -z "$BUILD_DIR" ] && [ -z "$BIN_KIN" ] && [ "${#ARCHIVES[@]}" -eq 0 ] && [ -z "$RC_RUN" ]; then
+  usage >&2; exit 64
+fi
+# A run id resolved out of a URL or an error message is a number that names no
+# run, and gh answers it with a 404 that reads like any other failure. Refuse
+# anything that is not a bare run id before the network is involved.
+case "$RC_RUN" in
+  ""|*[!0-9]*) [ -z "$RC_RUN" ] || { printf 'kin-release-preflight: --rc-run must be a numeric run id, got %s\n' "$RC_RUN" >&2; exit 64; } ;;
+esac
+case "$EXPECT_COMMIT" in ""|[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*) ;;
+  *) printf 'kin-release-preflight: --expect-commit must be a hex sha\n' >&2; exit 64 ;; esac
+
+# ---------------------------------------------------------------------- host
+HOST_OS="$(uname -s)"; HOST_MACHINE="$(uname -m)"
+case "$HOST_OS" in
+  Darwin) RUNNER_OS=macOS; SETUP_SHELL=zsh ;;
+  Linux) RUNNER_OS=Linux; SETUP_SHELL=bash ;;
+  *) die "unsupported host $HOST_OS" ;;
+esac
+case "$HOST_MACHINE" in
+  arm64|aarch64) RUNNER_ARCH=ARM64; HOST_ARCH_NAME=aarch64 ;;
+  x86_64|amd64) RUNNER_ARCH=X64; HOST_ARCH_NAME=x86_64 ;;
+  *) die "unsupported host architecture $HOST_MACHINE" ;;
+esac
+case "$RUNNER_OS" in macOS) HOST_TARGET="macos-$HOST_ARCH_NAME" ;; *) HOST_TARGET="linux-$HOST_ARCH_NAME" ;; esac
+TIMEOUT_BIN=""
+for candidate in timeout gtimeout /opt/homebrew/bin/timeout /usr/local/bin/timeout; do
+  if command -v "$candidate" >/dev/null 2>&1 && "$candidate" --version 2>/dev/null | command grep -q GNU; then
+    TIMEOUT_BIN="$(command -v "$candidate")"; break
+  fi
+done
+[ -n "$TIMEOUT_BIN" ] || warn "no GNU timeout on PATH; legs run without a wall-clock bound"
+[ -x "$KIN_LANE" ] || die "kin-lane not found at $KIN_LANE"
+[ -f "$HELPERS/proof-flow.sh" ] && [ -f "$HELPERS/validate.mjs" ] || die "helpers missing under $HELPERS"
+for tool in node git tar cc; do
+  command -v "$tool" >/dev/null 2>&1 || die "$tool is required on the host"
+done
+NODE_DIR="$(cd -P "$(dirname "$(command -v node)")" && pwd)"
+# The Codex TOML normalization needs a tomllib-capable Python, which is what
+# the hosted runners carry. Resolve and pass the exact executable rather than
+# asking the proof flow to perform a second, potentially different PATH lookup.
+PYTHON_BIN="$(resolve_tomllib_python)" || die "no python3 with tomllib (3.11+) found; the Codex TOML proof needs one"
+PY_DIR="$(dirname "$PYTHON_BIN")"
+FLOW_PATH="$NODE_DIR:$PY_DIR:/usr/bin:/bin:/usr/sbin:/sbin"
+if [ -n "$TIMEOUT_BIN" ]; then FLOW_PATH="$FLOW_PATH:$(dirname "$TIMEOUT_BIN")"; fi
+GIT_DIR_="$(cd -P "$(dirname "$(command -v git)")" && pwd)"
+case ":$FLOW_PATH:" in *":$GIT_DIR_:"*) ;; *) FLOW_PATH="$FLOW_PATH:$GIT_DIR_" ;; esac
+
+# ---------------------------------------------------------------- run layout
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+if [ -z "$RUN_ROOT" ]; then
+  # Short on purpose: the flow binds Unix sockets under the probe repository and
+  # macOS caps a socket path at 104 bytes.
+  case "$RUNNER_OS" in macOS) RUN_ROOT="/private/tmp/kpf/$STAMP" ;; *) RUN_ROOT="/tmp/kpf/$STAMP" ;; esac
+fi
+[ ! -e "$RUN_ROOT" ] || die "run root already exists: $RUN_ROOT"
+mkdir -p "$RUN_ROOT/tools" "$RUN_ROOT/dist" "$RUN_ROOT/legs" || die "could not create $RUN_ROOT"
+RUN_ROOT="$(cd "$RUN_ROOT" && pwd -P)"
+DURABLE="$WS/.kin-coord/preflight/$STAMP"
+LOG="$RUN_ROOT/preflight.log"
+REPORT="$RUN_ROOT/preflight.json"
+exec > >(tee -a "$LOG") 2>&1
+STATE_DIR="$WS/.kin-coord/preflight"
+HF_HOME_DIR="${KIN_PREFLIGHT_HF_HOME:-$STATE_DIR/hf-home}"
+mkdir -p "$STATE_DIR" "$HF_HOME_DIR"
+
+cat <<BANNER
+================================================================================
+  kin-release-preflight  DEV-LOCAL  NON-CITABLE
+  The release's own proofs against local bytes. Not a release, not a proof, not
+  investor evidence. What it can say: this landing would (or would not) survive
+  the Install Proof and the magic repro as they exist at the ref under test.
+  run root: $RUN_ROOT
+  log:      $LOG
+  running:  a private copy of $KIN_PREFLIGHT_ORIGIN (sha256 $(sha256_of "$KIN_PREFLIGHT_COPY"))
+================================================================================
+BANNER
+
+# ------------------------------------------------- release-candidate archives
+# rc-build.yml builds release-shaped archives for any ref without cutting a tag,
+# which is what lets the Linux leg run before the cut: this host cannot
+# cross-build a linux-aarch64 archive, so without a candidate build the Debian 12
+# container leg and its glibc floor guard were skipped on every pre-tag run.
+#
+# Every failure here is loud and names the run id. A run that produced no kin
+# archive must not degrade into the same skipped-Linux-leg verdict this option
+# exists to remove, because that verdict is indistinguishable from never having
+# passed the option at all.
+if [ -n "$RC_RUN" ]; then
+  command -v gh >/dev/null 2>&1 || die "gh is required for --rc-run $RC_RUN"
+  RC_DIR="$RUN_ROOT/rc/$RC_RUN"
+  mkdir -p "$RC_DIR" || die "could not create $RC_DIR for --rc-run $RC_RUN"
+  say "--rc-run $RC_RUN: downloading candidate archives from $RC_REPO"
+  if ! bounded 900 gh run download "$RC_RUN" --repo "$RC_REPO" --dir "$RC_DIR" > "$RUN_ROOT/rc-download.log" 2>&1; then
+    tail -n 20 "$RUN_ROOT/rc-download.log" >&2 || true
+    die "gh run download failed for run $RC_RUN in $RC_REPO (see $RUN_ROOT/rc-download.log); it is not an rc-build.yml run, or it published no artifact"
+  fi
+  rc_found=0
+  while IFS= read -r rc_archive; do
+    rc_name="$(basename "$rc_archive")"
+    case "$rc_name" in
+      kin-macos-aarch64.tar.gz|kin-macos-x86_64.tar.gz|kin-linux-aarch64.tar.gz|kin-linux-x86_64.tar.gz) ;;
+      *) continue ;;
+    esac
+    # The sidecar travels in the same artifact, and bin/kin-stranger refuses an
+    # archive without one, so a candidate that arrives unpaired is a defect in
+    # the run rather than something to work around here.
+    [ -f "$rc_archive.sha256" ] || die "--rc-run $RC_RUN: $rc_name arrived without its $rc_name.sha256 sidecar"
+    rc_want="$(cut -d' ' -f1 < "$rc_archive.sha256" | tr -d '[:space:]')"
+    rc_have="$(sha256_of "$rc_archive")"
+    [ "$rc_want" = "$rc_have" ] || die "--rc-run $RC_RUN: $rc_name checksum mismatch: sidecar $rc_want, bytes $rc_have"
+    ARCHIVES+=("$rc_archive")
+    rc_found=$((rc_found + 1))
+    say "--rc-run $RC_RUN: $rc_name (sha256 $rc_have)"
+  done < <(find "$RC_DIR" -type f -name 'kin-*.tar.gz' | sort)
+  [ "$rc_found" -gt 0 ] || die "--rc-run $RC_RUN: run $RC_RUN in $RC_REPO published no kin-<os>-<arch>.tar.gz artifact, so there is nothing to judge; dispatch one with 'gh workflow run rc-build.yml --repo $RC_REPO --ref <candidate-branch>'"
+  say "--rc-run $RC_RUN: $rc_found candidate archive(s) under judgment"
+fi
+
+# ------------------------------------------------------------- lock handling
+HELD_LOCKS=""
+release_locks() {
+  local held
+  for held in $HELD_LOCKS; do
+    "$KIN_LANE" release "$held" "$LANE" 2>&1 | sed 's/^/[kin-lane] /' || true
+  done
+  HELD_LOCKS=""
+}
+CONTAINERS=""
+cleanup() {
+  local rc=$? name
+  for name in $CONTAINERS; do docker rm -f "$name" >/dev/null 2>&1 || true; done
+  release_locks
+  [ -z "${KIN_PREFLIGHT_COPY:-}" ] || rm -f "$KIN_PREFLIGHT_COPY"
+  return "$rc"
+}
+trap cleanup EXIT
+trap 'say "interrupted"; exit 130' INT TERM
+
+acquire_lock() { # <resource>
+  local resource="$1" waited=0 holder
+  until "$KIN_LANE" acquire "$resource" "$LANE" --pid $$ "release preflight $STAMP"; do
+    holder="$("$KIN_LANE" holder "$resource" 2>/dev/null || true)"
+    if [ "$waited" -ge "$LOCK_WAIT" ]; then
+      say "$resource lock still held by '${holder:-unknown}' after ${waited}s; not stealing"
+      return 1
+    fi
+    say "waiting on the $resource lock (holder: ${holder:-unknown}); ${waited}s of ${LOCK_WAIT}s"
+    sleep 15; waited=$((waited + 15))
+  done
+  holder="$("$KIN_LANE" holder "$resource" 2>/dev/null || true)"
+  if [ "$holder" != "$LANE" ]; then
+    say "acquire returned 0 but the $resource holder reads '$holder', not '$LANE'; refusing to run under an unproven lease"
+    return 1
+  fi
+  HELD_LOCKS="$HELD_LOCKS $resource"
+  say "$resource lock held by $LANE (pid $$, verified by read-back)"
+}
+
+# --------------------------------------------------------- source under test
+# KIN_REPO / KIN_REF supply the installer, the floor guard, and the workflow the
+# assertions were ported from. TOOL_SRC names how each file is read.
+if [ -n "$BUILD_DIR" ]; then
+  [ -d "$BUILD_DIR" ] || die "--build directory not found: $BUILD_DIR"
+  BUILD_DIR="$(cd "$BUILD_DIR" && pwd -P)"
+  git -C "$BUILD_DIR" rev-parse --show-toplevel >/dev/null 2>&1 || die "$BUILD_DIR is not a git checkout"
+  [ -f "$BUILD_DIR/crates/kin-cli/Cargo.toml" ] || die "$BUILD_DIR does not look like a kin checkout"
+  [ -n "$KIN_REPO" ] || KIN_REPO="$BUILD_DIR"
+fi
+[ -n "$KIN_REPO" ] || KIN_REPO="$WS/kin"
+[ -d "$KIN_REPO" ] || die "kin repo not found: $KIN_REPO (pass --kin-repo)"
+KIN_REPO="$(cd "$KIN_REPO" && pwd -P)"
+read_kin_file() { # <relative path> <dest>: from the working tree (--build) or a git ref
+  local rel="$1" dest="$2"
+  if [ -z "$KIN_REF" ]; then
+    [ -f "$KIN_REPO/$rel" ] || return 1
+    cp "$KIN_REPO/$rel" "$dest"
+  else
+    git -C "$KIN_REPO" cat-file -e "$KIN_REF:$rel" 2>/dev/null || return 1
+    git -C "$KIN_REPO" show "$KIN_REF:$rel" > "$dest"
+  fi
+}
+if [ -z "$BUILD_DIR" ] && [ -z "$KIN_REF" ]; then
+  # Archives are judged with the tooling at origin/main: the guard that catches a
+  # glibc regression is the current one, not the one the archive's commit knew.
+  if bounded 90 git -C "$KIN_REPO" fetch -q origin main 2>/dev/null; then
+    KIN_REF="origin/main"
+  else
+    warn "could not fetch origin/main in $KIN_REPO; using the local origin/main ref"
+    KIN_REF="origin/main"
+  fi
+fi
+if [ -n "$KIN_REF" ]; then TOOL_SRC="$KIN_REPO @ $KIN_REF"; else TOOL_SRC="$KIN_REPO (working tree)"; fi
+read_kin_file scripts/install.sh "$RUN_ROOT/tools/install.sh" || die "scripts/install.sh not found at $TOOL_SRC"
+if read_kin_file scripts/check-glibc-floor.mjs "$RUN_ROOT/tools/check-glibc-floor.mjs"; then
+  GLIBC_GUARD="present"
+else
+  GLIBC_GUARD="absent at $TOOL_SRC"
+fi
+WORKFLOW_SHA=""
+if read_kin_file .github/workflows/install-proof.yml "$RUN_ROOT/tools/install-proof.yml"; then
+  WORKFLOW_SHA="$(sha256_of "$RUN_ROOT/tools/install-proof.yml")"
+fi
+PORTED_SHA="$(sed -n 's/^  sha256: "\([0-9a-f]\{64\}\)",$/\1/p' "$HELPERS/validate.mjs" | head -1)"
+cp "$HELPERS/proof-flow.sh" "$RUN_ROOT/tools/proof-flow.sh"
+cp "$HELPERS/validate.mjs" "$RUN_ROOT/tools/validate.mjs"
+# The acceptance suite comes from kin, never from a copy kept here. A release
+# archive carries kin, kin-daemon, kin-vfs, the shim, README and INSTALL and no
+# scripts directory, so the bytes under test cannot supply their own checks;
+# the suite is pinned to the same KIN_REPO @ KIN_REF that already supplies
+# scripts/install.sh and check-glibc-floor.mjs. bin/kin-acceptance-suite prints
+# the path, sha256 and tree sha it resolved, and refuses a copy that came from
+# outside that tree. The umbrella used to keep its own copy and it drifted six
+# checks behind kin's within two days, which is why there is one copy now.
+MAGIC_SRC="not staged"
+if [ ! -x "$SUITE_RESOLVER" ]; then
+  warn "bin/kin-acceptance-suite is missing at $SUITE_RESOLVER; no leg can run the acceptance suite"
+  MAGIC_SRC="UNAVAILABLE: no resolver at $SUITE_RESOLVER"
+else
+  if [ -n "$KIN_REF" ]; then
+    SUITE_ARGS=( --kin-repo "$KIN_REPO" --ref "$KIN_REF" )
+  else
+    SUITE_ARGS=( --checkout "$KIN_REPO" )
+  fi
+  if "$SUITE_RESOLVER" magic "${SUITE_ARGS[@]}" \
+       --dest "$RUN_ROOT/tools/kin-magic-repro" --label "preflight magic" \
+       --json "$RUN_ROOT/tools/magic-suite.json" >/dev/null; then
+    MAGIC_SRC="$TOOL_SRC:scripts/acceptance/magic_repro.py"
+  else
+    # Not fatal here on purpose. proof-flow.sh already refuses a leg asked to
+    # run a suite that was never staged, and that refusal names the leg, so a
+    # run that skipped the suite deliberately still works and a run that needed
+    # it fails where it needed it rather than here.
+    MAGIC_SRC="UNAVAILABLE from $TOOL_SRC"
+    warn "the acceptance suite could not be resolved from $TOOL_SRC; every leg that runs it will refuse"
+  fi
+fi
+chmod +x "$RUN_ROOT/tools/proof-flow.sh" "$RUN_ROOT/tools/install.sh" 2>/dev/null
+say "tooling from $TOOL_SRC: install.sh, check-glibc-floor.mjs $GLIBC_GUARD"
+say "acceptance suite: $MAGIC_SRC"
+# validate.mjs is a hand port of install-proof.yml's "Validate installed
+# capability proof" block. When the two disagree, a PASS here is a PASS against
+# assertions the release gate no longer runs, and it is quotable: the report
+# names a verdict without naming which contract produced it. That is worse than
+# no preflight, so the run refuses rather than warning. This used to warn and
+# continue, and it sat drifted across a release that then died on the very gate
+# the stale port could not have judged.
+drift_procedure() {
+  printf 'resync:\n'
+  printf '  1. read the "Validate installed capability proof" step of\n'
+  printf '     .github/workflows/install-proof.yml at %s\n' "$TOOL_SRC"
+  printf '  2. port every changed assertion into %s/validate.mjs,\n' "$HELPERS"
+  printf '     assertion for assertion, keeping PASS/FAIL/UNREADABLE reporting\n'
+  printf '  3. set PORTED_FROM.sha256 in that file to %s\n' "${WORKFLOW_SHA:-the sha printed above}"
+  printf '  4. re-run this command; the gate compares the two shas again\n'
+}
+if [ -z "$WORKFLOW_SHA" ]; then
+  drift_procedure >&2
+  die ".github/workflows/install-proof.yml could not be read at $TOOL_SRC, so the ported validator ($PORTED_SHA) cannot be checked against the contract it claims to mirror; an unverifiable port is not a gate"
+fi
+if [ "$WORKFLOW_SHA" != "$PORTED_SHA" ]; then
+  drift_procedure >&2
+  die "install-proof.yml at $TOOL_SRC is sha256 $WORKFLOW_SHA, but $HELPERS/validate.mjs records PORTED_FROM.sha256 $PORTED_SHA. The ported validator judges a contract the release gate no longer runs, so a PASS here would not be the workflow's PASS"
+fi
+
+# ---------------------------------------------------- expected lock provenance
+resolve_lock_sha() { # <commit> -> prints sha256 of that commit's Cargo.lock, or nothing
+  local commit="$1" tmp
+  tmp="$RUN_ROOT/tools/Cargo.lock.$commit"
+  if git -C "$KIN_REPO" cat-file -e "$commit:Cargo.lock" 2>/dev/null; then
+    git -C "$KIN_REPO" show "$commit:Cargo.lock" > "$tmp" && sha256_of "$tmp"; return
+  fi
+  if bounded 60 git -C "$KIN_REPO" fetch -q origin "$commit" 2>/dev/null \
+     && git -C "$KIN_REPO" cat-file -e "$commit:Cargo.lock" 2>/dev/null; then
+    git -C "$KIN_REPO" show "$commit:Cargo.lock" > "$tmp" && sha256_of "$tmp"; return
+  fi
+  if command -v curl >/dev/null 2>&1 \
+     && bounded 60 curl -fsSL "https://raw.githubusercontent.com/firelock-ai/kin/$commit/Cargo.lock" -o "$tmp" 2>/dev/null; then
+    sha256_of "$tmp"; return
+  fi
+  return 1
+}
+
+# ------------------------------------------------------ build / bin overlay
+LEG_NAMES=()      # display names, in run order
+LEG_KINDS=()      # host | linux
+LEG_ARCHIVES=()   # archive path per leg
+LEG_COMMITS=()    # expected commit per leg
+LEG_LOCKS=()      # expected lock sha per leg
+LEG_PLATFORMS=()  # docker platform for linux legs
+LEG_TARGETS=()    # kin-<os>-<arch>
+PROVENANCE=""     # human-readable lines about the bytes
+
+stamp_sha_of_line() { printf '%s\n' "$1" | sed -n 's/.*(\([0-9a-f]\{40\}\).*/\1/p'; }
+
+BUILT_KIN=""; BUILT_DAEMON=""; BUILD_SHA=""; BUILD_DIRTY=""; BUILD_BRANCH=""
+if [ -n "$BUILD_DIR" ]; then
+  BUILD_SHA="$(git -C "$BUILD_DIR" rev-parse HEAD)"
+  BUILD_BRANCH="$(git -C "$BUILD_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo detached)"
+  if [ -n "$(git -C "$BUILD_DIR" status --porcelain --untracked-files=no)" ]; then BUILD_DIRTY=1; else BUILD_DIRTY=0; fi
+  say "build tree: $BUILD_DIR @ ${BUILD_SHA} ($BUILD_BRANCH)$( [ "$BUILD_DIRTY" = 1 ] && printf ' DIRTY' )"
+  if [ "$BUILD_DIRTY" = 1 ] && [ "$ALLOW_DIRTY" != 1 ]; then
+    die "the build tree has uncommitted tracked changes; the release asserts a clean build. Commit to the lane branch (a dirty tree is not durable), or pass --allow-dirty to waive the clean-source assertions"
+  fi
+  # A kin-lane worktree builds through kin-lane so its CARGO_TARGET_DIR and the
+  # compiler cache are the lane's own; anything else builds in place.
+  lane_from_wt=""
+  case "$BUILD_DIR" in
+    "$WS/.kin-coord/worktrees/"*-kin)
+      lane_from_wt="$(basename "$BUILD_DIR")"; lane_from_wt="${lane_from_wt%-kin}" ;;
+  esac
+  [ -n "$LANE" ] || LANE="${lane_from_wt:-preflight}"
+  say "building kin-cli + kin-daemon (release, --locked)"
+  if [ -n "$lane_from_wt" ] && [ -d "$WS/.kin-coord/worktrees/$lane_from_wt-kin" ]; then
+    (
+      # kin-lane run exports KIN_VFS_DISABLE for the lane's own tooling; the
+      # flow later unsets everything it inherits, so that is fine here.
+      "$KIN_LANE" run "$lane_from_wt" kin -- cargo build --locked --release -p kin-cli -p kin-daemon
+    ) > "$RUN_ROOT/build.log" 2>&1
+    build_rc=$?
+    TARGET_DIR="$WS/.kin-coord/cargo-target/$lane_from_wt-kin"
+  else
+    (
+      cd "$BUILD_DIR" && CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$BUILD_DIR/target}" \
+        cargo build --locked --release -p kin-cli -p kin-daemon
+    ) > "$RUN_ROOT/build.log" 2>&1
+    build_rc=$?
+    TARGET_DIR="${CARGO_TARGET_DIR:-$BUILD_DIR/target}"
+  fi
+  if [ "$build_rc" -ne 0 ]; then
+    tail -n 30 "$RUN_ROOT/build.log" >&2
+    die "cargo build failed (rc=$build_rc); see $RUN_ROOT/build.log"
+  fi
+  BUILT_KIN="$TARGET_DIR/release/kin"; BUILT_DAEMON="$TARGET_DIR/release/kin-daemon"
+  [ -x "$BUILT_KIN" ] && [ -x "$BUILT_DAEMON" ] || die "build produced no kin/kin-daemon under $TARGET_DIR/release"
+  say "built: $BUILT_KIN"
+  say "built: $BUILT_DAEMON"
+elif [ -n "$BIN_KIN" ]; then
+  [ -x "$BIN_KIN" ] || die "--bin not executable: $BIN_KIN"
+  [ -x "$BIN_DAEMON" ] || die "--daemon not executable: $BIN_DAEMON"
+  BUILT_KIN="$(cd -P "$(dirname "$BIN_KIN")" && pwd)/$(basename "$BIN_KIN")"
+  BUILT_DAEMON="$(cd -P "$(dirname "$BIN_DAEMON")" && pwd)/$(basename "$BIN_DAEMON")"
+fi
+[ -n "$LANE" ] || LANE="preflight"
+
+fetch_base_archive() { # prints the path of a base archive for the host target
+  if [ -n "$BASE_ARCHIVE" ]; then
+    [ -f "$BASE_ARCHIVE" ] || die "--base-archive not found: $BASE_ARCHIVE"
+    printf '%s\n' "$(cd -P "$(dirname "$BASE_ARCHIVE")" && pwd)/$(basename "$BASE_ARCHIVE")"; return
+  fi
+  command -v gh >/dev/null 2>&1 || die "gh is required to fetch a base archive (or pass --base-archive)"
+  local tag dest
+  tag="$(bounded 60 gh release view --repo firelock-ai/kin --json tagName --jq .tagName 2>/dev/null || true)"
+  [ -n "$tag" ] || die "could not resolve the newest kin release tag through gh; pass --base-archive"
+  dest="$STATE_DIR/base/$tag"
+  mkdir -p "$dest"
+  if [ ! -f "$dest/kin-$HOST_TARGET.tar.gz" ] || [ ! -f "$dest/kin-$HOST_TARGET.tar.gz.sha256" ]; then
+    say "fetching base archive kin-$HOST_TARGET.tar.gz from release $tag" >&2
+    ( cd "$dest" && bounded 600 gh release download "$tag" --repo firelock-ai/kin \
+        -p "kin-$HOST_TARGET.tar.gz" -p "kin-$HOST_TARGET.tar.gz.sha256" --clobber ) >&2 \
+      || die "gh release download failed for $tag"
+  fi
+  local want have
+  want="$(cut -d' ' -f1 "$dest/kin-$HOST_TARGET.tar.gz.sha256")"
+  have="$(sha256_of "$dest/kin-$HOST_TARGET.tar.gz")"
+  [ "$want" = "$have" ] || die "base archive checksum mismatch for $tag: sidecar $want, bytes $have"
+  printf '%s\n' "$dest/kin-$HOST_TARGET.tar.gz"
+}
+
+if [ -n "$BUILT_KIN" ]; then
+  kin_line="$("$BUILT_KIN" --version 2>&1 | tail -1)"
+  daemon_line="$("$BUILT_DAEMON" --version 2>&1 | tail -1)"
+  kin_sha="$(stamp_sha_of_line "$kin_line")"; daemon_sha="$(stamp_sha_of_line "$daemon_line")"
+  say "kin:        $kin_line"
+  say "kin-daemon: $daemon_line"
+  [ -n "$kin_sha" ] && [ -n "$daemon_sha" ] || die "a --version line carries no full build sha ('$kin_line' / '$daemon_line')"
+  if [ "$kin_sha" != "$daemon_sha" ]; then
+    die "STAMP MISMATCH: kin names $kin_sha but kin-daemon names $daemon_sha. Rebuild both (-p kin-cli -p kin-daemon) from one tree; a mixed pair proves nothing about either"
+  fi
+  case "$kin_line$daemon_line" in *-dirty*) [ "$ALLOW_DIRTY" = 1 ] || die "the binaries stamp themselves dirty; commit and rebuild, or pass --allow-dirty" ;; esac
+  base="$(fetch_base_archive)" || exit 65
+  base_sha="$(sha256_of "$base")"
+  say "base archive: $base (sha256 $base_sha)"
+  assemble="$RUN_ROOT/assemble"; rm -rf "$assemble"; mkdir -p "$assemble"
+  tar -xzf "$base" -C "$assemble" || die "could not extract $base"
+  content_root="$(find "$assemble" -mindepth 1 -maxdepth 1 -type d -name 'kin-*' | head -1)"
+  [ -n "$content_root" ] || die "base archive has no kin-* content root"
+  [ "$(basename "$content_root")" = "kin-$HOST_TARGET" ] || die "base archive content root $(basename "$content_root") is not kin-$HOST_TARGET"
+  cp "$BUILT_KIN" "$content_root/kin" && cp "$BUILT_DAEMON" "$content_root/kin-daemon" || die "overlay failed"
+  chmod +x "$content_root/kin" "$content_root/kin-daemon"
+  host_archive="$RUN_ROOT/dist/kin-$HOST_TARGET.tar.gz"
+  ( cd "$assemble" && tar -czf "$host_archive" "kin-$HOST_TARGET" ) || die "could not assemble $host_archive"
+  rm -rf "$assemble"
+  expected_commit="${EXPECT_COMMIT:-${BUILD_SHA:-$kin_sha}}"
+  lock_sha=""
+  if [ -n "$BUILD_DIR" ]; then
+    lock_sha="$(sha256_of "$BUILD_DIR/Cargo.lock")"
+  else
+    lock_sha="$(resolve_lock_sha "$expected_commit" || true)"
+  fi
+  LEG_NAMES+=("host ($HOST_TARGET, built)"); LEG_KINDS+=(host); LEG_ARCHIVES+=("$host_archive")
+  LEG_COMMITS+=("$expected_commit"); LEG_LOCKS+=("$lock_sha"); LEG_PLATFORMS+=(""); LEG_TARGETS+=("kin-$HOST_TARGET")
+  PROVENANCE="$PROVENANCE
+  kin:          $BUILT_KIN
+                sha256 $(sha256_of "$BUILT_KIN")
+                $kin_line
+  kin-daemon:   $BUILT_DAEMON
+                sha256 $(sha256_of "$BUILT_DAEMON")
+                $daemon_line
+  base archive: $base (sha256 $base_sha) supplies kin-vfs, the shim and KinNotifier.app; kin and kin-daemon were overlaid onto it, so the assembled archive is neither a release nor a reproducible build
+  assembled:    $host_archive (sha256 $(sha256_of "$host_archive"))
+  expected:     commit $expected_commit${BUILD_DIR:+ (HEAD of $BUILD_DIR)}; Cargo.lock sha256 ${lock_sha:-UNRESOLVED}"
+fi
+
+# ----------------------------------------------------------- shipped archives
+container_stamp() { # <archive> <platform> -> prints "kin_line|daemon_line" read inside a container
+  local archive="$1" platform="$2" dir img
+  dir="$(dirname "$archive")"
+  img="$(linux_image_for "${platform#linux/}")"
+  docker run --rm --platform "$platform" -v "$dir:/d:ro" "$img" \
+    bash -c 'set -e; t="$(mktemp -d)"; tar -xzf "/d/'"$(basename "$archive")"'" -C "$t"; r="$(find "$t" -mindepth 1 -maxdepth 1 -type d | head -1)"; chmod +x "$r/kin" "$r/kin-daemon"; k="$("$r/kin" --version 2>&1 | tail -1)"; d="$("$r/kin-daemon" --version 2>&1 | tail -1)"; printf "%s|%s\n" "$k" "$d"' 2>"$RUN_ROOT/stamp-$(basename "$archive").err"
+}
+
+# One local image tag per platform. A single tag cannot serve both legs: docker
+# image inspect answers for whichever variant was built, so an arm64-only tag
+# passes the cache check and then an amd64 run finds no local variant, attempts
+# a registry pull, and fails with its stderr discarded, which read as two empty
+# build stamps on 2026-08-20. An explicit --linux-image is trusted for both.
+LINUX_IMAGE_ARM64=""; LINUX_IMAGE_AMD64=""
+linux_image_for() { case "$1" in arm64) printf '%s' "$LINUX_IMAGE_ARM64" ;; amd64) printf '%s' "$LINUX_IMAGE_AMD64" ;; esac; }
+set_linux_image_for() { case "$1" in arm64) LINUX_IMAGE_ARM64="$2" ;; amd64) LINUX_IMAGE_AMD64="$2" ;; esac; }
+ensure_linux_image() { # <arch: arm64|amd64>
+  local arch="$1"
+  [ -z "$(linux_image_for "$arch")" ] || return 0
+  command -v docker >/dev/null 2>&1 || return 1
+  docker info >/dev/null 2>&1 || return 1
+  if [ -n "$LINUX_IMAGE" ]; then set_linux_image_for "$arch" "$LINUX_IMAGE"; return 0; fi
+  local uid gid tag
+  uid="$(id -u)"; gid="$(id -g)"
+  tag="kin-release-preflight/debian12:u$uid-$arch"
+  if docker image inspect "$tag" >/dev/null 2>&1; then set_linux_image_for "$arch" "$tag"; return 0; fi
+  say "building the Debian 12 leg image $tag for linux/$arch (once; cached afterwards)"
+  bounded 1200 docker build --platform "linux/$arch" -t "$tag" \
+    --build-arg "UID=$uid" --build-arg "GID=$gid" -f "$HELPERS/Dockerfile" "$HELPERS" > "$RUN_ROOT/image-build-$arch.log" 2>&1 \
+    || { tail -n 30 "$RUN_ROOT/image-build-$arch.log" >&2; return 1; }
+  set_linux_image_for "$arch" "$tag"
+}
+
+LINUX_SKIPPED=""
+for archive in ${ARCHIVES[@]+"${ARCHIVES[@]}"}; do
+  [ -f "$archive" ] || die "--archive not found: $archive"
+  archive="$(cd -P "$(dirname "$archive")" && pwd)/$(basename "$archive")"
+  name="$(basename "$archive")"
+  case "$name" in
+    kin-macos-aarch64.tar.gz|kin-macos-x86_64.tar.gz|kin-linux-aarch64.tar.gz|kin-linux-x86_64.tar.gz) ;;
+    *) die "--archive must be a release-shaped kin-<os>-<arch>.tar.gz, got $name" ;;
+  esac
+  target="${name%.tar.gz}"
+  archive_sha="$(sha256_of "$archive")"
+  if [ "$target" = "kin-$HOST_TARGET" ]; then
+    # Read the stamps natively.
+    tmpx="$RUN_ROOT/dist/.x-$target"; rm -rf "$tmpx"; mkdir -p "$tmpx"
+    tar -xzf "$archive" -C "$tmpx" || die "could not extract $archive"
+    kin_line="$("$tmpx/$target/kin" --version 2>&1 | tail -1)"; daemon_line="$("$tmpx/$target/kin-daemon" --version 2>&1 | tail -1)"
+    rm -rf "$tmpx"
+    kin_sha="$(stamp_sha_of_line "$kin_line")"; daemon_sha="$(stamp_sha_of_line "$daemon_line")"
+    [ -n "$kin_sha" ] && [ -n "$daemon_sha" ] || die "$name: a --version line carries no full build sha ('$kin_line' / '$daemon_line')"
+    [ "$kin_sha" = "$daemon_sha" ] || die "STAMP MISMATCH in $name: kin names $kin_sha but kin-daemon names $daemon_sha"
+    expected_commit="${EXPECT_COMMIT:-$kin_sha}"
+    if [ -n "$EXPECT_COMMIT" ]; then commit_source=" (--expect-commit)"; else commit_source=" (the stamp both binaries carry)"; fi
+    lock_sha="$(resolve_lock_sha "$expected_commit" || true)"
+    LEG_NAMES+=("host ($HOST_TARGET, archive)"); LEG_KINDS+=(host); LEG_ARCHIVES+=("$archive")
+    LEG_COMMITS+=("$expected_commit"); LEG_LOCKS+=("$lock_sha"); LEG_PLATFORMS+=(""); LEG_TARGETS+=("$target")
+    PROVENANCE="$PROVENANCE
+  archive:      $archive (sha256 $archive_sha)
+                kin:        $kin_line
+                kin-daemon: $daemon_line
+  expected:     commit $expected_commit$commit_source; Cargo.lock sha256 ${lock_sha:-UNRESOLVED}"
+  else
+    case "$target" in
+      kin-linux-aarch64) platform="linux/arm64" ;;
+      kin-linux-x86_64) platform="linux/amd64" ;;
+      *) LINUX_SKIPPED="$LINUX_SKIPPED
+  $name: a $target archive cannot execute on this $HOST_TARGET host and has no container leg; skipped"; continue ;;
+    esac
+    if [ "$NO_LINUX" = 1 ]; then
+      LINUX_SKIPPED="$LINUX_SKIPPED
+  $name: --no-linux; skipped"; continue
+    fi
+    if ! ensure_linux_image "${platform#linux/}"; then
+      LINUX_SKIPPED="$LINUX_SKIPPED
+  $name: docker is unavailable or the leg image could not be built; the Linux leg was skipped (see $RUN_ROOT/image-build-*.log if present)"
+      continue
+    fi
+    case "$platform" in
+      linux/arm64) [ "$HOST_ARCH_NAME" = aarch64 ] || warn "$name runs under emulation on this $HOST_MACHINE host; it is slow and its timings mean nothing" ;;
+      linux/amd64) [ "$HOST_ARCH_NAME" = x86_64 ] || warn "$name runs under emulation on this $HOST_MACHINE host; it is slow and its timings mean nothing" ;;
+    esac
+    stamps="$(container_stamp "$archive" "$platform" || true)"
+    kin_line="${stamps%%|*}"; daemon_line="${stamps#*|}"
+    kin_sha="$(stamp_sha_of_line "$kin_line")"; daemon_sha="$(stamp_sha_of_line "$daemon_line")"
+    [ -n "$kin_sha" ] && [ -n "$daemon_sha" ] || die "$name: could not read both build stamps inside the container ('$kin_line' / '$daemon_line'); docker stderr: $(tail -3 "$RUN_ROOT/stamp-$name.err" 2>/dev/null | tr '\n' ' ' | cut -c1-300)"
+    [ "$kin_sha" = "$daemon_sha" ] || die "STAMP MISMATCH in $name: kin names $kin_sha but kin-daemon names $daemon_sha"
+    expected_commit="${EXPECT_COMMIT:-$kin_sha}"
+    if [ -n "$EXPECT_COMMIT" ]; then commit_source=" (--expect-commit)"; else commit_source=" (the stamp both binaries carry)"; fi
+    lock_sha="$(resolve_lock_sha "$expected_commit" || true)"
+    LEG_NAMES+=("linux (${platform#linux/}, debian 12, archive)"); LEG_KINDS+=(linux); LEG_ARCHIVES+=("$archive")
+    LEG_COMMITS+=("$expected_commit"); LEG_LOCKS+=("$lock_sha"); LEG_PLATFORMS+=("$platform"); LEG_TARGETS+=("$target")
+    PROVENANCE="$PROVENANCE
+  archive:      $archive (sha256 $archive_sha)
+                kin:        $kin_line
+                kin-daemon: $daemon_line
+  expected:     commit $expected_commit$commit_source; Cargo.lock sha256 ${lock_sha:-UNRESOLVED}
+  container:    $(linux_image_for "${platform#linux/}") ($platform)"
+  fi
+done
+if [ -n "$BUILT_KIN" ] && [ "$NO_LINUX" != 1 ]; then
+  linux_from_archive=0
+  for kind in ${LEG_KINDS[@]+"${LEG_KINDS[@]}"}; do [ "$kind" = linux ] && linux_from_archive=1; done
+  if [ "$linux_from_archive" = 0 ]; then
+    LINUX_SKIPPED="$LINUX_SKIPPED
+  no Linux archive was given and this host cannot cross-build one, so the Linux leg (Debian 12 container + glibc floor) was skipped; pass --archive kin-linux-aarch64.tar.gz from a release or an RC build to run it"
+  fi
+fi
+[ "${#LEG_NAMES[@]}" -gt 0 ] || die "nothing to run: no leg could be formed from the inputs${LINUX_SKIPPED}"
+
+printf '\n-- bytes under judgment --%s\n' "$PROVENANCE"
+[ -z "$LINUX_SKIPPED" ] || printf -- '-- skipped --%s\n' "$LINUX_SKIPPED"
+printf -- '-- tooling --\n  %s\n  validate.mjs ported from install-proof.yml sha256 %s (gate: the ref carries the same sha)\n  hf cache: %s\n\n' \
+  "$TOOL_SRC" "$PORTED_SHA" "$HF_HOME_DIR"
+
+# Seed the embedding model from the operator's own Hugging Face cache when it is
+# already there, so a run does not spend the network on bytes this machine holds.
+# The proof exercises the embedder, not the download.
+if [ "${KIN_PREFLIGHT_SEED_HF:-1}" = 1 ]; then
+  seed_model="models--nomic-ai--nomic-embed-text-v1.5"
+  if [ ! -d "$HF_HOME_DIR/hub/$seed_model" ] && [ -d "$HOME/.cache/huggingface/hub/$seed_model" ]; then
+    say "seeding $seed_model into $HF_HOME_DIR from ~/.cache/huggingface"
+    mkdir -p "$HF_HOME_DIR/hub"
+    cp -R "$HOME/.cache/huggingface/hub/$seed_model" "$HF_HOME_DIR/hub/" 2>/dev/null || warn "seeding the model cache failed; the leg will download it"
+  fi
+fi
+
+# ------------------------------------------------------------------ the legs
+# GPU priming: everything above staged inputs without holding anything. The
+# locks are taken now, immediately before compute, and released by the trap.
+need_gpu=0
+for kind in "${LEG_KINDS[@]}"; do [ "$kind" = host ] && [ "$CPU_EMBED" != 1 ] && need_gpu=1; done
+acquire_lock daemon || exit 66
+if [ "$need_gpu" = 1 ]; then
+  acquire_lock gpu || { say "the host leg embeds on Metal and needs the gpu lock; --cpu-embed runs the same flow on the CPU without it"; exit 66; }
+fi
+[ "$CPU_EMBED" != 1 ] || say "host leg embeds on the CPU (--cpu-embed); no gpu lock taken and no Metal work runs"
+
+LEG_VERDICTS=(); LEG_FAILING=(); LEG_REPRO=(); LEG_RESULTS=(); LEG_GLIBC=(); LEG_WAIVED=()
+i=0
+while [ "$i" -lt "${#LEG_NAMES[@]}" ]; do
+  name="${LEG_NAMES[$i]}"; kind="${LEG_KINDS[$i]}"; archive="${LEG_ARCHIVES[$i]}"
+  commit="${LEG_COMMITS[$i]}"; lock_sha="${LEG_LOCKS[$i]}"; platform="${LEG_PLATFORMS[$i]}"; target="${LEG_TARGETS[$i]}"
+  case "$kind" in host) slug="host" ;; *) slug="linux-${platform#linux/}" ;; esac
+  [ "$i" -eq 0 ] || slug="$slug$((i + 1))"
+  leg_dir="$RUN_ROOT/legs/$slug"
+  mkdir -p "$leg_dir"
+  say "== leg $name =="
+  say "   archive $archive"
+  t0=$(date +%s)
+  if [ "$kind" = host ]; then
+    wrap=()
+    [ -z "$TIMEOUT_BIN" ] || wrap=("$TIMEOUT_BIN" -k 60 "$LEG_TIMEOUT")
+    lang=C.UTF-8; [ "$RUNNER_OS" != macOS ] || lang=en_US.UTF-8
+    shell=/bin/bash; [ "$SETUP_SHELL" != zsh ] || shell=/bin/zsh
+    repro_flag=1; [ "$NO_REPRO" != 1 ] || repro_flag=0
+    # A fresh environment: nothing from this shell reaches the flow except what
+    # a hosted runner would also have.
+    env -i \
+      PATH="$FLOW_PATH" USER="${USER:-$(id -un)}" LOGNAME="${LOGNAME:-$(id -un)}" \
+      LANG="$lang" TERM="${TERM:-xterm}" SHELL="$shell" \
+      PF_ROOT="$leg_dir" PF_ARCHIVE="$archive" PF_TOOLS="$RUN_ROOT/tools" PF_LEG="$slug" \
+      PF_RUNNER_OS="$RUNNER_OS" PF_RUNNER_ARCH="$RUNNER_ARCH" PF_SETUP_SHELL="$SETUP_SHELL" \
+      PF_EXPECTED_COMMIT="$commit" PF_EXPECTED_LOCK_SHA="$lock_sha" PF_ALLOW_DIRTY="$ALLOW_DIRTY" \
+      PF_HF_HOME="$HF_HOME_DIR" PF_EMBED_SECONDS="$EMBED_SECONDS" \
+      PF_PYTHON="$PYTHON_BIN" \
+      PF_GLIBC_FLOOR=0 PF_MAGIC_REPRO="$repro_flag" PF_EMBED_BACKEND="$( [ "$CPU_EMBED" = 1 ] && printf cpu )" \
+      ${wrap[@]+"${wrap[@]}"} bash "$RUN_ROOT/tools/proof-flow.sh"
+    leg_rc=$?
+    result_json="$leg_dir/result.json"
+  else
+    cname="kin-preflight-$STAMP-$slug"
+    CONTAINERS="$CONTAINERS $cname"
+    case "$platform" in linux/arm64) c_arch=ARM64 ;; *) c_arch=X64 ;; esac
+    repro_flag=1; [ "$NO_REPRO" != 1 ] || repro_flag=0
+    # An emulated leg binds archive shape, install, and the glibc floor only.
+    # Under qemu the daemon starves its own enrichment (5s LSP timeouts fire on
+    # a ~10x slowdown: the same commit built 24 relations natively and 13
+    # emulated on 2026-08-20) and the repro suite's provenance guard can only
+    # ever see /usr/bin/qemu-x86_64 as the serving binary, so daemon-runtime
+    # judgments here are structurally unable to pass and are not attempted.
+    # release.yml's Public Install Proof on real runners is the binding
+    # daemon-runtime authority for the foreign arch, post-tag.
+    emulated=0
+    case "$platform" in
+      linux/arm64) [ "$HOST_ARCH_NAME" = aarch64 ] || emulated=1 ;;
+      linux/amd64) [ "$HOST_ARCH_NAME" = x86_64 ] || emulated=1 ;;
+    esac
+    if [ "$emulated" = 1 ]; then
+      repro_flag=0
+      say "   emulated leg: daemon-runtime steps are out of scope here (install + glibc floor bind; real-runner legs in release.yml carry the daemon-runtime proof)"
+    fi
+    # The archive is copied under the run root so the container sees it at a
+    # fixed path; the leg itself runs on the container's own filesystem and
+    # exports its logs, captures and result back to /rig/legs/<slug>.
+    cp "$archive" "$RUN_ROOT/dist/$target.tar.gz" 2>/dev/null || true
+    bounded "$LEG_TIMEOUT" docker run --rm --name "$cname" --platform "$platform" \
+      -v "$RUN_ROOT:/rig" -v "$HF_HOME_DIR:/rig-hf" \
+      -e PF_ROOT=/home/dev/preflight -e PF_ARCHIVE="/rig/dist/$target.tar.gz" -e PF_TOOLS=/rig/tools \
+      -e PF_LEG="$slug" -e PF_RUNNER_OS=Linux -e PF_RUNNER_ARCH="$c_arch" -e PF_SETUP_SHELL=bash \
+      -e PF_EXPECTED_COMMIT="$commit" -e PF_EXPECTED_LOCK_SHA="$lock_sha" -e PF_ALLOW_DIRTY="$ALLOW_DIRTY" \
+      -e PF_HF_HOME=/rig-hf -e PF_EMBED_SECONDS="$EMBED_SECONDS" -e PF_GLIBC_FLOOR=1 \
+      -e PF_MAGIC_REPRO="$repro_flag" -e PF_EMULATED="$emulated" \
+      -e PF_EXPORT_DIR="/rig/legs/$slug" \
+      -e HOME=/home/dev -e USER=dev -e LOGNAME=dev -e LANG=C.UTF-8 -e TERM=xterm -e SHELL=/bin/bash \
+      "$(linux_image_for "${platform#linux/}")" bash /rig/tools/proof-flow.sh
+    leg_rc=$?
+    CONTAINERS="$(printf '%s' "$CONTAINERS" | sed "s| $cname||")"
+    result_json="$leg_dir/result.json"
+  fi
+  t1=$(date +%s)
+  say "   leg exit $leg_rc in $((t1 - t0))s"
+  # Read the verdict off the result the leg wrote, never off its exit alone: a
+  # leg that died before writing one is UNREADABLE, not PASS.
+  if [ -f "$result_json" ]; then
+    verdict="$(node -e 'const r=require(process.argv[1]);process.stdout.write(r.verdict||"UNREADABLE")' "$result_json")"
+    failing="$(node -e 'const r=require(process.argv[1]);const f=r.failing||[];const u=r.unreadable||[];process.stdout.write(f.length?f.map(x=>`${x.kind} ${x.name}: ${x.message}`).join("\n"):(u.length?u.map(x=>`${x.kind} ${x.name}: ${x.message}`).join("\n"):""))' "$result_json")"
+    repro="$(node -e 'const r=require(process.argv[1]);const m=r.magic_repro;process.stdout.write(m?`${m.verdict} (${m.counts.PASS} pass, ${m.counts.FAIL} fail, ${m.counts.UNREADABLE} unreadable of ${m.total}${m.note?`; ${m.note}`:""}${m.checks.filter(c=>c.status!=="PASS").map(c=>`; ${c.id}/${c.ticket} ${c.status}: ${c.detail}`).join("")})`:"not run")' "$result_json")"
+    glibc="$(node -e 'const r=require(process.argv[1]);const g=r.glibc_floor;process.stdout.write(g?`${g.status}: ${g.detail}`:"")' "$result_json")"
+    waived="$(node -e 'const r=require(process.argv[1]);process.stdout.write((r.waived||[]).map(x=>`${x.name}: ${x.message}`).join("\n"))' "$result_json")"
+  else
+    verdict="UNREADABLE"; failing="the leg wrote no result.json (exit $leg_rc); see $LOG and $leg_dir/logs"; repro="not run"; glibc=""; waived=""
+  fi
+  LEG_VERDICTS+=("$verdict"); LEG_FAILING+=("$failing"); LEG_REPRO+=("$repro"); LEG_RESULTS+=("$result_json"); LEG_GLIBC+=("$glibc"); LEG_WAIVED+=("$waived")
+  i=$((i + 1))
+done
+release_locks
+
+# ---------------------------------------------------------------- the verdict
+overall=PASS
+i=0
+while [ "$i" -lt "${#LEG_NAMES[@]}" ]; do
+  case "${LEG_VERDICTS[$i]}" in FAIL) overall=FAIL ;; UNREADABLE) [ "$overall" = FAIL ] || overall=UNREADABLE ;; esac
+  case "${LEG_REPRO[$i]}" in FAIL*) overall=FAIL ;; UNREADABLE*) [ "$overall" = FAIL ] || overall=UNREADABLE ;; esac
+  i=$((i + 1))
+done
+printf '\n'
+printf '================================================================================\n'
+printf '  kin-release-preflight VERDICT  (DEV-LOCAL, NON-CITABLE)  run %s\n' "$STAMP"
+printf '================================================================================\n'
+i=0
+while [ "$i" -lt "${#LEG_NAMES[@]}" ]; do
+  printf '  leg %-42s %s\n' "${LEG_NAMES[$i]}" "${LEG_VERDICTS[$i]}"
+  if [ -n "${LEG_FAILING[$i]}" ]; then
+    printf '%s\n' "${LEG_FAILING[$i]}" | while IFS= read -r line; do printf '      %s\n' "$line"; done
+  fi
+  [ -z "${LEG_GLIBC[$i]}" ] || printf '      glibc floor: %s\n' "${LEG_GLIBC[$i]}"
+  if [ -n "${LEG_WAIVED[$i]}" ]; then
+    printf '%s\n' "${LEG_WAIVED[$i]}" | while IFS= read -r line; do printf '      waived: %s\n' "$line"; done
+  fi
+  printf '      magic-repro: %s\n' "${LEG_REPRO[$i]}"
+  printf '      result: %s\n' "${LEG_RESULTS[$i]}"
+  i=$((i + 1))
+done
+[ -z "$LINUX_SKIPPED" ] || printf '  skipped:%s\n' "$LINUX_SKIPPED"
+[ "$CPU_EMBED" != 1 ] || printf '  note: host leg embedded on the CPU (--cpu-embed); the macOS Metal path did not run\n'
+printf '  FINAL: %s  (NON-CITABLE)  report %s  log %s\n' "$overall" "$REPORT" "$LOG"
+printf '================================================================================\n'
+
+# ------------------------------------------------------------------ the report
+LEG_INDEX_JSON="$RUN_ROOT/legs.tsv"
+: > "$LEG_INDEX_JSON"
+i=0
+while [ "$i" -lt "${#LEG_NAMES[@]}" ]; do
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "${LEG_NAMES[$i]}" "${LEG_KINDS[$i]}" "${LEG_TARGETS[$i]}" "${LEG_ARCHIVES[$i]}" "${LEG_VERDICTS[$i]}" "${LEG_RESULTS[$i]}" "${LEG_REPRO[$i]}" >> "$LEG_INDEX_JSON"
+  i=$((i + 1))
+done
+STAMP="$STAMP" OVERALL="$overall" RUN_ROOT="$RUN_ROOT" LOG="$LOG" LEGS_TSV="$LEG_INDEX_JSON" \
+PROVENANCE="$PROVENANCE" SKIPPED="$LINUX_SKIPPED" TOOL_SRC="$TOOL_SRC" PORTED_SHA="$PORTED_SHA" WORKFLOW_SHA="$WORKFLOW_SHA" \
+LANE="$LANE" HOST="$(uname -srm)" ALLOW_DIRTY="$ALLOW_DIRTY" CPU_EMBED="$CPU_EMBED" \
+node - > "$REPORT" <<'NODE'
+const fs = require("fs");
+const legs = fs.readFileSync(process.env.LEGS_TSV, "utf8").split("\n").filter(Boolean).map((line) => {
+  const [name, kind, target, archive, verdict, result, repro] = line.split("\t");
+  let detail = null;
+  try { detail = JSON.parse(fs.readFileSync(result, "utf8")); } catch { detail = null; }
+  return { name, kind, target, archive, verdict, magic_repro: repro, result_path: result, result: detail };
+});
+process.stdout.write(`${JSON.stringify({
+  schema: "kin.release-preflight.v1",
+  citable: false,
+  lane: "DEV-LOCAL",
+  run: process.env.STAMP,
+  host: process.env.HOST,
+  lock_lane: process.env.LANE,
+  verdict: process.env.OVERALL,
+  allow_dirty: process.env.ALLOW_DIRTY === "1",
+  cpu_embed: process.env.CPU_EMBED === "1",
+  tooling: { source: process.env.TOOL_SRC, validator_ported_from_sha256: process.env.PORTED_SHA, workflow_sha256_at_ref: process.env.WORKFLOW_SHA || null },
+  provenance: process.env.PROVENANCE.split("\n").map((l) => l.trim()).filter(Boolean),
+  skipped: process.env.SKIPPED.split("\n").map((l) => l.trim()).filter(Boolean),
+  legs,
+  run_root: process.env.RUN_ROOT,
+  log: process.env.LOG,
+}, null, 2)}\n`);
+NODE
+mkdir -p "$DURABLE" && cp "$REPORT" "$LOG" "$DURABLE/" 2>/dev/null && say "report and log copied to $DURABLE"
+
+# ------------------------------------------------------- publish the evidence
+# The release train's gate reads evidence/<candidate-sha>/preflight.json off
+# kin's release-evidence branch. Nothing wrote that record before this, because
+# this report has only ever landed in the operator's local .kin-coord, which no
+# Actions job can see. That gap is how v0.5.44 shipped itself with no captain
+# and no proof evidence.
+#
+# The candidate sha is read back out of the report just written rather than
+# derived a second way. The gate requires every leg to name the same commit, so
+# reading the same field the gate reads means a record that publishes is a
+# record the gate can accept, and legs that disagree stop the publish here
+# instead of surfacing later as a release nobody can explain.
+#
+# Never fatal to the verdict. This runs after the verdict is decided and cannot
+# change it. A passed run that failed to publish is a passed run whose record
+# can be posted again; a run failed by its own bookkeeping would teach
+# operators to skip the bookkeeping.
+if [ "$overall" = PASS ] && [ "${KIN_PREFLIGHT_NO_PUBLISH:-0}" != 1 ]; then
+  candidate="$(node -e '
+    const report = require(process.argv[1]);
+    const legs = Array.isArray(report.legs) ? report.legs : [];
+    const commits = [...new Set(legs
+      .map((leg) => leg && leg.result && leg.result.expected && leg.result.expected.commit)
+      .filter(Boolean))];
+    if (commits.length === 1 && /^[0-9a-f]{40}$/.test(commits[0])) {
+      process.stdout.write(commits[0]);
+    }
+  ' "$REPORT" 2>/dev/null || true)"
+  if [ -z "$candidate" ]; then
+    warn "NOT PUBLISHED: the report names no single 40-character candidate commit across its legs, so there is no sha to record it under. The verdict above stands."
+  else
+    publish_record "$candidate" "$REPORT"
+  fi
+fi
+
+if [ "$KEEP" != 1 ]; then
+  # Keep logs, captures, results and the dist; drop the installed trees, HOMEs,
+  # probe repositories and repro fixtures, which are the bulk.
+  i=0
+  while [ "$i" -lt "${#LEG_NAMES[@]}" ]; do
+    leg_dir="$(dirname "${LEG_RESULTS[$i]}")"
+    for heavy in home archive stub w repro temp; do
+      [ -e "$leg_dir/$heavy" ] && rm -rf "$leg_dir/$heavy"
+    done
+    i=$((i + 1))
+  done
+fi
+
+case "$overall" in PASS) exit 0 ;; FAIL) exit 1 ;; *) exit 2 ;; esac

--- a/scripts/release-proof/bin/kin-release-preflight.d/Dockerfile
+++ b/scripts/release-proof/bin/kin-release-preflight.d/Dockerfile
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+#
+# The Linux leg of kin-release-preflight: Debian 12 (bookworm, glibc 2.36),
+# which is the oldest distribution the published Linux archive must start on
+# and the one whose loader refused v0.5.38's kin-vfs. node:22-bookworm is
+# Debian 12 with node, git, gcc and binutils already present; the leg needs
+# ps (procps) for the VFS proof's daemon-stop wait and a non-root user so the
+# VFS negative control (a mode-000 file must be unreadable) can mean anything.
+FROM node:22-bookworm
+
+ARG UID=1001
+ARG GID=1001
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends procps python3 python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN (getent group "$GID" >/dev/null || groupadd -o -g "$GID" dev) \
+    && useradd -m -o -u "$UID" -g "$GID" -s /bin/bash dev
+
+USER dev
+WORKDIR /home/dev
+ENV HOME=/home/dev

--- a/scripts/release-proof/bin/kin-release-preflight.d/proof-flow.sh
+++ b/scripts/release-proof/bin/kin-release-preflight.d/proof-flow.sh
@@ -1,0 +1,1316 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+#
+# One leg of the local release preflight: kin's Install Proof, run against a
+# release-shaped archive on this machine. The step bodies are the workflow's own
+# (kin/.github/workflows/install-proof.yml), in the workflow's order, under the
+# runner contract the proof depends on (RUNNER_OS/ARCH/TEMP, GITHUB_ENV/PATH,
+# an ambient PSModulePath, a fresh HOME). The publish-fetch surface is the one
+# thing not exercised: nothing here downloads from get.kinlab.dev, verifies an
+# attestation, or binds a tag. That is why the result is DEV-LOCAL and never
+# citable.
+#
+# Runs on the host (macOS or Linux) and unchanged inside a Linux container. The
+# driver is bin/kin-release-preflight; this file is not meant to be run by hand.
+#
+# Contract (environment):
+#   PF_ROOT             leg root (created); HOME, KIN_HOME, temp, probe live under it
+#   PF_ARCHIVE          the release-shaped kin-<os>-<arch>.tar.gz to install
+#   PF_TOOLS            dir holding install.sh, validate.mjs and, when present,
+#                       check-glibc-floor.mjs and kin-magic-repro
+#   PF_LEG              leg name for the result
+#   PF_RUNNER_OS        macOS | Linux         PF_RUNNER_ARCH  ARM64 | X64
+#   PF_SETUP_SHELL      zsh | bash            (what kin setup is told)
+#   PF_EXPECTED_COMMIT  40-hex the binaries must report (may be empty)
+#   PF_EXPECTED_LOCK_SHA sha256 of that commit's Cargo.lock (may be empty)
+#   PF_ALLOW_DIRTY      1 waives the clean-source assertions
+#   PF_HF_HOME          Hugging Face cache the embedder may use (persisted)
+#   PF_EMBED_SECONDS    kin embed --max-seconds (default 300, the workflow's)
+#   PF_EMBED_BACKEND    when set, exported as KIN_EMBED_BACKEND (cpu forces the CPU path)
+#   PF_PYTHON           exact tomllib-capable Python executable (default python3)
+#   PF_SETTLE_SECONDS   settle budget (default 180, the workflow's)
+#   PF_QUIESCE_SECONDS  kin status --wait-quiesce (default 60, the workflow's)
+#   PF_GLIBC_FLOOR      1 runs check-glibc-floor.mjs on kin-vfs and the shim
+#   PF_MAGIC_REPRO      1 runs kin-magic-repro against the installed binaries
+#   PF_EMULATED         1 marks a leg running under CPU emulation: the daemon-
+#                       runtime probe steps are skipped because they are
+#                       structurally unable to pass under an interpreter
+#   PF_EXPORT_DIR       when set, logs/captures/result are copied here on exit
+#   PF_HOST_APPS        comma list of clients this host detects by an installed
+#                       application outside HOME (cursor, windsurf, antigravity),
+#                       which no HOME isolation can hide from kin setup
+#
+# Exit status: 0 leg PASS, 1 leg FAIL, 2 leg UNREADABLE (nothing failed but
+# something could not be judged), 3 the flow itself could not start.
+set -uo pipefail
+
+: "${PF_ROOT:?PF_ROOT is required}"
+: "${PF_ARCHIVE:?PF_ARCHIVE is required}"
+: "${PF_TOOLS:?PF_TOOLS is required}"
+PF_LEG="${PF_LEG:-leg}"
+PF_RUNNER_OS="${PF_RUNNER_OS:-}"
+PF_RUNNER_ARCH="${PF_RUNNER_ARCH:-}"
+PF_SETUP_SHELL="${PF_SETUP_SHELL:-}"
+PF_EXPECTED_COMMIT="${PF_EXPECTED_COMMIT:-}"
+PF_EXPECTED_LOCK_SHA="${PF_EXPECTED_LOCK_SHA:-}"
+PF_ALLOW_DIRTY="${PF_ALLOW_DIRTY:-0}"
+PF_HF_HOME="${PF_HF_HOME:-}"
+PF_EMBED_SECONDS="${PF_EMBED_SECONDS:-300}"
+PF_EMBED_BACKEND="${PF_EMBED_BACKEND:-}"
+PF_PYTHON="${PF_PYTHON:-python3}"
+PF_SETTLE_SECONDS="${PF_SETTLE_SECONDS:-180}"
+PF_QUIESCE_SECONDS="${PF_QUIESCE_SECONDS:-60}"
+PF_GLIBC_FLOOR="${PF_GLIBC_FLOOR:-0}"
+PF_MAGIC_REPRO="${PF_MAGIC_REPRO:-0}"
+PF_EMULATED="${PF_EMULATED:-0}"
+PF_EXPORT_DIR="${PF_EXPORT_DIR:-}"
+PF_HOST_APPS="${PF_HOST_APPS:-}"
+if [ -z "$PF_HOST_APPS" ] && [ -d /Applications ]; then
+  apps=""
+  [ -e "/Applications/Cursor.app" ] && apps="$apps,cursor"
+  [ -e "/Applications/Windsurf.app" ] && apps="$apps,windsurf"
+  { [ -e "/Applications/Antigravity.app" ] || [ -e "/Applications/Antigravity IDE.app" ]; } && apps="$apps,antigravity"
+  PF_HOST_APPS="${apps#,}"
+fi
+
+if [ -z "$PF_RUNNER_OS" ]; then
+  case "$(uname -s)" in Darwin) PF_RUNNER_OS=macOS ;; Linux) PF_RUNNER_OS=Linux ;; *) PF_RUNNER_OS="$(uname -s)" ;; esac
+fi
+if [ -z "$PF_RUNNER_ARCH" ]; then
+  case "$(uname -m)" in arm64|aarch64) PF_RUNNER_ARCH=ARM64 ;; x86_64|amd64) PF_RUNNER_ARCH=X64 ;; *) PF_RUNNER_ARCH="$(uname -m)" ;; esac
+fi
+if [ -z "$PF_SETUP_SHELL" ]; then
+  case "$PF_RUNNER_OS" in macOS) PF_SETUP_SHELL=zsh ;; *) PF_SETUP_SHELL=bash ;; esac
+fi
+
+ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+say() { printf '[%s] proof-flow(%s): %s\n' "$(ts)" "$PF_LEG" "$*"; }
+
+for tool in node git tar; do
+  command -v "$tool" >/dev/null 2>&1 || { say "REFUSED: $tool is not on PATH"; exit 3; }
+done
+[ -x "$PF_PYTHON" ] || command -v "$PF_PYTHON" >/dev/null 2>&1 || {
+  say "REFUSED: configured Python is not executable: $PF_PYTHON"; exit 3;
+}
+"$PF_PYTHON" -c 'import tomllib' >/dev/null 2>&1 || {
+  say "REFUSED: configured Python cannot import tomllib: $PF_PYTHON"; exit 3;
+}
+[ -f "$PF_ARCHIVE" ] || { say "REFUSED: archive not found: $PF_ARCHIVE"; exit 3; }
+[ -f "$PF_TOOLS/install.sh" ] || { say "REFUSED: $PF_TOOLS/install.sh missing"; exit 3; }
+[ -f "$PF_TOOLS/validate.mjs" ] || { say "REFUSED: $PF_TOOLS/validate.mjs missing"; exit 3; }
+
+mkdir -p "$PF_ROOT" || exit 3
+PF_ROOT="$(cd "$PF_ROOT" && pwd -P)"
+LOGS="$PF_ROOT/logs"
+export HOME="$PF_ROOT/home"
+export RUNNER_TEMP="$PF_ROOT/temp"
+WORKSPACE="$PF_ROOT/w"
+PROBE="$WORKSPACE/kin-install-proof"
+CAPTURES="$RUNNER_TEMP/kin-proof-captures"
+mkdir -p "$LOGS" "$HOME" "$RUNNER_TEMP" "$WORKSPACE" "$CAPTURES" || exit 3
+
+# The runner contract the workflow's step bodies rely on. PSModulePath is set
+# the way a hosted image that ships PowerShell exports it into every Unix step;
+# a shell-detection defect once hid behind exactly that marker, so the leg
+# reproduces it rather than running cleaner than CI. Steps that unset it do so
+# themselves, per step, as the workflow does.
+export CI=true
+export GITHUB_ACTIONS=true
+export RUNNER_OS="$PF_RUNNER_OS"
+export RUNNER_ARCH="$PF_RUNNER_ARCH"
+export GITHUB_WORKSPACE="$WORKSPACE"
+export GITHUB_ENV="$PF_ROOT/github_env"
+export GITHUB_PATH="$PF_ROOT/github_path"
+: > "$GITHUB_ENV"; : > "$GITHUB_PATH"
+case "$PF_RUNNER_OS" in
+  macOS) export PSModulePath="$HOME/.local/share/powershell/Modules:/usr/local/share/powershell/Modules:/usr/local/microsoft/powershell/7/Modules" ;;
+  *)     export PSModulePath="/home/runner/.local/share/powershell/Modules:/usr/local/share/powershell/Modules:/opt/microsoft/powershell/7/Modules" ;;
+esac
+export PROOF_SHELL="$PF_SETUP_SHELL"
+if [ -n "$PF_HF_HOME" ]; then
+  mkdir -p "$PF_HF_HOME" || exit 3
+  export HF_HOME="$PF_HF_HOME"
+fi
+# Nothing from the operator's shell may leak into the flow: no daemon
+# coordinates, no VFS interposition, no KIN_HOME pin pointing elsewhere.
+unset KIN_HOME KIN_DIR KIN_MANAGED_BIN KIN_NO_PROVISION KIN_LAUNCHER_ADOPT KIN_MCP_REPO
+unset KIN_SESSION KIN_SESSION_ID KIN_SESSION_DIR KIN_DAEMON_URL KIN_DAEMON_AUTH_TOKEN
+unset KIN_REPO_ID KIN_REPO_IDS KIN_PRIMARY_REPO_ID KIN_DAEMON_BIN KIN_DAEMON_AUTO_EMBED
+unset KIN_VFS_DISABLE KIN_NO_VFS KIN_VFS_WORKSPACE KIN_VFS_WORKSPACE_ALIASES KIN_VFS_SOCK KIN_VFS_PIPE
+unset KIN_VFS_CANARY KIN_VFS_INTERPOSE_ACTIVE KIN_VFS_LAST_DIR _KIN_VFS_LAST_DIR
+unset KIN_SOURCE_ROOT KIN_ORIGINAL_PATH KIN_DISCOVERY_MODE KIN_CONTENT_MODE
+unset DYLD_INSERT_LIBRARIES LD_PRELOAD GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM XDG_CONFIG_HOME
+if [ -n "$PF_EMBED_BACKEND" ]; then
+  # The override is announced by kin as a WARN on stderr at every start, and the
+  # workflow captures `kin status --json` with 2>&1, so the announcement would
+  # land inside a JSON capture and read as an unparsable status. The override is
+  # this leg's own doing, so its announcement is turned off with it.
+  export KIN_EMBED_BACKEND="$PF_EMBED_BACKEND"
+  export KIN_ENV_VALIDATION=off
+fi
+# No other Kin install may answer to `kin` before the one this leg installs.
+PATH="$(printf '%s' "$PATH" | tr ':' '\n' | command grep -v -e '/\.kin/bin$' -e '^$' | paste -sd: -)"
+export PATH
+
+# --------------------------------------------------------------- bookkeeping
+STEP_N=0
+STEPS_TSV="$PF_ROOT/steps.tsv"
+: > "$STEPS_TSV"
+STOP=0
+sha256_of() {
+  if command -v shasum >/dev/null 2>&1; then shasum -a 256 "$1" | cut -d' ' -f1
+  else sha256sum "$1" | cut -d' ' -f1; fi
+}
+apply_runner_files() {
+  # The Actions contract: lines appended to GITHUB_PATH become PATH prefixes for
+  # later steps, and KEY=VALUE lines in GITHUB_ENV become their environment.
+  local line
+  if [ -s "$GITHUB_PATH" ]; then
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      case ":$PATH:" in *":$line:"*) ;; *) PATH="$line:$PATH" ;; esac
+    done < "$GITHUB_PATH"
+    export PATH
+    : > "$GITHUB_PATH"
+  fi
+  if [ -s "$GITHUB_ENV" ]; then
+    while IFS= read -r line; do
+      case "$line" in
+        [A-Za-z_]*=*) export "$line" ;;
+      esac
+    done < "$GITHUB_ENV"
+    : > "$GITHUB_ENV"
+  fi
+}
+run_step() { # <slug> <critical 0|1> <workdir> <function>
+  local slug="$1" critical="$2" wd="$3" fn="$4" log rc t0 t1
+  STEP_N=$((STEP_N + 1))
+  log="$LOGS/$(printf '%02d' "$STEP_N")-$slug.log"
+  if [ "$STOP" = 1 ]; then
+    printf 'not run: an earlier critical step failed\n' > "$log"
+    printf '%s\t%s\t%s\t%s\n' "$slug" "skipped" "0" "$log" >> "$STEPS_TSV"
+    say "step $slug: skipped (earlier critical step failed)"
+    return 0
+  fi
+  say "step $slug"
+  t0=$(date +%s)
+  ( set -euo pipefail; cd "$wd" && "$fn" ) > "$log" 2>&1
+  rc=$?
+  t1=$(date +%s)
+  apply_runner_files
+  printf '%s\t%s\t%s\t%s\n' "$slug" "$rc" "$((t1 - t0))" "$log" >> "$STEPS_TSV"
+  case "$rc" in
+    0)  say "step $slug: ok ($((t1 - t0))s)" ;;
+    99) say "step $slug: UNREADABLE ($((t1 - t0))s)"; tail -n 6 "$log" | sed 's/^/      /' ;;
+    *)  say "step $slug: FAIL rc=$rc ($((t1 - t0))s)"; tail -n 12 "$log" | sed 's/^/      /'
+        [ "$critical" = 1 ] && STOP=1 ;;
+  esac
+  return 0
+}
+
+# ------------------------------------------------------------------- cleanup
+stop_daemons() {
+  # kin daemon stop --all skips daemons whose home it cannot see, so pid files
+  # and a path-anchored pgrep close the gap. Everything this leg started lives
+  # under PF_ROOT, which is what makes the pgrep safe.
+  local pid pidfile
+  if [ -d "$PROBE" ] && [ -x "$HOME/.kin/bin/kin" ]; then
+    ( cd "$PROBE" && "$HOME/.kin/bin/kin" daemon stop --all --json ) >> "$LOGS/daemon-stop.log" 2>&1 || true
+  fi
+  # Only a path that is unmistakably this leg's may anchor a kill sweep.
+  case "/$PF_ROOT/" in
+    */kpf/*|*/preflight/*)
+      if command -v pgrep >/dev/null 2>&1; then
+        while IFS= read -r pid; do
+          [ -n "$pid" ] || continue
+          [ "$pid" = "$$" ] && continue
+          kill "$pid" 2>/dev/null || true
+        done < <(pgrep -f -- "$PF_ROOT/" 2>/dev/null || true)
+      fi
+      ;;
+  esac
+  for pidfile in "$PROBE"/.kin/daemon.pid "$PF_ROOT"/repro/*/.kin/daemon.pid; do
+    [ -f "$pidfile" ] || continue
+    pid="$(tr -d '[:space:]' < "$pidfile" 2>/dev/null)"
+    case "$pid" in ''|*[!0-9]*) continue ;; esac
+    kill "$pid" 2>/dev/null || true
+  done
+}
+snapshot_captures() {
+  # The captures are the evidence the assertions were read from; keep a copy
+  # beside the logs so the installed tree and probe repo can be discarded.
+  if [ -d "$CAPTURES" ]; then
+    mkdir -p "$PF_ROOT/captures"
+    cp -R "$CAPTURES"/. "$PF_ROOT/captures/" 2>/dev/null || true
+  fi
+  if [ -f "$PROBE/.agents/mcp_config.json" ]; then
+    mkdir -p "$PF_ROOT/captures/.agents"
+    cp "$PROBE/.agents/mcp_config.json" "$PF_ROOT/captures/.agents/" 2>/dev/null || true
+  fi
+  return 0
+}
+export_results() {
+  snapshot_captures
+  [ -n "$PF_EXPORT_DIR" ] || return 0
+  mkdir -p "$PF_EXPORT_DIR" || return 0
+  cp -R "$LOGS" "$PF_EXPORT_DIR/" 2>/dev/null || true
+  [ -d "$PF_ROOT/captures" ] && cp -R "$PF_ROOT/captures" "$PF_EXPORT_DIR/" 2>/dev/null
+  local f
+  for f in result.json steps.tsv validate.json repro.json repro.log archive.env; do
+    [ -f "$PF_ROOT/$f" ] && cp "$PF_ROOT/$f" "$PF_EXPORT_DIR/" 2>/dev/null
+  done
+  return 0
+}
+FINAL_RC=3
+on_exit() {
+  stop_daemons
+  export_results
+  exit "$FINAL_RC"
+}
+trap on_exit EXIT
+trap 'say "interrupted"; FINAL_RC=130; exit 130' INT TERM
+
+# ------------------------------------------------------------- 1. the archive
+ARCHIVE_NAME="$(basename "$PF_ARCHIVE")"
+ARCHIVE_SHA=""
+CONTENT_ROOT=""
+ARTIFACT_NAME="${ARCHIVE_NAME%.tar.gz}"
+case "$PF_RUNNER_OS" in
+  Linux) SHIM_NAME="libkin_vfs_shim.so" ;;
+  macOS) SHIM_NAME="libkin_vfs_shim.dylib" ;;
+  *) SHIM_NAME="" ;;
+esac
+case "$PF_RUNNER_OS/$PF_RUNNER_ARCH" in
+  Linux/X64) HOST_TARGET="linux-x86_64" ;;
+  Linux/ARM64) HOST_TARGET="linux-aarch64" ;;
+  macOS/X64) HOST_TARGET="macos-x86_64" ;;
+  macOS/ARM64) HOST_TARGET="macos-aarch64" ;;
+  *) HOST_TARGET="" ;;
+esac
+KIN_VERSION_LINE=""
+DAEMON_VERSION_LINE=""
+INSTALL_VERSION=""
+STAMP_SHA=""
+
+step_stage_archive() {
+  ARCHIVE_SHA="$(sha256_of "$PF_ARCHIVE")"
+  echo "archive: $PF_ARCHIVE"
+  echo "archive sha256: $ARCHIVE_SHA"
+  local extract="$PF_ROOT/archive"
+  rm -rf "$extract"; mkdir -p "$extract"
+  tar -xzf "$PF_ARCHIVE" -C "$extract"
+  local root
+  root="$(find "$extract" -mindepth 1 -maxdepth 1 -type d -name 'kin-*' | head -1)"
+  [ -n "$root" ] || { echo "archive has no kin-* content root" >&2; exit 1; }
+  CONTENT_ROOT="$root"
+  echo "content root: $CONTENT_ROOT"
+  for required in kin kin-daemon; do
+    [ -f "$CONTENT_ROOT/$required" ] || { echo "$required missing from $ARCHIVE_NAME" >&2; exit 1; }
+  done
+  ls -la "$CONTENT_ROOT"
+  # The archive under test must be the one this host can run: a Linux archive
+  # reaches this script only inside a Linux container.
+  case "$ARTIFACT_NAME" in
+    kin-"$HOST_TARGET") ;;
+    *) echo "archive $ARTIFACT_NAME is not the host target kin-$HOST_TARGET; this leg cannot execute it" >&2; exit 1 ;;
+  esac
+  chmod +x "$CONTENT_ROOT/kin" "$CONTENT_ROOT/kin-daemon"
+  KIN_VERSION_LINE="$("$CONTENT_ROOT/kin" --version 2>&1 | tail -1)"
+  DAEMON_VERSION_LINE="$("$CONTENT_ROOT/kin-daemon" --version 2>&1 | tail -1)"
+  echo "kin --version: $KIN_VERSION_LINE"
+  echo "kin-daemon --version: $DAEMON_VERSION_LINE"
+  echo "kin sha256: $(sha256_of "$CONTENT_ROOT/kin")"
+  echo "kin-daemon sha256: $(sha256_of "$CONTENT_ROOT/kin-daemon")"
+  [ -f "$CONTENT_ROOT/kin-vfs" ] && echo "kin-vfs sha256: $(sha256_of "$CONTENT_ROOT/kin-vfs")"
+  [ -n "$SHIM_NAME" ] && [ -f "$CONTENT_ROOT/$SHIM_NAME" ] && echo "$SHIM_NAME sha256: $(sha256_of "$CONTENT_ROOT/$SHIM_NAME")"
+  local kin_sha daemon_sha
+  kin_sha="$(printf '%s\n' "$KIN_VERSION_LINE" | sed -n 's/.*(\([0-9a-f]\{40\}\).*/\1/p')"
+  daemon_sha="$(printf '%s\n' "$DAEMON_VERSION_LINE" | sed -n 's/.*(\([0-9a-f]\{40\}\).*/\1/p')"
+  if [ -z "$kin_sha" ] || [ -z "$daemon_sha" ]; then
+    echo "a version line carries no full build SHA: '$KIN_VERSION_LINE' / '$DAEMON_VERSION_LINE'" >&2; exit 1
+  fi
+  if [ "$kin_sha" != "$daemon_sha" ]; then
+    echo "STAMP MISMATCH: kin names $kin_sha but kin-daemon names $daemon_sha; refusing to judge a mixed pair" >&2; exit 1
+  fi
+  STAMP_SHA="$kin_sha"
+  INSTALL_VERSION="$(printf '%s\n' "$KIN_VERSION_LINE" | awk '{print $2}')"
+  case "$INSTALL_VERSION" in [0-9]*) ;; *) echo "could not read a version out of '$KIN_VERSION_LINE'" >&2; exit 1 ;; esac
+  # A file:// release mirror for the real installer: <base>/download/v<ver>/<archive>
+  # and its shasum sidecar, exactly the layout get.kinlab.dev's installer fetches.
+  local stub="$PF_ROOT/stub/download/v$INSTALL_VERSION"
+  rm -rf "$PF_ROOT/stub"; mkdir -p "$stub"
+  cp "$PF_ARCHIVE" "$stub/$ARCHIVE_NAME"
+  printf '%s  %s\n' "$ARCHIVE_SHA" "$ARCHIVE_NAME" > "$stub/$ARCHIVE_NAME.sha256"
+  echo "install mirror: $PF_ROOT/stub (version $INSTALL_VERSION)"
+  {
+    printf 'archive=%s\narchive_sha256=%s\ncontent_root=%s\nkin_version_line=%s\ndaemon_version_line=%s\nstamp_sha=%s\ninstall_version=%s\n' \
+      "$PF_ARCHIVE" "$ARCHIVE_SHA" "$CONTENT_ROOT" "$KIN_VERSION_LINE" "$DAEMON_VERSION_LINE" "$STAMP_SHA" "$INSTALL_VERSION"
+  } > "$PF_ROOT/archive.env"
+}
+run_step stage-archive 1 "$PF_ROOT" step_stage_archive
+if [ -f "$PF_ROOT/archive.env" ]; then
+  # Re-read the values the subshell resolved.
+  ARCHIVE_SHA="$(sed -n 's/^archive_sha256=//p' "$PF_ROOT/archive.env")"
+  CONTENT_ROOT="$(sed -n 's/^content_root=//p' "$PF_ROOT/archive.env")"
+  KIN_VERSION_LINE="$(sed -n 's/^kin_version_line=//p' "$PF_ROOT/archive.env")"
+  DAEMON_VERSION_LINE="$(sed -n 's/^daemon_version_line=//p' "$PF_ROOT/archive.env")"
+  STAMP_SHA="$(sed -n 's/^stamp_sha=//p' "$PF_ROOT/archive.env")"
+  INSTALL_VERSION="$(sed -n 's/^install_version=//p' "$PF_ROOT/archive.env")"
+fi
+if [ -z "$PF_EXPECTED_COMMIT" ] && [ -n "$STAMP_SHA" ]; then
+  PF_EXPECTED_COMMIT="$STAMP_SHA"
+  say "expected commit not supplied; using the binaries' own stamp $STAMP_SHA (both agree)"
+fi
+
+# --------------------------------------------------------- 2. glibc floor guard
+step_glibc_floor() {
+  if [ ! -f "$PF_TOOLS/check-glibc-floor.mjs" ]; then
+    echo "check-glibc-floor.mjs is absent from the tools staged for this run (the kin ref under test predates the floor guard); the floor cannot be judged" >&2
+    exit 99
+  fi
+  if [ ! -f "$CONTENT_ROOT/kin-vfs" ] || [ ! -f "$CONTENT_ROOT/$SHIM_NAME" ]; then
+    echo "archive carries no kin-vfs or $SHIM_NAME to check" >&2
+    exit 1
+  fi
+  node "$PF_TOOLS/check-glibc-floor.mjs" "$CONTENT_ROOT/kin-vfs" "$CONTENT_ROOT/$SHIM_NAME"
+}
+if [ "$PF_GLIBC_FLOOR" = 1 ] && [ "$PF_RUNNER_OS" = Linux ]; then
+  run_step glibc-floor 0 "$PF_ROOT" step_glibc_floor
+fi
+
+# ------------------------------------------------------- 3. Public install (Unix)
+step_install() {
+  # The repo's own installer, pointed at the local mirror. KIN_NO_SETUP binds
+  # to sh, as the workflow's comment insists, and the version is pinned so the
+  # installer never asks GitHub which release is latest.
+  export KIN_BASE_URL="file://$PF_ROOT/stub"
+  export KIN_VERSION="$INSTALL_VERSION"
+  export KIN_NO_SETUP=1
+  sh "$PF_TOOLS/install.sh"
+  echo "$HOME/.kin/bin" >> "$GITHUB_PATH"
+}
+run_step install 1 "$PF_ROOT" step_install
+
+# ---------------------------------------- 4. Verify binaries installed + runnable
+step_verify_binaries() {
+  kin_version_line="$(kin --version)"
+  daemon_version_line="$(kin-daemon --version)"
+  printf '%s\n' "$kin_version_line" | tee kin-version.txt
+  printf '%s\n' "$daemon_version_line" | tee kin-daemon-version.txt
+
+  RUNNER_OS="$RUNNER_OS" node <<'NODE'
+  const fs = require("fs");
+  const os = require("os");
+  const path = require("path");
+  const { execFileSync } = require("child_process");
+
+  const executable = process.env.RUNNER_OS === "Windows" ? "kin.exe" : "kin";
+  const installedKin = path.join(os.homedir(), ".kin", "bin", executable);
+  if (!fs.statSync(installedKin).isFile()) {
+    throw new Error(`public installer did not create a regular Kin launcher at ${installedKin}`);
+  }
+  const directVersion = execFileSync(installedKin, ["--version"], { encoding: "utf8" }).trim();
+  const pathVersion = fs.readFileSync("kin-version.txt", "utf8").trim();
+  if (directVersion !== pathVersion) {
+    throw new Error(`PATH selected ${pathVersion}, but the installed launcher reports ${directVersion}`);
+  }
+  fs.writeFileSync("installed-kin-command.txt", `${installedKin}\n`);
+NODE
+
+  # The tag/attestation/provenance half of this step is the publish-fetch
+  # surface and is not run locally. What stands in for it: the expected version
+  # is what the archive's own kin reports, and the expected commit and lock
+  # sha256 were resolved by the driver from the source under test.
+  installed_version="$(printf '%s\n' "$kin_version_line" | awk '{print $2}')"
+  installed_daemon_version="$(printf '%s\n' "$daemon_version_line" | awk '{print $2}')"
+  expected_version="$INSTALL_VERSION"
+  if [ "$installed_version" != "$expected_version" ]; then
+    echo "installed kin $installed_version, expected $expected_version" >&2
+    exit 1
+  fi
+  if [ "$installed_daemon_version" != "$expected_version" ]; then
+    echo "installed kin-daemon $installed_daemon_version, expected $expected_version" >&2
+    exit 1
+  fi
+  printf '%s\n' "$expected_version" > expected-version.txt
+  printf '%s\n' "$PF_EXPECTED_COMMIT" > expected-commit.txt
+  printf '%s\n' "$PF_EXPECTED_LOCK_SHA" > expected-lock-sha.txt
+  echo "expected commit: ${PF_EXPECTED_COMMIT:-<unresolved>}"
+  echo "expected Cargo.lock sha256: ${PF_EXPECTED_LOCK_SHA:-<unresolved>}"
+}
+run_step verify-binaries 1 "$WORKSPACE" step_verify_binaries
+
+# The installed kin-vfs and shim must be the archive's own bytes. This is the
+# component half of the same workflow step, kept apart so a projection the
+# installer refused to keep (a loader that cannot start it) reads as its own
+# failure instead of stopping the leg before the flow has said anything else.
+step_vfs_components() {
+  CONTENT_ROOT="$CONTENT_ROOT" \
+  INSTALLED_VFS="$HOME/.kin/bin/kin-vfs" \
+  INSTALLED_SHIM="$HOME/.kin/lib/$SHIM_NAME" \
+  SHIM_NAME="$SHIM_NAME" node <<'NODE'
+  const crypto = require("crypto");
+  const fs = require("fs");
+  const path = require("path");
+
+  const fail = (condition, message) => {
+    if (!condition) throw new Error(message);
+  };
+  const sha256Bytes = (bytes) => crypto.createHash("sha256").update(bytes).digest("hex");
+  const components = [
+    { name: "kin-vfs", installed: process.env.INSTALLED_VFS },
+    { name: process.env.SHIM_NAME, installed: process.env.INSTALLED_SHIM },
+  ].map((component) => {
+    const archived = path.join(process.env.CONTENT_ROOT, component.name);
+    fail(fs.existsSync(component.installed),
+      `installed ${component.name} is missing at ${component.installed} (the installer did not keep it, or the archive never carried it)`);
+    const installedBytes = fs.readFileSync(component.installed);
+    const archivedBytes = fs.readFileSync(archived);
+    fail(installedBytes.equals(archivedBytes),
+      `installed ${component.name} differs from the attested public archive`);
+    return { name: component.name, installed_path: component.installed, sha256: sha256Bytes(installedBytes) };
+  });
+  for (const component of components) console.log(`${component.name}: ${component.sha256} (${component.installed_path})`);
+NODE
+}
+run_step vfs-components 0 "$WORKSPACE" step_vfs_components
+
+# ------------------------------- 5. First-run repository, daemon, and setup proof
+step_first_run() {
+  case "$PROOF_SHELL" in
+    bash)
+      unset PSModulePath PSVersionTable
+      export SHELL=/bin/bash
+      printf 'SHELL=%s\n' "$SHELL" >> "$GITHUB_ENV"
+      ;;
+    zsh)
+      unset PSModulePath PSVersionTable
+      export SHELL=/bin/zsh
+      printf 'SHELL=%s\n' "$SHELL" >> "$GITHUB_ENV"
+      ;;
+    powershell)
+      ;;
+    *) echo "unsupported install-proof setup shell: $PROOF_SHELL" >&2; exit 1 ;;
+  esac
+
+  mkdir -p kin-install-proof && cd kin-install-proof
+  git init -q && git config user.email ci@firelock.ai && git config user.name ci
+  printf 'def hello():\n    return 42\n' > probe.py
+  git add -A && git commit -qm "probe"
+  captures="$RUNNER_TEMP/kin-proof-captures"
+  mkdir -p "$captures"
+  init_status=0
+  kin init > "$captures/kin-init.txt" 2>&1 || init_status=$?
+  cat "$captures/kin-init.txt"
+  if [ "$init_status" -ne 0 ]; then exit "$init_status"; fi
+  kin status > "$captures/kin-status.txt" 2>&1
+  cat "$captures/kin-status.txt"
+  kin status --json > "$captures/kin-status.json" 2>&1
+  cat "$captures/kin-status.json"
+  kin bench-meta --json > "$captures/kin-build-meta.json"
+  cat "$captures/kin-build-meta.json"
+  proof_base_path="$PATH"
+  fake_agent_bin="$RUNNER_TEMP/kin-proof-agent-bin"
+  mkdir -p "$fake_agent_bin"
+  for agent in claude cursor codex gemini windsurf agy; do
+    if [ "$RUNNER_OS" = "Windows" ]; then
+      cp "$(command -v kin)" "$fake_agent_bin/$agent.exe"
+    else
+      printf '#!/bin/sh\nexit 0\n' > "$fake_agent_bin/$agent"
+      chmod +x "$fake_agent_bin/$agent"
+    fi
+  done
+  export PATH="$fake_agent_bin:$proof_base_path"
+  printf '%s\n' "$fake_agent_bin" >> "$GITHUB_PATH"
+
+  antigravity_legacy="$HOME/.gemini/antigravity-ide/mcp_config.json"
+  mkdir -p "$(dirname "$antigravity_legacy")"
+  ANTIGRAVITY_LEGACY="$antigravity_legacy" node <<'NODE'
+  const fs = require("fs");
+  const path = require("path");
+  const config = {
+    userPolicy: "preserve",
+    mcpServers: {
+      kin: {
+        command: "/stale/kin",
+        args: ["mcp", "start"],
+        cwd: fs.realpathSync(process.cwd()),
+        env: { USER_POLICY: "preserve" },
+      },
+    },
+  };
+  fs.writeFileSync(process.env.ANTIGRAVITY_LEGACY, `${JSON.stringify(config, null, 2)}\n`);
+NODE
+
+  # Never pipe setup, for the reason `kin status` above is not piped. Setup
+  # leaves a long-lived child behind in an admitted repository, and that child
+  # inherits the write end of the pipe and holds it until it idles out, so
+  # `tee` blocks reading a pipe nobody will close even though setup itself has
+  # finished and printed everything it will print. The workflow's Windows leg
+  # measured that wait twice on v0.5.49, at 1805 s and 1868 s, which is the
+  # 1800 s daemon idle window plus startup and shutdown slack. Redirecting ends
+  # the wait whatever the child turns out to be, because nothing waits on a
+  # file. Setup's own exit status is captured rather than left to `set -e` so a
+  # failure still reaches the log instead of aborting before the `cat`.
+  setup_status=0
+  kin setup --no-interactive --intent agent --shell "$PROOF_SHELL" \
+    > "$captures/kin-setup.txt" 2>&1 || setup_status=$?
+  cat "$captures/kin-setup.txt"
+  if [ "$setup_status" -ne 0 ]; then exit "$setup_status"; fi
+
+  CODEX_CONFIG="$HOME/.codex/config.toml" PROOF_CAPTURES="$captures" "$PF_PYTHON" - <<'PY'
+import json
+import os
+import pathlib
+import tomllib
+
+config = pathlib.Path(os.environ["CODEX_CONFIG"])
+with config.open("rb") as handle:
+    entry = tomllib.load(handle)["mcp_servers"]["kin"]
+pathlib.Path(os.environ["PROOF_CAPTURES"], "kin-codex-config.json").write_text(
+    json.dumps({"mcpServers": {"kin": entry}}, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+  primary_home="$HOME"
+  claude_fallback_home="$RUNNER_TEMP/kin-proof-claude-fallback-home"
+  claude_fallback_bin="$RUNNER_TEMP/kin-proof-claude-fallback-bin"
+  mkdir -p "$claude_fallback_home/.claude"
+  mkdir -p "$claude_fallback_bin"
+  printf '{}\n' > "$claude_fallback_home/.claude/config.json"
+  if [ "$RUNNER_OS" = "Windows" ]; then
+    cp "$(command -v kin)" "$claude_fallback_bin/claude.exe"
+  else
+    printf '#!/bin/sh\nexit 0\n' > "$claude_fallback_bin/claude"
+    chmod +x "$claude_fallback_bin/claude"
+  fi
+  claude_fallback_path="$claude_fallback_bin:$primary_home/.kin/bin:/usr/bin:/bin"
+  # Unpiped for the same reason as the setup above, and it cost the same: this
+  # second setup left the child that held the second pipe for its own full idle
+  # window.
+  fallback_setup_status=0
+  HOME="$claude_fallback_home" USERPROFILE="$claude_fallback_home" \
+  KIN_HOME="$primary_home/.kin" PATH="$claude_fallback_path" \
+    kin setup --no-interactive --intent agent --shell "$PROOF_SHELL" \
+    > "$captures/kin-claude-fallback-setup.txt" 2>&1 || fallback_setup_status=$?
+  cat "$captures/kin-claude-fallback-setup.txt"
+  if [ "$fallback_setup_status" -ne 0 ]; then exit "$fallback_setup_status"; fi
+  if [ -e "$claude_fallback_home/.claude.json" ]; then
+    echo "Claude fallback proof unexpectedly wrote the primary ~/.claude.json path" >&2
+    exit 1
+  fi
+  cp "$claude_fallback_home/.claude/config.json" "$captures/kin-claude-fallback-config.json"
+  HOME="$claude_fallback_home" USERPROFILE="$claude_fallback_home" \
+  KIN_HOME="$primary_home/.kin" PATH="$claude_fallback_path" \
+    kin setup status --json > "$captures/kin-claude-fallback-health.json"
+  HOME="$claude_fallback_home" USERPROFILE="$claude_fallback_home" \
+  KIN_HOME="$primary_home/.kin" PATH="$claude_fallback_path" \
+    kin doctor --json > "$captures/kin-claude-fallback-doctor.json"
+}
+run_step first-run 1 "$WORKSPACE" step_first_run
+
+# ------------------------------------------ 6. Graph query and MCP tool-call proof
+step_graph_query_mcp() {
+  captures="$RUNNER_TEMP/kin-proof-captures"
+  mkdir -p "$captures"
+  kin search hello --json > "$captures/kin-search.json"
+  cat "$captures/kin-search.json"
+  kin locate hello --json --explain --max-files 5 > "$captures/kin-locate.json"
+  cat "$captures/kin-locate.json"
+
+  daemon_port="$(tr -d '[:space:]' < .kin/daemon.port)"
+  case "$daemon_port" in
+    ''|*[!0-9]*)
+      echo "installed daemon published an invalid port: $daemon_port" >&2
+      exit 1
+      ;;
+  esac
+  DAEMON_PORT="$daemon_port" node <<'NODE' > "$captures/kin-daemon-health.json"
+  const http = require("http");
+  const request = http.get(
+    `http://127.0.0.1:${process.env.DAEMON_PORT}/health`,
+    (response) => {
+      const chunks = [];
+      response.on("data", (chunk) => chunks.push(chunk));
+      response.on("end", () => {
+        const body = Buffer.concat(chunks);
+        if (response.statusCode !== 200) {
+          console.error(`daemon health returned HTTP ${response.statusCode}: ${body}`);
+          process.exitCode = 1;
+          return;
+        }
+        process.stdout.write(body);
+      });
+    }
+  );
+  request.setTimeout(30000, () => {
+    request.destroy(new Error("daemon health request exceeded 30 seconds"));
+  });
+  request.on("error", (error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+NODE
+  cat "$captures/kin-daemon-health.json"
+  kin setup status --json | tee "$captures/kin-health.json"
+  kin doctor --json | tee "$captures/kin-doctor.json"
+
+  PROOF_CAPTURES="$captures" node <<'NODE'
+  const fs = require("fs");
+  const path = require("path");
+  const { execFileSync, spawn, spawnSync } = require("child_process");
+
+  const captures = process.env.PROOF_CAPTURES;
+
+  const resolver = process.platform === "win32"
+    ? ["where.exe", ["kin"]]
+    : ["sh", ["-c", "command -v kin"]];
+  const resolved = execFileSync(resolver[0], resolver[1], { encoding: "utf8" })
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean);
+  if (!resolved) throw new Error("could not resolve the installed Kin binary");
+  const kinBinary = fs.realpathSync(resolved);
+  const installDir = path.dirname(kinBinary);
+  const normalizePath = (value) => {
+    let normalized;
+    try {
+      normalized = fs.realpathSync(value);
+    } catch {
+      normalized = path.resolve(value);
+    }
+    return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+  };
+  const proofEnv = { ...process.env };
+  delete proofEnv.KIN_DAEMON_BIN;
+  const pathKey = Object.keys(proofEnv).find((key) => key.toUpperCase() === "PATH") ?? "PATH";
+  proofEnv[pathKey] = (proofEnv[pathKey] ?? "")
+    .split(path.delimiter)
+    .filter((entry) => entry && normalizePath(entry) !== normalizePath(installDir))
+    .join(path.delimiter);
+  if ((proofEnv[pathKey] ?? "")
+    .split(path.delimiter)
+    .some((entry) => entry && normalizePath(entry) === normalizePath(installDir))) {
+    throw new Error("PATH-free MCP proof still contains the Kin install directory");
+  }
+
+  const stopDaemons = (phase) => {
+    const stopped = spawnSync(
+      kinBinary,
+      ["daemon", "stop", "--all", "--json"],
+      {
+        cwd: process.cwd(),
+        env: proofEnv,
+        encoding: "utf8",
+        timeout: 60_000,
+      },
+    );
+    fs.appendFileSync(
+      path.join(captures, "kin-mcp-daemon-stop.txt"),
+      `${phase}: status=${stopped.status}\n${stopped.stdout ?? ""}${stopped.stderr ?? ""}\n`,
+    );
+    if (stopped.error || stopped.status !== 0) {
+      throw new Error(
+        `${phase}: failed to stop installed daemons: ${stopped.error ?? stopped.stderr}`,
+      );
+    }
+  };
+
+  stopDaemons("before MCP startup");
+
+  const requests = [
+    { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+    { jsonrpc: "2.0", method: "notifications/initialized", params: {} },
+    { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+    {
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: {
+        name: "semantic_search",
+        arguments: { query: "hello", compact: true, limit: 5 },
+      },
+    },
+  ];
+
+  const configPath = path.join(process.cwd(), ".agents", "mcp_config.json");
+  const entry = JSON.parse(fs.readFileSync(configPath, "utf8"))?.mcpServers?.kin;
+  if (!entry || typeof entry.command !== "string" || !Array.isArray(entry.args) || typeof entry.cwd !== "string") {
+    throw new Error(`${configPath}: captured MCP launch entry is missing`);
+  }
+  const stripVerbatim = (p) => (typeof p === "string" && p.startsWith("\\\\?\\") ? p.slice(4) : p);
+  const child = spawn(entry.command, entry.args, {
+    cwd: stripVerbatim(entry.cwd),
+    env: { ...proofEnv, ...(entry.env ?? {}) },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  let lineBuffer = "";
+  let revivalRequested = false;
+  let settled = false;
+  const finish = (error) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(timer);
+    fs.writeFileSync(path.join(captures, "kin-mcp-out.jsonl"), stdout);
+    fs.writeFileSync(path.join(captures, "kin-mcp-err.txt"), stderr);
+    if (error) {
+      if (!child.killed) child.kill("SIGKILL");
+      console.error(error);
+      console.error(stderr);
+      process.exit(1);
+    }
+  };
+  const timer = setTimeout(() => {
+    child.kill("SIGKILL");
+    finish(new Error("installed MCP startup/revival proof did not exit within 120 seconds"));
+  }, 120_000);
+  const validateSearch = (message, label) => {
+    if (!message?.result || message.error || message.result.isError === true) {
+      throw new Error(`${label} failed: ${JSON.stringify(message ?? null)}`);
+    }
+    const rendered = JSON.stringify(message.result);
+    if (!rendered.includes("hello") || !rendered.includes("probe.py")) {
+      throw new Error(`${label} did not return the seeded hello entity`);
+    }
+  };
+  child.stdout.on("data", (chunk) => {
+    const text = chunk.toString();
+    stdout += text;
+    lineBuffer += text;
+    const lines = lineBuffer.split(/\r?\n/);
+    lineBuffer = lines.pop() ?? "";
+    try {
+      for (const line of lines) {
+        if (!line.trim().startsWith("{")) continue;
+        const message = JSON.parse(line);
+        if (message.id === 3 && !revivalRequested) {
+          validateSearch(message, "initial MCP semantic_search");
+          stopDaemons("between MCP calls");
+          revivalRequested = true;
+          child.stdin.write(`${JSON.stringify({
+            jsonrpc: "2.0",
+            id: 4,
+            method: "tools/call",
+            params: {
+              name: "semantic_search",
+              arguments: { query: "hello", compact: true, limit: 5 },
+            },
+          })}\n`);
+        } else if (message.id === 4) {
+          validateSearch(message, "revived MCP semantic_search");
+          child.stdin.end();
+        }
+      }
+    } catch (error) {
+      finish(error);
+    }
+  });
+  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  child.on("error", finish);
+  child.on("close", (code) => {
+    if (code !== 0) {
+      finish(new Error(`installed MCP server exited ${code}`));
+      return;
+    }
+    try {
+      const messages = stdout
+        .split(/\r?\n/)
+        .filter((line) => line.trim().startsWith("{"))
+        .map((line) => JSON.parse(line));
+      const byId = new Map(messages.filter((message) => message.id != null).map((message) => [message.id, message]));
+      if (!byId.get(1)?.result) throw new Error("MCP initialize response missing");
+      if (!JSON.stringify(byId.get(2)?.result ?? {}).includes("semantic_search")) {
+        throw new Error("MCP tools/list omitted semantic_search");
+      }
+      validateSearch(byId.get(3), "initial MCP semantic_search");
+      if (!revivalRequested) throw new Error("MCP daemon revival was not exercised");
+      validateSearch(byId.get(4), "revived MCP semantic_search");
+      finish();
+    } catch (error) {
+      finish(error);
+    }
+  });
+  child.stdin.write(`${requests.map((request) => JSON.stringify(request)).join("\n")}\n`);
+NODE
+}
+if [ "$PF_EMULATED" = 1 ]; then
+  say "step graph-query-mcp: SKIPPED (emulated leg; daemon-runtime behavior binds on real runners)"
+else
+  run_step graph-query-mcp 0 "$PROBE" step_graph_query_mcp
+fi
+
+# ------------------------------------------------ 7. Graph-backed VFS projection proof
+step_vfs_projection() {
+  captures="$RUNNER_TEMP/kin-proof-captures"
+  mkdir -p "$captures"
+  probe_bin="$RUNNER_TEMP/vfs-open-probe"
+  cc -O2 -Wall -Wextra -Werror -x c -o "$probe_bin" - <<'C'
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+    if (argc != 2) {
+        fputs("usage: vfs-open-probe <path>\n", stderr);
+        return 2;
+    }
+
+    struct stat stdout_stat;
+    if (fstat(STDOUT_FILENO, &stdout_stat) != 0) {
+        perror("fstat(stdout)");
+        return 3;
+    }
+
+    int fd = open(argv[1], O_RDONLY);
+    if (fd < 0) {
+        perror("open");
+        return 4;
+    }
+
+    char buffer[4096];
+    for (;;) {
+        ssize_t count = read(fd, buffer, sizeof(buffer));
+        if (count == 0) {
+            break;
+        }
+        if (count < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            perror("read");
+            close(fd);
+            return 5;
+        }
+        for (ssize_t written = 0; written < count;) {
+            ssize_t step = write(STDOUT_FILENO, buffer + written, (size_t)(count - written));
+            if (step < 0 && errno == EINTR) {
+                continue;
+            }
+            if (step <= 0) {
+                perror("write");
+                close(fd);
+                return 6;
+            }
+            written += step;
+        }
+    }
+
+    if (close(fd) != 0) {
+        perror("close");
+        return 7;
+    }
+    return 0;
+}
+C
+
+  vfs_pid=""
+  cleanup_vfs() {
+    cleanup_status=0
+    chmod u+rw probe.py || cleanup_status=1
+    if [ -n "$vfs_pid" ]; then
+      kin-vfs stop --workspace . >> "$captures/kin-vfs-daemon.log" 2>&1 || cleanup_status=1
+      stopped=false
+      for _ in $(seq 1 150); do
+        process_state="$(ps -o stat= -p "$vfs_pid" 2>/dev/null || true)"
+        process_state="$(printf '%s' "$process_state" | tr -d '[:space:]')"
+        if [ -z "$process_state" ] || printf '%s\n' "$process_state" | grep -q 'Z'; then
+          stopped=true
+          break
+        fi
+        sleep 0.1
+      done
+      if [ "$stopped" != true ]; then
+        cat "$captures/kin-vfs-daemon.log" >&2
+        echo "installed kin-vfs daemon did not stop cleanly" >&2
+        kill "$vfs_pid" 2>/dev/null || true
+        sleep 1
+        kill -9 "$vfs_pid" 2>/dev/null || true
+        wait "$vfs_pid" 2>/dev/null || true
+        cleanup_status=1
+      else
+        wait_status=0
+        wait "$vfs_pid" || wait_status=$?
+        case "$wait_status" in
+          0|143) ;;
+          *)
+            echo "installed kin-vfs daemon exited with unexpected status $wait_status" >&2
+            cleanup_status=1
+            ;;
+        esac
+      fi
+      vfs_pid=""
+    fi
+    if [ -S .kin/vfs.sock ]; then
+      echo "installed kin-vfs socket remained after shutdown" >&2
+      cleanup_status=1
+    fi
+    test -r probe.py || cleanup_status=1
+    return "$cleanup_status"
+  }
+  on_vfs_signal() {
+    signal_status="$1"
+    trap - EXIT INT TERM
+    cleanup_vfs || true
+    exit "$signal_status"
+  }
+  trap 'cleanup_vfs || true' EXIT
+  trap 'on_vfs_signal 130' INT
+  trap 'on_vfs_signal 143' TERM
+
+  kin-vfs start --workspace . > "$captures/kin-vfs-daemon.log" 2>&1 &
+  vfs_pid=$!
+  socket_ready=false
+  for _ in $(seq 1 150); do
+    if [ -S .kin/vfs.sock ]; then
+      socket_ready=true
+      break
+    fi
+    if ! kill -0 "$vfs_pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.1
+  done
+  if [ "$socket_ready" != true ]; then
+    cat "$captures/kin-vfs-daemon.log" >&2
+    echo "installed kin-vfs daemon did not bind its socket" >&2
+    exit 1
+  fi
+
+  chmod 000 probe.py
+  set +e
+  "$probe_bin" "$PWD/probe.py" > "$captures/vfs-negative.txt" 2>&1
+  negative_status=$?
+  set -e
+  if [ "$negative_status" -ne 4 ]; then
+    cat "$captures/vfs-negative.txt" >&2
+    echo "negative control failed before the expected raw-disk open denial (status $negative_status)" >&2
+    exit 1
+  fi
+  if ! grep -Eq '^open: (Permission denied|Operation not permitted)$' "$captures/vfs-negative.txt"; then
+    cat "$captures/vfs-negative.txt" >&2
+    echo "negative control did not fail with the expected raw-disk permission error" >&2
+    exit 1
+  fi
+
+  KIN_VFS_STRICT=1 kin-vfs exec --workspace . -- \
+    "$probe_bin" "$PWD/probe.py" \
+    > "$captures/vfs-graph-read.txt" 2> "$captures/vfs-graph-read.stderr.txt"
+  printf 'def hello():\n    return 42\n' > "$captures/vfs-expected.txt"
+  if ! cmp -s "$captures/vfs-expected.txt" "$captures/vfs-graph-read.txt"; then
+    cmp -l "$captures/vfs-expected.txt" "$captures/vfs-graph-read.txt" >&2 || true
+    echo "installed VFS did not return the exact graph-owned probe.py bytes" >&2
+    exit 1
+  fi
+
+  trap - EXIT
+  cleanup_vfs
+  trap - INT TERM
+}
+if [ "$PF_EMULATED" = 1 ]; then
+  say "step vfs-projection: SKIPPED (emulated leg; the projection is served by the kin-vfs daemon through the preload shim, daemon-runtime that binds on real runners)"
+else
+  run_step vfs-projection 0 "$PROBE" step_vfs_projection
+fi
+
+# ------------------------------------- 8. Unix embedding and semantic retrieval proof
+step_embedding_retrieval() {
+  case "$PROOF_SHELL" in
+    bash)
+      unset PSModulePath PSVersionTable
+      export SHELL=/bin/bash
+      ;;
+    zsh)
+      unset PSModulePath PSVersionTable
+      export SHELL=/bin/zsh
+      ;;
+    *) echo "unsupported Unix install-proof shell: $PROOF_SHELL" >&2; exit 1 ;;
+  esac
+  captures="$RUNNER_TEMP/kin-proof-captures"
+  mkdir -p "$captures"
+  kin embed --max-seconds "$PF_EMBED_SECONDS" --json | tee "$captures/kin-embed.json"
+
+  PROOF_CAPTURES="$captures" PF_SETTLE_SECONDS="$PF_SETTLE_SECONDS" node <<'NODE'
+  const fs = require("fs");
+  const path = require("path");
+  const { execFileSync } = require("child_process");
+
+  const captures = process.env.PROOF_CAPTURES;
+  const budgetMs = Number(process.env.PF_SETTLE_SECONDS || 180) * 1000;
+  const pollSeconds = 1;
+  const log = [];
+  const record = (line) => {
+    log.push(line);
+    console.log(line);
+  };
+  const flush = () => {
+    fs.writeFileSync(
+      path.join(captures, "kin-embedding-settle.txt"),
+      `${log.join("\n")}\n`,
+    );
+  };
+
+  const fingerprint = (status) => {
+    const enrichment = status.semantic_enrichment ?? {};
+    const coverage = status.embedding_coverage ?? {};
+    return JSON.stringify({
+      repository_generation: status.repository?.generation,
+      workspace_generation: status.workspace?.generation,
+      authority_generation: enrichment.authority_generation,
+      enrichment_workspace_generation: enrichment.workspace_generation,
+      entity_count: enrichment.entity_count,
+      relation_count: enrichment.relation_count,
+      semantic_change_count: enrichment.semantic_change_count,
+      coverage_state: coverage.state,
+      coverage_reason: coverage.reason,
+      indexed: coverage.indexed,
+      pending: coverage.pending,
+      total: coverage.total,
+    });
+  };
+
+  const deadline = Date.now() + budgetMs;
+  let previous = null;
+  let last = "no status read completed";
+  let reads = 0;
+  let settled = false;
+  while (Date.now() < deadline) {
+    reads += 1;
+    let status;
+    try {
+      status = JSON.parse(
+        execFileSync("kin", ["status", "--json"], { encoding: "utf8", timeout: 120_000 }),
+      );
+    } catch (error) {
+      last = `kin status --json failed: ${error.message}`;
+      previous = null;
+      execFileSync("sleep", [String(pollSeconds)]);
+      continue;
+    }
+    const current = fingerprint(status);
+    last = current;
+    const coverage = status.embedding_coverage ?? {};
+    const drained =
+      coverage.state === "observed" &&
+      coverage.total > 0 &&
+      coverage.pending === 0 &&
+      coverage.indexed === coverage.total;
+    if (drained && current === previous) {
+      record(`settled after ${reads} reads: ${current}`);
+      settled = true;
+      break;
+    }
+    previous = current;
+    execFileSync("sleep", [String(pollSeconds)]);
+  }
+  if (!settled) {
+    record(`did not settle within ${budgetMs / 1000}s over ${reads} reads: ${last}`);
+    flush();
+    console.log(
+      `::error::the store never settled: ${last}. ` +
+      "Embedding coverage must reach observed with pending 0 and indexed equal to total, " +
+      "and two consecutive reads must agree that nothing new was admitted between them.",
+    );
+    process.exit(1);
+  }
+  flush();
+NODE
+
+  settle_probe="$(kin status --help 2>&1 || true)"
+  case "$settle_probe" in
+    *--wait-quiesce*)
+      printf 'bounded settle (kin status --wait-quiesce %s)\n' "$PF_QUIESCE_SECONDS" \
+        | tee "$captures/kin-status-settle-mode.txt"
+      kin status --json --wait-quiesce "$PF_QUIESCE_SECONDS" | tee "$captures/kin-embedded-status.json"
+      ;;
+    *)
+      printf 'single sample (installed kin has no --wait-quiesce)\n' \
+        | tee "$captures/kin-status-settle-mode.txt" >&2
+      kin status --json | tee "$captures/kin-embedded-status.json"
+      ;;
+  esac
+  kin setup status --json | tee "$captures/kin-embedded-health.json"
+  kin doctor --json | tee "$captures/kin-embedded-doctor.json"
+  kin search hello --semantic --json | tee "$captures/kin-semantic-search.json"
+  kin locate hello --json --explain --max-files 5 | tee "$captures/kin-semantic-locate.json"
+}
+if [ "$PF_EMULATED" = 1 ]; then
+  say "step embedding-retrieval: SKIPPED (emulated leg; daemon-runtime behavior binds on real runners)"
+else
+  run_step embedding-retrieval 0 "$PROBE" step_embedding_retrieval
+fi
+
+# ------------------------------- 9. Restore captured proof reports into the repo
+step_restore_captures() {
+  captures="$RUNNER_TEMP/kin-proof-captures"
+  destination="$PWD/kin-install-proof"
+  if [ ! -d "$captures" ]; then
+    echo "no proof captures were taken"
+    exit 0
+  fi
+  if [ ! -d "$destination" ]; then
+    echo "no proof repository exists to restore captures into"
+    exit 0
+  fi
+  restored=0
+  while IFS= read -r capture; do
+    [ -n "$capture" ] || continue
+    cp "$captures/$capture" "$destination/$capture"
+    restored=$((restored + 1))
+  done < <(ls -1 "$captures")
+  echo "restored $restored proof capture(s) into the proof repository"
+}
+# The restore and the validator run whatever happened before them, as the
+# workflow's always() steps do; a leg that died early still hands over what it
+# captured, and the assertions on missing captures read UNREADABLE beside the
+# step that failed.
+STOP_SAVED=$STOP
+STOP=0
+run_step restore-captures 0 "$WORKSPACE" step_restore_captures
+
+# ------------------------------------------ 10. Validate installed capability proof
+step_validate() {
+  PF_CAPTURES="$PWD" \
+  PF_HOME="$HOME" \
+  PF_INSTALLED_KIN="$(cat ../installed-kin-command.txt 2>/dev/null || true)" \
+  PF_EXPECTED_COMMIT="$PF_EXPECTED_COMMIT" \
+  PF_EXPECTED_LOCK_SHA="$PF_EXPECTED_LOCK_SHA" \
+  PF_RUNNER_OS="$RUNNER_OS" \
+  PF_ALLOW_DIRTY="$PF_ALLOW_DIRTY" \
+  PF_HOST_APPS="$PF_HOST_APPS" \
+  PF_RESULT_JSON="$PF_ROOT/validate.json" \
+    node "$PF_TOOLS/validate.mjs"
+}
+if [ -d "$PROBE" ]; then
+  run_step validate 0 "$PROBE" step_validate
+else
+  say "validate: no probe repository exists; nothing to validate"
+fi
+STOP=$STOP_SAVED
+
+# ------------------------------------------------------- 11. daemons off, then repro
+say "stopping the leg's daemons"
+stop_daemons
+
+step_magic_repro() {
+  if [ ! -f "$PF_TOOLS/kin-magic-repro" ]; then
+    echo "kin-magic-repro is absent from the tools staged for this run" >&2
+    exit 99
+  fi
+  [ -x "$PF_PYTHON" ] || command -v "$PF_PYTHON" >/dev/null 2>&1 || { echo "Python is required for kin-magic-repro" >&2; exit 99; }
+  mkdir -p "$PF_ROOT/repro"
+  # The suite mints kin commits in its fixtures, and kin refuses a commit with no
+  # configured author rather than inventing one. A developer host carries a
+  # global Git identity; this fresh HOME does not, so give it one here, after
+  # the install proof ran without it exactly as a hosted runner does.
+  git config --global user.name "kin-release-preflight"
+  git config --global user.email "preflight@firelock.invalid"
+  "$PF_PYTHON" "$PF_TOOLS/kin-magic-repro" \
+    --kin "$HOME/.kin/bin/kin" --daemon "$HOME/.kin/bin/kin-daemon" \
+    --workdir "$PF_ROOT/repro" --json "$PF_ROOT/repro.json" \
+    --label "preflight-$PF_LEG" --verbose 2>&1 | tee "$PF_ROOT/repro.log"
+  # The suite's own status is what decides; tee's is not.
+  return "${PIPESTATUS[0]}"
+}
+if [ "$PF_MAGIC_REPRO" = 1 ] && [ -x "$HOME/.kin/bin/kin" ] && [ -x "$HOME/.kin/bin/kin-daemon" ]; then
+  run_step magic-repro 0 "$PF_ROOT" step_magic_repro
+  stop_daemons
+fi
+
+# ------------------------------------------------------------------ 12. result
+PF_ROOT="$PF_ROOT" PF_LEG="$PF_LEG" STEPS_TSV="$STEPS_TSV" ARCHIVE_ENV="$PF_ROOT/archive.env" \
+PF_RUNNER_OS="$PF_RUNNER_OS" PF_RUNNER_ARCH="$PF_RUNNER_ARCH" PF_EXPECTED_COMMIT="$PF_EXPECTED_COMMIT" \
+PF_EXPECTED_LOCK_SHA="$PF_EXPECTED_LOCK_SHA" PF_ALLOW_DIRTY="$PF_ALLOW_DIRTY" \
+node - <<'NODE'
+const fs = require("fs");
+const path = require("path");
+const root = process.env.PF_ROOT;
+const readMaybe = (file) => (fs.existsSync(file) ? fs.readFileSync(file, "utf8") : "");
+const lastLines = (text, n) => text.split(/\r?\n/).map((l) => l.trimEnd()).filter(Boolean).slice(-n);
+const failingLine = (text) => {
+  const lines = text.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  const named = [...lines].reverse().find((l) => /^(Error:|::error::|STAMP MISMATCH|installed |negative control|kin init|the store never settled)/.test(l));
+  return named ?? lines[lines.length - 1] ?? "";
+};
+const steps = readMaybe(process.env.STEPS_TSV).split("\n").filter(Boolean).map((line) => {
+  const [slug, rc, seconds, log] = line.split("\t");
+  const status = rc === "skipped" ? "SKIPPED" : rc === "0" ? "PASS" : rc === "99" ? "UNREADABLE" : "FAIL";
+  const text = readMaybe(log);
+  return {
+    step: slug, status, exit: rc === "skipped" ? null : Number(rc), seconds: Number(seconds), log,
+    failing: status === "PASS" || status === "SKIPPED" ? "" : failingLine(text),
+    tail: status === "PASS" ? [] : lastLines(text, 8),
+  };
+});
+const archiveEnv = Object.fromEntries(readMaybe(process.env.ARCHIVE_ENV).split("\n").filter(Boolean).map((l) => {
+  const i = l.indexOf("="); return [l.slice(0, i), l.slice(i + 1)];
+}));
+let validate = null;
+if (fs.existsSync(path.join(root, "validate.json"))) validate = JSON.parse(fs.readFileSync(path.join(root, "validate.json"), "utf8"));
+let repro = null;
+const reproStep = steps.find((s) => s.step === "magic-repro") ?? null;
+if (reproStep && !fs.existsSync(path.join(root, "repro.json"))) {
+  repro = { version: null, counts: { PASS: 0, FAIL: 0, UNREADABLE: 0 }, total: 0, checks: [],
+    verdict: "UNREADABLE", note: `the suite wrote no repro.json (${reproStep.status}: ${reproStep.failing || "no detail"})` };
+}
+if (fs.existsSync(path.join(root, "repro.json"))) {
+  const r = JSON.parse(fs.readFileSync(path.join(root, "repro.json"), "utf8"));
+  const counts = { PASS: 0, FAIL: 0, UNREADABLE: 0 };
+  for (const row of r.results ?? []) counts[row.status] = (counts[row.status] ?? 0) + 1;
+  repro = {
+    version: r.version, counts, total: (r.results ?? []).length,
+    checks: (r.results ?? []).map((row) => ({ id: row.id, ticket: row.ticket, status: row.status, detail: row.detail })),
+    verdict: counts.FAIL > 0 ? "FAIL" : counts.UNREADABLE > 0 || (r.results ?? []).length === 0 ? "UNREADABLE" : "PASS",
+  };
+}
+// The leg verdict: the flow steps and the ported assertions. The magic repro
+// is reported beside it, not inside it, so each answers for itself.
+// The validate step's own exit is the tally of its assertions, which are
+// listed individually below, so it is not counted a second time as a step.
+const flowSteps = steps.filter((s) => s.step !== "magic-repro" && s.step !== "validate");
+const failing = [];
+for (const s of flowSteps) if (s.status === "FAIL") failing.push({ kind: "step", name: s.step, message: s.failing });
+for (const a of validate?.assertions ?? []) if (a.status === "FAIL") failing.push({ kind: "assertion", name: a.name, message: a.message });
+const unreadable = [];
+for (const s of flowSteps) if (s.status === "UNREADABLE") unreadable.push({ kind: "step", name: s.step, message: s.failing });
+for (const a of validate?.assertions ?? []) if (a.status === "UNREADABLE") unreadable.push({ kind: "assertion", name: a.name, message: a.message });
+if (!validate && !flowSteps.some((s) => s.status === "FAIL")) unreadable.push({ kind: "assertion", name: "validate", message: "the validator never ran" });
+const waived = (validate?.assertions ?? []).filter((a) => /^WAIVED/.test(a.message ?? "")).map((a) => ({ name: a.name, message: a.message }));
+const verdict = failing.length > 0 ? "FAIL" : unreadable.length > 0 ? "UNREADABLE" : "PASS";
+const glibc = steps.find((s) => s.step === "glibc-floor") ?? null;
+const result = {
+  schema: "kin.release-preflight.leg.v1",
+  leg: process.env.PF_LEG,
+  citable: false,
+  runner_os: process.env.PF_RUNNER_OS,
+  runner_arch: process.env.PF_RUNNER_ARCH,
+  archive: { path: archiveEnv.archive ?? null, sha256: archiveEnv.archive_sha256 ?? null },
+  binaries: {
+    kin: { version_line: archiveEnv.kin_version_line ?? null },
+    kin_daemon: { version_line: archiveEnv.daemon_version_line ?? null },
+    stamp_sha: archiveEnv.stamp_sha ?? null,
+    version: archiveEnv.install_version ?? null,
+  },
+  expected: { commit: process.env.PF_EXPECTED_COMMIT || null, lock_sha256: process.env.PF_EXPECTED_LOCK_SHA || null, allow_dirty: process.env.PF_ALLOW_DIRTY === "1" },
+  steps,
+  glibc_floor: glibc ? { status: glibc.status, detail: glibc.status === "PASS" ? lastLines(readMaybe(glibc.log), 2).join(" | ") : glibc.failing } : null,
+  assertions: validate,
+  magic_repro: repro,
+  failing,
+  unreadable,
+  waived,
+  verdict,
+};
+fs.writeFileSync(path.join(root, "result.json"), `${JSON.stringify(result, null, 2)}\n`);
+console.log(`proof-flow(${result.leg}): verdict ${verdict}` +
+  (failing.length ? `; first failure: ${failing[0].kind} ${failing[0].name}: ${failing[0].message}` : "") +
+  (repro ? `; magic-repro ${repro.counts.PASS} pass, ${repro.counts.FAIL} fail, ${repro.counts.UNREADABLE} unreadable` : ""));
+process.exit(verdict === "PASS" ? 0 : verdict === "FAIL" ? 1 : 2);
+NODE
+FINAL_RC=$?
+exit "$FINAL_RC"

--- a/scripts/release-proof/bin/kin-release-preflight.d/validate.mjs
+++ b/scripts/release-proof/bin/kin-release-preflight.d/validate.mjs
@@ -1,0 +1,656 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+//
+// The "Validate installed capability proof" block of kin's install-proof.yml,
+// ported assertion for assertion, plus the local-run substitutes for the
+// publish-fetch bindings that block reads from files.
+//
+// Every assertion is recorded rather than thrown at first failure, so one run
+// names every failing assertion instead of the first. Three outcomes:
+//   PASS        the assertion held
+//   FAIL        the assertion was evaluated and did not hold (the workflow
+//               would have thrown exactly this message)
+//   UNREADABLE  the assertion could not be evaluated: a capture is missing or
+//               unparsable, or the expected value was never resolved locally.
+//               Never reported as PASS.
+//
+// PORTED_FROM records the sha256 of the install-proof.yml this file was ported
+// from. The driver compares it against the workflow at the ref under test and
+// REFUSES to run when they differ, because a PASS produced by a stale port is a
+// PASS against assertions the release gate no longer runs, and the report names
+// the verdict without naming which contract produced it. Re-read the block by
+// hand and update this constant; the driver prints the procedure when it
+// refuses.
+//
+// Inputs (environment):
+//   PF_CAPTURES         directory holding the captured proof files
+//   PF_HOME             the isolated HOME the flow ran under
+//   PF_INSTALLED_KIN    the launcher path recorded by the install step
+//   PF_EXPECTED_COMMIT  40-hex commit the binaries must report, or empty
+//   PF_EXPECTED_LOCK_SHA 64-hex sha256 of that commit's Cargo.lock, or empty
+//   PF_RUNNER_OS        macOS | Linux
+//   PF_LOCAL_BUILD      1 declares that the bytes under test carry no kin-vfs,
+//                       the port of the workflow's `local_artifact` mode. The
+//                       workflow sets that input when a pull request installs
+//                       binaries it built itself, which exist for kin and
+//                       kin-daemon only, and the capability contract then
+//                       requires vfs_projection unsupported rather than
+//                       healthy. No preflight leg sets it today: --archive and
+//                       --rc-run judge whole release-layout archives, and
+//                       --build overlays the built kin and kin-daemon onto a
+//                       base release archive that supplies kin-vfs, the shim
+//                       and KinNotifier.app. It is carried so the two
+//                       contracts stay diffable, and so a future mode that
+//                       does drop the VFS bytes has to say so rather than
+//                       silently failing an assertion that was right
+//   PF_EMULATED         1 waives assertions whose capture is missing: an
+//                       emulated leg skips the daemon-runtime producer steps,
+//                       so those captures are absent by design (present
+//                       captures are still judged in full)
+//   PF_ALLOW_DIRTY      1 waives the clean-source assertions (dirty, commit,
+//                       lock provenance) and reports them as WAIVED
+//   PF_HOST_APPS        comma list of clients this host detects through an
+//                       application installed outside HOME (cursor, windsurf,
+//                       antigravity). kin setup detects those by absolute
+//                       /Applications paths, which no HOME isolation hides, so
+//                       their appearance in the isolated fallback HOME is a fact
+//                       about this host and not a leak; the exposure assertion
+//                       is waived for exactly those ids and says so
+//   PF_RESULT_JSON      where to write the assertion list
+//   cwd                 the probe repository (kin-install-proof)
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Resynced 2026-08-22 (third time) against install-proof.yml carrying
+// kin#1079, which makes every matrix row gate the release by dropping the
+// Windows leg's continue-on-error waiver and its experimental flag, and stops
+// the two `kin setup` steps piping through `tee`, because the long-lived child
+// setup leaves behind inherits the write end of the pipe and holds it for the
+// daemon's full idle window. Neither change is an assertion. The gating
+// posture is job-level, and the setup capture is a producer step, ported into
+// proof-flow.sh beside this file. The mirrored "Validate installed capability
+// proof" step is byte for byte identical between the two pins, so this resync
+// moves the pin with no assertion delta, as the kin#1069 (job timeout) and
+// kin#1060 (Windows repo-free provenance step) resyncs before it did.
+export const PORTED_FROM = {
+  file: ".github/workflows/install-proof.yml",
+  sha256: "0c469d2871a1a6b02944a2ddc5f12482a1556af4179f8f66bbfa018443ee2878",
+};
+
+class Unreadable extends Error {}
+
+const captures = process.env.PF_CAPTURES || process.cwd();
+const runnerOs = process.env.PF_RUNNER_OS || (process.platform === "darwin" ? "macOS" : "Linux");
+const isWindows = runnerOs === "Windows";
+// The workflow's `isPullRequestBuild`, which it derives from the LOCAL_ARTIFACT
+// input. See PF_LOCAL_BUILD above for why no preflight leg sets this.
+const isLocalBuild = process.env.PF_LOCAL_BUILD === "1";
+const allowDirty = process.env.PF_ALLOW_DIRTY === "1";
+const emulated = process.env.PF_EMULATED === "1";
+const home = process.env.PF_HOME || os.homedir();
+const hostApps = (process.env.PF_HOST_APPS || "").split(",").map((s) => s.trim()).filter(Boolean);
+
+const results = [];
+const record = (status, name, message) => {
+  results.push({ status, name, message });
+  const line = `ASSERT ${status.padEnd(10)} ${name}${message ? `: ${message}` : ""}`;
+  console.log(line);
+};
+
+const check = (name, fn) => {
+  try {
+    const message = fn();
+    record("PASS", name, typeof message === "string" ? message : "");
+  } catch (error) {
+    const missing =
+      error instanceof Unreadable || (error && error.code === "ENOENT");
+    if (missing && emulated) {
+      // An emulated leg skips the daemon-runtime steps, so their captures are
+      // absent by design rather than lost; a capture that IS present is still
+      // judged in full above. Real-runner legs bind these assertions.
+      record(
+        "PASS",
+        name,
+        `WAIVED emulated leg: ${error.message}; its producer step is daemon-runtime and does not run under CPU emulation`,
+      );
+    } else if (error instanceof Unreadable) {
+      record("UNREADABLE", name, error.message);
+    } else if (error && error.code === "ENOENT") {
+      record("UNREADABLE", name, `capture missing: ${error.path ?? error.message}`);
+    } else {
+      record("FAIL", name, error.message);
+    }
+  }
+};
+
+const readText = (file) => {
+  const resolved = path.isAbsolute(file) ? file : path.join(captures, file);
+  if (!fs.existsSync(resolved)) {
+    throw new Unreadable(`capture missing: ${resolved}`);
+  }
+  return fs.readFileSync(resolved, "utf8");
+};
+const readJson = (file) => {
+  const text = readText(file);
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Unreadable(`${file}: not JSON (${error.message}); first bytes: ${JSON.stringify(text.slice(0, 120))}`);
+  }
+};
+const readJsonAt = (absolute) => {
+  if (!fs.existsSync(absolute)) {
+    throw new Unreadable(`file missing: ${absolute}`);
+  }
+  try {
+    return JSON.parse(fs.readFileSync(absolute, "utf8"));
+  } catch (error) {
+    throw new Unreadable(`${absolute}: not JSON (${error.message})`);
+  }
+};
+
+const expectedCommit = (process.env.PF_EXPECTED_COMMIT || "").trim();
+const expectedLock = (process.env.PF_EXPECTED_LOCK_SHA || "").trim();
+const installedKin = (process.env.PF_INSTALLED_KIN || "").trim();
+
+// ---------------------------------------------------------------------------
+// Verify binaries installed + runnable (the local half of that step)
+// ---------------------------------------------------------------------------
+check("installed launcher path", () => {
+  const expectedInstalledKin = path.join(home, ".kin", "bin", isWindows ? "kin.exe" : "kin");
+  if (installedKin !== expectedInstalledKin) {
+    throw new Error(`installed Kin command proof ${installedKin || "missing"} does not equal ${expectedInstalledKin}`);
+  }
+  return installedKin;
+});
+
+// ---------------------------------------------------------------------------
+// Validate installed capability proof
+// ---------------------------------------------------------------------------
+const fullSha = /^[0-9a-f]{40}$/;
+const lockSha = /^[0-9a-f]{64}$/;
+
+check("kin-build-meta.json schema", () => {
+  const cliMeta = readJson("kin-build-meta.json");
+  if (cliMeta.schema !== "kin.bench-meta.v2") {
+    throw new Error(`kin-build-meta.json: unsupported schema ${cliMeta.schema ?? "missing"}`);
+  }
+});
+
+const buildsOf = () => {
+  const cliMeta = readJson("kin-build-meta.json");
+  const daemonHealth = readJson("kin-daemon-health.json");
+  return new Map([
+    ["cli", {
+      sha: cliMeta.kin_commit,
+      dirty: cliMeta.kin_dirty,
+      sourceKnown: cliMeta.kin_source_known,
+      dependencyProvenance: cliMeta.dependency_provenance,
+    }],
+    ["daemon", {
+      sha: daemonHealth.build?.sha,
+      dirty: daemonHealth.build?.dirty,
+      sourceKnown: daemonHealth.build?.source_known,
+      dependencyProvenance: daemonHealth.build?.dependency_provenance,
+    }],
+  ]);
+};
+
+for (const side of ["cli", "daemon"]) {
+  check(`${side} build SHA is a full commit`, () => {
+    const build = buildsOf().get(side);
+    if (!fullSha.test(build.sha ?? "")) {
+      throw new Error(`${side} build SHA is not a full 40-hex commit: ${build.sha ?? "missing"}`);
+    }
+    return build.sha;
+  });
+  check(`${side} build SHA matches the expected commit`, () => {
+    const build = buildsOf().get(side);
+    if (!expectedCommit) {
+      throw new Unreadable("no expected commit was resolved for this run");
+    }
+    if (build.sha !== expectedCommit) {
+      if (allowDirty) return `WAIVED (--allow-dirty): ${side} build SHA ${build.sha} does not match ${expectedCommit}`;
+      throw new Error(`${side} build SHA ${build.sha} does not match release tag ${expectedCommit}`);
+    }
+  });
+  check(`${side} release binary is clean`, () => {
+    const build = buildsOf().get(side);
+    if (build.dirty !== false) {
+      if (allowDirty) return `WAIVED (--allow-dirty): ${side} binary reports dirty=${build.dirty}`;
+      throw new Error(`${side} release binary is dirty or did not report a clean build`);
+    }
+  });
+  check(`${side} release binary proves source_known`, () => {
+    const build = buildsOf().get(side);
+    if (build.sourceKnown !== true) {
+      throw new Error(`${side} release binary did not prove source_known=true`);
+    }
+  });
+  check(`${side} Cargo.lock provenance is well formed`, () => {
+    const build = buildsOf().get(side);
+    if (!lockSha.test(build.dependencyProvenance ?? "")) {
+      throw new Error(`${side} Cargo.lock provenance is missing or malformed`);
+    }
+  });
+  check(`${side} Cargo.lock provenance matches the source`, () => {
+    const build = buildsOf().get(side);
+    if (!expectedLock) {
+      throw new Unreadable("no expected Cargo.lock sha256 was resolved for this run");
+    }
+    if (build.dependencyProvenance !== expectedLock) {
+      if (allowDirty) return `WAIVED (--allow-dirty): ${side} Cargo.lock provenance ${build.dependencyProvenance} does not match ${expectedLock}`;
+      throw new Error(`${side} Cargo.lock provenance ${build.dependencyProvenance} does not match release source ${expectedLock}`);
+    }
+  });
+}
+check("CLI and daemon share Cargo.lock provenance", () => {
+  const builds = buildsOf();
+  if (builds.get("cli").dependencyProvenance !== builds.get("daemon").dependencyProvenance) {
+    throw new Error("CLI and daemon were built from different Cargo.lock provenance");
+  }
+});
+
+check("kin-status.json schema", () => {
+  const status = readJson("kin-status.json");
+  if (status.schema !== "kin.status.v3") {
+    throw new Error(`kin-status.json: unsupported schema ${status.schema ?? "missing"}`);
+  }
+});
+
+const validateEmbeddingCoverage = (coverage, label) => {
+  if (!coverage || typeof coverage !== "object" || Array.isArray(coverage)) {
+    throw new Error(`${label}: embedding_coverage is missing or malformed`);
+  }
+  if (coverage.state === "observed") {
+    if (coverage.source !== "live_query_graph") {
+      throw new Error(`${label}: observed coverage has source ${coverage.source ?? "missing"}`);
+    }
+    for (const field of ["indexed", "pending", "total"]) {
+      if (!Number.isSafeInteger(coverage[field]) || coverage[field] < 0) {
+        throw new Error(`${label}: embedding_coverage.${field} is not a non-negative integer`);
+      }
+    }
+    if (coverage.reason !== undefined || coverage.indexed > coverage.total || coverage.pending < coverage.total - coverage.indexed) {
+      throw new Error(`${label}: observed embedding coverage violates kin.status.v3 invariants`);
+    }
+  } else if (coverage.state === "unobserved") {
+    if (typeof coverage.reason !== "string" || coverage.reason.length === 0) {
+      throw new Error(`${label}: unobserved embedding coverage carries no reason`);
+    }
+    for (const field of ["source", "indexed", "pending", "total"]) {
+      if (coverage[field] !== undefined) {
+        throw new Error(`${label}: unobserved embedding coverage carries ${field}`);
+      }
+    }
+  } else {
+    throw new Error(`${label}: unknown embedding coverage state ${coverage.state ?? "missing"}`);
+  }
+};
+
+check("bench metadata proves vector and embedding support", () => {
+  const cliMeta = readJson("kin-build-meta.json");
+  if (cliMeta.embeddings?.vector_enabled !== true || cliMeta.embeddings?.embeddings_enabled !== true) {
+    throw new Error(`${runnerOs} bench metadata does not prove vector and embedding support`);
+  }
+});
+if (!isWindows) {
+  check("kin-status.json embedding coverage shape", () => {
+    const status = readJson("kin-status.json");
+    validateEmbeddingCoverage(status.embedding_coverage, "kin-status.json");
+  });
+}
+
+// --- BEGIN HEALTH JOIN ---
+// A check is out of scope only when the platform or the context puts it out of
+// scope, which is exactly `unsupported`. Every other status is a component that
+// is not answering at full strength, so a report claiming readiness over one
+// claims more than its components support (FIR-2919).
+const healthNeedsAttention = (check) =>
+  check.status !== "healthy" && check.status !== "unsupported";
+// Something wrong with the INSTALL, as against work in flight or ground the
+// host never had. A different question from the one above, and conflating the
+// two is what fenced v0.6.1.
+const healthBlocksReadiness = (check) =>
+  check.status === "missing" ||
+  check.status === "misconfigured" ||
+  (check.id === "semantic_query_readiness" && check.status === "stale");
+const healthJoin = (checks) => {
+  if (checks.some(healthBlocksReadiness)) return "failing";
+  return checks.some(healthNeedsAttention) ? "needs_attention" : "ready";
+};
+// --- END HEALTH JOIN ---
+const attentionRows = (report) => (report.checks ?? [])
+  .filter(healthNeedsAttention)
+  .map((check) => `${check.id}=${check.status}`)
+  .join(", ") || "none";
+const validateHealthReport = (report, reportPath) => {
+  if (!Array.isArray(report.checks)) {
+    throw new Error(`${reportPath}: checks is missing or malformed`);
+  }
+  const checks = new Map(report.checks.map((check) => [check.id, check]));
+  if (checks.size !== report.checks.length) {
+    throw new Error(`${reportPath}: duplicate health-check ids are not authoritative`);
+  }
+  // Required, not optional. A report with no `verdict` came from a build that
+  // predates FIR-2919, whose aggregate gated on missing and misconfigured alone
+  // and read `true` over a pending or degraded row. Grading it against either
+  // rule would be a claim about bytes that cannot carry it.
+  if (report.verdict === undefined) {
+    throw new Error(
+      `${reportPath}: the report carries no verdict field, so these bytes predate FIR-2919 and their aggregate cannot be graded against the health join`
+    );
+  }
+  const verdict = healthJoin(report.checks);
+  if (report.verdict !== verdict) {
+    throw new Error(`${reportPath}: verdict=${report.verdict} disagrees with checks; expected ${verdict}`);
+  }
+  if (report.healthy !== (verdict === "ready")) {
+    throw new Error(
+      `${reportPath}: aggregate healthy=${report.healthy} disagrees with checks; expected ${verdict === "ready"}`
+    );
+  }
+  return checks;
+};
+
+for (const fallbackReportPath of [
+  "kin-claude-fallback-health.json",
+  "kin-claude-fallback-doctor.json",
+]) {
+  check(`${fallbackReportPath} forced Claude fallback`, () => {
+    const fallbackReport = readJson(fallbackReportPath);
+    const fallbackChecks = validateHealthReport(fallbackReport, fallbackReportPath);
+    if (fallbackChecks.get("mcp_client_claude")?.status !== "healthy") {
+      throw new Error(`${fallbackReportPath}: forced Claude fallback config is not healthy`);
+    }
+    const waived = [];
+    for (const absentId of [
+      "mcp_client_cursor",
+      "mcp_client_codex",
+      "mcp_client_gemini",
+      "mcp_client_windsurf",
+      "mcp_client_antigravity",
+    ]) {
+      if (fallbackChecks.has(absentId)) {
+        const client = absentId.replace(/^mcp_client_/, "");
+        if (hostApps.includes(client)) {
+          waived.push(absentId);
+          continue;
+        }
+        throw new Error(`${fallbackReportPath}: isolated fallback HOME unexpectedly exposed ${absentId}`);
+      }
+    }
+    if (waived.length > 0) {
+      return `WAIVED host divergence: ${waived.join(", ")} detected through /Applications on this host (a hosted runner has no such app); PATH- and HOME-detected clients were still required absent`;
+    }
+  });
+}
+
+const required = new Map([
+  ["kin_binary", "healthy"],
+  ["kin_daemon_binary", "healthy"],
+  ["daemon_running", "healthy"],
+  ["repo_init", "healthy"],
+  ["shell_path", "healthy"],
+  ["setup_ledger", "healthy"],
+  ["registry_authority", isWindows ? "unsupported" : "healthy"],
+  ["vfs_projection", isWindows || isLocalBuild ? "unsupported" : "healthy"],
+  ["mcp_client_claude", "healthy"],
+  ["mcp_client_cursor", "healthy"],
+  ["mcp_client_codex", "healthy"],
+  ["mcp_client_gemini", "healthy"],
+  ["mcp_client_windsurf", "healthy"],
+  ["mcp_client_antigravity", "healthy"],
+  ["mcp_client_antigravity_workspace", "healthy"],
+]);
+
+for (const reportPath of ["kin-health.json", "kin-doctor.json"]) {
+  check(`${reportPath} aggregate health`, () => {
+    const report = readJson(reportPath);
+    const checks = validateHealthReport(report, reportPath);
+    // Every row a correct fresh Unix install reports beyond healthy and
+    // not-applicable, named with the statuses it may hold. This capture
+    // runs before `kin embed`, so the daemon graph still has embeddings
+    // pending and the model has never been fetched.
+    //
+    // This used to read `report.healthy !== true` with one tolerance for
+    // a stale readiness. On the v0.6.1 release run's own
+    // `install-proof-ubuntu-latest-33235776577` artifact,
+    // `kin-health.json` carried FIVE rows needing attention under
+    // `healthy: true`, so that assertion passed while naming none of
+    // them. Listing them is what makes a sixth fail (FIR-2919).
+    const firstRunAttention = new Map([
+      ["projection_mode", ["stale"]],
+      ["semantic_query_readiness", ["pending", "stale"]],
+      ["reference_edge_coverage", ["pending"]],
+      ["embedding_model", ["pending"]],
+      ["memory_floor", ["degraded"]],
+      // The first relation census is its own background pass, so a
+      // capture that beats it reads `pending`, the same first-run
+      // class as reference_edge_coverage above. The v0.6.2 preflight
+      // measured exactly that on a native-arch containerized fresh
+      // install (both health captures pending) while the workflow's
+      // own v0.6.1 arm leg happened to win the race and read healthy,
+      // so whether the row appears is host timing, not install state
+      // (kin#1238).
+      ["relation_census", ["pending"]],
+    ]);
+    const untolerated = report.checks.filter(
+      (check) =>
+        healthNeedsAttention(check) &&
+        !(firstRunAttention.get(check.id) ?? []).includes(check.status)
+    );
+    if (untolerated.length > 0) {
+      throw new Error(
+        `${reportPath}: rows needing attention that a fresh install does not expect: ` +
+        `${untolerated.map((check) => `${check.id}=${check.status}`).join(", ")}; ` +
+        `verdict=${report.verdict}; every row needing attention: ${attentionRows(report)}`
+      );
+    }
+    void checks;
+  });
+  check(`${reportPath} required check statuses`, () => {
+    const report = readJson(reportPath);
+    const checks = validateHealthReport(report, reportPath);
+    for (const [id, expected] of required) {
+      const actual = checks.get(id)?.status;
+      if (actual !== expected) {
+        throw new Error(`${reportPath}: ${id} is ${actual ?? "missing"}, expected ${expected}`);
+      }
+    }
+  });
+  check(`${reportPath} semantic_query_readiness`, () => {
+    const report = readJson(reportPath);
+    const checks = validateHealthReport(report, reportPath);
+    const semanticReadiness = checks.get("semantic_query_readiness")?.status;
+    const allowedSemanticReadiness = ["healthy", "pending", "stale"];
+    if (!allowedSemanticReadiness.includes(semanticReadiness)) {
+      throw new Error(
+        `${reportPath}: semantic_query_readiness is ${semanticReadiness ?? "missing"}, expected ${allowedSemanticReadiness.join(" or ")}`
+      );
+    }
+    return semanticReadiness;
+  });
+  check(`${reportPath} no hard failures`, () => {
+    const report = readJson(reportPath);
+    validateHealthReport(report, reportPath);
+    const hardFailures = report.checks.filter((check) =>
+      check.status === "missing" || check.status === "misconfigured"
+    );
+    if (hardFailures.length > 0) {
+      throw new Error(`${reportPath}: hard failures: ${hardFailures.map((c) => c.id).join(", ")}`);
+    }
+  });
+}
+
+check("lexical kin search returns the seeded hello entity", () => {
+  const search = readJson("kin-search.json");
+  if (!Array.isArray(search) || !search.some((record) => record.name === "hello" && record.file === "probe.py")) {
+    throw new Error("lexical kin search did not return the seeded hello entity");
+  }
+});
+check("kin locate returns the seeded probe.py graph artifact", () => {
+  const locate = readJson("kin-locate.json");
+  if (!locate.files?.some((entry) => entry.path === "probe.py")) {
+    throw new Error("kin locate did not return the seeded probe.py graph artifact");
+  }
+});
+
+check("MCP client configs bind the installed launcher", () => {
+  const repoRoot = fs.realpathSync(process.cwd());
+  const ordinaryArgs = ["mcp", "start"];
+  const repositoryArgs = ["mcp", "start", "--repo", repoRoot];
+  const mcpConfigs = [
+    { path: path.join(home, ".claude.json"), args: ordinaryArgs },
+    { path: path.join(home, ".cursor", "mcp.json"), args: ordinaryArgs },
+    { path: path.join(home, ".gemini", "settings.json"), args: ordinaryArgs },
+    { path: path.join(home, ".codeium", "windsurf", "mcp_config.json"), args: ordinaryArgs },
+    { path: path.join(captures, "kin-claude-fallback-config.json"), args: ordinaryArgs },
+    { path: path.join(captures, "kin-codex-config.json"), args: repositoryArgs },
+    { path: path.join(home, ".gemini", "config", "mcp_config.json"), args: repositoryArgs, cwd: repoRoot },
+    { path: path.join(home, ".gemini", "antigravity-ide", "mcp_config.json"), args: repositoryArgs, cwd: repoRoot },
+    { path: path.join(repoRoot, ".agents", "mcp_config.json"), args: repositoryArgs, cwd: repoRoot },
+  ];
+  const stripVerbatim = (p) => (typeof p === "string" && p.startsWith("\\\\?\\") ? p.slice(4) : p);
+  for (const expected of mcpConfigs) {
+    const entry = readJsonAt(expected.path)?.mcpServers?.kin;
+    const entryArgs = Array.isArray(entry?.args) ? entry.args.map(stripVerbatim) : entry?.args;
+    if (
+      !entry ||
+      entry.command !== installedKin ||
+      JSON.stringify(entryArgs) !== JSON.stringify(expected.args) ||
+      entry.env?.KIN_MCP_TOOL_PROFILE !== "agent-default" ||
+      (expected.cwd !== undefined && stripVerbatim(entry.cwd) !== expected.cwd)
+    ) {
+      throw new Error(`${expected.path}: Kin MCP entry is missing or malformed`);
+    }
+  }
+  return `${mcpConfigs.length} configs`;
+});
+check("Antigravity legacy repair preserved user policy", () => {
+  const legacy = readJsonAt(path.join(home, ".gemini", "antigravity-ide", "mcp_config.json"));
+  if (legacy.userPolicy !== "preserve" || legacy.mcpServers.kin.env.USER_POLICY !== "preserve") {
+    throw new Error("Antigravity legacy repair did not preserve unrelated user policy");
+  }
+});
+
+if (!isWindows) {
+  check("bounded clean-install embedding reached full coverage", () => {
+    const embed = readJson("kin-embed.json");
+    if (embed.pending_entities !== 0 || embed.pending_artifacts !== 0 || embed.time_limited === true) {
+      throw new Error(`bounded clean-install embedding did not reach full coverage: ${JSON.stringify(embed)}`);
+    }
+  });
+  check("kin-embedded-status.json schema", () => {
+    const embeddedStatus = readJson("kin-embedded-status.json");
+    if (embeddedStatus.schema !== "kin.status.v3") {
+      throw new Error(`kin-embedded-status.json: unsupported schema ${embeddedStatus.schema ?? "missing"}`);
+    }
+  });
+  check("kin-embedded-status.json embedding coverage shape", () => {
+    const embeddedStatus = readJson("kin-embedded-status.json");
+    validateEmbeddingCoverage(embeddedStatus.embedding_coverage, "kin-embedded-status.json");
+  });
+  check("Unix status observed embedding coverage after settle", () => {
+    const embeddedStatus = readJson("kin-embedded-status.json");
+    const embeddedCoverage = embeddedStatus.embedding_coverage;
+    const settleMode = fs.existsSync(path.join(captures, "kin-status-settle-mode.txt"))
+      ? fs.readFileSync(path.join(captures, "kin-status-settle-mode.txt"), "utf8").trim()
+      : "unrecorded";
+    if (embeddedCoverage?.state !== "observed") {
+      throw new Error(
+        `Unix status could not observe embedding coverage after a ${settleMode} read: ` +
+        `${JSON.stringify(embeddedCoverage)}`
+      );
+    }
+    return settleMode;
+  });
+  check("Unix status proves complete observed embedding coverage", () => {
+    const embeddedStatus = readJson("kin-embedded-status.json");
+    const embeddedCoverage = embeddedStatus.embedding_coverage ?? {};
+    if (
+      embeddedCoverage.source !== "live_query_graph" ||
+      embeddedCoverage.total === 0 ||
+      embeddedCoverage.indexed !== embeddedCoverage.total ||
+      embeddedCoverage.pending !== 0
+    ) {
+      throw new Error(`Unix status did not prove complete observed embedding coverage: ${JSON.stringify(embeddedCoverage)}`);
+    }
+    return `indexed ${embeddedCoverage.indexed}/${embeddedCoverage.total}`;
+  });
+  for (const reportPath of ["kin-embedded-health.json", "kin-embedded-doctor.json"]) {
+    check(`${reportPath} healthy with semantic readiness`, () => {
+      const report = readJson(reportPath);
+      const checks = validateHealthReport(report, reportPath);
+      const readiness = checks.get("semantic_query_readiness")?.status;
+      if (readiness !== "healthy") {
+        throw new Error(
+          `${reportPath}: semantic_query_readiness=${readiness ?? "missing"} after a ` +
+          `completed embed; verdict=${report.verdict}; every row needing attention: ` +
+          `${attentionRows(report)}`
+        );
+      }
+      // What a completed embed leaves behind on this runner, named. The
+      // model is cached and the fill is done, so `embedding_model` and
+      // `semantic_query_readiness` are gone from the list the pre-embed
+      // capture carries; the three below are the runner, not the embed.
+      // This used to read `report.healthy !== true`, which passed on the
+      // v0.6.1 run's own `kin-embedded-health.json` while those three
+      // rows sat inside it unnamed (FIR-2919). Naming them is what makes
+      // a fourth fail.
+      const postEmbedAttention = new Map([
+        ["projection_mode", ["stale"]],
+        ["reference_edge_coverage", ["pending"]],
+        ["memory_floor", ["degraded"]],
+        // The census pass is not tied to `kin embed`, so a capture can
+        // still beat it after a completed embed; same measurement as
+        // the pre-embed entry (kin#1238).
+        ["relation_census", ["pending"]],
+      ]);
+      const stillWaiting = report.checks.filter(
+        (check) =>
+          healthNeedsAttention(check) &&
+          !(postEmbedAttention.get(check.id) ?? []).includes(check.status)
+      );
+      if (stillWaiting.length > 0) {
+        throw new Error(
+          `${reportPath}: rows needing attention after a completed embed that this ` +
+          `runner does not expect: ` +
+          `${stillWaiting.map((check) => `${check.id}=${check.status}`).join(", ")}; ` +
+          `verdict=${report.verdict}`
+        );
+      }
+    });
+  }
+  check("semantic kin search returns the seeded hello entity", () => {
+    const semanticSearch = readJson("kin-semantic-search.json");
+    if (!Array.isArray(semanticSearch) || !semanticSearch.some((record) => record.name === "hello" && record.file === "probe.py")) {
+      throw new Error("semantic kin search did not return the seeded hello entity");
+    }
+  });
+  check("semantic kin locate proves complete coverage and returns probe.py", () => {
+    const semanticLocate = readJson("kin-semantic-locate.json");
+    if (semanticLocate.semantic_coverage?.supported !== true || semanticLocate.semantic_coverage?.complete !== true || !semanticLocate.files?.some((entry) => entry.path === "probe.py")) {
+      throw new Error(
+        "semantic kin locate did not prove complete coverage and return probe.py; " +
+        `semantic_coverage=${JSON.stringify(semanticLocate.semantic_coverage ?? null)} ` +
+        `files=${JSON.stringify((semanticLocate.files ?? []).map((entry) => entry.path))}`
+      );
+    }
+    return `semantic_coverage=${JSON.stringify(semanticLocate.semantic_coverage)}`;
+  });
+}
+
+const counts = { PASS: 0, FAIL: 0, UNREADABLE: 0 };
+for (const result of results) counts[result.status] += 1;
+console.log(`validate: ${counts.PASS} pass, ${counts.FAIL} fail, ${counts.UNREADABLE} unreadable`);
+if (process.env.PF_RESULT_JSON) {
+  fs.writeFileSync(
+    process.env.PF_RESULT_JSON,
+    `${JSON.stringify({ ported_from: PORTED_FROM, counts, assertions: results }, null, 2)}\n`,
+  );
+}
+process.exit(counts.FAIL > 0 ? 1 : counts.UNREADABLE > 0 ? 2 : 0);

--- a/scripts/release-proof/merge-preflight-records.mjs
+++ b/scripts/release-proof/merge-preflight-records.mjs
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+// Merge the per-archive preflight leg records rc-build.yml uploads into the one
+// preflight.json the mint reads.
+//
+// The local preflight judges every archive in one run and writes one record.
+// Hosted, each archive is judged on the runner that can execute it (macOS for
+// the macOS archive, an arm64 and an x86_64 Linux runner for the Linux ones),
+// so the legs arrive as separate records under separate artifacts. The evidence
+// branch is append-only and keyed by candidate sha, so those records cannot be
+// published one after another under one sha: the second would be refused as a
+// different answer for the same candidate. They are merged here instead, and
+// the merged record is judged by the mint's own gate before anything publishes
+// it, so a record this tool writes is a record the mint can accept.
+//
+// Deterministic on purpose. The publisher treats a byte-identical re-publish as
+// a no-op and a different one as tampering, so a merge repeated for the same
+// leg records has to reproduce the same bytes: nothing about the merging run
+// (its id, its clock) reaches the output, and the legs are ordered by target.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { PREFLIGHT_SCHEMA, judgePreflight } from '../check-release-proof-artifacts.mjs';
+
+export const HOSTED_LANE = 'HOSTED-CI';
+const COMMIT_SHA = /^[0-9a-f]{40}$/;
+
+function usage(message) {
+  process.stderr.write(
+    `${message}\n\n` +
+    'usage: merge-preflight-records.mjs --candidate <40-hex sha> --out <file> <leg record>...\n',
+  );
+  process.exit(2);
+}
+
+export function parseArgs(argv) {
+  const args = { records: [] };
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    switch (flag) {
+      case '--candidate': args.candidate = argv[i + 1]; i += 1; break;
+      case '--out': args.out = argv[i + 1]; i += 1; break;
+      default:
+        if (flag.startsWith('--')) usage(`unknown argument: ${flag}`);
+        args.records.push(flag);
+    }
+  }
+  if (!args.candidate || !COMMIT_SHA.test(args.candidate)) {
+    usage(`--candidate must be a 40-character commit sha, got "${args.candidate ?? ''}"`);
+  }
+  if (!args.out) usage('--out is required');
+  if (args.records.length === 0) usage('at least one leg record is required');
+  return args;
+}
+
+function requireObject(value, where) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${where} is not a preflight record object`);
+  }
+  return value;
+}
+
+// Every leg record has to be a passing preflight record about this candidate
+// on its own before it contributes a leg. A merge that admitted a failing leg
+// record and then reported PASS because the other legs passed would be the
+// silent half of exactly the class the gate exists to refuse.
+export function admitLegRecord(record, candidate, where) {
+  requireObject(record, where);
+  if (record.schema !== PREFLIGHT_SCHEMA) {
+    throw new Error(`${where} carries schema "${record.schema ?? '<none>'}", not ${PREFLIGHT_SCHEMA}`);
+  }
+  if (record.verdict !== 'PASS') {
+    throw new Error(`${where} records verdict ${record.verdict ?? '<none>'}, not PASS`);
+  }
+  if (record.allow_dirty === true) {
+    throw new Error(`${where} was run with allow_dirty and cannot evidence a tag`);
+  }
+  const legs = Array.isArray(record.legs) ? record.legs : [];
+  if (legs.length === 0) {
+    throw new Error(`${where} records no legs`);
+  }
+  for (const leg of legs) {
+    requireObject(leg, `${where} leg`);
+    const commit = leg?.result?.expected?.commit;
+    if (commit !== candidate) {
+      throw new Error(
+        `${where} leg "${leg.name ?? '<unnamed>'}" judged commit ${commit ?? '<none>'}, not ${candidate}`,
+      );
+    }
+    if (leg.verdict !== 'PASS') {
+      throw new Error(`${where} leg "${leg.name ?? '<unnamed>'}" records verdict ${leg.verdict ?? '<none>'}`);
+    }
+    if (typeof leg.target !== 'string' || !leg.target) {
+      throw new Error(`${where} leg "${leg.name ?? '<unnamed>'}" names no target`);
+    }
+  }
+  return legs;
+}
+
+export function mergeRecords(records, candidate) {
+  if (!COMMIT_SHA.test(candidate ?? '')) {
+    throw new Error(`"${candidate}" is not a 40-character commit sha`);
+  }
+  if (!Array.isArray(records) || records.length === 0) {
+    throw new Error('no leg records to merge');
+  }
+  // Order every downstream field off ONE ordering, decided here from the leg
+  // targets rather than from the order the artifacts happened to download in.
+  // Sorting only the outputs is not enough: `provenance` and `skipped` are
+  // concatenations, and merging the same three leg records in two orders
+  // produced two different documents. The publisher reads a differing document
+  // under a sha that already has one as tampering and refuses it forever, so a
+  // re-publish after an interrupted upload would have been unrecoverable.
+  const admittedByEntry = records.map((entry, index) => {
+    const where = entry.where ?? `record ${index}`;
+    return { where, record: entry.record, legs: admitLegRecord(entry.record, candidate, where) };
+  });
+  admittedByEntry.sort((left, right) => {
+    const key = (entry) => entry.legs.map((leg) => leg.target).sort().join(',');
+    return key(left).localeCompare(key(right));
+  });
+
+  const legs = [];
+  const sources = [];
+  const tooling = [];
+  let cpuEmbed = true;
+  admittedByEntry.forEach(({ where, record, legs: admitted }) => {
+    for (const leg of admitted) {
+      const twin = legs.find((seen) => seen.target === leg.target);
+      if (twin) {
+        throw new Error(
+          `two leg records judged ${leg.target}; which one evidences the candidate is ambiguous`,
+        );
+      }
+      legs.push(leg);
+    }
+    sources.push({
+      run: record.run ?? null,
+      host: record.host ?? null,
+      lane: record.lane ?? null,
+      cpu_embed: record.cpu_embed === true,
+      targets: admitted.map((leg) => leg.target).sort(),
+    });
+    tooling.push(JSON.stringify(record.tooling ?? null));
+    if (record.cpu_embed !== true) cpuEmbed = false;
+  });
+  if (new Set(tooling).size !== 1) {
+    throw new Error('the leg records were produced by different tooling; refusing to merge them into one answer');
+  }
+  const archives = new Map();
+  for (const leg of legs) {
+    const sha = leg?.result?.archive?.sha256;
+    if (typeof sha !== 'string') continue;
+    if (archives.has(sha) && archives.get(sha) !== leg.target) {
+      throw new Error(`archive sha256 ${sha} is claimed by ${archives.get(sha)} and ${leg.target}`);
+    }
+    archives.set(sha, leg.target);
+  }
+  legs.sort((left, right) => left.target.localeCompare(right.target));
+  const merged = {
+    schema: PREFLIGHT_SCHEMA,
+    citable: false,
+    lane: HOSTED_LANE,
+    run: `merged:${sources.map((source) => source.run ?? 'unknown').join('+')}`,
+    host: `github-actions:${sources.map((source) => source.host ?? 'unknown').join('+')}`,
+    lock_lane: 'release-proof',
+    verdict: 'PASS',
+    allow_dirty: false,
+    cpu_embed: cpuEmbed,
+    tooling: JSON.parse(tooling[0]),
+    provenance: admittedByEntry.flatMap(({ record }) => (Array.isArray(record.provenance) ? record.provenance : [])),
+    skipped: admittedByEntry.flatMap(({ record }) => (Array.isArray(record.skipped) ? record.skipped : [])),
+    legs,
+    merged_from: sources,
+    run_root: null,
+    log: null,
+  };
+  // The mint's own judge, on the bytes about to be published. This is the
+  // assertion that turns "the merge looked right" into "the mint accepts it".
+  const { archives: judged } = judgePreflight(merged, candidate);
+  return { merged, archives: judged };
+}
+
+export function main(argv = process.argv.slice(2), { log = console.log } = {}) {
+  const args = parseArgs(argv);
+  const records = args.records.map((file) => {
+    let record;
+    try {
+      record = JSON.parse(readFileSync(file, 'utf8'));
+    } catch (cause) {
+      throw new Error(`${file} is not a readable JSON record: ${cause.message}`, { cause });
+    }
+    return { where: file, record };
+  });
+  const { merged, archives } = mergeRecords(records, args.candidate);
+  writeFileSync(args.out, `${JSON.stringify(merged, null, 2)}\n`);
+  log(
+    `merged ${merged.legs.length} leg(s) for ${args.candidate} into ${args.out}: ` +
+    `${merged.legs.map((leg) => `${leg.target} (${leg.result.archive.sha256.slice(0, 12)})`).join(', ')}; ` +
+    `the mint's gate judged ${archives.length} archive(s) PASS`,
+  );
+  return merged;
+}
+
+// Real-path comparison, for the same reason check-release-proof-artifacts.mjs
+// gives: a copy run through a symlinked directory would otherwise judge nothing
+// and exit 0.
+function isDirectRun() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  const self = fileURLToPath(import.meta.url);
+  if (entry === self) return true;
+  try {
+    return realpathSync(entry) === realpathSync(self);
+  } catch {
+    return true;
+  }
+}
+
+if (isDirectRun()) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`::error::${error.message}`);
+    process.exit(1);
+  }
+}
+
+export const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+export const GATE_PATH = join(SCRIPT_DIR, '..', 'check-release-proof-artifacts.mjs');

--- a/scripts/release-proof/merge-preflight-records.test.mjs
+++ b/scripts/release-proof/merge-preflight-records.test.mjs
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { PREFLIGHT_SCHEMA, judgePreflight } from '../check-release-proof-artifacts.mjs';
+import { HOSTED_LANE, admitLegRecord, main, mergeRecords, parseArgs } from './merge-preflight-records.mjs';
+
+const SHA = 'a'.repeat(40);
+const OTHER_SHA = 'b'.repeat(40);
+const SCRIPT = fileURLToPath(new URL('./merge-preflight-records.mjs', import.meta.url));
+
+// Shaped on the record the local preflight published for f2854caf on
+// 2026-08-30: schema kin.release-preflight.v1, verdict PASS, citable false,
+// lane DEV-LOCAL, allow_dirty false, and legs whose result.expected.commit all
+// name the candidate while each carries its own archive sha256.
+function leg(target, archive, over = {}) {
+  return {
+    name: `host (${target.slice(4)}, archive)`,
+    kind: 'host',
+    target,
+    archive: `/tmp/kpf-rc/${target}.tar.gz`,
+    verdict: 'PASS',
+    magic_repro: 'PASS (25 pass, 0 fail, 0 unreadable of 25)',
+    result_path: `/tmp/kpf-rc/legs/host/result.json`,
+    result: {
+      expected: { commit: SHA, lock_sha256: 'c'.repeat(64), allow_dirty: false },
+      archive: { path: `/tmp/kpf-rc/${target}.tar.gz`, sha256: archive },
+    },
+    ...over,
+  };
+}
+
+function record(legs, over = {}) {
+  return {
+    schema: PREFLIGHT_SCHEMA,
+    citable: false,
+    lane: 'DEV-LOCAL',
+    run: '20260902T200000Z',
+    host: 'Darwin 25.4.0 arm64',
+    lock_lane: 'release-proof',
+    verdict: 'PASS',
+    allow_dirty: false,
+    cpu_embed: true,
+    tooling: { source: '/w @ HEAD', validator_ported_from_sha256: '0'.repeat(64), workflow_sha256_at_ref: '0'.repeat(64) },
+    provenance: [`archive: ${legs.map((entry) => entry.target).join(',')}`],
+    skipped: [],
+    legs,
+    run_root: '/tmp/kpf-rc',
+    log: '/tmp/kpf-rc/preflight.log',
+    ...over,
+  };
+}
+
+const macos = () => record([leg('kin-macos-aarch64', '1'.repeat(64))], { run: '20260902T200001Z', host: 'Darwin' });
+const arm = () => record([leg('kin-linux-aarch64', '2'.repeat(64))], { run: '20260902T200002Z', host: 'Linux aarch64' });
+const x86 = () => record([leg('kin-linux-x86_64', '3'.repeat(64))], { run: '20260902T200003Z', host: 'Linux x86_64' });
+
+const entries = (...records) => records.map((entry, index) => ({ where: `record ${index}`, record: entry }));
+
+test('three passing leg records merge into one record the mint accepts', () => {
+  const { merged, archives } = mergeRecords(entries(macos(), arm(), x86()), SHA);
+  assert.equal(merged.schema, PREFLIGHT_SCHEMA);
+  assert.equal(merged.verdict, 'PASS');
+  assert.equal(merged.lane, HOSTED_LANE);
+  assert.equal(merged.citable, false);
+  assert.equal(merged.allow_dirty, false);
+  assert.equal(merged.cpu_embed, true);
+  assert.deepEqual(merged.legs.map((entry) => entry.target), ['kin-linux-aarch64', 'kin-linux-x86_64', 'kin-macos-aarch64']);
+  assert.deepEqual(archives, ['2'.repeat(64), '3'.repeat(64), '1'.repeat(64)]);
+  // The gate that reads the published record agrees with the one the merge ran.
+  assert.deepEqual(judgePreflight(merged, SHA).archives, archives);
+  assert.equal(merged.merged_from.length, 3);
+});
+
+test('the merge is deterministic whatever order the records arrive in', () => {
+  const forward = JSON.stringify(mergeRecords(entries(macos(), arm(), x86()), SHA).merged);
+  const backward = JSON.stringify(mergeRecords(entries(x86(), arm(), macos()), SHA).merged);
+  assert.equal(forward, backward);
+});
+
+test('a leg record about another commit is refused, and the refusal names the file', () => {
+  const foreign = macos();
+  foreign.legs[0].result.expected.commit = OTHER_SHA;
+  const bad = { where: 'kin-release-preflight-kin-macos-aarch64/preflight.json', record: foreign };
+  const good = { where: 'kin-release-preflight-kin-linux-aarch64/preflight.json', record: arm() };
+  assert.throws(() => mergeRecords([bad, good], SHA), /judged commit b{40}, not a{40}/);
+  // The mint's gate re-checks the commit on the merged record, so removing the
+  // per-record check still refuses. What only the per-record check can give is
+  // WHICH artifact was wrong: three legs arrive from three runners and a
+  // refusal naming only the leg sends a captain to read all three. Assert the
+  // source file is in the message, which is the half the gate cannot supply.
+  assert.throws(
+    () => mergeRecords([bad, good], SHA),
+    /kin-release-preflight-kin-macos-aarch64\/preflight\.json/,
+  );
+});
+
+test('a failing leg record cannot hide behind passing ones', () => {
+  const failing = arm();
+  failing.verdict = 'FAIL';
+  assert.throws(() => mergeRecords(entries(macos(), failing, x86()), SHA), /record 1 records verdict FAIL/);
+  const failingLeg = arm();
+  failingLeg.legs[0].verdict = 'FAIL';
+  assert.throws(() => mergeRecords(entries(macos(), failingLeg), SHA), /leg "host \(linux-aarch64, archive\)" records verdict FAIL/);
+});
+
+test('an unreadable verdict is refused, never read as PASS', () => {
+  const unreadable = x86();
+  unreadable.verdict = 'UNREADABLE';
+  assert.throws(() => mergeRecords(entries(unreadable), SHA), /records verdict UNREADABLE, not PASS/);
+});
+
+test('allow_dirty, a wrong schema and an empty leg list refuse', () => {
+  const dirty = macos();
+  dirty.allow_dirty = true;
+  assert.throws(() => mergeRecords(entries(dirty), SHA), /allow_dirty/);
+  const schema = macos();
+  schema.schema = 'kin.release-preflight.v0';
+  assert.throws(() => mergeRecords(entries(schema), SHA), /carries schema "kin.release-preflight.v0"/);
+  const empty = macos();
+  empty.legs = [];
+  assert.throws(() => mergeRecords(entries(empty), SHA), /records no legs/);
+});
+
+test('two records judging the same archive target are ambiguous', () => {
+  assert.throws(() => mergeRecords(entries(macos(), macos()), SHA), /two leg records judged kin-macos-aarch64/);
+});
+
+test('one archive sha256 claimed by two targets is refused', () => {
+  const twin = arm();
+  twin.legs[0].result.archive.sha256 = '1'.repeat(64);
+  // Named in the merge's own deterministic order, not the order they arrived.
+  assert.throws(() => mergeRecords(entries(macos(), twin), SHA), /claimed by kin-linux-aarch64 and kin-macos-aarch64/);
+  assert.throws(() => mergeRecords(entries(twin, macos()), SHA), /claimed by kin-linux-aarch64 and kin-macos-aarch64/);
+});
+
+test('records from different tooling do not merge into one answer', () => {
+  const other = arm();
+  other.tooling = { ...other.tooling, validator_ported_from_sha256: 'f'.repeat(64) };
+  assert.throws(() => mergeRecords(entries(macos(), other), SHA), /different tooling/);
+});
+
+test('a leg without an archive sha256 is refused by the gate inside the merge', () => {
+  const bare = macos();
+  delete bare.legs[0].result.archive;
+  assert.throws(() => mergeRecords(entries(bare), SHA), /records no archive sha256/);
+});
+
+test('cpu_embed is true only when every leg embedded on the CPU', () => {
+  const metal = macos();
+  metal.cpu_embed = false;
+  assert.equal(mergeRecords(entries(metal, arm()), SHA).merged.cpu_embed, false);
+});
+
+test('admitLegRecord names the record it refuses', () => {
+  assert.throws(() => admitLegRecord(null, SHA, 'leg-a.json'), /leg-a.json is not a preflight record object/);
+  assert.throws(() => admitLegRecord([], SHA, 'leg-a.json'), /leg-a.json is not a preflight record object/);
+});
+
+test('parseArgs refuses a loose sha and a missing output', () => {
+  assert.throws(() => {
+    const exit = process.exit;
+    process.exit = (code) => { throw new Error(`exit ${code}`); };
+    try {
+      parseArgs(['--candidate', 'abc', '--out', 'x', 'a.json']);
+    } finally {
+      process.exit = exit;
+    }
+  }, /exit 2/);
+});
+
+test('the command line merges files, writes the record and exits 1 on a refusal', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-merge-'));
+  const files = [macos(), arm(), x86()].map((entry, index) => {
+    const file = path.join(dir, `leg-${index}.json`);
+    fs.writeFileSync(file, JSON.stringify(entry));
+    return file;
+  });
+  const out = path.join(dir, 'preflight.json');
+  const stdout = execFileSync(process.execPath, [SCRIPT, '--candidate', SHA, '--out', out, ...files], { encoding: 'utf8' });
+  assert.match(stdout, /merged 3 leg\(s\)/);
+  const written = JSON.parse(fs.readFileSync(out, 'utf8'));
+  assert.equal(written.verdict, 'PASS');
+  assert.equal(written.legs.length, 3);
+  // Identical bytes on a second run, which is what lets a re-publish be a no-op.
+  const again = path.join(dir, 'again.json');
+  execFileSync(process.execPath, [SCRIPT, '--candidate', SHA, '--out', again, ...files.slice().reverse()]);
+  assert.equal(fs.readFileSync(again, 'utf8'), fs.readFileSync(out, 'utf8'));
+
+  let failed = null;
+  try {
+    execFileSync(process.execPath, [SCRIPT, '--candidate', OTHER_SHA, '--out', path.join(dir, 'no.json'), ...files], { encoding: 'utf8', stdio: 'pipe' });
+  } catch (error) {
+    failed = error;
+  }
+  assert.ok(failed, 'a merge for the wrong candidate must fail');
+  assert.equal(failed.status, 1);
+  assert.match(String(failed.stderr), /judged commit a{40}, not b{40}/);
+  assert.equal(fs.existsSync(path.join(dir, 'no.json')), false);
+
+  const programmatic = main(['--candidate', SHA, '--out', path.join(dir, 'main.json'), ...files], { log: () => {} });
+  assert.equal(programmatic.legs.length, 3);
+});

--- a/scripts/release-proof/vendored.test.mjs
+++ b/scripts/release-proof/vendored.test.mjs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+// The vendored proof tooling is a byte-identical copy of the umbrella's, and
+// this is the check that keeps the manifest honest: an edit to a vendored file
+// that does not move VENDORED.json fails here, so a local fix cannot fork the
+// copy silently. The lock shim beside them is written for this tree and is
+// held to its contract instead.
+
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const MANIFEST = JSON.parse(fs.readFileSync(path.join(HERE, 'VENDORED.json'), 'utf8'));
+const SHIM = path.join(HERE, 'bin', 'kin-lane');
+
+const sha256 = (file) => createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+
+test('the manifest names the umbrella commit and every vendored file', () => {
+  assert.equal(MANIFEST.source_repository, 'firelock-ai/kin-ecosystem');
+  assert.match(MANIFEST.source_commit, /^[0-9a-f]{40}$/);
+  const expected = [
+    'bin/kin-acceptance-suite',
+    'bin/kin-evidence-publish',
+    'bin/kin-release-preflight',
+    'bin/kin-release-preflight.d/Dockerfile',
+    'bin/kin-release-preflight.d/proof-flow.sh',
+    'bin/kin-release-preflight.d/validate.mjs',
+  ];
+  assert.deepEqual(Object.keys(MANIFEST.files).sort(), expected);
+});
+
+test('every vendored file carries the bytes the manifest records', () => {
+  for (const [relative, entry] of Object.entries(MANIFEST.files)) {
+    const file = path.join(HERE, relative);
+    assert.ok(fs.existsSync(file), `${relative} is missing`);
+    assert.match(entry.sha256, /^[0-9a-f]{64}$/);
+    assert.equal(sha256(file), entry.sha256, `${relative} drifted from VENDORED.json`);
+    assert.equal(entry.source, relative);
+  }
+});
+
+test('the executables are executable', () => {
+  for (const relative of ['bin/kin-release-preflight', 'bin/kin-evidence-publish', 'bin/kin-acceptance-suite', 'bin/kin-release-preflight.d/proof-flow.sh', 'bin/kin-lane']) {
+    const mode = fs.statSync(path.join(HERE, relative)).mode;
+    assert.ok(mode & 0o111, `${relative} is not executable`);
+  }
+});
+
+test('the lock shim keeps the acquire, holder and release contract the preflight relies on', () => {
+  const locks = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-shim-'));
+  const env = { ...process.env, KIN_RELEASE_PROOF_LOCKS: locks };
+  const run = (...args) => spawnSync('bash', [SHIM, ...args], { env, encoding: 'utf8' });
+
+  // Acquire, then read the holder back: this is the read the preflight refuses
+  // to run a leg without.
+  assert.equal(run('acquire', 'daemon', 'release-proof', '--pid', '123', 'release preflight').status, 0);
+  assert.equal(run('holder', 'daemon').stdout.trim(), 'release-proof');
+  // The same lane may re-acquire; another lane may not.
+  assert.equal(run('acquire', 'daemon', 'release-proof').status, 0);
+  const contended = run('acquire', 'daemon', 'other-lane');
+  assert.notEqual(contended.status, 0);
+  assert.match(contended.stderr, /daemon is held by release-proof/);
+  // A release by the wrong lane is refused; by the holder it clears the table.
+  const wrong = run('release', 'daemon', 'other-lane');
+  assert.notEqual(wrong.status, 0);
+  assert.match(wrong.stderr, /held by 'release-proof', not 'other-lane'/);
+  assert.equal(run('release', 'daemon', 'release-proof').status, 0);
+  assert.equal(run('holder', 'daemon').stdout.trim(), '');
+  assert.equal(run('release', 'daemon', 'release-proof').status, 0);
+  assert.notEqual(run('frobnicate').status, 0);
+});
+
+test('the preflight resolves the shim beside itself rather than the fleet tool', () => {
+  const preflight = fs.readFileSync(path.join(HERE, 'bin', 'kin-release-preflight'), 'utf8');
+  assert.match(preflight, /KIN_LANE="\$BIN_DIR\/kin-lane"/);
+  assert.match(preflight, /\[ -x "\$KIN_LANE" \] \|\| die/);
+  // And it copies itself before running, which is why `bash -n` on the vendored
+  // copy is a meaningful check here rather than a formality.
+  assert.equal(execFileSync('bash', ['-n', path.join(HERE, 'bin', 'kin-release-preflight')], { encoding: 'utf8' }), '');
+  assert.equal(execFileSync('bash', ['-n', path.join(HERE, 'bin', 'kin-release-preflight.d', 'proof-flow.sh')], { encoding: 'utf8' }), '');
+  assert.equal(execFileSync('bash', ['-n', SHIM], { encoding: 'utf8' }), '');
+});

--- a/scripts/select-release-candidate.py
+++ b/scripts/select-release-candidate.py
@@ -1,0 +1,995 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Select the release candidate the proof loop proves next, with nobody at a keyboard.
+
+release-tag.yml mints a tag for the newest reviewed main commit in the staged
+version's range that carries both proof records, and it refuses a required
+context that appears more than once at that sha as ambiguous authority. Until
+now a captain chose the sha those records would be filed under, pushed the
+candidate branch, dispatched rc-build.yml and ran the preflight by hand. On
+2026-09-02 that procedure lost a day: a rerun of a flaky required job made the
+first candidate unmintable, and the host carrying the proof ran out of memory.
+
+This script is the selection half of the pipeline. `select` reads everything
+the decision rests on and answers one of four things:
+
+  stand-down  nothing to do now: the version is tagged, a fully evidenced sha
+              is waiting on the mint, the current candidate's preflight is
+              recorded and only the stranger record is missing, an rc-build is
+              still running, or no complete green sha exists yet
+  arm         move release/v<version>-candidate to the chosen sha and dispatch
+              rc-build.yml there
+  proof       an rc-build for the current candidate succeeded and carries the
+              preflight leg records; merge and publish them
+  refuse      no reviewed main commit carrying the version qualifies, named sha
+              by sha with the context that disqualified it
+
+The rule, in the order it is applied:
+
+1. v<version> exists as a tag: the cut is done and the train owns the next
+   version.
+2. A sha in the range carries both records: the mint owns it.
+3. A current candidate, the branch tip, which must lie in the range, is kept
+   until it is proven or dead. With its preflight recorded it waits for the
+   stranger. Alive with a usable rc-build it is proven; alive with none it is
+   armed again, up to RC_BUILD_ATTEMPT_LIMIT attempts. Dead means a required
+   context that is red or duplicated, a CI or Acceptance push run that did not
+   conclude success, or exhausted rc-build attempts.
+4. Otherwise the newest main commit in the range whose CI and Acceptance push
+   runs concluded success, and whose required contexts each appear exactly once
+   under push provenance and concluded green, becomes the candidate. A sha still
+   being graded is skipped rather than waited for: on a busy night the newest
+   sha is always pending, and a selector that waits never converges. A sha that
+   is red or ambiguous is named and skipped.
+
+Every judgment is a pure function over one snapshot document, so the test feeds
+it fixtures and asserts the decision with no GitHub in the loop.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import subprocess
+import sys
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+
+EXPECTED_REPOSITORY = "firelock-ai/kin"
+BASE_BRANCH = "main"
+EVIDENCE_REF = "release-evidence"
+PREFLIGHT_RECORD = "preflight.json"
+STRANGER_RECORD = "stranger.env"
+CI_WORKFLOW = ".github/workflows/ci.yml"
+CI_WORKFLOW_NAME = "CI"
+ACCEPTANCE_WORKFLOW = ".github/workflows/acceptance.yml"
+RC_BUILD_WORKFLOW = ".github/workflows/rc-build.yml"
+RC_BUILD_WORKFLOW_NAME = "RC Build"
+# The artifacts rc-build.yml's preflight job uploads, one leg record per
+# archive. A run missing one of them proved less than a record built from it
+# would claim, so it is not usable evidence.
+PREFLIGHT_ARTIFACT_PREFIX = "kin-release-preflight-"
+PREFLIGHT_ARTIFACTS = ("kin-linux-aarch64", "kin-linux-x86_64", "kin-macos-aarch64")
+# One rebuild is a flake allowance. A second failure on the same sha is a
+# verdict about the sha, and the next landing supplies a new one.
+RC_BUILD_ATTEMPT_LIMIT = 2
+RANGE_LIMIT = 1000
+PAGE_SIZE = 100
+LOWER_SHA = re.compile(r"^[0-9a-f]{40}$")
+VERSION = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+CANDIDATE_BRANCH = re.compile(r"^release/v([0-9]+\.[0-9]+\.[0-9]+)-candidate$")
+# Only the GitHub Actions App may write a required context name, pinned by
+# numeric id as well as slug so a renamed or impersonating App cannot inherit
+# the name. Mirrors release-tag.yml.
+GITHUB_ACTIONS_APP = (15368, "github-actions")
+# release-tag.yml's REQUIRED_CHECKS with the workflow provenance its mint binds
+# each context to. scripts/test-select-release-candidate.py holds this table
+# equal to the mint's own, so the selector cannot pick a sha the mint refuses
+# for a context it never read.
+REQUIRED_CONTEXTS = (
+    ("Check & Test (ubuntu-latest)", 245803170, CI_WORKFLOW),
+    ("Check & Test (macos-latest)", 245803170, CI_WORKFLOW),
+    ("Falsify guards", 245803170, CI_WORKFLOW),
+    ("Feature permutation tests (ubuntu-latest)", 245803170, CI_WORKFLOW),
+    ("Feature permutation tests (macos-latest)", 245803170, CI_WORKFLOW),
+    ("DCO Sign-off", 245803170, CI_WORKFLOW),
+    ("cargo-deny", 251549972, ".github/workflows/sast.yml"),
+    ("gitleaks (full history)", 293452372, ".github/workflows/secret-scan.yml"),
+    ("Windows installer + vector release build", 245803170, CI_WORKFLOW),
+)
+SKIPPABLE_REQUIRED = frozenset({"DCO Sign-off"})
+# The typed manual kick and who may send it, mirroring release-tag.yml's
+# break-glass shape: a repository_dispatch always runs this workflow from the
+# default branch, and the actor is pinned to the captain and the release App.
+KICK_ACTION = "release_cut"
+KICK_ACTORS = frozenset({"troyjr4103", "kin-release-bot[bot]"})
+KICK_REASON_LIMIT = 200
+TRIGGER_KICK = "kick"
+TRIGGER_CI = "ci-completed"
+TRIGGER_RC_BUILD = "rc-build-completed"
+TRIGGER_SWEEP = "sweep"
+
+STAND_DOWN = "stand-down"
+ARM = "arm"
+PROOF = "proof"
+REFUSE = "refuse"
+GREEN = "green"
+PENDING = "pending"
+DEAD = "dead"
+MOVE_CREATE = "create"
+MOVE_FAST_FORWARD = "fast-forward"
+MOVE_RESET = "reset"
+MOVE_NONE = "none"
+
+
+class SelectionError(RuntimeError):
+    """The candidate could not be selected on a trustworthy reading."""
+
+
+class NotFound(SelectionError):
+    """GitHub answered 404: the one answer a caller may act on differently."""
+
+
+Fetch = Callable[[str], Any]
+Grader = Callable[[str], dict[str, Any]]
+
+
+# ---------------------------------------------------------------------------
+# Endpoints. Named here so the live gather and the test agree byte for byte.
+# ---------------------------------------------------------------------------
+
+
+def candidate_branch(version: str) -> str:
+    return f"release/v{version}-candidate"
+
+
+def tag_endpoint(repository: str, version: str) -> str:
+    return f"repos/{repository}/git/ref/tags/v{version}"
+
+
+def evidence_tree_endpoint(repository: str) -> str:
+    return f"repos/{repository}/git/trees/{EVIDENCE_REF}?recursive=1"
+
+
+def branch_endpoint(repository: str, branch: str) -> str:
+    return f"repos/{repository}/git/ref/heads/{branch}"
+
+
+def rc_build_runs_endpoint(repository: str, branch: str, page: int = 1) -> str:
+    return (
+        f"repos/{repository}/actions/workflows/rc-build.yml/runs"
+        f"?branch={branch}&event=workflow_dispatch&per_page={PAGE_SIZE}&page={page}"
+    )
+
+
+def run_artifacts_endpoint(repository: str, run_id: int, page: int = 1) -> str:
+    return f"repos/{repository}/actions/runs/{run_id}/artifacts?per_page={PAGE_SIZE}&page={page}"
+
+
+def check_runs_endpoint(repository: str, sha: str, page: int = 1) -> str:
+    # `filter=all` is deliberate: a rerun that claims one required name is
+    # ambiguous authority, not evidence to collapse by recency.
+    return f"repos/{repository}/commits/{sha}/check-runs?per_page={PAGE_SIZE}&filter=all&page={page}"
+
+
+def workflow_runs_endpoint(repository: str, sha: str, page: int = 1) -> str:
+    return f"repos/{repository}/actions/runs?head_sha={sha}&per_page={PAGE_SIZE}&page={page}"
+
+
+# ---------------------------------------------------------------------------
+# Trigger validation, from GitHub-owned context only.
+# ---------------------------------------------------------------------------
+
+
+def _sha(value: Any) -> str | None:
+    if isinstance(value, str) and LOWER_SHA.fullmatch(value):
+        return value
+    return None
+
+
+def validate_trigger(
+    *,
+    event_name: str,
+    event_action: str,
+    actor: str,
+    repository: str,
+    default_branch: str,
+    ref: str,
+    workflow_sha: str,
+    event: Any,
+) -> dict[str, Any]:
+    """Admit one of four trigger shapes, every one resolved from protected main.
+
+    A CI completion for a main push and an RC Build completion on a candidate
+    branch are the occasions that move the cut along; the typed kick is the
+    manual arm GitHub's cron cannot stall; the schedule is the fallback. The
+    event only decides when to look. Which sha is released is re-derived from
+    scratch by `gather` and `judge`, never read off the event.
+    """
+
+    if repository != EXPECTED_REPOSITORY:
+        raise SelectionError(f"repository must be {EXPECTED_REPOSITORY!r}, got {repository!r}")
+    if default_branch != BASE_BRANCH:
+        raise SelectionError(f"default branch must be {BASE_BRANCH!r}, got {default_branch!r}")
+    if ref != f"refs/heads/{BASE_BRANCH}":
+        raise SelectionError(f"workflow ref must be refs/heads/{BASE_BRANCH}, got {ref!r}")
+    if _sha(workflow_sha) is None:
+        raise SelectionError(f"workflow sha must be 40-character lowercase hex, got {workflow_sha!r}")
+    if not isinstance(event, dict):
+        raise SelectionError("event document must be an object")
+    if event_name == "repository_dispatch":
+        if event_action != KICK_ACTION:
+            raise SelectionError(f"event action must be {KICK_ACTION!r}, got {event_action!r}")
+        if event.get("action") != event_action:
+            raise SelectionError("event document action differs from the trigger context")
+        if actor not in KICK_ACTORS:
+            raise SelectionError(f"actor {actor!r} may not kick the release cut")
+        payload = event.get("client_payload")
+        if payload is None:
+            payload = {}
+        if not isinstance(payload, dict) or set(payload) - {"reason"}:
+            raise SelectionError("kick payload may carry a reason and nothing else")
+        reason = payload.get("reason", "")
+        if not isinstance(reason, str) or len(reason) > KICK_REASON_LIMIT:
+            raise SelectionError("kick reason must be text of at most 200 characters")
+        return {"trigger": TRIGGER_KICK, "actor": actor, "reason": reason}
+    if event_name == "workflow_run":
+        if event_action != "completed":
+            raise SelectionError(f"workflow_run action must be 'completed', got {event_action!r}")
+        run = event.get("workflow_run")
+        if not isinstance(run, dict):
+            raise SelectionError("workflow_run event omitted its run")
+        head_repository = run.get("head_repository")
+        if (
+            not isinstance(head_repository, dict)
+            or head_repository.get("full_name") != repository
+        ):
+            raise SelectionError("workflow_run head repository is not first-party")
+        if run.get("status") != "completed":
+            raise SelectionError("workflow_run is not completed")
+        head_branch = run.get("head_branch")
+        if run.get("path") == CI_WORKFLOW:
+            if run.get("event") != "push" or head_branch != BASE_BRANCH:
+                raise SelectionError(
+                    f"a CI completion is an occasion only for a push to {BASE_BRANCH}, "
+                    f"got {run.get('event')!r} on {head_branch!r}"
+                )
+            return {
+                "trigger": TRIGGER_CI,
+                "conclusion": run.get("conclusion"),
+                "head_sha": run.get("head_sha"),
+            }
+        if run.get("path") == RC_BUILD_WORKFLOW:
+            if run.get("event") != "workflow_dispatch" or not (
+                isinstance(head_branch, str) and CANDIDATE_BRANCH.fullmatch(head_branch)
+            ):
+                raise SelectionError(
+                    "an RC Build completion is an occasion only for a dispatch on a "
+                    f"release/v<version>-candidate branch, got {run.get('event')!r} on "
+                    f"{head_branch!r}"
+                )
+            return {
+                "trigger": TRIGGER_RC_BUILD,
+                "conclusion": run.get("conclusion"),
+                "head_sha": run.get("head_sha"),
+                "head_branch": head_branch,
+                "run_id": run.get("id"),
+            }
+        raise SelectionError(
+            f"workflow_run path {run.get('path')!r} is neither {CI_WORKFLOW} nor {RC_BUILD_WORKFLOW}"
+        )
+    if event_name == "schedule":
+        if event_action != "":
+            raise SelectionError(f"scheduled event action must be empty, got {event_action!r}")
+        return {"trigger": TRIGGER_SWEEP}
+    raise SelectionError(
+        f"event name must be workflow_run, repository_dispatch or schedule, got {event_name!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# GitHub reads.
+# ---------------------------------------------------------------------------
+
+
+def gh_json(endpoint: str) -> Any:
+    result = subprocess.run(
+        ["gh", "api", endpoint],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "no output"
+        if "HTTP 404" in detail:
+            raise NotFound(f"gh api {endpoint}: {detail}")
+        raise SelectionError(f"gh api {endpoint} failed: {detail}")
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise SelectionError(f"GitHub returned malformed JSON for {endpoint}") from exc
+
+
+def _count(value: Any, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise SelectionError(f"{label} is not a count: {value!r}")
+    return value
+
+
+def flatten_pages(pages: Any, key: str) -> list[dict[str, Any]]:
+    """Flatten a paged listing and refuse one that does not add up.
+
+    The endpoints page at 100 and fail toward green: a page that arrives short
+    reads exactly like a sha with fewer checks. Every page carries the same
+    `total_count`, so the listed length is asserted against it.
+    """
+
+    if not isinstance(pages, list) or not pages:
+        raise SelectionError(f"{key} listing has no pages")
+    items: list[dict[str, Any]] = []
+    totals: set[int] = set()
+    for page in pages:
+        if not isinstance(page, dict):
+            raise SelectionError(f"{key} page is not an object")
+        totals.add(_count(page.get("total_count"), f"{key} total_count"))
+        chunk = page.get(key)
+        if not isinstance(chunk, list):
+            raise SelectionError(f"{key} page carries no {key} list")
+        for item in chunk:
+            if not isinstance(item, dict):
+                raise SelectionError(f"{key} entry is not an object")
+            items.append(item)
+    if len(totals) != 1:
+        raise SelectionError(
+            f"{key} listing changed under the read: total_count {sorted(totals)}"
+        )
+    total = totals.pop()
+    if len(items) != total:
+        raise SelectionError(f"{key} listing is incomplete: {len(items)} listed of {total}")
+    return items
+
+
+def read_listing(fetch: Fetch, endpoint_for_page: Callable[[int], str], key: str) -> list[dict[str, Any]]:
+    first = fetch(endpoint_for_page(1))
+    if not isinstance(first, dict):
+        raise SelectionError(f"{key} listing is not an object")
+    total = _count(first.get("total_count"), f"{key} total_count")
+    pages = [first]
+    for page in range(2, max(1, math.ceil(total / PAGE_SIZE)) + 1):
+        pages.append(fetch(endpoint_for_page(page)))
+    return flatten_pages(pages, key)
+
+
+def read_tag_exists(fetch: Fetch, repository: str, version: str) -> bool:
+    try:
+        document = fetch(tag_endpoint(repository, version))
+    except NotFound:
+        return False
+    ref_object = document.get("object") if isinstance(document, dict) else None
+    if not isinstance(ref_object, dict) or _sha(ref_object.get("sha")) is None:
+        raise SelectionError(f"tag v{version} read back without an exact object sha")
+    return True
+
+
+def read_evidence(fetch: Fetch, repository: str) -> dict[str, list[str]]:
+    """Which candidates the proof loop recorded, the way the mint reads them.
+
+    An unreadable listing is not an empty one, and a truncated listing could
+    hide a newer proven candidate, so both refuse rather than answer.
+    """
+
+    listing = fetch(evidence_tree_endpoint(repository))
+    if not isinstance(listing, dict) or not isinstance(listing.get("tree"), list):
+        raise SelectionError(
+            f"the {EVIDENCE_REF} listing is not a git tree object, so the proof "
+            "loop's records cannot be read"
+        )
+    if listing.get("truncated") is True:
+        raise SelectionError(
+            f"the {EVIDENCE_REF} listing is truncated, so a newer proven candidate "
+            "could be invisible"
+        )
+    pattern = re.compile(r"^evidence/([0-9a-f]{40})/(preflight\.json|stranger\.env)$")
+    evidence: dict[str, list[str]] = {}
+    for entry in listing["tree"]:
+        if not isinstance(entry, dict) or entry.get("type") != "blob":
+            continue
+        match = pattern.fullmatch(str(entry.get("path", "")))
+        if match is None:
+            continue
+        records = evidence.setdefault(match.group(1), [])
+        if match.group(2) not in records:
+            records.append(match.group(2))
+    return evidence
+
+
+def read_branch(fetch: Fetch, repository: str, branch: str) -> str | None:
+    try:
+        document = fetch(branch_endpoint(repository, branch))
+    except NotFound:
+        return None
+    ref_object = document.get("object") if isinstance(document, dict) else None
+    sha = _sha(ref_object.get("sha")) if isinstance(ref_object, dict) else None
+    if sha is None:
+        raise SelectionError(f"branch {branch} read back without an exact object sha")
+    return sha
+
+
+def read_rc_builds(fetch: Fetch, repository: str, branch: str) -> list[dict[str, Any]]:
+    """Every rc-build dispatch on the candidate branch, newest first.
+
+    A completed successful run also carries the names of its artifacts, which
+    is how a run from before the preflight job existed is told apart from one
+    whose leg records can be published.
+    """
+
+    runs = read_listing(
+        fetch, lambda page: rc_build_runs_endpoint(repository, branch, page), "workflow_runs"
+    )
+    builds = []
+    for run in runs:
+        run_id = _count(run.get("id"), "rc-build run id")
+        record = {
+            "id": run_id,
+            "head_sha": run.get("head_sha"),
+            "head_branch": run.get("head_branch"),
+            "event": run.get("event"),
+            "status": run.get("status"),
+            "conclusion": run.get("conclusion"),
+            "created_at": run.get("created_at") or "",
+            "artifacts": [],
+        }
+        if record["status"] == "completed" and record["conclusion"] == "success":
+            artifacts = read_listing(
+                fetch, lambda page, rid=run_id: run_artifacts_endpoint(repository, rid, page), "artifacts"
+            )
+            record["artifacts"] = sorted(
+                str(artifact.get("name")) for artifact in artifacts if not artifact.get("expired")
+            )
+        builds.append(record)
+    builds.sort(key=lambda build: (build["created_at"], build["id"]), reverse=True)
+    return builds
+
+
+def run_git(workspace: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(workspace), *arguments],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "no output"
+        raise SelectionError(f"git {' '.join(arguments)} failed: {detail}")
+    return result.stdout.strip()
+
+
+def workspace_version(cargo_toml: str) -> str:
+    try:
+        version = tomllib.loads(cargo_toml)["workspace"]["package"]["version"]
+    except (tomllib.TOMLDecodeError, KeyError, TypeError) as exc:
+        raise SelectionError(f"Cargo.toml carries no [workspace.package] version: {exc}") from exc
+    if not isinstance(version, str) or VERSION.fullmatch(version) is None:
+        raise SelectionError(f"workspace version {version!r} is not semver-shaped")
+    return version
+
+
+def version_range(workspace: Path, tip: str, version: str) -> list[str]:
+    """The reviewed main commits carrying `version`, newest first.
+
+    The floor is the squash of the version bump: the oldest first-parent commit
+    whose Cargo.toml carries this version. Nothing before it can be this
+    release, because nothing before it carries the version the tag names.
+    """
+
+    log = run_git(workspace, "log", "--first-parent", f"--max-count={RANGE_LIMIT}", "--format=%H", tip)
+    shas = []
+    for sha in log.splitlines():
+        sha = sha.strip()
+        if _sha(sha) is None:
+            raise SelectionError(f"git log produced a non-sha line {sha!r}")
+        if workspace_version(run_git(workspace, "show", f"{sha}:Cargo.toml")) != version:
+            break
+        shas.append(sha)
+    if not shas:
+        raise SelectionError(f"the tip {tip} does not carry version {version}")
+    return shas
+
+
+# ---------------------------------------------------------------------------
+# Grading one sha. Pure over the two listings the mint reads.
+# ---------------------------------------------------------------------------
+
+
+def grade_sha(sha: str, check_run_pages: Any, workflow_run_pages: Any) -> dict[str, Any]:
+    """Decide whether one sha is green, pending or dead for the mint.
+
+    Green means the CI and Acceptance push runs on main concluded success and
+    every required context appears exactly once under push provenance at this
+    sha, by the GitHub Actions App, concluded success (DCO Sign-off may report
+    skipped on a merged commit). Pending means a producing run has not finished.
+    Everything else is dead, and a rerun is the reason that matters most: the
+    mint refuses a required context that appears more than once as ambiguous
+    authority, whatever the copies concluded.
+    """
+
+    if _sha(sha) is None:
+        raise SelectionError(f"cannot grade {sha!r}: not a 40-character lowercase sha")
+    check_runs = flatten_pages(check_run_pages, "check_runs")
+    workflow_runs = flatten_pages(workflow_run_pages, "workflow_runs")
+    dead: list[str] = []
+    pending: list[str] = []
+
+    by_suite: dict[Any, list[dict[str, Any]]] = {}
+    for run in workflow_runs:
+        by_suite.setdefault(run.get("check_suite_id"), []).append(run)
+
+    def push_runs(path: str) -> list[dict[str, Any]]:
+        return [
+            run
+            for run in workflow_runs
+            if run.get("path") == path
+            and run.get("event") == "push"
+            and run.get("head_branch") == BASE_BRANCH
+            and run.get("head_sha") == sha
+        ]
+
+    for label, path in (("CI", CI_WORKFLOW), ("Acceptance", ACCEPTANCE_WORKFLOW)):
+        runs = push_runs(path)
+        if not runs:
+            pending.append(f"no {label} push run on {BASE_BRANCH} at this sha yet")
+        elif len(runs) > 1:
+            dead.append(f"{len(runs)} {label} push runs at this sha: ambiguous authority")
+        else:
+            run = runs[0]
+            if run.get("status") != "completed":
+                pending.append(f"{label} push run {run.get('id')} is {run.get('status')}")
+            elif run.get("conclusion") != "success":
+                dead.append(f"{label} push run {run.get('id')} concluded {run.get('conclusion')}")
+
+    by_name: dict[Any, list[dict[str, Any]]] = {}
+    for check in check_runs:
+        by_name.setdefault(check.get("name"), []).append(check)
+
+    for name, workflow_id, path in REQUIRED_CONTEXTS:
+        admitted = []
+        for check in by_name.get(name, []):
+            app = check.get("app") if isinstance(check.get("app"), dict) else {}
+            if (app.get("id"), app.get("slug")) != GITHUB_ACTIONS_APP:
+                dead.append(f"required check name claimed by another app: {name} ({app.get('slug')!r})")
+                continue
+            suite = check.get("check_suite") if isinstance(check.get("check_suite"), dict) else {}
+            producers = by_suite.get(suite.get("id"), [])
+            if len(producers) != 1:
+                dead.append(
+                    f"required check has ambiguous workflow provenance: {name} "
+                    f"(suite={suite.get('id')}, workflow-runs={len(producers)})"
+                )
+                continue
+            producer = producers[0]
+            on_main_push = (
+                producer.get("event") == "push"
+                and producer.get("head_branch") == BASE_BRANCH
+                and producer.get("head_sha") == sha
+                and producer.get("conclusion") != "cancelled"
+            )
+            if (producer.get("workflow_id"), producer.get("path")) != (workflow_id, path):
+                if on_main_push:
+                    # A second writer of a required context name on the ref this
+                    # release is proved from is an authority conflict, never a
+                    # fallback. Off that ref it is somebody else's build at the
+                    # same sha and is discounted.
+                    dead.append(
+                        f"required check workflow provenance mismatch: {name} "
+                        f"produced by {producer.get('path')} run {producer.get('id')}"
+                    )
+                continue
+            if on_main_push:
+                admitted.append(check)
+        if not admitted:
+            producers_running = any(
+                run.get("status") != "completed" for run in push_runs(path)
+            )
+            (pending if producers_running else dead).append(
+                f"missing required check: {name} "
+                f"({len(by_name.get(name, []))} same-named check-runs, none under push provenance)"
+            )
+            continue
+        if len(admitted) != 1:
+            dead.append(
+                f"ambiguous required check: {name} ({len(admitted)} check-runs under one "
+                "provenance; a rerun is what makes a sha unmintable)"
+            )
+            continue
+        check = admitted[0]
+        if check.get("status") != "completed":
+            pending.append(f"required check not completed: {name} ({check.get('status')})")
+            continue
+        allowed = {"success", "skipped"} if name in SKIPPABLE_REQUIRED else {"success"}
+        if check.get("conclusion") not in allowed:
+            dead.append(f"required check not green: {name} (conclusion={check.get('conclusion')})")
+
+    verdict = DEAD if dead else (PENDING if pending else GREEN)
+    return {"sha": sha, "verdict": verdict, "dead": dead, "pending": pending}
+
+
+def grade_live(fetch: Fetch, repository: str, sha: str) -> dict[str, Any]:
+    check_pages = [fetch(check_runs_endpoint(repository, sha, 1))]
+    total = _count(check_pages[0].get("total_count"), "check_runs total_count") if isinstance(check_pages[0], dict) else 0
+    for page in range(2, max(1, math.ceil(total / PAGE_SIZE)) + 1):
+        check_pages.append(fetch(check_runs_endpoint(repository, sha, page)))
+    run_pages = [fetch(workflow_runs_endpoint(repository, sha, 1))]
+    total = _count(run_pages[0].get("total_count"), "workflow_runs total_count") if isinstance(run_pages[0], dict) else 0
+    for page in range(2, max(1, math.ceil(total / PAGE_SIZE)) + 1):
+        run_pages.append(fetch(workflow_runs_endpoint(repository, sha, page)))
+    return grade_sha(sha, check_pages, run_pages)
+
+
+# ---------------------------------------------------------------------------
+# The judgment.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Decision:
+    decision: str
+    reason: str
+    version: str
+    branch: str
+    candidate: str | None = None
+    rc_run: int | None = None
+    move: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def document(self) -> dict[str, Any]:
+        return {
+            "decision": self.decision,
+            "reason": self.reason,
+            "version": self.version,
+            "branch": self.branch,
+            "candidate": self.candidate,
+            "rc_run": self.rc_run,
+            "move": self.move,
+            "details": self.details,
+        }
+
+
+def stranger_command(version: str, sha: str, rc_run: int | None) -> str:
+    """The local step the workflow prints while the stranger has no hosted host.
+
+    An exported ANTHROPIC_API_KEY drives it on a key instead of the account
+    login: bin/kin-stranger scrubs that variable only for a local endpoint.
+    """
+
+    run_id = f"rc{version.replace('.', '')}-{sha[:7]}"
+    download = f"/tmp/kin-rc-{sha[:12]}"
+    lines = [
+        f"gh run download {rc_run if rc_run is not None else '<rc-build run id>'} --repo {EXPECTED_REPOSITORY} --dir {download}",
+        f"bin/kin-stranger prepare --run {run_id} --arms green,brown,vcs",
+        f"bin/kin-stranger run --run {run_id} --archive {download}/kin-linux-aarch64/kin-linux-aarch64.tar.gz --candidate-sha {sha}",
+    ]
+    return "\n".join(lines)
+
+
+def _snapshot_field(snapshot: dict[str, Any], key: str, kind: type) -> Any:
+    value = snapshot.get(key)
+    if not isinstance(value, kind) or (kind is int and isinstance(value, bool)):
+        raise SelectionError(f"snapshot {key} is not a {kind.__name__}")
+    return value
+
+
+def judge(snapshot: dict[str, Any], grade: Grader) -> Decision:
+    """Decide what the cut does next from one snapshot and a grader.
+
+    The grader is called lazily and only for the shas the rule reaches, newest
+    first, so a range with a green newest sha costs one grading.
+    """
+
+    if not isinstance(snapshot, dict):
+        raise SelectionError("snapshot must be an object")
+    version = _snapshot_field(snapshot, "version", str)
+    if VERSION.fullmatch(version) is None:
+        raise SelectionError(f"snapshot version {version!r} is not semver-shaped")
+    shas = _snapshot_field(snapshot, "range", list)
+    if not shas or any(_sha(sha) is None for sha in shas):
+        raise SelectionError("snapshot range must be a non-empty list of 40-character shas")
+    if len(set(shas)) != len(shas):
+        raise SelectionError("snapshot range repeats a sha")
+    tag_exists = _snapshot_field(snapshot, "tag_exists", bool)
+    evidence = _snapshot_field(snapshot, "evidence", dict)
+    candidate = snapshot.get("candidate")
+    if candidate is not None and _sha(candidate) is None:
+        raise SelectionError(f"snapshot candidate {candidate!r} is not a 40-character sha")
+    rc_builds = _snapshot_field(snapshot, "rc_builds", list)
+    branch = candidate_branch(version)
+    tip = shas[0]
+
+    if tag_exists:
+        return Decision(
+            STAND_DOWN,
+            f"v{version} already exists; the cut is done and the train owns the next version",
+            version,
+            branch,
+            details={"tip": tip},
+        )
+
+    def records(sha: str) -> set[str]:
+        value = evidence.get(sha, [])
+        if not isinstance(value, list):
+            raise SelectionError(f"evidence for {sha} is not a list")
+        return set(value)
+
+    proven = [sha for sha in shas if {PREFLIGHT_RECORD, STRANGER_RECORD} <= records(sha)]
+    if proven:
+        return Decision(
+            STAND_DOWN,
+            f"{proven[0]} carries both proof records and awaits the mint",
+            version,
+            branch,
+            candidate=proven[0],
+            details={"proven": proven},
+        )
+
+    dead: dict[str, list[str]] = {}
+    notes: list[str] = []
+    if candidate is not None:
+        if candidate not in shas:
+            return Decision(
+                REFUSE,
+                f"{branch} points at {candidate}, which is not a reviewed {BASE_BRANCH} commit "
+                f"carrying {version}; delete or move the branch by hand",
+                version,
+                branch,
+                candidate=candidate,
+            )
+        if PREFLIGHT_RECORD in records(candidate):
+            return Decision(
+                STAND_DOWN,
+                f"preflight is recorded for {candidate}; the stranger record is the missing half",
+                version,
+                branch,
+                candidate=candidate,
+                details={"stranger_command": stranger_command(version, candidate, _newest_usable_run(rc_builds, candidate))},
+            )
+        grade_of = grade(candidate)
+        if grade_of.get("verdict") == PENDING:
+            return Decision(
+                STAND_DOWN,
+                f"candidate {candidate} is being graded again: {'; '.join(grade_of.get('pending', []))}",
+                version,
+                branch,
+                candidate=candidate,
+            )
+        if grade_of.get("verdict") == DEAD:
+            dead[candidate] = list(grade_of.get("dead", []))
+            notes.append(f"current candidate {candidate} died: {'; '.join(dead[candidate])}")
+        else:
+            builds = [build for build in rc_builds if build.get("head_sha") == candidate]
+            active = [build for build in builds if build.get("status") != "completed"]
+            if active:
+                return Decision(
+                    STAND_DOWN,
+                    f"rc-build {active[0]['id']} is {active[0].get('status')} for {candidate}",
+                    version,
+                    branch,
+                    candidate=candidate,
+                    rc_run=active[0]["id"],
+                )
+            usable = [build for build in builds if _usable(build)]
+            if usable:
+                return Decision(
+                    PROOF,
+                    f"rc-build {usable[0]['id']} succeeded for {candidate} with the preflight leg records",
+                    version,
+                    branch,
+                    candidate=candidate,
+                    rc_run=usable[0]["id"],
+                    details={"stranger_command": stranger_command(version, candidate, usable[0]["id"])},
+                )
+            spent = [f"{build['id']} ({build.get('conclusion') or 'no preflight legs'})" for build in builds]
+            if len(spent) >= RC_BUILD_ATTEMPT_LIMIT:
+                dead[candidate] = [f"rc-build attempts exhausted: {', '.join(spent)}"]
+                notes.append(f"current candidate {candidate} died: {dead[candidate][0]}")
+            else:
+                return Decision(
+                    ARM,
+                    f"{candidate} is green with no usable rc-build yet"
+                    + (f" (prior attempts: {', '.join(spent)})" if spent else ""),
+                    version,
+                    branch,
+                    candidate=candidate,
+                    move=MOVE_NONE,
+                    details={"attempts": spent},
+                )
+
+    pending: dict[str, list[str]] = {}
+    disqualified: dict[str, list[str]] = {}
+    for sha in shas:
+        if sha in dead:
+            disqualified[sha] = dead[sha]
+            continue
+        grade_of = grade(sha)
+        verdict = grade_of.get("verdict")
+        if verdict == GREEN:
+            if candidate is None:
+                move = MOVE_CREATE
+            elif candidate == sha:
+                move = MOVE_NONE
+            elif shas.index(sha) < shas.index(candidate):
+                move = MOVE_FAST_FORWARD
+            else:
+                move = MOVE_RESET
+            return Decision(
+                ARM,
+                f"{sha} is the newest reviewed {BASE_BRANCH} commit carrying {version} whose push "
+                "runs concluded success with every required context present exactly once",
+                version,
+                branch,
+                candidate=sha,
+                move=move,
+                details={
+                    "notes": notes,
+                    "skipped_pending": pending,
+                    "disqualified": disqualified,
+                    "previous_candidate": candidate,
+                },
+            )
+        if verdict == PENDING:
+            pending[sha] = list(grade_of.get("pending", []))
+            continue
+        if verdict != DEAD:
+            raise SelectionError(f"grader answered {verdict!r} for {sha}")
+        disqualified[sha] = list(grade_of.get("dead", []))
+
+    if pending:
+        return Decision(
+            STAND_DOWN,
+            f"no complete green sha carries {version} yet; {len(pending)} still being graded",
+            version,
+            branch,
+            details={"notes": notes, "pending": pending, "disqualified": disqualified},
+        )
+    newest = shas[0]
+    return Decision(
+        REFUSE,
+        f"no reviewed {BASE_BRANCH} commit carrying {version} qualifies; newest {newest}: "
+        + "; ".join(disqualified.get(newest, ["not graded"])),
+        version,
+        branch,
+        details={"notes": notes, "disqualified": disqualified},
+    )
+
+
+def _usable(build: dict[str, Any]) -> bool:
+    if build.get("status") != "completed" or build.get("conclusion") != "success":
+        return False
+    names = set(build.get("artifacts") or [])
+    return all(f"{PREFLIGHT_ARTIFACT_PREFIX}{artifact}" in names for artifact in PREFLIGHT_ARTIFACTS)
+
+
+def _newest_usable_run(rc_builds: list[dict[str, Any]], sha: str) -> int | None:
+    for build in rc_builds:
+        if build.get("head_sha") == sha and _usable(build):
+            return build["id"]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Live gather.
+# ---------------------------------------------------------------------------
+
+
+def gather(repository: str, workspace: Path, fetch: Fetch | None = None) -> dict[str, Any]:
+    read = gh_json if fetch is None else fetch
+    tip = run_git(workspace, "rev-parse", f"refs/remotes/origin/{BASE_BRANCH}")
+    if _sha(tip) is None:
+        raise SelectionError(f"origin/{BASE_BRANCH} did not resolve to an exact sha")
+    version = workspace_version(run_git(workspace, "show", f"{tip}:Cargo.toml"))
+    shas = version_range(workspace, tip, version)
+    branch = candidate_branch(version)
+    return {
+        "repository": repository,
+        "version": version,
+        "range": shas,
+        "tag_exists": read_tag_exists(read, repository, version),
+        "evidence": read_evidence(read, repository),
+        "candidate": read_branch(read, repository, branch),
+        "rc_builds": read_rc_builds(read, repository, branch),
+    }
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    trigger = commands.add_parser("validate-trigger", help="admit the trigger from GitHub-owned context")
+    trigger.add_argument("--event-file", required=True)
+    trigger.add_argument("--event-name", required=True)
+    trigger.add_argument("--event-action", default="")
+    trigger.add_argument("--actor", required=True)
+    trigger.add_argument("--repository", required=True)
+    trigger.add_argument("--default-branch", required=True)
+    trigger.add_argument("--ref", required=True)
+    trigger.add_argument("--workflow-sha", required=True)
+
+    select = commands.add_parser("select", help="decide what the cut does next")
+    select.add_argument("--repository", default=EXPECTED_REPOSITORY)
+    select.add_argument("--workspace", help="the protected-main checkout the range is read from")
+    select.add_argument(
+        "--snapshot",
+        help="judge this snapshot document instead of reading GitHub; it carries the grades",
+    )
+    return parser.parse_args(argv)
+
+
+def _emit(decision: Decision) -> int:
+    document = decision.document()
+    print(json.dumps(document, sort_keys=True))
+    output = os.environ.get("GITHUB_OUTPUT")
+    if output:
+        with open(output, "a", encoding="utf-8") as handle:
+            for key in ("decision", "version", "branch", "candidate", "rc_run", "move"):
+                value = document.get(key)
+                handle.write(f"{key}={'' if value is None else value}\n")
+            handle.write(f"reason={decision.reason.replace(chr(10), ' ')}\n")
+    if decision.decision == REFUSE:
+        print(f"::error title=Release cut refused::{decision.reason}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    try:
+        if args.command == "validate-trigger":
+            with open(args.event_file, encoding="utf-8") as handle:
+                event = json.load(handle)
+            verdict = validate_trigger(
+                event_name=args.event_name,
+                event_action=args.event_action,
+                actor=args.actor,
+                repository=args.repository,
+                default_branch=args.default_branch,
+                ref=args.ref,
+                workflow_sha=args.workflow_sha,
+                event=event,
+            )
+            print(json.dumps(verdict, sort_keys=True))
+            return 0
+        if args.snapshot:
+            with open(args.snapshot, encoding="utf-8") as handle:
+                document = json.load(handle)
+            grades = document.get("grades") if isinstance(document, dict) else None
+            if not isinstance(grades, dict):
+                raise SelectionError("a snapshot document must carry its grades")
+
+            def grade(sha: str) -> dict[str, Any]:
+                pages = grades.get(sha)
+                if not isinstance(pages, dict):
+                    raise SelectionError(f"snapshot carries no grade for {sha}")
+                return grade_sha(sha, pages.get("check_runs"), pages.get("workflow_runs"))
+
+            return _emit(judge(document, grade))
+        if not args.workspace:
+            raise SelectionError("select needs --workspace (or --snapshot)")
+        if args.repository.count("/") != 1:
+            raise SelectionError("repository must be owner/name")
+        snapshot = gather(args.repository, Path(args.workspace))
+        return _emit(judge(snapshot, lambda sha: grade_live(gh_json, args.repository, sha)))
+    except SelectionError as exc:
+        print(f"::error title=Release cut could not decide::{exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -851,6 +851,18 @@ EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
     ".github/workflows/registry-index-migrate.yml": {
         "migrate": None,
     },
+    # The automatic candidate selection and the hosted half of its proof. Every
+    # trigger resolves from protected main and none of its jobs runs on a
+    # pull_request or merge_group event, so none can claim a required context;
+    # it is registered here because this census is what would otherwise let a
+    # new workflow's job NAME appear unreviewed.
+    ".github/workflows/release-cut.yml": {
+        "select": "Select the release candidate",
+        "arm": "Arm the release candidate",
+        "preflight": "Preflight ${{ matrix.artifact }}",
+        "publish": "Publish the candidate's preflight record",
+        "report": "Report the cut's decision",
+    },
     ".github/workflows/release-recovery.yml": {
         "reconcile": "Reconcile failed release",
     },
@@ -930,6 +942,10 @@ EXPECTED_DYNAMIC_JOB_CONTEXT_SHA256 = {
         ".github/workflows/rc-build.yml",
         "capability",
     ): "3e7512c3b44ab447531be464599f6237bff7efe798d54728c012676a7c3aed23",
+    (
+        ".github/workflows/release-cut.yml",
+        "preflight",
+    ): "f86f3c6f46bcacba012e93cd28dab5aaa2d711a66078007e4a4fbeb21e6629e7",
     (
         ".github/workflows/release.yml",
         "build",

--- a/scripts/test-select-release-candidate.py
+++ b/scripts/test-select-release-candidate.py
@@ -1,0 +1,889 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Deterministic contract tests for the automatic release-candidate selection.
+
+`scripts/select-release-candidate.py` decides which main commit the proof loop
+proves next, and both of its judgments are pure functions over one snapshot, so
+every case here is a fixture and a verdict with no GitHub in the loop. The
+fixtures are shaped on real listings read on 2026-09-02:
+
+  * 57228997f carried three check-runs per required name, because a CI push run
+    was rerun to attempt 3, and a second `gitleaks (full history)` produced by a
+    push to the candidate branch. That sha is what taught the fleet that a rerun
+    is what makes a sha unmintable, whatever the copies concluded.
+  * 59c2239c2's `Windows installer + vector release build` concluded cancelled
+    at the 60-minute job cap while Acceptance passed, so a red required context
+    has to disqualify a sha its Acceptance run says nothing about.
+  * 390fbdc54 carried every required context exactly once and became v0.6.4.
+
+The workflow contract tests pin the shape of release-cut.yml, because a step
+that stops calling the selector reads exactly like one that never needed it.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SELECTOR_PATH = ROOT / "scripts" / "select-release-candidate.py"
+CUT_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "release-cut.yml"
+RELEASE_TAG_PATH = ROOT / ".github" / "workflows" / "release-tag.yml"
+REPO = "firelock-ai/kin"
+VERSION = "0.6.5"
+NEWEST = "a" * 40
+MIDDLE = "b" * 40
+OLDEST = "c" * 40
+FOREIGN = "d" * 40
+CI_SUITE = 91_000_000_001
+ACCEPTANCE_SUITE = 91_000_000_002
+SAST_SUITE = 91_000_000_003
+SECRET_SUITE = 91_000_000_004
+CI_RUN = 33_000_000_001
+ACCEPTANCE_RUN = 33_000_000_002
+SAST_RUN = 33_000_000_003
+SECRET_RUN = 33_000_000_004
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+selector = load_module("kin_release_candidate_selector", SELECTOR_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders for the two listings the grader reads.
+# ---------------------------------------------------------------------------
+
+
+def check_run(
+    name: str,
+    *,
+    suite: int,
+    status: str = "completed",
+    conclusion: str | None = "success",
+    app: tuple[int, str] = selector.GITHUB_ACTIONS_APP,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "status": status,
+        "conclusion": conclusion,
+        "check_suite": {"id": suite},
+        "app": {"id": app[0], "slug": app[1]},
+    }
+
+
+def workflow_run(
+    path: str,
+    *,
+    run_id: int,
+    suite: int,
+    sha: str,
+    workflow_id: int,
+    event: str = "push",
+    branch: str = "main",
+    status: str = "completed",
+    conclusion: str | None = "success",
+) -> dict[str, Any]:
+    return {
+        "id": run_id,
+        "workflow_id": workflow_id,
+        "path": path,
+        "event": event,
+        "head_branch": branch,
+        "head_sha": sha,
+        "status": status,
+        "conclusion": conclusion,
+        "check_suite_id": suite,
+    }
+
+
+def pages(items: list[dict[str, Any]], key: str, total: int | None = None) -> list[dict[str, Any]]:
+    return [{"total_count": len(items) if total is None else total, key: items}]
+
+
+def green_checks(sha: str = NEWEST) -> list[dict[str, Any]]:
+    suites = {
+        ".github/workflows/ci.yml": CI_SUITE,
+        ".github/workflows/sast.yml": SAST_SUITE,
+        ".github/workflows/secret-scan.yml": SECRET_SUITE,
+    }
+    runs = []
+    for name, _workflow_id, path in selector.REQUIRED_CONTEXTS:
+        conclusion = "skipped" if name in selector.SKIPPABLE_REQUIRED else "success"
+        runs.append(check_run(name, suite=suites[path], conclusion=conclusion))
+    return runs
+
+
+def green_workflow_runs(sha: str = NEWEST) -> list[dict[str, Any]]:
+    return [
+        workflow_run(".github/workflows/ci.yml", run_id=CI_RUN, suite=CI_SUITE, sha=sha, workflow_id=245803170),
+        workflow_run(
+            ".github/workflows/acceptance.yml",
+            run_id=ACCEPTANCE_RUN,
+            suite=ACCEPTANCE_SUITE,
+            sha=sha,
+            workflow_id=339594603,
+        ),
+        workflow_run(".github/workflows/sast.yml", run_id=SAST_RUN, suite=SAST_SUITE, sha=sha, workflow_id=251549972),
+        workflow_run(
+            ".github/workflows/secret-scan.yml",
+            run_id=SECRET_RUN,
+            suite=SECRET_SUITE,
+            sha=sha,
+            workflow_id=293452372,
+        ),
+    ]
+
+
+def grade_pages(checks: list[dict[str, Any]], runs: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"check_runs": pages(checks, "check_runs"), "workflow_runs": pages(runs, "workflow_runs")}
+
+
+def green_grade(sha: str = NEWEST) -> dict[str, Any]:
+    return grade_pages(green_checks(sha), green_workflow_runs(sha))
+
+
+def with_duplicate(grade: dict[str, Any], name: str, suite: int) -> dict[str, Any]:
+    """Append a second check-run under one required name, total_count included.
+
+    The total has to move with it. `flatten_pages` asserts the listed length
+    against `total_count` precisely so a short page cannot read as a sha with
+    fewer checks, and a fixture that appends without bumping the total tests
+    that assertion rather than the duplication it meant to test.
+    """
+
+    grade = copy.deepcopy(grade)
+    page = grade["check_runs"][0]
+    page["check_runs"].append(check_run(name, suite=suite))
+    page["total_count"] = len(page["check_runs"])
+    return grade
+
+
+def rc_build(
+    sha: str,
+    *,
+    run_id: int = 34_000_000_001,
+    status: str = "completed",
+    conclusion: str | None = "success",
+    artifacts: list[str] | None = None,
+    created_at: str = "2026-09-02T20:00:00Z",
+) -> dict[str, Any]:
+    if artifacts is None:
+        artifacts = [f"{selector.PREFLIGHT_ARTIFACT_PREFIX}{name}" for name in selector.PREFLIGHT_ARTIFACTS]
+    return {
+        "id": run_id,
+        "head_sha": sha,
+        "head_branch": selector.candidate_branch(VERSION),
+        "event": "workflow_dispatch",
+        "status": status,
+        "conclusion": conclusion,
+        "created_at": created_at,
+        "artifacts": sorted(artifacts),
+    }
+
+
+def snapshot(**overrides: Any) -> dict[str, Any]:
+    document = {
+        "repository": REPO,
+        "version": VERSION,
+        "range": [NEWEST, MIDDLE, OLDEST],
+        "tag_exists": False,
+        "evidence": {},
+        "candidate": None,
+        "rc_builds": [],
+    }
+    document.update(overrides)
+    return document
+
+
+class Grader:
+    """Serve a grade per sha and record which shas were actually graded."""
+
+    def __init__(self, grades: dict[str, dict[str, Any]]) -> None:
+        self.grades = grades
+        self.calls: list[str] = []
+
+    def __call__(self, sha: str) -> dict[str, Any]:
+        self.calls.append(sha)
+        if sha not in self.grades:
+            raise AssertionError(f"unexpected grading of {sha}")
+        return selector.grade_sha(sha, self.grades[sha]["check_runs"], self.grades[sha]["workflow_runs"])
+
+
+# ---------------------------------------------------------------------------
+# Grading one sha.
+# ---------------------------------------------------------------------------
+
+
+class GradeShaTests(unittest.TestCase):
+    def grade(self, checks: list[dict[str, Any]], runs: list[dict[str, Any]], sha: str = NEWEST) -> dict[str, Any]:
+        return selector.grade_sha(sha, pages(checks, "check_runs"), pages(runs, "workflow_runs"))
+
+    def test_green_sha(self) -> None:
+        verdict = self.grade(green_checks(), green_workflow_runs())
+        self.assertEqual(verdict["verdict"], selector.GREEN, verdict)
+        self.assertEqual(verdict["dead"], [])
+        self.assertEqual(verdict["pending"], [])
+
+    def test_a_rerun_duplicating_one_required_context_is_dead(self) -> None:
+        """57228997f: a rerun claims the name twice and the mint calls that ambiguous."""
+
+        checks = green_checks()
+        checks.append(check_run("Falsify guards", suite=CI_SUITE))
+        verdict = self.grade(checks, green_workflow_runs())
+        self.assertEqual(verdict["verdict"], selector.DEAD)
+        self.assertTrue(
+            any("ambiguous required check: Falsify guards" in line for line in verdict["dead"]),
+            verdict["dead"],
+        )
+
+    def test_a_red_required_context_is_dead(self) -> None:
+        """59c2239c2: the Windows leg was cancelled at the job cap."""
+
+        checks = [
+            check_run(name, suite=CI_SUITE, conclusion="cancelled")
+            if name == "Windows installer + vector release build"
+            else run
+            for name, run in ((entry["name"], entry) for entry in green_checks())
+        ]
+        verdict = self.grade(checks, green_workflow_runs())
+        self.assertEqual(verdict["verdict"], selector.DEAD)
+        self.assertIn(
+            "required check not green: Windows installer + vector release build (conclusion=cancelled)",
+            verdict["dead"],
+        )
+
+    def test_a_running_required_context_is_pending_not_dead(self) -> None:
+        checks = green_checks()
+        checks[0] = check_run(checks[0]["name"], suite=CI_SUITE, status="in_progress", conclusion=None)
+        verdict = self.grade(checks, green_workflow_runs())
+        self.assertEqual(verdict["verdict"], selector.PENDING)
+        self.assertTrue(any("not completed" in line for line in verdict["pending"]))
+
+    def test_a_missing_required_context_is_dead_once_its_producer_finished(self) -> None:
+        checks = [entry for entry in green_checks() if entry["name"] != "cargo-deny"]
+        verdict = self.grade(checks, green_workflow_runs())
+        self.assertEqual(verdict["verdict"], selector.DEAD)
+        self.assertTrue(any("missing required check: cargo-deny" in line for line in verdict["dead"]))
+
+    def test_a_missing_required_context_waits_while_its_producer_runs(self) -> None:
+        checks = [entry for entry in green_checks() if entry["name"] != "cargo-deny"]
+        runs = [
+            workflow_run(
+                ".github/workflows/sast.yml",
+                run_id=SAST_RUN,
+                suite=SAST_SUITE,
+                sha=NEWEST,
+                workflow_id=251549972,
+                status="in_progress",
+                conclusion=None,
+            )
+            if run["path"] == ".github/workflows/sast.yml"
+            else run
+            for run in green_workflow_runs()
+        ]
+        verdict = self.grade(checks, runs)
+        self.assertEqual(verdict["verdict"], selector.PENDING)
+
+    def test_dco_may_be_skipped_but_nothing_else_may(self) -> None:
+        checks = green_checks()
+        for entry in checks:
+            if entry["name"] == "Falsify guards":
+                entry["conclusion"] = "skipped"
+        verdict = self.grade(checks, green_workflow_runs())
+        self.assertEqual(verdict["verdict"], selector.DEAD)
+        self.assertTrue(any("Falsify guards" in line for line in verdict["dead"]))
+
+    def test_a_red_ci_push_run_is_dead_even_with_green_contexts(self) -> None:
+        runs = [
+            workflow_run(
+                ".github/workflows/ci.yml",
+                run_id=CI_RUN,
+                suite=CI_SUITE,
+                sha=NEWEST,
+                workflow_id=245803170,
+                conclusion="cancelled",
+            )
+            if run["path"] == ".github/workflows/ci.yml"
+            else run
+            for run in green_workflow_runs()
+        ]
+        verdict = self.grade(green_checks(), runs)
+        self.assertEqual(verdict["verdict"], selector.DEAD)
+        self.assertTrue(any("CI push run" in line for line in verdict["dead"]))
+
+    def test_a_red_acceptance_push_run_is_dead(self) -> None:
+        """Acceptance grades main's push and nothing else, so a red one stops the cut."""
+
+        runs = [
+            workflow_run(
+                ".github/workflows/acceptance.yml",
+                run_id=ACCEPTANCE_RUN,
+                suite=ACCEPTANCE_SUITE,
+                sha=NEWEST,
+                workflow_id=339594603,
+                conclusion="failure",
+            )
+            if run["path"] == ".github/workflows/acceptance.yml"
+            else run
+            for run in green_workflow_runs()
+        ]
+        verdict = self.grade(green_checks(), runs)
+        self.assertEqual(verdict["verdict"], selector.DEAD)
+        self.assertTrue(any("Acceptance push run" in line for line in verdict["dead"]))
+
+    def test_an_absent_acceptance_run_is_pending(self) -> None:
+        runs = [run for run in green_workflow_runs() if run["path"] != ".github/workflows/acceptance.yml"]
+        verdict = self.grade(green_checks(), runs)
+        self.assertEqual(verdict["verdict"], selector.PENDING)
+        self.assertTrue(any("no Acceptance push run" in line for line in verdict["pending"]))
+
+    def test_a_context_from_another_app_is_dead(self) -> None:
+        checks = green_checks()
+        checks[0] = check_run(checks[0]["name"], suite=CI_SUITE, app=(99, "impostor"))
+        verdict = self.grade(checks, green_workflow_runs())
+        self.assertEqual(verdict["verdict"], selector.DEAD)
+        self.assertTrue(any("claimed by another app" in line for line in verdict["dead"]))
+
+    def test_a_candidate_branch_twin_is_discounted_not_counted(self) -> None:
+        """57228997f carried a second gitleaks from the candidate branch's own push."""
+
+        checks = green_checks()
+        checks.append(check_run("gitleaks (full history)", suite=91_000_000_099))
+        runs = green_workflow_runs()
+        runs.append(
+            workflow_run(
+                ".github/workflows/secret-scan.yml",
+                run_id=33_000_000_099,
+                suite=91_000_000_099,
+                sha=NEWEST,
+                workflow_id=293452372,
+                branch=f"release/v{VERSION}-candidate",
+            )
+        )
+        verdict = self.grade(checks, runs)
+        self.assertEqual(verdict["verdict"], selector.GREEN, verdict)
+
+    def test_a_second_producer_of_a_required_name_on_main_is_dead(self) -> None:
+        checks = green_checks()
+        checks.append(check_run("Falsify guards", suite=91_000_000_098))
+        runs = green_workflow_runs()
+        runs.append(
+            workflow_run(
+                ".github/workflows/impostor.yml",
+                run_id=33_000_000_098,
+                suite=91_000_000_098,
+                sha=NEWEST,
+                workflow_id=999,
+            )
+        )
+        verdict = self.grade(checks, runs)
+        self.assertEqual(verdict["verdict"], selector.DEAD)
+        self.assertTrue(any("provenance mismatch" in line for line in verdict["dead"]))
+
+    def test_a_truncated_listing_refuses_rather_than_reading_as_green(self) -> None:
+        checks = green_checks()
+        with self.assertRaises(selector.SelectionError) as caught:
+            selector.grade_sha(
+                NEWEST,
+                pages(checks, "check_runs", total=len(checks) + 5),
+                pages(green_workflow_runs(), "workflow_runs"),
+            )
+        self.assertIn("incomplete", str(caught.exception))
+
+    def test_a_loose_sha_refuses(self) -> None:
+        with self.assertRaises(selector.SelectionError):
+            selector.grade_sha("abc", pages([], "check_runs"), pages([], "workflow_runs"))
+
+
+# ---------------------------------------------------------------------------
+# The decision.
+# ---------------------------------------------------------------------------
+
+
+class JudgeTests(unittest.TestCase):
+    def assertDecision(self, decision: Any, expected: str, needle: str = "") -> None:
+        self.assertEqual(decision.decision, expected, decision.reason)
+        if needle:
+            self.assertIn(needle, decision.reason)
+
+    def test_a_finalized_tag_stands_the_cut_down(self) -> None:
+        """Today's tree: main carries 0.6.4 and v0.6.4 exists, so there is nothing to cut."""
+
+        grader = Grader({})
+        decision = selector.judge(snapshot(tag_exists=True), grader)
+        self.assertDecision(decision, selector.STAND_DOWN, "already exists")
+        self.assertEqual(grader.calls, [], "a tagged version must cost no grading")
+
+    def test_a_fully_evidenced_candidate_stands_the_cut_down(self) -> None:
+        grader = Grader({})
+        decision = selector.judge(
+            snapshot(evidence={MIDDLE: [selector.PREFLIGHT_RECORD, selector.STRANGER_RECORD]}),
+            grader,
+        )
+        self.assertDecision(decision, selector.STAND_DOWN, "awaits the mint")
+        self.assertEqual(decision.candidate, MIDDLE)
+        self.assertEqual(grader.calls, [])
+
+    def test_a_half_evidenced_candidate_waits_for_the_stranger_and_prints_its_command(self) -> None:
+        grader = Grader({})
+        decision = selector.judge(
+            snapshot(candidate=MIDDLE, evidence={MIDDLE: [selector.PREFLIGHT_RECORD]}),
+            grader,
+        )
+        self.assertDecision(decision, selector.STAND_DOWN, "the stranger record is the missing half")
+        command = decision.details["stranger_command"]
+        self.assertIn("bin/kin-stranger prepare", command)
+        self.assertIn("--arms green,brown,vcs", command)
+        self.assertIn(f"--candidate-sha {MIDDLE}", command)
+        self.assertEqual(grader.calls, [])
+
+    def test_the_newest_green_sha_is_armed(self) -> None:
+        grader = Grader({NEWEST: green_grade(NEWEST)})
+        decision = selector.judge(snapshot(), grader)
+        self.assertDecision(decision, selector.ARM)
+        self.assertEqual(decision.candidate, NEWEST)
+        self.assertEqual(decision.move, selector.MOVE_CREATE)
+        self.assertEqual(decision.branch, f"release/v{VERSION}-candidate")
+        self.assertEqual(grader.calls, [NEWEST], "a green newest sha must cost exactly one grading")
+
+    def test_an_older_green_sha_behind_a_red_newest_is_armed(self) -> None:
+        red = with_duplicate(green_grade(NEWEST), "Falsify guards", CI_SUITE)
+        grader = Grader({NEWEST: red, MIDDLE: green_grade(MIDDLE)})
+        decision = selector.judge(snapshot(), grader)
+        self.assertDecision(decision, selector.ARM)
+        self.assertEqual(decision.candidate, MIDDLE)
+        self.assertEqual(grader.calls, [NEWEST, MIDDLE])
+        self.assertIn(NEWEST, decision.details["disqualified"])
+
+    def test_a_pending_newest_is_skipped_rather_than_waited_for(self) -> None:
+        """On a busy night the newest sha is always mid-grading; waiting never converges."""
+
+        pending = green_grade(NEWEST)
+        pending["check_runs"][0]["check_runs"][0]["status"] = "in_progress"
+        pending["check_runs"][0]["check_runs"][0]["conclusion"] = None
+        grader = Grader({NEWEST: pending, MIDDLE: green_grade(MIDDLE)})
+        decision = selector.judge(snapshot(), grader)
+        self.assertDecision(decision, selector.ARM)
+        self.assertEqual(decision.candidate, MIDDLE)
+        self.assertIn(NEWEST, decision.details["skipped_pending"])
+
+    def test_no_green_sha_anywhere_refuses_and_names_the_newest(self) -> None:
+        dead = {
+            sha: with_duplicate(green_grade(sha), "Falsify guards", CI_SUITE)
+            for sha in (NEWEST, MIDDLE, OLDEST)
+        }
+        decision = selector.judge(snapshot(), Grader(dead))
+        self.assertDecision(decision, selector.REFUSE, "no reviewed main commit")
+        self.assertIn(NEWEST, decision.reason)
+        self.assertIn("ambiguous required check: Falsify guards", decision.reason)
+
+    def test_every_sha_pending_stands_down_rather_than_refusing(self) -> None:
+        waiting = {}
+        for sha in (NEWEST, MIDDLE, OLDEST):
+            grade = green_grade(sha)
+            grade["check_runs"][0]["check_runs"][0]["status"] = "queued"
+            grade["check_runs"][0]["check_runs"][0]["conclusion"] = None
+            waiting[sha] = grade
+        decision = selector.judge(snapshot(), Grader(waiting))
+        self.assertDecision(decision, selector.STAND_DOWN, "still being graded")
+
+    def test_a_green_candidate_with_no_rc_build_is_armed_without_moving_the_branch(self) -> None:
+        grader = Grader({MIDDLE: green_grade(MIDDLE)})
+        decision = selector.judge(snapshot(candidate=MIDDLE), grader)
+        self.assertDecision(decision, selector.ARM)
+        self.assertEqual(decision.candidate, MIDDLE)
+        self.assertEqual(decision.move, selector.MOVE_NONE)
+
+    def test_a_running_rc_build_stands_down(self) -> None:
+        grader = Grader({MIDDLE: green_grade(MIDDLE)})
+        decision = selector.judge(
+            snapshot(candidate=MIDDLE, rc_builds=[rc_build(MIDDLE, status="in_progress", conclusion=None)]),
+            grader,
+        )
+        self.assertDecision(decision, selector.STAND_DOWN, "in_progress")
+        self.assertEqual(decision.rc_run, 34_000_000_001)
+
+    def test_a_successful_rc_build_with_every_leg_record_is_proof(self) -> None:
+        grader = Grader({MIDDLE: green_grade(MIDDLE)})
+        decision = selector.judge(snapshot(candidate=MIDDLE, rc_builds=[rc_build(MIDDLE)]), grader)
+        self.assertDecision(decision, selector.PROOF)
+        self.assertEqual(decision.rc_run, 34_000_000_001)
+        self.assertIn("bin/kin-stranger run", decision.details["stranger_command"])
+
+    def test_an_rc_build_missing_a_leg_record_is_not_proof(self) -> None:
+        """A run from before the preflight job existed proves less than a record would claim."""
+
+        partial = rc_build(MIDDLE, artifacts=[f"{selector.PREFLIGHT_ARTIFACT_PREFIX}kin-macos-aarch64"])
+        grader = Grader({MIDDLE: green_grade(MIDDLE)})
+        decision = selector.judge(snapshot(candidate=MIDDLE, rc_builds=[partial]), grader)
+        self.assertDecision(decision, selector.ARM)
+        self.assertEqual(decision.candidate, MIDDLE)
+
+    def test_exhausted_rc_build_attempts_kill_the_candidate_and_pick_the_next(self) -> None:
+        spent = [
+            rc_build(MIDDLE, run_id=1, conclusion="failure", created_at="2026-09-02T19:00:00Z"),
+            rc_build(MIDDLE, run_id=2, conclusion="failure", created_at="2026-09-02T20:00:00Z"),
+        ]
+        grader = Grader({MIDDLE: green_grade(MIDDLE), NEWEST: green_grade(NEWEST)})
+        decision = selector.judge(snapshot(candidate=MIDDLE, rc_builds=spent), grader)
+        self.assertDecision(decision, selector.ARM)
+        self.assertEqual(decision.candidate, NEWEST)
+        self.assertEqual(decision.move, selector.MOVE_FAST_FORWARD)
+        self.assertTrue(any("attempts exhausted" in note for note in decision.details["notes"]))
+
+    def test_a_dead_candidate_is_replaced_by_the_newest_green_sha(self) -> None:
+        dead = with_duplicate(green_grade(MIDDLE), "cargo-deny", SAST_SUITE)
+        grader = Grader({MIDDLE: dead, NEWEST: green_grade(NEWEST)})
+        decision = selector.judge(snapshot(candidate=MIDDLE), grader)
+        self.assertDecision(decision, selector.ARM)
+        self.assertEqual(decision.candidate, NEWEST)
+        self.assertEqual(decision.move, selector.MOVE_FAST_FORWARD)
+
+    def test_a_dead_candidate_replaced_by_an_older_sha_resets_rather_than_fast_forwards(self) -> None:
+        dead = with_duplicate(green_grade(MIDDLE), "cargo-deny", SAST_SUITE)
+        newest_dead = with_duplicate(green_grade(NEWEST), "cargo-deny", SAST_SUITE)
+        grader = Grader({MIDDLE: dead, NEWEST: newest_dead, OLDEST: green_grade(OLDEST)})
+        decision = selector.judge(snapshot(candidate=MIDDLE), grader)
+        self.assertDecision(decision, selector.ARM)
+        self.assertEqual(decision.candidate, OLDEST)
+        self.assertEqual(decision.move, selector.MOVE_RESET)
+
+    def test_a_candidate_off_the_version_range_refuses(self) -> None:
+        decision = selector.judge(snapshot(candidate=FOREIGN), Grader({}))
+        self.assertDecision(decision, selector.REFUSE, "is not a reviewed main commit")
+
+    def test_a_pending_candidate_stands_down_without_replacing_it(self) -> None:
+        pending = green_grade(MIDDLE)
+        pending["check_runs"][0]["check_runs"][0]["status"] = "in_progress"
+        pending["check_runs"][0]["check_runs"][0]["conclusion"] = None
+        grader = Grader({MIDDLE: pending})
+        decision = selector.judge(snapshot(candidate=MIDDLE), grader)
+        self.assertDecision(decision, selector.STAND_DOWN, "being graded again")
+        self.assertEqual(grader.calls, [MIDDLE])
+
+    def test_malformed_snapshots_refuse(self) -> None:
+        for broken, needle in (
+            (snapshot(version="0.6"), "semver"),
+            (snapshot(range=[]), "non-empty"),
+            (snapshot(range=[NEWEST, NEWEST]), "repeats"),
+            (snapshot(range=["nope"]), "40-character"),
+            (snapshot(candidate="nope"), "not a 40-character"),
+        ):
+            with self.assertRaises(selector.SelectionError):
+                selector.judge(broken, Grader({}))
+        with self.assertRaises(selector.SelectionError):
+            selector.judge("not an object", Grader({}))
+
+
+# ---------------------------------------------------------------------------
+# Trigger validation.
+# ---------------------------------------------------------------------------
+
+
+def trigger_context(**overrides: Any) -> dict[str, Any]:
+    context = {
+        "event_name": "schedule",
+        "event_action": "",
+        "actor": "troyjr4103",
+        "repository": REPO,
+        "default_branch": "main",
+        "ref": "refs/heads/main",
+        "workflow_sha": NEWEST,
+        "event": {},
+    }
+    context.update(overrides)
+    return context
+
+
+def completion_event(**overrides: Any) -> dict[str, Any]:
+    run = {
+        "path": ".github/workflows/ci.yml",
+        "event": "push",
+        "head_branch": "main",
+        "head_repository": {"full_name": REPO},
+        "status": "completed",
+        "conclusion": "success",
+        "head_sha": NEWEST,
+        "id": CI_RUN,
+    }
+    run.update(overrides)
+    return {"workflow_run": run}
+
+
+class TriggerTests(unittest.TestCase):
+    def test_the_sweep_is_admitted(self) -> None:
+        verdict = selector.validate_trigger(**trigger_context())
+        self.assertEqual(verdict["trigger"], selector.TRIGGER_SWEEP)
+
+    def test_a_ci_completion_for_a_main_push_is_admitted(self) -> None:
+        verdict = selector.validate_trigger(
+            **trigger_context(event_name="workflow_run", event_action="completed", event=completion_event())
+        )
+        self.assertEqual(verdict["trigger"], selector.TRIGGER_CI)
+
+    def test_an_rc_build_completion_on_a_candidate_branch_is_admitted(self) -> None:
+        verdict = selector.validate_trigger(
+            **trigger_context(
+                event_name="workflow_run",
+                event_action="completed",
+                event=completion_event(
+                    path=".github/workflows/rc-build.yml",
+                    event="workflow_dispatch",
+                    head_branch=f"release/v{VERSION}-candidate",
+                ),
+            )
+        )
+        self.assertEqual(verdict["trigger"], selector.TRIGGER_RC_BUILD)
+        self.assertEqual(verdict["run_id"], CI_RUN)
+
+    def test_completions_that_are_not_occasions_refuse(self) -> None:
+        for overrides, needle in (
+            ({"head_branch": "chore/lane-x"}, "occasion only for a push to main"),
+            ({"event": "pull_request"}, "occasion only for a push to main"),
+            ({"head_repository": {"full_name": "someone/fork"}}, "first-party"),
+            ({"status": "in_progress"}, "not completed"),
+            ({"path": ".github/workflows/acceptance.yml"}, "is neither"),
+        ):
+            with self.assertRaises(selector.SelectionError) as caught:
+                selector.validate_trigger(
+                    **trigger_context(
+                        event_name="workflow_run", event_action="completed", event=completion_event(**overrides)
+                    )
+                )
+            self.assertIn(needle, str(caught.exception))
+
+    def test_an_rc_build_completion_off_a_candidate_branch_refuses(self) -> None:
+        with self.assertRaises(selector.SelectionError) as caught:
+            selector.validate_trigger(
+                **trigger_context(
+                    event_name="workflow_run",
+                    event_action="completed",
+                    event=completion_event(path=".github/workflows/rc-build.yml", event="workflow_dispatch", head_branch="main"),
+                )
+            )
+        self.assertIn("release/v<version>-candidate", str(caught.exception))
+
+    def test_the_kick_is_admitted_only_from_the_allowlist(self) -> None:
+        for actor in sorted(selector.KICK_ACTORS):
+            verdict = selector.validate_trigger(
+                **trigger_context(
+                    event_name="repository_dispatch",
+                    event_action=selector.KICK_ACTION,
+                    actor=actor,
+                    event={"action": selector.KICK_ACTION, "client_payload": {"reason": "cut it"}},
+                )
+            )
+            self.assertEqual(verdict["trigger"], selector.TRIGGER_KICK)
+            self.assertEqual(verdict["actor"], actor)
+        with self.assertRaises(selector.SelectionError) as caught:
+            selector.validate_trigger(
+                **trigger_context(
+                    event_name="repository_dispatch",
+                    event_action=selector.KICK_ACTION,
+                    actor="a-stranger",
+                    event={"action": selector.KICK_ACTION},
+                )
+            )
+        self.assertIn("may not kick", str(caught.exception))
+
+    def test_kick_refusals(self) -> None:
+        for overrides, event, needle in (
+            ({"event_action": "release_something_else"}, {"action": "release_something_else"}, "event action must be"),
+            ({}, {"action": "mismatch"}, "differs from the trigger context"),
+            ({}, {"action": selector.KICK_ACTION, "client_payload": {"sha": NEWEST}}, "reason and nothing else"),
+            ({}, {"action": selector.KICK_ACTION, "client_payload": {"reason": "x" * 201}}, "at most 200"),
+        ):
+            context = {
+                "event_name": "repository_dispatch",
+                "event_action": selector.KICK_ACTION,
+                "event": event,
+            }
+            context.update(overrides)
+            with self.assertRaises(selector.SelectionError) as caught:
+                selector.validate_trigger(**trigger_context(**context))
+            self.assertIn(needle, str(caught.exception))
+
+    def test_context_that_is_not_protected_main_refuses(self) -> None:
+        for overrides, needle in (
+            ({"repository": "someone/kin"}, "repository must be"),
+            ({"default_branch": "trunk"}, "default branch must be"),
+            ({"ref": "refs/heads/chore/lane"}, "workflow ref must be"),
+            ({"workflow_sha": "abc"}, "40-character"),
+            ({"event_name": "push"}, "event name must be"),
+            ({"event": []}, "event document must be an object"),
+        ):
+            with self.assertRaises(selector.SelectionError) as caught:
+                selector.validate_trigger(**trigger_context(**overrides))
+            self.assertIn(needle, str(caught.exception))
+
+
+# ---------------------------------------------------------------------------
+# Contracts against the mint and the workflow.
+# ---------------------------------------------------------------------------
+
+
+class ContractTests(unittest.TestCase):
+    def test_the_required_contexts_match_the_mints_own_list(self) -> None:
+        """A selector that picks a sha on a different list picks one the mint refuses."""
+
+        source = RELEASE_TAG_PATH.read_text(encoding="utf-8")
+        match = re.search(r"(?m)^          REQUIRED_CHECKS: \|\n((?:            .*\n)+)", source)
+        self.assertIsNotNone(match, "release-tag.yml no longer declares REQUIRED_CHECKS as a block")
+        # Only the block scalar's own 12-space body. Reading to the next key
+        # would swallow the comment block between the two lists, which is how
+        # this assertion first read eighteen prose lines as required contexts.
+        mint = [line.strip() for line in match.group(1).splitlines() if line.strip()]
+        self.assertEqual([name for name, _id, _path in selector.REQUIRED_CONTEXTS], mint)
+
+    def test_the_provenance_table_matches_the_mints_own(self) -> None:
+        source = RELEASE_TAG_PATH.read_text(encoding="utf-8")
+        for name, workflow_id, path in selector.REQUIRED_CONTEXTS:
+            pattern = (
+                re.escape(f'"{name}": (')
+                + r"\s*"
+                + re.escape(f"{workflow_id:_}".replace("_", "_"))
+                + r"?"
+            )
+            # The mint writes the id with underscore separators for the two
+            # non-ci workflows and plain digits for ci.yml, so match either.
+            plain = str(workflow_id)
+            grouped = f"{workflow_id:,}".replace(",", "_")
+            block = re.search(rf'(?ms)"{re.escape(name)}": \((.*?)\),\n', source)
+            self.assertIsNotNone(block, f"release-tag.yml no longer binds {name}")
+            body = block.group(1)
+            self.assertTrue(
+                plain in body or grouped in body,
+                f"{name} is bound to a different workflow id in release-tag.yml: {body}",
+            )
+            self.assertIn(path, body, f"{name} is bound to a different workflow path")
+
+    def test_the_workflow_calls_the_selector_and_binds_its_trigger(self) -> None:
+        workflow = CUT_WORKFLOW_PATH.read_text(encoding="utf-8")
+        for needle in (
+            "python3 scripts/select-release-candidate.py validate-trigger",
+            "python3 scripts/select-release-candidate.py select",
+            "python3 scripts/verify-protected-main-history.py",
+            "node scripts/release-proof/merge-preflight-records.mjs",
+            "scripts/release-proof/bin/kin-evidence-publish",
+        ):
+            self.assertIn(needle, workflow, f"release-cut.yml must run {needle}")
+
+    def test_the_workflow_keeps_the_release_app_off_the_proof_runners(self) -> None:
+        """The preflight job downloads and judges; only the publish job may write."""
+
+        workflow = CUT_WORKFLOW_PATH.read_text(encoding="utf-8")
+        jobs = dict(re.findall(r"(?ms)^  ([a-z0-9-]+):\n(.*?)(?=^  [a-z0-9-]+:\n|\Z)", workflow))
+        self.assertIn("preflight", jobs)
+        self.assertNotIn("KIN_RELEASE_BOT_PRIVATE_KEY", jobs["preflight"])
+        self.assertNotIn("environment:", jobs["preflight"])
+        for job in ("arm", "publish"):
+            self.assertIn(job, jobs)
+            self.assertIn("environment: release-tag", jobs[job])
+
+    def test_the_workflow_declares_only_trusted_triggers(self) -> None:
+        workflow = CUT_WORKFLOW_PATH.read_text(encoding="utf-8")
+        header = re.search(r"(?ms)^on:\n(.*?)(?=^[a-z])", workflow)
+        self.assertIsNotNone(header)
+        self.assertNotIn("workflow_dispatch", header.group(1), "a dispatch could select branch-controlled code")
+        self.assertNotIn("pull_request", header.group(1))
+        for needle in ("workflow_run:", "repository_dispatch:", "schedule:", selector.KICK_ACTION):
+            self.assertIn(needle, header.group(1))
+
+
+class CommandLineTests(unittest.TestCase):
+    def run_selector(self, *arguments: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(SELECTOR_PATH), *arguments],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+    def test_a_snapshot_is_judged_and_its_decision_printed(self) -> None:
+        document = snapshot()
+        document["grades"] = {NEWEST: green_grade(NEWEST)}
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as handle:
+            json.dump(document, handle)
+            path = handle.name
+        result = self.run_selector("select", "--snapshot", path)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        decision = json.loads(result.stdout)
+        self.assertEqual(decision["decision"], selector.ARM)
+        self.assertEqual(decision["candidate"], NEWEST)
+
+    def test_a_refusal_exits_one_and_a_broken_read_exits_two(self) -> None:
+        """A refusal and an unreadable snapshot must not share an exit code."""
+
+        document = snapshot()
+        document["grades"] = {
+            sha: with_duplicate(green_grade(sha), "Falsify guards", CI_SUITE)
+            for sha in document["range"]
+        }
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as handle:
+            json.dump(document, handle)
+            path = handle.name
+        refusal = self.run_selector("select", "--snapshot", path)
+        self.assertEqual(refusal.returncode, 1, refusal.stdout)
+        self.assertIn("Release cut refused", refusal.stderr)
+
+        document.pop("grades")
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as handle:
+            json.dump(document, handle)
+            broken = handle.name
+        unreadable = self.run_selector("select", "--snapshot", broken)
+        self.assertEqual(unreadable.returncode, 2, unreadable.stdout)
+        self.assertIn("could not decide", unreadable.stderr)
+
+    def test_validate_trigger_exits_zero_only_on_an_admitted_trigger(self) -> None:
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as handle:
+            json.dump(completion_event(), handle)
+            event = handle.name
+        admitted = self.run_selector(
+            "validate-trigger",
+            "--event-file", event,
+            "--event-name", "workflow_run",
+            "--event-action", "completed",
+            "--actor", "troyjr4103",
+            "--repository", REPO,
+            "--default-branch", "main",
+            "--ref", "refs/heads/main",
+            "--workflow-sha", NEWEST,
+        )
+        self.assertEqual(admitted.returncode, 0, admitted.stderr)
+        refused = self.run_selector(
+            "validate-trigger",
+            "--event-file", event,
+            "--event-name", "workflow_run",
+            "--event-action", "completed",
+            "--actor", "troyjr4103",
+            "--repository", REPO,
+            "--default-branch", "main",
+            "--ref", "refs/heads/chore/lane",
+            "--workflow-sha", NEWEST,
+        )
+        self.assertEqual(refused.returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
The release cuts itself now, up to the stranger.

The mint tags the newest reviewed `main` commit in the staged version's range that carries both proof records, and nothing put those records there automatically. A captain picked the sha, pushed `release/vX.Y.Z-candidate`, dispatched rc-build, ran the preflight over its archives and published the record by hand. On 2026-09-02 that procedure cost a day. A rerun of a flaky required job made the first candidate unmintable, because the mint reads a duplicated required context as ambiguous authority. The stranger ran two arms while the gate required three, against an append-only branch. And the shared Mac ran out of memory under the host leg.

`release-cut.yml` takes the mechanical half. It selects the candidate itself, arms the candidate branch, dispatches the archive build, judges each archive on the runner that executes it natively, and publishes `preflight.json` exactly as the local run does.

### How it decides

`scripts/select-release-candidate.py` is the rule, and both of its judgments are pure functions over one snapshot, so the tests feed fixtures and assert verdicts with no GitHub in the loop. It stands down when the version is tagged, when a sha in range already carries both records, and while a candidate's stranger record is the only missing half. It keeps a live candidate until that candidate is proven or dead. Otherwise it takes the newest `main` commit in the range whose CI **and** Acceptance push runs concluded success and whose required contexts each appear exactly once under push provenance.

Two choices worth calling out. A sha still being graded is skipped rather than waited for, because on a busy `main` the newest sha is always pending and a selector that waits never converges. And nothing here reruns a required job: a duplicated required context kills the sha, and the next first-pass-green commit becomes the candidate instead.

### How it triggers

A CI completion for a `main` push, an RC Build completion for a candidate branch, the typed `release_cut` repository dispatch from the mint's own allowlist, and a fifteen-minute sweep offset from the mint's and the train's. There is deliberately no `workflow_dispatch`: a dispatch takes a ref, and the publish job reaches the release App's key, so a branch must never be able to select the code that runs beside it. GitHub's cron stalled for most of 2026-09-02, which is why the schedule is the fallback and never the only path.

### The proof

`scripts/release-proof/` carries the umbrella's preflight tooling, vendored byte-identical from `kin-ecosystem` at 3ace010db because kin holds no credential that can check out that private repo. `VENDORED.json` records each file's sha256 and `vendored.test.mjs` refuses one that drifted, so a local fix cannot fork the copy silently. Beside them is a single-host `bin/kin-lane` lock shim written for this tree, held to the acquire, holder and release contract the preflight refuses to run a leg without.

Each archive is judged on its own runner, which is strictly better evidence than the local run: the Linux legs that run emulated on the Mac, where the daemon starves its own enrichment under qemu and the daemon-runtime steps are out of scope, execute natively here. The three leg records merge through `merge-preflight-records.mjs`, which judges its own output with the mint's gate before anything publishes it.

### The stranger is still local, and that is a measured limit

Three arms at 12 GiB each do not fit a 16 GiB hosted runner beside a Docker daemon, and the driver is a Claude Code session that on the account login shares the founder's subscription limit, which cut three arms on 2026-09-02. Read in `bin/kin-stranger`, `driver_env_argv` drops `ANTHROPIC_API_KEY` only for `--local-model`, so the account path already passes an exported key through and no tool change is needed. What is missing is a runner with the memory and a secret carrying the key, which is step B of this ticket's program. Until then the publish job prints the exact command with all three arms named, and the mint stays refused for the missing `stranger.env` rather than being fed a partial record.

### Tests

49 selection tests and 19 proof-tooling tests, and 27 mutations each falsified red against the test that names them. The fixtures are shaped on real listings: 57228997f, whose rerun claimed three check-runs per required name and carried a second `gitleaks (full history)` from the candidate branch's own push; 59c2239c2, whose Windows leg was cancelled at the 60-minute job cap while Acceptance passed; and 390fbdc54, which carried every required context exactly once and became v0.6.4.

Three defects the tests found while being written. The merge was not deterministic, concatenating provenance in artifact arrival order, which against an append-only branch would have made a re-publish after an interrupted upload permanently refused as tampering. The vendored lock shim was not executable, which the preflight refuses at its first step. And four fixtures appended a check-run without moving `total_count`, caught by the selector's own paging assertion, which exists so a short page cannot read as a sha with fewer checks.

`rc-build.yml` is untouched, so its drift guard is unaffected: the proof lives in `release-cut.yml` precisely because rc-build holds no credential by design and publishing evidence needs the App's push.

Related: FIR-3084
