### PR TITLE
Trim the served property prose and grade the trace ceiling on a real server

### DIFF
--- a/crates/kin-mcp/src/agent_belt.rs
+++ b/crates/kin-mcp/src/agent_belt.rs
@@ -59,13 +59,13 @@ use crate::types::ToolsListResult;
 
 /// The most characters one `agent-default` description may carry.
 ///
-/// 520 is roughly two sentences of technical prose. It is a budget rather than a
+/// 265 is roughly two sentences of technical prose. It is a budget rather than a
 /// target: several tools here are shorter, and none should need more, because a
 /// description longer than this is documentation, and documentation belongs in
 /// the `full` profile where a reader has the room for it.
 /// `no_agent_default_description_exceeds_its_budget` below fails on any tool
 /// that exceeds it.
-pub const AGENT_DEFAULT_DESCRIPTION_BUDGET: usize = 520;
+pub const AGENT_DEFAULT_DESCRIPTION_BUDGET: usize = 265;
 
 /// The whole profile's description budget.
 ///
@@ -223,156 +223,89 @@ pub fn apply_belt_defaults(name: &str, arguments: &mut HashMap<String, serde_jso
 /// table has one key per tool and the rename stays a serving concern.
 fn short_descriptions() -> BTreeMap<&'static str, &'static str> {
     BTreeMap::from([
-        // ── Retrieval: the four questions an agent actually arrives with ──
-        (
-            "semantic_locate",
-            "Find the code behind a plain-language question, ranked from the graph. Call this when \
-             you know what the code does but not what it is called. Returns each hit's entity_id, \
-             name, kind, file, line, signature and score. Read `ranked_by` first: with no \
-             embeddings the ranking is lexical, so a plain word of your question can match a \
-             symbol of that name and crowd the first rows. If you already know the exact symbol \
-             name, call semantic_search instead.",
-        ),
-        (
-            DECLARATION_FILTER_CANONICAL,
-            "Filter declarations by name, kind or language: functions, methods, classes, structs, \
-             traits, enums, types and constants the graph already parsed. Call this when you know \
-             what the thing is called, or want every class in one language. It matches names, not \
-             meaning, and does not rank by your query. Returns id, name, kind, language, file and \
-             line range per match, plus the total. For a description rather than a name, call \
-             semantic_locate.",
-        ),
-        (
-            "list_file_entities",
-            "List every entity the graph holds for one file, given a repo-relative path. This is \
-             the only retrieval tool that can say what it left out: it returns the whole set and \
-             reports whether that set is complete, where a ranked tool cannot. Call it for \"what \
-             is in this file\" and before concluding a file contains nothing.",
-        ),
-        (
-            "kin_graph_status",
-            "Report the graph this call is answered from: entity and relation counts, and how many \
-             entities are embedded, pending or unindexed. Call it first when a search returns less \
-             than you expect, since an unembedded graph cannot rank by meaning. On a store under \
-             continuous reconcile it can answer `sampling=last_settled_selected_graph` instead of a \
-             live one: the same counters as of the last settled reading, with a `stale` block \
-             giving that reading's age. Read `sampling` to tell the two apart.",
-        ),
-        // ── Walking: the chain question, and where it is answered ──
-        (
-            "trace_data_flow",
-            "Walk the call chain out from one entity and get the whole path back in one call, as \
-             an ordered list of steps. Call it when you name ONE thing and ask what it reaches or \
-             what reaches it: give it a focal entity_id, a direction and a depth. It walks call \
-             and import edges, so it does not follow a value through a variable. When your question \
-             names TWO things and asks how one reaches the other, call trace_path instead.",
-        ),
-        (
-            crate::handlers::path::TOOL_NAME,
-            "Find how one entity reaches another and get the routes back as ordered hops. Call it \
-             when your question names TWO things: how does A reach B. Takes `from` and `to`, each an \
-             exact name, an entity id, or name@file to pin a twin. Every hop carries id, name, kind, \
-             file, line and the relation into the next. Read `found` and `gap` before concluding A \
-             never reaches B; a class stands for its members. For one endpoint, call \
-             trace_data_flow.",
-        ),
         (
             "find_references",
-            "Find who depends on one entity: its direct callers, importers and references, one row \
-             per referencing entity with that caller's id, name, kind, file and the lines it \
-             references from. Call it for \"what breaks if I change this\" at one hop. For a whole \
-             chain rather than one hop, call trace_data_flow.",
-        ),
-        (
-            "graph_neighborhood",
-            "Get what one entity depends on and what depends on it, out to a depth you choose, as \
-             lightweight summaries with ids. Call it to orient around unfamiliar code. Use \
-             find_references when you want callers only, and trace_data_flow when you want an \
-             ordered path rather than a neighborhood.",
-        ),
-        (
-            "impact_analysis",
-            "Walk the graph from a change to every entity it could affect. Target it one way at a \
-             time: entity_ids, file paths, base and head change ids, or change_ids. Call it before \
-             editing, to answer \"what breaks if I change this\" across the repository rather than \
-             at one hop.",
-        ),
-        // ── Reading ──
-        (
-            "get_entity_source",
-            "Return one entity's exact implementation body by entity_id, from graph-owned truth, \
-             with its name, kind, language, file, line range and signature. This is how you read \
-             the code once any other tool has handed you an id.",
+            "Find who depends on one entity: direct callers, importers and references, one row each with id, name, kind, file and the lines it references from. Call it for one hop. For a whole chain, use trace_data_flow.",
         ),
         (
             "get_context_pack",
-            "Assemble a ready-to-read bundle around one entity, fitted to a token budget: the \
-             focal body plus the signatures of what it depends on, and optionally its tests and \
-             transitive dependencies. Call it when you are about to change an entity and want its \
-             surroundings in one call instead of several get_entity_source reads.",
+            "Assemble a bundle around one entity within a token budget: the focal body plus the signatures of what it depends on, optionally its tests and transitive dependencies. Call it instead of several get_entity_source reads.",
+        ),
+        (
+            "get_entity_source",
+            "Return one entity's exact graph-owned body by id. Call it when you hold an id and need the real source text, not a snippet.",
+        ),
+        (
+            "graph_neighborhood",
+            "Get what one entity depends on and what depends on it, to a depth you choose, as summaries with ids. Call it to orient in unfamiliar code. Use find_references for callers only, trace_data_flow for an ordered path.",
+        ),
+        (
+            "impact_analysis",
+            "Walk the graph from a change to every entity it could affect. Target it one way at a time: entity_ids, file paths, base and head change ids, or change_ids. Call it before editing, across the whole repository.",
         ),
         (
             "kin_artifact_list",
-            "List the repository's tracked files at one semantic change, code and non-code alike: \
-             Dockerfiles, lockfiles, configuration, assets, symlinks and unsupported languages. \
-             Call it to answer what the repository contains, rather than what the parsers turned \
-             into entities.",
+            "List the repository's tracked files at one semantic change, code and non-code alike: Dockerfiles, lockfiles, configuration, assets, symlinks. Call it for what the repository contains, not what the parsers turned into entities.",
         ),
         (
             "kin_artifact_read",
-            "Read one tracked file's exact bytes by artifact_id or repo-relative path, returned as \
-             base64 and, when it is valid UTF-8, as text. Call it for a file the parsers produced \
-             no entities for, which is what a locate hit carrying artifact_path instead of \
-             entity_id means.",
+            "Read one tracked file's exact bytes by artifact_id or repo-relative path, as base64 and, when valid UTF-8, as text. Call it for a file the parsers made no entities for, which a locate hit's artifact_path means.",
+        ),
+        (
+            "kin_graph_status",
+            "The graph this call is answered from: entity and relation counts, and how many are embedded, pending or unindexed. Call it when a search returns less than you expect. `sampling=last_settled_selected_graph` means the last settled reading, aged in `stale`.",
         ),
         (
             "kin_provenance_query",
-            "Answer who changed an entity and whether it was approved: its change count, latest \
-             change, approvals on that change, a page of its changes newest first, and recent \
-             audit events. Call it before relying on code whose history matters.",
-        ),
-        // ── Sessions ──
-        (
-            "kin_session_start",
-            "Register this agent with Kin and get a session_id: who you are, your transport, \
-             working directory and capabilities. Call it once at the start of your work, before \
-             any transaction, so activity is attributed and other agents can see your presence.",
-        ),
-        (
-            "kin_session_heartbeat",
-            "Keep a session marked alive. Call it periodically during long work so Kin does not \
-             treat the session as stale and release what it holds.",
+            "Answer who changed an entity and whether it was approved: change count, latest change, approvals on it, a page of changes newest first, and recent audit events. Call it before relying on code whose history matters.",
         ),
         (
             "kin_session_end",
-            "End a session and release everything it held, freeing its intents so other agents are \
-             no longer warned off those scopes. Call it when your work finishes.",
-        ),
-        // ── Writing ──
-        (
-            "kin_transaction_begin",
-            "Open a repository mutation transaction and get a transaction_id. Call it before \
-             staging any change. Nothing is written until kin_transaction_commit.",
+            "Close this session and release what it holds. Call it when your work is done.",
         ),
         (
-            "kin_transaction_stage",
-            "Stage one or more mutations onto an open transaction. Four verbs: 'create' admits a \
-             file the graph has never seen, 'update' changes an entity inside one it holds, \
-             'delete' retires one, 'rename' moves one. An 'update' replaces the entity's whole \
-             body, so read the current one with get_entity_source first rather than guessing it.",
+            "kin_session_heartbeat",
+            "Keep this session alive. Call it periodically during long work so the session does not lapse at its idle TTL.",
         ),
         (
-            "kin_transaction_commit",
-            "Publish every staged mutation atomically: the daemon reparses the final bytes and \
-             journals the semantic change, the workspace tree and the ref together. All of it \
-             lands or none of it does. Re-sending a fenced commit is safe and reports whether it \
-             already landed.",
+            "kin_session_start",
+            "Register this agent with Kin and get a session_id: who you are, your transport, working directory and capabilities. Call it once at the start of your work, before any transaction, so activity is attributed.",
         ),
         (
             "kin_transaction_abort",
-            "Abandon an open transaction and discard everything staged on it. Call it when you \
-             decide against a change, or to start clean after a refusal. Refused once \
-             kin_transaction_commit has fenced the transaction; re-send the commit instead.",
+            "Abandon an open transaction and discard everything staged on it. Call it when you decide against a change, or to start clean after a refusal. Refused once kin_transaction_commit has fenced it.",
+        ),
+        (
+            "kin_transaction_begin",
+            "Open a transaction to stage mutations onto. Returns a transaction_id; nothing lands until kin_transaction_commit.",
+        ),
+        (
+            "kin_transaction_commit",
+            "Publish every staged mutation atomically: the daemon reparses the final bytes and journals the semantic change, the workspace tree and the ref together. All of it lands or none does. Re-sending a fenced commit is safe.",
+        ),
+        (
+            "kin_transaction_stage",
+            "Stage mutations onto an open transaction. Four verbs: 'create' admits a file the graph has never seen, 'update' changes an entity, 'delete' retires one, 'rename' moves one. An 'update' replaces the whole body; read it first with get_entity_source.",
+        ),
+        (
+            "list_file_entities",
+            "List every entity the graph holds for one file, by repo-relative path. The only retrieval tool that says what it left out: it returns the whole set and reports whether it is complete. Call it before concluding a file holds nothing.",
+        ),
+        (
+            "semantic_locate",
+            "Find code by a plain-language question, ranked from the graph. Call it when you know what the code does but not its name. Returns id, name, kind, file, line, signature, score. Read `ranked_by`. Know the exact name? Use semantic_search.",
+        ),
+        (
+            DECLARATION_FILTER_CANONICAL,
+            "Filter declarations by name, kind or language: functions, methods, classes, structs, traits, enums, types, constants. Call it when you know what the thing is called. It matches names, not meaning. For a description, use semantic_locate.",
+        ),
+        (
+            "trace_data_flow",
+            "Walk the call chain out from ONE entity and get the whole path back, as ordered steps. Give a focal, a direction and a depth. It walks call and import edges, not values through variables. Naming TWO things? Use trace_path.",
+        ),
+        (
+            "trace_path",
+            "Find how one entity reaches another, as ordered hops. Call it when your question names TWO things. `from` and `to` take a name, an id, or name@file. Read `found` and `gap` before concluding A never reaches B. One endpoint? Use trace_data_flow.",
         ),
     ])
 }
@@ -641,13 +574,13 @@ fn apply_belt_schema_defaults(tool: &str, schema: &mut serde_json::Value) {
 /// characters, and one of them, `max_chars`, carried the same 649 characters on
 /// seven different tools.
 ///
-/// 200 is one plain clause. A property description exists to tell a model what
+/// 90 is one plain clause. A property description exists to tell a model what
 /// to pass, and the shape, bounds and default are already machine-readable
 /// beside it in `type`, `enum`, `minimum`, `maximum` and `default`, so prose
 /// that restates them is paid for twice.
 /// `no_agent_default_property_description_exceeds_its_budget` fails on any
 /// property over it.
-pub const AGENT_DEFAULT_PROPERTY_DESCRIPTION_BUDGET: usize = 200;
+pub const AGENT_DEFAULT_PROPERTY_DESCRIPTION_BUDGET: usize = 90;
 
 /// The tools whose schemas this module does not rewrite at all.
 ///
@@ -669,20 +602,19 @@ fn shared_property_descriptions() -> BTreeMap<&'static str, &'static str> {
     BTreeMap::from([
         (
             "max_chars",
-            "Serialized characters this response may occupy. What the budget cut is named under \
-             `elisions` and `_kin.response`, and a list it cut keeps one entry, so an empty list \
-             means none were found.",
+            "Serialized characters this response may occupy; what was cut is named in `elisions`.",
         ),
         (
             "max_response_chars",
-            "Serialized characters this response may occupy. `max_chars` is the same parameter \
-             under the other retrieval tools' name. A cut chain keeps one step and reports the \
-             rest under `elisions.chain`.",
+            "Serialized characters this response may occupy; the same parameter as `max_chars`.",
         ),
         (
             "cursor",
-            "Opaque token from a prior result's `next_cursor`, returning the next page of the \
-             same collection. Pass it back unedited, and omit it for a fresh query.",
+            "Opaque token from a prior result's `next_cursor`. Pass it back unedited.",
+        ),
+        (
+            "session_id",
+            "Owning session UUID. In enforce mode it must match the authenticated caller.",
         ),
     ])
 }
@@ -697,35 +629,55 @@ fn tool_property_descriptions() -> BTreeMap<(&'static str, &'static str), &'stat
     BTreeMap::from([
         (
             ("semantic_locate", "include_tests"),
-            "Rank test-role entities alongside source. Off by default unless your query itself \
-             reads as being about tests; what it withheld is counted under \
-             `semantic_coverage.graph_bodies`.",
+            "Rank test-role entities alongside source. Off unless your query is about tests.",
+        ),
+        (
+            ("semantic_locate", "limit"),
+            "Max ranked rows per page: entities, or files at file granularity. Default 20.",
         ),
         (
             ("list_file_entities", "path"),
-            "Repository-relative path of the file to enumerate, such as \"lib/express.js\". No \
-             leading slash, no \"..\", no Kin or Git control component. Optional only when \
-             `cursor` names the file.",
+            "Repo-relative file path, no leading slash and no \"..\". Optional when `cursor` names it.",
+        ),
+        (
+            ("list_file_entities", "page_size"),
+            "Entities per page (default 200, 1..1000). `total_in_file` is the whole-file count.",
         ),
         (
             ("trace_data_flow", "target"),
-            "A symbol you are trying to reach, by exact name or UUID. Neighbours it stays \
-             reachable from survive the per-step cap first. Optional; one resolving to nothing \
-             is reported in degradations.",
+            "A symbol to reach, by exact name or UUID. Its branch survives the per-step cap first.",
         ),
         (
             ("trace_data_flow", "include_body"),
-            "Inline each step's source body. Pass false for the SHAPE of the chain, which is a \
-             fraction of the size and is what you want unless you mean to read the code.",
+            "Inline each step's source. False gives the chain's shape at a fraction of the size.",
         ),
         (
             ("trace_data_flow", "direction"),
             "Which way to walk: `calls` for callees, `callers` for callers, `both` merges.",
         ),
         (
+            ("trace_path", "direction"),
+            "`forward`: from reaches to. `reverse`: the other way. `either` (default) tries both.",
+        ),
+        (
+            ("trace_path", "max_depth"),
+            "Hops between the two ends (default 6, ceiling 12). Containment hops are not counted.",
+        ),
+        (
+            ("trace_path", "limit"),
+            "Routes returned, shortest first (default 3, ceiling 25). See `routes_total`.",
+        ),
+        (
+            ("trace_path", "from_file"),
+            "Pin `from` to the entity of that name in this file. Same as the name@file spelling.",
+        ),
+        (
+            ("find_references", "relation_kinds"),
+            "Filter to calls, imports or references. Defaults to all three.",
+        ),
+        (
             ("graph_neighborhood", "direction"),
-            "Which way to walk: `out` for what the focal depends on, `in` for what depends on it \
-             (blast radius), `both` merges.",
+            "`out` for what the focal depends on, `in` for what depends on it, `both` merges.",
         ),
     ])
 }
@@ -754,7 +706,17 @@ fn shorten_property_descriptions(tool: &str, schema: &mut serde_json::Value) {
         let (Some(short), Some(property)) = (short, property.as_object_mut()) else {
             continue;
         };
-        if property.contains_key("description") {
+        // Only when it is actually shorter. A "short form" table keyed by
+        // property name meets the same name on tools whose registered
+        // description is already one clause, and replacing those made three
+        // tools BIGGER when this table grew: `kin_transaction_begin` by 41
+        // bytes, `kin_session_end` and `kin_session_heartbeat` by 64 each. A
+        // trim that can lengthen its subject is not a trim, and the arithmetic
+        // hid it because the total still fell.
+        let Some(existing) = property.get("description").and_then(|value| value.as_str()) else {
+            continue;
+        };
+        if short.len() < existing.len() {
             property.insert(
                 "description".to_string(),
                 serde_json::Value::String((*short).to_string()),

--- a/scripts/acceptance/mcp_surface_contract.py
+++ b/scripts/acceptance/mcp_surface_contract.py
@@ -212,6 +212,16 @@ def grade_served_names_are_registered(listing, registry):
     return []
 
 
+def listing_bytes(listing):
+    """The bytes a client reads off the pipe.
+
+    Compact, the way serde writes it, with no separators of Python's own.
+    `json.dumps` defaults insert `", "` and `": "` and read 4.5 percent high on
+    this listing: 34,470 against the 32,976 the wire carries.
+    """
+    return len(json.dumps(listing, separators=(",", ":"), sort_keys=True))
+
+
 def grade_query_profile(query, default):
     """The query profile serves its exact set, no write tool, and far fewer bytes."""
     tools = query.get("tools")
@@ -236,8 +246,8 @@ def grade_query_profile(query, default):
     if not isinstance(baseline, list) or not baseline:
         problems.append("agent-default listed no tools, so there is nothing to measure against")
         return problems
-    query_bytes = len(json.dumps(query, sort_keys=True))
-    default_bytes = len(json.dumps(default, sort_keys=True))
+    query_bytes = listing_bytes(query)
+    default_bytes = listing_bytes(default)
     if query_bytes * 100 > default_bytes * AGENT_QUERY_LIST_CEILING_PERCENT:
         problems.append(
             "agent-query's tools/list is %d bytes against agent-default's %d (%d%%), over "
@@ -609,9 +619,9 @@ def run_checks(suite, verbose=False):
             "agent-query served %d tools in %d bytes against agent-default's %d in %d"
             % (
                 len(query.get("tools") or []),
-                len(json.dumps(query, sort_keys=True)),
+                listing_bytes(query),
                 len(served.get("tools") or []),
-                len(json.dumps(served, sort_keys=True)),
+                listing_bytes(served),
             ),
         )
         if AGENT_QUERY_PROFILE not in (query_stderr or ""):

--- a/scripts/acceptance/response_budget_elisions.py
+++ b/scripts/acceptance/response_budget_elisions.py
@@ -1606,6 +1606,110 @@ def check_11(suite):
     return res
 
 
+def grade_ceiling_walk(payload, ceiling, must_fit):
+    """A deep trace has to answer inside the ceiling it was given, or say it could not.
+
+    `must_fit` is the difference between the two arms and it is what makes this
+    able to fail. At the belt's own ceiling the answer has to FIT, and a
+    `response_over_budget` note there is a failure even when the bytes happen to
+    land under, because that note is the response saying it could not reach the
+    number it advertises. Measured on this fixture with the restatement pointer
+    disabled, the same walk ships 11,603 characters and carries that note; with
+    it, 8,719 and no note. At a ceiling too small for the part of a response the
+    budget never trims, the note is the honest answer and is allowed.
+    """
+    if not isinstance(payload, dict):
+        return ["the walk returned no payload"], None
+    shipped = len(json.dumps(payload, separators=(",", ":")))
+    reasons = [
+        entry.get("reason")
+        for entry in (payload.get("degradations") or [])
+        if isinstance(entry, dict)
+    ]
+    cut = isinstance(payload.get("elisions"), dict) and "chain" in payload["elisions"]
+    if not cut:
+        # Not a pass. A walk the ceiling never pressed says nothing about
+        # whether the ceiling holds, and reporting it green is the shape every
+        # check in this file exists to refuse.
+        return None, (shipped, reasons, cut)
+    if must_fit:
+        problems = []
+        if shipped > ceiling:
+            problems.append(
+                "the walk shipped %d characters against the %d ceiling it advertises"
+                % (shipped, ceiling)
+            )
+        if OVER_BUDGET_REASON in reasons:
+            problems.append(
+                "the walk discloses %s at its own advertised ceiling, so it did not reach it"
+                % OVER_BUDGET_REASON
+            )
+        return problems, (shipped, reasons, cut)
+    if shipped <= ceiling:
+        return [], (shipped, reasons, cut)
+    if OVER_BUDGET_REASON in reasons:
+        # Over, and it said so. That is the honest arm: the part of a response
+        # the budget never trims can exceed a small ceiling on its own.
+        return [], (shipped, reasons, cut)
+    return (
+        [
+            "the walk shipped %d characters against a %d ceiling and disclosed no %s"
+            % (shipped, ceiling, OVER_BUDGET_REASON)
+        ],
+        (shipped, reasons, cut),
+    )
+
+
+def check_12(suite):
+    """FIR-3107: a deep trace answers inside the ceiling the agent belt advertises.
+
+    The demo drove Kin's real MCP server on 2026-09-02 and `trace_data_flow`
+    returned 15,875 characters against the 12,000 its own schema advertises. It
+    had already cut every list it could: the part of a response the budget never
+    trims, the `_kin` envelope and the `negative` object, was 9,210 characters of
+    that ceiling, and roughly 7,700 of it was four verbatim copies of one
+    limiting-factor sentence.
+
+    Two arms. At the belt's own 12,000 the answer has to fit. At a ceiling small
+    enough that the fixed part cannot fit inside it, the answer may ship over,
+    and then it has to say so rather than ship over in silence. Neither arm
+    passes on a walk the ceiling never pressed.
+    """
+    res = Result("12", "FIR-3107", "a deep trace answers inside the ceiling it advertises")
+    args = {
+        "focal": "entry",
+        "depth": 8,
+        "direction": "calls",
+        "limit_per_step": 25,
+        "include_body": False,
+    }
+    # 12,000 is the number `agent-default` injects and advertises, so it is the
+    # one a client sizes on. 3,000 is below the fixed part of this response.
+    for ceiling, must_fit in ((12000, True), (3000, False)):
+        try:
+            payload = suite.mcp("trace_data_flow", dict(args, max_chars=ceiling))
+        except McpError as exc:
+            res.unknown("the walk at %d was unreadable: %s" % (ceiling, exc))
+            return res
+        problems, seen = grade_ceiling_walk(payload, ceiling, must_fit)
+        if problems is None:
+            res.unknown(
+                "the walk at %d was never cut, so the fixture does not press the ceiling "
+                "and this says nothing about whether it holds" % ceiling
+            )
+            return res
+        if problems:
+            for problem in problems:
+                res.bad(problem)
+            return res
+        shipped, reasons, _ = seen
+        res.ok(
+            "at a %d ceiling the cut walk shipped %d characters, disclosing %s"
+            % (ceiling, shipped, sorted(r for r in reasons if r) or ["nothing"])
+        )
+    return res
+
+
 CHECKS = [
     ("0", check_0),
     ("1", check_1),
@@ -1619,6 +1723,7 @@ CHECKS = [
     ("9", check_9),
     ("10", check_10),
     ("11", check_11),
+    ("12", check_12),
 ]
 
 


### PR DESCRIPTION
## What

The description trim already happened: kin-mcp's agent belt took the served descriptions from 47,739 characters to 6,188. What is left is **schemas**, 22,713 of the 32,976 bytes `agent-default` serves, and **14,060 of those schema bytes are property prose**. This trims that.

Two budgets come down. The per-property budget goes from 200 characters to 90, and the per-tool description budget from 520 to 265; 24 property descriptions and 17 tool descriptions are rewritten to fit. The largest single item was one paragraph repeated: `max_chars` carried 189 characters on eight tools, and `trace_data_flow` carried the same parameter twice under two names.

No tool is renamed. No argument is removed. No default moves. The shape, bounds and default of every property stay machine-readable beside the prose in `type`, `enum`, `minimum`, `maximum` and `default`, which is why the prose can go: it was restating them.

## Measured, on the wire

Compact bytes, the way serde writes them to the pipe.

| profile | before | after | off |
|---|---:|---:|---:|
| `agent-default` | 32,976 | **29,134** | 11.7% |
| `agent-query` | 17,174 | **13,725** | 20.1% |
| `full` | 142,850 | 142,850 | 0% |

Descriptions fall from 6,188 to 4,202 and schemas from 22,713 to 20,863. Taken with #1390, a query-only client's `tools/list` goes from the 32,976 `agent-default` served to **13,725**, which is 58 percent off.

### Why 265 and not the 220 first aimed for

Every tool description on this belt answers two questions, when to call this and what comes back, and where two tools are easy to confuse it names the other one. At 220 the naming is what goes. A model that cannot tell `semantic_locate` from `semantic_search`, or `trace_data_flow` from `trace_path`, spends more on wrong calls than the bytes are worth, and the founder's line is that every fact a model needs to CHOOSE and call the tool stays. 265 is the tightest budget that keeps the pointers, and the guard test fails on anything over it.

`full` is untouched, and so are `benchmark` and `context-bench`, whose `tools/list` bytes are an input to a citable benchmark result.

Per tool, on `agent-default`:

| tool | before | after | saved |
|---|---:|---:|---:|
| `trace_data_flow` | 2252 | 1664 | 588 |
| `semantic_locate` | 1903 | 1383 | 520 |
| `trace_path` | 2020 | 1568 | 452 |
| `list_file_entities` | 1210 | 875 | 335 |
| `semantic_search` | 1279 | 973 | 306 |
| `kin_graph_status` | 737 | 502 | 235 |
| `find_references` | 1175 | 948 | 227 |
| `graph_neighborhood` | 1218 | 1008 | 210 |
| `get_context_pack` | 1160 | 956 | 204 |
| `impact_analysis` | 1261 | 1096 | 165 |
| `get_entity_source` | 525 | 430 | 95 |
| `kin_transaction_abort` | 733 | 642 | 91 |
| `kin_transaction_stage` | 6146 | 6065 | 81 |
| `kin_session_end` | 462 | 386 | 76 |
| `kin_artifact_read` | 921 | 866 | 55 |
| `kin_transaction_commit` | 6096 | 6052 | 44 |
| `kin_artifact_list` | 779 | 739 | 40 |
| `kin_session_start` | 1320 | 1281 | 39 |
| `kin_transaction_begin` | 580 | 545 | 35 |
| `kin_session_heartbeat` | 458 | 431 | 27 |
| `kin_provenance_query` | 709 | 692 | 17 |
| **listing** | **32976** | **29134** | **3842** |

## A trim that lengthened three tools

Worth recording, because the total hid it. A short-form table keyed by property name meets tools whose registered description is already one clause, and replacing those made three tools **bigger**: `kin_transaction_begin` by 41 bytes, `kin_session_end` and `kin_session_heartbeat` by 64 each. The listing total still fell, so the arithmetic looked fine.

A description is now replaced only when the short form is actually shorter, and the re-measure confirms no tool grew.

## What this does not touch, and why

`kin_transaction_stage` and `kin_transaction_commit` are **12,242 bytes, 37 percent of the listing**, and they stay whole. `PROSE_EXEMPT_TOOLS` already carries the reasoning, and it was a deliberate decision rather than an oversight. Its own comment, forward into this body so the next reader does not have to find it:

> The tools whose schemas this module does not rewrite at all.
>
> 1353 left the nested transaction contracts whole, and they stay whole: a staged mutation's shape is the thing a caller gets wrong, and it is the one place on this belt where the schema IS the documentation. They cost 11,245 bytes and 2,423 tokens between them, which is 31 percent of every token in the served list, and **that number belongs in a product decision about which tools an agent is served rather than in a prose trim.**

So the two schemas are untouched here on purpose, by that decision, not by omission. The product decision it points at is with the founder now as a merge-candidate row in the per-tool audit: whether `kin_transaction_commit` should keep serving `operations` at all, given it is a near-verbatim second copy of the one on `kin_transaction_stage` and 5,318 bytes on its own. If that ruling lifts the exemption, the same trim extends into the nested operation shapes through the one function that already does this work, and the saving roughly doubles.

Their tool DESCRIPTIONS are trimmed here, since the exemption is about schemas and a description is not a schema.

## The scripted check FIR-3107 asked for

`response_budget_elisions.py` check 12 drives the suite's 60-hop chain through a real server at two ceilings.

- At **12,000**, the number `agent-default` injects and advertises, the answer has to FIT and may not disclose `response_over_budget`. That note at a tool's own advertised ceiling is the response saying it did not reach the number a client sized on.
- At **3,000**, below the part of a response the budget never trims, that disclosure is the honest answer and is allowed.
- A walk the ceiling never pressed reports UNREADABLE, never a pass.

Passing, on a real binary:

```
CHECK 12 FIR-3107 PASS at a 12000 ceiling the cut walk shipped 8719 characters, disclosing
['qualification_restatement_pointed', 'response_bounded']; at a 3000 ceiling the cut walk
shipped 10897 characters, disclosing ['qualification_restatement_pointed',
'response_over_budget', 'steps_omitted']
```

`qualification_restatement_pointed` in that line is the point: #1390's fix fires on a live server, not only in a unit test.

## Falsification

Two mutants survived before one bit, and the survivors are the interesting part.

**Mutant A**, disabling the post-loop pointer call only: check 12 **passed**, shipping 11,963 characters. A second defence caught it, the in-ladder call, exactly as the house rule predicts.

**Mutant B**, disabling `shed_restated_limiting_factor` at its source so the pointer never fires anywhere: check 12 **still passed**, shipping 11,603 against the 12,000 ceiling. This fixture is Python with clean coverage, so its envelope is small enough to fit without the fix. The first grader could not tell the two apart.

The answer was a new input only the target can catch, not a deleted guard. Without the fix the response carries `response_over_budget` at 12,000 even though the bytes land under; with it, they do not. So the arm now asserts the product claim rather than the byte count alone, and **Mutant B goes red**:

```
CHECK 12 FIR-3107 FAIL the walk discloses response_over_budget at its own advertised ceiling,
so it did not reach it
response budget elisions: 12 PASS, 1 FAIL, 0 UNREADABLE
```

Restored, it is 13 PASS, 0 FAIL, 0 UNREADABLE.

The property budget itself is guarded by `no_agent_default_property_description_exceeds_its_budget`, which fails on any served property over 90 characters.

## Verification

- `bin/kin-precheck kin` through `heavy-slot`: **16 gates ran, 16 passed, 0 failed**, on kin 097c91b91f93943f05a742b2eeec405cebb1bf1e, worktree `.kin-coord/worktrees/kin-mcp-readonly-kin`, branch `chore/lane-kin-mcp-readonly-kin`.
- `cargo test -p kin-mcp --lib`: 865 passed, 0 failed.
- `response_budget_elisions.py` against this branch's own binaries: **13 PASS, 0 FAIL, 0 UNREADABLE**.
- `mcp_surface_contract.py` against the same: **8 PASS, 0 FAIL, 0 UNREADABLE**, with check 7 now reading `agent-query served 14 tools in 15374 bytes against agent-default's 21 in 31126`.
- Both suites' `--self-test` graders pass their correct case and fail each break.

## One number corrected

The surface contract counted bytes with Python's default `json.dumps` separators, which read 4.5 percent high: 34,470 against the 32,976 the wire carries. It counts compact bytes now. The ratio never moved, because both profiles were always counted the same way.
