### PR TITLE
Delete the write-only projection cache from the daemon

### DIFF
--- a/crates/kin-daemon/src/background_work.rs
+++ b/crates/kin-daemon/src/background_work.rs
@@ -1326,9 +1326,16 @@ mod tests {
     /// Paired with the test above rather than written alone: the two run the
     /// identical wedged scenario and differ only in how the pass registered, so
     /// a sweep that stopped everything, or one that stopped nothing, fails one
-    /// of them. The projection rebuild is the real case — a single `await` with
-    /// no loop — and publishing `stopped` for work still running would make the
-    /// health surface lie about the one thing it exists to report.
+    /// of them. The projection rebuild was the real case — a single `await`
+    /// with no loop — and publishing `stopped` for work still running would
+    /// make the health surface lie about the one thing it exists to report.
+    ///
+    /// That pass was removed in 2026-09 along with the write-only projection
+    /// cache it rebuilt, so `PASS_PROJECTION` and `disclosed_pass` now have no
+    /// production caller and this pair is the only cover the disclose-only mode
+    /// has. The constant and the reasoning are kept rather than repointed at
+    /// another pass: a mode with no user is worth seeing, and the argument above
+    /// is the only written record of why the mode exists at all.
     #[test]
     fn a_disclose_only_pass_is_reported_but_never_claimed_stopped() {
         let supervisor = BackgroundWorkSupervisor::new(Duration::from_secs(60));

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -4296,31 +4296,6 @@ pub async fn run_with_authority_on(
         shutdown_escalation_grace(),
     );
 
-    // Spawn projection rebuild in background — VFS needs it but locate doesn't.
-    // The reconcile loop and API server can start immediately.
-    //
-    // Registered with the self-limit supervisor as disclose-only. The whole pass
-    // is a single `rebuild_projection().await`: there is no loop and so nowhere
-    // between start and finish for it to read a halt. Making it stoppable means
-    // threading cancellation through `ProjectionState::from_resolved_tree`,
-    // which is an API change rather than a registration. Until then the honest
-    // thing is to let a user see it working and how long since it advanced, and
-    // to never claim it was stopped.
-    let projection_state = Arc::clone(&state);
-    let projection_pass = state
-        .background_work
-        .disclosed_pass(crate::background_work::PASS_PROJECTION);
-    tokio::spawn(async move {
-        projection_pass.working(Instant::now());
-        if let Err(error) = projection_state.rebuild_projection().await {
-            tracing::error!(error = %error, "failed to rebuild projection state on startup");
-        } else {
-            projection_pass.advanced(1, Instant::now());
-            tracing::info!("projection state rebuilt in background");
-        }
-        projection_pass.idle();
-    });
-
     // Spawn the orphan session sweeper (Phase 7).
     let sweep_state = Arc::clone(&state);
     let sweep_interval = config.sweep_interval;

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -18,8 +18,8 @@ use tracing::{debug, error, info, warn};
 
 use crate::error::{DaemonError, Result};
 use crate::state::{
-    ChangeType, DaemonEvent, DaemonState, LspEnrichmentRequest, ProjectionChangedSet, RECON_IDLE,
-    RECON_PARKED, RECON_PROCESSING,
+    ChangeType, DaemonEvent, DaemonState, LspEnrichmentRequest, RECON_IDLE, RECON_PARKED,
+    RECON_PROCESSING,
 };
 
 pub(crate) const DISABLE_FILESYSTEM_RECONCILE_ENV: &str = "KIN_DAEMON_DISABLE_FILESYSTEM_RECONCILE";
@@ -2956,7 +2956,6 @@ pub async fn run_loop_armed(
         // zero however much work it did, which is the honest account of a loop
         // that is spending the machine and moving nothing.
         let mut admitted_events: u64 = 0;
-        let mut projection_changed = ProjectionChangedSet::default();
 
         let mut lsp_changed: Vec<(kin_model::FilePathId, Vec<kin_model::EntityId>)> = Vec::new();
         let graph_mutation = state.begin_graph_authority_mutation();
@@ -3152,7 +3151,6 @@ pub async fn run_loop_armed(
                         match enrichment_pipeline.index_any_content(&file_id, &content, blob_hash) {
                             Ok(indexed) => match persist_non_entity_enrichment(&state, indexed) {
                                 Ok((file_id, cleanup)) => {
-                                    projection_changed.remove(file_id.clone());
                                     for id in cleanup.removed_entities {
                                         state.emit_event(DaemonEvent::EntityChanged {
                                             entity_id: id,
@@ -3233,7 +3231,6 @@ pub async fn run_loop_armed(
                                     session_id: None,
                                 });
                             }
-                            projection_changed.remove(file_id.clone());
                             graph_changed |= cleanup.changed;
                             if tree_changed || cleanup.changed {
                                 state.bump_version();
@@ -3266,7 +3263,6 @@ pub async fn run_loop_armed(
                     match finalize_tree_removal(&state, file_id.as_ref(), tree_changed) {
                         Ok(cleanup) => {
                             if let Some(file_id) = &file_id {
-                                projection_changed.remove(file_id.clone());
                                 for id in cleanup.removed_entities {
                                     state.emit_event(DaemonEvent::EntityChanged {
                                         entity_id: id,
@@ -3362,7 +3358,6 @@ pub async fn run_loop_armed(
                         {
                             warn!(error = %e, "failed to persist projection truth after reconcile");
                         }
-                        projection_changed.record_reconcile_outcome(&outcome);
                         graph_changed = true;
                     }
 
@@ -3475,9 +3470,7 @@ pub async fn run_loop_armed(
                             }
                         }
                         match clear_incompatible_facets(&state, file_id, EnrichmentFacet::None) {
-                            Ok(_) => {
-                                projection_changed.remove(file_id.clone());
-                            }
+                            Ok(_) => {}
                             Err(error) => {
                                 warn!(
                                     file = %file_id,
@@ -3552,19 +3545,10 @@ pub async fn run_loop_armed(
             });
         }
 
-        // Refresh projection cache so VFS reads serve fresh content.
-        // Persistence is handled by the background save task — the reconcile
-        // loop just marks the graph dirty and refreshes touched projection rows.
+        // Persistence is handled by the background save task, so the reconcile
+        // loop just marks the graph dirty.
         if graph_changed {
             state.mark_dirty();
-            let projection_result = if projection_changed.is_empty() {
-                state.rebuild_projection().await
-            } else {
-                state.refresh_projection(&projection_changed).await
-            };
-            if let Err(e) = projection_result {
-                error!(error = %e, "failed to refresh projection after reconciliation");
-            }
         }
 
         // The pass boundary, after every event this pass produced. A consumer
@@ -8307,7 +8291,6 @@ async fn sync_filesystem_with_graph_publishing_inner(
     // never controls repository membership.
     let mut reconciler = state.reconciler.write().await;
     let mut graph_changed = true;
-    let mut projection_changed = ProjectionChangedSet::default();
     let enrichment_pipeline = IndexPipeline::new();
     state.bump_version();
 
@@ -8375,7 +8358,6 @@ async fn sync_filesystem_with_graph_publishing_inner(
                     match enrichment_pipeline.index_any_content(&file_id, &content, blob_hash) {
                         Ok(indexed) => match persist_non_entity_enrichment(state, indexed) {
                             Ok((file_id, cleanup)) => {
-                                projection_changed.remove(file_id.clone());
                                 for id in cleanup.removed_entities {
                                     state.emit_event(DaemonEvent::EntityChanged {
                                         entity_id: id,
@@ -8437,7 +8419,6 @@ async fn sync_filesystem_with_graph_publishing_inner(
                                 session_id: None,
                             });
                         }
-                        projection_changed.remove(file_id.clone());
                         graph_changed |= cleanup.changed;
                         debug!(
                             file = %file_id,
@@ -8464,7 +8445,6 @@ async fn sync_filesystem_with_graph_publishing_inner(
                 match finalize_tree_removal(state, file_id.as_ref(), tree_changed) {
                     Ok(cleanup) => {
                         if let Some(file_id) = &file_id {
-                            projection_changed.remove(file_id.clone());
                             for id in cleanup.removed_entities {
                                 state.emit_event(DaemonEvent::EntityChanged {
                                     entity_id: id,
@@ -8536,16 +8516,13 @@ async fn sync_filesystem_with_graph_publishing_inner(
                     {
                         warn!(error = %e, "failed to persist projection truth after sync");
                     }
-                    projection_changed.record_reconcile_outcome(&outcome);
 
                     if let ReconcileOutcome::FileRemoved {
                         removed, file_id, ..
                     } = &outcome
                     {
                         match clear_incompatible_facets(state, file_id, EnrichmentFacet::None) {
-                            Ok(_) => {
-                                projection_changed.remove(file_id.clone());
-                            }
+                            Ok(_) => {}
                             Err(error) => warn!(
                                 file = %file_id,
                                 error = %error,
@@ -8589,17 +8566,6 @@ async fn sync_filesystem_with_graph_publishing_inner(
         state.bump_version();
     }
     drop(graph_mutation);
-
-    if graph_changed {
-        let projection_result = if projection_changed.is_empty() {
-            state.rebuild_projection().await
-        } else {
-            state.refresh_projection(&projection_changed).await
-        };
-        if let Err(e) = projection_result {
-            error!(error = %e, "failed to refresh projection after sync");
-        }
-    }
 
     Ok(())
 }

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -22,7 +22,6 @@ use kin_model::{
     RepositoryId, ResolvedTree, SemanticChange, SemanticChangeId, TransactionDelta, TreeEntry,
     WorkspaceId,
 };
-use kin_projection::ProjectionState;
 use kin_reconcile::Reconciler;
 #[cfg(feature = "firestore")]
 // Needed for method-call syntax in some feature shapes and not others: the
@@ -1622,40 +1621,6 @@ impl GraphOwnedSourceView {
     }
 }
 
-#[derive(Debug, Default)]
-pub struct ProjectionChangedSet {
-    pub upserted: HashSet<FilePathId>,
-    pub removed: HashSet<FilePathId>,
-}
-
-impl ProjectionChangedSet {
-    pub fn is_empty(&self) -> bool {
-        self.upserted.is_empty() && self.removed.is_empty()
-    }
-
-    pub fn record_reconcile_outcome(&mut self, outcome: &kin_reconcile::ReconcileOutcome) {
-        match outcome {
-            kin_reconcile::ReconcileOutcome::Updated { file_id, .. } => {
-                self.upsert(file_id.clone());
-            }
-            kin_reconcile::ReconcileOutcome::FileRemoved { file_id, .. } => {
-                self.remove(file_id.clone());
-            }
-            _ => {}
-        }
-    }
-
-    pub fn upsert(&mut self, file_id: FilePathId) {
-        self.removed.remove(&file_id);
-        self.upserted.insert(file_id);
-    }
-
-    pub fn remove(&mut self, file_id: FilePathId) {
-        self.upserted.remove(&file_id);
-        self.removed.insert(file_id);
-    }
-}
-
 /// Messages sent to the LSP enrichment worker.
 #[derive(Debug)]
 pub enum LspEnrichmentMessage {
@@ -2766,12 +2731,6 @@ pub struct DaemonState {
     durable_entity_count: AtomicU64,
     pub blobs: Arc<BlobStore>,
     /// Why the derived ingestion CAS could not be hydrated from graph
-    /// authority when this state was opened, if it could not.
-    ///
-    /// Projection reads name this instead of surfacing a bare missing-blob
-    /// error, so an un-hydrated store is reported as the authority gap it is
-    /// rather than as a mysteriously absent object.
-    ingest_cas_hydration_gap: Option<String>,
     /// Why a persisted local or hosted vector artifact was not installed when
     /// this state was opened.
     ///
@@ -2786,9 +2745,6 @@ pub struct DaemonState {
     /// describe different stores and only one of them can be true at a time.
     vector_index_salvage: Option<crate::VectorSalvage>,
     pub reconciler: RwLock<Reconciler>,
-    /// Cached FileLayouts for all tracked files.
-    /// Populated on init, updated on commits.
-    pub projection: RwLock<ProjectionState>,
     /// Session and intent coordinator (Phase 7).
     pub coordinator: SessionCoordinator,
     /// Serializes daemon intent lifecycle mutations with MCP transaction
@@ -4686,10 +4642,10 @@ impl DaemonState {
     /// backend.
     ///
     /// The local path hydrates from repository authority so every blob the
-    /// projection later reads is present before the daemon serves anything.
-    /// The backend path reads the same store through `rebuild_projection` and
-    /// `refresh_projection` but used to open against whatever happened to be
-    /// on local disk, which on a fresh hosted instance is nothing.
+    /// layout backfill and the reconcile and commit paths later read is present
+    /// before the daemon serves anything. The backend path reads the same store
+    /// but used to open against whatever happened to be on local disk, which on
+    /// a fresh hosted instance is nothing.
     ///
     /// Returns the number of source bodies hydrated, or the reason the hosted
     /// backend could not supply them. A graph with no resolved artifacts needs
@@ -5138,11 +5094,9 @@ impl DaemonState {
             layout,
             graph,
             blobs: Arc::new(blobs),
-            ingest_cas_hydration_gap: None,
             vector_index_discarded: sidecar_open.discarded,
             vector_index_salvage: sidecar_open.salvage,
             reconciler: RwLock::new(reconciler),
-            projection: RwLock::new(ProjectionState::new()),
             coordinator,
             coordination_gate: tokio::sync::Mutex::new(()),
             graph_authority_clock: Arc::new(GraphAuthorityClock::default()),
@@ -5450,28 +5404,20 @@ impl DaemonState {
         // treat as a cache. That was true of the local path only; a hosted
         // instance opened against an empty local disk and every projection read
         // failed on a blob nothing had put there.
-        let ingest_cas_hydration_gap =
-            match Self::hydrate_backend_ingest_cas(repo_id, &backend, graph.as_ref(), &blobs) {
-                Ok(hydrated_source_bodies) => {
-                    info!(
-                        repo_id,
-                        hydrated_source_bodies,
-                        "hydrated derived ingestion CAS from hosted repository authority"
-                    );
-                    None
-                }
-                Err(reason) => {
-                    // Not fatal: a hosted graph whose backend carries no
-                    // repository authority still serves every query that does
-                    // not need source bodies. Recorded so the reads that DO
-                    // need them report this instead of a bare missing blob.
-                    warn!(
-                        repo_id,
-                        reason, "derived ingestion CAS was not hydrated on the backend open path"
-                    );
-                    Some(reason)
-                }
-            };
+        match Self::hydrate_backend_ingest_cas(repo_id, &backend, graph.as_ref(), &blobs) {
+            Ok(hydrated_source_bodies) => info!(
+                repo_id,
+                hydrated_source_bodies,
+                "hydrated derived ingestion CAS from hosted repository authority"
+            ),
+            // Not fatal: a hosted graph whose backend carries no repository
+            // authority still serves every query that does not need source
+            // bodies, so the gap is reported here and the open continues.
+            Err(reason) => warn!(
+                repo_id,
+                reason, "derived ingestion CAS was not hydrated on the backend open path"
+            ),
+        }
         // Hosted local disk is only a projection cache. Resolve the vector
         // artifact through the same backend authority as the graph, bind it to
         // the recovered generation and retrieval hash, then materialize it for
@@ -5506,11 +5452,9 @@ impl DaemonState {
             layout,
             graph: Arc::clone(&graph),
             blobs: Arc::new(blobs),
-            ingest_cas_hydration_gap,
             vector_index_discarded: sidecar_open.discarded,
             vector_index_salvage: sidecar_open.salvage,
             reconciler: RwLock::new(reconciler),
-            projection: RwLock::new(ProjectionState::new()),
             coordinator,
             coordination_gate: tokio::sync::Mutex::new(()),
             graph_authority_clock: Arc::new(GraphAuthorityClock::default()),
@@ -10694,22 +10638,6 @@ impl DaemonState {
                 .is_file()
     }
 
-    /// Name the open-path hydration gap on an error that a hydrated ingestion
-    /// CAS would not have produced.
-    ///
-    /// Without this a hosted daemon reports "cannot load graph-owned blob X",
-    /// which reads as graph corruption. The blob is fine; nothing ever put it
-    /// in this instance's derived store, and that is a different problem with a
-    /// different fix.
-    fn attribute_ingest_cas_gap(&self, error: DaemonError) -> DaemonError {
-        match &self.ingest_cas_hydration_gap {
-            Some(reason) => exact_source_storage_error(format!(
-                "{error}; the derived ingestion CAS was never hydrated on this open path: {reason}"
-            )),
-            None => error,
-        }
-    }
-
     /// Issue the derived ingestion CAS's deferred directory barriers.
     ///
     /// The store defers the barrier that makes a blob's *name* durable and
@@ -10721,99 +10649,6 @@ impl DaemonState {
     /// shutdown, including clean ones.
     pub fn sync_blob_store(&self) -> Result<()> {
         self.blobs.sync().map_err(DaemonError::from)
-    }
-
-    /// Rebuild projection state from the current graph.
-    ///
-    /// Loads every persisted [`FileLayout`] and its blob-backed base content
-    /// from the graph's exact resolved tree. Missing entries or blobs are
-    /// authority gaps and fail loudly; runtime projection never repairs graph
-    /// truth from raw filesystem contents.
-    ///
-    /// Called after graph init, snapshot load, or a write-notify reconcile.
-    pub async fn rebuild_projection(&self) -> Result<()> {
-        let mut projection = self.projection.write().await;
-
-        let tree = self.graph.resolved_tree();
-        let state =
-            ProjectionState::from_resolved_tree(self.graph.as_ref(), self.blobs.as_ref(), &tree)
-                .map_err(|error| self.attribute_ingest_cas_gap(DaemonError::from(error)))?;
-        let registered = state.file_ids().len();
-        *projection = state;
-        info!(
-            files = registered,
-            "rebuilt projection state from persisted graph truth"
-        );
-        Ok(())
-    }
-
-    /// Refresh projection state for a touched-file set.
-    ///
-    /// This is the warm path after reconcile/VFS writes: removed files are
-    /// evicted from the projection cache, and added/modified files are loaded
-    /// from graph-owned layout + blob content. Missing entries or blobs fail
-    /// loudly instead of being repaired from the filesystem.
-    pub async fn refresh_projection(&self, changed: &ProjectionChangedSet) -> Result<()> {
-        if changed.is_empty() {
-            return Ok(());
-        }
-
-        let mut projection = self.projection.write().await;
-        let mut loaded = 0usize;
-        let mut removed = 0usize;
-        let mut skipped = 0usize;
-
-        for file_id in &changed.removed {
-            projection.remove_file(file_id);
-            removed += 1;
-        }
-
-        for file_id in &changed.upserted {
-            let Some(layout) = self
-                .graph
-                .get_file_layout(file_id)
-                .map_err(DaemonError::from)?
-            else {
-                projection.remove_file(file_id);
-                skipped += 1;
-                continue;
-            };
-
-            let entry = self
-                .graph
-                .get_tree_entry(file_id)
-                .map_err(DaemonError::from)?
-                .ok_or_else(|| {
-                    exact_source_storage_error(format!(
-                        "projection refresh for {file_id} has no graph-owned tree entry"
-                    ))
-                })?;
-            let TreeEntry::Blob { hash, .. } = entry else {
-                return Err(exact_source_storage_error(format!(
-                    "projection refresh for {file_id} has a layout attached to a non-blob tree entry"
-                )));
-            };
-            let content = self
-                .blobs
-                .read(&kin_blobs::Hash256(*hash.as_bytes()))
-                .map_err(|error| {
-                    self.attribute_ingest_cas_gap(exact_source_storage_error(format!(
-                        "projection refresh for {file_id} cannot load graph-owned blob {}: {error}",
-                        hash
-                    )))
-                })?;
-            projection.register_file(layout, content);
-            loaded += 1;
-        }
-
-        info!(
-            upserted = loaded,
-            graph_backed = loaded,
-            removed,
-            skipped,
-            "refreshed projection state for changed files"
-        );
-        Ok(())
     }
 
     /// Mark the graph as dirty (mutated since last save).
@@ -17171,9 +17006,9 @@ mod tests {
     #[test]
     fn backend_hydration_installs_every_body_the_graph_names() {
         // "Rehydrated on every daemon open" used to be true of the local path
-        // only. The backend path reads the same derived store through
-        // `rebuild_projection`, keyed on exactly this resolved tree, and used to
-        // open against whatever happened to be on local disk.
+        // only. The backend path reads the same derived store, keyed on exactly
+        // this resolved tree, and used to open against whatever happened to be
+        // on local disk.
         let repo_dir = tempfile::tempdir().unwrap();
         let body = b"services:\n  api:\n    image: kin:dev\n";
         let init = kin_core::init(repo_dir.path()).unwrap();
@@ -17254,7 +17089,6 @@ mod tests {
         let state = DaemonState::open(init.layout).expect("local open");
 
         assert_eq!(state.blobs.read(&hash).unwrap(), body);
-        assert!(state.ingest_cas_hydration_gap.is_none());
     }
 
     #[test]
@@ -17267,40 +17101,17 @@ mod tests {
         let kindb_dir = init.layout.kindb_dir();
         let repo_id = kin_core::manifest::resolve_repo_id(&init.layout, None).unwrap();
 
-        let state = DaemonState::open_with_backend(
+        let opened = DaemonState::open_with_backend(
             init.layout,
             Box::new(LocalFileBackend::new(kindb_dir)),
             &repo_id,
             None,
-        )
-        .expect("backend open");
-
-        assert!(
-            state.ingest_cas_hydration_gap.is_none(),
-            "an empty tree is not an authority gap: {:?}",
-            state.ingest_cas_hydration_gap
         );
-    }
 
-    #[test]
-    fn a_recorded_hydration_gap_is_named_in_projection_errors() {
-        // A hosted graph whose backend carries no repository authority still
-        // serves every query that needs no source body, so an un-hydratable
-        // store is recorded rather than fatal. The reads that DO need one must
-        // then report the authority gap instead of a bare missing blob, which
-        // reads as graph corruption.
-        let repo_dir = tempfile::tempdir().unwrap();
-        let init = kin_core::init(repo_dir.path()).unwrap();
-        let mut state = DaemonState::open(init.layout).expect("local open");
-        state.ingest_cas_hydration_gap = Some("hosted backend carries no authority".to_string());
-
-        let reported = state
-            .attribute_ingest_cas_gap(exact_source_storage_error("cannot load graph-owned blob"))
-            .to_string();
         assert!(
-            reported.contains("never hydrated on this open path")
-                && reported.contains("hosted backend carries no authority"),
-            "the error must name the hydration gap: {reported}"
+            opened.is_ok(),
+            "an empty tree is not an authority gap: {:?}",
+            opened.err()
         );
     }
 
@@ -17605,21 +17416,6 @@ mod tests {
         assert_eq!(
             opened.salvage, None,
             "and nothing was salvaged either, since there was nothing to salvage"
-        );
-    }
-
-    #[test]
-    fn a_hydrated_state_reports_blob_errors_unchanged() {
-        let repo_dir = tempfile::tempdir().unwrap();
-        let init = kin_core::init(repo_dir.path()).unwrap();
-        let state = DaemonState::open(init.layout).expect("local open");
-
-        let reported = state
-            .attribute_ingest_cas_gap(exact_source_storage_error("cannot load graph-owned blob"))
-            .to_string();
-        assert!(
-            !reported.contains("never hydrated"),
-            "a hydrated store must not blame a gap it does not have: {reported}"
         );
     }
 


### PR DESCRIPTION
## The finding, first

FIR-3125 reported that projection state is never populated from persisted graph truth, and named
the virtual filesystem as a consumer working off an empty cache. Measuring before fixing changed
the answer twice.

**The virtual filesystem does not consume that cache and never did.** kin-vfs has no dependency on
`kin-projection` in any of its ten workspace manifests. It serves file content over `/vfs/tree` and
`/vfs/blob/` from repository-v6 content-addressed storage, by content address. So on that path the
thesis is intact: the derived view really is derived from graph truth.

**And nothing else consumes it either.** `DaemonState::projection` is write-only. That is what this
PR removes.

The other half of the ticket, a latent filesystem fallback in kin-reconcile, landed separately as
#1442.

## Why this is a deletion and not a fill

The field is an `RwLock`, so it is reachable only through its accessors. Repo-wide:

```
projection.read()                         -> 0
projection.write()                        -> 2   (both inside the two functions being deleted)
projection.get_mut()                      -> 0
projection.into_inner()                   -> 0
projection.try_read / try_write           -> 0
projection.blocking_read / blocking_write -> 0
```

The `write()` row is the positive control: the search shape finds the calls known to exist, so the
zeros are absences rather than a broken search.

Nothing outside this repository can reach it either, and that bound is stronger than the sweep: only
six manifests in the ecosystem depend on `kin-projection` at all, and every one is inside kin, namely
`crates/kin-cli`, `crates/kin-daemon`, `crates/kin-index`, `crates/kin-migrate`,
`crates/kin-reconcile` and `tests/integration`. Checked beyond that anyway, each with a positive
control that hits: kin-editor 0 (control: "kin" appears 55 times in its package.json), kinlab 0
(control: `boundary-contracts` in three workflow files), bundled `crates/kin-mcp` 0 (control: `pub fn`
across its modules, and its manifest depends on neither `kin-projection` nor `kin-daemon`), kin-vfs 0
across all ten manifests (control: `kin-model` in two).

Left in place it was not free. `ProjectionState` holds one owned `Vec<u8>` per file for the daemon's
life with no eviction, so filling it would have put the whole repository in memory for no reader.
And the startup pass logged `files=0`, which reads as a defect but is the designed state: exact
admission writes no facet layer, asserted by a checked-in test at
`crates/kin-cli/tests/graph_status_after_admission.rs:368-379` and documented at
`crates/kin-cli/src/commands/graph_health.rs:34-39`. Layouts are published after admission by
`backfill_missing_file_layouts`, which is untouched here and reads graph-owned CAS only.

## Size, and why every line of it is forced

297 removed, 41 added, across four files. That is larger than a one-field deletion sounds, so here is
the shape before the diff:

- `state.rs`: the field, both construction sites, `rebuild_projection`, `refresh_projection`, and
  `ProjectionChangedSet` with its impl.
- `loop_runner.rs`: sixteen sites that built and populated `ProjectionChangedSet` across the
  reconcile pass and the sync pass, plus the two call sites that consumed it.
- `daemon.rs`: the background startup pass that called `rebuild_projection`.
- `background_work.rs`: one doc-comment note, described below.

None of the sixteen is a judgment call. `ProjectionChangedSet` had no consumer other than
`refresh_projection`, so leaving any of them would leave code computing a value for a function that
no longer exists. This removes one field and everything that exists solely to feed it. It does not
change how projection works, and `kin-projection` itself is untouched.

## One cascade worth reading

Deleting the two functions made `ingest_cas_hydration_gap` unread and `attribute_ingest_cas_gap`
uncalled, and CI runs `-D warnings`, so both had to go.

That mechanism decorated one message: a hosted daemon reporting "cannot load graph-owned blob X"
when the real problem was that nothing had hydrated its derived CAS. Checked before removing it, that
exact string appeared in production nowhere but the two deleted functions, and the mechanism's own
test was named `a_recorded_hydration_gap_is_named_in_projection_errors`. Its entire subject was the
projection, and the decoration of an error that can no longer be produced is not a capability.

**The condition itself is still observed and still logged.** `hydrate_backend_ingest_cas` still runs
on the backend open path and still emits `warn!` naming the reason. That match was restructured from
a binding into a plain match so the log survives without the dead field.

Residual, stated rather than hidden: a future path reading graph-owned blobs on a hosted daemon with
an un-hydrated CAS will now report a bare error with no attribution. The nearest candidate today is
`backfill_missing_file_layouts`, which swallows that case at debug level and counts it as
`unreadable`. Tracked in FIR-3145 rather than fixed here.

## Tests

Two tests asserted on the removed field while guarding real properties, so they were adjusted rather
than deleted:

- `the_local_open_path_hydrates_the_ingest_cas` keeps its real assertion, that the body hydrates, and
  loses only the secondary field check.
- `an_empty_hosted_graph_needs_no_repository_authority` now asserts the open succeeds, which is what
  "not reported as a gap" observably means once the field is gone. It can still fail.

Two tests whose whole subject was the removed decoration are deleted, rather than left as checks that
cannot fail.

`PASS_PROJECTION` and `disclosed_pass` now have no production caller, leaving
`PassEnforcement::DiscloseOnly` covered only by its two tests. The constant, both tests and their
reasoning are kept rather than repointed at another pass, with a note recording that the original
real case was removed. That doc comment is the only written record of why the mode exists, and
repointing it would have left it describing a case that no longer exists. Tracked in FIR-3145.

## Verification

```
$ bin/kin-precheck kin --repo-dir kin=<lane worktree>
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
... 20 gates total ...
kin-precheck: 20 gates ran, 20 passed, 0 failed
```

```
$ cargo test -p kin-daemon --lib
test result: ok. 1341 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 224.51s
command exit rc=0 at 2026-09-03T20:01:50Z
```

```
$ cargo check -p kin-daemon --all-targets
Finished `dev` profile [unoptimized + debuginfo] target(s)
```
zero warnings from this change.

## Predicted result, stated before it runs

Lane `authoritydecode` read 33 recorded daemon cold opens out of `kin/.kin/daemon.log` spanning
2026-08-10 to 2026-09-02. `PASS_PROJECTION` is not one of the recorded startup phases
(`authority_open`, `workspace_snapshot`, `graph_text_index`, `vector_index`, `cas_hydrate`,
`cross_file_seed`, `lkg_seed`, `read_index`), so this deletion should move no number in that table.
If a phase moves, that is news rather than noise. Those 33 opens are that lane's measurement, not
this one's.

Refs FIR-3125, FIR-3145
