### PR TITLE
Bump kin-db to 0.7.96

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3289,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.93"
+version = "0.7.96"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "78376d102b7ba87e7e2bbe39f7ab9ddecb09e9ddfc9a05804072fc2948bd8b8b"
+checksum = "41bce744e7356004b6fd20c90160b574541bad99ce7c72434a193fa01257dc5e"
 dependencies = [
  "bincode",
  "bstr",
@@ -6671,7 +6671,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ kin-lsp = { version = "=0.7.13", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.93", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.96", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.24", registry = "kin" }
 
 [profile.release]


### PR DESCRIPTION
Moves kin's kin-db pin from `=0.7.93` to `=0.7.96`, three registry landings: 0.7.94, 0.7.95 and 0.7.96. The resolver wrote `Cargo.lock`; it was not hand-edited and carries no path patch.

`kin-model` stays at `=0.7.23` on purpose. kin-db 0.7.96 requires `kin-model =0.7.23` exactly, read from the registry index, so moving kin's kin-model pin to the published 0.7.24 is unsatisfiable. That coupling is also why the hourly Kin Registry Release Receiver run is red with `dependency wave blocked: cannot roll kin-model to 0.7.24`. That is the updater's designed blocked-wave signal, it is not a required context on main, and it clears when a later kin-db release pins kin-model 0.7.24 behind its own roots proof.

## Why this bump needs a golden-store proof

Exactly three kin-db source files differ across the range, and all three are in `src/storage/`:

- `authority_frame.rs`: `apply_to_envelope` now calls `trim_receipts_the_log_already_holds()` on the reader's side. This is a read-path change on the persisted format.
- `repository.rs`: adds that method, calls it on the write path too, and replaces the history-root fold over changes with a memoized `sorted_leaf_digests`.
- `change_map.rs`: the memo itself, keyed by change identity.

The delta rests on two claims about roots. The receipt trim "moves no identity and needs no schema or wire version" because no root folds `receipts`. The leaf-digest memo is "byte-identical to the fold it replaces rather than merely close to it" because `DomainRoot::unordered` sorts leaf digests before folding. Roots invariance is not incidental to this bump, it is the property under test, which is what FIR-3104 asks a golden store to check.

Persisted schema constants are unchanged across the range. Both 0.7.93 and 0.7.96 declare `REPOSITORY_AUTHORITY_SCHEMA_VERSION = 4`, `MIN_REPOSITORY_AUTHORITY_SCHEMA_VERSION = 3` and `MATERIALIZED_GRAPH_SCHEMA_VERSION = 1`.

## How the stores were shown to predate this binary

The obvious check here is wrong, and it is worth saying which one, because it is the check a reader would reach for. `.kin/kindb/<repo>/authority.json` has a field called `version`, and it is tempting to read as the envelope schema that moved 3 to 4 at kin-db 0.7.89. It is not. That file deserializes to `LocalAuthorityRecord`, whose `version` is checked against `LOCAL_AUTHORITY_VERSION` (3) and `LOCAL_AUTHORITY_FRAME_JOURNAL_VERSION` (4): a record moves to 4 on the first authority-frame append and back to 3 when a snapshot promotion empties the journal. Both constants read 3 and 4 in 0.7.88, 0.7.93 and 0.7.96 alike, so the field is journal state and identifies no writer. `REPOSITORY_AUTHORITY_SCHEMA_VERSION` lives on the envelope inside the snapshot `.kndb`, where no file read reaches it.

Nor is `.kin/manifest.json`'s `kin_version` evidence. `KinManifest::new()` stamps `env!("CARGO_PKG_VERSION")` at init and nothing rewrites it on reopen, so it is a birth certificate: it records which binary created the store, not which binary last wrote it.

So the check here is behavioural instead. kin's v0.6.4 tag is `390fbdc54`, it pins kin-db 0.7.88, and 0.7.88 checks the envelope schema with EQUALITY against 3, with no `MIN_` constant. That makes the released binary its own schema probe. If v0.6.4 opens a store, that store's envelope is schema 3, which is the shape 0.7.89 stopped writing. If it refuses with `unsupported repository authority schema N; expected 3`, the store is not schema 3 and the refusal proves the equality gate is live. `~/.kin/bin/kin` is a clean build of `390fbdc54` with no `-dirty`, and `~/.kin/bin/kin-daemon` is the matching pair, so the released binary really is doing the probing.

## What the first version of this proof would have got wrong

The obvious proof here is to open the store with the released binary, the pre-bump binary and the post-bump binary, and show `kin status --json` reports the same six authority roots. That was the shape I built, six arms across two stores, and it would have reported SAME while folding nothing at all.

The reason is that opening a store does not recompute its roots. `compute_roots` is reached only from `validate_against_snapshot_with` under `RootRecomputation::Required`, and a reopen carrying a durable history-validation record the binary trusts does not take that path. kin-db says so in the enum's own documentation: "a reopen carrying a valid record folds nothing, since that record is this validator's own verdict on those exact bytes". So `repository.roots` in that report is the persisted bundle read back out. Three binaries agreeing on it proves the envelope was not rewritten, which is worth stating, but it would report SAME even if the hashing changed underneath, because nothing hashed anything.

Body content-addressing is not affected by any of this and still runs unconditionally on every arm, so a tampered store is still caught. That is body CAS, not roots, and it should not be made to carry the roots claim's weight.

## The arm that does fold, and why it is not a synthetic mutation

Whether a record is trusted is decided by `verified_history_validation`, which requires `proof.validator_version == HISTORY_VALIDATION_VERSION` along with matching repository, generation, snapshot sha and journal. That constant is `1000 + REPOSITORY_AUTHORITY_SCHEMA_VERSION * 100 + HISTORY_VALIDATION_COVERAGE_REVISION`, so kin-db 0.7.88 computes 1302 (schema 3, coverage 2) and both 0.7.93 and 0.7.96 compute 1403 (schema 4, coverage 3).

That arithmetic is what makes the real upgrade path force the fold. A store whose record says 1403 is trusted by 0.7.93 and 0.7.96 and skipped. But the released binary computes 1302, refuses that record, and revalidates in full. That is not theory: the v0.6.4 arm on the Linux store did exactly that, exited 0, and left `validator_version` rewritten from 1403 to 1302 in its copy, which is how the value was learned rather than assumed.

So a store that v0.6.4 last validated carries 1302, and opening that with the post-bump binary refuses the record and forces a complete recomputation through the memoized fold. Writing 1302 onto a clone is therefore not a perturbation invented for the test. It is the state a user's machine is in the moment they upgrade off the last release.

The check is self-arming. After recomputing, `validate_against_snapshot_with` compares the result against the persisted bundle and returns "repository root bundle does not recompute from the persisted envelope" on any mismatch. A successful forced open is therefore the byte-identity proof for the memoized fold on a real store, and a failure is loud rather than quiet. Each forced arm is paired with a trusted-record arm on the same store and binary as a control: if the forced open is not markedly slower, the fold did not run and the arm proves nothing.

## A decision this bump makes, and what it costs

kin-db 0.7.96 changed the history-root fold and moved neither term of `HISTORY_VALIDATION_VERSION`, because the envelope schema stayed 4 and the coverage revision stayed 3. Coverage is documented as what open-time validation accepts and rejects, and a memo claimed byte-identical changes neither, so leaving it alone is defensible on the constant's own terms.

The decision is to leave it alone, and the cost is worth stating rather than discovering later. Forcing every existing store through a full revalidation to check a claim that can be checked once, here, is a bad trade. The price is that no store in the field will ever be forced to revalidate by this bump, so the byte-identity claim is never exercised on real data anywhere in normal operation. The forced arm below is the only place it is tested at all. That makes it a required gate on this pin and on every later change to the fold, not a nice-to-have on this pull request.

## Method

Every arm runs on a `cp -Rc` clonefile copy, never on a store in place, with `KIN_EMBED_BACKEND=cpu`, `KIN_DAEMON_AUTO_EMBED=0` and an isolated `HOME` and `KIN_HOME`. The roots come from an in-process authority open under `KIN_NO_DAEMON=1`.

Read-only-ness is not checked by hashing `authority.json` before and after, and that is deliberate rather than an oversight. An open rewrites that file even when it changes nothing that matters: on the released-binary arm the only field that moved was `history_validation.validator_version`, 1403 down to 1302, because each binary stamps its own validator revision. Anyone verifying a golden store by comparing that file's checksum would see it change and conclude the binary had corrupted the store. So each arm fingerprints the envelope schema and the snapshot separately, and it is the snapshot's sha256 staying byte-identical that shows nothing was rewritten.

One thing has to be said plainly because it cuts against this arm rather than for it. That same field shows the store already carried validator revision 1403 before any of this, so a binary newer than v0.6.4 had opened and validated it at some point. That does not make it a newer store: schema moves only when something commits, validation moves on any open, and the envelope is still in the shape kin-db 0.7.88 writes. But neither `validator_version` nor the envelope schema identifies the writing binary on its own, and this proof does not claim either does.


## The lock

Three changed lines. Two are kin-db's version and checksum; the new checksum `41bce744e7356004b6fd20c90160b574541bad99ce7c72434a193fa01257dc5e` is the one I verified the downloaded crate against, so the lock and the registry index agree.

The third is `winapi-util 0.1.11`'s `windows-sys` edge moving 0.61.2 to 0.48.0, and it is worth naming because it looks like drift. It is not caused by this bump: kin-db's `windows-sys` requirement is byte-identical across the range (`0.61`, `cfg(windows)`, the same five features), and the same five `windows-sys` versions are in the lock before and after. `winapi-util 0.1.11` declares `windows-sys ">=0.48.0, <=0.61.*"`, so the resolver may pick either. That edge oscillates on every registry wave refresh: #1393 moved it to 0.48.0, #1401 moved it back, #1403 moved it to 0.48.0 again, and the refresh carried in #1431 moved it back. It has landed on main in both directions. Left as the resolver wrote it.

The edge is Windows-only, so the check that speaks to it is `Windows cross-check`, and it is green on this head. The other Windows jobs (`Windows authority tests`, its CLI and runtime variants, and the installer build) report `skipped` on this pull request, so they say nothing either way and are not offered as evidence.

## Results

The gate passed. Every arm ran on a `cp -Rc` clonefile copy of the golden store, never in place.

### The measurement that makes the rest of this mean anything

Wall clock alone was suggestive and not proof (11s with the record trusted, 19s with it forced), so the pair was re-run under `RUST_LOG=kin_db::admission=debug` to read kin-db's own instrumentation rather than infer from elapsed time:

| arm | open_s | compute_roots_ms | admission events |
|---|---|---|---|
| trusted record | 11 | (absent) | 0 |
| forced record | 19 | **3294** | 6 |

The trusted arm folds nothing. Zero admission events, no `compute_roots_ms` emitted at all. That is not an aside, it is the whole point: the naive proof described above would have run six arms all shaped like that top row and printed SAME from six binaries that each hashed nothing. This table is the vacuum, measured. The forced arm spends 3,294 ms in `compute_roots`, which is what the eight-second gap actually was.

### The four gate arms

`vv` is `history_validation.validator_version` at open: 1302 is the value kin-db 0.7.88 mints, 1403 is what 0.7.93 and 0.7.96 expect.

| arm | mode | rc | seconds | vv | recompute refusal |
|---|---|---|---|---|---|
| post-bump, trusted record | trusted | 0 | 12 | 1403 | 0 |
| post-bump, forced record | forced | 0 | 20 | 1302 | 0 |
| pre-bump, trusted record | trusted | 0 | 11 | 1403 | 0 |
| pre-bump, forced record | forced | 0 | 19 | 1302 | 0 |

All six authority roots are identical across every arm:

```
history        8bb82decd3dafc39f87164a18d2bc855e548c0c15b31f2601c2c36e59ae8e85c
ref_state      9c6eebbe30cf9da68490cbcef8a6b483420ce87c3524319f9e067a3d31ab42fb
ref_log        f4fae24baeda4b6b4387734090384d74e6d2955c51237fe30f6077a843b949d6
collaboration  4ef93b68b251b5711389a21ad68e95c303f159c75cfbb017fe419c7725896974
replication    9bfd19d34e2d52c0c1a5a0a066a41d842e6d94126ad354a92054701a9a3eeb4e
local_state    af94aff35d140763f8e5e2655c98187c880a0507a5630390383ddf63f48a980c
```

The snapshot's sha256 is `3cd51e7a845f90dbe7ab542d88f533ac2523af4b08a5a1e238f3fcb80fdcf2d6` before and after every arm, so nothing was rewritten.

### Three folds, not one

The released-binary arm turned out to be a forced recomputation in its own right, without being set up as one: the store carries validator version 1403, kin-db 0.7.88 expects 1302, so it refuses the record and revalidates in full.

So three different implementations of the fold each recomputed this bundle from the same store: the unmemoized fold in 0.7.88, the fold in 0.7.93, and the memoized `sorted_leaf_digests` in 0.7.96. All three produced the six roots above, diffed directly and identical. The property this bump needs is only the last of those. The other two make it a comparison against the implementation the memo replaced, on real data, rather than only against a value read off disk.

### Refusal control, and the false pass inside it

"The store opens" is worth nothing unless a refusal on that path is real, so the local authority record's `version` was forced outside its valid `{3, 4}` on clones of the same store:

```
version 2 -> rc 1: storage error: unsupported local authority version 2 in .../authority.json
version 5 -> rc 1: storage error: unsupported local authority version 5 in .../authority.json
```

This is the `LocalAuthorityRecord.version` gate rather than the envelope schema gate, and it is offered as exactly that. The envelope schema range is exercised behaviourally instead, by the released binary's equality check accepting this store.

The first run of that control was a false pass, and it belongs in the body rather than in a private note. It returned `rc 1` and would have been recorded as a refusal. It was not one: the 1 came from a shell redirect failing on a relative output path after the script had changed directory, so kin never ran. The tell was the captured refusal message reading `NONE` instead of a storage error. Re-run with an absolute path, the refusals are real and carry the text above.

The rule that generalises, stated concretely because this arm nearly broke it: assert on the refusal's own text, never on the exit code alone. That applies with most force on exactly the arm whose job is to prove a check can fail.

### The store

A converted Linux subtree whose snapshot is 2,043,051,896 bytes. kin-db 0.7.96's own doc comment for `trim_receipts_the_log_already_holds` measures "a 2,043,051,848 byte body" on "a converted Linux subtree" with `receipts[0]` at 411,771,864 bytes of it, so this is the same shape the change was measured against.

## What was run

Per AGENTS.md, each claim below is the command and its actual output tail rather than prose. Full transcripts are in the lane report at `.kin-coord/reports/pinwave-20260903.md`.

Lint, policy and guard gates, against this branch's tree and sha:

```
$ .kin-coord/bin/heavy-slot.sh pinwave kin -- \
    bin/kin-precheck kin --repo-dir kin=<lane worktree>
kin-precheck: repo=kin tree=.../.kin-coord/worktrees/pinwave-kin \
  sha=3492dbcf56a2e115f0e9ea0e3e6775e1253c1bae branch=chore/lane-pinwave-kin
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows>
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
... 17 more
kin-precheck: 20 gates ran, 20 passed, 0 failed, on kin 3492dbcf56a2e115f0e9ea0e3e6775e1253c1bae
```

Targeted crate tests, for the crates whose source references the kin-db surface this bump changes (`PersistedCommitReceipt`, `RepositoryAuthorityManager`, `rejoin`, `history_root`, `RootBundle`):

```
$ cargo test --locked -p kin-core -p kin-reconcile -p kin-remote -p kin-migrate -p kin-git
test result: ok. 808 passed; 0 failed; 0 ignored ... finished in 23.71s
test result: ok. 125 passed; 0 failed; 0 ignored ... finished in 19.47s
test result: ok. 102 passed; 0 failed; 0 ignored ... finished in 16.20s
(23 test binaries in all)
TESTS_RC=0
```

1,204 passed, 0 failed. The zero is read with a control rather than trusted: `grep -cE 'test result: FAILED|panicked|failures:'` returns 0 on that log while `grep -c 'test result: ok'` returns 23, so the pattern and the file are both real.

`bin/kin-parity` was NOT run. It builds and runs the release's own acceptance suites, and the box has carried a benchmark round all afternoon. kin-cli, kin-daemon and kin-mcp also reference the changed kin-db surface and are not in the targeted run above. Hosted CI covers both: it is the gate of record for the full workspace, and `Check & Test` on macOS and ubuntu, both `Feature permutation tests`, all three `Fast gate test shard` jobs and `Fast gate lint and policy` are green on this head.

Hosted CI, read by name over the full check-run set rather than off a rollup (`per_page=100`, listed equals `total_count`):

```
ALL CHECKS CONCLUDED: success=32 skipped=17 failed=0
```

`Product Acceptance` reports `skipped`, as it does on every kin pull request: the job carries `if: ${{ github.event_name != 'pull_request' }}` and kin has no merge_group, so main's own push run is the only grader. I read that run after the squash lands and report its conclusion.
