### PR TITLE
Cut a release on the machine proof and gate Latest on first contact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1122,6 +1122,8 @@ jobs:
             scripts/check-kin-vfs-compat.test.mjs \
             scripts/check-rc-build-drift.test.mjs \
             scripts/check-release-proof-artifacts.test.mjs \
+            scripts/release-promotion-plan.test.mjs \
+            scripts/read-promotion-plan.test.mjs \
             scripts/release-train-body.test.mjs \
             scripts/check-release-version.test.mjs \
             scripts/release-intent.test.mjs \
@@ -1695,6 +1697,8 @@ jobs:
             scripts/check-kin-vfs-compat.test.mjs \
             scripts/check-rc-build-drift.test.mjs \
             scripts/check-release-proof-artifacts.test.mjs \
+            scripts/release-promotion-plan.test.mjs \
+            scripts/read-promotion-plan.test.mjs \
             scripts/release-train-body.test.mjs \
             scripts/check-release-version.test.mjs \
             scripts/release-intent.test.mjs \

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -578,9 +578,16 @@ jobs:
     needs: select
     if: needs.select.outputs.decision == 'stranger' && vars.KIN_STRANGER_RUNNER != ''
     runs-on: ${{ vars.KIN_STRANGER_RUNNER }}
-    # Three concurrent arms at phase caps of 3600 s and 7200 s, plus image and
-    # container setup. Six hours is headroom, not an expectation.
-    timeout-minutes: 360
+    # Three concurrent arms plus image and container setup. The arms run
+    # concurrently, so the wall clock is one phase 1 plus one phase 2, not three
+    # of each.
+    #
+    # A local endpoint gets a longer ceiling because it has longer phase
+    # budgets. bin/kin-stranger scales a local run's caps to 10800 s and 21600 s
+    # from a measured turn rate 4.7 to 9.7 times an account turn, so nine hours
+    # of arm can sit under a six-hour job and be cut by the job instead. Ten
+    # hours is headroom over that, and neither number is an expectation.
+    timeout-minutes: ${{ vars.KIN_STRANGER_LOCAL_MODEL != '' && 600 || 360 }}
     permissions:
       actions: read
       contents: read
@@ -590,6 +597,7 @@ jobs:
       - name: Refuse before spending an arm on a missing credential
         env:
           STRANGER_KEY: ${{ secrets.KIN_STRANGER_ANTHROPIC_API_KEY }}
+          LOCAL_MODEL: ${{ vars.KIN_STRANGER_LOCAL_MODEL }}
           UMBRELLA: ${{ vars.KIN_STRANGER_UMBRELLA }}
         run: |
           set -euo pipefail
@@ -597,8 +605,20 @@ jobs:
           # driver request out unauthenticated and the transcript records only a
           # server error, hours in; an absent umbrella fails at the first docker
           # exec with the same delay. Neither is worth discovering late.
-          if [ -z "${STRANGER_KEY:-}" ]; then
-            echo "::error::the repository secret KIN_STRANGER_ANTHROPIC_API_KEY is not set, so the stranger driver has no credential. Set it, or clear the KIN_STRANGER_RUNNER variable so the cut prints the local command instead."
+          #
+          # The key is required only on the ACCOUNT path. Naming
+          # vars.KIN_STRANGER_LOCAL_MODEL points the driver at an Anthropic
+          # Messages endpoint on the runner itself, and driver_env_argv then
+          # UNSETS ANTHROPIC_API_KEY for the driver child, because Claude Code
+          # prefers that key over ANTHROPIC_AUTH_TOKEN and a host carrying one
+          # would hand a local server a real credential and read back a 401
+          # nobody could place. Requiring a secret the run then throws away is
+          # how a rail stays blocked on a founder step it does not need.
+          if [ -n "${LOCAL_MODEL:-}" ]; then
+            echo "local endpoint: this cut drives the arms with '${LOCAL_MODEL}' on the runner, not the account"
+            echo "KIN_STRANGER_LOCAL_MODEL=${LOCAL_MODEL}" >> "$GITHUB_ENV"
+          elif [ -z "${STRANGER_KEY:-}" ]; then
+            echo "::error::no driver credential: the repository secret KIN_STRANGER_ANTHROPIC_API_KEY is not set and the variable KIN_STRANGER_LOCAL_MODEL names no local model. Set one of them, or clear KIN_STRANGER_RUNNER so the cut prints the local command instead."
             exit 1
           fi
           umbrella="${UMBRELLA:-$HOME/GitHub/kin-ecosystem}"
@@ -648,6 +668,10 @@ jobs:
           # untouched and Claude Code prefers it over ANTHROPIC_AUTH_TOKEN.
           # Exporting the secret is the whole integration; the harness needs no
           # change, which is why this job adds no --driver flag.
+          #
+          # On the local path the same variable is still exported and the same
+          # function still unsets it for the driver child, so this line is safe
+          # either way and there is exactly one place the key can reach.
           ANTHROPIC_API_KEY: ${{ secrets.KIN_STRANGER_ANTHROPIC_API_KEY }}
           CANDIDATE: ${{ needs.select.outputs.candidate }}
           VERSION: ${{ needs.select.outputs.version }}
@@ -670,9 +694,17 @@ jobs:
             # two-arm runs were refused at the mint, and evidence is
             # append-only, so a record missing an arm cannot be replaced.
             bin/kin-stranger prepare --run "$run_id" --arms green,brown,vcs
+            # One argv element per flag, built as an array, so an empty local
+            # model contributes nothing rather than an empty string the tool
+            # would read as a model named "".
+            local_flags=()
+            if [ -n "${KIN_STRANGER_LOCAL_MODEL:-}" ]; then
+              local_flags=(--local-model "$KIN_STRANGER_LOCAL_MODEL")
+            fi
             bin/kin-stranger run --run "$run_id" \
               --archive "$KIN_STRANGER_ARCHIVE" \
-              --candidate-sha "$CANDIDATE"
+              --candidate-sha "$CANDIDATE" \
+              "${local_flags[@]+"${local_flags[@]}"}"
           fi
           record="${root}/run.env"
           if [ ! -s "$record" ]; then
@@ -822,6 +854,19 @@ jobs:
             echo "gh variable set KIN_STRANGER_RUNNER --repo ${GITHUB_REPOSITORY} --body '<runner label>'"
             echo "gh secret set KIN_STRANGER_ANTHROPIC_API_KEY --repo ${GITHUB_REPOSITORY}"
             echo '```'
+            echo ""
+            echo "The secret is one of two ways to give the driver a credential, and the other"
+            echo "needs no secret at all. Naming a model the runner already serves points the"
+            echo "driver at an Anthropic Messages endpoint on that machine, and the harness then"
+            echo "unsets \`ANTHROPIC_API_KEY\` for the driver child, so no key is involved:"
+            echo ""
+            echo '```'
+            echo "gh variable set KIN_STRANGER_LOCAL_MODEL --repo ${GITHUB_REPOSITORY} --body '<model id the runner serves>'"
+            echo '```'
+            echo ""
+            echo "A local-model stranger is a WEAKER stranger. Its findings stand on their own"
+            echo "evidence; an empty finding list from it does not, and the record says which"
+            echo "driver produced it so no reader has to guess."
           } >> "$GITHUB_STEP_SUMMARY"
           echo "::warning::${CANDIDATE} has its preflight record and needs the stranger; no KIN_STRANGER_RUNNER is set, so the command is in this run's summary and a captain has to run it"
 

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -43,7 +43,18 @@ jobs:
     name: Promote proven releases to Latest
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    environment: release
+    # release-tag, not release, and the difference is load-bearing rather than
+    # cosmetic. The `release` environment's deployment branch policy admits
+    # `tag: v*.*.*` ONLY, so a job reaching it from a scheduled run on main is
+    # refused by the server before a step executes, every fifteen minutes,
+    # forever. `release-tag` admits `branch: main`, which is exactly the policy
+    # an automatic controller running from protected main needs, and it is what
+    # release-cut.yml's three credentialed jobs already use for the same reason.
+    #
+    # Found by reading the two policies rather than by reasoning about the
+    # names. Nothing in this file would have hinted at it, and the failure would
+    # have arrived on a release night.
+    environment: release-tag
     permissions:
       # One release flip and one body edit.
       contents: write

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+name: Release Promotion
+
+# Finishes a release whose first-contact proof arrived after its tag.
+#
+# The release chain has two tiers. release-tag.yml mints a tag on the machine
+# preflight alone, so a candidate is never held hostage to a driver; release.yml
+# publishes it as a prerelease and writes into its body that first-contact proof
+# is pending. GitHub Latest, which is what an installer resolves when a stranger
+# types the install line, still requires the complete stranger record.
+#
+# Without this workflow that second tier would be a dead end: the record lands
+# on the evidence branch hours later and nothing would notice. A push to the
+# release-evidence branch cannot trigger anything either, because that branch is
+# an orphan carrying no workflow files, so GitHub resolves no workflow from the
+# pushed ref. Hence a sweep.
+on:
+  # Offset from the train (7,22,37,52), recovery and the cut (3,18,33,48) and
+  # the sentinel (11,41), so this reads a settled rail rather than one
+  # mid-reconcile.
+  schedule:
+    - cron: "9,24,39,54 * * * *"
+  # For a captain who has just published a record and does not want to wait a
+  # quarter of an hour. Typed rather than a workflow_dispatch: a dispatch takes
+  # a ref, and this job reaches a credential that can flip a release.
+  repository_dispatch:
+    types: [release_promote]
+
+permissions:
+  contents: read
+
+# The same group release.yml holds, so a promotion can never run while a release
+# run is mid-flight on the tag it would flip. Serialized rather than cancelled,
+# because a cancelled promotion leaves a proven release un-promoted and silent.
+concurrency:
+  group: kin-release-promotion
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Promote proven releases to Latest
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: release
+    permissions:
+      # One release flip and one body edit.
+      contents: write
+      # The alarm, which is the only thing standing between a forgotten release
+      # and a rail that is quietly one version behind forever.
+      issues: write
+    steps:
+      - name: Checkout release policy
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Judge every held release, and write down what was decided before
+      # anything is changed. The plan is a file rather than a set of step
+      # outputs so a reader of a finished run can see exactly what this tick
+      # believed, including the releases it decided NOT to touch.
+      #
+      # The judging lives in scripts/release-promotion-plan.mjs rather than in
+      # this file. A sixty-line inline validator inside a YAML string is not
+      # reachable by `node --check` or by any test, and the first draft of this
+      # step carried a syntax error nothing here would have caught.
+      - name: Plan the promotions
+        id: plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KIN_PROMOTION_PLAN: ${{ runner.temp }}/promotion-plan.json
+        run: |
+          set -euo pipefail
+          node scripts/release-promotion-plan.mjs
+          test -s "$KIN_PROMOTION_PLAN"
+          {
+            echo "### Release promotion plan"
+            echo
+            echo '```json'
+            cat "$KIN_PROMOTION_PLAN"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Promote every release whose proof is now complete
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KIN_PROMOTION_PLAN: ${{ runner.temp }}/promotion-plan.json
+        run: |
+          set -euo pipefail
+          # zsh is not the shell here, but the same discipline applies: read the
+          # list one line at a time rather than word-splitting it.
+          while IFS=$'\t' read -r tag driver; do
+            [ -n "$tag" ] || continue
+            echo "::notice::promoting $tag to GitHub Latest; first-contact proof complete, driven on the ${driver} endpoint"
+            version="${tag#v}"
+            channel="$(node scripts/release-order.mjs channel "$version")"
+            # The same npm and rollback checks release.yml makes before it flips
+            # a release, run again here because this path reaches Latest too and
+            # a second door with a lower bar is not a second door, it is the bar.
+            for package in @kinlab/kin @kinlab/kin-mcp; do
+              npm_version="$(node scripts/release-order.mjs npm-channel "$package" "$channel")"
+              if [ "$npm_version" != "$version" ]; then
+                echo "::error::npm ${package}@${channel} serves ${npm_version}; ${tag} stays a prerelease"
+                exit 1
+              fi
+            done
+            current_tag="$(node scripts/release-order.mjs github-latest "$GITHUB_REPOSITORY")"
+            node scripts/release-order.mjs assert-not-rollback \
+              "$version" "${current_tag#v}" "GitHub Latest"
+
+            # Take the pending notice back out. A promoted release that still
+            # says its proof is pending is a false claim in the other direction,
+            # and the marker is what a later sweep keys on.
+            gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json body --jq '.body' \
+              | node scripts/read-promotion-plan.mjs strip-notice > "$RUNNER_TEMP/promoted-body.md"
+            gh release edit "$tag" --repo "$GITHUB_REPOSITORY" \
+              --notes-file "$RUNNER_TEMP/promoted-body.md"
+            gh release edit "$tag" --repo "$GITHUB_REPOSITORY" --prerelease=false --latest
+
+            # Read it back. A 200 from the edit is not the same fact as a
+            # release that is actually Latest.
+            actual="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" --jq '.prerelease')"
+            latest="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name')"
+            if [ "$actual" != "false" ] || [ "$latest" != "$tag" ]; then
+              echo "::error::${tag} did not become Latest: prerelease=${actual}, latest=${latest}"
+              exit 1
+            fi
+            echo "${tag} is GitHub Latest"
+          done < <(node scripts/read-promotion-plan.mjs promotions)
+
+      # The alarm runs whatever the promotion did, because the releases it
+      # reports are exactly the ones the promotion could NOT touch.
+      - name: Report releases still waiting for first-contact proof
+        if: ${{ always() && steps.plan.outcome == 'success' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KIN_PROMOTION_PLAN: ${{ runner.temp }}/promotion-plan.json
+        run: |
+          set -euo pipefail
+          node scripts/read-promotion-plan.mjs alarm \
+            --body "$RUNNER_TEMP/alarm-body.md" > "$RUNNER_TEMP/alarm-decision.txt"
+          IFS=$'\t' read -r action number title < "$RUNNER_TEMP/alarm-decision.txt"
+          case "$action" in
+            open)
+              # The label is how the next sweep finds this issue in a bounded
+              # read rather than paging every open issue, so it has to exist
+              # before the issue does. `--force` makes this idempotent; a
+              # missing label would otherwise fail the create and leave the
+              # alarm silent, which is the one outcome this job exists to
+              # prevent.
+              gh label create release-proof --repo "$GITHUB_REPOSITORY" --force \
+                --color B60205 \
+                --description "A published release is waiting for first-contact proof"
+              gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" \
+                --label release-proof --body-file "$RUNNER_TEMP/alarm-body.md"
+              ;;
+            update)
+              gh issue comment "$number" --repo "$GITHUB_REPOSITORY" \
+                --body-file "$RUNNER_TEMP/alarm-body.md"
+              ;;
+            close)
+              gh issue close "$number" --repo "$GITHUB_REPOSITORY" \
+                --comment "Every published release now carries complete first-contact proof, or is already GitHub Latest."
+              ;;
+            none)
+              echo "no release is overdue for first-contact proof"
+              ;;
+            *)
+              echo "::error::the promotion plan asked for an alarm action this job does not know: ${action}"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1712,6 +1712,36 @@ jobs:
 
       # The proof-loop refusal, on the artifact it is actually about.
       #
+      # WHAT THIS GATE REQUIRES BEFORE A TAG, AND WHAT IT NO LONGER DOES.
+      #
+      # It requires the machine proof: a preflight record that judged THIS
+      # candidate's own bytes, PASS on every leg, with an archive sha256 per leg.
+      # That record can always exist before a tag, because rc-build produces the
+      # archives and release-cut publishes the judgement with nobody at the
+      # button.
+      #
+      # It no longer requires the stranger. Until 2026-09-02 it did, and the
+      # consequence was that a release the account's weekly limit stopped could
+      # not be cut at all: run rc0551 died on `"rateLimitType": "seven_day"` with
+      # a proven candidate waiting, and the only signal was a hold alarm. A gate
+      # whose failure mode is "no tag, forever, quietly" is not protecting the
+      # release, it is preventing it.
+      #
+      # What replaces it is not less proof, it is proof at the point the claim is
+      # made. A tag is not a claim of first-contact coverage; GitHub Latest is,
+      # because that is the version an installer resolves. release.yml's
+      # finalize_release still requires the complete stranger record before it
+      # flips a release out of prerelease, so a release with no first-contact
+      # proof exists, is installable by anyone who names it, and never becomes
+      # the one a stranger gets by default. The record cannot claim coverage it
+      # does not have, and the release stops being hostage to a driver.
+      #
+      # `require: preflight` narrows exactly one condition: an ABSENT
+      # stranger.env becomes a reported pending state. A stranger record that
+      # exists is judged here exactly as it always was, and an unreadable one
+      # still fails closed, so this relaxation cannot be used to ship a record
+      # that is wrong rather than missing.
+      #
       # On 2026-08-20 the train merged its own bump kin#986, tagged v0.5.44 and
       # promoted it to Latest with no preflight record for that candidate and no
       # stranger run on its bytes. The gate that closed that hole lived in
@@ -1767,15 +1797,23 @@ jobs:
           # reports it, because a stack trace buries the sentence that says
           # which record was missing and an operator reading a blocked release
           # needs that sentence first.
+          # The whole result goes to a file and only the sha goes to stdout, so
+          # the comparison below still reads one thing and cannot mistake a
+          # second line for a candidate.
+          record="$RUNNER_TEMP/release-proof.json"
           proven="$(KIN_RELEASE_GATE="file://${gate}" \
             CANDIDATE_SHA="$SHA" \
             GITHUB_REPOSITORY="$REPO" \
+            KIN_RELEASE_REQUIRE=preflight \
+            KIN_RELEASE_RECORD="$record" \
             node --input-type=module -e '
+              import { writeFileSync } from "node:fs";
               const { main } = await import(process.env.KIN_RELEASE_GATE);
               try {
                 const result = await main({
                   log: (line) => process.stderr.write(line + "\n"),
                 });
+                writeFileSync(process.env.KIN_RELEASE_RECORD, JSON.stringify(result));
                 process.stdout.write(result.sha);
               } catch (error) {
                 process.stderr.write("::error::" + error.message + "\n");
@@ -1795,6 +1833,37 @@ jobs:
             echo "::error::the tagged tree is not the proven tree; these paths differ between $proven and $SHA:"
             printf '%s\n' "$delta"
             exit 1
+          fi
+          # What the release is allowed to say about itself, decided here and
+          # written down, rather than re-derived by every later reader.
+          #
+          # An unreadable result file is a refusal, not an unknown: this step
+          # wrote it one command ago, so a file that will not parse means the
+          # gate did something other than what this job believes it did.
+          state="$(STATE_RECORD="$record" node --input-type=module -e '
+            import { readFileSync } from "node:fs";
+            const r = JSON.parse(readFileSync(process.env.STATE_RECORD, "utf8"));
+            const s = r.stranger ?? {};
+            const driver = s.driver?.endpoint ?? "unrecorded";
+            process.stdout.write([s.state ?? "unknown", driver, (s.arms ?? []).join("+") || "none"].join(" "));
+          ')"
+          read -r stranger_state stranger_driver stranger_arms <<< "$state"
+          case "$stranger_state" in
+            complete|pending) ;;
+            *) echo "::error::the proof gate reported stranger state '${stranger_state}', which this job does not know how to record"; exit 1 ;;
+          esac
+          {
+            echo "stranger_state=$stranger_state"
+            echo "stranger_driver=$stranger_driver"
+            echo "stranger_arms=$stranger_arms"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$stranger_state" = pending ]; then
+            # A warning, not an error. The release proceeds and says what it is
+            # missing; a red run here would put the rail back where it was.
+            echo "::warning::first-contact proof is PENDING for $SHA: no stranger.env exists, so $TAG will be published as a prerelease and will not become GitHub Latest until the stranger record lands"
+          else
+            echo "::notice::first-contact proof complete for $SHA on arms ${stranger_arms}, driven on the ${stranger_driver} endpoint"
           fi
           echo "release proof records verified for $SHA, and the tagged tree is the proven tree"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2524,7 +2524,16 @@ jobs:
       # gap nobody outside this run can see, and a prerelease with no
       # explanation reads as an accident rather than as a decision.
       - name: Record the missing first-contact proof on the release itself
-        if: ${{ steps.proof.outputs.stranger_state == 'pending' }}
+        # Stable tags only. A prerelease TAG is a prerelease because that is
+        # what it is, not because proof is missing, and it never becomes Latest
+        # whatever its record says. Telling a reader that an rc "stays a
+        # prerelease until its record lands" would promise something no path in
+        # this chain delivers.
+        if: >-
+          ${{
+            steps.proof.outputs.stranger_state == 'pending' &&
+            !contains(github.ref_name, '-')
+          }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2389,6 +2389,14 @@ jobs:
       }}
     runs-on: ubuntu-latest
     environment: release
+    # Whether this release actually became GitHub Latest, for the jobs whose
+    # whole meaning is "this IS Latest". They gate on it rather than on this
+    # job's conclusion, because a release held as a prerelease for want of
+    # first-contact proof is a SUCCESSFUL run of this job and a release that
+    # must not move GHCR's `latest` or be sealed as a completed stable release.
+    outputs:
+      promoted: ${{ steps.promote.outputs.promoted }}
+      stranger_state: ${{ steps.proof.outputs.stranger_state }}
     permissions:
       contents: write
       # Resolving the pull request behind the tagged commit, which is how the
@@ -2431,7 +2439,23 @@ jobs:
       # tree, which is exactly the approximation this rekey removes. With it,
       # a bridged answer can only ever shape a refusal; it can no longer admit
       # one.
+      #
+      # WHY THIS GATE READS `preflight` AND STILL BLOCKS LATEST.
+      #
+      # `require: preflight` does not lower this job's bar. It changes what an
+      # ABSENT stranger record does: instead of throwing here, it comes back as
+      # a reported pending state that the steps below act on. Every other
+      # stranger failure -- unreadable, about another build, an incomplete arm,
+      # bytes no preflight leg judged -- still throws exactly as before.
+      #
+      # The distinction the release chain now makes is between a tag and Latest.
+      # A tag is an artifact somebody must name to install. Latest is what an
+      # installer resolves when a stranger types the install line, so Latest is
+      # the claim of first-contact coverage and Latest is where the stranger
+      # record is required. A pending release is published, installable, and
+      # marked prerelease until its record lands.
       - name: Require proof-loop artifacts for the tagged candidate
+        id: proof
         env:
           GH_TOKEN: ${{ github.token }}
           CANDIDATE_SHA: ${{ github.sha }}
@@ -2443,14 +2467,20 @@ jobs:
           # The gate's narration goes to stderr so stdout carries exactly the
           # sha it verified and nothing the comparison below could mistake for
           # one, and a refusal is reported as the sentence naming what was
-          # missing rather than as a stack trace.
+          # missing rather than as a stack trace. The rest of the result goes to
+          # a file for the same reason.
+          record="$RUNNER_TEMP/release-proof.json"
           proven="$(KIN_RELEASE_GATE="file://${gate}" \
+            KIN_RELEASE_REQUIRE=preflight \
+            KIN_RELEASE_RECORD="$record" \
             node --input-type=module -e '
+              import { writeFileSync } from "node:fs";
               const { main } = await import(process.env.KIN_RELEASE_GATE);
               try {
                 const result = await main({
                   log: (line) => process.stderr.write(line + "\n"),
                 });
+                writeFileSync(process.env.KIN_RELEASE_RECORD, JSON.stringify(result));
                 process.stdout.write(result.sha);
               } catch (error) {
                 process.stderr.write("::error::" + error.message + "\n");
@@ -2465,14 +2495,90 @@ jobs:
             echo "::error::the proof gate verified $proven but this job promotes $CANDIDATE_SHA; refusing to flip a tag to Latest on evidence about a different commit"
             exit 1
           fi
+          state="$(STATE_RECORD="$record" node --input-type=module -e '
+            import { readFileSync } from "node:fs";
+            const r = JSON.parse(readFileSync(process.env.STATE_RECORD, "utf8"));
+            const s = r.stranger ?? {};
+            const driver = s.driver?.endpoint ?? "unrecorded";
+            process.stdout.write([s.state ?? "unknown", driver, (s.arms ?? []).join("+") || "none"].join(" "));
+          ')"
+          read -r stranger_state stranger_driver stranger_arms <<< "$state"
+          case "$stranger_state" in
+            complete|pending) ;;
+            *) echo "::error::the proof gate reported stranger state '${stranger_state}', which this job does not know how to act on"; exit 1 ;;
+          esac
+          {
+            echo "stranger_state=$stranger_state"
+            echo "stranger_driver=$stranger_driver"
+            echo "stranger_arms=$stranger_arms"
+          } >> "$GITHUB_OUTPUT"
           echo "release proof records verified for $CANDIDATE_SHA, the commit this job promotes"
+          if [ "$stranger_state" = pending ]; then
+            echo "::warning::first-contact proof is PENDING for ${GITHUB_REF_NAME}; this release stays a prerelease and will not become GitHub Latest until its stranger.env lands"
+          else
+            echo "::notice::first-contact proof complete on arms ${stranger_arms}, driven on the ${stranger_driver} endpoint"
+          fi
 
-      - name: Promote stable tag after public and npm proof
-        if: ${{ !contains(github.ref_name, '-') }}
+      # The release says what it is missing, in the release, where a human
+      # reading it will see it. A gap that lives only in a CI annotation is a
+      # gap nobody outside this run can see, and a prerelease with no
+      # explanation reads as an accident rather than as a decision.
+      - name: Record the missing first-contact proof on the release itself
+        if: ${{ steps.proof.outputs.stranger_state == 'pending' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          marker='<!-- kin-first-contact-proof -->'
+          body="$(gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --json body --jq '.body')"
+          # Idempotent: a recovery re-run of this job must not stack the notice.
+          if printf '%s' "$body" | grep -qF "$marker"; then
+            echo "the release already carries the first-contact notice"
+            exit 0
+          fi
+          # Unquoted heredoc on purpose: the marker has exactly one definition
+          # and the notice interpolates it, so the grep above and the text below
+          # cannot drift into an idempotency check that never matches. There is
+          # no other expansion in this text.
+          cat > "$RUNNER_TEMP/release-body.md" <<NOTE
+          ${marker}
+          > **First-contact proof pending.** This release cleared the machine preflight on its
+          > own bytes. It has NOT been through the stranger arms (green, brown, vcs) that
+          > measure what a first-time user actually meets. It stays a prerelease and is not
+          > GitHub Latest until that record lands. Install it only if you meant this exact
+          > version.
+
+          NOTE
+          printf '%s\n' "$body" >> "$RUNNER_TEMP/release-body.md"
+          gh release edit "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
+            --notes-file "$RUNNER_TEMP/release-body.md"
+
+      # Latest is the claim of first-contact coverage, so this is where the
+      # stranger record is required. `promoted` is written on BOTH paths,
+      # because a downstream job reading an unset output cannot tell "held" from
+      # "this step never ran".
+      - name: Promote stable tag after public and npm proof
+        id: promote
+        if: ${{ !contains(github.ref_name, '-') }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STRANGER_STATE: ${{ steps.proof.outputs.stranger_state }}
+        run: |
+          set -euo pipefail
+          if [ "$STRANGER_STATE" != complete ]; then
+            echo "promoted=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::holding ${GITHUB_REF_NAME} as a prerelease: first-contact proof is ${STRANGER_STATE}"
+            {
+              echo "### GitHub Latest held"
+              echo
+              echo "\`${GITHUB_REF_NAME}\` is published and installable, and is NOT GitHub Latest."
+              echo "Its stranger record is \`${STRANGER_STATE}\`, so nothing here has been through the"
+              echo "green, brown and vcs first-contact arms. Latest moves on its own once that record"
+              echo "lands under this commit on the release-evidence branch."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "promoted=true" >> "$GITHUB_OUTPUT"
           version="${GITHUB_REF_NAME#v}"
           channel="$(node scripts/release-order.mjs channel "$version")"
           for package in @kinlab/kin @kinlab/kin-mcp; do
@@ -2495,13 +2601,19 @@ jobs:
       - name: Verify final release channel
         env:
           GH_TOKEN: ${{ github.token }}
+          PROMOTED: ${{ steps.promote.outputs.promoted }}
         run: |
           set -euo pipefail
           actual="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}" --jq '.prerelease')"
           expected=true
           case "$GITHUB_REF_NAME" in
             *-*) ;;
-            *) expected=false ;;
+            # A stable tag whose first-contact proof is still pending stays a
+            # prerelease ON PURPOSE, so this verification expects what the
+            # promote step above actually decided rather than what the tag's
+            # shape alone would imply. Read off that step's own output, so a
+            # promotion that silently failed to happen still fails here.
+            *) [ "${PROMOTED:-}" = true ] && expected=false ;;
           esac
           if [ "$actual" != "$expected" ]; then
             echo "::error::release prerelease=$actual, expected $expected after proof"
@@ -2531,6 +2643,7 @@ jobs:
         needs.build_daemon_image.result == 'success' &&
         needs.attest_daemon_image.result == 'success' &&
         needs.config.outputs.release_channel == 'latest' &&
+        needs.finalize_release.outputs.promoted == 'true' &&
         startsWith(github.ref, 'refs/tags/v') &&
         !contains(github.ref_name, '-')
       }}
@@ -3103,6 +3216,7 @@ jobs:
         needs.publish_boundary_contracts.result == 'success' &&
         needs.version_tag_image.result == 'success' &&
         needs.config.outputs.release_channel == 'latest' &&
+        needs.finalize_release.outputs.promoted == 'true' &&
         startsWith(github.ref, 'refs/tags/v') &&
         !contains(github.ref_name, '-')
       }}

--- a/scripts/check-release-proof-artifacts.mjs
+++ b/scripts/check-release-proof-artifacts.mjs
@@ -43,6 +43,30 @@ export const STRANGER_RECORD = 'stranger.env';
 // these names into run.env, so this is a contract with the proof harness rather
 // than a prose convention in a release note.
 export const REQUIRED_STRANGER_ARMS = Object.freeze(['green', 'brown', 'vcs']);
+// What a caller may require. 'all' is the historical contract and stays the
+// default, so a caller that says nothing is judged exactly as it was before
+// this mode existed. 'preflight' is the release TAG's contract: the machine
+// proof must exist, and a missing first-contact record is reported as pending
+// rather than thrown, because a tag that cannot be cut cannot be proven either
+// and the fleet spent 2026-09-02 discovering that a stranger the account's
+// weekly limit stopped is a release nobody can ship.
+//
+// The narrowing is exactly one condition wide. An unreadable stranger record, a
+// record about another build, a record with an incomplete arm and a record on
+// bytes no preflight leg judged all still refuse in BOTH modes. Only ABSENCE
+// becomes pending, and only under 'preflight'. "We could not tell" must never
+// widen into "proceed".
+export const REQUIRE_MODES = Object.freeze(['all', 'preflight']);
+// The stranger record's own statement of which driver produced it.
+// bin/kin-stranger writes driver_endpoint on every run; records written before
+// that key existed carry only `endpoint`, which says the same thing under a
+// name a gate would have to know to look for.
+export const DRIVER_ENDPOINT_FIELD = 'driver_endpoint';
+export const LEGACY_DRIVER_ENDPOINT_FIELD = 'endpoint';
+// The endpoint whose proof this release chain was designed around. Every other
+// value is a real record and a weaker one, and the difference has to reach the
+// operator rather than being flattened into "a stranger ran".
+export const REFERENCE_DRIVER_ENDPOINT = 'account';
 // The release train's version bump branch, and the ONLY branch whose head ever
 // carried proof records. It bounds the bridge below. release-train.yml declares
 // the same literal, and the authority suite pins the two together so they
@@ -179,6 +203,85 @@ export function judgePreflight(record, sha) {
 // it let a partial local-model run look like release evidence. Require the
 // harness's explicit coverage fields, refuse any incomplete arm, and preserve
 // the complete arm set in the returned result for callers and logs.
+// Which driver produced this record, said out loud.
+//
+// A local-model stranger and an opus stranger both write a stranger.env with
+// the same keys, the same arms and the same archive sha256. Before this
+// function the gate read those two records identically and logged one sentence
+// for both, so a release proven by a 4-bit model on this laptop and a release
+// proven by the account were indistinguishable to every downstream reader. The
+// findings such a run reports are real; what does not carry over is the
+// ABSENCE of findings, and a record that cannot say which driver produced it
+// cannot support that distinction at all.
+//
+// Absence and emptiness are different answers on purpose. A record with neither
+// key was written by a tool too old to say, which is a knowable historical
+// fact; a record carrying `driver_endpoint=` claims to answer and does not, and
+// a field that answers with nothing is worse than one that is missing, because
+// only the second is obviously unanswered.
+export function readDriverEndpoint(env, sha) {
+  const where = evidencePath(sha, STRANGER_RECORD);
+  const present = (field) =>
+    Object.prototype.hasOwnProperty.call(env ?? {}, field);
+  const read = (field) => {
+    const raw = env[field];
+    if (typeof raw !== 'string') {
+      throw new Error(
+        `${where} carries a non-text ${field}, so which driver produced it is unknown`,
+      );
+    }
+    const value = raw.trim();
+    if (!value) {
+      throw new Error(
+        `${where} carries an empty ${field}; a record that claims to name its ` +
+        'driver and names nothing is not evidence about which driver ran',
+      );
+    }
+    return value;
+  };
+
+  const hasCurrent = present(DRIVER_ENDPOINT_FIELD);
+  const hasLegacy = present(LEGACY_DRIVER_ENDPOINT_FIELD);
+  if (!hasCurrent && !hasLegacy) {
+    // Not an error. Every record published before bin/kin-stranger learned the
+    // key is shaped this way, and refusing them would rewrite history rather
+    // than describe it.
+    return { endpoint: null, field: null, reference: false };
+  }
+  const current = hasCurrent ? read(DRIVER_ENDPOINT_FIELD) : null;
+  const legacy = hasLegacy ? read(LEGACY_DRIVER_ENDPOINT_FIELD) : null;
+  if (current !== null && legacy !== null && current !== legacy) {
+    throw new Error(
+      `${where} records ${DRIVER_ENDPOINT_FIELD}=${current} and ` +
+      `${LEGACY_DRIVER_ENDPOINT_FIELD}=${legacy}; the record disagrees with ` +
+      'itself about which driver produced it, so neither value can be believed',
+    );
+  }
+  const endpoint = current ?? legacy;
+  return {
+    endpoint,
+    field: current !== null ? DRIVER_ENDPOINT_FIELD : LEGACY_DRIVER_ENDPOINT_FIELD,
+    reference: endpoint === REFERENCE_DRIVER_ENDPOINT,
+  };
+}
+
+// One sentence naming the driver, for a log line and for a release note.
+// Written here rather than at each caller so the mint, the promotion gate and
+// the release body cannot describe the same record three different ways.
+export function describeDriver(driver) {
+  if (!driver || driver.endpoint === null) {
+    return 'by a driver the record does not name (written before the harness recorded one)';
+  }
+  if (driver.reference) {
+    return `on the ${driver.endpoint} endpoint`;
+  }
+  return (
+    `on the ${driver.endpoint} endpoint, which is a WEAKER stranger than the ` +
+    `${REFERENCE_DRIVER_ENDPOINT} one: its findings stand, an empty finding ` +
+    'list from it does not'
+  );
+}
+
 export function judgeStranger(env, sha, archives) {
   const where = evidencePath(sha, STRANGER_RECORD);
   const archive = env?.archive_sha256;
@@ -246,7 +349,7 @@ export function judgeStranger(env, sha, archives) {
       'so the stranger proof did not finish',
     );
   }
-  return { archive, arms: requested };
+  return { archive, arms: requested, driver: readDriverEndpoint(env, sha) };
 }
 
 // Fails closed. An unreadable record is not a passing check, so a transport
@@ -452,17 +555,36 @@ async function locateCandidate({ sha, resolveFromCommit, options, log }) {
   };
 }
 
-// Two callers, one judge.
+// Three callers, one judge.
+//
+// `require` is the only thing that differs between them, and it moves exactly
+// one condition: whether an ABSENT stranger record is a refusal or a reported
+// pending state. Everything else about the stranger record is judged the same
+// way in both modes, because the failure this gate exists to stop is a release
+// claiming coverage it does not have, and a wrong record is that failure while
+// a missing one is a known gap.
 export async function main({
   sha = process.env.CANDIDATE_SHA,
   resolveFromCommit = process.env.RESOLVE_FROM_COMMIT,
   repository = process.env.GITHUB_REPOSITORY,
+  require: requireMode = process.env.KIN_RELEASE_REQUIRE || 'all',
   env = process.env,
   fetchImpl = fetch,
   log = console.log,
 } = {}) {
   if (!repository) {
     throw new Error('no repository given; set GITHUB_REPOSITORY');
+  }
+  // An unknown mode refuses rather than defaulting. A typo that silently fell
+  // back to 'all' would look like a working gate on the day someone meant to
+  // relax it, and a typo that silently fell back to 'preflight' would ship an
+  // unproven release; refusing is the only answer that is wrong in neither
+  // direction.
+  if (!REQUIRE_MODES.includes(requireMode)) {
+    throw new Error(
+      `unknown require mode "${requireMode}"; this gate knows ` +
+      `${REQUIRE_MODES.join(' and ')}`,
+    );
   }
   const token = env.GH_TOKEN || env.GITHUB_TOKEN;
   const options = { repository, token, fetchImpl };
@@ -486,14 +608,46 @@ export async function main({
   }
   const { archives } = judgePreflight(preflight, sha);
 
-  const strangerText = await fetchEvidence(sha, STRANGER_RECORD, options);
-  const { archive, arms } = judgeStranger(parseRunEnv(strangerText), sha, archives);
+  let strangerText;
+  try {
+    strangerText = await fetchEvidence(sha, STRANGER_RECORD, options);
+  } catch (error) {
+    // Only absence, and only under 'preflight'. `evidenceAbsent` is set by
+    // fetchEvidence on a 404 alone; a transport failure and an unreadable
+    // response deliberately carry no flag, so they land in the rethrow below
+    // in both modes.
+    if (!error.evidenceAbsent || requireMode !== 'preflight') {
+      throw error;
+    }
+    const stranger = {
+      state: 'pending',
+      arms: [],
+      archive: null,
+      driver: { endpoint: null, field: null, reference: false },
+    };
+    log(
+      `Verified the machine proof for ${sha}: preflight PASS across ` +
+      `${archives.length} leg(s). FIRST-CONTACT PROOF IS PENDING: no ` +
+      `${STRANGER_RECORD} exists under this candidate, so nothing here has ` +
+      `been through the ${REQUIRED_STRANGER_ARMS.join(', ')} arms and this ` +
+      'release may not be described as first-contact proven',
+    );
+    return { sha, archives, archive: null, stranger };
+  }
+
+  const { archive, arms, driver } = judgeStranger(
+    parseRunEnv(strangerText),
+    sha,
+    archives,
+  );
+  const stranger = { state: 'complete', arms, archive, driver };
 
   log(
     `Verified release proof artifacts for ${sha}: preflight PASS across ` +
-    `${archives.length} leg(s), stranger completed ${arms.join(', ')} on archive sha256 ${archive}`,
+    `${archives.length} leg(s), stranger completed ${arms.join(', ')} on archive sha256 ${archive}, ` +
+    `driven ${describeDriver(driver)}`,
   );
-  return { sha, archives, archive };
+  return { sha, archives, archive, stranger };
 }
 
 // Run only when this file IS the entry point, comparing REAL paths.

--- a/scripts/check-release-proof-artifacts.test.mjs
+++ b/scripts/check-release-proof-artifacts.test.mjs
@@ -11,16 +11,22 @@ import { fileURLToPath } from 'node:url';
 
 import {
   BUMP_BRANCH,
+  DRIVER_ENDPOINT_FIELD,
   EVIDENCE_REF,
+  LEGACY_DRIVER_ENDPOINT_FIELD,
   PREFLIGHT_RECORD,
   PREFLIGHT_SCHEMA,
+  REFERENCE_DRIVER_ENDPOINT,
+  REQUIRE_MODES,
   STRANGER_RECORD,
+  describeDriver,
   evidencePath,
   fetchEvidence,
   judgePreflight,
   judgeStranger,
   main,
   parseRunEnv,
+  readDriverEndpoint,
   resolveCandidateSha,
 } from './check-release-proof-artifacts.mjs';
 
@@ -196,7 +202,30 @@ test('judgeStranger accepts a run on bytes a preflight leg judged', () => {
   assert.deepEqual(judgeStranger(strangerEnv(), SHA, [ARCHIVE_A, ARCHIVE_B]), {
     archive: ARCHIVE_A,
     arms: ['green', 'brown', 'vcs'],
+    // The fixture is a record from before bin/kin-stranger wrote a driver key,
+    // which is what every already-published record on the evidence branch looks
+    // like. Unrecorded, not assumed to be the account.
+    driver: { endpoint: null, field: null, reference: false },
   });
+});
+
+test('judgeStranger carries the driver its record names', () => {
+  const local = judgeStranger(
+    strangerEnv({ [DRIVER_ENDPOINT_FIELD]: 'local', [LEGACY_DRIVER_ENDPOINT_FIELD]: 'local' }),
+    SHA,
+    [ARCHIVE_A],
+  );
+  assert.deepEqual(local.driver, {
+    endpoint: 'local',
+    field: DRIVER_ENDPOINT_FIELD,
+    reference: false,
+  });
+  const account = judgeStranger(
+    strangerEnv({ [DRIVER_ENDPOINT_FIELD]: REFERENCE_DRIVER_ENDPOINT }),
+    SHA,
+    [ARCHIVE_A],
+  );
+  assert.equal(account.driver.reference, true);
 });
 
 test('judgeStranger refuses a record that names no bytes or never finished', () => {
@@ -289,6 +318,84 @@ test('judgeStranger refuses a record that never declares its coverage fields', (
   throwsWith(
     () => judgeStranger(withoutIncomplete, SHA, [ARCHIVE_A]),
     /carries no arms_incomplete, so its arm coverage is unknown/,
+  );
+});
+
+// ── which driver produced the record ──────────────────────────────────────
+//
+// A local-model stranger and an account stranger write the same keys, the same
+// arms and the same archive sha256. Everything below exists so those two
+// records cannot reach an operator as the same sentence.
+
+test('readDriverEndpoint reads the current key, the legacy key, and neither', () => {
+  assert.deepEqual(
+    readDriverEndpoint(strangerEnv({ [DRIVER_ENDPOINT_FIELD]: 'local' }), SHA),
+    { endpoint: 'local', field: DRIVER_ENDPOINT_FIELD, reference: false },
+  );
+  // Every record published before bin/kin-stranger learned driver_endpoint
+  // carries only `endpoint`. Reading it is what stops this gate calling the
+  // whole existing evidence branch unrecorded.
+  assert.deepEqual(
+    readDriverEndpoint(strangerEnv({ [LEGACY_DRIVER_ENDPOINT_FIELD]: 'account' }), SHA),
+    {
+      endpoint: 'account',
+      field: LEGACY_DRIVER_ENDPOINT_FIELD,
+      reference: true,
+    },
+  );
+  assert.deepEqual(readDriverEndpoint(strangerEnv(), SHA), {
+    endpoint: null,
+    field: null,
+    reference: false,
+  });
+});
+
+test('readDriverEndpoint refuses a record that disagrees with itself', () => {
+  throwsWith(
+    () => readDriverEndpoint(
+      strangerEnv({
+        [DRIVER_ENDPOINT_FIELD]: 'account',
+        [LEGACY_DRIVER_ENDPOINT_FIELD]: 'local',
+      }),
+      SHA,
+    ),
+    /disagrees with itself about which driver produced it/,
+  );
+});
+
+// A key that is present and empty is worse than a key that is missing: only the
+// second is obviously unanswered. Both keys are checked, because a record that
+// answers with nothing under either name is the same failure.
+test('readDriverEndpoint refuses a key that claims to answer and does not', () => {
+  throwsWith(
+    () => readDriverEndpoint(strangerEnv({ [DRIVER_ENDPOINT_FIELD]: '' }), SHA),
+    new RegExp(`carries an empty ${DRIVER_ENDPOINT_FIELD}`),
+  );
+  throwsWith(
+    () => readDriverEndpoint(strangerEnv({ [DRIVER_ENDPOINT_FIELD]: '   ' }), SHA),
+    new RegExp(`carries an empty ${DRIVER_ENDPOINT_FIELD}`),
+  );
+  throwsWith(
+    () => readDriverEndpoint(strangerEnv({ [LEGACY_DRIVER_ENDPOINT_FIELD]: '' }), SHA),
+    new RegExp(`carries an empty ${LEGACY_DRIVER_ENDPOINT_FIELD}`),
+  );
+});
+
+test('describeDriver says weaker for anything but the reference endpoint', () => {
+  assert.match(
+    describeDriver({ endpoint: REFERENCE_DRIVER_ENDPOINT, reference: true }),
+    new RegExp(`on the ${REFERENCE_DRIVER_ENDPOINT} endpoint`),
+  );
+  const local = describeDriver({ endpoint: 'local', reference: false });
+  assert.match(local, /WEAKER stranger/);
+  // The exact claim that does NOT carry over from a weaker driver, spelled out
+  // rather than left to the reader: findings stand, an empty finding list does
+  // not. A sentence that only said "weaker" would let a quiet local run be read
+  // as a clean build.
+  assert.match(local, /an empty finding list from it does not/);
+  assert.match(
+    describeDriver({ endpoint: null, field: null, reference: false }),
+    /does not name/,
   );
 });
 
@@ -407,6 +514,166 @@ test('main holds a candidate whose preflight ran but whose stranger did not', as
     }),
     new RegExp(`evidence/${SHA}/${STRANGER_RECORD} does not exist`),
   );
+});
+
+// ── the two require modes ─────────────────────────────────────────────────
+//
+// Until 2026-09-02 a missing stranger.env meant no tag, forever, with no signal
+// but a hold alarm. The founder's instruction was to make the stranger
+// non-blocking without letting a release claim coverage it does not have, and
+// these cases are the line between those two.
+
+test('require preflight proceeds on the machine proof and reports the gap', async () => {
+  const lines = [];
+  const result = await main({
+    sha: SHA,
+    repository: REPO,
+    require: 'preflight',
+    env: {},
+    log: (line) => lines.push(line),
+    fetchImpl: stubFetch({
+      [PREFLIGHT_RECORD]: ok(JSON.stringify(preflightRecord())),
+    }),
+  });
+  assert.equal(result.sha, SHA);
+  assert.deepEqual(result.archives, [ARCHIVE_A, ARCHIVE_B]);
+  assert.equal(result.stranger.state, 'pending');
+  // No archive, because no stranger ran on one. A pending result that carried
+  // the preflight's archive would let a caller believe bytes had been through
+  // the arms.
+  assert.equal(result.archive, null);
+  assert.deepEqual(result.stranger.arms, []);
+  const said = lines.join('\n');
+  assert.match(said, /FIRST-CONTACT PROOF IS PENDING/);
+  assert.match(said, /may not be described as first-contact proven/);
+});
+
+// The narrowing is one condition wide. Under 'preflight' a stranger record that
+// EXISTS is judged exactly as it always was, so relaxing the tag gate cannot be
+// used to ship a record that is wrong rather than missing.
+test('require preflight still judges a stranger record that exists', async () => {
+  await assert.rejects(
+    main({
+      sha: SHA,
+      repository: REPO,
+      require: 'preflight',
+      env: {},
+      log: () => {},
+      fetchImpl: stubFetch({
+        [PREFLIGHT_RECORD]: ok(JSON.stringify(preflightRecord())),
+        [STRANGER_RECORD]: ok(strangerRecordText({ arms_incomplete: 'brown' })),
+      }),
+    }),
+    /records incomplete stranger arm\(s\) brown/,
+  );
+  await assert.rejects(
+    main({
+      sha: SHA,
+      repository: REPO,
+      require: 'preflight',
+      env: {},
+      log: () => {},
+      fetchImpl: stubFetch({
+        [PREFLIGHT_RECORD]: ok(JSON.stringify(preflightRecord())),
+        [STRANGER_RECORD]: ok(strangerRecordText({ archive_sha256: ARCHIVE_UNJUDGED })),
+      }),
+    }),
+    /the stranger ran, but not on these bytes/,
+  );
+});
+
+// "We could not tell" must never become "proceed". fetchEvidence flags a 404
+// and deliberately flags nothing else, and this is the case that proves the
+// relaxation keys on that flag rather than on any failure to read.
+test('require preflight fails closed on an unreadable stranger record', async () => {
+  await assert.rejects(
+    main({
+      sha: SHA,
+      repository: REPO,
+      require: 'preflight',
+      env: {},
+      log: () => {},
+      fetchImpl: stubFetch({
+        [PREFLIGHT_RECORD]: ok(JSON.stringify(preflightRecord())),
+        [STRANGER_RECORD]: {
+          ok: false,
+          status: 500,
+          statusText: 'Internal Server Error',
+          text: async () => '',
+        },
+      }),
+    }),
+    /HTTP 500 Internal Server Error/,
+  );
+});
+
+// The preflight half is not relaxed at all. A candidate with no machine proof
+// is refused in both modes, because that record is the one this gate can always
+// have before a tag exists.
+test('require preflight still refuses a candidate with no preflight record', async () => {
+  await assert.rejects(
+    main({
+      sha: SHA,
+      repository: REPO,
+      require: 'preflight',
+      env: {},
+      log: () => {},
+      fetchImpl: stubFetch({}),
+    }),
+    /the proof loop has not recorded this candidate/,
+  );
+});
+
+test('main defaults to requiring both records', async () => {
+  assert.deepEqual([...REQUIRE_MODES], ['all', 'preflight']);
+  // No require given: the historical contract, so a caller written before this
+  // mode existed is judged the way it always was.
+  await assert.rejects(
+    main({
+      sha: SHA,
+      repository: REPO,
+      env: {},
+      log: () => {},
+      fetchImpl: stubFetch({
+        [PREFLIGHT_RECORD]: ok(JSON.stringify(preflightRecord())),
+      }),
+    }),
+    new RegExp(`evidence/${SHA}/${STRANGER_RECORD} does not exist`),
+  );
+});
+
+test('main refuses an unknown require mode rather than picking one', async () => {
+  await assert.rejects(
+    main({
+      sha: SHA,
+      repository: REPO,
+      require: 'stranger-only',
+      env: {},
+      log: () => {},
+      fetchImpl: stubFetch({
+        [PREFLIGHT_RECORD]: ok(JSON.stringify(preflightRecord())),
+      }),
+    }),
+    /unknown require mode "stranger-only"/,
+  );
+});
+
+test('a complete run reports its state and its driver to the caller', async () => {
+  const lines = [];
+  const result = await main({
+    sha: SHA,
+    repository: REPO,
+    require: 'preflight',
+    env: {},
+    log: (line) => lines.push(line),
+    fetchImpl: stubFetch({
+      [PREFLIGHT_RECORD]: ok(JSON.stringify(preflightRecord())),
+      [STRANGER_RECORD]: ok(strangerRecordText({ [DRIVER_ENDPOINT_FIELD]: 'local' })),
+    }),
+  });
+  assert.equal(result.stranger.state, 'complete');
+  assert.equal(result.stranger.driver.endpoint, 'local');
+  assert.match(lines.join('\n'), /WEAKER stranger/);
 });
 
 test('main holds when the records exist but describe a different build', async () => {

--- a/scripts/read-promotion-plan.mjs
+++ b/scripts/read-promotion-plan.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+// The three reads release-promote.yml makes of the plan it just wrote.
+//
+// They live in a file rather than inside YAML strings because an inline
+// validator in a workflow is unreachable by `node --check` and by every test in
+// this repository, and the first draft of that workflow carried a syntax error
+// no gate here would have caught. A workflow step should be a line that names
+// what it wants, not a program.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import process from 'node:process';
+
+import { ALARM_TITLE, PENDING_MARKER, buildBody } from './release-promotion-plan.mjs';
+
+function readPlan(path = process.env.KIN_PROMOTION_PLAN) {
+  if (!path) {
+    throw new Error('no plan path given; set KIN_PROMOTION_PLAN');
+  }
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+// One line per release to promote, tab separated, so the caller can read it
+// with `while IFS=$'\t' read -r` and never word-split a value.
+export function renderPromotions(plan) {
+  return (plan.promote ?? [])
+    .map((entry) => `${entry.tag}\t${entry.driver ?? 'unrecorded'}`)
+    .join('\n');
+}
+
+// action, issue number and title on one tab-separated line, with the body
+// written to its own file. The title travels with the decision because the
+// alarm's title is the only thing that makes a second run update the first
+// run's issue rather than open a second one.
+//
+// The number is 0 rather than empty when no issue is open, and that is not
+// cosmetic. Bash treats a tab set as IFS as whitespace and COLLAPSES runs of
+// it, so `open\t\tTitle` read with `IFS=$'\t' read -r action number title`
+// binds number to the title and leaves title empty. Measured, not assumed. A
+// never-empty field is the only shape that survives that read, and the two
+// branches that use the number are only reachable when a real issue exists.
+export const NO_OPEN_ISSUE = '0';
+
+export function renderAlarm(plan, bodyPath) {
+  const overdue = plan.overdue ?? [];
+  writeFileSync(bodyPath, overdue.length ? buildBody(overdue) : '');
+  const number = plan.openIssue ?? NO_OPEN_ISSUE;
+  const action = plan.alarm ?? 'none';
+  if ((action === 'update' || action === 'close') && String(number) === NO_OPEN_ISSUE) {
+    throw new Error(
+      `the plan asks to ${action} an alarm issue and names none, so there is ` +
+      'nothing to act on',
+    );
+  }
+  return [action, number, ALARM_TITLE].join('\t');
+}
+
+// Take the pending notice back out of a promoted release's body.
+//
+// A promoted release that still says its proof is pending is a false claim in
+// the other direction, and the marker is what the next sweep keys on, so
+// leaving it would make a promoted release look held forever.
+export function stripPendingNotice(text) {
+  const at = String(text).indexOf(PENDING_MARKER);
+  if (at === -1) {
+    return String(text);
+  }
+  const lines = String(text).slice(at).split('\n');
+  // The marker line, then the quoted block that follows it: everything up to
+  // the first line that is neither a quote nor blank. Bounded by the block this
+  // release chain writes, so a body a human edited underneath keeps its text.
+  let cut = 1;
+  while (cut < lines.length && (lines[cut].startsWith('>') || lines[cut].trim() === '')) {
+    cut += 1;
+  }
+  return String(text).slice(0, at) + lines.slice(cut).join('\n');
+}
+
+async function readStdin() {
+  let text = '';
+  for await (const chunk of process.stdin) {
+    text += chunk;
+  }
+  return text;
+}
+
+export async function run(argv) {
+  const [command, ...rest] = argv;
+  switch (command) {
+    case 'promotions':
+      return `${renderPromotions(readPlan())}\n`;
+    case 'alarm': {
+      const flag = rest.indexOf('--body');
+      if (flag === -1 || !rest[flag + 1]) {
+        throw new Error('alarm needs --body <path> to write the issue text to');
+      }
+      return `${renderAlarm(readPlan(), rest[flag + 1])}\n`;
+    }
+    case 'strip-notice':
+      return stripPendingNotice(await readStdin());
+    default:
+      throw new Error(
+        `unknown command ${JSON.stringify(command ?? '')}; this reader knows ` +
+        'promotions, alarm and strip-notice',
+      );
+  }
+}
+
+if (process.argv[1] && process.argv[1].endsWith('read-promotion-plan.mjs')) {
+  run(process.argv.slice(2))
+    .then((out) => process.stdout.write(out))
+    .catch((error) => {
+      console.error(`::error::${error.message}`);
+      process.exit(1);
+    });
+}

--- a/scripts/read-promotion-plan.test.mjs
+++ b/scripts/read-promotion-plan.test.mjs
@@ -4,6 +4,7 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -139,4 +140,52 @@ test('renderAlarm refuses to act on an issue the plan does not name', () => {
       /names none, so there is nothing to act on/,
     );
   }
+});
+
+// release-promote.yml calls both of these as scripts. A module whose direct-run
+// guard does not fire exits 0 having done nothing, which is the failure
+// check-release-proof-artifacts.mjs carries its own comment about: the naive
+// `import.meta.url` versus `argv[1]` comparison disagrees when a file is reached
+// through a symlinked directory, and the workflow step then passes while
+// planning nothing. So run them the way the workflow does, and require the
+// refusal rather than silence.
+test('both plan CLIs run as scripts and refuse rather than doing nothing', () => {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const runs = [
+    ['release-promotion-plan.mjs', [], /no plan path given/],
+    ['read-promotion-plan.mjs', [], /unknown command ""/],
+  ];
+  for (const [script, argv, expected] of runs) {
+    let status = 0;
+    let stderr = '';
+    try {
+      execFileSync('node', [path.join(here, script), ...argv], {
+        encoding: 'utf8',
+        env: { ...process.env, KIN_PROMOTION_PLAN: '', GITHUB_REPOSITORY: '' },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    } catch (error) {
+      status = error.status;
+      stderr = error.stderr ?? '';
+    }
+    assert.equal(status, 1, `${script} must exit 1, not ${status}`);
+    assert.match(stderr, expected);
+  }
+});
+
+// The exact bytes release-promote.yml reads back, produced by the shipped CLI
+// rather than by calling the function in process.
+test('the promotions CLI emits the tab-separated lines the workflow reads', () => {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const dir = tmp();
+  const plan = path.join(dir, 'plan.json');
+  fs.writeFileSync(
+    plan,
+    JSON.stringify({ promote: [{ tag: 'v9.9.9', driver: 'local' }], overdue: [], alarm: 'none', openIssue: null }),
+  );
+  const out = execFileSync('node', [path.join(here, 'read-promotion-plan.mjs'), 'promotions'], {
+    encoding: 'utf8',
+    env: { ...process.env, KIN_PROMOTION_PLAN: plan },
+  });
+  assert.equal(out, 'v9.9.9\tlocal\n');
 });

--- a/scripts/read-promotion-plan.test.mjs
+++ b/scripts/read-promotion-plan.test.mjs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { ALARM_TITLE, PENDING_MARKER } from './release-promotion-plan.mjs';
+import {
+  NO_OPEN_ISSUE,
+  renderAlarm,
+  renderPromotions,
+  run,
+  stripPendingNotice,
+} from './read-promotion-plan.mjs';
+
+const tmp = () => fs.mkdtempSync(path.join(os.tmpdir(), 'kin-promotion-'));
+
+const HELD_BODY = `${PENDING_MARKER}
+> **First-contact proof pending.** This release cleared the machine preflight on its
+> own bytes.
+
+## What changed
+
+- a real release note a human wrote
+`;
+
+test('renderPromotions emits one tab-separated line per release', () => {
+  assert.equal(
+    renderPromotions({ promote: [{ tag: 'v0.6.5', driver: 'local' }, { tag: 'v0.6.6' }] }),
+    'v0.6.5\tlocal\nv0.6.6\tunrecorded',
+  );
+  assert.equal(renderPromotions({ promote: [] }), '');
+  assert.equal(renderPromotions({}), '');
+});
+
+test('renderAlarm writes the body and returns the decision with its title', () => {
+  const dir = tmp();
+  const body = path.join(dir, 'alarm.md');
+  const line = renderAlarm(
+    { alarm: 'open', openIssue: null, overdue: [{ tag: 'v0.6.6', reason: 'pending', minutes: 400 }] },
+    body,
+  );
+  const [action, number, title] = line.split('\t');
+  assert.equal(action, 'open');
+  // Never empty. Bash collapses runs of a tab set as IFS, so an empty field
+  // here would shift the title into the number when the workflow reads this
+  // line back and `gh issue create --title ""` would follow.
+  assert.equal(number, NO_OPEN_ISSUE);
+  assert.notEqual(number, '');
+  // The title travels with the decision, because it is the only thing that
+  // makes a later run comment on this issue instead of opening a second one.
+  assert.equal(title, ALARM_TITLE);
+  assert.match(fs.readFileSync(body, 'utf8'), /v0\.6\.6/);
+
+  const quiet = path.join(dir, 'quiet.md');
+  assert.equal(renderAlarm({ alarm: 'none', openIssue: null, overdue: [] }, quiet).split('\t')[0], 'none');
+  assert.equal(fs.readFileSync(quiet, 'utf8'), '');
+});
+
+test('stripPendingNotice removes the block this chain wrote and nothing else', () => {
+  const stripped = stripPendingNotice(HELD_BODY);
+  assert.doesNotMatch(stripped, /First-contact proof pending/);
+  assert.doesNotMatch(stripped, new RegExp(PENDING_MARKER.replace(/[-[\]{}()*+?.,\\^$|#]/g, '\\$&')));
+  // The human's own notes survive. A strip that took the whole body would lose
+  // the release notes, which is a worse failure than leaving the notice.
+  assert.match(stripped, /a real release note a human wrote/);
+  assert.match(stripped, /## What changed/);
+});
+
+test('stripPendingNotice leaves a body that never carried the notice alone', () => {
+  const plain = '## What changed\n\n- nothing to do with proof\n';
+  assert.equal(stripPendingNotice(plain), plain);
+  assert.equal(stripPendingNotice(''), '');
+});
+
+// The property the "quote or blank" bound actually provides, stated as the
+// only thing that can distinguish it: stripping the notice returns the body
+// BYTE FOR BYTE, not merely a body with the notice text gone.
+//
+// This assertion replaced a weaker one. The first version checked that the
+// notice text was absent and the author's own quoted line survived, and a
+// mutant that stopped consuming the blank line separating the notice from the
+// body passed it: the notice was still gone and the quote was still there, and
+// only a stray leading newline separated the two answers. A round trip is the
+// input only this clause can get right.
+test('stripPendingNotice returns the original body byte for byte', () => {
+  // Exactly the shape release.yml writes: the marker, the quoted block, one
+  // blank line, then the release notes as they were.
+  const notes = '## Notes\n\n> a quote the author wrote\n';
+  const written = `${PENDING_MARKER}\n> **First-contact proof pending.** one\n> two\n\n${notes}`;
+  assert.equal(stripPendingNotice(written), notes);
+});
+
+test('run refuses a command it does not know rather than doing nothing', async () => {
+  await assert.rejects(run(['publish']), /unknown command "publish"/);
+  await assert.rejects(run([]), /unknown command ""/);
+  await assert.rejects(run(['alarm']), /needs --body/);
+});
+
+test('run reads the plan the workflow names in the environment', async () => {
+  const dir = tmp();
+  const plan = path.join(dir, 'plan.json');
+  fs.writeFileSync(plan, JSON.stringify({ promote: [{ tag: 'v1.2.3', driver: 'account' }] }));
+  const previous = process.env.KIN_PROMOTION_PLAN;
+  process.env.KIN_PROMOTION_PLAN = plan;
+  try {
+    assert.equal(await run(['promotions']), 'v1.2.3\taccount\n');
+  } finally {
+    if (previous === undefined) delete process.env.KIN_PROMOTION_PLAN;
+    else process.env.KIN_PROMOTION_PLAN = previous;
+  }
+});
+
+// The read this line is written for, run for real. bash 3.2 and bash 5 both
+// treat a tab set as IFS as whitespace and collapse runs of it, which is the
+// defect the sentinel exists to prevent; this asserts the shipped line survives
+// that read rather than asserting a property of the string in isolation.
+test('the alarm line survives the shell read the workflow performs', () => {
+  const dir = tmp();
+  const body = path.join(dir, 'alarm.md');
+  const line = renderAlarm({ alarm: 'open', openIssue: null, overdue: [] }, body);
+  const script = path.join(dir, 'read.sh');
+  fs.writeFileSync(script, "IFS=$'\\t' read -r action number title < \"$1\"\nprintf '%s|%s|%s' \"$action\" \"$number\" \"$title\"\n");
+  const decision = path.join(dir, 'decision.txt');
+  fs.writeFileSync(decision, `${line}\n`);
+  const read = execFileSync('bash', [script, decision], { encoding: 'utf8' });
+  assert.equal(read, `open|${NO_OPEN_ISSUE}|${ALARM_TITLE}`);
+});
+
+test('renderAlarm refuses to act on an issue the plan does not name', () => {
+  const dir = tmp();
+  for (const alarm of ['update', 'close']) {
+    assert.throws(
+      () => renderAlarm({ alarm, openIssue: null, overdue: [] }, path.join(dir, `${alarm}.md`)),
+      /names none, so there is nothing to act on/,
+    );
+  }
+});

--- a/scripts/release-promotion-plan.mjs
+++ b/scripts/release-promotion-plan.mjs
@@ -1,0 +1,313 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+// Decides which published releases are now allowed to become GitHub Latest, and
+// when a release that is still waiting has waited long enough to be worth
+// alarming about.
+//
+// This module exists because of a shape the release rail did not have before
+// 2026-09-02. The tag gate used to require first-contact proof, so a release
+// either had it or did not exist; there was nothing to promote later. Now a
+// candidate that clears the machine preflight is tagged and published as a
+// prerelease, and the stranger record arrives afterwards, from a run that may
+// be driven by a local model on a laptop. Something has to notice that arrival
+// and finish the job with nobody at the button, or "non-blocking" would just
+// mean "stuck one step further along".
+//
+// Every decision here is a pure function of what the workflow read, so each
+// state the rail can reach is testable without a rail. The workflow does the
+// reading, the judging and the writing; it never makes the judgement itself,
+// which is the same division scripts/release-hold-alarm.mjs uses and for the
+// same reason.
+
+import { realpathSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import process from 'node:process';
+
+// The one title the alarm ever uses. It names the CONDITION, not the tag,
+// because the tag moves while the condition does not and a title that moves
+// opens a second issue every time it does. release-promote.yml repeats this
+// string and the release authority suite asserts the two agree.
+export const ALARM_TITLE = 'Release published without first-contact proof';
+
+// The marker release.yml writes into a held release's own body. Repeated here
+// so the promotion can take it back out, and asserted equal by the authority
+// suite so a promoted release cannot keep claiming it is unproven.
+export const PENDING_MARKER = '<!-- kin-first-contact-proof -->';
+
+// How long a release may sit unpromoted before it is worth an issue. The
+// promoter ticks four times an hour, and a stranger run on this fleet takes
+// hours rather than minutes, so an alarm inside one cycle would ring on every
+// healthy release. Six hours is long enough that a normal proof run finishes
+// first and short enough that a forgotten one is found the same day.
+export const DEFAULT_ALARM_AFTER_MINUTES = 360;
+
+const STABLE_TAG = /^v\d+\.\d+\.\d+$/;
+
+// Which releases this promoter is even allowed to touch.
+//
+// Draft releases are excluded because they are not published and nothing about
+// them is a claim yet. Prerelease TAGS (anything carrying a hyphen) are
+// excluded because they are meant to stay prereleases; promoting one would be
+// the bug, not the fix. What remains is the exact set this design creates: a
+// stable tag, published, still marked prerelease.
+export function selectCandidates(releases) {
+  if (!Array.isArray(releases)) {
+    throw new Error('the release listing did not come back as an array, so nothing can be selected from it');
+  }
+  return releases
+    .filter((release) => release && typeof release.tag_name === 'string')
+    .filter((release) => STABLE_TAG.test(release.tag_name))
+    .filter((release) => release.draft !== true)
+    .filter((release) => release.prerelease === true)
+    .map((release) => ({
+      tag: release.tag_name,
+      publishedAt: release.published_at ?? null,
+      // Whether THIS design held it, as opposed to a human marking a stable tag
+      // as a prerelease for some other reason. A release with no marker is
+      // reported and never promoted: the promoter finishes what the release
+      // chain started and does not overrule a person.
+      held: typeof release.body === 'string' && release.body.includes(PENDING_MARKER),
+    }));
+}
+
+function minutesSince(iso, now) {
+  if (typeof iso !== 'string' || !iso) return null;
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return null;
+  return (now - then) / 60000;
+}
+
+// Turn one judgement per candidate into the three lists the workflow acts on.
+//
+// A judgement is `{ tag, publishedAt, held, proven, reason }`. `proven` true
+// means the full gate passed for that tag's commit. `proven` false with a
+// reason is every other answer, and the reason is carried verbatim into the
+// alarm, because "which record was missing" is the first thing a reader needs
+// and a generic "not proven" sends them to read three logs.
+export function planPromotion(
+  judgements,
+  { now = Date.now(), alarmAfterMinutes = DEFAULT_ALARM_AFTER_MINUTES, openIssue = null } = {},
+) {
+  const promote = [];
+  const waiting = [];
+  const foreign = [];
+  for (const judgement of judgements ?? []) {
+    if (!judgement || typeof judgement.tag !== 'string' || !judgement.tag) {
+      throw new Error('a promotion judgement names no tag, so it cannot be acted on');
+    }
+    if (!judgement.held) {
+      // Not ours to promote. Reported so a stable prerelease nobody explained
+      // is still visible, never acted on.
+      foreign.push({ tag: judgement.tag, reason: 'this release carries no first-contact hold marker' });
+      continue;
+    }
+    if (judgement.proven === true) {
+      promote.push({ tag: judgement.tag, driver: judgement.driver ?? null });
+      continue;
+    }
+    waiting.push({
+      tag: judgement.tag,
+      reason: judgement.reason || 'the proof gate gave no reason',
+      minutes: minutesSince(judgement.publishedAt, now),
+    });
+  }
+
+  // Alarm only on a release that has waited past the threshold. A release
+  // whose publication time cannot be read counts as overdue rather than as
+  // fresh: an unreadable timestamp must not buy silence.
+  const overdue = waiting.filter(
+    (entry) => entry.minutes === null || entry.minutes >= alarmAfterMinutes,
+  );
+  let alarm = 'none';
+  if (overdue.length > 0) {
+    alarm = openIssue ? 'update' : 'open';
+  } else if (openIssue && waiting.length === 0) {
+    // Closed only when nothing is waiting at all, not merely when nothing is
+    // overdue. A release that is inside the window is still unproven, and
+    // closing on it would reopen the alarm an hour later.
+    alarm = 'close';
+  }
+  return { promote, waiting, foreign, overdue, alarm };
+}
+
+export function buildBody(overdue, { alarmAfterMinutes = DEFAULT_ALARM_AFTER_MINUTES } = {}) {
+  const lines = [
+    `These releases are published, are not GitHub Latest, and have been waiting more than ${alarmAfterMinutes} minutes for first-contact proof.`,
+    '',
+    'Each one cleared the machine preflight on its own bytes. None has been through the green, brown and vcs stranger arms, so none may be described as first-contact proven, and none will become Latest until its `stranger.env` lands under its commit on the `release-evidence` branch.',
+    '',
+    '| tag | waiting | what the gate said |',
+    '| --- | --- | --- |',
+  ];
+  for (const entry of overdue) {
+    const waited = entry.minutes === null ? 'unknown' : `${Math.floor(entry.minutes)} min`;
+    lines.push(`| \`${entry.tag}\` | ${waited} | ${entry.reason.replace(/\|/g, '\\|')} |`);
+  }
+  lines.push(
+    '',
+    'To clear one: run the stranger on that candidate with all three arms, let it publish, and the promoter takes Latest on its next tick. A local-model run is allowed and is a weaker stranger; the record says which driver produced it and every reader of this rail is told.',
+    '',
+    'This issue closes itself when no published release is waiting.',
+  );
+  return lines.join('\n');
+}
+
+
+// ── reading the rail ──────────────────────────────────────────────────────
+//
+// Everything above is a pure function of what was read. This is the reading,
+// kept in the same file and behind the same direct-run guard the proof gate
+// uses, so the promoter workflow stays three short shell steps and every line
+// of judgement below is reachable from a test with stub transports.
+
+const COMMIT_SHA = /^[0-9a-f]{40}$/;
+
+// Resolve a tag to the commit it names, dereferencing an annotated tag.
+// release-tag.yml writes lightweight tags, so the first read usually answers;
+// the second exists because a hand-pushed annotated tag would otherwise
+// resolve to the tag object's sha and key the evidence lookup at a sha no
+// preflight ever judged.
+export async function resolveTagCommit(tag, api) {
+  const ref = await api(`/git/ref/tags/${tag}`);
+  let sha = ref?.object?.sha;
+  if (ref?.object?.type === 'tag') {
+    sha = (await api(`/git/tags/${sha}`))?.object?.sha;
+  }
+  if (!COMMIT_SHA.test(sha ?? '')) {
+    throw new Error(`${tag} does not resolve to a commit sha`);
+  }
+  return sha;
+}
+
+export async function buildPlan({
+  repository,
+  api,
+  judge,
+  alarmTitle = ALARM_TITLE,
+  now = Date.now(),
+  log = () => {},
+}) {
+  if (!repository) {
+    throw new Error('no repository given; set GITHUB_REPOSITORY');
+  }
+  const releases = await api('/releases?per_page=100');
+  // A full page is a refusal, not an answer. A promoter that silently read
+  // only the newest hundred releases would go quiet exactly when the list
+  // grew past them, and it would look identical to a healthy rail.
+  if (Array.isArray(releases) && releases.length === 100) {
+    throw new Error(
+      'the release listing filled a whole page, so it may be truncated; page ' +
+      'it before trusting this sweep',
+    );
+  }
+  const candidates = selectCandidates(releases);
+  log(`${candidates.length} published stable release(s) are not GitHub Latest`);
+
+  const judgements = [];
+  for (const candidate of candidates) {
+    const judgement = { ...candidate, sha: null, proven: false, reason: '', driver: null };
+    try {
+      judgement.sha = await resolveTagCommit(candidate.tag, api);
+      const result = await judge(judgement.sha);
+      judgement.proven = true;
+      judgement.driver = result?.stranger?.driver?.endpoint ?? 'unrecorded';
+    } catch (error) {
+      // Every refusal is a reason to WAIT, never a reason to fail this sweep.
+      // A missing stranger record is the expected state of a held release, and
+      // a promoter that went red on it would page a human four times an hour
+      // about a rail that is behaving exactly as designed.
+      judgement.reason = error.message;
+    }
+    judgements.push(judgement);
+  }
+
+  const issues = await api('/issues?state=open&per_page=100&labels=release-proof');
+  const openIssue =
+    (Array.isArray(issues) ? issues : []).find((issue) => issue?.title === alarmTitle) ?? null;
+  const plan = planPromotion(judgements, { now, openIssue });
+  return { ...plan, openIssue: openIssue?.number ?? null, judgements };
+}
+
+function githubApi(repository, token, fetchImpl = fetch) {
+  const headers = {
+    accept: 'application/vnd.github+json',
+    'user-agent': 'kin-release-promoter',
+    'x-github-api-version': '2022-11-28',
+  };
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+  return async (path) => {
+    const response = await fetchImpl(`https://api.github.com/repos/${repository}${path}`, {
+      headers,
+    });
+    if (!response.ok) {
+      throw new Error(
+        `GET ${path} failed: HTTP ${response.status} ${response.statusText}`,
+      );
+    }
+    return response.json();
+  };
+}
+
+export async function main({
+  repository = process.env.GITHUB_REPOSITORY,
+  token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN,
+  out = process.env.KIN_PROMOTION_PLAN,
+  fetchImpl = fetch,
+  log = (line) => process.stderr.write(`${line}\n`),
+} = {}) {
+  if (!out) {
+    throw new Error('no plan path given; set KIN_PROMOTION_PLAN');
+  }
+  const api = githubApi(repository, token, fetchImpl);
+  const { main: judgeCandidate } = await import('./check-release-proof-artifacts.mjs');
+  const plan = await buildPlan({
+    repository,
+    api,
+    judge: (sha) =>
+      judgeCandidate({
+        sha,
+        repository,
+        // Spelled out rather than left to the gate's default. This is the
+        // decision point that reaches GitHub Latest, so it must require
+        // everything; inheriting the mode from the environment would let a
+        // stray KIN_RELEASE_REQUIRE in a workflow promote a release on the
+        // machine proof alone, which is the exact failure the two-tier design
+        // exists to prevent.
+        require: 'all',
+        env: { GH_TOKEN: token },
+        fetchImpl,
+        log: (line) => log(`  ${line}`),
+      }),
+    log,
+  });
+  writeFileSync(out, JSON.stringify(plan, null, 2));
+  log(JSON.stringify({ promote: plan.promote, waiting: plan.waiting, alarm: plan.alarm }, null, 2));
+  return plan;
+}
+
+// Same real-path comparison the proof gate uses, and for the same reason: the
+// naive `import.meta.url` versus `argv[1]` form disagrees when the file is
+// reached through a symlinked directory, and this file would then read
+// nothing, plan nothing and exit 0.
+function isDirectRun() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  const self = fileURLToPath(import.meta.url);
+  if (entry === self) return true;
+  try {
+    return realpathSync(entry) === realpathSync(self);
+  } catch {
+    return true;
+  }
+}
+
+if (isDirectRun()) {
+  main().catch((error) => {
+    console.error(`::error::${error.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/release-promotion-plan.mjs
+++ b/scripts/release-promotion-plan.mjs
@@ -132,6 +132,29 @@ export function planPromotion(
   return { promote, waiting, foreign, overdue, alarm };
 }
 
+// One gate refusal, rendered safely into one Markdown table cell.
+//
+// The reason is data: it comes from whatever the proof gate said, which is a
+// sentence assembled from a record on an append-only branch. Two characters in
+// it break the table it lands in, and escaping only one of them is worse than
+// escaping neither.
+//
+// Backslash FIRST, then pipe, and both in a single pass so the escapes this
+// adds cannot themselves be escaped. A reason containing `a\|b` escaped for the
+// pipe alone becomes `a\\|b`, which Markdown renders as a literal backslash
+// followed by an unescaped delimiter, and the row silently gains a column.
+// Found by CodeQL on this pull request, not by a test, which is why the test
+// beneath it now uses that exact input.
+//
+// Whitespace collapses last. A gate message may carry a newline, and a newline
+// inside a table row ends the row.
+function tableCell(text) {
+  return String(text ?? '')
+    .replace(/[\\|]/g, '\\$&')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 export function buildBody(overdue, { alarmAfterMinutes = DEFAULT_ALARM_AFTER_MINUTES } = {}) {
   const lines = [
     `These releases are published, are not GitHub Latest, and have been waiting more than ${alarmAfterMinutes} minutes for first-contact proof.`,
@@ -143,7 +166,7 @@ export function buildBody(overdue, { alarmAfterMinutes = DEFAULT_ALARM_AFTER_MIN
   ];
   for (const entry of overdue) {
     const waited = entry.minutes === null ? 'unknown' : `${Math.floor(entry.minutes)} min`;
-    lines.push(`| \`${entry.tag}\` | ${waited} | ${entry.reason.replace(/\|/g, '\\|')} |`);
+    lines.push(`| \`${entry.tag}\` | ${waited} | ${tableCell(entry.reason)} |`);
   }
   lines.push(
     '',

--- a/scripts/release-promotion-plan.test.mjs
+++ b/scripts/release-promotion-plan.test.mjs
@@ -150,10 +150,41 @@ test('buildBody names every overdue tag and what the gate said about it', () => 
   assert.match(body, /incomplete stranger arm/);
   assert.match(body, /400 min/);
   assert.match(body, /unknown/);
-  // The reason is data from a gate, and a pipe in it would silently break the
-  // table it is rendered into.
-  assert.match(buildBody([{ tag: 'v1.0.0', reason: 'a | b', minutes: 400 }]), /a \\\| b/);
   assert.match(body, /closes itself/);
+});
+
+// The reason is data. It comes from whatever the proof gate said about a record
+// on an append-only branch, and two characters in it break the table it lands
+// in. CodeQL found the first version of this escaping incomplete on the pull
+// request that introduced it, so the inputs here are the ones that broke it.
+test('buildBody renders a gate refusal into one table cell whatever it contains', () => {
+  const row = (reason) =>
+    buildBody([{ tag: 'v1.0.0', reason, minutes: 400 }])
+      .split('\n')
+      .find((line) => line.startsWith('| `v1.0.0`'));
+
+  // A bare pipe: one escape, one cell.
+  assert.equal(row('a | b'), '| `v1.0.0` | 400 min | a \\| b |');
+
+  // A backslash BEFORE a pipe. Escaping the pipe alone turns this into a
+  // literal backslash followed by an unescaped delimiter, and the row silently
+  // gains a column. Both characters have to be escaped in one pass.
+  assert.equal(row('a\\|b'), '| `v1.0.0` | 400 min | a\\\\\\|b |');
+
+  // A newline inside a table row ends the row.
+  assert.equal(row('line one\nline two'), '| `v1.0.0` | 400 min | line one line two |');
+
+  // Every rendered row has exactly the four pipes of a three-column row, so a
+  // cell can never smuggle in a fifth.
+  for (const reason of ['a | b', 'a\\|b', 'line one\nline two', '|||', '\\\\']) {
+    const rendered = row(reason);
+    const unescaped = rendered.replace(/\\./g, '');
+    assert.equal(
+      unescaped.split('|').length - 1,
+      4,
+      `reason ${JSON.stringify(reason)} rendered ${JSON.stringify(rendered)}`,
+    );
+  }
 });
 
 test('the alarm title names the condition and never a tag', () => {

--- a/scripts/release-promotion-plan.test.mjs
+++ b/scripts/release-promotion-plan.test.mjs
@@ -1,0 +1,374 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  ALARM_TITLE,
+  DEFAULT_ALARM_AFTER_MINUTES,
+  PENDING_MARKER,
+  buildBody,
+  buildPlan,
+  main,
+  planPromotion,
+  resolveTagCommit,
+  selectCandidates,
+} from './release-promotion-plan.mjs';
+
+const NOW = Date.parse('2026-09-03T00:00:00Z');
+const ago = (minutes) => new Date(NOW - minutes * 60000).toISOString();
+
+const release = (over = {}) => ({
+  tag_name: 'v0.6.5',
+  draft: false,
+  prerelease: true,
+  published_at: ago(10),
+  body: `${PENDING_MARKER}\n> first-contact proof pending`,
+  ...over,
+});
+
+test('selectCandidates takes exactly the shape this design creates', () => {
+  const picked = selectCandidates([
+    release(),
+    // Already Latest. Nothing to do, and promoting it again would be a no-op
+    // that still rewrites its body.
+    release({ tag_name: 'v0.6.4', prerelease: false }),
+    // A draft is not published, so it is not a claim yet.
+    release({ tag_name: 'v0.6.6', draft: true }),
+    // A prerelease TAG is meant to stay a prerelease. Promoting one would be
+    // the bug this promoter could introduce, not the gap it closes.
+    release({ tag_name: 'v0.6.7-rc.1' }),
+    // Not a version tag at all.
+    release({ tag_name: 'nightly' }),
+  ]);
+  assert.deepEqual(picked.map((entry) => entry.tag), ['v0.6.5']);
+  assert.equal(picked[0].held, true);
+});
+
+test('selectCandidates refuses a listing it cannot read rather than returning nothing', () => {
+  // An empty array and an unreadable answer are different findings. Returning
+  // [] for the second would report "nothing to promote" on a broken read,
+  // which is the check-that-cannot-fail shape.
+  assert.throws(() => selectCandidates(null), /did not come back as an array/);
+  assert.throws(() => selectCandidates({ releases: [] }), /did not come back as an array/);
+  assert.deepEqual(selectCandidates([]), []);
+});
+
+test('selectCandidates marks a stable prerelease this design did not hold', () => {
+  const [entry] = selectCandidates([release({ body: 'hand-marked for another reason' })]);
+  assert.equal(entry.held, false);
+});
+
+test('planPromotion promotes only a proven release this design held', () => {
+  const plan = planPromotion(
+    [
+      { tag: 'v0.6.5', held: true, proven: true, driver: 'local', publishedAt: ago(10) },
+      { tag: 'v0.6.6', held: true, proven: false, reason: 'stranger.env does not exist', publishedAt: ago(10) },
+      { tag: 'v0.6.7', held: false, proven: true, publishedAt: ago(10) },
+    ],
+    { now: NOW },
+  );
+  assert.deepEqual(plan.promote, [{ tag: 'v0.6.5', driver: 'local' }]);
+  assert.deepEqual(plan.waiting.map((e) => e.tag), ['v0.6.6']);
+  // Proven, but not held by this design. The promoter finishes what the release
+  // chain started; it never overrules a person who marked a release by hand.
+  assert.deepEqual(plan.foreign.map((e) => e.tag), ['v0.6.7']);
+});
+
+test('planPromotion refuses a judgement that names no tag', () => {
+  assert.throws(() => planPromotion([{ held: true, proven: true }]), /names no tag/);
+  assert.throws(() => planPromotion([null]), /names no tag/);
+});
+
+test('planPromotion alarms only after the threshold, and only on a real wait', () => {
+  const fresh = planPromotion(
+    [{ tag: 'v0.6.6', held: true, proven: false, reason: 'pending', publishedAt: ago(5) }],
+    { now: NOW },
+  );
+  assert.equal(fresh.alarm, 'none');
+  assert.deepEqual(fresh.overdue, []);
+
+  const old = planPromotion(
+    [{ tag: 'v0.6.6', held: true, proven: false, reason: 'pending', publishedAt: ago(DEFAULT_ALARM_AFTER_MINUTES + 1) }],
+    { now: NOW },
+  );
+  assert.equal(old.alarm, 'open');
+  assert.deepEqual(old.overdue.map((e) => e.tag), ['v0.6.6']);
+
+  const already = planPromotion(
+    [{ tag: 'v0.6.6', held: true, proven: false, reason: 'pending', publishedAt: ago(DEFAULT_ALARM_AFTER_MINUTES + 1) }],
+    { now: NOW, openIssue: { number: 7 } },
+  );
+  assert.equal(already.alarm, 'update');
+});
+
+// An unreadable publication time must not buy silence. This is the direction
+// the check could have failed safe-looking and been wrong: treating "no
+// timestamp" as "just published" hides a release that has waited for days.
+test('planPromotion treats an unreadable publication time as overdue', () => {
+  for (const publishedAt of [null, '', 'not-a-date']) {
+    const plan = planPromotion(
+      [{ tag: 'v0.6.6', held: true, proven: false, reason: 'pending', publishedAt }],
+      { now: NOW },
+    );
+    assert.equal(plan.alarm, 'open', `publishedAt ${JSON.stringify(publishedAt)} should be overdue`);
+    assert.equal(plan.overdue[0].minutes, null);
+  }
+});
+
+test('planPromotion closes an open alarm only when nothing is waiting at all', () => {
+  const stillInsideWindow = planPromotion(
+    [{ tag: 'v0.6.6', held: true, proven: false, reason: 'pending', publishedAt: ago(5) }],
+    { now: NOW, openIssue: { number: 7 } },
+  );
+  // Waiting but not overdue. Closing here would reopen the same issue an hour
+  // later, which trains a reader to ignore it.
+  assert.equal(stillInsideWindow.alarm, 'none');
+
+  const nothingWaiting = planPromotion(
+    [{ tag: 'v0.6.5', held: true, proven: true, publishedAt: ago(5) }],
+    { now: NOW, openIssue: { number: 7 } },
+  );
+  assert.equal(nothingWaiting.alarm, 'close');
+
+  const noneAtAll = planPromotion([], { now: NOW, openIssue: { number: 7 } });
+  assert.equal(noneAtAll.alarm, 'close');
+});
+
+test('buildBody names every overdue tag and what the gate said about it', () => {
+  const body = buildBody([
+    { tag: 'v0.6.6', reason: 'evidence/abc/stranger.env does not exist', minutes: 400 },
+    { tag: 'v0.6.7', reason: 'records incomplete stranger arm(s) brown', minutes: null },
+  ]);
+  assert.match(body, /v0\.6\.6/);
+  assert.match(body, /v0\.6\.7/);
+  assert.match(body, /does not exist/);
+  assert.match(body, /incomplete stranger arm/);
+  assert.match(body, /400 min/);
+  assert.match(body, /unknown/);
+  // The reason is data from a gate, and a pipe in it would silently break the
+  // table it is rendered into.
+  assert.match(buildBody([{ tag: 'v1.0.0', reason: 'a | b', minutes: 400 }]), /a \\\| b/);
+  assert.match(body, /closes itself/);
+});
+
+test('the alarm title names the condition and never a tag', () => {
+  assert.equal(ALARM_TITLE, 'Release published without first-contact proof');
+  assert.doesNotMatch(ALARM_TITLE, /v\d/);
+});
+
+// ── reading the rail ──────────────────────────────────────────────────────
+
+const stubApi = (routes) => async (path) => {
+  for (const [fragment, value] of Object.entries(routes)) {
+    if (path.includes(fragment)) {
+      if (value instanceof Error) throw value;
+      return value;
+    }
+  }
+  throw new Error(`GET ${path} failed: HTTP 404 Not Found`);
+};
+
+test('resolveTagCommit dereferences an annotated tag', async () => {
+  const lightweight = await resolveTagCommit(
+    'v0.6.5',
+    stubApi({ '/git/ref/tags/': { object: { type: 'commit', sha: 'a'.repeat(40) } } }),
+  );
+  assert.equal(lightweight, 'a'.repeat(40));
+
+  // An annotated tag's ref points at a TAG object, whose sha is not a commit.
+  // Keying the evidence lookup on it would ask about a sha no preflight ever
+  // judged, and the refusal would read as "unproven" rather than as a bug.
+  const annotated = await resolveTagCommit(
+    'v0.6.6',
+    stubApi({
+      '/git/ref/tags/': { object: { type: 'tag', sha: 'c'.repeat(40) } },
+      '/git/tags/': { object: { sha: 'b'.repeat(40) } },
+    }),
+  );
+  assert.equal(annotated, 'b'.repeat(40));
+
+  await assert.rejects(
+    resolveTagCommit('v0.6.7', stubApi({ '/git/ref/tags/': { object: { type: 'commit', sha: 'nope' } } })),
+    /does not resolve to a commit sha/,
+  );
+});
+
+const listing = (over = {}) => ({
+  '/releases?': [release(over)],
+  '/git/ref/tags/': { object: { type: 'commit', sha: 'a'.repeat(40) } },
+  '/issues?': [],
+});
+
+test('buildPlan promotes a held release the gate now passes', async () => {
+  const plan = await buildPlan({
+    repository: 'firelock-ai/kin',
+    api: stubApi(listing()),
+    judge: async () => ({ stranger: { driver: { endpoint: 'local' } } }),
+    now: NOW,
+  });
+  assert.deepEqual(plan.promote, [{ tag: 'v0.6.5', driver: 'local' }]);
+  assert.equal(plan.judgements[0].sha, 'a'.repeat(40));
+});
+
+// The reason a gate gives is the first thing a reader needs, so it has to
+// survive into the plan rather than being flattened to "not proven".
+test('buildPlan carries the gate refusal verbatim and never fails the sweep', async () => {
+  const plan = await buildPlan({
+    repository: 'firelock-ai/kin',
+    api: stubApi(listing()),
+    judge: async () => {
+      throw new Error('evidence/aaa/stranger.env does not exist on the release-evidence branch');
+    },
+    now: NOW,
+  });
+  assert.deepEqual(plan.promote, []);
+  assert.equal(plan.waiting.length, 1);
+  assert.match(plan.waiting[0].reason, /stranger\.env does not exist/);
+});
+
+// A tag that will not resolve is a wait with a reason, not a red sweep. This
+// promoter ticks four times an hour and a red run on a rail that is behaving
+// trains a reader to ignore it.
+test('buildPlan turns an unresolvable tag into a wait, not a failure', async () => {
+  const plan = await buildPlan({
+    repository: 'firelock-ai/kin',
+    api: stubApi({ '/releases?': [release()], '/issues?': [] }),
+    judge: async () => {
+      throw new Error('the judge must not be reached for an unresolvable tag');
+    },
+    now: NOW,
+  });
+  assert.deepEqual(plan.promote, []);
+  assert.match(plan.waiting[0].reason, /HTTP 404 Not Found/);
+});
+
+// The one read that must NOT fail soft. A truncated listing looks exactly like
+// a short one, and a promoter that silently read only the newest hundred
+// releases would go quiet at the moment the list outgrew them.
+test('buildPlan refuses a release listing that filled a whole page', async () => {
+  await assert.rejects(
+    buildPlan({
+      repository: 'firelock-ai/kin',
+      api: stubApi({ '/releases?': Array.from({ length: 100 }, () => release()) }),
+      judge: async () => ({}),
+      now: NOW,
+    }),
+    /filled a whole page/,
+  );
+  // The control: ninety-nine is an answer, and it must be read as one.
+  const short = await buildPlan({
+    repository: 'firelock-ai/kin',
+    api: stubApi({
+      '/releases?': Array.from({ length: 99 }, () => release()),
+      '/git/ref/tags/': { object: { type: 'commit', sha: 'a'.repeat(40) } },
+      '/issues?': [],
+    }),
+    judge: async () => ({ stranger: { driver: { endpoint: 'account' } } }),
+    now: NOW,
+  });
+  assert.equal(short.promote.length, 99);
+});
+
+test('buildPlan finds the open alarm by its exact title and nothing else', async () => {
+  const withIssue = await buildPlan({
+    repository: 'firelock-ai/kin',
+    api: stubApi({
+      ...listing({ published_at: ago(DEFAULT_ALARM_AFTER_MINUTES + 1) }),
+      '/issues?': [{ number: 12, title: ALARM_TITLE }],
+    }),
+    judge: async () => {
+      throw new Error('pending');
+    },
+    now: NOW,
+  });
+  assert.equal(withIssue.openIssue, 12);
+  assert.equal(withIssue.alarm, 'update');
+
+  // A near-miss title must not be adopted, or a rename would silently comment
+  // on somebody else's issue forever.
+  const other = await buildPlan({
+    repository: 'firelock-ai/kin',
+    api: stubApi({
+      ...listing({ published_at: ago(DEFAULT_ALARM_AFTER_MINUTES + 1) }),
+      '/issues?': [{ number: 12, title: `${ALARM_TITLE} (v0.6.6)` }],
+    }),
+    judge: async () => {
+      throw new Error('pending');
+    },
+    now: NOW,
+  });
+  assert.equal(other.openIssue, null);
+  assert.equal(other.alarm, 'open');
+});
+
+test('buildPlan refuses without a repository', async () => {
+  await assert.rejects(
+    buildPlan({ api: stubApi({}), judge: async () => ({}) }),
+    /no repository given/,
+  );
+});
+
+// The promoter reaches GitHub Latest, so it must require everything and must
+// not inherit that decision from the environment. A stray KIN_RELEASE_REQUIRE
+// would otherwise promote a release on the machine proof alone, which is the
+// exact failure the two-tier design exists to prevent.
+//
+// The input has to be the one case where the two modes DISAGREE: a preflight
+// record that exists and a stranger record that does not. An absent preflight
+// throws in both modes, so a test built on one would pass whichever mode ran
+// and prove nothing.
+test('the promoter asks the gate for every record, whatever the environment says', async () => {
+  const SHA = 'a'.repeat(40);
+  const ARCHIVE = '1'.repeat(64);
+  const preflight = {
+    schema: 'kin.release-preflight.v1',
+    verdict: 'PASS',
+    allow_dirty: false,
+    legs: [
+      {
+        name: 'linux (arm64, debian 12, archive)',
+        verdict: 'PASS',
+        result: { expected: { commit: SHA }, archive: { sha256: ARCHIVE } },
+      },
+    ],
+  };
+  const previous = process.env.KIN_RELEASE_REQUIRE;
+  process.env.KIN_RELEASE_REQUIRE = 'preflight';
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-promoter-'));
+  const out = path.join(dir, 'plan.json');
+  try {
+    await main({
+      repository: 'firelock-ai/kin',
+      token: 'x',
+      out,
+      log: () => {},
+      fetchImpl: async (url) => {
+        const answer = (body) => ({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: async () => body,
+          text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+        });
+        if (url.includes('/releases?')) return answer([release()]);
+        if (url.includes('/git/ref/tags/')) return answer({ object: { type: 'commit', sha: SHA } });
+        if (url.includes('/issues?')) return answer([]);
+        if (url.includes('preflight.json')) return answer(JSON.stringify(preflight));
+        return { ok: false, status: 404, statusText: 'Not Found', text: async () => '' };
+      },
+    });
+  } finally {
+    if (previous === undefined) delete process.env.KIN_RELEASE_REQUIRE;
+    else process.env.KIN_RELEASE_REQUIRE = previous;
+  }
+  const plan = JSON.parse(fs.readFileSync(out, 'utf8'));
+  // Under 'preflight' this release would have been proven and promoted. Under
+  // 'all', which is what the promoter must ask for, it waits.
+  assert.deepEqual(plan.promote, []);
+  assert.match(plan.waiting[0].reason, /stranger\.env does not exist/);
+});

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -1306,6 +1306,37 @@ def assert_stranger_driver_credential_is_either(release_cut: str) -> None:
         )
 
 
+# The `release` environment's deployment branch policy admits tag: v*.*.* and
+# nothing else, so a job that reaches it from a branch is refused by the server
+# before a step runs. That is invisible in the workflow file and fatal on a
+# schedule, where the refusal repeats every cycle forever.
+#
+# The policies themselves live in repository settings and cannot be read from
+# the tree, so this asserts the rule the tree CAN carry: a workflow that fires
+# on a schedule or a repository_dispatch runs from a branch, and must not
+# declare the tag-only environment.
+TAG_ONLY_ENVIRONMENT = "release"
+BRANCH_ENVIRONMENT = "release-tag"
+
+
+def assert_branch_triggered_workflows_avoid_the_tag_environment(
+    workflows: dict[Path, str],
+) -> None:
+    for path, source in workflows.items():
+        head = source.split("\njobs:", 1)[0]
+        if "schedule:" not in head and "repository_dispatch:" not in head:
+            continue
+        for line in active_lines(source):
+            if line == f"environment: {TAG_ONLY_ENVIRONMENT}":
+                raise AssertionError(
+                    f"{path.name} can fire from a branch and declares "
+                    f"environment: {TAG_ONLY_ENVIRONMENT}, whose deployment "
+                    f"branch policy admits tags alone; use "
+                    f"{BRANCH_ENVIRONMENT}, which admits main, or the job is "
+                    "refused before any step runs"
+                )
+
+
 def expect_assertion(
     label: str,
     expected_error: str,
@@ -16598,6 +16629,19 @@ def main() -> None:
     # The two-tier proof contract, and a falsification arm per direction it
     # could collapse. Each mutant is the smallest edit that would actually be
     # made by someone "tidying up", not a syntactic wreck.
+    assert_branch_triggered_workflows_avoid_the_tag_environment(workflow_sources)
+    expect_assertion(
+        "a scheduled workflow reaches the tag-only release environment",
+        "whose deployment branch policy admits tags alone",
+        lambda mutant={
+            **workflow_sources,
+            WORKFLOWS / "release-promote.yml": (
+                WORKFLOWS / "release-promote.yml"
+            ).read_text(encoding="utf-8").replace(
+                "environment: release-tag", "environment: release", 1
+            ),
+        }: assert_branch_triggered_workflows_avoid_the_tag_environment(mutant),
+    )
     assert_stranger_driver_credential_is_either(release_cut)
     expect_assertion(
         "the cut demands an API key even when a local model drives",

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -24,6 +24,7 @@ ROOT = Path(__file__).resolve().parent.parent
 WORKFLOWS = ROOT / ".github" / "workflows"
 README = ROOT / "README.md"
 RELEASE = WORKFLOWS / "release.yml"
+RELEASE_CUT = WORKFLOWS / "release-cut.yml"
 RELEASE_RECOVERY = WORKFLOWS / "release-recovery.yml"
 RELEASE_TAG = WORKFLOWS / "release-tag.yml"
 RC_BUILD = WORKFLOWS / "rc-build.yml"
@@ -1263,6 +1264,45 @@ def assert_require_modes_match_the_gate(
             f"the release workflows ask the proof gate for mode(s) {unknown} "
             f"that it does not declare (it knows {sorted(modes)}); move both "
             "sides together"
+        )
+
+
+def assert_stranger_driver_credential_is_either(release_cut: str) -> None:
+    """The cut must accept a local model OR a key, and must still refuse with neither.
+
+    The key is required only on the account path. Naming a local model points
+    the driver at an endpoint on the runner and `driver_env_argv` then UNSETS
+    ANTHROPIC_API_KEY for the driver child, so demanding a secret the run
+    throws away is how a rail stays blocked on a founder step it does not need.
+
+    Both halves are asserted, because the refusal is the load-bearing one: an
+    absent credential sends every driver request out unauthenticated and the
+    transcript records only a server error, hours in.
+    """
+
+    lines = active_lines(release_cut)
+    joined = "\n".join(lines)
+    if "vars.KIN_STRANGER_LOCAL_MODEL" not in joined:
+        raise AssertionError(
+            "release-cut.yml must let a local model drive the stranger; without "
+            "it the cut demands an API key the local path immediately discards"
+        )
+    if '--local-model' not in joined:
+        raise AssertionError(
+            "release-cut.yml names a local model and never passes --local-model "
+            "to the harness, so the run would drive the account anyway"
+        )
+    # The refusal must still exist, and it must still be reachable when neither
+    # credential is configured.
+    if 'if [ -n "${LOCAL_MODEL:-}" ]; then' not in joined:
+        raise AssertionError(
+            "release-cut.yml must branch on the local model before it demands a key"
+        )
+    if 'elif [ -z "${STRANGER_KEY:-}" ]; then' not in joined:
+        raise AssertionError(
+            "release-cut.yml must still refuse when NEITHER a local model nor a "
+            "key is configured; a driver with no credential fails hours in with "
+            "a bare server error"
         )
 
 
@@ -10229,6 +10269,7 @@ def main() -> None:
             )
 
     release = RELEASE.read_text(encoding="utf-8")
+    release_cut = RELEASE_CUT.read_text(encoding="utf-8")
     release_recovery = RELEASE_RECOVERY.read_text(encoding="utf-8")
     release_tag = RELEASE_TAG.read_text(encoding="utf-8")
     release_train = RELEASE_TRAIN.read_text(encoding="utf-8")
@@ -16557,6 +16598,21 @@ def main() -> None:
     # The two-tier proof contract, and a falsification arm per direction it
     # could collapse. Each mutant is the smallest edit that would actually be
     # made by someone "tidying up", not a syntactic wreck.
+    assert_stranger_driver_credential_is_either(release_cut)
+    expect_assertion(
+        "the cut demands an API key even when a local model drives",
+        "must let a local model drive the stranger",
+        lambda mutant=release_cut.replace("vars.KIN_STRANGER_LOCAL_MODEL", "vars.KIN_STRANGER_UNUSED"): (
+            assert_stranger_driver_credential_is_either(mutant)
+        ),
+    )
+    expect_assertion(
+        "the cut accepts a driverless run with no credential at all",
+        "must still refuse when NEITHER",
+        lambda mutant=release_cut.replace(
+            'elif [ -z "${STRANGER_KEY:-}" ]; then', 'elif false; then', 1
+        ): assert_stranger_driver_credential_is_either(mutant),
+    )
     assert_tag_tier_requires_only_the_machine_proof(release_tag)
     assert_latest_requires_the_stranger(release)
     assert_latest_claims_gate_on_promotion(release)

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -872,6 +872,16 @@ EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
         "stranger-standby": "Report the stranger a runner cannot take",
         "report": "Report the cut's decision",
     },
+    # The second tier of the proof contract. A tag now mints on the machine
+    # preflight alone and the release is published as a prerelease; this sweep
+    # is what takes it to GitHub Latest once its stranger record lands, and what
+    # alarms while it has not. None of its jobs runs on a pull_request or
+    # merge_group event, so none can claim a required context; it is registered
+    # here because this census is what would otherwise let a new workflow's job
+    # NAME appear unreviewed.
+    ".github/workflows/release-promote.yml": {
+        "promote": "Promote proven releases to Latest",
+    },
     ".github/workflows/release-recovery.yml": {
         "reconcile": "Reconcile failed release",
     },
@@ -1121,6 +1131,119 @@ EXTERNAL_REQUIRED_CONTEXT_SPOOF = textwrap.dedent(
 def require(content: str, needle: str, context: str) -> None:
     if needle not in content:
         raise AssertionError(f"{context} is missing required policy: {needle}")
+
+
+# ── the two-tier proof contract ───────────────────────────────────────────
+#
+# Until 2026-09-02 both decision points required the same thing: a preflight
+# record AND a complete stranger record, or no release at all. That made every
+# release hostage to a driver, and on run rc0551 the account's weekly limit
+# turned a proven candidate into a tag that could not be cut, with a hold alarm
+# as the only signal.
+#
+# The contract now has two tiers, and these assertions are what stop the tiers
+# collapsing back into one in either direction. Collapsing UP puts the outage
+# back. Collapsing DOWN promotes a release to GitHub Latest with no first-contact
+# proof, which is the 2026-08-20 failure this whole gate exists for.
+#
+# Every assertion reads active lines, never raw text, because each of these
+# files carries prose ABOUT the thing being asserted and a check satisfied by
+# its own explanatory comment cannot fail.
+TAG_TIER_MODE = "KIN_RELEASE_REQUIRE=preflight"
+PROMOTION_STATE = "complete"
+
+
+def assert_tag_tier_requires_only_the_machine_proof(release_tag: str) -> None:
+    """The mint must ask for the preflight tier, so a missing stranger cannot hold a tag."""
+
+    lines = active_lines(release_tag)
+    if not any(TAG_TIER_MODE in line for line in lines):
+        raise AssertionError(
+            "release-tag.yml must run the proof gate with "
+            f"{TAG_TIER_MODE}; without it a candidate whose stranger has not "
+            "run yet cannot be tagged at all, which is the outage this tier "
+            "exists to end"
+        )
+    # Reading the state is not optional. A mint that relaxed the requirement and
+    # then said nothing would cut tags that silently claim nothing, and the
+    # release would carry no record of what it is missing.
+    if not any("stranger_state=" in line for line in lines):
+        raise AssertionError(
+            "release-tag.yml must record the stranger state it proceeded on"
+        )
+
+
+def assert_latest_requires_the_stranger(release: str) -> None:
+    """GitHub Latest is the claim of first-contact coverage, so it needs the record."""
+
+    lines = active_lines(release)
+    gate = f'"$STRANGER_STATE" != {PROMOTION_STATE}'
+    if not any(gate in line for line in lines):
+        raise AssertionError(
+            "release.yml must refuse to promote a release to GitHub Latest "
+            f"unless its stranger state is {PROMOTION_STATE}; Latest is what an "
+            "installer resolves, so it is the claim first-contact proof backs"
+        )
+    if not any("promoted=false" in line for line in lines):
+        raise AssertionError(
+            "release.yml must record promoted=false when it holds a release, so "
+            "a downstream job can tell 'held' from 'this step never ran'"
+        )
+
+
+def assert_latest_claims_gate_on_promotion(release: str) -> None:
+    """Every job whose meaning is "this IS Latest" must gate on the promotion, not the job."""
+
+    needed = "needs.finalize_release.outputs.promoted == 'true'"
+    for job in ("promote_ghcr_latest", "seal_release_completion"):
+        start = release.index(f"\n  {job}:")
+        end = release.index("\n    steps:", start)
+        if needed not in "\n".join(active_lines(release[start:end])):
+            raise AssertionError(
+                f"{job} must gate on {needed}; it claims that this release IS "
+                "Latest, and finalize_release now succeeds without promoting "
+                "when first-contact proof is pending"
+            )
+
+
+def assert_require_modes_match_the_gate(
+    release_tag: str, release: str, proof_gate: str
+) -> None:
+    """The mode both workflows ask for must be one the gate module actually knows.
+
+    This is the coupling that would otherwise fail on a release night. A mode
+    renamed in the module and not in the workflows refuses at run time with
+    "unknown require mode", which is correct behaviour and a stopped release.
+    """
+
+    declared = re.search(
+        r"export const REQUIRE_MODES = Object\.freeze\(\[([^\]]*)\]\)",
+        proof_gate,
+    )
+    if declared is None:
+        raise AssertionError(
+            "the proof gate must declare REQUIRE_MODES for the workflows to be "
+            "checked against"
+        )
+    modes = set(re.findall(r"'([^']+)'", declared.group(1)))
+    asked = set()
+    for source in (release_tag, release):
+        for line in active_lines(source):
+            found = re.search(r"KIN_RELEASE_REQUIRE=([A-Za-z-]+)", line)
+            if found:
+                asked.add(found.group(1))
+    if not asked:
+        raise AssertionError(
+            "no workflow asks the proof gate for a require mode, so this "
+            "coupling checks nothing"
+        )
+    unknown = sorted(asked - modes)
+    if unknown:
+        raise AssertionError(
+            f"the release workflows ask the proof gate for mode(s) {unknown} "
+            f"that it does not declare (it knows {sorted(modes)}); move both "
+            "sides together"
+        )
 
 
 def expect_assertion(
@@ -16411,6 +16534,69 @@ def main() -> None:
                 assert_ruleset_mirror_stays_a_superset(mutant)
             ),
         )
+    # The two-tier proof contract, and a falsification arm per direction it
+    # could collapse. Each mutant is the smallest edit that would actually be
+    # made by someone "tidying up", not a syntactic wreck.
+    assert_tag_tier_requires_only_the_machine_proof(release_tag)
+    assert_latest_requires_the_stranger(release)
+    assert_latest_claims_gate_on_promotion(release)
+    assert_require_modes_match_the_gate(release_tag, release, proof_gate)
+    expect_assertion(
+        "the mint goes back to requiring a stranger before a tag",
+        "must run the proof gate with",
+        lambda mutant=release_tag.replace(
+            "            KIN_RELEASE_REQUIRE=preflight \\\n", "", 1
+        ): assert_tag_tier_requires_only_the_machine_proof(mutant),
+    )
+    expect_assertion(
+        "promotion to Latest stops asking about the stranger",
+        "must refuse to promote a release to GitHub Latest",
+        lambda mutant=release.replace(
+            'if [ "$STRANGER_STATE" != complete ]; then',
+            'if [ "$STRANGER_STATE" = never ]; then',
+            1,
+        ): assert_latest_requires_the_stranger(mutant),
+    )
+    expect_assertion(
+        "GHCR latest moves on a release that was held as a prerelease",
+        "must gate on needs.finalize_release.outputs.promoted",
+        lambda mutant=release.replace(
+            "        needs.config.outputs.release_channel == 'latest' &&\n"
+            "        needs.finalize_release.outputs.promoted == 'true' &&\n"
+            "        startsWith(github.ref, 'refs/tags/v') &&\n"
+            "        !contains(github.ref_name, '-')\n"
+            "      }}\n"
+            "    runs-on: ubuntu-latest\n"
+            "    environment: release\n"
+            "    # Least privilege for one registry-side tag move",
+            "        needs.config.outputs.release_channel == 'latest' &&\n"
+            "        startsWith(github.ref, 'refs/tags/v') &&\n"
+            "        !contains(github.ref_name, '-')\n"
+            "      }}\n"
+            "    runs-on: ubuntu-latest\n"
+            "    environment: release\n"
+            "    # Least privilege for one registry-side tag move",
+            1,
+        ): assert_latest_claims_gate_on_promotion(mutant),
+    )
+    expect_assertion(
+        "a workflow asks for a mode the gate module does not know",
+        "that it does not declare",
+        lambda mutant=release_tag.replace(
+            "KIN_RELEASE_REQUIRE=preflight", "KIN_RELEASE_REQUIRE=machine", 1
+        ): assert_require_modes_match_the_gate(mutant, release, proof_gate),
+    )
+    # The coupling must also be able to notice that nothing asks at all, or it
+    # would pass forever on a tree where the mode was deleted from both sides.
+    expect_assertion(
+        "no workflow asks the gate for a mode at all",
+        "so this coupling checks nothing",
+        lambda: assert_require_modes_match_the_gate(
+            release_tag.replace("KIN_RELEASE_REQUIRE=preflight", "", 1),
+            release.replace("KIN_RELEASE_REQUIRE=preflight", "", 1),
+            proof_gate,
+        ),
+    )
     assert_soft_decline_is_legible(release_tag)
     assert_recovery_escalation_classifies(
         RELEASE_RECOVERY.read_text(encoding="utf-8")

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -1189,6 +1189,26 @@ def assert_latest_requires_the_stranger(release: str) -> None:
             "release.yml must record promoted=false when it holds a release, so "
             "a downstream job can tell 'held' from 'this step never ran'"
         )
+    # The pending notice explains why a STABLE release is not Latest. A
+    # prerelease tag is a prerelease because that is what it is, and it never
+    # becomes Latest whatever its record says, so telling its reader that it
+    # "stays a prerelease until its record lands" promises something no path in
+    # this chain delivers.
+    anchor = "      - name: Record the missing first-contact proof on the release itself\n"
+    if release.count(anchor) != 1:
+        raise AssertionError(
+            "release.yml must declare exactly one step recording a missing "
+            "first-contact proof on the release"
+        )
+    start = release.index(anchor)
+    notice = release[start : release.index("\n      - name: ", start + len(anchor))]
+    condition = "\n".join(active_lines(notice))
+    for required in ("stranger_state == 'pending'", "!contains(github.ref_name, '-')"):
+        if required not in condition:
+            raise AssertionError(
+                "the first-contact notice must be written only for a held "
+                f"STABLE release; its condition is missing {required}"
+            )
 
 
 def assert_latest_claims_gate_on_promotion(release: str) -> None:
@@ -16554,6 +16574,16 @@ def main() -> None:
         lambda mutant=release.replace(
             'if [ "$STRANGER_STATE" != complete ]; then',
             'if [ "$STRANGER_STATE" = never ]; then',
+            1,
+        ): assert_latest_requires_the_stranger(mutant),
+    )
+    expect_assertion(
+        "the pending notice is written onto a prerelease tag too",
+        "written only for a held",
+        lambda mutant=release.replace(
+            "            steps.proof.outputs.stranger_state == 'pending' &&\n"
+            "            !contains(github.ref_name, '-')\n",
+            "            steps.proof.outputs.stranger_state == 'pending'\n",
             1,
         ): assert_latest_requires_the_stranger(mutant),
     )


### PR DESCRIPTION
The stranger was a single point of failure for the whole release rail, and the
founder's instruction tonight was to end that: "can we make that not blocking
please? I want the release process to be fully automatic."

## What was wrong

Both decision points required the same evidence. `release-tag.yml` refused to
write a tag without `preflight.json` AND `stranger.env`, and `release.yml`
refused to promote without both. So a candidate whose stranger had not run could
not be tagged at all, and there was no path forward except running the stranger.
On run rc0551 the account's weekly limit killed the driver with a proven
candidate waiting, and the only signal was a hold alarm. A gate whose failure
mode is "no tag, forever, quietly" is preventing releases, not protecting them.

## The choice, argued

The brief offered three shapes and asked for a deliberate choice.

**(a) Mint on preflight, mark the release `stranger: pending`, alarm loudly.**
This unblocks the tag and keeps the record honest, and it is most of what
shipped. On its own it is not enough: nothing stops an unproven release becoming
the version an installer resolves, so the record would still end up claiming
coverage it does not have.

**(b) Wait a bounded time, then proceed and note the omission.** Rejected. A
timer is a poll loop that burns a runner, and it still stalls, just for less
long. Worse, the length of the wait becomes the real policy and nobody writes it
down. A bounded wait answers "how long" when the question is "what does this
release claim".

**(c) Make the stranger a post-release gate on promotion to Latest.** Chosen,
with (a)'s honesty folded in, because the release chain already had the second
decision point and the distinction it draws is real:

- A **tag** is an artifact somebody has to name to install. It claims the
  machine proof: these archives were built from this commit, a preflight judged
  these exact bytes, and the tagged tree is the proven tree. That record can
  always exist before a tag, produced by rc-build and published by release-cut
  with nobody at the button.
- **GitHub Latest** is what an installer resolves when a stranger types the
  install line. That is the claim first-contact proof backs, so that is where
  the stranger record is required.

So the tag mints, the release publishes as a prerelease, and Latest waits.

## What that means for a Kin release

A release can now exist without first-contact proof. That is a real change and
it is stated in three places rather than implied:

1. The held release carries the statement in its own body, not only in a CI
   annotation, so anyone reading the release sees what it is missing before they
   install it.
2. `Release Promotion` sweeps four times an hour, promotes every held release
   whose stranger record has since landed, and opens one tracked issue naming
   any release that has waited more than six hours.
3. The proof gate names which driver produced a record it accepted.

The sweep is what keeps "non-blocking" from meaning "stuck one step further
along". A push to the `release-evidence` branch cannot trigger anything, because
that orphan branch carries no workflow files and GitHub resolves a push event's
workflows from the pushed ref, so a cron is the only automatic route.

The two jobs whose whole meaning is "this IS Latest", the GHCR `latest` move and
the completion seal, now gate on `finalize_release.outputs.promoted` rather than
on the job's conclusion. Without that they would go red on a release that was
correctly held, which is exactly the red-run-on-a-healthy-release noise #1394
just removed.

## The relaxation is one condition wide

Under `require: preflight` an **absent** stranger record becomes a reported
pending state. A record that is unreadable, about another build, missing an arm,
or on bytes no preflight leg judged still refuses, in both tiers. `fetchEvidence`
flags a 404 and deliberately flags nothing else, and the relaxation keys on that
flag, so "we could not tell" never widens into "proceed". An unknown mode
refuses rather than defaulting, because a typo that fell back to `all` would
look like a working gate on the day someone meant to relax it and a typo that
fell back to `preflight` would ship an unproven release.

The promoter asks for `all` explicitly rather than inheriting the mode from the
environment, so a stray `KIN_RELEASE_REQUIRE` cannot promote a release on the
machine proof alone.

## The drivers stop being flattened

A local-model stranger and an account stranger write the same keys, the same
arms and the same archive sha256, and until now both reached a reader as one
sentence. The gate now reads the record's own `driver_endpoint` (falling back to
the legacy `endpoint` key that every already-published record carries), refuses
a record whose two keys disagree, refuses a key that claims to answer and
answers nothing, and names a weaker driver as weaker in the line it logs. The
distinction it protects is precise: a local run's findings stand on their own
evidence, and its silence does not.

`bin/kin-stranger` writes `driver_endpoint` on every run; that half is
kin-ecosystem #273.

## Gates

| gate | result |
| --- | --- |
| `scripts/test-release-workflow-authority.py` | rc 0 |
| `scripts/test-assertion-reachability.py` | rc 0 |
| `scripts/test-release-policy-gate.sh` | rc 0 |
| `scripts/check-rc-build-drift.mjs` | rc 0 |
| `scripts/test-select-release-candidate.py` | rc 0, 55 tests |
| `actionlint` repo-wide | rc 0, zero findings |
| `node --test` across five release suites | 98 tests, 0 fail |

## Falsification

26 mutations, each breaking one behaviour and each required to turn its named
test red, driven by a script that also asserts the test passes on the clean tree
first. 26 red, 0 survived. Five more falsification arms are built into the
authority suite itself and run on every invocation, covering the mint going back
to requiring a stranger, promotion dropping the stranger check, GHCR `latest`
moving on a held release, a workflow asking for a mode the gate does not
declare, and no workflow asking at all.

Two things that pass deserve naming, because both were found by falsifying
rather than by testing:

**A mutant survived and the assertion was the problem.** Removing the
blank-line clause from `stripPendingNotice` left its test green: the notice text
was still gone and the author's own quoted line still survived, and only a stray
leading newline separated the two answers. The fix was a stronger assertion, not
a new guard: stripping the notice must return the body BYTE FOR BYTE. That is
the input only the clause can get right.

**A real defect the tests would not have caught.** The alarm decision travels as
one tab-separated line, and bash treats a tab set as `IFS` as whitespace and
collapses runs of it, so `open\t\tTitle` binds the title to the issue NUMBER and
leaves the title empty. Measured with a real `bash -c`, not assumed. The number
is now `0` rather than empty when no issue is open, `renderAlarm` refuses to ask
for a comment on an issue the plan does not name, and the test that guards it
runs the actual shell read rather than asserting a property of the string.

Related: FIR-3084
