### PR TITLE
Falsify the Windows cross-check against the kin#1405 shape

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1291,15 +1291,107 @@ jobs:
       - name: Report quarantined flakes
         run: python3 scripts/check-quarantine.py --report-junit target/nextest/default/junit.xml
 
+  # Windows compilation, graded on the pull request that breaks it.
+  #
+  # kin's four native Windows jobs all carry
+  # `if: ${{ github.event_name != 'pull_request' }}` (lines 201, 454, 533 and
+  # 638), so a pull request cannot see a Windows break at all: it lands, and
+  # main's push run reports it afterwards. On 2026-09-02 that cost an hour of
+  # red main. kin#1405 added an open-file helper at module scope whose only
+  # caller sat inside `#[cfg(unix)] mod imp`, so on Windows the function was
+  # dead code, and this workflow compiles with `-D warnings` (line 40):
+  #
+  #     error: function `target_soft_limit` is never used
+  #       --> crates\kin-core\src\file_limit.rs:57:4
+  #        = note: `-D dead-code` implied by `-D warnings`
+  #
+  # All four Windows jobs failed to compile on ddc3e0621 while its own pull
+  # request read green; c99d9065a before it was green on every one; kin#1410
+  # fixed it at eb321488c. This job is what turns that class into a red pull
+  # request instead, and it is cheap enough to sit on the admission path: the
+  # native legs measured 1.8 to 12.6 minutes and the installer 32.7, against a
+  # pull request whose longest job is a fast-gate shard at 8.9 to 10.1.
+  #
+  # Why `gnu` rather than `msvc`. The class is `cfg(unix)`, which is false for
+  # both Windows targets, so either target reproduces it. Only one of them can
+  # run here: `x86_64-pc-windows-msvc` cannot be cross-compiled off Windows,
+  # because ring and the tree-sitter grammars build C and there are no MSVC
+  # headers, which is the wall kin#1410's author hit cross-compiling from
+  # macOS. `x86_64-pc-windows-gnu` needs only mingw-w64, and that pull request
+  # proved this exact package set checks clean under it.
+  #
+  # What this is not. It checks rather than links, and gnu is not the C runtime
+  # Kin ships, so it proves compilation and name resolution for the Windows cfg
+  # set and nothing about the msvc link or about behavior. The native jobs still
+  # own that, on the merge queue and on every commit that reaches main.
+  #
+  # It publishes no required context. `fast-gate-tests-aggregate` below needs it
+  # and admits no result but `success`, so a pull request cannot merge around
+  # it, and that `needs:` line is pinned in
+  # scripts/test-release-workflow-authority.py, which is what stops this job
+  # being dropped quietly.
+  windows-cross-check:
+    name: Windows cross-check
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
+    # The heavy-runner switch; see `fast-gate-lint` for what it resolves to.
+    runs-on: ${{ vars.KIN_HEAVY_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: ./.github/actions/rust-toolchain
+        with:
+          targets: x86_64-pc-windows-gnu
+
+      # Restore on every event and save only from main, as every cache step in
+      # this file does. No `shared-key`, so this keys on the job id: a
+      # cross-target `target` directory holds nothing another job wants, and
+      # sharing one would only evict what those jobs do want.
+      - name: Cache cargo registry and build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # FIR-2744, and see the note on the first cache step in this file.
+          add-rust-environment-hash-key: false
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-on-failure: true
+
+      # ring, the tree-sitter grammars, sqlite and oniguruma compile C for the
+      # target, so a cross check needs the target's own C toolchain exactly as
+      # the musl steps in `check` need musl-tools. Through the bounded wrapper
+      # rather than a bare `apt-get`, so a stalled mirror fails in minutes with
+      # its own error line instead of holding the job to its timeout.
+      - name: Install the mingw-w64 cross toolchain
+        run: scripts/ci-apt-install.sh mingw-w64
+
+      # The package set the Windows release build ships, which is the set both
+      # musl steps in `check` check for their targets too. Not `--workspace`:
+      # `kin-notifier-macos` is a macOS-only member and `tests/integration` is a
+      # test crate, and neither is in a shipped Windows binary. `cargo check`
+      # with no target flags takes libs and bins, and both matter here, because
+      # the two call sites kin#1410 exists for are in `kin-cli/src/main.rs` and
+      # `kin-daemon/src/bin/kin-daemon.rs` while the dead helper was in the
+      # `kin-core` lib beneath them.
+      - name: Check the Windows target compiles
+        run: |
+          cargo check --locked --target x86_64-pc-windows-gnu \
+            -p kin-cli -p kin-daemon
+
   # The required context, and the only job that publishes it. It always runs, on
   # every event, because a required context that is never reported is a silent
   # hang. It names which case it passed on rather than passing quietly, and it
   # admits `success` from the shards and nothing else: a skipped or cancelled
   # shard left part of the selection unrun, and a required context that goes
   # green on that is worse than no context at all.
+  #
+  # It grades the Windows cross-check on the same terms, and that is how a
+  # Windows compile break blocks a pull request at all. The job itself publishes
+  # a name no ruleset requires, so without this `needs:` a red Windows leg would
+  # sit beside six green required contexts and merge.
   fast-gate-tests-aggregate:
     name: Fast gate build and tests
-    needs: [changes, fast-gate-tests]
+    needs: [changes, fast-gate-tests, windows-cross-check]
     if: ${{ !cancelled() }}
     # Deliberately a literal `ubuntu-latest` rather than the heavy-runner switch,
     # for the reason `check-aggregate` is not on one either. This job compiles
@@ -1314,6 +1406,7 @@ jobs:
         env:
           DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
           SHARDS: ${{ needs.fast-gate-tests.result }}
+          WINDOWS: ${{ needs.windows-cross-check.result }}
         run: |
           set -euo pipefail
           if [ "$DOCS_ONLY" = "true" ]; then
@@ -1327,7 +1420,15 @@ jobs:
             echo "'cancelled' mean a shard did not run at all." >&2
             exit 1
           fi
-          echo "every fast-gate shard succeeded"
+          if [ "$WINDOWS" != "success" ]; then
+            echo "::error title=the Windows cross-check did not pass::windows-cross-check reported '$WINDOWS'"
+            echo "kin's four native Windows jobs are all off the pull-request" >&2
+            echo "path, so this is the only leg that can report a Windows" >&2
+            echo "compile break before it reaches main. 'skipped' and" >&2
+            echo "'cancelled' mean it never graded the target at all." >&2
+            exit 1
+          fi
+          echo "every fast-gate shard succeeded, and the Windows target compiles"
 
   # The served MCP surface, graded on the pull request that moves it.
   #

--- a/crates/kin-core/src/file_limit.rs
+++ b/crates/kin-core/src/file_limit.rs
@@ -48,32 +48,23 @@ pub struct OpenFileLimit {
     pub hard: Option<u64>,
 }
 
+/// The soft limit to ask for, or `None` when the one in force is already at
+/// least as high as anything this would achieve.
+///
+/// Separated from the syscalls so the decision is testable. Every path that
+/// would not improve the limit returns `None`, so a process an operator already
+/// tuned is left exactly as it was found.
+fn target_soft_limit(current: OpenFileLimit) -> Option<u64> {
+    let ceiling = match current.hard {
+        Some(hard) => hard.min(TARGET_OPEN_FILES),
+        None => TARGET_OPEN_FILES,
+    };
+    (ceiling > current.soft).then_some(ceiling)
+}
+
 #[cfg(unix)]
 mod imp {
-    use super::{OpenFileLimit, TARGET_OPEN_FILES};
-
-    /// The soft limit to ask for, or `None` when the one in force is already at
-    /// least as high as anything this would achieve.
-    ///
-    /// Separated from the syscalls so the decision is testable. Every path that
-    /// would not improve the limit returns `None`, so a process an operator
-    /// already tuned is left exactly as it was found.
-    ///
-    /// It lives inside this module rather than beside the public surface for a
-    /// reason that cost a red main. `raise` is its only caller and `raise` is
-    /// cfg-gated, so at the outer level this function was dead code on every
-    /// platform without an `rlimit`, and the workspace builds with
-    /// `-D warnings`. Windows found that; the pull request could not, because
-    /// kin's Windows jobs do not run on a pull request. Keeping a helper inside
-    /// the same cfg as its caller makes that class impossible rather than
-    /// remembered.
-    fn target_soft_limit(current: OpenFileLimit) -> Option<u64> {
-        let ceiling = match current.hard {
-            Some(hard) => hard.min(TARGET_OPEN_FILES),
-            None => TARGET_OPEN_FILES,
-        };
-        (ceiling > current.soft).then_some(ceiling)
-    }
+    use super::OpenFileLimit;
 
     /// Read this process's open-file limit, or `None` when the kernel refuses
     /// to say.
@@ -120,7 +111,7 @@ mod imp {
         let Some(current) = read() else {
             return;
         };
-        let Some(target) = target_soft_limit(current) else {
+        let Some(target) = super::target_soft_limit(current) else {
             return;
         };
         let hard = match current.hard {
@@ -139,59 +130,7 @@ mod imp {
     #[cfg(test)]
     mod tests {
         use super::*;
-
-        #[test]
-        fn a_stock_macos_limit_is_raised_to_the_target() {
-            assert_eq!(
-                target_soft_limit(OpenFileLimit {
-                    soft: 256,
-                    hard: None
-                }),
-                Some(TARGET_OPEN_FILES)
-            );
-        }
-
-        #[test]
-        fn a_hard_limit_below_the_target_caps_the_request() {
-            assert_eq!(
-                target_soft_limit(OpenFileLimit {
-                    soft: 256,
-                    hard: Some(4096)
-                }),
-                Some(4096)
-            );
-        }
-
-        #[test]
-        fn a_limit_an_operator_already_raised_is_left_alone() {
-            assert_eq!(
-                target_soft_limit(OpenFileLimit {
-                    soft: 1_048_576,
-                    hard: None
-                }),
-                None
-            );
-            assert_eq!(
-                target_soft_limit(OpenFileLimit {
-                    soft: TARGET_OPEN_FILES,
-                    hard: Some(TARGET_OPEN_FILES)
-                }),
-                None
-            );
-        }
-
-        /// A pinned hard limit is the case the error path exists for: nothing
-        /// can be asked for, so nothing is.
-        #[test]
-        fn a_soft_limit_pinned_at_its_hard_limit_asks_for_nothing() {
-            assert_eq!(
-                target_soft_limit(OpenFileLimit {
-                    soft: 256,
-                    hard: Some(256)
-                }),
-                None
-            );
-        }
+        use crate::file_limit::TARGET_OPEN_FILES;
 
         /// The ladder must be able to reach the floor, or a machine with a low
         /// `kern.maxfilesperproc` would spin rather than settle.
@@ -225,20 +164,6 @@ mod imp {
     }
 
     pub fn raise() {}
-
-    #[cfg(test)]
-    mod tests {
-        /// The no-op contract, asserted rather than assumed, because
-        /// `kin_cli::open_files` renders its guidance from exactly these two
-        /// answers: a limit of `None` prints the remedy with no limit line, and
-        /// a raise that cannot panic is what lets it be called unconditionally
-        /// at startup.
-        #[test]
-        fn a_platform_without_rlimit_reports_no_limit_and_raises_nothing() {
-            super::raise();
-            assert!(super::read().is_none());
-        }
-    }
 }
 
 /// Raise this process's open-file soft limit toward its hard limit.
@@ -257,6 +182,64 @@ pub fn raise_open_file_limit() {
 /// number in an error message is the number that was in force.
 pub fn open_file_limit() -> Option<OpenFileLimit> {
     imp::read()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_stock_macos_limit_is_raised_to_the_target() {
+        assert_eq!(
+            target_soft_limit(OpenFileLimit {
+                soft: 256,
+                hard: None
+            }),
+            Some(TARGET_OPEN_FILES)
+        );
+    }
+
+    #[test]
+    fn a_hard_limit_below_the_target_caps_the_request() {
+        assert_eq!(
+            target_soft_limit(OpenFileLimit {
+                soft: 256,
+                hard: Some(4096)
+            }),
+            Some(4096)
+        );
+    }
+
+    #[test]
+    fn a_limit_an_operator_already_raised_is_left_alone() {
+        assert_eq!(
+            target_soft_limit(OpenFileLimit {
+                soft: 1_048_576,
+                hard: None
+            }),
+            None
+        );
+        assert_eq!(
+            target_soft_limit(OpenFileLimit {
+                soft: TARGET_OPEN_FILES,
+                hard: Some(TARGET_OPEN_FILES)
+            }),
+            None
+        );
+    }
+
+    /// A pinned hard limit is the case the error path exists for: nothing can
+    /// be asked for, so nothing is.
+    #[test]
+    fn a_soft_limit_pinned_at_its_hard_limit_asks_for_nothing() {
+        assert_eq!(
+            target_soft_limit(OpenFileLimit {
+                soft: 256,
+                hard: Some(256)
+            }),
+            None
+        );
+    }
 }
 
 /// The margin between the target and what an admission was measured to need,

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -701,6 +701,15 @@ CI_JOB_DISPLAY_NAMES = {
     "fast-gate-lint": "Fast gate lint and policy",
     "fast-gate-tests": "Fast gate test shard",
     "fast-gate-tests-aggregate": "Fast gate build and tests",
+    # The pull request's only Windows evidence. All four native Windows jobs
+    # carry `github.event_name != 'pull_request'`, so on 2026-09-02 a helper
+    # that was dead code under `cfg(not(unix))` read green through its whole
+    # pull request and turned every Windows job on main red for an hour. This
+    # cross-compiles the shipped package set for x86_64-pc-windows-gnu, which
+    # reproduces that class because `cfg(unix)` is false for both Windows
+    # targets and msvc cannot cross-compile off Windows. It publishes a name no
+    # ruleset requires and blocks through the aggregate's `needs:` below.
+    "windows-cross-check": "Windows cross-check",
     # The served MCP surface, graded on the pull request that moves it. Five
     # assertions read that surface and all five run only on main's push, so a
     # profile change that moved a served name and trimmed three schema knobs and
@@ -4801,7 +4810,10 @@ FAST_GATE_SHARD_STEPS = (
 FAST_GATE_SHARD_MATRIX = "shard: [1, 2, 3]"
 FAST_GATE_SHARD_INDEPENDENT_LEGS = "fail-fast: false"
 FAST_GATE_AGGREGATE_ALWAYS_RUNS = "if: ${{ !cancelled() }}"
-FAST_GATE_AGGREGATE_NEEDS = "needs: [changes, fast-gate-tests]"
+# The Windows cross-check is in here rather than left advisory because the job
+# publishes no required context of its own. Without this line a red Windows leg
+# sits beside six green required contexts and the pull request merges.
+FAST_GATE_AGGREGATE_NEEDS = "needs: [changes, fast-gate-tests, windows-cross-check]"
 FAST_GATE_AGGREGATE_SUCCESS_GATE = 'if [ "$SHARDS" != "success" ]; then'
 
 


### PR DESCRIPTION
Throwaway, to falsify the new job on kin#1416. Close after reading.

This tree is main plus kin#1416's `windows-cross-check`, with `crates/kin-core/src/file_limit.rs` restored byte for byte from `ddc3e0621`, the sha kin#1405 landed. `target_soft_limit` sits at module scope while its only caller sits inside `#[cfg(unix)] mod imp`, so it is dead code on Windows and the workspace compiles with `-D warnings`. That pull request read green while all four Windows jobs failed to compile on main.

What has to happen for the new job to be evidence: `Windows cross-check` red here, naming

```
error: function `target_soft_limit` is never used
```

and green on kin#1416, which carries the identical job against a tree without the defect. A guard nobody has watched fail is not a guard.

No local gate ran on either branch. A benchmark round holds the compute quiet lock, so hosted CI is doing the grading.
