### PR TITLE
FALSIFICATION ARM, do not land: put the whole entity back on the last-known-good entry

### DIFF
--- a/crates/kin-reconcile/src/cross_file.rs
+++ b/crates/kin-reconcile/src/cross_file.rs
@@ -41,6 +41,7 @@
 //! stays independent of repository size.
 
 use std::collections::{BTreeSet, HashMap, HashSet};
+use std::sync::Arc;
 
 use kin_index::{
     bare_entity_name, link_cross_file_incremental_with_completeness, FileParseCompletenessMap,
@@ -191,7 +192,15 @@ pub struct LiveCrossFileLinker {
     artifact_id_by_file: HashMap<String, ArtifactId>,
     file_by_artifact_id: HashMap<ArtifactId, String>,
     /// Entity identity to the file that declares it, same reason.
-    file_by_entity: HashMap<EntityId, String>,
+    ///
+    /// The path is shared rather than copied. One entry exists per entity in the
+    /// repository and it is held for the process lifetime, so an owned `String`
+    /// here was one heap allocation of the same path per entity: on a tree with
+    /// 6,160 files and 264,615 entities that is 264,615 copies of 6,160 distinct
+    /// strings. An `Arc<str>` is one allocation per distinct file, and both
+    /// readers below want either the path itself or an equality against another
+    /// entity's path, which share unchanged.
+    file_by_entity: HashMap<EntityId, Arc<str>>,
     /// Files retained because they still name something the graph lacks.
     pending: HashMap<String, PendingFile>,
     /// Reverse index: destination name -> files waiting on it. This is what
@@ -330,8 +339,12 @@ impl LiveCrossFileLinker {
             .insert(file_path.to_string(), artifact_id);
         self.file_by_artifact_id
             .insert(artifact_id, file_path.to_string());
+        // One allocation for the path, shared by every entity this file
+        // declares, rather than one per entity.
+        let shared_path: Arc<str> = Arc::from(file_path);
         for entity in entities {
-            self.file_by_entity.insert(entity.id, file_path.to_string());
+            self.file_by_entity
+                .insert(entity.id, Arc::clone(&shared_path));
         }
     }
 
@@ -460,7 +473,7 @@ impl LiveCrossFileLinker {
                         continue;
                     };
                     // Only edges sourced by a file this pass resolved.
-                    if !batched_paths.contains(src_file) {
+                    if !batched_paths.contains(&**src_file) {
                         continue;
                     }
                     if self.file_by_entity.get(&dst) == Some(src_file) {

--- a/crates/kin-reconcile/src/lkg.rs
+++ b/crates/kin-reconcile/src/lkg.rs
@@ -24,6 +24,9 @@ use kin_model::{Entity, EntityId, SemanticFingerprint};
 #[derive(Debug, Clone)]
 pub struct LkgEntry {
     pub fingerprint: SemanticFingerprint,
+    // FALSIFICATION ARM, not for landing: today's shape under a new name, so
+    // the guard has to catch an entry that reaches the entity it recorded.
+    pub entity: Entity,
 }
 
 /// Tracks LKG state for all entities. The reconciler consults this when
@@ -49,6 +52,7 @@ impl LkgStore {
             entity.id,
             LkgEntry {
                 fingerprint: entity.fingerprint.clone(),
+                entity: entity.clone(),
             },
         );
     }

--- a/crates/kin-reconcile/src/lkg.rs
+++ b/crates/kin-reconcile/src/lkg.rs
@@ -3,17 +3,27 @@
 
 use std::collections::HashMap;
 
-use kin_model::{Entity, EntityId, Relation, SemanticFingerprint};
+use kin_model::{Entity, EntityId, SemanticFingerprint};
 
-/// Last Known Good state for an entity.
+/// Last Known Good state for an entity: the fingerprint the reconciler last
+/// admitted for it.
 ///
-/// When a file edit produces a broken AST, the entity retains its LKG
-/// fingerprint, signature, and relations. The broken parse is noted but
-/// does not propagate to dependents.
+/// The entry holds a fingerprint and nothing else because a fingerprint is all
+/// any reader has ever taken out of this store. [`LkgStore::has_changed`]
+/// compares three of its hashes and there is no other read.
+///
+/// It used to hold a whole owned [`Entity`] and a `Vec<Relation>` beside it. A
+/// serving daemon seeds one entry per entity in the repository and keeps the
+/// store for its life, so that was a second complete copy of every entity: the
+/// name, the signature, the doc summary and two separate allocations of the
+/// same file path, none of which anything read. The relations vector had no
+/// reader at all and every live call site passed an empty one. The reconcile
+/// path also clones this whole store before deriving a transaction, so the copy
+/// was duplicated again on every file edit; a fingerprint is plain data, so that
+/// snapshot now allocates nothing.
 #[derive(Debug, Clone)]
 pub struct LkgEntry {
-    pub entity: Entity,
-    pub relations: Vec<Relation>,
+    pub fingerprint: SemanticFingerprint,
 }
 
 /// Tracks LKG state for all entities. The reconciler consults this when
@@ -30,9 +40,17 @@ impl LkgStore {
     }
 
     /// Record the current good state of an entity.
-    pub fn record(&mut self, entity: Entity, relations: Vec<Relation>) {
-        self.entries
-            .insert(entity.id, LkgEntry { entity, relations });
+    ///
+    /// Takes the entity by reference and keeps a copy of its fingerprint, so a
+    /// caller that already owns an entity does not have to clone it to record
+    /// one.
+    pub fn record(&mut self, entity: &Entity) {
+        self.entries.insert(
+            entity.id,
+            LkgEntry {
+                fingerprint: entity.fingerprint.clone(),
+            },
+        );
     }
 
     /// Get the LKG state for an entity.
@@ -50,9 +68,9 @@ impl LkgStore {
     pub fn has_changed(&self, id: &EntityId, new_fingerprint: &SemanticFingerprint) -> bool {
         match self.entries.get(id) {
             Some(entry) => {
-                entry.entity.fingerprint.ast_hash != new_fingerprint.ast_hash
-                    || entry.entity.fingerprint.signature_hash != new_fingerprint.signature_hash
-                    || entry.entity.fingerprint.behavior_hash != new_fingerprint.behavior_hash
+                entry.fingerprint.ast_hash != new_fingerprint.ast_hash
+                    || entry.fingerprint.signature_hash != new_fingerprint.signature_hash
+                    || entry.fingerprint.behavior_hash != new_fingerprint.behavior_hash
             }
             None => true, // No LKG means it's new
         }
@@ -109,7 +127,7 @@ mod tests {
         let mut store = LkgStore::new();
         let entity = test_entity("foo");
         let id = entity.id;
-        store.record(entity, vec![]);
+        store.record(&entity);
 
         assert!(store.get(&id).is_some());
         assert_eq!(store.len(), 1);
@@ -120,7 +138,7 @@ mod tests {
         let mut store = LkgStore::new();
         let entity = test_entity("bar");
         let id = entity.id;
-        store.record(entity, vec![]);
+        store.record(&entity);
 
         // Same fingerprint
         let same = SemanticFingerprint {
@@ -164,9 +182,35 @@ mod tests {
         let mut store = LkgStore::new();
         let entity = test_entity("baz");
         let id = entity.id;
-        store.record(entity, vec![]);
+        store.record(&entity);
         store.remove(&id);
         assert!(store.get(&id).is_none());
         assert!(store.is_empty());
+    }
+
+    /// The entry is exactly the fingerprint it holds and nothing beside it,
+    /// which is the property the daemon's retained footprint rests on. An
+    /// `Entity`, a `String` or a `Vec` back on this struct moves the size and
+    /// fails here. The bytes the entry does not reach are proved separately, by
+    /// the allocator guard in `tests/lkg_retained_bytes.rs`.
+    #[test]
+    fn an_entry_is_exactly_a_fingerprint() {
+        assert_eq!(
+            std::mem::size_of::<LkgEntry>(),
+            std::mem::size_of::<SemanticFingerprint>(),
+            "an entry must be exactly the fingerprint it holds"
+        );
+    }
+
+    /// Recording an entity twice under the same id keeps one entry, so a
+    /// reconcile loop that re-records unchanged entities cannot grow the store.
+    #[test]
+    fn re_recording_an_entity_does_not_grow_the_store() {
+        let mut store = LkgStore::new();
+        let entity = test_entity("qux");
+        store.record(&entity);
+        store.record(&entity);
+        store.record(&entity);
+        assert_eq!(store.len(), 1);
     }
 }

--- a/crates/kin-reconcile/src/reconciler.rs
+++ b/crates/kin-reconcile/src/reconciler.rs
@@ -346,22 +346,6 @@ impl Reconciler {
         &self.policy
     }
 
-    /// Seed the LKG store from an existing graph so incremental reconcile
-    /// correctly detects which entities actually changed vs. which are unchanged.
-    /// Without this, the first reconcile after daemon startup reports all entities
-    /// as modified (LKG empty → has_changed returns true for everything).
-    pub fn seed_lkg_from_graph<G: GraphStore>(&mut self, graph: &G) {
-        if let Ok(entities) = graph.list_all_entities() {
-            for entity in entities {
-                let relations = graph
-                    .get_all_relations_for_entity(&entity.id)
-                    .unwrap_or_default();
-                self.lkg.record(entity, relations);
-            }
-            tracing::info!(count = self.lkg.len(), "seeded LKG from graph snapshot");
-        }
-    }
-
     /// Seed only entity fingerprints from an existing graph.
     ///
     /// This is the daemon-startup fast path. The reconciler only consults LKG
@@ -369,8 +353,8 @@ impl Reconciler {
     /// on large persisted graphs adds minutes to daemon startup.
     pub fn seed_lkg_entities_from_graph<G: GraphStore>(&mut self, graph: &G) {
         if let Ok(entities) = graph.list_all_entities() {
-            for entity in entities {
-                self.lkg.record(entity, vec![]);
+            for entity in &entities {
+                self.lkg.record(entity);
             }
             tracing::info!(
                 count = self.lkg.len(),
@@ -920,11 +904,11 @@ impl Reconciler {
                     // fingerprint. Span and blob provenance must advance even for
                     // source edits that are semantically equivalent.
                     if updated != *old {
+                        self.lkg.record(&updated);
                         delta.entity_deltas.push(EntityDelta::Modified {
                             old: old.clone(),
-                            new: updated.clone(),
+                            new: updated,
                         });
-                        self.lkg.record(updated.clone(), vec![]);
                         modified.push(old.id);
 
                         debug!(
@@ -933,7 +917,7 @@ impl Reconciler {
                             "entity modified"
                         );
                     } else {
-                        self.lkg.record(old.clone(), vec![]);
+                        self.lkg.record(old);
                         debug!(
                             entity = %old.name,
                             "entity payload unchanged, skipping"
@@ -962,7 +946,7 @@ impl Reconciler {
                     delta.entity_deltas.push(EntityDelta::Added {
                         new: added_entity.clone(),
                     });
-                    self.lkg.record(added_entity.clone(), vec![]);
+                    self.lkg.record(&added_entity);
                     added.push(added_entity.id);
 
                     debug!(
@@ -2647,7 +2631,7 @@ mod tests {
         let entity = make_entity("bar", "src/main.rs");
         let id = entity.id;
 
-        reconciler.lkg.record(entity, vec![]);
+        reconciler.lkg.record(&entity);
         assert!(reconciler.lkg().get(&id).is_some());
     }
 
@@ -3888,8 +3872,8 @@ mod tests {
 
         // Seed the reconciler LKG with the file_a entities.
         let mut reconciler = Reconciler::new(dir.path().to_path_buf());
-        reconciler.lkg.record(entity_a.clone(), vec![]);
-        reconciler.lkg.record(stale_entity.clone(), vec![]);
+        reconciler.lkg.record(&entity_a);
+        reconciler.lkg.record(&stale_entity);
 
         // Construct an IndexedFile that represents a re-parse of file_a:
         //   - entity_a is present (same name/kind → matched, no fingerprint change)

--- a/crates/kin-reconcile/tests/lkg_retained_bytes.rs
+++ b/crates/kin-reconcile/tests/lkg_retained_bytes.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! What the reconciler's last-known-good store keeps, counted rather than
+//! asserted.
+//!
+//! A serving daemon seeds one LKG entry per entity in the repository at open and
+//! holds the store for its life. On this machine's `torvalds__linux` store that
+//! is 264,615 entries, and while the entry held a whole owned `Entity` it was a
+//! second complete copy of every entity's name, signature, doc summary and file
+//! path, none of which any reader ever looked at. The entry now holds the
+//! fingerprint that `LkgStore::has_changed` compares, so what it keeps must not
+//! move when the strings on the entities it was seeded from get longer.
+//!
+//! This is its own test binary on purpose. The counter below is process global,
+//! so a second test running beside it would be measured into it.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use kin_model::{
+    Entity, EntityId, EntityKind, EntityMetadata, EntityRole, FilePathId, FingerprintAlgorithm,
+    Hash256, LanguageId, SemanticFingerprint, SourceSpan, Visibility,
+};
+use kin_reconcile::lkg::LkgStore;
+
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+
+struct Counting;
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc(layout);
+        if !ptr.is_null() {
+            LIVE.fetch_add(layout.size(), Ordering::Relaxed);
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+        LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let out = System.realloc(ptr, layout, new_size);
+        if !out.is_null() {
+            LIVE.fetch_add(new_size, Ordering::Relaxed);
+            LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
+        }
+        out
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: Counting = Counting;
+
+fn live() -> usize {
+    LIVE.load(Ordering::Relaxed)
+}
+
+const ENTITIES: usize = 256;
+
+/// One entity carrying strings of a stated size, so the arms below differ in
+/// exactly one thing.
+fn entity(index: usize, doc_bytes: usize) -> Entity {
+    let path = format!("src/vs/workbench/services/generated/module_{index:05}.ts");
+    Entity {
+        id: EntityId::new(),
+        kind: EntityKind::Function,
+        name: format!("resolveConfigurationForWorkspaceFolder_{index:05}"),
+        language: LanguageId::TypeScript,
+        fingerprint: SemanticFingerprint {
+            algorithm: FingerprintAlgorithm::V1TreeSitter,
+            ast_hash: Hash256::from_bytes([index as u8; 32]),
+            signature_hash: Hash256::from_bytes([(index >> 8) as u8; 32]),
+            behavior_hash: Hash256::from_bytes([0xcc; 32]),
+            equivalence_hash: Hash256::from_bytes([0; 32]),
+            stability_score: 0.95,
+        },
+        file_origin: Some(FilePathId::new(&path)),
+        span: Some(SourceSpan {
+            file: FilePathId::new(&path),
+            start_byte: 0,
+            end_byte: 128,
+            start_line: 1,
+            start_col: 0,
+            end_line: 9,
+            end_col: 1,
+        }),
+        signature: format!("export function resolveConfigurationForWorkspaceFolder_{index:05}(folder: IWorkspaceFolder, section: string): IConfigurationValue"),
+        visibility: Visibility::Public,
+        role: EntityRole::Source,
+        doc_summary: Some("d".repeat(doc_bytes)),
+        metadata: EntityMetadata::default(),
+        lineage_parent: None,
+        created_in: None,
+        superseded_by: None,
+    }
+}
+
+/// Seed a store from entities carrying `doc_bytes` of doc summary and return
+/// the bytes the store still holds once the entities it was seeded from are
+/// gone, which is the daemon's own shape: `list_all_entities` hands over an
+/// owned vector, the seed walks it, and the vector is dropped.
+fn retained_for(doc_bytes: usize) -> usize {
+    let entities: Vec<Entity> = (0..ENTITIES).map(|i| entity(i, doc_bytes)).collect();
+
+    let before = live();
+    let mut store = LkgStore::new();
+    for e in &entities {
+        store.record(e);
+    }
+    let after = live();
+
+    assert_eq!(
+        store.len(),
+        ENTITIES,
+        "the store must hold every entity, or the byte count above is about nothing"
+    );
+
+    drop(entities);
+    drop(store);
+
+    after.saturating_sub(before)
+}
+
+#[test]
+fn the_lkg_retains_nothing_that_scales_with_an_entity_s_strings() {
+    // Positive control on the instrument itself. A counter that never moves
+    // makes every assertion below pass for the wrong reason.
+    let control_before = live();
+    let ballast = vec![0u8; 4 << 20];
+    let control_after = live();
+    assert!(
+        control_after - control_before >= ballast.len(),
+        "the counting allocator did not observe a {} byte allocation, so it \
+         cannot observe the store either",
+        ballast.len()
+    );
+    drop(ballast);
+
+    let small_doc = 64usize;
+    let large_doc = 8192usize;
+
+    let small = retained_for(small_doc);
+    let large = retained_for(large_doc);
+
+    // The doc summaries alone differ by two megabytes between the arms. An
+    // entry that reaches the entity carries that difference; one that holds a
+    // fingerprint does not.
+    let string_difference = ENTITIES * (large_doc - small_doc);
+    let tolerance = ENTITIES * 64;
+    assert!(
+        large.abs_diff(small) < tolerance,
+        "what the store retains moved by {} bytes when the entities' doc \
+         summaries grew by {} bytes; an entry must not reach the entity it was \
+         recorded from (small arm {} bytes, large arm {} bytes)",
+        large.abs_diff(small),
+        string_difference,
+        small,
+        large
+    );
+
+    // And an absolute ceiling, so an entry that shrank but still copies cannot
+    // pass on the scale-free test alone. A fingerprint is 132 bytes and a map
+    // entry adds an id and a control byte, so 512 per entity is roughly three
+    // times the true cost and well under the 4,288 bytes of string an entity
+    // carries in the large arm.
+    let ceiling = ENTITIES * 512;
+    assert!(
+        large < ceiling,
+        "the store retains {} bytes for {} entities, over the {} byte ceiling",
+        large,
+        ENTITIES,
+        ceiling
+    );
+}


### PR DESCRIPTION
**Not for landing. Close this once its shard has reported.**

This is the falsification arm for the guard on #1419. It restores the copy that branch removes:
`LkgEntry` carries the whole `Entity` again beside the fingerprint, and `record` fills both, which is
today's shape under a new name.

Two tests must go red under it, and nothing else in the workspace may:

- `kin-reconcile::lkg_retained_bytes the_lkg_retains_nothing_that_scales_with_an_entity_s_strings`,
  on the arm difference. The two arms carry 64-byte and 8,192-byte doc summaries over 256 entities,
  so an entry that reaches the entity carries about two megabytes more in the large arm.
- `kin-reconcile lkg::tests::an_entry_is_exactly_a_fingerprint`, on the size equality.

A guard that stays green under this arm is not a guard, which is why the arm is run rather than
asserted.

Related: FIR-3064
