### PR TITLE
Run the stranger on a runner the fleet owns, and say so when none is registered

### DIFF
--- a/.github/workflows/registry-index-migrate.yml
+++ b/.github/workflows/registry-index-migrate.yml
@@ -64,7 +64,7 @@ jobs:
           for pkg in $PACKAGES; do
             path="$(index_path "$pkg")"
             status=""
-            for attempt in $(seq 1 50); do
+            for _ in $(seq 1 50); do
               code=$(curl -sS -m 30 -o idx.body -w '%{http_code}' "$BASE_URL/registry/cargo/$path")
               if [ "$code" = "200" ]; then
                 status="serving"

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -525,17 +525,270 @@ jobs:
             --file "$RUNNER_TEMP/preflight.json" \
             --repo "$GITHUB_REPOSITORY"
 
-      # The stranger is still local, and this is where a captain reads what to
-      # run. Three arms at 12 GiB each do not fit a 16 GiB hosted runner beside
-      # a Docker daemon, and the driver is a Claude Code session: on the account
-      # login it shares the founder's subscription limit, which cut three arms
-      # on 2026-09-02, and there is no repository secret carrying an API key for
-      # it yet. bin/kin-stranger already passes ANTHROPIC_API_KEY through on the
-      # account endpoint (it scrubs that variable only for --local-model), so
-      # the remaining work is a runner with the memory and a key, not a change
-      # to the tool. Until then this prints the exact command, and the mint
-      # stays refused for the missing stranger.env rather than fed a fake one.
-      - name: Say what the stranger still has to run
+      - name: Say what the stranger will run next
+        env:
+          CANDIDATE: ${{ needs.select.outputs.candidate }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Preflight recorded for \`${CANDIDATE}\`"
+            echo ""
+            echo "\`evidence/${CANDIDATE}/preflight.json\` is on the \`release-evidence\` branch."
+            echo "The mint needs \`stranger.env\` beside it. The next cycle decides \`stranger\`"
+            echo "and runs it, on the self-hosted runner when one is registered and otherwise"
+            echo "printing the exact local command."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice::preflight.json published for ${CANDIDATE}"
+
+  # The stranger, on a runner the fleet owns.
+  #
+  # Why this cannot be a hosted runner, in numbers rather than in impressions.
+  # bin/kin-stranger launches one background process per arm and waits on all of
+  # them afterwards, and each container is created --cpus=5 --memory=12g from
+  # DEF_CPUS and DEF_MEMORY. Three concurrent arms therefore demand 15 CPUs and
+  # 36 GB, which no standard hosted tier holds, and the argument does not turn on
+  # which tier applies because 36 GB beats the most generous one. Wall clock is
+  # NOT the constraint and an earlier reading that said so was wrong: DEF_P1 is
+  # 3600 and DEF_P2 is 7200, the arms run concurrently, so a run fits inside a
+  # six-hour cap with room. Memory is what refuses.
+  #
+  # And the arm cannot be shrunk to fit. The tool's own reference says the caps
+  # are deliberately below the capability tier that gates the fused pipeline,
+  # because they are the hardware a laptop audience actually has, and that THE
+  # CAP IS THE MEASUREMENT: it prints MEASUREMENT CONTAMINATED when the cgroup
+  # ceiling at capture differs from the flag the container was created with. A
+  # smaller arm is not a smaller proof, it is an unfilable one.
+  #
+  # The gate is a repository variable, not a live runner query. GitHub's
+  # GITHUB_TOKEN cannot list runners: `administration` is not among the
+  # permissions a workflow token can be granted, and the release App carries
+  # contents, issues and pull-requests only. More importantly a job whose
+  # `runs-on` labels match no online runner does not skip, it QUEUES until the
+  # job timeout, which is the silent hang this repository refuses everywhere
+  # else. So the switch is explicit and follows the same shape ci.yml already
+  # uses for vars.KIN_HEAVY_RUNNER: a captain sets
+  #   gh variable set KIN_STRANGER_RUNNER --repo firelock-ai/kin --body "kin-stranger"
+  # when the runner is registered, and clears it when it goes away.
+  #
+  # It reads the API key and no other secret, and it publishes nothing: the
+  # record it produces is filed by publish-stranger below, so the release App
+  # never reaches the machine executing candidate bytes under a Claude driver.
+  stranger:
+    name: Run the stranger on the candidate archive
+    needs: select
+    if: needs.select.outputs.decision == 'stranger' && vars.KIN_STRANGER_RUNNER != ''
+    runs-on: ${{ vars.KIN_STRANGER_RUNNER }}
+    # Three concurrent arms at phase caps of 3600 s and 7200 s, plus image and
+    # container setup. Six hours is headroom, not an expectation.
+    timeout-minutes: 360
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      recorded: ${{ steps.run.outputs.recorded }}
+    steps:
+      - name: Refuse before spending an arm on a missing credential
+        env:
+          STRANGER_KEY: ${{ secrets.KIN_STRANGER_ANTHROPIC_API_KEY }}
+          UMBRELLA: ${{ vars.KIN_STRANGER_UMBRELLA }}
+        run: |
+          set -euo pipefail
+          # Both refusals are at the door on purpose. An absent key sends every
+          # driver request out unauthenticated and the transcript records only a
+          # server error, hours in; an absent umbrella fails at the first docker
+          # exec with the same delay. Neither is worth discovering late.
+          if [ -z "${STRANGER_KEY:-}" ]; then
+            echo "::error::the repository secret KIN_STRANGER_ANTHROPIC_API_KEY is not set, so the stranger driver has no credential. Set it, or clear the KIN_STRANGER_RUNNER variable so the cut prints the local command instead."
+            exit 1
+          fi
+          umbrella="${UMBRELLA:-$HOME/GitHub/kin-ecosystem}"
+          if [ ! -x "$umbrella/bin/kin-stranger" ]; then
+            echo "::error::no kin-stranger at ${umbrella}/bin/kin-stranger. This job runs on a runner the fleet owns because the harness lives in the private kin-ecosystem umbrella beside its missions, drivers and image; point vars.KIN_STRANGER_UMBRELLA at that checkout."
+            exit 1
+          fi
+          echo "KIN_UMBRELLA=$umbrella" >> "$GITHUB_ENV"
+          echo "stranger harness: ${umbrella}/bin/kin-stranger"
+
+      - name: Download the candidate archive the preflight judged
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RC_RUN: ${{ needs.select.outputs.rc_run }}
+          CANDIDATE: ${{ needs.select.outputs.candidate }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$RC_RUN" =~ ^[1-9][0-9]*$ ]] || [[ ! "$CANDIDATE" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::selection handed over no exact candidate and rc-build run"
+            exit 1
+          fi
+          dir="${RUNNER_TEMP}/kin-rc-${CANDIDATE:0:12}"
+          rm -rf "$dir"
+          gh run download "$RC_RUN" --repo "$GITHUB_REPOSITORY" \
+            --name kin-linux-aarch64 --dir "$dir/kin-linux-aarch64"
+          archive="$dir/kin-linux-aarch64/kin-linux-aarch64.tar.gz"
+          test -f "$archive"
+          # The sidecar travels in the same artifact and kin-stranger refuses an
+          # archive without one, so a candidate that arrives unpaired is a defect
+          # in the rc-build rather than something to work around here.
+          test -f "$archive.sha256"
+          want="$(cut -d' ' -f1 < "$archive.sha256")"
+          have="$(shasum -a 256 "$archive" | cut -d' ' -f1)"
+          if [ "$want" != "$have" ]; then
+            echo "::error::kin-linux-aarch64.tar.gz sidecar says ${want}, bytes are ${have}"
+            exit 1
+          fi
+          echo "KIN_STRANGER_ARCHIVE=$archive" >> "$GITHUB_ENV"
+          echo "archive sha256 ${have}"
+
+      - name: Drive the three arms
+        id: run
+        env:
+          # The account path, with a key. driver_env_argv drops
+          # ANTHROPIC_API_KEY on exactly one branch, `[ "$ep" = local ]`, and
+          # the endpoint defaults to account, so an exported key rides through
+          # untouched and Claude Code prefers it over ANTHROPIC_AUTH_TOKEN.
+          # Exporting the secret is the whole integration; the harness needs no
+          # change, which is why this job adds no --driver flag.
+          ANTHROPIC_API_KEY: ${{ secrets.KIN_STRANGER_ANTHROPIC_API_KEY }}
+          CANDIDATE: ${{ needs.select.outputs.candidate }}
+          VERSION: ${{ needs.select.outputs.version }}
+        run: |
+          set -euo pipefail
+          run_id="rc${VERSION//./}-${CANDIDATE:0:7}"
+          cd "$KIN_UMBRELLA"
+          # A run root that already exists is an interrupted run, not a fresh
+          # one. `prepare` refuses a reused container without --force because a
+          # reused container tests an upgrade path, a different question, so the
+          # documented recovery is `resume`, which restarts only the phases that
+          # did not finish. Forcing here would silently change what is measured.
+          root="${KIN_STRANGER_ROOT:-/Users/Shared/kin-stranger}/${run_id}"
+          if [ -d "$root" ]; then
+            echo "::notice::${run_id} already has a run root; resuming rather than re-preparing"
+            bin/kin-stranger resume --run "$run_id" --candidate-sha "$CANDIDATE"
+          else
+            # Every arm the mint's coverage gate requires. The tool defaults to
+            # this set now, and it is named anyway: on 2026-09-02 two complete
+            # two-arm runs were refused at the mint, and evidence is
+            # append-only, so a record missing an arm cannot be replaced.
+            bin/kin-stranger prepare --run "$run_id" --arms green,brown,vcs
+            bin/kin-stranger run --run "$run_id" \
+              --archive "$KIN_STRANGER_ARCHIVE" \
+              --candidate-sha "$CANDIDATE"
+          fi
+          record="${root}/run.env"
+          if [ ! -s "$record" ]; then
+            echo "::error::the stranger finished but wrote no run.env under ${root}"
+            exit 1
+          fi
+          mkdir -p "$RUNNER_TEMP/stranger"
+          cp "$record" "$RUNNER_TEMP/stranger/stranger.env"
+          echo "recorded=true" >> "$GITHUB_OUTPUT"
+          echo "stranger record at ${record}"
+
+      - name: Upload the stranger record
+        if: success()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: kin-stranger-record
+          path: ${{ runner.temp }}/stranger/stranger.env
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-stranger:
+    name: Publish the candidate's stranger record
+    needs: [select, stranger]
+    if: needs.select.outputs.decision == 'stranger' && needs.stranger.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: release-tag
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout the queued proof tooling
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Re-bind the publish to protected main history
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE: ${{ needs.select.outputs.candidate }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$CANDIDATE" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::selection handed over no exact candidate sha"
+            exit 1
+          fi
+          python3 scripts/verify-protected-main-history.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --policy-sha "$GITHUB_SHA" \
+            --branch main
+          python3 scripts/verify-protected-main-history.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --policy-sha "$CANDIDATE" \
+            --branch main
+
+      - name: Collect the stranger record
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
+        with:
+          name: kin-stranger-record
+          path: ${{ runner.temp }}/stranger
+
+      - name: Mint repository-scoped evidence token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.KIN_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.KIN_RELEASE_BOT_PRIVATE_KEY }}
+          owner: firelock-ai
+          repositories: kin
+          permission-contents: write
+
+      # --require-archive is the link, checked at write time rather than
+      # discovered by the gate at release time: the publisher refuses unless the
+      # preflight already published for this candidate judged this exact
+      # archive. It also turns a mistyped candidate into a named failure instead
+      # of a record that sits unread until a release is held by it.
+      - name: Publish stranger.env for the candidate
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          CANDIDATE: ${{ needs.select.outputs.candidate }}
+        run: |
+          set -euo pipefail
+          record="$RUNNER_TEMP/stranger/stranger.env"
+          archive="$(sed -n 's/^archive_sha256=//p' "$record" | head -1)"
+          if [[ ! "$archive" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "::error::the stranger record names no archive_sha256, so nothing links it to the bytes the preflight judged"
+            exit 1
+          fi
+          scripts/release-proof/bin/kin-evidence-publish \
+            --sha "$CANDIDATE" \
+            --name stranger.env \
+            --file "$record" \
+            --repo "$GITHUB_REPOSITORY" \
+            --require-archive "$archive"
+          {
+            echo "## Both proof records are filed for \`${CANDIDATE}\`"
+            echo ""
+            echo "The mint selects the newest fully evidenced sha in the version range on its"
+            echo "next evaluation, which is its cron or any completed CI run for a main push."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # No runner, so say so loudly and hand over the exact command. This is the
+  # path that keeps the release moving: the cut still selects, arms and
+  # preflights, and only the last step waits on a person.
+  stranger-standby:
+    name: Report the stranger a runner cannot take
+    needs: select
+    if: needs.select.outputs.decision == 'stranger' && vars.KIN_STRANGER_RUNNER == ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Print the command a captain has to run
         env:
           CANDIDATE: ${{ needs.select.outputs.candidate }}
           VERSION: ${{ needs.select.outputs.version }}
@@ -545,10 +798,15 @@ jobs:
           run_id="rc${VERSION//./}-${CANDIDATE:0:7}"
           download="/tmp/kin-rc-${CANDIDATE:0:12}"
           {
-            echo "## Preflight recorded for \`${CANDIDATE}\`"
+            echo "## The stranger is waiting on a runner"
             echo ""
-            echo "\`evidence/${CANDIDATE}/preflight.json\` is on the \`release-evidence\` branch."
-            echo "The mint needs \`stranger.env\` beside it, which is still a local step:"
+            echo "\`evidence/${CANDIDATE}/preflight.json\` is filed and \`stranger.env\` is the"
+            echo "only missing half. No runner carries the \`KIN_STRANGER_RUNNER\` variable, so"
+            echo "this cycle cannot run it. Three arms at 5 CPUs and 12g each need 15 CPUs and"
+            echo "36 GB concurrently, which no hosted runner holds, and the caps are the"
+            echo "measurement rather than a knob."
+            echo ""
+            echo "Run it here:"
             echo ""
             echo '```'
             echo "gh run download ${RC_RUN} --repo ${GITHUB_REPOSITORY} --dir ${download}"
@@ -558,10 +816,14 @@ jobs:
             echo "  --candidate-sha ${CANDIDATE}"
             echo '```'
             echo ""
-            echo "Name all three arms: the coverage gate refuses a record missing one, and"
-            echo "the evidence branch is append-only, so a two-arm record cannot be replaced."
+            echo "Or register a runner and set the variable, which deletes this step:"
+            echo ""
+            echo '```'
+            echo "gh variable set KIN_STRANGER_RUNNER --repo ${GITHUB_REPOSITORY} --body '<runner label>'"
+            echo "gh secret set KIN_STRANGER_ANTHROPIC_API_KEY --repo ${GITHUB_REPOSITORY}"
+            echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "::notice::preflight.json published for ${CANDIDATE}; the stranger run is still local"
+          echo "::warning::${CANDIDATE} has its preflight record and needs the stranger; no KIN_STRANGER_RUNNER is set, so the command is in this run's summary and a captain has to run it"
 
   # A refusal is a real outcome and has to be loud. The selector exits 1 and
   # names the contexts that disqualified the newest sha, which fails the select

--- a/docs/release-bot.md
+++ b/docs/release-bot.md
@@ -131,14 +131,45 @@ which judges its own output with the mint's gate before anything is published;
 the merge is deterministic because the evidence branch is append-only and a
 re-publish of differing bytes is refused as tampering.
 
-**The stranger is still a local step.** Three arms at 12 GiB each do not fit a
-16 GiB hosted runner beside a Docker daemon, and the driver is a Claude Code
-session that on the account login shares the founder's subscription limit, which
-cut three arms on 2026-09-02. `bin/kin-stranger` already passes
-`ANTHROPIC_API_KEY` through on the account endpoint, so what is missing is a
-runner with the memory and a key, not a change to the tool. The publish job
-prints the exact command with all three arms named, and the mint stays refused
-for the missing `stranger.env` rather than being fed a partial one.
+**The stranger runs on a runner the fleet owns.** It cannot run on a hosted one,
+and the reason is memory rather than wall clock. `bin/kin-stranger` launches one
+background process per arm and waits on them together, and each container is
+created `--cpus=5 --memory=12g`, so three concurrent arms demand 15 CPUs and
+36 GB, which no standard hosted tier holds. The caps cannot be lowered to fit:
+the tool's own reference says they are deliberately below the capability tier
+that gates the fused pipeline because they are the hardware a laptop audience
+actually has, and that **the cap is the measurement**, printing MEASUREMENT
+CONTAMINATED when the cgroup ceiling at capture differs from the flag the
+container was created with. A smaller arm is not a smaller proof, it is an
+unfilable one. Wall clock is not the constraint: the phase caps are 3600 s and
+7200 s and the arms are concurrent, so a run fits a six-hour cap with room.
+
+The job is gated on the repository variable `KIN_STRANGER_RUNNER`, which names
+the runner, in the same shape `ci.yml` already uses for `KIN_HEAVY_RUNNER`. The
+gate is a variable rather than a live runner query for two reasons: `GITHUB_TOKEN`
+cannot list runners, because `administration` is not among the permissions a
+workflow token can hold, and more importantly a job whose `runs-on` labels match
+no online runner does not skip, it queues until the job timeout, which is the
+silent hang this repository refuses everywhere else. Set the variable when a
+runner is registered and clear it when it goes away:
+
+```
+gh variable set KIN_STRANGER_RUNNER --repo firelock-ai/kin --body '<runner label>'
+gh secret set KIN_STRANGER_ANTHROPIC_API_KEY --repo firelock-ai/kin
+```
+
+With the variable unset the cut still selects, arms and preflights, and the
+`stranger-standby` job prints the exact local command with all three arms named
+and raises a warning. Either way the mint stays refused for the missing
+`stranger.env` rather than being fed a partial one.
+
+The driver takes its credential from `KIN_STRANGER_ANTHROPIC_API_KEY`, exported
+as `ANTHROPIC_API_KEY`. No harness change was needed: `driver_env_argv` unsets
+that variable on exactly one branch, the local endpoint, and the endpoint
+defaults to the account, so an exported key rides through and Claude Code
+prefers it over `ANTHROPIC_AUTH_TOKEN`. The job refuses at the door when the
+secret is empty rather than sending every request out unauthenticated and
+discovering it hours later in a transcript that records only a server error.
 
 ## Tag admission (fail-closed checks, in order)
 

--- a/scripts/select-release-candidate.py
+++ b/scripts/select-release-candidate.py
@@ -16,13 +16,14 @@ This script is the selection half of the pipeline. `select` reads everything
 the decision rests on and answers one of four things:
 
   stand-down  nothing to do now: the version is tagged, a fully evidenced sha
-              is waiting on the mint, the current candidate's preflight is
-              recorded and only the stranger record is missing, an rc-build is
-              still running, or no complete green sha exists yet
+              is waiting on the mint, an rc-build is still running, or no
+              complete green sha exists yet
   arm         move release/v<version>-candidate to the chosen sha and dispatch
               rc-build.yml there
   proof       an rc-build for the current candidate succeeded and carries the
               preflight leg records; merge and publish them
+  stranger    preflight.json is filed for the candidate and stranger.env is the
+              only missing half; run the three-arm stranger on the same archive
   refuse      no reviewed main commit carrying the version qualifies, named sha
               by sha with the context that disqualified it
 
@@ -32,9 +33,13 @@ The rule, in the order it is applied:
    version.
 2. A sha in the range carries both records: the mint owns it.
 3. A current candidate, the branch tip, which must lie in the range, is kept
-   until it is proven or dead. With its preflight recorded it waits for the
-   stranger. Alive with a usable rc-build it is proven; alive with none it is
-   armed again, up to RC_BUILD_ATTEMPT_LIMIT attempts. Dead means a required
+   until it is proven or dead. With its preflight recorded the stranger is what
+   is left, and it must run on the very bytes that preflight judged, so a
+   candidate whose rc-build artifacts have expired is refused rather than
+   rebuilt: a second build is not guaranteed to reproduce the archive sha256
+   the published record already names. Alive with a usable rc-build it is
+   proven; alive with none it is armed again, up to RC_BUILD_ATTEMPT_LIMIT
+   attempts. Dead means a required
    context that is red or duplicated, a CI or Acceptance push run that did not
    conclude success, or exhausted rc-build attempts.
 4. Otherwise the newest main commit in the range whose CI and Acceptance push
@@ -120,6 +125,7 @@ TRIGGER_SWEEP = "sweep"
 STAND_DOWN = "stand-down"
 ARM = "arm"
 PROOF = "proof"
+STRANGER = "stranger"
 REFUSE = "refuse"
 GREEN = "green"
 PENDING = "pending"
@@ -753,13 +759,34 @@ def judge(snapshot: dict[str, Any], grade: Grader) -> Decision:
                 candidate=candidate,
             )
         if PREFLIGHT_RECORD in records(candidate):
+            # The stranger has to run on the very bytes the published preflight
+            # judged, because kin-evidence-publish refuses a stranger record
+            # naming an archive no preflight leg for this candidate judged. The
+            # rc-build's artifacts carry those bytes and they expire, so an
+            # expired run is a refusal rather than a rebuild: a second build of
+            # the same sha is not guaranteed to reproduce the archive sha256 the
+            # record already names, and a candidate that can no longer be proven
+            # needs a human rather than a retry.
+            rc_run = _newest_usable_run(rc_builds, candidate)
+            if rc_run is None:
+                return Decision(
+                    REFUSE,
+                    f"preflight is recorded for {candidate} but no rc-build still holds the "
+                    "archives it judged, so the stranger cannot run on the bytes the record "
+                    "names; this candidate can no longer be proven and the next landing "
+                    "supplies a new one",
+                    version,
+                    branch,
+                    candidate=candidate,
+                )
             return Decision(
-                STAND_DOWN,
+                STRANGER,
                 f"preflight is recorded for {candidate}; the stranger record is the missing half",
                 version,
                 branch,
                 candidate=candidate,
-                details={"stranger_command": stranger_command(version, candidate, _newest_usable_run(rc_builds, candidate))},
+                rc_run=rc_run,
+                details={"stranger_command": stranger_command(version, candidate, rc_run)},
             )
         grade_of = grade(candidate)
         if grade_of.get("verdict") == PENDING:

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -861,6 +861,15 @@ EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
         "arm": "Arm the release candidate",
         "preflight": "Preflight ${{ matrix.artifact }}",
         "publish": "Publish the candidate's preflight record",
+        # The stranger runs on a runner the fleet owns, gated by the
+        # KIN_STRANGER_RUNNER variable, because three concurrent arms need 15
+        # CPUs and 36 GB and a job whose labels match no online runner queues
+        # rather than skipping. It reads the driver's API key and nothing else;
+        # the record it produces is filed by publish-stranger, so the release
+        # App never reaches the machine executing candidate bytes.
+        "stranger": "Run the stranger on the candidate archive",
+        "publish-stranger": "Publish the candidate's stranger record",
+        "stranger-standby": "Report the stranger a runner cannot take",
         "report": "Report the cut's decision",
     },
     ".github/workflows/release-recovery.yml": {

--- a/scripts/test-select-release-candidate.py
+++ b/scripts/test-select-release-candidate.py
@@ -444,18 +444,56 @@ class JudgeTests(unittest.TestCase):
         self.assertEqual(decision.candidate, MIDDLE)
         self.assertEqual(grader.calls, [])
 
-    def test_a_half_evidenced_candidate_waits_for_the_stranger_and_prints_its_command(self) -> None:
+    def test_a_half_evidenced_candidate_asks_for_the_stranger_and_names_its_archive(self) -> None:
         grader = Grader({})
         decision = selector.judge(
-            snapshot(candidate=MIDDLE, evidence={MIDDLE: [selector.PREFLIGHT_RECORD]}),
+            snapshot(
+                candidate=MIDDLE,
+                evidence={MIDDLE: [selector.PREFLIGHT_RECORD]},
+                rc_builds=[rc_build(MIDDLE)],
+            ),
             grader,
         )
-        self.assertDecision(decision, selector.STAND_DOWN, "the stranger record is the missing half")
+        self.assertDecision(decision, selector.STRANGER, "the stranger record is the missing half")
+        # The rc-build run travels with the decision, because the stranger has
+        # to run on the very bytes the published preflight judged.
+        self.assertEqual(decision.rc_run, 34_000_000_001)
         command = decision.details["stranger_command"]
         self.assertIn("bin/kin-stranger prepare", command)
         self.assertIn("--arms green,brown,vcs", command)
         self.assertIn(f"--candidate-sha {MIDDLE}", command)
-        self.assertEqual(grader.calls, [])
+        self.assertEqual(grader.calls, [], "a filed preflight must cost no grading")
+
+    def test_a_half_evidenced_candidate_whose_archives_expired_refuses(self) -> None:
+        """The record names an archive sha256; a rebuild is not guaranteed to reproduce it."""
+
+        decision = selector.judge(
+            snapshot(candidate=MIDDLE, evidence={MIDDLE: [selector.PREFLIGHT_RECORD]}, rc_builds=[]),
+            Grader({}),
+        )
+        self.assertDecision(decision, selector.REFUSE, "no rc-build still holds the archives it judged")
+        self.assertEqual(decision.candidate, MIDDLE)
+
+    def test_an_expired_rc_build_is_not_a_usable_archive_source(self) -> None:
+        stale = rc_build(MIDDLE, artifacts=[])
+        decision = selector.judge(
+            snapshot(candidate=MIDDLE, evidence={MIDDLE: [selector.PREFLIGHT_RECORD]}, rc_builds=[stale]),
+            Grader({}),
+        )
+        self.assertDecision(decision, selector.REFUSE, "no rc-build still holds")
+
+    def test_both_records_beat_the_stranger_decision(self) -> None:
+        """Once stranger.env lands the candidate belongs to the mint, not to another run."""
+
+        decision = selector.judge(
+            snapshot(
+                candidate=MIDDLE,
+                evidence={MIDDLE: [selector.PREFLIGHT_RECORD, selector.STRANGER_RECORD]},
+                rc_builds=[rc_build(MIDDLE)],
+            ),
+            Grader({}),
+        )
+        self.assertDecision(decision, selector.STAND_DOWN, "awaits the mint")
 
     def test_the_newest_green_sha_is_armed(self) -> None:
         grader = Grader({NEWEST: green_grade(NEWEST)})
@@ -787,6 +825,76 @@ class ContractTests(unittest.TestCase):
             "scripts/release-proof/bin/kin-evidence-publish",
         ):
             self.assertIn(needle, workflow, f"release-cut.yml must run {needle}")
+
+    def test_the_stranger_is_gated_on_a_variable_rather_than_a_runner_query(self) -> None:
+        """A job whose labels match no online runner queues; it does not skip.
+
+        GITHUB_TOKEN cannot list runners (`administration` is not among the
+        permissions a workflow token can hold) and the release App carries
+        contents, issues and pull-requests only, so live availability is not
+        readable from inside the run. The switch is therefore explicit, and
+        every path has to be covered: one job when it is set, one when it is not.
+        """
+
+        workflow = CUT_WORKFLOW_PATH.read_text(encoding="utf-8")
+        jobs = dict(re.findall(r"(?ms)^  ([a-z0-9-]+):\n(.*?)(?=^  [a-z0-9-]+:\n|\Z)", workflow))
+        self.assertIn("stranger", jobs)
+        self.assertIn("stranger-standby", jobs)
+        self.assertIn("vars.KIN_STRANGER_RUNNER != ''", jobs["stranger"])
+        self.assertIn("vars.KIN_STRANGER_RUNNER == ''", jobs["stranger-standby"])
+        self.assertIn("runs-on: ${{ vars.KIN_STRANGER_RUNNER }}", jobs["stranger"])
+        # The standby path is the one that keeps a release moving without a
+        # runner, so it has to carry the whole command rather than a pointer.
+        for needle in ("bin/kin-stranger prepare", "--arms green,brown,vcs", "--candidate-sha", "::warning::"):
+            self.assertIn(needle, jobs["stranger-standby"], f"the standby path must print {needle}")
+
+    def test_the_stranger_refuses_before_spending_an_arm_on_a_missing_credential(self) -> None:
+        workflow = CUT_WORKFLOW_PATH.read_text(encoding="utf-8")
+        jobs = dict(re.findall(r"(?ms)^  ([a-z0-9-]+):\n(.*?)(?=^  [a-z0-9-]+:\n|\Z)", workflow))
+        stranger = jobs["stranger"]
+        self.assertIn("KIN_STRANGER_ANTHROPIC_API_KEY", stranger)
+        self.assertIn('if [ -z "${STRANGER_KEY:-}" ]; then', stranger)
+        # An interrupted run resumes rather than re-preparing: `prepare` refuses
+        # a reused container without --force because a reused container tests an
+        # upgrade path, which is a different question.
+        self.assertIn("bin/kin-stranger resume", stranger)
+        # Read the executable lines only. A bare substring search cannot tell a
+        # comment explaining why --force is wrong from a command using it, and
+        # would fail on the explanation that keeps the decision reviewable.
+        active = [
+            line for line in stranger.splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        ]
+        self.assertFalse(
+            [line for line in active if "--force" in line],
+            "the stranger job must never force a reused container: that tests an upgrade path",
+        )
+
+    def test_the_stranger_never_publishes_and_the_publisher_never_drives(self) -> None:
+        """The App key must not reach the machine running a Claude driver on candidate bytes."""
+
+        workflow = CUT_WORKFLOW_PATH.read_text(encoding="utf-8")
+        jobs = dict(re.findall(r"(?ms)^  ([a-z0-9-]+):\n(.*?)(?=^  [a-z0-9-]+:\n|\Z)", workflow))
+        self.assertNotIn("KIN_RELEASE_BOT_PRIVATE_KEY", jobs["stranger"])
+        self.assertNotIn("kin-evidence-publish", jobs["stranger"])
+        self.assertNotIn("environment:", jobs["stranger"])
+        self.assertIn("environment: release-tag", jobs["publish-stranger"])
+        self.assertIn("kin-evidence-publish", jobs["publish-stranger"])
+        self.assertNotIn("ANTHROPIC_API_KEY", jobs["publish-stranger"])
+        # --require-archive is what binds the record to the bytes the preflight
+        # judged, checked at write time rather than by the gate at release time.
+        # Read the executable lines only: the comment above that step explains
+        # the flag, and a bare substring search is satisfied by the explanation
+        # alone, so removing the flag itself left this assertion green.
+        publisher_active = [
+            line for line in jobs["publish-stranger"].splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        ]
+        self.assertTrue(
+            [line for line in publisher_active if "--require-archive" in line],
+            "the stranger record must be published with --require-archive, which binds it "
+            "to an archive the published preflight actually judged",
+        )
 
     def test_the_workflow_keeps_the_release_app_off_the_proof_runners(self) -> None:
         """The preflight job downloads and judges; only the publish job may write."""


### PR DESCRIPTION
The cut has selected, armed and preflighted on its own since #1391, and stopped one step short: `stranger.env` was left to a captain. This closes that step where a runner exists and makes the gap loud where one does not.

### The selector gains a stranger decision

A candidate whose `preflight.json` is filed and whose `stranger.env` is missing is no longer a stand-down. It carries the rc-build run whose archives the preflight judged, because the stranger has to run on those exact bytes.

A candidate whose artifacts have expired past their retention is refused rather than rebuilt. A second build of the same sha is not guaranteed to reproduce the archive sha256 the published record already names, and `kin-evidence-publish` refuses a stranger record naming bytes no preflight leg judged, so a rebuild would file nothing and lose the candidate quietly.

### Why this cannot be a hosted runner

Memory, not wall clock. `bin/kin-stranger` launches one background process per arm and waits on them together, and each container is created `--cpus=5 --memory=12g`, so three concurrent arms demand 15 CPUs and 36 GB. No standard hosted tier holds that, and the argument does not turn on which tier applies because 36 GB beats the most generous one.

The arm cannot be shrunk to fit. The tool's own reference says the caps sit deliberately below the capability tier that gates the fused pipeline, because they are the hardware a laptop audience actually has, and that **the cap is the measurement**: it prints MEASUREMENT CONTAMINATED when the cgroup ceiling at capture differs from the flag the container was created with. A smaller arm is not a smaller proof, it is an unfilable one.

Wall clock is not the constraint, and an earlier reading of mine that implied otherwise was wrong. `DEF_P1` is 3600 and `DEF_P2` is 7200 and the arms are concurrent, so a run fits a six-hour cap with room.

### Why the gate is a variable and not a runner query

Two reasons, and the second is the one that matters.

`GITHUB_TOKEN` cannot list runners: `administration` is not among the permissions a workflow token can hold, and the release App carries contents, issues and pull-requests only. So live availability is not readable from inside the run.

More importantly, **a job whose `runs-on` labels match no online runner does not skip. It queues until the job timeout.** That is the silent hang this repository refuses everywhere else, and a six-hour timeout on the stranger job would make it an expensive one. So the switch is explicit, in the same shape `ci.yml` already uses for `KIN_HEAVY_RUNNER`:

```
gh variable set KIN_STRANGER_RUNNER --repo firelock-ai/kin --body '<runner label>'
gh secret set KIN_STRANGER_ANTHROPIC_API_KEY --repo firelock-ai/kin
```

With the variable unset the cut still selects, arms and preflights, and `stranger-standby` prints the exact command with all three arms named and raises a warning. Neither secret nor variable exists yet: `gh secret list` on kin returns `CODECOV_TOKEN`, `KINLAB_CARGO_TOKEN`, `KIN_RELEASE_APP_ID`, `KIN_RELEASE_APP_PRIVATE_KEY`, `MCP_PRIVATE_KEY`, and the org endpoint adds only `CODECOV_TOKEN`, so both need creating before the automatic path runs.

### The credential, and why the harness needed no change

The driver reads `KIN_STRANGER_ANTHROPIC_API_KEY` exported as `ANTHROPIC_API_KEY`. `driver_env_argv` unsets that variable on exactly one branch, `[ "$ep" = local ]`, and the endpoint defaults to the account, so an exported key rides through untouched and Claude Code prefers it over `ANTHROPIC_AUTH_TOKEN`. Exporting the secret is the whole integration.

The job refuses at the door when the secret is empty rather than sending every request out unauthenticated and discovering it hours later in a transcript that records only a server error. It refuses the same way when the umbrella harness is absent, because the stranger's missions, drivers and image live beside it in the private `kin-ecosystem` checkout that kin holds no credential to fetch, which is precisely why this job wants a runner the fleet owns.

An interrupted run resumes rather than re-preparing: `prepare` refuses a reused container without `--force` because a reused container tests an upgrade path, a different question, and forcing would silently change what is measured.

### The credential boundary holds

The stranger job reads the API key and no other secret, declares no environment, and publishes nothing. `publish-stranger` files the record with `--require-archive`, which binds it at write time to an archive the published preflight actually judged. So the release App never reaches the machine executing candidate bytes under a Claude driver, which is the same split `#1391` drew for the preflight.

### Tests

55 selection tests and 36 mutations falsified red. Two of those mutations were caught only after a first pass survived, and both were the same defect in my own assertions: a bare substring search for `--force` and for `--require-archive` was satisfied by the comment explaining the flag, so removing the flag itself left the check green. Both now read executable lines only, and a positive control confirms each still catches a real regression.

### Also in here

A pre-existing `actionlint` failure in `registry-index-migrate.yml`, an unused loop variable, which made repo-wide `actionlint` red for everyone. Confirmed pre-existing by stashing this branch and running it against a clean tree. `actionlint` now returns 0 with zero findings across every workflow.

Related: FIR-3084
