### PR TITLE
Re-vendor the evidence publisher's permission door from umbrella 2a0d6d265

### DIFF
--- a/scripts/release-proof/VENDORED.json
+++ b/scripts/release-proof/VENDORED.json
@@ -1,13 +1,13 @@
 {
   "source_repository": "firelock-ai/kin-ecosystem",
-  "source_commit": "6aaf42ad0b37e12273ee4bfc3b59f6bc5ae210a4",
+  "source_commit": "2a0d6d265ca2035c0683d2dbc291968610e0b4b3",
   "note": "Byte-identical copies of the umbrella proof tooling so the hosted preflight runs from kin alone; bin/kin-lane is a single-host lock shim written for this tree, not a copy. scripts/release-proof/vendored.test.mjs refuses a file whose sha256 left this manifest.",
   "files": {
     "bin/kin-release-preflight": {"source": "bin/kin-release-preflight", "sha256": "d42617e79966bf6d3548e00a9d303c38cf4689f6ff33610b6d9526019a028854"},
     "bin/kin-release-preflight.d/Dockerfile": {"source": "bin/kin-release-preflight.d/Dockerfile", "sha256": "e6c0e30c2bf46fc889484fb7e32c73163c3cf315d60351be3acd2428d22d12f6"},
     "bin/kin-release-preflight.d/proof-flow.sh": {"source": "bin/kin-release-preflight.d/proof-flow.sh", "sha256": "3a44e377a8c6bfcdfb688608ae5b9ba64293e3a955b711afe20ee237e2516b2b"},
     "bin/kin-release-preflight.d/validate.mjs": {"source": "bin/kin-release-preflight.d/validate.mjs", "sha256": "53badad40150ee0a4d8c817af77f48f04ad2ae89616dce33686532b82afa35b9"},
-    "bin/kin-evidence-publish": {"source": "bin/kin-evidence-publish", "sha256": "7e82d4b09402bacc33881aa3b77ef5ea60677c8166df2cc8146bd86c10311d14"},
+    "bin/kin-evidence-publish": {"source": "bin/kin-evidence-publish", "sha256": "4e85d110c89b37ee80f0cb3739b89acf3e361f2dee1009c02d80fdf850092222"},
     "bin/kin-acceptance-suite": {"source": "bin/kin-acceptance-suite", "sha256": "7ce214e6563e227695cf02411762ca5e8d01edf8898634db465ee30f455918f7"}
   }
 }

--- a/scripts/release-proof/bin/kin-evidence-publish
+++ b/scripts/release-proof/bin/kin-evidence-publish
@@ -307,8 +307,27 @@ async function assertCanWrite(token, repo, log = console.log) {
   if (!info.ok) {
     throw new Error(`this token was refused by ${repo}: HTTP ${info.status} ${apiReason(info)}`);
   }
+  // The block is only about THIS token when it agrees with what this request
+  // already proved. The read above succeeded, so a block claiming `pull: false`
+  // is describing something other than the caller and none of its other fields
+  // mean anything either.
+  //
+  // Measured on 2026-09-03, run 33705610718: an installation token minted with
+  // `permission-contents: write` got back
+  // {"admin":false,"maintain":false,"push":false,"triage":false,"pull":false}
+  // on a request it had just performed successfully. The block is the
+  // repo-COLLABORATOR projection, an installation is not a collaborator, so it
+  // reads all false. `contents: write` is a different axis and does not appear
+  // here at all. That is why no reading of `push` off this object is correct:
+  // the object is not wrong about the answer, it is answering a different
+  // question.
   const permissions = info.body?.permissions;
-  if (permissions !== null && typeof permissions === 'object') {
+  const describesThisToken =
+    permissions !== null && typeof permissions === 'object' && permissions.pull === true;
+  if (describesThisToken) {
+    // A real read-only token: it can read, the block says so, and it says push
+    // is not available. That is the case this door was added for and it still
+    // refuses at the door rather than at the write.
     if (permissions.push !== true) {
       throw new Error(
         `this token can read ${repo} but has no push permission, so the record would be refused at the write. Use a token with write access to ${repo}.`,
@@ -316,8 +335,9 @@ async function assertCanWrite(token, repo, log = console.log) {
     }
     return;
   }
+  const saw = permissions === undefined ? 'no permissions block' : JSON.stringify(permissions);
   log(
-    `${repo} returned no permissions block, which is what a GitHub App installation token gets because that block reports a user's permissions; proceeding, and the write refuses by name if this token cannot push.`,
+    `${repo} returned ${saw}, which does not describe the token that just read it, so it cannot say whether this token may write; proceeding, and the write refuses by name if it may not.`,
   );
 }
 


### PR DESCRIPTION
kin-ecosystem#285 measured what `kin-evidence-publish`'s door was reading: an installation token minted with `permission-contents: write` gets `{"admin":false,"maintain":false,"push":false,"triage":false,"pull":false}` back from `GET /repos/firelock-ai/kin` on a request it had just performed successfully. That block is the repository collaborator projection, an installation is not a collaborator, and `contents: write` is a different axis that never appears on it. So no reading of `push` off that object is correct, which is why both earlier tunings of this door failed.

The door now believes the block only when it agrees with what the request already proved: a successful read beside `pull: false` is not about this caller, so the publisher proceeds and the write refuses by name if it may not; a block with `pull: true` and no push is still the read-only case, refused at the door. The refusal log quotes the block it saw.

This is the vendored half. Bytes from kin-ecosystem main at `2a0d6d265ca2035c0683d2dbc291968610e0b4b3`, sha256 `4e85d110c89b37ee80f0cb3739b89acf3e361f2dee1009c02d80fdf850092222` computed from the landed file; `VENDORED.json` moves to both and nothing else in the manifest changes. Mode stays 755.

Why now: the last three release-cut cycles on 0.6.5 (runs 33705833160, 33706153486, 33706156749) failed at "Publish the candidate's preflight record" with exactly this refusal for candidate `febf5d85`. The cycle after this lands is the first that can file that record.

Gates run: `node --test scripts/release-proof/vendored.test.mjs` 5 passed, 0 failed. Not run: every cargo gate, because the box holds a compute quiet for an overnight benchmark and this change touches no Rust; hosted CI grades it.

Sixth link of the release-cut chain after #1404, #1407, #1409, #1411 and #1413.
