### PR TITLE
Wire Go reference enrichment and install gopls where the daemon looks

### DIFF
--- a/crates/kin-cli/src/commands/language_servers.rs
+++ b/crates/kin-cli/src/commands/language_servers.rs
@@ -23,6 +23,7 @@
 //! download into a shared global prefix, and Kin does not spend a user's
 //! bandwidth or mutate their toolchain on a probe's say-so.
 
+use std::ffi::OsString;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -158,6 +159,71 @@ impl LanguageServerRecipe {
         which::which(self.program).is_ok()
     }
 
+    /// Whether this recipe redirects with `GOBIN` rather than an installer flag.
+    ///
+    /// `go install` has no prefix argument at all. Its destination is the
+    /// `GOBIN` environment variable, defaulting to `$(go env GOPATH)/bin`, so
+    /// the Go row's redirect is an environment entry where every npm row's is
+    /// an argument. The two cannot share one shape, and a Go recipe pushed
+    /// through the npm shape would hand `go` a `--prefix` flag it rejects.
+    fn redirects_through_gobin(&self) -> bool {
+        self.program == "go"
+    }
+
+    /// The environment the managed route runs its installer under.
+    ///
+    /// Empty for every npm recipe, which redirects with `--prefix`. For Go it
+    /// is `GOBIN` pointed at [`kin_core::tool_prefix::managed_tool_bin_dir`],
+    /// a directory both binaries already append to `PATH` at startup through
+    /// `augment_path_with_managed_tools`. That is the whole answer to the gap
+    /// wiring the adapter does not close: an ordinary `go install` writes into
+    /// `$(go env GOPATH)/bin`, which nothing puts on `PATH`, and the daemon
+    /// starts a language server with a bare `Command::new("gopls")`.
+    pub(crate) fn managed_prefix_env(&self) -> Vec<(String, String)> {
+        if self.redirects_through_gobin() {
+            return vec![(
+                "GOBIN".to_string(),
+                kin_core::tool_prefix::managed_tool_bin_dir()
+                    .display()
+                    .to_string(),
+            )];
+        }
+        Vec::new()
+    }
+
+    /// The directory the managed route needs to exist before it runs.
+    pub(crate) fn managed_prefix_dir(&self) -> PathBuf {
+        if self.redirects_through_gobin() {
+            kin_core::tool_prefix::managed_tool_bin_dir()
+        } else {
+            kin_core::tool_prefix::managed_node_prefix()
+        }
+    }
+
+    /// Where the managed route's binary lands, as the report says it back.
+    ///
+    /// Not the same as [`Self::managed_prefix_dir`] for npm, which installs
+    /// into a prefix and links executables into `node_modules/.bin` beneath it.
+    /// Naming the wrong one is a run that reports success over a binary nothing
+    /// can reach.
+    pub(crate) fn managed_prefix_bin_dir(&self) -> PathBuf {
+        if self.redirects_through_gobin() {
+            kin_core::tool_prefix::managed_tool_bin_dir()
+        } else {
+            kin_core::tool_prefix::managed_node_bin_dir()
+        }
+    }
+
+    /// What vouches for the bytes the managed route installs.
+    fn managed_route_source(&self) -> String {
+        if self.redirects_through_gobin() {
+            return format!(
+                "{GOPLS_MODULE}, built from source and verified against the Go checksum database"
+            );
+        }
+        format!("{}, integrity checked by npm", self.program)
+    }
+
     /// The arguments for the same installer pointed at a prefix Kin owns.
     ///
     /// `-g` is dropped and `--prefix` inserted, which turns a global install
@@ -165,6 +231,13 @@ impl LanguageServerRecipe {
     /// arguments are untouched, pin included, because the whole hazard the
     /// TypeScript pin exists for is a copy that quietly drops it.
     pub(crate) fn managed_prefix_args(&self, prefix: &Path) -> Vec<String> {
+        // The Go route redirects through the environment, so its arguments are
+        // the recipe's own, module pin included. Rewriting them would be the
+        // exact copy that drops a pin, in a route whose whole reason to exist
+        // is that the default destination is unreachable.
+        if self.redirects_through_gobin() {
+            return self.args.iter().map(|arg| (*arg).to_string()).collect();
+        }
         let mut args: Vec<String> = vec!["install".to_string()];
         args.push("--prefix".to_string());
         args.push(prefix.display().to_string());
@@ -185,12 +258,19 @@ impl LanguageServerRecipe {
     pub(crate) fn route_command_line(&self, route: InstallRoute) -> String {
         match route {
             InstallRoute::Installer => self.command_line(),
-            InstallRoute::ManagedPrefix => format!(
-                "{} {}",
-                self.program,
-                self.managed_prefix_args(&kin_core::tool_prefix::managed_node_prefix())
-                    .join(" ")
-            ),
+            InstallRoute::ManagedPrefix => {
+                // The environment is part of the command for the Go route,
+                // because GOBIN is the whole redirect. A printed `go install`
+                // with the environment stripped is a command that installs
+                // somewhere else, handed to an operator as the thing that ran.
+                let environment: String = self
+                    .managed_prefix_env()
+                    .iter()
+                    .map(|(key, value)| format!("{key}={value} "))
+                    .collect();
+                let arguments = self.managed_prefix_args(&self.managed_prefix_dir());
+                format!("{environment}{} {}", self.program, arguments.join(" "))
+            }
             InstallRoute::PinnedRelease => match self.fallback {
                 Fallback::PinnedRelease(release) => format!(
                     "download {} {} from the {} release binaries",
@@ -241,6 +321,20 @@ pub(crate) fn resolve_route(recipe: &LanguageServerRecipe) -> Option<InstallRout
 /// because `typescript-language-server` declares no peer dependency on
 /// typescript at all.
 const TYPESCRIPT_PACKAGE: &str = "typescript@^5";
+
+/// The gopls module `go install` builds, pinned to a tag.
+///
+/// Pinned for the reason the typescript package is. `@latest` resolves to
+/// whatever upstream tagged that morning, so two machines set up a week apart
+/// index one repository with two different servers and nothing records which of
+/// them produced an edge. The failure is invisible from the install side: both
+/// runs exit zero, both put `gopls` on PATH, and only the graph disagrees.
+///
+/// A source pin rather than a binary one, because gopls is distributed as a Go
+/// module rather than as prebuilt release assets. `go install` builds it with
+/// the host's own toolchain, so this route adds nothing to Kin's release
+/// archive and redistributes nothing.
+const GOPLS_MODULE: &str = "golang.org/x/tools/gopls@v0.22.0";
 
 /// Every language this build can enrich, with the server that enriches it.
 ///
@@ -294,6 +388,15 @@ pub(crate) const LANGUAGE_SERVERS: &[LanguageServerRecipe] = &[
         fallback: Fallback::ManagedPrefix,
         disclosure: "downloads the typescript-language-server and typescript npm packages into \
                      your global npm prefix",
+    },
+    LanguageServerRecipe {
+        language: LanguageId::Go,
+        binaries: &["gopls"],
+        program: "go",
+        args: &["install", GOPLS_MODULE],
+        fallback: Fallback::ManagedPrefix,
+        disclosure: "builds gopls from source with your Go toolchain and installs it into your \
+                     Go bin directory",
     },
 ];
 
@@ -452,6 +555,17 @@ pub(crate) fn install_fix_line(missing_names: &[&str]) -> String {
 pub(crate) fn route_disclosure(recipe: &LanguageServerRecipe, route: InstallRoute) -> String {
     match route {
         InstallRoute::Installer => recipe.disclosure.to_string(),
+        // The Go route is not a redirected npm install and must not describe
+        // itself as one. It builds from source with the operator's own
+        // toolchain, and the reason it redirects is a PATH gap rather than a
+        // permission one. Different spend, different repair, different sentence.
+        InstallRoute::ManagedPrefix if recipe.redirects_through_gobin() => format!(
+            "builds gopls from source with your Go toolchain and installs it into {}, a \
+             directory Kin owns under KIN_HOME and already appends to PATH. An ordinary `go \
+             install` writes into your Go bin directory instead, which this host's PATH does \
+             not carry, and the daemon starts a language server with a bare `gopls`",
+            kin_core::tool_prefix::managed_tool_bin_dir().display()
+        ),
         InstallRoute::ManagedPrefix => format!(
             "runs the same install against {}, a prefix Kin owns under KIN_HOME, because this \
              host's global npm prefix refuses this user",
@@ -739,14 +853,79 @@ pub(crate) fn npm_prefix_blocker(prefix: &NpmGlobalPrefix) -> Option<String> {
     ))
 }
 
+/// Where a bare `go install` would put the binary.
+///
+/// `GOBIN` when the toolchain has one, otherwise `$(go env GOPATH)/bin`. Asked
+/// of the toolchain rather than assembled from `$HOME`, because GOPATH is
+/// configurable and a guess would name the wrong directory in the one message
+/// whose whole job is to name the right one. `None` when there is no `go` to
+/// ask, which is the same host state `installer_available` already reports.
+fn go_default_bin_dir() -> Option<PathBuf> {
+    let output = Command::new("go")
+        .args(["env", "GOBIN", "GOPATH"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut lines = text.lines();
+    let gobin = lines.next().unwrap_or_default().trim();
+    if !gobin.is_empty() {
+        return Some(PathBuf::from(gobin));
+    }
+    let gopath = lines.next().unwrap_or_default().trim();
+    if gopath.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(gopath).join("bin"))
+}
+
+/// Whether a binary installed into `dir` would be reachable from `path`.
+///
+/// Pure over its inputs, so the rule that decides Go's route is decidable with
+/// no host, no toolchain and no subprocess, exactly as [`choose_route`] is.
+pub(crate) fn directory_is_on_path(dir: &Path, path: Option<&OsString>) -> bool {
+    path.is_some_and(|value| std::env::split_paths(value).any(|entry| entry == dir))
+}
+
+/// The reason a bare `go install` cannot close this gap, stated before it runs.
+///
+/// `go install` has no prefix flag and nothing resolves for it afterwards. It
+/// writes into `$(go env GOPATH)/bin`, which nothing puts on `PATH` by default,
+/// and `kin_lsp::lifecycle::LspServer::start` runs the bare string `gopls` with
+/// no `which` and no GOPATH fallback. So the ordinary install succeeds and the
+/// daemon still starts nothing: the same exit-zero-over-an-open-gap the npm
+/// prefix blocker exists for, arriving through a different door.
+pub(crate) fn go_default_bin_blocker(dir: &Path, path: Option<&OsString>) -> Option<String> {
+    if directory_is_on_path(dir, path) {
+        return None;
+    }
+    Some(format!(
+        "`go install` writes gopls into {}, which is not on this process's PATH, and the daemon \
+         starts a language server with a bare `gopls` and no GOPATH fallback, so a server \
+         installed there is one nothing can start",
+        dir.display()
+    ))
+}
+
 /// Why this install cannot succeed, known before it is attempted.
 ///
-/// Only the npm recipes have one today, and it is the one a container hits:
-/// the Node base images set the global prefix to `/usr/local`, whose
-/// `lib/node_modules` is owned by root, and a Kin running as an unprivileged
-/// user cannot write there. Attempting it anyway spends the download and ends
-/// in npm's own EACCES trace, which reads as a Kin defect and names no remedy.
+/// The npm recipes have the one a container hits: the Node base images set the
+/// global prefix to `/usr/local`, whose `lib/node_modules` is owned by root, and
+/// a Kin running as an unprivileged user cannot write there. Attempting it
+/// anyway spends the download and ends in npm's own EACCES trace, which reads as
+/// a Kin defect and names no remedy.
+///
+/// Go's is the same failure with a different cause: the install succeeds and
+/// lands somewhere nothing reads. Both are "running this installer against its
+/// own default target cannot close the gap", which is what
+/// `HostRoutes::default_target_blocked` means and what routes each of them to a
+/// destination Kin owns.
 fn install_blocker(recipe: &LanguageServerRecipe) -> Option<String> {
+    if recipe.redirects_through_gobin() {
+        return go_default_bin_blocker(&go_default_bin_dir()?, std::env::var_os("PATH").as_ref());
+    }
     if recipe.program != "npm" {
         return None;
     }
@@ -916,8 +1095,10 @@ fn proxy_environment_lines(program: &str) -> Vec<String> {
                 .to_string(),
         );
     } else {
-        // rustup reads the lowercase spellings only, and its downloader takes
-        // the certificate bundle from the OS store.
+        // rustup reads the lowercase spellings only and takes its certificate
+        // bundle from the OS store; the Go toolchain reads either case and its
+        // module fetches honour the same pair. Neither reads npm's config, so
+        // quoting npm's keys at them is advice that does nothing.
         lines
             .push("    export https_proxy=\"$HTTPS_PROXY\" http_proxy=\"$HTTP_PROXY\"".to_string());
     }
@@ -1062,23 +1243,25 @@ pub(crate) fn run_install(
                     .iter()
                     .map(|a| (*a).to_string())
                     .collect::<Vec<_>>(),
+                &[],
                 &recipe.command_line(),
             )
             .map(|()| Vec::new())
         }
         InstallRoute::ManagedPrefix => {
-            let prefix = kin_core::tool_prefix::managed_node_prefix();
+            let prefix = recipe.managed_prefix_dir();
             std::fs::create_dir_all(&prefix).map_err(|error| InstallProblem::Failed {
                 reason: format!("could not create {}: {error}", prefix.display()),
             })?;
             let args = recipe.managed_prefix_args(&prefix);
             let command = recipe.route_command_line(route);
-            run_program(recipe, recipe.program, &args, &command).map(|()| {
+            let environment = recipe.managed_prefix_env();
+            run_program(recipe, recipe.program, &args, &environment, &command).map(|()| {
                 vec![
-                    format!("source:   {}, integrity checked by npm", recipe.program),
+                    format!("source:   {}", recipe.managed_route_source()),
                     format!(
                         "installed to: {}",
-                        kin_core::tool_prefix::managed_node_bin_dir().display()
+                        recipe.managed_prefix_bin_dir().display()
                     ),
                 ]
             })
@@ -1134,11 +1317,16 @@ fn run_program(
     recipe: &LanguageServerRecipe,
     program: &str,
     args: &[String],
+    environment: &[(String, String)],
     command_line: &str,
 ) -> Result<(), InstallProblem> {
     let _ = recipe;
+    // Set rather than inherited, because one route's redirect lives here: `go
+    // install` takes no prefix argument and writes wherever GOBIN says. The npm
+    // routes pass an empty slice and keep the environment they already had.
     let mut child = Command::new(program)
         .args(args)
+        .envs(environment.iter().cloned())
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|error| InstallProblem::Failed {
@@ -1314,6 +1502,42 @@ mod tests {
         assert_eq!(
             recipe_for(LanguageId::Rust).unwrap().command_line(),
             "rustup component add rust-analyzer"
+        );
+        assert_eq!(
+            recipe_for(LanguageId::Go).unwrap().command_line(),
+            "go install golang.org/x/tools/gopls@v0.22.0"
+        );
+    }
+
+    /// The gopls module must never be installed unpinned.
+    ///
+    /// `@latest` resolves to whatever upstream tagged that morning, so two
+    /// machines set up a week apart index one repository with two different
+    /// servers and nothing records which of them produced an edge. The same
+    /// argument the TypeScript pin exists for, and the same failure shape: both
+    /// installs exit zero, both put the binary on PATH, and only the graph
+    /// disagrees. `go install` with no `@version` is a hard error rather than a
+    /// silent latest, so the case this guards is a bare `@latest` somebody
+    /// wrote to stop thinking about the tag.
+    #[test]
+    fn the_gopls_module_is_pinned_to_a_tag_rather_than_to_latest() {
+        let recipe = recipe_for(LanguageId::Go).expect("go must have a recipe");
+        let module = recipe
+            .args
+            .iter()
+            .find(|arg| arg.starts_with("golang.org/x/tools/gopls"))
+            .expect("the go recipe must install the gopls module");
+        let (_, version) = module
+            .split_once('@')
+            .unwrap_or_else(|| panic!("{module}: `go install` needs an explicit @version"));
+        assert_ne!(
+            version, "latest",
+            "{module}: an unpinned gopls gives two machines two different servers with nothing \
+             recording why"
+        );
+        assert!(
+            version.starts_with('v') && version[1..].starts_with(|c: char| c.is_ascii_digit()),
+            "{module}: the gopls module must carry an explicit vX.Y.Z tag, got `{version}`"
         );
     }
 
@@ -2086,6 +2310,108 @@ mod tests {
         assert!(
             !args.contains(&"-g".to_string()),
             "a redirected install must not also be global"
+        );
+    }
+
+    /// The Go managed route installs where Kin has already put PATH.
+    ///
+    /// This is the half of the ticket that wiring the adapter does not close.
+    /// `kin_lsp::lifecycle::LspServer::start` runs the bare string `gopls`, an
+    /// ordinary `go install` writes into `$(go env GOPATH)/bin`, and nothing
+    /// puts that directory on PATH. Both Kin binaries call
+    /// `augment_path_with_managed_tools` at startup, which appends
+    /// `managed_tool_bin_dir`, so pointing GOBIN there is what makes an
+    /// installed server one the daemon can actually start.
+    #[test]
+    fn the_go_managed_route_points_gobin_at_a_directory_kin_puts_on_path() {
+        let go = recipe_for(LanguageId::Go).expect("go must have a recipe");
+        let bin = kin_core::tool_prefix::managed_tool_bin_dir();
+
+        assert_eq!(
+            go.managed_prefix_env(),
+            vec![("GOBIN".to_string(), bin.display().to_string())],
+            "GOBIN is the only redirect `go install` has"
+        );
+        assert_eq!(go.managed_prefix_bin_dir(), bin);
+        assert!(
+            kin_core::tool_prefix::managed_tool_dirs().contains(&bin),
+            "the directory GOBIN names has to be one PATH actually gains, or this route reports \
+             success over a server nothing can start"
+        );
+
+        // The command an operator reads back has to be the command that ran,
+        // environment included. A printed `go install` with GOBIN stripped
+        // sends them to install into the directory this route exists to avoid.
+        let line = go.route_command_line(InstallRoute::ManagedPrefix);
+        assert_eq!(
+            line,
+            format!("GOBIN={} go install {GOPLS_MODULE}", bin.display()),
+            "the redirect and the pin both have to survive the rewrite"
+        );
+
+        // The control, and the reason this is not a blanket change: the npm
+        // route keeps the shape it had, with no environment and the same
+        // `--prefix` rewrite.
+        let typescript = recipe_for(LanguageId::TypeScript).expect("typescript must have a recipe");
+        assert!(typescript.managed_prefix_env().is_empty());
+        assert_eq!(
+            typescript.managed_prefix_bin_dir(),
+            kin_core::tool_prefix::managed_node_bin_dir()
+        );
+        assert!(
+            typescript
+                .route_command_line(InstallRoute::ManagedPrefix)
+                .starts_with("npm install --prefix "),
+            "the npm route must be untouched by the Go branch"
+        );
+    }
+
+    /// A Go bin directory off PATH routes the install to the prefix Kin owns.
+    ///
+    /// The blocker is what makes `choose_route` prefer the managed route here.
+    /// Without it the recipe's own installer wins on every host that has Go:
+    /// the build succeeds, gopls lands in `$(go env GOPATH)/bin`, and the daemon
+    /// still starts nothing, which is the gap wearing a green install's
+    /// clothes. Asserted over an explicit PATH rather than this process's, so
+    /// the test states the host it grades instead of inheriting whichever
+    /// machine ran it.
+    #[test]
+    fn a_go_bin_directory_off_path_routes_the_install_to_the_prefix_kin_owns() {
+        let dir = Path::new("/home/u/go/bin");
+
+        let elsewhere = OsString::from("/usr/local/bin:/usr/bin");
+        let blocker = go_default_bin_blocker(dir, Some(&elsewhere))
+            .expect("a Go bin directory off PATH must be named before the install runs");
+        assert!(blocker.contains("/home/u/go/bin"), "{blocker}");
+        assert!(
+            blocker.contains("not on this process's PATH"),
+            "the reason has to name the mechanism rather than only refuse: {blocker}"
+        );
+
+        // Controls, in both directions. A host that already carries the
+        // directory must keep its own toolchain's install, and a check that
+        // reported a blocker for every host would route everyone through Kin's
+        // prefix and prove nothing.
+        let carrying = OsString::from("/usr/bin:/home/u/go/bin");
+        assert_eq!(go_default_bin_blocker(dir, Some(&carrying)), None);
+        assert!(directory_is_on_path(dir, Some(&carrying)));
+        assert!(!directory_is_on_path(dir, None));
+
+        let go = recipe_for(LanguageId::Go).expect("go must have a recipe");
+        assert_eq!(
+            choose_route(go, host(true, true, false)),
+            Some(InstallRoute::ManagedPrefix),
+            "a Go toolchain whose bin directory PATH does not carry must reach the managed route"
+        );
+        assert_eq!(
+            choose_route(go, host(true, false, false)),
+            Some(InstallRoute::Installer),
+            "a host whose PATH already carries it keeps its own toolchain's install"
+        );
+        assert_eq!(
+            choose_route(go, host(false, false, false)),
+            None,
+            "no Go toolchain means no route: Kin does not install a language toolchain unasked"
         );
     }
 

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -23651,7 +23651,7 @@ $value = if ($env:KIN_TEST_PATH_PRESENT -eq '1') { $env:KIN_TEST_PATH_VALUE } el
             "both scopes have to be named or the reader guesses: {text}"
         );
         assert!(
-            text.contains("rust, python, typescript, javascript"),
+            text.contains("rust, python, typescript, javascript, go"),
             "it has to name what it would have checked: {text}"
         );
         assert!(
@@ -23671,7 +23671,7 @@ $value = if ($env:KIN_TEST_PATH_PRESENT -eq '1') { $env:KIN_TEST_PATH_VALUE } el
             "{text}"
         );
         assert!(
-            text.contains("rust, python, typescript, javascript"),
+            text.contains("rust, python, typescript, javascript, go"),
             "naming the set is what separates this from a silent exit: {text}"
         );
         assert!(

--- a/crates/kin-cli/tests/doctor_language_servers.rs
+++ b/crates/kin-cli/tests/doctor_language_servers.rs
@@ -140,7 +140,7 @@ fn outside_a_repository_the_fix_run_says_where_to_run_it_instead() {
         "both scopes have to be named or the reader guesses. stderr={stderr}"
     );
     assert!(
-        stderr.contains("rust, python, typescript, javascript"),
+        stderr.contains("rust, python, typescript, javascript, go"),
         "it has to name what it would have checked. stderr={stderr}"
     );
 }

--- a/crates/kin-core/src/reference_coverage.rs
+++ b/crates/kin-core/src/reference_coverage.rs
@@ -55,6 +55,7 @@ pub const ENRICHABLE_LANGUAGES: &[LanguageId] = &[
     LanguageId::Python,
     LanguageId::TypeScript,
     LanguageId::JavaScript,
+    LanguageId::Go,
 ];
 
 /// What a host's language server can actually do for one language.
@@ -2028,14 +2029,20 @@ mod tests {
 
     /// The language-server state is filled from a probe the caller ran, not
     /// guessed here. A language this build wires no adapter for is Unsupported
-    /// whatever is installed, which is why gopls on PATH buys Go nothing.
+    /// whatever is installed, which is why jdtls on PATH buys Java nothing.
+    ///
+    /// The unwired example used to be Go, and Go was the right one until the
+    /// daemon gained its `gopls` arm. The property this test guards outlives
+    /// any one language, so it moved to Java rather than being deleted: kin-lsp
+    /// carries a complete `jdtls` provider that the daemon deliberately does not
+    /// construct, which is exactly the shape the assertion is about.
     #[test]
     fn language_server_state_is_attached_rather_than_assumed() {
         let unfilled = ReferenceEdgeCoverage {
             parse: None,
             languages: vec![
                 language_row("python", ReferenceEnrichment::Unknown),
-                language_row("go", ReferenceEnrichment::Unknown),
+                language_row("java", ReferenceEnrichment::Unknown),
             ],
             totals: None,
         };
@@ -2046,7 +2053,7 @@ mod tests {
 
         let filled = unfilled
             .clone()
-            .with_language_servers(&usable(&[LanguageId::Go]));
+            .with_language_servers(&usable(&[LanguageId::Java]));
         assert_eq!(
             filled.languages_missing_a_language_server(),
             vec!["python"],
@@ -2055,7 +2062,7 @@ mod tests {
         assert_eq!(
             filled.languages[1].reference_enrichment,
             ReferenceEnrichment::Unsupported,
-            "gopls on PATH gives Go nothing: no adapter consumes it"
+            "jdtls on PATH gives Java nothing: no adapter consumes it"
         );
 
         let complete =

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -315,7 +315,7 @@ pub(crate) fn reset_vector_index_and_requeue_after_contention_for_test(
 /// it for the query paths.
 ///
 /// Spawned rather than awaited. Probing means starting each server and running
-/// the initialize handshake, and four languages against the probe budget would
+/// the initialize handshake, and five languages against the probe budget would
 /// add seconds to daemon startup in the healthy case and far more when a server
 /// hangs. Nothing waits on the answer: until it publishes, every observation
 /// reads the readiness as unknown, which already keeps the absence-trust gate
@@ -429,6 +429,10 @@ pub fn lsp_adapter_for(
             &kin_lsp::adapters::typescript::TypeScriptAdapter,
             workspace_root,
         )),
+        kin_model::LanguageId::Go => Some(describe(
+            &kin_lsp::adapters::go::GoplsAdapter,
+            workspace_root,
+        )),
         _ => None,
     }
 }
@@ -463,6 +467,19 @@ mod adapter_wiring_tests {
     use kin_core::reference_coverage::ENRICHABLE_LANGUAGES;
     use kin_model::LanguageId;
     use std::path::Path;
+
+    /// Languages kin-lsp registers a complete provider for that this build
+    /// deliberately does not construct yet.
+    ///
+    /// A decision written down, not an oversight left implicit. Each of these
+    /// has a `ProviderSpec` in `ProviderRegistry::with_defaults` and an adapter
+    /// module in `kin_lsp::adapters`, so wiring one is the same shape the Go row
+    /// already is: an arm here, an entry in `ENRICHABLE_LANGUAGES`, and an
+    /// install recipe in kin-cli. None is wired today because none has an
+    /// install recipe and none is on the corpus the enrichment work is measured
+    /// against, and a language with an arm and no recipe fails
+    /// `every_enrichable_language_has_an_install_command`.
+    const NOT_YET_WIRED: &[LanguageId] = &[LanguageId::Java, LanguageId::C, LanguageId::Cpp];
 
     /// `ENRICHABLE_LANGUAGES` documents itself as the set the daemon wires an
     /// adapter for. This is that sentence as an assertion, in both directions.
@@ -513,6 +530,7 @@ mod adapter_wiring_tests {
             (LanguageId::Python, "pyright-langserver"),
             (LanguageId::TypeScript, "typescript-language-server"),
             (LanguageId::JavaScript, "typescript-language-server"),
+            (LanguageId::Go, "gopls"),
         ] {
             let (cmd, _, _) =
                 lsp_adapter_for(language, root).unwrap_or_else(|| panic!("{language} not wired"));
@@ -555,6 +573,58 @@ mod adapter_wiring_tests {
             assert!(
                 lsp_adapter_for(language, root).is_none(),
                 "{language} must not be wired without being declared enrichable"
+            );
+        }
+    }
+
+    /// Every language kin-lsp registers a provider for is either wired here or
+    /// named above as a decision somebody made.
+    ///
+    /// This is the class that shipped in v0.6.4 and it is invisible to the
+    /// set-equality test above. kin-lsp's adapter suite grew to six languages
+    /// while this map stayed at four, so a Go repository was told its reference
+    /// edges were `unsupported` while a complete `gopls` adapter sat inside the
+    /// same binary. `the_adapter_map_and_the_enrichable_set_name_the_same_languages`
+    /// cannot catch that: a language missing from BOTH constants agrees with
+    /// itself, and the two stayed in lockstep the whole time they were wrong.
+    ///
+    /// So this one reads the third constant, kin-lsp's own registry, which is
+    /// the thing that actually grew. A seventh provider arriving there now fails
+    /// here rather than going quiet for a release.
+    #[test]
+    fn every_registered_provider_is_wired_or_named_as_a_decision() {
+        let root = Path::new("/nonexistent-workspace");
+        let registered: Vec<LanguageId> = kin_lsp::registry::ProviderRegistry::with_defaults()
+            .known_binaries()
+            .into_iter()
+            .map(|(language, _)| language)
+            .collect();
+
+        // Positive controls, not decoration. A registry that answered with an
+        // empty list, or with only the languages this build already wires,
+        // would satisfy every assertion below while grading nothing, and it
+        // would read exactly like a pass. One language from each side of the
+        // decision has to be in the set before the loop means anything.
+        assert!(
+            registered.contains(&LanguageId::Go),
+            "kin-lsp registers no Go provider, so this guard is reading the wrong list: \
+             {registered:?}"
+        );
+        assert!(
+            registered.contains(&LanguageId::Java),
+            "kin-lsp registers no Java provider, so nothing here exercises the deferred \
+             side: {registered:?}"
+        );
+
+        for language in registered {
+            let wired = lsp_adapter_for(language, root).is_some();
+            let deferred = NOT_YET_WIRED.contains(&language);
+            assert!(
+                wired != deferred,
+                "{language}: kin-lsp registers a provider for it, so it must either have an \
+                 arm in lsp_adapter_for (wired = {wired}) or be named on NOT_YET_WIRED \
+                 (deferred = {deferred}). Both at once is a list that rotted; neither is the \
+                 gap that shipped."
             );
         }
     }

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -429,10 +429,6 @@ pub fn lsp_adapter_for(
             &kin_lsp::adapters::typescript::TypeScriptAdapter,
             workspace_root,
         )),
-        kin_model::LanguageId::Go => Some(describe(
-            &kin_lsp::adapters::go::GoplsAdapter,
-            workspace_root,
-        )),
         _ => None,
     }
 }

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -429,6 +429,10 @@ pub fn lsp_adapter_for(
             &kin_lsp::adapters::typescript::TypeScriptAdapter,
             workspace_root,
         )),
+        kin_model::LanguageId::Go => Some(describe(
+            &kin_lsp::adapters::go::GoplsAdapter,
+            workspace_root,
+        )),
         _ => None,
     }
 }

--- a/docs/language-support.md
+++ b/docs/language-support.md
@@ -30,7 +30,7 @@ cannot drift apart.
 | TypeScript | ✓ | calls, contains, extends, implements, references | ✓ (jest) | ✓ | ✓ typescript-language-server |
 | JavaScript | ✓ | calls, contains, extends, references | ✓ | ✓ | ✓ typescript-language-server |
 | Python | ✓ | calls, contains, extends, references | ✓ (pytest) | ✓ | ✓ pyright / pylsp |
-| Go | ✓ | calls, contains, extends, implements, references, sends-message, spawns | ✓ | ✓ | not wired (gopls adapter exists) |
+| Go | ✓ | calls, contains, extends, implements, references, sends-message, spawns | ✓ | ✓ | ✓ gopls |
 | Java | ✓ | calls, contains, extends, implements, references | ✓ (junit) | ✓ | not wired (jdtls adapter exists) |
 | Rust | ✓ | calls, contains, implements, references | ✓ (cargo) | ✓ | ✓ rust-analyzer |
 | C++ | ✓ | calls, contains, extends, imports, references, uses-macro | ✓ | ✓ | not wired (clangd adapter exists) |
@@ -61,12 +61,14 @@ classifies it as `type_resolved` rather than as a name match.
 
 Two facts have to hold together before any of those edges can exist: the daemon
 has to wire an adapter for the language, and a server binary has to be installed
-on the host. The daemon wires **Rust, Python, TypeScript and JavaScript**, which
-is what `kin_core::reference_coverage::ENRICHABLE_LANGUAGES` names and what a
-test in `kin_daemon` holds it to. Every other language carries no reference,
+on the host. The daemon wires **Rust, Python, TypeScript, JavaScript and Go**,
+which is what `kin_core::reference_coverage::ENRICHABLE_LANGUAGES` names and what
+a test in `kin_daemon` holds it to. Every other language carries no reference,
 override or uses-type edge by construction, whatever is installed. kin-lsp does
-carry adapters for Go, Java, C and C++, and the table above says so, but those
-adapters are not reached from the runtime today.
+carry adapters for Java, C and C++, and the table above says so, but those
+adapters are not reached from the runtime today. That is a decision rather than
+an oversight: they are named on `NOT_YET_WIRED` in `kin_daemon`, and a test
+there fails if kin-lsp registers a provider that is neither wired nor listed.
 
 This matters because cross-file resolution without a language server falls back
 to matching bare names, which produces edges that name a plausible destination
@@ -75,10 +77,24 @@ rather than a proven one.
 Install the servers with:
 
 ```
-npm install -g pyright                                   # Python
-npm install -g typescript-language-server typescript     # TypeScript and JavaScript
-rustup component add rust-analyzer                       # Rust
+npm install -g pyright                                      # Python
+npm install -g typescript-language-server typescript@^5     # TypeScript and JavaScript
+rustup component add rust-analyzer                          # Rust
+go install golang.org/x/tools/gopls@v0.22.0                 # Go
 ```
+
+Both version pins are load-bearing. TypeScript 7 ships no `lib/tsserver.js`, so
+an unpinned `typescript` resolves to a version `typescript-language-server`
+cannot start. An unpinned `gopls@latest` gives two machines set up a week apart
+two different servers over one repository, with nothing recording which one
+produced an edge.
+
+`go install` writes into `$(go env GOPATH)/bin`, which is on nobody's PATH by
+default, and the daemon starts a server with a bare `gopls`. So run the command
+above only if that directory is already on your PATH. Otherwise let Kin install
+it: `kin doctor --fix --install-language-servers` sets `GOBIN` to a directory
+under `KIN_HOME` that both Kin binaries append to PATH at startup, which is the
+one destination the daemon is guaranteed to find.
 
 `kin setup` and `kin doctor --fix` will offer to run these for you. Neither
 installs without consent: interactively they ask once per command with the


### PR DESCRIPTION
Fixes FIR-3121.

## Root cause

`lsp_adapter_for` in kin-daemon is a hand-written match with four arms, and Go
falls to `_ => None`, so a Go repository's files are all recognised, counted and
walked, no server is ever started for them, and the sweep reports "this build
wires no language server for this language, so none was started". The `gopls`
adapter and its provider spec already ship inside the release binaries and are
simply never constructed.

## The four sites

| site | change |
| --- | --- |
| `kin-core/src/reference_coverage.rs` `ENRICHABLE_LANGUAGES` | gains `LanguageId::Go`, so the readiness probe runs for Go and `reference_enrichment_for` stops short-circuiting to `Unsupported` |
| `kin-daemon/src/daemon.rs` `lsp_adapter_for` | gains the arm constructing `kin_lsp::adapters::go::GoplsAdapter` |
| `kin-cli/src/commands/language_servers.rs` `LANGUAGE_SERVERS` | gains a Go recipe: `go install golang.org/x/tools/gopls@v0.22.0`, `binaries: ["gopls"]`, `fallback: ManagedPrefix` |
| `kin-core/src/reference_coverage.rs` test | the one that used Go as its worked example of a language no adapter consumes moves to Java, which kin-lsp still registers and this build still does not construct |

Also `wired_languages_name_the_binaries_an_operator_installs` gains
`(Go, "gopls")`, the probe-budget comment counts five languages, and
`docs/language-support.md` moves Go out of the "not wired" column.

Go only. Java, C and C++ stay out so the FIR-3110 before-and-after stays clean,
and they are now named on an explicit `NOT_YET_WIRED` list rather than left
implicit.

## The PATH gap, and the GOBIN answer

Wiring the adapter is necessary and not sufficient. `LspServer::start` does
`Command::new("gopls")` with no `which` resolution and no GOPATH fallback, and
an ordinary `go install` writes into `$(go env GOPATH)/bin`, which is on nobody's
PATH by default. So a host that installs gopls the normal way still gets nothing.

Kin already owns the answer. `augment_path_with_managed_tools` appends
`managed_tool_bin_dir()` to PATH at the start of both binaries, so the Go
recipe's managed route sets `GOBIN` to that directory. Two supporting changes
make that route the one a real host actually takes:

- `install_blocker` reports the Go recipe's default target as blocked whenever
  the toolchain's own bin directory is not on this process's PATH. Without it
  `choose_route` prefers the recipe's own installer on every host that has Go,
  the build succeeds, gopls lands somewhere nothing reads, and the daemon still
  starts nothing. That is the gap wearing a green install's clothes.
- `run_program` takes an environment, and the managed arm branches on the recipe
  rather than assuming npm. The npm branches keep their arguments, their
  destination and their reported lines byte for byte.

The gopls module is pinned rather than `@latest`, for the same reason
`typescript@^5` is pinned: two machines set up a week apart would otherwise index
one repository with two different servers, with nothing recording which produced
an edge. v0.22.0 is the tag `gopls version` reports on the dev host.

## What a stranger sees, before and after

- **`kin init`**: before, a Go-only repository takes the "finished without
  enriching any of the N files it walked" arm with the skip row above quoted
  verbatim. After, Go leaves `languages_skipped` and the files enrich.
- **`kin doctor`**: before, silent about Go. `Unsupported` is deliberately not an
  actionable gap, so a pure Go repository got a clean-looking row over a real
  hole. After, a host without gopls reads `NoLanguageServer`, which is
  actionable, so Go appears as a row with an install command behind it. That is
  the behaviour change a stranger actually feels, and it is the intended one:
  the limit stopped being a property of the build.
- **MCP `_kin` envelope**: `edge_coverage.reference_enrichment` for Go moves from
  `unsupported` to `available` on a host with gopls, which drops the
  `edge_coverage:reference_enrichment_unsupported` signal and stops one Go file
  pulling a mixed batch's verdict to the weakest state.

## Tests

- `every_registered_provider_is_wired_or_named_as_a_decision` (kin-daemon) is the
  stranger-class guard. The existing lockstep test cannot catch this class,
  because a language missing from BOTH constants agrees with itself, which is
  exactly how Go stayed unwired through the growth from four adapters to six.
  The new one reads kin-lsp's own registry instead and requires every registered
  language to be either wired or listed, with Go and Java asserted present first
  so the loop cannot grade an empty set.
- `the_gopls_module_is_pinned_to_a_tag_rather_than_to_latest`, in the style of
  the TypeScript pin test.
- `the_go_managed_route_points_gobin_at_a_directory_kin_puts_on_path`, which
  asserts GOBIN, the destination, that the destination is one PATH actually
  gains, and that the printed command carries both the redirect and the pin. It
  carries the npm route as its control.
- `a_go_bin_directory_off_path_routes_the_install_to_the_prefix_kin_owns`, stated
  over an explicit PATH rather than the running process's, with controls in both
  directions so the blocker cannot fire for every host.

`recipes_name_the_binaries_the_daemon_starts` already compares recipe binaries
against `ProviderRegistry::with_defaults().known_binaries()`, and the registry's
Go entry is `["gopls"]`, so the advice and the runtime agree by construction.

## Proof recipe

Not run here, and it is not a PR-time measurement. The recipe is section 6 of the
FIR-3121 investigation: clone `cli/cli` once at `4f80400a`, byte-copy per arm,
and count relations whose `origin` is `RelationOrigin::Lsp`, which is exclusive
to enrichment. `kin daemon sweep --json` carries the primary counters:
`files_done` up by the Go file count, `files_blocked` down by the same, and the
`{"language":"go", ...}` row gone from `languages_skipped`. Do not count
`type_resolved` rows; the parser already mints Go edges in every band that maps
to it, so the delta hides in a large baseline.

## Verification

Local gates did not run. A benchmark round holds this machine quiet with a 39 GB
model on the GPU and the captain forbids builders, so no cargo, clippy, fmt or
test ran here. The two static policy scans that need no toolchain did run and
pass: `scripts/zero_file_search_guard.sh` and
`scripts/verify-zero-file-search.py`. Everything else is graded by hosted CI,
read by name over the full check-run set.
