### PR TITLE
Admit the successor a promotion named on the publication-control record

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -16700,7 +16700,9 @@ async fn publication_control_authorize_next_reader(
     // Redacted, unlike admit-reader's echo of the caller's own record. The
     // caller wants to read back the identity it just wrote, and nothing on this
     // route needs a lease token in the response to do that.
-    Ok(Json(crate::publication_lease::PublicationControlStatus::from(record)))
+    Ok(Json(
+        crate::publication_lease::PublicationControlStatus::from(record),
+    ))
 }
 
 async fn publication_control_release_rollout(

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -16681,12 +16681,15 @@ async fn publication_control_admit_reader(
 /// Name the image identity that may admit itself at its next startup.
 ///
 /// This is the one route on this surface that does not act on the daemon
-/// serving it. The promotion calls it against the healthy outgoing daemon
-/// before the new image is applied, so nothing ever has to reach an unready or
-/// restarting pod, and the successor admits itself at its own startup under the
-/// authorization written here. The daemon still admits only itself: admit-reader
-/// refuses any reader but the one running, which is why the promotion writes an
-/// authorization rather than the reader.
+/// serving it, and the one that takes no lease proof. The promotion calls it
+/// against the healthy outgoing daemon before the new image is applied, so
+/// nothing ever has to reach an unready or restarting pod, and it holds nothing
+/// while doing so, so the running daemon's readiness is untouched. The daemon
+/// still admits only itself: admit-reader refuses any reader but the one
+/// running, which is why the promotion writes an authorization rather than the
+/// reader. The administrator token is the whole authorization to write here,
+/// which is why this route must stay under the publication-control prefix that
+/// demands it.
 async fn publication_control_authorize_next_reader(
     State(state): State<Arc<DaemonState>>,
     Json(request): Json<crate::publication_lease::AuthorizeNextReaderRequest>,
@@ -32091,37 +32094,6 @@ mod tests {
              reader: {admitted}"
         );
 
-        // The rest of the promotion's own sequence: name the successor under
-        // the lease it already holds, then release. A promotion that held its
-        // lease until the successor started would close production readiness
-        // for the whole apply, so the authorization has to be on the record
-        // rather than on the lease.
-        let (status, authorized) = publication_post(
-            app.clone(),
-            "/authority/publication-control/rollout/authorize-next-reader",
-            serde_json::json!({
-                "scope": scope,
-                "token": token,
-                "fence": fence,
-                "identity": READER_B
-            }),
-        )
-        .await;
-        assert_eq!(
-            status,
-            StatusCode::OK,
-            "the promotion must be able to name its successor: {authorized}"
-        );
-        assert_eq!(
-            authorized["next_reader_identity"].as_str(),
-            Some(READER_B),
-            "{authorized}"
-        );
-        assert!(
-            !authorized.to_string().contains("\"token\""),
-            "authorizing must not disclose live lease capability: {authorized}"
-        );
-
         let (status, released) = publication_post(
             app.clone(),
             "/authority/publication-control/rollout/release",
@@ -32130,8 +32102,58 @@ mod tests {
         .await;
         assert_eq!(status, StatusCode::OK, "release must succeed: {released}");
 
-        // The successor starts long after this lease is gone, so the record and
-        // not the lease is what has to still carry the authorization.
+        // The point of the whole sequence: a reader is admitted afterwards and
+        // semantic readiness is open. Asserting only the three 200s would pass
+        // on routes that returned 200 and changed nothing.
+        let readiness = app
+            .clone()
+            .oneshot(Request::get("/readiness").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            readiness.status(),
+            StatusCode::OK,
+            "the daemon must be reader-ready once the rollout has released"
+        );
+
+        // The promotion's own call, in the state production is actually in when
+        // it runs: settled, ready, no lease anywhere. It presents no proof
+        // because there is none to present.
+        let (status, authorized) = publication_post(
+            app.clone(),
+            "/authority/publication-control/rollout/authorize-next-reader",
+            serde_json::json!({ "scope": scope, "identity": READER_B }),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "the promotion must name its successor with no lease at all: {authorized}"
+        );
+        assert_eq!(
+            authorized["next_reader_identity"].as_str(),
+            Some(READER_B),
+            "{authorized}"
+        );
+        assert!(
+            authorized["active_lease"].is_null(),
+            "naming the successor must take no lease: {authorized}"
+        );
+
+        // And it costs the running daemon nothing. This is the property that
+        // paid for dropping the lease: readiness is open on the same daemon
+        // immediately after the call, so a promotion opens no gap at all.
+        let readiness = app
+            .clone()
+            .oneshot(Request::get("/readiness").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            readiness.status(),
+            StatusCode::OK,
+            "naming a successor must not close the running daemon's readiness"
+        );
+
         let control_status = app
             .clone()
             .oneshot(
@@ -32146,26 +32168,76 @@ mod tests {
         let status_body = axum::body::to_bytes(control_status.into_body(), 256 * 1024)
             .await
             .unwrap();
+        let status_text = String::from_utf8(status_body.to_vec()).unwrap();
         let status_json: serde_json::Value = serde_json::from_slice(&status_body).unwrap();
-        assert!(status_json["active_lease"].is_null());
         assert_eq!(
             status_json["next_reader_identity"].as_str(),
             Some(READER_B),
-            "releasing the lease must not drop the authorization: {status_json}"
+            "the successor starts long after this call, so the record has to carry it: {status_json}"
         );
+        assert!(
+            !status_text.contains("\"token\""),
+            "read-only publication status must not disclose live lease capability: {status_text}"
+        );
+    }
 
-        // The point of the whole sequence: a reader is admitted afterwards and
-        // semantic readiness is open. Asserting only the three 200s would pass
-        // on routes that returned 200 and changed nothing.
-        let readiness = app
-            .clone()
-            .oneshot(Request::get("/readiness").body(Body::empty()).unwrap())
+    /// The route sits on the administrator surface, not the daemon one. It is
+    /// the only publication-control route a caller reaches while holding no
+    /// lease, so nothing else stands between an ordinary daemon credential and
+    /// a write that decides which image opens readiness on the whole fleet.
+    #[tokio::test]
+    async fn authorizing_the_next_reader_demands_the_administrator_token() {
+        const READER_B: &str =
+            "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        let app = router_with_publication_control_auth(
+            test_state(),
+            Some("daemon-test-token".to_string()),
+            Some("publication-test-token".to_string()),
+        );
+        let authorize = |app: Router, token: Option<&'static str>| async move {
+            let mut request = Request::post(
+                "/authority/publication-control/rollout/authorize-next-reader",
+            )
+            .header("content-type", "application/json");
+            if let Some(token) = token {
+                request = request.header("authorization", format!("Bearer {token}"));
+            }
+            app.oneshot(
+                request
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({
+                            "scope": "gcs://fixture/v2",
+                            "identity": READER_B
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
             .await
-            .unwrap();
+            .unwrap()
+            .status()
+        };
+
+        // An ordinary daemon token is authenticated and unauthorized here, so
+        // 403 rather than 401: telling a caller holding a live credential that
+        // it holds none sends it to rotate a working token.
         assert_eq!(
-            readiness.status(),
-            StatusCode::OK,
-            "the daemon must be reader-ready once the rollout has released"
+            authorize(app.clone(), Some("daemon-test-token")).await,
+            StatusCode::FORBIDDEN
+        );
+        assert_eq!(
+            authorize(app.clone(), Some("not-a-token")).await,
+            StatusCode::UNAUTHORIZED
+        );
+        assert_eq!(authorize(app.clone(), None).await, StatusCode::UNAUTHORIZED);
+
+        // The control the refusals need: the administrator token passes the
+        // guard. Without it every assertion above would also hold on a route
+        // that refuses everyone, including the caller it exists for.
+        let admin = authorize(app, Some("publication-test-token")).await;
+        assert!(
+            admin != StatusCode::UNAUTHORIZED && admin != StatusCode::FORBIDDEN,
+            "the administrator token must pass the auth guard, got {admin}"
         );
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -32197,10 +32197,9 @@ mod tests {
             Some("publication-test-token".to_string()),
         );
         let authorize = |app: Router, token: Option<&'static str>| async move {
-            let mut request = Request::post(
-                "/authority/publication-control/rollout/authorize-next-reader",
-            )
-            .header("content-type", "application/json");
+            let mut request =
+                Request::post("/authority/publication-control/rollout/authorize-next-reader")
+                    .header("content-type", "application/json");
             if let Some(token) = token {
                 request = request.header("authorization", format!("Bearer {token}"));
             }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -2074,6 +2074,10 @@ fn api_routes() -> Router<Arc<DaemonState>> {
             post(publication_control_admit_reader),
         )
         .route(
+            "/authority/publication-control/rollout/authorize-next-reader",
+            post(publication_control_authorize_next_reader),
+        )
+        .route(
             "/authority/publication-control/rollout/release",
             post(publication_control_release_rollout),
         )
@@ -16672,6 +16676,28 @@ async fn publication_control_admit_reader(
         .map_err(|error| (StatusCode::SERVICE_UNAVAILABLE, error))?;
     let _ = control.refresh_runtime_admission(kin_db::GraphSnapshot::CURRENT_VERSION);
     Ok(Json(record))
+}
+
+/// Name the image identity that may admit itself at its next startup.
+///
+/// This is the one route on this surface that does not act on the daemon
+/// serving it. The promotion calls it against the healthy outgoing daemon
+/// before the new image is applied, so nothing ever has to reach an unready or
+/// restarting pod, and the successor admits itself at its own startup under the
+/// authorization written here. The daemon still admits only itself: admit-reader
+/// refuses any reader but the one running, which is why the promotion writes an
+/// authorization rather than the reader.
+async fn publication_control_authorize_next_reader(
+    State(state): State<Arc<DaemonState>>,
+    Json(request): Json<crate::publication_lease::AuthorizeNextReaderRequest>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let record = publication_control(&state)?
+        .authorize_next_reader(request)
+        .map_err(publication_control_error)?;
+    // Redacted, unlike admit-reader's echo of the caller's own record. The
+    // caller wants to read back the identity it just wrote, and nothing on this
+    // route needs a lease token in the response to do that.
+    Ok(Json(crate::publication_lease::PublicationControlStatus::from(record)))
 }
 
 async fn publication_control_release_rollout(
@@ -31928,6 +31954,8 @@ mod tests {
     async fn publication_control_api_drives_the_rollout_to_release() {
         const READER_A: &str =
             "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        const READER_B: &str =
+            "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
         let fleet = vec![
             "kin".to_string(),
             "kin-db".to_string(),
@@ -32063,6 +32091,37 @@ mod tests {
              reader: {admitted}"
         );
 
+        // The rest of the promotion's own sequence: name the successor under
+        // the lease it already holds, then release. A promotion that held its
+        // lease until the successor started would close production readiness
+        // for the whole apply, so the authorization has to be on the record
+        // rather than on the lease.
+        let (status, authorized) = publication_post(
+            app.clone(),
+            "/authority/publication-control/rollout/authorize-next-reader",
+            serde_json::json!({
+                "scope": scope,
+                "token": token,
+                "fence": fence,
+                "identity": READER_B
+            }),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "the promotion must be able to name its successor: {authorized}"
+        );
+        assert_eq!(
+            authorized["next_reader_identity"].as_str(),
+            Some(READER_B),
+            "{authorized}"
+        );
+        assert!(
+            !authorized.to_string().contains("\"token\""),
+            "authorizing must not disclose live lease capability: {authorized}"
+        );
+
         let (status, released) = publication_post(
             app.clone(),
             "/authority/publication-control/rollout/release",
@@ -32070,6 +32129,30 @@ mod tests {
         )
         .await;
         assert_eq!(status, StatusCode::OK, "release must succeed: {released}");
+
+        // The successor starts long after this lease is gone, so the record and
+        // not the lease is what has to still carry the authorization.
+        let control_status = app
+            .clone()
+            .oneshot(
+                Request::get("/authority/publication-control")
+                    .header("authorization", "Bearer publication-test-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(control_status.status(), StatusCode::OK);
+        let status_body = axum::body::to_bytes(control_status.into_body(), 256 * 1024)
+            .await
+            .unwrap();
+        let status_json: serde_json::Value = serde_json::from_slice(&status_body).unwrap();
+        assert!(status_json["active_lease"].is_null());
+        assert_eq!(
+            status_json["next_reader_identity"].as_str(),
+            Some(READER_B),
+            "releasing the lease must not drop the authorization: {status_json}"
+        );
 
         // The point of the whole sequence: a reader is admitted afterwards and
         // semantic readiness is open. Asserting only the three 200s would pass

--- a/crates/kin-daemon/src/publication_lease.rs
+++ b/crates/kin-daemon/src/publication_lease.rs
@@ -355,15 +355,21 @@ pub struct AdmitReaderRequest {
     pub legacy_writer_drain_proof_sha256: Option<String>,
 }
 
-/// Name the image identity that may admit itself at its next startup. The
-/// promotion pipeline holds a rollout lease for this one write and releases it
-/// immediately, because a live rollout lease closes readiness for every image
-/// including the one currently serving production.
+/// Name the image identity that may admit itself at its next startup.
+///
+/// No lease proof, deliberately. A rollout lease closes reader admission for
+/// every image including the one currently serving production, so requiring one
+/// here would buy serialization at the price of a readiness gap on every
+/// promotion, and the promotion would have to acquire and then release a
+/// rollout it has no other use for. The record's own CAS loop already makes the
+/// write atomic. What the lease bought is ordering between two overlapping
+/// promotions, and that resolves to the last write: the digest that did not win
+/// is refused at its bootstrap with a message naming what the record admits and
+/// what it authorizes, which is visible and recoverable rather than a deadlock.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AuthorizeNextReaderRequest {
-    #[serde(flatten)]
-    pub lease: LeaseProof,
+    pub scope: String,
     pub identity: String,
 }
 
@@ -750,9 +756,19 @@ impl PublicationControl {
         require_complete_record_authority_fence(&record)?;
         validate_reader_against_authority_fence(&record.reader, &record.last_authority_fence)?;
         if record.reader.identity != self.runtime_reader_identity {
+            // Name the outstanding authorization too. Two promotions that
+            // overlap resolve to the last write, and without this the digest
+            // that lost is told only that it is not the admitted reader, which
+            // is equally true of an image nobody ever promoted.
+            let authorized = match record.next_reader_identity.as_deref() {
+                Some(next) if next != self.runtime_reader_identity => {
+                    format!("; the record authorizes {next} to admit itself next")
+                }
+                _ => String::new(),
+            };
             return Err(PublicationControlError::Admission(format!(
-                "scope {} admits reader {}, but this daemon is {}",
-                self.scope, record.reader.identity, self.runtime_reader_identity
+                "scope {} admits reader {}, but this daemon is {}{}",
+                self.scope, record.reader.identity, self.runtime_reader_identity, authorized
             )));
         }
         if snapshot_schema < record.reader.min_snapshot_schema
@@ -1676,29 +1692,31 @@ impl PublicationControl {
         ))
     }
 
-    /// Record the image identity the promotion pipeline will start next, under
-    /// an asserted rollout lease.
+    /// Record the image identity the promotion will start next.
     ///
-    /// The pipeline cannot admit the successor itself. `admit_reader` runs
+    /// The promotion cannot admit the successor itself. `admit_reader` runs
     /// through `prepare_hosted_spine_rollout`, which refuses any reader but the
     /// daemon serving the request, so a healthy outgoing daemon can only ever
     /// admit itself. What it can do is say who comes next. The successor then
     /// admits itself at its own startup, and legitimacy still rests with the
     /// holder of the administrator token rather than with any image that can
     /// reach the bucket.
+    ///
+    /// This holds nothing. It takes no rollout lease, so it opens no readiness
+    /// gap on the daemon it is called against, and the promotion makes exactly
+    /// one call before the apply. The administrator token authenticates the
+    /// caller and the record's CAS makes the write atomic; ordering between two
+    /// overlapping promotions is last-write-wins by design, and the losing
+    /// digest is refused at its bootstrap rather than left waiting.
     pub fn authorize_next_reader(
         &self,
         request: AuthorizeNextReaderRequest,
     ) -> Result<PublicationControlRecord, PublicationControlError> {
-        self.validate_scope(&request.lease.scope)?;
+        self.validate_scope(&request.scope)?;
         validate_image_identity(&request.identity)?;
         for _ in 0..MAX_CAS_ATTEMPTS {
-            let now = self.clock.now();
             let stored = self.load_required()?;
             self.validate_record(&stored.record)?;
-            // The token is what authenticates the caller; the lease is what
-            // serializes it against every other writer of this record.
-            require_lease(&stored.record, &request.lease, LeaseKind::Rollout, now)?;
             if stored.record.next_reader_identity.as_deref() == Some(request.identity.as_str()) {
                 return Ok(stored.record);
             }
@@ -5005,26 +5023,16 @@ mod tests {
         );
     }
 
-    /// Acquire a rollout on the running daemon and name the successor, exactly
-    /// as the promotion does. The returned lease is still held: releasing it
-    /// re-admits the running image, which the release path requires and which
-    /// the promotion script therefore has to do too, so each caller decides
-    /// whether the promotion finished or died here.
-    fn authorize_next_reader_for(
-        control: &Arc<PublicationControl>,
-        request_id: &str,
-        identity: &str,
-    ) -> ActivePublicationLease {
-        let pipeline = control
-            .acquire_rollout(rollout_request("promotion", request_id, None))
-            .unwrap();
+    /// Name the successor exactly as the promotion does: one call, holding
+    /// nothing. There is no lease to acquire and none to release, which is the
+    /// whole reason this costs production no readiness.
+    fn authorize_next_reader_for(control: &Arc<PublicationControl>, identity: &str) {
         control
             .authorize_next_reader(AuthorizeNextReaderRequest {
-                lease: proof(&pipeline),
+                scope: SCOPE.to_string(),
                 identity: identity.to_string(),
             })
             .unwrap();
-        pipeline
     }
 
     /// The upgrade path this authorization exists for. A settled record admits
@@ -5044,16 +5052,17 @@ mod tests {
             .unwrap()
             .expect("first runtime must bootstrap");
         release(&outgoing, &first);
+        let settled_fence = outgoing.status().unwrap().last_fence;
 
-        let pipeline = authorize_next_reader_for(&outgoing, "promote-reader-b", READER_B);
-        release(&outgoing, &pipeline);
+        authorize_next_reader_for(&outgoing, READER_B);
 
-        // The authorization has to outlive the lease that wrote it. If it lived
-        // on the lease, the promotion would have to hold that lease across the
-        // whole apply, and a live rollout lease closes readiness for every
-        // image including the one still serving production.
+        // Naming the successor takes nothing and admits nobody. The outgoing
+        // daemon is still the reader and still ready, and the fence has not
+        // moved, so production sees no gap at all between this call and the
+        // apply that follows it.
         let authorized = outgoing.status().unwrap();
         assert!(authorized.active_lease.is_none());
+        assert_eq!(authorized.last_fence, settled_fence);
         assert_eq!(authorized.next_reader_identity.as_deref(), Some(READER_B));
         assert_eq!(
             authorized.reader.identity, READER_A,
@@ -5070,9 +5079,8 @@ mod tests {
             .expect("an authorized image must run its own startup rollout");
         assert_eq!(startup.holder, STARTUP_BOOTSTRAP_HOLDER);
         assert!(
-            startup.fence > pipeline.fence,
-            "the startup rollout must raise the fence past {}",
-            pipeline.fence
+            startup.fence > settled_fence,
+            "the startup rollout must raise the fence past {settled_fence}"
         );
         release(&incoming, &startup);
 
@@ -5085,6 +5093,98 @@ mod tests {
             .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
             .unwrap_err();
         assert!(displaced.to_string().contains(READER_B), "{displaced}");
+    }
+
+    /// The write holds no rollout lease, and that is the property that makes
+    /// the promotion free. A rollout lease closes reader admission for every
+    /// image, so requiring one here would have put a readiness gap on the
+    /// running daemon at the start of every upgrade, to serialize a single
+    /// field the record's own CAS already writes atomically.
+    #[test]
+    fn authorizing_the_next_reader_needs_no_rollout_lease() {
+        let store = Arc::new(InMemoryPublicationControlStore::default());
+        let clock = Arc::new(ManualClock::new());
+        let daemon = control(Arc::clone(&store), Arc::clone(&clock), READER_A);
+        let first = daemon
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("first runtime must bootstrap");
+        release(&daemon, &first);
+
+        // A settled record carries no lease at all, so there is no proof any
+        // caller could have presented.
+        let settled = daemon.status().unwrap();
+        assert!(settled.active_lease.is_none());
+        authorize_next_reader_for(&daemon, READER_B);
+        let authorized = daemon.status().unwrap();
+        assert_eq!(authorized.next_reader_identity.as_deref(), Some(READER_B));
+        assert!(authorized.active_lease.is_none(), "the write must take none");
+        assert_eq!(authorized.last_fence, settled.last_fence);
+
+        // And a rollout somebody else holds neither blocks the write nor is
+        // disturbed by it.
+        let operator = daemon
+            .acquire_rollout(rollout_request("deploy", "unrelated-rollout", None))
+            .unwrap();
+        authorize_next_reader_for(&daemon, READER_C);
+        let during = daemon.status().unwrap();
+        assert_eq!(during.next_reader_identity.as_deref(), Some(READER_C));
+        assert_eq!(
+            during.active_lease.as_ref().unwrap().fence,
+            operator.fence,
+            "the write must not disturb a rollout it does not hold"
+        );
+    }
+
+    /// Two promotions that overlap resolve to the last write. That is the whole
+    /// cost of dropping the lease, and it is a recoverable one: the digest that
+    /// lost is refused at its own bootstrap, and the refusal says what the
+    /// record admits and what it now authorizes, so an operator reads the cause
+    /// off the message rather than off two workflow logs.
+    #[test]
+    fn two_authorizations_resolve_to_the_last_write() {
+        let store = Arc::new(InMemoryPublicationControlStore::default());
+        let clock = Arc::new(ManualClock::new());
+        let outgoing = control(Arc::clone(&store), Arc::clone(&clock), READER_A);
+        let first = outgoing
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("first runtime must bootstrap");
+        release(&outgoing, &first);
+
+        authorize_next_reader_for(&outgoing, READER_B);
+        authorize_next_reader_for(&outgoing, READER_C);
+        assert_eq!(
+            outgoing.status().unwrap().next_reader_identity.as_deref(),
+            Some(READER_C),
+            "the last write wins"
+        );
+
+        let loser = control(Arc::clone(&store), Arc::clone(&clock), READER_B);
+        let unchanged = loser.status().unwrap();
+        assert!(
+            loser.bootstrap_runtime_if_absent().unwrap().is_none(),
+            "the digest that lost must not admit itself"
+        );
+        assert_eq!(loser.status().unwrap(), unchanged);
+        let refusal = loser
+            .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            refusal.contains(READER_A) && refusal.contains(READER_B) && refusal.contains(READER_C),
+            "the loser's refusal must name the admitted reader, itself and the winner: {refusal}"
+        );
+
+        // The winner is unaffected, which is what makes last-write-wins a
+        // resolution rather than a stalemate.
+        let winner = control(Arc::clone(&store), Arc::clone(&clock), READER_C);
+        let startup = winner
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("the digest that won must run its startup rollout");
+        release(&winner, &startup);
+        assert_eq!(winner.status().unwrap().reader.identity, READER_C);
     }
 
     /// The authorization names one digest. An image nobody named is refused
@@ -5102,8 +5202,7 @@ mod tests {
             .expect("first runtime must bootstrap");
         release(&outgoing, &first);
 
-        let pipeline = authorize_next_reader_for(&outgoing, "promote-reader-b", READER_B);
-        release(&outgoing, &pipeline);
+        authorize_next_reader_for(&outgoing, READER_B);
         let before = outgoing.status().unwrap();
 
         let unnamed = control(Arc::clone(&store), Arc::clone(&clock), READER_C);
@@ -5123,8 +5222,8 @@ mod tests {
 
     /// Single-use, and spent by the admission that used it. An authorization
     /// left on the record after its image is in is a standing invitation for a
-    /// digest nobody is promoting any more, and it is why a rollback needs a
-    /// compensating authorization rather than the leftovers of this one.
+    /// digest nobody is promoting any more, and it is why a rollback needs its
+    /// own compensating call rather than the leftovers of this one.
     #[test]
     fn a_consumed_authorization_does_not_survive_its_own_admission() {
         let store = Arc::new(InMemoryPublicationControlStore::default());
@@ -5136,8 +5235,7 @@ mod tests {
             .expect("first runtime must bootstrap");
         release(&outgoing, &first);
 
-        let pipeline = authorize_next_reader_for(&outgoing, "promote-reader-b", READER_B);
-        release(&outgoing, &pipeline);
+        authorize_next_reader_for(&outgoing, READER_B);
 
         let incoming = control(Arc::clone(&store), Arc::clone(&clock), READER_B);
         let startup = incoming
@@ -5154,19 +5252,31 @@ mod tests {
         );
 
         // So a rollback to the outgoing image is refused on the record that
-        // image wrote itself, and the promotion has to re-authorize it.
+        // image wrote itself, and the promotion has to re-authorize it. That
+        // one call is the compensation, and it is the same one call as the
+        // promotion itself.
         let rolled_back = outgoing
             .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
             .unwrap_err();
         assert!(rolled_back.to_string().contains(READER_B), "{rolled_back}");
+        authorize_next_reader_for(&incoming, READER_A);
+        let recovered = outgoing
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("the compensating authorization must let the outgoing image back in");
+        release(&outgoing, &recovered);
+        assert_eq!(outgoing.status().unwrap().reader.identity, READER_A);
+        outgoing
+            .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
+            .unwrap();
     }
 
-    /// kin#1421's boundary, restated for the promotion's lease. An expired
-    /// startup lease is takeover-eligible because no other actor can recover
-    /// it; an expired promotion lease belongs to the next promotion, and the
-    /// image it named may not walk in under it.
+    /// kin#1421's boundary, held for the new path. An expired startup lease is
+    /// takeover-eligible because no other actor can recover it. Any other
+    /// expired rollout is not, and an authorized digest may not walk in under
+    /// one: the record has to be settled before this branch will touch it.
     #[test]
-    fn an_expired_pipeline_lease_does_not_admit_the_image_it_authorized() {
+    fn an_expired_rollout_lease_does_not_admit_the_image_the_promotion_authorized() {
         let store = Arc::new(InMemoryPublicationControlStore::default());
         let clock = Arc::new(ManualClock::new());
         let outgoing = control(Arc::clone(&store), Arc::clone(&clock), READER_A);
@@ -5176,68 +5286,27 @@ mod tests {
             .expect("first runtime must bootstrap");
         release(&outgoing, &first);
 
-        // The promotion writes the authorization and then dies, so nothing
-        // releases or renews its lease.
-        let pipeline = authorize_next_reader_for(&outgoing, "promote-reader-b", READER_B);
+        authorize_next_reader_for(&outgoing, READER_B);
+        let operator = outgoing
+            .acquire_rollout(rollout_request("deploy", "operator-rollout", None))
+            .unwrap();
         clock.advance(MAX_ROLLOUT_LEASE_SECONDS as i64 + 1);
         let before = outgoing.status().unwrap();
 
         let incoming = control(Arc::clone(&store), Arc::clone(&clock), READER_B);
         assert!(
             incoming.bootstrap_runtime_if_absent().unwrap().is_none(),
-            "a dead promotion lease is the next promotion's to recover"
+            "a dead rollout is its own holder's to recover, not an opening"
         );
         assert_eq!(incoming.status().unwrap(), before);
         assert_eq!(
             incoming.status().unwrap().active_lease.unwrap().fence,
-            pipeline.fence
+            operator.fence
         );
         let refusal = incoming
             .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
             .unwrap_err();
         assert!(refusal.to_string().contains("never released"), "{refusal}");
-    }
-
-    /// The administrator token authenticates the caller. The rollout lease is
-    /// what serializes the write against every other writer of this record, so
-    /// a token holder with no lease, or one whose lease lapsed, writes nothing.
-    #[test]
-    fn authorizing_the_next_reader_requires_a_live_rollout_lease() {
-        let store = Arc::new(InMemoryPublicationControlStore::default());
-        let clock = Arc::new(ManualClock::new());
-        let daemon = control(Arc::clone(&store), Arc::clone(&clock), READER_A);
-        let first = daemon
-            .bootstrap_runtime_if_absent()
-            .unwrap()
-            .expect("first runtime must bootstrap");
-        release(&daemon, &first);
-
-        let settled = daemon.status().unwrap();
-        let unheld = daemon
-            .authorize_next_reader(AuthorizeNextReaderRequest {
-                lease: LeaseProof {
-                    scope: SCOPE.to_string(),
-                    token: "not-a-lease".to_string(),
-                    fence: settled.last_fence,
-                },
-                identity: READER_B.to_string(),
-            })
-            .unwrap_err();
-        assert!(unheld.to_string().contains("is not active"), "{unheld}");
-        assert_eq!(daemon.status().unwrap().next_reader_identity, None);
-
-        let pipeline = daemon
-            .acquire_rollout(rollout_request("promotion", "promote-reader-b", None))
-            .unwrap();
-        clock.advance(MAX_ROLLOUT_LEASE_SECONDS as i64 + 1);
-        let lapsed = daemon
-            .authorize_next_reader(AuthorizeNextReaderRequest {
-                lease: proof(&pipeline),
-                identity: READER_B.to_string(),
-            })
-            .unwrap_err();
-        assert!(lapsed.to_string().contains("expired at"), "{lapsed}");
-        assert_eq!(daemon.status().unwrap().next_reader_identity, None);
     }
 
     /// The field decides which image opens readiness on the hosted fleet, so it
@@ -5254,12 +5323,9 @@ mod tests {
             .expect("first runtime must bootstrap");
         release(&daemon, &first);
 
-        let pipeline = daemon
-            .acquire_rollout(rollout_request("promotion", "promote-latest", None))
-            .unwrap();
         let refused = daemon
             .authorize_next_reader(AuthorizeNextReaderRequest {
-                lease: proof(&pipeline),
+                scope: SCOPE.to_string(),
                 identity: "latest".to_string(),
             })
             .unwrap_err();
@@ -5293,7 +5359,7 @@ mod tests {
         // The control the absence above needs: the key does appear when it is
         // set, so the assertion is about absence and not about a field name
         // this test spelled wrong.
-        let pipeline = authorize_next_reader_for(&daemon, "promote-reader-b", READER_B);
+        authorize_next_reader_for(&daemon, READER_B);
         let authorized = serde_json::to_value(daemon.status().unwrap()).unwrap();
         assert_eq!(
             authorized
@@ -5302,7 +5368,6 @@ mod tests {
             Some(READER_B),
             "{authorized}"
         );
-        release(&daemon, &pipeline);
     }
 
     /// Nothing in the API leaves an authorization naming the reader it admitted,

--- a/crates/kin-daemon/src/publication_lease.rs
+++ b/crates/kin-daemon/src/publication_lease.rs
@@ -5095,6 +5095,47 @@ mod tests {
         assert!(displaced.to_string().contains(READER_B), "{displaced}");
     }
 
+    /// The clear fires only when the admission consumes exactly the identity the
+    /// record authorizes next. `a_pipeline_authorized_image_admits_itself_at_startup`
+    /// is not enough to guard this: every admit_reader call it drives happens to
+    /// admit the identity that was actually authorized, so an unconditional clear
+    /// looks identical to the guarded one throughout that test. This is the case
+    /// that tells them apart: the OUTGOING daemon is re-admitted, under an
+    /// unrelated operator rollout, while the record still authorizes someone else
+    /// next. Nothing about who reads is changing here, so nothing about who is
+    /// authorized next may change either, or unrelated daemon activity could
+    /// silently erase the pipeline's authorization before the successor ever
+    /// starts.
+    #[test]
+    fn an_unrelated_admission_of_the_current_reader_leaves_the_authorization_alone() {
+        let store = Arc::new(InMemoryPublicationControlStore::default());
+        let clock = Arc::new(ManualClock::new());
+        let outgoing = control(Arc::clone(&store), Arc::clone(&clock), READER_A);
+        let first = outgoing
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("first runtime must bootstrap");
+        release(&outgoing, &first);
+
+        authorize_next_reader_for(&outgoing, READER_B);
+
+        // An operator rollout that re-admits the SAME image. Its own release
+        // path runs admit_reader with `outgoing`'s own identity, READER_A, which
+        // is not the identity the record now authorizes next.
+        let reaffirm = outgoing
+            .acquire_rollout(rollout_request("deploy", "reaffirm-reader-a", None))
+            .unwrap();
+        release(&outgoing, &reaffirm);
+
+        let after = outgoing.status().unwrap();
+        assert_eq!(after.reader.identity, READER_A);
+        assert_eq!(
+            after.next_reader_identity.as_deref(),
+            Some(READER_B),
+            "an admission of a different identity than the one authorized must not consume it"
+        );
+    }
+
     /// The write holds no rollout lease, and that is the property that makes
     /// the promotion free. A rollout lease closes reader admission for every
     /// image, so requiring one here would have put a readiness gap on the
@@ -5118,7 +5159,10 @@ mod tests {
         authorize_next_reader_for(&daemon, READER_B);
         let authorized = daemon.status().unwrap();
         assert_eq!(authorized.next_reader_identity.as_deref(), Some(READER_B));
-        assert!(authorized.active_lease.is_none(), "the write must take none");
+        assert!(
+            authorized.active_lease.is_none(),
+            "the write must take none"
+        );
         assert_eq!(authorized.last_fence, settled.last_fence);
 
         // And a rollout somebody else holds neither blocks the write nor is

--- a/crates/kin-daemon/src/publication_lease.rs
+++ b/crates/kin-daemon/src/publication_lease.rs
@@ -190,6 +190,28 @@ pub struct PublicationControlRecord {
     pub reader_spine_rollout_fence_payload_sha256: Option<String>,
     #[serde(default)]
     pub reader_spine_rollout_fence_update_time: Option<String>,
+    /// Image identity the promotion pipeline has authorized to admit itself at
+    /// its next startup, written under a rollout lease through
+    /// `authorize_next_reader`.
+    ///
+    /// A settled record admits only the reader it names, so without this a
+    /// promoted image is refused forever and the fleet is upgradable exactly
+    /// once. The authorization lives on the record rather than on the lease so
+    /// that releasing the lease does not drop it: the pipeline holds its lease
+    /// for a few calls before the apply, and production readiness closes for
+    /// seconds rather than for the whole rollout. It is consumed by the
+    /// admission it authorizes, so it is single-use.
+    ///
+    /// `skip_serializing_if` unlike its siblings here, and deliberately. This
+    /// struct carries `deny_unknown_fields`, so a key an older daemon does not
+    /// know refuses the whole record at deserialization, before any validation
+    /// that could explain it. The first image carrying this field rewrites the
+    /// record at its own startup rollout, and a rollback from that deploy would
+    /// otherwise meet a record its predecessor can no longer read. Absent when
+    /// unset, the settled record stays exactly the shape the outgoing image
+    /// already reads.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_reader_identity: Option<String>,
     pub active_lease: Option<ActivePublicationLease>,
     pub last_completed_lease: Option<CompletedPublicationLease>,
     #[serde(default)]
@@ -215,6 +237,7 @@ pub struct PublicationControlStatus {
     pub spine_rollout_fence_update_time: Option<String>,
     pub reader_spine_rollout_fence_payload_sha256: Option<String>,
     pub reader_spine_rollout_fence_update_time: Option<String>,
+    pub next_reader_identity: Option<String>,
     pub active_lease: Option<ActivePublicationLeaseStatus>,
 }
 
@@ -253,6 +276,7 @@ impl From<PublicationControlRecord> for PublicationControlStatus {
             reader_spine_rollout_fence_payload_sha256: record
                 .reader_spine_rollout_fence_payload_sha256,
             reader_spine_rollout_fence_update_time: record.reader_spine_rollout_fence_update_time,
+            next_reader_identity: record.next_reader_identity,
             active_lease: record
                 .active_lease
                 .map(|active| ActivePublicationLeaseStatus {
@@ -329,6 +353,18 @@ pub struct AdmitReaderRequest {
     /// migration seal exists.
     #[serde(default)]
     pub legacy_writer_drain_proof_sha256: Option<String>,
+}
+
+/// Name the image identity that may admit itself at its next startup. The
+/// promotion pipeline holds a rollout lease for this one write and releases it
+/// immediately, because a live rollout lease closes readiness for every image
+/// including the one currently serving production.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuthorizeNextReaderRequest {
+    #[serde(flatten)]
+    pub lease: LeaseProof,
+    pub identity: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -798,6 +834,15 @@ impl PublicationControl {
     /// recovery performed here is resuming this exact startup lease after a
     /// crash or retry.
     ///
+    /// One further transition is admitted, and only one: an image the promotion
+    /// pipeline named in `next_reader_identity` while it held a rollout lease on
+    /// the outgoing daemon. That authorization is written by the holder of the
+    /// administrator token, against a healthy reachable daemon, before the new
+    /// image is ever applied. The record's own reader still wins when it names
+    /// this image, so a restart of an admitted daemon opens readiness without
+    /// re-fencing the fleet. Nothing here lets an image admit itself on its own
+    /// say-so.
+    ///
     /// A crash mid-bootstrap is the one case where the next image differs from
     /// the recorded reader. The failed image wrote its own identity into the
     /// record before it died, so requiring an identity match would leave the
@@ -826,7 +871,17 @@ impl PublicationControl {
                     && (stored.record.reader.identity == self.runtime_reader_identity
                         || active.expires_at <= now)
             });
-            if !resumes_startup {
+            // The settled record admits only the reader it names, which is why
+            // a promoted image was refused forever before this branch existed.
+            // The pipeline says who comes next; this is the daemon reading that
+            // authorization and running one startup rollout to admit itself. An
+            // authorization naming any other digest is not ours to take, and a
+            // record that already admits this image needs no rollout at all.
+            let admits_authorized_reader = stored.record.active_lease.is_none()
+                && stored.record.reader.identity != self.runtime_reader_identity
+                && stored.record.next_reader_identity.as_deref()
+                    == Some(self.runtime_reader_identity.as_str());
+            if !resumes_startup && !admits_authorized_reader {
                 let _ = self.refresh_runtime_admission(kin_db::GraphSnapshot::CURRENT_VERSION);
                 return Ok(None);
             }
@@ -915,6 +970,7 @@ impl PublicationControl {
                         spine_rollout_fence_update_time: None,
                         reader_spine_rollout_fence_payload_sha256: None,
                         reader_spine_rollout_fence_update_time: None,
+                        next_reader_identity: None,
                         active_lease: Some(lease.clone()),
                         last_completed_lease: None,
                         last_completed_rollout: None,
@@ -1580,7 +1636,17 @@ impl PublicationControl {
                 &active.target_repositories,
             )?;
             let current_reader_evidence = reader_spine_rollout_fence_evidence(&stored.record)?;
-            if stored.record.reader.identity == request.reader.identity
+            // The pipeline's authorization is single-use, and this is the
+            // admission that uses it. Clearing it in the same CAS as the
+            // admission is what makes it single-use: no later step has to
+            // remember, and no crash can strand a spent authorization on the
+            // record. It fires only when the admitted identity is the one
+            // named, so an operator admitting the running daemon over an
+            // authorization for its successor leaves that authorization alone.
+            let consumes_authorization = stored.record.next_reader_identity.as_deref()
+                == Some(request.reader.identity.as_str());
+            if !consumes_authorization
+                && stored.record.reader.identity == request.reader.identity
                 && stored.record.reader.min_snapshot_schema == request.reader.min_snapshot_schema
                 && stored.record.reader.max_snapshot_schema == request.reader.max_snapshot_schema
                 && current_reader_evidence.as_ref() == Some(&active_spine_evidence)
@@ -1596,6 +1662,9 @@ impl PublicationControl {
             record.reader_spine_rollout_fence_payload_sha256 =
                 Some(active_spine_evidence.payload_sha256);
             record.reader_spine_rollout_fence_update_time = Some(active_spine_evidence.update_time);
+            if consumes_authorization {
+                record.next_reader_identity = None;
+            }
             match self.store.update(&stored.version, &record) {
                 Ok(_) => return Ok(record),
                 Err(error) if error.is_cas_conflict() => continue,
@@ -1604,6 +1673,46 @@ impl PublicationControl {
         }
         Err(PublicationControlError::Conflict(
             "publication record changed during every reader admission attempt".to_string(),
+        ))
+    }
+
+    /// Record the image identity the promotion pipeline will start next, under
+    /// an asserted rollout lease.
+    ///
+    /// The pipeline cannot admit the successor itself. `admit_reader` runs
+    /// through `prepare_hosted_spine_rollout`, which refuses any reader but the
+    /// daemon serving the request, so a healthy outgoing daemon can only ever
+    /// admit itself. What it can do is say who comes next. The successor then
+    /// admits itself at its own startup, and legitimacy still rests with the
+    /// holder of the administrator token rather than with any image that can
+    /// reach the bucket.
+    pub fn authorize_next_reader(
+        &self,
+        request: AuthorizeNextReaderRequest,
+    ) -> Result<PublicationControlRecord, PublicationControlError> {
+        self.validate_scope(&request.lease.scope)?;
+        validate_image_identity(&request.identity)?;
+        for _ in 0..MAX_CAS_ATTEMPTS {
+            let now = self.clock.now();
+            let stored = self.load_required()?;
+            self.validate_record(&stored.record)?;
+            // The token is what authenticates the caller; the lease is what
+            // serializes it against every other writer of this record.
+            require_lease(&stored.record, &request.lease, LeaseKind::Rollout, now)?;
+            if stored.record.next_reader_identity.as_deref() == Some(request.identity.as_str()) {
+                return Ok(stored.record);
+            }
+            let mut record = stored.record;
+            record.revision = checked_revision(record.revision)?;
+            record.next_reader_identity = Some(request.identity.clone());
+            match self.store.update(&stored.version, &record) {
+                Ok(_) => return Ok(record),
+                Err(error) if error.is_cas_conflict() => continue,
+                Err(error) => return Err(error),
+            }
+        }
+        Err(PublicationControlError::Conflict(
+            "publication record changed during every next-reader authorization attempt".to_string(),
         ))
     }
 
@@ -2064,6 +2173,13 @@ impl PublicationControl {
             )));
         }
         validate_reader_shape(&record.reader)?;
+        if let Some(next_reader_identity) = record.next_reader_identity.as_deref() {
+            validate_image_identity(next_reader_identity).map_err(|error| {
+                PublicationControlError::Admission(format!(
+                    "stored next reader identity is invalid: {error}"
+                ))
+            })?;
+        }
         let record_spine_evidence = record_spine_rollout_fence_evidence(record)?;
         let reader_spine_evidence = reader_spine_rollout_fence_evidence(record)?;
         match record.last_authority_fenced_at {
@@ -4340,6 +4456,8 @@ mod tests {
         "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     const READER_B: &str =
         "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const READER_C: &str =
+        "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
     const SCOPE: &str = "gcs://fixture/v2";
 
     #[cfg(feature = "gcs")]
@@ -4887,6 +5005,343 @@ mod tests {
         );
     }
 
+    /// Acquire a rollout on the running daemon and name the successor, exactly
+    /// as the promotion does. The returned lease is still held: releasing it
+    /// re-admits the running image, which the release path requires and which
+    /// the promotion script therefore has to do too, so each caller decides
+    /// whether the promotion finished or died here.
+    fn authorize_next_reader_for(
+        control: &Arc<PublicationControl>,
+        request_id: &str,
+        identity: &str,
+    ) -> ActivePublicationLease {
+        let pipeline = control
+            .acquire_rollout(rollout_request("promotion", request_id, None))
+            .unwrap();
+        control
+            .authorize_next_reader(AuthorizeNextReaderRequest {
+                lease: proof(&pipeline),
+                identity: identity.to_string(),
+            })
+            .unwrap();
+        pipeline
+    }
+
+    /// The upgrade path this authorization exists for. A settled record admits
+    /// only the image that wrote it, so the hosted fleet could be upgraded
+    /// exactly once: the promoted daemon was refused, served 503, and the
+    /// rollout gate rolled it back after the apply had already moved web and
+    /// the control plane. The promotion now names its successor on the record
+    /// while the outgoing daemon is still healthy and reachable, and the
+    /// successor admits itself at its own startup.
+    #[test]
+    fn a_pipeline_authorized_image_admits_itself_at_startup() {
+        let store = Arc::new(InMemoryPublicationControlStore::default());
+        let clock = Arc::new(ManualClock::new());
+        let outgoing = control(Arc::clone(&store), Arc::clone(&clock), READER_A);
+        let first = outgoing
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("first runtime must bootstrap");
+        release(&outgoing, &first);
+
+        let pipeline = authorize_next_reader_for(&outgoing, "promote-reader-b", READER_B);
+        release(&outgoing, &pipeline);
+
+        // The authorization has to outlive the lease that wrote it. If it lived
+        // on the lease, the promotion would have to hold that lease across the
+        // whole apply, and a live rollout lease closes readiness for every
+        // image including the one still serving production.
+        let authorized = outgoing.status().unwrap();
+        assert!(authorized.active_lease.is_none());
+        assert_eq!(authorized.next_reader_identity.as_deref(), Some(READER_B));
+        assert_eq!(
+            authorized.reader.identity, READER_A,
+            "naming the successor must not admit it"
+        );
+        outgoing
+            .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
+            .unwrap();
+
+        let incoming = control(Arc::clone(&store), Arc::clone(&clock), READER_B);
+        let startup = incoming
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("an authorized image must run its own startup rollout");
+        assert_eq!(startup.holder, STARTUP_BOOTSTRAP_HOLDER);
+        assert!(
+            startup.fence > pipeline.fence,
+            "the startup rollout must raise the fence past {}",
+            pipeline.fence
+        );
+        release(&incoming, &startup);
+
+        let settled = incoming.status().unwrap();
+        assert_eq!(settled.reader.identity, READER_B);
+        incoming
+            .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
+            .unwrap();
+        let displaced = outgoing
+            .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
+            .unwrap_err();
+        assert!(displaced.to_string().contains(READER_B), "{displaced}");
+    }
+
+    /// The authorization names one digest. An image nobody named is refused
+    /// exactly as it was before the authorization existed, which is what keeps
+    /// legitimacy with the holder of the administrator token rather than with
+    /// any image that can reach the bucket.
+    #[test]
+    fn an_authorization_naming_another_image_does_not_admit_this_one() {
+        let store = Arc::new(InMemoryPublicationControlStore::default());
+        let clock = Arc::new(ManualClock::new());
+        let outgoing = control(Arc::clone(&store), Arc::clone(&clock), READER_A);
+        let first = outgoing
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("first runtime must bootstrap");
+        release(&outgoing, &first);
+
+        let pipeline = authorize_next_reader_for(&outgoing, "promote-reader-b", READER_B);
+        release(&outgoing, &pipeline);
+        let before = outgoing.status().unwrap();
+
+        let unnamed = control(Arc::clone(&store), Arc::clone(&clock), READER_C);
+        assert!(
+            unnamed.bootstrap_runtime_if_absent().unwrap().is_none(),
+            "an authorization for another digest must not admit this image"
+        );
+        assert_eq!(unnamed.status().unwrap(), before);
+        let refusal = unnamed
+            .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
+            .unwrap_err();
+        assert!(
+            refusal.to_string().contains(READER_A) && refusal.to_string().contains(READER_C),
+            "{refusal}"
+        );
+    }
+
+    /// Single-use, and spent by the admission that used it. An authorization
+    /// left on the record after its image is in is a standing invitation for a
+    /// digest nobody is promoting any more, and it is why a rollback needs a
+    /// compensating authorization rather than the leftovers of this one.
+    #[test]
+    fn a_consumed_authorization_does_not_survive_its_own_admission() {
+        let store = Arc::new(InMemoryPublicationControlStore::default());
+        let clock = Arc::new(ManualClock::new());
+        let outgoing = control(Arc::clone(&store), Arc::clone(&clock), READER_A);
+        let first = outgoing
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("first runtime must bootstrap");
+        release(&outgoing, &first);
+
+        let pipeline = authorize_next_reader_for(&outgoing, "promote-reader-b", READER_B);
+        release(&outgoing, &pipeline);
+
+        let incoming = control(Arc::clone(&store), Arc::clone(&clock), READER_B);
+        let startup = incoming
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("an authorized image must run its own startup rollout");
+        release(&incoming, &startup);
+
+        let settled = incoming.status().unwrap();
+        assert_eq!(settled.reader.identity, READER_B);
+        assert_eq!(
+            settled.next_reader_identity, None,
+            "the admission it authorized must consume it"
+        );
+
+        // So a rollback to the outgoing image is refused on the record that
+        // image wrote itself, and the promotion has to re-authorize it.
+        let rolled_back = outgoing
+            .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
+            .unwrap_err();
+        assert!(rolled_back.to_string().contains(READER_B), "{rolled_back}");
+    }
+
+    /// kin#1421's boundary, restated for the promotion's lease. An expired
+    /// startup lease is takeover-eligible because no other actor can recover
+    /// it; an expired promotion lease belongs to the next promotion, and the
+    /// image it named may not walk in under it.
+    #[test]
+    fn an_expired_pipeline_lease_does_not_admit_the_image_it_authorized() {
+        let store = Arc::new(InMemoryPublicationControlStore::default());
+        let clock = Arc::new(ManualClock::new());
+        let outgoing = control(Arc::clone(&store), Arc::clone(&clock), READER_A);
+        let first = outgoing
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("first runtime must bootstrap");
+        release(&outgoing, &first);
+
+        // The promotion writes the authorization and then dies, so nothing
+        // releases or renews its lease.
+        let pipeline = authorize_next_reader_for(&outgoing, "promote-reader-b", READER_B);
+        clock.advance(MAX_ROLLOUT_LEASE_SECONDS as i64 + 1);
+        let before = outgoing.status().unwrap();
+
+        let incoming = control(Arc::clone(&store), Arc::clone(&clock), READER_B);
+        assert!(
+            incoming.bootstrap_runtime_if_absent().unwrap().is_none(),
+            "a dead promotion lease is the next promotion's to recover"
+        );
+        assert_eq!(incoming.status().unwrap(), before);
+        assert_eq!(
+            incoming.status().unwrap().active_lease.unwrap().fence,
+            pipeline.fence
+        );
+        let refusal = incoming
+            .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
+            .unwrap_err();
+        assert!(refusal.to_string().contains("never released"), "{refusal}");
+    }
+
+    /// The administrator token authenticates the caller. The rollout lease is
+    /// what serializes the write against every other writer of this record, so
+    /// a token holder with no lease, or one whose lease lapsed, writes nothing.
+    #[test]
+    fn authorizing_the_next_reader_requires_a_live_rollout_lease() {
+        let store = Arc::new(InMemoryPublicationControlStore::default());
+        let clock = Arc::new(ManualClock::new());
+        let daemon = control(Arc::clone(&store), Arc::clone(&clock), READER_A);
+        let first = daemon
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("first runtime must bootstrap");
+        release(&daemon, &first);
+
+        let settled = daemon.status().unwrap();
+        let unheld = daemon
+            .authorize_next_reader(AuthorizeNextReaderRequest {
+                lease: LeaseProof {
+                    scope: SCOPE.to_string(),
+                    token: "not-a-lease".to_string(),
+                    fence: settled.last_fence,
+                },
+                identity: READER_B.to_string(),
+            })
+            .unwrap_err();
+        assert!(unheld.to_string().contains("is not active"), "{unheld}");
+        assert_eq!(daemon.status().unwrap().next_reader_identity, None);
+
+        let pipeline = daemon
+            .acquire_rollout(rollout_request("promotion", "promote-reader-b", None))
+            .unwrap();
+        clock.advance(MAX_ROLLOUT_LEASE_SECONDS as i64 + 1);
+        let lapsed = daemon
+            .authorize_next_reader(AuthorizeNextReaderRequest {
+                lease: proof(&pipeline),
+                identity: READER_B.to_string(),
+            })
+            .unwrap_err();
+        assert!(lapsed.to_string().contains("expired at"), "{lapsed}");
+        assert_eq!(daemon.status().unwrap().next_reader_identity, None);
+    }
+
+    /// The field decides which image opens readiness on the hosted fleet, so it
+    /// carries an image digest or it carries nothing. A tag is not an identity:
+    /// the same tag names different bytes on different days.
+    #[test]
+    fn authorizing_a_next_reader_that_is_not_a_digest_is_refused() {
+        let store = Arc::new(InMemoryPublicationControlStore::default());
+        let clock = Arc::new(ManualClock::new());
+        let daemon = control(Arc::clone(&store), Arc::clone(&clock), READER_A);
+        let first = daemon
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("first runtime must bootstrap");
+        release(&daemon, &first);
+
+        let pipeline = daemon
+            .acquire_rollout(rollout_request("promotion", "promote-latest", None))
+            .unwrap();
+        let refused = daemon
+            .authorize_next_reader(AuthorizeNextReaderRequest {
+                lease: proof(&pipeline),
+                identity: "latest".to_string(),
+            })
+            .unwrap_err();
+        assert!(refused.to_string().contains("sha256:"), "{refused}");
+        assert_eq!(daemon.status().unwrap().next_reader_identity, None);
+    }
+
+    /// A record this daemon writes still has to be readable by the image it
+    /// replaces. `PublicationControlRecord` carries `deny_unknown_fields`, so a
+    /// key an older daemon does not know refuses the whole record before any
+    /// validation could explain it, and the rollback the promotion depends on
+    /// would meet an unreadable record rather than a refusal. The authorization
+    /// is therefore absent from the bytes unless it is actually set.
+    #[test]
+    fn a_cleared_authorization_leaves_no_key_an_older_daemon_would_refuse() {
+        let store = Arc::new(InMemoryPublicationControlStore::default());
+        let clock = Arc::new(ManualClock::new());
+        let daemon = control(Arc::clone(&store), Arc::clone(&clock), READER_A);
+        let first = daemon
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("first runtime must bootstrap");
+        release(&daemon, &first);
+
+        let settled = serde_json::to_value(daemon.status().unwrap()).unwrap();
+        assert!(
+            settled.get("next_reader_identity").is_none(),
+            "a settled record must carry no authorization key at all: {settled}"
+        );
+
+        // The control the absence above needs: the key does appear when it is
+        // set, so the assertion is about absence and not about a field name
+        // this test spelled wrong.
+        let pipeline = authorize_next_reader_for(&daemon, "promote-reader-b", READER_B);
+        let authorized = serde_json::to_value(daemon.status().unwrap()).unwrap();
+        assert_eq!(
+            authorized
+                .get("next_reader_identity")
+                .and_then(serde_json::Value::as_str),
+            Some(READER_B),
+            "{authorized}"
+        );
+        release(&daemon, &pipeline);
+    }
+
+    /// Nothing in the API leaves an authorization naming the reader it admitted,
+    /// because the admission spends it. A record edited outside the API still
+    /// can, and re-fencing every graph object on each restart of a daemon the
+    /// record already admits is a real cost paid for nothing, so the record's
+    /// own reader wins over an authorization that names the same image.
+    #[test]
+    fn an_authorization_naming_the_admitted_reader_takes_no_rollout() {
+        let store = Arc::new(InMemoryPublicationControlStore::default());
+        let clock = Arc::new(ManualClock::new());
+        let daemon = control(Arc::clone(&store), Arc::clone(&clock), READER_A);
+        let first = daemon
+            .bootstrap_runtime_if_absent()
+            .unwrap()
+            .expect("first runtime must bootstrap");
+        release(&daemon, &first);
+
+        let stored = store
+            .load()
+            .unwrap()
+            .expect("the settled record must be readable");
+        let mut edited = stored.record.clone();
+        edited.revision += 1;
+        edited.next_reader_identity = Some(READER_A.to_string());
+        store.update(&stored.version, &edited).unwrap();
+
+        let before = daemon.status().unwrap();
+        assert_eq!(before.next_reader_identity.as_deref(), Some(READER_A));
+        assert!(
+            daemon.bootstrap_runtime_if_absent().unwrap().is_none(),
+            "a daemon the record already admits must not run another rollout"
+        );
+        assert_eq!(daemon.status().unwrap(), before);
+        daemon
+            .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
+            .unwrap();
+    }
+
     /// The hosted cutover of 2026-09-03 failed here. A daemon image died
     /// mid-bootstrap on 2026-09-02 holding the startup rollout lease, and for
     /// the next twenty hours every replacement image was refused by that lease
@@ -5209,6 +5664,7 @@ mod tests {
             spine_rollout_fence_update_time: None,
             reader_spine_rollout_fence_payload_sha256: None,
             reader_spine_rollout_fence_update_time: None,
+            next_reader_identity: None,
             active_lease: None,
             last_completed_lease: None,
             last_completed_rollout: None,


### PR DESCRIPTION
The kin half of FIR-3126. The kin-infra and kinlab halves follow once this route is on main. The promotion's call shape here is the captain's ruling recorded in a comment on that ticket, not the shape the original spec comment sketched.

## The problem

The hosted daemon can be upgraded exactly once. A settled publication-control record carries no active lease and names the digest that landed as its admitted reader, so a promoted image reaches `evaluate_runtime_admission` and is refused with "scope ... admits reader &lt;old digest&gt;, but this daemon is &lt;new digest&gt;". It serves 503, the startup probe reads it, and the rollout gate rolls back after the apply has already moved web and the control plane.

That refusal is deliberate and stays. What was missing is a way to follow the instruction its doc comment gives: the rollout routes can only admit the daemon serving the request, because `prepare_hosted_spine_rollout` refuses any other reader, so a healthy outgoing daemon cannot admit its successor and the successor cannot be reached before its probe kills it.

## The change

The promotion writes an authorization rather than a reader. It names the digest that comes next on the record of the running, healthy daemon, before the apply. The successor still admits only itself, at its own startup, and only when the record already names it.

- `PublicationControlRecord` gains `next_reader_identity: Option<String>`.
- `POST /authority/publication-control/rollout/authorize-next-reader` writes it, taking a scope and an identity and nothing else.
- `bootstrap_runtime_if_absent` acquires one startup rollout when the record is settled, names this image, and does not already admit it.
- `admit_reader` clears the field in the same CAS as the admission that used it.

**One call, holding nothing.** The route takes no lease proof. A rollout lease closes reader admission for every image including the one serving production, so requiring one would put a readiness gap on the running daemon at the start of every upgrade. It would also have been expensive to get out of: `release` refuses until a reader admission has moved `reader_spine_rollout_fence_*`, and the only reader that daemon can admit is itself, through `prepare_hosted_spine_rollout`, which reloads and republishes every repository in the fleet. The `HOSTED_ROLLOUT_LEASE_SECONDS` doc comment records one repository of 27,987 entities taking 153 s, measured on 2026-09-02 against production's own record. So the lease would have cost a full republication and a readiness gap on every promotion, to serialize a single field.

The record's CAS already makes the write atomic. What the lease bought is ordering between two overlapping promotions, and that resolves to last-write-wins. The digest that lost is refused at its own bootstrap rather than left waiting, and `evaluate_runtime_admission` now names the outstanding authorization alongside the admitted reader, so an operator reads the cause off the refusal instead of correlating two workflow logs. The administrator token is the whole authorization for this write, which makes the route's place under the publication-control prefix load-bearing: `authorizing_the_next_reader_demands_the_administrator_token` pins an ordinary daemon token at 403 and an unknown one at 401, with the administrator token passing the guard as the control, because every refusal in that test would also hold on a route that refused everyone.

The rollback compensation is the same one call, naming the outgoing digest. `a_consumed_authorization_does_not_survive_its_own_admission` runs it: the outgoing image is refused after its successor consumed the authorization, is re-authorized, and comes back.

## kin#1421's boundary

Unchanged in both directions. An expired startup lease stays takeover-eligible; any other expired rollout does not, because the new branch requires the record to carry no active lease at all. `an_expired_operator_rollout_reads_as_expired_and_is_left_alone` and `startup_bootstrap_never_auto_admits_over_an_existing_reader` are untouched, and `an_expired_rollout_lease_does_not_admit_the_image_the_promotion_authorized` asserts the same boundary for the new path.

## Two places this differs from the spec's letter

**Where the clear lives.** The spec puts it in `complete_hosted_startup_rollout`. It is in `admit_reader` instead, keyed on the admitted identity equalling `next_reader_identity`. `complete_hosted_startup_rollout` still clears it, because it admits through that path. A clear atomic with its own consumption cannot be dropped by a later edit and cannot be stranded by a crash between two writes. It is also the only placement this repo can test honestly: a unit test for a clear at the end of `complete_hosted_startup_rollout` would have had to reproduce that sequence rather than exercise it, and would then stay green if someone deleted the call.

**`skip_serializing_if = "Option::is_none"`,** which the sibling optional fields on that struct do not carry. `PublicationControlRecord` carries `deny_unknown_fields`, so a key an older daemon does not know refuses the whole record at deserialization, before any validation could explain it. `serde(default)` governs reading, not writing, and an unset `Option` still serializes as an explicit null, so the first image carrying this field would rewrite the record at its own startup rollout and a rollback from that deploy would meet a record its predecessor can no longer read. With the attribute, the key is present only while an authorization is outstanding. The canonical rollout fence is built from explicit fields in `spine_rollout_fence` rather than from a serialization of the record, so neither the field nor the attribute moves any digest. `PublicationControlStatus` deliberately does not get the attribute: it is a read surface where an explicit null distinguishes "no authorization" from a daemon too old to have the concept.

## Gates, all green

Two heavy slots, both through `.kin-coord/bin/heavy-slot.sh`, on head `a08aa3bea`. Full output is in the lane report.

- `cargo fmt --all -- --check`: two diffs on first run, both in this branch's own new code, fixed from `cargo fmt`'s own check output.
- Baseline `cargo test -p kin-daemon --lib publication`: green, 78 passed, 0 failed, both before and after the mutant sweep.
- **Mutants: 12 started, 12 killed, 0 survived, 0 broken.** One survivor on the first sweep (`m9-always-consumed`, below), closed with a new test, confirmed killed on the re-run.
- `cargo nextest run -p kin-daemon --features gcs,firestore --locked`, matching `ci.yml`'s `feature-tests` job exactly: **1405 tests run, 1405 passed** (2 slow, 2 leaky), 4 skipped.
- `cargo clippy --all-targets --all-features -- $allows`, byte-identical to `ci.yml`'s check job (`$allows` read live from `.github/clippy-allowed-lints.txt`, 45 entries): clean.
- `bin/kin-precheck kin --repo-dir kin=<this worktree>`: printed `repo=kin tree=.../pipelinerollout-kin sha=a08aa3bea... branch=chore/lane-pipelinerollout-kin`, confirming it graded this tree and not the primary checkout. **20 gates ran, 20 passed, 0 failed.**
- `python3 scripts/verify-zero-file-search.py`: passes, with a positive control on both changed files (a `std::fs::read_to_string` injected into each in turn, named by the scanner, then restored to its exact prior sha256).

Hosted CI on this same sha, `a08aa3bea`, read by name with `per_page=100` (47 listed, 47 total): every non-skipped check is `success`. The skipped ones are the documented main-only and conditional jobs (`Check & Test ubuntu shard`, `Product Acceptance`, `Windows authority *`, `Release version gate`, and the rest of that class).

## The one surviving mutant, and what closed it

`m9-always-consumed` removes the `if consumes_authorization { ... }` guard around the clear in `admit_reader`, so every admission clears `next_reader_identity` unconditionally rather than only the admission that actually consumes it.

It survived `a_pipeline_authorized_image_admits_itself_at_startup` on the first sweep. Every `admit_reader` call that test drives happens to admit the identity the record actually authorizes next, so the guarded clear and the unconditional clear produce the same record throughout it; the test cannot tell them apart.

`an_unrelated_admission_of_the_current_reader_leaves_the_authorization_alone` is the input that does. It re-admits the OUTGOING daemon, under an unrelated operator rollout, while the record still authorizes a different image next, and asserts the authorization survives that admission. Nothing about who reads is changing there, so nothing about who is authorized next should change either. Per the lane's falsification rule, this answers the survivor with a new input; the guard itself, `consumes_authorization`, is untouched. Re-run confirmed: `m9-always-consumed` now reads killed.

## Mutants

Each row deletes or weakens exactly one guard. A row whose test stays green gets a new input, never a deleted guard.

| Mutation | Guard removed | Test that must go red | Result |
| --- | --- | --- | --- |
| m1-branch-off | the authorized-startup branch entirely | `a_pipeline_authorized_image_admits_itself_at_startup`, `a_consumed_authorization_does_not_survive_its_own_admission` | killed |
| m2-no-lease-guard | `active_lease.is_none()`, so a dead rollout becomes an opening | `an_expired_rollout_lease_does_not_admit_the_image_the_promotion_authorized` | killed |
| m3-no-admitted-reader-guard | the record's own reader winning over an authorization naming it | `an_authorization_naming_the_admitted_reader_takes_no_rollout` | killed |
| m4-any-authorization-admits | the identity match, so any authorization admits any image | `an_authorization_naming_another_image_does_not_admit_this_one` | killed |
| m5-never-consumed | the clear, so the authorization outlives its admission | `a_consumed_authorization_does_not_survive_its_own_admission` | killed |
| m9-always-consumed | the `consumes_authorization` condition, so any admission drops it | `an_unrelated_admission_of_the_current_reader_leaves_the_authorization_alone` (new) | killed (survived on first sweep, closed with this new test, confirmed on re-run) |
| m6-first-write-wins | last-write-wins, so a second promotion cannot correct the first | `two_authorizations_resolve_to_the_last_write` | killed |
| m7-no-digest-validation | `validate_image_identity` on the request | `authorizing_a_next_reader_that_is_not_a_digest_is_refused` | killed |
| m8-route-unregistered | the route registration | `publication_control_api_drives_the_rollout_to_release` | killed |
| m11-route-off-admin-surface | the route's place under the publication-control prefix, so a daemon token reaches it | `authorizing_the_next_reader_demands_the_administrator_token` | killed |
| m12-refusal-omits-authorization | the outstanding authorization in the admission refusal | `two_authorizations_resolve_to_the_last_write` | killed |
| m10-no-skip-serializing | `skip_serializing_if`, so a settled record carries a null key | `a_cleared_authorization_leaves_no_key_an_older_daemon_would_refuse` | killed |
