### PR TITLE
Filter the multihop walk to walkable relation kinds before it budgets

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -10142,6 +10142,16 @@ fn extract_multihop_signals(
                 }
 
                 let mut rels = graph.get_all_relations_for_entity(&current)?;
+                // Keep only the kinds this walk can follow, BEFORE the frontier
+                // cut and before the source-degree count both read this list.
+                // `get_all_relations_for_entity` returns every kind, and the
+                // kinds outside `allowed_kinds` are not a rounding error: on a
+                // TypeScript repository `UsesType` and `Contains` alone are 46%
+                // of all relations. Counting them spent frontier budget on edges
+                // the loop below then skipped, and inflated the source-degree
+                // dampener that gates every neighbour, so raising the frontier
+                // limit made the walk reach FEWER files rather than more.
+                rels.retain(|rel| allowed_kinds.contains(&rel.kind));
                 // The frontier cut below keeps a PREFIX, so the order must be
                 // deterministic (adjacency iteration order is per-process):
                 // highest-priority relations first, id as the total tie-break —
@@ -10164,9 +10174,8 @@ fn extract_multihop_signals(
                     &rels
                 };
                 for rel in rels_to_process {
-                    if !allowed_kinds.contains(&rel.kind) {
-                        continue;
-                    }
+                    // `rels` was filtered to `allowed_kinds` above, so every
+                    // relation here is one the walk follows.
                     let neighbor_id = if rel.src == GraphNodeId::Entity(current) {
                         rel.dst
                     } else {
@@ -31681,6 +31690,109 @@ mod tests {
         )
         .unwrap();
         assert!(hits.contains_key("pkg/prompt/prompt.go"));
+    }
+
+    /// Relations the walk cannot follow must not decide whether it follows the
+    /// ones it can.
+    ///
+    /// `get_all_relations_for_entity` returns every kind. `allowed_kinds` names
+    /// a subset, and `UsesType` and `Contains` are outside it. Before the
+    /// `retain` in `extract_multihop_signals` those kinds still reached the
+    /// source-degree dampener, which gates every neighbour through the hard
+    /// cutoff, so an entity holding sixty type annotations and one call was
+    /// treated as a sixty-one-edge hub and its one call was dropped from the
+    /// walk entirely, not merely from the ranking.
+    ///
+    /// The arithmetic, on the shipped constants. The target file holds 20
+    /// entities, so `hub_dampen` is `1/log2(21)` = 0.2277. Counting all 61
+    /// relations puts `source_degree_dampen` at `1/log2(61)` = 0.1686 and their
+    /// product at 0.0384, under the 0.05 cutoff. Counting only the one
+    /// walkable relation leaves the dampener at 1.0 and the product at 0.2277,
+    /// over it.
+    ///
+    /// Measured on VS Code (FIR-3129): with the unwalkable kinds counted, the
+    /// walk reached 790 files and never `cursorTypeOperations.ts`; without
+    /// them, 882 files including it.
+    #[test]
+    fn extract_multihop_signals_degree_dampening_ignores_unwalkable_relation_kinds() {
+        fn build(noise_edges: usize) -> (kin_db::InMemoryGraph, HashMap<String, Vec<FileHit>>) {
+            let graph = kin_db::InMemoryGraph::new();
+            let seed = test_entity("Seed", "src/seed.ts", 1, 10);
+            graph.upsert_entity(&seed).unwrap();
+
+            // The target file needs real entities, because `hub_dampen` counts
+            // them off the graph rather than off the edge.
+            let mut target_first = None;
+            for i in 0..20 {
+                let entity = test_entity(&format!("Target{i}"), "src/target.ts", 1, 5);
+                graph.upsert_entity(&entity).unwrap();
+                if target_first.is_none() {
+                    target_first = Some(entity.id);
+                }
+            }
+            let target_first = target_first.expect("20 target entities were inserted");
+
+            let relate = |kind: RelationKind, dst| {
+                graph
+                    .upsert_relation(&Relation {
+                        id: RelationId::new(),
+                        kind,
+                        src: GraphNodeId::Entity(seed.id),
+                        dst: GraphNodeId::Entity(dst),
+                        confidence: 1.0,
+                        origin: RelationOrigin::Parsed,
+                        created_in: None,
+                        import_source: None,
+                        evidence: Vec::new(),
+                    })
+                    .unwrap();
+            };
+
+            // The one edge the walk is supposed to follow.
+            relate(RelationKind::Calls, target_first);
+            // Edges it never follows, which used to count anyway.
+            for i in 0..noise_edges {
+                let noise = test_entity(&format!("Noise{i}"), "src/noise.ts", 1, 5);
+                graph.upsert_entity(&noise).unwrap();
+                relate(RelationKind::UsesType, noise.id);
+            }
+
+            let seeds = HashMap::from([(
+                String::from("src/seed.ts"),
+                vec![FileHit {
+                    score: 100.0,
+                    spans: vec![],
+                }],
+            )]);
+            (graph, seeds)
+        }
+
+        // Baseline first, so a failure below cannot be the fixture. With no
+        // unwalkable edges at all the call must project the target file.
+        let (graph, seeds) = build(0);
+        let baseline =
+            extract_multihop_signals(&[&seeds], &graph, LocateProfile::Standard, false, None)
+                .unwrap();
+        assert!(
+            baseline.contains_key("src/target.ts"),
+            "fixture is wrong: a lone Calls edge should already project the target file"
+        );
+
+        // Now the same graph plus sixty edges of a kind the walk never follows.
+        // Nothing about the Calls edge or the target file has changed.
+        let (graph, seeds) = build(60);
+        let hits =
+            extract_multihop_signals(&[&seeds], &graph, LocateProfile::Standard, false, None)
+                .unwrap();
+        assert!(
+            hits.contains_key("src/target.ts"),
+            "sixty UsesType edges made the source look like a hub and cost the walk its \
+             only Calls edge; the degree count must read the relations the walk follows"
+        );
+        assert!(
+            !hits.contains_key("src/noise.ts"),
+            "UsesType is outside allowed_kinds, so the noise file must never be projected"
+        );
     }
 
     #[test]


### PR DESCRIPTION
FIR-3129, the typing-path answer on VS Code. The whole typing chain is in the graph (every edge certified through `kin path`, which walks seed file three to `TypeOperations.typeWithInterceptors` in 3 hops and 13 ms) and the locate multihop walk, with a depth budget of 4 and 1,000 ms, never reaches it.

Cause: the walk counted every relation kind toward the frontier cut, the sort and the source-degree dampener, then skipped unwalkable kinds one at a time inside the loop. UsesType and Contains are 46 percent of this store's relations. `CursorsController.type` has 64 relations, 22 of them unwalkable; counting them puts its call into `cursorTypeOperations.ts` at 0.0427 against the 0.05 hard cutoff, which prunes traversal rather than ranking despite its comment, so the file is never expanded. Counting walkable relations only gives 42, below the hub threshold, dampener 1.0, product 0.2560.

Change: apply the allowed-kind filter once before the sort, the frontier truncation and the degree count. Offline against the store's own graph file: 790 reached files without the target under the shipped walk, 882 with it here, sorting 23 percent fewer relations (12.2M to 9.5M).

Evidence on this branch: `cargo test -p kin-cli extract_multihop_signals` ran the three multihop unit tests including the new `extract_multihop_signals_degree_dampening_ignores_unwalkable_relation_kinds`, 3 passed (lib unit tests, 2,125 filtered out). Falsified: with the `retain` replaced by a no-op the new test fails (1 failed, 0 passed) and the file restored byte-identical. `kin-precheck kin` ran through heavy-slot on this tree, sha `47990742f`: 20 of 20 gates (fmt, clippy, every guard script and node-test) passed. The seeding follow-up (walk from the answer's own top entities) is a separate PR; the two offline simulations and the ticket comments carry the measurements.
