### PR TITLE
Record what the coverage runner disk actually measured

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2611,16 +2611,27 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # Measured across eleven consecutive main pushes on 2026-09-03: the
-      # disk, not the code, is what ends this job. A hosted ubuntu runner carries tens of gigabytes of Android, .NET,
-      # GHC and CodeQL toolchains that no kin build touches, and tarpaulin's
-      # instrumented debug build of the whole workspace does not fit in what is
-      # left. The two deaths are one cause. `rust-lld` mmaps its output, so a
-      # write with no blocks behind it arrives as `ld terminated with signal 7
-      # [Bus error]` and reads as a compiler crash; or the runner's worker hits
-      # `No space left on device` writing its own log and takes the job with
-      # it. The `df` on both sides is what lets the next reader see a near miss
-      # instead of inferring one from a linker signal.
+      # The runner is not small; the build is enormous, and the margin was
+      # under half a gigabyte. Measured on main's push run 33711619735, the
+      # first to carry this step: 145G of disk with 86.1 GiB free before the
+      # reclaim, 30.4 GiB free after tarpaulin finished, so the instrumented
+      # build of the whole workspace consumes about 85.7 GiB. Without the
+      # reclaim it was landing inside 0.4 GiB of the wall, which is why eleven
+      # consecutive main pushes on 2026-09-03 failed in two shapes rather than
+      # one, and why some of them squeaked through. Whether a run crossed the
+      # line came down to how much the image already held.
+      #
+      # Both shapes are that one cause. `rust-lld` mmaps its output, so a write
+      # with no blocks behind it arrives as `ld terminated with signal 7 [Bus
+      # error]` and reads as a compiler crash; or the runner's own worker hits
+      # `No space left on device` writing its diagnostic log and takes the job
+      # down with no failed step in it.
+      #
+      # Reclaiming the toolchains no kin build touches buys 30 GiB, which is
+      # about 35% headroom over the build. That is a margin, not a fix in
+      # perpetuity: it erodes as the workspace grows, and the `df` lines on both
+      # sides are what let the next reader see the next near miss coming instead
+      # of inferring it from a linker signal.
       #
       # `continue-on-error` because a reclaim that does not apply on some future
       # runner image is not a reason to stop a build. The script already exits 0


### PR DESCRIPTION
The first push run to carry the reclaim step has reported, and it corrects the comment #1422 shipped. That comment implied a small runner. The runner is not small; the build is enormous, and the margin was under half a gigabyte.

Measured on main's push run 33711619735, Code Coverage job 100512145914:

```
ci-free-disk: before
/dev/root       145G   59G   87G  41% /
ci-free-disk: removed /usr/local/lib/android
ci-free-disk: removed /opt/hostedtoolcache/CodeQL
ci-free-disk: removed /usr/share/dotnet
ci-free-disk: removed /usr/local/.ghcup
ci-free-disk: removed /usr/share/swift
ci-free-disk: removed /usr/local/share/powershell
ci-free-disk: removed /usr/local/share/chromium
ci-free-disk: removed /opt/az
ci-free-disk: pruned docker images
ci-free-disk: after
/dev/root       145G   29G  117G  20% /
ci-free-disk: reclaimed 30.1 GiB (86.1 GiB free before, 116.1 GiB free after)
...
coverage: 30.4 GiB free after the run
```

| Figure | Value |
|---|---|
| Disk size | 145G |
| Free before the reclaim | 86.1 GiB |
| Free after the reclaim | 116.1 GiB |
| Free after tarpaulin finished | 30.4 GiB |
| So the instrumented build consumes | ~85.7 GiB |
| Margin without the reclaim | **0.4 GiB** |
| Headroom with the reclaim | 30.4 GiB, about 35% over the build |

That 0.4 GiB is the fact the original comment was missing. It explains why eleven consecutive main pushes on 2026-09-03 failed in two different shapes rather than one, and why several squeaked through green: whether a run crossed the line came down to how much the runner image already held, which varies between images. It also sets the right expectation, which the old comment did not. Thirty gigabytes is a margin, not a fix in perpetuity; it erodes as the workspace grows, and the next reader should watch the `df` lines rather than assume the class is closed.

Comment only. No behaviour changes in this PR.

## The step worked, including the branch I could only test with shims

`Free runner disk` concluded success and reclaimed 30.1 GiB. `Run coverage` then ran the full thirty minutes and hit its `timeout 30m` bound, and the new named-cause logic picked the right branch on live evidence rather than in a sandbox:

```
coverage: 30.4 GiB free after the run
::warning::Tarpaulin exceeded its 30m bound (rc=124) with disk to spare, so the bound is what stopped it.
```

It correctly declined to blame the disk, because 30.4 GiB is above the 2 GiB floor. No linker SIGBUS, no `No space left on device`, no runner death, and the job concluded success.

## What is still not fixed

Coverage still produced no report: `not_found_files: ["cobertura.xml"]`. The disk was the blocker in front of the 30m bound, and the bound is now the one in view. Whether raising it inside the 45-minute job cap is enough is the next measurement, and it now has a number to start from rather than a guess.

Also worth stating plainly: main's push run on 6c9c0dabe still concluded failure, and not on coverage. Graded over the complete check set, 162 of 162 after pagination, the four reds were `Check & Test ubuntu shard (1)`, `Fast gate test shard (3)` and their two aggregates, all from one flaky kin-cli test at `crates/kin-cli/src/daemon_client.rs:12544`. Code Coverage concluded success.

## Verified locally

`python3 scripts/test-release-workflow-authority.py` rc=0, `python3 scripts/test-assertion-reachability.py` rc=0, and the patched workflow parses with the coverage job still carrying eight steps and no job-level `continue-on-error`.

FIR-3122.
