### PR TITLE
Refuse a projection miss instead of reading the working copy

### DIFF
--- a/crates/kin-reconcile/src/reconciler.rs
+++ b/crates/kin-reconcile/src/reconciler.rs
@@ -1664,24 +1664,29 @@ impl Reconciler {
             let body = if let Some(supplied) = entity_bodies.get(&id) {
                 supplied.clone()
             } else if let Some(ref span) = entity.span {
-                // Try cached content first (race-safe), fall back to disk.
-                let contents = if let Some(cached) = self.projection.get_content(&span.file) {
-                    cached.to_vec()
-                } else {
-                    let file_path = self.working_dir.join(span.file.0.as_str());
-                    if file_path.exists() {
-                        std::fs::read(&file_path).map_err(|e| {
-                            ReconcileError::BodyExtractionFailed {
-                                entity_id: id,
-                                reason: format!("failed to read {}: {}", file_path.display(), e),
-                            }
-                        })?
-                    } else {
-                        return Err(ReconcileError::BodyExtractionFailed {
-                            entity_id: id,
-                            reason: format!("file not found and no cached content: {}", span.file),
-                        });
-                    }
+                // Membership first. Reading a path this projection did not
+                // register would make the working copy an answer authority for
+                // graph misses, which is the one thing this boundary must never
+                // become. kin-vfs holds the identical line at its own staging
+                // boundary (`KinWriter::read_staged`) in the same words, and the
+                // two are one policy rather than two decisions that happen to
+                // agree.
+                //
+                // The registered bytes are also the only ones these spans are
+                // valid against: they were cached by the reconcile that produced
+                // the spans, so a working-copy read could return a newer file
+                // written by a concurrent editor and splice at misaligned
+                // offsets. Refusing therefore costs nothing that was correct.
+                let Some(contents) = self.projection.get_content(&span.file).map(<[u8]>::to_vec)
+                else {
+                    return Err(ReconcileError::BodyExtractionFailed {
+                        entity_id: id,
+                        reason: format!(
+                            "no registered projection content for {}; graph-derived state missed \
+                             and the working copy is not an answer authority",
+                            span.file
+                        ),
+                    });
                 };
                 let start = span.start_byte;
                 let end = span.end_byte;
@@ -2772,6 +2777,66 @@ mod tests {
                 assert!(reason.contains("no source span"));
             }
             other => panic!("expected BodyExtractionFailed, got: {:?}", other),
+        }
+    }
+
+    /// A projection miss refuses instead of reading the working copy.
+    ///
+    /// The file is written to the working directory holding exactly the bytes
+    /// the span is valid against, so a fallback that read it would succeed and
+    /// return a correct-looking body. That is the point: the refusal must not
+    /// depend on the file being absent, because absence is the easy case and
+    /// presence is the one that silently makes the working copy an answer
+    /// authority for a graph miss.
+    #[test]
+    fn project_transaction_refuses_a_projection_miss_rather_than_reading_the_working_copy() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = "pub fn cached() -> u32 { 7 }\n";
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src/lib.rs"), source).unwrap();
+
+        let mut reconciler = Reconciler::new(dir.path().to_path_buf());
+        let mut entity = make_entity("cached", "src/lib.rs");
+        entity.span = Some(kin_model::SourceSpan {
+            file: FilePathId::new("src/lib.rs"),
+            start_byte: 0,
+            end_byte: source.len(),
+            start_line: 1,
+            start_col: 0,
+            end_line: 1,
+            end_col: source.len() as u32,
+        });
+        let entity_id = entity.id;
+        let mut old = entity.clone();
+        old.fingerprint.ast_hash = Hash256::from_bytes([0; 32]);
+        let transaction = TransactionDelta {
+            entity_deltas: vec![EntityDelta::Modified { old, new: entity }],
+            ..TransactionDelta::default()
+        };
+
+        // Positive control. A refusal proves nothing unless the bytes a
+        // fallback would have reached are really on disk and really readable.
+        assert_eq!(
+            std::fs::read(dir.path().join("src/lib.rs")).unwrap(),
+            source.as_bytes(),
+            "the working copy must hold the readable bytes this test refuses to read"
+        );
+
+        match reconciler
+            .project_transaction_to_files(&transaction, &HashMap::new())
+            .unwrap_err()
+        {
+            ReconcileError::BodyExtractionFailed {
+                entity_id: failed_id,
+                reason,
+            } => {
+                assert_eq!(failed_id, entity_id);
+                assert!(
+                    reason.contains("not an answer authority"),
+                    "the refusal must say why it refused, got: {reason}"
+                );
+            }
+            other => panic!("expected BodyExtractionFailed, got: {other:?}"),
         }
     }
 


### PR DESCRIPTION
## The finding, first

FIR-3125 reported that the projection state is never populated from persisted graph truth, and
named two consumers working off an empty cache: the virtual filesystem and entity-mutation
projection. Measuring before fixing changed the answer.

**The virtual filesystem does not consume that cache and never did.** kin-vfs has no dependency on
`kin-projection` in any of its ten workspace manifests, and it serves file content over `/vfs/tree`
and `/vfs/blob/` from repository-v6 content-addressed storage, by content address. The ticket read
as a thesis problem, and on that path the thesis is intact: the derived view really is derived from
graph truth.

The honest remaining half is what this PR closes. A latent filesystem fallback sits one new caller
away from making the working copy an answer authority on a graph miss.

## What this changes

`Reconciler::project_transaction_to_files` extracted entity body bytes from the projection when it
held the file, and from the working copy when it did not:

```rust
let contents = if let Some(cached) = self.projection.get_content(&span.file) {
    cached.to_vec()
} else {
    let file_path = self.working_dir.join(span.file.0.as_str());
    if file_path.exists() {
        std::fs::read(&file_path)...
```

A runtime path that answers from raw filesystem contents on a graph-derived miss is what the zero
file-search rule forbids. The miss now returns `BodyExtractionFailed` naming why.

kin-vfs already holds this exact line at its own staging boundary, in `KinWriter::read_staged`
(`kin-vfs/crates/kin-vfs-daemon/src/kin_writer.rs:480`): "Reading a path this writer did not stage
would make the working copy an answer authority for graph misses, which is the one thing this
boundary must never become." The new comment quotes that reasoning so the two read as one policy
rather than two independent decisions that happen to agree.

Refusing costs nothing that was correct. The registered bytes are the only ones these spans are
valid against, because they were cached by the reconcile that produced the spans. A working-copy
read could return a newer file written by a concurrent editor and splice at misaligned offsets. The
old code said as much in its own comment, immediately above, and then read the file anyway.

## Scope, and how live this was

Latent, not live. `project_transaction_to_files` has no production caller: every call site sits
below the `#[cfg(test)]` at `reconciler.rs:2550` or in `crates/kin-reconcile/tests/round_trip.rs`.
I am not claiming this was leaking in production. It is a loaded gun, because the function is `pub`,
the fallback is the first thing a new caller inherits, and the projection it falls back from is
never seeded from graph truth at daemon open.

Nothing else in the crate changes. No daemon construction site is touched.

## Test design

The test writes the file into the working copy holding **exactly the bytes the span is valid
against**, then asserts the refusal. That matters: if the fixture left the file absent, the guard
would pass for the wrong reason and the test would be checking the filesystem rather than the
refusal. It also asserts those bytes are really on disk and readable first, so a refusal can never
be mistaken for a missing fixture.

## Verification

Full crate suite, guard in place:

```
$ cargo test -p kin-reconcile
test reconciler::tests::project_transaction_refuses_a_projection_miss_rather_than_reading_the_working_copy ... ok
test result: ok. 78 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s
test result: ok. 5 passed; 0 failed; ...
test result: ok. 11 passed; 0 failed; ...
test result: ok. 7 passed; 0 failed; ...
test result: ok. 5 passed; 0 failed; ...
test result: ok. 2 passed; 0 failed; ...
command exit rc=0 at 2026-09-03T19:41:20Z
```

The new test ran by name, rather than the suite merely being green. Every pre-existing test stayed
green, which also says none of them relied on the disk fallback.

Falsification, disk read restored and nothing else changed:

```
$ cargo test -p kin-reconcile --lib refuses_a_projection_miss
test reconciler::tests::project_transaction_refuses_a_projection_miss_rather_than_reading_the_working_copy ... FAILED

panicked at crates/kin-reconcile/src/reconciler.rs:2835:14:
called `Result::unwrap_err()` on an `Ok` value: ([], [])

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 77 filtered out
command exit rc=101 at 2026-09-03T19:40:16Z
```

The assertion the test was written for went red. Read precisely: with the fallback restored the call
no longer refuses, it succeeds. Body extraction had to have read the working copy, because with an
empty projection there is no other source, and the span extracted cleanly against those bytes. That
is the hazard, demonstrated.

Format:

```
$ cargo fmt --all -- --check
FMT_OK
```

Clippy on the crate reports one `clippy::map_entry` warning at line 72 of an untouched file, present
before this change. This diff touches only lines 1667-1690 and 2783-2843.

## Why this was not caught before

Neither zero-file-search gate can see the crate. `scripts/zero_file_search_guard.sh` scans ten files,
all under `crates/kin-cli/src/commands/`. `scripts/verify-zero-file-search.py` walks every crate then
skips `BOUNDARY_DIRS`, and that list carries `crates/kin-reconcile/` and `crates/kin-projection/` as
whole directories.

Measured rather than assumed: with those two removed the checker goes from "Scanned 202 source
files... PASSED" to "Scanned 217 source files... FAILED: Found 60 zero-file-search violations", and
while the falsification arm was in the tree it flagged `if file_path.exists()` and
`std::fs::read(&file_path)` at exactly these lines. So the narrowed gate does catch this class.

The narrowing is not in this PR. Most of those 60 are legitimate materialization and ingest-boundary
IO, so it needs roughly 58 justified allowlist entries rather than a one-line delete, and coupling an
unbounded cleanup to a small provably-safe refusal risks both. Filed separately as FIR-3144, which
also records that kin-daemon was deliberately removed from that same exemption for exactly this
reason and that nobody applied the argument to kin-reconcile.

Refs FIR-3125, FIR-3144
