### PR TITLE
Exempt the ignored real-store heap test's three fixture variables

### DIFF
--- a/crates/kin-core/env_var_allowlist.txt
+++ b/crates/kin-core/env_var_allowlist.txt
@@ -75,3 +75,11 @@ KIN_UPDATE_TEST_WORKER_STAGE
 # nothing an operator sets.
 KIN_RECEIVER_HOP_CORPUS
 KIN_RECEIVER_HOP_FOCAL
+
+# Read only by the ignored real-store heap measurement in
+# crates/kin-reconcile/tests/lkg_real_store_heap.rs, which names the store,
+# repository and workspace an operator points it at by hand. A fixture input
+# for one #[ignore] test, not an operator lever, and nothing at runtime reads it.
+KIN_LKG_STORE
+KIN_LKG_REPO
+KIN_LKG_WORKSPACE


### PR DESCRIPTION
Main went red at de1767ad1 (kin#1419) on every_kin_env_read_in_workspace_is_registered on all three platforms: the new ignored heap test in crates/kin-reconcile/tests/lkg_real_store_heap.rs reads KIN_LKG_STORE, KIN_LKG_REPO and KIN_LKG_WORKSPACE to locate a store an operator names by hand, and none is registered or exempted. The guard runs in the check job, which grades main and not pull requests, so #1419 landed green. These are fixture inputs for one #[ignore] test and nothing at runtime reads them, which is the allowlist's stated purpose; this exempts the three with the reason beside them. Verified without cargo by reproducing the guard's scan in a script: before the change the three names were the only unregistered, unallowlisted direct KIN_ reads across crates/; after it, none. The check job on main's next push is the grader.