### PR TITLE
Spend one budget on the lexical parity floor's prose lifts

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -7296,6 +7296,12 @@ fn apply_lexical_parity_floor(
     }
 
     let mut admitted: Vec<(String, f32)> = Vec::new();
+    // A lift of a file already in `fused` REPLACES what retrieval computed:
+    // `parity` carries the name match and `tiebreak * original` carries five
+    // per cent of everything else. That is a rescue when a handful of files
+    // take it and it is the ranking when hundreds do, so the lifts are staged
+    // here and spent under one budget below rather than applied in place.
+    let mut present_lifts: Vec<(usize, f32, f32, &String)> = Vec::new();
     for (path, record) in &matches {
         // The floor anchors on a term matching an entity NAME, which a tracked
         // artifact can never satisfy, and this is deliberately still where that
@@ -7320,13 +7326,46 @@ fn apply_lexical_parity_floor(
             if let Some(&idx) = existing.get(path) {
                 let original = fused[idx].1;
                 if parity > original {
-                    let tiebreak = locate_env_f32("KIN_LOCATE_LEXICAL_FLOOR_TIEBREAK", 0.05);
-                    fused[idx].1 = parity + tiebreak * original;
+                    present_lifts.push((idx, parity, original, path));
                 }
             }
         } else if admit_ok {
             admitted.push((path.clone(), parity));
         }
+    }
+    // Spend one budget across the ranked window: strongest lexical evidence
+    // first, then the pre-floor score, so retrieval decides among files whose
+    // name match is equally good. The sort is also what makes the budget
+    // deterministic, since `matches` is a HashMap and its iteration order is
+    // not; without a budget every lift was applied and the order could not
+    // matter.
+    // The budget binds on a PROSE question only, which is the same gate the
+    // file-anchor route uses (`locate.rs`, `anchors_enabled`). On a bare
+    // identifier lookup the query IS a name, so every file whose entity carries
+    // that name has earned the floor, and bounding it there costs a real
+    // definition: measured on microsoft/vscode, a `Cursor` lookup lost one of
+    // its two `Cursor` class rows at every budget tried.
+    let lift_budget = if locate_query_is_symbol_lookup(text) {
+        usize::MAX
+    } else {
+        locate_env_usize("KIN_LOCATE_LEXICAL_FLOOR_BUDGET", 12)
+    };
+    present_lifts.sort_by(|left, right| {
+        right
+            .1
+            .partial_cmp(&left.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| {
+                right
+                    .2
+                    .partial_cmp(&left.2)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| left.3.cmp(right.3))
+    });
+    let tiebreak = locate_env_f32("KIN_LOCATE_LEXICAL_FLOOR_TIEBREAK", 0.05);
+    for (idx, parity, original, _) in present_lifts.into_iter().take(lift_budget) {
+        fused[idx].1 = parity + tiebreak * original;
     }
     fused.extend(admitted);
 
@@ -23755,6 +23794,200 @@ mod tests {
             fused, before,
             "empty graph yields no lexical matches, so the floor must not change fusion"
         );
+    }
+
+    /// One budget for the parity floor, spent across the ranked window.
+    ///
+    /// A present-file lift REPLACES what retrieval computed: the parity score
+    /// carries the name match and only `tiebreak * original` (five per cent)
+    /// carries everything else. Unbounded, that turns the floor from a rescue
+    /// into the ranking. Measured on the microsoft/vscode store with the
+    /// catalogue's own typing question, the floor re-scored 234 of 748 files
+    /// and `browser/view/viewController.ts` went from rank 23 to rank 245
+    /// without its score moving, because the query term "editor" names an
+    /// entity in most of `src/vs/editor/` and `ViewController` matches none of
+    /// the surviving terms.
+    ///
+    /// The fixture deliberately reuses the catalogue's own question text, so
+    /// the reason `type_operations.rs` cannot be rescued is visible: "type" is
+    /// an `is_common_english_word`, and the floor filters those out, so the
+    /// verb naming the whole operation is never a floor term.
+    #[test]
+    fn one_lexical_floor_budget_is_spent_across_the_ranked_window() {
+        const QUESTION: &str = "When I type a character in the editor, how does it end up in the document? Walk me through the path.";
+        const JUNK: usize = 16;
+
+        // `Editor` is an exact part-set match for the term "editor" (quality
+        // 5.0, full lexical strength); `EditorWidget` is a superset match
+        // (quality 3.0, 0.6 strength); `Unrelated` and `TypeOperations` match
+        // no surviving term at all.
+        let graph = kin_db::InMemoryGraph::new();
+        let mut line = 100;
+        let mut define = |name: &str, path: &str| {
+            let entity = test_entity(name, path, line, line + 4);
+            line += 10;
+            graph.upsert_entity(&entity).unwrap();
+        };
+        define("Unrelated", "src/plain.rs");
+        define("Editor", "src/hot_editor.rs");
+        define("Editor", "src/warm_editor.rs");
+        define("TypeOperations", "src/type_operations.rs");
+        define("EditorWidget", "src/weak_editor.rs");
+        let junk: Vec<String> = (0..JUNK)
+            .map(|i| format!("src/junk_{i:02}_editor.rs"))
+            .collect();
+        for path in &junk {
+            define("Editor", path);
+        }
+
+        // The fused ranking the floor is handed. `plain.rs` is the highest
+        // scored file the floor does NOT lift, so it fixes `nonlexical_top`
+        // and every full-strength parity is 0.70 * 1.05 = 0.735. The junk band
+        // is the measured shape: a long tail of name matches carrying almost
+        // no retrieval evidence.
+        let base = || {
+            let mut fused = vec![
+                ("src/plain.rs".to_string(), 0.70_f32),
+                ("src/hot_editor.rs".to_string(), 0.60_f32),
+                ("src/warm_editor.rs".to_string(), 0.40_f32),
+                ("src/type_operations.rs".to_string(), 0.30_f32),
+                ("src/weak_editor.rs".to_string(), 0.20_f32),
+            ];
+            for (i, path) in junk.iter().enumerate() {
+                fused.push((path.clone(), 0.016_f32 - 0.001_f32 * i as f32));
+            }
+            fused
+        };
+        let order = |fused: &[(String, f32)]| -> Vec<String> {
+            fused
+                .iter()
+                .map(|(path, _)| {
+                    path.trim_start_matches("src/")
+                        .trim_end_matches(".rs")
+                        .to_string()
+                })
+                .collect()
+        };
+        let place = |fused: &[(String, f32)], name: &str| -> usize {
+            order(fused).iter().position(|p| p == name).expect(name)
+        };
+
+        // CONTROL, and it is the defect. Unbounded, every "editor" name takes
+        // the floor and `type_operations`, which retrieval ranked FOURTH,
+        // finishes last behind eighteen files it outscored by up to 300 to 1.
+        {
+            let _budget =
+                kin_core::test_env::EnvVarGuard::set("KIN_LOCATE_LEXICAL_FLOOR_BUDGET", "1024");
+            let mut fused = base();
+            apply_lexical_parity_floor(&mut fused, &graph, QUESTION);
+            assert_eq!(
+                order(&fused).last().map(String::as_str),
+                Some("type_operations"),
+                "unbounded, the floor is the ranking: {:?}",
+                order(&fused)
+            );
+            assert!(
+                place(&fused, "junk_15_editor") < place(&fused, "type_operations"),
+                "the weakest junk file outranks the file retrieval put fourth"
+            );
+        }
+
+        // THE SHIPPED DEFAULT. Twelve lifts, spent on the strongest lexical
+        // evidence and then on the pre-floor score, so the junk tail past the
+        // budget keeps its fused score and stays below `type_operations`.
+        {
+            let _budget = kin_core::test_env::EnvVarGuard::unset("KIN_LOCATE_LEXICAL_FLOOR_BUDGET");
+            let mut fused = base();
+            apply_lexical_parity_floor(&mut fused, &graph, QUESTION);
+            let o = order(&fused);
+            assert_eq!(
+                &o[..2],
+                &["hot_editor", "warm_editor"],
+                "the two best-evidenced name matches lead: {o:?}"
+            );
+            assert_eq!(
+                &o[12..14],
+                &["plain", "type_operations"],
+                "exactly twelve files took the floor, and the ranking resumes \
+                 behind them: {o:?}"
+            );
+            for i in 10..JUNK {
+                let name = format!("junk_{i:02}_editor");
+                assert!(
+                    place(&fused, "type_operations") < place(&fused, &name),
+                    "{name} is past the budget and must keep its fused score: {o:?}"
+                );
+            }
+            assert!(
+                place(&fused, "type_operations") < place(&fused, "weak_editor"),
+                "the 0.6-strength match is past the budget too: {o:?}"
+            );
+        }
+
+        // A smaller budget, to pin that the constant is what binds.
+        {
+            let _budget =
+                kin_core::test_env::EnvVarGuard::set("KIN_LOCATE_LEXICAL_FLOOR_BUDGET", "2");
+            let mut fused = base();
+            apply_lexical_parity_floor(&mut fused, &graph, QUESTION);
+            let o = order(&fused);
+            assert_eq!(
+                &o[..4],
+                &["hot_editor", "warm_editor", "plain", "type_operations"],
+                "at budget 2 only the two best-evidenced files are rescued: {o:?}"
+            );
+        }
+
+        // The spend order is by lexical evidence FIRST and pre-floor score
+        // second, not the other way round. At budget 3 the third slot goes to
+        // a full-strength match scoring 0.016, not to the 0.6-strength match
+        // scoring 0.20.
+        {
+            let _budget =
+                kin_core::test_env::EnvVarGuard::set("KIN_LOCATE_LEXICAL_FLOOR_BUDGET", "3");
+            let mut fused = base();
+            apply_lexical_parity_floor(&mut fused, &graph, QUESTION);
+            let scores: HashMap<&str, f32> = fused.iter().map(|(p, s)| (p.as_str(), *s)).collect();
+            assert!(
+                scores["src/junk_00_editor.rs"] > 0.7,
+                "the third slot goes to the full-strength match: {scores:?}"
+            );
+            assert_eq!(
+                scores["src/weak_editor.rs"], 0.20,
+                "the 0.6-strength match keeps its fused score: {scores:?}"
+            );
+        }
+
+        // The budget binds on a prose question only. The same fixture and the
+        // same budget under a bare identifier lookup keeps the unbounded floor,
+        // because there the query IS a name and every name match has earned it.
+        {
+            let _budget =
+                kin_core::test_env::EnvVarGuard::set("KIN_LOCATE_LEXICAL_FLOOR_BUDGET", "2");
+            let mut fused = base();
+            apply_lexical_parity_floor(&mut fused, &graph, "editor");
+            assert_eq!(
+                order(&fused).last().map(String::as_str),
+                Some("type_operations"),
+                "a symbol lookup keeps the unbounded floor"
+            );
+        }
+
+        // ZERO IS NOT OFF. `locate_env_usize` filters values at `> 0` and falls
+        // back to the default, so `KIN_LOCATE_LEXICAL_FLOOR_BUDGET=0` reads as
+        // unset. Pinned here because an operator reaching for "0" to disable a
+        // budget gets the default instead, and this is the shared helper every
+        // `KIN_LOCATE_*` count knob goes through.
+        {
+            let _zero =
+                kin_core::test_env::EnvVarGuard::set("KIN_LOCATE_LEXICAL_FLOOR_BUDGET", "0");
+            let mut zeroed = base();
+            apply_lexical_parity_floor(&mut zeroed, &graph, QUESTION);
+            let _unset = kin_core::test_env::EnvVarGuard::unset("KIN_LOCATE_LEXICAL_FLOOR_BUDGET");
+            let mut defaulted = base();
+            apply_lexical_parity_floor(&mut defaulted, &graph, QUESTION);
+            assert_eq!(order(&zeroed), order(&defaulted), "0 reads as unset");
+        }
     }
 
     #[test]

--- a/crates/kin-core/src/env_registry_generated.rs
+++ b/crates/kin-core/src/env_registry_generated.rs
@@ -128,6 +128,7 @@ pub const GENERATED_KNOBS: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_LOCATE_INFERRED_ORIGIN_WEIGHT", kind: Kind::NonNegF32, default: "0.7", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: inferred origin weight" },
     EnvVarSpec { name: "KIN_LOCATE_INNER_METHOD_TOPK", kind: Kind::Usize, default: "5", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: inner method topk" },
     EnvVarSpec { name: "KIN_LOCATE_LEXICAL_FLOOR_ADMIT_STRENGTH", kind: Kind::NonNegF32, default: "0.6", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: lexical floor admit strength" },
+    EnvVarSpec { name: "KIN_LOCATE_LEXICAL_FLOOR_BUDGET", kind: Kind::Usize, default: "12", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: lexical floor budget" },
     EnvVarSpec { name: "KIN_LOCATE_LEXICAL_FLOOR_COMMON_FRAC", kind: Kind::NonNegF32, default: "0.02", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: lexical floor common frac" },
     EnvVarSpec { name: "KIN_LOCATE_LEXICAL_FLOOR_LIFT", kind: Kind::NonNegF32, default: "1.05", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: lexical floor lift" },
     EnvVarSpec { name: "KIN_LOCATE_LEXICAL_FLOOR_LIFT_PRESENT", kind: Kind::Bool, default: "true", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: lexical floor lift present" },

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -3,7 +3,7 @@
 
 # Kin environment variables
 
-This is the authoritative list of supported `KIN_*` environment variables (525 total, 355 correctness-relevant), generated from the central registry in `kin-core`.
+This is the authoritative list of supported `KIN_*` environment variables (526 total, 356 correctness-relevant), generated from the central registry in `kin-core`.
 
 At CLI and daemon startup Kin validates this surface (`KIN_ENV_VALIDATION`, default `warn`):
 
@@ -430,6 +430,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_LOCATE_INFERRED_ORIGIN_WEIGHT` | float>=0 | 0.7 | correctness | locate tuning knob: inferred origin weight |
 | `KIN_LOCATE_INNER_METHOD_TOPK` | usize | 5 | correctness | locate tuning knob: inner method topk |
 | `KIN_LOCATE_LEXICAL_FLOOR_ADMIT_STRENGTH` | float>=0 | 0.6 | correctness | locate tuning knob: lexical floor admit strength |
+| `KIN_LOCATE_LEXICAL_FLOOR_BUDGET` | usize | 12 | correctness | locate tuning knob: lexical floor budget |
 | `KIN_LOCATE_LEXICAL_FLOOR_COMMON_FRAC` | float>=0 | 0.02 | correctness | locate tuning knob: lexical floor common frac |
 | `KIN_LOCATE_LEXICAL_FLOOR_LIFT` | float>=0 | 1.05 | correctness | locate tuning knob: lexical floor lift |
 | `KIN_LOCATE_LEXICAL_FLOOR_LIFT_PRESENT` | bool | true | correctness | locate tuning knob: lexical floor lift present |


### PR DESCRIPTION
## What this changes

`apply_lexical_parity_floor` replaced the fused score of every name-anchored file with
`parity + 0.05 * original`, so ninety-five per cent of a lifted file's score was its name-match
quality and five per cent was everything retrieval computed. **Nothing bounded how many files took
that deal.** This spends one budget across the ranked window instead.

Measured 2026-09-02 on the demo catalogue's VS Code question, "When I type a character in the
editor, how does it end up in the document? Walk me through the path.", against a copy of the
demo's microsoft/vscode store:

| file | pre-floor score | pre-floor rank | rank after the floor |
|---|---|---|---|
| `contrib/find/browser/findModel.ts` | 0.01016 | 258 | **32** |
| `contrib/wordHighlighter/browser/wordHighlighter.ts` | 0.01026 | 249 | **27** |
| `browser/view/viewController.ts` | **0.06685** | **23** | **245** |

`viewController.ts` owns `ViewController.type`, the first step of the real typing path. Its score
did not move. 234 of 748 files were re-scored and 222 of them jumped over it. It has no name the
floor accepts because the floor's own term filter drops every `is_common_english_word`, and "type"
is on that list, so the surviving terms on a question about typing are `character`, `document`,
`editor`, `walk` and the whole of `src/vs/editor/contrib/` matches "editor".

The stage trace, one `--diagnose` run with `KIN_LOCATE_DEBUG_STAGE_LIMIT` lifted. Ten stages move
nothing on this question; one decides it.

| stage | snippetParser | codeEditorWidget | viewController | textModel |
|---|---|---|---|---|
| `after_zero_signal_demote` | 10 / 0.12642 | 16 / 0.06920 | **23 / 0.06685** | 51 / 0.05037 |
| `after_lexical_parity_floor` | **1 / 0.25489** | **2 / 0.25203** | **245 / 0.06685** | 60 / 0.15166 |

## The mechanism

Present-file lifts are staged instead of applied in place, then one budget is spent across them,
ordered by parity (the lexical evidence), then by the pre-floor score so retrieval decides among
equally good name matches, then by path so the result does not depend on the `matches` HashMap's
iteration order. Admissions of files not already in the fused list are untouched. Scoring is
otherwise unchanged.

**The budget binds on a prose question only,** which is the gate the file-anchor route already uses
(`locate_query_is_symbol_lookup`, itself `!query_is_prose`). On a bare identifier lookup the query
IS a name, so every name match has earned the floor, and bounding it there cost a real definition: a
`Cursor` lookup lost one of its two `Cursor` class rows at every budget tried before the gate was
added. That is measured, not assumed, and it is the whole reason the gate is here.

| knob | default | meaning |
|---|---|---|
| `KIN_LOCATE_LEXICAL_FLOOR_BUDGET` | **12**, new | how many already-ranked files the floor may re-score on a prose query |

## The A/B, seven questions and twenty-two lookups on four stores

One release build of the lane tree, a daemon per store started with that arm's environment and
stopped between arms, the knob asserted in the daemon's own bytes
(`strings kin-daemon | grep -c KIN_LOCATE_LEXICAL_FLOOR_BUDGET` = 1 against a control
`KIN_LOCATE_ZZZ_NO_SUCH_KNOB` = 0), and none of the four stores re-embedded anything.

**Inertness control:** at `KIN_LOCATE_LEXICAL_FLOOR_BUDGET=4096` the change is identical to the
pre-change binary on all seven questions, all twenty-two lookups and the VS Code file ranks. A
second inert arm eighteen minutes later was identical to the first, so there is no store-drift
confounder in this window.

| clause | shipped today | at the new default |
|---|---|---|
| rank one on all seven questions | `captureCommitPhaseError`, `Store.getSuspendable…`, `CodeEditorWidget.onDidCompositionEnd`, `slice_has_bom`, `WalkBuilder::ignore`, `redisFormatCommand`, `redisCreateSSLContextWithOptions` | **identical** |
| twenty-two identifier lookups | baseline | **22 of 22 identical** |
| `CodeEditorWidget` entity rank on VS Code | 5, inside the five focals | **5** |
| react-schedule-commit | 3 of 4 | **3 of 4**, same ranks |
| hiredis P2 | `redisReaderGetReply` at 17 | **17** |
| rg-walk focals | no single-letter generic | **unchanged** |

| VS Code file | shipped today | at the new default |
|---|---|---|
| `codeEditorWidget.ts` | 2 | 2 |
| `viewController.ts` | **245** | **29** |
| `viewModelImpl.ts` | 57 | **42** |
| `textModel.ts` | 60 | 59 |

Two files on the real typing path enter a fifty-file answer where none did before.

**Budget 8 was measured and rejected.** It puts `viewController.ts` at 27 and `viewModelImpl.ts` at
39 and improves hiredis P2 from 17 to 14, and it changes rank one on two questions where rank one
was already wrong. The pre-registered rule grades rank one's identity, so 12 is the smallest
constant that passes every clause. Budget 4 fails twice over: it changes rank one on two questions
and pushes `CodeEditorWidget` out of VS Code's five focals.

## Tests

`one_lexical_floor_budget_is_spent_across_the_ranked_window` builds the measured shape at
twenty-one files: two well-evidenced name matches, a sixteen-file junk tail of name matches carrying
almost no retrieval evidence, one file the terms do not touch, and one weak match. It asserts by
name what happens.

- **Control, and it is the defect:** unbounded, `type_operations`, which retrieval ranked fourth,
  finishes last behind eighteen files it outscored by up to 300 to 1.
- **The shipped default:** exactly twelve files take the floor and the ranking resumes behind them,
  so the junk past the budget keeps its fused score and stays below `type_operations`.
- **The spend order** is lexical evidence first and pre-floor score second, pinned by a budget-3
  arm where the third slot goes to a full-strength match scoring 0.016 rather than a 0.6-strength
  match scoring 0.20.
- **The prose gate:** the same fixture and budget under a bare identifier lookup keeps the
  unbounded floor.
- **Zero is not off:** `locate_env_usize` filters at `> 0`, so `=0` reads as unset. Pinned because
  an operator reaching for zero to disable a budget gets the default instead, and that helper is
  shared by every `KIN_LOCATE_*` count knob.

Falsified with five mutation arms, each asserting the new test goes RED **and** that
`lexical_parity_floor_is_noop_when_no_entities_match` stays GREEN, restored from an explicit
pristine copy rather than `git checkout --`, and refusing with `MUTATION MISSING` if the target
string is absent. The run asserts the UNMUTATED baseline is GREEN first, which caught two invalid
falsification runs earlier in this work.

| arm | mutation | verdict |
|---|---|---|
| A | the budget truncation never runs | PASS |
| B | the spend order is inverted, weakest evidence first | PASS |
| C | the pre-floor score is dropped from the spend order | PASS |
| D | the spend order sorts by pre-floor score before lexical evidence | PASS |
| E | the prose gate is removed, so the budget binds on a symbol lookup | PASS |

## Gates

| suite | result |
|---|---|
| `cargo test -p kin-cli --lib one_lexical_floor_budget` | 1 passed, 0 failed |
| `cargo test -p kin-ranking --lib` | 132 passed, 0 failed |
| `cargo test -p kin-core --lib env_registry` | 34 passed, 0 failed |
| `cargo test -p kin-cli --lib` (post-rebase, full crate) | **2,111 passed, 0 failed, 1 ignored**, 140.9 s |
| `bin/kin-precheck kin` (pre-rebase) | 19 gates enumerated from ci.yml's own check job, **19 ran, 19 passed, 0 failed** |
| `node scripts/read-promotion-plan.test.mjs` | 11 pass, 0 fail |
| `node scripts/release-promotion-plan.test.mjs` | 19 pass, 0 fail |

The knob is registered through `scripts/gen_env_registry.py` and `docs/env-vars.md` is regenerated
from the registry.

**One honest note on the precheck tally.** Run again after the rebase, `bin/kin-precheck kin`
REFUSED with exit 2 rather than reporting a verdict: main's check job has gained
`scripts/read-promotion-plan.test.mjs` and `scripts/release-promotion-plan.test.mjs` and the tool
neither runs them nor has a recorded reason not to, so it declines to print a tally over gates
nobody has decided about. That is the tool working as designed and it is not about this change; the
two scripts are run by hand above and both pass. Someone should teach `bin/kin-precheck` about them
so the next lane gets a tally.

Refs FIR-3118, FIR-3106
