### PR TITLE
Judge a release candidate by the archives its rc-build holds

### DIFF
--- a/scripts/release-proof/merge-preflight-records.mjs
+++ b/scripts/release-proof/merge-preflight-records.mjs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-// Merge the per-archive preflight leg records rc-build.yml uploads into the one
-// preflight.json the mint reads.
+// Merge the per-archive preflight leg records release-cut.yml's preflight job
+// uploads into the one preflight.json the mint reads.
 //
 // The local preflight judges every archive in one run and writes one record.
 // Hosted, each archive is judged on the runner that can execute it (macOS for

--- a/scripts/select-release-candidate.py
+++ b/scripts/select-release-candidate.py
@@ -20,8 +20,8 @@ the decision rests on and answers one of four things:
               complete green sha exists yet
   arm         move release/v<version>-candidate to the chosen sha and dispatch
               rc-build.yml there
-  proof       an rc-build for the current candidate succeeded and carries the
-              preflight leg records; merge and publish them
+  proof       an rc-build for the current candidate succeeded and still holds
+              the candidate archives; preflight them and publish the record
   stranger    preflight.json is filed for the candidate and stranger.env is the
               only missing half; run the three-arm stranger on the same archive
   refuse      no reviewed main commit carrying the version qualifies, named sha
@@ -78,11 +78,20 @@ CI_WORKFLOW_NAME = "CI"
 ACCEPTANCE_WORKFLOW = ".github/workflows/acceptance.yml"
 RC_BUILD_WORKFLOW = ".github/workflows/rc-build.yml"
 RC_BUILD_WORKFLOW_NAME = "RC Build"
-# The artifacts rc-build.yml's preflight job uploads, one leg record per
-# archive. A run missing one of them proved less than a record built from it
-# would claim, so it is not usable evidence.
-PREFLIGHT_ARTIFACT_PREFIX = "kin-release-preflight-"
-PREFLIGHT_ARTIFACTS = ("kin-linux-aarch64", "kin-linux-x86_64", "kin-macos-aarch64")
+# The artifacts rc-build.yml's build matrix uploads, one archive per row, named
+# by `matrix.artifact` alone. These are the bytes release-cut.yml's preflight
+# job downloads by that same name, so a run missing one of them cannot feed the
+# leg that judges it and is not usable evidence.
+#
+# These names were once written with a `kin-release-preflight-` prefix, which is
+# what release-cut.yml's own preflight job calls the LEG RECORDS it uploads into
+# its own run. No rc-build run has ever carried a name of that shape, so no
+# rc-build could ever be usable, the decision never reached `proof`, and the
+# preflight job that would have produced those records is gated on that very
+# decision. The loop armed a fresh build every cycle and burned the candidate at
+# RC_BUILD_ATTEMPT_LIMIT. A selector reads the run it is judging for what that
+# run produces, never for what a later consumer of it produces.
+RC_BUILD_ARTIFACTS = ("kin-linux-aarch64", "kin-linux-x86_64", "kin-macos-aarch64")
 # One rebuild is a flake allowance. A second failure on the same sha is a
 # verdict about the sha, and the next landing supplies a new one.
 RC_BUILD_ATTEMPT_LIMIT = 2
@@ -433,9 +442,9 @@ def read_branch(fetch: Fetch, repository: str, branch: str) -> str | None:
 def read_rc_builds(fetch: Fetch, repository: str, branch: str) -> list[dict[str, Any]]:
     """Every rc-build dispatch on the candidate branch, newest first.
 
-    A completed successful run also carries the names of its artifacts, which
-    is how a run from before the preflight job existed is told apart from one
-    whose leg records can be published.
+    A completed successful run also carries the names of its unexpired
+    artifacts, which is how a run still holding the candidate archives is told
+    apart from one whose archives have aged out of the artifact store.
     """
 
     runs = read_listing(
@@ -816,14 +825,14 @@ def judge(snapshot: dict[str, Any], grade: Grader) -> Decision:
             if usable:
                 return Decision(
                     PROOF,
-                    f"rc-build {usable[0]['id']} succeeded for {candidate} with the preflight leg records",
+                    f"rc-build {usable[0]['id']} succeeded for {candidate} and still holds its archives",
                     version,
                     branch,
                     candidate=candidate,
                     rc_run=usable[0]["id"],
                     details={"stranger_command": stranger_command(version, candidate, usable[0]["id"])},
                 )
-            spent = [f"{build['id']} ({build.get('conclusion') or 'no preflight legs'})" for build in builds]
+            spent = [f"{build['id']} ({build.get('conclusion') or 'no conclusion'})" for build in builds]
             if len(spent) >= RC_BUILD_ATTEMPT_LIMIT:
                 dead[candidate] = [f"rc-build attempts exhausted: {', '.join(spent)}"]
                 notes.append(f"current candidate {candidate} died: {dead[candidate][0]}")
@@ -898,10 +907,18 @@ def judge(snapshot: dict[str, Any], grade: Grader) -> Decision:
 
 
 def _usable(build: dict[str, Any]) -> bool:
+    """A completed rc-build still holding every candidate archive it built.
+
+    `artifacts` is filtered to unexpired names when the run is read, so a run
+    whose archives aged out reads as missing them and is refused rather than
+    reused: the stranger has to run on the very bytes a published preflight
+    record names, and a rebuild is not guaranteed to reproduce that sha256.
+    """
+
     if build.get("status") != "completed" or build.get("conclusion") != "success":
         return False
     names = set(build.get("artifacts") or [])
-    return all(f"{PREFLIGHT_ARTIFACT_PREFIX}{artifact}" in names for artifact in PREFLIGHT_ARTIFACTS)
+    return all(artifact in names for artifact in RC_BUILD_ARTIFACTS)
 
 
 def _newest_usable_run(rc_builds: list[dict[str, Any]], sha: str) -> int | None:

--- a/scripts/test-select-release-candidate.py
+++ b/scripts/test-select-release-candidate.py
@@ -40,6 +40,7 @@ ROOT = Path(__file__).resolve().parents[1]
 SELECTOR_PATH = ROOT / "scripts" / "select-release-candidate.py"
 CUT_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "release-cut.yml"
 RELEASE_TAG_PATH = ROOT / ".github" / "workflows" / "release-tag.yml"
+RC_BUILD_PATH = ROOT / ".github" / "workflows" / "rc-build.yml"
 REPO = "firelock-ai/kin"
 VERSION = "0.6.5"
 NEWEST = "a" * 40
@@ -54,6 +55,25 @@ CI_RUN = 33_000_000_001
 ACCEPTANCE_RUN = 33_000_000_002
 SAST_RUN = 33_000_000_003
 SECRET_RUN = 33_000_000_004
+
+
+def job_block(source: str, job: str) -> str:
+    """One job's own YAML, from its two-space key to the next one.
+
+    Both workflows carry more than one `artifact:` matrix, so a whole-file
+    search reads rows from a job the assertion is not about: rc-build.yml's
+    capability matrix carries a windows row the build matrix deliberately does
+    not. Slicing by job is what keeps a contract test honest about its subject.
+    """
+
+    match = re.search(rf"(?ms)^  {re.escape(job)}:\n(.*?)(?=^  [a-z][a-z0-9_-]*:\n|\Z)", source)
+    if match is None:
+        raise AssertionError(f"no job named {job} in this workflow")
+    return match.group(1)
+
+
+def matrix_artifacts(block: str) -> list[str]:
+    return re.findall(r"(?m)^ +artifact: ([A-Za-z0-9._-]+)$", block)
 
 
 def load_module(name: str, path: Path):
@@ -188,7 +208,7 @@ def rc_build(
     created_at: str = "2026-09-02T20:00:00Z",
 ) -> dict[str, Any]:
     if artifacts is None:
-        artifacts = [f"{selector.PREFLIGHT_ARTIFACT_PREFIX}{name}" for name in selector.PREFLIGHT_ARTIFACTS]
+        artifacts = list(selector.RC_BUILD_ARTIFACTS)
     return {
         "id": run_id,
         "head_sha": sha,
@@ -420,6 +440,62 @@ class GradeShaTests(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 
+class ReadRcBuildsTests(unittest.TestCase):
+    """The read that decides what `_usable` is allowed to see.
+
+    `_usable` never sees an expired artifact, because the read filters them out
+    before the judgment. That filter is the whole of the expiry refusal, so it
+    is asserted here rather than assumed by a fixture that hands over an empty
+    list.
+    """
+
+    BRANCH = f"release/v{VERSION}-candidate"
+
+    def read(self, runs: list[dict[str, Any]], artifacts: dict[int, list[dict[str, Any]]]):
+        def fetch(endpoint: str) -> Any:
+            if endpoint == selector.rc_build_runs_endpoint(REPO, self.BRANCH, 1):
+                return {"total_count": len(runs), "workflow_runs": runs}
+            for run_id, listing in artifacts.items():
+                if endpoint == selector.run_artifacts_endpoint(REPO, run_id, 1):
+                    return {"total_count": len(listing), "artifacts": listing}
+            raise AssertionError(f"unexpected endpoint {endpoint}")
+
+        return selector.read_rc_builds(fetch, REPO, self.BRANCH)
+
+    def run_row(self, run_id: int, *, status: str = "completed", conclusion: str | None = "success"):
+        return {
+            "id": run_id,
+            "head_sha": MIDDLE,
+            "head_branch": self.BRANCH,
+            "event": "workflow_dispatch",
+            "status": status,
+            "conclusion": conclusion,
+            "created_at": "2026-09-02T22:52:23Z",
+        }
+
+    def test_every_live_archive_is_read_and_the_run_is_usable(self) -> None:
+        listing = [{"name": name, "expired": False} for name in selector.RC_BUILD_ARTIFACTS]
+        builds = self.read([self.run_row(1)], {1: listing})
+        self.assertEqual(builds[0]["artifacts"], sorted(selector.RC_BUILD_ARTIFACTS))
+        self.assertTrue(selector._usable(builds[0]))
+
+    def test_an_expired_archive_is_dropped_and_costs_the_run_its_usability(self) -> None:
+        listing = [
+            {"name": name, "expired": name == "kin-macos-aarch64"}
+            for name in selector.RC_BUILD_ARTIFACTS
+        ]
+        builds = self.read([self.run_row(1)], {1: listing})
+        self.assertNotIn("kin-macos-aarch64", builds[0]["artifacts"])
+        self.assertFalse(selector._usable(builds[0]))
+
+    def test_an_unsuccessful_run_costs_no_artifact_read_and_is_not_usable(self) -> None:
+        for status, conclusion in (("completed", "failure"), ("in_progress", None)):
+            with self.subTest(status=status, conclusion=conclusion):
+                builds = self.read([self.run_row(1, status=status, conclusion=conclusion)], {})
+                self.assertEqual(builds[0]["artifacts"], [])
+                self.assertFalse(selector._usable(builds[0]))
+
+
 class JudgeTests(unittest.TestCase):
     def assertDecision(self, decision: Any, expected: str, needle: str = "") -> None:
         self.assertEqual(decision.decision, expected, decision.reason)
@@ -481,6 +557,15 @@ class JudgeTests(unittest.TestCase):
             Grader({}),
         )
         self.assertDecision(decision, selector.REFUSE, "no rc-build still holds")
+
+    def test_one_expired_archive_costs_the_run_its_usability(self) -> None:
+        """A partially aged-out run cannot feed the leg whose archive is gone."""
+
+        survivor = rc_build(MIDDLE, artifacts=["kin-linux-aarch64", "kin-linux-x86_64"])
+        self.assertFalse(selector._usable(survivor))
+        grader = Grader({MIDDLE: green_grade(MIDDLE)})
+        decision = selector.judge(snapshot(candidate=MIDDLE, rc_builds=[survivor]), grader)
+        self.assertDecision(decision, selector.ARM)
 
     def test_both_records_beat_the_stranger_decision(self) -> None:
         """Once stranger.env lands the candidate belongs to the mint, not to another run."""
@@ -561,21 +646,63 @@ class JudgeTests(unittest.TestCase):
         self.assertDecision(decision, selector.STAND_DOWN, "in_progress")
         self.assertEqual(decision.rc_run, 34_000_000_001)
 
-    def test_a_successful_rc_build_with_every_leg_record_is_proof(self) -> None:
+    def test_a_successful_rc_build_holding_every_archive_is_proof(self) -> None:
         grader = Grader({MIDDLE: green_grade(MIDDLE)})
         decision = selector.judge(snapshot(candidate=MIDDLE, rc_builds=[rc_build(MIDDLE)]), grader)
         self.assertDecision(decision, selector.PROOF)
         self.assertEqual(decision.rc_run, 34_000_000_001)
         self.assertIn("bin/kin-stranger run", decision.details["stranger_command"])
 
-    def test_an_rc_build_missing_a_leg_record_is_not_proof(self) -> None:
-        """A run from before the preflight job existed proves less than a record would claim."""
+    def test_an_rc_build_missing_an_archive_is_not_proof(self) -> None:
+        """The preflight downloads one archive per row; a run short of one cannot feed it."""
 
-        partial = rc_build(MIDDLE, artifacts=[f"{selector.PREFLIGHT_ARTIFACT_PREFIX}kin-macos-aarch64"])
+        partial = rc_build(MIDDLE, artifacts=["kin-macos-aarch64"])
         grader = Grader({MIDDLE: green_grade(MIDDLE)})
         decision = selector.judge(snapshot(candidate=MIDDLE, rc_builds=[partial]), grader)
         self.assertDecision(decision, selector.ARM)
         self.assertEqual(decision.candidate, MIDDLE)
+
+    def test_a_failed_rc_build_holding_every_archive_is_not_proof(self) -> None:
+        """A red run's artifacts are not evidence; only a successful build is."""
+
+        failed = rc_build(MIDDLE, conclusion="failure")
+        grader = Grader({MIDDLE: green_grade(MIDDLE)})
+        decision = selector.judge(snapshot(candidate=MIDDLE, rc_builds=[failed]), grader)
+        self.assertDecision(decision, selector.ARM)
+        self.assertEqual(decision.candidate, MIDDLE)
+
+    def test_the_deadlocked_shape_of_2026_09_02_is_usable(self) -> None:
+        """Regression: run 33692452573 for febf5d851, the shape that burned the loop.
+
+        The rc-build succeeded and carried exactly the three archive names, none
+        expired. The selector asked for `kin-release-preflight-` prefixed names,
+        which only release-cut.yml's own preflight job ever uploads and only on
+        the `proof` decision this reading could never produce, so the loop armed
+        a fresh build every cycle and killed the candidate at the attempt limit.
+        These are the live names read from that run's artifacts endpoint.
+        """
+
+        live = rc_build(
+            MIDDLE,
+            run_id=33_692_452_573,
+            artifacts=["kin-macos-aarch64", "kin-linux-x86_64", "kin-linux-aarch64"],
+        )
+        self.assertTrue(selector._usable(live), live["artifacts"])
+        grader = Grader({MIDDLE: green_grade(MIDDLE)})
+        decision = selector.judge(snapshot(candidate=MIDDLE, rc_builds=[live]), grader)
+        self.assertDecision(decision, selector.PROOF, "still holds its archives")
+        self.assertEqual(decision.rc_run, 33_692_452_573)
+
+    def test_a_run_carrying_only_leg_record_names_is_not_usable(self) -> None:
+        """The inverse control: leg-record names alone are not candidate archives.
+
+        release-cut.yml uploads `kin-release-preflight-<artifact>` into its OWN
+        run. If those names ever appear on an rc-build run, they are still not
+        the archives the preflight downloads by bare name.
+        """
+
+        legs = rc_build(MIDDLE, artifacts=[f"kin-release-preflight-{name}" for name in selector.RC_BUILD_ARTIFACTS])
+        self.assertFalse(selector._usable(legs))
 
     def test_exhausted_rc_build_attempts_kill_the_candidate_and_pick_the_next(self) -> None:
         spent = [
@@ -814,6 +941,54 @@ class ContractTests(unittest.TestCase):
                 f"{name} is bound to a different workflow id in release-tag.yml: {body}",
             )
             self.assertIn(path, body, f"{name} is bound to a different workflow path")
+
+    def test_the_usable_artifacts_are_the_names_rc_build_actually_uploads(self) -> None:
+        """The deadlock, as an assertion.
+
+        `_usable` judges an rc-build run, so the names it requires have to be
+        the names that run uploads. They were once the leg-record names
+        release-cut.yml uploads into its own run, which no rc-build can carry,
+        so no candidate could ever be proven and the preflight that would have
+        produced those records was gated on the decision they blocked.
+        """
+
+        source = RC_BUILD_PATH.read_text(encoding="utf-8")
+        build = job_block(source, "build")
+        self.assertEqual(
+            sorted(matrix_artifacts(build)),
+            sorted(selector.RC_BUILD_ARTIFACTS),
+            "rc-build.yml's build matrix and the selector's usable set have drifted",
+        )
+        # The row value is only the artifact name if the upload step names it
+        # unadorned. A prefix added here would make every row a different
+        # artifact than the selector asks for, silently.
+        self.assertIn("          name: ${{ matrix.artifact }}\n", build)
+
+    def test_the_preflight_downloads_exactly_the_artifacts_the_selector_requires(self) -> None:
+        """The consumer side: each leg pulls one archive from the run by bare name."""
+
+        source = CUT_WORKFLOW_PATH.read_text(encoding="utf-8")
+        preflight = job_block(source, "preflight")
+        self.assertEqual(
+            sorted(matrix_artifacts(preflight)),
+            sorted(selector.RC_BUILD_ARTIFACTS),
+            "release-cut.yml's preflight matrix and the selector's usable set have drifted",
+        )
+        self.assertIn('--name "$ARTIFACT"', preflight)
+
+    def test_the_leg_records_are_uploaded_by_the_cut_not_by_the_candidate_build(self) -> None:
+        """Where the prefixed names live, so nobody re-derives the wrong owner.
+
+        A reader who believes rc-build.yml uploads the leg records writes the
+        selector's usable set as the prefixed names again. rc-build.yml uploads
+        one thing, and release-cut.yml's preflight job uploads the other.
+        """
+
+        cut = CUT_WORKFLOW_PATH.read_text(encoding="utf-8")
+        self.assertIn("          name: kin-release-preflight-${{ matrix.artifact }}\n", cut)
+        self.assertIn("          pattern: kin-release-preflight-*\n", cut)
+        rc = RC_BUILD_PATH.read_text(encoding="utf-8")
+        self.assertNotIn("name: kin-release-preflight-", rc)
 
     def test_the_workflow_calls_the_selector_and_binds_its_trigger(self) -> None:
         workflow = CUT_WORKFLOW_PATH.read_text(encoding="utf-8")


### PR DESCRIPTION
The release cut has been deadlocked since the selector started judging rc-builds: it asked every rc-build run for artifacts named `kin-release-preflight-<archive>`, and only release-cut.yml's own preflight job uploads names of that shape, into its own run. So no rc-build could ever be usable, the decision never reached `proof`, the preflight job that would have produced those records is itself gated on that decision, and every cycle armed another build until `RC_BUILD_ATTEMPT_LIMIT` burned the candidate.

`_usable` now requires the three archive names rc-build.yml's build matrix actually uploads, which are the same names release-cut.yml's preflight downloads by hand. Status, conclusion and expiry are unchanged, so a candidate whose archives aged out is still refused rather than rebuilt.

Measured before the change: run 33692452573 for `febf5d85138091079fafaa139df3a9f5b0c217db` carried exactly `kin-linux-aarch64`, `kin-linux-x86_64` and `kin-macos-aarch64`, none expired, and was refused; release-cut run 33695497452 decided `arm` with reason `febf5d85138091079fafaa139df3a9f5b0c217db is green with no usable rc-build yet (prior attempts: 33692452573 (success))`.

Ten new assertions, each falsified by breaking what it guards and confirmed red. Three of them are contract tests that read rc-build.yml's build matrix, release-cut.yml's preflight matrix and the leg-record upload names, so a rename on either side reddens a pull request instead of deadlocking a cut a release later.

Gates run locally on this tree: `python3 scripts/test-select-release-candidate.py` (65 tests, OK), the other three release-policy Python suites, the 13-file `node --test` release-policy batch (206 tests, 0 fail) and `python3 scripts/test-assertion-reachability.py`. No Rust changed. `bin/kin-precheck kin` refuses with exit 2 on this tree and refuses identically on a pristine `origin/main` checkout at the same sha, over a coverage gap about `scripts/release-proof` that predates this branch.

Related: FIR-3084
