### PR TITLE
Re-vendor the evidence publisher from the landed umbrella fix

### DIFF
--- a/scripts/release-proof/VENDORED.json
+++ b/scripts/release-proof/VENDORED.json
@@ -1,13 +1,13 @@
 {
   "source_repository": "firelock-ai/kin-ecosystem",
-  "source_commit": "3ace010dbe6d3db43d8da2c38fa6290d0834a180",
+  "source_commit": "6aaf42ad0b37e12273ee4bfc3b59f6bc5ae210a4",
   "note": "Byte-identical copies of the umbrella proof tooling so the hosted preflight runs from kin alone; bin/kin-lane is a single-host lock shim written for this tree, not a copy. scripts/release-proof/vendored.test.mjs refuses a file whose sha256 left this manifest.",
   "files": {
     "bin/kin-release-preflight": {"source": "bin/kin-release-preflight", "sha256": "d42617e79966bf6d3548e00a9d303c38cf4689f6ff33610b6d9526019a028854"},
     "bin/kin-release-preflight.d/Dockerfile": {"source": "bin/kin-release-preflight.d/Dockerfile", "sha256": "e6c0e30c2bf46fc889484fb7e32c73163c3cf315d60351be3acd2428d22d12f6"},
     "bin/kin-release-preflight.d/proof-flow.sh": {"source": "bin/kin-release-preflight.d/proof-flow.sh", "sha256": "3a44e377a8c6bfcdfb688608ae5b9ba64293e3a955b711afe20ee237e2516b2b"},
     "bin/kin-release-preflight.d/validate.mjs": {"source": "bin/kin-release-preflight.d/validate.mjs", "sha256": "53badad40150ee0a4d8c817af77f48f04ad2ae89616dce33686532b82afa35b9"},
-    "bin/kin-evidence-publish": {"source": "bin/kin-evidence-publish", "sha256": "38ae34733b38feb3344ed8cecfa9ab52219e463b4beb99d3f9c39889dd662d46"},
+    "bin/kin-evidence-publish": {"source": "bin/kin-evidence-publish", "sha256": "7e82d4b09402bacc33881aa3b77ef5ea60677c8166df2cc8146bd86c10311d14"},
     "bin/kin-acceptance-suite": {"source": "bin/kin-acceptance-suite", "sha256": "7ce214e6563e227695cf02411762ca5e8d01edf8898634db465ee30f455918f7"}
   }
 }

--- a/scripts/release-proof/bin/kin-evidence-publish
+++ b/scripts/release-proof/bin/kin-evidence-publish
@@ -276,8 +276,23 @@ function apiReason(response) {
 // path gives, so an empty environment makes every read here say "no record yet"
 // and "no branch yet" and walks the run all the way to the write before failing
 // there. The read side wears the costume of a normal first run. Asking for the
-// repo and requiring push turns that into one named refusal at the door.
-async function assertCanWrite(token, repo) {
+// repo turns that into one named refusal at the door.
+//
+// The push half of that door reads `permissions` off the repository object, and
+// that block reports the AUTHENTICATED USER's permissions. A GitHub App
+// installation token is not a user, so it does not get one, and requiring
+// `push === true` refused the exact token release-cut.yml mints for this call:
+// on 2026-09-03 runs 33701924830 and 33702001129 both died here while the same
+// App, same installation, same `permission-contents: write`, had already moved
+// the candidate branch by PATCHing a ref in the arm job of run 33695497452.
+//
+// So an explicit `push: false` is still a refusal, because a token that says it
+// cannot push cannot, and that is the read-only-user case this door was added
+// for. An ABSENT block says nothing either way and is reported rather than
+// treated as a denial: the write is a few lines further on and GitHub refuses it
+// by name if the token really cannot push, which is a worse error than this one
+// but a far better error than refusing a token that works.
+async function assertCanWrite(token, repo, log = console.log) {
   if (!token) {
     throw new Error(
       `no GitHub token: GH_TOKEN and GITHUB_TOKEN are unset and "gh auth token" returned nothing, so nothing can be recorded on ${repo}. Run "gh auth login" or export GH_TOKEN.`,
@@ -292,15 +307,22 @@ async function assertCanWrite(token, repo) {
   if (!info.ok) {
     throw new Error(`this token was refused by ${repo}: HTTP ${info.status} ${apiReason(info)}`);
   }
-  if (info.body?.permissions?.push !== true) {
-    throw new Error(
-      `this token can read ${repo} but has no push permission, so the record would be refused at the write. Use a token with write access to ${repo}.`,
-    );
+  const permissions = info.body?.permissions;
+  if (permissions !== null && typeof permissions === 'object') {
+    if (permissions.push !== true) {
+      throw new Error(
+        `this token can read ${repo} but has no push permission, so the record would be refused at the write. Use a token with write access to ${repo}.`,
+      );
+    }
+    return;
   }
+  log(
+    `${repo} returned no permissions block, which is what a GitHub App installation token gets because that block reports a user's permissions; proceeding, and the write refuses by name if this token cannot push.`,
+  );
 }
 
 async function publish({ sha, name, file, repo, requireArchive }, { token = resolveToken(), log = console.log } = {}) {
-  await assertCanWrite(token, repo);
+  await assertCanWrite(token, repo, log);
   if (requireArchive) {
     await assertArchiveJudged(token, repo, sha, requireArchive);
   }


### PR DESCRIPTION
kin-ecosystem#276 stopped `kin-evidence-publish` refusing the GitHub App installation token release-cut.yml mints to file evidence. The door read `permissions.push` off `GET /repos`, that block reports the authenticated *user's* permissions, and an installation token gets none, so `undefined !== true` refused a token that had already moved the candidate branch earlier in the same workflow.

This is the vendored half. The bytes come from kin-ecosystem main at `6aaf42ad0b37e12273ee4bfc3b59f6bc5ae210a4` and hash to `7e82d4b09402bacc33881aa3b77ef5ea60677c8166df2cc8146bd86c10311d14`, computed from the landed file rather than from the branch that proposed it, and `VENDORED.json` moves to both. Nothing else in the manifest changes, and the diff is two values.

Behaviour is unchanged from the umbrella commit: an explicit `push: false` is still a refusal, an absent or null block is reported and proceeds because it says nothing either way, and the 404 branch that catches an unauthenticated read of a private repo is untouched.

`scripts/release-proof/vendored.test.mjs` holds the copy to the manifest, and it was falsified three ways here rather than trusted: the old sha256 against the new bytes, the old bytes against the new sha256, and a 39-character `source_commit`. Each went red, the first two naming `bin/kin-evidence-publish drifted from VENDORED.json`. Worth recording plainly that a well-formed but invented `source_commit` does **not** go red, because that field is checked for shape and never against its target; I measured that with `0123456789abcdef0123456789abcdef01234567`, which passes at exit 0. The gap is filed as a trap class rather than papered over here.

Gates on this tree: the 13-file `node --test` release-policy batch at 210 passing 0 failing, all five release-policy Python suites at exit 0, the vendored copy still executable, and `git diff --summary` showing no mode change.

Fourth and last link of tonight's chain in the release cut, each one invisible until the link above it opened: #1404 let the cut reach `proof` at all, #1407 let the publisher run, #1409 let the leg records merge, and this lets the write happen. Whether the record actually publishes gets proved by dispatching after this lands, not asserted here.

Related: FIR-3084
