### PR TITLE
ci(kin-actions): guard the pin the workflow-pin bot cannot see

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1036,6 +1036,22 @@ jobs:
       - name: Falsify Docker daemon production feature guard
         run: bash scripts/check-docker-daemon-features.test.sh
 
+      # kin#1450 (`app/kin-workflow-pin`) bumped kin-actions to v0.1.34 in
+      # three `uses: firelock-ai/kin-actions/.github/workflows/*.yml@vX.Y.Z`
+      # files; kin#1449 had to move `kin-registry-release.yml`'s own
+      # `KIN_ACTIONS_SHA` pin by hand the same night, because that pin is a
+      # job-level env var feeding an `actions/checkout` `ref:`, not a `uses:`
+      # value, and the bot only ever looks at `uses:`. Nothing graded that
+      # gap before tonight, so it would have drifted again on the next
+      # kin-actions release. This is a pure scanner over `.github/workflows`
+      # with no toolchain and no network, so it belongs beside the two
+      # guards above for the same reason they do.
+      - name: Check kin-actions pin visibility
+        run: python3 scripts/verify-kin-actions-pin-visibility.py
+
+      - name: Falsify kin-actions pin visibility guard
+        run: python3 scripts/falsify-kin-actions-pin-visibility.py
+
       # ADDED here rather than moved out of `check`, for the reason the kin-vfs
       # step below records. `check` carries `github.event_name != 'pull_request'`,
       # so for as long as these two guards ran only there, a pull request could

--- a/scripts/falsify-kin-actions-pin-visibility.py
+++ b/scripts/falsify-kin-actions-pin-visibility.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+"""Falsify verify-kin-actions-pin-visibility.py against synthetic mutants.
+
+Every probe plants one kin-actions reference the guard must refuse to let
+through ungoverned, or removes the tree state one ALLOWLIST entry depends on,
+and requires the guard to fail naming the right thing. Two controls run
+first and must PASS, so a guard that has stopped recognizing anything and
+therefore rejects everything cannot read as "working" by refusing every
+probe below for the wrong reason. A probe the guard lets through silently is
+worse than no guard: a passing check that proves nothing is exactly the
+shape that let kin#1449 happen unnoticed.
+
+Usage: falsify-kin-actions-pin-visibility.py
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GUARD = REPO_ROOT / "scripts" / "verify-kin-actions-pin-visibility.py"
+
+# ALLOWLIST is checked against the whole scanned tree, not file-by-file: an
+# entry that matches nothing anywhere is stale. So every synthetic tree below
+# except [6/6], which tests staleness on purpose, carries this companion
+# alongside its own probe file, standing in for the real kin-registry-
+# release.yml and keeping both real entries satisfied while only the probe
+# file is new. Content only has to contain the two allowlisted substrings;
+# it does not have to be valid step YAML.
+COMPANION_KIN_REGISTRY_RELEASE = (
+    "jobs:\n"
+    "  prepare-wave:\n"
+    "    env:\n"
+    "      KIN_ACTIONS_SHA: b424aa4f22684d91abe43d23fa7c4ab5b27c9a2f # v0.1.34\n"
+    "    steps:\n"
+    "      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0\n"
+    "        with:\n"
+    "          repository: firelock-ai/kin-actions\n"
+    "          ref: ${{ env.KIN_ACTIONS_SHA }}\n"
+)
+
+
+def run_guard(root: Path) -> tuple[int, str]:
+    completed = subprocess.run(
+        [sys.executable, str(GUARD), str(root)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return completed.returncode, completed.stdout + completed.stderr
+
+
+def make_tree(workflows: dict[str, str]) -> Path:
+    root = Path(tempfile.mkdtemp(prefix="kin-actions-pin-falsify-"))
+    workflow_dir = root / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    for name, content in workflows.items():
+        (workflow_dir / name).write_text(content, encoding="utf-8")
+    return root
+
+
+def expect(
+    label: str,
+    root: Path,
+    *,
+    want_pass: bool,
+    must_name: str | None = None,
+) -> None:
+    code, output = run_guard(root)
+    passed = code == 0
+    if passed != want_pass:
+        print(f"FALSIFICATION FAILED: {label}", file=sys.stderr)
+        print(
+            f"  wanted {'PASS' if want_pass else 'FAIL'}, got "
+            f"{'PASS' if passed else 'FAIL'} (exit {code})",
+            file=sys.stderr,
+        )
+        print(output, file=sys.stderr)
+        sys.exit(1)
+    if must_name is not None and must_name not in output:
+        print(f"FALSIFICATION FAILED: {label}", file=sys.stderr)
+        print(f"  failed, but never named {must_name!r}", file=sys.stderr)
+        print(output, file=sys.stderr)
+        sys.exit(1)
+    print(f"  ok: {label}")
+
+
+def main() -> int:
+    tmp_roots: list[Path] = []
+    try:
+        # [1/6] The real repository, today, passes: the two references this
+        # guard is coupled to are named in ALLOWLIST and nothing ungoverned
+        # has crept into any workflow file since.
+        expect("real repository tree passes clean", REPO_ROOT, want_pass=True)
+
+        # [2/6] Positive control on the recognizer: a bare bot-visible pin,
+        # alone, must pass with no allowlist entry. If this fails, the
+        # recognizer regex is broken, not the governance logic below it, and
+        # every FAIL probe after this one would be meaningless. Shaped like
+        # the real thing: kin-actions is called as a job-level reusable
+        # workflow (`jobs.<id>.uses:`), never as a step inside `steps:`.
+        root = make_tree(
+            {
+                "recognized.yml": (
+                    "jobs:\n"
+                    "  notify:\n"
+                    "    uses: firelock-ai/kin-actions/.github/workflows/"
+                    "notify-approver.yml@v0.1.34\n"
+                ),
+                "kin-registry-release.yml": COMPANION_KIN_REGISTRY_RELEASE,
+            }
+        )
+        tmp_roots.append(root)
+        expect("bare bot-visible pin passes alone", root, want_pass=True)
+
+        # [3/6] Positive control on the comment skip: a full-line comment
+        # naming kin-actions, alone, must pass without an allowlist entry.
+        root = make_tree(
+            {
+                "commentary.yml": (
+                    "# The shared implementation lives in "
+                    "firelock-ai/kin-actions.\n"
+                    "jobs:\n"
+                    "  x:\n"
+                    "    steps:\n"
+                    "      - run: echo hi\n"
+                ),
+                "kin-registry-release.yml": COMPANION_KIN_REGISTRY_RELEASE,
+            }
+        )
+        tmp_roots.append(root)
+        expect(
+            "full-line comment mention passes without allowlisting",
+            root,
+            want_pass=True,
+        )
+
+        # [4/6] The actual bug class: a fresh KIN_ACTIONS_SHA-shaped env pin
+        # with no allowlist entry must fail, naming the file it appeared in.
+        root = make_tree(
+            {
+                "new-consumer.yml": (
+                    "jobs:\n"
+                    "  x:\n"
+                    "    env:\n"
+                    "      KIN_ACTIONS_SHA: "
+                    "0123456789abcdef0123456789abcdef01234567 # v9.9.9\n"
+                    "    steps:\n"
+                    "      - run: echo hi\n"
+                ),
+                "kin-registry-release.yml": COMPANION_KIN_REGISTRY_RELEASE,
+            }
+        )
+        tmp_roots.append(root)
+        expect(
+            "new ungoverned KIN_ACTIONS_SHA pin fails",
+            root,
+            want_pass=False,
+            must_name="new-consumer.yml",
+        )
+
+        # [5/6] The other half of the same bug: a fresh checkout-by-repository
+        # reference with no allowlist entry must also fail.
+        root = make_tree(
+            {
+                "new-checkout.yml": (
+                    "jobs:\n"
+                    "  x:\n"
+                    "    steps:\n"
+                    "      - uses: actions/checkout@"
+                    "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0\n"
+                    "        with:\n"
+                    "          repository: firelock-ai/kin-actions\n"
+                    "          ref: deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n"
+                ),
+                "kin-registry-release.yml": COMPANION_KIN_REGISTRY_RELEASE,
+            }
+        )
+        tmp_roots.append(root)
+        expect(
+            "new ungoverned checkout reference fails",
+            root,
+            want_pass=False,
+            must_name="new-checkout.yml",
+        )
+
+        # [6/6] A stale ALLOWLIST entry must fail too, so the allowlist can
+        # only ever shrink honestly, by deleting the entry, never by drifting
+        # out of sync with a tree that moved the pin without it. Neither
+        # allowlisted substring appears anywhere in this fixture tree, so
+        # both entries go stale at once; the guard need only report one.
+        root = make_tree(
+            {
+                "kin-registry-release.yml": (
+                    "jobs:\n"
+                    "  x:\n"
+                    "    steps:\n"
+                    "      - run: echo the pin moved elsewhere\n"
+                )
+            }
+        )
+        tmp_roots.append(root)
+        expect(
+            "stale ALLOWLIST entry fails",
+            root,
+            want_pass=False,
+            must_name="stale ALLOWLIST entry",
+        )
+
+        print(
+            "verify-kin-actions-pin-visibility.py is falsifiable: "
+            "every probe was caught."
+        )
+        return 0
+    finally:
+        for root in tmp_roots:
+            shutil.rmtree(root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify-kin-actions-pin-visibility.py
+++ b/scripts/verify-kin-actions-pin-visibility.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+"""Fail when a kin-actions reference exists that the workflow-pin bot cannot see.
+
+The dedicated `kin-workflow-pin[bot]` App (firelock-ai/kin-actions,
+scripts/update-kin-actions-pins.py) rewrites exactly one shape of pin:
+
+    uses: firelock-ai/kin-actions/.github/workflows/<file>.yml@v<semver>
+
+Its manifest (firelock-ai/kin-actions .kin-release/consumers.json) lists the
+workflow paths it owns in this repository, and its own self-check refuses a
+manifest that is not exact. Both of those live in a different repository and
+can only ever police the shape they already recognize. Neither can see a
+kin-actions reference that never becomes a `uses:` value at all, which is
+exactly how kin#1449 happened: `kin-registry-release.yml` pins kin-actions
+through a job-level `KIN_ACTIONS_SHA` environment variable, consumed by
+`actions/checkout`'s `repository:`/`ref:` inputs to check kin-actions out as a
+script library and run its scripts in-job rather than call it as a reusable
+workflow. The bot bumped three other files in kin#1450 the same night; this
+one had to be moved by hand in kin#1449, and nothing reported the gap.
+
+This guard runs entirely inside this repository: it scans every workflow file
+for a live reference to `firelock-ai/kin-actions` or a `KIN_ACTIONS`-named
+variable, accepts the one shape the bot owns, and requires everything else to
+be named, with a reason, in the ALLOWLIST below. An unnamed reference fails
+the build. An allowlist entry that no longer matches anything live fails it
+too, the same direction verify-zero-file-search.py's own allowlist is held
+to: a stale entry cannot silently keep excusing something that moved.
+
+Full-line comments are skipped: a prose mention of kin-actions carries no
+version to go stale, and this repository already has several. A mention
+inside a trailing comment on an otherwise-live code line is out of scope, the
+same trade check-docker-daemon-features.sh makes reading line-shaped text
+instead of parsing YAML: every case here today is a whole-line comment, and
+the day that stops being true is the day this needs a real YAML parser
+instead of a line scan.
+
+Usage: verify-kin-actions-pin-visibility.py [repo_root]
+
+The optional repo_root selects the tree to scan (default: the repository
+containing this script). The allowlist always travels with the script, which
+lets a falsifier point the guard at a synthetic tree and assert it fails.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+BOT_VISIBLE_PIN = re.compile(
+    r"^\s*uses:\s*firelock-ai/kin-actions/\.github/workflows/"
+    r"[A-Za-z0-9_.-]+\.ya?ml@v(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\b"
+)
+
+# Any of these appearing on a non-comment line means the line is talking
+# about a specific kin-actions commit or release: exactly what the bot's own
+# rewrite has to be able to find, and was never built to look for outside a
+# `uses:` scalar.
+REFERENCE_HINTS = (
+    re.compile(r"firelock-ai/kin-actions"),
+    re.compile(r"KIN_ACTIONS"),
+)
+
+# Every reference the scan finds outside the bot-visible shape has to be
+# named here, with a reason. "match" is a substring: exact enough to identify
+# the one thing it excuses, loose enough to survive the sha or version inside
+# it changing under a hand-edit.
+ALLOWLIST = [
+    {
+        "file": ".github/workflows/kin-registry-release.yml",
+        "match": "KIN_ACTIONS_SHA",
+        "reason": (
+            "kin-actions is checked out as a script library and its scripts "
+            "(update-cargo-registry-deps.py, validate-dependency-wave.py) "
+            "run inline in this job, sharing its cargo/registry state, "
+            "rather than being called as a workflow_call reusable workflow "
+            "in a job of their own. It is deliberately sha-pinned, matching "
+            "every other external action in this file, rather than "
+            "tag-pinned like a bot-managed pin. update-kin-actions-pins.py "
+            "only rewrites `uses: firelock-ai/kin-actions/.github/"
+            "workflows/*.yml@vX.Y.Z`; this pin needs a human, or a taught "
+            "bot, on every kin-actions release until the mechanism changes."
+        ),
+    },
+    {
+        "file": ".github/workflows/kin-registry-release.yml",
+        "match": "repository: firelock-ai/kin-actions",
+        "reason": "The checkout that KIN_ACTIONS_SHA (above) pins. Same gap.",
+    },
+]
+
+
+def is_comment(line: str) -> bool:
+    return line.lstrip().startswith("#")
+
+
+def find_references(text: str) -> list[tuple[int, str]]:
+    """Return (line_number, line) for every non-comment line that names a
+    specific kin-actions reference outside the bot-visible pin shape."""
+
+    found: list[tuple[int, str]] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if is_comment(line):
+            continue
+        if BOT_VISIBLE_PIN.match(line):
+            continue
+        if any(hint.search(line) for hint in REFERENCE_HINTS):
+            found.append((lineno, line))
+    return found
+
+
+def check(root: Path) -> list[str]:
+    root = root.resolve()
+    workflow_dir = root / ".github" / "workflows"
+    if not workflow_dir.is_dir():
+        return [f"no .github/workflows directory under {root}"]
+
+    live: dict[str, list[tuple[int, str]]] = {}
+    for path in sorted(workflow_dir.rglob("*")):
+        if path.is_symlink() or not path.is_file():
+            continue
+        if path.suffix not in (".yml", ".yaml"):
+            continue
+        relative = path.relative_to(root).as_posix()
+        refs = find_references(path.read_text(encoding="utf-8"))
+        if refs:
+            live[relative] = refs
+
+    errors: list[str] = []
+    matched_allowlist: set[int] = set()
+    for relative, refs in live.items():
+        for lineno, line in refs:
+            covered = False
+            for index, entry in enumerate(ALLOWLIST):
+                if entry["file"] == relative and entry["match"] in line:
+                    covered = True
+                    matched_allowlist.add(index)
+                    break
+            if not covered:
+                errors.append(
+                    f"{relative}:{lineno}: kin-actions reference is not the "
+                    "bot-visible `uses: firelock-ai/kin-actions/.github/"
+                    "workflows/*.yml@vX.Y.Z` pin and is not named in "
+                    f"ALLOWLIST: {line.strip()!r}"
+                )
+
+    # Never short-circuit on a stale entry: report it alongside whatever else
+    # was found, the same order verify-zero-file-search.py holds its own
+    # allowlist to, so a red run always shows every problem it can see.
+    for index, entry in enumerate(ALLOWLIST):
+        if index not in matched_allowlist:
+            errors.append(
+                "stale ALLOWLIST entry matches nothing in the tree: "
+                f"{entry['file']} {entry['match']!r}"
+            )
+
+    return errors
+
+
+def main(argv: list[str]) -> int:
+    root = Path(argv[1]) if len(argv) > 1 else Path(__file__).resolve().parent.parent
+    errors = check(root)
+    if errors:
+        print(
+            f"kin-actions pin visibility check FAILED ({len(errors)} problem(s)):",
+            file=sys.stderr,
+        )
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    print("kin-actions pin visibility check: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
kin#1450 (`app/kin-workflow-pin`) bumped kin-actions to v0.1.34 in three files tonight. Every one of them uses `uses: firelock-ai/kin-actions/.github/workflows/*.yml@vX.Y.Z`, a reusable-workflow call. `kin-registry-release.yml`'s own kin-actions pin isn't that shape. It's a job-level `KIN_ACTIONS_SHA` environment variable, sha-pinned, feeding `actions/checkout`'s `repository:`/`ref:` inputs so the job can check kin-actions out as a script library and run its scripts (`update-cargo-registry-deps.py`, `validate-dependency-wave.py`) inline, sharing this job's cargo and registry state. The bot's updater only ever looks at `uses:` scalars. It never saw this pin, and it had to be moved by hand in kin#1449.

**Measured first.** Every kin-actions reference in this repo lives under `.github/workflows/*.yml`. `approve-to-merge.yml`, `merge-queue-ejection-notice.yml` and `notify-approver.yml` each carry a bot-visible `uses:` pin, and kin-actions' own consumer manifest already lists all three. `kin-registry-release.yml` carries the env-var/checkout pin above, invisible to the bot and absent from that manifest. Everything else that mentions kin-actions is a comment, or lives in one unrelated test fixture. The same sweep across the other ten repos in the ecosystem (kin-bench, kinlab, kin-model, kin-db, kin-lsp, kin-vfs, kin-infer, kin-vector, kin-search, kin-blobs, origin/main only) turned up zero instances of the env-var idiom. This repo is the only place in the fleet where it exists.

**The smaller fix isn't the smaller fix here.** Converting the env var to the bot's `uses:`-tag shape would mean calling kin-actions as a `workflow_call` reusable workflow instead, which runs as its own job and can't share this job's cargo and registry state the way inline script execution does. The alternative is trusting a mutable tag instead of an immutable sha, in a job that executes fetched code before `cargo check` runs. That would weaken a file where every other external action (`actions/checkout`, `create-github-app-token`, `upload-artifact`, `create-pull-request`) is sha-pinned on purpose. Teaching the bot the env-var shape costs neither property, but it means changing `update-kin-actions-pins.py`'s regex and manifest schema in `firelock-ai/kin-actions`, a different repository running a security-sensitive release App, outside this lane's ownership and worktree. Recommending it as follow-up, not doing it here.

**What this PR adds** is the seam nothing was grading. `scripts/verify-kin-actions-pin-visibility.py` scans every workflow file for a kin-actions reference outside the bot-visible `uses:` shape and fails unless it's named, with a reason, in an explicit allowlist. A stale allowlist entry fails the same way. `scripts/falsify-kin-actions-pin-visibility.py` proves the guard works. The real tree passes clean. A bare bot-visible pin passes on its own, and so does a comment-only mention. A fresh, unallowlisted env-var pin fails and names the file it appeared in. The same is true for a fresh checkout reference. A stale allowlist entry fails too, and says which one. Both scripts are wired into the required `Fast gate lint and policy` job, right beside the Docker-daemon and zero-file-search guards it already runs the same way.

I also hand-verified the guard against the real file. I renamed `KIN_ACTIONS_SHA` to `KIN_ACTIONS_PIN` in place and watched the guard go red, naming every drifted line plus the now-stale allowlist entry. Then I restored from a diffed copy and watched it go green again.

Five times tonight, one shape has repeated. An invariant gets enforced in more than one place, and nothing grades the seam between them. The real question is this: when a pin lives in more than one form, what grades the ones the bot cannot see?
