### PR TITLE
Keep the open-file helper inside the cfg gate that owns its caller

### DIFF
--- a/crates/kin-core/src/file_limit.rs
+++ b/crates/kin-core/src/file_limit.rs
@@ -48,23 +48,32 @@ pub struct OpenFileLimit {
     pub hard: Option<u64>,
 }
 
-/// The soft limit to ask for, or `None` when the one in force is already at
-/// least as high as anything this would achieve.
-///
-/// Separated from the syscalls so the decision is testable. Every path that
-/// would not improve the limit returns `None`, so a process an operator already
-/// tuned is left exactly as it was found.
-fn target_soft_limit(current: OpenFileLimit) -> Option<u64> {
-    let ceiling = match current.hard {
-        Some(hard) => hard.min(TARGET_OPEN_FILES),
-        None => TARGET_OPEN_FILES,
-    };
-    (ceiling > current.soft).then_some(ceiling)
-}
-
 #[cfg(unix)]
 mod imp {
-    use super::OpenFileLimit;
+    use super::{OpenFileLimit, TARGET_OPEN_FILES};
+
+    /// The soft limit to ask for, or `None` when the one in force is already at
+    /// least as high as anything this would achieve.
+    ///
+    /// Separated from the syscalls so the decision is testable. Every path that
+    /// would not improve the limit returns `None`, so a process an operator
+    /// already tuned is left exactly as it was found.
+    ///
+    /// It lives inside this module rather than beside the public surface for a
+    /// reason that cost a red main. `raise` is its only caller and `raise` is
+    /// cfg-gated, so at the outer level this function was dead code on every
+    /// platform without an `rlimit`, and the workspace builds with
+    /// `-D warnings`. Windows found that; the pull request could not, because
+    /// kin's Windows jobs do not run on a pull request. Keeping a helper inside
+    /// the same cfg as its caller makes that class impossible rather than
+    /// remembered.
+    fn target_soft_limit(current: OpenFileLimit) -> Option<u64> {
+        let ceiling = match current.hard {
+            Some(hard) => hard.min(TARGET_OPEN_FILES),
+            None => TARGET_OPEN_FILES,
+        };
+        (ceiling > current.soft).then_some(ceiling)
+    }
 
     /// Read this process's open-file limit, or `None` when the kernel refuses
     /// to say.
@@ -111,7 +120,7 @@ mod imp {
         let Some(current) = read() else {
             return;
         };
-        let Some(target) = super::target_soft_limit(current) else {
+        let Some(target) = target_soft_limit(current) else {
             return;
         };
         let hard = match current.hard {
@@ -130,7 +139,59 @@ mod imp {
     #[cfg(test)]
     mod tests {
         use super::*;
-        use crate::file_limit::TARGET_OPEN_FILES;
+
+        #[test]
+        fn a_stock_macos_limit_is_raised_to_the_target() {
+            assert_eq!(
+                target_soft_limit(OpenFileLimit {
+                    soft: 256,
+                    hard: None
+                }),
+                Some(TARGET_OPEN_FILES)
+            );
+        }
+
+        #[test]
+        fn a_hard_limit_below_the_target_caps_the_request() {
+            assert_eq!(
+                target_soft_limit(OpenFileLimit {
+                    soft: 256,
+                    hard: Some(4096)
+                }),
+                Some(4096)
+            );
+        }
+
+        #[test]
+        fn a_limit_an_operator_already_raised_is_left_alone() {
+            assert_eq!(
+                target_soft_limit(OpenFileLimit {
+                    soft: 1_048_576,
+                    hard: None
+                }),
+                None
+            );
+            assert_eq!(
+                target_soft_limit(OpenFileLimit {
+                    soft: TARGET_OPEN_FILES,
+                    hard: Some(TARGET_OPEN_FILES)
+                }),
+                None
+            );
+        }
+
+        /// A pinned hard limit is the case the error path exists for: nothing
+        /// can be asked for, so nothing is.
+        #[test]
+        fn a_soft_limit_pinned_at_its_hard_limit_asks_for_nothing() {
+            assert_eq!(
+                target_soft_limit(OpenFileLimit {
+                    soft: 256,
+                    hard: Some(256)
+                }),
+                None
+            );
+        }
 
         /// The ladder must be able to reach the floor, or a machine with a low
         /// `kern.maxfilesperproc` would spin rather than settle.
@@ -164,6 +225,20 @@ mod imp {
     }
 
     pub fn raise() {}
+
+    #[cfg(test)]
+    mod tests {
+        /// The no-op contract, asserted rather than assumed, because
+        /// `kin_cli::open_files` renders its guidance from exactly these two
+        /// answers: a limit of `None` prints the remedy with no limit line, and
+        /// a raise that cannot panic is what lets it be called unconditionally
+        /// at startup.
+        #[test]
+        fn a_platform_without_rlimit_reports_no_limit_and_raises_nothing() {
+            super::raise();
+            assert!(super::read().is_none());
+        }
+    }
 }
 
 /// Raise this process's open-file soft limit toward its hard limit.
@@ -182,64 +257,6 @@ pub fn raise_open_file_limit() {
 /// number in an error message is the number that was in force.
 pub fn open_file_limit() -> Option<OpenFileLimit> {
     imp::read()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn a_stock_macos_limit_is_raised_to_the_target() {
-        assert_eq!(
-            target_soft_limit(OpenFileLimit {
-                soft: 256,
-                hard: None
-            }),
-            Some(TARGET_OPEN_FILES)
-        );
-    }
-
-    #[test]
-    fn a_hard_limit_below_the_target_caps_the_request() {
-        assert_eq!(
-            target_soft_limit(OpenFileLimit {
-                soft: 256,
-                hard: Some(4096)
-            }),
-            Some(4096)
-        );
-    }
-
-    #[test]
-    fn a_limit_an_operator_already_raised_is_left_alone() {
-        assert_eq!(
-            target_soft_limit(OpenFileLimit {
-                soft: 1_048_576,
-                hard: None
-            }),
-            None
-        );
-        assert_eq!(
-            target_soft_limit(OpenFileLimit {
-                soft: TARGET_OPEN_FILES,
-                hard: Some(TARGET_OPEN_FILES)
-            }),
-            None
-        );
-    }
-
-    /// A pinned hard limit is the case the error path exists for: nothing can
-    /// be asked for, so nothing is.
-    #[test]
-    fn a_soft_limit_pinned_at_its_hard_limit_asks_for_nothing() {
-        assert_eq!(
-            target_soft_limit(OpenFileLimit {
-                soft: 256,
-                hard: Some(256)
-            }),
-            None
-        );
-    }
 }
 
 /// The margin between the target and what an admission was measured to need,


### PR DESCRIPTION
kin main is red on Windows and this is the fix. All four Windows jobs failed to compile on `ddc3e0621`, and the sha before it was green on every one.

```
error: function `target_soft_limit` is never used
  --> crates\kin-core\src\file_limit.rs:57:4
   = note: `-D dead-code` implied by `-D warnings`
```

My change. The helper sat at module scope while its only caller, `imp::raise`, sat inside `#[cfg(unix)]`. So on any platform without an `rlimit` the function was dead code, and the workspace builds with `-D warnings`.

## The fix

The helper is now declared inside `#[cfg(unix)] mod imp`, beside the caller that owns it. That makes the class structural rather than remembered: a helper cannot outlive its caller's cfg if it lives in the same block. Its four decision tests move with it into the module's own test block.

The non-unix side gains a test of the contract it actually owes. `kin_cli::open_files` renders its guidance from exactly two answers, a limit of `None` and a raise that cannot panic, and nothing asserted either until now.

No behavior changes on any platform. This is where the code is declared, not what it does.

## Why the first change read green, and what I did about it

kin's Windows jobs carry `if: github.event_name != 'pull_request'`, so `Windows authority tests`, `Windows authority CLI tests`, `Windows authority runtime tests` and `Windows installer + vector release build` are all skipped on a pull request and run on main's push. A PR cannot see this class. That is the hazard the lane contract names, and I walked into it.

So this time the Windows build is proved locally rather than inferred:

```
RUSTFLAGS="-D warnings" cargo check -p kin-core   --lib --target x86_64-pc-windows-gnu   rc=0
RUSTFLAGS="-D warnings" cargo check -p kin-cli    --lib --target x86_64-pc-windows-gnu   rc=0
RUSTFLAGS="-D warnings" cargo check -p kin-daemon --lib --target x86_64-pc-windows-gnu   rc=0
RUSTFLAGS="-D warnings" cargo check -p kin-cli -p kin-daemon --bins --target x86_64-pc-windows-gnu   rc=0
```

The bins matter as much as the libs, because the two call sites this change exists for are in `kin-cli/src/main.rs` and `kin-daemon/src/bin/kin-daemon.rs`.

**That check was falsified before it was trusted.** Restoring the shipped shape, the helper hoisted back outside the cfg gate, reproduces the same single line CI reported:

```
error: function `target_soft_limit` is never used
falsify-arm rc=101
```

So a green from this check means something. A note for the next person: `x86_64-pc-windows-msvc` cannot cross-compile on an Apple Silicon Mac, because ring and the tree-sitter grammars build C and there are no MSVC headers. `x86_64-pc-windows-gnu` works with the Homebrew mingw toolchain, and `cfg(unix)` is false for both, so it reproduces this class exactly.

## Gates that ran

`cargo fmt -- --check` clean. Clippy exactly as `fast-gate-lint` runs it, `--all-targets --all-features` with the 45-lint allow list, clean, and with `RUSTFLAGS=-D warnings` set the way `ci.yml:40` sets it. `cargo test -p kin-core -p kin-cli --lib` for the touched modules: 13 passed. `cargo test -p kin-cli --test stock_macos_file_limit`: 12 passed.

`bin/kin-precheck kin` still refuses rather than grading, because `ci.yml`'s check job names `scripts/release-proof` and that tool has not been taught about it. That is a refusal, not a red gate, and the fix lives in the umbrella.

Fixes the Windows breakage from #1405. Related: FIR-3116.
