### PR TITLE
Choose the archive extractor by host and the layout by target

### DIFF
--- a/packages/kin-mcp/src/index.js
+++ b/packages/kin-mcp/src/index.js
@@ -424,9 +424,14 @@ function unixSystemToolPath(name) {
   );
 }
 
-function archiveExtraction(platform, env, archiveName) {
+// The archive layout comes from the TARGET, the extractor from the HOST, and
+// conflating the two is what broke the native Windows leg once already: a
+// Windows host has no /usr/bin, and the cross-target tests unpack a linux
+// archive on it. `host` is a parameter rather than a read of `process.platform`
+// so every combination is testable from one machine.
+export function archiveExtraction(platform, env, archiveName, host = process.platform) {
   if (platform === 'win32') {
-    if (process.platform === 'win32') {
+    if (host === 'win32') {
       return {
         executable: windowsSystemTarPath(env),
         args: ['-xf', archiveName, '-C', '.']
@@ -440,8 +445,12 @@ function archiveExtraction(platform, env, archiveName) {
       args: ['-q', archiveName, '-d', '.']
     };
   }
+  // A Unix archive. On a Unix host that is the absolute system tar; on a
+  // Windows host, which only ever happens under a cross-target test, it is the
+  // same System32 bsdtar the Windows arm above uses, and bsdtar reads .tar.gz.
+  // Either way the extractor is named absolutely rather than found on PATH.
   return {
-    executable: unixSystemToolPath('tar'),
+    executable: host === 'win32' ? windowsSystemTarPath(env) : unixSystemToolPath('tar'),
     args: ['-xf', archiveName, '-C', '.']
   };
 }

--- a/packages/kin-mcp/test/index.test.js
+++ b/packages/kin-mcp/test/index.test.js
@@ -10,6 +10,7 @@ import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import {
+  archiveExtraction,
   assertSecureReleaseBaseUrl,
   childEnv,
   DEFAULT_RELEASE_BASE_URL,
@@ -21,6 +22,46 @@ import {
   runKinMcp,
   isTruthyEnv
 } from '../src/index.js';
+
+// The archive layout is a property of the target; the extractor is a property
+// of the host. Reading `process.platform` inside the target branch conflated
+// them, and the native Windows leg went red on three tests that unpack a Unix
+// archive on a Windows runner, where /usr/bin/tar does not exist. All four
+// combinations are asserted here rather than only the two a single runner can
+// reach, so neither leg has to be the place this is discovered.
+test('the extractor is chosen by the host and the layout by the target', () => {
+  const winEnv = { SystemRoot: 'C:\\Windows' };
+  const sys32Tar = path.win32.join('C:\\Windows', 'System32', 'tar.exe');
+
+  // Windows target.
+  assert.deepEqual(archiveExtraction('win32', winEnv, 'a.zip', 'win32'), {
+    executable: sys32Tar,
+    args: ['-xf', 'a.zip', '-C', '.']
+  });
+  assert.deepEqual(archiveExtraction('win32', {}, 'a.zip', 'linux'), {
+    executable: '/usr/bin/unzip',
+    args: ['-q', 'a.zip', '-d', '.']
+  });
+
+  // Unix target. On a Windows host this is the cross-target case, and it must
+  // not reach for /usr/bin.
+  assert.deepEqual(archiveExtraction('linux', winEnv, 'a.tar.gz', 'win32'), {
+    executable: sys32Tar,
+    args: ['-xf', 'a.tar.gz', '-C', '.']
+  });
+
+  // On a Unix host it is an absolute system tar, never a bare name PATH would
+  // resolve. Asserted as a property so the test does not care which of the two
+  // trusted directories this machine keeps tar in.
+  if (process.platform !== 'win32') {
+    const unix = archiveExtraction('linux', {}, 'a.tar.gz', 'linux');
+    assert.ok(
+      unix.executable === '/usr/bin/tar' || unix.executable === '/bin/tar',
+      `expected an absolute system tar, got ${unix.executable}`
+    );
+    assert.deepEqual(unix.args, ['-xf', 'a.tar.gz', '-C', '.']);
+  }
+});
 
 test('MCP auto-init boolean accepts the generated env-contract vocabulary', () => {
   for (const token of ['1', 'true', 'TRUE', 'TrUe', 'yes', 'YES', 'on', 'ON', ' on ']) {

--- a/packages/kin/lib/provision.mjs
+++ b/packages/kin/lib/provision.mjs
@@ -412,9 +412,14 @@ function unixSystemToolPath(name) {
   );
 }
 
-function archiveExtraction(platform, env, file) {
+// The archive layout comes from the TARGET, the extractor from the HOST, and
+// conflating the two is what broke the native Windows leg once already: a
+// Windows host has no /usr/bin, and the cross-target tests unpack a darwin
+// archive on it. `host` is a parameter rather than a read of `process.platform`
+// so every combination is testable from one machine.
+export function archiveExtraction(platform, env, file, host = process.platform) {
   if (platform === 'win32') {
-    if (process.platform === 'win32') {
+    if (host === 'win32') {
       return {
         executable: windowsSystemTarPath(env),
         args: ['-xf', file, '-C', '.'],
@@ -428,8 +433,12 @@ function archiveExtraction(platform, env, file) {
       args: ['-q', file, '-d', '.'],
     };
   }
+  // A Unix archive. On a Unix host that is the absolute system tar; on a
+  // Windows host, which only ever happens under a cross-target test, it is the
+  // same System32 bsdtar the Windows arm above uses, and bsdtar reads .tar.gz.
+  // Either way the extractor is named absolutely rather than found on PATH.
   return {
-    executable: unixSystemToolPath('tar'),
+    executable: host === 'win32' ? windowsSystemTarPath(env) : unixSystemToolPath('tar'),
     args: ['-xf', file, '-C', '.'],
   };
 }

--- a/packages/kin/test/provision.test.mjs
+++ b/packages/kin/test/provision.test.mjs
@@ -10,6 +10,7 @@ import { spawnSync } from 'node:child_process';
 import { test } from 'node:test';
 
 import {
+  archiveExtraction,
   artifactName,
   releaseDownloadUrl,
   parseSha256File,
@@ -31,6 +32,42 @@ import { binaryName, readLauncherStamp, writeLauncherStamp } from '../lib/resolv
 // bundle-only assertions remain authoritative on macOS/Linux; Windows runs the
 // native ZIP path and all platform-neutral provisioning policy below.
 const macArchiveModeTest = process.platform === 'win32' ? test.skip : test;
+
+// The archive layout is a property of the target; the extractor is a property
+// of the host. Reading `process.platform` inside the target branch conflated
+// them, and the native Windows leg went red on three tests that unpack a darwin
+// archive on a Windows runner, where /usr/bin/tar does not exist. All four
+// combinations are asserted here rather than only the two a single runner can
+// reach, so neither leg has to be the place this is discovered.
+test('the extractor is chosen by the host and the layout by the target', () => {
+  const winEnv = { SystemRoot: 'C:\\Windows' };
+  const sys32Tar = path.win32.join('C:\\Windows', 'System32', 'tar.exe');
+
+  assert.deepEqual(archiveExtraction('win32', winEnv, 'a.zip', 'win32'), {
+    executable: sys32Tar,
+    args: ['-xf', 'a.zip', '-C', '.'],
+  });
+  assert.deepEqual(archiveExtraction('win32', {}, 'a.zip', 'darwin'), {
+    executable: '/usr/bin/unzip',
+    args: ['-q', 'a.zip', '-d', '.'],
+  });
+
+  // Unix target on a Windows host: the cross-target case, which must not reach
+  // for /usr/bin.
+  assert.deepEqual(archiveExtraction('darwin', winEnv, 'a.tar.gz', 'win32'), {
+    executable: sys32Tar,
+    args: ['-xf', 'a.tar.gz', '-C', '.'],
+  });
+
+  if (process.platform !== 'win32') {
+    const unix = archiveExtraction('darwin', {}, 'a.tar.gz', 'darwin');
+    assert.ok(
+      unix.executable === '/usr/bin/tar' || unix.executable === '/bin/tar',
+      `expected an absolute system tar, got ${unix.executable}`,
+    );
+    assert.deepEqual(unix.args, ['-xf', 'a.tar.gz', '-C', '.']);
+  }
+});
 
 test('artifactName maps every released host and matches release.yml naming', () => {
   assert.equal(artifactName('darwin', 'arm64'), 'kin-macos-aarch64.tar.gz');

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -5136,10 +5136,25 @@ def assert_windows_npm_archive_authority(
             f"{label} absolute System32 extraction authority",
         )
         for policy in (
+            # The TARGET decides the archive layout.
             "if (platform === 'win32') {",
-            "if (process.platform === 'win32') {",
+            # The HOST decides the extractor, and it arrives as a parameter
+            # defaulting to the real platform rather than being read inline.
+            # That default is what keeps production honest; the parameter is
+            # what makes the cross-target case testable from one machine. It
+            # used to read `process.platform` here, and a Unix archive unpacked
+            # on a Windows host was then reachable only on the native Windows
+            # leg, which does not grade a pull request. It reddened main once.
+            "host = process.platform",
+            "if (host === 'win32') {",
             "executable: windowsSystemTarPath(env)",
             "executable: '/usr/bin/unzip'",
+            # The Unix arm names its extractor absolutely too, falling back to
+            # the same System32 bsdtar on a Windows host rather than to a PATH
+            # lookup. A bare `tar` here is what this line pins shut: PATH
+            # belongs to whoever started the process, and the archive being
+            # unpacked is the one whose SHA-256 was just verified.
+            "host === 'win32' ? windowsSystemTarPath(env) : unixSystemToolPath('tar')",
         ):
             require(extraction, policy, f"{label} Windows ZIP extraction authority")
 
@@ -5165,6 +5180,9 @@ def assert_windows_npm_archive_authority(
             "'/usr/bin/zip'",
             "subarray(0, 4).toString('hex')",
             "'504b0304'",
+            # The host/target matrix, asserted on every runner rather than only
+            # on the one whose platform the branch happens to name.
+            "the extractor is chosen by the host and the layout by the target",
         ):
             require(active_test, policy, f"{label} genuine Windows ZIP regression")
 


### PR DESCRIPTION
Main is red on "Windows authority tests" and this is the fix. My own #1432 broke it, on a leg that does not run on pull requests.

#1432 named `tar` absolutely so a `tar` planted on PATH could not unpack the archive whose SHA-256 had just been verified (FIR-3124 row 15). It decided by reading `process.platform`, and that conflated two different questions.

The archive **layout** is a property of the target: a `.zip` for Windows, a `.tar.gz` for Unix. The **extractor** is a property of the host, and a Windows host has no `/usr/bin`. Three tests in `packages/kin` unpack a darwin archive on the native Windows runner, and they failed with `tar was not found in /usr/bin or /bin; refusing to resolve it through PATH`. The Windows arm one branch up had this right from the day it was written, checking `process.platform` separately from the target it was building for. The Unix arm I added did not.

## The fix

`archiveExtraction` takes `host` as a parameter defaulting to `process.platform`, and the Unix-archive branch names the same absolute System32 bsdtar the Windows arm uses when the host is Windows. bsdtar reads `.tar.gz`, which is how those three tests passed before #1432, through a PATH lookup that happened to find it. The security property is unchanged and now holds on both hosts: the extractor is named absolutely and never found on PATH. Identical change in both packages, since both carry the same function.

Passing `host` rather than reading the global is the part that matters. It is what makes the cross-target case testable from a machine that is not Windows.

## The test that would have caught it

`the extractor is chosen by the host and the layout by the target`, in both packages, asserts all four combinations of target and host, including Windows-host-with-a-Unix-archive, which no Unix runner reaches on its own. The Unix-host row asserts the property (`/usr/bin/tar` or `/bin/tar`) rather than one path, so it does not care which of the two trusted directories a given machine keeps tar in.

Falsified: restoring the unconditional `unixSystemToolPath('tar')` turns that test red in both packages and nothing else. kin-mcp 25 pass to 24 pass and 1 fail; kin 49 pass to 48 pass and 1 fail. Restored, both green at 25 and 49.

## The guard moved with the code, and got stronger

`scripts/test-release-workflow-authority.py` pins this function's shape literally, and it caught the refactor on the first CI round: "canonical npm provisioner Windows ZIP extraction authority is missing required policy: `if (process.platform === 'win32') {`". Working exactly as intended. It now requires `host = process.platform` in the signature and `if (host === 'win32') {` in the target branch, which together say the default is still the real platform and the host decision is still being made.

It also gains a pin the property never actually had: that the Unix arm names its extractor absolutely, `host === 'win32' ? windowsSystemTarPath(env) : unixSystemToolPath('tar')`, rather than taking a bare `tar`. Nothing pinned that before, which is why row 15's finding existed in the first place. Falsified: putting `executable: 'tar'` back fails the guard by name at that new line. The matrix test is required by name in both packages too.

## What ran

`npm run lint` and `npm test` in `packages/kin-mcp` (25 pass, 0 fail) and in `packages/kin` (49 pass, 0 fail), plus `python3 scripts/test-release-workflow-authority.py` (rc 0), in the lane worktree `.kin-coord/worktrees/nfsfollow2-kin` on `chore/lane-nfsfollow2-kin`. No Rust changed, so no cargo ran and no builder slot was taken.

## Why the first PR went green

`Windows authority tests` reads `success` on main at `9f18585d2` and `failure` at `0776d91bd`, the squash of #1432, so the regression is unambiguous and it is mine. It did not appear on #1432's own check set: 47 runs, 47 listed, 30 success and 17 skipped, nothing failed. This is the same class as the served-tool-name incident, a leg that grades main and not the PR, and the lesson is narrower than "run more legs": a function that reads `process.platform` while deciding something about a target platform cannot be exercised on one host, so the host belongs in the signature. It is now in the signature.

## What this PR's green does and does not prove

Hosted CI concluded on `e2dd219b2`: 47 check runs, 47 listed against a `total_count` of 47, 30 success and 17 skipped, nothing failed and nothing pending. `npm launcher tests` is green, which is the job whose policy guard caught the refactor.

`Windows authority tests` is **skipped**, along with the CLI and runtime legs beside it. That is the gap this PR is fixing the consequences of, so it is worth naming rather than burying: the job carries `if: github.event_name != 'pull_request'` on purpose, its own comment explaining that the longest of the three legs measured 11.7 minutes against a ten-minute open-to-merge bar. So this PR cannot execute the fix on a real Windows host, and neither could the one that broke it.

What the PR does prove is the logic, on every runner: the new matrix test asserts that a Unix archive on a Windows host resolves to `C:\Windows\System32\tar.exe` and never to `/usr/bin`. That assertion is only possible because `host` is a parameter now, and it is the difference between this being provable here and provable only on main.

One thing for the captain, found while reading that job. Its comment says the three legs "stay on the merge queue and on every commit that reaches main" and that the proof "runs in the queue, which is what the release mint reads". kin has had no `merge_group` run since 2026-08-27T08:35:32Z, the classic flip (2705 historical merge_group runs, none since; push runs continue, 7725, as the control). So the native Windows admission contract is now proved only by main's push run, after landing, and the rationale written into the job assumes a queue that no longer runs. That is a shape worth a decision rather than a comment, and it is not this lane's to make.
