### PR TITLE
Free a daemon start lock whose holder is gone, and name the wait

### DIFF
--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -5585,11 +5585,89 @@ fn startup_lock_is_stale(path: &Path, stale_after: Duration) -> bool {
         .unwrap_or(false)
 }
 
+/// The process identifier a startup lock names, when its holder wrote one.
+///
+/// The writer's line is `pid=<n> acquired_at=<instant>`. `None` means the file
+/// says nothing readable about an owner, which is not the same as saying nobody
+/// owns it, and every caller here reads it that way.
+fn startup_lock_holder(path: &Path) -> Option<u32> {
+    let text = std::fs::read_to_string(path).ok()?;
+    text.split_whitespace()
+        .find_map(|field| field.strip_prefix("pid="))?
+        .trim()
+        .parse::<u32>()
+        .ok()
+}
+
+/// Free a startup lock whose recorded holder is provably gone, and say whether
+/// it did.
+///
+/// `daemon.start.lock` is a create-new sentinel rather than an advisory lock, so
+/// unlike the supervisor's file lock it outlives the process that took it. A kin
+/// command killed while it starts a daemon leaves the file behind, which is
+/// what a caller that caps a question and kills the process group does, and
+/// until this, the only recovery was the mtime rule below, which needs twice the
+/// startup timeout. Every command in that repository meanwhile waits the whole
+/// timeout for a holder that cannot finish, and on a store whose daemon is not
+/// already serving, that wait is the entire answer the caller gets.
+///
+/// Conservative by construction: only an affirmative death frees the lock. An
+/// unreadable file, an unparseable pid and an indeterminate probe all keep the
+/// wait, because taking a lock a live starter holds would let two spawns race
+/// for one repository. The pid is re-read immediately before the unlink so a
+/// holder that took the lock since the decision is not unlinked under it.
+fn clear_abandoned_startup_lock(path: &Path) -> bool {
+    let Some(holder) = startup_lock_holder(path) else {
+        return false;
+    };
+    if holder == std::process::id() || process_liveness(holder) != ProcessLiveness::Dead {
+        return false;
+    }
+    if startup_lock_holder(path) != Some(holder) {
+        return false;
+    }
+    debug!(
+        path = %path.display(),
+        holder,
+        "cleared a startup lock whose holder process is gone"
+    );
+    std::fs::remove_file(path).is_ok()
+}
+
+/// The line a caller prints while another kin command holds the startup lock.
+///
+/// Named rather than generic: a reader who waits needs to know that the wait is
+/// on another command in this repository and which one, because that is the
+/// difference between a hang to report and a queue to sit in.
+fn startup_lock_wait_line(holder: Option<u32>, waited: Duration) -> String {
+    let waited = waited.as_secs_f64();
+    match holder {
+        Some(pid) => format!(
+            "waiting for another kin command (pid {pid}) to finish starting this repository's \
+             daemon ({waited:.1}s)"
+        ),
+        None => format!(
+            "waiting for another kin command to finish starting this repository's daemon \
+             ({waited:.1}s)"
+        ),
+    }
+}
+
+/// How long a caller waits on a held startup lock before it says so.
+///
+/// A handoff between two commands is routine and usually over in well under a
+/// second, so announcing every one of them would be noise. Past this, the wait
+/// is long enough that a caller with a budget needs to know what it is in.
+const STARTUP_LOCK_NOTICE_AFTER: Duration = Duration::from_secs(1);
+
 async fn acquire_startup_lock(kin_root: &Path) -> Result<StartupLock> {
     let path = kin_root.join("daemon.start.lock");
     let timeout = Duration::from_secs(startup_lock_timeout_secs());
     let stale_after = timeout.saturating_mul(2).max(Duration::from_secs(10));
-    let deadline = Instant::now() + timeout;
+    let started = Instant::now();
+    let deadline = started + timeout;
+    let mut notice: Option<crate::progress::Progress> = None;
+    let mut announced_at: Option<Instant> = None;
 
     loop {
         match OpenOptions::new().write(true).create_new(true).open(&path) {
@@ -5600,9 +5678,19 @@ async fn acquire_startup_lock(kin_root: &Path) -> Result<StartupLock> {
                     std::process::id(),
                     std::time::SystemTime::now()
                 );
+                if let Some(notice) = notice.as_ref() {
+                    notice.finish_with(format_args!(
+                        "the other kin command finished after {:.1}s; starting this repository's \
+                         daemon now",
+                        started.elapsed().as_secs_f64()
+                    ));
+                }
                 return Ok(StartupLock { path, _file: file });
             }
             Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                if clear_abandoned_startup_lock(&path) {
+                    continue;
+                }
                 if startup_lock_is_stale(&path, stale_after) {
                     debug!(
                         path = %path.display(),
@@ -5612,6 +5700,9 @@ async fn acquire_startup_lock(kin_root: &Path) -> Result<StartupLock> {
                     continue;
                 }
                 if Instant::now() >= deadline {
+                    if let Some(notice) = notice.as_ref() {
+                        notice.finish();
+                    }
                     bail!(
                         "timed out waiting for daemon startup lock at {} after {}s: another kin \
                          command in this repository still holds it. Wait for it to finish, or \
@@ -5620,6 +5711,18 @@ async fn acquire_startup_lock(kin_root: &Path) -> Result<StartupLock> {
                         path.display(),
                         timeout.as_secs()
                     );
+                }
+                let waited = started.elapsed();
+                if waited >= STARTUP_LOCK_NOTICE_AFTER
+                    && announced_at.is_none_or(|last| last.elapsed() >= Duration::from_secs(1))
+                {
+                    notice
+                        .get_or_insert_with(crate::progress::Progress::stderr)
+                        .update(format_args!(
+                            "{}",
+                            startup_lock_wait_line(startup_lock_holder(&path), waited)
+                        ));
+                    announced_at = Some(Instant::now());
                 }
                 tokio::time::sleep(Duration::from_millis(100)).await;
             }
@@ -12166,6 +12269,104 @@ mod tests {
 
         assert!(startup_lock_is_stale(&lock, Duration::ZERO));
         assert!(!startup_lock_is_stale(&lock, Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn startup_lock_holder_reads_the_pid_its_own_writer_recorded() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock = dir.path().join("daemon.start.lock");
+        // Exactly what `acquire_startup_lock` writes.
+        std::fs::write(
+            &lock,
+            format!(
+                "pid={} acquired_at={:?}\n",
+                4321,
+                std::time::SystemTime::now()
+            ),
+        )
+        .unwrap();
+        assert_eq!(startup_lock_holder(&lock), Some(4321));
+
+        // A file that says nothing readable about an owner says exactly that,
+        // and the caller must not read it as "nobody holds this".
+        std::fs::write(&lock, "written by something else\n").unwrap();
+        assert_eq!(startup_lock_holder(&lock), None);
+        std::fs::write(&lock, "pid=not-a-number\n").unwrap();
+        assert_eq!(startup_lock_holder(&lock), None);
+        assert_eq!(startup_lock_holder(&dir.path().join("absent")), None);
+    }
+
+    /// A startup lock outlives its holder, so the holder's liveness is what
+    /// decides whether the next command may take it. Both directions are here:
+    /// clearing every lock races two spawns for one repository, clearing none
+    /// strands the next question behind a process that has already exited.
+    #[cfg(unix)]
+    #[test]
+    fn only_a_startup_lock_whose_holder_is_gone_is_cleared() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock = dir.path().join("daemon.start.lock");
+
+        let mut live = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn a live stand-in for a command still starting a daemon");
+        std::fs::write(&lock, format!("pid={} acquired_at=now\n", live.id())).unwrap();
+        assert!(
+            !clear_abandoned_startup_lock(&lock),
+            "a lock a live process holds must survive"
+        );
+        assert!(lock.exists(), "and must still be on disk");
+        let _ = live.kill();
+        let _ = live.wait();
+
+        std::fs::write(
+            &lock,
+            format!("pid={} acquired_at=now\n", std::process::id()),
+        )
+        .unwrap();
+        assert!(
+            !clear_abandoned_startup_lock(&lock),
+            "our own pid is alive by definition"
+        );
+
+        let mut gone = std::process::Command::new("sleep")
+            .arg("0")
+            .spawn()
+            .expect("spawn a stand-in for a command that died mid-start");
+        let dead = gone.id();
+        gone.wait().expect("reap the stand-in");
+        std::fs::write(&lock, format!("pid={dead} acquired_at=now\n")).unwrap();
+        assert!(
+            clear_abandoned_startup_lock(&lock),
+            "a lock whose holder has exited is free"
+        );
+        assert!(
+            !lock.exists(),
+            "and is unlinked so the next command can take it"
+        );
+
+        // Nothing to clear is not the same as clearing something.
+        assert!(!clear_abandoned_startup_lock(&lock));
+    }
+
+    #[test]
+    fn the_startup_lock_wait_line_names_what_the_wait_is_on() {
+        let line = startup_lock_wait_line(Some(4321), Duration::from_millis(2500));
+        assert!(
+            line.contains("waiting for another kin command (pid 4321)"),
+            "the line names the holder: {line}"
+        );
+        assert!(
+            line.contains("starting this repository's daemon"),
+            "and what it is doing: {line}"
+        );
+        assert!(line.contains("(2.5s)"), "and how long this has run: {line}");
+
+        let anonymous = startup_lock_wait_line(None, Duration::from_secs(1));
+        assert!(
+            anonymous.contains("waiting for another kin command to finish starting"),
+            "a lock with no readable holder still says what the wait is: {anonymous}"
+        );
     }
 
     // ── startup deadline is patience, not a death sentence ─────────────────

--- a/crates/kin-cli/tests/common/mod.rs
+++ b/crates/kin-cli/tests/common/mod.rs
@@ -1708,6 +1708,11 @@ fn is_allowed_runtime_override(key: &OsStr) -> bool {
         "KIN_DAEMON_IDLE_TIMEOUT_SECS",
         "KIN_SUPERVISOR_IDLE_TIMEOUT_SECS",
         "KIN_DAEMON_READY_TIMEOUT_SECS",
+        // The wait for another command's daemon start, which defaults from the
+        // ready timeout above and is the same kind of per-command patience. A
+        // test about that wait cannot bound it without carrying this, and a
+        // 300 s default is not a bound a test can sit through.
+        "KIN_DAEMON_STARTUP_LOCK_TIMEOUT_SECS",
         "KIN_BYPASS_EMBEDDING_COVERAGE_CHECK",
         "KIN_EMBED_BACKEND",
         // A runtime-bound command that sets this and is not carried proves the

--- a/crates/kin-cli/tests/daemon_start_lock_recovery.rs
+++ b/crates/kin-cli/tests/daemon_start_lock_recovery.rs
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! A lock nobody holds is taken; a lock somebody holds is waited on, out loud.
+//!
+//! `daemon.start.lock` is a create-new sentinel, not an advisory lock, so a kin
+//! command killed while it starts a daemon leaves the file behind. Every later
+//! command in that repository then waits the whole startup-lock timeout, which
+//! defaults to 300 seconds, before it has spoken to any daemon at all. A caller
+//! that caps a question below that sees the cap and nothing else: no output, no
+//! CPU anywhere, and a store doing no work.
+//!
+//! Both halves are asserted here because either alone is satisfiable by a broken
+//! implementation. Clearing every lock passes the first test and races two
+//! spawns for one repository; clearing none passes the second and strands the
+//! next question behind a process that has already exited.
+
+use serial_test::serial;
+use std::fs;
+use std::path::Path;
+use std::time::Instant;
+use tempfile::tempdir;
+
+mod common;
+
+use common::Command;
+
+fn kin_command(runtime: &common::IsolatedDaemonRuntime) -> Command<'_> {
+    let mut cmd = runtime.kin_command();
+    cmd.env("KIN_DAEMON_DISABLE_LSP", "1")
+        .env("KIN_DAEMON_BIN", runtime.daemon_bin())
+        .env("KIN_DAEMON_READY_TIMEOUT_SECS", "60")
+        // The wait this test is about, kept short so a red run fails fast.
+        .env("KIN_DAEMON_STARTUP_LOCK_TIMEOUT_SECS", "5")
+        .env("KIN_BYPASS_EMBEDDING_COVERAGE_CHECK", "1");
+    cmd
+}
+
+fn git(repo: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .unwrap_or_else(|error| panic!("git {args:?}: {error}"));
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// A one-file repository with a store, and no daemon serving it.
+fn seeded_store(repo: &Path, runtime: &common::IsolatedDaemonRuntime) {
+    fs::create_dir_all(repo.join("src")).expect("create src dir");
+    fs::write(
+        repo.join("src/lib.rs"),
+        "pub fn lexer() -> &'static str { \"lexer\" }\n",
+    )
+    .expect("write source");
+    git(repo, &["init", "-q"]);
+    git(repo, &["add", "-A"]);
+    git(
+        repo,
+        &[
+            "-c",
+            "user.name=kin-ci",
+            "-c",
+            "user.email=ci@kin.dev",
+            "commit",
+            "-q",
+            "-m",
+            "seed",
+        ],
+    );
+
+    let init = kin_command(runtime)
+        .arg("init")
+        .arg(".")
+        .current_dir(repo)
+        .output()
+        .expect("run kin init");
+    assert!(
+        init.status.success(),
+        "kin init failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let stop = kin_command(runtime)
+        .args(["daemon", "stop"])
+        .current_dir(repo)
+        .output()
+        .expect("run kin daemon stop");
+    assert!(
+        stop.status.success(),
+        "kin daemon stop failed: {}",
+        String::from_utf8_lossy(&stop.stderr)
+    );
+}
+
+/// Write the lock exactly as the CLI writes it, naming `pid` as its holder.
+fn plant_startup_lock(repo: &Path, pid: u32) -> std::path::PathBuf {
+    let path = repo.join(".kin").join("daemon.start.lock");
+    fs::write(
+        &path,
+        format!("pid={pid} acquired_at={:?}\n", std::time::SystemTime::now()),
+    )
+    .expect("plant a startup lock");
+    path
+}
+
+/// A process identifier whose process has exited and been reaped.
+#[cfg(unix)]
+fn reaped_pid() -> u32 {
+    let mut child = std::process::Command::new("sleep")
+        .arg("0")
+        .spawn()
+        .expect("spawn a stand-in for a kin command that died mid-start");
+    let pid = child.id();
+    child.wait().expect("reap the stand-in");
+    pid
+}
+
+#[cfg(unix)]
+#[test]
+#[serial]
+fn a_question_behind_a_dead_starters_lock_answers_instead_of_waiting_out_the_budget() {
+    let repo = tempdir().expect("temp repo");
+    let runtime = common::IsolatedDaemonRuntime::new(repo.path());
+    seeded_store(repo.path(), &runtime);
+
+    let lock = plant_startup_lock(repo.path(), reaped_pid());
+    let started = Instant::now();
+    let locate = kin_command(&runtime)
+        .args(["locate", "lexer", "--json"])
+        .current_dir(repo.path())
+        .output()
+        .expect("run kin locate behind an abandoned startup lock");
+    let stderr = String::from_utf8_lossy(&locate.stderr).to_string();
+
+    assert!(
+        locate.status.success(),
+        "a lock whose holder is gone must not stop the question: {stderr}"
+    );
+    assert!(
+        !stderr.contains("timed out waiting for daemon startup lock"),
+        "and it must not be waited out either: {stderr}"
+    );
+    serde_json::from_slice::<serde_json::Value>(&locate.stdout)
+        .expect("stdout is still one JSON document");
+    assert!(
+        !lock.exists(),
+        "the abandoned lock is gone once the command that took it over finished"
+    );
+    // The wait it would have paid is the whole startup-lock timeout, which this
+    // test sets to 5 s. The answer arrives without it; the ready wait for the
+    // daemon this command starts is a separate, longer bound and is not what is
+    // asserted here.
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(120),
+        "the run must not have sat out a startup-lock wait"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+#[serial]
+fn a_startup_lock_a_live_command_holds_is_respected_and_named() {
+    let repo = tempdir().expect("temp repo");
+    let runtime = common::IsolatedDaemonRuntime::new(repo.path());
+    seeded_store(repo.path(), &runtime);
+
+    // Outlives the whole wait on purpose. A stand-in that exits mid-test becomes
+    // an unreaped corpse, which `process_liveness` calls dead, and the lock this
+    // test is about would be freed for the right reason at the wrong moment.
+    let mut holder = std::process::Command::new("sleep")
+        .arg("300")
+        .spawn()
+        .expect("spawn a live stand-in for a kin command still starting a daemon");
+    let holder_pid = holder.id();
+    let lock = plant_startup_lock(repo.path(), holder_pid);
+
+    let locate = kin_command(&runtime)
+        .args(["locate", "lexer", "--json"])
+        .current_dir(repo.path())
+        .output()
+        .expect("run kin locate behind a held startup lock");
+    let stderr = String::from_utf8_lossy(&locate.stderr).to_string();
+
+    let _ = holder.kill();
+    let _ = holder.wait();
+
+    assert!(
+        !locate.status.success(),
+        "a lock a live command holds must not be taken: {stderr}"
+    );
+    assert!(
+        stderr.contains("timed out waiting for daemon startup lock"),
+        "the wait ends at its own bound, with its own cause: {stderr}"
+    );
+    assert!(
+        stderr.contains(&format!(
+            "waiting for another kin command (pid {holder_pid}) to finish starting this \
+             repository's daemon"
+        )),
+        "and while it waits it says what it is waiting for, and on whom: {stderr}"
+    );
+    assert!(
+        fs::read_to_string(&lock)
+            .expect("the held lock is still there")
+            .contains(&format!("pid={holder_pid}")),
+        "the live holder's lock is left exactly as it was"
+    );
+}


### PR DESCRIPTION
The first question after a daemon restart could spend its whole budget without ever speaking to a daemon. `.kin/daemon.start.lock` is a create-new sentinel rather than an advisory lock, so it outlives the process that took it. A kin command killed while it starts a daemon leaves the file behind, and the next command in that repository waits `startup_lock_timeout_secs()` for a holder that cannot finish, which defaults from `KIN_DAEMON_READY_TIMEOUT_SECS` to 300 seconds. That wait is taken at `daemon_client.rs:7765`, before `StartupNotice::open()` at 7792, so nothing is printed for any of it. The only recovery was an mtime rule at twice the timeout, ten minutes on the default.

Measured on a clonefile copy of the demo's VS Code store (1.5 GiB, 29,392 entities), with the demo's own sandbox profile, its environment and its 120 second cap, running the demo's own `kin locate ... --json --max-files 8`:

| arm | wall | rc | stdout |
|---|---|---|---|
| orphaned lock, nothing serving the repo | 120.1 s, killed at the cap | 143 | 0 B |
| same question, lock removed | 31.8 s | 0 | 30,100 B |
| cold start with no lock | 26.1 s, `kin daemon ready in 11.9s` | 0 | 30,100 B |

During the first arm there was no repo daemon running at all, the store's `.kin` stayed at 1,557,088 KB, and `sample` showed every client thread parked in `_pthread_cond_wait` while `lsof` listed one open file, its own executable. Killing a client four seconds into a start is what leaves the lock behind, and a question that finds a daemon already serving never reaches the lock at all, which is why this shows up after a restart and not otherwise.

What changed. `clear_abandoned_startup_lock` reads the pid the lock's own writer recorded and frees the file when `process_liveness` proves that process dead, so the next question proceeds instead of waiting out a process that has exited. Only an affirmative death frees it: an unreadable file, an unparseable pid, our own pid and an indeterminate probe all keep the wait, because taking a lock a live starter holds would race two spawns for one repository. The pid is re-read immediately before the unlink so a holder that arrived since the decision is not unlinked under it. A wait past one second now opens the CLI's stderr progress line and names it, `waiting for another kin command (pid 23209) to finish starting this repository's daemon (12.3s)`, refreshed once a second and closed with how long the handoff took. stdout is untouched, so a `--json` caller still emits one document.

Guards. `crates/kin-cli/tests/daemon_start_lock_recovery.rs` runs both shapes against a real store: a lock naming an exited process must not stop the question and must be gone afterwards, and a lock naming a live one must be refused at its own bound, left byte for byte as it was, and named on stderr while it is waited on. Three unit tests beside `startup_lock_is_stale` cover the pieces: the holder pid round-trips through the writer's own format, only an affirmatively dead holder frees the lock, and the wait line names the holder, the act and the elapsed time. Both integration tests together run in 15 s. This is a crate test rather than an acceptance case because the class is size-independent: the wait is on a file lock and is paid before the client opens anything, so a 1.5 GiB store and a one-file store wait identically, and acceptance does not grade pull requests.

Falsification, all three run:

| break | unit | dead starter's lock | live holder respected |
|---|---|---|---|
| never clear an abandoned lock (the old behavior) | FAILED | FAILED | ok |
| clear every lock unconditionally | FAILED | ok | FAILED |
| never announce the wait | ok | ok | FAILED |
| restored | 4 passed | ok | ok |

Each guard goes red under its own break and stays green under the others.

`KIN_DAEMON_STARTUP_LOCK_TIMEOUT_SECS` joins `is_allowed_runtime_override`'s list so the live-holder test can bound its own wait; without it the harness scrubs the override and the test measures the 300 second default.

Gates run locally: `cargo fmt -- --check`, `cargo clippy --all-targets --all-features` with ci.yml's own allow list, `scripts/zero_file_search_guard.sh`, `scripts/check-quarantine.py`, `cargo test -p kin-cli --lib startup_lock`, and `cargo test -p kin-cli --test daemon_start_lock_recovery`. `bin/kin-parity` finished on this tree: `FINAL PASS-WITH-ALLOWANCES in 1490.6s (NON-CITABLE)`, rc 0, with its three standing allowances (firstrun/9 FIR-2580, firstrun/3 FIR-2501, brownfield/4 FIR-2464) and nothing new. `bin/kin-precheck kin` refuses on this tree for a reason that predates it: ci.yml's check job names `scripts/release-proof` and precheck neither runs it nor classifies it, so it exits 2 with no tally.

Not in this change, and worth a look separately: the mtime staleness rule can still take a lock from a live holder once the file is twice the timeout old. It predates the pid being written into the file, and now that the pid is read, an old mtime with a live holder is a different judgement from an old mtime with no holder at all.

Closes FIR-3114
