### PR TITLE
Ask kin-vfs for a writable NFS mount and name tar absolutely

### DIFF
--- a/crates/kin-cli/src/commands/projection.rs
+++ b/crates/kin-cli/src/commands/projection.rs
@@ -68,11 +68,9 @@ use crate::commands::setup::{check_binary_in_path, home_dir, kin_dir, shim_filen
 
 /// Every `kin-vfs` subcommand Kin drives, named once.
 ///
-/// The mount features are compiled out of the shipped driver, and the work that
-/// makes them real is landing in `kin-vfs` under these names. Keeping them in
-/// one place means a rename downstream is one edit here, and the probe that
-/// asks a driver which subcommands it carries reads the same constants the
-/// engage path spawns.
+/// Keeping them in one place means a rename downstream is one edit here, and
+/// the probe that asks a driver which subcommands it carries reads the same
+/// constants the engage path spawns.
 pub(crate) mod driver {
     /// Present in every build. Used as the control that proves a parsed help
     /// listing is readable at all, so an unparseable help cannot masquerade as
@@ -90,12 +88,23 @@ pub(crate) mod driver {
 }
 
 /// Where a driver carrying the mount features comes from, for every message
-/// that has to explain an absent one. Naming the build is the honest remedy
-/// while the shipped binary has neither feature.
+/// that has to explain an absent one.
+///
+/// The shipped driver is not featureless. `.github/workflows/release.yml`
+/// builds macOS with `--features nfs` and Linux with `--features fuse` in its
+/// "Build kin-vfs (native)" step, and only the cross-built targets get neither.
+/// So a driver reaching one of these messages is an older install, a
+/// cross-built target, or a `kin-vfs` from somewhere other than this install,
+/// which makes updating the first remedy and building one the second. This
+/// text used to say the shipped binary carried neither feature, which sent a
+/// reporter off to build a driver they already had.
 pub(crate) const MOUNT_FEATURE_REMEDY: &str =
-    "the shipped kin-vfs is built without the mount features; build one that has them with \
+    "the shipped kin-vfs carries the mount feature its platform supports, nfs on macOS and \
+     fuse on Linux, so a driver without one is an older install or a target that ships \
+     neither; run `kin update`, or build one with \
      `cargo build --release -p kin-vfs-cli --features nfs` (or `--features fuse`) from the \
-     kin-vfs repository, then point Kin at it with KIN_VFS_BIN=/path/to/kin-vfs";
+     kin-vfs repository and point Kin at it with KIN_VFS_BIN=/path/to/kin-vfs. What the NFS \
+     export does and does not enforce is in kin-vfs docs/security/nfs-export.md";
 
 /// A projection: one way graph truth is presented as files.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
@@ -2065,18 +2074,46 @@ fn engage_shim(shim: &ShimPresence, modes: &[ModeProbe]) -> Result<()> {
     Ok(())
 }
 
+/// The `nfs-start` argv for a driver advertising these flags.
+///
+/// Pure so the shape is testable without a driver, and one place to read what
+/// Kin asks a driver to do.
+pub(crate) fn nfs_start_args(root: &str, takes_repo: bool, takes_writable: bool) -> Vec<&str> {
+    let mut args = vec![driver::NFS_START];
+    if takes_repo {
+        args.push("--repo");
+        args.push(root);
+    }
+    if takes_writable {
+        args.push("--writable");
+    }
+    args
+}
+
 fn engage_nfs(driver: &DriverProbe, repo_root: &Path) -> Result<()> {
     let Some(path) = driver.path.as_deref().filter(|_| driver.runs()) else {
         anyhow::bail!("no kin-vfs driver to start the NFS mount with");
     };
     let root = repo_root.to_string_lossy().into_owned();
 
+    // The export is read-only unless asked, because NFSv3 authenticates no
+    // client and every account on the machine can reach it, so an unasked-for
+    // writable export commits another account's writes to this repository
+    // under this user's name. `kin mode nfs` is a request for a projection
+    // this repository is worked in, so Kin asks for writes explicitly rather
+    // than leaving the user a mount they cannot edit through.
+    //
+    // Probed rather than assumed, exactly as `--repo` is: a driver predating
+    // the flag already served writable and would refuse an argument it does
+    // not know, taking the whole mount down with it.
+    let takes_writable = subcommand_supports_flag(path, driver::NFS_START, "--writable");
+
     // One command where the driver takes a repository: `nfs-start --repo`
     // registers it on first use and serves it. Registering separately is the
     // older two-step shape, and doing both would register a repository the
     // server is about to register again.
     if subcommand_supports_flag(path, driver::NFS_START, "--repo") {
-        let out = run_driver(path, &[driver::NFS_START, "--repo", &root])?;
+        let out = run_driver(path, &nfs_start_args(&root, true, takes_writable))?;
         println!("{} {}", style("\u{2713}").green(), first_line(&out));
         return Ok(());
     }
@@ -2085,7 +2122,7 @@ fn engage_nfs(driver: &DriverProbe, repo_root: &Path) -> Result<()> {
         let out = run_driver(path, &[driver::WORKSPACES, "add", "--path", &root])?;
         println!("{} {}", style("\u{2713}").green(), first_line(&out));
     }
-    let out = run_driver(path, &[driver::NFS_START])?;
+    let out = run_driver(path, &nfs_start_args(&root, false, takes_writable))?;
     println!("{} {}", style("\u{2713}").green(), first_line(&out));
     Ok(())
 }
@@ -3148,6 +3185,53 @@ Options:
             "a longer flag must not answer for a shorter one"
         );
         assert!(!help_lists_flag("", "--repo"));
+    }
+
+    /// kin-vfs 0.4.24 flipped the NFS export's default. `nfs-start` served
+    /// writable and took `--read-only`; it now serves read-only and takes
+    /// `--writable`, because NFSv3 authenticates no client and every account
+    /// on the machine can reach the export. `kin mode nfs` has to produce a
+    /// writable mount from both, which means asking the new driver for writes
+    /// and asking the old one for nothing: an argument a driver does not know
+    /// fails the start outright rather than degrading to a read-only mount.
+    #[test]
+    fn a_writable_mount_is_asked_for_only_from_a_driver_that_offers_the_flag() {
+        // The flag set of the real `nfs-start` at each version.
+        const BEFORE: &str = "Usage: kin-vfs nfs-start [OPTIONS]\n\nOptions:\n      --repo <REPO>\n      --port <PORT>\n      --mount-point <MOUNT_POINT>\n      --read-only\n  -h, --help\n";
+        const AFTER: &str = "Usage: kin-vfs nfs-start [OPTIONS]\n\nOptions:\n      --repo <REPO>\n      --port <PORT>\n      --mount-point <MOUNT_POINT>\n      --writable\n  -h, --help\n";
+
+        assert!(help_lists_flag(AFTER, "--writable"));
+        assert!(
+            !help_lists_flag(BEFORE, "--writable"),
+            "a driver predating the flag must not be handed it"
+        );
+        // The control: both bodies are readable, so a miss above is the flag
+        // being absent rather than the match failing on every input.
+        assert!(help_lists_flag(BEFORE, "--read-only") && help_lists_flag(AFTER, "--repo"));
+
+        let argv = |help: &str| {
+            nfs_start_args(
+                "/w/repo",
+                help_lists_flag(help, "--repo"),
+                help_lists_flag(help, "--writable"),
+            )
+        };
+        assert_eq!(
+            argv(AFTER),
+            ["nfs-start", "--repo", "/w/repo", "--writable"]
+        );
+        assert_eq!(argv(BEFORE), ["nfs-start", "--repo", "/w/repo"]);
+
+        // The two-step shape, where the repository is registered separately.
+        assert_eq!(
+            nfs_start_args("/w/repo", false, true),
+            ["nfs-start", "--writable"]
+        );
+        assert_eq!(nfs_start_args("/w/repo", false, false), ["nfs-start"]);
+
+        // A help that could not be read offers nothing, so the start is the
+        // oldest shape rather than a guess at what the driver accepts.
+        assert_eq!(argv(""), ["nfs-start"]);
     }
 
     /// The mount test must be able to answer both ways on any host, or it is a

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -157,6 +157,17 @@ The daemon-side counterpart of projection, materializing graph-owned files into
 a workspace for a session or an exec request, runs within the same-user
 daemon trust boundary described above.
 
+Preload interposition is not the only projection surface Kin ships. The macOS
+release builds `kin-vfs` with `--features nfs` and the Linux release with
+`--features fuse` (`.github/workflows/release.yml`), so `kin mode nfs` and
+`kin mode fuse` present the graph through a mount the operating system serves
+rather than through a library in one process. A mount is not per-process: the
+NFS export in particular authenticates no client, so every account on the
+machine can read what it serves for as long as it runs. What that export does
+and does not enforce, including the read-only default and where writes are
+contained, is owned by `kin-vfs` and stated in its
+`docs/security/nfs-export.md`.
+
 ## Blob-Store Integrity
 
 Kin stores file and artifact content in a content-addressed blob store (the

--- a/packages/kin-mcp/src/index.js
+++ b/packages/kin-mcp/src/index.js
@@ -397,6 +397,33 @@ function windowsSystemTarPath(env) {
   return path.win32.join(systemRoot, 'System32', 'tar.exe');
 }
 
+// Where a Unix system tool is allowed to come from.
+//
+// `execFile('tar', ...)` resolves through PATH, and PATH belongs to whoever
+// started this process. A `tar` planted earlier in it unpacks the archive
+// whose SHA-256 was just verified, so the integrity check ends up protecting
+// bytes that somebody else's program reads. These directories are root-owned
+// on macOS and Linux and SIP-protected on macOS. The Windows arm has named its
+// extractor absolutely since it was written; this is the same rule on Unix.
+const UNIX_TOOL_DIRECTORIES = ['/usr/bin', '/bin'];
+
+// The absolute path of a Unix system tool, refused when it is in none of the
+// trusted directories.
+//
+// Refusing rather than falling back to PATH: a fallback makes the guard
+// advisory, and installFromArchive already reports an extractor that will not
+// run.
+function unixSystemToolPath(name) {
+  for (const directory of UNIX_TOOL_DIRECTORIES) {
+    const candidate = path.posix.join(directory, name);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  throw new Error(
+    `${name} was not found in ${UNIX_TOOL_DIRECTORIES.join(' or ')}; refusing to resolve it ` +
+      'through PATH, where a planted binary would run in its place'
+  );
+}
+
 function archiveExtraction(platform, env, archiveName) {
   if (platform === 'win32') {
     if (process.platform === 'win32') {
@@ -413,7 +440,10 @@ function archiveExtraction(platform, env, archiveName) {
       args: ['-q', archiveName, '-d', '.']
     };
   }
-  return { executable: 'tar', args: ['-xf', archiveName, '-C', '.'] };
+  return {
+    executable: unixSystemToolPath('tar'),
+    args: ['-xf', archiveName, '-C', '.']
+  };
 }
 
 async function installFromArchive({
@@ -436,9 +466,10 @@ async function installFromArchive({
     await fsp.writeFile(archivePath, archiveBytes);
     const toolEnv = mergeEnvironment(process.env, env);
     const extraction = archiveExtraction(platform, toolEnv, archiveName);
-    // Windows authority is the absolute System32 bsdtar, never a Git/MSYS or
-    // user-provided `tar` found through PATH. Relative operands also avoid the
-    // GNU remote-host interpretation of `C:\\...` paths.
+    // The extractor is named absolutely on both platforms: System32 bsdtar on
+    // Windows, never a Git/MSYS `tar` earlier in PATH, and /usr/bin/tar or
+    // /bin/tar on Unix. Relative operands also avoid the GNU remote-host
+    // interpretation of `C:\\...` paths.
     await execFile(extraction.executable, extraction.args, {
       cwd: tmpRoot,
       env: toolEnv

--- a/packages/kin-mcp/test/index.test.js
+++ b/packages/kin-mcp/test/index.test.js
@@ -529,6 +529,48 @@ test('ensureKinBinary installs the flat native Windows zip and .exe pair', async
   }
 });
 
+// The Unix arm of the same rule the Windows test above proves. `tar` was
+// resolved through PATH, so a planted `tar` unpacked the archive whose SHA-256
+// had just been verified: the integrity check protected bytes an attacker's
+// program then read. The hostile `tar` here exits 97, so this test is red
+// against a PATH lookup and green against an absolute one.
+test(
+  'ensureKinBinary unpacks the Unix archive with an absolute tar under a hostile PATH',
+  { skip: process.platform === 'win32' },
+  async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'kin-mcp-hostile-tar-'));
+    const assetName = 'kin-linux-x86_64';
+    const version = '9.9.9-test';
+    const { archiveBytes, archiveName, checksum, kinBytes, daemonBytes } =
+      await buildReleaseArchive(tmpDir, assetName);
+    const server = startReleaseServer(version, archiveName, archiveBytes, checksum);
+
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    const baseUrl = `http://127.0.0.1:${address.port}`;
+    const env = await environmentWithHostileTar(tmpDir, {
+      KIN_MCP_CACHE_DIR: tmpDir,
+      KIN_MCP_RELEASE_BASE_URL: baseUrl
+    });
+
+    try {
+      const binaryPath = await ensureKinBinary({
+        env,
+        platform: 'linux',
+        arch: 'x64',
+        version
+      });
+
+      assert.equal(await fs.readFile(binaryPath, 'utf8'), kinBytes.toString('utf8'));
+      const daemonPath = resolveDaemonBinaryPath(binaryPath);
+      assert.equal(await fs.readFile(daemonPath, 'utf8'), daemonBytes.toString('utf8'));
+    } finally {
+      await new Promise(resolve => server.close(resolve));
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  }
+);
+
 test('ensureKinBinary fails with a precise message when the archive omits kin-daemon', async () => {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'kin-mcp-nodaemon-'));
   const assetName = 'kin-linux-x86_64';

--- a/packages/kin/lib/provision.mjs
+++ b/packages/kin/lib/provision.mjs
@@ -386,6 +386,32 @@ function windowsSystemTarPath(env) {
   return path.win32.join(systemRoot, 'System32', 'tar.exe');
 }
 
+// Where a Unix system tool is allowed to come from.
+//
+// `spawnSync('tar', ...)` resolves through PATH, and PATH belongs to whoever
+// started this process. A `tar` planted earlier in it unpacks the archive
+// whose SHA-256 was just verified, so the integrity check ends up protecting
+// bytes that somebody else's program reads. These directories are root-owned
+// on macOS and Linux and SIP-protected on macOS. The Windows arm has named its
+// extractor absolutely since it was written; this is the same rule on Unix.
+const UNIX_TOOL_DIRECTORIES = ['/usr/bin', '/bin'];
+
+// The absolute path of a Unix system tool, refused when it is in none of the
+// trusted directories.
+//
+// Refusing rather than falling back to PATH: a fallback makes the guard
+// advisory, and provision already reports an extractor that will not run.
+function unixSystemToolPath(name) {
+  for (const directory of UNIX_TOOL_DIRECTORIES) {
+    const candidate = path.posix.join(directory, name);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  throw new Error(
+    `${name} was not found in ${UNIX_TOOL_DIRECTORIES.join(' or ')}; refusing to resolve it ` +
+      'through PATH, where a planted binary would run in its place',
+  );
+}
+
 function archiveExtraction(platform, env, file) {
   if (platform === 'win32') {
     if (process.platform === 'win32') {
@@ -402,7 +428,10 @@ function archiveExtraction(platform, env, file) {
       args: ['-q', file, '-d', '.'],
     };
   }
-  return { executable: 'tar', args: ['-xf', file, '-C', '.'] };
+  return {
+    executable: unixSystemToolPath('tar'),
+    args: ['-xf', file, '-C', '.'],
+  };
 }
 
 /**
@@ -493,9 +522,10 @@ export async function provision(version, opts = {}) {
 
     const toolEnv = mergeEnvironment(process.env, env);
     const extraction = archiveExtraction(platform, toolEnv, file);
-    // Windows authority is the absolute System32 bsdtar, never a Git/MSYS or
-    // user-provided `tar` found through PATH. Relative operands also avoid the
-    // GNU remote-host interpretation of `C:\\...` paths.
+    // The extractor is named absolutely on both platforms: System32 bsdtar on
+    // Windows, never a Git/MSYS `tar` earlier in PATH, and /usr/bin/tar or
+    // /bin/tar on Unix. Relative operands also avoid the GNU remote-host
+    // interpretation of `C:\\...` paths.
     const extracted = spawnSync(extraction.executable, extraction.args, {
       cwd: tmp,
       encoding: 'utf8',

--- a/packages/kin/test/provision.test.mjs
+++ b/packages/kin/test/provision.test.mjs
@@ -345,6 +345,34 @@ test('provision uses deterministic Windows ZIP extraction under a hostile PATH',
   }
 });
 
+// The Unix arm of the rule the Windows test above proves. `tar` was resolved
+// through PATH, so a planted `tar` unpacked the archive whose SHA-256 had just
+// been verified: the integrity check protected bytes an attacker's program
+// then read. The hostile `tar` here exits 97, so this test is red against a
+// PATH lookup and green against an absolute one.
+macArchiveModeTest(
+  'provision unpacks the Unix archive with an absolute tar under a hostile PATH',
+  async () => {
+    const { work, fetchImpl } = makeFixture();
+    const home = path.join(work, 'kin-home');
+    const env = environmentWithHostileTar(work, { KIN_HOME: home });
+    try {
+      const installed = await provision('9.9.9', {
+        env,
+        platform: 'darwin',
+        arch: 'arm64',
+        fetchImpl,
+        log: () => {},
+      });
+      assert.equal(installed, path.join(home, 'bin', 'kin'));
+      assert.ok(fs.existsSync(path.join(home, 'bin', 'kin-daemon')));
+      assert.equal(readLauncherStamp(env), '9.9.9');
+    } finally {
+      fs.rmSync(work, { recursive: true, force: true });
+    }
+  },
+);
+
 test('provision streams live archive byte and percent progress without touching checksum semantics', async () => {
   const { work, bytes, fetchImpl, platform, arch } = makeHostProvisionFixture({
     streamArchive: true,


### PR DESCRIPTION
`kin mode nfs` was about to start handing people a projection they cannot write to.

kin-vfs #144 landed this morning as 0.4.24 and flipped the NFS export's default. `nfs-start` served writable and took `--read-only`; it now serves read-only and takes `--writable`. The reason is good: NFSv3 through `nfsserve` carries no client authentication that server can enforce, so every account on the machine can reach the export, and a writable one commits their writes to your repository under your name. But kin drives that binary from `engage_nfs` with no posture flag, so the moment kin resolves 0.4.24, `kin mode nfs` produces a mount the user cannot edit through and nothing says why.

## What changed

**`engage_nfs` asks for writes, probed off the driver's own help.** `subcommand_supports_flag(path, "nfs-start", "--writable")` runs exactly as the existing `--repo` probe does, and the argv both call sites build now lives in one pure function, `nfs_start_args`. A 0.4.24 driver gets `nfs-start --repo <root> --writable`. A driver predating the flag gets `nfs-start --repo <root>` and serves writable already, so the outcome is the same from both. The probe is not decoration: clap refuses an unknown argument and fails the start outright, so an unprobed `--writable` would take the whole mount down on every older driver rather than degrade to a read-only one.

**Row 15 of the launch attack-surface review (FIR-3124): `tar` resolved through PATH.** Both npm provisioners, `packages/kin-mcp/src/index.js` and `packages/kin/lib/provision.mjs`, unpacked the archive whose SHA-256 they had just verified with a `tar` found on PATH, while the line above each named `/usr/bin/unzip` absolutely and the Windows arm named System32 bsdtar absolutely. A `tar` planted earlier in PATH read the verified bytes instead, so the integrity check protected somebody else's program. Both now take the tool from `/usr/bin` or `/bin` and refuse rather than fall back, the same rule kin-vfs #144 applied to `sudo`, `mount`, `umount` and `diskutil`.

**Row 34: the stale mount-feature remedy in shipped code.** `MOUNT_FEATURE_REMEDY` told the reader the shipped kin-vfs is built without the mount features, while `release.yml` builds macOS with `--features nfs` and Linux with `--features fuse` in its "Build kin-vfs (native)" step. Only the cross-built targets get neither. It sent a reporter off to build a driver they already had. It now says what actually ships, puts `kin update` first, keeps the build line second, and points at kin-vfs `docs/security/nfs-export.md` for what the export does and does not enforce. The `driver` module's own doc carried the same stale claim two lines up and lost it.

The tree already disagreed with that text in a way nothing read. `scripts/test-release-workflow-authority.py` carries `assert_kin_vfs_mount_features_built`, which refuses release.yml unless it builds macOS with `--features nfs` and Linux with `--features fuse`, saying in its own words that without the flag "the shipped driver carries no nfs-start and every NFS mount reports itself unavailable on every install". That guard is in ci.yml's gate list and passes. So a guard enforced the opposite of what the shipped remedy told the reader, and the remedy is the half that was wrong.

`engage_nfs` is the only place kin spawns `nfs-start`. The two other hits in `crates/kin-cli/src/commands/update.rs` match the subcommand in a running process's argv to decide what to restart after an update; they spawn nothing.

While I was in `docs/security/`: the threat model's Filesystem Projection section described only the preload shim, so it read as though interposition were the whole projection surface. It now names the mount surfaces that ship, says a mount is not per-process, and points at the same kin-vfs doc. Three sentences, no new claims.

## No pin move here, and one thing to watch

The dependency wave's PR #1430 already moves `kin-vfs-core` from `=0.4.23` to `=0.4.24`, so this branch leaves `Cargo.toml` and `Cargo.lock` alone rather than duplicating it. Everything above is probe-gated on the driver's own help and is correct against either pin, so the two can land in either order.

One thing to know if you are watching #1430: it is red, and correctly so. kin pins the kin-vfs source checkout at `ff59dfeb8fc9ad6a0b7f1e7d4505763e00792428` (kin-vfs #141, which builds kin-vfs-core 0.4.23), and `scripts/check-kin-vfs-compat.mjs` in ci.yml's `fast-gate-lint` job discovers that sha out of `.github/workflows` and `scripts`, fetches its Cargo.lock, and compares. On 1430's head sha 074f5680: 90 check runs, 90 listed, one failure, step "Verify Kin/kin-vfs compatibility at the pinned release input", saying Kin resolves 0.4.24 while the pinned checkout builds 0.4.23. So 1430 needs the immutable pin advanced to kin-vfs `4ff5262` before it can land, which is captain work and not this lane's. Nothing here depends on the outcome.

## Tests, each falsified by breaking the behaviour it guards

- **`a_writable_mount_is_asked_for_only_from_a_driver_that_offers_the_flag`** drives `nfs_start_args` off the real `nfs-start` flag sets at 0.4.23 and 0.4.24, including the two-step shape and an unreadable help. Replacing the `--writable` push with a discard turned it red and nothing else: 46 passed to 45 passed, 1 failed, named. Restored and green again at 46. It carries its own positive control, `--read-only` on the old body and `--repo` on the new, so a miss is the flag being absent rather than the matcher failing on every input.
- **`ensureKinBinary unpacks the Unix archive with an absolute tar under a hostile PATH`** plants a `tar` that exits 97 first on PATH, reusing the `environmentWithHostileTar` helper the Windows test already had. Restoring the PATH lookup turned it red and nothing else: 24 pass to 23 pass, 1 fail.
- **`provision unpacks the Unix archive with an absolute tar under a hostile PATH`**, the same shape in the launcher package. Restoring the PATH lookup: 48 pass to 47 pass, 1 fail.

Where the checks live, per the Lane Contract: both classes are expressible as tests in the crate and the package, and `Product Acceptance` carries `if: ${{ github.event_name != 'pull_request' }}`, so a rule under `scripts/acceptance/` would not run on the PR that breaks it. These run on this PR.

## What ran locally

Against the lane worktree `.kin-coord/worktrees/nfsfollow-kin` on `chore/lane-nfsfollow-kin`, every cargo command through `.kin-coord/bin/heavy-slot.sh`:

- `cargo test -p kin-cli --lib projection`: 46 passed, 0 failed.
- `cargo test -p kin-cli --test projection_modes`: 16 passed, 0 failed. This is the suite that reads `MOUNT_FEATURE_REMEDY` back out of the JSON health rows.
- `rustfmt --edition 2021 --check` on the one touched Rust file: clean, rc 0 read off its own line rather than through a pipe.
- `npm run lint` and `npm test` in `packages/kin-mcp`: 24 pass, 0 fail.
- `npm run lint` and `npm test` in `packages/kin`: 48 pass, 0 fail.
- `bin/kin-precheck kin`: 20 gates ran, 19 passed, 1 failed, on `kin 1d7df30f7`, path, sha and branch read off the tool's own printed line. The one failure is not this branch's, and it is worth saying loudly rather than in a footnote.

`guard:verify-zero-file-search.py` fails on `crates/kin-daemon/src/supervisor.rs:1191`, `std::fs::read_to_string(supervisor_token_path(&supervisor_dir()))`. That line came from #1426 (`git log -L 1188,1194`), this branch touches no file in `kin-daemon`, and its Rust diff adds no filesystem call at all. **kin's main is red on it right now**: the full check set at `9f18585d2`, paged to 220 of 220 rows, has four failures, and the one that matters is "Check & Test ubuntu shard (1)" failing at its "Check Zero File-Search Invariant" step. That is kin's own thesis guard, a red main stops a cut, and it has gone to the captain rather than being quietly fixed here, because the likely remedy is an exemption entry in a file this lane does not own.

It also cannot fail on a pull request. The `check` job carries `if: github.event_name != 'pull_request'`, so #1426 landed green and reds main after the fact. Same shape as the served-tool-name class.

The first precheck run also failed clippy, and that one WAS mine: `needless_lifetimes` on `nfs_start_args`, since one input reference elides to the return. Fixed by taking the explicit `'a` off, amended into the one commit, and clippy passes in the re-run above.

Hosted CI is the gate of record for the full workspace, and it has concluded on `1d7df30f7`: 47 check runs, 47 listed (`total_count` 47, paged, length asserted equal), 30 success and 17 skipped, nothing failed and nothing pending. `mergeStateStatus` CLEAN, `mergeable` MERGEABLE. Draft lifted on that read rather than on a rollup.
