### PR TITLE
Scan kin-projection and kin-reconcile, and grade both guards on the PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1036,6 +1036,26 @@ jobs:
       - name: Falsify Docker daemon production feature guard
         run: bash scripts/check-docker-daemon-features.test.sh
 
+      # ADDED here rather than moved out of `check`, for the reason the kin-vfs
+      # step below records. `check` carries `github.event_name != 'pull_request'`,
+      # so for as long as these two guards ran only there, a pull request could
+      # introduce a raw filesystem read on an answer path and no check on that
+      # pull request could report it; the guards graded the invariant only after
+      # the merge, on main's own push run. This job carries the required "Fast
+      # gate lint and policy" context, so the answer now arrives while a commit
+      # can still change it. Moving rather than adding was not an option:
+      # `bin/kin-precheck` in the umbrella enumerates the gate list out of the
+      # `check` job by name and refuses with no tally when a script it expects is
+      # missing there, so a move would drop both guards from every lane's local
+      # verdict at the same moment it added them to the pull request. Both are
+      # pure scanners over the tree with no toolchain and no network, so the cost
+      # of running them in both places is seconds.
+      - name: Check Zero File-Search Invariant
+        run: python3 scripts/verify-zero-file-search.py
+
+      - name: Check Zero File-Search Invariant (answer modules)
+        run: bash scripts/zero_file_search_guard.sh
+
       # ADDED here rather than moved out of `check`, deliberately, for two
       # reasons. `check` carries `github.event_name != 'pull_request'`, so the
       # thinned six-context pull-request gate never runs it and main failed its

--- a/scripts/verify-zero-file-search.py
+++ b/scripts/verify-zero-file-search.py
@@ -264,12 +264,25 @@ BOUNDARY_DIRS = [
     # is now scanned by default and its boundary IO is declared per file in
     # scripts/zero-file-search-allowlist.json, so a new daemon module, a new
     # query handler above all, is covered the moment it is added.
+    #
+    # kin-projection and kin-reconcile are absent for the same reason, and the
+    # argument is the daemon's applied a second time rather than a new one.
+    # Both were whole-directory entries, so neither gate could see either
+    # crate: this one skipped them here, and the shell guard beside it scans a
+    # fixed list of kin-cli command modules and reaches no other crate by
+    # construction. What the exemption was covering was a graph-miss path in
+    # the reconciler that read the working copy, latent only because its one
+    # caller was a test. Narrowing surfaced 58 sites across five files;
+    # 57 are materialization, write and ingest-boundary IO and are declared per
+    # file in the allowlist with an owner and an expiry, and the fifty-eighth,
+    # a working-copy probe deciding a placement answer, is recorded there as
+    # debt rather than as a boundary. A boundary directory carries neither an
+    # owner nor an expiry, which is why converting one is worth the entries it
+    # costs.
     "crates/kin-migrate/",
     "crates/kin-index/",
     "crates/kin-registry/",
     "crates/kin-buildinfo/",
-    "crates/kin-projection/",
-    "crates/kin-reconcile/",
     # kin-core is a mixed crate: it carries the semantic repo's config, layout,
     # init, projection, ingestion, and git-history boundary IO — all legitimate
     # input/output boundaries — but it must not be broadly exempted, or an

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -749,6 +749,114 @@
         "read_window_record",
         "write_window_record"
       ]
+    },
+    {
+      "file": "crates/kin-projection/src/tree.rs",
+      "reason": "Exact graph-tree materialization, end to end. This module takes a ResolvedTree the graph has already resolved and publishes it as filesystem objects, then proves what it published still matches. Nothing here decides an answer: every path it touches comes from a RepoPath the graph named, every byte it writes comes from a BlobStore hash the graph named, and no locate, search, context, trace, review, xref or rename result derives from any of it. Four shapes, each pinned to its exact line. (1) Root and staging lifecycle: proving the projection root is a directory, emptying it, and minting uniquely named staging and backup siblings beside it. The `std::process::id()` there is this process's own pid, used to make that sibling name unique; it spawns nothing, and the guard reports it only because the subprocess pattern matches the `process::` path. (2) Materialization: creating parent directories and writing the planned entries. (3) Pre-mutation refusal: `validate_existing_entry` compares the working copy against the graph's blob and refuses with LocalModification when the bytes, the mode or the symlink target differ, and `validate_target_collision` and `validate_directory_is_fully_displaced` refuse an untracked collision before anything is mutated. Those reads decide only whether to refuse; the graph still says what the tree should be. (4) Rollback and durability: removing what the transaction created and fsyncing the staged directories before the swap, which is what the `std::fs::File::open` is. Pinned by exact expression rather than exempted whole-file, so a filesystem primitive added anywhere in this module, including inside one of these functions, fails the guard until it is re-justified.",
+      "owner": "kin-projection",
+      "expiration": "2026-12-31",
+      "allow_match": [
+        "match fs::symlink_metadata(root) {",
+        "Ok(metadata) if !metadata.file_type().is_dir() => {",
+        "fs::read_dir(root).map_err(|error| transaction.abort(io(root, error)))?;",
+        "fs::remove_dir(root).map_err(|error| transaction.abort(io(root, error)))?;",
+        "let root_recovery = fs::create_dir(root)",
+        "fs::create_dir(&backup_root).map_err(|error| transaction.abort(io(&backup_root, error)))?;",
+        "let metadata = fs::symlink_metadata(root).map_err(|error| io(root, error))?;",
+        "if !metadata.file_type().is_dir() {",
+        "name.push(format!(\".{role}.{}.{}\", std::process::id(), ordinal));",
+        "match fs::create_dir(&candidate) {",
+        "fs::create_dir_all(parent).map_err(|error| io(parent, error))?;",
+        "fs::symlink_metadata(&path).map_err(|error| ProjectionError::LocalModification {",
+        "if !metadata.file_type().is_file() {",
+        "let actual = fs::read(&path).map_err(|error| io(&path, error))?;",
+        "if !metadata.file_type().is_symlink() {",
+        "fs::read_link(path)",
+        "match fs::symlink_metadata(&path) {",
+        "Ok(metadata) if metadata.file_type().is_dir() => {}",
+        "match fs::symlink_metadata(&destination) {",
+        {
+          "expr": "Ok(metadata) if metadata.file_type().is_dir() => {",
+          "count": 4
+        },
+        "for child in fs::read_dir(&current).map_err(|error| io(&current, error))? {",
+        "fs::symlink_metadata(&child_path).map_err(|error| io(&child_path, error))?;",
+        {
+          "expr": "if metadata.file_type().is_dir() {",
+          "count": 2
+        },
+        "match fs::remove_dir(&directory) {",
+        {
+          "expr": "match fs::symlink_metadata(path) {",
+          "count": 3
+        },
+        {
+          "expr": "fs::remove_dir(path).map_err(|error| io(path, error))",
+          "count": 2
+        },
+        {
+          "expr": "Ok(_) => fs::remove_file(path).map_err(|error| io(path, error)),",
+          "count": 2
+        },
+        "for child in fs::read_dir(&directory).map_err(|error| io(&directory, error))? {",
+        "fs::symlink_metadata(child.path()).map_err(|error| io(child.path(), error))?;",
+        "std::fs::File::open(&directory)",
+        "fs::remove_dir_all(path).map_err(|error| io(path, error))"
+      ]
+    },
+    {
+      "file": "crates/kin-projection/src/engine.rs",
+      "reason": "Projection write boundary: the two-phase commit that materializes entity mutations. Every pinned expression sits in `project_entity_mutations_with_policy`, which splices graph-owned content, writes each result to a temp path, then renames the temps into place and cleans up every temp file on any failure. One read appears in it and it is a refusal rather than an answer: before renaming, the committer compares the file on disk against `state.file_contents`, the content the projection based its splices on, and skips that file when a concurrent editor has changed it rather than overwriting the editor's work. Nothing read there reaches a locate, search, context, trace, review or xref result, and the content being written comes from the graph, never from the tree. Pinned by exact expression rather than exempted whole-file, so a filesystem primitive added anywhere in this module fails the guard, which is what should happen if a projection path ever starts reading the working copy to decide what to project.",
+      "owner": "kin-projection",
+      "expiration": "2026-12-31",
+      "allow_match": [
+        "std::fs::create_dir_all(parent).map_err(|e| ProjectionError::io(parent, e))?;",
+        "std::fs::write(&tmp_path, &new_content).map_err(|e| {",
+        "let _ = std::fs::remove_file(prev_tmp);",
+        {
+          "expr": "let _ = std::fs::remove_file(&tmp_path);",
+          "count": 4
+        },
+        "if file_path.exists() {",
+        "match std::fs::read(&file_path) {",
+        "if let Err(e) = std::fs::rename(&tmp_path, &file_path) {"
+      ]
+    },
+    {
+      "file": "crates/kin-projection/src/living_docs.rs",
+      "reason": "Documentation write boundary, and it only writes. `generate_living_docs` lists entities from the graph, renders ARCHITECTURE.md, AGENTS.md and CONTEXT.md from what the graph returned, and writes them under the docs directory it was given. It reads nothing from the filesystem at all: the pinned expressions are one `create_dir_all` for the output directory and three identical `write` calls, one per rendered document. A generated document is an output of graph truth, never an input to it. Pinned rather than exempted whole-file so a read added to this module fails the guard.",
+      "owner": "kin-projection",
+      "expiration": "2026-12-31",
+      "allow_match": [
+        "std::fs::create_dir_all(docs_dir).map_err(|e| ProjectionError::io(docs_dir, e))?;",
+        {
+          "expr": "std::fs::write(&path, doc).map_err(|e| ProjectionError::io(&path, e))?;",
+          "count": 3
+        }
+      ]
+    },
+    {
+      "file": "crates/kin-projection/src/placement.rs",
+      "reason": "Known violation under repair, not a boundary claim. Unlike the other kin-projection entries here, this read decides the answer: step 1 of `decide_placement` probes the working copy with `path.exists()` to choose between PlacementDecision::ExistingFile and PlacementDecision::NewFile for an entity whose `file_origin` the graph already names. The graph owns that fact in its exact tree, so the filesystem is answering a question the graph can answer. That is the same shape this guard's own note beside `graph.rs` records for the orphan count that used to probe each entity's file_origin with `.exists()`, and the same shape as the reconciler's working-copy fallback that was refused instead. The entry exists so the violation is visible, owned and dated rather than invisible, which is what it was for as long as this crate was exempt as a directory; it must not be read as evidence the path is graph-backed. Two facts bound it. `decide_placement` has no production caller: it is `pub` here and re-exported from `lib.rs`, and a workspace sweep finds those two mentions and its own test and nothing else, so no product surface observes the answer today. And it cannot be fixed in place, because the graph's exact tree reaches callers through `resolved_tree()` on the concrete store while this function is generic over GraphStore, whose supertraits do not carry it, so the fix is a bound change on a public signature rather than a line edit. Tracked on the internal board; the pin and this entry come out when the decision reads graph truth. Dated sooner than the boundary entries beside it because it is debt rather than a boundary.",
+      "owner": "kin-projection",
+      "expiration": "2026-10-31",
+      "allow_match": [
+        "if path.exists() {"
+      ]
+    },
+    {
+      "file": "crates/kin-reconcile/src/reconciler.rs",
+      "reason": "Ingest boundary: the file-event edge where the working tree becomes graph truth, plus the freshness checks that keep that edge honest. Reconcile is the direction that reads files by definition, and none of the pinned expressions produces an answer. `reconcile_file_change` probes `path.exists()` on a Removed event because an editor's atomic save writes a temp, deletes the original and renames, so a surviving Removed in a dedup batch can name a file that is back on disk; the probe decides which reconcile path runs, not what anything means. `comparable_event_path` canonicalizes the closest existing ancestor of an event path so a macOS /var event and a /private/var repository root compare as the same repository, which is path identity rather than content. The two `std::fs::read` calls re-read a file after the indexing pipeline already indexed it and hash the bytes: when the hash differs from the indexed one the reconcile returns FileModifiedDuringReconcile and defers to the next tick, and the bytes are discarded either way, so the content the graph receives still comes from the pipeline. The graph-miss path that once read the working copy from this module now refuses instead. Pinned by exact expression rather than exempted whole-file, so a read added to this crate, above all one on a miss path, fails the guard the moment it appears.",
+      "owner": "kin-reconcile",
+      "expiration": "2026-12-31",
+      "allow_match": [
+        "if path.exists() {",
+        "match ancestor.canonicalize() {",
+        {
+          "expr": "match std::fs::read(path) {",
+          "count": 2
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Both zero-file-search gates were blind to kin-projection and kin-reconcile. They are not now, and
the 58 sites that silence was covering carry an owner and an expiry. The checker goes from scanning
202 source files to 217. This change declares 57 genuine boundary sites and surfaces one real
violation that was hidden.

FIR-3143, ask 1. Asks 2 and 3 are answered as FIR-3149, and the one real violation the conversion
surfaced is FIR-3148. Report: `.kin-coord/reports/boundaryowner-20260903.md` in the umbrella.

## Why

`BOUNDARY_DIRS` carried `crates/kin-projection/` and `crates/kin-reconcile/` as whole directories,
and the shell guard beside it scans a fixed list of ten kin-cli command modules and reaches no other
crate by construction. So neither gate could see either crate. What that silence was covering was a
graph-miss path in the reconciler that read the working copy, latent only because its one caller was
a test, which kin#1442 already replaced with a refusal.

The comment above `BOUNDARY_DIRS` already records why kin-daemon stopped being a directory exemption
and declared its boundary IO per file instead. Nobody had applied that argument to these two. This
applies it, and adds a comment recording the second application in the same shape.

A directory entry carries no owner, no expiry and no reason. An allowlist entry carries all three
and the loader refuses one that is missing or past due. The weaker mechanism was protecting the
larger surface.

## What the 58 are

Fifty-seven are boundary IO, declared per file with an owner and an expiry. `tree.rs` is exact
graph-tree materialization end to end: it publishes a `ResolvedTree` the graph already resolved,
then proves what it published still matches. `engine.rs` is the two-phase projection commit, whose
one read is a refusal rather than an answer, skipping a file a concurrent editor changed instead of
overwriting it. `living_docs.rs` only writes. `reconciler.rs` is the file-event edge plus two
freshness checks that hash and discard.

Pins are exact expressions rather than function bodies, deliberately. `allow_fn` exempts a whole
body, so a primitive added inside a listed function inherits the exemption. An exact pin does not.

## The one real violation this surfaced

`crates/kin-projection/src/placement.rs:37` is not boundary IO and its entry does not pretend it is.
Step 1 of `decide_placement` probes the working copy with `path.exists()` to choose between
`PlacementDecision::ExistingFile` and `PlacementDecision::NewFile` for an entity whose `file_origin`
the graph already names. That is a raw filesystem read deciding an answer, which is the thing the
rule exists to forbid, and a whole-directory exemption is why nobody had seen it. It is the same
shape as the orphan count the guard's own `graph.rs` note records, and the same shape as the
reconciler fallback kin#1442 refused.

It is latent rather than live. `decide_placement` has no production caller: it is `pub` and
re-exported from `lib.rs`, and a sweep finds those two mentions plus its own test. It is also not
fixable here, because `resolved_tree()` lives on the concrete store while this function is generic
over `GraphStore`, whose seven supertraits do not carry it, so the fix is a bound change on a public
signature rather than a line edit. So it is recorded as debt, dated `2026-10-31` rather than
`2026-12-31`, with the argument written into the entry, and filed as FIR-3148.

## One consequence worth naming now

Putting both guards in a required context makes an allowlist expiry a hard pull-request blocker on
its date rather than a warning nobody reads.

**Two entries expire on 2026-10-31, not one.** Across all 47 entries there are exactly two distinct
dates, so on that morning both lapse together and every kin pull request fails "Fast gate lint and
policy" with two refusals until both are addressed:

- `crates/kin-projection/src/placement.rs` (owner kin-projection), added here, tracked as FIR-3148.
- `crates/kin-cli/src/commands/spec.rs` (owner kin-cli), which predates this change and is the more
  serious of the two: its own reason says the reads ARE the answer authority, since `kin spec list`
  and `kin spec show` resolve by walking and parsing `.kin/specs/*.json`. Tracked as FIR-1810 and
  FIR-1830, both open, and neither knew until now that its date had become a merge blocker.

That is the mechanism working, and it is the whole reason an expiry beats a directory exemption. It
is written down here so that when it fires it reads as the alarm it is rather than as a broken gate,
because a dated expiry nobody remembers is how a good guard gets disabled in a hurry. Naming both
matters for the same reason: someone arriving on that morning will find two refusals, and two
unexplained refusals read like a broken gate faster than one does.

## Both guards now run on the pull request

The `check` job that carried them takes `github.event_name != 'pull_request'` (`ci.yml:1601`), so a
pull request could introduce a raw filesystem read on an answer path and no check on that pull
request could report it. That is FIR-2892, and it also meant this change would have been graded only
after landing. Both guards are pure scanners over the tree with no toolchain and no network, and
`fast-gate-lint` already runs three policy scripts, so this costs seconds in the required "Fast gate
lint and policy" context.

Added rather than moved. `bin/kin-precheck` enumerates its gate list out of the `check` job by name
and refuses with no tally when a script it expects is missing there, so a move would have dropped
both guards from every lane's local verdict at the moment it added them to the pull request. Same
move kin#1226 made for the kin-vfs compat guard, and the comment beside that step records the
pattern.

## Verification, with output

Baseline on this base, with the list untouched:

```
$ python3 scripts/verify-zero-file-search.py
Scanned 202 source files (11 with function-scoped exemptions, 4 exempt whole-file).
Verification PASSED: Zero File-Search Invariant holds.
rc=0
```

With the two directories removed and nothing else changed:

```
Scanned 217 source files (11 with function-scoped exemptions, 4 exempt whole-file).
Verification FAILED: Found 58 zero-file-search violations.
rc=1
```

With the five entries in place:

```
Scanned 217 source files (11 with function-scoped exemptions, 4 exempt whole-file).
Verification PASSED: Zero File-Search Invariant holds.
rc=0
```

Pin counts were computed by importing the checker's own `count_pins_in_scan`, not by hand, and the
44 pins clear all 58 sites with nothing residual:

```
crates/kin-projection/src/tree.rs: 39 viol -> 31 pins; count-mismatch=[]; residual=0
crates/kin-projection/src/engine.rs: 10 viol -> 7 pins; count-mismatch=[]; residual=0
crates/kin-projection/src/living_docs.rs: 4 viol -> 2 pins; count-mismatch=[]; residual=0
crates/kin-projection/src/placement.rs: 1 viol -> 1 pins; count-mismatch=[]; residual=0
crates/kin-reconcile/src/reconciler.rs: 4 viol -> 3 pins; count-mismatch=[]; residual=0
```

## Falsification

A gate that was blind and is now green proves nothing on its own, so the control is the arm that
matters. A graph-miss working-copy read planted in one file per crate that neither gate has ever
named:

```
[VIOLATION] crates/kin-projection/src/splice.rs contains forbidden filesystem access:
  Line  194: if path.exists() { (filesystem existence probe (exists))
  Line  195: return std::fs::read(path).ok(); (std::fs API usage, fs API usage)

[VIOLATION] crates/kin-reconcile/src/cross_file.rs contains forbidden filesystem access:
  Line  705: std::fs::read(path).ok() (std::fs API usage, fs API usage)

Verification FAILED: Found 3 zero-file-search violations.
rc=1
```

The same two injections, with both script files restored to the base and left otherwise untouched:

```
Scanned 202 source files (11 with function-scoped exemptions, 4 exempt whole-file).
Verification PASSED: Zero File-Search Invariant holds.
rc=0
```

That is the finding in two runs. Four more arms, each red:

A new primitive inside two files this change allowlists, so the pins are not a blanket exemption:

```
  Line  868: let _falsify = root.join("x").is_file(); (filesystem existence probe (is_file))
  Line  692: let _falsify = std::fs::read_to_string(path).ok(); (std::fs API usage, fs API usage)
Verification FAILED: Found 2 zero-file-search violations.
```

Owner removed from the new kin-reconcile entry. It fails loud: the entry is discarded, so all four
of that file's sites are reported as well as the missing field.

```
Verification FAILED: Found 4 zero-file-search violations.

Allowlist validation FAILED:
  entry #46 (crates/kin-reconcile/src/reconciler.rs) missing required field(s): owner
```

Expiry back-dated one day on the new `tree.rs` entry:

```
  entry crates/kin-projection/src/tree.rs exemption expired 2026-09-02 (owner: kin-projection) - re-justify or remove
```

One extra occurrence of an already-pinned expression, so the exact-count budget holds:

```
  entry crates/kin-projection/src/living_docs.rs allow_match 'std::fs::write(&path, doc).map_err(|e| ProjectionError::io(&path, e))?;' occurs 4 times in scanned code (want 3)
```

Every injected file was restored from a copy taken before the edit, never with `git checkout`, and
`git status --porcelain` was read back after each arm.

## Gates

`bin/kin-precheck kin` through the fleet's heavy slot, from the lane worktree, re-run after the
ci.yml edit:

```
kin-precheck: repo=kin tree=/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/boundaryowner-kin sha=28f0014d4fcd684de0784094aba23ccf44f191d8 branch=chore/lane-boundaryowner-kin DIRTY
kin-precheck: behind origin/main 0 commit(s)
kin-precheck: 20 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
kin-precheck: 20 gates ran, 20 passed, 0 failed, on kin 28f0014d4fcd684de0784094aba23ccf44f191d8 DIRTY
PRECHECK_RC=0
```

`actionlint .github/workflows/ci.yml` passes, and the `fast-gate-lint` step list reads back with
both new steps and no job-level `if:`. `bin/kin-parity` does not exist in this checkout, so it did
not run. No cargo test: this change touches no Rust, and the two crates it makes visible are
unmodified.

The `Release version gate` does not apply. It runs only when the head ref is
`automation/release-next` or the PR carries `release:automated` (`ci.yml:84-87`), and this branch is
neither.

## Not claiming

That any live answer path was leaking through these two crates. It was not; the one real fallback
was latent and kin#1442 already refused it. That the six remaining directory exemptions hide a
violation. They do not, on the reads in FIR-3149. And that acceptance has graded this: it grades
main, not this PR.
