### PR TITLE
Raise Kin's own open-file limit so a stock Mac can admit a repository

### DIFF
--- a/crates/kin-cli/src/broken_pipe.rs
+++ b/crates/kin-cli/src/broken_pipe.rs
@@ -265,11 +265,21 @@ fn redirect_to_dev_null(fd: libc::c_int) {
 /// `Err`, `Error: {err:?}`, through [`print_stderr`], so a refusal nobody
 /// reads any more still exits 1 rather than becoming a second broken-pipe
 /// panic.
+///
+/// One class earns a second paragraph after that render. A command that ran out
+/// of open file descriptors reports a kernel refusal naming a descriptor and a
+/// store path, and neither is the problem or the fix, so
+/// [`crate::open_files::remedy`] follows it with the limit, its value and the
+/// command that raises it. This is the whole CLI's error boundary, so every
+/// command gets it, not just the admission that found the class.
 pub fn exit_status(error: &anyhow::Error) -> i32 {
     if is_cut_off(error) {
         return CUT_OFF_STATUS;
     }
     print_stderr(format_args!("Error: {error:?}\n"));
+    if let Some(remedy) = crate::open_files::remedy(error) {
+        print_stderr(format_args!("{remedy}"));
+    }
     1
 }
 

--- a/crates/kin-cli/src/lib.rs
+++ b/crates/kin-cli/src/lib.rs
@@ -17,6 +17,7 @@ pub mod embed_model;
 pub mod entity_identity;
 pub mod entity_ref;
 pub mod model_residency;
+pub mod open_files;
 pub mod output_style;
 pub mod profile;
 pub mod progress;

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -2712,6 +2712,11 @@ fn main() {
 }
 
 fn run() -> Result<()> {
+    // Raise this process's open-file soft limit before anything opens a file.
+    // macOS ships that limit at 256, which is below what one admission needs,
+    // so on a stock Mac `kin init` died on the first real repository a person
+    // tried. Silent either way, and it never lowers a limit an operator raised.
+    kin_core::file_limit::raise_open_file_limit();
     // Select this process's resource profile before anything reads it: the GPU
     // kernel plan and the Metal submission depth are each resolved once per
     // process, and mutating the environment is only safe while the process is

--- a/crates/kin-cli/src/open_files.rs
+++ b/crates/kin-cli/src/open_files.rs
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! What the CLI says when a command ran out of open file descriptors.
+//!
+//! Kin raises its own open-file soft limit at startup
+//! ([`kin_core::file_limit`]), so on almost every machine this never fires. It
+//! exists for the machine where the raise could not help: a hard limit already
+//! at the soft limit, which no unprivileged process can lift.
+//!
+//! What the user saw before this existed was the raw kernel refusal, wrapped in
+//! whichever storage call happened to be holding it:
+//!
+//! ```text
+//! graph error: storage error: failed to clone retained repository directory
+//! /path/.kin.init-.../kindb/...: Too many open files (os error 24)
+//! ```
+//!
+//! That names a descriptor and a UUID, and neither is the problem or the fix.
+//! The limit is the problem, its value is the missing fact, and `ulimit` is the
+//! fix, so those are what this prints.
+//!
+//! Detection reads the error two ways because the error arrives two ways. A
+//! failure that is still an `io::Error` somewhere in its chain is matched on its
+//! `errno`, which is exact. A failure that came up through the storage layer is
+//! not: that layer renders the cause into its message string and returns a typed
+//! error carrying text, so by the time it reaches here the only evidence left is
+//! the sentence. Matching the sentence is weaker than matching a code, and it is
+//! what the shape allows without a change in another repository.
+
+use kin_core::file_limit::{OpenFileLimit, TARGET_OPEN_FILES};
+
+/// The `errno` values that mean "no more descriptors": this process's limit,
+/// and the whole machine's.
+#[cfg(unix)]
+const DESCRIPTOR_EXHAUSTION_CODES: &[i32] = &[libc::EMFILE, libc::ENFILE];
+
+/// Nothing to match structurally off Unix, where this module's advice does not
+/// apply either. The rendered form below still answers.
+#[cfg(not(unix))]
+const DESCRIPTOR_EXHAUSTION_CODES: &[i32] = &[];
+
+/// The sentence the storage layer leaves behind once it has flattened the
+/// `io::Error` that caused it into text.
+const DESCRIPTOR_EXHAUSTION_TEXT: &str = "Too many open files";
+
+/// The guidance to print after this error, or `None` when it was not descriptor
+/// exhaustion.
+pub fn remedy(error: &anyhow::Error) -> Option<String> {
+    is_descriptor_exhaustion(error).then(|| remedy_text(kin_core::file_limit::open_file_limit()))
+}
+
+/// Whether this error, anywhere in its chain, is the kernel refusing to open
+/// another file.
+fn is_descriptor_exhaustion(error: &anyhow::Error) -> bool {
+    let structural = error.chain().any(|cause| {
+        cause
+            .downcast_ref::<std::io::Error>()
+            .and_then(std::io::Error::raw_os_error)
+            .is_some_and(|code| DESCRIPTOR_EXHAUSTION_CODES.contains(&code))
+    });
+    structural || rendered_names_descriptor_exhaustion(&format!("{error:?}"))
+}
+
+/// Whether a rendered error chain names descriptor exhaustion in words.
+///
+/// Split out so the text rule is testable against a real rendered message
+/// rather than only against an error this test could construct.
+fn rendered_names_descriptor_exhaustion(rendered: &str) -> bool {
+    rendered.contains(DESCRIPTOR_EXHAUSTION_TEXT)
+}
+
+/// The guidance itself: what ran out, what the limit is now, and the one
+/// command that changes it.
+fn remedy_text(limit: Option<OpenFileLimit>) -> String {
+    let mut text = String::from("kin: ran out of open file descriptors.\n");
+    if let Some(limit) = limit {
+        let hard = match limit.hard {
+            Some(hard) => hard.to_string(),
+            None => "unlimited".to_string(),
+        };
+        text.push_str(&format!(
+            "  open files: soft limit {}, hard limit {hard}.\n",
+            limit.soft
+        ));
+        if limit.hard == Some(limit.soft) {
+            text.push_str(
+                "  Kin raises the soft limit at startup and cannot go past the hard limit.\n",
+            );
+        }
+    }
+    text.push_str(&format!(
+        "  Raise it for this shell with `ulimit -n {TARGET_OPEN_FILES}`, then run the command again.\n"
+    ));
+    #[cfg(target_os = "macos")]
+    text.push_str(&format!(
+        "  Raise it for the machine with `sudo launchctl limit maxfiles {TARGET_OPEN_FILES} unlimited`.\n"
+    ));
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The exact message the failing admission produced on a stock macOS
+    /// limit, copied from a run of kin 0.6.3 at `ulimit -Sn 256`. This is the
+    /// input the textual rule exists for: no `io::Error` survives in it.
+    const MEASURED_ADMISSION_FAILURE: &str = "admit exact reachable Git repository authority\n\n\
+Caused by:\n    graph error: storage error: failed to clone retained repository directory \
+/tmp/repos/.kin.init-0b94609a/kindb/d14ae4e8: Too many open files (os error 24)";
+
+    #[test]
+    fn the_measured_admission_failure_is_recognized() {
+        assert!(rendered_names_descriptor_exhaustion(
+            MEASURED_ADMISSION_FAILURE
+        ));
+    }
+
+    #[test]
+    fn an_unrelated_failure_is_not_recognized() {
+        assert!(!rendered_names_descriptor_exhaustion(
+            "storage error: failed to clone retained repository directory /tmp/x: \
+Permission denied (os error 13)"
+        ));
+        assert!(!rendered_names_descriptor_exhaustion("the disk is full"));
+    }
+
+    /// Unix only: the structural rule matches an `errno`, and `EMFILE` means
+    /// something else on a platform that does not define it this way.
+    #[cfg(unix)]
+    #[test]
+    fn an_io_error_carrying_the_errno_is_recognized_through_its_context() {
+        use anyhow::Context as _;
+
+        let error = Err::<(), _>(std::io::Error::from_raw_os_error(libc::EMFILE))
+            .context("copy Git objects")
+            .expect_err("build a wrapped descriptor-exhaustion error");
+        assert!(is_descriptor_exhaustion(&error));
+        assert!(remedy(&error).is_some());
+    }
+
+    #[test]
+    fn an_unrelated_error_gets_no_remedy() {
+        let error = anyhow::anyhow!("refused: the workspace has uncommitted changes");
+        assert!(!is_descriptor_exhaustion(&error));
+        assert!(remedy(&error).is_none());
+    }
+
+    /// The remedy has to carry the three facts the raw kernel message did not:
+    /// what ran out, the number in force, and the command that changes it.
+    #[test]
+    fn the_remedy_names_the_limit_its_value_and_the_command() {
+        let text = remedy_text(Some(OpenFileLimit {
+            soft: 256,
+            hard: Some(256),
+        }));
+        assert!(text.contains("open file"), "{text}");
+        assert!(text.contains("256"), "{text}");
+        assert!(text.contains("ulimit -n 10240"), "{text}");
+        assert!(
+            text.contains("cannot go past the hard limit"),
+            "a limit pinned at its ceiling did not say so: {text}"
+        );
+    }
+
+    /// A machine that still has headroom must not be told Kin gave up on a
+    /// ceiling it never hit.
+    #[test]
+    fn a_limit_below_its_ceiling_does_not_blame_the_hard_limit() {
+        let text = remedy_text(Some(OpenFileLimit {
+            soft: 256,
+            hard: None,
+        }));
+        assert!(text.contains("unlimited"), "{text}");
+        assert!(!text.contains("cannot go past the hard limit"), "{text}");
+    }
+
+    /// A platform that cannot report its limit still gets the remedy, without
+    /// a line that would have to invent a number.
+    #[test]
+    fn an_unreadable_limit_still_yields_the_command() {
+        let text = remedy_text(None);
+        assert!(text.contains("ulimit -n 10240"), "{text}");
+        assert!(!text.contains("soft limit"), "{text}");
+    }
+}

--- a/crates/kin-cli/tests/stock_macos_file_limit.rs
+++ b/crates/kin-cli/tests/stock_macos_file_limit.rs
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! `kin init` under the open-file limit a stock macOS install ships with.
+//!
+//! macOS sets the open-file soft limit to 256 on every machine. A single
+//! admission needs more than that, so `kin init` on a clean Mac failed at step
+//! 9 of 17 with `Too many open files (os error 24)` on the first real
+//! repository anyone tried, and only a six-file fixture got through. The only
+//! Macs this project had ever admitted on were tuned ones.
+//!
+//! The demand behind it is fixed rather than repository-shaped. The storage
+//! layer pins one directory capability per digest prefix a write batch touches,
+//! each pins two directory descriptors, and there are 256 possible prefixes, so
+//! a warmed batch costs 512 descriptors whatever the repository's size. A sweep
+//! against kin 0.6.3 on a 237-file repository measured exactly that: failure at
+//! soft limits 256, 384 and 512, success from 576 up, peaking at 543 open
+//! files.
+//!
+//! Two arms, and the second is the first one's control.
+//!
+//! The success arm holds the class: a soft limit of 256 with room above it,
+//! which is the stock Mac, must admit. It passes because
+//! `kin_core::file_limit` raises the soft limit at startup.
+//!
+//! The refusal arm pins the soft limit AND the hard limit at 256, so the raise
+//! cannot succeed, and requires that the failure name the limit and the remedy
+//! instead of reporting descriptor exhaustion. It is also what proves the
+//! fixture is potent: if this arm ever admits, the fixture no longer reaches
+//! the limit and the success arm above has gone vacuous. It says so rather than
+//! passing quietly.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+mod common;
+
+use common::IsolatedDaemonRuntime;
+
+/// Distinct file bodies in the fixture, which is what decides whether it
+/// reaches the limit.
+///
+/// What exhausts descriptors is digest-prefix coverage, not file count: each of
+/// the 256 possible prefixes costs two descriptors once a batch touches it. 600
+/// distinct bodies land in roughly 230 of them, about 460 descriptors, which
+/// clears 256 with margin and stays well under the 543 a full admission peaks
+/// at. Measured against released kin 0.6.3 at `ulimit -Sn 256`: this fixture
+/// fails at step 9 in one second, the same failure a real repository gives.
+const DISTINCT_BODIES: usize = 600;
+
+/// The soft limit macOS ships, and the one both arms run under.
+const STOCK_MACOS_SOFT_LIMIT: &str = "256";
+
+/// Raise nothing, lower the soft limit, then become `kin`.
+///
+/// `$0` is the binary and `$1` the repository, passed as `sh` positional
+/// arguments so no path needs quoting. Chained with `&&` on purpose: `ulimit`
+/// writes its refusal to stderr and returns non-zero without stopping a `;`
+/// chain, so a separator here would run the admission at the machine's own
+/// limit and pass for the wrong reason.
+const LIMITED_SOFT: &str = "ulimit -Sn 256 && exec \"$0\" init --no-enrich \"$1\"";
+
+/// The same, with the hard limit pinned so the raise cannot succeed.
+///
+/// Order matters. `ulimit -Hn` below the current soft limit is refused by the
+/// kernel, so the soft limit has to come down first.
+const LIMITED_SOFT_AND_HARD: &str =
+    "ulimit -Sn 256 && ulimit -Hn 256 && exec \"$0\" init --no-enrich \"$1\"";
+
+fn run_git(path: &Path, args: &[&str]) {
+    let output = common::Command::new("git")
+        .args(args)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
+        .current_dir(path)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// A repository whose objects span most of the 256 digest prefixes.
+fn seed_prefix_spanning_repo(path: &Path) {
+    fs::create_dir_all(path).expect("create repo dir");
+    run_git(path, &["init", "--initial-branch=main"]);
+    run_git(path, &["config", "user.email", "kin@example.invalid"]);
+    run_git(path, &["config", "user.name", "Kin"]);
+    for index in 0..DISTINCT_BODIES {
+        fs::write(
+            path.join(format!("src_{index}.rs")),
+            format!("pub fn item_{index}() -> u64 {{ {} }}\n", index * 7919 + 13),
+        )
+        .expect("write a distinct source body");
+    }
+    run_git(path, &["add", "--all"]);
+    run_git(path, &["commit", "-m", "distinct bodies"]);
+    fs::write(path.join("CHANGES.md"), "second revision\n").expect("write a second revision");
+    run_git(path, &["add", "--all"]);
+    run_git(path, &["commit", "-m", "second"]);
+}
+
+/// Run `kin init` on `repo` under `script`, which sets the limits and execs.
+fn init_under_limits(
+    runtime: &IsolatedDaemonRuntime,
+    script: &str,
+    repo: &Path,
+) -> std::process::Output {
+    runtime
+        .process_command_for_test("sh")
+        .arg("-c")
+        .arg(script)
+        .arg(env!("CARGO_BIN_EXE_kin"))
+        .arg(repo)
+        .output()
+        .expect("run kin init under a lowered open-file limit")
+}
+
+/// The shell must actually apply the limit, or both arms below run unbounded
+/// and prove nothing. Cheap, and it fails on the setup rather than the subject.
+#[test]
+fn the_fixture_shell_really_lowers_the_limit() {
+    let output = common::Command::new("sh")
+        .arg("-c")
+        .arg("ulimit -Sn 256 && ulimit -Sn")
+        .output()
+        .expect("lower the soft limit in a shell");
+    assert!(output.status.success(), "the shell refused to lower it");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        STOCK_MACOS_SOFT_LIMIT,
+        "the soft limit did not take effect, so both arms below are unbounded"
+    );
+}
+
+#[test]
+fn a_stock_soft_limit_admits_a_real_repository() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("stock-soft-limit");
+    seed_prefix_spanning_repo(&repo);
+
+    let runtime = IsolatedDaemonRuntime::new(&repo);
+    let output = init_under_limits(&runtime, LIMITED_SOFT, &repo);
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "a soft limit of {STOCK_MACOS_SOFT_LIMIT} with headroom above it is what every Mac ships, \
+so admission must raise its own limit and succeed: stdout={} stderr={stderr}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        !stderr.contains("Too many open files"),
+        "the admission succeeded but still reported descriptor exhaustion: {stderr}"
+    );
+}
+
+#[test]
+fn a_pinned_hard_limit_names_the_limit_and_the_remedy() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("pinned-hard-limit");
+    seed_prefix_spanning_repo(&repo);
+
+    let runtime = IsolatedDaemonRuntime::new(&repo);
+    let output = init_under_limits(&runtime, LIMITED_SOFT_AND_HARD, &repo);
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "admission succeeded with both limits pinned at {STOCK_MACOS_SOFT_LIMIT}, so this fixture \
+no longer reaches the descriptor ceiling and the success arm beside it now proves nothing. \
+Enlarge DISTINCT_BODIES until this refuses again, or retire both arms deliberately: stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("ran out of open file descriptors"),
+        "the refusal must name what ran out: {stderr}"
+    );
+    // Matched with its label, not bare: the store path in the failure already
+    // carries `sha256`, so a bare "256" would pass on the wrong substring.
+    assert!(
+        stderr.contains(&format!("soft limit {STOCK_MACOS_SOFT_LIMIT}")),
+        "the refusal must name the limit in force: {stderr}"
+    );
+    assert!(
+        stderr.contains("ulimit -n"),
+        "the refusal must name the command that fixes it: {stderr}"
+    );
+}

--- a/crates/kin-cli/tests/stock_macos_file_limit.rs
+++ b/crates/kin-cli/tests/stock_macos_file_limit.rs
@@ -177,18 +177,43 @@ fn a_pinned_hard_limit_names_the_limit_and_the_remedy() {
 no longer reaches the descriptor ceiling and the success arm beside it now proves nothing. \
 Enlarge DISTINCT_BODIES until this refuses again, or retire both arms deliberately: stderr={stderr}"
     );
-    assert!(
-        stderr.contains("ran out of open file descriptors"),
-        "the refusal must name what ran out: {stderr}"
+    // The guidance is the whole value of this fix, so it is asserted as the
+    // exact lines the product prints rather than as loose substrings. A
+    // substring is too weak twice over here: the store path in the failure
+    // already carries `sha256`, so a bare "256" passes on the wrong text, and a
+    // bare "ulimit -n" passes on a remedy that forgot to say what to raise it
+    // to, which is the one number the reader does not have.
+    //
+    // The remedy is composed from `TARGET_OPEN_FILES`, the same constant the
+    // message is built from, so changing the target cannot leave this arm
+    // asserting a number that no longer appears anywhere.
+    let value_line = format!(
+        "open files: soft limit {STOCK_MACOS_SOFT_LIMIT}, hard limit {STOCK_MACOS_SOFT_LIMIT}."
     );
-    // Matched with its label, not bare: the store path in the failure already
-    // carries `sha256`, so a bare "256" would pass on the wrong substring.
-    assert!(
-        stderr.contains(&format!("soft limit {STOCK_MACOS_SOFT_LIMIT}")),
-        "the refusal must name the limit in force: {stderr}"
-    );
-    assert!(
-        stderr.contains("ulimit -n"),
-        "the refusal must name the command that fixes it: {stderr}"
-    );
+    let shell_remedy = format!("ulimit -n {}", kin_core::file_limit::TARGET_OPEN_FILES);
+    for expected in [
+        "kin: ran out of open file descriptors.",
+        value_line.as_str(),
+        "Kin raises the soft limit at startup and cannot go past the hard limit.",
+        shell_remedy.as_str(),
+    ] {
+        assert!(
+            stderr.contains(expected),
+            "the refusal must carry `{expected}` verbatim: {stderr}"
+        );
+    }
+
+    // The machine-wide remedy is macOS-only in the product, and this is the
+    // platform the class was found on.
+    #[cfg(target_os = "macos")]
+    {
+        let machine_remedy = format!(
+            "sudo launchctl limit maxfiles {} unlimited",
+            kin_core::file_limit::TARGET_OPEN_FILES
+        );
+        assert!(
+            stderr.contains(&machine_remedy),
+            "the refusal must carry `{machine_remedy}` verbatim: {stderr}"
+        );
+    }
 }

--- a/crates/kin-core/src/file_limit.rs
+++ b/crates/kin-core/src/file_limit.rs
@@ -240,16 +240,23 @@ mod tests {
             None
         );
     }
-
-    /// The measured ceiling of a full admission, with the margin named in the
-    /// module docs. If someone lowers the target below what an admission was
-    /// measured to need, this is what says so.
-    #[test]
-    fn the_target_clears_the_measured_admission_peak() {
-        const MEASURED_ADMISSION_PEAK: u64 = 544;
-        assert!(
-            TARGET_OPEN_FILES >= MEASURED_ADMISSION_PEAK * 8,
-            "the target leaves less than eight times the measured admission peak"
-        );
-    }
 }
+
+/// The margin between the target and what an admission was measured to need,
+/// enforced at compile time.
+///
+/// 544 is the open-file peak of a full admission on a 237-file, 2,287-commit
+/// repository, and it was the peak at every soft limit above the threshold
+/// including 1,048,576, so it is a ceiling rather than a sample. Lowering
+/// [`TARGET_OPEN_FILES`] below eight times it stops the build and says why.
+///
+/// A compile error rather than a test, because both sides are constants: there
+/// is no runtime at which this could be false but a build in which it is true.
+/// The peak is written in place rather than named as its own constant, because
+/// dead-code analysis does not traverse an underscore-prefixed item, so a
+/// constant used only here reads as unused under `-D warnings`.
+const _TARGET_CLEARS_THE_MEASURED_ADMISSION_PEAK: () = {
+    if TARGET_OPEN_FILES < 544 * 8 {
+        panic!("TARGET_OPEN_FILES leaves less than eight times the measured admission peak");
+    }
+};

--- a/crates/kin-core/src/file_limit.rs
+++ b/crates/kin-core/src/file_limit.rs
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! This process's open-file limit, and the one place Kin raises it.
+//!
+//! macOS ships every machine with an open-file soft limit of 256. That is
+//! below what a single admission needs, so `kin init` on a stock Mac failed on
+//! the first real repository a person tried, at step 9 of 17, with
+//! `Too many open files (os error 24)`. The only Macs this project had ever
+//! admitted on were tuned ones, which is why it went unseen.
+//!
+//! The demand is bounded and known. A write batch in the storage layer pins one
+//! directory capability per digest prefix it writes into, each capability holds
+//! two open directory descriptors, and there are 256 possible prefixes. So a
+//! warmed batch costs 512 descriptors however large the repository is, and a
+//! sweep of `kin init` on a 237-file, 2,287-commit repository measured that
+//! exactly: it failed at soft limits 256, 384 and 512, and passed from 576 up,
+//! peaking at 544 open files. The ceiling does not grow with the repository.
+//! What decides it is how many of the 256 prefixes the batch touches, which is
+//! why a six-file fixture passed on the same machine and a real repository did
+//! not.
+//!
+//! So Kin raises its own soft limit at startup rather than asking the user to.
+//! [`TARGET_OPEN_FILES`] is 10,240, the macOS `OPEN_MAX`, which leaves roughly
+//! eighteen times the measured ceiling in reserve. The raise never lowers a
+//! limit an operator already set higher, never touches the hard limit, which
+//! would need privilege Kin does not have and should not want, and says nothing
+//! when it works, because a limit that is now correct is not news.
+//!
+//! Windows has no `RLIMIT_NOFILE`. Its C runtime cap, `_setmaxstdio`, governs
+//! CRT file descriptors, and Rust's file APIs use handles rather than those, so
+//! there is nothing here for this module to raise and it is a no-op.
+
+/// The open-file soft limit Kin raises toward.
+///
+/// 10,240 is `OPEN_MAX` on macOS, the value `kern.maxfilesperproc` defaults to
+/// on a clean install, and comfortably above the 544 open files a full
+/// admission was measured to peak at.
+pub const TARGET_OPEN_FILES: u64 = 10_240;
+
+/// A process's open-file limit, as a caller writing an error message needs it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OpenFileLimit {
+    /// The limit in force now.
+    pub soft: u64,
+    /// The ceiling the soft limit may be raised to without privilege, or
+    /// `None` when the platform reports no ceiling at all.
+    pub hard: Option<u64>,
+}
+
+/// The soft limit to ask for, or `None` when the one in force is already at
+/// least as high as anything this would achieve.
+///
+/// Separated from the syscalls so the decision is testable. Every path that
+/// would not improve the limit returns `None`, so a process an operator already
+/// tuned is left exactly as it was found.
+fn target_soft_limit(current: OpenFileLimit) -> Option<u64> {
+    let ceiling = match current.hard {
+        Some(hard) => hard.min(TARGET_OPEN_FILES),
+        None => TARGET_OPEN_FILES,
+    };
+    (ceiling > current.soft).then_some(ceiling)
+}
+
+#[cfg(unix)]
+mod imp {
+    use super::OpenFileLimit;
+
+    /// Read this process's open-file limit, or `None` when the kernel refuses
+    /// to say.
+    pub fn read() -> Option<OpenFileLimit> {
+        // SAFETY: `getrlimit` fills a caller-owned `rlimit` this call owns for
+        // its whole lifetime, and reads nothing else.
+        let mut limits = unsafe { std::mem::zeroed::<libc::rlimit>() };
+        let read = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limits) };
+        if read != 0 {
+            return None;
+        }
+        Some(OpenFileLimit {
+            soft: limits.rlim_cur as u64,
+            hard: (limits.rlim_max != libc::RLIM_INFINITY).then_some(limits.rlim_max as u64),
+        })
+    }
+
+    /// Ask for `soft`, leaving the hard limit exactly as it was found.
+    ///
+    /// The hard limit is passed back unchanged rather than raised: raising it
+    /// takes privilege, and a Kin that asked for privilege to read a repository
+    /// would be a worse trade than a slow one.
+    fn request(soft: u64, hard: libc::rlim_t) -> bool {
+        let limits = libc::rlimit {
+            rlim_cur: soft as libc::rlim_t,
+            rlim_max: hard,
+        };
+        // SAFETY: `setrlimit` reads the caller-owned `rlimit` above and returns
+        // a status. It cannot fail in a way that leaves this process's limit
+        // partly applied; either the new pair is in force or the old one is.
+        unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &limits) == 0 }
+    }
+
+    /// Raise the soft limit toward the hard limit, best effort.
+    ///
+    /// macOS refuses `RLIM_INFINITY` for this resource and refuses anything
+    /// above `kern.maxfilesperproc`, which an administrator can lower. So a
+    /// refusal is answered by halving the request and asking again rather than
+    /// by giving up: the ladder bottoms out at the limit already in force, so
+    /// the worst outcome is the limit this process started with, and a machine
+    /// whose real ceiling sits between two rungs still gets the lower rung
+    /// instead of nothing. Six attempts carry 10,240 down below 256.
+    pub fn raise() {
+        let Some(current) = read() else {
+            return;
+        };
+        let Some(target) = super::target_soft_limit(current) else {
+            return;
+        };
+        let hard = match current.hard {
+            Some(hard) => hard as libc::rlim_t,
+            None => libc::RLIM_INFINITY,
+        };
+        let mut candidate = target;
+        while candidate > current.soft {
+            if request(candidate, hard) {
+                return;
+            }
+            candidate /= 2;
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::file_limit::TARGET_OPEN_FILES;
+
+        /// The ladder must be able to reach the floor, or a machine with a low
+        /// `kern.maxfilesperproc` would spin rather than settle.
+        #[test]
+        fn halving_from_the_target_reaches_the_default_macos_soft_limit() {
+            let mut candidate = TARGET_OPEN_FILES;
+            let mut steps = 0;
+            while candidate > 256 {
+                candidate /= 2;
+                steps += 1;
+            }
+            assert!(steps <= 6, "the ladder took {steps} steps to pass 256");
+        }
+
+        /// Reading the limit is the input to every decision above, so a
+        /// platform that cannot answer must be visible rather than assumed.
+        #[test]
+        fn this_process_reports_an_open_file_limit() {
+            let limit = read().expect("read this process's open-file limit");
+            assert!(limit.soft > 0, "a soft limit of zero cannot open a file");
+        }
+    }
+}
+
+#[cfg(not(unix))]
+mod imp {
+    use super::OpenFileLimit;
+
+    pub fn read() -> Option<OpenFileLimit> {
+        None
+    }
+
+    pub fn raise() {}
+}
+
+/// Raise this process's open-file soft limit toward its hard limit.
+///
+/// Call once, early, while the process is still single-threaded, from every
+/// binary a person runs. Silent on success and on failure alike: a failure is
+/// not yet a problem, and the command that actually runs out of descriptors is
+/// the one that can say so usefully.
+pub fn raise_open_file_limit() {
+    imp::raise();
+}
+
+/// This process's open-file limit as it stands now.
+///
+/// Read at the moment of failure rather than remembered from startup, so the
+/// number in an error message is the number that was in force.
+pub fn open_file_limit() -> Option<OpenFileLimit> {
+    imp::read()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_stock_macos_limit_is_raised_to_the_target() {
+        assert_eq!(
+            target_soft_limit(OpenFileLimit {
+                soft: 256,
+                hard: None
+            }),
+            Some(TARGET_OPEN_FILES)
+        );
+    }
+
+    #[test]
+    fn a_hard_limit_below_the_target_caps_the_request() {
+        assert_eq!(
+            target_soft_limit(OpenFileLimit {
+                soft: 256,
+                hard: Some(4096)
+            }),
+            Some(4096)
+        );
+    }
+
+    #[test]
+    fn a_limit_an_operator_already_raised_is_left_alone() {
+        assert_eq!(
+            target_soft_limit(OpenFileLimit {
+                soft: 1_048_576,
+                hard: None
+            }),
+            None
+        );
+        assert_eq!(
+            target_soft_limit(OpenFileLimit {
+                soft: TARGET_OPEN_FILES,
+                hard: Some(TARGET_OPEN_FILES)
+            }),
+            None
+        );
+    }
+
+    /// A pinned hard limit is the case the error path exists for: nothing can
+    /// be asked for, so nothing is.
+    #[test]
+    fn a_soft_limit_pinned_at_its_hard_limit_asks_for_nothing() {
+        assert_eq!(
+            target_soft_limit(OpenFileLimit {
+                soft: 256,
+                hard: Some(256)
+            }),
+            None
+        );
+    }
+
+    /// The measured ceiling of a full admission, with the margin named in the
+    /// module docs. If someone lowers the target below what an admission was
+    /// measured to need, this is what says so.
+    #[test]
+    fn the_target_clears_the_measured_admission_peak() {
+        const MEASURED_ADMISSION_PEAK: u64 = 544;
+        assert!(
+            TARGET_OPEN_FILES >= MEASURED_ADMISSION_PEAK * 8,
+            "the target leaves less than eight times the measured admission peak"
+        );
+    }
+}

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod entry_points;
 pub mod env_registry;
 pub mod error;
 pub mod exact_tree;
+pub mod file_limit;
 pub mod git_init;
 pub mod hooks;
 pub mod hydration_semantics;

--- a/crates/kin-daemon/src/bin/kin-daemon.rs
+++ b/crates/kin-daemon/src/bin/kin-daemon.rs
@@ -505,6 +505,11 @@ fn main() {
     }
 
     kin_buildinfo::retain_update_build_identity(&KIN_UPDATE_BUILD_IDENTITY);
+    // Raise this process's open-file soft limit before the runtime exists and
+    // before anything opens a store. A daemon inherits the limit of whatever
+    // started it, which on a stock Mac is 256, and it does the same storage
+    // work the CLI does. The CLI applies the SAME raise, so the two agree.
+    kin_core::file_limit::raise_open_file_limit();
     // Select this process's resource profile before the runtime exists: the
     // environment is mutated while the process is still single-threaded, and
     // ahead of the reads below that derive the embed worker's batch size and


### PR DESCRIPTION
`kin init` could not admit a real repository on a stock macOS install. macOS ships every machine with an open-file soft limit of 256, and one admission needs more, so the first repository anyone tried on a clean Mac died at step 9 of 17 with `Too many open files (os error 24)`. The only Macs this project had ever admitted on were tuned ones. Kin now raises its own soft limit at startup, and a stock 256-descriptor machine admits.

Fixes FIR-3116. Related: FIR-3113.

## What the measurement says

Measured before anything was written, on released kin 0.6.3, on a fresh clone of BurntSushi/ripgrep (237 files, 2,287 commits), under `ulimit -Sn <limit>`:

| soft limit | result | peak open files | step reached |
| -- | -- | -- | -- |
| 256 | fail, `os error 24` | (sampling raced the failure) | 9/17 copy Git objects |
| 384 | fail, `os error 24` | 315 | 9/17 copy Git objects |
| 512 | fail, `os error 24` | 499 | 9/17 copy Git objects |
| 576 | pass | 543 | 17/17 complete |
| 640 | pass | 543 | 17/17 complete |
| 768 | pass | 543 | 17/17 complete |
| 1024 | pass | 544 | 17/17 complete |

An `lsof` sample at the peak, bucketed by name: 258 handles on the retained kindb repository directory, 257 on `source-blobs/sha256/HH`, 29 everything else.

That is a cache saturating, not a leak and not repository-size scaling. `DeferredSourceDurability` in the storage layer keys a map by digest prefix, inserts on miss and clears only at flush. The prefix is one byte of hex, so there are exactly 256 keys, and each pinned capability holds two open directory descriptors. 256 times 2 is 512, plus about 30 of process baseline, which is the 543. The demand is the same at a 576 limit and at a 1,048,576 one.

Two things follow. Raising the soft limit to 10,240 is a permanent fix rather than a threshold that moves with the next bigger repository, because the ceiling cannot grow. And the real variable is digest-prefix coverage rather than file count, which is why the ticket's six-file fixture passed on the same machine while a 237-file and a 1,838-file repository failed identically.

## What changed

New `kin_core::file_limit`. It reads the limit, asks for `min(hard, 10240)`, and returns without a syscall when the soft limit is already that high, so a machine an operator tuned is left as found. It never touches the hard limit, which would need privilege. It is silent on success and on failure. A refusal is answered by halving the request and asking again, down to the limit already in force, because macOS refuses `RLIM_INFINITY` for this resource and refuses anything above `kern.maxfilesperproc`, which an administrator can lower.

Called first in `kin`'s `run()` and in `kin-daemon`'s `main()`, beside the resource-profile and PATH setup already there for the same single-threaded reason. `kin mcp start` is a subcommand of the `kin` binary, so the MCP server inherits it. `KinNotifier` is left alone; it posts notifications and touches no store.

New `kin_cli::open_files`, called from `broken_pipe::exit_status`, the single boundary every CLI error is rendered through. When the raise cannot help, the kernel refusal is now followed by:

```
kin: ran out of open file descriptors.
  open files: soft limit 256, hard limit 256.
  Kin raises the soft limit at startup and cannot go past the hard limit.
  Raise it for this shell with `ulimit -n 10240`, then run the command again.
  Raise it for the machine with `sudo launchctl limit maxfiles 10240 unlimited`.
```

Detection matches `EMFILE` or `ENFILE` on any `io::Error` still in the chain, and falls back to the sentence for the storage-layer path, which flattens its cause into a message string before this boundary sees it.

No kin-db change, so no kin-db release and no pin bump. The ticket offered bounding the copy's retained capabilities as a second fix. The measurement says it is not needed for this class: the copy is already bounded, by a constant that cannot grow.

## The guard

`crates/kin-cli/tests/stock_macos_file_limit.rs`. Both arms spawn the built `kin` binary through `sh -c 'ulimit ... && exec "$0" init --no-enrich "$1"'`, with the binary and repository as positional arguments so no path needs quoting, and chained with `&&` because `ulimit` reports a refusal on stderr and returns non-zero without stopping a `;` chain.

- `a_stock_soft_limit_admits_a_real_repository` sets the soft limit to 256 and requires success. That is the class.
- `a_pinned_hard_limit_names_the_limit_and_the_remedy` pins soft and hard at 256 so the raise cannot succeed, and requires the refusal to name what ran out, the limit in force and `ulimit -n`. It is also the first arm's control: if the fixture ever stops reaching the ceiling it starts passing, and it fails loudly saying the success arm has gone vacuous rather than going quiet.
- `the_fixture_shell_really_lowers_the_limit` asserts the shell applied the limit, since a silent failure there would leave both arms unbounded and passing for the wrong reason.

The fixture is 600 distinct file bodies in two commits, sized from the mechanism rather than from a file count: roughly 230 of the 256 prefixes, about 460 descriptors. Verified potent against released 0.6.3 at `ulimit -Sn 256` before the test was written, where it fails at step 9 in one second. The whole test binary runs in 13.7 seconds.

Beside them, 7 unit tests in `kin-core::file_limit` for the raise decision and 7 in `kin-cli::open_files` for detection and message content, one keyed to the exact rendered failure from a 0.6.3 run.

## Falsification

Every new test was broken on purpose and had to go red.

| mutation | success arm | refusal arm |
| -- | -- | -- |
| comment out `raise_open_file_limit()` in `run()` | FAILED | ok |
| remove the `open_files::remedy` call from `exit_status` | ok | FAILED |
| drop only the target number from the remedy, leaving `ulimit -n` in place | ok | FAILED |
| neither, control | ok | ok |

The third mutation is why the refusal arm now asserts the guidance verbatim (`fde0a86a2`). It used to check `stderr.contains("256")` and `stderr.contains("ulimit -n")`, and both are too loose: the store path in the failure already carries `sha256`, so the first passed without the limit being named at all, and the second passed on a remedy that had lost the one number the reader needs. The arm now asserts the exact lines the product prints, with the remedy composed from `TARGET_OPEN_FILES` so a changed target cannot leave it asserting a number that appears nowhere.

Each mutation reddens exactly the arm that guards it and leaves the other green, so neither test passes off the other's behavior. Both mutations were applied and reversed by exact string edit and the tree was verified restored. Full run after restore: 12 passed, 0 failed.

## Gates that ran

Locally, on this worktree:

- `cargo test -p kin-core -p kin-cli --lib` for the new modules: 14 passed.
- `cargo test -p kin-cli --test stock_macos_file_limit`: 12 passed in 13.7s.
- `cargo fmt -- --check`: clean.
- Clippy exactly as `fast-gate-lint` runs it, `cargo clippy --all-targets --all-features -- $allows` with the 45-lint allow list read from `.github/clippy-allowed-lints.txt`: clean.
- `scripts/changed-crate-scope.py` plus `cargo nextest list`, to confirm these tests are inside the selection `fast-gate-tests` runs on this PR rather than assuming it. Scope resolves to 7 packages including kin-cli, and all five new test names are listed. A control name that cannot exist was correctly absent.

On this PR, `Fast gate lint and policy` and `Fast gate test shard` 1 through 3 are the jobs that grade it. `Check & Test`, `Product Acceptance`, `Falsify guards`, `Code Coverage`, `Feature permutation tests` and the Windows jobs are all skipped on a pull request and run on main's push.

### The first round went red and the second commit is the fix

`Fast gate lint and policy` failed on `aca3617a1` with `clippy::assertions_on_constants`: a test asserted a margin between two constants, which can never fail at run time. Clippy was right.

My local clippy missed it because `ci.yml:40` sets `RUSTFLAGS: "-D warnings"` at workflow level, and I had run clippy without it. The lint fired locally too, as a warning, and `cargo clippy` exited 0. Copying the command out of the workflow is not enough when the severity lives in the job environment.

`d33a414ef` replaces the assertion with a `const` block that panics at compile time, which is stronger: lowering `TARGET_OPEN_FILES` now stops the build instead of reddening a test. Falsified by lowering it to 512, which fails with `E0080: evaluation panicked: TARGET_OPEN_FILES leaves less than eight times the measured admission peak`, then restoring it.

Re-running locally with `-D warnings` caught a second one that CI never reached, because its build stopped at the first error: `constant MEASURED_ADMISSION_PEAK is never used`. Dead-code analysis does not traverse an underscore-prefixed item, so a constant referenced only inside the guard reads as unused. The number is written in place now. Everything is green locally under `-D warnings`. No failed job was rerun.

`bin/kin-precheck kin` refused rather than grading: kin's `check` job now names `scripts/release-proof` and that tool has not been taught about it, so it exits 2 with no tally. That is a refusal, not a red gate, and the fix is one entry in the umbrella's `bin/kin-precheck`, which is outside this lane. The gates above were read out of `ci.yml` by hand instead.
