### PR TITLE
Move the immutable kin-vfs release checkout to the tree that builds 0.4.24

### DIFF
--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -191,7 +191,7 @@ jobs:
           repository: firelock-ai/kin-vfs
           path: kin-vfs
           # Release inputs must never move under an unchanged Kin tag.
-          ref: ff59dfeb8fc9ad6a0b7f1e7d4505763e00792428
+          ref: 4ff5262bb345d2d08846b0e8e09abc9fad639aed
           persist-credentials: false
 
       - name: Verify canonical release input bytes
@@ -665,7 +665,7 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: ff59dfeb8fc9ad6a0b7f1e7d4505763e00792428
+          EXPECTED_VFS_COMMIT: 4ff5262bb345d2d08846b0e8e09abc9fad639aed
         run: |
           set -euo pipefail
           node <<'NODE'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -583,7 +583,7 @@ jobs:
           repository: firelock-ai/kin-vfs
           path: kin-vfs
           # Release inputs must never move under an unchanged Kin tag.
-          ref: ff59dfeb8fc9ad6a0b7f1e7d4505763e00792428
+          ref: 4ff5262bb345d2d08846b0e8e09abc9fad639aed
           persist-credentials: false
 
       - name: Verify canonical release input bytes
@@ -1209,7 +1209,7 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: ff59dfeb8fc9ad6a0b7f1e7d4505763e00792428
+          EXPECTED_VFS_COMMIT: 4ff5262bb345d2d08846b0e8e09abc9fad639aed
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1501,7 +1501,7 @@ jobs:
         with:
           repository: firelock-ai/kin-vfs
           path: release-inputs/kin-vfs
-          ref: ff59dfeb8fc9ad6a0b7f1e7d4505763e00792428
+          ref: 4ff5262bb345d2d08846b0e8e09abc9fad639aed
           persist-credentials: false
 
       - name: Download all artifacts
@@ -1569,7 +1569,7 @@ jobs:
 
       - name: Verify and aggregate release provenance
         env:
-          EXPECTED_VFS_COMMIT: ff59dfeb8fc9ad6a0b7f1e7d4505763e00792428
+          EXPECTED_VFS_COMMIT: 4ff5262bb345d2d08846b0e8e09abc9fad639aed
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1943,7 +1943,7 @@ jobs:
     uses: ./.github/workflows/install-proof.yml
     with:
       release_tag: ${{ github.ref_name }}
-      expected_vfs_commit: ff59dfeb8fc9ad6a0b7f1e7d4505763e00792428
+      expected_vfs_commit: 4ff5262bb345d2d08846b0e8e09abc9fad639aed
     permissions:
       contents: read
       attestations: read

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3289,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.92"
+version = "0.7.93"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "391894df477e5beb5d9963ea7134b7cf57dc3113878dde1d7412b237a2c7e7a7"
+checksum = "78376d102b7ba87e7e2bbe39f7ab9ddecb09e9ddfc9a05804072fc2948bd8b8b"
 dependencies = [
  "bincode",
  "bstr",
@@ -3784,9 +3784,9 @@ dependencies = [
 
 [[package]]
 name = "kin-vfs-core"
-version = "0.4.23"
+version = "0.4.24"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "e8cb6f31620f6f3cd83b99ad81f354c8fa6cfac827ec19944e5b8bc51e5e629f"
+checksum = "6c1247c07fd55f47e11390c74df6f5cb643f2a4e789cbf60cde58fb0bdf98e7d"
 dependencies = [
  "lru",
  "parking_lot",
@@ -6671,7 +6671,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,8 +158,8 @@ kin-lsp = { version = "=0.7.13", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.92", registry = "kin", default-features = false }
-kin-vfs-core = { version = "=0.4.23", registry = "kin" }
+kin-db = { version = "=0.7.93", registry = "kin", default-features = false }
+kin-vfs-core = { version = "=0.4.24", registry = "kin" }
 
 [profile.release]
 opt-level = 3

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -17032,7 +17032,7 @@ jobs:
         "always()",
         "needs.publish.result == 'success'",
         "uses: ./.github/workflows/install-proof.yml",
-        "expected_vfs_commit: ff59dfeb8fc9ad6a0b7f1e7d4505763e00792428",
+        "expected_vfs_commit: 4ff5262bb345d2d08846b0e8e09abc9fad639aed",
     ):
         require(install_proof_job, policy, "mandatory public install proof")
 


### PR DESCRIPTION
Captain-submitted workflow pin, carrying the registry wave's refresh (kin#1430, held as a draft) so the two halves land as one commit.

The wave moves kin-vfs-core to 0.4.24 (and kin-db to 0.7.93, registry-only). release.yml and rc-build.yml pin the kin-vfs source checkout at ff59dfeb, the tree that builds 0.4.23, and the cut's "Verify canonical release input bytes" step refuses a mismatch between the resolved crate version and the pinned checkout's version in either direction. Neither workflow grades a pull request (release.yml runs on a v* tag push, rc-build.yml is dispatch-only), so the refresh alone would go green here and fail the next cut.

Moved: the checkout ref and EXPECTED_VFS_COMMIT in release.yml (five sites) and rc-build.yml (two), plus the fixture in scripts/test-release-workflow-authority.py, all from ff59dfeb8fc9ad6a0b7f1e7d4505763e00792428 to 4ff5262bb345d2d08846b0e8e09abc9fad639aed (kin-vfs #144, which publishes 0.4.24). Verified with git grep that no old-sha site remains and an absent-sha control exits 1.

Ran: scripts/test-release-workflow-authority.py (exit 0). No cargo on this box for this PR; the Cargo change is the wave's own commit, cherry-picked byte for byte (074f56809), and hosted CI grades the build.