### PR TITLE
Make the evidence publisher's refusal name its own evidence

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -551,18 +551,34 @@ jobs:
           body="$(gh api "repos/${GITHUB_REPOSITORY}" 2>&1)" || body=''
           if [ -z "$body" ]; then
             perms='UNREADABLE (the repo read itself failed)'
+            shape='UNREADABLE'
           else
             perms="$(printf '%s' "$body" | jq -c 'if has("permissions") then .permissions else "ABSENT" end' 2>/dev/null)" || perms='UNPARSEABLE'
+            shape="$(printf '%s' "$body" | jq -r 'if has("permissions") then (.permissions | type) else "key absent" end' 2>/dev/null)" || shape='UNPARSEABLE'
           fi
+          # Whether this is an installation token at all, which decides whether
+          # the field above is even meant to carry an answer. /installation/repositories
+          # is the one endpoint that answers for an installation token and refuses
+          # every other kind, so its status is the discriminator rather than a guess
+          # from the shape of something else.
+          inst="$(gh api /installation/repositories --jq '.total_count' 2>/dev/null)" || inst=''
+          if [ -n "$inst" ]; then kind="installation token (sees ${inst} repo(s))"; else kind='not an installation token, or that endpoint refused it'; fi
+          # contents:write is what the App holds; permissions.push is a repo-collaborator
+          # concept and is not obliged to project into it. If these disagree, the door
+          # is consulting the wrong field rather than the right field wrongly.
           {
             echo '### Evidence token scope'
             echo ''
-            printf 'GET /repos/%s returned permissions: %s\n' "$GITHUB_REPOSITORY" "${perms:-EMPTY}"
-            echo ''
+            printf 'GET /repos/%s permissions: %s\n\n' "$GITHUB_REPOSITORY" "${perms:-EMPTY}"
+            printf 'permissions field type: %s\n\n' "${shape:-EMPTY}"
+            printf 'token kind: %s\n\n' "$kind"
             echo 'The publisher refuses on a block whose push is not true, and proceeds when'
-            echo 'the block is absent, so the line above says which branch it took.'
+            echo 'the block is absent, so the lines above say which branch it took and'
+            echo 'whether that field could have carried the answer in the first place.'
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "evidence token sees permissions: ${perms:-EMPTY}"
+          echo "evidence token permissions: ${perms:-EMPTY}"
+          echo "evidence token permissions type: ${shape:-EMPTY}"
+          echo "evidence token kind: $kind"
           exit 0
 
       - name: Publish preflight.json for the candidate

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -528,6 +528,43 @@ jobs:
       # sha, which GitHub rejects when the path exists, so a re-publish of
       # identical bytes is a no-op success and a re-publish of different bytes
       # is a loud refusal. That is why the merge above has to be deterministic.
+      # What the publisher's door actually sees, recorded before it decides.
+      #
+      # kin-evidence-publish proves its token against GET /repos before reading
+      # or writing anything, and the push half of that check reads the
+      # `permissions` block, which reports the AUTHENTICATED USER's permissions.
+      # What a GitHub App installation token gets back there is not obvious, and
+      # on 2026-09-03 it was guessed wrong twice while four cycles refused at
+      # this step with a message that named the verdict and never the evidence.
+      # One API read makes the refusal name its own evidence, so the next
+      # operator reads the answer instead of inferring it.
+      #
+      # This prints repository metadata, never the token. It cannot fail the
+      # job: a diagnostic that can break the thing it explains is worse than no
+      # diagnostic, so every command here is guarded and the step ends true.
+      - name: Record what the evidence token can do
+        if: always()
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -uo pipefail
+          body="$(gh api "repos/${GITHUB_REPOSITORY}" 2>&1)" || body=''
+          if [ -z "$body" ]; then
+            perms='UNREADABLE (the repo read itself failed)'
+          else
+            perms="$(printf '%s' "$body" | jq -c 'if has("permissions") then .permissions else "ABSENT" end' 2>/dev/null)" || perms='UNPARSEABLE'
+          fi
+          {
+            echo '### Evidence token scope'
+            echo ''
+            printf 'GET /repos/%s returned permissions: %s\n' "$GITHUB_REPOSITORY" "${perms:-EMPTY}"
+            echo ''
+            echo 'The publisher refuses on a block whose push is not true, and proceeds when'
+            echo 'the block is absent, so the line above says which branch it took.'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "evidence token sees permissions: ${perms:-EMPTY}"
+          exit 0
+
       - name: Publish preflight.json for the candidate
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/scripts/test-select-release-candidate.py
+++ b/scripts/test-select-release-candidate.py
@@ -1083,6 +1083,34 @@ class ContractTests(unittest.TestCase):
         self.assertIn("needs.preflight.result == 'success'", condition)
         self.assertIn("needs.select.outputs.decision == 'proof'", condition)
 
+    def test_the_publisher_records_the_token_scope_before_it_decides(self) -> None:
+        """A refusal has to name its own evidence, and cannot be caused by naming it.
+
+        The publisher proves its token against GET /repos before writing, and
+        the push half of that check reads a block reporting the authenticated
+        USER's permissions. What an App installation token gets there was
+        guessed wrong twice on 2026-09-03 while four cycles refused with a
+        message naming the verdict and never the evidence. So the scope is
+        recorded first, and the recording is barred from failing the job:
+        a diagnostic that can break the thing it explains is worse than none.
+        """
+
+        publish = job_block(CUT_WORKFLOW_PATH.read_text(encoding="utf-8"), "publish")
+        record = publish.find("- name: Record what the evidence token can do")
+        write = publish.find("- name: Publish preflight.json for the candidate")
+        self.assertNotEqual(record, -1, "the publish job no longer records the token scope")
+        self.assertNotEqual(write, -1, "the publish job no longer publishes")
+        self.assertLess(
+            record,
+            write,
+            "the token scope is recorded after the write it exists to explain, so a refusal "
+            "at the write leaves no record of what the token looked like",
+        )
+        diagnostic = publish[record:write]
+        self.assertIn("if: always()", diagnostic)
+        self.assertIn("exit 0", diagnostic)
+        self.assertNotIn("set -euo pipefail", diagnostic)
+
     def test_the_workflow_calls_the_selector_and_binds_its_trigger(self) -> None:
         workflow = CUT_WORKFLOW_PATH.read_text(encoding="utf-8")
         for needle in (


### PR DESCRIPTION
Four release-cut cycles have now refused at the write with "this token can read firelock-ai/kin but has no push permission", and not one of them recorded what the token actually presented. The door reads the `permissions` block from `GET /repos/<owner>/<name>`, that block reports the authenticated *user's* permissions, and what a GitHub App installation token gets back there has been guessed wrong twice: first as absent, then, when the fix for absent still refused, as something else again. A verdict without its evidence costs a full landing round per guess.

This records the block before the publisher decides, to the step summary and the log. It prints repository metadata and never the token.

It records the field's **type** and the token's **kind** as well as its value, because a wrong value and a wrong field need different fixes and the first version could not tell them apart. `permissions.push` on `GET /repos` is a repo-collaborator concept, and what this App holds is `contents: write`, which is not obliged to project into that field at all. So the step also asks `/installation/repositories`, the one endpoint that answers for an installation token and refuses every other kind, which reads the token's kind rather than inferring it from the shape of something else. One round then decides between three different fixes: tuning the check, replacing it with the installation's own permissions, or letting the write be the authority while the 404 branch keeps the unauthenticated case.

The diagnostic cannot fail the job it explains. It carries `if: always()`, runs under `set -uo` rather than `-euo`, guards every command, and ends in `exit 0`, so a GitHub outage or a `jq` that cannot parse the answer leaves the publish exactly as it would have been. A diagnostic that can break the thing it explains is worse than no diagnostic.

The test pins the properties that make it useful rather than its wording: it runs before the write, since a refusal at the write leaves no record otherwise, and it keeps `always()`, the `exit 0` and the absence of `-e`. Falsified three ways and each went red: making it able to fail, replacing `always()` with `success()`, and dropping the exit.

**This is a measurement, not a fix,** and it is deliberately not the tempting change. The token demonstrably writes: run 33692394800 decided `move: fast-forward` and its arm job PATCHed `refs/heads/release/v0.6.5-candidate` with this same App, same installation and same `permission-contents: write` at 22:52:21Z, printing its closing line only after the read-back comparison passed. So the door is refusing a token that works, and the open question is what the door sees. The obvious move is to downgrade the push pre-check to a warning and let the write be the authority, but that removes a real guard for read-only user tokens on a hunch, and I have been wrong about this token once already. The next cycle answers it with data instead.

Correction worth recording, since the wrong version is already in kin-ecosystem#276's body: my earlier evidence for "the token can write" cited run 33695497452, whose decision carries `move: none`. That branch of the arm step performs no write at all, prints a notice and succeeds having only read the ref back. A green arm job is not evidence of a write. The claim survives on 33692394800, which actually wrote.

Gates: `actionlint` exit 0, `python3 scripts/test-select-release-candidate.py` 68 tests OK, the other four release-policy Python suites exit 0, and the four node suites that read these files at 92 passing 0 failing.

Related: FIR-3084
