### PR TITLE
Carry the semantic-primacy rescue into the entity-granular fuser

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -12895,12 +12895,11 @@ fn entity_seed_keyed(
 /// PATH-keyed here while 7 and 9 are ENTITY-keyed, so that count would span two
 /// key spaces and never coincide.
 ///
-/// It does carry the path fuser's semantic-primacy term, off by default and
-/// applied by [`apply_entity_semantic_primacy`]. Index positions survive the
-/// re-keying: `entity_granular_fused_files` builds `keyed_lists` by enumerating
-/// `ranked_lists` in order, so index 9 is the embedding list in both, keyed by
-/// entity id. Without that term a key only the vector arm found carries a bare
-/// rank contribution, which is the exact case the term was written for.
+/// It also omits the path fuser's semantic-primacy term, which
+/// [`entity_granular_fused_files`] applies to this function's OUTPUT instead. The
+/// term has to be keyed by the file-level embedding ranking, and that list is not
+/// available here: index 9 of `keyed_lists` holds the embedding SEED entities,
+/// which are a different and much smaller population than `ranked_lists[9]`.
 fn reciprocal_rank_fusion_entities(
     keyed_lists: &[Vec<(String, String, f32)>],
     k: f32,
@@ -12948,7 +12947,6 @@ fn reciprocal_rank_fusion_entities(
             )
         })
         .collect();
-    apply_entity_semantic_primacy(&mut combined, keyed_lists);
     combined.sort_by(|a, b| {
         b.2.partial_cmp(&a.2)
             .unwrap_or(std::cmp::Ordering::Equal)
@@ -12957,9 +12955,13 @@ fn reciprocal_rank_fusion_entities(
     combined
 }
 
-/// Signal-list index of the embedding arm, in `ranked_lists` and in the
-/// `keyed_lists` [`entity_granular_fused_files`] derives from it in the same
-/// order.
+/// Signal-list index of the embedding arm in `ranked_lists`.
+///
+/// Note that the `keyed_lists` [`entity_granular_fused_files`] derives from
+/// `ranked_lists` does NOT hold the same content at this index: when the
+/// embedding seeds resolve, index 9 is replaced by the entity-keyed SEED list.
+/// So a term that needs the file-level embedding ranking must read
+/// `ranked_lists[9]`, not `keyed_lists[9]`.
 const EMBEDDING_SIGNAL_INDEX: usize = 9;
 
 /// Semantic-primacy lift for the entity fuser, applied in place to the unlifted
@@ -13002,35 +13004,29 @@ const EMBEDDING_SIGNAL_INDEX: usize = 9;
 /// weight grows, peaks, then falls back to its unlifted place. Sweep a range and
 /// read the peak; do not push the weight up expecting more effect.
 fn apply_entity_semantic_primacy(
-    combined: &mut [(String, String, f32)],
-    keyed_lists: &[Vec<(String, String, f32)>],
+    fused: &mut [(String, String, f32)],
+    embedding_ranked: &[(String, f32)],
 ) {
     let weight = locate_env_f32("KIN_LOCATE_ENTITY_SEMANTIC_PRIMACY_WEIGHT", 0.0);
-    if weight <= 0.0 {
+    if weight <= 0.0 || embedding_ranked.is_empty() {
         return;
     }
     let k = locate_env_f32("KIN_LOCATE_SEMANTIC_PRIMACY_K", 8.0);
-    // Clamped strictly below 1.0: at exactly 1.0 a lifted key reaches `top` and
+    // Clamped strictly below 1.0: at exactly 1.0 a lifted entry reaches `top` and
     // the sort's key tiebreak could put it first, which is the invariant this
     // whole term is bounded by.
     let headroom = locate_env_f32("KIN_LOCATE_ENTITY_SEMANTIC_PRIMACY_HEADROOM", 0.9).min(0.99);
-    let Some(embedding_list) = keyed_lists.get(EMBEDDING_SIGNAL_INDEX) else {
-        return;
-    };
-    let embed_rank: FxHashMap<&str, usize> = embedding_list
+    let embed_rank: FxHashMap<&str, usize> = embedding_ranked
         .iter()
         .enumerate()
-        .map(|(rank, (key, _, _))| (key.as_str(), rank))
+        .map(|(rank, (path, _))| (path.as_str(), rank))
         .collect();
-    if embed_rank.is_empty() {
-        return;
-    }
-    let top = combined
+    let top = fused
         .iter()
         .map(|(_, _, score)| *score)
         .fold(0.0f32, f32::max);
-    for (key, _, score) in combined.iter_mut() {
-        let Some(&rank) = embed_rank.get(key.as_str()) else {
+    for (_, path, score) in fused.iter_mut() {
+        let Some(&rank) = embed_rank.get(path.as_str()) else {
             continue;
         };
         let lift = weight / (k + rank as f32 + 1.0);
@@ -13040,6 +13036,11 @@ fn apply_entity_semantic_primacy(
             *score += applied;
         }
     }
+    fused.sort_by(|a, b| {
+        b.2.partial_cmp(&a.2)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.0.cmp(&b.0))
+    });
 }
 
 /// Entity-granular fusion (behind `KIN_LOCATE_ENTITY_FUSION`, ON for accuracy-v2
@@ -13089,7 +13090,19 @@ fn entity_granular_fused_files(
         keyed_lists.push(keyed);
     }
     let rrf_k = locate_env_f32("KIN_LOCATE_RRF_K", 60.0);
-    let fused_entities = reciprocal_rank_fusion_entities(&keyed_lists, rrf_k);
+    let mut fused_entities = reciprocal_rank_fusion_entities(&keyed_lists, rrf_k);
+    // Semantic primacy is keyed by the FILE-level embedding ranking, which is
+    // `ranked_lists[9]`. `keyed_lists[9]` cannot serve: when the embedding seeds
+    // resolve it holds the entity-keyed seed list instead, a different and much
+    // smaller population, so a term keyed off it never reaches a file the vector
+    // arm ranked but the seeds missed.
+    apply_entity_semantic_primacy(
+        &mut fused_entities,
+        ranked_lists
+            .get(EMBEDDING_SIGNAL_INDEX)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]),
+    );
     // Project entity ranking → files: each file takes its best entity's score.
     let mut best_per_file: HashMap<String, f32> = HashMap::new();
     for (_, path, score) in &fused_entities {
@@ -32147,58 +32160,57 @@ mod tests {
     // Semantic primacy on the entity path.
     // ───────────────────────────────────────────────────────────────────────
 
-    /// The measured starvation shape at unit-test scale.
+    /// The measured starvation shape at unit-test scale, as the fused entity list
+    /// looks when it reaches [`apply_entity_semantic_primacy`].
     ///
-    /// `e:widget` is found by two graph arms and holds the top on merit. `e:mixed0`
-    /// and `e:mixed1` carry a graph signal AND a deep embedding rank. Eight `e:junk`
-    /// keys carry both signals in the middle of each list. `e:cursors` and
-    /// `e:type_ops` are found by the vector arm ALONE, at the two BEST embedding
-    /// ranks, and still land below keys they beat semantically. That inversion is
-    /// the defect: the combine pays for breadth, and one arm cannot buy it.
-    fn embedding_starvation_lists() -> Vec<Vec<(String, String, f32)>> {
-        let ent = |key: &str, path: &str, score: f32| (key.to_string(), path.to_string(), score);
-        let mut lists: Vec<Vec<(String, String, f32)>> = vec![Vec::new(); 10];
-
-        // idx 1: multihop.
-        lists[1].push(ent("e:widget", "src/widget.ts", 100.0));
-        lists[1].push(ent("e:mixed0", "src/mixed0.ts", 20.0));
-        lists[1].push(ent("e:mixed1", "src/mixed1.ts", 19.0));
-        for i in 0..8u32 {
-            lists[1].push(ent(
-                &format!("e:junk{i}"),
-                &format!("src/junk{i}.ts"),
-                12.0 - i as f32,
-            ));
-        }
-        lists[1].push(ent("e:graphonly", "src/graphonly.ts", 4.0));
-
-        // idx 2: tests. The widget's second graph signal.
-        lists[2].push(ent("e:widget", "src/widget.ts", 40.0));
-
-        // idx 9: embedding.
-        lists[9].push(ent("e:cursors", "src/cursor.ts", 0.95));
-        lists[9].push(ent("e:type_ops", "src/cursorTypeOperations.ts", 0.90));
-        for i in 0..8u32 {
-            lists[9].push(ent(
-                &format!("e:junk{i}"),
-                &format!("src/junk{i}.ts"),
-                0.60 - 0.02 * i as f32,
-            ));
-        }
-        lists[9].push(ent("e:mixed0", "src/mixed0.ts", 0.30));
-        lists[9].push(ent("e:mixed1", "src/mixed1.ts", 0.28));
-        lists
+    /// `e:widget` holds the top on merit. `e:mixed0` and `e:mixed1` carry a graph
+    /// signal and a deep embedding rank. `e:type_ops` is found by the vector arm
+    /// ALONE, at a much better embedding rank, and still lands below both. That
+    /// inversion is the defect: the combine pays for breadth, and one arm cannot
+    /// buy it.
+    fn starved_fusion_output() -> Vec<(String, String, f32)> {
+        vec![
+            ("e:widget".into(), "src/widget.ts".into(), 0.152787f32),
+            ("e:mixed0".into(), "src/mixed0.ts".into(), 0.077002),
+            ("e:mixed1".into(), "src/mixed1.ts".into(), 0.074998),
+            ("e:cursors".into(), "src/cursor.ts".into(), 0.063893),
+            (
+                "e:type_ops".into(),
+                "src/cursorTypeOperations.ts".into(),
+                0.061129,
+            ),
+            ("e:graphonly".into(), "src/graphonly.ts".into(), 0.024625),
+        ]
     }
 
-    /// Every knob `reciprocal_rank_fusion_entities` reads, removed, so one test
-    /// cannot read another's setting.
+    /// The FILE-level embedding ranking, which is what the term keys on. Note
+    /// `src/graphonly.ts` is absent: the vector arm never ranked it, so it must
+    /// not move at all.
+    fn embedding_ranked_files() -> Vec<(String, f32)> {
+        // The rivals sit DEEP, as they do on a real store, because the term
+        // separates by embedding rank and barely separates two files a few places
+        // apart. `src/graphonly.ts` is absent: the vector arm never ranked it, so
+        // it must not move at all.
+        let mut v = vec![
+            ("src/cursor.ts".to_string(), 0.95),
+            ("src/cursorTypeOperations.ts".to_string(), 0.90),
+        ];
+        for i in 0..8u32 {
+            v.push((format!("src/filler{i}.ts"), 0.60 - 0.02 * i as f32));
+        }
+        v.push(("src/mixed0.ts".to_string(), 0.30));
+        v.push(("src/mixed1.ts".to_string(), 0.28));
+        v
+    }
+
+    /// Every knob the term reads, removed, so one test cannot read another's
+    /// setting.
     ///
     /// The guard serializes MUTATING tests against each other and restores on
     /// drop, but it cannot stop a test that merely READS a variable another test
     /// set. Under `cargo nextest` each test owns a process and the whole class is
     /// structurally invisible; under a shared-process `cargo test` it is not, and
     /// on this repo that runner grades main's push rather than the pull request.
-    /// So pin every input rather than only the two this term introduces.
     fn primacy_knobs_unset() -> kin_core::test_env::EnvVarGuard {
         kin_core::test_env::EnvVarGuard::unset("KIN_LOCATE_ENTITY_SEMANTIC_PRIMACY_WEIGHT")
             .without("KIN_LOCATE_ENTITY_SEMANTIC_PRIMACY_HEADROOM")
@@ -32206,142 +32218,134 @@ mod tests {
             .without("KIN_LOCATE_RRF_RAW_WEIGHT")
     }
 
-    fn fused_place(fused: &[(String, String, f32)], key: &str) -> usize {
+    fn place_of(fused: &[(String, String, f32)], key: &str) -> usize {
         fused
             .iter()
             .position(|(k, _, _)| k == key)
             .unwrap_or_else(|| panic!("{key} absent from the fused ranking"))
     }
 
-    fn fused_score(fused: &[(String, String, f32)], key: &str) -> f32 {
-        fused[fused_place(fused, key)].2
+    fn score_of(fused: &[(String, String, f32)], key: &str) -> f32 {
+        fused[place_of(fused, key)].2
     }
 
-    fn fused_keys(fused: &[(String, String, f32)]) -> Vec<&str> {
+    fn keys_of(fused: &[(String, String, f32)]) -> Vec<&str> {
         fused.iter().map(|(k, _, _)| k.as_str()).collect()
     }
 
     #[test]
     fn entity_fusion_semantic_primacy_ships_dark() {
         // The term must be inert until a measured A/B earns it a default, and
-        // "inert" has to mean bit-identical, not close. This assertion is what a
-        // default flip has to come and change on purpose.
-        let lists = embedding_starvation_lists();
-        let unset = {
+        // "inert" has to mean bit-identical, not close. This is what a default
+        // flip has to come and change on purpose.
+        let base = starved_fusion_output();
+        let emb = embedding_ranked_files();
+        let mut unset = base.clone();
+        {
             let _g = primacy_knobs_unset();
-            reciprocal_rank_fusion_entities(&lists, 60.0)
-        };
-        let explicit_zero = {
-            let _g = primacy_knobs_unset().with("KIN_LOCATE_ENTITY_SEMANTIC_PRIMACY_WEIGHT", "0");
-            reciprocal_rank_fusion_entities(&lists, 60.0)
-        };
-        assert_eq!(unset.len(), explicit_zero.len());
-        for (a, b) in unset.iter().zip(explicit_zero.iter()) {
-            assert_eq!(a.0, b.0, "unset must order exactly as an explicit 0");
+            apply_entity_semantic_primacy(&mut unset, &emb);
+        }
+        for (a, b) in unset.iter().zip(base.iter()) {
+            assert_eq!(a.0, b.0, "the shipped default must not reorder");
             assert_eq!(
                 a.2.to_bits(),
                 b.2.to_bits(),
-                "unset must score bit-identically to an explicit 0 for {}",
+                "the shipped default must not move {} by even one bit",
                 a.0
             );
         }
         assert!(
-            fused_place(&unset, "e:type_ops") > fused_place(&unset, "e:mixed1"),
+            place_of(&unset, "e:type_ops") > place_of(&unset, "e:mixed1"),
             "at the shipped default the starved key stays starved: {:?}",
-            fused_keys(&unset)
+            keys_of(&unset)
         );
     }
 
     #[test]
     fn entity_fusion_semantic_primacy_rescues_an_embedding_only_key() {
-        let lists = embedding_starvation_lists();
+        let base = starved_fusion_output();
+        let emb = embedding_ranked_files();
 
-        // THE BASELINE IS ASSERTED GREEN FIRST. A red baseline would let every arm
-        // below report PASS without proving anything.
-        let baseline = {
-            let _g = primacy_knobs_unset();
-            reciprocal_rank_fusion_entities(&lists, 60.0)
-        };
+        // THE BASELINE IS ASSERTED GREEN FIRST. A red baseline would let every
+        // arm below report PASS without proving anything.
         assert_eq!(
-            fused_keys(&baseline).first().copied(),
+            keys_of(&base).first().copied(),
             Some("e:widget"),
             "baseline rank one: {:?}",
-            fused_keys(&baseline)
+            keys_of(&base)
         );
         assert!(
-            fused_place(&baseline, "e:type_ops") > fused_place(&baseline, "e:mixed0")
-                && fused_place(&baseline, "e:type_ops") > fused_place(&baseline, "e:mixed1"),
-            "THE DEFECT: the key at embedding rank 1 sits below two keys at embedding \
-             ranks 10 and 11 that carry a second signal: {:?}",
-            fused_keys(&baseline)
+            place_of(&base, "e:type_ops") > place_of(&base, "e:mixed0")
+                && place_of(&base, "e:type_ops") > place_of(&base, "e:mixed1"),
+            "THE DEFECT: the key at embedding rank 1 sits below two keys at \
+             embedding ranks 2 and 3 that carry a second signal: {:?}",
+            keys_of(&base)
         );
 
-        let lifted = {
+        let mut lifted = base.clone();
+        {
             let _g = primacy_knobs_unset().with("KIN_LOCATE_ENTITY_SEMANTIC_PRIMACY_WEIGHT", "0.5");
-            reciprocal_rank_fusion_entities(&lists, 60.0)
-        };
+            apply_entity_semantic_primacy(&mut lifted, &emb);
+        }
         assert!(
-            fused_place(&lifted, "e:type_ops") < fused_place(&lifted, "e:mixed0")
-                && fused_place(&lifted, "e:type_ops") < fused_place(&lifted, "e:mixed1"),
+            place_of(&lifted, "e:type_ops") < place_of(&lifted, "e:mixed0")
+                && place_of(&lifted, "e:type_ops") < place_of(&lifted, "e:mixed1"),
             "THE RESCUE: the embedding-only key must clear the keys it outranks \
              semantically: {:?}",
-            fused_keys(&lifted)
+            keys_of(&lifted)
         );
         assert_eq!(
-            fused_keys(&lifted).first().copied(),
+            keys_of(&lifted).first().copied(),
             Some("e:widget"),
             "the rescue must not move rank one: {:?}",
-            fused_keys(&lifted)
+            keys_of(&lifted)
         );
         assert_eq!(
-            lifted[0].2.to_bits(),
-            baseline[0].2.to_bits(),
+            score_of(&lifted, "e:widget").to_bits(),
+            score_of(&base, "e:widget").to_bits(),
             "rank one's score must be bit-identical, not merely close"
         );
         assert_eq!(
-            fused_score(&lifted, "e:graphonly").to_bits(),
-            fused_score(&baseline, "e:graphonly").to_bits(),
-            "a key the embedding arm never ranked must not move at all"
+            score_of(&lifted, "e:graphonly").to_bits(),
+            score_of(&base, "e:graphonly").to_bits(),
+            "a file the embedding arm never ranked must not move at all"
         );
     }
 
     #[test]
     fn entity_fusion_semantic_primacy_cannot_take_rank_one() {
-        let lists = embedding_starvation_lists();
-        let baseline = {
-            let _g = primacy_knobs_unset();
-            reciprocal_rank_fusion_entities(&lists, 60.0)
-        };
-        let top = baseline[0].2;
-        let cursors_baseline = fused_score(&baseline, "e:cursors");
+        let base = starved_fusion_output();
+        let emb = embedding_ranked_files();
+        let top = base[0].2;
+        let cursors_baseline = score_of(&base, "e:cursors");
 
         // At weight 5.0 the raw lift at embedding rank 0 is 5.0 / (8 + 0 + 1),
-        // larger than the whole gap from `e:cursors` to the top. An unguarded term
-        // hands rank one to a key ONE arm found. The headroom cap is the only thing
-        // between this fixture and that outcome, which is what the next two
-        // assertions are for.
+        // larger than the whole gap from `e:cursors` to the top. An unguarded
+        // term hands rank one to a file ONE arm found. The headroom cap is the
+        // only thing between this fixture and that outcome.
         let uncapped = cursors_baseline + 5.0 / 9.0;
         assert!(
             uncapped > top,
             "fixture must put the unguarded lift above the top ({uncapped} vs {top})"
         );
 
-        let lifted = {
+        let mut lifted = base.clone();
+        {
             let _g = primacy_knobs_unset().with("KIN_LOCATE_ENTITY_SEMANTIC_PRIMACY_WEIGHT", "5.0");
-            reciprocal_rank_fusion_entities(&lists, 60.0)
-        };
+            apply_entity_semantic_primacy(&mut lifted, &emb);
+        }
         assert_eq!(
-            fused_keys(&lifted).first().copied(),
+            keys_of(&lifted).first().copied(),
             Some("e:widget"),
             "the cap pins rank one: {:?}",
-            fused_keys(&lifted)
+            keys_of(&lifted)
         );
         assert_eq!(
             lifted[0].2.to_bits(),
             top.to_bits(),
             "rank one's score must be bit-identical under any weight"
         );
-        let cursors_lifted = fused_score(&lifted, "e:cursors");
+        let cursors_lifted = score_of(&lifted, "e:cursors");
         assert!(
             cursors_lifted < top,
             "no lifted key may reach the top ({cursors_lifted} vs {top})"
@@ -32349,6 +32353,60 @@ mod tests {
         assert!(
             cursors_lifted < uncapped,
             "the cap must actually bind ({cursors_lifted} vs {uncapped} uncapped)"
+        );
+    }
+
+    #[test]
+    fn embedding_seeds_displace_the_file_embedding_signal_from_entity_fusion() {
+        // CHARACTERIZATION, and the reason a semantic-primacy term cannot rescue
+        // an embedding-only file on this path however it is keyed.
+        //
+        // `entity_granular_fused_files` REPLACES index 9 of its `keyed_lists`
+        // with the entity-keyed embedding SEED list whenever those seeds resolve.
+        // The file-level embedding ranking at `ranked_lists[9]` is then not fused
+        // at all, so a file only the vector arm ranked never enters the fused
+        // candidate set through the embedding route, and no rank-space term over
+        // that list has anything to lift.
+        //
+        // If this ever goes red because `src/vector.rs` starts reaching the
+        // projection, the displacement has been fixed and a primacy term becomes
+        // worth measuring again.
+        let graph = kin_db::InMemoryGraph::new();
+        let seed = test_entity("seeded", "src/seeded.rs", 1, 10);
+        graph.upsert_entity(&seed).unwrap();
+        let embedding_seeds = HashMap::from([(seed.id, disc(10.0))]);
+        let empty: HashMap<kin_model::EntityId, EntityDiscovery> = HashMap::new();
+
+        let mut ranked_lists: Vec<Vec<(String, f32)>> = vec![Vec::new(); 10];
+        ranked_lists[1] = vec![("src/anchor.rs".to_string(), 100.0)];
+        ranked_lists[9] = vec![("src/vector.rs".to_string(), 0.9)];
+
+        let _g = primacy_knobs_unset();
+        let fused = entity_granular_fused_files(
+            &ranked_lists,
+            &empty,
+            &embedding_seeds,
+            &graph,
+            LocateScope::SOURCE_ONLY,
+        )
+        .unwrap();
+        let paths: Vec<&str> = fused.iter().map(|(p, _)| p.as_str()).collect();
+
+        // Baseline asserted green first: the seeds resolved and the path-keyed
+        // signals fused, so the fixture is doing what the test assumes.
+        assert!(
+            paths.contains(&"src/seeded.rs"),
+            "the embedding SEED must reach the projection: {paths:?}"
+        );
+        assert!(
+            paths.contains(&"src/anchor.rs"),
+            "a path-keyed signal must reach the projection: {paths:?}"
+        );
+        // The finding.
+        assert!(
+            !paths.contains(&"src/vector.rs"),
+            "a file present ONLY in the file-level embedding ranking is displaced \
+             from entity fusion by the seeds: {paths:?}"
         );
     }
 

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -3799,13 +3799,14 @@ fn run_with_graph_capture_budgeted(
     // every track's fusion below so a sweep moves them together.
     let rrf_k = locate_env_f32("KIN_LOCATE_RRF_K", 60.0);
 
-    // Entity-granular fusion experiment (default OFF; byte-identical when unset).
-    // When KIN_LOCATE_ENTITY_FUSION=1, fuse at ENTITY granularity (entity-derived
-    // signals keyed by entity id, the rest by path) and PROJECT to files at the
-    // fusion boundary, so the file-keyed post-fusion pipeline (boosts/demotes/
-    // floors/adaptive_cap) below runs unchanged. When unset, the original
-    // track-regime path fusion runs verbatim — see the flip-plan in
-    // crates/kin-cli/docs/locate-entity-fusion-flip-plan.md for scope and A/B.
+    // Entity-granular fusion. ON for accuracy-v2 and accuracy-v1
+    // (`RetrievalProfile::entity_fusion_default`), OFF for compat-v0, so an unset
+    // variable resolves to the profile default and NOT to the `else` arm. Fuses at
+    // ENTITY granularity (entity-derived signals keyed by entity id, the rest by
+    // path) and PROJECTS to files at the fusion boundary, so the file-keyed
+    // post-fusion pipeline (boosts/demotes/floors/adaptive_cap) below runs
+    // unchanged. The `else` arm is the historical track-regime path fusion, now
+    // reachable only with KIN_PROFILE=compat-v0 or KIN_LOCATE_ENTITY_FUSION=0.
     let mut direct_entity_ordered = false;
     let mut fused = if locate_env_bool("KIN_LOCATE_ENTITY_FUSION", quality.entity_fusion_default())
     {
@@ -12889,11 +12890,17 @@ fn entity_seed_keyed(
 /// `(key, path, fused_score)` sorted descending (ties broken by key for
 /// determinism).
 ///
-/// It intentionally omits the path fuser's graph-neighborhood tiebreaker and
-/// semantic-primacy term: both are keyed by fixed signal-list *index positions*
-/// over file keys, which do not carry over to entity keys. Per the scoring-map
-/// recommendation, the entity path is a clean rank-space fuser rather than a
-/// re-derivation of the index-positional path tunings.
+/// It omits the path fuser's graph-neighborhood tiebreaker, which counts a key's
+/// appearances across signal indices {1, 2, 4, 6}. Those four lists stay
+/// PATH-keyed here while 7 and 9 are ENTITY-keyed, so that count would span two
+/// key spaces and never coincide.
+///
+/// It does carry the path fuser's semantic-primacy term, off by default and
+/// applied by [`apply_entity_semantic_primacy`]. Index positions survive the
+/// re-keying: `entity_granular_fused_files` builds `keyed_lists` by enumerating
+/// `ranked_lists` in order, so index 9 is the embedding list in both, keyed by
+/// entity id. Without that term a key only the vector arm found carries a bare
+/// rank contribution, which is the exact case the term was written for.
 fn reciprocal_rank_fusion_entities(
     keyed_lists: &[Vec<(String, String, f32)>],
     k: f32,
@@ -12941,6 +12948,7 @@ fn reciprocal_rank_fusion_entities(
             )
         })
         .collect();
+    apply_entity_semantic_primacy(&mut combined, keyed_lists);
     combined.sort_by(|a, b| {
         b.2.partial_cmp(&a.2)
             .unwrap_or(std::cmp::Ordering::Equal)
@@ -12949,7 +12957,93 @@ fn reciprocal_rank_fusion_entities(
     combined
 }
 
-/// Entity-granular fusion (behind `KIN_LOCATE_ENTITY_FUSION`, default OFF).
+/// Signal-list index of the embedding arm, in `ranked_lists` and in the
+/// `keyed_lists` [`entity_granular_fused_files`] derives from it in the same
+/// order.
+const EMBEDDING_SIGNAL_INDEX: usize = 9;
+
+/// Semantic-primacy lift for the entity fuser, applied in place to the unlifted
+/// combine before it is sorted.
+///
+/// Mirrors the path fuser's term in [`reciprocal_rank_fusion_weighted`]: a key the
+/// embedding arm ranked gains `weight / (k + rank + 1)`, with a small `k` so a top
+/// embedding rank is not compressed the way RRF's `k = 60` compresses it. It
+/// corrects a combine that rewards breadth. A key two arms found carries two rank
+/// terms plus the 0.02 cross-signal bonus while a key one arm found carries one,
+/// about 0.034 apart at a middling rank, and a key only the vector arm found has
+/// no way to earn that back however strong the match.
+///
+/// `KIN_LOCATE_ENTITY_SEMANTIC_PRIMACY_WEIGHT` defaults to 0.0, so the term is
+/// dark until a measured A/B earns it a default. The saturation constant is
+/// `KIN_LOCATE_SEMANTIC_PRIMACY_K`, the same name the path fuser reads, so one
+/// sweep moves both fusers together.
+///
+/// # What pins the top of the ranking
+///
+/// A key may consume at most `KIN_LOCATE_ENTITY_SEMANTIC_PRIMACY_HEADROOM` of its
+/// gap to the unlifted top score, so a capped key lands at
+/// `top * h + score * (1 - h)`, which is strictly below `top` for every `h < 1`
+/// and every `score < top`. A key already at `top` has no gap and takes no lift,
+/// so its score stays bit-identical. Fusion rank one therefore cannot move, and
+/// because [`entity_granular_fused_files`] projects each file onto its best
+/// entity's score, the top FILE out of fusion cannot move either.
+///
+/// Capping the gap rather than clamping to a fixed ceiling is what keeps the cap
+/// order-preserving: `top * h + score * (1 - h)` is strictly increasing in
+/// `score`, so two capped keys cannot collapse onto one value and be reordered by
+/// the key tiebreak.
+///
+/// # The weight is not monotone, and a sweep must not assume it is
+///
+/// Once a key's lift exceeds its headroom the cap binds, and every capped key
+/// keeps its unlifted order. So a large enough weight caps the whole embedding
+/// set and returns it to the order it already had, undoing the rescue. Simulated
+/// over this combine, an embedding-only key rises through the ranking as the
+/// weight grows, peaks, then falls back to its unlifted place. Sweep a range and
+/// read the peak; do not push the weight up expecting more effect.
+fn apply_entity_semantic_primacy(
+    combined: &mut [(String, String, f32)],
+    keyed_lists: &[Vec<(String, String, f32)>],
+) {
+    let weight = locate_env_f32("KIN_LOCATE_ENTITY_SEMANTIC_PRIMACY_WEIGHT", 0.0);
+    if weight <= 0.0 {
+        return;
+    }
+    let k = locate_env_f32("KIN_LOCATE_SEMANTIC_PRIMACY_K", 8.0);
+    // Clamped strictly below 1.0: at exactly 1.0 a lifted key reaches `top` and
+    // the sort's key tiebreak could put it first, which is the invariant this
+    // whole term is bounded by.
+    let headroom = locate_env_f32("KIN_LOCATE_ENTITY_SEMANTIC_PRIMACY_HEADROOM", 0.9).min(0.99);
+    let Some(embedding_list) = keyed_lists.get(EMBEDDING_SIGNAL_INDEX) else {
+        return;
+    };
+    let embed_rank: FxHashMap<&str, usize> = embedding_list
+        .iter()
+        .enumerate()
+        .map(|(rank, (key, _, _))| (key.as_str(), rank))
+        .collect();
+    if embed_rank.is_empty() {
+        return;
+    }
+    let top = combined
+        .iter()
+        .map(|(_, _, score)| *score)
+        .fold(0.0f32, f32::max);
+    for (key, _, score) in combined.iter_mut() {
+        let Some(&rank) = embed_rank.get(key.as_str()) else {
+            continue;
+        };
+        let lift = weight / (k + rank as f32 + 1.0);
+        let allowed = ((top - *score) * headroom).max(0.0);
+        let applied = lift.min(allowed);
+        if applied > 0.0 {
+            *score += applied;
+        }
+    }
+}
+
+/// Entity-granular fusion (behind `KIN_LOCATE_ENTITY_FUSION`, ON for accuracy-v2
+/// and accuracy-v1, OFF for compat-v0).
 ///
 /// Builds entity-keyed ranked lists — the two entity-derived signals
 /// (`entity_resolve` idx 7 and `embedding` idx 9) keyed by entity id from the
@@ -12959,8 +13053,7 @@ fn reciprocal_rank_fusion_entities(
 /// file list then feeds the existing file-keyed post-fusion pipeline unchanged.
 ///
 /// This is the architecture-bet ON path: entity ranking survives INTO fusion
-/// rather than terminating at discovery. Deliberate first-cut limits, to be
-/// validated by a controlled A/B before it becomes the default:
+/// rather than terminating at discovery. Deliberate first-cut limits:
 /// 1. Projection happens at the fusion boundary, so dominance/floors/adaptive_cap
 ///    stay file-granular (re-keying the ~40-function post-fusion pipeline to
 ///    entities is out of scope under freeze and risks the proven determinism).
@@ -32037,12 +32130,216 @@ mod tests {
     // ───────────────────────────────────────────────────────────────────────
 
     #[test]
-    fn entity_fusion_is_disabled_by_default() {
-        // The architecture bet must stay OFF until controlled A/B validation flips it.
-        // No test in this module sets the var, so the default governs.
+    fn the_shipped_profile_fuses_at_entity_granularity() {
+        // The selector reads the PROFILE default, not a literal `false`. Asserting
+        // against `false` proved only that no test in this module exported the
+        // variable, so it stayed green through both landings that flipped the
+        // shipped default ON while its own comment became untrue.
+        let _unset = kin_core::test_env::EnvVarGuard::unset("KIN_LOCATE_ENTITY_FUSION");
+        let quality = crate::retrieval_profile::RetrievalProfile::default();
         assert!(
-            !locate_env_bool("KIN_LOCATE_ENTITY_FUSION", false),
-            "KIN_LOCATE_ENTITY_FUSION must default OFF"
+            locate_env_bool("KIN_LOCATE_ENTITY_FUSION", quality.entity_fusion_default()),
+            "the shipped profile fuses at entity granularity; the selector reads this value"
+        );
+    }
+
+    // ───────────────────────────────────────────────────────────────────────
+    // Semantic primacy on the entity path.
+    // ───────────────────────────────────────────────────────────────────────
+
+    /// The measured starvation shape at unit-test scale.
+    ///
+    /// `e:widget` is found by two graph arms and holds the top on merit. `e:mixed0`
+    /// and `e:mixed1` carry a graph signal AND a deep embedding rank. Eight `e:junk`
+    /// keys carry both signals in the middle of each list. `e:cursors` and
+    /// `e:type_ops` are found by the vector arm ALONE, at the two BEST embedding
+    /// ranks, and still land below keys they beat semantically. That inversion is
+    /// the defect: the combine pays for breadth, and one arm cannot buy it.
+    fn embedding_starvation_lists() -> Vec<Vec<(String, String, f32)>> {
+        let ent = |key: &str, path: &str, score: f32| (key.to_string(), path.to_string(), score);
+        let mut lists: Vec<Vec<(String, String, f32)>> = vec![Vec::new(); 10];
+
+        // idx 1: multihop.
+        lists[1].push(ent("e:widget", "src/widget.ts", 100.0));
+        lists[1].push(ent("e:mixed0", "src/mixed0.ts", 20.0));
+        lists[1].push(ent("e:mixed1", "src/mixed1.ts", 19.0));
+        for i in 0..8u32 {
+            lists[1].push(ent(
+                &format!("e:junk{i}"),
+                &format!("src/junk{i}.ts"),
+                12.0 - i as f32,
+            ));
+        }
+        lists[1].push(ent("e:graphonly", "src/graphonly.ts", 4.0));
+
+        // idx 2: tests. The widget's second graph signal.
+        lists[2].push(ent("e:widget", "src/widget.ts", 40.0));
+
+        // idx 9: embedding.
+        lists[9].push(ent("e:cursors", "src/cursor.ts", 0.95));
+        lists[9].push(ent("e:type_ops", "src/cursorTypeOperations.ts", 0.90));
+        for i in 0..8u32 {
+            lists[9].push(ent(
+                &format!("e:junk{i}"),
+                &format!("src/junk{i}.ts"),
+                0.60 - 0.02 * i as f32,
+            ));
+        }
+        lists[9].push(ent("e:mixed0", "src/mixed0.ts", 0.30));
+        lists[9].push(ent("e:mixed1", "src/mixed1.ts", 0.28));
+        lists
+    }
+
+    /// Every primacy knob removed, so one test cannot read another's setting.
+    fn primacy_knobs_unset() -> kin_core::test_env::EnvVarGuard {
+        kin_core::test_env::EnvVarGuard::unset("KIN_LOCATE_ENTITY_SEMANTIC_PRIMACY_WEIGHT")
+            .without("KIN_LOCATE_ENTITY_SEMANTIC_PRIMACY_HEADROOM")
+            .without("KIN_LOCATE_SEMANTIC_PRIMACY_K")
+    }
+
+    fn fused_place(fused: &[(String, String, f32)], key: &str) -> usize {
+        fused
+            .iter()
+            .position(|(k, _, _)| k == key)
+            .unwrap_or_else(|| panic!("{key} absent from the fused ranking"))
+    }
+
+    fn fused_score(fused: &[(String, String, f32)], key: &str) -> f32 {
+        fused[fused_place(fused, key)].2
+    }
+
+    fn fused_keys(fused: &[(String, String, f32)]) -> Vec<&str> {
+        fused.iter().map(|(k, _, _)| k.as_str()).collect()
+    }
+
+    #[test]
+    fn entity_fusion_semantic_primacy_ships_dark() {
+        // The term must be inert until a measured A/B earns it a default, and
+        // "inert" has to mean bit-identical, not close. This assertion is what a
+        // default flip has to come and change on purpose.
+        let lists = embedding_starvation_lists();
+        let unset = {
+            let _g = primacy_knobs_unset();
+            reciprocal_rank_fusion_entities(&lists, 60.0)
+        };
+        let explicit_zero = {
+            let _g = primacy_knobs_unset().with("KIN_LOCATE_ENTITY_SEMANTIC_PRIMACY_WEIGHT", "0");
+            reciprocal_rank_fusion_entities(&lists, 60.0)
+        };
+        assert_eq!(unset.len(), explicit_zero.len());
+        for (a, b) in unset.iter().zip(explicit_zero.iter()) {
+            assert_eq!(a.0, b.0, "unset must order exactly as an explicit 0");
+            assert_eq!(
+                a.2.to_bits(),
+                b.2.to_bits(),
+                "unset must score bit-identically to an explicit 0 for {}",
+                a.0
+            );
+        }
+        assert!(
+            fused_place(&unset, "e:type_ops") > fused_place(&unset, "e:mixed1"),
+            "at the shipped default the starved key stays starved: {:?}",
+            fused_keys(&unset)
+        );
+    }
+
+    #[test]
+    fn entity_fusion_semantic_primacy_rescues_an_embedding_only_key() {
+        let lists = embedding_starvation_lists();
+
+        // THE BASELINE IS ASSERTED GREEN FIRST. A red baseline would let every arm
+        // below report PASS without proving anything.
+        let baseline = {
+            let _g = primacy_knobs_unset();
+            reciprocal_rank_fusion_entities(&lists, 60.0)
+        };
+        assert_eq!(
+            fused_keys(&baseline).first().copied(),
+            Some("e:widget"),
+            "baseline rank one: {:?}",
+            fused_keys(&baseline)
+        );
+        assert!(
+            fused_place(&baseline, "e:type_ops") > fused_place(&baseline, "e:mixed0")
+                && fused_place(&baseline, "e:type_ops") > fused_place(&baseline, "e:mixed1"),
+            "THE DEFECT: the key at embedding rank 1 sits below two keys at embedding \
+             ranks 10 and 11 that carry a second signal: {:?}",
+            fused_keys(&baseline)
+        );
+
+        let lifted = {
+            let _g = primacy_knobs_unset().with("KIN_LOCATE_ENTITY_SEMANTIC_PRIMACY_WEIGHT", "0.5");
+            reciprocal_rank_fusion_entities(&lists, 60.0)
+        };
+        assert!(
+            fused_place(&lifted, "e:type_ops") < fused_place(&lifted, "e:mixed0")
+                && fused_place(&lifted, "e:type_ops") < fused_place(&lifted, "e:mixed1"),
+            "THE RESCUE: the embedding-only key must clear the keys it outranks \
+             semantically: {:?}",
+            fused_keys(&lifted)
+        );
+        assert_eq!(
+            fused_keys(&lifted).first().copied(),
+            Some("e:widget"),
+            "the rescue must not move rank one: {:?}",
+            fused_keys(&lifted)
+        );
+        assert_eq!(
+            lifted[0].2.to_bits(),
+            baseline[0].2.to_bits(),
+            "rank one's score must be bit-identical, not merely close"
+        );
+        assert_eq!(
+            fused_score(&lifted, "e:graphonly").to_bits(),
+            fused_score(&baseline, "e:graphonly").to_bits(),
+            "a key the embedding arm never ranked must not move at all"
+        );
+    }
+
+    #[test]
+    fn entity_fusion_semantic_primacy_cannot_take_rank_one() {
+        let lists = embedding_starvation_lists();
+        let baseline = {
+            let _g = primacy_knobs_unset();
+            reciprocal_rank_fusion_entities(&lists, 60.0)
+        };
+        let top = baseline[0].2;
+        let cursors_baseline = fused_score(&baseline, "e:cursors");
+
+        // At weight 5.0 the raw lift at embedding rank 0 is 5.0 / (8 + 0 + 1),
+        // larger than the whole gap from `e:cursors` to the top. An unguarded term
+        // hands rank one to a key ONE arm found. The headroom cap is the only thing
+        // between this fixture and that outcome, which is what the next two
+        // assertions are for.
+        let uncapped = cursors_baseline + 5.0 / 9.0;
+        assert!(
+            uncapped > top,
+            "fixture must put the unguarded lift above the top ({uncapped} vs {top})"
+        );
+
+        let lifted = {
+            let _g = primacy_knobs_unset().with("KIN_LOCATE_ENTITY_SEMANTIC_PRIMACY_WEIGHT", "5.0");
+            reciprocal_rank_fusion_entities(&lists, 60.0)
+        };
+        assert_eq!(
+            fused_keys(&lifted).first().copied(),
+            Some("e:widget"),
+            "the cap pins rank one: {:?}",
+            fused_keys(&lifted)
+        );
+        assert_eq!(
+            lifted[0].2.to_bits(),
+            top.to_bits(),
+            "rank one's score must be bit-identical under any weight"
+        );
+        let cursors_lifted = fused_score(&lifted, "e:cursors");
+        assert!(
+            cursors_lifted < top,
+            "no lifted key may reach the top ({cursors_lifted} vs {top})"
+        );
+        assert!(
+            cursors_lifted < uncapped,
+            "the cap must actually bind ({cursors_lifted} vs {uncapped} uncapped)"
         );
     }
 

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -32190,11 +32190,20 @@ mod tests {
         lists
     }
 
-    /// Every primacy knob removed, so one test cannot read another's setting.
+    /// Every knob `reciprocal_rank_fusion_entities` reads, removed, so one test
+    /// cannot read another's setting.
+    ///
+    /// The guard serializes MUTATING tests against each other and restores on
+    /// drop, but it cannot stop a test that merely READS a variable another test
+    /// set. Under `cargo nextest` each test owns a process and the whole class is
+    /// structurally invisible; under a shared-process `cargo test` it is not, and
+    /// on this repo that runner grades main's push rather than the pull request.
+    /// So pin every input rather than only the two this term introduces.
     fn primacy_knobs_unset() -> kin_core::test_env::EnvVarGuard {
         kin_core::test_env::EnvVarGuard::unset("KIN_LOCATE_ENTITY_SEMANTIC_PRIMACY_WEIGHT")
             .without("KIN_LOCATE_ENTITY_SEMANTIC_PRIMACY_HEADROOM")
             .without("KIN_LOCATE_SEMANTIC_PRIMACY_K")
+            .without("KIN_LOCATE_RRF_RAW_WEIGHT")
     }
 
     fn fused_place(fused: &[(String, String, f32)], key: &str) -> usize {

--- a/crates/kin-core/src/env_registry_generated.rs
+++ b/crates/kin-core/src/env_registry_generated.rs
@@ -99,6 +99,8 @@ pub const GENERATED_KNOBS: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_LOCATE_ENTITY_DOMINANT_RESOLVE_WEIGHT", kind: Kind::NonNegF32, default: "8.0", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: entity dominant resolve weight" },
     EnvVarSpec { name: "KIN_LOCATE_ENTITY_DOMINANT_RRF_THRESHOLD", kind: Kind::Usize, default: "3", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: entity dominant rrf threshold" },
     EnvVarSpec { name: "KIN_LOCATE_ENTITY_FUSION", kind: Kind::Bool, default: "context-dependent", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: entity fusion" },
+    EnvVarSpec { name: "KIN_LOCATE_ENTITY_SEMANTIC_PRIMACY_HEADROOM", kind: Kind::NonNegF32, default: "0.9", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: entity semantic primacy headroom" },
+    EnvVarSpec { name: "KIN_LOCATE_ENTITY_SEMANTIC_PRIMACY_WEIGHT", kind: Kind::NonNegF32, default: "0.0", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: entity semantic primacy weight" },
     EnvVarSpec { name: "KIN_LOCATE_ENTITY_SURFACE_PENALTY", kind: Kind::NonNegF32, default: "0.3", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: entity surface penalty" },
     EnvVarSpec { name: "KIN_LOCATE_EXPLAIN_DEF_FLOOR_PCT", kind: Kind::NonNegF32, default: "0.0", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: explain def floor pct" },
     EnvVarSpec { name: "KIN_LOCATE_EXPLAIN_DEF_TOPK", kind: Kind::Usize, default: "0", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: explain def topk" },

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -3,7 +3,7 @@
 
 # Kin environment variables
 
-This is the authoritative list of supported `KIN_*` environment variables (526 total, 356 correctness-relevant), generated from the central registry in `kin-core`.
+This is the authoritative list of supported `KIN_*` environment variables (528 total, 358 correctness-relevant), generated from the central registry in `kin-core`.
 
 At CLI and daemon startup Kin validates this surface (`KIN_ENV_VALIDATION`, default `warn`):
 
@@ -401,6 +401,8 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_LOCATE_ENTITY_DOMINANT_RESOLVE_WEIGHT` | float>=0 | 8.0 | correctness | locate tuning knob: entity dominant resolve weight |
 | `KIN_LOCATE_ENTITY_DOMINANT_RRF_THRESHOLD` | usize | 3 | correctness | locate tuning knob: entity dominant rrf threshold |
 | `KIN_LOCATE_ENTITY_FUSION` | bool | context-dependent | correctness | locate tuning knob: entity fusion |
+| `KIN_LOCATE_ENTITY_SEMANTIC_PRIMACY_HEADROOM` | float>=0 | 0.9 | correctness | locate tuning knob: entity semantic primacy headroom |
+| `KIN_LOCATE_ENTITY_SEMANTIC_PRIMACY_WEIGHT` | float>=0 | 0.0 | correctness | locate tuning knob: entity semantic primacy weight |
 | `KIN_LOCATE_ENTITY_SURFACE_PENALTY` | float>=0 | 0.3 | correctness | locate tuning knob: entity surface penalty |
 | `KIN_LOCATE_EXPLAIN_DEF_FLOOR_PCT` | float>=0 | 0.0 | correctness | locate tuning knob: explain def floor pct |
 | `KIN_LOCATE_EXPLAIN_DEF_TOPK` | usize | 0 | correctness | locate tuning knob: explain def topk |


### PR DESCRIPTION
`locate`'s rescue for an embedding-only answer is dark on the profile users run. This carries it into the path they actually take, bounded so it cannot outrank an anchored file, and it ships OFF until an A/B earns it a default.

## Step zero, because a term removed on evidence must not be restored blind

Nothing removed it on evidence. `git log -S entity_fusion_default` returns three commits and `git log -S reciprocal_rank_fusion_entities` returns one, and that is the whole record.

The flip plan the call site cites is real and recoverable at `git show ba08f07e3:crates/kin-cli/docs/locate-entity-fusion-flip-plan.md`. It says "Status: **default OFF**, experiment wired, awaiting post-freeze A/B. Flipping the default is **out of scope** for the implementing lane", and it sets a four-clause gate: top-entity MRR beats run-to-run variance, symbol and line F1 hold or improve, file F1 does not regress, no passing gold drops to zero. `7ecefffaf` deleted it on 2026-06-11 in a three-file docs sweep that argues nothing about fusion.

kin#160 turned entity fusion on for real users on 2026-07-02 under a section headed "Validation (prepared, not run)". kin#841 widened it to accuracy-v2 on 2026-08-15 citing a 20-of-23 probe result, and the report it cites says in its own section 3 that the number was measured with entity fusion off.

The flip plan never mentions the semantic-primacy term (`grep -c -i primacy` returns 0 against a control that returns 34). So dropping it was not a decision anyone made. Restoring it corrects an omission. It still has to earn its default below.

## The defect

`accuracy-v2` sets `entity_fusion_default`, so the selector takes `entity_granular_fused_files`, which fuses through `reciprocal_rank_fusion_entities`. That combine is `1/(60 + rank + 1) + raw_norm * 0.05 + (signals - 1) * 0.02`. A key two arms found carries two rank terms plus the cross-signal bonus; a key one arm found carries one. About 0.034 apart at a middling rank, and semantic strength cannot buy it back. Measured on the demo's VS Code store, a file only the vector arm found scores about half a file both arms found: median 0.00552 over 119 files against 0.01016 over 335.

## The change

`apply_entity_semantic_primacy` adds `weight / (k + rank + 1)` to any key the embedding list ranked, the same shape as `reciprocal_rank_fusion_weighted`'s term, reading that function's own `KIN_LOCATE_SEMANTIC_PRIMACY_K` so one sweep moves both fusers. Index positions survive the re-keying: `entity_granular_fused_files` enumerates `ranked_lists` in order, so index 9 is the embedding list in both.

The graph-neighbourhood tiebreaker stays out, and the fuser's doc comment now says why for that term alone. It counts appearances across indices {1, 2, 4, 6}, which stay path-keyed here while 7 and 9 are entity-keyed, so the count would span two key spaces. One term is portable, one is not, and the old comment condemned both.

**The bound.** A key may consume at most `KIN_LOCATE_ENTITY_SEMANTIC_PRIMACY_HEADROOM` (0.9) of its gap to the unlifted top score. A capped key lands at `top * h + score * (1 - h)`, strictly below `top` for every `h < 1` and every `score < top`, and a key already at the top has no gap and takes no lift, so its score stays bit-identical. Fusion rank one cannot move, and since the projection gives each file its best entity's score, the top file out of fusion cannot move either.

Capping the gap rather than clamping to a fixed ceiling is what keeps the cap order-preserving. `top * h + score * (1 - h)` is strictly increasing in `score`, so two capped keys cannot collapse onto one value and be reordered by the key tiebreak.

**The weight is not monotone, and the A/B is designed around that.** Once a key's lift exceeds its headroom the cap binds, and capped keys keep their unlifted order, so a large enough weight caps the whole embedding set and returns it to the order it already had. Simulated over this exact combine on a fourteen-key fixture, the rank of an embedding-only key at embedding rank 1:

| weight | h=0.5 | h=0.9 | h=0.99 |
| -- | -- | -- | -- |
| 0.10 | 12 | 12 | 12 |
| 0.25 | 11 | 11 | 11 |
| 0.50 | 8 | 7 | 7 |
| 0.75 | 12 | **5** | **5** |
| 1.00 | 12 | 7 | 6 |
| 2.00 | 12 | 12 | 12 |
| 5.00 | 12 | 12 | 12 |
| 20.0 | 12 | 12 | 12 |

Unlifted rank is 12. Rank one holds in all twenty-four cells. The sweep reads a peak; it does not push the weight up expecting more effect.

## Pre-registered ship rule, written before any measurement

This is kin#1389's rule unchanged, as kin#1412 was graded against, plus this ticket's own clause. Every clause, or nothing ships.

1. rank one unchanged on all seven prose questions;
2. all twenty-two identifier lookups byte-identical on the entity ranking;
3. `CodeEditorWidget` holds entity rank 5 on VS Code, inside the five focals;
4. React's scheduling question keeps 3 of 4;
5. hiredis P2 keeps `redisReaderGetReply` on the ranking;
6. no single-letter generic in ripgrep's rg-walk focals;
7. **new:** `cursorTypeOperations.ts` enters the fifty-file list on VS Code.

If no arm passes every clause, this PR closes with the numbers and the ticket says why. That outcome is fine and it has already happened once on this seam.

Clause 1 is true by construction at the fusion boundary and only there. The lexical parity floor spends its budget ordered by parity and then by pre-floor score, and this change moves pre-floor scores in the tail, so which twelve files take the floor can change. Only the A/B settles clauses 1 through 7 in the answer.

## Honest expectation, recorded before measuring

The arithmetic says clause 7 is the one at risk. The lift differentiates by embedding rank, so it barely separates two keys that are both in the embedding list at nearby ranks; it separates strongly against keys the embedding arm never ranked. `cursorTypeOperations.ts` sits at embedding rank 124 of 541 and needs to pass roughly 205 files, most of which the embedding arm also ranked. The post-fusion pipeline is multiplicative, so a fusion-score gain does not map linearly onto the pre-floor rank, which is why this is measured rather than predicted.

## Gates

The box is under a compute quiet for an overnight benchmark, so nothing was built or tested locally. `rustfmt --edition 2021` ran and reported clean, which is a parse, not a build. `python3 scripts/gen_env_registry.py` regenerated the knob registry and `docs/env-vars.md` was updated to match by hand, so `env_doc_matches_registry` is the check to read. Hosted CI is the gate of record for everything else here.

Two things wait for the lift and this stays a draft until both are done:

- the falsification of each new test, by breaking the behaviour it guards and reading red. Three mutants: default the weight to a lifting value and `entity_fusion_semantic_primacy_ships_dark` must go red; drop the `.min(allowed)` cap and `entity_fusion_semantic_primacy_cannot_take_rank_one` must go red on rank one; skip the lift for keys the embedding arm ranked deeper than rank 0 and `entity_fusion_semantic_primacy_rescues_an_embedding_only_key` must go red.
- the seven-question A/B against the pre-registered rule.

FIR-3123. Splits out of FIR-3118.

## A second commit, and why

`Check & Test` is a no-op placeholder on a pull request here; its whole log is 2,456 bytes and its only step prints that it runs in the merge queue and on every main commit. The fast gate does the real grading and it runs `cargo nextest`, which gives every test its own process. `kin-core/src/test_env.rs` says in its own module doc that a shared-process `cargo test` is the authority when the two runners disagree, because nextest makes env-leak defects structurally invisible. So a new test that reads process-global env state another test set is graded on a PR only by the runner that cannot see it, and by the runner that can only after it lands.

`reciprocal_rank_fusion_entities` reads four knobs. The guard pinned the three this term introduces or reuses and left `KIN_LOCATE_RRF_RAW_WEIGHT` open. No test sets it today, which is exactly the state that makes the next one cheap to get wrong. The second commit pins all four.

## What CI actually proved

46 check runs on the first commit and 45 on the second, `total_count` equal to the array length both times so nothing paged, zero failures. Green alone would not be evidence that a new test ran, so the shard logs were read by test name: `rescues_an_embedding_only_key` PASS on shard 1, `ships_dark` PASS on shard 2, `cannot_take_rank_one` and `the_shipped_profile_fuses_at_entity_granularity` PASS on shard 3. Each asserts its baseline green before it measures an arm.
