### PR TITLE
Let a release mint and promote on its preflight record alone

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -90,6 +90,7 @@ jobs:
       candidate: ${{ steps.select.outputs.candidate }}
       rc_run: ${{ steps.select.outputs.rc_run }}
       move: ${{ steps.select.outputs.move }}
+      stranger_state: ${{ steps.select.outputs.stranger_state }}
       reason: ${{ steps.select.outputs.reason }}
     steps:
       # The literal trusted context value, as in kin-registry-wave-land.yml.
@@ -872,8 +873,9 @@ jobs:
           {
             echo "## Both proof records are filed for \`${CANDIDATE}\`"
             echo ""
-            echo "The mint selects the newest fully evidenced sha in the version range on its"
-            echo "next evaluation, which is its cron or any completed CI run for a main push."
+            echo "The mint already selects any sha in the range carrying \`preflight.json\`. With"
+            echo "\`stranger.env\` filed too, the release it cuts also claims first-contact coverage"
+            echo "and is eligible for GitHub Latest instead of shipping as a prerelease."
           } >> "$GITHUB_STEP_SUMMARY"
 
   # No runner, so say so loudly and hand over the exact command. This is the

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -873,9 +873,10 @@ jobs:
           {
             echo "## Both proof records are filed for \`${CANDIDATE}\`"
             echo ""
-            echo "The mint already selects any sha in the range carrying \`preflight.json\`. With"
-            echo "\`stranger.env\` filed too, the release it cuts also claims first-contact coverage"
-            echo "and is eligible for GitHub Latest instead of shipping as a prerelease."
+            echo "The mint already selects any sha in the range carrying \`preflight.json\`, and the"
+            echo "release it cuts becomes GitHub Latest either way. With \`stranger.env\` filed too,"
+            echo "that release also gets to claim first-contact coverage instead of carrying a"
+            echo "pending notice saying nobody measured what a first-time user meets."
           } >> "$GITHUB_STEP_SUMMARY"
 
   # No runner, so say so loudly and hand over the exact command. This is the

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -5,17 +5,25 @@ name: Release Promotion
 
 # Finishes a release whose first-contact proof arrived after its tag.
 #
-# The release chain has two tiers. release-tag.yml mints a tag on the machine
-# preflight alone, so a candidate is never held hostage to a driver; release.yml
-# publishes it as a prerelease and writes into its body that first-contact proof
-# is pending. GitHub Latest, which is what an installer resolves when a stranger
-# types the install line, still requires the complete stranger record.
+# release-tag.yml mints a tag on the machine preflight alone and release.yml
+# publishes and promotes it, writing into its body that first-contact proof is
+# pending. Nothing waits for the stranger any more, so what this workflow
+# finishes is the RECORD rather than the release: the pending notice has to come
+# back out once the record lands, or a measured release goes on claiming it was
+# never measured.
 #
-# Without this workflow that second tier would be a dead end: the record lands
-# on the evidence branch hours later and nothing would notice. A push to the
+# Without this workflow that would be a dead end: the record lands on the
+# evidence branch hours later and nothing would notice. A push to the
 # release-evidence branch cannot trigger anything either, because that branch is
 # an orphan carrying no workflow files, so GitHub resolves no workflow from the
 # pushed ref. Hence a sweep.
+#
+# KNOWN GAP, tracked as FIR-3152. selectCandidates in
+# scripts/release-promotion-plan.mjs still filters on `prerelease === true`,
+# which was how a held release was recognised. Nothing is held now, so this
+# sweep finds nothing, the notice is never stripped, and the
+# "Release published without first-contact proof" alarm never fires. Fixing it
+# means selecting on the pending marker instead of on the prerelease flag.
 on:
   # Offset from the train (7,22,37,52), recovery and the cut (3,18,33,48) and
   # the sentinel (11,41), so this reads a settled rail rather than one
@@ -112,7 +120,7 @@ jobs:
             for package in @kinlab/kin @kinlab/kin-mcp; do
               npm_version="$(node scripts/release-order.mjs npm-channel "$package" "$channel")"
               if [ "$npm_version" != "$version" ]; then
-                echo "::error::npm ${package}@${channel} serves ${npm_version}; ${tag} stays a prerelease"
+                echo "::error::npm ${package}@${channel} serves ${npm_version}; refusing to move GitHub Latest to ${tag}"
                 exit 1
               fi
             done

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -268,10 +268,11 @@ jobs:
             # take both records, and that made the listing stricter than the
             # gate it feeds, so a preflight-only sha was never proposed and the
             # mint no-opped in silence while the gate that would have admitted
-            # it never saw a candidate. `stranger.env` still decides what the
-            # release may CLAIM: release.yml keeps a stranger-pending release a
-            # prerelease and off GitHub Latest, and the summary below records
-            # which of the two this mint tagged. This is what lets
+            # it never saw a candidate. `stranger.env` no longer holds anything
+            # either: it decides only what the release may CLAIM. A release
+            # missing it is tagged, published and promoted like any other and
+            # carries a pending notice, and the summary below records which of
+            # the two this mint tagged. This is what lets
             # main keep moving through a proof window. The candidate used to be
             # the head of the version bump branch, and the train rewrites that
             # head every cycle it finds drift, so evidence published for it went
@@ -1871,7 +1872,7 @@ jobs:
           if [ "$stranger_state" = pending ]; then
             # A warning, not an error. The release proceeds and says what it is
             # missing; a red run here would put the rail back where it was.
-            echo "::warning::first-contact proof is PENDING for $SHA: no stranger.env exists, so $TAG will be published as a prerelease and will not become GitHub Latest until the stranger record lands"
+            echo "::warning::first-contact proof is PENDING for $SHA: no stranger.env exists, so nothing has measured what a first-time user meets. $TAG is tagged and promoted anyway and carries a pending notice until the stranger record lands"
           else
             echo "::notice::first-contact proof complete for $SHA on arms ${stranger_arms}, driven on the ${stranger_driver} endpoint"
           fi
@@ -1985,10 +1986,10 @@ jobs:
           fi
           if [ "$STRANGER_STATE" = complete ]; then
             first_contact="complete on arms \`${STRANGER_ARMS}\`, driven on the \`${STRANGER_DRIVER}\` endpoint"
-            claim="This tag carries first-contact proof and its release is eligible for GitHub Latest."
+            claim="This tag carries first-contact proof, so its release claims first-contact coverage rather than carrying a pending notice."
           else
             first_contact="**pending** (no \`stranger.env\`)"
-            claim="This tag was minted on the machine preflight alone. Nothing has measured what a first-time user meets, so \`release.yml\` publishes it as a prerelease and holds GitHub Latest until the stranger record lands."
+            claim="This tag was minted on the machine preflight alone. Nothing has measured what a first-time user meets. It is published and promoted anyway, and \`release.yml\` stamps that gap onto the release body until the stranger record lands."
           fi
           {
             echo "## Release tag minted"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -260,7 +260,18 @@ jobs:
             done < <(git log --first-parent --format=%H "$sha" -- Cargo.toml)
 
             # The release is the NEWEST reviewed main commit in that range for
-            # which the proof loop published both records. This is what lets
+            # which the proof loop published `preflight.json`. The machine
+            # preflight alone is what makes a candidate mint-eligible, matching
+            # the preflight-only require tier the gate below runs: a
+            # stranger that has not run, because a runner is offline or a
+            # weekly limit was reached, must not hold a release. It used to
+            # take both records, and that made the listing stricter than the
+            # gate it feeds, so a preflight-only sha was never proposed and the
+            # mint no-opped in silence while the gate that would have admitted
+            # it never saw a candidate. `stranger.env` still decides what the
+            # release may CLAIM: release.yml keeps a stranger-pending release a
+            # prerelease and off GitHub Latest, and the summary below records
+            # which of the two this mint tagged. This is what lets
             # main keep moving through a proof window. The candidate used to be
             # the head of the version bump branch, and the train rewrites that
             # head every cycle it finds drift, so evidence published for it went
@@ -313,13 +324,12 @@ jobs:
             fi
             jq -r '
               [.tree[] | select(.type == "blob") | .path]
-              | map(capture("^evidence/(?<sha>[0-9a-f]{40})/(?<name>preflight\\.json|stranger\\.env)$"))
-              | group_by(.sha)
-              | map(select((map(.name) | unique | length) == 2) | .[0].sha)
+              | map(capture("^evidence/(?<sha>[0-9a-f]{40})/preflight\\.json$") | .sha)
+              | unique
               | .[]
             ' <<< "$listing" > "$proven"
             recorded="$(command grep -c '' "$proven" || true)"
-            echo "proof loop has recorded ${recorded} fully-evidenced candidate(s)"
+            echo "proof loop has recorded ${recorded} mint-eligible candidate(s) carrying preflight.json"
 
             candidate=""
             if [ -s "$proven" ]; then
@@ -1925,6 +1935,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           ACTOR: ${{ github.actor }}
+          # What the proof gate decided this tag is allowed to claim. The mint
+          # computed it three steps ago and, until 2026-09-04, wrote it only to
+          # GITHUB_OUTPUT, which nothing in this workflow read back. A mint that
+          # now tags on the machine preflight alone has to say so in its own
+          # record, or a release minted without first-contact proof is
+          # indistinguishable from one that has it.
+          STRANGER_STATE: ${{ steps.proof.outputs.stranger_state }}
+          STRANGER_ARMS: ${{ steps.proof.outputs.stranger_arms }}
+          STRANGER_DRIVER: ${{ steps.proof.outputs.stranger_driver }}
         run: |
           set -euo pipefail
           # The ref was just created, and the API is read-after-write eventually
@@ -1964,6 +1983,13 @@ jobs:
             echo "::error::post-verify failed: tag $TAG points at $got, not $SHA"
             exit 1
           fi
+          if [ "$STRANGER_STATE" = complete ]; then
+            first_contact="complete on arms \`${STRANGER_ARMS}\`, driven on the \`${STRANGER_DRIVER}\` endpoint"
+            claim="This tag carries first-contact proof and its release is eligible for GitHub Latest."
+          else
+            first_contact="**pending** (no \`stranger.env\`)"
+            claim="This tag was minted on the machine preflight alone. Nothing has measured what a first-time user meets, so \`release.yml\` publishes it as a prerelease and holds GitHub Latest until the stranger record lands."
+          fi
           {
             echo "## Release tag minted"
             echo ""
@@ -1973,7 +1999,11 @@ jobs:
             echo "| sha | \`$SHA\` |"
             echo "| actor | \`$ACTOR\` |"
             echo "| repo | \`$REPO\` |"
+            echo "| first contact | ${first_contact} |"
+            echo ""
+            echo "$claim"
             echo ""
             echo "Tag ref created with the kin-release-bot installation token, which triggers the fail-closed \`release.yml\` DAG."
           } >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice::minted $TAG at $SHA with first-contact proof ${STRANGER_STATE}"
           echo "release tag $TAG minted and verified at $SHA"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1738,14 +1738,21 @@ jobs:
       # whose failure mode is "no tag, forever, quietly" is not protecting the
       # release, it is preventing it.
       #
-      # What replaces it is not less proof, it is proof at the point the claim is
-      # made. A tag is not a claim of first-contact coverage; GitHub Latest is,
-      # because that is the version an installer resolves. release.yml's
-      # finalize_release still requires the complete stranger record before it
-      # flips a release out of prerelease, so a release with no first-contact
-      # proof exists, is installable by anyone who names it, and never becomes
-      # the one a stranger gets by default. The record cannot claim coverage it
-      # does not have, and the release stops being hostage to a driver.
+      # What replaced it, from 2026-09-02, was proof at the point the claim is
+      # made: the tag moved on the preflight and GitHub Latest still required
+      # the stranger record. That held the line in the wrong place. Latest is
+      # what an installer resolves, so holding it kept a finished, installable
+      # release out of every default install path while every machine signal
+      # was green, for want of a driver nobody could summon. Founder decision,
+      # 2026-09-03: "I dont even want that to block. If I run out of limit.
+      # Ship anyways. Stranger is nice to have."
+      #
+      # So since 2026-09-04 nothing waits, and what replaces the hold is a
+      # LABEL. The tag, the release and Latest all move on the preflight, and a
+      # release with no first-contact proof says so on its own body, in this
+      # mint's step summary, and in release.yml's promote summary. The record
+      # still cannot claim coverage it does not have. What it no longer does is
+      # withhold the release while it lacks it.
       #
       # `require: preflight` narrows exactly one condition: an ABSENT
       # stranger.env becomes a reported pending state. A stranger record that

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -732,13 +732,18 @@ jobs:
       #
       # The refusal did not go away, it moved to the artifact that actually
       # ships. release-tag.yml now selects the newest main commit carrying the
-      # staged version for which the proof loop published records, and refuses
-      # to create the tag ref without them. That is the stronger placement: a
-      # tag run resolves its workflows from the tag and can never be repaired,
-      # so refusing before the ref exists beats refusing after. release.yml's
-      # finalize_release still refuses to promote a tag with no records, so both
-      # decision points keep importing one judge. What this branch's head is at
-      # any moment no longer decides anything, which is what lets main move.
+      # staged version for which the proof loop published `preflight.json`, and
+      # refuses to create the tag ref without it. That is the stronger
+      # placement: a tag run resolves its workflows from the tag and can never
+      # be repaired, so refusing before the ref exists beats refusing after.
+      # release.yml's finalize_release imports the same judge before it
+      # publishes, so both decision points keep one judge rather than two.
+      #
+      # `stranger.env` is not part of either refusal. Since 2026-09-04 a missing
+      # first-contact record labels the release rather than holding it, because
+      # a driver nobody can summon must not be able to stop a finished release.
+      # What this branch's head is at any moment no longer decides anything,
+      # which is what lets main move.
       - name: Arm protected auto-merge
         if: steps.plan.outputs.needed == 'true'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2514,7 +2514,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "release proof records verified for $CANDIDATE_SHA, the commit this job promotes"
           if [ "$stranger_state" = pending ]; then
-            echo "::warning::first-contact proof is PENDING for ${GITHUB_REF_NAME}; this release stays a prerelease and will not become GitHub Latest until its stranger.env lands"
+            echo "::warning::first-contact proof is PENDING for ${GITHUB_REF_NAME}; it is published and promoted anyway and carries a pending notice until its stranger.env lands"
           else
             echo "::notice::first-contact proof complete on arms ${stranger_arms}, driven on the ${stranger_driver} endpoint"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2391,8 +2391,8 @@ jobs:
     environment: release
     # Whether this release actually became GitHub Latest, for the jobs whose
     # whole meaning is "this IS Latest". They gate on it rather than on this
-    # job's conclusion, because a release held as a prerelease for want of
-    # first-contact proof is a SUCCESSFUL run of this job and a release that
+    # job's conclusion, because this job succeeds on paths that promote nothing:
+    # a prerelease tag never runs the promote step at all, and such a release
     # must not move GHCR's `latest` or be sealed as a completed stable release.
     outputs:
       promoted: ${{ steps.promote.outputs.promoted }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2526,9 +2526,8 @@ jobs:
       - name: Record the missing first-contact proof on the release itself
         # Stable tags only. A prerelease TAG is a prerelease because that is
         # what it is, not because proof is missing, and it never becomes Latest
-        # whatever its record says. Telling a reader that an rc "stays a
-        # prerelease until its record lands" would promise something no path in
-        # this chain delivers.
+        # whatever its record says, so the notice would be answering a question
+        # nobody installing an rc is asking.
         if: >-
           ${{
             steps.proof.outputs.stranger_state == 'pending' &&
@@ -2553,19 +2552,23 @@ jobs:
           ${marker}
           > **First-contact proof pending.** This release cleared the machine preflight on its
           > own bytes. It has NOT been through the stranger arms (green, brown, vcs) that
-          > measure what a first-time user actually meets. It stays a prerelease and is not
-          > GitHub Latest until that record lands. Install it only if you meant this exact
-          > version.
+          > measure what a first-time user actually meets. It ships and is promoted anyway,
+          > so this notice is how you tell it apart from a release that was measured.
 
           NOTE
           printf '%s\n' "$body" >> "$RUNNER_TEMP/release-body.md"
           gh release edit "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
             --notes-file "$RUNNER_TEMP/release-body.md"
 
-      # Latest is the claim of first-contact coverage, so this is where the
-      # stranger record is required. `promoted` is written on BOTH paths,
-      # because a downstream job reading an unset output cannot tell "held" from
-      # "this step never ran".
+      # First contact is a LABEL, not a gate (founder decision 2026-09-03:
+      # "I dont even want that to block. If I run out of limit. Ship anyways.
+      # Stranger is nice to have."). Latest used to require the stranger record
+      # here, which meant an offline runner or a spent weekly limit could keep a
+      # finished, installable release off /releases/latest indefinitely while
+      # every machine signal was green. It now says what it is missing, on the
+      # release body and in this summary, and promotes. `promoted` is still
+      # written explicitly, because a downstream job reading an unset output
+      # cannot tell a decision from a step that never ran.
       - name: Promote stable tag after public and npm proof
         id: promote
         if: ${{ !contains(github.ref_name, '-') }}
@@ -2575,17 +2578,17 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$STRANGER_STATE" != complete ]; then
-            echo "promoted=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::holding ${GITHUB_REF_NAME} as a prerelease: first-contact proof is ${STRANGER_STATE}"
+            echo "::warning::promoting ${GITHUB_REF_NAME} with first-contact proof ${STRANGER_STATE}: nothing has measured what a first-time user meets"
             {
-              echo "### GitHub Latest held"
+              echo "### Promoted with first contact ${STRANGER_STATE}"
               echo
-              echo "\`${GITHUB_REF_NAME}\` is published and installable, and is NOT GitHub Latest."
+              echo "\`${GITHUB_REF_NAME}\` becomes GitHub Latest on its machine preflight alone."
               echo "Its stranger record is \`${STRANGER_STATE}\`, so nothing here has been through the"
-              echo "green, brown and vcs first-contact arms. Latest moves on its own once that record"
-              echo "lands under this commit on the release-evidence branch."
+              echo "green, brown and vcs first-contact arms. The release body carries that notice, and"
+              echo "this is the label rather than a hold."
             } >> "$GITHUB_STEP_SUMMARY"
-            exit 0
+          else
+            echo "::notice::promoting ${GITHUB_REF_NAME} with first-contact proof complete"
           fi
           echo "promoted=true" >> "$GITHUB_OUTPUT"
           version="${GITHUB_REF_NAME#v}"
@@ -2617,11 +2620,11 @@ jobs:
           expected=true
           case "$GITHUB_REF_NAME" in
             *-*) ;;
-            # A stable tag whose first-contact proof is still pending stays a
-            # prerelease ON PURPOSE, so this verification expects what the
-            # promote step above actually decided rather than what the tag's
-            # shape alone would imply. Read off that step's own output, so a
-            # promotion that silently failed to happen still fails here.
+            # Read the promote step's own output rather than the tag shape.
+            # Every stable tag is promoted now, whatever its first-contact
+            # record says, so this reads true on that path; keeping the output
+            # as the source means a promotion that silently failed to happen
+            # still fails here rather than being assumed from the tag name.
             *) [ "${PROMOTED:-}" = true ] && expected=false ;;
           esac
           if [ "$actual" != "$expected" ]; then

--- a/docs/release-bot.md
+++ b/docs/release-bot.md
@@ -93,8 +93,12 @@ changelog against newer code.
 ## Automatic release cut
 
 The mint tags the newest reviewed `main` commit in the staged version's range
-that carries both proof records under `evidence/<sha>/` on the `release-evidence`
-branch. `release-cut.yml` is what puts a record there without a captain.
+that carries `preflight.json` under `evidence/<sha>/` on the `release-evidence`
+branch. The machine preflight alone is what makes a candidate mint-eligible, and
+`stranger.env` beside it is a label on the release rather than a gate in front of
+it: a stranger that cannot run, because a runner is offline or a weekly limit is
+spent, must not hold a finished release. `release-cut.yml` is what puts a record
+there without a captain.
 
 It runs on a completed CI run for a `main` push, on a completed RC Build for a
 `release/v*-candidate` branch, on the typed `release_cut` repository dispatch
@@ -108,9 +112,12 @@ judgments are pure functions over one snapshot:
 1. `vX.Y.Z` already exists, so the cut is done.
 2. A sha in the range carries both records, so the mint owns it.
 3. The current candidate is kept until it is proven or dead. With `preflight.json`
-   recorded it waits for the stranger; alive with a usable RC Build it is proven;
-   alive with none it is armed again, twice at most.
-4. Otherwise the newest `main` commit in the range whose CI **and** Acceptance
+   recorded the mint can already tag it and the cut still runs the stranger,
+   because that record is what the release gets to claim; alive with a usable RC
+   Build it is proven; alive with none it is armed again, twice at most.
+4. A sha carries `preflight.json` alone, so the mint owns it and the cut stands
+   down rather than arming a newer sha it would only race.
+5. Otherwise the newest `main` commit in the range whose CI **and** Acceptance
    push runs concluded success, and whose required contexts each appear exactly
    once under push provenance, becomes the candidate.
 
@@ -160,8 +167,13 @@ gh secret set KIN_STRANGER_ANTHROPIC_API_KEY --repo firelock-ai/kin
 
 With the variable unset the cut still selects, arms and preflights, and the
 `stranger-standby` job prints the exact local command with all three arms named
-and raises a warning. Either way the mint stays refused for the missing
-`stranger.env` rather than being fed a partial one.
+and raises a warning. The mint tags either way. What a missing `stranger.env`
+costs is the claim, not the release: the mint's step summary carries a first
+contact row reading `pending`, `release.yml` stamps the same statement onto the
+release body behind the `<!-- kin-first-contact-proof -->` marker, and the
+release still becomes GitHub Latest. A partial record is still refused rather
+than accepted, because a record that overstates its own coverage is worse than
+no record.
 
 The driver takes its credential from `KIN_STRANGER_ANTHROPIC_API_KEY`, exported
 as `ANTHROPIC_API_KEY`. No harness change was needed: `driver_env_argv` unsets

--- a/scripts/select-release-candidate.py
+++ b/scripts/select-release-candidate.py
@@ -15,15 +15,16 @@ first candidate unmintable, and the host carrying the proof ran out of memory.
 This script is the selection half of the pipeline. `select` reads everything
 the decision rests on and answers one of four things:
 
-  stand-down  nothing to do now: the version is tagged, a fully evidenced sha
+  stand-down  nothing to do now: the version is tagged, a mint-eligible sha
               is waiting on the mint, an rc-build is still running, or no
               complete green sha exists yet
   arm         move release/v<version>-candidate to the chosen sha and dispatch
               rc-build.yml there
   proof       an rc-build for the current candidate succeeded and still holds
               the candidate archives; preflight them and publish the record
-  stranger    preflight.json is filed for the candidate and stranger.env is the
-              only missing half; run the three-arm stranger on the same archive
+  stranger    preflight.json is filed for the candidate, so the mint can tag it
+              already, and stranger.env is what would let the release claim
+              GitHub Latest; run the three-arm stranger on the same archive
   refuse      no reviewed main commit carrying the version qualifies, named sha
               by sha with the context that disqualified it
 
@@ -31,7 +32,8 @@ The rule, in the order it is applied:
 
 1. v<version> exists as a tag: the cut is done and the train owns the next
    version.
-2. A sha in the range carries both records: the mint owns it.
+2. A sha in the range carries both records: the mint owns it, and its release
+   may claim first-contact coverage.
 3. A current candidate, the branch tip, which must lie in the range, is kept
    until it is proven or dead. With its preflight recorded the stranger is what
    is left, and it must run on the very bytes that preflight judged, so a
@@ -42,7 +44,14 @@ The rule, in the order it is applied:
    attempts. Dead means a required
    context that is red or duplicated, a CI or Acceptance push run that did not
    conclude success, or exhausted rc-build attempts.
-4. Otherwise the newest main commit in the range whose CI and Acceptance push
+4. A sha in the range carries preflight.json alone: the mint owns it too. Since
+   2026-09-04 the mint tags on the machine preflight alone, matching the
+   KIN_RELEASE_REQUIRE=preflight tier its gate runs, so a stranger that cannot
+   run does not hold a release. The cut stands down rather than arming a newer
+   sha it would only race. `stranger_state` on the decision says which of the
+   two records backed it, and release.yml keeps a pending release a prerelease
+   and off GitHub Latest.
+5. Otherwise the newest main commit in the range whose CI and Acceptance push
    runs concluded success, and whose required contexts each appear exactly once
    under push provenance and concluded green, becomes the candidate. A sha still
    being graded is skipped rather than waited for: on a busy night the newest
@@ -73,6 +82,15 @@ BASE_BRANCH = "main"
 EVIDENCE_REF = "release-evidence"
 PREFLIGHT_RECORD = "preflight.json"
 STRANGER_RECORD = "stranger.env"
+# The first-contact vocabulary check-release-proof-artifacts.mjs returns in
+# `result.stranger.state`, and that release-tag.yml and release.yml both case
+# on. It is deliberately the gate's words rather than new ones, so a decision
+# this selector emits and a state a workflow read from the gate compare
+# directly. STRANGER_PENDING shares its value with the grading verdict PENDING
+# and means something else: PENDING is "this sha is still being graded",
+# STRANGER_PENDING is "no stranger.env exists for this candidate yet".
+STRANGER_COMPLETE = "complete"
+STRANGER_PENDING = "pending"
 CI_WORKFLOW = ".github/workflows/ci.yml"
 CI_WORKFLOW_NAME = "CI"
 ACCEPTANCE_WORKFLOW = ".github/workflows/acceptance.yml"
@@ -143,6 +161,12 @@ MOVE_CREATE = "create"
 MOVE_FAST_FORWARD = "fast-forward"
 MOVE_RESET = "reset"
 MOVE_NONE = "none"
+# Every key `_emit` writes to GITHUB_OUTPUT, in order. release-cut.yml's select
+# job republishes these as job outputs, and scripts/test-select-release-candidate.py
+# holds the two lists equal, so a value this selector decides cannot go missing
+# between the step that decided it and the jobs that read it. `reason` is written
+# separately because its newlines have to be flattened first.
+OUTPUT_KEYS = ("decision", "version", "branch", "candidate", "rc_run", "move", "stranger_state")
 
 
 class SelectionError(RuntimeError):
@@ -664,6 +688,12 @@ class Decision:
     candidate: str | None = None
     rc_run: int | None = None
     move: str | None = None
+    # First-contact state for the candidate this decision names, in the proof
+    # gate's own vocabulary, or None when the decision names no candidate. It
+    # is a field rather than a `details` key because `details` is a free-form
+    # bag that never reaches GITHUB_OUTPUT, and the whole point of this value
+    # is that a workflow reads it back.
+    stranger_state: str | None = None
     details: dict[str, Any] = field(default_factory=dict)
 
     def document(self) -> dict[str, Any]:
@@ -675,6 +705,7 @@ class Decision:
             "candidate": self.candidate,
             "rc_run": self.rc_run,
             "move": self.move,
+            "stranger_state": self.stranger_state,
             "details": self.details,
         }
 
@@ -752,8 +783,20 @@ def judge(snapshot: dict[str, Any], grade: Grader) -> Decision:
             version,
             branch,
             candidate=proven[0],
+            stranger_state=STRANGER_COMPLETE,
             details={"proven": proven},
         )
+
+    # Mint-eligible on the machine preflight alone. release-tag.yml lists any
+    # sha carrying preflight.json and runs its proof gate with
+    # KIN_RELEASE_REQUIRE=preflight, so a filed preflight is already a tag
+    # whether or not a stranger ever runs. The cut still files the stranger
+    # when it can, because that record is what promotes a release to GitHub
+    # Latest; what it no longer does is treat a missing one as a reason to hold
+    # the version. Computed here and consumed after the candidate block, so the
+    # STRANGER decision below stays reachable and release-cut.yml's stranger
+    # job keeps running.
+    mintable = [sha for sha in shas if PREFLIGHT_RECORD in records(sha)]
 
     dead: dict[str, list[str]] = {}
     notes: list[str] = []
@@ -782,20 +825,27 @@ def judge(snapshot: dict[str, Any], grade: Grader) -> Decision:
                     REFUSE,
                     f"preflight is recorded for {candidate} but no rc-build still holds the "
                     "archives it judged, so the stranger cannot run on the bytes the record "
-                    "names; this candidate can no longer be proven and the next landing "
-                    "supplies a new one",
+                    f"names; first contact can never be recorded for {candidate}, and the "
+                    "mint may still tag it with the stranger pending",
                     version,
                     branch,
                     candidate=candidate,
+                    stranger_state=STRANGER_PENDING,
                 )
             return Decision(
                 STRANGER,
-                f"preflight is recorded for {candidate}; the stranger record is the missing half",
+                f"preflight is recorded for {candidate}, which the mint can already tag; the "
+                "stranger record is what promotes the release to GitHub Latest, so run it "
+                "while the archives it must judge still exist",
                 version,
                 branch,
                 candidate=candidate,
                 rc_run=rc_run,
-                details={"stranger_command": stranger_command(version, candidate, rc_run)},
+                stranger_state=STRANGER_PENDING,
+                details={
+                    "stranger_command": stranger_command(version, candidate, rc_run),
+                    "mintable": mintable,
+                },
             )
         grade_of = grade(candidate)
         if grade_of.get("verdict") == PENDING:
@@ -847,6 +897,23 @@ def judge(snapshot: dict[str, Any], grade: Grader) -> Decision:
                     move=MOVE_NONE,
                     details={"attempts": spent},
                 )
+
+    if mintable:
+        # Nothing left for the cut to do on this version. The candidate block
+        # above already returned for a mintable current candidate, so reaching
+        # here means the mint owns a sha the cut has no further work on, and
+        # arming a newer one would only race the tag.
+        return Decision(
+            STAND_DOWN,
+            f"{mintable[0]} carries {PREFLIGHT_RECORD} and awaits the mint, which tags on the "
+            "machine preflight alone; first contact is still unrecorded, so the release will "
+            "ship as a prerelease naming that gap",
+            version,
+            branch,
+            candidate=mintable[0],
+            stranger_state=STRANGER_PENDING,
+            details={"mintable": mintable, "notes": notes},
+        )
 
     pending: dict[str, list[str]] = {}
     disqualified: dict[str, list[str]] = {}
@@ -982,7 +1049,7 @@ def _emit(decision: Decision) -> int:
     output = os.environ.get("GITHUB_OUTPUT")
     if output:
         with open(output, "a", encoding="utf-8") as handle:
-            for key in ("decision", "version", "branch", "candidate", "rc_run", "move"):
+            for key in OUTPUT_KEYS:
                 value = document.get(key)
                 handle.write(f"{key}={'' if value is None else value}\n")
             handle.write(f"reason={decision.reason.replace(chr(10), ' ')}\n")

--- a/scripts/select-release-candidate.py
+++ b/scripts/select-release-candidate.py
@@ -24,7 +24,7 @@ the decision rests on and answers one of four things:
               the candidate archives; preflight them and publish the record
   stranger    preflight.json is filed for the candidate, so the mint can tag it
               already, and stranger.env is what would let the release claim
-              GitHub Latest; run the three-arm stranger on the same archive
+              first-contact coverage; run the three-arm stranger on that archive
   refuse      no reviewed main commit carrying the version qualifies, named sha
               by sha with the context that disqualified it
 
@@ -46,11 +46,12 @@ The rule, in the order it is applied:
    conclude success, or exhausted rc-build attempts.
 4. A sha in the range carries preflight.json alone: the mint owns it too. Since
    2026-09-04 the mint tags on the machine preflight alone, matching the
-   KIN_RELEASE_REQUIRE=preflight tier its gate runs, so a stranger that cannot
-   run does not hold a release. The cut stands down rather than arming a newer
-   sha it would only race. `stranger_state` on the decision says which of the
-   two records backed it, and release.yml keeps a pending release a prerelease
-   and off GitHub Latest.
+   preflight-only tier its gate runs, so a stranger that cannot run does not
+   hold a release. The cut stands down rather than arming a newer sha it would
+   only race. `stranger_state` on the decision says which of the two records
+   backed it, and a release missing stranger.env is published and promoted like
+   any other, carrying a pending notice that says nobody has measured what a
+   first-time user meets.
 5. Otherwise the newest main commit in the range whose CI and Acceptance push
    runs concluded success, and whose required contexts each appear exactly once
    under push provenance and concluded green, becomes the candidate. A sha still
@@ -791,9 +792,10 @@ def judge(snapshot: dict[str, Any], grade: Grader) -> Decision:
     # sha carrying preflight.json and runs its proof gate with
     # KIN_RELEASE_REQUIRE=preflight, so a filed preflight is already a tag
     # whether or not a stranger ever runs. The cut still files the stranger
-    # when it can, because that record is what promotes a release to GitHub
-    # Latest; what it no longer does is treat a missing one as a reason to hold
-    # the version. Computed here and consumed after the candidate block, so the
+    # when it can, because that record is the only thing that tells a measured
+    # release from an unmeasured one; what it no longer does is treat a missing
+    # one as a reason to hold the version, or the release. Computed here and
+    # consumed after the candidate block, so the
     # STRANGER decision below stays reachable and release-cut.yml's stranger
     # job keeps running.
     mintable = [sha for sha in shas if PREFLIGHT_RECORD in records(sha)]
@@ -834,9 +836,9 @@ def judge(snapshot: dict[str, Any], grade: Grader) -> Decision:
                 )
             return Decision(
                 STRANGER,
-                f"preflight is recorded for {candidate}, which the mint can already tag; the "
-                "stranger record is what promotes the release to GitHub Latest, so run it "
-                "while the archives it must judge still exist",
+                f"preflight is recorded for {candidate}, which the mint can already tag and "
+                "promote; the stranger record is the only thing that will tell that release "
+                "from a measured one, so run it while the archives it must judge still exist",
                 version,
                 branch,
                 candidate=candidate,
@@ -907,7 +909,7 @@ def judge(snapshot: dict[str, Any], grade: Grader) -> Decision:
             STAND_DOWN,
             f"{mintable[0]} carries {PREFLIGHT_RECORD} and awaits the mint, which tags on the "
             "machine preflight alone; first contact is still unrecorded, so the release will "
-            "ship as a prerelease naming that gap",
+            "ship and be promoted carrying a notice that names that gap",
             version,
             branch,
             candidate=mintable[0],

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -7765,25 +7765,42 @@ def assert_the_mint_records_the_state_it_tagged_on(release_tag: str) -> None:
             f"the mint failed on a fully proven tag: {proven_run.stdout}{proven_run.stderr}"
         )
 
-    if MINT_FIRST_CONTACT_ROW not in held[0]:
-        raise AssertionError(
-            "the minted-tag summary must carry a first-contact row "
-            f"({MINT_FIRST_CONTACT_ROW}); the step summary is the mint's own "
-            f"record of what the tag it just created may claim: {held[0]}"
-        )
-    if held[0] == proven[0]:
+    # Read the ROW, not the whole summary. Asserting on the summary text lets a
+    # prose sentence elsewhere in it satisfy the check: the complete branch's
+    # own claim sentence contains the word "pending" (it says the release does
+    # NOT carry a pending notice), which silently defeated a whole-summary
+    # search for that word and was caught only by this function's own
+    # falsification arm.
+    def row(summary: str) -> str:
+        rows = [
+            line for line in summary.splitlines() if MINT_FIRST_CONTACT_ROW in line
+        ]
+        if len(rows) != 1:
+            raise AssertionError(
+                "the minted-tag summary must carry exactly one first-contact row "
+                f"({MINT_FIRST_CONTACT_ROW}); the step summary is the mint's own "
+                f"record of what the tag it just created may claim: {summary}"
+            )
+        return rows[0]
+
+    held_row, proven_row = row(held[0]), row(proven[0])
+    if held_row == proven_row:
         raise AssertionError(
             "the mint writes the same record whether or not the tag carries "
             "first-contact proof, so a release minted on the machine preflight "
             "alone is indistinguishable from a proven one"
         )
-    if "pending" not in held[0]:
+    if "pending" not in held_row:
         raise AssertionError(
-            f"the minted-tag summary must name a pending first contact: {held[0]}"
+            f"the minted-tag summary must name a pending first contact: {held_row}"
         )
-    if "green+brown+vcs" not in proven[0]:
+    if "pending" in proven_row:
         raise AssertionError(
-            f"the minted-tag summary must name the arms that proved it: {proven[0]}"
+            f"the minted-tag summary calls a proven tag pending: {proven_row}"
+        )
+    if "green+brown+vcs" not in proven_row:
+        raise AssertionError(
+            f"the minted-tag summary must name the arms that proved it: {proven_row}"
         )
 
 
@@ -16870,7 +16887,7 @@ def main() -> None:
     assert_the_mint_records_the_state_it_tagged_on(release_tag)
     expect_assertion(
         "the minted-tag summary drops its first-contact row",
-        "must carry a first-contact row",
+        "must carry exactly one first-contact row",
         lambda mutant=release_tag.replace(
             '            echo "| first contact | ${first_contact} |"\n', "", 1
         ): assert_the_mint_records_the_state_it_tagged_on(mutant),
@@ -16891,8 +16908,6 @@ def main() -> None:
             '            echo "| first contact | ${first_contact} |"\n',
             '            echo "| first contact | recorded |"\n',
             1,
-        ).replace(
-            '            echo "$claim"\n', '            echo "recorded"\n', 1
         ): assert_the_mint_records_the_state_it_tagged_on(mutant),
     )
     assert_the_stranger_labels_a_release_and_never_holds_it(release)

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -16949,7 +16949,7 @@ def main() -> None:
         ): assert_the_stranger_labels_a_release_and_never_holds_it(mutant),
     )
     expect_assertion(
-        "GHCR latest moves on a release that was held as a prerelease",
+        "GHCR latest moves on a release that was never promoted",
         "must gate on needs.finalize_release.outputs.promoted",
         lambda mutant=release.replace(
             "        needs.config.outputs.release_channel == 'latest' &&\n"

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -1183,27 +1183,94 @@ def assert_tag_tier_requires_only_the_machine_proof(release_tag: str) -> None:
         )
 
 
-def assert_latest_requires_the_stranger(release: str) -> None:
-    """GitHub Latest is the claim of first-contact coverage, so it needs the record."""
+# ── the mint's candidate listing ──────────────────────────────────────────
+#
+# The tier above is what the proof GATE requires. This is what the mint ever
+# OFFERS it, and until 2026-09-04 the two disagreed. The gate ran the preflight
+# tier while the listing proposed only a sha carrying BOTH records, so a
+# preflight-only candidate never reached the gate that would have admitted it,
+# and the mint reported "no candidate" and exited 0. That path is a deliberate
+# no-op rather than a decline, so it raises nothing: half the rail was relaxed
+# and the half that picks the sha was not, silently. Nothing guarded the
+# listing expression at all before this assertion.
+CANDIDATE_LISTING_CAPTURE = 'capture("^evidence/'
+MINT_FIRST_CONTACT_ROW = "| first contact |"
+
+
+def assert_the_mint_lists_preflight_only_candidates(release_tag: str) -> None:
+    """A missing stranger must label a release, never hide its candidate.
+
+    Three things together, because any one of them alone ships inert: the
+    listing has to propose a preflight-only sha, the mint has to read back the
+    stranger state it computes, and it has to write that state where a person
+    reading the mint run finds it.
+    """
+
+    lines = active_lines(release_tag)
+    listing = [line for line in lines if CANDIDATE_LISTING_CAPTURE in line]
+    if len(listing) != 1:
+        raise AssertionError(
+            "release-tag.yml must build its candidate list from exactly one "
+            f"evidence path capture; found {len(listing)}"
+        )
+    if "preflight" not in listing[0]:
+        raise AssertionError(
+            "release-tag.yml's candidate listing no longer keys on preflight.json"
+        )
+    if "stranger" in listing[0]:
+        raise AssertionError(
+            "release-tag.yml's candidate listing requires a stranger record "
+            "again, so a candidate whose stranger has not run is never offered "
+            "to the gate that would admit it and the mint no-ops in silence. "
+            "The rule is that a missing stranger labels a release; it does not "
+            "hold one"
+        )
+    if not any("steps.proof.outputs.stranger_state" in line for line in lines):
+        raise AssertionError(
+            "release-tag.yml computes a stranger state and reads it back "
+            "nowhere, so a release minted without first-contact proof is "
+            "indistinguishable from one that has it"
+        )
+
+
+def assert_the_stranger_labels_a_release_and_never_holds_it(release: str) -> None:
+    """First contact is a label on the release, not a gate in front of it.
+
+    Until 2026-09-04 GitHub Latest required the stranger record, and the
+    outage that bought was real: an offline runner or a spent weekly limit kept
+    a finished, installable release off /releases/latest while every machine
+    signal was green. The founder's ruling is to ship anyway and say what is
+    missing. These assertions hold both halves at once, because either one
+    alone is a different failure. Losing the hold and the label together
+    promotes an unmeasured release silently, which is the 2026-08-20 failure.
+    Keeping the hold puts the outage back.
+    """
 
     lines = active_lines(release)
-    gate = f'"$STRANGER_STATE" != {PROMOTION_STATE}'
-    if not any(gate in line for line in lines):
+    if any("promoted=false" in line for line in lines):
         raise AssertionError(
-            "release.yml must refuse to promote a release to GitHub Latest "
-            f"unless its stranger state is {PROMOTION_STATE}; Latest is what an "
-            "installer resolves, so it is the claim first-contact proof backs"
+            "release.yml holds a release back from GitHub Latest again; first "
+            "contact is a label, not a gate, and a stranger that cannot run "
+            "must not keep a finished release off the channel an installer "
+            "resolves"
         )
-    if not any("promoted=false" in line for line in lines):
+    if not any("promoted=true" in line for line in lines):
         raise AssertionError(
-            "release.yml must record promoted=false when it holds a release, so "
-            "a downstream job can tell 'held' from 'this step never ran'"
+            "release.yml must record promoted=true when it promotes, so a "
+            "downstream job can tell a decision from a step that never ran"
         )
-    # The pending notice explains why a STABLE release is not Latest. A
-    # prerelease tag is a prerelease because that is what it is, and it never
-    # becomes Latest whatever its record says, so telling its reader that it
-    # "stays a prerelease until its record lands" promises something no path in
-    # this chain delivers.
+    labelled = f'"$STRANGER_STATE" != {PROMOTION_STATE}'
+    if not any(labelled in line for line in lines):
+        raise AssertionError(
+            "release.yml must still branch on the stranger state to label the "
+            "release it promotes; a promotion that stops reading the state "
+            "cannot say which releases were measured, and unmeasured then "
+            "looks exactly like measured"
+        )
+    # The pending notice is what carries the label onto the release itself, and
+    # it is for STABLE releases only. A prerelease tag is a prerelease because
+    # that is what it is, and it never becomes Latest whatever its record says,
+    # so the notice would answer a question nobody installing an rc is asking.
     anchor = "      - name: Record the missing first-contact proof on the release itself\n"
     if release.count(anchor) != 1:
         raise AssertionError(
@@ -1216,13 +1283,19 @@ def assert_latest_requires_the_stranger(release: str) -> None:
     for required in ("stranger_state == 'pending'", "!contains(github.ref_name, '-')"):
         if required not in condition:
             raise AssertionError(
-                "the first-contact notice must be written only for a held "
+                "the first-contact notice must be written only for a pending "
                 f"STABLE release; its condition is missing {required}"
             )
 
 
 def assert_latest_claims_gate_on_promotion(release: str) -> None:
-    """Every job whose meaning is "this IS Latest" must gate on the promotion, not the job."""
+    """Every job whose meaning is "this IS Latest" must gate on the promotion, not the job.
+
+    `finalize_release` succeeding is not the same fact as this tag having been
+    promoted. The promote step does not run at all on a prerelease tag, and a
+    job that read the job's result instead of its output would move a mutable
+    `latest` alias for a release that never became Latest.
+    """
 
     needed = "needs.finalize_release.outputs.promoted == 'true'"
     for job in ("promote_ghcr_latest", "seal_release_completion"):
@@ -1231,8 +1304,8 @@ def assert_latest_claims_gate_on_promotion(release: str) -> None:
         if needed not in "\n".join(active_lines(release[start:end])):
             raise AssertionError(
                 f"{job} must gate on {needed}; it claims that this release IS "
-                "Latest, and finalize_release now succeeds without promoting "
-                "when first-contact proof is pending"
+                "Latest, which finalize_release succeeding on its own does not "
+                "say"
             )
 
 
@@ -7575,8 +7648,20 @@ def tag_readback_source(release_tag: str) -> str:
 def execute_tag_readback(
     source: str,
     responses: list[tuple[int, str]],
+    *,
+    stranger_state: str = "pending",
+    stranger_arms: str = "none",
+    stranger_driver: str = "unrecorded",
+    summary: list[str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    """Run the readback against a scripted sequence of API answers."""
+    """Run the readback against a scripted sequence of API answers.
+
+    The first-contact values are the ones the step's own `env:` block binds
+    from the proof step's outputs, so the fixture has to bind them too: the
+    step runs under `set -u` and an unbound one would die here for a reason
+    production never has. `summary`, when given, collects the step summary the
+    run wrote, which is where the mint records what its tag may claim.
+    """
 
     with tempfile.TemporaryDirectory() as directory:
         root = Path(directory)
@@ -7620,13 +7705,85 @@ def execute_tag_readback(
                 "RUNNER_TEMP": str(root),
             }
         )
-        return subprocess.run(
+        environment.update(
+            {
+                "STRANGER_STATE": stranger_state,
+                "STRANGER_ARMS": stranger_arms,
+                "STRANGER_DRIVER": stranger_driver,
+            }
+        )
+        completed = subprocess.run(
             ["bash", str(script)],
             capture_output=True,
             text=True,
             env=environment,
             timeout=30,
             check=False,
+        )
+        if summary is not None:
+            written = root / "summary.md"
+            summary.append(
+                written.read_text(encoding="utf-8") if written.exists() else ""
+            )
+        return completed
+
+
+def assert_the_mint_records_the_state_it_tagged_on(release_tag: str) -> None:
+    """A release minted without first-contact proof must say so in the mint's record.
+
+    Run the real readback step twice, once per state the proof gate can report,
+    and read the step summary it wrote. Two identical summaries mean the mint
+    tagged on the machine preflight alone and left no trace of it, which is the
+    gap this whole change exists to close: the mint has computed this state
+    since 2026-09-02 and, until 2026-09-04, wrote it only to GITHUB_OUTPUT,
+    where nothing in the workflow read it back.
+    """
+
+    source = tag_readback_source(release_tag)
+    readable = (0, RELEASE_GATE_FIXTURE_SHA)
+
+    held: list[str] = []
+    held_run = execute_tag_readback(
+        source, [readable], stranger_state="pending", summary=held
+    )
+    if held_run.returncode != 0:
+        raise AssertionError(
+            "the mint failed on a stranger-pending tag, which is the release "
+            f"the founder asked to ship: {held_run.stdout}{held_run.stderr}"
+        )
+    proven: list[str] = []
+    proven_run = execute_tag_readback(
+        source,
+        [readable],
+        stranger_state="complete",
+        stranger_arms="green+brown+vcs",
+        stranger_driver="account",
+        summary=proven,
+    )
+    if proven_run.returncode != 0:
+        raise AssertionError(
+            f"the mint failed on a fully proven tag: {proven_run.stdout}{proven_run.stderr}"
+        )
+
+    if MINT_FIRST_CONTACT_ROW not in held[0]:
+        raise AssertionError(
+            "the minted-tag summary must carry a first-contact row "
+            f"({MINT_FIRST_CONTACT_ROW}); the step summary is the mint's own "
+            f"record of what the tag it just created may claim: {held[0]}"
+        )
+    if held[0] == proven[0]:
+        raise AssertionError(
+            "the mint writes the same record whether or not the tag carries "
+            "first-contact proof, so a release minted on the machine preflight "
+            "alone is indistinguishable from a proven one"
+        )
+    if "pending" not in held[0]:
+        raise AssertionError(
+            f"the minted-tag summary must name a pending first contact: {held[0]}"
+        )
+    if "green+brown+vcs" not in proven[0]:
+        raise AssertionError(
+            f"the minted-tag summary must name the arms that proved it: {proven[0]}"
         )
 
 
@@ -16688,7 +16845,57 @@ def main() -> None:
         ): assert_stranger_driver_credential_is_either(mutant),
     )
     assert_tag_tier_requires_only_the_machine_proof(release_tag)
-    assert_latest_requires_the_stranger(release)
+    assert_the_mint_lists_preflight_only_candidates(release_tag)
+    expect_assertion(
+        "the mint goes back to listing only fully evidenced candidates",
+        "requires a stranger record again",
+        lambda mutant=release_tag.replace(
+            r'map(capture("^evidence/(?<sha>[0-9a-f]{40})/preflight\\.json$") | .sha)'
+            "\n              | unique",
+            r'map(capture("^evidence/(?<sha>[0-9a-f]{40})/(?<name>preflight\\.json|stranger\\.env)$"))'
+            "\n              | group_by(.sha)"
+            "\n              | map(select((map(.name) | unique | length) == 2) | .[0].sha)",
+            1,
+        ): assert_the_mint_lists_preflight_only_candidates(mutant),
+    )
+    expect_assertion(
+        "the mint computes a stranger state and reads it back nowhere",
+        "reads it back",
+        lambda mutant=release_tag.replace(
+            "          STRANGER_STATE: ${{ steps.proof.outputs.stranger_state }}\n",
+            "",
+            1,
+        ): assert_the_mint_lists_preflight_only_candidates(mutant),
+    )
+    assert_the_mint_records_the_state_it_tagged_on(release_tag)
+    expect_assertion(
+        "the minted-tag summary drops its first-contact row",
+        "must carry a first-contact row",
+        lambda mutant=release_tag.replace(
+            '            echo "| first contact | ${first_contact} |"\n', "", 1
+        ): assert_the_mint_records_the_state_it_tagged_on(mutant),
+    )
+    expect_assertion(
+        "the mint calls every tag proven regardless of the state it read",
+        "must name a pending first contact",
+        lambda mutant=release_tag.replace(
+            '          if [ "$STRANGER_STATE" = complete ]; then\n',
+            '          if true; then\n',
+            1,
+        ): assert_the_mint_records_the_state_it_tagged_on(mutant),
+    )
+    expect_assertion(
+        "the mint writes one fixed record for both first-contact states",
+        "indistinguishable from a proven one",
+        lambda mutant=release_tag.replace(
+            '            echo "| first contact | ${first_contact} |"\n',
+            '            echo "| first contact | recorded |"\n',
+            1,
+        ).replace(
+            '            echo "$claim"\n', '            echo "recorded"\n', 1
+        ): assert_the_mint_records_the_state_it_tagged_on(mutant),
+    )
+    assert_the_stranger_labels_a_release_and_never_holds_it(release)
     assert_latest_claims_gate_on_promotion(release)
     assert_require_modes_match_the_gate(release_tag, release, proof_gate)
     expect_assertion(
@@ -16699,23 +16906,32 @@ def main() -> None:
         ): assert_tag_tier_requires_only_the_machine_proof(mutant),
     )
     expect_assertion(
-        "promotion to Latest stops asking about the stranger",
-        "must refuse to promote a release to GitHub Latest",
+        "GitHub Latest waits on the stranger again",
+        "holds a release back from GitHub Latest again",
+        lambda mutant=release.replace(
+            '            echo "### Promoted with first contact ${STRANGER_STATE}"\n',
+            '            echo "promoted=false" >> "$GITHUB_OUTPUT"\n',
+            1,
+        ): assert_the_stranger_labels_a_release_and_never_holds_it(mutant),
+    )
+    expect_assertion(
+        "promotion stops reading the state, so nothing is labelled",
+        "must still branch on the stranger state",
         lambda mutant=release.replace(
             'if [ "$STRANGER_STATE" != complete ]; then',
-            'if [ "$STRANGER_STATE" = never ]; then',
+            'if [ "$GITHUB_REF_NAME" = never ]; then',
             1,
-        ): assert_latest_requires_the_stranger(mutant),
+        ): assert_the_stranger_labels_a_release_and_never_holds_it(mutant),
     )
     expect_assertion(
         "the pending notice is written onto a prerelease tag too",
-        "written only for a held",
+        "written only for a pending",
         lambda mutant=release.replace(
             "            steps.proof.outputs.stranger_state == 'pending' &&\n"
             "            !contains(github.ref_name, '-')\n",
             "            steps.proof.outputs.stranger_state == 'pending'\n",
             1,
-        ): assert_latest_requires_the_stranger(mutant),
+        ): assert_the_stranger_labels_a_release_and_never_holds_it(mutant),
     )
     expect_assertion(
         "GHCR latest moves on a release that was held as a prerelease",

--- a/scripts/test-select-release-candidate.py
+++ b/scripts/test-select-release-candidate.py
@@ -554,6 +554,7 @@ class JudgeTests(unittest.TestCase):
         )
         self.assertDecision(decision, selector.STAND_DOWN, "awaits the mint")
         self.assertEqual(decision.candidate, MIDDLE)
+        self.assertEqual(decision.stranger_state, selector.STRANGER_COMPLETE)
         self.assertEqual(grader.calls, [])
 
     def test_a_half_evidenced_candidate_asks_for_the_stranger_and_names_its_archive(self) -> None:
@@ -566,10 +567,11 @@ class JudgeTests(unittest.TestCase):
             ),
             grader,
         )
-        self.assertDecision(decision, selector.STRANGER, "the stranger record is the missing half")
+        self.assertDecision(decision, selector.STRANGER, "promotes the release to GitHub Latest")
         # The rc-build run travels with the decision, because the stranger has
         # to run on the very bytes the published preflight judged.
         self.assertEqual(decision.rc_run, 34_000_000_001)
+        self.assertEqual(decision.stranger_state, selector.STRANGER_PENDING)
         command = decision.details["stranger_command"]
         self.assertIn("bin/kin-stranger prepare", command)
         self.assertIn("--arms green,brown,vcs", command)
@@ -585,6 +587,12 @@ class JudgeTests(unittest.TestCase):
         )
         self.assertDecision(decision, selector.REFUSE, "no rc-build still holds the archives it judged")
         self.assertEqual(decision.candidate, MIDDLE)
+        # The refusal is about the cut, not about the mint. Since 2026-09-04 a
+        # preflight-only sha is mint-eligible, so this candidate is going to be
+        # tagged with first contact permanently unrecordable, and the reason a
+        # human reads has to say that rather than implying the release is held.
+        self.assertIn("the mint may still tag it", decision.reason)
+        self.assertEqual(decision.stranger_state, selector.STRANGER_PENDING)
 
     def test_an_expired_rc_build_is_not_a_usable_archive_source(self) -> None:
         stale = rc_build(MIDDLE, artifacts=[])
@@ -615,6 +623,50 @@ class JudgeTests(unittest.TestCase):
             Grader({}),
         )
         self.assertDecision(decision, selector.STAND_DOWN, "awaits the mint")
+
+    def test_a_preflight_only_sha_is_mint_eligible_and_stands_the_cut_down(self) -> None:
+        """The founder decision of 2026-09-03: a missing stranger must not hold a release.
+
+        release-tag.yml lists any sha carrying `preflight.json` and runs its
+        proof gate with `KIN_RELEASE_REQUIRE=preflight`, so this sha is already
+        a tag. The cut arming a newer candidate for the same version would only
+        race that tag.
+        """
+
+        grader = Grader({})
+        decision = selector.judge(
+            snapshot(evidence={MIDDLE: [selector.PREFLIGHT_RECORD]}),
+            grader,
+        )
+        self.assertDecision(decision, selector.STAND_DOWN, "awaits the mint")
+        self.assertEqual(decision.candidate, MIDDLE)
+        self.assertEqual(decision.stranger_state, selector.STRANGER_PENDING)
+        self.assertIn("prerelease naming that gap", decision.reason)
+        self.assertEqual(decision.details["mintable"], [MIDDLE])
+        self.assertEqual(grader.calls, [], "a filed preflight must cost no grading")
+
+    def test_the_stranger_still_runs_for_a_mint_eligible_candidate(self) -> None:
+        """Mint-eligible is not stranger-optional for the cut.
+
+        `release-cut.yml`'s stranger job is gated on
+        `needs.select.outputs.decision == 'stranger'`. If a preflight-only sha
+        stood the cut down before reaching the candidate block, that job would
+        never run again and "nice to have" would quietly become "deleted".
+        """
+
+        grader = Grader({})
+        decision = selector.judge(
+            snapshot(
+                candidate=MIDDLE,
+                evidence={MIDDLE: [selector.PREFLIGHT_RECORD]},
+                rc_builds=[rc_build(MIDDLE)],
+            ),
+            grader,
+        )
+        self.assertDecision(decision, selector.STRANGER)
+        self.assertEqual(decision.candidate, MIDDLE)
+        self.assertEqual(decision.details["mintable"], [MIDDLE])
+        self.assertEqual(grader.calls, [])
 
     def test_the_newest_green_sha_is_armed(self) -> None:
         grader = Grader({NEWEST: green_grade(NEWEST)})
@@ -977,6 +1029,24 @@ class ContractTests(unittest.TestCase):
                 f"{name} is bound to a different workflow id in release-tag.yml: {body}",
             )
             self.assertIn(path, body, f"{name} is bound to a different workflow path")
+
+    def test_every_emitted_output_is_republished_as_a_select_job_output(self) -> None:
+        """A value decided here and dropped in the workflow is decided nowhere.
+
+        `_emit` writes one line per key to GITHUB_OUTPUT, and only the keys
+        release-cut.yml lists under the `select` job's `outputs:` reach any
+        other job. `stranger_state` was added on both sides at once; this
+        assertion is what stops a future key landing on one side alone.
+        """
+
+        source = CUT_WORKFLOW_PATH.read_text(encoding="utf-8")
+        select = job_block(source, "select")
+        for key in (*selector.OUTPUT_KEYS, "reason"):
+            self.assertRegex(
+                select,
+                rf"(?m)^      {re.escape(key)}: \$\{{\{{ steps\.select\.outputs\.{re.escape(key)}",
+                f"release-cut.yml's select job does not republish {key}",
+            )
 
     def test_the_usable_artifacts_are_the_names_rc_build_actually_uploads(self) -> None:
         """The deadlock, as an assertion.

--- a/scripts/test-select-release-candidate.py
+++ b/scripts/test-select-release-candidate.py
@@ -567,7 +567,7 @@ class JudgeTests(unittest.TestCase):
             ),
             grader,
         )
-        self.assertDecision(decision, selector.STRANGER, "promotes the release to GitHub Latest")
+        self.assertDecision(decision, selector.STRANGER, "will tell that release from a measured one")
         # The rc-build run travels with the decision, because the stranger has
         # to run on the very bytes the published preflight judged.
         self.assertEqual(decision.rc_run, 34_000_000_001)
@@ -641,7 +641,7 @@ class JudgeTests(unittest.TestCase):
         self.assertDecision(decision, selector.STAND_DOWN, "awaits the mint")
         self.assertEqual(decision.candidate, MIDDLE)
         self.assertEqual(decision.stranger_state, selector.STRANGER_PENDING)
-        self.assertIn("prerelease naming that gap", decision.reason)
+        self.assertIn("promoted carrying a notice that names that gap", decision.reason)
         self.assertEqual(decision.details["mintable"], [MIDDLE])
         self.assertEqual(grader.calls, [], "a filed preflight must cost no grading")
 


### PR DESCRIPTION
## What changes

A stranger that cannot run no longer holds a release. It labels one.

Founder decision, 2026-09-03: "I dont even want that to block. If I run out of limit. Ship anyways. Stranger is nice to have." Followed by the ruling to flip everything: the tag, the release and GitHub Latest all move on the machine preflight alone, with the pending label kept on the record so a reader can see which releases were measured.

## The bug this closes

The mint's proof gate has run `KIN_RELEASE_REQUIRE=preflight` since 2026-09-02 (`release-tag.yml:1817`, `release.yml:2474`). The listing that picks the sha it grades did not move with it. `release-tag.yml` selected on `(map(.name) | unique | length) == 2`, so a sha carrying only `preflight.json` was never proposed to the gate that would have admitted it. The mint then printed "no reviewed main commit carrying X has release proof records yet", wrote `needed=false` and exited 0. That path is a deliberate no-op rather than a decline, so it escalated nothing. Half the rail was relaxed and the half that picks the sha was not, silently, and nothing guarded that expression either way.

## Both binding sites, plus the flip

**`.github/workflows/release-tag.yml`**
- The candidate listing proposes any sha carrying `preflight.json`. The comment above it and the `fully-evidenced` echo now say what the code does.
- The mint records the state it tagged on. It has computed `stranger_state` since 2026-09-02 and wrote it only to `GITHUB_OUTPUT`, where nothing in the workflow read it back.

**`.github/workflows/release.yml`**
- The `Promote stable tag` step no longer exits early on `STRANGER_STATE != complete`. It warns, writes a step summary section naming the gap, and promotes. `promoted=true` on both paths.
- The release-body stamp stays, minus one sentence. It claimed "It stays a prerelease and is not GitHub Latest until that record lands", which the flip makes false, and a false claim on a public release page is worse than a missing one. It now reads: "It ships and is promoted anyway, so this notice is how you tell it apart from a release that was measured."

**`scripts/select-release-candidate.py`**
- `STRANGER_COMPLETE` / `STRANGER_PENDING` constants, in the vocabulary `check-release-proof-artifacts.mjs` already returns and both workflows already `case` on.
- Mint-eligible on `preflight.json` alone. The cut stands down rather than arming a newer sha it would only race.
- The `stranger` decision stays **above** that stand-down, so `release-cut.yml`'s stranger job (gated on `decision == 'stranger'`) still runs while the archives it must judge exist. A naive rewrite that short-circuits earlier makes both that decision and the archives refusal dead code; falsification arm 2 below is exactly that mutation.
- The expired-archives refusal still refuses. Its reason now says first contact can never be recorded for that candidate and the mint may tag it anyway, instead of implying the release is held.
- `stranger_state` is a top-level `Decision` field rather than a `details` key, so the JSON document and the `GITHUB_OUTPUT` line are the same value read from the same place. `details` carries the `mintable` list beside it.

**`.github/workflows/release-cut.yml`** republishes `stranger_state` as a `select` job output.

**`docs/release-bot.md`** lines 96, 111 and 163 state the new rule.

## Where a reader finds the label

Three places, all durable, none of them a log line:

1. The mint's own step summary, the "Release tag minted" table, now carries a `first contact` row reading either `**pending** (no stranger.env)` or `complete on arms <arms>, driven on the <driver> endpoint`.
2. The release body, behind the `<!-- kin-first-contact-proof -->` marker, unchanged except for the sentence the flip falsified.
3. `release.yml`'s promote step summary, which now reads "Promoted with first contact pending" instead of "GitHub Latest held".

The mint creates a lightweight tag ref, not an annotated tag object, so there is no tag annotation to write into; making it annotated would change what `gh api .../git/ref/tags/<tag> -q .object.sha` returns and break the mint's own post-verify. The step summary is the mint's record.

## Falsification

Every new assertion goes red when the behavior it guards is broken. The three workflow assertions carry `expect_assertion` arms that run on every CI invocation of the authority suite, and each was additionally run against the real file on disk:

```
ARM 1  revert mintable to require both records
       AssertionError: unexpected grading of aaaa...  (the sha should never have been graded)
ARM 2  move the mintable stand-down above the candidate block  (the ordering trap)
       AssertionError: 'stand-down' != 'stranger'
ARM 3  drop stranger_state from release-cut.yml's select outputs
       AssertionError: release-cut.yml's select job does not republish stranger_state
ARM 4  revert the archives refusal reason
       AssertionError: 'the mint may still tag it' not found in '...'
ARM 5  restore the both-records listing in release-tag.yml
       AssertionError: release-tag.yml's candidate listing requires a stranger record again...
ARM 6  restore the Latest hold in release.yml
       AssertionError: release.yml holds a release back from GitHub Latest again...
ARM 7  delete the STRANGER_STATE env binding in release-tag.yml
       AssertionError: release-tag.yml computes a stranger state and reads it back nowhere...
```

Every file was restored byte-identical afterwards (`diff -q` against pre-arm copies) and both suites re-run green.

The record test is behavioral, not a grep. `assert_the_mint_records_the_state_it_tagged_on` executes the real readback step twice through the existing `execute_tag_readback` harness, once per state, and compares the two step summaries. Two identical summaries fail. That harness needed the step's first-contact env taught to it, since it runs under `set -u`.

## Local gates run

```
python3 scripts/test-select-release-candidate.py     Ran 71 tests ... OK   (68 before)
python3 scripts/test-release-workflow-authority.py   green
node --test scripts/release-promotion-plan.test.mjs scripts/read-promotion-plan.test.mjs \
            scripts/check-release-proof-artifacts.test.mjs    # tests 82  pass 82  fail 0
ruby -ryaml                                          release-tag.yml, release-cut.yml, release.yml all parse
bash -n + a real run of the new summary block in both states
jq                                                   the new listing expression lists a preflight-only sha; the old one did not
```

`bin/kin-precheck kin` is running through the heavy slot as this opens; its cargo gates are slower than hosted CI and the release this unblocks is time-critical, so the rest is left to CI. These are Python, YAML and Markdown changes; no Rust is touched.

## Known follow-on, not fixed here

`release-promote.yml` selects candidates on `prerelease === true` (`scripts/release-promotion-plan.mjs`, `selectCandidates`). Now that nothing is held, it finds nothing, so a release promoted with a pending notice does not get that notice stripped if a stranger record lands later, and the "Release published without first-contact proof" alarm goes quiet. The notice stays true about what was known at publication. Worth its own ticket.
