### PR TITLE
Judge a daemon start lock by what holds it, not by how old it is

### DIFF
--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -2832,10 +2832,10 @@ pub fn is_process_alive(pid: u32) -> bool {
 /// the supervisor, the CLI, and any development or test build named after them,
 /// and excludes the `msedgewebview2.exe` that inherited PID 8468 in FIR-3055.
 ///
-/// Compiled only where it is reachable. Its one caller outside the tests is the
-/// `#[cfg(windows)]` arm of [`pid_runs_a_foreign_image`], so on every other
-/// platform the non-test build carries a function nothing calls.
-#[cfg(any(windows, test))]
+/// Reachable on every platform. Windows reaches it through
+/// [`pid_runs_a_foreign_image`], and every platform reaches it through
+/// [`startup_lock_holder_is_foreign`], which is the start lock's own reader for
+/// a recycled PID.
 fn image_path_could_be_kin(image: &str) -> bool {
     let file_name = image.rsplit(['/', '\\']).next().unwrap_or(image);
     // An empty stem means the only dot is a leading one, so the whole name is
@@ -2876,6 +2876,76 @@ fn process_image_path(pid: u32) -> Option<String> {
         return None;
     }
     Some(String::from_utf16_lossy(&buffer[..len as usize]))
+}
+
+/// The executable image running at `pid` on this Unix host, or `None` when it
+/// cannot be read.
+///
+/// macOS answers through `proc_pidpath`, which reports the resolved executable
+/// of a process this user may query; Linux answers through `/proc/<pid>/exe`,
+/// the same link `ps` reads. Both are one call, which is what lets a poll loop
+/// ask per iteration. Every other Unix answers `None`, which is indeterminate
+/// and authorizes nothing.
+#[cfg(unix)]
+fn process_image_path(pid: u32) -> Option<String> {
+    #[cfg(target_os = "macos")]
+    {
+        let mut buffer = vec![0u8; libc::PROC_PIDPATHINFO_MAXSIZE as usize];
+        let written = unsafe {
+            libc::proc_pidpath(
+                libc::pid_t::try_from(pid).ok()?,
+                buffer.as_mut_ptr().cast(),
+                buffer.len() as u32,
+            )
+        };
+        if written <= 0 {
+            return None;
+        }
+        buffer.truncate(written as usize);
+        return String::from_utf8(buffer).ok();
+    }
+    #[cfg(target_os = "linux")]
+    {
+        return std::fs::read_link(format!("/proc/{pid}/exe"))
+            .ok()
+            .map(|path| path.to_string_lossy().into_owned());
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        let _ = pid;
+        None
+    }
+}
+
+/// A target with neither reader answers `None`, which is indeterminate and
+/// authorizes nothing, exactly as an unreadable image does.
+#[cfg(not(any(unix, windows)))]
+fn process_image_path(pid: u32) -> Option<String> {
+    let _ = pid;
+    None
+}
+
+/// Whether the process holding a startup lock is running an image that is not
+/// Kin's, which is the one shape affirmative liveness cannot see.
+///
+/// A PID is a lookup key the kernel reissues. A lock whose recorded holder
+/// exited and whose number now belongs to an unrelated program reports `Alive`,
+/// so liveness alone keeps every later command waiting out the whole timeout
+/// for a starter that finished long ago. The image behind the number is what
+/// separates the two, and only Kin's own binaries can legitimately hold this
+/// lock, because only they write it.
+///
+/// Conservative in the same direction as everything else here: an image this
+/// session could not read is indeterminate and keeps the wait. This is
+/// deliberately not [`pid_runs_a_foreign_image`], which answers `false` on Unix
+/// by policy for the legacy supervisor endpoint. Widening that is a separate
+/// decision about a different piece of state; this reader is scoped to the lock
+/// whose holder Kin itself recorded.
+fn startup_lock_holder_is_foreign(pid: u32) -> bool {
+    match process_image_path(pid) {
+        Some(image) => !image_path_could_be_kin(&image),
+        None => false,
+    }
 }
 
 /// Whether the process at `pid` is affirmatively not a Kin process.
@@ -4749,6 +4819,39 @@ fn startup_lock_timeout_secs() -> u64 {
         .unwrap_or_else(|| daemon_ready_timeout_secs().max(5))
 }
 
+/// The repo daemon start lock's own floor, in seconds.
+///
+/// Waiting for a file another command holds and waiting for a daemon to finish
+/// loading a graph are different waits, and until this the first one simply
+/// took the second one's number: lowering `KIN_DAEMON_READY_TIMEOUT_SECS`
+/// retuned a lock wait nobody was thinking about. This is that wait's own name.
+const REPO_STARTUP_LOCK_FLOOR_SECS: u64 = 300;
+
+/// How long a caller waits for another kin command to finish starting this
+/// repository's daemon.
+///
+/// Its own floor, and never shorter than the window the holder itself is
+/// allowed, because the holder is a live kin start whose patience is the ready
+/// timeout: an operator who raises that for a large store would otherwise leave
+/// every waiter timing out under a starter still inside its own budget. An
+/// explicit `KIN_DAEMON_STARTUP_LOCK_TIMEOUT_SECS` is the operator's decision
+/// and wins over both.
+fn resolve_repo_startup_lock_timeout(explicit: Option<u64>, ready_timeout: u64) -> u64 {
+    match explicit {
+        Some(secs) if secs > 0 => secs,
+        _ => REPO_STARTUP_LOCK_FLOOR_SECS.max(ready_timeout),
+    }
+}
+
+fn repo_startup_lock_timeout_secs() -> u64 {
+    resolve_repo_startup_lock_timeout(
+        std::env::var("KIN_DAEMON_STARTUP_LOCK_TIMEOUT_SECS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok()),
+        daemon_ready_timeout_secs(),
+    )
+}
+
 fn daemon_health_client() -> reqwest::Client {
     reqwest::Client::builder()
         .timeout(Duration::from_secs(2))
@@ -5611,46 +5714,87 @@ fn startup_lock_holder(path: &Path) -> Option<u32> {
 /// timeout for a holder that cannot finish, and on a store whose daemon is not
 /// already serving, that wait is the entire answer the caller gets.
 ///
-/// Conservative by construction: only an affirmative death frees the lock. An
-/// unreadable file, an unparseable pid and an indeterminate probe all keep the
-/// wait, because taking a lock a live starter holds would let two spawns race
-/// for one repository. The pid is re-read immediately before the unlink so a
-/// holder that took the lock since the decision is not unlinked under it.
+/// Conservative by construction: the holder must be provably gone. It is gone
+/// two ways, and both are affirmative. Either the process is dead, or the number
+/// now runs an image that is not Kin's, which is the reused-PID case liveness
+/// reports as alive and cannot see through. An unreadable file, an unparseable
+/// pid, an image this session could not read and an indeterminate probe all keep
+/// the wait, because taking a lock a live starter holds would let two spawns
+/// race for one repository. The pid is re-read immediately before the unlink so
+/// a holder that took the lock since the decision is not unlinked under it.
 fn clear_abandoned_startup_lock(path: &Path) -> bool {
     let Some(holder) = startup_lock_holder(path) else {
         return false;
     };
-    if holder == std::process::id() || process_liveness(holder) != ProcessLiveness::Dead {
+    if holder == std::process::id() {
         return false;
     }
+    let reason = if process_liveness(holder) == ProcessLiveness::Dead {
+        "holder process is gone"
+    } else if startup_lock_holder_is_foreign(holder) {
+        "holder pid was reused by another program"
+    } else {
+        return false;
+    };
     if startup_lock_holder(path) != Some(holder) {
         return false;
     }
     debug!(
         path = %path.display(),
         holder,
-        "cleared a startup lock whose holder process is gone"
+        reason,
+        "cleared an abandoned startup lock"
     );
     std::fs::remove_file(path).is_ok()
 }
 
+/// Whether a startup lock names a holder this session can see is still running.
+///
+/// The one question the age rule below must ask before it acts. `false` covers
+/// a lock with no readable pid and a probe that could not answer, which are the
+/// cases age is the only reader left for.
+fn startup_lock_holder_is_alive(path: &Path) -> bool {
+    startup_lock_holder(path)
+        .map(|holder| process_liveness(holder) == ProcessLiveness::Alive)
+        .unwrap_or(false)
+}
+
+/// How old the lock file on disk is, when that can be read.
+fn startup_lock_age(path: &Path) -> Option<Duration> {
+    std::fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| modified.elapsed().ok())
+}
+
 /// The line a caller prints while another kin command holds the startup lock.
 ///
-/// Named rather than generic: a reader who waits needs to know that the wait is
-/// on another command in this repository and which one, because that is the
-/// difference between a hang to report and a queue to sit in.
-fn startup_lock_wait_line(holder: Option<u32>, waited: Duration) -> String {
-    let waited = waited.as_secs_f64();
-    match holder {
-        Some(pid) => format!(
-            "waiting for another kin command (pid {pid}) to finish starting this repository's \
-             daemon ({waited:.1}s)"
-        ),
-        None => format!(
-            "waiting for another kin command to finish starting this repository's daemon \
-             ({waited:.1}s)"
-        ),
-    }
+/// Named rather than generic, and specific enough to act on. A reader who waits
+/// needs four things: that the wait is on another command in this repository,
+/// which one, when it gives up, and where the lock it is waiting on lives. That
+/// is the difference between a hang to report and a queue to sit in, and a
+/// caller whose own cap fires first at least leaves that line on the screen.
+fn startup_lock_wait_line(
+    path: &Path,
+    holder: Option<u32>,
+    waited: Duration,
+    timeout: Duration,
+    lock_age: Option<Duration>,
+) -> String {
+    let who = match holder {
+        Some(pid) => format!("another kin command (pid {pid})"),
+        None => "another kin command".to_string(),
+    };
+    let held = match lock_age {
+        Some(age) => format!(", lock held {}s", age.as_secs()),
+        None => String::new(),
+    };
+    format!(
+        "waiting for {who} to finish starting this repository's daemon: {:.1}s of {}s{held} at {}",
+        waited.as_secs_f64(),
+        timeout.as_secs(),
+        path.display()
+    )
 }
 
 /// How long a caller waits on a held startup lock before it says so.
@@ -5662,7 +5806,7 @@ const STARTUP_LOCK_NOTICE_AFTER: Duration = Duration::from_secs(1);
 
 async fn acquire_startup_lock(kin_root: &Path) -> Result<StartupLock> {
     let path = kin_root.join("daemon.start.lock");
-    let timeout = Duration::from_secs(startup_lock_timeout_secs());
+    let timeout = Duration::from_secs(repo_startup_lock_timeout_secs());
     let stale_after = timeout.saturating_mul(2).max(Duration::from_secs(10));
     let started = Instant::now();
     let deadline = started + timeout;
@@ -5691,7 +5835,14 @@ async fn acquire_startup_lock(kin_root: &Path) -> Result<StartupLock> {
                 if clear_abandoned_startup_lock(&path) {
                     continue;
                 }
-                if startup_lock_is_stale(&path, stale_after) {
+                // Age is the last reader, not a second opinion. It runs only
+                // where nothing better can answer: a lock with no readable pid,
+                // or a holder this session may not probe. A holder it can see is
+                // running keeps its lock however old the file is, because the
+                // one thing worse than waiting behind a slow start is two starts
+                // racing for one repository.
+                if !startup_lock_holder_is_alive(&path) && startup_lock_is_stale(&path, stale_after)
+                {
                     debug!(
                         path = %path.display(),
                         "cleared a startup lock left by an interrupted kin command"
@@ -5703,13 +5854,24 @@ async fn acquire_startup_lock(kin_root: &Path) -> Result<StartupLock> {
                     if let Some(notice) = notice.as_ref() {
                         notice.finish();
                     }
+                    let held = match startup_lock_age(&path) {
+                        Some(age) => format!(" (held {}s)", age.as_secs()),
+                        None => String::new(),
+                    };
+                    let who = match startup_lock_holder(&path) {
+                        Some(pid) => format!("pid {pid}"),
+                        None => "an unnamed holder".to_string(),
+                    };
                     bail!(
-                        "timed out waiting for daemon startup lock at {} after {}s: another kin \
-                         command in this repository still holds it. Wait for it to finish, or \
-                         raise KIN_DAEMON_STARTUP_LOCK_TIMEOUT_SECS (it defaults from \
-                         KIN_DAEMON_READY_TIMEOUT_SECS) to wait longer.",
+                        "timed out waiting for daemon startup lock at {}{held} after {}s: another \
+                         kin command in this repository ({who}) still holds it and is still \
+                         running. Wait for it to finish, or raise \
+                         KIN_DAEMON_STARTUP_LOCK_TIMEOUT_SECS (it defaults to {}s here, this \
+                         wait's own floor or KIN_DAEMON_READY_TIMEOUT_SECS, whichever is larger) \
+                         to wait longer.",
                         path.display(),
-                        timeout.as_secs()
+                        timeout.as_secs(),
+                        REPO_STARTUP_LOCK_FLOOR_SECS.max(daemon_ready_timeout_secs()),
                     );
                 }
                 let waited = started.elapsed();
@@ -5720,7 +5882,13 @@ async fn acquire_startup_lock(kin_root: &Path) -> Result<StartupLock> {
                         .get_or_insert_with(crate::progress::Progress::stderr)
                         .update(format_args!(
                             "{}",
-                            startup_lock_wait_line(startup_lock_holder(&path), waited)
+                            startup_lock_wait_line(
+                                &path,
+                                startup_lock_holder(&path),
+                                waited,
+                                timeout,
+                                startup_lock_age(&path),
+                            )
                         ));
                     announced_at = Some(Instant::now());
                 }
@@ -12296,28 +12464,93 @@ mod tests {
         assert_eq!(startup_lock_holder(&dir.path().join("absent")), None);
     }
 
-    /// A startup lock outlives its holder, so the holder's liveness is what
-    /// decides whether the next command may take it. Both directions are here:
-    /// clearing every lock races two spawns for one repository, clearing none
-    /// strands the next question behind a process that has already exited.
+    /// Environment variable that turns the fixture test below into a process
+    /// that holds still, so a parent test can point a lock at it.
+    #[cfg(unix)]
+    const HOLD_AS_LOCK_HOLDER: &str = "KIN_TEST_HOLD_AS_STARTUP_LOCK_HOLDER";
+
+    /// A live process running an image named the way Kin's binaries are.
+    ///
+    /// This test binary is that process. It is `kin_cli-<hash>`, which the image
+    /// reader treats as possibly ours, and re-running it with the fixture below
+    /// gives a second process that simply waits. A copied `sleep` will not do
+    /// twice over: its image is foreign, which is now its own reason to free a
+    /// lock, and macOS kills a copy of a signed system binary outright.
+    #[cfg(unix)]
+    fn spawn_kin_named_holder() -> std::process::Child {
+        let own = std::env::current_exe().expect("this test binary is on disk");
+        assert!(
+            image_path_could_be_kin(&own.to_string_lossy()),
+            "this fixture depends on the test binary being kin-named: {}",
+            own.display()
+        );
+        std::process::Command::new(own)
+            .args([
+                "--exact",
+                "daemon_client::tests::a_held_startup_lock_fixture_that_waits",
+                "--nocapture",
+            ])
+            .env(HOLD_AS_LOCK_HOLDER, "1")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn a live stand-in for a kin command still starting a daemon")
+    }
+
+    /// Instant in an ordinary run; a process that waits when a parent test asked
+    /// for one. It never touches a store, a lock or a daemon.
     #[cfg(unix)]
     #[test]
-    fn only_a_startup_lock_whose_holder_is_gone_is_cleared() {
+    fn a_held_startup_lock_fixture_that_waits() {
+        if std::env::var(HOLD_AS_LOCK_HOLDER).is_err() {
+            return;
+        }
+        std::thread::sleep(Duration::from_secs(120));
+    }
+
+    /// A startup lock outlives its holder, so what the holder IS decides whether
+    /// the next command may take it. Every direction is here, because each one
+    /// is satisfiable by a wrong implementation: clearing every lock races two
+    /// spawns for one repository, clearing none strands the next question behind
+    /// a process that has already exited, and reading liveness alone strands it
+    /// behind a PID number the kernel handed to something else.
+    #[cfg(unix)]
+    #[test]
+    fn a_startup_lock_is_freed_only_when_no_live_kin_holder_is_behind_it() {
         let dir = tempfile::tempdir().unwrap();
         let lock = dir.path().join("daemon.start.lock");
 
-        let mut live = std::process::Command::new("sleep")
-            .arg("30")
-            .spawn()
-            .expect("spawn a live stand-in for a command still starting a daemon");
+        let mut live = spawn_kin_named_holder();
         std::fs::write(&lock, format!("pid={} acquired_at=now\n", live.id())).unwrap();
         assert!(
             !clear_abandoned_startup_lock(&lock),
-            "a lock a live process holds must survive"
+            "a lock a live kin process holds must survive"
         );
         assert!(lock.exists(), "and must still be on disk");
+        assert!(
+            startup_lock_holder_is_alive(&lock),
+            "and the age rule must be able to see that it is alive"
+        );
         let _ = live.kill();
         let _ = live.wait();
+
+        // The reused-PID case: alive, and not us. Liveness cannot see this one.
+        let mut foreign = std::process::Command::new("sleep")
+            .arg("300")
+            .spawn()
+            .expect("spawn a live process running an image that is not ours");
+        let foreign_pid = foreign.id();
+        std::fs::write(&lock, format!("pid={foreign_pid} acquired_at=now\n")).unwrap();
+        assert!(
+            startup_lock_holder_is_foreign(foreign_pid),
+            "a live sleep is not a kin binary and must read as foreign"
+        );
+        assert!(
+            clear_abandoned_startup_lock(&lock),
+            "a lock whose pid now runs another program is free"
+        );
+        let _ = foreign.kill();
+        let _ = foreign.wait();
 
         std::fs::write(
             &lock,
@@ -12347,11 +12580,52 @@ mod tests {
 
         // Nothing to clear is not the same as clearing something.
         assert!(!clear_abandoned_startup_lock(&lock));
+        assert!(
+            !startup_lock_holder_is_alive(&lock),
+            "and a lock that is not there names no live holder"
+        );
+    }
+
+    /// Age is the last reader, not a second opinion. A holder this session can
+    /// see running keeps its lock however old the file is; age answers only
+    /// where nothing better can.
+    #[cfg(unix)]
+    #[test]
+    fn an_old_lock_a_live_kin_holder_still_owns_is_not_taken_on_age() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock = dir.path().join("daemon.start.lock");
+        let mut live = spawn_kin_named_holder();
+        std::fs::write(&lock, format!("pid={} acquired_at=now\n", live.id())).unwrap();
+
+        // Old enough that the age rule would have taken it.
+        assert!(startup_lock_is_stale(&lock, Duration::ZERO));
+        assert!(
+            startup_lock_holder_is_alive(&lock),
+            "the holder is running, so age must not be consulted"
+        );
+        assert!(
+            !clear_abandoned_startup_lock(&lock),
+            "and the affirmative reader must not free it either"
+        );
+        let _ = live.kill();
+        let _ = live.wait();
+
+        // With no readable holder, age is the only reader left and still works.
+        std::fs::write(&lock, "written by something else\n").unwrap();
+        assert!(!startup_lock_holder_is_alive(&lock));
+        assert!(startup_lock_is_stale(&lock, Duration::ZERO));
     }
 
     #[test]
     fn the_startup_lock_wait_line_names_what_the_wait_is_on() {
-        let line = startup_lock_wait_line(Some(4321), Duration::from_millis(2500));
+        let path = Path::new("/repo/.kin/daemon.start.lock");
+        let line = startup_lock_wait_line(
+            path,
+            Some(4321),
+            Duration::from_millis(2500),
+            Duration::from_secs(300),
+            Some(Duration::from_secs(640)),
+        );
         assert!(
             line.contains("waiting for another kin command (pid 4321)"),
             "the line names the holder: {line}"
@@ -12360,12 +12634,63 @@ mod tests {
             line.contains("starting this repository's daemon"),
             "and what it is doing: {line}"
         );
-        assert!(line.contains("(2.5s)"), "and how long this has run: {line}");
+        assert!(
+            line.contains("2.5s of 300s"),
+            "and how long this has run against when it gives up: {line}"
+        );
+        assert!(
+            line.contains("lock held 640s"),
+            "and how old the lock itself is: {line}"
+        );
+        assert!(
+            line.contains("/repo/.kin/daemon.start.lock"),
+            "and which lock it is: {line}"
+        );
 
-        let anonymous = startup_lock_wait_line(None, Duration::from_secs(1));
+        let anonymous = startup_lock_wait_line(
+            path,
+            None,
+            Duration::from_secs(1),
+            Duration::from_secs(300),
+            None,
+        );
         assert!(
             anonymous.contains("waiting for another kin command to finish starting"),
             "a lock with no readable holder still says what the wait is: {anonymous}"
+        );
+        assert!(
+            !anonymous.contains("lock held"),
+            "and an age nobody could read is left out rather than invented: {anonymous}"
+        );
+    }
+
+    /// The repo lock wait is its own knob with its own floor, and still never
+    /// shorter than the window the holder it waits on is allowed.
+    #[test]
+    fn the_repo_startup_lock_wait_has_its_own_floor_and_still_tracks_a_raised_ready_window() {
+        assert_eq!(
+            resolve_repo_startup_lock_timeout(None, 300),
+            REPO_STARTUP_LOCK_FLOOR_SECS
+        );
+        assert_eq!(
+            resolve_repo_startup_lock_timeout(None, 30),
+            REPO_STARTUP_LOCK_FLOOR_SECS,
+            "lowering the ready timeout must not retune a file wait nobody was thinking about"
+        );
+        assert_eq!(
+            resolve_repo_startup_lock_timeout(None, 900),
+            900,
+            "raising it for a large store must not leave waiters timing out under a legitimate start"
+        );
+        assert_eq!(
+            resolve_repo_startup_lock_timeout(Some(5), 900),
+            5,
+            "an operator's explicit value wins over both"
+        );
+        assert_eq!(
+            resolve_repo_startup_lock_timeout(Some(0), 300),
+            REPO_STARTUP_LOCK_FLOOR_SECS,
+            "and zero is not a bound, it is an unset"
         );
     }
 

--- a/crates/kin-cli/tests/daemon_start_lock_recovery.rs
+++ b/crates/kin-cli/tests/daemon_start_lock_recovery.rs
@@ -5,20 +5,29 @@
 //!
 //! `daemon.start.lock` is a create-new sentinel, not an advisory lock, so a kin
 //! command killed while it starts a daemon leaves the file behind. Every later
-//! command in that repository then waits the whole startup-lock timeout, which
-//! defaults to 300 seconds, before it has spoken to any daemon at all. A caller
-//! that caps a question below that sees the cap and nothing else: no output, no
-//! CPU anywhere, and a store doing no work.
+//! command in that repository then waits the whole startup-lock timeout before
+//! it has spoken to any daemon. A caller that caps a question below that sees
+//! the cap and nothing else: no output, no CPU anywhere, and a store doing no
+//! work.
 //!
-//! Both halves are asserted here because either alone is satisfiable by a broken
-//! implementation. Clearing every lock passes the first test and races two
-//! spawns for one repository; clearing none passes the second and strands the
-//! next question behind a process that has already exited.
+//! Three shapes are asserted, because each is satisfiable by an implementation
+//! that gets the others right. A holder that exited must not stop the question.
+//! A holder whose PID the kernel handed to another program must not stop it
+//! either, which liveness alone cannot see. And a holder that is genuinely a
+//! live kin start must be waited on, named on stderr, and left alone however old
+//! its lock file is, because two spawns racing for one repository is worse than
+//! a wait.
+//!
+//! Unix only, and the whole file is gated rather than each test: the live-holder
+//! arms need a process whose executable this session can place and name, and the
+//! Windows authority legs build `-p kin-cli --lib`, so nothing here runs there.
+#![cfg(unix)]
 
 use serial_test::serial;
 use std::fs;
-use std::path::Path;
-use std::time::Instant;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant, SystemTime};
 use tempfile::tempdir;
 
 mod common;
@@ -99,18 +108,17 @@ fn seeded_store(repo: &Path, runtime: &common::IsolatedDaemonRuntime) {
 }
 
 /// Write the lock exactly as the CLI writes it, naming `pid` as its holder.
-fn plant_startup_lock(repo: &Path, pid: u32) -> std::path::PathBuf {
+fn plant_startup_lock(repo: &Path, pid: u32) -> PathBuf {
     let path = repo.join(".kin").join("daemon.start.lock");
     fs::write(
         &path,
-        format!("pid={pid} acquired_at={:?}\n", std::time::SystemTime::now()),
+        format!("pid={pid} acquired_at={:?}\n", SystemTime::now()),
     )
     .expect("plant a startup lock");
     path
 }
 
 /// A process identifier whose process has exited and been reaped.
-#[cfg(unix)]
 fn reaped_pid() -> u32 {
     let mut child = std::process::Command::new("sleep")
         .arg("0")
@@ -121,7 +129,62 @@ fn reaped_pid() -> u32 {
     pid
 }
 
-#[cfg(unix)]
+/// Environment variable that turns the fixture test below into a process that
+/// holds still, so a test can point a lock at it.
+const HOLD_AS_LOCK_HOLDER: &str = "KIN_TEST_HOLD_AS_STARTUP_LOCK_HOLDER";
+
+/// A long-lived process whose executable is named the way Kin's binaries are.
+///
+/// Outlives the whole test on purpose, three times over. A stand-in that exits
+/// becomes an unreaped corpse, which reads as dead; a stand-in still called
+/// `sleep` reads as a foreign image; and macOS kills a copy of a signed system
+/// binary outright, so `sleep` cannot simply be copied under a kin name. What
+/// does work is this test binary, which is ours and runs from anywhere: copy it
+/// under a kin-shaped name and re-run it against the fixture test below, which
+/// waits and touches nothing.
+fn spawn_kin_named_holder(dir: &Path) -> std::process::Child {
+    let holder = dir.join("kin-startup-lock-fixture");
+    fs::copy(
+        std::env::current_exe().expect("this test binary is on disk"),
+        &holder,
+    )
+    .expect("copy this test binary under a kin-shaped name");
+    fs::set_permissions(&holder, fs::Permissions::from_mode(0o755))
+        .expect("make the fixture executable");
+    std::process::Command::new(&holder)
+        .args([
+            "--exact",
+            "a_held_startup_lock_fixture_that_waits",
+            "--nocapture",
+        ])
+        .env(HOLD_AS_LOCK_HOLDER, "1")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn a live stand-in for a kin command still starting a daemon")
+}
+
+/// Instant in an ordinary run; a process that waits when a test asked for one.
+/// It never touches a store, a lock or a daemon.
+#[test]
+fn a_held_startup_lock_fixture_that_waits() {
+    if std::env::var(HOLD_AS_LOCK_HOLDER).is_err() {
+        return;
+    }
+    std::thread::sleep(Duration::from_secs(120));
+}
+
+/// Age the lock file so the staleness rule would fire on it.
+fn age_lock(path: &Path, by: Duration) {
+    let when = SystemTime::now() - by;
+    let file = fs::File::options()
+        .write(true)
+        .open(path)
+        .expect("open the lock to age it");
+    file.set_times(fs::FileTimes::new().set_accessed(when).set_modified(when))
+        .expect("age the lock file");
+}
+
 #[test]
 #[serial]
 fn a_question_behind_a_dead_starters_lock_answers_instead_of_waiting_out_the_budget() {
@@ -152,31 +215,62 @@ fn a_question_behind_a_dead_starters_lock_answers_instead_of_waiting_out_the_bud
         !lock.exists(),
         "the abandoned lock is gone once the command that took it over finished"
     );
-    // The wait it would have paid is the whole startup-lock timeout, which this
-    // test sets to 5 s. The answer arrives without it; the ready wait for the
-    // daemon this command starts is a separate, longer bound and is not what is
-    // asserted here.
     assert!(
-        started.elapsed() < std::time::Duration::from_secs(120),
+        started.elapsed() < Duration::from_secs(120),
         "the run must not have sat out a startup-lock wait"
     );
 }
 
-#[cfg(unix)]
+/// The reused-PID case. The recorded holder exited, the kernel handed its number
+/// to something else, and liveness reports that something else as alive. Only
+/// the image behind the number separates the two.
 #[test]
 #[serial]
-fn a_startup_lock_a_live_command_holds_is_respected_and_named() {
+fn a_question_behind_a_recycled_pids_lock_answers_instead_of_waiting_out_the_budget() {
     let repo = tempdir().expect("temp repo");
     let runtime = common::IsolatedDaemonRuntime::new(repo.path());
     seeded_store(repo.path(), &runtime);
 
-    // Outlives the whole wait on purpose. A stand-in that exits mid-test becomes
-    // an unreaped corpse, which `process_liveness` calls dead, and the lock this
-    // test is about would be freed for the right reason at the wrong moment.
-    let mut holder = std::process::Command::new("sleep")
+    let mut squatter = std::process::Command::new("sleep")
         .arg("300")
         .spawn()
-        .expect("spawn a live stand-in for a kin command still starting a daemon");
+        .expect("spawn a live process running an image that is not ours");
+    let lock = plant_startup_lock(repo.path(), squatter.id());
+
+    let locate = kin_command(&runtime)
+        .args(["locate", "lexer", "--json"])
+        .current_dir(repo.path())
+        .output()
+        .expect("run kin locate behind a lock whose pid was reused");
+    let stderr = String::from_utf8_lossy(&locate.stderr).to_string();
+
+    let _ = squatter.kill();
+    let _ = squatter.wait();
+
+    assert!(
+        locate.status.success(),
+        "a live pid running a foreign image is not a holder: {stderr}"
+    );
+    assert!(
+        !stderr.contains("timed out waiting for daemon startup lock"),
+        "and must not be waited out: {stderr}"
+    );
+    serde_json::from_slice::<serde_json::Value>(&locate.stdout)
+        .expect("stdout is still one JSON document");
+    assert!(!lock.exists(), "the squatter's lock was taken over");
+}
+
+#[test]
+#[serial]
+fn a_startup_lock_a_live_kin_command_holds_is_respected_and_named() {
+    let repo = tempdir().expect("temp repo");
+    let runtime = common::IsolatedDaemonRuntime::new(repo.path());
+    seeded_store(repo.path(), &runtime);
+
+    // Outside the repository: this fixture is a copy of a test binary, and the
+    // store under test must not be asked to admit one.
+    let holder_home = tempdir().expect("temp dir for the holder fixture");
+    let mut holder = spawn_kin_named_holder(holder_home.path());
     let holder_pid = holder.id();
     let lock = plant_startup_lock(repo.path(), holder_pid);
 
@@ -192,7 +286,7 @@ fn a_startup_lock_a_live_command_holds_is_respected_and_named() {
 
     assert!(
         !locate.status.success(),
-        "a lock a live command holds must not be taken: {stderr}"
+        "a lock a live kin command holds must not be taken: {stderr}"
     );
     assert!(
         stderr.contains("timed out waiting for daemon startup lock"),
@@ -206,9 +300,69 @@ fn a_startup_lock_a_live_command_holds_is_respected_and_named() {
         "and while it waits it says what it is waiting for, and on whom: {stderr}"
     );
     assert!(
+        stderr.contains("of 5s"),
+        "the line says when the wait gives up: {stderr}"
+    );
+    assert!(
+        stderr.contains("daemon.start.lock"),
+        "and which lock it is on: {stderr}"
+    );
+    assert!(
         fs::read_to_string(&lock)
             .expect("the held lock is still there")
             .contains(&format!("pid={holder_pid}")),
         "the live holder's lock is left exactly as it was"
+    );
+}
+
+/// Age is the last reader, not a second opinion. A lock old enough for the
+/// staleness rule is still not taken while its holder is demonstrably running,
+/// because taking it puts two starts on one store.
+#[test]
+#[serial]
+fn an_old_lock_a_live_kin_command_holds_is_not_taken_on_age() {
+    let repo = tempdir().expect("temp repo");
+    let runtime = common::IsolatedDaemonRuntime::new(repo.path());
+    seeded_store(repo.path(), &runtime);
+
+    let holder_home = tempdir().expect("temp dir for the holder fixture");
+    let mut holder = spawn_kin_named_holder(holder_home.path());
+    let holder_pid = holder.id();
+    let lock = plant_startup_lock(repo.path(), holder_pid);
+    // The bound is 5 s here, so the staleness rule fires at 10 s. Sixty is well
+    // past it and cheap.
+    age_lock(&lock, Duration::from_secs(60));
+
+    let locate = kin_command(&runtime)
+        .args(["locate", "lexer", "--json"])
+        .current_dir(repo.path())
+        .output()
+        .expect("run kin locate behind an old, held startup lock");
+    let stderr = String::from_utf8_lossy(&locate.stderr).to_string();
+
+    let _ = holder.kill();
+    let _ = holder.wait();
+
+    assert!(
+        !locate.status.success(),
+        "an old lock with a live holder must still not be taken: {stderr}"
+    );
+    assert!(
+        stderr.contains("timed out waiting for daemon startup lock"),
+        "the waiter gives up at its bound rather than stealing the lock: {stderr}"
+    );
+    assert!(
+        stderr.contains(&format!("(pid {holder_pid})")),
+        "and names the holder it waited on: {stderr}"
+    );
+    assert!(
+        stderr.contains("lock held "),
+        "and how old that lock is, which is what age would have acted on: {stderr}"
+    );
+    assert!(
+        fs::read_to_string(&lock)
+            .expect("the held lock is still there")
+            .contains(&format!("pid={holder_pid}")),
+        "the live holder keeps its lock however old the file is"
     );
 }


### PR DESCRIPTION
Three things a caller could not learn while it waited on `.kin/daemon.start.lock`, and one way it could still lose the lock it held. kin#1408 freed a lock whose recorded holder had exited; this finishes the job.

**A recycled PID is not a holder.** A PID is a lookup key the kernel reissues, so a lock whose holder exited and whose number now belongs to an unrelated program reports `Alive`, and every later command waits out the whole bound for a starter that finished long ago. `process_image_path` gains a Unix reader, `proc_pidpath` on macOS and `/proc/<pid>/exe` on Linux, and `startup_lock_holder_is_foreign` frees a lock whose number runs an image that is not ours. Only Kin's binaries write this file, so only they can legitimately hold it. It stays conservative in the same direction as everything else here: an image this session could not read is indeterminate and keeps the wait. This is deliberately not `pid_runs_a_foreign_image`, which answers `false` on Unix by policy for the legacy supervisor endpoint; widening that is a separate decision about different state.

**The wait now says where it is and when it ends.** `waiting for another kin command (pid 23209) to finish starting this repository's daemon: 12.3s of 300s, lock held 640s at /repo/.kin/daemon.start.lock`, refreshed once a second, and the timeout message names the holder and the lock's age too. A caller whose own cap fires first at least leaves that line on the screen.

**The lock wait gets its own floor.** `REPO_STARTUP_LOCK_FLOOR_SECS`, resolved as the larger of that floor and the ready timeout. Waiting for a file another command holds and waiting for a daemon to load a graph are different waits, and the first was simply taking the second's number: lowering `KIN_DAEMON_READY_TIMEOUT_SECS` retuned a file wait nobody was thinking about. Raising it for a large store still lifts this wait, so no waiter times out under a starter that is inside its own budget. The supervisor lock's `startup_lock_timeout_secs` is untouched, because its timeout message promises exactly the inheritance it still has.

**FIR-3120: age is the last reader, not a second opinion.** The mtime rule fires only where nothing better can answer, meaning a lock with no readable pid or a holder this session may not probe. A holder it can see running keeps its lock however old the file is, because the one thing worse than waiting behind a slow start is two starts racing for one repository.

Guards, in `crates/kin-cli/tests/daemon_start_lock_recovery.rs` and the unit tests beside `startup_lock_is_stale`. Four end-to-end arms against a real store: a dead holder's lock answers, a recycled PID's lock answers, a live kin holder's lock is refused at its own bound and named on stderr with its path and timeout, and an aged lock with a live kin holder is still refused. The unit tests cover the pieces: the holder pid round-trips, only a dead-or-foreign holder frees the lock with a live kin process, a live foreign process, our own pid and an empty file as controls, the wait line carries all five fields, and the floor resolves against a lowered and a raised ready timeout.

One fixture fact worth knowing for anyone writing a test like this: macOS SIGKILLs a copy of a signed system binary, so a live kin-named holder cannot be a renamed `/bin/sleep`. These tests re-run their own test binary under a kin-shaped name against a fixture test that waits, which is ours and runs from anywhere.

Falsification, each break red only where it should be:

| break | unit | end to end |
|---|---|---|
| no dead-holder check | FAILED | dead starter's lock FAILED |
| clear every lock | FAILED | not proven, see below |
| no image check for a recycled pid | ok | recycled pid FAILED |
| never announce the wait | ok | both naming tests FAILED |
| age ignores liveness | ok | not proven, see below |
| the wait line drops the lock age | FAILED | aged lock FAILED |
| no floor of its own for the lock wait | FAILED | ok |
| restored | 6 passed | 14 passed |

Two of those breaks are not yet proven, and the reason is worth stating rather than rounding off. Each deleted the only non-test caller of the function it was about, so under `-D warnings` the integration target failed to BUILD instead of failing an assertion. A build error proves the compiler noticed, not that the test would catch the behavior change, so I do not count it. Both are rewritten to keep the call and force the wrong answer, and that run is held until the fleet's bench round ends, on the captain's instruction that no further build starts before then. `clear every lock` is already falsified at the unit level, where the live-kin-holder assertion goes red. `age ignores liveness` is the one with no true red yet; the same test it targets does go red under `the wait line drops the lock age`, so the test can fail, but that its subject is the age rule is unproven until the re-run. I will post the result here.

Gates: `cargo fmt -- --check` clean, `cargo clippy --all-targets --all-features` with ci.yml's own allow list rc 0, `scripts/zero_file_search_guard.sh` and `scripts/check-quarantine.py` rc 0, `cargo test -p kin-cli --lib startup_lock` 6 passed, `cargo test -p kin-cli --test daemon_start_lock_recovery` 14 passed in 78 s, all under `RUSTFLAGS="-D warnings"`, which is what ci.yml sets for every step and what a helper outside its caller's cfg gate trips. `bin/kin-precheck kin` still refuses on this tree for the `scripts/release-proof` coverage gap that predates it.

Closes FIR-3120
