### PR TITLE
Close six local attack-surface findings before launch

### DIFF
--- a/crates/kin-cli/src/commands/auth.rs
+++ b/crates/kin-cli/src/commands/auth.rs
@@ -147,8 +147,84 @@ fn fallback_credential_root() -> Result<PathBuf> {
 
 fn fallback_credential_path(base_url: &str) -> Result<PathBuf> {
     let root = fallback_credential_root()?;
-    fs::create_dir_all(&root)?;
+    create_private_dir(&root)
+        .with_context(|| format!("could not create {} owner-only", root.display()))?;
     Ok(root.join(format!("{}.json.age", account_key(base_url))))
+}
+
+/// Create the credential directory owner-only, and tighten it if it already
+/// exists wider than that.
+///
+/// The plain `create_dir_all` this replaces took the process umask, so on a
+/// typical host the directory holding a KinLab bearer token, the account email
+/// and the display name was 0755. The file inside is 0600, so this closed no
+/// hole on its own, but a world-readable directory over a credential store is
+/// not a posture to ship, and the tightening pass is what fixes a machine that
+/// already has the wide one.
+fn create_private_dir(path: &std::path::Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+        fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(path)?;
+        let mode = fs::metadata(path)?.permissions().mode();
+        if mode & 0o077 != 0 {
+            fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+        }
+        Ok(())
+    }
+    #[cfg(not(unix))]
+    {
+        fs::create_dir_all(path)
+    }
+}
+
+/// Write `bytes` to `path`, owner-only from the moment the file exists.
+///
+/// `fs::write` then `set_permissions` leaves a window in which the file carries
+/// the umask's mode, which on a common umask is 0644. The mode belongs at
+/// creation, which is the idiom `kin-registry`'s `atomic_file` and
+/// `kin-core::init` already use.
+fn write_owner_only(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        // An existing file keeps the mode it had, so set it too rather than
+        // trusting the create-time mode alone.
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+        Ok(())
+    }
+    #[cfg(not(unix))]
+    {
+        fs::write(path, bytes)
+    }
+}
+
+/// What `kin auth login` prints when it takes the plaintext tier.
+///
+/// There are three tiers, and the docs named two. Falling back to the third
+/// silently is the part that matters: a headless Linux host is both the place
+/// most likely to have no keyring and the place without macOS's private
+/// `Application Support`, so the user most exposed by the plaintext tier was the
+/// one least likely to know they had it.
+fn plaintext_tier_warning(path: &std::path::Path) -> String {
+    format!(
+        "Kin: no OS keyring is available, so your KinLab credential was stored as PLAINTEXT \
+         JSON at {} (file 0600, directory 0700). It carries the bearer token, your account \
+         email and your display name. Set KINLAB_AUTH_PASSPHRASE and run `kin auth login` again \
+         to store it age-encrypted instead.",
+        path.display()
+    )
 }
 
 /// The same path without creating the directory, for read-only probes that
@@ -174,12 +250,7 @@ fn write_encrypted_file(path: &PathBuf, plaintext: &[u8]) -> Result<()> {
     let recipient = ScryptRecipient::new(passphrase);
     let encrypted =
         encrypt(&recipient, plaintext).context("failed to encrypt KinLab credential file")?;
-    fs::write(path, encrypted)?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
-    }
+    write_owner_only(path, &encrypted)?;
     Ok(())
 }
 
@@ -225,12 +296,8 @@ fn store_credential(base_url: &str, credential: &StoredCredential) -> Result<()>
 
     let path = fallback_credential_path(base_url)?;
     let plaintext_path = path.with_extension("json");
-    fs::write(&plaintext_path, &serialized)?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&plaintext_path, fs::Permissions::from_mode(0o600))?;
-    }
+    write_owner_only(&plaintext_path, &serialized)?;
+    eprintln!("{}", plaintext_tier_warning(&plaintext_path));
     Ok(())
 }
 
@@ -937,6 +1004,98 @@ mod tests {
         assert_eq!(
             stored_credential_provider(base_url),
             Some("github".to_string())
+        );
+    }
+
+    /// The third credential tier, the one the docs did not name.
+    ///
+    /// With no keyring and no passphrase, `kin auth login` writes the bearer
+    /// token, the account email and the display name as plaintext JSON. That
+    /// tier stays, because the alternative is a login that cannot complete on a
+    /// headless host, but it is owner-only in an owner-only directory and it
+    /// says so on stderr.
+    #[cfg(unix)]
+    #[test]
+    #[serial]
+    fn the_plaintext_tier_is_owner_only_and_announced() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let base_url = "https://kinlab.example.com";
+        let store = tempfile::tempdir().expect("a private credential store");
+        let root = store.path().join("auth");
+        let _root = TestCredentialRoot::set(&root);
+        let _passphrase = kin_core::test_env::EnvVarGuard::unset("KINLAB_AUTH_PASSPHRASE");
+
+        store_credential(
+            base_url,
+            &StoredCredential {
+                base_url: base_url.to_string(),
+                token: "kinlab-bearer-token".to_string(),
+                expires_at: "2026-03-21T00:00:00Z".to_string(),
+                user_email: "troy@firelock.ai".to_string(),
+                user_display_name: "Troy Fortin".to_string(),
+                provider: None,
+            },
+        )
+        .unwrap();
+
+        let plaintext = fallback_credential_probe_path(base_url)
+            .unwrap()
+            .with_extension("json");
+        assert!(
+            plaintext.exists(),
+            "the plaintext tier must write where the reader looks: {plaintext:?}"
+        );
+        assert_eq!(
+            fs::metadata(&plaintext).unwrap().permissions().mode() & 0o777,
+            0o600,
+            "a plaintext credential file must be owner-only"
+        );
+        assert_eq!(
+            fs::metadata(&root).unwrap().permissions().mode() & 0o777,
+            0o700,
+            "the credential directory must be owner-only"
+        );
+
+        let warning = plaintext_tier_warning(&plaintext);
+        assert!(
+            warning.contains("PLAINTEXT"),
+            "the warning must name the tier: {warning}"
+        );
+        assert!(
+            warning.contains(&plaintext.display().to_string()),
+            "the warning must name the file: {warning}"
+        );
+        assert!(
+            warning.contains("KINLAB_AUTH_PASSPHRASE"),
+            "the warning must name the way out: {warning}"
+        );
+    }
+
+    /// A machine that already has the wide directory gets it tightened, so the
+    /// fix reaches an existing install rather than only a fresh one.
+    #[cfg(unix)]
+    #[test]
+    #[serial]
+    fn an_existing_world_readable_credential_directory_is_tightened() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let store = tempfile::tempdir().expect("a private credential store");
+        let root = store.path().join("auth");
+        fs::create_dir_all(&root).unwrap();
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o755)).unwrap();
+        // The control: the wide mode is really there before the call.
+        assert_eq!(
+            fs::metadata(&root).unwrap().permissions().mode() & 0o777,
+            0o755
+        );
+
+        let _root = TestCredentialRoot::set(&root);
+        fallback_credential_path("https://kinlab.example.com").unwrap();
+
+        assert_eq!(
+            fs::metadata(&root).unwrap().permissions().mode() & 0o777,
+            0o700
         );
     }
 }

--- a/crates/kin-cli/src/commands/auth.rs
+++ b/crates/kin-cli/src/commands/auth.rs
@@ -1039,15 +1039,22 @@ mod tests {
         )
         .unwrap();
 
-        let plaintext = fallback_credential_probe_path(base_url)
+        // The credential path and the warning built from it are both derived
+        // from `account_key`, which CodeQL's `rust/cleartext-logging` treats as
+        // a sensitive value. Neither is a secret, it is a SHA-256 of the base
+        // URL, but a panic message that interpolates either one is a sink as far
+        // as that rule is concerned. So these assertions compare the value and
+        // report the property, never the value. The array of needles below is
+        // beside its assertion, so a failure still names what was missing.
+        let credential_file = fallback_credential_probe_path(base_url)
             .unwrap()
             .with_extension("json");
         assert!(
-            plaintext.exists(),
-            "the plaintext tier must write where the reader looks: {plaintext:?}"
+            credential_file.exists(),
+            "the plaintext tier must write where the reader looks"
         );
         assert_eq!(
-            fs::metadata(&plaintext).unwrap().permissions().mode() & 0o777,
+            fs::metadata(&credential_file).unwrap().permissions().mode() & 0o777,
             0o600,
             "a plaintext credential file must be owner-only"
         );
@@ -1057,18 +1064,16 @@ mod tests {
             "the credential directory must be owner-only"
         );
 
-        let warning = plaintext_tier_warning(&plaintext);
+        let warning = plaintext_tier_warning(&credential_file);
+        for needle in ["PLAINTEXT", "0600", "0700", "KINLAB_AUTH_PASSPHRASE"] {
+            assert!(
+                warning.contains(needle),
+                "the plaintext-tier warning must name {needle}"
+            );
+        }
         assert!(
-            warning.contains("PLAINTEXT"),
-            "the warning must name the tier: {warning}"
-        );
-        assert!(
-            warning.contains(&plaintext.display().to_string()),
-            "the warning must name the file: {warning}"
-        );
-        assert!(
-            warning.contains("KINLAB_AUTH_PASSPHRASE"),
-            "the warning must name the way out: {warning}"
+            warning.contains(&credential_file.display().to_string()),
+            "the plaintext-tier warning must name the credential file it wrote"
         );
     }
 

--- a/crates/kin-cli/src/commands/verify.rs
+++ b/crates/kin-cli/src/commands/verify.rs
@@ -311,7 +311,7 @@ pub fn execute_verify_run(
     request: &VerifyRunRequest,
 ) -> Result<VerifyRunResponse> {
     let plan = build_verification_plan(graph, &request.entity, request.depth)?;
-    let test_runner = parse_runner(&request.runner);
+    let test_runner = parse_runner(&request.runner)?;
     let cmd_str = build_runner_command(&test_runner, &plan.entity.name, &plan.tests);
     let mut lines = Vec::new();
 
@@ -835,15 +835,62 @@ where
     }
 }
 
-fn parse_runner(runner: &str) -> TestRunner {
+fn parse_runner(runner: &str) -> Result<TestRunner> {
     match runner {
-        "cargo" => TestRunner::Cargo,
-        "jest" => TestRunner::Jest,
-        "pytest" => TestRunner::Pytest,
-        "go" => TestRunner::Go,
-        "junit" => TestRunner::JUnit,
-        other => TestRunner::Custom(other.to_string()),
+        "cargo" => Ok(TestRunner::Cargo),
+        "jest" => Ok(TestRunner::Jest),
+        "pytest" => Ok(TestRunner::Pytest),
+        "go" => Ok(TestRunner::Go),
+        "junit" => Ok(TestRunner::JUnit),
+        other => {
+            if let Some(refusal) = custom_runner_refusal(other) {
+                bail!("{refusal}");
+            }
+            Ok(TestRunner::Custom(other.to_string()))
+        }
     }
+}
+
+/// Characters a custom runner may carry, and why the set is this short.
+///
+/// A runner name arrives on the `POST /verify/run` body, and the command this
+/// module builds from it is handed to `/bin/sh -c`. Every character a shell
+/// reads as syntax is absent here on purpose: `;`, `&`, `|`, `$`, backtick,
+/// `(`, `)`, `<`, `>`, `\`, quotes and newline. What is left still spells the
+/// runners this is for, `npm test`, `env FOO=1 pytest`, `./scripts/test.sh`,
+/// because a runner is a program and its flags rather than a shell script.
+const CUSTOM_RUNNER_EXTRA_CHARS: &str = " ._-/=+:,@";
+
+/// Why this runner cannot be run, in the caller's terms, or `None` when it can.
+///
+/// Paired with the quoting in [`build_runner_command`] rather than trusted
+/// alone. Either one closes the injection; both are here so that a later edit
+/// to one of them cannot silently reopen it.
+fn custom_runner_refusal(runner: &str) -> Option<String> {
+    if runner.trim().is_empty() {
+        return Some(
+            "refusing an empty test runner: name one of cargo, jest, pytest, go, junit, or a \
+             program to run"
+                .to_string(),
+        );
+    }
+    let bad: Vec<char> = runner
+        .chars()
+        .filter(|c| !c.is_ascii_alphanumeric() && !CUSTOM_RUNNER_EXTRA_CHARS.contains(*c))
+        .collect();
+    if bad.is_empty() {
+        return None;
+    }
+    let rendered = bad
+        .iter()
+        .map(|c| format!("{c:?}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    Some(format!(
+        "refusing the test runner {runner:?}: it carries {rendered}, which a shell reads as \
+         syntax rather than as part of a program name. A custom runner may carry letters, \
+         digits and{CUSTOM_RUNNER_EXTRA_CHARS}. Put anything else in a script and name the script."
+    ))
 }
 
 fn build_runner_command(test_runner: &TestRunner, entity_name: &str, tests: &[TestCase]) -> String {
@@ -904,7 +951,20 @@ fn build_runner_command(test_runner: &TestRunner, entity_name: &str, tests: &[Te
             };
             format!("mvn test -Dtest={}", shell_quote(&pattern))
         }
-        TestRunner::Custom(command) => format!("{} {}", command, shell_quote(entity_name)),
+        // Quoted word by word, exactly as every arm above quotes its one
+        // interpolated value. A custom runner is a program and its flags, so
+        // each word is one argv slot and nothing in it reaches the shell as
+        // syntax. `parse_runner` has already refused the characters that would
+        // matter; this is the second of the two defences, and it is the one
+        // that holds if a future caller reaches here without the first.
+        TestRunner::Custom(command) => {
+            let quoted = command
+                .split_whitespace()
+                .map(shell_quote)
+                .collect::<Vec<_>>()
+                .join(" ");
+            format!("{} {}", quoted, shell_quote(entity_name))
+        }
     }
 }
 
@@ -983,6 +1043,82 @@ mod tests {
 
         assert!(output.status.success());
         assert_eq!(output.stdout, b"path-independent");
+    }
+
+    #[test]
+    fn parse_runner_refuses_a_runner_carrying_shell_syntax() {
+        // The exact shape a `POST /verify/run` body can carry: a runner field
+        // whose job is to end the runner word and start a second command.
+        let refusal = parse_runner("notarealrunner; touch pwned")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            refusal.contains("refusing the test runner"),
+            "the refusal must name itself: {refusal}"
+        );
+        assert!(
+            refusal.contains("';'"),
+            "the refusal must name the character it rejected: {refusal}"
+        );
+
+        for hostile in [
+            "pytest && curl http://example.invalid",
+            "pytest | sh",
+            "pytest $(id)",
+            "pytest `id`",
+            "pytest\nid",
+            "pytest > /tmp/out",
+        ] {
+            assert!(
+                parse_runner(hostile).is_err(),
+                "a runner carrying shell syntax must be refused: {hostile:?}"
+            );
+        }
+
+        // The runners this route is actually for still parse.
+        assert!(matches!(parse_runner("cargo").unwrap(), TestRunner::Cargo));
+        assert!(matches!(
+            parse_runner("env /bin/echo").unwrap(),
+            TestRunner::Custom(_)
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_custom_runner_cannot_reach_the_shell_through_the_built_command() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("pwned");
+        let hostile = format!("notarealrunner; touch {}", marker.display());
+
+        // The quoting layer on its own, reached the way it would be if a later
+        // caller built a command without going through `parse_runner`.
+        let command = build_runner_command(&TestRunner::Custom(hostile), "Entity", &[]);
+        assert!(
+            !command.contains("; touch"),
+            "the runner field reached the shell line unquoted: {command}"
+        );
+
+        let _ = verification_command(dir.path(), &command).output().unwrap();
+        assert!(
+            !marker.exists(),
+            "the runner field executed a second command: {} exists",
+            marker.display()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_multi_word_custom_runner_still_runs_its_program() {
+        let dir = tempfile::tempdir().unwrap();
+        let runner = parse_runner("env /bin/echo").unwrap();
+        let command = build_runner_command(&runner, "Entity", &[]);
+
+        let output = verification_command(dir.path(), &command).output().unwrap();
+        assert!(
+            output.status.success(),
+            "a legitimate multi-word runner must still run: {command}"
+        );
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "Entity");
     }
 
     #[tokio::test]

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -564,6 +564,64 @@ fn daemon_auth_token_from_layout(layout: &KinLayout) -> Option<String> {
     (!token.is_empty()).then_some(token)
 }
 
+/// Whether a daemon endpoint names this machine's own loopback interface.
+///
+/// The one question that decides whether a locally provisioned bearer token may
+/// be attached to a request, and whether an endpoint handed over by another
+/// process may be routed to at all. Answered on the parsed URL rather than on a
+/// prefix match, because `http://127.0.0.1.example.com/` and
+/// `http://localhost@evil.example/` both start with the strings a prefix test
+/// looks for and neither is loopback.
+///
+/// A scheme other than http or https is not an endpoint this client speaks, and
+/// userinfo in the authority is a way to make the host look like something it is
+/// not, so both answer false.
+pub(crate) fn endpoint_is_loopback(base_url: &str) -> bool {
+    let Ok(url) = url::Url::parse(base_url.trim()) else {
+        return false;
+    };
+    if !matches!(url.scheme(), "http" | "https") {
+        return false;
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return false;
+    }
+    match url.host() {
+        Some(url::Host::Domain(name)) => name.eq_ignore_ascii_case("localhost"),
+        Some(url::Host::Ipv4(addr)) => addr.is_loopback(),
+        Some(url::Host::Ipv6(addr)) => addr.is_loopback(),
+        None => false,
+    }
+}
+
+/// Refuse to hand the locally provisioned daemon token to an endpoint that is
+/// not this machine's own.
+///
+/// `<repo>/.kin/daemon.token` authenticates the daemon on this machine and
+/// nothing else. `KIN_DAEMON_URL` carried no scheme or host check, and the
+/// supervisor's route table is written by whoever registers, so both could name
+/// a host somebody else answers on; the token then went out on the first
+/// request, to a server that also gets to shape every answer the CLI reads back.
+///
+/// The one token that may travel is an explicit `KIN_DAEMON_AUTH_TOKEN`, because
+/// pairing a credential with an endpoint by hand is exactly what that variable
+/// is for. A remote endpoint without one is refused by name rather than
+/// authenticated with a local secret.
+fn refuse_local_token_leaving_loopback(base_url: &str, auth_token: &str) -> Result<()> {
+    if endpoint_is_loopback(base_url) {
+        return Ok(());
+    }
+    if daemon_auth_token_from_env().as_deref() == Some(auth_token) {
+        return Ok(());
+    }
+    bail!(
+        "refusing to send the local daemon token to {base_url}, which is not loopback. \
+         <repo>/.kin/daemon.token authenticates the daemon on this machine only. Point \
+         KIN_DAEMON_URL at http://127.0.0.1, http://localhost or an https loopback address, or \
+         pair the remote endpoint with its own credential in KIN_DAEMON_AUTH_TOKEN."
+    )
+}
+
 fn daemon_client_headers(
     auth_token: Option<String>,
     session_id: Option<&str>,
@@ -656,6 +714,9 @@ impl DaemonClient {
         session_id: Option<&str>,
     ) -> Result<Self> {
         let base_url = base_url.into();
+        if let Some(token) = auth_token.as_deref() {
+            refuse_local_token_leaving_loopback(&base_url, token)?;
+        }
         let headers = daemon_client_headers(auth_token, session_id)?;
         let request_timeout = std::env::var("KIN_DAEMON_HTTP_TIMEOUT_SECS")
             .ok()
@@ -3922,6 +3983,50 @@ fn supervisor_auth_token() -> Option<String> {
                 .map(|value| value.trim().to_string())
                 .filter(|value| !value.is_empty())
         })
+}
+
+/// Attach the supervisor bearer token to an async request, when there is one.
+fn with_supervisor_auth(request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+    match supervisor_auth_token() {
+        Some(token) => request.bearer_auth(token),
+        None => request,
+    }
+}
+
+/// The blocking twin of [`with_supervisor_auth`].
+fn with_supervisor_auth_blocking(
+    request: reqwest::blocking::RequestBuilder,
+) -> reqwest::blocking::RequestBuilder {
+    match supervisor_auth_token() {
+        Some(token) => request.bearer_auth(token),
+        None => request,
+    }
+}
+
+/// The endpoint a supervisor route may send this process to, or `None`.
+///
+/// The supervisor stores whatever endpoint a registration reports and a
+/// heartbeat overwrites it, so this value is written by another process rather
+/// than derived here. Its sibling `supervisor_route_for_repo` never trusted it:
+/// that one keeps the port and rebuilds a loopback URL. This is the path that
+/// used the string verbatim, and then built an authenticated client on it, so a
+/// process that repointed a repository's route collected the repository's
+/// bearer token and answered every question the CLI asked afterwards.
+///
+/// A repo daemon always registers `http://127.0.0.1:<port>`
+/// (`supervisor::repo_registration_payload`), so nothing legitimate is refused
+/// here. A refusal is loud rather than silent, because a route that names
+/// another host is not a stale record.
+fn trusted_supervisor_endpoint(endpoint: &str) -> Option<String> {
+    if endpoint_is_loopback(endpoint) {
+        return Some(endpoint.to_string());
+    }
+    tracing::warn!(
+        %endpoint,
+        "refusing a supervisor route that does not name loopback; no request was sent to it and \
+         no daemon token left this process"
+    );
+    None
 }
 
 /// Remove the supervisor's pid/port endpoint files. Called after a confirmed
@@ -7638,20 +7743,19 @@ fn supervisor_instance_id(pid: u32, port: u16) -> String {
 
 async fn supervisor_route_for_repo(kin_root: &Path, supervisor_url: &str) -> Option<String> {
     let repo_id = repo_id_for_kin_root(kin_root)?;
-    let route: SupervisorRouteResponse = daemon_health_client()
-        .get(format!(
-            "{}/repos/{}/route",
-            supervisor_url.trim_end_matches('/'),
-            urlencoding::encode(&repo_id)
-        ))
-        .send()
-        .await
-        .ok()?
-        .error_for_status()
-        .ok()?
-        .json()
-        .await
-        .ok()?;
+    let route: SupervisorRouteResponse = with_supervisor_auth(daemon_health_client().get(format!(
+        "{}/repos/{}/route",
+        supervisor_url.trim_end_matches('/'),
+        urlencoding::encode(&repo_id)
+    )))
+    .send()
+    .await
+    .ok()?
+    .error_for_status()
+    .ok()?
+    .json()
+    .await
+    .ok()?;
 
     let port = route
         .endpoint
@@ -7685,22 +7789,22 @@ fn supervisor_route_for_repo_if_running(kin_root: &Path) -> Option<String> {
         .timeout(Duration::from_secs(2))
         .build()
         .ok()?;
-    let route: SupervisorRouteResponse = client
-        .get(format!(
-            "{}/repos/{}/route",
-            supervisor_url.trim_end_matches('/'),
-            urlencoding::encode(&repo_id)
-        ))
-        .send()
-        .ok()?
-        .error_for_status()
-        .ok()?
-        .json()
-        .ok()?;
+    let route: SupervisorRouteResponse = with_supervisor_auth_blocking(client.get(format!(
+        "{}/repos/{}/route",
+        supervisor_url.trim_end_matches('/'),
+        urlencoding::encode(&repo_id)
+    )))
+    .send()
+    .ok()?
+    .error_for_status()
+    .ok()?
+    .json()
+    .ok()?;
 
+    let endpoint = trusted_supervisor_endpoint(&route.endpoint)?;
     let working_dir = kin_root.parent()?;
     let health: HealthResponse = client
-        .get(format!("{}/health", route.endpoint.trim_end_matches('/')))
+        .get(format!("{}/health", endpoint.trim_end_matches('/')))
         .send()
         .ok()?
         .error_for_status()
@@ -7708,7 +7812,7 @@ fn supervisor_route_for_repo_if_running(kin_root: &Path) -> Option<String> {
         .json()
         .ok()?;
     validate_health_repo(&health, working_dir).ok()?;
-    Some(route.endpoint)
+    Some(endpoint)
 }
 
 async fn supervisor_route_for_repo_if_running_async(kin_root: &Path) -> Option<String> {
@@ -7719,24 +7823,24 @@ async fn supervisor_route_for_repo_if_running_async(kin_root: &Path) -> Option<S
         .timeout(Duration::from_secs(2))
         .build()
         .ok()?;
-    let route: SupervisorRouteResponse = client
-        .get(format!(
-            "{}/repos/{}/route",
-            supervisor_url.trim_end_matches('/'),
-            urlencoding::encode(&repo_id)
-        ))
-        .send()
-        .await
-        .ok()?
-        .error_for_status()
-        .ok()?
-        .json()
-        .await
-        .ok()?;
+    let route: SupervisorRouteResponse = with_supervisor_auth(client.get(format!(
+        "{}/repos/{}/route",
+        supervisor_url.trim_end_matches('/'),
+        urlencoding::encode(&repo_id)
+    )))
+    .send()
+    .await
+    .ok()?
+    .error_for_status()
+    .ok()?
+    .json()
+    .await
+    .ok()?;
 
+    let endpoint = trusted_supervisor_endpoint(&route.endpoint)?;
     let working_dir = kin_root.parent()?;
     let health: HealthResponse = client
-        .get(format!("{}/health", route.endpoint.trim_end_matches('/')))
+        .get(format!("{}/health", endpoint.trim_end_matches('/')))
         .send()
         .await
         .ok()?
@@ -7746,7 +7850,7 @@ async fn supervisor_route_for_repo_if_running_async(kin_root: &Path) -> Option<S
         .await
         .ok()?;
     validate_health_repo(&health, working_dir).ok()?;
-    Some(route.endpoint)
+    Some(endpoint)
 }
 
 async fn register_repo_daemon_with_supervisor(
@@ -7817,15 +7921,14 @@ async fn post_supervisor_registration(
     supervisor_url: &str,
     registration: &SupervisorRegistration,
 ) -> Result<(), reqwest::Error> {
-    daemon_health_client()
-        .post(format!(
-            "{}/daemons/register",
-            supervisor_url.trim_end_matches('/')
-        ))
-        .json(registration)
-        .send()
-        .await?
-        .error_for_status()?;
+    with_supervisor_auth(daemon_health_client().post(format!(
+        "{}/daemons/register",
+        supervisor_url.trim_end_matches('/')
+    )))
+    .json(registration)
+    .send()
+    .await?
+    .error_for_status()?;
     Ok(())
 }
 
@@ -13143,6 +13246,124 @@ mod tests {
             assert!(
                 !message.contains("no Kin daemon is reachable"),
                 "from_override={from_override}: {message}"
+            );
+        }
+    }
+
+    /// What counts as this machine's own daemon, and what only looks like it.
+    #[test]
+    fn only_a_real_loopback_endpoint_reads_as_loopback() {
+        for trusted in [
+            "http://127.0.0.1:4219",
+            "http://127.0.0.1",
+            "http://127.7.7.7:4219",
+            "http://localhost:4219",
+            "http://LOCALHOST:4219",
+            "http://[::1]:4219",
+            "https://127.0.0.1:4219",
+            "https://localhost",
+        ] {
+            assert!(
+                endpoint_is_loopback(trusted),
+                "{trusted} names this machine and must be trusted"
+            );
+        }
+
+        for hostile in [
+            "http://attacker.example:4219",
+            "http://10.0.0.5:4219",
+            // Every one of these starts with a string a prefix test looks for.
+            "http://127.0.0.1.attacker.example:4219",
+            "http://localhost.attacker.example:4219",
+            "http://localhost@attacker.example:4219",
+            "http://127.0.0.1:4219@attacker.example",
+            // Not an endpoint this client speaks.
+            "file:///etc/passwd",
+            "ftp://127.0.0.1",
+            "127.0.0.1:4219",
+            "",
+        ] {
+            assert!(
+                !endpoint_is_loopback(hostile),
+                "{hostile} is not this machine and must not be trusted"
+            );
+        }
+    }
+
+    /// The repo-local daemon token authenticates one daemon on this machine.
+    /// A `KIN_DAEMON_URL` naming somewhere else must not collect it.
+    #[test]
+    #[serial_test::serial]
+    fn the_local_daemon_token_never_leaves_loopback() {
+        let _paired = kin_core::test_env::EnvVarGuard::unset("KIN_DAEMON_AUTH_TOKEN");
+
+        // Control: the same token on a loopback endpoint is the ordinary path.
+        assert!(DaemonClient::from_base_url_with_explicit_authority(
+            "http://127.0.0.1:4219",
+            Some("repo-local-token".to_string()),
+            None,
+        )
+        .is_ok());
+
+        let refusal = DaemonClient::from_base_url_with_explicit_authority(
+            "http://attacker.example:4219",
+            Some("repo-local-token".to_string()),
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            refusal.contains("refusing to send the local daemon token"),
+            "the refusal must name what it refused: {refusal}"
+        );
+        assert!(
+            refusal.contains("attacker.example"),
+            "the refusal must name the endpoint: {refusal}"
+        );
+
+        // A remote endpoint an operator paired with its own credential is the
+        // documented way to reach one, and it still works.
+        let mut paired =
+            kin_core::test_env::EnvVarGuard::set("KIN_DAEMON_AUTH_TOKEN", "paired-remote-token");
+        assert!(
+            DaemonClient::from_base_url_with_explicit_authority(
+                "https://daemon.example:4219",
+                Some("paired-remote-token".to_string()),
+                None,
+            )
+            .is_ok(),
+            "a remote endpoint paired with KIN_DAEMON_AUTH_TOKEN must still be reachable"
+        );
+
+        // The pairing is per token, not a blanket opt-out: the repo-local token
+        // still cannot ride to that endpoint.
+        assert!(DaemonClient::from_base_url_with_explicit_authority(
+            "https://daemon.example:4219",
+            Some("repo-local-token".to_string()),
+            None,
+        )
+        .is_err());
+
+        paired.apply("KIN_DAEMON_AUTH_TOKEN", None::<&str>);
+    }
+
+    /// A supervisor route is written by whichever process registered, so the
+    /// endpoint it hands back is another process's claim rather than a fact.
+    #[test]
+    fn a_supervisor_route_naming_another_host_is_refused() {
+        assert_eq!(
+            trusted_supervisor_endpoint("http://127.0.0.1:4219").as_deref(),
+            Some("http://127.0.0.1:4219"),
+            "the endpoint a repo daemon actually registers must route"
+        );
+        for hostile in [
+            "http://attacker.example:4219",
+            "http://10.0.0.5:4219",
+            "http://127.0.0.1.attacker.example:4219",
+        ] {
+            assert!(
+                trusted_supervisor_endpoint(hostile).is_none(),
+                "{hostile} must not become this command's daemon"
             );
         }
     }

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -13305,13 +13305,16 @@ mod tests {
         )
         .is_ok());
 
-        let refusal = DaemonClient::from_base_url_with_explicit_authority(
+        // Matched rather than unwrapped: `DaemonClient` is not `Debug`, so
+        // `unwrap_err` cannot render the Ok side.
+        let refusal = match DaemonClient::from_base_url_with_explicit_authority(
             "http://attacker.example:4219",
             Some("repo-local-token".to_string()),
             None,
-        )
-        .unwrap_err()
-        .to_string();
+        ) {
+            Ok(_) => panic!("a non-loopback endpoint must not receive the local daemon token"),
+            Err(error) => error.to_string(),
+        };
         assert!(
             refusal.contains("refusing to send the local daemon token"),
             "the refusal must name what it refused: {refusal}"

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -13251,9 +13251,15 @@ mod tests {
     }
 
     /// What counts as this machine's own daemon, and what only looks like it.
+    ///
+    /// Reported by index rather than by value. Two of the refused entries carry
+    /// userinfo, which is the whole point of having them, and CodeQL's
+    /// `rust/cleartext-logging` reads a URL interpolated into a panic message as
+    /// a credential reaching a sink. The index maps to the line above it, so a
+    /// failure is still one line away from the input that caused it.
     #[test]
     fn only_a_real_loopback_endpoint_reads_as_loopback() {
-        for trusted in [
+        for (index, endpoint) in [
             "http://127.0.0.1:4219",
             "http://127.0.0.1",
             "http://127.7.7.7:4219",
@@ -13262,14 +13268,17 @@ mod tests {
             "http://[::1]:4219",
             "https://127.0.0.1:4219",
             "https://localhost",
-        ] {
+        ]
+        .into_iter()
+        .enumerate()
+        {
             assert!(
-                endpoint_is_loopback(trusted),
-                "{trusted} names this machine and must be trusted"
+                endpoint_is_loopback(endpoint),
+                "loopback case {index} names this machine and must be trusted"
             );
         }
 
-        for hostile in [
+        for (index, endpoint) in [
             "http://attacker.example:4219",
             "http://10.0.0.5:4219",
             // Every one of these starts with a string a prefix test looks for.
@@ -13282,10 +13291,13 @@ mod tests {
             "ftp://127.0.0.1",
             "127.0.0.1:4219",
             "",
-        ] {
+        ]
+        .into_iter()
+        .enumerate()
+        {
             assert!(
-                !endpoint_is_loopback(hostile),
-                "{hostile} is not this machine and must not be trusted"
+                !endpoint_is_loopback(endpoint),
+                "refused case {index} is not this machine and must not be trusted"
             );
         }
     }
@@ -13317,11 +13329,11 @@ mod tests {
         };
         assert!(
             refusal.contains("refusing to send the local daemon token"),
-            "the refusal must name what it refused: {refusal}"
+            "the refusal must name what it refused"
         );
         assert!(
             refusal.contains("attacker.example"),
-            "the refusal must name the endpoint: {refusal}"
+            "the refusal must name the endpoint it refused"
         );
 
         // A remote endpoint an operator paired with its own credential is the

--- a/crates/kin-core/src/env_registry.rs
+++ b/crates/kin-core/src/env_registry.rs
@@ -241,7 +241,7 @@ pub const OPERATIONAL: &[EnvVarSpec] = &[
     // ---- supervisor -----------------------------------------------------------
     EnvVarSpec { name: "KIN_SUPERVISOR_URL", kind: Kind::Url, default: "", sensitivity: Sensitivity::Operational, summary: "explicit supervisor endpoint URL" },
     EnvVarSpec { name: "KIN_SUPERVISOR_BIND_HOST", kind: Kind::Str, default: "", sensitivity: Sensitivity::Operational, summary: "host/interface the supervisor binds to" },
-    EnvVarSpec { name: "KIN_SUPERVISOR_REQUIRE_TOKEN", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Operational, summary: "require a bearer token for supervisor requests" },
+    EnvVarSpec { name: "KIN_SUPERVISOR_REQUIRE_TOKEN", kind: Kind::Bool, default: "true", sensitivity: Sensitivity::Operational, summary: "require a bearer token for supervisor requests; set falsy to opt out" },
     EnvVarSpec { name: "KIN_SUPERVISOR_IDLE_TIMEOUT_SECS", kind: Kind::Secs, default: "3600", sensitivity: Sensitivity::Operational, summary: "supervisor auto-shutdown idle period; 0 disables idle shutdown" },
     EnvVarSpec { name: "KIN_SUPERVISOR_STARTUP_GENERATION", kind: Kind::Str, default: "", sensitivity: Sensitivity::Operational, summary: "internal versioned supervisor launch capability generation" },
     EnvVarSpec { name: "KIN_SUPERVISOR_REAP_CPU", kind: Kind::Bool, default: "true", sensitivity: Sensitivity::Operational, summary: "enable the CPU-heuristic zombie reaper; set falsey to disable" },

--- a/crates/kin-daemon/src/supervisor.rs
+++ b/crates/kin-daemon/src/supervisor.rs
@@ -505,15 +505,14 @@ async fn post_registration(
     supervisor_url: &str,
     payload: &RepoDaemonRegistration,
 ) -> Result<(), reqwest::Error> {
-    client
-        .post(format!(
-            "{}/daemons/register",
-            supervisor_url.trim_end_matches('/')
-        ))
-        .json(payload)
-        .send()
-        .await?
-        .error_for_status()?;
+    with_supervisor_auth(client.post(format!(
+        "{}/daemons/register",
+        supervisor_url.trim_end_matches('/')
+    )))
+    .json(payload)
+    .send()
+    .await?
+    .error_for_status()?;
     Ok(())
 }
 
@@ -522,16 +521,15 @@ async fn post_heartbeat(
     supervisor_url: &str,
     payload: &RepoDaemonRegistration,
 ) -> Result<(), reqwest::Error> {
-    client
-        .post(format!(
-            "{}/daemons/{}/heartbeat",
-            supervisor_url.trim_end_matches('/'),
-            payload.repo_id
-        ))
-        .json(payload)
-        .send()
-        .await?
-        .error_for_status()?;
+    with_supervisor_auth(client.post(format!(
+        "{}/daemons/{}/heartbeat",
+        supervisor_url.trim_end_matches('/'),
+        payload.repo_id
+    )))
+    .json(payload)
+    .send()
+    .await?
+    .error_for_status()?;
     Ok(())
 }
 
@@ -540,16 +538,15 @@ async fn delete_registration(
     supervisor_url: &str,
     payload: &RepoDaemonRegistration,
 ) -> Result<(), reqwest::Error> {
-    client
-        .delete(format!(
-            "{}/daemons/{}?instance_id={}",
-            supervisor_url.trim_end_matches('/'),
-            payload.repo_id,
-            payload.instance_id
-        ))
-        .send()
-        .await?
-        .error_for_status()?;
+    with_supervisor_auth(client.delete(format!(
+        "{}/daemons/{}?instance_id={}",
+        supervisor_url.trim_end_matches('/'),
+        payload.repo_id,
+        payload.instance_id
+    )))
+    .send()
+    .await?
+    .error_for_status()?;
     Ok(())
 }
 
@@ -1152,17 +1149,58 @@ fn ensure_loopback_token(dir: &Path) -> std::io::Result<String> {
 }
 
 /// Whether the supervisor should ENFORCE the per-install loopback token.
-/// Opt-in via `KIN_SUPERVISOR_REQUIRE_TOKEN`, mirroring the repo daemon's
-/// `KIN_DAEMON_REQUIRE_TOKEN`. The Host/Origin guard is always active regardless.
+///
+/// Enforcement is default-on, byte for byte the policy `api::loopback_token_enforced`
+/// holds for the repo daemon: `KIN_SUPERVISOR_REQUIRE_TOKEN` is the documented
+/// escape hatch and takes a falsy value (`0`/`false`/`no`/`off`) to run without
+/// bearer auth, and anything else, including unset, enforces.
+///
+/// It used to be the inverse, opt-in, and that made this the softer of two
+/// adjacent surfaces rather than the harder one. The supervisor is machine-wide:
+/// unauthenticated it lists every repository this user has open and accepts
+/// `/shutdown` from any local process. Loopback is not a user boundary, and
+/// every client that reaches these routes already reads the auto-provisioned
+/// `supervisor.token` beside them, so a fresh install authenticates with no
+/// operator setup. The Host/Origin guard is always active regardless of this
+/// flag.
 fn loopback_token_enforced() -> bool {
     std::env::var("KIN_SUPERVISOR_REQUIRE_TOKEN")
         .map(|value| {
-            matches!(
+            !matches!(
                 value.trim().to_ascii_lowercase().as_str(),
-                "1" | "true" | "yes" | "on"
+                "0" | "false" | "no" | "off"
             )
         })
-        .unwrap_or(false)
+        .unwrap_or(true)
+}
+
+/// The bearer token this process presents to a supervisor it calls.
+///
+/// The mirror of [`resolve_serve_auth_token`] on the client side, and the same
+/// order the CLI's `daemon_client::supervisor_auth_token` uses: an explicit
+/// `KIN_SUPERVISOR_AUTH_TOKEN` wins, otherwise the already-provisioned
+/// per-install token is adopted. Read rather than provisioned, because a
+/// registering worker must never be the process that creates the supervisor's
+/// credential.
+fn supervisor_client_auth_token() -> Option<String> {
+    std::env::var(SUPERVISOR_AUTH_TOKEN_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            std::fs::read_to_string(supervisor_token_path(&supervisor_dir()))
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        })
+}
+
+/// Attach the supervisor bearer token to a request, when there is one to send.
+fn with_supervisor_auth(request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+    match supervisor_client_auth_token() {
+        Some(token) => request.bearer_auth(token),
+        None => request,
+    }
 }
 
 /// Resolve the auth token the serving supervisor enforces: an explicit
@@ -4117,16 +4155,32 @@ mod tests {
             assert_eq!(mode & 0o777, 0o600, "supervisor token file must be 0600");
         }
 
-        // Default: enforcement OFF — the file is provisioned but not required, so
-        // existing unauthenticated local clients keep working.
-        assert!(resolve_serve_auth_token(&dir).is_none());
+        // Default: enforcement ON, the same default the repo daemon holds. The
+        // provisioned token is returned and required, so the machine-wide
+        // control plane is not readable by every local process.
+        assert_eq!(
+            resolve_serve_auth_token(&dir).as_deref(),
+            Some(token.as_str()),
+            "the supervisor must enforce its loopback token by default"
+        );
 
-        // Opt-in via KIN_SUPERVISOR_REQUIRE_TOKEN returns the provisioned token.
+        // A truthy KIN_SUPERVISOR_REQUIRE_TOKEN is the same as the default.
         tokens.apply("KIN_SUPERVISOR_REQUIRE_TOKEN", Some("1"));
         assert_eq!(
             resolve_serve_auth_token(&dir).as_deref(),
             Some(token.as_str())
         );
+
+        // The documented escape hatch: a falsy value opts out, matching
+        // `KIN_DAEMON_REQUIRE_TOKEN`.
+        for opted_out in ["0", "false", "no", "off", " OFF "] {
+            tokens.apply("KIN_SUPERVISOR_REQUIRE_TOKEN", Some(opted_out));
+            assert!(
+                resolve_serve_auth_token(&dir).is_none(),
+                "{opted_out:?} must opt out of supervisor bearer auth"
+            );
+        }
+        tokens.apply("KIN_SUPERVISOR_REQUIRE_TOKEN", None::<&str>);
 
         // An explicit KIN_SUPERVISOR_AUTH_TOKEN override always wins.
         tokens.apply("KIN_SUPERVISOR_AUTH_TOKEN", Some("explicit-override"));
@@ -4134,6 +4188,57 @@ mod tests {
             resolve_serve_auth_token(&dir).as_deref(),
             Some("explicit-override")
         );
+    }
+
+    /// The two routes an unauthenticated local process must not reach.
+    ///
+    /// `supervisor_bearer_token_protects_control_routes` above covers `/repos`.
+    /// These two are the ones with teeth: `/shutdown` stops the supervisor for
+    /// every repository this user has open, and `/daemons/register` is what
+    /// writes the endpoint the CLI later routes to.
+    #[tokio::test]
+    async fn supervisor_mutating_routes_refuse_an_unauthenticated_caller() {
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let app = router_with_auth_and_shutdown(
+            Arc::new(SupervisorState::new()),
+            Some("supervisor-token".to_string()),
+            Some(shutdown_tx),
+        );
+
+        for path in ["/shutdown", "/daemons/register"] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::post(path)
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .body(Body::from("{}"))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                response.status(),
+                StatusCode::UNAUTHORIZED,
+                "POST {path} answered an unauthenticated caller"
+            );
+        }
+        assert!(
+            !*shutdown_rx.borrow(),
+            "an unauthenticated caller reached /shutdown"
+        );
+
+        // Positive control: the same router answers a caller that presents the
+        // token, so the assertions above read auth rather than a dead router.
+        let authorized = app
+            .oneshot(
+                Request::get("/repos")
+                    .header(header::AUTHORIZATION, "Bearer supervisor-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(authorized.status(), StatusCode::OK);
     }
 
     #[test]

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -158,7 +158,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_SUPERVISOR_REDEPLOY_DISABLE` | bool | false | operational | disable supervisor auto-redeploy |
 | `KIN_SUPERVISOR_REDEPLOY_GRACE` | seconds>=0 | *(unset)* | operational | grace period before a supervisor redeploy |
 | `KIN_SUPERVISOR_REEXEC_DISABLE` | bool | false | operational | disable supervisor self-reexec on binary mtime change |
-| `KIN_SUPERVISOR_REQUIRE_TOKEN` | bool | false | operational | require a bearer token for supervisor requests |
+| `KIN_SUPERVISOR_REQUIRE_TOKEN` | bool | true | operational | require a bearer token for supervisor requests; set falsy to opt out |
 | `KIN_SUPERVISOR_STARTUP_GENERATION` | string | *(unset)* | operational | internal versioned supervisor launch capability generation |
 | `KIN_SUPERVISOR_URL` | url | *(unset)* | operational | explicit supervisor endpoint URL |
 

--- a/docs/security/signing-and-update-trust.md
+++ b/docs/security/signing-and-update-trust.md
@@ -268,6 +268,26 @@ asserts `kin-daemon` is present in the archive before moving any files, so a
 daemon-less archive aborts cleanly instead of leaving a half-installed
 environment.
 
+### What the installer writes outside its own prefix
+
+Worth knowing before you pipe it to a shell. It needs no sudo, pipes nothing into
+a second shell, and never relaxes TLS, but it is not confined to its install
+prefix:
+
+- **A PATH line in your shell startup file.** `scripts/install.sh` writes to
+  `~/.zshenv` or `~/.bashrc` depending on the host's actual shell, and it will
+  create `~/.bash_profile` if that is the file it needs.
+- **Agent MCP configuration.** The `kin setup` step the installer runs writes MCP
+  server entries into the agent configuration files it finds, so an editor or CLI
+  agent on the machine gains a Kin server it did not have.
+- **A per-user LaunchAgent on macOS.** The daemon installs a plist under
+  `~/Library/LaunchAgents`. It is per-user, not a system LaunchDaemon, and the
+  loader refuses a plist that is not a singly-linked regular file owned by you.
+  Nothing in this repository ships a scheduled background updater: there is no
+  `StartInterval` or `StartCalendarInterval` in either service template.
+
+`kin update` writes only inside its own 0700 root.
+
 ### Unattended pinned updater contract
 
 An unattended mutating `kin update` requires the complete

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -98,6 +98,27 @@ Enforcement of the per-install token is **on by default**:
   and is always enforced, even while `KIN_DAEMON_REQUIRE_TOKEN` is opted out;
   this is also the token required to bind a non-loopback address.
 
+### The machine-wide supervisor
+
+The supervisor is a second HTTP control plane, one per user rather than one per
+repository, and it holds the same policy. It provisions `~/.kin/supervisor.token`
+on first run and enforces it by default; `KIN_SUPERVISOR_REQUIRE_TOKEN` set to a
+falsy value (`0`, `false`, `no`, `off`) is the escape hatch, and
+`KIN_SUPERVISOR_AUTH_TOKEN` is the explicit override that always wins. Only
+`/health` and `/readiness` are public. Everything else, including `/repos`,
+`/daemons`, `/daemons/register` and `/shutdown`, needs the bearer token, because
+unauthenticated those routes name every repository the user has open and let any
+local process stop the supervisor for all of them.
+
+The CLI trusts a route the supervisor hands back only when it names loopback. The
+supervisor stores whatever endpoint a registration reports, so that value is
+another process's claim rather than a fact, and a route naming another host is
+refused before any request is sent to it. The same rule governs `KIN_DAEMON_URL`:
+the auto-provisioned `<repo>/.kin/daemon.token` is attached only to a loopback
+endpoint, and a remote endpoint must be paired with its own
+`KIN_DAEMON_AUTH_TOKEN` or the client refuses by name rather than sending a local
+credential to a host it cannot vouch for.
+
 ### Resulting trust boundary
 
 In its default configuration the daemon's effective trust boundary is **any

--- a/docs/security/what-leaves-the-machine.md
+++ b/docs/security/what-leaves-the-machine.md
@@ -10,24 +10,32 @@ The short version: in the default configuration, your source code, the graph bui
 it, and every query you run stay on the machine. The exits below are the complete list,
 and each is either a download of a public artifact or a surface you explicitly
 configured. If a claim here stops matching the code, treat that as a bug and report it
-per [SECURITY.md](../../SECURITY.md).
+per [SECURITY.md](../../SECURITY.md). A source review on 2026-09-03 found three exits this
+list did not name and one sentence that overstated the default posture. All four are
+corrected below, which is worth saying out loud: a document that claims completeness earns
+exactly this kind of audit.
 
 ## The Default Posture
 
 Kin is local-first by construction, not by policy. The daemon binds `127.0.0.1`,
 authenticates requests with a bearer token, and rejects cross-origin and DNS-rebinding
 tricks (see the threat model for the mechanics). Retrieval, search, context, trace, and
-review all execute against the local graph over loopback. No code path serializes
-repository content into an outbound request unless you configure one of the two opt-in
-surfaces named below, and both are off until you turn them on.
+review all execute against the local graph over loopback. Two surfaces serialize
+repository content into an outbound request, a remote embedding provider and
+`kin agent run`, and neither can happen until you configure it: one needs
+`KIN_EMBED_PROVIDER` set away from `local`, the other needs an endpoint passed on the
+command line.
 
 ## Every Network Exit
 
 **Release acquisition.** The npm launcher (`@kinlab/kin`) downloads the matching release
 archive and its checksums from GitHub releases
 (`github.com/firelock-ai/kin/releases/download`) on demand, verifies them, and caches
-the binaries. `KIN_MCP_RELEASE_BASE_URL` points it at a mirror if you host one. The
-request carries nothing but the fetch itself.
+the binaries. `KIN_MCP_RELEASE_BASE_URL` points it at a mirror if you host one, and must
+be https or a loopback address. The request carries nothing but the fetch itself. The
+checksum comes from the same base URL as the archive, which is covered in
+[signing-and-update-trust.md](./signing-and-update-trust.md); that document also lists
+what the shell installer writes outside its own prefix.
 
 **The update surface.** `kin update` reads release metadata from
 `api.github.com/repos/firelock-ai/kin` and downloads checksum-verified assets from the
@@ -46,17 +54,48 @@ the fetch, inference is fully local. The download sends nothing outbound but the
 itself; entity text never rides along.
 
 **Hosted login and remote surfaces (opt-in).** `kin auth login` speaks to the host you
-name (default `https://kinlab.ai`). Credentials are stored in the OS keyring, or in an
-`age`-encrypted file where no keyring exists, and are sent only to the host you logged
-into. The remote command families (`remote`, `publish`, and the other hosted surfaces)
-send exactly what the command says they send, to the remote you configured, and nothing
-runs against a remote you never set up.
+name (default `https://kinlab.ai`), and the credential it stores is sent only to that
+host. There are three storage tiers, tried in this order
+(`crates/kin-cli/src/commands/auth.rs`, `store_credential`): the OS keyring; an
+`age`-encrypted file when `KINLAB_AUTH_PASSPHRASE` is set; and, where neither is
+available, plaintext JSON carrying the bearer token, your account email and your display
+name. The third tier is the one to know about. It exists so a login can complete on a
+headless host with no keyring, which is where it fires most often. The file is created
+0600 inside a 0700 directory, and `kin auth login` prints a warning on stderr naming the
+file and the tier when it takes it. Set `KINLAB_AUTH_PASSPHRASE` before logging in to get
+the encrypted tier instead. The remote command families (`remote`, `publish`, and the
+other hosted surfaces) send exactly what the command says they send, to the remote you
+configured, and nothing runs against a remote you never set up.
 
 **Remote embedding providers (opt-in).** Setting `KIN_EMBED_PROVIDER` to an
 OpenAI-compatible provider sends entity text to the endpoint you configure, because that
-is what remote embedding is. This is the one configuration in which source-derived text
-leaves the machine outside the hosted remote surfaces. The default is `local`, and
-nothing selects a remote provider on its own.
+is what remote embedding is. The default is `local`, and nothing selects a remote
+provider on its own.
+
+**Agent runs against a model endpoint (opt-in).** `kin agent run --base-url <URL>` posts
+repository-derived text to the OpenAI-compatible endpoint you name. The endpoint is a
+required argument, so there is no default and no host to be surprised by, but the content
+is worth stating plainly: the run drives Kin's own MCP tools and pushes every tool result
+back into the conversation as a message (`crates/kin-agent/src/run.rs`, the `"role":
+"tool"` push), so graph answers and entity source ride along to that endpoint. Together
+with remote embedding this is the second configuration in which source-derived text
+leaves the machine, and the sentence that used to call remote embedding the only one was
+wrong.
+
+**Language-server install (opt-in).** `kin doctor --fix --install-language-servers`
+downloads rust-analyzer's own release binary from `github.com/rust-lang/rust-analyzer`
+(`crates/kin-cli/src/commands/language_server_release.rs`, `RUST_ANALYZER_RELEASE`). The
+release tag, the asset name, the SHA-256 and the byte size are all pinned in the source,
+the digest is checked before anything is installed, and the base-URL override is honoured
+only alongside a digest override. The request carries nothing but the fetch.
+
+**A reachability probe in `kin doctor`.** When the embedding model is not in the cache and
+nothing is blocking a fetch, `kin doctor` opens a TCP connection to `huggingface.co:443`
+and closes it, so it can tell "this host has no route to the weights" apart from "the
+weights are still downloading" (`crates/kin-cli/src/commands/health.rs`,
+`model_host_reachable`). `HF_ENDPOINT` changes the host it probes. It is a connect and a
+close rather than an HTTP request, and it carries no repository data. A machine that
+already holds the model is never probed.
 
 **Telemetry: none.** Kin uploads no telemetry. The opt-in `locate` telemetry described
 in [PRIVACY.md](../../PRIVACY.md) writes to a local spool under `.kin/telemetry/` and
@@ -66,7 +105,9 @@ stays there.
 
 Source code. Graph entities, edges, and history. Embeddings and the vector index.
 Queries and their results. The telemetry spool. Credentials, beyond the single host you
-chose to log into.
+chose to log into. Two opt-in surfaces move source-derived text once you turn them on,
+and only then: a remote embedding provider, and `kin agent run` against an endpoint you
+name.
 
 ## Hosted Deployments
 

--- a/packages/kin-mcp/src/index.js
+++ b/packages/kin-mcp/src/index.js
@@ -16,6 +16,46 @@ export const PACKAGE_VERSION = packageJson.version;
 export const DEFAULT_RELEASE_BASE_URL =
   'https://github.com/firelock-ai/kin/releases/download';
 
+/**
+ * The base URL the release archive and its checksum are both fetched from.
+ *
+ * They come from the same host by construction: `checksumUrl` is derived from
+ * `archiveUrl`. Over plain http anyone on the path serves both, so the
+ * integrity check compares their bytes against their digest, and what lands is
+ * chmod 0755 and executed. https is required, with one exception: a loopback
+ * address, where there is no network path to sit on and a local mirror is a
+ * real thing people run.
+ *
+ * This closes the passive-network attacker only. An attacker who can set this
+ * variable can still point it at an https host they control, because the
+ * checksum travels beside the artifact; see docs/security/signing-and-update-trust.md.
+ */
+export function assertSecureReleaseBaseUrl(baseUrl) {
+  let parsed;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    throw new Error(
+      `KIN_MCP_RELEASE_BASE_URL is not a URL: ${baseUrl}`
+    );
+  }
+  if (parsed.protocol === 'https:') {
+    return baseUrl;
+  }
+  const host = parsed.hostname.replace(/^\[|\]$/g, '');
+  const isLoopback =
+    host === 'localhost' || host === '::1' || /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host);
+  if (parsed.protocol === 'http:' && isLoopback) {
+    return baseUrl;
+  }
+  throw new Error(
+    `refusing to download the Kin release over ${parsed.protocol}// from ${baseUrl}. ` +
+      'The archive and its checksum come from this same base URL, so plain http lets anyone ' +
+      'on the path serve both and the integrity check passes on their bytes. Use https, or a ' +
+      'loopback address for a local mirror.'
+  );
+}
+
 export function resolveReleaseTag(version = PACKAGE_VERSION) {
   return version.startsWith('v') ? version : `v${version}`;
 }
@@ -300,9 +340,8 @@ async function installKinBinary({ binaryPath, env, platform, arch, version }) {
     arch
   );
   const tag = resolveReleaseTag(version);
-  const baseUrl = (env.KIN_MCP_RELEASE_BASE_URL || DEFAULT_RELEASE_BASE_URL).replace(
-    /\/$/,
-    ''
+  const baseUrl = assertSecureReleaseBaseUrl(
+    (env.KIN_MCP_RELEASE_BASE_URL || DEFAULT_RELEASE_BASE_URL).replace(/\/$/, '')
   );
   const archiveUrl = `${baseUrl}/${tag}/${archiveName}`;
   const checksumUrl = `${archiveUrl}.sha256`;

--- a/packages/kin-mcp/test/index.test.js
+++ b/packages/kin-mcp/test/index.test.js
@@ -10,7 +10,9 @@ import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import {
+  assertSecureReleaseBaseUrl,
   childEnv,
+  DEFAULT_RELEASE_BASE_URL,
   ensureKinBinary,
   resolveCachedBinaryPath,
   resolveDaemonBinaryPath,
@@ -822,4 +824,48 @@ test('auto-init keeps MCP stdout protocol-only from process start', async () => 
   } finally {
     await fs.rm(tmpDir, { recursive: true, force: true });
   }
+});
+
+test('the release base URL must be https, or loopback for a local mirror', () => {
+  // The shipped default and any https mirror are fine.
+  assert.equal(
+    assertSecureReleaseBaseUrl(DEFAULT_RELEASE_BASE_URL),
+    DEFAULT_RELEASE_BASE_URL
+  );
+  assert.equal(
+    assertSecureReleaseBaseUrl('https://mirror.example/kin'),
+    'https://mirror.example/kin'
+  );
+
+  // A loopback mirror has no network path to sit on, so plain http is allowed
+  // there and only there. The wrapper's own tests drive one.
+  for (const loopback of [
+    'http://127.0.0.1:1',
+    'http://127.0.0.1:8080/kin',
+    'http://localhost:8080',
+    'http://[::1]:8080'
+  ]) {
+    assert.equal(assertSecureReleaseBaseUrl(loopback), loopback);
+  }
+
+  // The archive and its checksum come from this same base URL, so plain http
+  // to anywhere else means the integrity check grades the attacker's bytes
+  // against the attacker's digest, and what lands is chmod 0755 and executed.
+  for (const insecure of [
+    'http://mirror.example/kin',
+    'http://127.0.0.1.attacker.example/kin',
+    'http://localhost.attacker.example/kin',
+    'ftp://127.0.0.1/kin'
+  ]) {
+    assert.throws(
+      () => assertSecureReleaseBaseUrl(insecure),
+      /refusing to download the Kin release over/,
+      insecure
+    );
+  }
+
+  assert.throws(
+    () => assertSecureReleaseBaseUrl('not a url'),
+    /is not a URL/
+  );
 });


### PR DESCRIPTION
Six local attack-surface findings from tonight's source review (FIR-3124), each with a test that fails on the shipped behaviour. None of this is reachable from the network and none of it is reachable from a web page. It is a local privilege story: a process running as the same user, or a repository you cloned supplying an env block. That is worth saying plainly, and so is the other half, that "a request field lands on a shell line" and "any process on your Mac lists every repo you have open" are not sentences we want a reader to write for us before launch.

## What changed

**Command injection on `POST /verify/run`.** The request's `runner` field went onto an `sh -c` line unquoted while every sibling arm quoted its one interpolated value. Anyone who could read `<repo>/.kin/daemon.token` had arbitrary code execution as the user, which is what made that token worth stealing. Two defences now: `parse_runner` refuses a custom runner carrying anything outside letters, digits and ` ._-/=+:,@`, naming the characters it rejected; and the Custom arm quotes word by word, so each word is one argv slot. `npm test`, `env FOO=1 pytest` and `./scripts/test.sh` still work.

**The machine-wide supervisor enforced no bearer token by default**, the exact inverse of the repo daemon's default one file over. Unauthenticated it served `/repos`, `/daemons`, `/daemons/register`, heartbeat, delete, `/auth/rotation` and `/shutdown`. Loopback is not a user boundary. The default is now on with a falsy escape hatch, word for word the policy `KIN_DAEMON_REQUIRE_TOKEN` already holds, and every client that reaches those routes now sends the already-provisioned `~/.kin/supervisor.token`: the daemon's registration, heartbeat and deregistration loop, and the CLI's route reads and registration post. A fresh install authenticates with no operator setup.

**A repointed endpoint collected the repo's token.** The supervisor stores whatever endpoint a registration reports and a heartbeat overwrites it, so `supervisor_route_for_repo_if_running` routed on another process's claim and then built an authenticated client on it. Its sibling never trusted that string, keeping only the port and rebuilding a loopback URL. Both now refuse a route that does not name loopback, before any request is sent to it.

**`KIN_DAEMON_URL` had no scheme or host check,** so the repo-local `daemon.token` was attached to whatever host it named. Every `DaemonClient` goes through one constructor, and that constructor now refuses to attach a locally provisioned token to a non-loopback endpoint. Pointing at a remote daemon on purpose still works: pair it with its own `KIN_DAEMON_AUTH_TOKEN`. The local token still cannot ride along. `endpoint_is_loopback` answers on the parsed URL, so `http://127.0.0.1.attacker.example` and `http://localhost@attacker.example` are refused rather than matched by a prefix test.

**`KIN_MCP_RELEASE_BASE_URL` accepted plain http.** It moves the archive and its checksum together, so the integrity check graded the attacker's bytes against the attacker's digest, and what lands is chmod 0755 and executed. It now requires https, with one exception: a loopback address, where there is no network path to sit on and a local mirror is a real thing to run. The wrapper's own test drives `http://127.0.0.1:1` and still passes.

**`kin auth login` took the plaintext tier silently.** There are three tiers: keyring, an age-encrypted file when `KINLAB_AUTH_PASSPHRASE` is set, and plaintext JSON carrying the bearer token, the account email and the display name. The third was silent and its directory was created with the process umask, so 0755 on a typical host. Headless Linux is both the platform most likely to hit it and the one without macOS's private Application Support. The tier stays, because the alternative is a login that cannot complete on a headless host. It is now 0700 for the directory, with an existing wider one tightened, mode 0600 set at file creation rather than chmod'd after, and a warning on stderr naming the file, the tier, what it holds and the way to the encrypted tier.

## Disclosures that ship with this, not fixes

The npm launcher's checksum still travels beside the artifact: an attacker who can set `KIN_MCP_RELEASE_BASE_URL` can still name an https host they control and be believed. The scheme check closes the passive-network attacker only. Same shape for the shell installer and `kin update`, which is already stated in `signing-and-update-trust.md`.

`what-leaves-the-machine.md` claimed to be the complete list of network exits and missed three, now added with the source named beside each: the rust-analyzer download behind `kin doctor --fix --install-language-servers` (pinned tag, asset, SHA-256 and size; digest checked before install), the TCP connect-and-close `kin doctor` makes to `huggingface.co:443` when the model is absent, and `kin agent run --base-url`, which posts repository-derived text to the endpoint it is given because it pushes every MCP tool result back into the conversation. That last one falsified the doc's line calling remote embedding the only configuration in which source-derived text leaves the machine. There are two. The credential tiers are named as three rather than two, and `signing-and-update-trust.md` now lists what the shell installer writes outside its prefix: a PATH line in a shell startup file, agent MCP configuration through `kin setup`, and a per-user LaunchAgent on macOS. No scheduled background updater ships from this repo, and the absence was checked with `KeepAlive` as the positive control.

## Tests

- A runner carrying `; touch <marker>` is refused by name; the same string driven straight through `build_runner_command` and executed leaves no marker; a legitimate multi-word runner still runs its program.
- The supervisor's default is enforcement, with each of `0`, `false`, `no`, `off` opting out; `/shutdown` and `/daemons/register` are 401 to an unauthenticated caller and the shutdown channel stays unfired, with an authenticated `/repos` as the positive control.
- The loopback predicate's truth table, including four lookalike hosts and two non-http schemes.
- The repo-local token is refused on a remote endpoint by name, a paired `KIN_DAEMON_AUTH_TOKEN` still reaches one, and the pairing is per token rather than a blanket opt-out.
- A supervisor route naming another host does not become the command's daemon.
- The plaintext credential tier lands 0600 in a 0700 directory, the warning names the file, the tier and the remedy, and an existing 0755 credential directory is tightened.
- The launcher accepts https and loopback http, refuses plain http elsewhere, a non-http scheme and a lookalike host.

## Two things I hit on the way, both in their own commit

**CodeQL reported five `rust/cleartext-logging` alerts, all in assertions this branch added.** Four in the credential test, where the path and the warning built from it both derive from `account_key`, a SHA-256 of the base URL that the rule treats as sensitive. One in the loopback truth table, where two refused entries carry userinfo on purpose and a URL interpolated into a panic message reads as a credential reaching a sink. None is a real disclosure, and `docs/security/code-scanning-triage.md` carries the standing disposition for this rule with its evidence. It also says dismissal is a founder decision rather than a lane's, and these were my own new assertions, so they are fixed instead: each one compares the value and reports the property, and the truth table reports by index, one line from the input that caused it.

**A flake in a test this branch never touched, now main's fix rather than mine.** `a_startup_lock_is_freed_only_when_no_live_kin_holder_is_behind_it` went red on a loaded runner, on a sha whose only diff was assertion messages. It turned out #1428 had landed a fix for exactly that race on main two minutes before my push, in the same file, so my own fix conflicted with it. Theirs landed first and carries stronger evidence, two named red runs against two green ones either side, so this branch is rebased onto it and my commit is gone. Worth knowing why the conflict was invisible for half an hour: a PR that conflicts with its base gets no `pull_request` workflow run created at all, because there is no `refs/pull/N/merge` for GitHub to build, so the check set goes quiet rather than red. Eleven checks, all green, none pending, reads exactly like a clean pass on a small PR. `mergeStateStatus` was `DIRTY` the whole time. That is a trap class and it has gone to the captain for the catalogue.

## What this PR cannot prove yet

A compute quiet holds builders at zero on the box until about 09:15Z, so no cargo ran here. What did run locally: `rustfmt --check` clean on every touched Rust file, `node --test` green on all 23 `@kinlab/kin-mcp` tests including the new one, and `npm run lint` on that package. The new launcher test was falsified: relaxing the guard to accept `http:` turned it red, and restoring the guard turned it green again.

Hosted CI has since run the Rust tests on its own runners and all ten pass, read out of the shard logs by name rather than inferred from a green tally, because `changed-crate-scope.py` widens this diff to `--workspace`. So clippy under `-D warnings` and all three fast-gate shards graded them, and the selection question is answered better than a `nextest list` would answer it: the tests were not merely selected, they ran and passed. What is still owed after the lift is **falsification**: break each new behaviour and read the matching test red. Staying a draft until that pass is done.

## Scope notes

`crates/kin-core/src/env_registry.rs` and `docs/env-vars.md` carry the `KIN_SUPERVISOR_REQUIRE_TOKEN` default as data, and `env_doc_matches_registry` compares them byte for byte, so both move with the code. Three findings from the same review are deliberately not here: the `/mcp/tools/call` ceilings and transaction staging caps live in `api.rs` and `kin-mcp`, which another lane owns tonight, and the `kin-vfs` NFS surface is another repo. The supervisor still stores an endpoint a registration reports without judging it; the refusal is on the consuming side, where the token would have left.

Part of FIR-3124, which carries nine High findings. Six are here. Findings 2 (`kin-vfs nfs-start`), 6 (`/mcp/tools/call` ceilings) and 7 (transaction staging caps) belong to another repo and another lane, so the ticket stays open.
