### PR TITLE
ci(registry): teach the dependency wave about the detached fuzz workspace lock

### DIFF
--- a/.github/workflows/kin-registry-release.yml
+++ b/.github/workflows/kin-registry-release.yml
@@ -231,6 +231,7 @@ jobs:
           set +e
           output="$(python3 .kin-actions/scripts/update-cargo-registry-deps.py \
             --manifest Cargo.toml \
+            --manifest fuzz/Cargo.toml \
             "${crate_args[@]}" 2>&1)"
           code=$?
           set -e
@@ -290,6 +291,7 @@ jobs:
             > "$validator"
           generated="$(python3 "$validator" \
             --manifest Cargo.toml \
+            --manifest fuzz/Cargo.toml \
             --version-mode manual \
             --bump-own-version false \
             --ephemeral-path .kin-actions)"
@@ -309,6 +311,7 @@ jobs:
             > "$validator"
           admission="$(python3 "$validator" \
             --manifest Cargo.toml \
+            --manifest fuzz/Cargo.toml \
             --version-mode manual \
             --bump-own-version false \
             --expected-tree "$EXPECTED_TREE" \

--- a/.github/workflows/kin-registry-release.yml
+++ b/.github/workflows/kin-registry-release.yml
@@ -255,6 +255,30 @@ jobs:
           esac
           echo "title=$title" >> "$GITHUB_OUTPUT"
 
+      # fuzz/Cargo.toml declares its own empty [workspace] table (see the
+      # comment there), so it carries a separate fuzz/Cargo.lock that the
+      # update above never touches: kin#1444 is the second wave the Fuzz
+      # workflow's `cargo metadata --locked` caught for exactly this reason,
+      # after kin#1213 re-locked it by hand. kin-parser's `kin-model =
+      # { workspace = true }` still inherits from THIS checkout's now-updated
+      # root Cargo.toml (Cargo walks up from crates/kin-parser, which has no
+      # [workspace] of its own, to find it), so a plain `cargo update` against
+      # the detached manifest re-resolves it correctly with the registry
+      # config already written above. No nightly toolchain needed: nightly is
+      # only required to build cargo-fuzz's libFuzzer targets, never to
+      # resolve a lockfile. This has to run before the snapshot below, not
+      # after: every later re-check in this pipeline (apply_candidate's
+      # re-validation in mutate-wave, and the final verify-generated-head
+      # check against the pushed PR head) compares against the tree recorded
+      # by that snapshot, so fuzz/Cargo.lock has to already be in the working
+      # tree it snapshots, not added on afterward.
+      - name: Update the detached fuzz workspace lock to match
+        if: steps.update.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          cargo update --manifest-path fuzz/Cargo.toml
+          git add fuzz/Cargo.lock
+
       - name: Snapshot the exact generated dependency delta
         id: generated
         if: steps.update.outputs.changed == 'true'
@@ -476,6 +500,7 @@ jobs:
           add-paths: |
             Cargo.lock
             Cargo.toml
+            fuzz/Cargo.lock
           delete-branch: true
           signoff: true
           labels: release:consumer-bump,proof-impacting

--- a/.github/workflows/kin-registry-release.yml
+++ b/.github/workflows/kin-registry-release.yml
@@ -147,7 +147,7 @@ jobs:
       title: ${{ steps.update.outputs.title }}
       base_sha: ${{ steps.base.outputs.base_sha }}
     env:
-      KIN_ACTIONS_SHA: 398595fa14ba1eaebca6eb176facd8a57ce9db05 # v0.1.33
+      KIN_ACTIONS_SHA: b424aa4f22684d91abe43d23fa7c4ab5b27c9a2f # v0.1.34
       BASE_BRANCH: main
     steps:
       # github.sha, the literal trusted context value: see the comment on the

--- a/scripts/kin-registry-wave-artifact.py
+++ b/scripts/kin-registry-wave-artifact.py
@@ -18,7 +18,15 @@ from typing import Any, Sequence
 
 EXPECTED_REPOSITORY = "firelock-ai/kin"
 EXPECTED_WORKFLOW_PATH = ".github/workflows/kin-registry-release.yml"
-ALLOWED_PATHS = ("Cargo.lock", "Cargo.toml")
+# Kept as its own ordered tuple rather than importing verify-kin-registry-wave-
+# head.py's ALLOWED_PATHS frozenset: this constant is serialized as
+# `list(ALLOWED_PATHS)` into the candidate.json handoff and compared for exact
+# list equality across two separate CI processes (prepare-wave writes it,
+# mutate-wave reads it back). Python randomizes string-hash seeds per process,
+# so a frozenset's iteration order is not guaranteed stable across processes; a
+# literal tuple is. land-kin-registry-wave.py can safely import the frozenset
+# because it only ever uses it for membership and sorted() there.
+ALLOWED_PATHS = ("Cargo.lock", "Cargo.toml", "fuzz/Cargo.lock")
 LOWER_SHA = re.compile(r"^[0-9a-f]{40}$")
 HEX_64 = re.compile(r"^[0-9a-f]{64}$")
 VERSION_EVIDENCE = re.compile(r"^(?:absent|[0-9A-Za-z.+-]+)$")
@@ -121,13 +129,37 @@ def _safe_regular(path: Path) -> bytes:
 
 
 def _exact_entries(directory: Path, expected: frozenset[str]) -> None:
+    """Require the directory tree to hold exactly the expected file paths.
+
+    Walks recursively rather than listing top-level names only, because
+    ALLOWED_PATHS now includes fuzz/Cargo.lock: a shallow `iterdir()` would see
+    a bare `fuzz` directory entry that can never equal the string
+    "fuzz/Cargo.lock", refusing every candidate. Every directory encountered is
+    rejected if it is a symlink before being walked into, so a symlinked
+    subdirectory can never smuggle a read from outside `directory`; the same
+    rejection applies to any non-regular leaf.
+    """
+
     if directory.is_symlink() or not directory.is_dir():
         raise ArtifactError("artifact path is not an exact directory")
-    entries = frozenset(item.name for item in directory.iterdir())
-    if entries != expected:
+    found: set[str] = set()
+    pending = [directory]
+    while pending:
+        current = pending.pop()
+        for item in current.iterdir():
+            relative = item.relative_to(directory).as_posix()
+            if item.is_symlink():
+                raise ArtifactError(f"artifact entry {relative} is a symlink")
+            if item.is_dir():
+                pending.append(item)
+            elif item.is_file():
+                found.add(relative)
+            else:
+                raise ArtifactError(f"artifact entry {relative} is not a regular file")
+    if found != expected:
         raise ArtifactError(
             "artifact entries differ from the allowlist: "
-            + ", ".join(sorted(entries ^ expected))
+            + ", ".join(sorted(found ^ expected))
         )
 
 
@@ -159,7 +191,21 @@ def _validate_candidate(
         item = value.get(field)
         if not isinstance(item, str) or VERSION_EVIDENCE.fullmatch(item) is None:
             raise ArtifactError(f"candidate {field} is invalid")
-    if value.get("paths") != list(ALLOWED_PATHS):
+    # "paths" is the subset of ALLOWED_PATHS this delta actually touched, in
+    # ALLOWED_PATHS's own canonical order, not the full allowlist: a wave that
+    # moves a pin fuzz/Cargo.lock does not depend on (kin-blobs, say) never
+    # touches it, and validate_index_delta/validate_delta already admit that
+    # subset. Every real wave happened to touch every one of the previous two
+    # paths together, which is what let this check hard-require the full list
+    # without it ever being exercised as a subset.
+    paths_value = value.get("paths")
+    if (
+        not isinstance(paths_value, list)
+        or not paths_value
+        or len(set(paths_value)) != len(paths_value)
+        or any(path not in ALLOWED_PATHS for path in paths_value)
+        or paths_value != [path for path in ALLOWED_PATHS if path in paths_value]
+    ):
         raise ArtifactError("candidate paths differ from the exact allowlist")
     files = value.get("files")
     if not isinstance(files, dict) or frozenset(files) != frozenset(ALLOWED_PATHS):
@@ -209,6 +255,10 @@ def prepare_candidate(
     files: dict[str, str] = {}
     for path in ALLOWED_PATHS:
         content = _git(workspace, "show", f":{path}")
+        # ALLOWED_PATHS now includes fuzz/Cargo.lock, the first admitted path
+        # with a directory component; output_dir itself is created above but
+        # not its subdirectories.
+        (output_dir / path).parent.mkdir(parents=True, exist_ok=True)
         (output_dir / path).write_bytes(content)
         files[path] = _sha256(content)
     manifest: dict[str, Any] = {
@@ -220,7 +270,12 @@ def prepare_candidate(
         "delta_sha256": evidence.delta_sha256,
         "package_version": evidence.package_version,
         "workspace_version": evidence.workspace_version,
-        "paths": list(ALLOWED_PATHS),
+        # The subset of ALLOWED_PATHS this delta actually touched (evidence.paths
+        # comes from validate_index_delta's real git diff), not the full
+        # allowlist: `files` below always carries all of ALLOWED_PATHS, because
+        # apply_candidate needs every admitted path's current bytes to
+        # reconstruct the tree, changed or not, but "paths" describes the delta.
+        "paths": [path for path in ALLOWED_PATHS if path in evidence.paths],
         "files": files,
     }
     _validate_candidate(
@@ -264,6 +319,7 @@ def apply_candidate(
         if _sha256(content) != value["files"][path]:
             raise ArtifactError(f"artifact bytes for {path} differ from their digest")
     for path in ALLOWED_PATHS:
+        (workspace / path).parent.mkdir(parents=True, exist_ok=True)
         (workspace / path).write_bytes((artifact_dir / path).read_bytes())
     _git(workspace, "add", "--", *ALLOWED_PATHS)
 

--- a/scripts/test-kin-registry-release-receiver.py
+++ b/scripts/test-kin-registry-release-receiver.py
@@ -137,7 +137,17 @@ def initialize_repo(repo: Path) -> str:
     (repo / "Cargo.toml").write_text(manifest(), encoding="utf-8")
     (repo / "Cargo.lock").write_text("version = 4\nkin-db 0.7.67\n", encoding="utf-8")
     (repo / "README.md").write_text("base\n", encoding="utf-8")
-    run_git(repo, "add", "Cargo.toml", "Cargo.lock", "README.md")
+    # A baseline fuzz/Cargo.lock, mirroring the real repo shape: fuzz/Cargo.lock
+    # is always a tracked file there, so ALLOWED_PATHS admits it as a path that
+    # may be absent from a given wave's diff, never as a path absent from the
+    # tree. Seeding it here keeps every other fixture's diff exactly as before
+    # (an untouched tracked file produces no diff entry) and lets the two
+    # fixtures that do touch it below register as modifications, not adds.
+    (repo / "fuzz").mkdir(parents=True, exist_ok=True)
+    (repo / "fuzz" / "Cargo.lock").write_text(
+        "version = 4\nkin-model 0.7.23\n", encoding="utf-8"
+    )
+    run_git(repo, "add", "Cargo.toml", "Cargo.lock", "README.md", "fuzz/Cargo.lock")
     run_git(repo, "commit", "-q", "-m", "base")
     return run_git(repo, "rev-parse", "HEAD")
 
@@ -165,6 +175,7 @@ def commit_dependency_head(
     lock_version: str = "0.7.69",
     marker: bool = True,
     readme: str | None = None,
+    fuzz_lock_version: str | None = None,
 ) -> str:
     (repo / "Cargo.toml").write_text(
         manifest(dependency, workspace_version=workspace_version, extra=extra),
@@ -175,6 +186,13 @@ def commit_dependency_head(
     )
     if readme is not None:
         (repo / "README.md").write_text(readme, encoding="utf-8")
+    if fuzz_lock_version is not None:
+        # A modification, not an add: initialize_repo already committed a
+        # baseline fuzz/Cargo.lock, matching how the real wave only ever
+        # rewrites an already-tracked file.
+        (repo / "fuzz" / "Cargo.lock").write_text(
+            f"version = 4\nkin-model {fuzz_lock_version}\n", encoding="utf-8"
+        )
     run_git(repo, "add", "-A")
     message = "dependency wave"
     if marker:
@@ -696,7 +714,10 @@ class HeadAdmissionTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             repo = Path(directory)
             base = initialize_repo(repo)
-            head = commit_dependency_head(repo)
+            # Touches all three admitted paths, so evidence.paths below covers
+            # the full ALLOWED_PATHS set, including the detached fuzz workspace
+            # lock the receiver now regenerates alongside the root pins.
+            head = commit_dependency_head(repo, fuzz_lock_version="0.7.24")
             reviews, comments = attestation_documents(repo, base, head)
             evidence = head_guard.validate_attestation(
                 repo,
@@ -2377,6 +2398,9 @@ class WorkflowContractTests(unittest.TestCase):
         admission = step_block(
             self.workflow, "Admit the generated dependency delta before compilation"
         )
+        fuzz_lock = step_block(
+            self.workflow, "Update the detached fuzz workspace lock to match"
+        )
         self.assertIn(
             "run: cargo check --locked -p kin-core -p kin-cli -p kin-daemon -p kin-mcp",
             smoke,
@@ -2386,7 +2410,16 @@ class WorkflowContractTests(unittest.TestCase):
             self.assertIn("--bump-own-version false", block)
         self.assertIn("expected_tree=", snapshot)
         self.assertIn('--expected-tree "$EXPECTED_TREE"', admission)
+        # This has to run before the snapshot below, not after: every later
+        # re-check in this pipeline (apply_candidate's re-validation in
+        # mutate-wave, and the final verify-generated-head check against the
+        # pushed PR head) compares against the tree the snapshot step records,
+        # so fuzz/Cargo.lock has to already be in the working tree by then.
+        self.assertIn("if: steps.update.outputs.changed == 'true'", fuzz_lock)
+        self.assertIn("cargo update --manifest-path fuzz/Cargo.toml", fuzz_lock)
+        self.assertIn("git add fuzz/Cargo.lock", fuzz_lock)
         prepare_names = [
+            "Update the detached fuzz workspace lock to match",
             "Snapshot the exact generated dependency delta",
             "Admit the generated dependency delta before compilation",
             "Build the hash-bound data-only candidate handoff",
@@ -2446,6 +2479,7 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("add-paths: |", writer)
         self.assertIn("Cargo.lock", writer)
         self.assertIn("Cargo.toml", writer)
+        self.assertIn("fuzz/Cargo.lock", writer)
         self.assertIn("ADMITTED_BASE", verifier)
         self.assertIn(".base.sha", verifier)
         self.assertIn(".auto_merge == null", verifier)

--- a/scripts/test-kin-registry-wave-landing.py
+++ b/scripts/test-kin-registry-wave-landing.py
@@ -93,20 +93,46 @@ def initialize_repo(repo: Path) -> str:
     (repo / "Cargo.toml").write_text(manifest(), encoding="utf-8")
     (repo / "Cargo.lock").write_text("version = 4\nkin-db 0.7.67\n", encoding="utf-8")
     (repo / "README.md").write_text("base\n", encoding="utf-8")
+    # A baseline fuzz/Cargo.lock, mirroring the real repo: it is always a
+    # tracked file there, so ALLOWED_PATHS admits it as a path a given wave's
+    # diff may leave untouched, never as a path absent from the tree. Seeding
+    # it here leaves every fixture that never touches it unaffected (an
+    # untouched tracked file produces no diff entry) and lets commit_wave's
+    # optional fuzz_lock_version below register as a modification, not an add.
+    (repo / "fuzz").mkdir(parents=True, exist_ok=True)
+    (repo / "fuzz" / "Cargo.lock").write_text(
+        "version = 4\nkin-model 0.7.23\n", encoding="utf-8"
+    )
     run_git(repo, "add", "-A")
     run_git(repo, "commit", "-q", "-m", "base")
     return run_git(repo, "rev-parse", "HEAD")
 
 
-def write_pins(repo: Path, dependency: str, lock_version: str) -> None:
+def write_pins(
+    repo: Path,
+    dependency: str,
+    lock_version: str,
+    *,
+    fuzz_lock_version: str | None = None,
+) -> None:
     (repo / "Cargo.toml").write_text(manifest(dependency), encoding="utf-8")
     (repo / "Cargo.lock").write_text(
         f"version = 4\nkin-db {lock_version}\n", encoding="utf-8"
     )
+    if fuzz_lock_version is not None:
+        (repo / "fuzz" / "Cargo.lock").write_text(
+            f"version = 4\nkin-model {fuzz_lock_version}\n", encoding="utf-8"
+        )
 
 
-def commit_wave(repo: Path, dependency: str = "=0.7.69", lock_version: str = "0.7.69") -> str:
-    write_pins(repo, dependency, lock_version)
+def commit_wave(
+    repo: Path,
+    dependency: str = "=0.7.69",
+    lock_version: str = "0.7.69",
+    *,
+    fuzz_lock_version: str | None = None,
+) -> str:
+    write_pins(repo, dependency, lock_version, fuzz_lock_version=fuzz_lock_version)
     run_git(repo, "add", "-A")
     run_git(repo, "commit", "-q", "-m", f"dependency wave\n\n{head_guard.COMMIT_MARKER}")
     return run_git(repo, "rev-parse", "HEAD")
@@ -1149,7 +1175,11 @@ class AdmittedHeadTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             repo = Path(directory)
             base = initialize_repo(repo)
-            admitted_head = commit_wave(repo)
+            # fuzz_lock_version touches all three admitted paths, so
+            # evidence.paths below covers the full ALLOWED_PATHS set, including
+            # the detached fuzz workspace lock the receiver now regenerates
+            # alongside the root pins.
+            admitted_head = commit_wave(repo, fuzz_lock_version="0.7.24")
             admitted = head_guard.validate_delta(repo, base, admitted_head, require_marker=True)
             tip = advance_main(repo, base)
             run_git(repo, "cherry-pick", admitted_head)

--- a/scripts/verify-kin-registry-wave-head.py
+++ b/scripts/verify-kin-registry-wave-head.py
@@ -31,7 +31,16 @@ ATTESTATION_CREATOR_ID = 308181894
 COMMIT_MARKER = "Kin-Registry-Dependency-Wave: v1"
 RECEIVER_WORKFLOW_NAME = "Kin Registry Release Receiver"
 RECEIVER_WORKFLOW_PATH = ".github/workflows/kin-registry-release.yml"
-ALLOWED_PATHS = frozenset({"Cargo.toml", "Cargo.lock"})
+# fuzz/Cargo.lock: the detached fuzz workspace's own lock (fuzz/Cargo.toml
+# declares its own empty [workspace] table). kin-parser's workspace = true
+# dependency inheritance still pulls its kin-model pin from THIS repo's root
+# Cargo.toml, so a registry wave that moves the root pins can desync fuzz's
+# lock against them; kin#1444 is the second time that broke the Fuzz workflow.
+# The receiver now regenerates fuzz/Cargo.lock in the same job that updates
+# the root pins (kin-registry-release.yml), so it has to be an admitted path
+# here too, or that regeneration would itself be refused as an unexpected
+# change.
+ALLOWED_PATHS = frozenset({"Cargo.toml", "Cargo.lock", "fuzz/Cargo.lock"})
 LOWER_SHA = re.compile(r"^[0-9a-f]{40}$")
 VERSION_EVIDENCE = re.compile(r"^(?:absent|[0-9A-Za-z.+-]+)$")
 


### PR DESCRIPTION
The dependency wave updates the root lockfile and never touches `fuzz/Cargo.lock`. `fuzz/Cargo.toml` declares its own empty `[workspace]` table, so that package is detached from the parent workspace and carries a separate lock, and `.github/workflows/fuzz.yml` enforces the committed lock with `cargo metadata --locked` plus a check that the build did not rewrite it. So every wave that moves a pin turns both `cargo-fuzz` jobs red.

## The manual fix could never have survived, and that is demonstrated rather than argued

Branch `chore/lane-fuzzlock-kin` carries a single commit from three weeks ago, "Regenerate the fuzz lock for the kin-model 0.7.8 and kin-vector 0.1.11 pins", touching only `fuzz/Cargo.lock`. The same wall, patched by hand.

Tonight showed why that could never hold. A hand-pushed `fuzz/Cargo.lock` fix turned PR #1444's fuzz jobs green at around 21:00. At 21:41:47Z the wave regenerated on top of `fdecafd5c`, producing head `4b9a69be4`, which touches `Cargo.toml` and `Cargo.lock` and nothing else. The fix was simply gone, because the wave rebuilds that branch from scratch rather than amending it.

So a manual lock regeneration on `automation/kin-registry-dependency-wave` is ephemeral by construction. The three-week-old fix did not merely fail to teach the tooling; it could not have survived even if nobody had touched it again. That is why this change is in the generator.

It also means PR #1444 needs neither rescuing nor abandoning. It self-heals on each regeneration and stays red until this lands.

## What changed

Three edits that only work together.

`kin-registry-release.yml` gets a step running `cargo update --manifest-path fuzz/Cargo.toml` in the same job that updates the root pins, before the delta is snapshotted.

`--manifest fuzz/Cargo.toml` is added at all three validator invocations. The kin-actions validator derives a lockfile only for a manifest the caller actually lists, so without this the new validator behaves exactly like the old one and rejects the staged lock.

`KIN_ACTIONS_SHA` moves to `b424aa4f22684d91abe43d23fa7c4ab5b27c9a2f` (v0.1.34), which carries that derivation:

```python
locks = {"Cargo.lock"}
locks.update(
    PurePosixPath(path).with_name("Cargo.lock").as_posix()
    for path in manifest_paths
)
allowed = set(manifest_paths)
allowed.update(lock for lock in sorted(locks) if tracked_at_head(lock))
```

Sibling derivation per listed manifest, with the root lock still admitted unconditionally, so the allowlist stays closed. Verified present at that exact sha rather than only on the merge commit.

`verify-kin-registry-wave-head.py` and `kin-registry-wave-artifact.py` both admit `fuzz/Cargo.lock` as a third write-set path. Widening that set from two entries to three surfaced three real latent bugs in `kin-registry-wave-artifact.py`, all fixed here: a missing parent-directory mkdir, a directory listing check that only looked at the top level, and a candidate `paths` field hardcoded to the full allowlist instead of derived from the actual diff. None were reachable while the set held two entries that happened to be siblings.

## Why this class kept surviving

The same allowlist lives in three places across two repos. Two were taught about the detached fuzz lock and one was not, and nothing graded the seam. That is the shape to check for on review: when an invariant is enforced in more than one place, what tests the boundary? kin-actions v0.1.34 carries a test that fails when a wave changes a lockfile the validator does not admit, so this particular seam now has a grader.

## Tests

`test-kin-registry-release-receiver.py` (59) and `test-kin-registry-wave-landing.py` (64) extended rather than duplicated, both green. Falsified by reverting the workflow half and watching three assertions go red for the right reasons: missing step, missing add-paths entry, and ALLOWED_PATHS drift. Restored, green again. Full red and green output is in the lane report.
