### PR TITLE
Give the mint an evaluate-now dispatch that runs its own selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1112,6 +1112,7 @@ jobs:
         run: |
           bash scripts/release-policy-gate.sh <<'RELEASE_POLICY'
           python3 scripts/test-release-workflow-authority.py
+          python3 scripts/test-release-tag-evaluate-dispatch.py
           python3 scripts/test-select-release-candidate.py
           python3 scripts/test-guard-duplicate-release-run.py
           node --test \
@@ -1684,6 +1685,7 @@ jobs:
         run: |
           bash scripts/release-policy-gate.sh <<'RELEASE_POLICY'
           python3 scripts/test-release-workflow-authority.py
+          python3 scripts/test-release-tag-evaluate-dispatch.py
           python3 scripts/test-select-release-candidate.py
           python3 scripts/test-guard-duplicate-release-run.py
           node --test \

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -26,8 +26,27 @@ on:
   # Unlike workflow_dispatch, repository_dispatch always executes the workflow
   # from the last commit on the default branch and only when this file exists
   # there. The typed event preserves break glass without branch-selectable code.
+  #
+  # Two types, and the difference is which ALGORITHM runs, never who may run it:
+  #
+  #   release_tag           break glass. The caller names an exact tag and sha,
+  #                         which must be current main HEAD. Tagging a chosen
+  #                         commit on purpose is a legitimate act and this is
+  #                         unchanged.
+  #   release_tag_evaluate  evaluate now. The scheduled algorithm on demand:
+  #                         main HEAD, the version range, both proof records,
+  #                         every required context unique. It names nothing.
+  #
+  # The second exists because the schedule is not reliable enough to be the
+  # only way to reach the automatic path. On 2026-09-02 GitHub's cron produced
+  # one scheduled run on this repository between 09:58Z and 14:22Z, and the
+  # only manual trigger was break glass, which refuses a proven candidate that
+  # is no longer main's tip: "break-glass release sha a047b784e is not current
+  # origin/main HEAD" at 12:11Z. That is the guard working and the wrong tool
+  # being the only one available. A manual trigger for the automatic path must
+  # run the same algorithm, not a second one.
   repository_dispatch:
-    types: [release_tag]
+    types: [release_tag, release_tag_evaluate]
 
 # The App installation token carries the only write capability (creating the
 # tag ref). The workflow's own GITHUB_TOKEN stays read-only: contents:read for
@@ -111,10 +130,16 @@ jobs:
             echo "trusted automatic trigger: $EVENT_NAME"
             exit 0
           fi
-          if [ "$EVENT_ACTION" != release_tag ]; then
-            echo "::error::unsupported repository dispatch action '$EVENT_ACTION'"
-            exit 1
-          fi
+          # Both typed actions face the identical authority checks below: the
+          # same actor allowlist, the same main-only ref, the same exact-hex
+          # workflow sha. The type chooses the algorithm, never the permission.
+          case "$EVENT_ACTION" in
+            release_tag|release_tag_evaluate) ;;
+            *)
+              echo "::error::unsupported repository dispatch action '$EVENT_ACTION'"
+              exit 1
+              ;;
+          esac
           if [ "$DEFAULT_BRANCH" != main ]; then
             echo "::error::release-tag requires main as the repository default branch (got '$DEFAULT_BRANCH')"
             exit 1
@@ -149,6 +174,7 @@ jobs:
         id: resolve
         env:
           EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
           RAW_TAG: ${{ github.event.client_payload.tag }}
           RAW_SHA: ${{ github.event.client_payload.sha }}
           # Reading the proof loop's published candidates needs no more than the
@@ -165,9 +191,26 @@ jobs:
           tag=""
           case "$EVENT_NAME" in
             repository_dispatch)
-              automatic=false
-              tag="$RAW_TAG"
-              sha="$(printf '%s' "$RAW_SHA" | tr '[:upper:]' '[:lower:]')"
+              if [ "$EVENT_ACTION" = release_tag_evaluate ]; then
+                # Evaluate now. This arm is deliberately identical to the
+                # schedule's: read protected main HEAD and let the range
+                # selection below decide, so a manual ask for the automatic
+                # path cannot become a second algorithm that drifts from it.
+                #
+                # A payload naming a tag or a sha is REFUSED rather than
+                # ignored. A caller who passed one meant break glass, and
+                # silently dropping it would tag whatever the selection chose
+                # while the caller believed they had named the commit.
+                if [ -n "$RAW_TAG" ] || [ -n "$RAW_SHA" ]; then
+                  echo "::error::release_tag_evaluate runs the automatic selection and takes no tag or sha (got tag='$RAW_TAG' sha='$RAW_SHA'). Dispatch release_tag to name an exact commit."
+                  exit 1
+                fi
+                sha="$(git rev-parse refs/remotes/origin/main)"
+              else
+                automatic=false
+                tag="$RAW_TAG"
+                sha="$(printf '%s' "$RAW_SHA" | tr '[:upper:]' '[:lower:]')"
+              fi
               ;;
             workflow_run|schedule)
               # Both automatic arms read the same freshly fetched protected

--- a/scripts/test-release-tag-evaluate-dispatch.py
+++ b/scripts/test-release-tag-evaluate-dispatch.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""The mint's evaluate-now dispatch: authority, algorithm choice, and refusals.
+
+release-tag.yml carries two repository_dispatch types. `release_tag` is break
+glass: the caller names an exact tag and sha, and the sha must be current main
+HEAD. `release_tag_evaluate` runs the scheduled algorithm on demand and names
+nothing.
+
+The second exists because the schedule cannot be the only route to the
+automatic path. On 2026-09-02 GitHub's cron produced one scheduled mint run on
+this repository between 09:58Z and 14:22Z, and the only manual trigger was break
+glass, which correctly refused a proven candidate that was no longer main's tip.
+
+What has to hold, and what this file proves:
+
+1. Both types pass the SAME authority checks. A new trigger that widened who may
+   mint would be a far worse defect than the one it fixes.
+2. The evaluate type resolves `automatic=true`, so it takes the range selection
+   and the reviewed-ancestor admission rather than the break-glass equality.
+3. The break-glass type is untouched: still `automatic=false`, still equality
+   against main HEAD.
+4. The evaluate type REFUSES a payload carrying a tag or a sha. Ignoring one
+   would tag a commit the caller did not choose while they believed otherwise.
+5. An unknown dispatch action is still refused.
+
+The two shell fragments are extracted from the workflow and run under `bash`
+with the event environment set, so these are the real guards rather than a
+paraphrase of them. Extraction is asserted, so a renamed step fails loudly
+instead of silently testing nothing.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = ROOT / ".github" / "workflows" / "release-tag.yml"
+
+
+def extract_step_run(workflow: str, step_name: str) -> str:
+    """Pull one step's `run:` body out of the workflow, dedented."""
+    anchor = f"      - name: {step_name}\n"
+    if anchor not in workflow:
+        raise AssertionError(
+            f"step '{step_name}' is gone from release-tag.yml, so this test would "
+            "prove nothing. Update the anchor deliberately."
+        )
+        # unreachable, kept explicit
+    start = workflow.index(anchor)
+    tail = workflow[start:]
+    run_at = tail.index("\n        run: |\n") + len("\n        run: |\n")
+    body_start = start + run_at
+    # Cut at the next step only. A blank-line marker looks tempting and is
+    # wrong: every line of a run body is indented, so a "blank line then
+    # indentation" pattern matches inside the body and silently truncates it at
+    # the first paragraph break.
+    rest = workflow[body_start:]
+    idx = rest.find("\n      - name:")
+    end = body_start + idx if idx != -1 else len(workflow)
+    body = workflow[body_start:end]
+    lines = [l[10:] if l.startswith(" " * 10) else l for l in body.split("\n")]
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def run_fragment(script: str, env: dict[str, str], cwd: Path | None = None):
+    with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as fh:
+        fh.write(script)
+        path = fh.name
+    try:
+        return subprocess.run(
+            ["bash", path],
+            env={"PATH": "/usr/bin:/bin:/usr/local/bin", **env},
+            capture_output=True,
+            text=True,
+            timeout=60,
+            cwd=str(cwd) if cwd else None,
+        )
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+# ---- 1. authority is identical for both types ----------------------------
+
+GUARD_BASE = {
+    "ACTOR": "troyjr4103",
+    "REF": "refs/heads/main",
+    "EVENT_SHA": "a" * 40,
+    "DEFAULT_BRANCH": "main",
+    "ALLOWED_ACTORS": "troyjr4103\nkin-release-bot[bot]\n",
+}
+
+
+def guard_cases(guard: str) -> None:
+    def check(name: str, over: dict[str, str], want_rc: int) -> None:
+        env = {"EVENT_NAME": "repository_dispatch", **GUARD_BASE, **over}
+        got = run_fragment(guard, env)
+        if (got.returncode == 0) != (want_rc == 0):
+            raise AssertionError(
+                f"guard {name}: rc={got.returncode}, wanted {'0' if want_rc == 0 else 'non-zero'}\n"
+                f"stdout={got.stdout}\nstderr={got.stderr}"
+            )
+
+    # Both types admitted for an allowed actor on main.
+    check("evaluate admitted", {"EVENT_ACTION": "release_tag_evaluate"}, 0)
+    check("break glass admitted", {"EVENT_ACTION": "release_tag"}, 0)
+    # An unknown action is still refused.
+    check("unknown action refused", {"EVENT_ACTION": "release_tag_please"}, 1)
+    check("empty action refused", {"EVENT_ACTION": ""}, 1)
+
+    # The authority checks apply to the NEW type exactly as to the old one.
+    # Each of these would be a widened mint if it passed.
+    for action in ("release_tag", "release_tag_evaluate"):
+        check(f"{action}: foreign actor", {"EVENT_ACTION": action, "ACTOR": "mallory"}, 1)
+        check(
+            f"{action}: off-main ref",
+            {"EVENT_ACTION": action, "REF": "refs/heads/feature"},
+            1,
+        )
+        check(
+            f"{action}: non-hex sha",
+            {"EVENT_ACTION": action, "EVENT_SHA": "not-a-sha"},
+            1,
+        )
+        check(
+            f"{action}: default branch not main",
+            {"EVENT_ACTION": action, "DEFAULT_BRANCH": "trunk"},
+            1,
+        )
+
+    # An automatic trigger short-circuits before any of it.
+    for event in ("schedule", "workflow_run"):
+        got = run_fragment(guard, {"EVENT_NAME": event, **GUARD_BASE, "EVENT_ACTION": ""})
+        if got.returncode != 0:
+            raise AssertionError(f"guard refused automatic trigger {event}: {got.stderr}")
+
+    print("ok: trigger authority, both types under identical checks")
+
+
+# ---- 2. the resolve arm picks the right algorithm ------------------------
+#
+# The resolve step's full body reaches for the network and the version range, so
+# the arm under test is the case statement that sets `automatic` and `sha`. It
+# is extracted from the workflow by its own markers rather than retyped.
+
+
+def extract_dispatch_arm(resolve: str) -> str:
+    """The case statement that sets `automatic` and `sha`, already dedented."""
+    marker = 'case "$EVENT_NAME" in'
+    if marker not in resolve:
+        raise AssertionError(
+            "the resolve step no longer opens with a case on $EVENT_NAME, so the "
+            "arm under test cannot be located"
+        )
+    start = resolve.index(marker)
+    end = resolve.index("\nesac", start) + len("\nesac")
+    return resolve[start:end]
+
+
+def resolve_cases(resolve: str) -> None:
+    arm = extract_dispatch_arm(resolve)
+    for needle in ("release_tag_evaluate", "RAW_TAG", "automatic=false"):
+        if needle not in arm:
+            raise AssertionError(f"resolve arm lost '{needle}', so this test proves nothing")
+
+    # A stand-in for `git rev-parse refs/remotes/origin/main`, so the arm runs
+    # with no repository. Everything else is the workflow's own text.
+    head = "b" * 40
+    harness = (
+        "set -euo pipefail\n"
+        "git() { if [ \"$1\" = rev-parse ]; then printf '%s\\n' \"$MAIN_HEAD\"; "
+        "else return 0; fi; }\n"
+        "automatic=true\n"
+        "tag=\"\"\n"
+        "sha=\"\"\n"
+        + arm
+        + "\nprintf 'automatic=%s tag=%s sha=%s\\n' \"$automatic\" \"$tag\" \"$sha\"\n"
+    )
+
+    def check(name: str, env: dict[str, str], want_rc: int, want: str | None) -> None:
+        got = run_fragment(harness, {"MAIN_HEAD": head, "RAW_TAG": "", "RAW_SHA": "", **env})
+        if (got.returncode == 0) != (want_rc == 0):
+            raise AssertionError(
+                f"resolve {name}: rc={got.returncode} wanted {want_rc}\n"
+                f"stdout={got.stdout}\nstderr={got.stderr}"
+            )
+        if want is not None and want not in got.stdout:
+            raise AssertionError(f"resolve {name}: wanted {want!r} in stdout, got {got.stdout!r}")
+
+    # Evaluate runs the automatic algorithm against main HEAD, naming nothing.
+    check(
+        "evaluate is automatic",
+        {"EVENT_NAME": "repository_dispatch", "EVENT_ACTION": "release_tag_evaluate"},
+        0,
+        f"automatic=true tag= sha={head}",
+    )
+    # Break glass is untouched.
+    check(
+        "break glass unchanged",
+        {
+            "EVENT_NAME": "repository_dispatch",
+            "EVENT_ACTION": "release_tag",
+            "RAW_TAG": "v0.6.4",
+            "RAW_SHA": "C" * 40,
+        },
+        0,
+        f"automatic=false tag=v0.6.4 sha={'c' * 40}",
+    )
+    # Evaluate refuses a named commit rather than ignoring it.
+    check(
+        "evaluate refuses a sha",
+        {
+            "EVENT_NAME": "repository_dispatch",
+            "EVENT_ACTION": "release_tag_evaluate",
+            "RAW_SHA": "d" * 40,
+        },
+        1,
+        None,
+    )
+    check(
+        "evaluate refuses a tag",
+        {
+            "EVENT_NAME": "repository_dispatch",
+            "EVENT_ACTION": "release_tag_evaluate",
+            "RAW_TAG": "v9.9.9",
+        },
+        1,
+        None,
+    )
+    # The scheduled arm still reads main HEAD.
+    check(
+        "schedule is automatic",
+        {"EVENT_NAME": "schedule", "EVENT_ACTION": ""},
+        0,
+        f"automatic=true tag= sha={head}",
+    )
+    print("ok: resolve picks the automatic algorithm for evaluate and leaves break glass alone")
+
+
+# ---- 3. falsification ----------------------------------------------------
+
+
+def falsify(workflow_text: str) -> None:
+    """Break one rule at a time; the suite must go red for each."""
+    guard_name = "Guard trigger authority"
+    resolve_name = "Resolve exact coherent release commit"
+
+    mutations = [
+        (
+            "admit the evaluate type without the actor allowlist",
+            'release_tag|release_tag_evaluate) ;;',
+            'release_tag) ;;\n            release_tag_evaluate) exit 0 ;;',
+        ),
+        (
+            "let evaluate keep a caller-named sha",
+            'if [ -n "$RAW_TAG" ] || [ -n "$RAW_SHA" ]; then',
+            "if false; then",
+        ),
+        (
+            "make evaluate take the break-glass algorithm",
+            'if [ "$EVENT_ACTION" = release_tag_evaluate ]; then',
+            "if false; then",
+        ),
+    ]
+
+    for label, needle, replacement in mutations:
+        if needle not in workflow_text:
+            raise AssertionError(f"mutation '{label}' no longer applies: {needle}")
+        broken = workflow_text.replace(needle, replacement, 1)
+        try:
+            guard_cases(extract_step_run(broken, guard_name))
+            resolve_cases(extract_step_run(broken, resolve_name))
+        except AssertionError:
+            continue
+        raise AssertionError(f"mutation survived, so it is untested: {label}")
+
+    print(f"ok: {len(mutations)} workflow mutations each turned the suite red")
+
+
+def main() -> int:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    if "release_tag_evaluate" not in text:
+        raise AssertionError("release-tag.yml declares no release_tag_evaluate dispatch")
+    if "types: [release_tag, release_tag_evaluate]" not in text:
+        raise AssertionError("the evaluate type is not declared on the repository_dispatch trigger")
+
+    guard_cases(extract_step_run(text, "Guard trigger authority"))
+    resolve_cases(extract_step_run(text, "Resolve exact coherent release commit"))
+    falsify(text)
+    print("release-tag evaluate dispatch: authority, algorithm and refusals hold")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -10649,14 +10649,28 @@ def main() -> None:
         "github.event.workflow_run.event == 'push'",
         "github.event.workflow_run.head_branch == 'main'",
         "repository_dispatch:",
-        "types: [release_tag]",
+        # Two typed dispatches, pinned as one literal so adding a third is a
+        # reviewed edit here rather than a quiet trigger widening. release_tag
+        # is break glass and names an exact commit; release_tag_evaluate runs
+        # the scheduled algorithm on demand and names nothing. Both face the
+        # same actor allowlist and main-only ref below.
+        "types: [release_tag, release_tag_evaluate]",
         "github.event.action",
         "github.event.repository.default_branch",
         "github.event.client_payload.tag",
         "github.event.client_payload.sha",
         "EVENT_SHA: ${{ github.sha }}",
         'EVENT_NAME" != repository_dispatch',
-        'EVENT_ACTION" != release_tag',
+        # The dispatch action allowlist. It was a single `!=` test while there
+        # was one type; with two it is a case whose only admitting arm is this
+        # literal, so an unlisted action still falls to the refusing arm.
+        "release_tag|release_tag_evaluate) ;;",
+        "unsupported repository dispatch action",
+        # Evaluate runs the automatic selection, so it must never accept a
+        # caller-named commit. Ignoring one would tag a different commit than
+        # the caller believed they had chosen.
+        'EVENT_ACTION" = release_tag_evaluate',
+        "release_tag_evaluate runs the automatic selection and takes no tag or sha",
         'DEFAULT_BRANCH" != main',
         'REF" != "refs/heads/$DEFAULT_BRANCH"',
         "environment: release-tag",


### PR DESCRIPTION
The mint's only manual trigger was break glass, which names an exact commit. When
the automatic selection is what you want, there was no way to ask for it.

## The defect

`release-tag.yml` has one manual path: a `release_tag` repository_dispatch where the
caller names a tag and a sha, and the sha must equal current main HEAD. Dispatching
it for a proven candidate on 2026-09-02 refused with "break-glass release sha
a047b784e is not current origin/main HEAD". That refusal is correct. The problem is
that it was the only tool available, and the thing actually wanted was the scheduled
algorithm run now.

That is not a convenience gap. The schedule cannot be the sole route to the automatic
path: GitHub's cron produced one scheduled mint run on this repository between 09:58Z
and 14:22Z that day. An automatic path reachable only by an unreliable cron needs a
manual trigger, and it has to run the same algorithm rather than a second one that
drifts from it.

## The change

A second typed dispatch, `release_tag_evaluate`. It resolves `automatic=true` and
reads protected main HEAD exactly as the schedule's arm does, so it inherits the
version-range selection, the both-proof-records requirement and the reviewed-ancestor
admission with no duplicated logic. It names nothing.

A payload carrying a tag or a sha is refused, not ignored. A caller who passed one
meant break glass, and silently dropping it would tag whatever the selection chose
while the caller believed they had named the commit.

Break glass is untouched: still `automatic=false`, still equality against main HEAD.
Tagging a chosen commit on purpose is a different and legitimate act.

The type chooses the algorithm, never the permission. Both actions face the same
actor allowlist, the same main-only ref and the same exact-hex workflow sha, and an
unlisted action still falls to the refusing arm. A new trigger that widened who may
mint would be a worse defect than the one this fixes, so that is the property the
tests spend most of their cases on.

## Proof

`scripts/test-release-tag-evaluate-dispatch.py` extracts the trigger guard and the
resolve arm out of the workflow and runs them under `bash` with the event environment
set, so it exercises the real shell rather than a paraphrase of it. Extraction is
asserted, so a renamed step fails loudly instead of quietly testing nothing. Both
types are run against every refusal: foreign actor, off-main ref, non-hex sha,
default branch not main, unknown action, empty action. The resolve arm is checked for
the algorithm it picks in each case, including that the scheduled arm still reads main
HEAD and that break glass still lowercases and keeps a caller's sha.

Three workflow mutations, each turning the suite red: admitting the evaluate type
before the actor allowlist, letting it keep a caller-named sha, and making it take the
break-glass algorithm.

The three new policy needles in the authority suite were falsified the same way.
Dropping the evaluate type from the trigger, dropping the allowlist arm, or dropping
the no-sha refusal message each turns `test-release-workflow-authority.py` red, and
the restored file is byte-identical with it green again.

Gates: the authority suite (which refused this change twice on pinned policy until each
was deliberately updated), `test-release-policy-gate.sh`, actionlint on both edited
workflows, and the new suite.

## Live behaviour to expect

Dispatching `release_tag_evaluate` today should print a stand-down: v0.6.5's version
bump is on main but no tag is due until both proof records exist for a candidate in
that range. That is the automatic algorithm answering, which is the point.

Related: FIR-3084
