### PR TITLE
Stop a full runner disk in Code Coverage from reddening CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2611,6 +2611,24 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Measured across eleven consecutive main pushes on 2026-09-03: the
+      # disk, not the code, is what ends this job. A hosted ubuntu runner carries tens of gigabytes of Android, .NET,
+      # GHC and CodeQL toolchains that no kin build touches, and tarpaulin's
+      # instrumented debug build of the whole workspace does not fit in what is
+      # left. The two deaths are one cause. `rust-lld` mmaps its output, so a
+      # write with no blocks behind it arrives as `ld terminated with signal 7
+      # [Bus error]` and reads as a compiler crash; or the runner's worker hits
+      # `No space left on device` writing its own log and takes the job with
+      # it. The `df` on both sides is what lets the next reader see a near miss
+      # instead of inferring one from a linker signal.
+      #
+      # `continue-on-error` because a reclaim that does not apply on some future
+      # runner image is not a reason to stop a build. The script already exits 0
+      # on every path it can reach; this covers the paths it cannot.
+      - name: Free runner disk
+        continue-on-error: true
+        run: bash scripts/ci-free-disk.sh
+
       - name: Install Rust toolchain
         uses: ./.github/actions/rust-toolchain
 
@@ -2641,16 +2659,58 @@ jobs:
         with:
           tool: cargo-tarpaulin
 
+      # The exit-0 contract here is unchanged from main. Tarpaulin is
+      # non-blocking for the public alpha and this change neither hardens nor
+      # softens that; hardening it belongs after a run proves tarpaulin can
+      # finish, which none of the 39 sampled runs did. What is new is that a
+      # failure now says WHICH failure it was. A tarpaulin nonzero next to a
+      # near-empty disk is a runner infrastructure failure and says so by name,
+      # rc=124 is the 30m bound rather than a defect, and anything else keeps
+      # the alpha warning.
+      #
+      # This can only speak when the step itself survives. When the disk kills
+      # the runner's worker process instead, no step-level line is ever written,
+      # which is why freeing the disk above is the fix and this is the report.
       - name: Run coverage
         run: |
-          if ! timeout 30m cargo tarpaulin --out xml --out stdout; then
-            echo "::warning::Tarpaulin is currently non-blocking in CI for the public alpha."
+          # Two GiB. Below this the next link or report write is what fails, so
+          # a tarpaulin nonzero here is the disk and not the code.
+          disk_floor_kb=2097152
+          rc=0
+          timeout 30m cargo tarpaulin --out xml --out stdout || rc=$?
+          free_kb="$(df -Pk . | awk 'NR == 2 { print $4 }')"
+          if [ -z "$free_kb" ]; then
+            echo "::warning::could not read free disk after the coverage run"
+            free_kb=-1
+          else
+            awk -v k="$free_kb" 'BEGIN { printf "coverage: %.1f GiB free after the run\n", k / 1048576 }'
+          fi
+          if [ "$rc" -ne 0 ]; then
+            if [ "$free_kb" -ge 0 ] && [ "$free_kb" -lt "$disk_floor_kb" ]; then
+              echo "::error::runner out of disk: tarpaulin exited $rc with under 2 GiB free. This is a runner infrastructure failure, not a coverage regression."
+            elif [ "$rc" -eq 124 ]; then
+              echo "::warning::Tarpaulin exceeded its 30m bound (rc=124) with disk to spare, so the bound is what stopped it."
+            else
+              echo "::warning::Tarpaulin is currently non-blocking in CI for the public alpha (rc=$rc)."
+            fi
           fi
 
+      # `continue-on-error` here so an upload that fails concludes with a named
+      # cause rather than leaving a null step behind a dead job.
+      #
+      # `disable_search` because without it this step is not merely useless when
+      # tarpaulin wrote nothing, it is wrong. Read on the green run at
+      # c99d9065a: `not_found_files: ["cobertura.xml"]`, and then the action
+      # walked the tree, decided eleven paths whose names happen to contain
+      # "coverage" were coverage files, and uploaded those. Two were fingerprint
+      # JSON out of target/debug and three were Rust sources. The setting
+      # confines this step to the file it was pointed at.
       - name: Upload coverage reports to Codecov
+        continue-on-error: true
         uses: codecov/codecov-action@v7
         with:
           files: cobertura.xml
+          disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: firelock-ai/kin
           fail_ci_if_error: false

--- a/scripts/ci-free-disk.sh
+++ b/scripts/ci-free-disk.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Reclaim preinstalled runner disk before a build that will not otherwise fit.
+#
+# A GitHub-hosted ubuntu runner ships tens of gigabytes of toolchains for
+# languages this repository does not build: the Android SDK and NDK, .NET, GHC
+# and ghcup, the CodeQL bundles, Swift, PowerShell, and a set of preloaded
+# Docker images. None of it is on any kin build path, and none of it is worth
+# the two ways a full disk ends a job.
+#
+# Both ways are silent about their cause. `rust-lld` mmaps its output file, so
+# an allocation that fails after `ftruncate` succeeded arrives as SIGBUS during
+# the link and reads as a compiler crash: "ld terminated with signal 7 [Bus
+# error]". If the disk instead runs out while the runner's own worker is
+# writing its diagnostic log, that worker dies with an unhandled
+# `System.IO.IOException: No space left on device` and the job is marked failed
+# with no failed step in it.
+#
+# Printing `df` on both sides is the point as much as the removal is. A job
+# that fills the disk again should say by how much it missed, in its own log,
+# rather than leave the next reader to infer a cause from a linker signal.
+#
+# This never fails its caller. A removal that does not apply on some future
+# image is not a reason to stop a build, and the `df` line after the sweep is
+# what says whether the space actually arrived.
+set -uo pipefail
+
+# Refuse to touch a machine the fleet owns. `runs-on` for the callers here is
+# `${{ vars.KIN_HEAVY_RUNNER || 'ubuntu-latest' }}`, so setting that variable to
+# a self-hosted label would otherwise point these removals at a persistent host
+# and delete another lane's toolchains along with the sweep's own targets.
+if [ "${RUNNER_ENVIRONMENT:-}" != "github-hosted" ]; then
+  echo "ci-free-disk: RUNNER_ENVIRONMENT=${RUNNER_ENVIRONMENT:-unset} is not github-hosted; nothing removed"
+  exit 0
+fi
+
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "ci-free-disk: $(uname -s) is not Linux; nothing removed"
+  exit 0
+fi
+
+# Bound every removal. The Android tree alone is millions of small files, and a
+# stalled unlink on a degraded runner disk must cost a bounded number of
+# seconds rather than the job's whole budget.
+REMOVE_BOUND=${CI_FREE_DISK_REMOVE_BOUND:-120}
+
+avail_kb() {
+  df -Pk / | awk 'NR == 2 { print $4 }'
+}
+
+before_kb="$(avail_kb)"
+echo "ci-free-disk: before"
+df -h /
+
+# Ordered by what these images actually carry, largest first, so the sweep has
+# already paid for itself if a later entry is missing on a newer image.
+for path in \
+  /usr/local/lib/android \
+  /opt/hostedtoolcache/CodeQL \
+  /usr/share/dotnet \
+  /opt/ghc \
+  /usr/local/.ghcup \
+  /usr/share/swift \
+  /usr/local/share/powershell \
+  /usr/local/share/chromium \
+  /usr/local/lib/node_modules \
+  /opt/az \
+  /usr/local/share/boost; do
+  [ -e "$path" ] || continue
+  timeout "$REMOVE_BOUND" sudo rm -rf "$path"
+  rc=$?
+  case "$rc" in
+    0) echo "ci-free-disk: removed $path" ;;
+    124) echo "ci-free-disk: $path did not finish removing within ${REMOVE_BOUND}s; continuing" ;;
+    *) echo "ci-free-disk: could not remove $path (rc=$rc); continuing" ;;
+  esac
+done
+
+# The preloaded images are never pulled by anything in this repository's CI.
+if command -v docker >/dev/null 2>&1; then
+  timeout "$REMOVE_BOUND" sudo docker image prune --all --force >/dev/null 2>&1
+  rc=$?
+  case "$rc" in
+    0) echo "ci-free-disk: pruned docker images" ;;
+    124) echo "ci-free-disk: docker prune did not finish within ${REMOVE_BOUND}s; continuing" ;;
+    *) echo "ci-free-disk: could not prune docker images (rc=$rc); continuing" ;;
+  esac
+fi
+
+after_kb="$(avail_kb)"
+echo "ci-free-disk: after"
+df -h /
+
+if [ -n "$before_kb" ] && [ -n "$after_kb" ]; then
+  awk -v b="$before_kb" -v a="$after_kb" \
+    'BEGIN { printf "ci-free-disk: reclaimed %.1f GiB (%.1f GiB free before, %.1f GiB free after)\n", (a - b) / 1048576, b / 1048576, a / 1048576 }'
+fi
+
+exit 0


### PR DESCRIPTION
The CI workflow has been concluding failure on main pushes since 00:49Z tonight, and Code Coverage is the only failing job. `scripts/select-release-candidate.py` admits only a sha whose CI push run concluded success, so a job that sits in no required context set and in no `needs` has been holding the release mint. This fixes the cause underneath rather than muting the job.

## What I measured

Read from the hosted runs, read-only. The job runs on `ubuntu-latest`: `KIN_HEAVY_RUNNER` is not set, and this repo has exactly one Actions variable, `RELEASE_FOLLOWUP_READY`. It uses `cargo tarpaulin`, caches the cargo registry only (~201 MB, hitting), and prints no disk figure anywhere.

Eleven consecutive main pushes, 00:30Z to 02:06Z on 2026-09-03:

| sha | Coverage job | CI run | Duration | How coverage ended |
|---|---|---|---|---|
| c99d9065a | success | success | 30m24s | `timeout 30m` killed tarpaulin mid-tests |
| ddc3e0621 | success | failure | 30m27s | `timeout 30m` killed tarpaulin mid-tests |
| 54dc78e3b | failure | failure | 29m54s | runner worker died, log unretrievable |
| beb3f6e25 | failure | failure | 12m17s | No space left on device |
| 51f338945 | success | failure | 9m40s | linker SIGBUS |
| df5ad34e2 | success | failure | 9m36s | linker SIGBUS |
| eb321488c | failure | failure | 9m37s | runner worker died, log unretrievable |
| c253cb7a8 | success | failure | 9m43s | linker SIGBUS |
| 6d717b1b5 | failure | failure | 24m53s | No space left on device |
| 081b10e6f | failure | failure | 10m26s | No space left on device |
| 64d3e75b9 | success | success | 10m20s | linker SIGBUS |

One cause, two deaths, and which one you get is luck about what touches the full disk first.

`rust-lld` mmaps its output file. When the filesystem has no blocks behind the reservation, the write to the mapped page arrives as SIGBUS, so job 100493975525 logged `collect2: fatal error: ld terminated with signal 7 [Bus error], core dumped`. That reads as a compiler crash and it is a full disk, and the step's pre-existing `if ! ...; then warn; fi` swallows it, so the job goes green.

## The runner kill lands outside every step

This is the evidence for the shape below, so it is worth being exact about.

Annotation on job **100488676687** (6d717b1b5, run 33703852042):

```
Unhandled exception. System.IO.IOException: No space left on device :
  '/home/runner/actions-runner/cached/2.336.0/_diag/Worker_20260903-012940-utc.log'
  at GitHub.Runner.Worker.Program.Main(String[] args)
```

The runner's own worker process dies writing its diagnostic log. Its step table: `Run coverage` concluded **success** at 01:54:25Z, `Upload coverage reports to Codecov` started at 01:54:25Z and **never concluded**, `Post Cache cargo registry` and `Post Run actions/checkout@v7` stayed **pending**, and the job was marked failed 8 seconds later at 01:54:33Z.

Job **100487792942** (eb321488c) and job **100479009104** (54dc78e3b) are the same shape one step earlier: `Run coverage` itself stuck `in_progress` with a null conclusion and every later step `pending`. Their log blobs return BlobNotFound.

So no step-level guard can cover this case. There is no step to attach one to; the process that would have run it is gone. Freeing the disk is the only thing that addresses it, and that is what this PR does.

## The finding I did not go looking for

This job has not produced a coverage report in any run I can read. Across 39 retrievable Code Coverage jobs on main pushes back to 0bc74670d, every log contains `not_found_files: ["cobertura.xml"]` and none contains a coverage percentage. Positive control on that negative: 36 of the same logs contain `cargo_tarpaulin`, so the search reaches the text.

Because `codecov-action` searches the tree when its named file is missing, it then decides eleven paths whose names merely contain "coverage" are coverage files and uploads those. From c99d9065a: `crates/kin-mcp/src/edge_coverage.rs`, `crates/kin-core/src/reference_coverage.rs`, `target/debug/.fingerprint/kin-cli-.../test-integration-test-locate_fresh_init_body_coverage.json`, and eight more. Codecov is being fed Rust sources and cargo fingerprint JSON.

## What this changes

**Free the disk.** A new `scripts/ci-free-disk.sh` runs right after checkout and removes the preinstalled trees no kin build touches, printing `df -h /` before and after plus a reclaimed-GiB line. It exits 0 doing nothing unless `RUNNER_ENVIRONMENT` is `github-hosted`, because `runs-on` here is `${{ vars.KIN_HEAVY_RUNNER || 'ubuntu-latest' }}` and pointing these removals at a self-hosted machine would delete another lane's toolchains. Every removal is bounded by `timeout` and every failure is named and skipped.

**Name the cause on the way out.** The coverage step keeps the exit-0 contract it already had, and now reports free disk after the run and distinguishes three endings: a nonzero next to a near-empty disk is a runner infrastructure failure and says so with `::error::runner out of disk`, `rc=124` is the 30m bound rather than a defect, and anything else keeps the alpha warning. If `df` is unreadable it says that instead of guessing.

**The job stays hard.** Nothing here carries `continue-on-error` at the job level, and `Run coverage` does not carry one either. If freeing the disk proves insufficient, the job goes red again, which is the outcome worth learning about loudly.

**`continue-on-error` on the two steps that report rather than decide:** the Codecov upload, so a failed upload concludes with a named cause instead of a null, and the reclaim, whose script already exits 0 on every path it can reach. The upload also gets `disable_search` so it stops scavenging.

## What I did not change, and why

I did not harden the tarpaulin wrapper. It is soft on main already and this PR neither hardens nor softens it. Hardening it belongs after a run proves tarpaulin can finish, which none of the 39 sampled runs did; doing it tonight would guarantee a red main rather than expose a regression.

I did not change the runner class. `ubuntu-latest` is not obviously too small; nothing had measured what this job needs because nothing printed `df`. After this lands the log carries the number, and the label change and its cost belong in a follow-up with that number in hand.

I did not raise `timeout 30m`. If freeing the disk lets the build finish, 30m may still cut the test run short, and that is the known next step. Leaving it also keeps the healthy path away from the 45-minute job cap, which matters here: `continue-on-error` absorbs failure but not cancellation, and a job timeout lands as cancellation.

## What this PR cannot prove

Code Coverage carries `if: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}` at `ci.yml:2607`, so this PR's own checks will not run the job. Nothing on this PR exercises the change. That is also why no PR could ever have caught this.

The proof is main's push run after landing: CI must conclude success with the `ci-free-disk` output and both `df -h` lines visible in the Code Coverage log. I will watch that run to conclusion over the full check-run set and report it, and open the follow-up the same hour if it is red again.

## Verified locally

Ran in the lane worktree, no cargo:

- `python3 scripts/test-release-workflow-authority.py`, rc=0
- `python3 scripts/test-select-release-candidate.py`, rc=0, 68 tests
- `python3 scripts/test-assertion-reachability.py`, rc=0
- `bash -n` and `shellcheck` on the new script, both clean
- The reclaim script's three refusal arms each run: `RUNNER_ENVIRONMENT` unset, `self-hosted`, and `github-hosted` on Darwin. All three printed their reason, removed nothing, rc=0.
- Positive control in a sandbox with `uname` and `sudo` shimmed and the path list rewritten to throwaway directories: the removable target was removed, a target rigged to fail removal printed `could not remove ... (rc=9); continuing` and survived, an absent path was skipped, and the script exited 0 with both `df` lines printed.
- The coverage step's new branching driven through all five arms, on the step body extracted verbatim out of the workflow, with `timeout` and `df` shimmed to control the exit code and the free space. Clean run prints only the disk line; nonzero at 1 GiB free names runner out of disk; `rc=124` at 38 GiB free names the bound; `rc=101` at 38 GiB free keeps the alpha warning; an unreadable `df` says so and does not claim out-of-disk. Every arm exits 0, so the contract is intact.
- The authority guard was falsified rather than trusted. Renaming the job's display name to `Code Coverage Mutant` took it to rc=1 with `workflow-wide required-check producer census requires the exact reviewed workflow paths, job ids, and display names`. Restoring from a byte copy returned it to rc=0.

FIR-3122.
