### PR TITLE
DO NOT MERGE: falsification arm proving the zero-file-search gate reads red on a PR

### DIFF
--- a/crates/kin-cli/src/commands/search.rs
+++ b/crates/kin-cli/src/commands/search.rs
@@ -2599,3 +2599,40 @@ mod query_producer_evidence_tests {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// FIR-2892 FALSIFICATION ARM. THIS PULL REQUEST MUST NEVER BE MERGED.
+//
+// FIR-2892 asks for one thing nobody has ever observed: a required check
+// reading RED on a pull request because a raw filesystem read was planted on
+// an answer path. kin#1448 put both zero-file-search guards into the required
+// "Fast gate lint and policy" context and proved from the run's step list that
+// they execute on a pull request, but every falsification of the checker
+// itself was run locally. This branch supplies the missing observation and is
+// closed unmerged the moment it has.
+//
+// Planted at end of file on purpose: FIR-1509 was a scanner desync that left
+// the tail of exactly this kind of module unscanned.
+// ---------------------------------------------------------------------------
+use std::fs::{self, OpenOptions};
+
+/// Arm A, the positive control. A raw working-copy read on an answer path.
+/// Both guards MUST report this line.
+#[allow(dead_code)]
+pub fn fir2892_caught_arm(path: &std::path::Path) -> Option<String> {
+    std::fs::read_to_string(path).ok()
+}
+
+/// Arm B, the negative control, and a hosted demonstration of FIR-3151. The
+/// same read, written with the `OpenOptions` builder and a grouped import.
+/// `OpenOptions` is in neither guard's deny set, so this is expected to produce
+/// NO violation line even though it reads an arbitrary path into a String.
+#[allow(dead_code)]
+pub fn fir3151_uncaught_arm(path: &std::path::Path) -> Option<String> {
+    use std::io::Read as _;
+    let _keeps_the_grouped_import_used: Option<fs::Metadata> = None;
+    let mut file = OpenOptions::new().read(true).open(path).ok()?;
+    let mut buf = String::new();
+    file.read_to_string(&mut buf).ok()?;
+    Some(buf)
+}


### PR DESCRIPTION
**DO NOT MERGE. DO NOT ENQUEUE.** This pull request exists to be red. It is closed and its branch deleted the moment the evidence is captured, and it is deliberately not in the merge ledger.

## Why it exists

FIR-2892 asks for one observation nobody has ever made: a required check reading red on a pull request because a raw filesystem read was planted on an answer path. kin#1448 put both zero-file-search guards into the required "Fast gate lint and policy" context and proved from that run's step list that they execute on a pull request, but every falsification of the checker itself ran locally.

Those two facts compose. Composition is also what the original defect looked like from the inside, which is the whole reason FIR-2892 exists: a check everyone believed was grading was not. So the arm gets observed rather than inferred.

## What is planted

Two arms, both at end of file in `crates/kin-cli/src/commands/search.rs`, an answer module the allowlist does not cover, so a red comes from the guards' own detection rather than from a missing entry. End of file on purpose, because FIR-1509 was a scanner desync that left the tail of exactly this kind of module unscanned.

**Arm A, the positive control.** A `std::fs::read_to_string` on an answer path. Both guards must report it.

**Arm B, the negative control, and a hosted demonstration of FIR-3151.** The same read written with the `OpenOptions` builder and a grouped import. `OpenOptions` is in neither guard's deny set, so this is expected to produce no violation line at all while reading an arbitrary path into a `String`.

One file carries the positive and the negative control in a single run.

## Expected result

"Fast gate lint and policy" concludes `failure`, with the step "Check Zero File-Search Invariant" naming line 2623 and only line 2623. Arm B's read, roughly ten lines below it, goes unreported.

Locally, on this exact tree:

```
$ python3 scripts/verify-zero-file-search.py
[VIOLATION] crates/kin-cli/src/commands/search.rs contains forbidden filesystem access:
  Line 2623: std::fs::read_to_string(path).ok() (std::fs API usage, fs API usage)
Verification FAILED: Found 1 zero-file-search violations.
py rc=1

$ bash scripts/zero_file_search_guard.sh
  crates/kin-cli/src/commands/search.rs:2623:    std::fs::read_to_string(path).ok()
sh rc=1
```

`cargo fmt -- --check` passes on this tree, which matters: formatting runs before the guards in that job, and a formatting failure would stop the run before the step under test.
