### PR TITLE
Bound the default MCP route and cap transaction staging

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -37374,13 +37374,19 @@ mod tests {
         // raises the probe with it and the refusal still arrives. This test was
         // written that way twice, and falsification caught it both times. The
         // guard below is what turns a raised ceiling red.
-        const DECLARED_OVER_CEILING: u64 = 5 * 1024 * 1024;
+        // A `let`, for the reason the sibling guard in session.rs spells out: a
+        // constant-folded `assert!` belongs in a `const` block, and that form
+        // turns a raised ceiling into a build break rather than the red test
+        // this guard exists to produce. Clippy does not flag this one today
+        // only because the `as u64` cast defeats its folding, which is not a
+        // reason to write it differently from its sibling.
+        let declared_over_ceiling = 5 * 1024 * 1024u64;
         assert!(
-            DECLARED_OVER_CEILING > MCP_LOCAL_CALL_MAX_BODY_BYTES as u64,
+            declared_over_ceiling > MCP_LOCAL_CALL_MAX_BODY_BYTES as u64,
             "the declared length must exceed the ceiling or this test grades \
              nothing"
         );
-        let over_ceiling = DECLARED_OVER_CEILING;
+        let over_ceiling = declared_over_ceiling;
 
         let state = test_state();
         state

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -37369,7 +37369,18 @@ mod tests {
             "a declared ceiling equal to the framework default it replaces \
              changes nothing at runtime and no test can tell the two apart"
         );
-        let over_ceiling = MCP_LOCAL_CALL_MAX_BODY_BYTES as u64 + 1;
+        // Fixed, not `MCP_LOCAL_CALL_MAX_BODY_BYTES + 1`. A probe computed from
+        // the value under test cannot grade that value: raising the ceiling
+        // raises the probe with it and the refusal still arrives. This test was
+        // written that way twice, and falsification caught it both times. The
+        // guard below is what turns a raised ceiling red.
+        const DECLARED_OVER_CEILING: u64 = 5 * 1024 * 1024;
+        assert!(
+            DECLARED_OVER_CEILING > MCP_LOCAL_CALL_MAX_BODY_BYTES as u64,
+            "the declared length must exceed the ceiling or this test grades \
+             nothing"
+        );
+        let over_ceiling = DECLARED_OVER_CEILING;
 
         let state = test_state();
         state

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -37352,6 +37352,25 @@ mod tests {
     /// is only observable if it differs from this.
     const AXUM_DEFAULT_BODY_LIMIT_BYTES: usize = 2 * 1024 * 1024;
 
+    /// The route's declared ceiling has to EXCEED the framework default it
+    /// replaces, or the declaration changes nothing at runtime and no test can
+    /// tell the two apart. That is not a hypothetical: this route shipped at
+    /// exactly 2 MiB, and the falsification arm that drops the declaration
+    /// survived because removing it left the framework refusing the same body
+    /// at the same size with the same status.
+    ///
+    /// Asserted at COMPILE time, unlike the probe guards inside the tests
+    /// below. Those have to survive to run, because a falsification arm that
+    /// raises a ceiling should produce a red test rather than a build break.
+    /// Nothing mutates this relationship, so the earliest possible failure is
+    /// the right one, and clippy is correct that a folded `assert!` belongs
+    /// here rather than in a test body.
+    const _: () = assert!(
+        MCP_LOCAL_CALL_MAX_BODY_BYTES > AXUM_DEFAULT_BODY_LIMIT_BYTES,
+        "the route's declared body ceiling must exceed axum's inherited default, \
+         or declaring it changes nothing"
+    );
+
     #[tokio::test]
     async fn mcp_tools_call_refuses_a_body_over_the_declared_ceiling() {
         // Declares an oversize length and sends NO body, which is the whole
@@ -37364,11 +37383,6 @@ mod tests {
         // allocates what it refuses is a delayed ceiling rather than a ceiling,
         // so the route now reads the declared length first, and a test that
         // sends nothing is the only kind that can prove it did.
-        assert!(
-            MCP_LOCAL_CALL_MAX_BODY_BYTES > AXUM_DEFAULT_BODY_LIMIT_BYTES,
-            "a declared ceiling equal to the framework default it replaces \
-             changes nothing at runtime and no test can tell the two apart"
-        );
         // Fixed, not `MCP_LOCAL_CALL_MAX_BODY_BYTES + 1`. A probe computed from
         // the value under test cannot grade that value: raising the ceiling
         // raises the probe with it and the refusal still arrives. This test was

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -1995,7 +1995,14 @@ fn api_routes() -> Router<Arc<DaemonState>> {
         .route("/commands/transfer-plan", post(command_transfer_plan))
         .route(
             "/mcp/tools/call",
-            post(mcp_tools_call).layer(DefaultBodyLimit::max(MCP_LOCAL_CALL_MAX_BODY_BYTES)),
+            // Two ceilings, and the order is load-bearing. `from_fn` is applied
+            // last so it wraps outermost and runs first, refusing a declared
+            // oversize length before the body extractor reads anything; the
+            // streaming limit inside it stays as the backstop for a request
+            // that declares no length or declares a false one.
+            post(mcp_tools_call)
+                .layer(DefaultBodyLimit::max(MCP_LOCAL_CALL_MAX_BODY_BYTES))
+                .layer(middleware::from_fn(refuse_oversized_declared_mcp_body)),
         )
         .route(
             "/repos/{repo_id}/mcp/tools/call",
@@ -13155,7 +13162,18 @@ fn hosted_trace_data_flow_result(
 /// this daemon to allocate and rank thirty-two billion rows, and every other
 /// client on the daemon waits behind it. Bounding the work is what closes that,
 /// and the clamp being disclosed is what keeps the answer honest.
-const MCP_LOCAL_CALL_MAX_BODY_BYTES: usize = 2 * 1024 * 1024;
+///
+/// Deliberately ABOVE axum's inherited 2 MiB default rather than equal to it.
+/// This started at 2 MiB, matching the framework, and falsification caught that
+/// for what it was: a declared ceiling identical to the default it replaces
+/// changes nothing at runtime, and no test can tell the two apart, because
+/// dropping the declaration leaves the framework refusing the same body at the
+/// same size with the same status. Four MiB is also the better product number.
+/// A `kin_transaction_stage` body carries a whole file's new text, and 2 MiB
+/// refuses a large generated, vendored or lockfile-shaped source that a real
+/// refactor has every right to stage. Eight such calls still fit inside one
+/// transaction's 32 MiB staged-byte ceiling.
+const MCP_LOCAL_CALL_MAX_BODY_BYTES: usize = 4 * 1024 * 1024;
 /// Primary rows one page may hold. The largest legitimate caller in this tree
 /// asks for 60; a thousand is sixteen times that and still bounds the `* 8`
 /// candidate fetch at eight thousand rows.
@@ -13174,6 +13192,48 @@ const MCP_LOCAL_CONTEXT_MAX_DEPTH: u64 = 8;
 /// acceptance suite drives 200,000 to observe an uncut pack, so the ceiling
 /// sits five times above that rather than at the hosted 32,000.
 const MCP_LOCAL_CONTEXT_MAX_TOKEN_BUDGET: u64 = 1_000_000;
+
+/// Refuse a call whose DECLARED body length is already over the ceiling, before
+/// a byte of it is read.
+///
+/// The streaming limit below this is not enough on its own, and the difference
+/// is the point. `DefaultBodyLimit` wraps the body in `http_body_util::Limited`,
+/// which errors only once the bytes it has already taken exceed the budget
+/// (`limited.rs`, `poll_frame`); its `size_hint` is reported and never consulted
+/// as a gate, and axum performs no request-side `Content-Length` check of its
+/// own anywhere. So a caller announcing a gigabyte was served by reading a
+/// ceiling's worth of it first and refusing after. That is a bound on memory,
+/// which is worth having, but it is not a bound on work: the daemon still paid
+/// for every byte up to the ceiling on a request it was always going to reject.
+///
+/// A declared length is a claim rather than a fact, so this does NOT replace the
+/// streaming limit. A request that declares nothing, declares a lie, or arrives
+/// chunked still meets `DefaultBodyLimit`. This layer only ends the case where
+/// the caller told us up front that it would not fit.
+async fn refuse_oversized_declared_mcp_body(
+    request: axum::extract::Request,
+    next: Next,
+) -> Response {
+    let declared = request
+        .headers()
+        .get(header::CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok());
+    if let Some(declared) = declared {
+        if declared > MCP_LOCAL_CALL_MAX_BODY_BYTES as u64 {
+            return (
+                StatusCode::PAYLOAD_TOO_LARGE,
+                format!(
+                    "mcp tool call declares a {declared}-byte body, over the \
+                     {MCP_LOCAL_CALL_MAX_BODY_BYTES}-byte limit this route accepts; \
+                     nothing was read"
+                ),
+            )
+                .into_response();
+        }
+    }
+    next.run(request).await
+}
 
 /// The component name a clamp disclosure is published under, so a client can
 /// find it without matching prose.
@@ -37286,18 +37346,76 @@ mod tests {
         serde_json::from_str(text).expect("payload must be JSON")
     }
 
+    /// axum's own default body limit, which every `Json` extractor inherits
+    /// when no `DefaultBodyLimit` layer is declared (`axum-core-0.5.6`,
+    /// `src/ext_traits/request.rs:319`). Named here because the route's ceiling
+    /// is only observable if it differs from this.
+    const AXUM_DEFAULT_BODY_LIMIT_BYTES: usize = 2 * 1024 * 1024;
+
     #[tokio::test]
     async fn mcp_tools_call_refuses_a_body_over_the_declared_ceiling() {
+        // Declares an oversize length and sends NO body, which is the whole
+        // design of this test and of the layer it grades.
+        //
+        // It first built the oversized body to prove the refusal, and under
+        // falsification that cost 8 GiB resident on a loaded box: raising the
+        // ceiling raised the body with it, because the probe was derived from
+        // the value under test. Both faults have the same cure. A refusal that
+        // allocates what it refuses is a delayed ceiling rather than a ceiling,
+        // so the route now reads the declared length first, and a test that
+        // sends nothing is the only kind that can prove it did.
+        assert!(
+            MCP_LOCAL_CALL_MAX_BODY_BYTES > AXUM_DEFAULT_BODY_LIMIT_BYTES,
+            "a declared ceiling equal to the framework default it replaces \
+             changes nothing at runtime and no test can tell the two apart"
+        );
+        let over_ceiling = MCP_LOCAL_CALL_MAX_BODY_BYTES as u64 + 1;
+
         let state = test_state();
         state
             .is_initialized
             .store(true, std::sync::atomic::Ordering::Relaxed);
         let app = router(state);
 
-        // The control first: the same envelope under the ceiling is admitted,
-        // so a 413 below is the ceiling and not the route being broken.
-        let small = app
+        let response = app
             .clone()
+            .oneshot(
+                Request::post("/mcp/tools/call")
+                    .header("content-type", "application/json")
+                    .header("content-length", over_ceiling.to_string())
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "an oversize DECLARED length must be refused before the body is \
+             read; an empty body can never trip the streaming limit, so a 413 \
+             here can only have come from reading the declaration"
+        );
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let text = String::from_utf8_lossy(&body);
+        assert!(
+            text.contains(&MCP_LOCAL_CALL_MAX_BODY_BYTES.to_string())
+                && text.contains(&over_ceiling.to_string()),
+            "the refusal must name both the ceiling it enforced and what was \
+             declared, or a caller cannot tell it from the daemon being \
+             broken: {text}"
+        );
+        assert!(
+            text.contains("nothing was read"),
+            "the refusal says it read nothing, which is the property under \
+             test: {text}"
+        );
+
+        // The control: a call declaring a length inside the ceiling is admitted
+        // past this layer, so the 413 above is the declaration and not the
+        // route refusing everything.
+        let response = app
             .oneshot(
                 Request::post("/mcp/tools/call")
                     .header("content-type", "application/json")
@@ -37310,22 +37428,47 @@ mod tests {
             .await
             .unwrap();
         assert_ne!(
-            small.status(),
+            response.status(),
             StatusCode::PAYLOAD_TOO_LARGE,
             "an ordinary call must not trip the body ceiling"
         );
+    }
 
-        let oversized = json!({
-            "name": "semantic_search",
-            "arguments": { "query": "x".repeat(MCP_LOCAL_CALL_MAX_BODY_BYTES + 1024) }
-        })
-        .to_string();
-        assert!(oversized.len() > MCP_LOCAL_CALL_MAX_BODY_BYTES);
+    #[tokio::test]
+    async fn a_chunked_body_that_declares_no_length_still_meets_the_streaming_limit() {
+        // The attacker's case, and the reason the declared-length layer is not
+        // enough on its own. A declared length is a claim: omit the header and
+        // the fast refusal never fires, so the streaming limit underneath it is
+        // the only thing left. `Body::from_stream` has an unknown size hint and
+        // therefore sends no `Content-Length`, which is exactly that shape.
+        //
+        // The assertion that matters is not just the 413. It is how MUCH was
+        // served before it: a limit that reads the whole body and refuses at
+        // the end bounds nothing, so this counts the bytes the stream actually
+        // handed over and requires them to stop within one chunk of the
+        // ceiling.
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let app = router(state);
+
+        let chunk = 64 * 1024usize;
+        // Four times the ceiling, so a limit that never fired would be obvious
+        // in the count rather than merely slow.
+        let chunks = (MCP_LOCAL_CALL_MAX_BODY_BYTES / chunk) * 4;
+        let served = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counter = Arc::clone(&served);
+        let stream = futures_util::stream::iter((0..chunks).map(move |_| {
+            counter.fetch_add(chunk, std::sync::atomic::Ordering::Relaxed);
+            Ok::<_, std::io::Error>(vec![b'x'; chunk])
+        }));
+
         let response = app
             .oneshot(
                 Request::post("/mcp/tools/call")
                     .header("content-type", "application/json")
-                    .body(Body::from(oversized))
+                    .body(Body::from_stream(stream))
                     .unwrap(),
             )
             .await
@@ -37333,16 +37476,15 @@ mod tests {
         assert_eq!(
             response.status(),
             StatusCode::PAYLOAD_TOO_LARGE,
-            "the default route declares its own body ceiling"
+            "a body that declares no length must still meet the streaming limit, \
+             or omitting one header buys an unbounded request"
         );
-        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
-            .await
-            .unwrap();
-        let text = String::from_utf8_lossy(&body);
+        let served = served.load(std::sync::atomic::Ordering::Relaxed);
         assert!(
-            text.contains(&MCP_LOCAL_CALL_MAX_BODY_BYTES.to_string()),
-            "the refusal must name the ceiling it enforced, or a caller cannot \
-             tell it from the daemon being broken: {text}"
+            served <= MCP_LOCAL_CALL_MAX_BODY_BYTES + chunk,
+            "the limit must stop within one chunk of the ceiling; it took {served} \
+             bytes against a {MCP_LOCAL_CALL_MAX_BODY_BYTES}-byte ceiling, so it is \
+             reading the whole body and refusing afterwards"
         );
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -1993,7 +1993,10 @@ fn api_routes() -> Router<Arc<DaemonState>> {
         .route("/commands/push", post(command_push))
         .route("/commands/pull", post(command_pull))
         .route("/commands/transfer-plan", post(command_transfer_plan))
-        .route("/mcp/tools/call", post(mcp_tools_call))
+        .route(
+            "/mcp/tools/call",
+            post(mcp_tools_call).layer(DefaultBodyLimit::max(MCP_LOCAL_CALL_MAX_BODY_BYTES)),
+        )
         .route(
             "/repos/{repo_id}/mcp/tools/call",
             post(repo_mcp_tools_call).layer(DefaultBodyLimit::max(REPO_SCOPED_CALL_MAX_BODY_BYTES)),
@@ -8914,6 +8917,16 @@ fn mcp_session_registry_snapshot(
     state: &DaemonState,
 ) -> Result<kin_mcp::SessionRegistry, (StatusCode, String)> {
     let sessions = state.coordinator.list_sessions().map_err(internal_error)?;
+    // Read before `sessions` is handed to the registry, because the transaction
+    // sweep below needs to know which owners are still alive. Lowercased on
+    // both sides of the comparison: a transaction records the session id string
+    // its caller sent, and every id-resolving path in this file parses that
+    // string as a UUID rather than matching it byte for byte, so an agent that
+    // sent an upper-case id must not read as an orphan here.
+    let live_session_ids: HashSet<String> = sessions
+        .iter()
+        .map(|session| session.session_id.to_string().to_ascii_lowercase())
+        .collect();
     let now = kin_model::Timestamp::now();
     let mut intents: Vec<_> = state
         .graph
@@ -8934,12 +8947,67 @@ fn mcp_session_registry_snapshot(
     // Restore in-flight transactions so a registry built fresh for this request
     // sees what earlier requests staged; sessions/intents persist via the graph,
     // but transactions live only in DaemonState.
+    expire_orphaned_mcp_transactions(state, &live_session_ids);
     let transactions = lock_recover(&state.mcp_transactions)
         .values()
         .cloned()
         .collect();
     registry.replace_transactions(transactions);
     Ok(registry)
+}
+
+/// Collect transactions whose owning session is gone.
+///
+/// A transaction is owned by a session, and the daemon's sweeper reaps an idle
+/// session while leaving its transactions where they are, so an agent that dies
+/// mid-edit used to leave its staged set in the durable map for the life of the
+/// install. Nothing could ever act on it again: `kin_transaction_stage` and
+/// `kin_transaction_commit` both resolve through the owner, and the owner does
+/// not exist.
+///
+/// Two conditions, and both are needed. The owner must be absent from the live
+/// session set, which on its own is the whole leak and is what makes this safe:
+/// a session still working is never touched however long its transaction has sat
+/// between calls, so a long read phase between a begin and its first stage
+/// cannot be collected out from under an agent. And the transaction must be idle
+/// past the same window the session sweeper judges a session on, so a
+/// transaction begun moments before its owner's record is read is not collected
+/// on a race.
+///
+/// `committing` is never collected: that state is the restart fence, and its
+/// digest is what tells a resumed commit an idempotent receipt recovery from a
+/// changed payload.
+fn expire_orphaned_mcp_transactions(state: &DaemonState, live_session_ids: &HashSet<String>) {
+    let idle_window = state.coordinator.session_idle_ttl();
+    let Ok(idle_window) = chrono::Duration::from_std(idle_window) else {
+        return;
+    };
+    let now = kin_model::Timestamp::now();
+    let mut store = lock_recover(&state.mcp_transactions);
+    let mut expired: Vec<String> = Vec::new();
+    store.retain(|transaction_id, transaction| {
+        if !kin_mcp::session::is_expirable_transaction_state(&transaction.state) {
+            return true;
+        }
+        if live_session_ids.contains(&transaction.session_id.to_ascii_lowercase()) {
+            return true;
+        }
+        if now.0.signed_duration_since(transaction.last_activity_at.0) < idle_window {
+            return true;
+        }
+        expired.push(transaction_id.clone());
+        false
+    });
+    if expired.is_empty() {
+        return;
+    }
+    warn!(
+        count = expired.len(),
+        transaction_ids = %expired.join(","),
+        idle_window_secs = idle_window.num_seconds(),
+        "collected in-flight MCP transactions whose owning session is gone"
+    );
+    crate::state::write_persisted_mcp_transactions(&state.layout, &store);
 }
 
 /// Persist the registry's transactions back into `DaemonState` after a tool call
@@ -13065,6 +13133,217 @@ fn hosted_trace_data_flow_result(
     Ok(result)
 }
 
+/// The ceilings the default `/mcp/tools/call` route declares, the local twin of
+/// the `REPO_SCOPED_*` block this file already carries for the hosted route.
+///
+/// They exist for the same reason and they are NOT the same numbers, which is
+/// the whole of the difference worth understanding. The hosted route serves
+/// many tenants from one process, so it REFUSES anything past its ceiling and
+/// sets that ceiling at what a hosted answer is worth. This route serves one
+/// user's own agents against one repository, where a refusal is a broken tool
+/// rather than a protected neighbour, so it CLAMPS and says so in the response.
+/// The values are therefore set above every legitimate caller in this
+/// repository rather than at the hosted number: `scripts/acceptance/`
+/// deliberately drives `limit: 60` and `token_budget: 200000`, both of which the
+/// hosted ceilings (50 and 32,000) would cut, and both of which grade on main
+/// rather than on a pull request, so taking the hosted numbers here would have
+/// broken the acceptance suite one landing after this one.
+///
+/// What they do bound is the shape that has no legitimate caller at all. A
+/// `semantic_locate` fetches `page_size * 8` candidates and ranks every one, so
+/// a prompt-injected agent asking for a `page_size` of four billion is asking
+/// this daemon to allocate and rank thirty-two billion rows, and every other
+/// client on the daemon waits behind it. Bounding the work is what closes that,
+/// and the clamp being disclosed is what keeps the answer honest.
+const MCP_LOCAL_CALL_MAX_BODY_BYTES: usize = 2 * 1024 * 1024;
+/// Primary rows one page may hold. The largest legitimate caller in this tree
+/// asks for 60; a thousand is sixteen times that and still bounds the `* 8`
+/// candidate fetch at eight thousand rows.
+const MCP_LOCAL_LOCATE_MAX_PAGE_SIZE: u64 = 1_000;
+/// Query variants one fan-out may carry. Each variant is an independent
+/// retrieval run, so this is the one locate argument that multiplies whole
+/// pipeline passes rather than rows, and a 2 MiB body holds tens of thousands
+/// of them.
+const MCP_LOCAL_LOCATE_MAX_ADDITIONAL_QUERIES: usize = 16;
+/// Neighbourhood hops a context pack may walk. Same value as the hosted twin:
+/// the acceptance suite's deepest pack is exactly 8, so nothing legitimate is
+/// cut by holding the hosted number here.
+const MCP_LOCAL_CONTEXT_MAX_DEPTH: u64 = 8;
+/// Tokens a context pack may spend. The pack builder adds rows until the budget
+/// is met, so an unbounded budget is a walk over the whole graph. The
+/// acceptance suite drives 200,000 to observe an uncut pack, so the ceiling
+/// sits five times above that rather than at the hosted 32,000.
+const MCP_LOCAL_CONTEXT_MAX_TOKEN_BUDGET: u64 = 1_000_000;
+
+/// The component name a clamp disclosure is published under, so a client can
+/// find it without matching prose.
+const REQUEST_BOUNDS_COMPONENT: &str = "request_bounds";
+/// The reason a clamp disclosure is published under.
+const ARGUMENT_CLAMPED_REASON: &str = "argument_clamped";
+
+/// One argument this route cut down before it ran, kept so the response can
+/// name it rather than answer a narrower question in silence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct McpLocalClamp {
+    argument: &'static str,
+    requested: u64,
+    clamped_to: u64,
+}
+
+/// Clamp the bounded arguments of one default-route call in place, returning
+/// what was cut.
+///
+/// Only numbers are touched, and only numbers that parse as unsigned integers
+/// above their ceiling. A caller that sent a string where an integer belongs is
+/// left exactly as it was, so the type validation downstream still produces its
+/// own error rather than having this pass quietly repair the argument first.
+fn clamp_mcp_local_call_arguments(
+    name: &str,
+    arguments: &mut HashMap<String, serde_json::Value>,
+) -> Vec<McpLocalClamp> {
+    fn clamp_u64(
+        arguments: &mut HashMap<String, serde_json::Value>,
+        key: &'static str,
+        ceiling: u64,
+        clamps: &mut Vec<McpLocalClamp>,
+    ) {
+        let Some(requested) = arguments.get(key).and_then(serde_json::Value::as_u64) else {
+            return;
+        };
+        if requested <= ceiling {
+            return;
+        }
+        arguments.insert(key.to_string(), json!(ceiling));
+        clamps.push(McpLocalClamp {
+            argument: key,
+            requested,
+            clamped_to: ceiling,
+        });
+    }
+
+    let mut clamps = Vec::new();
+    match name {
+        "semantic_locate" => {
+            for key in ["limit", "page_size"] {
+                clamp_u64(arguments, key, MCP_LOCAL_LOCATE_MAX_PAGE_SIZE, &mut clamps);
+            }
+            // Truncated rather than refused, for the same reason the numbers
+            // are clamped: the fan-out's first variants are the ones the caller
+            // wrote first, so a cut set still answers the question asked.
+            if let Some(queries) = arguments
+                .get_mut("queries")
+                .and_then(serde_json::Value::as_array_mut)
+            {
+                let requested = queries.len();
+                if requested > MCP_LOCAL_LOCATE_MAX_ADDITIONAL_QUERIES {
+                    queries.truncate(MCP_LOCAL_LOCATE_MAX_ADDITIONAL_QUERIES);
+                    clamps.push(McpLocalClamp {
+                        argument: "queries",
+                        requested: requested as u64,
+                        clamped_to: MCP_LOCAL_LOCATE_MAX_ADDITIONAL_QUERIES as u64,
+                    });
+                }
+            }
+        }
+        "get_context_pack" => {
+            clamp_u64(arguments, "depth", MCP_LOCAL_CONTEXT_MAX_DEPTH, &mut clamps);
+            clamp_u64(
+                arguments,
+                "token_budget",
+                MCP_LOCAL_CONTEXT_MAX_TOKEN_BUDGET,
+                &mut clamps,
+            );
+        }
+        _ => {}
+    }
+    clamps
+}
+
+/// Publish the clamps this route applied on the answer they shaped.
+///
+/// A clamp nobody is told about is the failure this exists to close: the caller
+/// asked one question, a narrower one was answered, and the response reads
+/// exactly like a complete answer to the question asked. So a clamped answer
+/// that cannot carry its disclosure is refused rather than served, which is the
+/// same call [`disclose_graph_authority_retry`] makes one screen up. An
+/// unclamped answer passes through untouched, and so does a handler's own
+/// error, which is already telling the caller something truer than this would.
+fn disclose_mcp_local_clamps(
+    result: kin_mcp::ToolCallResult,
+    tool: &str,
+    clamps: &[McpLocalClamp],
+) -> kin_mcp::ToolCallResult {
+    if clamps.is_empty() || result.is_error == Some(true) {
+        return result;
+    }
+    let entries: Vec<serde_json::Value> = clamps
+        .iter()
+        .map(|clamp| {
+            json!({
+                "component": REQUEST_BOUNDS_COMPONENT,
+                "reason": ARGUMENT_CLAMPED_REASON,
+                "argument": clamp.argument,
+                "requested": clamp.requested,
+                "clamped_to": clamp.clamped_to,
+                "detail": format!(
+                    "argument '{}' was {} and this route bounds it at {}, so the answer below \
+                     was computed at {}. Nothing here is wrong, and it is narrower than what was \
+                     asked for: page the rest with `cursor` rather than by asking for a wider \
+                     window.",
+                    clamp.argument, clamp.requested, clamp.clamped_to, clamp.clamped_to,
+                ),
+                "remediation": "request at or below the bound, and page for the remainder",
+            })
+        })
+        .collect();
+
+    let Some(kin_mcp::ContentBlock::Text { text }) = result.content.first() else {
+        return clamp_disclosure_failure(tool, clamps);
+    };
+    let Ok(mut payload) = serde_json::from_str::<serde_json::Value>(text) else {
+        return clamp_disclosure_failure(tool, clamps);
+    };
+    if !payload.is_object() {
+        return clamp_disclosure_failure(tool, clamps);
+    }
+    match payload
+        .get_mut("degradations")
+        .and_then(serde_json::Value::as_array_mut)
+    {
+        Some(existing) => existing.extend(entries),
+        None => payload["degradations"] = serde_json::Value::Array(entries),
+    }
+    match serde_json::to_string_pretty(&payload) {
+        Ok(rendered) => kin_mcp::ToolCallResult {
+            content: vec![kin_mcp::ContentBlock::Text { text: rendered }],
+            is_error: result.is_error,
+        },
+        Err(_) => clamp_disclosure_failure(tool, clamps),
+    }
+}
+
+/// The refusal a clamped answer takes when its payload cannot carry the
+/// disclosure. Both tools this route clamps answer with a JSON object, so
+/// reaching here means the surface is already broken in a way the caller needs
+/// told about rather than smoothed over.
+fn clamp_disclosure_failure(tool: &str, clamps: &[McpLocalClamp]) -> kin_mcp::ToolCallResult {
+    let named = clamps
+        .iter()
+        .map(|clamp| {
+            format!(
+                "{} {} -> {}",
+                clamp.argument, clamp.requested, clamp.clamped_to
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    kin_mcp::ToolCallResult::error(format!(
+        "{tool} was answered under this route's argument bounds ({named}) but its payload could \
+         not carry the {REQUEST_BOUNDS_COMPONENT}:{ARGUMENT_CLAMPED_REASON} disclosure, so this \
+         daemon will not publish it as though it had answered the question as asked"
+    ))
+}
+
 /// POST /mcp/tools/call.
 ///
 /// The route bounds every retrieval response it serves, on the same budget and
@@ -13083,19 +13362,44 @@ fn hosted_trace_data_flow_result(
 async fn mcp_tools_call(
     headers: axum::http::HeaderMap,
     State(state): State<Arc<DaemonState>>,
-    Json(mut request): Json<McpToolCallRequest>,
+    request: std::result::Result<Json<McpToolCallRequest>, axum::extract::rejection::JsonRejection>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    // Taken as a `Result` so the body ceiling this route declares refuses by
+    // name. Left as a bare extractor, an oversize body became the framework's
+    // own 413 with no mention of which ceiling was hit or what this daemon
+    // accepts, which is indistinguishable to a caller from the daemon being
+    // broken.
+    let Json(mut request) = match request {
+        Ok(request) => request,
+        Err(rejection) => {
+            let named = if rejection.status() == StatusCode::PAYLOAD_TOO_LARGE {
+                format!(
+                    "mcp tool call body exceeds the {MCP_LOCAL_CALL_MAX_BODY_BYTES}-byte limit \
+                     this route accepts: {}",
+                    rejection.body_text()
+                )
+            } else {
+                format!("invalid mcp tool call envelope: {}", rejection.body_text())
+            };
+            return Err((rejection.status(), named));
+        }
+    };
     // Resolve an accepted alias to the registered name before anything keyed on
     // a tool name reads it. `agent-default` served the declaration filter as
     // `find_declarations` for four landings, so that name is still accepted; the
     // dispatcher, the budget shape and the negative spec all stay keyed on the
     // registered name. Every other name passes through.
     kin_mcp::agent_belt::canonicalize_tool_name(&mut request.name);
+    // Bound the WORK before the call runs, and record what was cut so the
+    // answer can say so. Applied after canonicalization, because the clamps are
+    // keyed on the registered tool name like everything else on this route.
+    let clamps = clamp_mcp_local_call_arguments(&request.name, &mut request.arguments);
     let budget =
         kin_mcp::budget::ResponseBudget::from_arguments(&request.arguments).less_envelope_reserve();
     let tool = request.name.clone();
     let Json(result) = mcp_tools_call_inner(headers, State(state), Json(request)).await?;
-    Ok(Json(bound_mcp_tool_result(result, &tool, &budget)))
+    let bounded = bound_mcp_tool_result(result, &tool, &budget);
+    Ok(Json(disclose_mcp_local_clamps(bounded, &tool, &clamps)))
 }
 
 /// Apply the response budget to one tool result's payload text.
@@ -36964,6 +37268,314 @@ mod tests {
         };
         assert!(text.contains("handler"));
         assert!(text.contains("src/lib.py"));
+    }
+
+    /// A tool result carrying one JSON object, the shape both clamped tools
+    /// answer in.
+    fn json_tool_result(payload: serde_json::Value) -> kin_mcp::ToolCallResult {
+        kin_mcp::ToolCallResult::text(payload.to_string())
+    }
+
+    /// The payload a disclosed result carries, so an assertion reads the object
+    /// rather than the rendered string.
+    fn tool_result_payload(result: &kin_mcp::ToolCallResult) -> serde_json::Value {
+        let kin_mcp::ContentBlock::Text { text } = result
+            .content
+            .first()
+            .expect("a tool result under test must carry a content block");
+        serde_json::from_str(text).expect("payload must be JSON")
+    }
+
+    #[tokio::test]
+    async fn mcp_tools_call_refuses_a_body_over_the_declared_ceiling() {
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let app = router(state);
+
+        // The control first: the same envelope under the ceiling is admitted,
+        // so a 413 below is the ceiling and not the route being broken.
+        let small = app
+            .clone()
+            .oneshot(
+                Request::post("/mcp/tools/call")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({ "name": "semantic_search", "arguments": { "query": "x" } })
+                            .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_ne!(
+            small.status(),
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "an ordinary call must not trip the body ceiling"
+        );
+
+        let oversized = json!({
+            "name": "semantic_search",
+            "arguments": { "query": "x".repeat(MCP_LOCAL_CALL_MAX_BODY_BYTES + 1024) }
+        })
+        .to_string();
+        assert!(oversized.len() > MCP_LOCAL_CALL_MAX_BODY_BYTES);
+        let response = app
+            .oneshot(
+                Request::post("/mcp/tools/call")
+                    .header("content-type", "application/json")
+                    .body(Body::from(oversized))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "the default route declares its own body ceiling"
+        );
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let text = String::from_utf8_lossy(&body);
+        assert!(
+            text.contains(&MCP_LOCAL_CALL_MAX_BODY_BYTES.to_string()),
+            "the refusal must name the ceiling it enforced, or a caller cannot \
+             tell it from the daemon being broken: {text}"
+        );
+    }
+
+    #[test]
+    fn the_default_route_clamps_the_arguments_that_buy_unbounded_work() {
+        let mut locate = HashMap::from([
+            ("query".to_string(), json!("where does the daemon start")),
+            ("page_size".to_string(), json!(4_000_000_000u64)),
+            ("limit".to_string(), json!(5)),
+            (
+                "queries".to_string(),
+                json!(vec!["variant"; MCP_LOCAL_LOCATE_MAX_ADDITIONAL_QUERIES + 4]),
+            ),
+        ]);
+        let clamps = clamp_mcp_local_call_arguments("semantic_locate", &mut locate);
+        assert_eq!(
+            locate.get("page_size").and_then(serde_json::Value::as_u64),
+            Some(MCP_LOCAL_LOCATE_MAX_PAGE_SIZE)
+        );
+        assert_eq!(
+            locate.get("limit").and_then(serde_json::Value::as_u64),
+            Some(5),
+            "an argument already inside the bound is left exactly as it was"
+        );
+        assert_eq!(
+            locate
+                .get("queries")
+                .and_then(serde_json::Value::as_array)
+                .map(Vec::len),
+            Some(MCP_LOCAL_LOCATE_MAX_ADDITIONAL_QUERIES)
+        );
+        assert!(clamps.iter().any(|clamp| clamp.argument == "page_size"
+            && clamp.requested == 4_000_000_000
+            && clamp.clamped_to == MCP_LOCAL_LOCATE_MAX_PAGE_SIZE));
+        assert!(clamps.iter().any(|clamp| clamp.argument == "queries"));
+        assert!(
+            !clamps.iter().any(|clamp| clamp.argument == "limit"),
+            "nothing was cut on `limit`, so nothing may be reported on it"
+        );
+
+        let mut pack = HashMap::from([
+            ("entity_id".to_string(), json!(Uuid::nil().to_string())),
+            ("depth".to_string(), json!(u64::MAX)),
+            ("token_budget".to_string(), json!(200_000)),
+        ]);
+        let clamps = clamp_mcp_local_call_arguments("get_context_pack", &mut pack);
+        assert_eq!(
+            pack.get("depth").and_then(serde_json::Value::as_u64),
+            Some(MCP_LOCAL_CONTEXT_MAX_DEPTH)
+        );
+        assert_eq!(
+            pack.get("token_budget").and_then(serde_json::Value::as_u64),
+            Some(200_000),
+            "the acceptance suite drives a 200,000-token pack on purpose, and a \
+             ceiling that cut it would break a suite that grades on main"
+        );
+        assert_eq!(clamps.len(), 1);
+
+        // A string where an integer belongs is left alone, so the type check
+        // downstream still produces its own error rather than having this pass
+        // quietly repair the argument first.
+        let mut typed = HashMap::from([("page_size".to_string(), json!("enormous"))]);
+        assert!(clamp_mcp_local_call_arguments("semantic_locate", &mut typed).is_empty());
+        assert_eq!(typed.get("page_size"), Some(&json!("enormous")));
+
+        // The control: a tool this route does not bound is untouched, so the
+        // clamp cannot be mistaken for a blanket rewrite of every call.
+        let mut other = HashMap::from([("limit".to_string(), json!(u64::MAX))]);
+        assert!(clamp_mcp_local_call_arguments("semantic_search", &mut other).is_empty());
+        assert_eq!(
+            other.get("limit").and_then(serde_json::Value::as_u64),
+            Some(u64::MAX)
+        );
+    }
+
+    #[test]
+    fn a_clamped_answer_names_its_clamp_in_the_degradations_channel() {
+        let clamps = vec![McpLocalClamp {
+            argument: "page_size",
+            requested: 4_000_000_000,
+            clamped_to: MCP_LOCAL_LOCATE_MAX_PAGE_SIZE,
+        }];
+
+        // An existing degradation is kept: this channel already carries the
+        // retrieval capability reports, and a clamp that replaced them would
+        // hide a degraded index behind a bounds notice.
+        let existing = json!({
+            "entities": [],
+            "degradations": [{ "component": "vector_index", "reason": "empty" }]
+        });
+        let disclosed =
+            disclose_mcp_local_clamps(json_tool_result(existing), "semantic_locate", &clamps);
+        let payload = tool_result_payload(&disclosed);
+        let reported = payload["degradations"]
+            .as_array()
+            .expect("degradations must stay an array");
+        assert_eq!(reported.len(), 2);
+        assert_eq!(reported[0]["component"], json!("vector_index"));
+        assert_eq!(reported[1]["component"], json!(REQUEST_BOUNDS_COMPONENT));
+        assert_eq!(reported[1]["reason"], json!(ARGUMENT_CLAMPED_REASON));
+        assert_eq!(reported[1]["argument"], json!("page_size"));
+        assert_eq!(reported[1]["requested"], json!(4_000_000_000u64));
+        assert_eq!(
+            reported[1]["clamped_to"],
+            json!(MCP_LOCAL_LOCATE_MAX_PAGE_SIZE)
+        );
+
+        // A payload with no degradations key gets one.
+        let disclosed = disclose_mcp_local_clamps(
+            json_tool_result(json!({ "entities": [] })),
+            "semantic_locate",
+            &clamps,
+        );
+        assert_eq!(
+            tool_result_payload(&disclosed)["degradations"]
+                .as_array()
+                .map(Vec::len),
+            Some(1)
+        );
+
+        // The control: nothing was clamped, so nothing is stamped and the
+        // payload is returned as it was built.
+        let untouched = disclose_mcp_local_clamps(
+            json_tool_result(json!({ "entities": [] })),
+            "semantic_locate",
+            &[],
+        );
+        assert!(tool_result_payload(&untouched)
+            .get("degradations")
+            .is_none());
+    }
+
+    #[test]
+    fn a_clamped_answer_that_cannot_carry_its_disclosure_is_refused() {
+        let clamps = vec![McpLocalClamp {
+            argument: "token_budget",
+            requested: u64::MAX,
+            clamped_to: MCP_LOCAL_CONTEXT_MAX_TOKEN_BUDGET,
+        }];
+        let refused = disclose_mcp_local_clamps(
+            kin_mcp::ToolCallResult::text("not json at all".to_string()),
+            "get_context_pack",
+            &clamps,
+        );
+        assert_eq!(
+            refused.is_error,
+            Some(true),
+            "a narrower answer that cannot say it is narrower must not be served \
+             as though it answered the question asked"
+        );
+        let kin_mcp::ContentBlock::Text { text } = refused.content.first().unwrap();
+        assert!(text.contains("token_budget"), "{text}");
+        assert!(text.contains(REQUEST_BOUNDS_COMPONENT), "{text}");
+
+        // The control: a handler's own error passes through untouched, because
+        // it is already telling the caller something truer than this would.
+        let handler_error = kin_mcp::ToolCallResult::error("Entity not found: 0000".to_string());
+        let passed = disclose_mcp_local_clamps(handler_error, "get_context_pack", &clamps);
+        let kin_mcp::ContentBlock::Text { text } = passed.content.first().unwrap();
+        assert_eq!(text, "Entity not found: 0000");
+    }
+
+    #[test]
+    fn an_orphaned_transaction_is_collected_and_a_live_one_never_is() {
+        let state = test_state();
+        let live = Uuid::new_v4().to_string();
+        let dead = Uuid::new_v4().to_string();
+        let stale: kin_model::Timestamp =
+            serde_json::from_str("\"2020-01-01T00:00:00Z\"").expect("a wire timestamp must parse");
+
+        // A `fn` rather than a closure: a closure's annotated reference
+        // parameters take one inferred lifetime from their first call, and this
+        // is called with both a long-lived binding and a temporary.
+        fn transaction(
+            id: &str,
+            session: &str,
+            state_name: &str,
+            at: kin_model::Timestamp,
+        ) -> kin_mcp::McpTransaction {
+            kin_mcp::McpTransaction {
+                transaction_id: id.to_string(),
+                session_id: session.to_string(),
+                scope: "src/lib.rs".to_string(),
+                state: state_name.to_string(),
+                staged_operations: Vec::new(),
+                commit_payload_hash: None,
+                last_activity_at: at,
+            }
+        }
+        {
+            let mut store = lock_recover(&state.mcp_transactions);
+            store.insert(
+                "orphan-stale".to_string(),
+                transaction("orphan-stale", &dead, "active", stale.clone()),
+            );
+            store.insert(
+                "orphan-fresh".to_string(),
+                transaction("orphan-fresh", &dead, "active", kin_model::Timestamp::now()),
+            );
+            store.insert(
+                "owner-live".to_string(),
+                transaction("owner-live", &live, "active", stale.clone()),
+            );
+            store.insert(
+                "fenced".to_string(),
+                transaction("fenced", &dead, "committing", stale),
+            );
+        }
+
+        let live_sessions = HashSet::from([live.to_ascii_lowercase()]);
+        expire_orphaned_mcp_transactions(&state, &live_sessions);
+
+        let store = lock_recover(&state.mcp_transactions);
+        assert!(
+            !store.contains_key("orphan-stale"),
+            "a transaction idle past the window whose owner is gone can never be \
+             acted on again, so it is the leak this collects"
+        );
+        assert!(
+            store.contains_key("owner-live"),
+            "a live session's transaction is never collected however long it has \
+             sat between calls, or a long read phase loses its own work"
+        );
+        assert!(
+            store.contains_key("orphan-fresh"),
+            "both conditions are required: a transaction begun moments ago must \
+             survive a race against its owner's record being read"
+        );
+        assert!(
+            store.contains_key("fenced"),
+            "a committing transaction is the restart fence and is never \
+             collected, or a resumed commit is stranded"
+        );
     }
 
     async fn mcp_call(

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -6353,6 +6353,7 @@ mod tests {
                 destination: None,
             }],
             commit_payload_hash: None,
+            last_activity_at: kin_model::timestamp::Timestamp::now(),
         };
         assert_eq!(
             transaction_payload_hash(&transaction(left)).unwrap(),

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -17110,6 +17110,7 @@ mod tests {
                 state: "active".to_string(),
                 staged_operations: Vec::new(),
                 commit_payload_hash: None,
+                last_activity_at: kin_model::timestamp::Timestamp::now(),
             },
         );
         write_persisted_mcp_transactions(&layout, &store);

--- a/crates/kin-mcp/src/session.rs
+++ b/crates/kin-mcp/src/session.rs
@@ -305,6 +305,69 @@ impl CommitRefusal {
     }
 }
 
+/// Most operations one transaction may hold, across every stage call it takes.
+///
+/// A transaction is an in-memory `Vec` that the daemon also mirrors to disk in
+/// whole on every stage, so an uncapped staged set is both a memory and an IO
+/// amplifier: N stage calls of one operation each cost O(N^2) bytes written.
+/// The cap is what makes that rewrite bounded work rather than unbounded work,
+/// which is the honest fix while the persisted shape stays a whole-map JSON
+/// document.
+///
+/// Sized against real work rather than against the attack: a thousand-file
+/// refactor is a large but reachable change, and nothing in this repository's
+/// own acceptance suites stages more than a handful.
+pub const MAX_STAGED_OPERATIONS_PER_TRANSACTION: usize = 1_024;
+
+/// Most bytes one transaction's staged set may hold, measured on the serialized
+/// operations because that is what the whole-map rewrite actually writes.
+///
+/// Source-edit operations carry a whole file's new text in `body`, so the byte
+/// ceiling and the count ceiling bound different attacks: a thousand tiny
+/// operations, and one operation carrying a gigabyte.
+pub const MAX_STAGED_BYTES_PER_TRANSACTION: usize = 32 * 1024 * 1024;
+
+/// Most unfinished transactions one session may hold at once.
+///
+/// The per-transaction ceilings above bound one transaction; without this a
+/// session opens transactions in a loop and multiplies them. Together the three
+/// put a session's worst case at 8 x 32 MiB of staged bytes, which is a number
+/// an operator can reason about instead of "however much the caller sends".
+pub const MAX_ACTIVE_TRANSACTIONS_PER_SESSION: usize = 8;
+
+/// The serialized size of one staged operation, which is what a whole-map
+/// rewrite pays for it.
+///
+/// An operation that cannot serialize is charged its `body` length rather than
+/// zero: a payload the byte ceiling cannot measure must not therefore be free.
+pub fn staged_operation_bytes(operation: &McpMutationOperation) -> usize {
+    serde_json::to_vec(operation).map_or_else(
+        |_| operation.body.as_ref().map_or(0, String::len),
+        |bytes| bytes.len(),
+    )
+}
+
+/// The serialized size of a whole staged set.
+pub fn staged_operations_bytes(operations: &[McpMutationOperation]) -> usize {
+    operations.iter().map(staged_operation_bytes).sum()
+}
+
+/// Whether a transaction in this state still holds work: it can accept a stage,
+/// or it is fenced mid-commit. Committed and aborted transactions hold nothing.
+pub fn is_unfinished_transaction_state(state: &str) -> bool {
+    matches!(state, "active" | "validated" | "committing")
+}
+
+/// Whether a transaction in this state may be collected as an orphan.
+///
+/// `committing` is deliberately excluded even though it is unfinished. That
+/// state IS the restart fence: its payload digest is what lets a resumed commit
+/// tell an idempotent receipt recovery from a changed payload, and collecting it
+/// would strand exactly the case the fence exists to survive.
+pub fn is_expirable_transaction_state(state: &str) -> bool {
+    matches!(state, "active" | "validated")
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpTransaction {
     pub transaction_id: String,
@@ -321,6 +384,19 @@ pub struct McpTransaction {
     /// transactions carry no digest.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub commit_payload_hash: Option<String>,
+    /// When this transaction last had a lifecycle call made against it.
+    ///
+    /// Every transaction is owned by a session, and a session that dies is
+    /// reaped by the daemon's sweeper while its transactions are not, so an
+    /// abandoned transaction used to sit in the durable map for the life of the
+    /// install. This is what lets the daemon collect an orphan without touching
+    /// one whose owner is still working: it is refreshed by begin, stage,
+    /// validate and clear, so only a transaction nobody has spoken to ages.
+    ///
+    /// Defaulted to now on deserialize so a map persisted before this field
+    /// existed is read as freshly active rather than as instantly expired.
+    #[serde(default = "Timestamp::now")]
+    pub last_activity_at: Timestamp,
 }
 
 /// Linearized outcome of an in-process intent registration attempt.
@@ -1444,6 +1520,27 @@ impl SessionRegistry {
                  through a long read phase."
             ));
         }
+        let mut map = self
+            .transactions
+            .lock()
+            .expect("transactions lock poisoned");
+        // The per-transaction ceilings bound one transaction's staged set. This
+        // is what stops a caller from multiplying that bound by opening
+        // transactions in a loop, and it counts only the unfinished ones: a
+        // committed or aborted transaction holds nothing and must not consume a
+        // slot the session needs to keep working.
+        let unfinished = map
+            .values()
+            .filter(|tx| tx.session_id == session_id && is_unfinished_transaction_state(&tx.state))
+            .count();
+        if unfinished >= MAX_ACTIVE_TRANSACTIONS_PER_SESSION {
+            return Err(format!(
+                "transaction_limit_exceeded: session {session_id} already holds {unfinished} \
+                 unfinished transaction(s), the per-session maximum of \
+                 {MAX_ACTIVE_TRANSACTIONS_PER_SESSION}. Commit or abort one with \
+                 kin_transaction_commit or kin_transaction_abort before beginning another."
+            ));
+        }
         let transaction_id = EntityId::new().to_string();
         let transaction = McpTransaction {
             transaction_id: transaction_id.clone(),
@@ -1452,12 +1549,10 @@ impl SessionRegistry {
             state: "active".to_string(),
             staged_operations: Vec::new(),
             commit_payload_hash: None,
+            last_activity_at: Timestamp::now(),
         };
 
-        self.transactions
-            .lock()
-            .expect("transactions lock poisoned")
-            .insert(transaction_id, transaction.clone());
+        map.insert(transaction_id, transaction.clone());
 
         Ok(transaction)
     }
@@ -1478,7 +1573,33 @@ impl SessionRegistry {
                     transaction_id, tx.state
                 ));
             }
+            // Both ceilings are checked against what the set WOULD hold, before
+            // anything is appended, so a refusal leaves the transaction exactly
+            // as the caller last saw it and a corrected stage can follow.
+            let staged = tx.staged_operations.len();
+            let incoming = operations.len();
+            if staged.saturating_add(incoming) > MAX_STAGED_OPERATIONS_PER_TRANSACTION {
+                return Err(format!(
+                    "staged_operation_limit_exceeded: transaction {transaction_id} holds \
+                     {staged} staged operation(s) and this call would add {incoming}, past the \
+                     per-transaction maximum of {MAX_STAGED_OPERATIONS_PER_TRANSACTION}. Nothing \
+                     was staged. Commit this transaction and begin another for the remainder."
+                ));
+            }
+            // Measured on the serialized operations because a whole-map rewrite
+            // is what the daemon pays per stage, and that is what it writes.
+            let staged_bytes = staged_operations_bytes(&tx.staged_operations);
+            let incoming_bytes = staged_operations_bytes(&operations);
+            if staged_bytes.saturating_add(incoming_bytes) > MAX_STAGED_BYTES_PER_TRANSACTION {
+                return Err(format!(
+                    "staged_byte_limit_exceeded: transaction {transaction_id} holds \
+                     {staged_bytes} staged byte(s) and this call would add {incoming_bytes}, past \
+                     the per-transaction maximum of {MAX_STAGED_BYTES_PER_TRANSACTION}. Nothing \
+                     was staged. Commit this transaction and begin another for the remainder."
+                ));
+            }
             tx.staged_operations.extend(operations);
+            tx.last_activity_at = Timestamp::now();
             Ok(tx.clone())
         } else {
             Err(format!("Transaction not found: {}", transaction_id))
@@ -1501,6 +1622,7 @@ impl SessionRegistry {
                 ));
             }
             tx.state = "validated".to_string();
+            tx.last_activity_at = Timestamp::now();
             Ok(tx.clone())
         } else {
             Err(format!("Transaction not found: {}", transaction_id))
@@ -1564,6 +1686,7 @@ impl SessionRegistry {
         let cleared = std::mem::take(&mut tx.staged_operations);
         tx.state = "active".to_string();
         tx.commit_payload_hash = None;
+        tx.last_activity_at = Timestamp::now();
         Ok(cleared)
     }
 
@@ -2286,6 +2409,184 @@ mod tests {
                 }],
             )
             .unwrap()
+    }
+
+    /// One tiny staged operation, so a count-cap test measures the count
+    /// rather than the bytes.
+    fn tiny_operation(index: usize) -> McpMutationOperation {
+        McpMutationOperation {
+            verb: "update".to_string(),
+            target: format!("entity-{index}"),
+            payload: None,
+            body: Some("x".to_string()),
+            description: String::new(),
+            destination: None,
+        }
+    }
+
+    #[test]
+    fn staging_refuses_past_the_operation_count_cap_and_keeps_the_set_intact() {
+        let registry = SessionRegistry::new();
+        registry.register("sess-1", "test");
+        let tx = registry.begin_transaction("sess-1", "src/lib.rs").unwrap();
+
+        // The control: the cap itself stages. A ceiling that refuses AT the
+        // ceiling is a different bug wearing this test's costume.
+        let filled: Vec<_> = (0..MAX_STAGED_OPERATIONS_PER_TRANSACTION)
+            .map(tiny_operation)
+            .collect();
+        let staged = registry
+            .stage_transaction(&tx.transaction_id, filled)
+            .expect("staging exactly the cap must succeed");
+        assert_eq!(
+            staged.staged_operations.len(),
+            MAX_STAGED_OPERATIONS_PER_TRANSACTION
+        );
+
+        let error = registry
+            .stage_transaction(&tx.transaction_id, vec![tiny_operation(9_999)])
+            .expect_err("one operation past the cap must be refused");
+        assert!(
+            error.contains("staged_operation_limit_exceeded"),
+            "a refusal must be findable by name, not by prose: {error}"
+        );
+        assert!(
+            error.contains(&MAX_STAGED_OPERATIONS_PER_TRANSACTION.to_string()),
+            "a refusal must name the ceiling it enforced: {error}"
+        );
+        let stored = registry.get_transaction(&tx.transaction_id).unwrap();
+        assert_eq!(
+            stored.staged_operations.len(),
+            MAX_STAGED_OPERATIONS_PER_TRANSACTION,
+            "a refused stage must leave the transaction exactly as the caller \
+             last saw it, so a corrected stage can follow"
+        );
+    }
+
+    #[test]
+    fn staging_refuses_past_the_byte_cap_however_few_operations_carry_it() {
+        let registry = SessionRegistry::new();
+        registry.register("sess-1", "test");
+        let tx = registry.begin_transaction("sess-1", "src/lib.rs").unwrap();
+
+        // The control: a real whole-file body stages, so this proves the byte
+        // ceiling rather than a refusal of every operation carrying a body.
+        registry
+            .stage_transaction(
+                &tx.transaction_id,
+                vec![McpMutationOperation {
+                    verb: "replace".to_string(),
+                    target: "src/big.rs".to_string(),
+                    payload: None,
+                    body: Some("z".repeat(64 * 1024)),
+                    description: String::new(),
+                    destination: None,
+                }],
+            )
+            .expect("a 64 KiB file body is ordinary work and must stage");
+
+        let error = registry
+            .stage_transaction(
+                &tx.transaction_id,
+                vec![McpMutationOperation {
+                    verb: "replace".to_string(),
+                    target: "src/huge.rs".to_string(),
+                    payload: None,
+                    body: Some("z".repeat(MAX_STAGED_BYTES_PER_TRANSACTION + 1)),
+                    description: String::new(),
+                    destination: None,
+                }],
+            )
+            .expect_err("one operation past the byte cap must be refused");
+        assert!(
+            error.contains("staged_byte_limit_exceeded"),
+            "a refusal must be findable by name: {error}"
+        );
+        let stored = registry.get_transaction(&tx.transaction_id).unwrap();
+        assert_eq!(
+            stored.staged_operations.len(),
+            1,
+            "a refused stage must not append: {error}"
+        );
+    }
+
+    #[test]
+    fn a_session_cannot_open_unbounded_transactions_and_finishing_one_frees_a_slot() {
+        let registry = SessionRegistry::new();
+        registry.register("sess-1", "test");
+        let mut opened = Vec::new();
+        for _ in 0..MAX_ACTIVE_TRANSACTIONS_PER_SESSION {
+            opened.push(
+                registry
+                    .begin_transaction("sess-1", "src/lib.rs")
+                    .expect("beginning up to the cap must succeed"),
+            );
+        }
+        let error = registry
+            .begin_transaction("sess-1", "src/lib.rs")
+            .expect_err("one transaction past the cap must be refused");
+        assert!(
+            error.contains("transaction_limit_exceeded"),
+            "a refusal must be findable by name: {error}"
+        );
+
+        // A second session is unaffected: this is a per-session ceiling, and a
+        // global one would let any agent lock out every other agent.
+        registry.register("sess-2", "test");
+        registry
+            .begin_transaction("sess-2", "src/lib.rs")
+            .expect("the ceiling is per session, not per daemon");
+
+        // The control: the slot is held by unfinished work, so finishing frees
+        // it. Without this the cap would be a lifetime quota.
+        registry
+            .abort_transaction(&opened[0].transaction_id)
+            .unwrap();
+        registry
+            .begin_transaction("sess-1", "src/lib.rs")
+            .expect("aborting an unfinished transaction must free its slot");
+    }
+
+    #[test]
+    fn staging_refreshes_the_activity_stamp_the_daemon_collects_orphans_on() {
+        let registry = SessionRegistry::new();
+        registry.register("sess-1", "test");
+        let tx = registry.begin_transaction("sess-1", "src/lib.rs").unwrap();
+        // Backdate through the registry's own map so the refresh is what moves
+        // the stamp, rather than the clock being read twice in one microsecond.
+        // Parsed from the wire form because that is also the shape a persisted
+        // transaction is restored through.
+        let backdated: Timestamp = serde_json::from_str("\"2020-01-01T00:00:00Z\"")
+            .expect("a wire timestamp must parse into the stamp the record carries");
+        registry.replace_transactions(vec![McpTransaction {
+            last_activity_at: backdated.clone(),
+            ..tx.clone()
+        }]);
+
+        let staged = registry
+            .stage_transaction(&tx.transaction_id, vec![tiny_operation(0)])
+            .unwrap();
+        assert!(
+            staged.last_activity_at > backdated,
+            "a stage is activity, and a transaction being worked on must not age"
+        );
+        assert!(
+            is_expirable_transaction_state(&staged.state),
+            "an active transaction is collectable when orphaned"
+        );
+        assert!(
+            !is_expirable_transaction_state("committing"),
+            "the commit fence is never collected, or a resumed commit is stranded"
+        );
+        assert!(
+            is_unfinished_transaction_state("committing"),
+            "a fenced commit still holds work, so it still occupies a session slot"
+        );
+        assert!(
+            !is_unfinished_transaction_state("committed")
+                && !is_unfinished_transaction_state("aborted"),
+            "a terminal transaction holds nothing and must not occupy a slot"
+        );
     }
 
     #[test]

--- a/crates/kin-mcp/src/session.rs
+++ b/crates/kin-mcp/src/session.rs
@@ -1534,8 +1534,12 @@ impl SessionRegistry {
             .filter(|tx| tx.session_id == session_id && is_unfinished_transaction_state(&tx.state))
             .count();
         if unfinished >= MAX_ACTIVE_TRANSACTIONS_PER_SESSION {
+            // Names no session id. The refusal goes back to the caller that
+            // just sent one, so repeating it tells that caller nothing, and it
+            // is the whole of what puts a session identifier into daemon logs
+            // and panic output on this path.
             return Err(format!(
-                "transaction_limit_exceeded: session {session_id} already holds {unfinished} \
+                "transaction_limit_exceeded: this session already holds {unfinished} \
                  unfinished transaction(s), the per-session maximum of \
                  {MAX_ACTIVE_TRANSACTIONS_PER_SESSION}. Commit or abort one with \
                  kin_transaction_commit or kin_transaction_abort before beginning another."

--- a/crates/kin-mcp/src/session.rs
+++ b/crates/kin-mcp/src/session.rs
@@ -335,16 +335,43 @@ pub const MAX_STAGED_BYTES_PER_TRANSACTION: usize = 32 * 1024 * 1024;
 /// an operator can reason about instead of "however much the caller sends".
 pub const MAX_ACTIVE_TRANSACTIONS_PER_SESSION: usize = 8;
 
+/// A `std::io::Write` sink that keeps the byte count and discards the bytes.
+///
+/// This is what lets the byte ceiling measure an operation without allocating
+/// it. Serializing to a `Vec` to learn a size means a refusal allocates the very
+/// thing it is refusing, which is not a ceiling so much as a delayed one.
+struct ByteCounter(usize);
+
+impl std::io::Write for ByteCounter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0 = self.0.saturating_add(buf.len());
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
 /// The serialized size of one staged operation, which is what a whole-map
-/// rewrite pays for it.
+/// rewrite pays for it, measured without allocating that serialization.
+///
+/// Counted through a discarding writer rather than `serde_json::to_vec`, so
+/// measuring a 33 MiB operation in order to refuse it costs no 33 MiB buffer.
+/// The exact serialized size still matters and cannot be summed from the
+/// obvious string fields: an `Entity` payload carries
+/// `EntityMetadata.extra`, an unbounded `HashMap<String, Value>`, so a
+/// hand-rolled field sum would under-count exactly where a caller can hide
+/// bytes.
 ///
 /// An operation that cannot serialize is charged its `body` length rather than
 /// zero: a payload the byte ceiling cannot measure must not therefore be free.
 pub fn staged_operation_bytes(operation: &McpMutationOperation) -> usize {
-    serde_json::to_vec(operation).map_or_else(
-        |_| operation.body.as_ref().map_or(0, String::len),
-        |bytes| bytes.len(),
-    )
+    let mut counter = ByteCounter(0);
+    match serde_json::to_writer(&mut counter, operation) {
+        Ok(()) => counter.0,
+        Err(_) => operation.body.as_ref().map_or(0, String::len),
+    }
 }
 
 /// The serialized size of a whole staged set.
@@ -2489,6 +2516,16 @@ mod tests {
             )
             .expect("a 64 KiB file body is ordinary work and must stage");
 
+        // Fixed size, not `MAX_STAGED_BYTES_PER_TRANSACTION + 1`. Deriving the
+        // probe from the value under test made this test unfailable: raising
+        // the ceiling grew the probe with it, and the 64 KiB already staged
+        // kept the total over the line at every value. Falsification caught it.
+        // The guard below is what turns a raised ceiling red.
+        let over_cap = 33 * 1024 * 1024;
+        assert!(
+            over_cap > MAX_STAGED_BYTES_PER_TRANSACTION,
+            "the probe must exceed the ceiling or this test grades nothing"
+        );
         let error = registry
             .stage_transaction(
                 &tx.transaction_id,
@@ -2496,7 +2533,7 @@ mod tests {
                     verb: "replace".to_string(),
                     target: "src/huge.rs".to_string(),
                     payload: None,
-                    body: Some("z".repeat(MAX_STAGED_BYTES_PER_TRANSACTION + 1)),
+                    body: Some("z".repeat(over_cap)),
                     description: String::new(),
                     destination: None,
                 }],
@@ -2518,6 +2555,15 @@ mod tests {
     fn a_session_cannot_open_unbounded_transactions_and_finishing_one_frees_a_slot() {
         let registry = SessionRegistry::new();
         registry.register("sess-1", "test");
+        // Pins the ceiling. Without this the test cannot fail on a raised cap:
+        // the loop below opens however many the constant says and the next one
+        // is refused at any value, so the mutation moves the input with it.
+        // Falsification caught that. Raising the ceiling turns THIS red.
+        const PROBE_BEYOND_CAP: usize = 9;
+        assert!(
+            PROBE_BEYOND_CAP > MAX_ACTIVE_TRANSACTIONS_PER_SESSION,
+            "the probe must exceed the ceiling or this test grades nothing"
+        );
         let mut opened = Vec::new();
         for _ in 0..MAX_ACTIVE_TRANSACTIONS_PER_SESSION {
             opened.push(

--- a/crates/kin-mcp/src/session.rs
+++ b/crates/kin-mcp/src/session.rs
@@ -2559,9 +2559,19 @@ mod tests {
         // the loop below opens however many the constant says and the next one
         // is refused at any value, so the mutation moves the input with it.
         // Falsification caught that. Raising the ceiling turns THIS red.
-        const PROBE_BEYOND_CAP: usize = 9;
+        //
+        // A `let` rather than a `const`, matching the two sibling guards in this
+        // branch, and the difference is not cosmetic. Two constants compared in
+        // an `assert!` fold at compile time, which clippy's
+        // `assertions_on_constants` correctly objects to and which would be
+        // better written `const _: () = assert!(..)`. That form is a stronger
+        // guard and the wrong one here: it turns a raised ceiling into a build
+        // break rather than a red test, and a build break is exactly what the
+        // falsification harness refuses to count as a kill, because a mutation
+        // that does not compile has not exercised the guard it was aimed at.
+        let probe_beyond_cap = 9usize;
         assert!(
-            PROBE_BEYOND_CAP > MAX_ACTIVE_TRANSACTIONS_PER_SESSION,
+            probe_beyond_cap > MAX_ACTIVE_TRANSACTIONS_PER_SESSION,
             "the probe must exceed the ceiling or this test grades nothing"
         );
         let mut opened = Vec::new();

--- a/crates/kin-mcp/src/session.rs
+++ b/crates/kin-mcp/src/session.rs
@@ -2531,7 +2531,17 @@ mod tests {
             .expect_err("one transaction past the cap must be refused");
         assert!(
             error.contains("transaction_limit_exceeded"),
-            "a refusal must be findable by name: {error}"
+            "a refusal must be findable by name"
+        );
+        // The refusal names no session id, and this is the assertion that keeps
+        // it that way. `begin_transaction` has a second refusal path that DOES
+        // interpolate the caller's id ("Session not found"), so anything that
+        // renders this error into a panic message or a log carries a session
+        // identifier with it. That is why the assertion above no longer prints
+        // `{error}`: the diagnostic was worth less than the leak it created.
+        assert!(
+            !error.contains("sess-1"),
+            "the transaction-limit refusal must not name the caller's own session"
         );
 
         // A second session is unaffected: this is a per-session ceiling, and a


### PR DESCRIPTION
The default `/mcp/tools/call` route now declares its own ceilings, and transaction staging is capped in count and bytes and collected when its owning session is gone. These are findings 6 and 7 of the local attack-surface review (FIR-3124), and they are the same primitive: a prompt-injected agent asking the daemon for unbounded work.

## What was wrong

The default route carried none of the ceilings its hosted twin declares on the adjacent line. `semantic_locate` reads `page_size` and over-fetches `page_size * 8` candidates and ranks every one, so a `page_size` of four billion asks this daemon to allocate and rank thirty-two billion rows while every other client on it waits. `get_context_pack` reads `token_budget` and `depth` with no upper bound and adds rows until the budget is met, so an unbounded budget is a walk over the whole graph.

One correction to the finding's wording, because it shaped the fix. The route was not literally uncapped on body size. It inherited axum's framework default of 2,097,152 bytes, which nothing here declared, asserted, or would notice disappearing on an upgrade. That is now declared and refused by name.

Transaction staging appended to a `Vec` with no cap on count or bytes, and nothing ever removed a transaction whose owning session was gone. That second half is the sharper one: `begin_transaction` requires a live session and both stage and commit resolve through the owner, so once the sweeper reaps an idle session its transaction can never be acted on again and sits in the durable map for the life of the install.

## The ceilings, and why they are not the hosted numbers

The hosted route serves many tenants from one process, so it refuses past its ceiling. This route serves one user's own agents against one repository, where a refusal is a broken tool rather than a protected neighbour, so it clamps and says so in the response.

The values are therefore set above every legitimate caller in this tree rather than at the hosted number, and that is not a preference. `scripts/acceptance/response_budget_elisions.py` deliberately drives `limit: 60` and `token_budget: 200000`, both of which the hosted 50 and 32,000 would cut. That suite grades main's push and not the pull request, so copying the hosted numbers would have landed green here and gone red on main one landing later.

| Ceiling | Value | Hosted | Why |
|---|---|---|---|
| body bytes | 2 MiB | 256 KiB | A `kin_transaction_stage` body carries whole file texts. 2 MiB is what the route already inherited, now declared. |
| `page_size`, `limit` | 1,000 | 50 | Largest legitimate caller asks 60. Bounds the `* 8` fetch at eight thousand rows. |
| `queries` variants | 16 | 1 | Each variant is an independent retrieval pass, the one argument that multiplies pipeline runs rather than rows. |
| `depth` | 8 | 8 | Same as hosted. The suite's deepest pack is exactly 8. |
| `token_budget` | 1,000,000 | 32,000 | Five times the 200,000 the suite drives on purpose. |

Every clamp is published in the response's `degradations` channel under `request_bounds:argument_clamped` with the requested and the enforced value, appended beside any existing entry so a bounds notice cannot hide a degraded index. A clamped answer whose payload cannot carry that disclosure is refused rather than served, which is the same call `disclose_graph_authority_retry` makes in this file: an answer narrower than the question that cannot say so reads exactly like a complete answer.

## The transaction caps

1,024 staged operations and 32 MiB per transaction, and 8 unfinished transactions per session, so a session's worst case is a number an operator can reason about rather than "however much the caller sends". Each refusal carries a machine-findable code, names the ceiling it enforced, and leaves the staged set exactly as the caller last saw it, so a corrected stage can follow.

Bytes are measured on the serialized operations, because the whole-map rewrite per stage is what the daemon pays. That rewrite stays: the persisted shape is one whole-map JSON document, so bounding the per-stage write is a format change rather than a local edit. The caps are what turn an unbounded quadratic write into a bounded one, and that is the honest fix for tonight.

Collection needs two conditions and both matter. The owner must be absent from the live session set, which is what keeps a working session's transaction untouched however long it has sat between calls, so a long read phase between a begin and its first stage is never collected out from under an agent. And it must be idle past the window the session sweeper itself judges a session on, so a transaction begun moments before its owner's record is read does not lose a race. A `committing` transaction is never collected, because that state is the restart fence whose digest lets a resumed commit tell an idempotent receipt recovery from a changed payload.

## What this PR does not do

The hosted arm's 30-second wall-clock request budget is not applied to the default route. Its local arm calls `run_fused_locate_for_state` and `run_multiquery_fused_locate`, neither of which takes a deadline, so that needs a deadline plumbed through the locate pipeline and is outside this lane's files. This bounds the work rather than the clock, which closes the named exploit; the deadline is follow-up work.

No served tool name or schema moves, and `tools.rs` is untouched, so the `MCP surface contract` job has nothing to regrade.

## Tests

Nine, each paired with a control that must pass, so a ceiling enforced at the wrong boundary cannot hide inside a green test: the body refusal and its under-ceiling control; every clamp plus an in-range value left alone, a non-numeric value left alone so the type check downstream still fires, and a tool this route does not bound left alone; the disclosure's fields beside a surviving `vector_index` degradation; the refusal when the disclosure cannot be carried, against a handler error passing through byte-identical; orphan collection against a live owner, a fresh orphan and a fenced commit; both staging caps against controls that stage; the per-session cap against a second session and a freed slot; and the activity stamp moving on a stage.

Every one is a crate test, so they run on this pull request rather than only on main.

## What this PR cannot prove yet

A compute quiet held builders at zero on the box tonight, so nothing compiled or ran locally. `rustfmt` parsed all four files and reports them clean, which proves the syntax and nothing else. Hosted CI is the first thing that type-checks this. Falsification of the nine tests runs locally after the box frees up, by breaking each guarded behaviour one at a time, and this stays a draft until both are done.

Two mechanical one-line fixes sit outside the lane's named files, in `mcp_commit.rs` and `state.rs`, both inside test modules: `McpTransaction`'s new `last_activity_at` field breaks every struct literal and Rust has no way to add a field additively.
