### PR TITLE
Excuse the supervisor's own bearer-token read from the file-search guard

### DIFF
--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -298,7 +298,7 @@
     },
     {
       "file": "crates/kin-daemon/src/supervisor.rs",
-      "reason": "Supervisor process lifecycle boundary. The supervisor owns the daemon process, not any query answer, and each excused body is one of four classes. Endpoint records: the pid and port files, written through a temp-and-rename and removed only by the process that owns them, plus the url and canonical-path helpers that read them back. Singleton locks: the lifecycle guard file and its owner stamp, which decide whether another supervisor is already live. Install and process identity: the loopback auth token, same-binary comparison against the running executable, the log length and mtime probes, re-exec of the supervisor binary, and the reaper that kills rogue daemons. Registration payload and health: the repository record sent to the control plane and the local status report. None of these reads repository content, and no query result derives from any of them. Function-scoped rather than whole-file so the rest of the module, and anything added to it, stays scanned; the single expression pin is a struct field holding the lock file handle.",
+      "reason": "Supervisor process lifecycle boundary. The supervisor owns the daemon process, not any query answer, and each excused body is one of four classes. Endpoint records: the pid and port files, written through a temp-and-rename and removed only by the process that owns them, plus the url and canonical-path helpers that read them back. Singleton locks: the lifecycle guard file and its owner stamp, which decide whether another supervisor is already live. Install and process identity: the loopback auth token, both provisioning it and reading it back to present as this process's bearer credential when it calls a supervisor, same-binary comparison against the running executable, the log length and mtime probes, re-exec of the supervisor binary, and the reaper that kills rogue daemons. Registration payload and health: the repository record sent to the control plane and the local status report. None of these reads repository content, and no query result derives from any of them. Function-scoped rather than whole-file so the rest of the module, and anything added to it, stays scanned; the single expression pin is a struct field holding the lock file handle.",
       "owner": "kin-daemon",
       "expiration": "2026-12-31",
       "allow_fn": [
@@ -312,6 +312,7 @@
         "canonical_path_string",
         "repo_registration_payload",
         "ensure_loopback_token",
+        "supervisor_client_auth_token",
         "health",
         {
           "fn": "spawn_rogue_daemon_reaper",


### PR DESCRIPTION
Main went red on the sha my last landing produced (#1426, squash `9f18585d2`), and this is the one line that did it.

`supervisor_client_auth_token` reads `~/.kin/supervisor.token` so this process can present it when it calls a supervisor, and the zero file-search guard flagged the `std::fs::read_to_string` at `supervisor.rs:1191`. It is the same install-and-process-identity boundary `ensure_loopback_token` occupies one screen up, which provisions that same file and has been excused for it since before this change. This is that boundary read in the other direction: it carries a credential, answers no question about repository content, and no query result derives from it.

The exemption is function-scoped, so the rest of the module and anything added to it stay scanned, and the row's reason names the new body rather than leaving a reader to infer why it is there.

## Why the pull request did not catch it

`python3 scripts/verify-zero-file-search.py` runs in the `check` job, `Check & Test ubuntu shard`, which the `changes` filter marked `skipped` on #1426 and which runs on main's push. Same shape as the rule already written down for `Product Acceptance`: a gate that grades main and not the PR can be broken by a green PR and is found a landing later. Worth knowing that this guard is in that set, because the fast gate's own `scripts/zero_file_search_guard.sh` is a different, narrower scanner: it covers ten answer-authority modules under `crates/kin-cli/src/commands/`, while the python one walks 202 files across every crate. Reading the first and stopping is what let me believe `crates/kin-daemon` was out of scope.

## Verification

- `python3 scripts/verify-zero-file-search.py`: PASSED, 202 files scanned.
- `bash scripts/zero_file_search_guard.sh`: passed.
- Falsified: removing `supervisor_client_auth_token` from the allowlist turns the python guard red at exactly `supervisor.rs:1191`, and restoring it turns it green. So the entry is what makes it pass, not something else.
