### PR TITLE
Say that CLAUDE.md is a regular file that imports AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,11 @@ This repository (`kin`) is part of the Kin ecosystem. The canonical source of tr
 thesis, boundaries, lane arbitration and commit hygiene is the umbrella workspace's
 **`kin-ecosystem/AGENTS.md`** (also symlinked as `kin-ecosystem/CLAUDE.md`), and it is loaded
 automatically when you work inside the umbrella. Read it before making architectural or process
-decisions. `CLAUDE.md` at this repo's root is a symlink to this file, because Claude Code reads
-`CLAUDE.md` and not `AGENTS.md`, so a standalone checkout still loads this note.
+decisions. `CLAUDE.md` at this repo's root is a regular file that imports this one, because Claude Code reads
+that filename and this repository's source is archived into kin-infra's promotion bundle, whose
+validator refuses any non-regular entry; a symlink there failed production image promotion of
+v0.6.4 after the release was already public. Edit this file, never that one, and keep every
+tracked path in this repository a regular file.
 
 ## This repo's role
 


### PR DESCRIPTION
kin #1395 replaced the `CLAUDE.md` symlink with a regular file, because kin-infra's promotion bundle validator refuses any non-regular entry and the symlink failed production image promotion of v0.6.4 after the release was already public. This paragraph still described the symlink.

It now says what the file is, that it imports this one, and why every tracked path in this repository has to stay a regular file.

Related: FIR-3057
