### PR TITLE
Make CLAUDE.md a regular file so the promotion bundle admits kin's source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,12 @@
-AGENTS.md
+# Kin
+
+Claude Code reads this filename; the repository's agent contract lives in `AGENTS.md`, imported
+below so both filenames load the same text. Edit `AGENTS.md`, never this file.
+
+This is a regular file rather than a symlink to `AGENTS.md` on purpose. kin's source is archived
+into a promotion bundle (`git archive --prefix=kin/` in kin-infra's `promote-image.yml`) and the
+bundle validator refuses any non-regular entry, so a symlink here fails production image
+promotion with `kin-contracts-source.tar: non-regular entry kin/CLAUDE.md` after the release has
+already been tagged and published. Keep every tracked path in this repository a regular file.
+
+@AGENTS.md


### PR DESCRIPTION
kin-infra's `promote-image.yml` archives this repository with `git archive --prefix=kin/` and its bundle validator refuses any non-regular entry. The `CLAUDE.md` symlink added after v0.6.3 therefore failed production image promotion for v0.6.4 with "kin-contracts-source.tar: non-regular entry kin/CLAUDE.md", after the release had already been tagged, published and served on npm.

CLAUDE.md becomes a regular file carrying the same text through an in-repo `@AGENTS.md` import, which agent CLIs load without an external-import prompt, and its comment says why it must stay regular. AGENTS.md remains the file to edit.

Follow-up worth doing separately: a CI guard that `git ls-files -s` reports no mode 120000 path in this repository, so the class cannot return. kin-actions and kin-bench carry the same symlink but neither is archived into a promotion bundle.

Related: FIR-3057
