### PR TITLE
Wait for a spawned stand-in to exec before asking what image it runs

### DIFF
--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -12573,11 +12573,15 @@ mod tests {
         // sees a kin image on a process that is about to become `sleep`. That
         // window reddened two shards on 2026-09-03. Wait for the exec to land
         // before asking the question the assertion is about.
-        assert!(
-            wait_until_image_is_not_ours(foreign_pid),
-            "the spawned sleep never left this test binary's image within {:?}",
-            EXEC_SETTLE_BOUND
-        );
+        if !wait_until_image_is_not_ours(foreign_pid) {
+            // Reap before failing, or the sleep outlives the test as a leak.
+            let _ = foreign.kill();
+            let _ = foreign.wait();
+            panic!(
+                "the spawned sleep never left this test binary's image within {:?}",
+                EXEC_SETTLE_BOUND
+            );
+        }
         std::fs::write(&lock, format!("pid={foreign_pid} acquired_at=now\n")).unwrap();
         assert!(
             startup_lock_holder_is_foreign(foreign_pid),

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -12497,6 +12497,33 @@ mod tests {
             .expect("spawn a live stand-in for a kin command still starting a daemon")
     }
 
+    /// How long a just-spawned child may take to exec its image before the test
+    /// calls the wait a failure. Generous against a loaded CI runner; the wait
+    /// returns the moment the image changes, so a fast box pays a few
+    /// milliseconds.
+    #[cfg(unix)]
+    const EXEC_SETTLE_BOUND: Duration = Duration::from_secs(10);
+
+    /// Polls the image reader until the process at `pid` is running an image that
+    /// is not kin-named, or the bound passes. Between fork and exec a child still
+    /// wears its parent's image, and this test binary is kin-named, so a reader
+    /// that asks too early sees a kin process where a foreign one is about to be.
+    /// The wait uses the same reader the assertion does, so what it waits for is
+    /// exactly what the assertion then reads.
+    #[cfg(unix)]
+    fn wait_until_image_is_not_ours(pid: u32) -> bool {
+        let deadline = std::time::Instant::now() + EXEC_SETTLE_BOUND;
+        loop {
+            if startup_lock_holder_is_foreign(pid) {
+                return true;
+            }
+            if std::time::Instant::now() >= deadline {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+
     /// Instant in an ordinary run; a process that waits when a parent test asked
     /// for one. It never touches a store, a lock or a daemon.
     #[cfg(unix)]
@@ -12540,6 +12567,17 @@ mod tests {
             .spawn()
             .expect("spawn a live process running an image that is not ours");
         let foreign_pid = foreign.id();
+        // `spawn` returns as soon as the child exists, and on Linux the child
+        // exists before it has exec'd: until then `/proc/<pid>/exe` still names
+        // this test binary, which is kin-named, so a reader that looks at once
+        // sees a kin image on a process that is about to become `sleep`. That
+        // window reddened two shards on 2026-09-03. Wait for the exec to land
+        // before asking the question the assertion is about.
+        assert!(
+            wait_until_image_is_not_ours(foreign_pid),
+            "the spawned sleep never left this test binary's image within {:?}",
+            EXEC_SETTLE_BOUND
+        );
         std::fs::write(&lock, format!("pid={foreign_pid} acquired_at=now\n")).unwrap();
         assert!(
             startup_lock_holder_is_foreign(foreign_pid),


### PR DESCRIPTION
`daemon_client::tests::a_startup_lock_is_freed_only_when_no_live_kin_holder_is_behind_it` spawns `sleep 300` and asserts at once that `startup_lock_holder_is_foreign` sees a foreign image. On Linux `spawn` returns before the child has exec'd, and until it does `/proc/<pid>/exe` names the parent, this kin-named test binary. A reader that asks inside that window sees a kin image on a process about to become `sleep`, and the test panics at daemon_client.rs:12544 with "a live sleep is not a kin binary and must read as foreign".

Evidence it is a race and not a regression: it failed on main's push run for 408f6622f (run 33708274779, 02:41Z) and on a pull request at 03:07Z (run 33709967778), cancelling the shard's remaining tests both times, and passed on 1bc3a1448 and 6c9c0dabe with the same code either side.

The fix is test-only. The test waits, bounded at ten seconds and polling the same reader the assertion uses, until the spawned child's image is no longer kin-named, then writes the lock and asserts. The production reader is unchanged on purpose: a mid-exec or unreadable image keeps the wait, which is the direction that never frees a lock a live Kin process may own.

Falsification is the two red runs above against the green runs beside them; a timing race has no deterministic mutant, and the wait's bound fails loudly by name if the exec never lands. The other `sleep` stand-ins in this file read liveness or process identity rather than the image and do not race.

Gates: none ran locally, since the box holds a compute quiet for an overnight benchmark round; hosted CI grades the change.
