### PR TITLE
Identify preflight tooling by its ref, not by the runner that read it

### DIFF
--- a/scripts/release-proof/merge-preflight-records.mjs
+++ b/scripts/release-proof/merge-preflight-records.mjs
@@ -102,6 +102,40 @@ export function admitLegRecord(record, candidate, where) {
   return legs;
 }
 
+// `tooling.source` is `<checkout> @ <ref>`, and the checkout is where the
+// tooling was READ, not what it is. Hosted, one candidate is judged on three
+// runners, and a macOS runner's checkout is /Users/runner/work/kin/kin while a
+// Linux runner's is /home/runner/work/kin/kin. Comparing the raw field called
+// three legs of one commit "different tooling" and refused to merge them, which
+// on 2026-09-03 failed run 33700686594 with all three legs green on
+// 54dc78e3b7ab41b1cac12bf95aa345fbf57eca39 and both sha256 fields identical.
+//
+// The identity is the ref and the hashes. A source with no ` @ ` is a working
+// tree, which names no ref, so it stays compared whole: two working trees are
+// not known to be the same bytes.
+function toolingIdentity(tooling) {
+  if (tooling === null || typeof tooling !== 'object') return JSON.stringify(tooling ?? null);
+  const source = typeof tooling.source === 'string' ? tooling.source : null;
+  const at = source === null ? -1 : source.lastIndexOf(' @ ');
+  return JSON.stringify({ ...tooling, source: at === -1 ? source : source.slice(at + 3) });
+}
+
+// Identical sources stay verbatim, so a merge of records from one checkout
+// writes exactly the bytes it wrote before. Where they differ only by checkout
+// directory, no single one of them is true of the merged record, so it names
+// how many checkouts agreed and the ref they agreed on. Deterministic either
+// way: the publisher reads a differing document under a sha that already has
+// one as tampering.
+function mergedTooling(toolings) {
+  const first = toolings[0];
+  const sources = new Set(toolings.map((entry) => (entry && typeof entry === 'object' ? entry.source : null)));
+  if (sources.size === 1) return first;
+  const source = typeof first?.source === 'string' ? first.source : '';
+  const at = source.lastIndexOf(' @ ');
+  const ref = at === -1 ? source : source.slice(at + 3);
+  return { ...first, source: `${sources.size} checkouts @ ${ref}` };
+}
+
 export function mergeRecords(records, candidate) {
   if (!COMMIT_SHA.test(candidate ?? '')) {
     throw new Error(`"${candidate}" is not a 40-character commit sha`);
@@ -149,8 +183,12 @@ export function mergeRecords(records, candidate) {
     tooling.push(JSON.stringify(record.tooling ?? null));
     if (record.cpu_embed !== true) cpuEmbed = false;
   });
-  if (new Set(tooling).size !== 1) {
-    throw new Error('the leg records were produced by different tooling; refusing to merge them into one answer');
+  const identities = new Set(tooling.map((entry) => toolingIdentity(JSON.parse(entry))));
+  if (identities.size !== 1) {
+    throw new Error(
+      'the leg records were produced by different tooling; refusing to merge them into one answer: ' +
+      [...identities].sort().join(' vs '),
+    );
   }
   const archives = new Map();
   for (const leg of legs) {
@@ -172,7 +210,7 @@ export function mergeRecords(records, candidate) {
     verdict: 'PASS',
     allow_dirty: false,
     cpu_embed: cpuEmbed,
-    tooling: JSON.parse(tooling[0]),
+    tooling: mergedTooling(tooling.map((entry) => JSON.parse(entry))),
     provenance: admittedByEntry.flatMap(({ record }) => (Array.isArray(record.provenance) ? record.provenance : [])),
     skipped: admittedByEntry.flatMap(({ record }) => (Array.isArray(record.skipped) ? record.skipped : [])),
     legs,

--- a/scripts/release-proof/merge-preflight-records.test.mjs
+++ b/scripts/release-proof/merge-preflight-records.test.mjs
@@ -141,6 +141,58 @@ test('one archive sha256 claimed by two targets is refused', () => {
   assert.throws(() => mergeRecords(entries(twin, macos()), SHA), /claimed by kin-linux-aarch64 and kin-macos-aarch64/);
 });
 
+test('one commit read on a macOS and a Linux runner is one tooling', () => {
+  // Regression, run 33700686594 on 2026-09-03. The publisher ran for the first
+  // time ever and refused three green legs of 54dc78e3b because the macOS
+  // runner's checkout is /Users/runner/work/kin/kin and the Linux runners' is
+  // /home/runner/work/kin/kin. These are the exact values read off that run's
+  // three leg records; both sha256 fields were already identical.
+  const ported = '0c469d2871a1a6b02944a2ddc5f12482a1556af4179f8f66bbfa018443ee2878';
+  const at = (home) => ({
+    source: `${home}/runner/work/kin/kin @ 54dc78e3b7ab41b1cac12bf95aa345fbf57eca39`,
+    validator_ported_from_sha256: ported,
+    workflow_sha256_at_ref: ported,
+  });
+  const mac = macos();
+  mac.tooling = at('/Users');
+  const linux = record([leg('kin-linux-aarch64', 'd'.repeat(64))], { tooling: at('/home') });
+  const { merged } = mergeRecords(entries(mac, linux), SHA);
+  assert.equal(merged.legs.length, 2);
+  // No runner's own directory may stand for a record spanning three of them,
+  // and the ref they agreed on is what identified the tooling in the first place.
+  assert.equal(merged.tooling.source, '2 checkouts @ 54dc78e3b7ab41b1cac12bf95aa345fbf57eca39');
+  assert.equal(merged.tooling.validator_ported_from_sha256, ported);
+  assert.equal(merged.tooling.workflow_sha256_at_ref, ported);
+});
+
+test('one checkout keeps its source verbatim, so a single-host merge is unchanged', () => {
+  const { merged } = mergeRecords(entries(macos()), SHA);
+  assert.equal(merged.tooling.source, '/w @ HEAD');
+});
+
+test('two working trees name no ref, so they are not assumed to be one tooling', () => {
+  const other = macos();
+  const mine = record([leg('kin-linux-aarch64', 'd'.repeat(64))], {
+    tooling: { ...other.tooling, source: '/elsewhere (working tree)' },
+  });
+  other.tooling = { ...other.tooling, source: '/w (working tree)' };
+  assert.throws(() => mergeRecords(entries(other, mine), SHA), /different tooling/);
+});
+
+test('a differing ref is still different tooling, and the message names both', () => {
+  const other = macos();
+  const mine = record([leg('kin-linux-aarch64', 'd'.repeat(64))], {
+    tooling: { ...other.tooling, source: '/home/runner/work/kin/kin @ HEAD~1' },
+  });
+  other.tooling = { ...other.tooling, source: '/Users/runner/work/kin/kin @ HEAD' };
+  assert.throws(
+    () => mergeRecords(entries(other, mine), SHA),
+    (error) => /different tooling/.test(error.message)
+      && error.message.includes('HEAD~1')
+      && error.message.includes('HEAD'),
+  );
+});
+
 test('records from different tooling do not merge into one answer', () => {
   const other = arm();
   other.tooling = { ...other.tooling, validator_ported_from_sha256: 'f'.repeat(64) };


### PR DESCRIPTION
The publisher ran for the first time ever on run 33700686594 and refused three green legs with "the leg records were produced by different tooling". They were not different. All three named commit `54dc78e3b7ab41b1cac12bf95aa345fbf57eca39` and carried identical `validator_ported_from_sha256` and `workflow_sha256_at_ref`. The only difference was the checkout directory inside `tooling.source`, which is `/Users/runner/work/kin/kin` on the macOS runner and `/home/runner/work/kin/kin` on the two Linux ones.

`tooling.source` is `<checkout> @ <ref>`, and the checkout is where the tooling was read rather than what it is. The comparison now reads the ref and the two hashes. A source naming no ref is a working tree, so it is still compared whole, because two working trees are not known to be the same bytes. A differing ref is still different tooling, and the message now names both sides instead of leaving the reader to diff three artifacts by hand.

The merged record's `tooling.source` no longer takes one runner's directory to stand for a record spanning three of them. Where the sources are identical it stays verbatim, so a merge of records from a single checkout writes exactly the bytes it wrote before. Where they differ it names how many checkouts agreed and the ref they agreed on. Both are deterministic, which matters because the publisher reads a differing document under a sha that already has one as tampering.

This is the third link in one chain, all of it invisible until the link above it opened. #1404 let the cut reach `proof` at all, #1407 let the publisher run, and this is what the publisher hit. Each was unreachable while its predecessor was broken.

Five tests, each falsified by breaking exactly what it guards and confirmed red: comparing the raw field again, letting the merged record take one runner's path, dropping `source` from the identity, keeping the path half instead of the ref half, and synthesising a source for a single-checkout merge. The regression case carries the three values read off run 33700686594.

Gates run locally: the 13-file `node --test` release-policy batch at 210 passing and 0 failing, and all five release-policy Python suites at exit 0. `merge-preflight-records.mjs` is not in `scripts/release-proof/VENDORED.json`, so its sha-pinned vendored test is unaffected and passed.

Related: FIR-3084
