### PR TITLE
Refuse a release run whose tag another run already released

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1113,6 +1113,7 @@ jobs:
           bash scripts/release-policy-gate.sh <<'RELEASE_POLICY'
           python3 scripts/test-release-workflow-authority.py
           python3 scripts/test-select-release-candidate.py
+          python3 scripts/test-guard-duplicate-release-run.py
           node --test \
             scripts/release-proof/merge-preflight-records.test.mjs \
             scripts/release-proof/vendored.test.mjs \
@@ -1684,6 +1685,7 @@ jobs:
           bash scripts/release-policy-gate.sh <<'RELEASE_POLICY'
           python3 scripts/test-release-workflow-authority.py
           python3 scripts/test-select-release-candidate.py
+          python3 scripts/test-guard-duplicate-release-run.py
           node --test \
             scripts/release-proof/merge-preflight-records.test.mjs \
             scripts/release-proof/vendored.test.mjs \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,59 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Refuse a run whose tag another run already released.
+  #
+  # On 2026-09-02 tag v0.6.4 produced two Release runs, 147 and 148, seven
+  # seconds apart. This repository pushed once: release-tag.yml holds a single
+  # `POST /git/refs` call, refs/tags/v0.6.4 still reads as a lightweight tag at
+  # the sha the mint wrote, and the trigger above is a single `push: tags`
+  # entry. The two runs carry different check suites, so GitHub delivered one
+  # tag-creation push twice, and no change here can suppress that delivery.
+  #
+  # The concurrency group above serializes rather than cancels, so a duplicate
+  # does not go away on its own: run 148 sat pending for over forty minutes and
+  # would then have re-run publish, npm publish, promotion and the completion
+  # marker against an already released tag. This job is where the duplicate
+  # stops instead.
+  #
+  # Every other job reaches `config`, and `config` needs this one, so a
+  # `duplicate=true` verdict skips the whole release. The jobs guarded by
+  # `always()` skip with it, because each also requires a named dependency's
+  # result to equal 'success' and a skipped dependency's result is 'skipped'.
+  duplicate_guard:
+    name: Refuse a duplicate release run
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      duplicate: ${{ steps.verdict.outputs.duplicate }}
+    steps:
+      - name: Checkout release policy
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Judge this run against earlier runs for the tag
+        id: verdict
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_NUMBER: ${{ github.run_number }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          python3 scripts/guard-duplicate-release-run.py \
+            --repo "$REPO" \
+            --tag "$TAG" \
+            --run-id "$RUN_ID" \
+            --run-number "$RUN_NUMBER" \
+            --run-attempt "$RUN_ATTEMPT" \
+            --workflow .github/workflows/release.yml \
+            >> "$GITHUB_OUTPUT"
+
   # Resolve a single effective "notarize on Linux" flag for the whole run. The
   # macOS legs still build + codesign natively; only the Apple Notary submission
   # moves to a 1x Linux runner (macOS minutes bill 10x) when this is on.
@@ -41,6 +94,13 @@ jobs:
   config:
     name: Resolve release config
     runs-on: ubuntu-latest
+    # The root of the job graph, so this pair is what turns one duplicate
+    # verdict into a skipped release. A failing guard is deliberately NOT the
+    # same as a duplicate: the run goes red on the guard rather than skipping
+    # the release quietly, because a silent no-release is the one outcome
+    # nobody would be paged for.
+    needs: duplicate_guard
+    if: needs.duplicate_guard.outputs.duplicate != 'true'
     outputs:
       notarize_on_linux: ${{ steps.flags.outputs.notarize_on_linux }}
       release_channel: ${{ steps.release_order.outputs.release_channel }}

--- a/scripts/guard-duplicate-release-run.py
+++ b/scripts/guard-duplicate-release-run.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Refuse a release run whose tag another run already released.
+
+On 2026-09-02 the v0.6.4 tag produced two Release runs, 147 and 148, seven
+seconds apart. kin pushed once: release-tag.yml holds a single `POST /git/refs`
+call, the ref still reads as a lightweight tag at the sha the mint wrote, and
+release.yml's trigger is a single `push: tags` entry. The two runs carry
+different check suites, so GitHub delivered one tag-creation push twice. Nothing
+in this repository can suppress that delivery.
+
+What it can do is refuse the second run. `concurrency: kin-release-promotion`
+sets `cancel-in-progress: false`, so a duplicate does not disappear; it sits
+pending for the whole release and then re-executes publish, npm publish,
+promotion and the completion marker against a tag that is already out. Run 148
+idled for over forty minutes that way.
+
+This script is the decision. release.yml runs it in a first job that every other
+job hangs off, and a `duplicate=true` verdict skips the release.
+
+The rule:
+
+1. A rerun is never a duplicate. `run_attempt > 1` means a human asked for this
+   run on purpose, and refusing it would make the rerun button silently do
+   nothing.
+2. Otherwise the run is a duplicate when some OTHER run of this workflow, for
+   this same tag, from a push, with a LOWER run number, has already concluded
+   `success`.
+3. Anything else proceeds.
+
+Only a completed successful run counts. A failed earlier run leaves the release
+undone, so a second delivery is the only thing left to finish it and must be
+allowed to. An earlier run still in flight is not evidence either, because it
+may yet fail.
+
+Direction of failure is deliberate. When the listing cannot be trusted, the
+verdict is `false` and the release proceeds, with a warning on the job. Refusing
+on an unreadable answer would let one bad API page cancel a real release, which
+is strictly worse than the duplicate this guards against: a duplicate is noisy
+and its mutations are individually guarded, while a skipped release ships
+nothing and nobody is paged.
+
+`decide()` is a pure function over one snapshot document, so the test feeds it
+fixtures with no GitHub in the loop.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+
+WORKFLOW_PATH = ".github/workflows/release.yml"
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """One decision, plus the sentence a reader of the job log needs."""
+
+    duplicate: bool
+    reason: str
+    # The run that already released this tag, when there is one.
+    prior_run_id: int | None = None
+    # Set when the snapshot could not be trusted and the guard stood aside.
+    unreadable: bool = False
+
+
+def _int(value: Any) -> int | None:
+    """Read an int that may arrive as a string, or as nothing at all."""
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def decide(snapshot: dict[str, Any]) -> Verdict:
+    """Judge one run against every earlier run for its tag.
+
+    `snapshot` carries the run's own identity (`tag`, `run_id`, `run_number`,
+    `run_attempt`), the `runs` listing, and the `total_count` the API reported
+    beside it so a short page is caught rather than read as an absence.
+    """
+    tag = snapshot.get("tag")
+    run_id = _int(snapshot.get("run_id"))
+    run_number = _int(snapshot.get("run_number"))
+    attempt = _int(snapshot.get("run_attempt"))
+
+    if not tag or run_id is None or run_number is None:
+        return Verdict(
+            False,
+            "run identity incomplete, so no duplicate can be proven; proceeding",
+            unreadable=True,
+        )
+
+    # A rerun is a deliberate act. Never refuse one.
+    if attempt is not None and attempt > 1:
+        return Verdict(
+            False,
+            f"run attempt {attempt} is a deliberate rerun, not a duplicate delivery",
+        )
+
+    runs = snapshot.get("runs")
+    if not isinstance(runs, list):
+        return Verdict(
+            False,
+            "no readable run listing, so no duplicate can be proven; proceeding",
+            unreadable=True,
+        )
+
+    # The listing pages, and a short page reads exactly like "no earlier run".
+    # Assert the count the API reported beside it rather than trusting length.
+    total = _int(snapshot.get("total_count"))
+    if total is not None and total != len(runs):
+        return Verdict(
+            False,
+            (
+                f"run listing is short, {len(runs)} of {total} reported, so an "
+                "earlier release could be missing from it; proceeding"
+            ),
+            unreadable=True,
+        )
+
+    for run in sorted(
+        (r for r in runs if isinstance(r, dict)),
+        key=lambda r: _int(r.get("run_number")) or 0,
+    ):
+        other_id = _int(run.get("id"))
+        other_number = _int(run.get("run_number"))
+        if other_id is None or other_number is None:
+            continue
+        # Never judge against itself.
+        if other_id == run_id:
+            continue
+        # A run with a higher number is a later duplicate of THIS run, and must
+        # not silence the run it duplicated.
+        if other_number >= run_number:
+            continue
+        # A tag filter is applied server-side, but a filter that silently stops
+        # matching is a check that cannot fail, so it is applied here too.
+        if run.get("head_branch") != tag:
+            continue
+        if run.get("event") != "push":
+            continue
+        if run.get("status") != "completed":
+            continue
+        if run.get("conclusion") != "success":
+            continue
+        return Verdict(
+            True,
+            (
+                f"run {other_id} (number {other_number}) already released tag "
+                f"{tag} and concluded success"
+            ),
+            prior_run_id=other_id,
+        )
+
+    return Verdict(False, f"no earlier successful release run for tag {tag}")
+
+
+def fetch_snapshot(
+    repo: str,
+    tag: str,
+    run_id: int,
+    run_number: int,
+    run_attempt: int,
+    workflow: str,
+) -> dict[str, Any]:
+    """Ask GitHub for every push run of this workflow against this tag."""
+    query = (
+        f"repos/{repo}/actions/workflows/{_workflow_key(workflow)}/runs"
+        f"?branch={tag}&event=push&per_page=100"
+    )
+    snapshot: dict[str, Any] = {
+        "tag": tag,
+        "run_id": run_id,
+        "run_number": run_number,
+        "run_attempt": run_attempt,
+    }
+    try:
+        raw = subprocess.run(
+            ["gh", "api", query],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        ).stdout
+        payload = json.loads(raw)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        detail = getattr(exc, "stderr", "") or str(exc)
+        snapshot["error"] = f"listing runs failed: {detail.strip()[:400]}"
+        return snapshot
+    except json.JSONDecodeError as exc:
+        snapshot["error"] = f"run listing was not JSON: {exc}"
+        return snapshot
+
+    snapshot["runs"] = payload.get("workflow_runs")
+    snapshot["total_count"] = payload.get("total_count")
+    return snapshot
+
+
+def _workflow_key(workflow: str) -> str:
+    """The API takes a workflow file name, not a repo-relative path."""
+    return workflow.rsplit("/", 1)[-1]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo")
+    parser.add_argument("--tag")
+    parser.add_argument("--run-id", type=int)
+    parser.add_argument("--run-number", type=int)
+    parser.add_argument("--run-attempt", type=int, default=1)
+    parser.add_argument("--workflow", default=WORKFLOW_PATH)
+    parser.add_argument(
+        "--snapshot",
+        help="judge this snapshot file instead of asking GitHub",
+    )
+    args = parser.parse_args(argv)
+
+    if args.snapshot:
+        with open(args.snapshot, encoding="utf-8") as handle:
+            snapshot = json.load(handle)
+    else:
+        missing = [
+            name
+            for name, value in (
+                ("--repo", args.repo),
+                ("--tag", args.tag),
+                ("--run-id", args.run_id),
+                ("--run-number", args.run_number),
+            )
+            if value in (None, "")
+        ]
+        if missing:
+            parser.error(f"needs {', '.join(missing)} when no --snapshot is given")
+        snapshot = fetch_snapshot(
+            args.repo,
+            args.tag,
+            args.run_id,
+            args.run_number,
+            args.run_attempt,
+            args.workflow,
+        )
+        if "error" in snapshot:
+            print(f"::warning::{snapshot['error']}", file=sys.stderr)
+
+    verdict = decide(snapshot)
+
+    if verdict.unreadable:
+        print(f"::warning::duplicate guard stood aside: {verdict.reason}", file=sys.stderr)
+    elif verdict.duplicate:
+        print(f"::notice::skipping this release: {verdict.reason}", file=sys.stderr)
+    else:
+        print(f"releasing: {verdict.reason}", file=sys.stderr)
+
+    print(f"duplicate={'true' if verdict.duplicate else 'false'}")
+    if verdict.prior_run_id is not None:
+        print(f"prior_run_id={verdict.prior_run_id}")
+    print(f"reason={verdict.reason}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-guard-duplicate-release-run.py
+++ b/scripts/test-guard-duplicate-release-run.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Fixtures for the duplicate-release-run guard, and a mutation pass over it.
+
+Every case is a snapshot document, so the decision is exercised with no GitHub
+in the loop. The falsification pass at the end breaks the guard one rule at a
+time and asserts that a NAMED case goes red for each break, because a test that
+passes against a broken guard is not evidence.
+"""
+
+from __future__ import annotations
+
+import copy
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import importlib
+
+guard = importlib.import_module("guard-duplicate-release-run")
+decide = guard.decide
+
+
+def run(
+    run_id: int,
+    number: int,
+    conclusion: str | None = "success",
+    status: str = "completed",
+    branch: str = "v0.6.4",
+    event: str = "push",
+) -> dict:
+    return {
+        "id": run_id,
+        "run_number": number,
+        "status": status,
+        "conclusion": conclusion,
+        "head_branch": branch,
+        "event": event,
+    }
+
+
+def snapshot(runs: list[dict] | None, **over) -> dict:
+    base = {
+        "tag": "v0.6.4",
+        "run_id": 33674383157,
+        "run_number": 148,
+        "run_attempt": 1,
+        "runs": runs,
+        "total_count": len(runs) if isinstance(runs, list) else 0,
+    }
+    base.update(over)
+    return base
+
+
+# name -> (snapshot, expected duplicate, expected unreadable)
+CASES: dict[str, tuple[dict, bool, bool]] = {
+    # The run that actually happened: 148 arrives behind a successful 147.
+    "v0_6_4_duplicate_delivery": (
+        snapshot([run(33674370002, 147), run(33674383157, 148, None, "in_progress")]),
+        True,
+        False,
+    ),
+    # The first release run for a tag has nothing behind it.
+    "first_run_for_tag": (
+        snapshot([run(33674370002, 147, None, "in_progress")], run_id=33674370002, run_number=147),
+        False,
+        False,
+    ),
+    "no_runs_at_all": (snapshot([]), False, False),
+    # A failed earlier run leaves the release undone, so the second delivery is
+    # the only thing left that can finish it.
+    "earlier_run_failed": (
+        snapshot([run(33674370002, 147, "failure"), run(33674383157, 148, None, "in_progress")]),
+        False,
+        False,
+    ),
+    "earlier_run_cancelled": (
+        snapshot([run(33674370002, 147, "cancelled")]),
+        False,
+        False,
+    ),
+    # Still in flight is not proof it will succeed.
+    "earlier_run_in_progress": (
+        snapshot([run(33674370002, 147, None, "in_progress")]),
+        False,
+        False,
+    ),
+    # A success on a different tag says nothing about this one.
+    "success_on_other_tag": (
+        snapshot([run(33674370002, 147, "success", branch="v0.6.3")]),
+        False,
+        False,
+    ),
+    # A later run must not silence the run it duplicated.
+    "later_run_succeeded": (
+        snapshot(
+            [run(33674370002, 147, None, "in_progress"), run(33674383157, 148, "success")],
+            run_id=33674370002,
+            run_number=147,
+        ),
+        False,
+        False,
+    ),
+    # A rerun is a deliberate act even when an earlier success exists.
+    "deliberate_rerun": (
+        snapshot([run(33674370002, 147)], run_attempt=2),
+        False,
+        False,
+    ),
+    # A short page reads exactly like "no earlier run", so it must not.
+    "short_listing": (
+        snapshot([run(33674370002, 147, None, "in_progress")], total_count=9),
+        False,
+        True,
+    ),
+    "listing_absent": (snapshot(None), False, True),
+    "identity_incomplete": (snapshot([run(33674370002, 147)], run_id=None), False, True),
+    # A non-push run (a dispatch, say) is not the duplicate this guards against.
+    "earlier_run_not_push": (
+        snapshot([run(33674370002, 147, "success", event="workflow_dispatch")]),
+        False,
+        False,
+    ),
+    # Judging against itself would refuse every run.
+    "only_itself_listed": (
+        snapshot([run(33674383157, 148, "success")]),
+        False,
+        False,
+    ),
+    # The two rows below violate the API's own invariants on purpose. A real
+    # listing never carries them, which is exactly why they are here: each one
+    # isolates a rule that a well-formed row lets a neighbouring rule catch
+    # first, so without them those two rules would be untested and could be
+    # deleted with every case still green.
+    #
+    # Our own run id, reported with a lower run number. Only the self-exclusion
+    # stops this, because the run-number comparison now reads it as older.
+    "self_row_claims_lower_number": (
+        snapshot([run(33674383157, 1, "success")]),
+        False,
+        False,
+    ),
+    # A run still in flight that already claims success. Only the completion
+    # check stops this, because the conclusion alone reads green.
+    "incomplete_row_claims_success": (
+        snapshot([run(33674370002, 147, "success", status="in_progress")]),
+        False,
+        False,
+    ),
+}
+
+
+def check(name: str) -> None:
+    snap, want_dup, want_unreadable = CASES[name]
+    got = decide(copy.deepcopy(snap))
+    if got.duplicate != want_dup:
+        raise AssertionError(
+            f"{name}: duplicate={got.duplicate}, wanted {want_dup} ({got.reason})"
+        )
+    if got.unreadable != want_unreadable:
+        raise AssertionError(
+            f"{name}: unreadable={got.unreadable}, wanted {want_unreadable} ({got.reason})"
+        )
+    if want_dup and got.prior_run_id is None:
+        raise AssertionError(f"{name}: duplicate verdict named no prior run")
+
+
+def run_cases() -> None:
+    for name in CASES:
+        check(name)
+    print(f"ok: {len(CASES)} duplicate-guard cases")
+
+
+# ---- falsification -------------------------------------------------------
+#
+# Each mutation removes exactly one rule. The named case MUST go red under it.
+# A mutation that leaves every case green means the case for that rule is
+# missing, not that the rule is safe.
+
+MUTATIONS: list[tuple[str, str, str]] = [
+    (
+        "ignore the rerun exemption",
+        "deliberate_rerun",
+        "attempt is not None and attempt > 1",
+    ),
+    (
+        "ignore the short-page assertion",
+        "short_listing",
+        "total is not None and total != len(runs)",
+    ),
+    (
+        "stop excluding this run itself",
+        "self_row_claims_lower_number",
+        "other_id == run_id",
+    ),
+    (
+        "stop excluding later runs",
+        "later_run_succeeded",
+        "other_number >= run_number",
+    ),
+    (
+        "stop checking the tag",
+        "success_on_other_tag",
+        'run.get("head_branch") != tag',
+    ),
+    (
+        "stop checking the conclusion",
+        "earlier_run_failed",
+        'run.get("conclusion") != "success"',
+    ),
+    (
+        "stop checking completion",
+        "incomplete_row_claims_success",
+        'run.get("status") != "completed"',
+    ),
+    (
+        "stop checking the event",
+        "earlier_run_not_push",
+        'run.get("event") != "push"',
+    ),
+]
+
+
+def falsify() -> None:
+    source = Path(__file__).resolve().parent / "guard-duplicate-release-run.py"
+    original = source.read_text(encoding="utf-8")
+    survivors: list[str] = []
+
+    for index, (label, case_name, needle) in enumerate(MUTATIONS):
+        if needle not in original:
+            raise AssertionError(
+                f"mutation '{label}' does not apply: its guard text is gone, so this "
+                f"falsification is no longer checking anything. Needle: {needle}"
+            )
+        # Neutralise exactly one condition, leaving the rest of the guard intact.
+        broken = original.replace(needle, "False", 1)
+        # The mutant needs a real module entry: @dataclass resolves its own
+        # class through sys.modules, and a bare exec namespace makes it raise
+        # instead of building the Verdict type.
+        name = f"guard_mutant_{index}"
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+        try:
+            exec(compile(broken, str(source), "exec"), module.__dict__)  # noqa: S102
+            mutant_decide = module.__dict__["decide"]
+            snap, want_dup, want_unreadable = CASES[case_name]
+            got = mutant_decide(copy.deepcopy(snap))
+            if got.duplicate == want_dup and got.unreadable == want_unreadable:
+                survivors.append(f"{label} (case {case_name})")
+        finally:
+            sys.modules.pop(name, None)
+
+    if survivors:
+        raise AssertionError(
+            "mutations survived, so these rules are not actually tested:\n  "
+            + "\n  ".join(survivors)
+        )
+    print(f"ok: {len(MUTATIONS)} mutations each turned their named case red")
+
+
+# ---- the wiring ----------------------------------------------------------
+#
+# The decision above is worth nothing if release.yml stops consulting it, and
+# that is a silent failure: the release still runs, so nothing goes red. These
+# assertions read the workflow itself.
+
+WORKFLOW = Path(__file__).resolve().parent.parent / ".github/workflows/release.yml"
+GUARD_JOB = "duplicate_guard"
+GATE = "needs.duplicate_guard.outputs.duplicate != 'true'"
+
+
+def parse_jobs(text: str) -> dict[str, dict]:
+    """Read job ids with their `needs` and job-level `if`.
+
+    Hand-rolled because the runner image carries no YAML module, and because a
+    single-line regex silently misses the `if: >-` block form that 14 of these
+    jobs use.
+    """
+    import re
+
+    lines = text.split("\n")
+    start = next(i for i, l in enumerate(lines) if re.match(r"^jobs:\s*$", l))
+    heads = [
+        (i, re.match(r"^  ([A-Za-z0-9_-]+):\s*$", l).group(1))
+        for i, l in enumerate(lines[start + 1 :], start + 1)
+        if re.match(r"^  ([A-Za-z0-9_-]+):\s*$", l)
+    ]
+    heads.append((len(lines), None))
+    graph: dict[str, dict] = {}
+    for k in range(len(heads) - 1):
+        begin, jid = heads[k]
+        body = lines[begin + 1 : heads[k + 1][0]]
+        needs: list[str] = []
+        cond: list[str] = []
+        i = 0
+        while i < len(body):
+            m = re.match(r"^    (needs|if):(.*)$", body[i])
+            if not m:
+                i += 1
+                continue
+            key, rest = m.group(1), m.group(2).strip()
+            value = [rest] if rest else []
+            j = i + 1
+            while j < len(body) and (not body[j].strip() or body[j].startswith("      ")):
+                if body[j].strip():
+                    value.append(body[j].strip())
+                j += 1
+            if key == "needs":
+                joined = " ".join(value)
+                needs = (
+                    [x.strip().strip("\"'") for x in joined.strip("[]").split(",") if x.strip()]
+                    if joined.startswith("[")
+                    else [x.lstrip("- ").strip().strip("\"'") for x in value if x.strip()]
+                )
+            else:
+                cond = value
+            i = j
+        graph[jid] = {"needs": needs, "if": " ".join(cond)}
+    return graph
+
+
+def assert_wiring(text: str) -> None:
+    graph = parse_jobs(text)
+    if GUARD_JOB not in graph:
+        raise AssertionError(f"release.yml has no {GUARD_JOB} job")
+
+    roots = [j for j, v in graph.items() if not v["needs"]]
+    if roots != [GUARD_JOB]:
+        raise AssertionError(
+            f"release.yml must have {GUARD_JOB} as its only root job, found {roots}. "
+            "A second root would run the release without consulting the guard."
+        )
+
+    if GATE not in graph["config"]["if"]:
+        raise AssertionError(f"config is not gated on the guard verdict: {graph['config']['if']!r}")
+
+    def reaches(job: str, target: str, seen: set[str] | None = None) -> bool:
+        seen = seen or set()
+        if job in seen:
+            return False
+        seen.add(job)
+        return any(
+            n == target or reaches(n, target, seen) for n in graph.get(job, {}).get("needs", [])
+        )
+
+    stranded = [j for j in graph if j != GUARD_JOB and not reaches(j, GUARD_JOB)]
+    if stranded:
+        raise AssertionError(
+            f"these jobs do not descend from {GUARD_JOB}, so a duplicate would still "
+            f"run them: {stranded}"
+        )
+
+
+WIRING_MUTATIONS: list[tuple[str, str, str]] = [
+    ("drop the gate on config", GATE, "true"),
+    ("detach config from the guard", "needs: duplicate_guard", "needs: []"),
+]
+
+
+def check_wiring() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert_wiring(text)
+
+    for label, needle, replacement in WIRING_MUTATIONS:
+        if needle not in text:
+            raise AssertionError(f"wiring mutation '{label}' no longer applies: {needle}")
+        try:
+            assert_wiring(text.replace(needle, replacement, 1))
+        except AssertionError:
+            continue
+        raise AssertionError(f"wiring mutation survived, so it is untested: {label}")
+
+    print(f"ok: release.yml wiring, {len(WIRING_MUTATIONS)} mutations red")
+
+
+if __name__ == "__main__":
+    run_cases()
+    falsify()
+    check_wiring()
+    print("duplicate-release-run guard: fixtures, falsification and wiring green")

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -881,6 +881,7 @@ EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
         "hold-alarm": "Report a held rail",
     },
     ".github/workflows/release.yml": {
+        "duplicate_guard": "Refuse a duplicate release run",
         "config": "Resolve release config",
         "build_daemon_image": "Build immutable daemon image",
         "attest_daemon_image": "Attest immutable daemon image",


### PR DESCRIPTION
Tag v0.6.4 produced two Release runs on 2026-09-02, and the second one is still
sitting there. This makes the duplicate refuse itself.

## What actually happened

The framing to check first was "one tag push produces two runs". It does not.
Fifty-plus tags in this workflow's history produced exactly one Release run
each. v0.6.4 is the only one with two: run 147 (`33674370002`, 19:36:58Z) and
run 148 (`33674383157`, 19:37:05Z), same sha, same tag, both `event=push`, both
`run_attempt=1`, both from `kin-release-bot[bot]`.

kin pushed once, and four reads agree on it. `release-tag.yml` holds exactly one
ref-creating call, the `POST /git/refs` at line 1803. `refs/tags/v0.6.4` still
reads `object_type=commit` at `390fbdc54`, a lightweight tag at the mint's own
target, so there was one ref mutation and nothing re-pointed it. No other
workflow in the tree creates, updates or deletes a tag ref. And `release.yml`'s
trigger is a single `push: tags` entry, so a second pattern cannot double-fire
it. The two runs carry different check suites, `91258431770` and `91258466161`,
which is two delivered events rather than one event rendered twice.

So GitHub delivered the same tag-creation push twice. Nothing in this repository
can suppress that, which rules out "make one tag produce one release run". The
duplicate has to refuse itself instead.

The harm is not hypothetical. `concurrency: kin-release-promotion` sets
`cancel-in-progress: false`, so the duplicate does not disappear, it queues. Run
148 has been pending since 19:37Z, and when 147 finishes it would start and
re-run publish, npm publish, promote-to-stable and the completion marker against
a tag that is already out.

## The change

`release.yml` has 18 jobs and exactly one root, `config`. A new `duplicate_guard`
job becomes the only root, and `config` gains `needs` plus an `if` on its
verdict, so one skip takes all eighteen jobs with it.

That cascade is worth stating rather than assuming, because 14 of the 18 jobs
use `always()` and a first regex pass over the file missed every one of them.
`always()` does make those jobs evaluate when a dependency skipped, but each one
then requires a named dependency's result to equal `'success'`, and a skipped
dependency's result is `'skipped'`. Every always() job names at least one
dependency inside the cascade, traced job by job. A run whose jobs all skip
concludes success, so the duplicate ends clean rather than idling.

Three judgment calls in `scripts/guard-duplicate-release-run.py`:

A rerun is never a duplicate. `run_attempt > 1` means a human pressed the button,
and refusing it would make that button silently do nothing.

Only a completed successful run counts. A failed earlier run leaves the release
undone, so the second delivery is the only thing left that can finish it, and it
must be allowed to.

An unreadable listing releases rather than skips. That direction is deliberate:
a duplicate is noisy and its mutations are individually guarded, while a
silently skipped release ships nothing and pages nobody. A failing guard is not
the same as a duplicate either, and goes red rather than quietly skipping.

## Proof

16 fixtures, 8 mutations, each turning a named case red. Two cases use rows that
violate the API's own invariants on purpose: a well-formed row lets a
neighbouring rule catch the input one step earlier, so without them the
self-exclusion and completion rules would be untested and deletable with
everything still green. Two more mutations cover the wiring, which is the silent
half, since a `release.yml` that stopped consulting the guard would turn nothing
red.

Checked against the live listing: run 148 judged with 147 advanced to the state
it will hold when the concurrency group releases it returns `duplicate=true`
naming 147, and run 147 itself returns `duplicate=false`. actionlint is green on
both workflows, and a deliberately broken copy makes it exit 1, so it would have
caught bad wiring.

Gates run: `test-release-workflow-authority.py` (which refused the new job until
it was registered in the census, then went green), `test-release-policy-gate.sh`,
`actionlint`, and the new suite. The Release version gate does not apply to this
branch, so no version moved.

## Note for review

`ci.yml` gains one line in each of two gate blocks, at the same anchor #1391 uses
for its own additions, so whichever lands second resolves a one-line conflict by
keeping both. #1391 and this PR also both touch the job census in
`test-release-workflow-authority.py`, in different entries. Neither touches the
other's workflow.

Related: FIR-3084
