### PR TITLE
Grade the Windows target on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1291,15 +1291,107 @@ jobs:
       - name: Report quarantined flakes
         run: python3 scripts/check-quarantine.py --report-junit target/nextest/default/junit.xml
 
+  # Windows compilation, graded on the pull request that breaks it.
+  #
+  # kin's four native Windows jobs all carry
+  # `if: ${{ github.event_name != 'pull_request' }}` (lines 201, 454, 533 and
+  # 638), so a pull request cannot see a Windows break at all: it lands, and
+  # main's push run reports it afterwards. On 2026-09-02 that cost an hour of
+  # red main. kin#1405 added an open-file helper at module scope whose only
+  # caller sat inside `#[cfg(unix)] mod imp`, so on Windows the function was
+  # dead code, and this workflow compiles with `-D warnings` (line 40):
+  #
+  #     error: function `target_soft_limit` is never used
+  #       --> crates\kin-core\src\file_limit.rs:57:4
+  #        = note: `-D dead-code` implied by `-D warnings`
+  #
+  # All four Windows jobs failed to compile on ddc3e0621 while its own pull
+  # request read green; c99d9065a before it was green on every one; kin#1410
+  # fixed it at eb321488c. This job is what turns that class into a red pull
+  # request instead, and it is cheap enough to sit on the admission path: the
+  # native legs measured 1.8 to 12.6 minutes and the installer 32.7, against a
+  # pull request whose longest job is a fast-gate shard at 8.9 to 10.1.
+  #
+  # Why `gnu` rather than `msvc`. The class is `cfg(unix)`, which is false for
+  # both Windows targets, so either target reproduces it. Only one of them can
+  # run here: `x86_64-pc-windows-msvc` cannot be cross-compiled off Windows,
+  # because ring and the tree-sitter grammars build C and there are no MSVC
+  # headers, which is the wall kin#1410's author hit cross-compiling from
+  # macOS. `x86_64-pc-windows-gnu` needs only mingw-w64, and that pull request
+  # proved this exact package set checks clean under it.
+  #
+  # What this is not. It checks rather than links, and gnu is not the C runtime
+  # Kin ships, so it proves compilation and name resolution for the Windows cfg
+  # set and nothing about the msvc link or about behavior. The native jobs still
+  # own that, on the merge queue and on every commit that reaches main.
+  #
+  # It publishes no required context. `fast-gate-tests-aggregate` below needs it
+  # and admits no result but `success`, so a pull request cannot merge around
+  # it, and that `needs:` line is pinned in
+  # scripts/test-release-workflow-authority.py, which is what stops this job
+  # being dropped quietly.
+  windows-cross-check:
+    name: Windows cross-check
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
+    # The heavy-runner switch; see `fast-gate-lint` for what it resolves to.
+    runs-on: ${{ vars.KIN_HEAVY_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: ./.github/actions/rust-toolchain
+        with:
+          targets: x86_64-pc-windows-gnu
+
+      # Restore on every event and save only from main, as every cache step in
+      # this file does. No `shared-key`, so this keys on the job id: a
+      # cross-target `target` directory holds nothing another job wants, and
+      # sharing one would only evict what those jobs do want.
+      - name: Cache cargo registry and build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # FIR-2744, and see the note on the first cache step in this file.
+          add-rust-environment-hash-key: false
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-on-failure: true
+
+      # ring, the tree-sitter grammars, sqlite and oniguruma compile C for the
+      # target, so a cross check needs the target's own C toolchain exactly as
+      # the musl steps in `check` need musl-tools. Through the bounded wrapper
+      # rather than a bare `apt-get`, so a stalled mirror fails in minutes with
+      # its own error line instead of holding the job to its timeout.
+      - name: Install the mingw-w64 cross toolchain
+        run: scripts/ci-apt-install.sh mingw-w64
+
+      # The package set the Windows release build ships, which is the set both
+      # musl steps in `check` check for their targets too. Not `--workspace`:
+      # `kin-notifier-macos` is a macOS-only member and `tests/integration` is a
+      # test crate, and neither is in a shipped Windows binary. `cargo check`
+      # with no target flags takes libs and bins, and both matter here, because
+      # the two call sites kin#1410 exists for are in `kin-cli/src/main.rs` and
+      # `kin-daemon/src/bin/kin-daemon.rs` while the dead helper was in the
+      # `kin-core` lib beneath them.
+      - name: Check the Windows target compiles
+        run: |
+          cargo check --locked --target x86_64-pc-windows-gnu \
+            -p kin-cli -p kin-daemon
+
   # The required context, and the only job that publishes it. It always runs, on
   # every event, because a required context that is never reported is a silent
   # hang. It names which case it passed on rather than passing quietly, and it
   # admits `success` from the shards and nothing else: a skipped or cancelled
   # shard left part of the selection unrun, and a required context that goes
   # green on that is worse than no context at all.
+  #
+  # It grades the Windows cross-check on the same terms, and that is how a
+  # Windows compile break blocks a pull request at all. The job itself publishes
+  # a name no ruleset requires, so without this `needs:` a red Windows leg would
+  # sit beside six green required contexts and merge.
   fast-gate-tests-aggregate:
     name: Fast gate build and tests
-    needs: [changes, fast-gate-tests]
+    needs: [changes, fast-gate-tests, windows-cross-check]
     if: ${{ !cancelled() }}
     # Deliberately a literal `ubuntu-latest` rather than the heavy-runner switch,
     # for the reason `check-aggregate` is not on one either. This job compiles
@@ -1314,6 +1406,7 @@ jobs:
         env:
           DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
           SHARDS: ${{ needs.fast-gate-tests.result }}
+          WINDOWS: ${{ needs.windows-cross-check.result }}
         run: |
           set -euo pipefail
           if [ "$DOCS_ONLY" = "true" ]; then
@@ -1327,7 +1420,15 @@ jobs:
             echo "'cancelled' mean a shard did not run at all." >&2
             exit 1
           fi
-          echo "every fast-gate shard succeeded"
+          if [ "$WINDOWS" != "success" ]; then
+            echo "::error title=the Windows cross-check did not pass::windows-cross-check reported '$WINDOWS'"
+            echo "kin's four native Windows jobs are all off the pull-request" >&2
+            echo "path, so this is the only leg that can report a Windows" >&2
+            echo "compile break before it reaches main. 'skipped' and" >&2
+            echo "'cancelled' mean it never graded the target at all." >&2
+            exit 1
+          fi
+          echo "every fast-gate shard succeeded, and the Windows target compiles"
 
   # The served MCP surface, graded on the pull request that moves it.
   #

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -701,6 +701,15 @@ CI_JOB_DISPLAY_NAMES = {
     "fast-gate-lint": "Fast gate lint and policy",
     "fast-gate-tests": "Fast gate test shard",
     "fast-gate-tests-aggregate": "Fast gate build and tests",
+    # The pull request's only Windows evidence. All four native Windows jobs
+    # carry `github.event_name != 'pull_request'`, so on 2026-09-02 a helper
+    # that was dead code under `cfg(not(unix))` read green through its whole
+    # pull request and turned every Windows job on main red for an hour. This
+    # cross-compiles the shipped package set for x86_64-pc-windows-gnu, which
+    # reproduces that class because `cfg(unix)` is false for both Windows
+    # targets and msvc cannot cross-compile off Windows. It publishes a name no
+    # ruleset requires and blocks through the aggregate's `needs:` below.
+    "windows-cross-check": "Windows cross-check",
     # The served MCP surface, graded on the pull request that moves it. Five
     # assertions read that surface and all five run only on main's push, so a
     # profile change that moved a served name and trimmed three schema knobs and
@@ -4801,7 +4810,10 @@ FAST_GATE_SHARD_STEPS = (
 FAST_GATE_SHARD_MATRIX = "shard: [1, 2, 3]"
 FAST_GATE_SHARD_INDEPENDENT_LEGS = "fail-fast: false"
 FAST_GATE_AGGREGATE_ALWAYS_RUNS = "if: ${{ !cancelled() }}"
-FAST_GATE_AGGREGATE_NEEDS = "needs: [changes, fast-gate-tests]"
+# The Windows cross-check is in here rather than left advisory because the job
+# publishes no required context of its own. Without this line a red Windows leg
+# sits beside six green required contexts and the pull request merges.
+FAST_GATE_AGGREGATE_NEEDS = "needs: [changes, fast-gate-tests, windows-cross-check]"
 FAST_GATE_AGGREGATE_SUCCESS_GATE = 'if [ "$SHARDS" != "success" ]; then'
 
 


### PR DESCRIPTION
kin's four native Windows jobs are all off the pull-request path, so a Windows compile break cannot turn a pull request red. It lands, and main's push run reports it afterwards. On 2026-09-02 that cost an hour of red main. This adds the cheapest leg that would have caught it.

## What it checks

A new job, `windows-cross-check`, cross-compiles the package set the Windows release build ships:

```
cargo check --locked --target x86_64-pc-windows-gnu -p kin-cli -p kin-daemon
```

It runs on the same `vars.KIN_HEAVY_RUNNER || 'ubuntu-latest'` switch the other compile-heavy jobs use, installs mingw-w64 through `scripts/ci-apt-install.sh` rather than a bare `apt-get`, caches exactly like its siblings and skips on a documentation-only diff. The `-D warnings` that turns a dead-code lint into an error comes from this workflow's own `env:`, so nothing about the failure mode is restated here.

## The class it catches

kin#1405 added an open-file helper at module scope whose only caller sat inside `#[cfg(unix)] mod imp`. On Windows the function was dead code:

```
error: function `target_soft_limit` is never used
  --> crates\kin-core\src\file_limit.rs:57:4
   = note: `-D dead-code` implied by `-D warnings`
```

All four Windows jobs failed to compile on ddc3e0621 while that pull request read green. c99d9065a before it was green on every one, and kin#1410 fixed it at eb321488c.

## Why gnu and not msvc

The class is `cfg(unix)`, which is false for both Windows targets, so either one reproduces it. Only one of them can run here. `x86_64-pc-windows-msvc` cannot be cross-compiled off Windows, because ring and the tree-sitter grammars build C and there are no MSVC headers, which is the wall kin#1410's author hit cross-compiling from macOS. `x86_64-pc-windows-gnu` needs only mingw-w64, and that pull request proved this exact package set checks clean under it.

What this is not: it checks rather than links, and gnu is not the C runtime Kin ships. It proves compilation and name resolution for the Windows cfg set and nothing about the msvc link or about behavior. The native jobs keep that, on the merge queue and on every commit that reaches main.

## Why the aggregate needs it

`windows-cross-check` publishes a name no ruleset requires, so on its own a red Windows leg would sit beside main's six green required contexts and merge. `fast-gate-tests-aggregate`, which publishes the required `Fast gate build and tests`, now needs it and admits no result but `success`, after its documentation-only early exit.

## The second file

`scripts/test-release-workflow-authority.py` carries two exact-equality assertions over ci.yml: the job census in `CI_JOB_DISPLAY_NAMES`, and the aggregate's pinned `needs:` line. Both run inside `fast-gate-lint`, so a new job is red by construction without them. This is one census entry and one constant, with no assertion added and none removed. They are also what keeps the job from being dropped quietly: remove the job and leave the `needs:` and GitHub rejects the workflow, remove both and the census equality fails.

## Cost

The bar is that a pull request stays under ten minutes and the new job finishes inside the longest job already on that path. Measured on green pull-request run 33704986855 the longest is a fast-gate shard at 8.9 minutes, and 10.1 on run 33703139534. For contrast, on push run 33703556957 the native Windows legs measured 4.1, 7.6 and 12.6 minutes and the installer 32.7, which is why they are not here.

Measured on this pull request: **2 minutes 37 seconds**, 02:31:46Z to 02:34:23Z, with `No cache found` in the rust-cache step, so that is a cold number with no warm start. The `cargo check` step itself reported `Finished dev profile in 1m 55s`, and the log shows it checking `kin-core`, compiling `kin-cli` and checking `kin-daemon` for the target after pulling `winapi-x86_64-pc-windows-gnu`. It runs in parallel with the shards, so it adds nothing to the pull request's wall clock.

## Gates

A benchmark round holds the compute quiet lock with a 39 GB model wired on the GPU, so this lane ran no cargo, no clippy and no test locally. Hosted CI is the gate of record for a workflow change and grades it directly: this pull request's own `windows-cross-check` run is the evidence.

`actionlint` is clean on the edited workflow, and that check was falsified rather than trusted. Mistyping the `needs.windows-cross-check` reference takes it red naming the undefined property, so its green means the dependency graph resolves.

The job itself was falsified against a tree carrying kin#1405's broken shape plus this change: kin#1417, a draft since closed, whose only difference from this branch is `crates/kin-core/src/file_limit.rs` restored byte for byte from `ddc3e0621`.

`Windows cross-check` went red there in 1m49s with exactly the error the native Windows jobs reported on main:

```
error: function `target_soft_limit` is never used
  --> crates/kin-core/src/file_limit.rs:57:4
   |
57 | fn target_soft_limit(current: OpenFileLimit) -> Option<u64> {
   |
   = note: `-D dead-code` implied by `-D warnings`
error: could not compile `kin-core` (lib) due to 1 previous error
Process completed with exit code 101.
```

Green here, red there, same job, one file apart. Both read by name over the full check-run set, 46 of 46 runs on each sha with `total_count` asserted equal to the page length.
