### PR TITLE
Keep npm out of the CI disk reclaim list

### DIFF
--- a/scripts/ci-free-disk.sh
+++ b/scripts/ci-free-disk.sh
@@ -62,7 +62,6 @@ for path in \
   /usr/share/swift \
   /usr/local/share/powershell \
   /usr/local/share/chromium \
-  /usr/local/lib/node_modules \
   /opt/az \
   /usr/local/share/boost; do
   [ -e "$path" ] || continue


### PR DESCRIPTION
One line out of the reclaim list that #1422 added. `/usr/local/lib/node_modules` is where a hosted runner keeps its globally installed npm packages, npm itself among them, and `/usr/local/bin/npm` symlinks into it. Removing it buys a couple of hundred megabytes and leaves the runner without npm.

It never fired. Nothing in Code Coverage calls npm, and the JS actions in that job (`actions/checkout`, `actions/cache`, `taiki-e/install-action`, `codecov-action`) run under the runner's own bundled node rather than the system one. I caught it reviewing my own diff after #1422 had already merged.

It is still the wrong entry in a shared CI helper. `scripts/ci-free-disk.sh` is named for reuse, and the next job to call it may be one that does need npm; that failure would land a long way from the list that caused it. Every other entry is a toolchain for a language this repository does not build, which is the bar the list should hold to.

Verified in the lane worktree, no cargo: `bash -n` clean, `shellcheck` rc=0, `python3 scripts/test-release-workflow-authority.py` rc=0, and the script still refuses on a non-hosted runner (`RUNNER_ENVIRONMENT=self-hosted` printed its reason and removed nothing). Positive control on the edit: the landed script did contain the line at `scripts/ci-free-disk.sh:65` before this change and contains no `node_modules` after it.

Like #1422, this PR's own checks do not exercise the script, because Code Coverage carries `if: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}`. Main's push run is what runs it.

FIR-3122.
