### PR TITLE
Resume a startup rollout lease its holder can no longer hold

### DIFF
--- a/crates/kin-daemon/src/bin/kin-daemon.rs
+++ b/crates/kin-daemon/src/bin/kin-daemon.rs
@@ -319,9 +319,11 @@ fn create_state(
                     Ok(kin_daemon::publication_lease::RuntimeSpineAuthority::Completed(
                         evidence,
                     )) => runtime.block_on(state.adopt_hosted_spine_rollout_fence(evidence)),
-                    Ok(kin_daemon::publication_lease::RuntimeSpineAuthority::RolloutActive) => {
-                        Err("a hosted rollout remains active; semantic readiness stays closed while the authenticated publication-control API resumes or replaces it".to_string())
-                    }
+                    Ok(kin_daemon::publication_lease::RuntimeSpineAuthority::RolloutActive(
+                        blocking,
+                    )) => Err(format!(
+                        "a hosted {blocking}; semantic readiness stays closed while the authenticated publication-control API resumes or replaces it"
+                    )),
                     Err(error) => Err(error.to_string()),
                 }
             };

--- a/crates/kin-daemon/src/publication_lease.rs
+++ b/crates/kin-daemon/src/publication_lease.rs
@@ -344,10 +344,58 @@ pub enum RolloutReleaseDisposition {
     CompletedExact,
 }
 
+/// The rollout lease occupying a publication-control record, as an operator
+/// needs to read it. Whether the lease is still live decides what to do about
+/// it: a live lease has a holder that will finish or lapse on its own, while an
+/// expired one has no holder left to wait for and needs the release route.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BlockingRolloutLease {
+    pub holder: String,
+    pub fence: u64,
+    pub expires_at: DateTime<Utc>,
+    pub expired: bool,
+}
+
+impl BlockingRolloutLease {
+    /// Read a rollout lease as of `now`. Every path that refuses because of a
+    /// rollout builds its refusal from here, so none of them can drift into
+    /// calling a lapsed lease active.
+    pub(crate) fn observe(active: &ActivePublicationLease, now: DateTime<Utc>) -> Self {
+        Self {
+            holder: active.holder.clone(),
+            fence: active.fence,
+            expires_at: active.expires_at,
+            expired: active.expires_at <= now,
+        }
+    }
+}
+
+impl std::fmt::Display for BlockingRolloutLease {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.expired {
+            write!(
+                formatter,
+                "rollout fence {} held by {}, whose lease expired at {} and was never released",
+                self.fence,
+                self.holder,
+                self.expires_at.to_rfc3339()
+            )
+        } else {
+            write!(
+                formatter,
+                "rollout fence {} held by {} until {}",
+                self.fence,
+                self.holder,
+                self.expires_at.to_rfc3339()
+            )
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RuntimeSpineAuthority {
     Completed(kin_spine::SpineRolloutFenceEvidence),
-    RolloutActive,
+    RolloutActive(BlockingRolloutLease),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -653,9 +701,13 @@ impl PublicationControl {
             .as_ref()
             .filter(|active| active.kind == LeaseKind::Rollout)
         {
+            // Say whether the lease is still live. "Remains active" about a
+            // lease that lapsed hours ago sends an operator to wait on a holder
+            // that no longer exists.
             return Err(PublicationControlError::Admission(format!(
-                "scope {} rollout fence {} remains active and must be released or recovered before reader admission",
-                self.scope, active.fence
+                "scope {} is blocked by a {} and must be released or recovered before reader admission",
+                self.scope,
+                BlockingRolloutLease::observe(active, now)
             )));
         }
         validate_reader_admission(&record.reader, now)?;
@@ -706,13 +758,20 @@ impl PublicationControl {
     ) -> Result<RuntimeSpineAuthority, PublicationControlError> {
         let stored = self.load_required()?;
         self.validate_record(&stored.record)?;
-        if stored
+        let now = self.clock.now();
+        if let Some(active) = stored
             .record
             .active_lease
             .as_ref()
-            .is_some_and(|active| active.kind == LeaseKind::Rollout)
+            .filter(|active| active.kind == LeaseKind::Rollout)
         {
-            return Ok(RuntimeSpineAuthority::RolloutActive);
+            // Report the lease rather than the bare fact that one exists. A
+            // rollout whose lease lapsed hours ago has nobody left to wait for,
+            // and an operator told only that a rollout "remains active" waits
+            // for a holder that is already gone.
+            return Ok(RuntimeSpineAuthority::RolloutActive(
+                BlockingRolloutLease::observe(active, now),
+            ));
         }
         require_complete_record_authority_fence(&stored.record)?;
         record_spine_rollout_fence_evidence(&stored.record)?
@@ -738,12 +797,25 @@ impl PublicationControl {
     /// rollout must use the authenticated rollout API. The only existing-record
     /// recovery performed here is resuming this exact startup lease after a
     /// crash or retry.
+    ///
+    /// A crash mid-bootstrap is the one case where the next image differs from
+    /// the recorded reader. The failed image wrote its own identity into the
+    /// record before it died, so requiring an identity match would leave the
+    /// record owned forever by a daemon that no longer exists, and no
+    /// replacement image could ever start. An expired startup lease therefore
+    /// resumes on the surviving startup identifiers alone. Nothing is taken on
+    /// trust: the takeover runs through `acquire_rollout`, which refuses while
+    /// the lease is still live, raises the fence so the previous holder's proof
+    /// is stale, and re-fences every graph object; completion then re-admits
+    /// the reader under the running image. A completed record has no active
+    /// lease at all, so this never reopens a fleet that already settled.
     pub fn bootstrap_runtime_if_absent(
         &self,
     ) -> Result<Option<ActivePublicationLease>, PublicationControlError> {
         let existing = self.store.load()?;
         if let Some(stored) = existing.as_ref() {
             self.validate_record(&stored.record)?;
+            let now = self.clock.now();
             let resumes_startup = stored.record.active_lease.as_ref().is_some_and(|active| {
                 active.kind == LeaseKind::Rollout
                     && active.holder == STARTUP_BOOTSTRAP_HOLDER
@@ -751,7 +823,8 @@ impl PublicationControl {
                     && active.target_repositories == self.fleet_repositories
                     && active.previous_repositories == self.fleet_repositories
                     && active.fence_repositories == self.fleet_repositories
-                    && stored.record.reader.identity == self.runtime_reader_identity
+                    && (stored.record.reader.identity == self.runtime_reader_identity
+                        || active.expires_at <= now)
             });
             if !resumes_startup {
                 let _ = self.refresh_runtime_admission(kin_db::GraphSnapshot::CURRENT_VERSION);
@@ -4811,6 +4884,162 @@ mod tests {
         assert!(
             refusal.to_string().contains(READER_A) && refusal.to_string().contains(READER_B),
             "{refusal}"
+        );
+    }
+
+    /// The hosted cutover of 2026-09-03 failed here. A daemon image died
+    /// mid-bootstrap on 2026-09-02 holding the startup rollout lease, and for
+    /// the next twenty hours every replacement image was refused by that lease
+    /// even though it had expired five minutes after it was taken. Requiring
+    /// the recorded reader identity to match made the record permanently owned
+    /// by a daemon that no longer existed, because a replacement image never
+    /// carries the digest of the one it replaces.
+    #[test]
+    fn a_dead_startup_bootstrap_lease_does_not_brick_the_next_image() {
+        let store = Arc::new(InMemoryPublicationControlStore::default());
+        let clock = Arc::new(ManualClock::new());
+
+        let crashed = control(Arc::clone(&store), Arc::clone(&clock), READER_A);
+        let stranded = crashed
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("first runtime must bootstrap");
+        assert_eq!(stranded.holder, STARTUP_BOOTSTRAP_HOLDER);
+        let abandoned = crashed.status().unwrap();
+        assert_eq!(abandoned.reader.identity, READER_A);
+        assert!(abandoned.active_lease.is_some());
+
+        // The holder is gone, so nothing renews the lease.
+        clock.advance(HOSTED_ROLLOUT_LEASE_SECONDS as i64 + 1);
+
+        let replacement = control(Arc::clone(&store), Arc::clone(&clock), READER_B);
+        match replacement.runtime_spine_authority().unwrap() {
+            RuntimeSpineAuthority::RolloutActive(blocking) => {
+                assert!(blocking.expired, "{blocking}");
+                assert_eq!(blocking.fence, stranded.fence);
+                assert!(
+                    blocking.to_string().contains("never released"),
+                    "{blocking}"
+                );
+            }
+            other => panic!("the dead rollout must be reported: {other:?}"),
+        }
+
+        let resumed = replacement
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("an expired startup lease must be takeover-eligible");
+        assert!(
+            resumed.fence > stranded.fence,
+            "the takeover must raise the fence past {}",
+            stranded.fence
+        );
+
+        // Raising the fence is what makes the takeover safe. A predecessor that
+        // wakes up cannot mutate anything under its old proof.
+        let stale = crashed.assert_rollout_lease(&proof(&stranded)).unwrap_err();
+        assert!(
+            stale.to_string().contains("does not identify active"),
+            "{stale}"
+        );
+
+        release(&replacement, &resumed);
+        let settled = replacement.status().unwrap();
+        assert!(settled.active_lease.is_none());
+        assert_eq!(settled.reader.identity, READER_B);
+        replacement
+            .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
+            .unwrap();
+
+        // The image that crashed is now the one refused, which is the direction
+        // this fence must point.
+        let displaced = crashed
+            .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
+            .unwrap_err();
+        assert!(displaced.to_string().contains(READER_B), "{displaced}");
+    }
+
+    /// The read path and `acquire_rollout` must agree about what a live lease
+    /// means. Expiry is the only thing that makes a startup lease recoverable;
+    /// while it runs, a foreign image waits exactly as it did before.
+    #[test]
+    fn a_live_startup_bootstrap_lease_still_refuses_a_foreign_image() {
+        let store = Arc::new(InMemoryPublicationControlStore::default());
+        let clock = Arc::new(ManualClock::new());
+        let running = control(Arc::clone(&store), Arc::clone(&clock), READER_A);
+        let pending = running
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("first runtime must bootstrap");
+        let before = running.status().unwrap();
+
+        // Late in the window but still held: the holder may still be fencing.
+        clock.advance(HOSTED_ROLLOUT_LEASE_SECONDS as i64 - 60);
+
+        let intruder = control(Arc::clone(&store), Arc::clone(&clock), READER_B);
+        match intruder.runtime_spine_authority().unwrap() {
+            RuntimeSpineAuthority::RolloutActive(blocking) => {
+                assert!(!blocking.expired, "{blocking}");
+            }
+            other => panic!("the live rollout must be reported: {other:?}"),
+        }
+        assert!(intruder.bootstrap_runtime_if_absent().unwrap().is_none());
+        assert_eq!(intruder.status().unwrap(), before);
+
+        // The holder still owns its lease and finishes exactly as it would have.
+        release(&running, &pending);
+        let settled = running.status().unwrap();
+        assert!(settled.active_lease.is_none());
+        assert_eq!(settled.reader.identity, READER_A);
+    }
+
+    /// Startup recovery is for the daemon's own bootstrap lease only. An
+    /// operator's rollout stays the operator's to resume or replace, but the
+    /// refusal still has to say the lease died rather than calling it active.
+    #[test]
+    fn an_expired_operator_rollout_reads_as_expired_and_is_left_alone() {
+        let store = Arc::new(InMemoryPublicationControlStore::default());
+        let clock = Arc::new(ManualClock::new());
+        let daemon = control(Arc::clone(&store), Arc::clone(&clock), READER_A);
+        let bootstrap = daemon
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("first runtime must bootstrap");
+        release(&daemon, &bootstrap);
+
+        let operator = daemon
+            .acquire_rollout(rollout_request("deploy", "operator-rollout", None))
+            .unwrap();
+        match daemon.runtime_spine_authority().unwrap() {
+            RuntimeSpineAuthority::RolloutActive(blocking) => {
+                assert!(!blocking.expired, "{blocking}");
+                assert_eq!(blocking.holder, "deploy");
+            }
+            other => panic!("the operator rollout must be reported: {other:?}"),
+        }
+
+        clock.advance(MAX_ROLLOUT_LEASE_SECONDS as i64 + 1);
+        match daemon.runtime_spine_authority().unwrap() {
+            RuntimeSpineAuthority::RolloutActive(blocking) => {
+                assert!(blocking.expired, "{blocking}");
+                assert!(
+                    blocking.to_string().contains("never released"),
+                    "{blocking}"
+                );
+            }
+            other => panic!("the dead operator rollout must be reported: {other:?}"),
+        }
+        let refusal = daemon
+            .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
+            .unwrap_err();
+        assert!(refusal.to_string().contains("never released"), "{refusal}");
+
+        let unchanged = daemon.status().unwrap();
+        assert!(daemon.bootstrap_runtime_if_absent().unwrap().is_none());
+        assert_eq!(daemon.status().unwrap(), unchanged);
+        assert_eq!(
+            daemon.status().unwrap().active_lease.unwrap().fence,
+            operator.fence
         );
     }
 

--- a/crates/kin-daemon/src/publication_lease.rs
+++ b/crates/kin-daemon/src/publication_lease.rs
@@ -5043,6 +5043,48 @@ mod tests {
         );
     }
 
+    /// The holder is what separates the daemon's own bootstrap from an
+    /// operator's rollout, and this is the case that makes it carry that weight
+    /// alone. The test above differs from a startup lease in BOTH the holder and
+    /// the request id, so it cannot see the holder clause at all: the request id
+    /// refuses the input one step earlier, and deleting the holder check leaves
+    /// it green. An operator picks its own request id and nothing stops it
+    /// choosing the startup one, which is precisely why the holder is checked.
+    #[test]
+    fn an_operator_rollout_reusing_the_startup_request_id_is_still_not_startup() {
+        let store = Arc::new(InMemoryPublicationControlStore::default());
+        let clock = Arc::new(ManualClock::new());
+        let daemon = control(Arc::clone(&store), Arc::clone(&clock), READER_A);
+        let bootstrap = daemon
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("first runtime must bootstrap");
+        release(&daemon, &bootstrap);
+
+        // Every startup identifier matches except the holder.
+        let operator = daemon
+            .acquire_rollout(rollout_request(
+                "deploy",
+                STARTUP_BOOTSTRAP_REQUEST_ID,
+                None,
+            ))
+            .unwrap();
+        assert_eq!(operator.request_id, STARTUP_BOOTSTRAP_REQUEST_ID);
+        assert_ne!(operator.holder, STARTUP_BOOTSTRAP_HOLDER);
+        clock.advance(MAX_ROLLOUT_LEASE_SECONDS as i64 + 1);
+
+        let unchanged = daemon.status().unwrap();
+        assert!(
+            daemon.bootstrap_runtime_if_absent().unwrap().is_none(),
+            "startup recovery must not adopt a lease an operator holds"
+        );
+        assert_eq!(daemon.status().unwrap(), unchanged);
+        assert_eq!(
+            daemon.status().unwrap().active_lease.unwrap().fence,
+            operator.fence
+        );
+    }
+
     #[test]
     fn duplicate_rollout_retry_cannot_run_a_second_generation_fence() {
         let store = Arc::new(InMemoryPublicationControlStore::default());

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -6501,11 +6501,10 @@ impl DaemonState {
                 .map_err(|error| format!("load hosted spine runtime authority: {error}"))?
             {
                 crate::publication_lease::RuntimeSpineAuthority::Completed(evidence) => evidence,
-                crate::publication_lease::RuntimeSpineAuthority::RolloutActive => {
-                    return Err(
-                        "hosted spine rollout remains active; cached authority is not readable"
-                            .to_string(),
-                    )
+                crate::publication_lease::RuntimeSpineAuthority::RolloutActive(blocking) => {
+                    return Err(format!(
+                        "hosted spine {blocking}; cached authority is not readable"
+                    ))
                 }
             };
             let expected = self.expected_hosted_spine_rollout_fence()?;


### PR DESCRIPTION
## What this fixes

A hosted daemon that dies mid-bootstrap leaves the publication-control record holding its startup rollout lease, with its own image digest recorded as the admitted reader. `bootstrap_runtime_if_absent` required that digest to equal the running daemon's before it would resume the lease. A replacement image never carries the digest of the one it replaces, so the record stayed owned by a daemon that no longer existed, and no later image could open readiness.

`runtime_spine_authority` then reported that lease as `RolloutActive` without ever consulting `expires_at`, while `acquire_rollout` had always treated an expired lease as takeover-eligible. The read path and the write path disagreed about what a live lease is.

## The evidence

Production's record, `gs://kin-ecosystem-kin-graphs-dev/v2/.kin-graph-publication-control.json`, read 2026-09-03T02:50Z:

```
active_lease.kind         rollout
active_lease.holder       kin-daemon-startup-bootstrap
active_lease.fence        1
active_lease.acquired_at  2026-09-02T06:20:46.739774451Z
active_lease.expires_at   2026-09-02T06:25:46.739774451Z
reader.identity           sha256:fcedf4f9...  (the v0.6.3 daemon)
```

That lease expired twenty hours before the cutover attempt that it blocked. kinlab's Promote To Prod run 33706197746 rolled the daemon back at 02:33Z; production served 502 from 02:20:32 to 02:33:47.

## The change

An expired startup lease now resumes on the surviving startup identifiers alone: holder, request id and the three repository lists. Nothing is taken on trust. The takeover runs through `acquire_rollout`, which refuses while the lease is still live, raises the fence so the previous holder's proof is stale, and re-fences every graph object; `complete_hosted_startup_rollout` then re-admits the reader under the running image. A completed record carries no active lease at all, so a settled fleet is never reopened, and `startup_bootstrap_never_auto_admits_over_an_existing_reader` still holds.

Every path that refuses because of a rollout now reports whether the lease is live or lapsed, through one shared `BlockingRolloutLease::observe`. Telling an operator that a rollout "remains active" when it died hours ago sends them to wait for a holder that is already gone. That message cost this fleet an attempt.

## Deployment consequence

The recovery route the old message named, `POST /authority/publication-control/rollout/release`, is not reachable in the deployed shape: the failing startup probe kills the process that would serve it. So this cannot be worked around in production. It has to ship inside the image before any promotion can pass, which makes it a v0.6.6 item, alongside the stock-Mac init fix. The hosted cutover then rides that release rather than a production control-plane operation on an unrehearsed path.

## Tests

Three cases in `publication_lease.rs`:

- `a_dead_startup_bootstrap_lease_does_not_brick_the_next_image` reproduces the production record exactly, with a foreign reader identity, and asserts the takeover raises the fence, staleness of the predecessor's proof, and reader re-admission under the new image.
- `a_live_startup_bootstrap_lease_still_refuses_a_foreign_image` is the negative control: expiry is the only thing that makes a startup lease recoverable, and the record is untouched while the lease runs.
- `an_expired_operator_rollout_reads_as_expired_and_is_left_alone` holds the boundary. An operator's rollout stays the operator's to resume or replace, but the refusal now says the lease died.

Not yet falsified locally: this box is under a compute quiet for an overnight bench round, so no builder was taken. `rustfmt` parses and formats clean. The falsification arm runs after the quiet lifts and the result is posted here. Draft until then.
