### PR TITLE
Admit a scratch-file delete beside new files, and make kin admit's exit status honest

### DIFF
--- a/crates/kin-cli/src/commands/admit.rs
+++ b/crates/kin-cli/src/commands/admit.rs
@@ -166,6 +166,67 @@ pub fn graph_moved(report: &AdmitReport) -> bool {
     census_moved(report) || report.tree_moved == Some(true)
 }
 
+/// The one wording that means this pass did not admit the working copy.
+///
+/// A constant rather than a literal in two places, because the exit-status
+/// guard below keys on it: if the summary's wording drifts and the guard's copy
+/// does not, the guard silently stops recognizing a failure it is printing.
+pub const ADMIT_FAILURE_PREFIX: &str = "Complete exact-tree admission failed: ";
+
+/// The cause this admission must exit non-zero for, or `None` when it admitted.
+///
+/// Extracted from `run` so the decision is asserted directly rather than through
+/// a daemon round trip, and widened past the check it used to be (FIR-3098).
+///
+/// A stranger on the v0.6.4 candidate watched `kin admit` print
+/// `Complete exact-tree admission failed: ...` and exit 0. The check on
+/// `report.admitted` was already here and already correct; the hole was the arm
+/// beside it. `report` is `Option<AdmitReport>` carrying `#[serde(default)]`, so
+/// a response that omits the object deserializes to `None` and fell through to
+/// `Ok(())` while the failure the daemon had already rendered sat in `lines` on
+/// its way to the operator's terminal.
+///
+/// So the rule is no longer "the report says it failed". It is that success is
+/// the one answer this may not give unless something established it:
+///
+///   a report that says the pass failed        -> its recorded cause
+///   no report at all                          -> no outcome was established
+///   a summary line that announces the failure -> that line
+///
+/// The third arm is deliberately redundant with the first. It keys on the text
+/// the operator actually read, so any future response shape that renders a
+/// failure into `lines` without a matching report is caught by what it says
+/// rather than by what it forgot to set.
+pub fn admission_failure(response: &AdmitResponse) -> Option<String> {
+    if let Some(report) = response.report.as_ref() {
+        if !report.admitted {
+            return Some(
+                report
+                    .failure
+                    .as_deref()
+                    .or(report.reconcile.last_admission_error.as_deref())
+                    .unwrap_or("no cause recorded")
+                    .to_string(),
+            );
+        }
+    }
+    if let Some(line) = response
+        .lines
+        .iter()
+        .find(|line| line.starts_with(ADMIT_FAILURE_PREFIX))
+    {
+        return Some(line[ADMIT_FAILURE_PREFIX.len()..].to_string());
+    }
+    if response.report.is_none() {
+        return Some(
+            "the daemon returned no admission report, so whether the working copy was admitted \
+             is unknown; read `kin graph status` for the state it left behind"
+                .to_string(),
+        );
+    }
+    None
+}
+
 /// Render the operator-facing summary for one admission report.
 ///
 /// Kept separate from transport so the wording is asserted directly rather than
@@ -182,7 +243,7 @@ pub fn summary_lines(report: &AdmitReport) -> Vec<String> {
             .as_deref()
             .or(report.reconcile.last_admission_error.as_deref())
             .unwrap_or("no cause recorded");
-        lines.push(format!("Complete exact-tree admission failed: {cause}"));
+        lines.push(format!("{ADMIT_FAILURE_PREFIX}{cause}"));
         if graph_moved(report) {
             // Authority crossed before the failure. Calling that unchanged is
             // the one wording an operator cannot recover from, because it
@@ -462,18 +523,11 @@ pub async fn run() -> Result<()> {
     for line in &response.lines {
         println!("{line}");
     }
-    match response.report.as_ref() {
-        Some(report) if !report.admitted => {
-            let cause = report
-                .failure
-                .as_deref()
-                .or(report.reconcile.last_admission_error.as_deref())
-                .unwrap_or("no cause recorded");
-            Err(anyhow::anyhow!(
-                "complete exact-tree admission failed: {cause}"
-            ))
-        }
-        _ => Ok(()),
+    match admission_failure(&response) {
+        Some(cause) => Err(anyhow::anyhow!(
+            "complete exact-tree admission failed: {cause}"
+        )),
+        None => Ok(()),
     }
 }
 
@@ -510,6 +564,103 @@ mod tests {
         settled.entities_after = 39;
         settled.tree_moved = tree_moved;
         settled
+    }
+
+    /// One response as the daemon actually sends it, so a test cannot assert a
+    /// shape the wire never carries.
+    fn response(report: Option<AdmitReport>) -> AdmitResponse {
+        let lines = report.as_ref().map(summary_lines).unwrap_or_default();
+        AdmitResponse {
+            lines,
+            mutated: false,
+            report,
+        }
+    }
+
+    /// FIR-3098, the arm that already worked. Kept as the control: without it a
+    /// guard that returned `Some` for everything would pass every test below.
+    #[test]
+    fn a_failed_report_exits_nonzero_with_its_recorded_cause() {
+        let cause = admission_failure(&response(Some(report(false))))
+            .expect("a report that says the pass failed must exit nonzero");
+        assert!(
+            cause.contains("host entry changed after exact-tree admission"),
+            "the recorded cause is the news: {cause}"
+        );
+    }
+
+    /// FIR-3098, the hole. A stranger on the v0.6.4 candidate watched
+    /// `kin admit` print `Complete exact-tree admission failed:` and exit 0.
+    ///
+    /// The check on `report.admitted` was already present and already right, at
+    /// the candidate sha as well as on main, so the exit status did not come
+    /// from a missing check. It came from the arm beside it: `report` carries
+    /// `#[serde(default)]`, so a response that omits the object decodes to
+    /// `None` and fell through to `Ok(())` while the failure the daemon had
+    /// already rendered travelled to the terminal in `lines`. That is why the
+    /// rule is now about what was established rather than about one field.
+    #[test]
+    fn a_failure_line_with_no_report_still_exits_nonzero() {
+        let rendered = summary_lines(&report(false));
+        let wire = AdmitResponse {
+            lines: rendered.clone(),
+            mutated: false,
+            report: None,
+        };
+        assert!(
+            rendered
+                .first()
+                .is_some_and(|line| line.starts_with(ADMIT_FAILURE_PREFIX)),
+            "fixture check: the failure the operator reads is in the lines"
+        );
+        let cause = admission_failure(&wire)
+            .expect("a printed failure must never exit zero, whatever the report field holds");
+        assert!(
+            cause.contains("host entry changed after exact-tree admission"),
+            "{cause}"
+        );
+    }
+
+    /// A response that established no outcome at all is not a success either.
+    ///
+    /// No report and no lines is the shape a future transport change, or a
+    /// daemon that answered before it ran the pass, would produce. Success is
+    /// the one answer that must not be given for it.
+    #[test]
+    fn a_response_with_no_outcome_exits_nonzero() {
+        let cause = admission_failure(&AdmitResponse {
+            lines: Vec::new(),
+            mutated: false,
+            report: None,
+        })
+        .expect("a response that established nothing must not read as success");
+        assert!(cause.contains("no admission report"), "{cause}");
+    }
+
+    /// The control every assertion above depends on. A guard that refused
+    /// everything would satisfy all three and break `kin admit` completely.
+    #[test]
+    fn a_real_admission_exits_zero() {
+        assert_eq!(admission_failure(&response(Some(report(true)))), None);
+        assert_eq!(
+            admission_failure(&response(Some(content_only_pass(Some(true))))),
+            None
+        );
+    }
+
+    /// The wording and the guard are one string, checked to be one string.
+    ///
+    /// The line-scanning arm of `admission_failure` keys on the prefix the
+    /// summary prints. If the summary's wording ever drifts and the guard's copy
+    /// does not, that arm silently stops recognizing a failure it is printing,
+    /// which is the exact defect shape it was added to close.
+    #[test]
+    fn the_summary_uses_the_prefix_the_exit_guard_keys_on() {
+        let first = summary_lines(&report(false))
+            .first()
+            .cloned()
+            .expect("a failed pass renders a cause line first");
+        assert!(first.starts_with(ADMIT_FAILURE_PREFIX), "{first}");
     }
 
     /// FIR-2961. The stranger edited one tracked file, ran `kin admit`, and was

--- a/crates/kin-cli/src/commands/admit.rs
+++ b/crates/kin-cli/src/commands/admit.rs
@@ -648,19 +648,33 @@ mod tests {
         );
     }
 
-    /// The wording and the guard are one string, checked to be one string.
+    /// The failure wording is a cross-surface contract, so it is pinned to a
+    /// literal rather than to the constant.
     ///
-    /// The line-scanning arm of `admission_failure` keys on the prefix the
-    /// summary prints. If the summary's wording ever drifts and the guard's copy
-    /// does not, that arm silently stops recognizing a failure it is printing,
-    /// which is the exact defect shape it was added to close.
+    /// This asserted `summary_lines(..).starts_with(ADMIT_FAILURE_PREFIX)` and
+    /// survived the mutation written to break it, because after the refactor one
+    /// constant feeds both the producer and the assertion: changing it moves the
+    /// two together and the comparison stays true for any value. A test that
+    /// cannot fail is not evidence.
+    ///
+    /// What the drift would actually break is a reader that cannot see this
+    /// constant. `scripts/acceptance/scratch_file_commit_repro.py` carries its
+    /// own copy of this string and grades a run as failed only when it appears,
+    /// so a silent rewording here would leave that suite reporting a refused
+    /// admission as a clean one. Pinning the literal is what makes changing the
+    /// wording a deliberate act that updates both surfaces.
     #[test]
-    fn the_summary_uses_the_prefix_the_exit_guard_keys_on() {
+    fn the_failure_prefix_is_the_wording_the_acceptance_grader_matches() {
+        const WIRE: &str = "Complete exact-tree admission failed: ";
+        assert_eq!(
+            ADMIT_FAILURE_PREFIX, WIRE,
+            "scripts/acceptance/scratch_file_commit_repro.py matches this literal"
+        );
         let first = summary_lines(&report(false))
             .first()
             .cloned()
             .expect("a failed pass renders a cause line first");
-        assert!(first.starts_with(ADMIT_FAILURE_PREFIX), "{first}");
+        assert!(first.starts_with(WIRE), "{first}");
     }
 
     /// FIR-2961. The stranger edited one tracked file, ran `kin admit`, and was

--- a/crates/kin-core/src/exact_tree.rs
+++ b/crates/kin-core/src/exact_tree.rs
@@ -214,7 +214,10 @@ pub fn plan_observed_tree_deltas(
     }) {
         return Err(KinError::Other(format!(
             "identity-underdetermined repository transition for artifact {artifact_id:?} at {}: \
-             the same exact entry also appears at {}; use an explicit identity-bearing copy/move",
+             the same exact entry also appears at {}, so a copy and a move-plus-replacement are \
+             equally supported and choosing one would guess this artifact's identity. Commit the \
+             two paths in separate commits, or make their contents differ, so one transition \
+             names one identity",
             old.path, duplicate
         )));
     }
@@ -259,7 +262,9 @@ pub fn plan_observed_tree_deltas(
     }) {
         return Err(KinError::Other(format!(
             "ambiguous repository identity transition for artifact {artifact_id:?} at {}: \
-             exact entry also appears at {}; use an explicit identity-bearing move",
+             the same exact entry appears at {}, so nothing chooses which of them this artifact \
+             moved to. Commit the destinations in separate commits, or make their contents \
+             differ, so one path claims the identity",
             old.path,
             candidates
                 .iter()
@@ -291,23 +296,27 @@ pub fn plan_observed_tree_deltas(
         });
     }
 
-    if !old_by_id.is_empty() && !new_by_path.is_empty() {
-        let removed = old_by_id
-            .values()
-            .map(|old| old.path.to_string())
-            .collect::<Vec<_>>()
-            .join(", ");
-        let added = new_by_path
-            .keys()
-            .map(ToString::to_string)
-            .collect::<Vec<_>>()
-            .join(", ");
-        return Err(KinError::Other(format!(
-            "identity-underdetermined repository transition: unmatched removals [{removed}] and \
-             additions [{added}] may be move-plus-edit operations; use explicit identity-bearing \
-             add/remove/move commands"
-        )));
-    }
+    // What is left is a removal whose content appears nowhere in the observation
+    // beside an addition whose content matches no tracked artifact. Nothing
+    // links the two, and this used to refuse the whole transition on the theory
+    // that they MIGHT be one move-plus-edit.
+    //
+    // The refusal preserved no identity, which is why it is gone (FIR-3097).
+    // Every refusal above it is backed by evidence: a byte-identical entry in
+    // two places makes two identity assignments equally supported, so choosing
+    // one would be a guess. Here there is no evidence in either direction, and
+    // the planner reads hashes rather than content, so it cannot acquire any. A
+    // user who hit this had exactly one way forward, recreating the deleted file
+    // and splitting the work across two commits, and that lands the same
+    // Removed plus Added this now plans directly. The refusal cost a wedge and
+    // bought nothing, and it prescribed `add`, `remove` and `move` commands that
+    // exist on no Kin surface: `plan_artifact_move` and `plan_artifact_copy` are
+    // called only by this file's own tests.
+    //
+    // So an unmatched removal beside additions is a delete plus adds. When
+    // content similarity can be measured here, and when an identity-bearing move
+    // reaches a product surface, a similarity-gated refusal becomes worth having
+    // because it would then have both evidence and a remedy.
 
     deltas.extend(
         old_by_id
@@ -417,26 +426,159 @@ mod tests {
         assert!(error.to_string().contains("ambiguous repository identity"));
     }
 
+    /// An unmatched removal beside an unmatched addition is a delete plus an
+    /// add, and it plans rather than refusing (FIR-3097).
+    ///
+    /// This asserted the refusal until 2026-09-02. It is inverted rather than
+    /// deleted because the identity claim underneath it is the thing worth
+    /// pinning: the old artifact is Removed and the new path gets a FRESH
+    /// identity. Nothing is silently carried across, so the planner is not
+    /// guessing a move here any more than it was before; it is recording the
+    /// only transition the observation actually supports.
     #[test]
-    fn observation_fails_closed_on_move_plus_edit() {
+    fn observation_admits_an_unmatched_removal_beside_an_addition() {
         let id = ArtifactId::new();
+        let old_path = RepoPath::from_utf8("old").unwrap();
+        let new_path = RepoPath::from_utf8("new").unwrap();
         let previous = resolved(vec![(
             id,
-            RepoPath::from_utf8("old").unwrap(),
+            old_path.clone(),
             TreeEntry::blob(Hash256::from_bytes([0x61; 32]), false),
         )]);
 
-        let error = plan_observed_tree_deltas(
+        let deltas = plan_observed_tree_deltas(
             &previous,
             BTreeMap::from([(
-                RepoPath::from_utf8("new").unwrap(),
+                new_path.clone(),
                 TreeEntry::blob(Hash256::from_bytes([0x62; 32]), false),
             )]),
         )
-        .unwrap_err();
+        .expect("an unmatched removal beside an addition is a delete plus an add");
 
-        assert!(error.to_string().contains("identity-underdetermined"));
-        assert_eq!(previous.get(&id).unwrap().path.as_utf8(), Some("old"));
+        assert!(
+            deltas
+                .iter()
+                .any(|delta| matches!(delta, TreeDelta::Removed { artifact_id, .. } if *artifact_id == id)),
+            "the deleted artifact must be Removed by its own identity: {deltas:?}"
+        );
+        let added = deltas
+            .iter()
+            .filter_map(|delta| match delta {
+                TreeDelta::Added { artifact_id, new } => Some((*artifact_id, new.path.clone())),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(added.len(), 1, "one addition was observed: {deltas:?}");
+        assert_eq!(added[0].1, new_path);
+        assert_ne!(
+            added[0].0, id,
+            "the addition must mint a fresh identity, never inherit the removed one"
+        );
+
+        let next = previous.apply(&deltas).unwrap();
+        assert!(next.get(&id).is_none(), "the removed artifact is gone");
+        assert!(next.artifact_at_path(&new_path).is_some());
+    }
+
+    /// The stranger's shape, verbatim (FIR-3097): one scratch file created and
+    /// deleted between two commits, beside the real work.
+    ///
+    /// `kin commit` takes no paths and has no staging area, so it observes the
+    /// whole working tree every time and this is what any scratch file produces.
+    /// The v0.6.4 candidate refused it in 20 ms and told the user to reach for
+    /// `add`, `remove` and `move` commands that do not exist, and the only way
+    /// out anybody found was to recreate the file and split the work across two
+    /// commits, which lands exactly the deltas asserted here.
+    #[test]
+    fn observation_admits_a_deleted_scratch_file_beside_new_files() {
+        let scratch_id = ArtifactId::new();
+        let kept_id = ArtifactId::new();
+        let scratch = RepoPath::from_utf8("_smoke.py").unwrap();
+        let kept = RepoPath::from_utf8("notekeeper/notes.py").unwrap();
+        let kept_entry = TreeEntry::blob(Hash256::from_bytes([0x01; 32]), false);
+        let previous = resolved(vec![
+            (
+                scratch_id,
+                scratch.clone(),
+                TreeEntry::blob(Hash256::from_bytes([0x02; 32]), false),
+            ),
+            (kept_id, kept.clone(), kept_entry),
+        ]);
+
+        let additions = [
+            ".gitignore",
+            "notekeeper/__init__.py",
+            "notekeeper/parsing.py",
+        ];
+        let mut observed = BTreeMap::from([(kept.clone(), kept_entry)]);
+        for (index, path) in additions.into_iter().enumerate() {
+            observed.insert(
+                RepoPath::from_utf8(path).unwrap(),
+                TreeEntry::blob(Hash256::from_bytes([0x10 + index as u8; 32]), false),
+            );
+        }
+
+        let deltas = plan_observed_tree_deltas(&previous, observed)
+            .expect("a deleted scratch file beside new files is a delete plus adds");
+        let next = previous.apply(&deltas).unwrap();
+
+        assert!(next.get(&scratch_id).is_none(), "the scratch file is gone");
+        assert_eq!(
+            next.get(&kept_id).map(|artifact| artifact.path.clone()),
+            Some(kept),
+            "an untouched file keeps its identity and its path"
+        );
+        for path in additions {
+            assert!(
+                next.artifact_at_path(&RepoPath::from_utf8(path).unwrap())
+                    .is_some(),
+                "{path} was admitted"
+            );
+        }
+    }
+
+    /// Neither surviving refusal may prescribe a command that does not exist.
+    ///
+    /// The whole reason FIR-3097 wedged a first-time user is that the message
+    /// named `add`, `remove` and `move`; `kin --help` lists sixty-odd
+    /// subcommands and none of them. This keys on both halves, the fiction that
+    /// must be absent and the real remedy that must be present, because a
+    /// message asserted only by what it lacks passes when it says nothing.
+    #[test]
+    fn identity_refusals_name_a_remedy_that_exists() {
+        let id = ArtifactId::new();
+        let entry = TreeEntry::blob(Hash256::from_bytes([0x55; 32]), false);
+        let old = RepoPath::from_utf8("old").unwrap();
+
+        let ambiguous = plan_observed_tree_deltas(
+            &resolved(vec![(id, old.clone(), entry)]),
+            BTreeMap::from([
+                (RepoPath::from_utf8("copy-a").unwrap(), entry),
+                (RepoPath::from_utf8("copy-b").unwrap(), entry),
+            ]),
+        )
+        .unwrap_err()
+        .to_string();
+
+        let duplicate = plan_observed_tree_deltas(
+            &resolved(vec![(id, old.clone(), entry)]),
+            BTreeMap::from([(old, entry), (RepoPath::from_utf8("new").unwrap(), entry)]),
+        )
+        .unwrap_err()
+        .to_string();
+
+        for message in [&ambiguous, &duplicate] {
+            assert!(
+                !message.contains("add/remove/move")
+                    && !message.contains("identity-bearing copy/move")
+                    && !message.contains("identity-bearing move"),
+                "a refusal must not prescribe a command Kin does not ship: {message}"
+            );
+            assert!(
+                message.contains("separate commits"),
+                "a refusal must name what the operator can actually do: {message}"
+            );
+        }
     }
 
     #[test]

--- a/scripts/acceptance/scratch_file_commit_repro.py
+++ b/scripts/acceptance/scratch_file_commit_repro.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+"""NON-CITABLE acceptance suite for the scratch-file commit shape (FIR-3097, FIR-3098).
+
+Its output is a regression gate, never proof, never investor-facing, and never a
+released claim.
+
+What it is for
+--------------
+A stranger building a fresh Python package on the v0.6.4 candidate created
+``_smoke.py``, ran it, deleted it, wrote three new files, and committed. Kin
+refused in 20 ms:
+
+    identity-underdetermined repository transition: unmatched removals [_smoke.py]
+    and additions [.gitignore, notekeeper/__init__.py, notekeeper/parsing.py] may
+    be move-plus-edit operations; use explicit identity-bearing add/remove/move
+    commands
+
+Three separate defects rode on that one transition, and this suite grades all
+three because each can regress without the others.
+
+``commit`` is the shape itself. ``kin commit`` takes no paths and has no staging
+area, so it observes the whole working tree every time, and any scratch file
+created and deleted between two commits produces exactly this. The stranger's
+conclusion was "I now avoid scratch files in the repo entirely", which is a
+product outcome no message wording can repair.
+
+``remedy`` is the instruction. The refusal named ``add``, ``remove`` and ``move``
+commands; ``kin --help`` lists sixty-odd subcommands and none of them, and the
+closest, ``kin rename``, is a graph entity rename rather than a path move. This
+arm reads the help text at run time and requires every command a refusal
+prescribes to appear in it, so it grades the message against the product rather
+than against a list written here that would go stale.
+
+``exit`` is FIR-3098. After the refusal, ``kin admit`` printed
+``Complete exact-tree admission failed:`` and exited 0. Kin's own agents and
+every CI harness read ``$?``, so a failure that exits 0 is read as success. The
+arm is deliberately two-sided: a run that fails must exit non-zero AND a run that
+succeeds must exit zero, because a command that always exited non-zero would
+satisfy the first half and be useless.
+
+What it is blind to
+-------------------
+It grades one transition shape end to end. It does not grade rename detection,
+which Kin does not do, and it takes no position on whether a future
+similarity-gated refusal should exist: it requires only that a refusal, if one
+happens, names a remedy that exists and leaves the exit status honest.
+
+Each check prints one line:
+
+    CHECK <id> <ticket> PASS|FAIL|UNREADABLE <detail>
+
+Exit status is 1 when any check FAILs, 2 when none fail but some are UNREADABLE,
+3 on setup failure, and 0 only when every check passes. ``--self-test`` drives
+every grader against the input that must produce the opposite verdict, without
+building a repository or needing a kin binary.
+"""
+
+from __future__ import print_function
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+PASS = "PASS"
+FAIL = "FAIL"
+UNREADABLE = "UNREADABLE"
+
+TICKET = "FIR-3097"
+EXIT_TICKET = "FIR-3098"
+
+SCRATCH = "_smoke.py"
+SEED = "notekeeper/notes.py"
+ADDITIONS = (".gitignore", "notekeeper/__init__.py", "notekeeper/parsing.py")
+
+SEED_BODY = '"""Seed module."""\n\n\ndef make_note(title):\n    return {"title": title}\n'
+SCRATCH_BODY = '"""Scratch, deleted before the commit."""\n\nprint(make_note)\n'
+ADDITION_BODIES = {
+    ".gitignore": "__pycache__/\n*.pyc\n",
+    "notekeeper/__init__.py": 'from .parsing import parse_note\n\n__all__ = ["parse_note"]\n',
+    "notekeeper/parsing.py": (
+        '"""Markdown note parsing."""\n\n\ndef parse_note(text):\n'
+        "    return {\"body\": text.strip()}\n"
+    ),
+}
+
+# The refusal this suite exists for, matched on its stable head rather than on
+# the whole sentence, so a reworded tail does not silently stop matching.
+REFUSAL = "identity-underdetermined repository transition"
+
+# What `kin admit` prints when it did not admit. Shared with the CLI constant
+# `kin_cli::commands::admit::ADMIT_FAILURE_PREFIX`; if the two ever drift, the
+# `exit` arm reads a failure as a success and this suite says so.
+ADMIT_FAILURE = "Complete exact-tree admission failed:"
+
+# Commands a refusal has prescribed. Each is a bare word the message offers as
+# something to run, and every one must be a real subcommand.
+PRESCRIBED = re.compile(r"\b(?:use|run|try)\b[^.]*?\b(add|remove|move|mv|rm)\b[^.]*?\bcommands?\b",
+                        re.IGNORECASE)
+
+
+class Result(object):
+    def __init__(self, cid, status, detail):
+        self.id = cid
+        self.status = status
+        self.detail = detail
+
+
+def run(cmd, cwd=None, env=None, timeout=900):
+    process = subprocess.Popen(
+        cmd, cwd=cwd, env=env,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    try:
+        out, err = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        out, err = process.communicate()
+        return 124, out or "", err or ""
+    return process.returncode, out or "", err or ""
+
+
+# ── graders ──
+#
+# Pure functions, so --self-test drives every one against the input that must
+# produce the opposite verdict, with no repository and no binary.
+
+def help_subcommands(help_text):
+    """Every subcommand `kin --help` lists.
+
+    Read from the product rather than hardcoded, so a check about what Kin ships
+    cannot pass against a list that went stale. Clap indents each subcommand by
+    two spaces and follows it with its summary; the leading token of such a line
+    is the name.
+    """
+    if not isinstance(help_text, str):
+        return set()
+    names = set()
+    for line in help_text.splitlines():
+        if not line.startswith("  ") or line.startswith("   "):
+            continue
+        token = line.strip().split(" ", 1)[0]
+        if token and re.match(r"^[a-z][a-z0-9-]*$", token):
+            names.add(token)
+    return names
+
+
+def grade_commit_admitted_the_scratch_delete(rc, text):
+    """A scratch file deleted beside new files commits.
+
+    The refusal is named explicitly rather than inferred from `rc`, because a
+    commit can fail for reasons that have nothing to do with this ticket and
+    reporting one of those as this regression would send the next reader at the
+    wrong code.
+    """
+    if not isinstance(text, str):
+        return Result("commit", UNREADABLE, "no commit output to read")
+    if REFUSAL in text:
+        return Result("commit", FAIL,
+                      "kin commit refused the delete-plus-add transition: %s"
+                      % first_line_containing(text, REFUSAL))
+    if rc != 0:
+        return Result("commit", UNREADABLE,
+                      "kin commit failed for another reason (rc=%s): %s"
+                      % (rc, text.strip()[-200:]))
+    return Result("commit", PASS,
+                  "a scratch file deleted beside %d new files committed" % len(ADDITIONS))
+
+
+def grade_refusal_prescribes_a_real_remedy(text, subcommands):
+    """Any refusal must name only commands the product ships.
+
+    Two-sided on purpose. A message that prescribes nothing passes, because
+    prescribing nothing is not the defect; prescribing fiction is. And the
+    subcommand set has to be non-empty, or a help read that returned nothing
+    would let every message through.
+    """
+    if not isinstance(text, str):
+        return Result("remedy", UNREADABLE, "no message to read")
+    if not subcommands:
+        return Result("remedy", UNREADABLE,
+                      "kin --help listed no subcommands, so the message cannot be graded")
+    match = PRESCRIBED.search(text)
+    if not match:
+        return Result("remedy", PASS,
+                      "no message prescribed a command (%d subcommands available)"
+                      % len(subcommands))
+    named = match.group(1).lower()
+    if named in subcommands:
+        return Result("remedy", PASS, "the message prescribes `kin %s`, which exists" % named)
+    return Result("remedy", FAIL,
+                  "the message prescribes `%s`, which `kin --help` does not list: %s"
+                  % (named, match.group(0)))
+
+
+def grade_admit_exit_status(rc, text):
+    """`kin admit` exits non-zero exactly when it did not admit (FIR-3098).
+
+    Both directions in one grader, because they are one property. A command that
+    always exited non-zero would satisfy the half this ticket is about and break
+    every green run, so the arm that matters cannot be graded alone.
+    """
+    if not isinstance(text, str) or not isinstance(rc, int):
+        return Result("exit", UNREADABLE, "no admit result to read")
+    failed = ADMIT_FAILURE in text
+    if failed and rc == 0:
+        return Result("exit", FAIL,
+                      "kin admit printed a failure and exited 0, so a script reads it as success")
+    if not failed and rc != 0:
+        return Result("exit", FAIL,
+                      "kin admit exited %s without printing a failure" % rc)
+    if failed:
+        return Result("exit", PASS, "a refused admission exited %s" % rc)
+    return Result("exit", PASS, "a successful admission exited 0")
+
+
+def first_line_containing(text, needle):
+    for line in text.splitlines():
+        if needle in line:
+            return line.strip()[:200]
+    return ""
+
+
+def report_payload(results, label):
+    """The report shape `scripts/acceptance/gate.py` reads."""
+    return {
+        "label": label,
+        "ticket": TICKET,
+        "results": [
+            {"id": r.id,
+             "ticket": EXIT_TICKET if r.id == "exit" else TICKET,
+             "status": r.status,
+             "detail": r.detail}
+            for r in results
+        ],
+    }
+
+
+# ── fixture ──
+
+class Suite(object):
+    def __init__(self, kin, workdir, daemon=None, verbose=False):
+        self.kin = kin
+        self.workdir = workdir
+        self.verbose = verbose
+        self.home = os.path.join(workdir, "home")
+        os.makedirs(self.home)
+        # kin refuses to invent an author, which is correct. The run isolates
+        # HOME so it cannot read the machine's identity, so it brings one.
+        with open(os.path.join(self.home, ".gitconfig"), "w") as handle:
+            handle.write("[user]\n\tname = scratch-file-commit-repro\n"
+                         "\temail = repro@example.invalid\n"
+                         "[commit]\n\tgpgsign = false\n")
+        self.env = dict(os.environ)
+        self.env["HOME"] = self.home
+        self.env["USERPROFILE"] = self.home
+        self.env["KIN_DAEMON_AUTO_EMBED"] = "0"
+        self.env["KIN_EMBED_BACKEND"] = "cpu"
+        self.env["KIN_VFS_DISABLE"] = "1"
+        self.env["KIN_REGISTRY_PATH"] = os.path.join(self.home, "registry.toml")
+        self.env.pop("KIN_MCP_REPO", None)
+        self.env.pop("KIN_DAEMON_URL", None)
+        if daemon:
+            self.env["KIN_DAEMON_BIN"] = daemon
+        self._repo = None
+
+    def kin_run(self, repo, args, timeout=900):
+        rc, out, err = run([self.kin] + args, cwd=repo, env=self.env, timeout=timeout)
+        if self.verbose:
+            print("  $ kin %s -> rc=%s" % (" ".join(args), rc))
+        return rc, out, err
+
+    def git(self, repo, args, timeout=300):
+        rc, out, err = run(["git"] + args, cwd=repo, env=self.env, timeout=timeout)
+        if rc != 0:
+            raise RuntimeError("git %s failed: %s" % (" ".join(args), (err or out)[-300:]))
+        return out
+
+    def repo(self):
+        """A converted repository holding one seed file, and nothing else.
+
+        The scratch file is written and deleted AFTER conversion so the
+        transition under test is the one the stranger hit: a tracked artifact
+        whose content appears nowhere in the new observation, beside additions
+        that match no tracked artifact.
+        """
+        if self._repo:
+            return self._repo
+        path = os.path.realpath(os.path.join(self.workdir, "notekeeper"))
+        os.makedirs(path)
+        self.git(path, ["init", "-q", "-b", "main", "."])
+        self.git(path, ["config", "core.hooksPath", os.path.join(self.home, "no-hooks")])
+        self.git(path, ["config", "user.email", "repro@example.invalid"])
+        self.git(path, ["config", "user.name", "scratch-file-commit-repro"])
+        self._write(path, SEED, SEED_BODY)
+        self._write(path, SCRATCH, SCRATCH_BODY)
+        self.git(path, ["add", "-A"])
+        self.git(path, ["commit", "-q", "-m", "seed"])
+        rc, out, err = self.kin_run(path, ["init", "."])
+        if rc != 0:
+            raise RuntimeError("kin init failed: %s" % ((err or out)[-400:]))
+        # Fixture assertion. If the scratch file was never tracked, deleting it
+        # produces no unmatched removal and every arm below passes vacuously.
+        rc, out, err = self.kin_run(path, ["status"])
+        if rc != 0:
+            raise RuntimeError("kin status failed after init: %s" % ((err or out)[-400:]))
+        self._repo = path
+        return path
+
+    def transition(self):
+        """Delete the scratch file, write the new ones, and commit."""
+        path = self.repo()
+        os.remove(os.path.join(path, SCRATCH))
+        for relative in ADDITIONS:
+            self._write(path, relative, ADDITION_BODIES[relative])
+        return self.kin_run(path, ["commit", "-m", "Add markdown note parser"])
+
+    @staticmethod
+    def _write(root, relative, body):
+        target = os.path.join(root, relative)
+        directory = os.path.dirname(target)
+        if directory and not os.path.isdir(directory):
+            os.makedirs(directory)
+        with open(target, "w") as handle:
+            handle.write(body)
+
+    def stop_daemons(self):
+        if self._repo:
+            run([self.kin, "daemon", "stop"], cwd=self._repo, env=self.env, timeout=180)
+
+
+# ── checks ──
+
+def check_commit(suite):
+    rc, out, err = suite.transition()
+    return grade_commit_admitted_the_scratch_delete(rc, "%s\n%s" % (out, err))
+
+
+def check_remedy(suite):
+    path = suite.repo()
+    _, help_out, help_err = suite.kin_run(path, ["--help"], timeout=300)
+    rc, out, err = suite.transition()
+    return grade_refusal_prescribes_a_real_remedy(
+        "%s\n%s" % (out, err), help_subcommands("%s\n%s" % (help_out, help_err)))
+
+
+def check_exit(suite):
+    path = suite.repo()
+    suite.transition()
+    rc, out, err = suite.kin_run(path, ["admit"])
+    return grade_admit_exit_status(rc, "%s\n%s" % (out, err))
+
+
+CHECKS = (("commit", check_commit), ("remedy", check_remedy), ("exit", check_exit))
+
+
+# ── self-test ──
+
+def self_test():
+    failures = []
+
+    def expect(what, got, want):
+        if got != want:
+            failures.append("%s: expected %s, got %s" % (what, want, got))
+
+    refusal_text = (
+        "Error: daemon native commit failed (HTTP 500 Internal Server Error): Core error: "
+        "%s: unmatched removals [_smoke.py] and additions [.gitignore] may be "
+        "move-plus-edit operations; use explicit identity-bearing add/remove/move commands"
+        % REFUSAL
+    )
+    expect("commit FAILs on the refusal",
+           grade_commit_admitted_the_scratch_delete(1, refusal_text).status, FAIL)
+    expect("commit PASSes on a clean commit",
+           grade_commit_admitted_the_scratch_delete(0, "Created semantic change abc123").status,
+           PASS)
+    # A commit that failed for an unrelated reason is not this regression, and
+    # reporting it as one would send the next reader at the wrong code.
+    expect("commit is UNREADABLE on an unrelated failure",
+           grade_commit_admitted_the_scratch_delete(1, "Error: daemon not running").status,
+           UNREADABLE)
+
+    shipped = {"commit", "status", "admit", "rename", "init"}
+    expect("remedy FAILs on a prescribed command that does not exist",
+           grade_refusal_prescribes_a_real_remedy(refusal_text, shipped).status, FAIL)
+    expect("remedy PASSes when the message prescribes nothing",
+           grade_refusal_prescribes_a_real_remedy(
+               "%s: the same exact entry also appears at b. Commit the two paths in separate "
+               "commits, or make their contents differ" % REFUSAL, shipped).status, PASS)
+    # The control that keeps the arm honest: a message naming a real command
+    # must pass, or the grader is just banning the words.
+    expect("remedy PASSes on a real command",
+           grade_refusal_prescribes_a_real_remedy(
+               "use the move commands to fix this", shipped | {"move"}).status, PASS)
+    # A help read that returned nothing must not let every message through.
+    expect("remedy is UNREADABLE with no subcommands",
+           grade_refusal_prescribes_a_real_remedy(refusal_text, set()).status, UNREADABLE)
+
+    admit_failed = ("%s Core error: %s\nGraph authority is unchanged: 2 tracked artifacts."
+                    % (ADMIT_FAILURE, REFUSAL))
+    expect("exit FAILs when a printed failure exits 0",
+           grade_admit_exit_status(0, admit_failed).status, FAIL)
+    expect("exit PASSes when a printed failure exits nonzero",
+           grade_admit_exit_status(1, admit_failed).status, PASS)
+    expect("exit PASSes on a successful admission",
+           grade_admit_exit_status(0, "Admitted the complete exact tree").status, PASS)
+    # The other direction. Without this, always exiting nonzero would pass.
+    expect("exit FAILs when a silent run exits nonzero",
+           grade_admit_exit_status(1, "Admitted the complete exact tree").status, FAIL)
+
+    # The help parser is the one place this suite reads the product's own list.
+    parsed = help_subcommands(
+        "Commands:\n  commit   Record a semantic change\n  admit    Admit the tree\n"
+        "  status   Show status\n\nOptions:\n  -h, --help  Print help\n")
+    expect("help parser finds the subcommands", sorted(parsed) >= ["admit", "commit", "status"],
+           True)
+    expect("help parser rejects option lines", "-h," in parsed, False)
+
+    for line in failures:
+        print("SELFTEST FAIL %s" % line)
+    if failures:
+        return 1
+    print("SELFTEST PASS %s/%s graders inverted" % (TICKET, EXIT_TICKET))
+    return 0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kin", default=os.environ.get("KIN_BIN"))
+    parser.add_argument("--daemon", default=None)
+    parser.add_argument("--workdir", default=None)
+    parser.add_argument("--label", default="local")
+    parser.add_argument("--only", default=None)
+    parser.add_argument("--json", default=None)
+    parser.add_argument("--keep", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    if not args.kin:
+        print("error: --kin (or KIN_BIN) is required", file=sys.stderr)
+        return 3
+    # Absolutized before anything reads it: every probe runs with `cwd` set to
+    # the fixture repository, so a relative path would validate from the
+    # caller's directory and fail from the fixture's.
+    kin = os.path.abspath(args.kin)
+    if not os.path.isfile(kin) or not os.access(kin, os.X_OK):
+        print("error: %s is not an executable kin binary" % kin, file=sys.stderr)
+        return 3
+
+    daemon = os.path.abspath(args.daemon) if args.daemon else None
+    if not daemon:
+        beside = os.path.join(os.path.dirname(kin), "kin-daemon")
+        if os.path.isfile(beside) and os.access(beside, os.X_OK):
+            daemon = beside
+
+    selected = None
+    if args.only:
+        selected = {part.strip() for part in args.only.split(",") if part.strip()}
+
+    workdir = args.workdir or tempfile.mkdtemp(prefix="scratch-file-commit-")
+    os.makedirs(workdir, exist_ok=True)
+    suite = Suite(kin, workdir, daemon=daemon, verbose=args.verbose)
+    results = []
+    try:
+        for cid, check in CHECKS:
+            if selected and cid not in selected:
+                continue
+            try:
+                results.append(check(suite))
+            except Exception as exc:  # a probe that could not run is not a pass
+                results.append(Result(cid, UNREADABLE, "probe raised: %s" % exc))
+    finally:
+        try:
+            suite.stop_daemons()
+        except Exception:
+            pass
+        if not args.keep:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+    for result in results:
+        ticket = EXIT_TICKET if result.id == "exit" else TICKET
+        print("CHECK %s %s %s %s" % (result.id, ticket, result.status, result.detail))
+    if args.json:
+        with open(args.json, "w") as handle:
+            json.dump(report_payload(results, args.label), handle, indent=2)
+
+    if any(r.status == FAIL for r in results):
+        return 1
+    if any(r.status == UNREADABLE for r in results):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
A scratch file you create and delete between two commits no longer wedges the repo, and `kin admit` no longer reports a failure with exit 0.

Both came from one transition on the v0.6.4 candidate. A stranger building a fresh Python package created `_smoke.py`, ran it, deleted it, wrote three new files and committed. Kin refused in 20 ms and told them to use `add`, `remove` and `move` commands. There are none. `kin --help` lists sixty-odd subcommands and not one of those, and `kin rename` is a graph entity rename rather than a path move. Their conclusion was "I now avoid scratch files in the repo entirely".

## What changed

**kin-core stops refusing a delete beside unrelated adds.** The planner reads hashes, not content, so an unmatched removal sitting beside an unmatched addition gave it no evidence in either direction and no way to acquire any. The refusal preserved no identity either: the only way forward anyone found was to recreate the deleted file and split the work across two commits, and that lands exactly the `Removed` plus `Added` the planner now plans directly. It cost a wedge and bought nothing.

The two refusals above it are untouched, because those have evidence. A byte-identical entry in two places makes two identity assignments equally supported, and picking one would be a guess. That is the line: refuse where identical content makes the choice arbitrary, admit where nothing links a removal to an addition.

Both surviving messages now name a remedy that exists. They used to prescribe commands that ship on no Kin surface; `plan_artifact_move` and `plan_artifact_copy` have no callers outside kin-core's own tests.

**kin-cli exits non-zero from `kin admit` whenever no admission was established.** Worth being precise here, because the ticket's assumed mechanism was not the real one. The check on `report.admitted` was already present and already correct, at the candidate sha `a047b784e` as well as on main, so the exit status did not come from a missing check. The hole was the arm beside it. `report` is an `Option` carrying `serde(default)`, so a response that omits the object decodes to `None` and fell through to `Ok(())` while the failure the daemon had already rendered travelled to the terminal in `lines`. The transcript agrees: it shows the two summary lines and no second `Error:` line that an anyhow return would have printed.

So the rule is now about what the response established rather than about one field. The decision moved into `admission_failure`, which is asserted directly instead of through a daemon round trip, and the wording it scans for is one shared constant with the summary that prints it.

## Verification

`cargo test -p kin-core --lib exact_tree` 12 passed. `cargo test -p kin-cli --lib commands::admit` 18 passed. `cargo fmt --all -- --check` clean. Every cargo command ran through `.kin-coord/bin/heavy-slot.sh`, one builder at a time.

Every new assertion was falsified, and each one went red under the mutation written for it:

| Mutation | Assertion that had to break | Result |
|---|---|---|
| Put the blanket refusal back | both admit tests | 2 failed |
| Put the fictional remedy wording back | `identity_refusals_name_a_remedy_that_exists` | 1 failed |
| Drop the line-scanning arm | `a_failure_line_with_no_report_still_exits_nonzero` | 1 failed |
| Drop the no-report arm | `a_response_with_no_outcome_exits_nonzero` | 1 failed |
| Make the guard refuse everything | `a_real_admission_exits_zero`, the control | 1 failed |
| Drift the shared prefix constant | `the_failure_prefix_is_the_wording_the_acceptance_grader_matches` | 1 failed |

The last two matter as much as the rest. A guard that refused everything would satisfy the arms this ticket is about and break `kin admit` completely.

The prefix arm took two passes and is the more useful result. Written as "`summary_lines` starts with `ADMIT_FAILURE_PREFIX`" it survived its mutation, because after the refactor one constant feeds both the producer and the assertion, so changing it moves them together and the comparison holds for any value. The last commit pins the literal instead. What a silent rewording would really break is a reader that cannot see the constant: the acceptance case carries its own copy of the string and grades a run as failed only when it appears, so the drift would leave that suite calling a refused admission clean. With the literal pinned the mutation fails the test and the unmutated suite passes 18 of 18.

## The acceptance case

`scripts/acceptance/scratch_file_commit_repro.py` is new and touches no existing file. Three arms, because the three defects can regress independently: the transition commits, any refusal names only subcommands `kin --help` actually lists, and `kin admit`'s exit status tracks whether it admitted. The remedy arm reads the help text at run time rather than comparing against a list written in the file, so it grades the message against the product instead of against something that goes stale.

`--self-test` passes and was falsified four ways, one per grader, each restored green afterward.

**It is not registered yet, and that is deliberate.** A case only runs because `.github/workflows/acceptance.yml` carries a `run:` line for it, and that file belongs to other lanes tonight. The line to add is:

```
      - name: scratch-file commit shape
        run: python3 scripts/acceptance/scratch_file_commit_repro.py --self-test
```

Worth knowing either way: per `scripts/acceptance/README.md`, the Product Acceptance job carries `if: github.event_name != 'pull_request'`, so a rule added there does not run on the pull request that breaks it. The Rust tests in this PR do, through ci.yml's test job.

## Not fixed here

`kin commit` returns the refusal as `HTTP 500 Internal Server Error`. A user-input condition answering with a server-error status is its own defect, but it lives in kin-daemon rather than in the two crates this lane owns, so it is left alone and named rather than half-fixed.

Related: FIR-3097
Related: FIR-3098
