### PR TITLE
Hold a fingerprint in the last-known-good store instead of a whole entity

### DIFF
--- a/crates/kin-reconcile/src/cross_file.rs
+++ b/crates/kin-reconcile/src/cross_file.rs
@@ -41,6 +41,7 @@
 //! stays independent of repository size.
 
 use std::collections::{BTreeSet, HashMap, HashSet};
+use std::sync::Arc;
 
 use kin_index::{
     bare_entity_name, link_cross_file_incremental_with_completeness, FileParseCompletenessMap,
@@ -191,7 +192,15 @@ pub struct LiveCrossFileLinker {
     artifact_id_by_file: HashMap<String, ArtifactId>,
     file_by_artifact_id: HashMap<ArtifactId, String>,
     /// Entity identity to the file that declares it, same reason.
-    file_by_entity: HashMap<EntityId, String>,
+    ///
+    /// The path is shared rather than copied. One entry exists per entity in the
+    /// repository and it is held for the process lifetime, so an owned `String`
+    /// here was one heap allocation of the same path per entity: on a tree with
+    /// 6,160 files and 264,615 entities that is 264,615 copies of 6,160 distinct
+    /// strings. An `Arc<str>` is one allocation per distinct file, and both
+    /// readers below want either the path itself or an equality against another
+    /// entity's path, which share unchanged.
+    file_by_entity: HashMap<EntityId, Arc<str>>,
     /// Files retained because they still name something the graph lacks.
     pending: HashMap<String, PendingFile>,
     /// Reverse index: destination name -> files waiting on it. This is what
@@ -330,8 +339,12 @@ impl LiveCrossFileLinker {
             .insert(file_path.to_string(), artifact_id);
         self.file_by_artifact_id
             .insert(artifact_id, file_path.to_string());
+        // One allocation for the path, shared by every entity this file
+        // declares, rather than one per entity.
+        let shared_path: Arc<str> = Arc::from(file_path);
         for entity in entities {
-            self.file_by_entity.insert(entity.id, file_path.to_string());
+            self.file_by_entity
+                .insert(entity.id, Arc::clone(&shared_path));
         }
     }
 
@@ -460,7 +473,7 @@ impl LiveCrossFileLinker {
                         continue;
                     };
                     // Only edges sourced by a file this pass resolved.
-                    if !batched_paths.contains(src_file) {
+                    if !batched_paths.contains(&**src_file) {
                         continue;
                     }
                     if self.file_by_entity.get(&dst) == Some(src_file) {

--- a/crates/kin-reconcile/src/lkg.rs
+++ b/crates/kin-reconcile/src/lkg.rs
@@ -3,17 +3,27 @@
 
 use std::collections::HashMap;
 
-use kin_model::{Entity, EntityId, Relation, SemanticFingerprint};
+use kin_model::{Entity, EntityId, SemanticFingerprint};
 
-/// Last Known Good state for an entity.
+/// Last Known Good state for an entity: the fingerprint the reconciler last
+/// admitted for it.
 ///
-/// When a file edit produces a broken AST, the entity retains its LKG
-/// fingerprint, signature, and relations. The broken parse is noted but
-/// does not propagate to dependents.
+/// The entry holds a fingerprint and nothing else because a fingerprint is all
+/// any reader has ever taken out of this store. [`LkgStore::has_changed`]
+/// compares three of its hashes and there is no other read.
+///
+/// It used to hold a whole owned [`Entity`] and a `Vec<Relation>` beside it. A
+/// serving daemon seeds one entry per entity in the repository and keeps the
+/// store for its life, so that was a second complete copy of every entity: the
+/// name, the signature, the doc summary and two separate allocations of the
+/// same file path, none of which anything read. The relations vector had no
+/// reader at all and every live call site passed an empty one. The reconcile
+/// path also clones this whole store before deriving a transaction, so the copy
+/// was duplicated again on every file edit; a fingerprint is plain data, so that
+/// snapshot now allocates nothing.
 #[derive(Debug, Clone)]
 pub struct LkgEntry {
-    pub entity: Entity,
-    pub relations: Vec<Relation>,
+    pub fingerprint: SemanticFingerprint,
 }
 
 /// Tracks LKG state for all entities. The reconciler consults this when
@@ -30,9 +40,17 @@ impl LkgStore {
     }
 
     /// Record the current good state of an entity.
-    pub fn record(&mut self, entity: Entity, relations: Vec<Relation>) {
-        self.entries
-            .insert(entity.id, LkgEntry { entity, relations });
+    ///
+    /// Takes the entity by reference and keeps a copy of its fingerprint, so a
+    /// caller that already owns an entity does not have to clone it to record
+    /// one.
+    pub fn record(&mut self, entity: &Entity) {
+        self.entries.insert(
+            entity.id,
+            LkgEntry {
+                fingerprint: entity.fingerprint.clone(),
+            },
+        );
     }
 
     /// Get the LKG state for an entity.
@@ -50,9 +68,9 @@ impl LkgStore {
     pub fn has_changed(&self, id: &EntityId, new_fingerprint: &SemanticFingerprint) -> bool {
         match self.entries.get(id) {
             Some(entry) => {
-                entry.entity.fingerprint.ast_hash != new_fingerprint.ast_hash
-                    || entry.entity.fingerprint.signature_hash != new_fingerprint.signature_hash
-                    || entry.entity.fingerprint.behavior_hash != new_fingerprint.behavior_hash
+                entry.fingerprint.ast_hash != new_fingerprint.ast_hash
+                    || entry.fingerprint.signature_hash != new_fingerprint.signature_hash
+                    || entry.fingerprint.behavior_hash != new_fingerprint.behavior_hash
             }
             None => true, // No LKG means it's new
         }
@@ -109,7 +127,7 @@ mod tests {
         let mut store = LkgStore::new();
         let entity = test_entity("foo");
         let id = entity.id;
-        store.record(entity, vec![]);
+        store.record(&entity);
 
         assert!(store.get(&id).is_some());
         assert_eq!(store.len(), 1);
@@ -120,7 +138,7 @@ mod tests {
         let mut store = LkgStore::new();
         let entity = test_entity("bar");
         let id = entity.id;
-        store.record(entity, vec![]);
+        store.record(&entity);
 
         // Same fingerprint
         let same = SemanticFingerprint {
@@ -164,9 +182,35 @@ mod tests {
         let mut store = LkgStore::new();
         let entity = test_entity("baz");
         let id = entity.id;
-        store.record(entity, vec![]);
+        store.record(&entity);
         store.remove(&id);
         assert!(store.get(&id).is_none());
         assert!(store.is_empty());
+    }
+
+    /// The entry is exactly the fingerprint it holds and nothing beside it,
+    /// which is the property the daemon's retained footprint rests on. An
+    /// `Entity`, a `String` or a `Vec` back on this struct moves the size and
+    /// fails here. The bytes the entry does not reach are proved separately, by
+    /// the allocator guard in `tests/lkg_retained_bytes.rs`.
+    #[test]
+    fn an_entry_is_exactly_a_fingerprint() {
+        assert_eq!(
+            std::mem::size_of::<LkgEntry>(),
+            std::mem::size_of::<SemanticFingerprint>(),
+            "an entry must be exactly the fingerprint it holds"
+        );
+    }
+
+    /// Recording an entity twice under the same id keeps one entry, so a
+    /// reconcile loop that re-records unchanged entities cannot grow the store.
+    #[test]
+    fn re_recording_an_entity_does_not_grow_the_store() {
+        let mut store = LkgStore::new();
+        let entity = test_entity("qux");
+        store.record(&entity);
+        store.record(&entity);
+        store.record(&entity);
+        assert_eq!(store.len(), 1);
     }
 }

--- a/crates/kin-reconcile/src/reconciler.rs
+++ b/crates/kin-reconcile/src/reconciler.rs
@@ -346,22 +346,6 @@ impl Reconciler {
         &self.policy
     }
 
-    /// Seed the LKG store from an existing graph so incremental reconcile
-    /// correctly detects which entities actually changed vs. which are unchanged.
-    /// Without this, the first reconcile after daemon startup reports all entities
-    /// as modified (LKG empty → has_changed returns true for everything).
-    pub fn seed_lkg_from_graph<G: GraphStore>(&mut self, graph: &G) {
-        if let Ok(entities) = graph.list_all_entities() {
-            for entity in entities {
-                let relations = graph
-                    .get_all_relations_for_entity(&entity.id)
-                    .unwrap_or_default();
-                self.lkg.record(entity, relations);
-            }
-            tracing::info!(count = self.lkg.len(), "seeded LKG from graph snapshot");
-        }
-    }
-
     /// Seed only entity fingerprints from an existing graph.
     ///
     /// This is the daemon-startup fast path. The reconciler only consults LKG
@@ -369,8 +353,8 @@ impl Reconciler {
     /// on large persisted graphs adds minutes to daemon startup.
     pub fn seed_lkg_entities_from_graph<G: GraphStore>(&mut self, graph: &G) {
         if let Ok(entities) = graph.list_all_entities() {
-            for entity in entities {
-                self.lkg.record(entity, vec![]);
+            for entity in &entities {
+                self.lkg.record(entity);
             }
             tracing::info!(
                 count = self.lkg.len(),
@@ -920,11 +904,11 @@ impl Reconciler {
                     // fingerprint. Span and blob provenance must advance even for
                     // source edits that are semantically equivalent.
                     if updated != *old {
+                        self.lkg.record(&updated);
                         delta.entity_deltas.push(EntityDelta::Modified {
                             old: old.clone(),
-                            new: updated.clone(),
+                            new: updated,
                         });
-                        self.lkg.record(updated.clone(), vec![]);
                         modified.push(old.id);
 
                         debug!(
@@ -933,7 +917,7 @@ impl Reconciler {
                             "entity modified"
                         );
                     } else {
-                        self.lkg.record(old.clone(), vec![]);
+                        self.lkg.record(old);
                         debug!(
                             entity = %old.name,
                             "entity payload unchanged, skipping"
@@ -962,7 +946,7 @@ impl Reconciler {
                     delta.entity_deltas.push(EntityDelta::Added {
                         new: added_entity.clone(),
                     });
-                    self.lkg.record(added_entity.clone(), vec![]);
+                    self.lkg.record(&added_entity);
                     added.push(added_entity.id);
 
                     debug!(
@@ -2647,7 +2631,7 @@ mod tests {
         let entity = make_entity("bar", "src/main.rs");
         let id = entity.id;
 
-        reconciler.lkg.record(entity, vec![]);
+        reconciler.lkg.record(&entity);
         assert!(reconciler.lkg().get(&id).is_some());
     }
 
@@ -3888,8 +3872,8 @@ mod tests {
 
         // Seed the reconciler LKG with the file_a entities.
         let mut reconciler = Reconciler::new(dir.path().to_path_buf());
-        reconciler.lkg.record(entity_a.clone(), vec![]);
-        reconciler.lkg.record(stale_entity.clone(), vec![]);
+        reconciler.lkg.record(&entity_a);
+        reconciler.lkg.record(&stale_entity);
 
         // Construct an IndexedFile that represents a re-parse of file_a:
         //   - entity_a is present (same name/kind → matched, no fingerprint change)

--- a/crates/kin-reconcile/tests/lkg_real_store_heap.rs
+++ b/crates/kin-reconcile/tests/lkg_real_store_heap.rs
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! What the last-known-good store costs on a REAL repository, measured as live
+//! heap in this process rather than as a resident set read through the kernel.
+//!
+//! Resident set could not answer this. The four reads a daemon arm takes inside
+//! twelve seconds of its serving line land on the open's transient, which moves
+//! by 2.6 GiB, and the effect being measured is 0.19 to 0.23 GiB. That is a
+//! property of the instrument rather than of any particular machine: the
+//! endpoint is published while the open's peak is still draining, so the reads
+//! sit on a curve. A counting allocator inside one process cannot be reached by
+//! the kernel's reclaim, and both shapes are measured over the identical entity
+//! set in the same run, so there is no cross-binary comparison at all.
+//!
+//! Ignored by default: it needs a real store, named by three environment
+//! variables, and it holds two maps over every entity in that store at once.
+//!
+//! ```text
+//! KIN_LKG_STORE=<repo>/.kin/kindb \
+//! KIN_LKG_REPO=<repository uuid> \
+//! KIN_LKG_WORKSPACE=<workspace uuid> \
+//!   cargo test -p kin-reconcile --release --test lkg_real_store_heap -- --ignored --nocapture
+//! ```
+//!
+//! Its own test binary, because the counter below is process global.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use kin_db::{LocalFileBackend, RepositoryAuthorityManager};
+use kin_model::{Entity, EntityId, Relation, RepositoryId, WorkspaceId};
+use kin_reconcile::lkg::LkgStore;
+
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+
+struct Counting;
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc(layout);
+        if !ptr.is_null() {
+            LIVE.fetch_add(layout.size(), Ordering::Relaxed);
+        }
+        ptr
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc_zeroed(layout);
+        if !ptr.is_null() {
+            LIVE.fetch_add(layout.size(), Ordering::Relaxed);
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
+        System.dealloc(ptr, layout)
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let moved = System.realloc(ptr, layout, new_size);
+        if !moved.is_null() {
+            if new_size >= layout.size() {
+                LIVE.fetch_add(new_size - layout.size(), Ordering::Relaxed);
+            } else {
+                LIVE.fetch_sub(layout.size() - new_size, Ordering::Relaxed);
+            }
+        }
+        moved
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: Counting = Counting;
+
+fn live() -> usize {
+    LIVE.load(Ordering::Relaxed)
+}
+
+/// The entry as it was before this change, reproduced verbatim from the diff so
+/// both shapes can be priced in one process over one entity set.
+#[allow(dead_code)]
+struct BeforeEntry {
+    entity: Entity,
+    relations: Vec<Relation>,
+}
+
+/// The bytes an entity's own strings occupy, which is what the before entry
+/// reaches and the after entry does not. Measured independently so the heap half
+/// of the prediction is checkable against something other than itself.
+fn string_census(entities: &[Entity]) -> usize {
+    entities
+        .iter()
+        .map(|e| {
+            e.name.len()
+                + e.signature.len()
+                + e.file_origin.as_ref().map_or(0, |f| f.0.len())
+                + e.span.as_ref().map_or(0, |s| s.file.0.len())
+                + e.doc_summary.as_ref().map_or(0, |d| d.len())
+        })
+        .sum()
+}
+
+fn mib(bytes: usize) -> f64 {
+    bytes as f64 / (1024.0 * 1024.0)
+}
+
+#[test]
+#[ignore = "needs KIN_LKG_STORE, KIN_LKG_REPO and KIN_LKG_WORKSPACE naming a real store"]
+fn the_lkg_costs_on_a_real_store_what_the_registration_says() {
+    let store =
+        std::env::var("KIN_LKG_STORE").expect("set KIN_LKG_STORE to a .kin/kindb directory");
+    let repo = std::env::var("KIN_LKG_REPO").expect("set KIN_LKG_REPO to the repository uuid");
+    let workspace =
+        std::env::var("KIN_LKG_WORKSPACE").expect("set KIN_LKG_WORKSPACE to the workspace uuid");
+
+    // Positive control on the instrument. A counter that never moves makes every
+    // number below true for the wrong reason.
+    let control_floor = live();
+    let ballast = vec![0u8; 64 << 20];
+    assert!(
+        live() - control_floor >= ballast.len(),
+        "the counting allocator did not observe a {} byte allocation",
+        ballast.len()
+    );
+    drop(ballast);
+
+    let repository_id = RepositoryId::new(repo.as_str()).expect("repository id");
+    let workspace_id: WorkspaceId =
+        serde_json::from_str(&format!("\"{workspace}\"")).expect("workspace uuid");
+
+    let entities: Vec<Entity> = {
+        let backend = Arc::new(LocalFileBackend::new(&store));
+        let manager = RepositoryAuthorityManager::open(repository_id.clone(), backend)
+            .expect("the store opens");
+        let snapshot = manager
+            .workspace_graph_snapshot(&repository_id, &workspace_id)
+            .expect("the workspace materializes")
+            .expect("the authority carries this workspace");
+        snapshot.entities.values().cloned().collect()
+        // snapshot, lease and manager all drop here, so what follows is measured
+        // against the entities alone rather than against the store beside them.
+    };
+
+    let count = entities.len();
+    assert!(
+        count > 100_000,
+        "this is meant to run on a real repository, got {count} entities"
+    );
+    let census = string_census(&entities);
+
+    // The before shape.
+    let floor = live();
+    let before: HashMap<EntityId, BeforeEntry> = entities
+        .iter()
+        .map(|e| {
+            (
+                e.id,
+                BeforeEntry {
+                    entity: e.clone(),
+                    relations: Vec::new(),
+                },
+            )
+        })
+        .collect();
+    let before_bytes = live().saturating_sub(floor);
+    assert_eq!(before.len(), count, "the before map must hold every entity");
+    drop(before);
+
+    // The after shape, through the real store and the real record path.
+    let floor = live();
+    let mut after = LkgStore::new();
+    for e in &entities {
+        after.record(e);
+    }
+    let after_bytes = live().saturating_sub(floor);
+    assert_eq!(after.len(), count, "the after store must hold every entity");
+    drop(after);
+
+    let delta = before_bytes.saturating_sub(after_bytes);
+    println!(
+        "\n\
+         store            {store}\n\
+         entities         {count}\n\
+         string census    {census} bytes, {:.1} MiB, {:.1} B per entity\n\
+         before retained  {before_bytes} bytes, {:.1} MiB, {:.1} B per entity\n\
+         after retained   {after_bytes} bytes, {:.1} MiB, {:.1} B per entity\n\
+         SAVING           {delta} bytes, {:.1} MiB, {:.1} B per entity\n",
+        mib(census),
+        census as f64 / count as f64,
+        mib(before_bytes),
+        before_bytes as f64 / count as f64,
+        mib(after_bytes),
+        after_bytes as f64 / count as f64,
+        mib(delta),
+        delta as f64 / count as f64,
+    );
+
+    // Registered refutations, in the order section 7e states them.
+    let structural_floor = 316 * count;
+    assert!(
+        delta >= structural_floor,
+        "the saving is {delta} bytes, under the {structural_floor} byte structural floor of 316 \
+         per entity; the entry did not shrink the way the diff says, or something else still \
+         holds the entities"
+    );
+    assert!(
+        after_bytes / count < 512,
+        "the after store retains {} bytes per entity, over the 512 byte ceiling; the entry is \
+         still reaching the entity it was recorded from",
+        after_bytes / count
+    );
+    assert!(
+        delta >= census,
+        "the saving {delta} is under the {census} bytes of entity strings the before entry \
+         reaches; the heap half of the mechanism is not what this lane has claimed"
+    );
+}

--- a/crates/kin-reconcile/tests/lkg_retained_bytes.rs
+++ b/crates/kin-reconcile/tests/lkg_retained_bytes.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! What the reconciler's last-known-good store keeps, counted rather than
+//! asserted.
+//!
+//! A serving daemon seeds one LKG entry per entity in the repository at open and
+//! holds the store for its life. On this machine's `torvalds__linux` store that
+//! is 264,615 entries, and while the entry held a whole owned `Entity` it was a
+//! second complete copy of every entity's name, signature, doc summary and file
+//! path, none of which any reader ever looked at. The entry now holds the
+//! fingerprint that `LkgStore::has_changed` compares, so what it keeps must not
+//! move when the strings on the entities it was seeded from get longer.
+//!
+//! This is its own test binary on purpose. The counter below is process global,
+//! so a second test running beside it would be measured into it.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use kin_model::{
+    Entity, EntityId, EntityKind, EntityMetadata, EntityRole, FilePathId, FingerprintAlgorithm,
+    Hash256, LanguageId, SemanticFingerprint, SourceSpan, Visibility,
+};
+use kin_reconcile::lkg::LkgStore;
+
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+
+struct Counting;
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc(layout);
+        if !ptr.is_null() {
+            LIVE.fetch_add(layout.size(), Ordering::Relaxed);
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+        LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let out = System.realloc(ptr, layout, new_size);
+        if !out.is_null() {
+            LIVE.fetch_add(new_size, Ordering::Relaxed);
+            LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
+        }
+        out
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: Counting = Counting;
+
+fn live() -> usize {
+    LIVE.load(Ordering::Relaxed)
+}
+
+const ENTITIES: usize = 256;
+
+/// One entity carrying strings of a stated size, so the arms below differ in
+/// exactly one thing.
+fn entity(index: usize, doc_bytes: usize) -> Entity {
+    let path = format!("src/vs/workbench/services/generated/module_{index:05}.ts");
+    Entity {
+        id: EntityId::new(),
+        kind: EntityKind::Function,
+        name: format!("resolveConfigurationForWorkspaceFolder_{index:05}"),
+        language: LanguageId::TypeScript,
+        fingerprint: SemanticFingerprint {
+            algorithm: FingerprintAlgorithm::V1TreeSitter,
+            ast_hash: Hash256::from_bytes([index as u8; 32]),
+            signature_hash: Hash256::from_bytes([(index >> 8) as u8; 32]),
+            behavior_hash: Hash256::from_bytes([0xcc; 32]),
+            equivalence_hash: Hash256::from_bytes([0; 32]),
+            stability_score: 0.95,
+        },
+        file_origin: Some(FilePathId::new(&path)),
+        span: Some(SourceSpan {
+            file: FilePathId::new(&path),
+            start_byte: 0,
+            end_byte: 128,
+            start_line: 1,
+            start_col: 0,
+            end_line: 9,
+            end_col: 1,
+        }),
+        signature: format!("export function resolveConfigurationForWorkspaceFolder_{index:05}(folder: IWorkspaceFolder, section: string): IConfigurationValue"),
+        visibility: Visibility::Public,
+        role: EntityRole::Source,
+        doc_summary: Some("d".repeat(doc_bytes)),
+        metadata: EntityMetadata::default(),
+        lineage_parent: None,
+        created_in: None,
+        superseded_by: None,
+    }
+}
+
+/// Seed a store from entities carrying `doc_bytes` of doc summary and return
+/// the bytes the store still holds once the entities it was seeded from are
+/// gone, which is the daemon's own shape: `list_all_entities` hands over an
+/// owned vector, the seed walks it, and the vector is dropped.
+fn retained_for(doc_bytes: usize) -> usize {
+    let entities: Vec<Entity> = (0..ENTITIES).map(|i| entity(i, doc_bytes)).collect();
+
+    let before = live();
+    let mut store = LkgStore::new();
+    for e in &entities {
+        store.record(e);
+    }
+    let after = live();
+
+    assert_eq!(
+        store.len(),
+        ENTITIES,
+        "the store must hold every entity, or the byte count above is about nothing"
+    );
+
+    drop(entities);
+    drop(store);
+
+    after.saturating_sub(before)
+}
+
+#[test]
+fn the_lkg_retains_nothing_that_scales_with_an_entity_s_strings() {
+    // Positive control on the instrument itself. A counter that never moves
+    // makes every assertion below pass for the wrong reason.
+    let control_before = live();
+    let ballast = vec![0u8; 4 << 20];
+    let control_after = live();
+    assert!(
+        control_after - control_before >= ballast.len(),
+        "the counting allocator did not observe a {} byte allocation, so it \
+         cannot observe the store either",
+        ballast.len()
+    );
+    drop(ballast);
+
+    let small_doc = 64usize;
+    let large_doc = 8192usize;
+
+    let small = retained_for(small_doc);
+    let large = retained_for(large_doc);
+
+    // The doc summaries alone differ by two megabytes between the arms. An
+    // entry that reaches the entity carries that difference; one that holds a
+    // fingerprint does not.
+    let string_difference = ENTITIES * (large_doc - small_doc);
+    let tolerance = ENTITIES * 64;
+    assert!(
+        large.abs_diff(small) < tolerance,
+        "what the store retains moved by {} bytes when the entities' doc \
+         summaries grew by {} bytes; an entry must not reach the entity it was \
+         recorded from (small arm {} bytes, large arm {} bytes)",
+        large.abs_diff(small),
+        string_difference,
+        small,
+        large
+    );
+
+    // And an absolute ceiling, so an entry that shrank but still copies cannot
+    // pass on the scale-free test alone. A fingerprint is 132 bytes and a map
+    // entry adds an id and a control byte, so 512 per entity is roughly three
+    // times the true cost and well under the 4,288 bytes of string an entity
+    // carries in the large arm.
+    let ceiling = ENTITIES * 512;
+    assert!(
+        large < ceiling,
+        "the store retains {} bytes for {} entities, over the {} byte ceiling",
+        large,
+        ENTITIES,
+        ceiling
+    );
+}


### PR DESCRIPTION
## What this removes

A serving daemon seeds one last-known-good entry per entity at open and keeps the store for its
life. Each entry held a complete owned `Entity`: the name, the signature, the doc summary and two
separate allocations of the same file path. Nothing read any of it.

`LkgEntry.entity` has exactly one production reader, `LkgStore::has_changed`, which compares
`fingerprint.ast_hash`, `fingerprint.signature_hash` and `fingerprint.behavior_hash`.
`LkgEntry.relations` has no reader anywhere, production or test. It was also always empty in
production: every live `record` call site passed `vec![]`, and the one function that would have
filled it, `seed_lkg_from_graph`, had no callers at all. So the entry now holds the
`SemanticFingerprint`, and `seed_lkg_from_graph` goes with the field it existed for.

Beside it, `LiveCrossFileLinker.file_by_entity` allocated one owned path `String` per entity. It
now shares an `Arc<str>` per distinct file. Its two readers want either the path itself or an
equality against another entity's path, and both work unchanged over a shared string.

## The number, and its band

From the struct shapes, at a 1.5x hash-table fill midpoint:

| | before | after |
|---|---|---|
| LKG entry, resident | `Entity` 424 + `Vec` 24 + key 16 + control 1, so 465, plus 192 to 352 bytes of string heap | fingerprint 132 + key 16 + control 1, so 149, and no heap |
| per entity, with table slack | 889 to 1,049 B | 223 B |
| linker entry, per entity | 61 B of table plus a 48 B allocation | 49 B of table, one allocation per distinct file |

| store on this machine | entities | files | expected saving |
|---|---|---|---|
| `torvalds__linux` | 264,615 | 6,160 | 192 to 234 MB |
| `microsoft__vscode` | 29,392 | 1,355 | 21 to 26 MB |

Both entity counts are read off the daemon's own `seeded LKG entity baseline from graph snapshot
count=` line, which is exactly the number that enters this structure. The band is the table's real
fill factor, which swings every figure here by about half either way. Against the linux daemon's
9,155,165,136 bytes at rest that is 2.1 to 2.6 percent. It is small, it is real, and the measured
arms go in the report rather than being rounded up here.

**Measured below, in-process rather than by daemon RSS.** This lane tried a real daemon's resident
set twice on this same store and both attempts were deferred rather than reported: four reads
inside twelve seconds of a serving line land on the open's own transient, which moves by 2.6 GiB
against a 0.19 to 0.23 GiB effect, on any box, quiet or not. A counting global allocator in one
process, priced over the identical entity set, does not have that problem. Its result is below. The
resident-set confirmation against a real daemon, at rest and across the rollback-snapshot's
file-edit peak, is deferred to the quiet window after the bench round; until it runs, the number
below is the citable one.

## Measured

`crates/kin-reconcile/tests/lkg_real_store_heap.rs`, release mode, a counting global allocator, on
a clonefile copy of the `torvalds__linux` subtree store at `scratchpad/arms/instrument`: **264,615
entities**, the same store and the same count this PR's own table above sizes against.

| | bytes | MiB | per entity |
|---|---|---|---|
| before, the whole-entity LKG copy | 641,986,030 | 612.2 | 2,426.1 B |
| after, the fingerprint | 78,118,920 | 74.5 | 295.2 B |
| SAVING | 563,867,110 | 537.7 | 2,130.9 B |

String census, the independent check on the heap half: 50,503,582 bytes.

Against the 192 to 234 MB registration above, this is a **MISS above the top**: 2.4 to 2.9 times the
band. That registration is struct arithmetic, never an empirical daemon reading, so the miss is the
band being wrong rather than the change being wrong. The test's own three checks all passed: the
saving clears a 316 B per entity structural floor by 6.7x, it covers the 50.5 MB string census
several times over, and the after store holds 295.2 B per entity, under the 512 B ceiling. The
string half of the entry lines up with the hand count closely, 190.9 B per entity measured against
192 B predicted with no doc comment, so the gap sits almost entirely in the before shape's table
overhead: 2,235.2 B per entity net of the string census, against 697 B predicted at the 1.5x
hashbrown fill midpoint above. The real fill on this table costs more than that midpoint assumed.

The three `self.lkg.clone()` rollback-snapshot sites (`reconciler.rs:649`, `:749`, `:779`) were not
exercised by this harness; it prices the store's resting shape, not one file edit's rollback copy.
That effect stays registered at 235 to 278 MB peak and waits for the quiet-window daemon arm along
with the resident-set confirmation above.

## Two consequences beside the resident bytes

The reconcile path takes a rollback snapshot with `self.lkg.clone()` at three entry points before
deriving a transaction. Those clones deep copied every entity in the repository on every file edit,
which on the linux store is 264,615 entities and roughly a million string allocations per edit.
A fingerprint is plain data, so the snapshot is now a flat copy that allocates nothing.

The modified-entity arm cloned its entity twice, once into the delta and once into the store. It now
records by reference and moves the entity into the delta.

## The guard

`crates/kin-reconcile/tests/lkg_retained_bytes.rs`, an integration test with a counting global
allocator, in the shape kin-db's memory harnesses use. Its own binary, because the counter is
process global and a test running beside it would be measured into it.

It seeds 256 entities twice, once with 64-byte doc summaries and once with 8,192-byte ones, and
requires that what the store retains does not move between the arms. Two things sit beside that
assertion so it cannot pass for the wrong reason:

- a positive control on the instrument, a four megabyte allocation the counter must observe, since
  a counter that never moves makes every assertion below it true;
- an absolute ceiling of 512 bytes per entity as well as the scale-free comparison, so an entry
  that shrank but still copies cannot pass on the difference alone.

`LkgStore::len` is asserted inside each arm, so an arm that recorded nothing is caught rather than
reported as a saving.

Two smaller unit tests go in beside them: `an_entry_is_exactly_a_fingerprint`, which fails the
moment an `Entity`, a `String` or a `Vec` comes back onto the struct, and
`re_recording_an_entity_does_not_grow_the_store`.

## Falsification

The mutant is `LkgEntry { fingerprint: SemanticFingerprint, entity: Entity }` with `record` filling
both, which is today's shape under a different name. Under it the two arms of the guard differ by
about two megabytes, `ENTITIES * (8192 - 64)`, so both the scale-free assertion and the ceiling go
red, and `an_entry_is_exactly_a_fingerprint` goes red on the size. The arm is named here rather than
run, because this box builds nothing tonight; it runs before the landing and its result goes in the
report.

## Gates

Not run locally, and deliberately: the fleet holds a compute quiet for a benchmark round with a
39 GB model on the GPU, and builders are forbidden. Hosted CI is the grader for this branch.

Related: FIR-3064
