### PR TITLE
Make the zero-file-search guards detect the operation, and retire BOUNDARY_DIRS (FIR-3151, FIR-3149)

### DIFF
--- a/scripts/verify-zero-file-search.py
+++ b/scripts/verify-zero-file-search.py
@@ -36,6 +36,31 @@ ALLOWLIST_PATH = os.path.join(SCRIPT_DIR, "zero-file-search-allowlist.json")
 # owner and a date by which it is re-justified or removed.
 REQUIRED_FIELDS = ("file", "reason", "owner", "expiration")
 
+# How much runway an expiring exemption gets before the guard starts saying so.
+#
+# An expiry used to be a cliff. The check at the bottom of `load_allowlist` is
+# `exp_date < today`, so an entry is fine on the last day and fails the build on
+# the next one, with no signal in between. That was survivable while both guards
+# ran only on push to main. kin#1448 moved them into `fast-gate-lint`, which
+# carries the required "Fast gate lint and policy" context and no job-level `if`,
+# so from that landing an expiry blocks EVERY kin pull request on the day it
+# fires, whatever the pull request touches. Nobody re-read the dates when that
+# landed, because nothing asked them to.
+#
+# 45 days is a runway a re-justification actually fits inside. The spec.rs entry
+# is the worked example: its fix is a kin-model then kin-db then registry
+# publish train carrying a GraphSnapshot format version, which is not schedulable
+# inside a week of notice.
+EXPIRY_WARNING_DAYS = 45
+
+# A shared expiry date is worth naming even when it is far away, because the
+# risk it carries is not the individual entry, it is the cluster. Entries that
+# all say "end of the quarter" carry no information about any one exemption and
+# guarantee that whichever day they share takes the whole repository down at
+# once. This is the threshold above which a shared date is reported in the
+# summary rather than left to be discovered on the day.
+EXPIRY_CLUSTER_SIZE = 3
+
 
 class Policy:
     """What the allowlist exempts inside one file.
@@ -257,100 +282,116 @@ def load_allowlist():
     return policies, errors
 
 
-BOUNDARY_DIRS = [
-    # kin-daemon is deliberately absent. It used to be exempt as a directory,
-    # which exempted the RPC surface every agent and CLI reaches Kin through,
-    # and a six-handler opt-in rescued roughly a sixtieth of api.rs. The crate
-    # is now scanned by default and its boundary IO is declared per file in
-    # scripts/zero-file-search-allowlist.json, so a new daemon module, a new
-    # query handler above all, is covered the moment it is added.
-    #
-    # kin-projection and kin-reconcile are absent for the same reason, and the
-    # argument is the daemon's applied a second time rather than a new one.
-    # Both were whole-directory entries, so neither gate could see either
-    # crate: this one skipped them here, and the shell guard beside it scans a
-    # fixed list of kin-cli command modules and reaches no other crate by
-    # construction. What the exemption was covering was a graph-miss path in
-    # the reconciler that read the working copy, latent only because its one
-    # caller was a test. Narrowing surfaced 58 sites across five files;
-    # 57 are materialization, write and ingest-boundary IO and are declared per
-    # file in the allowlist with an owner and an expiry, and the fifty-eighth,
-    # a working-copy probe deciding a placement answer, is recorded there as
-    # debt rather than as a boundary. A boundary directory carries neither an
-    # owner nor an expiry, which is why converting one is worth the entries it
-    # costs.
-    "crates/kin-migrate/",
-    "crates/kin-index/",
-    "crates/kin-registry/",
-    "crates/kin-buildinfo/",
-    # kin-core is a mixed crate: it carries the semantic repo's config, layout,
-    # init, projection, ingestion, and git-history boundary IO — all legitimate
-    # input/output boundaries — but it must not be broadly exempted, or an
-    # answer-authority raw-filesystem path (like the retired text_refs source
-    # scan that backed `kin refs`/`kin rename`) could hide there again.
-    # Enumerate the boundary files explicitly so every other kin-core file,
-    # including any newly added one, is scanned by default.
-    "crates/kin-core/src/assistant.rs",
-    "crates/kin-core/src/assistant_sync.rs",
-    "crates/kin-core/src/config.rs",
-    # The Windows half of the same config writer. It is the identical boundary
-    # as config.rs, split out because publishing a file atomically shares no
-    # code between the two platforms, and it answers no query: every call here
-    # writes or proves the repository's own config file at a path the caller
-    # already validated, never resolves one by searching.
-    "crates/kin-core/src/config/windows.rs",
-    "crates/kin-core/src/dependencies.rs",
-    "crates/kin-core/src/env_registry.rs",
-    "crates/kin-core/src/federation.rs",
-    "crates/kin-core/src/git_init.rs",
-    "crates/kin-core/src/init.rs",
-    # The post-mortem for an interrupted init, and the same boundary as
-    # init_staging.rs beside it. It reads only the staging directories init
-    # itself minted in the repository's parent, to report where a killed
-    # conversion stopped and how much disk it is holding. It answers no
-    # locate/search/context/trace/review/xref query, reads no repository
-    # content, and runs before any graph exists.
-    "crates/kin-core/src/init_attempt.rs",
-    # Init's own staging directories, and nothing else. It runs before any
-    # graph exists, on paths init itself minted, and its whole output is
-    # whether a directory this process created still needs removing. It
-    # answers no locate/search/context/trace/review/xref query, and the
-    # directory it enumerates is the repository's parent, never repository
-    # content.
-    "crates/kin-core/src/init_staging.rs",
-    "crates/kin-core/src/layout.rs",
-    "crates/kin-core/src/lib.rs",
-    "crates/kin-core/src/manifest.rs",
-    "crates/kin-core/src/ref_view.rs",
-    "crates/kin-core/src/registry.rs",
-    "crates/kin-core/src/shims.rs",
-    "crates/kin-core/src/sync_state.rs",
-    "crates/kin-core/src/tree.rs",
-    # kin-git is scanned by default because it also carries answer-adjacent
-    # logic (co-change, blame-style history) that must come from graph truth.
-    # These four modules are the Git format boundary itself: capturing a Git
-    # repository, reporting what would stop one being admitted, proving a
-    # checkout matches its committed seed before admission, and materializing
-    # graph-owned history back out as Git. Reading a Git repository from disk is
-    # the entire point of an import boundary, and none of these modules answers
-    # a locate/search/context/trace/review/xref query. Enumerated file by file
-    # so every other kin-git module, including any newly added one, keeps being
-    # scanned.
-    "crates/kin-git/src/lossless.rs",
-    # Runs before any graph exists, on the source Git repository, and produces
-    # only refusals. Nothing it reads reaches a query answer, and its whole
-    # output is a list of reasons admission cannot start.
-    "crates/kin-git/src/admission_blockers.rs",
-    "crates/kin-git/src/preflight.rs",
-    "crates/kin-git/src/repository_export.rs",
-    "crates/kin-runtime/",
-    "crates/kin-parser/",
-    "crates/kin-ranking/src/ltr.rs",
-    "crates/kin-cli/src/daemon_client.rs",
-    "crates/kin-cli/src/profile.rs",
-    "crates/kin-cli/src/main.rs",
-    "crates/kin-cli/src/backend.rs"
-]
+def expiry_report(today=None):
+    """(warnings, summary) about allowlist expiries that have not fired yet.
+
+    Deliberately advisory. An expiry that has passed is an accountability
+    failure and fails the guard; an expiry that is approaching is information,
+    and turning it into a failure would just move the cliff earlier. So none of
+    this touches the exit status.
+
+    Reads the allowlist itself rather than taking `load_allowlist`'s parsed
+    output, which keeps that function's signature and its callers alone. The
+    file is small and the parse is not worth a coupling.
+
+    The summary line is unconditional, and that is the point of it. The failure
+    this exists to prevent was not that someone ignored a warning, it was that
+    47 entries quietly shared two dates and no run ever said so. One line naming
+    the next date and how many entries sit on it makes a cluster visible months
+    before it can hurt, with no threshold to tune and no noise on a clean run.
+    """
+    today = today or date.today()
+    try:
+        with open(ALLOWLIST_PATH, "r", encoding="utf-8") as handle:
+            entries = json.load(handle).get("allowlist", [])
+    except Exception:
+        # Loading already failed loudly in load_allowlist; do not report twice.
+        return [], None
+
+    upcoming = {}
+    for item in entries:
+        raw = item.get("expiration")
+        owner = item.get("owner", "?")
+        if not raw or not item.get("file"):
+            continue
+        try:
+            when = date.fromisoformat(raw)
+        except ValueError:
+            continue
+        if when < today:
+            continue  # already fired; load_allowlist reports it as an error
+        upcoming.setdefault(when, []).append((item["file"], owner))
+
+    if not upcoming:
+        return [], None
+
+    warnings = []
+    for when in sorted(upcoming):
+        days = (when - today).days
+        if days > EXPIRY_WARNING_DAYS:
+            continue
+        owners = sorted({owner for _, owner in upcoming[when]})
+        warnings.append(
+            f"  {len(upcoming[when])} exemption(s) expire {when.isoformat()}, "
+            f"in {days} day(s), owned by {', '.join(owners)}:"
+        )
+        for path, owner in sorted(upcoming[when]):
+            warnings.append(f"      {path} ({owner})")
+        warnings.append(
+            "    Re-justify with a later date and a stated reason, or remove the "
+            "exemption. After that date every kin pull request fails this gate."
+        )
+
+    soonest = min(upcoming)
+    count = len(upcoming[soonest])
+    summary = (
+        f"Next allowlist expiry: {soonest.isoformat()} "
+        f"({count} entr{'y' if count == 1 else 'ies'}, "
+        f"{(soonest - today).days} days)."
+    )
+    clusters = [
+        (when, len(rows))
+        for when, rows in sorted(upcoming.items())
+        if len(rows) >= EXPIRY_CLUSTER_SIZE
+    ]
+    if clusters:
+        shape = ", ".join(f"{n} on {when.isoformat()}" for when, n in clusters)
+        summary += (
+            f" Shared dates: {shape}. A date many entries share fails them all at"
+            " once; stagger by owner so each date means one owner's review."
+        )
+    return warnings, summary
+
+
+# BOUNDARY_DIRS is gone, and the deletion is the point of FIR-3149.
+#
+# It held 34 exemptions: six whole directories and 28 individual file paths.
+# None of the 34 carried an owner, an expiry or a reason, against 47 entries in
+# scripts/zero-file-search-allowlist.json that carry all three and are refused
+# by the loader when one is missing or past due. So the split was never
+# "directories are loose, files are owned"; it was one accountable list and one
+# unaccountable one, with a third of all exemptions living in the unaccountable
+# one. An uncounted exemption was its characteristic failure: kin-runtime and
+# kin-parser were whole-directory entries that no ticket in the class had ever
+# counted, because a directory line has no owner to notice it and no date to
+# surface it.
+#
+# It was also the only mechanism here that exempted code that did not exist yet.
+# An unlisted file inherited its directory's silence, so a new module in an
+# exempt crate was exempt on the day it was written, by nobody's decision. That
+# is how kin-daemon, kin-core, kin-projection and kin-reconcile each came to
+# hide a surface someone later had to find.
+#
+# What the conversion actually cost, measured rather than estimated: the six
+# directories covered 93 .rs files, 56 of them on the scanned runtime path, and
+# only 16 contain any filesystem primitive at all, so the exemption was roughly
+# three and a half times wider than anything it protected. Five of the 28
+# per-file paths reported zero sites and needed no entry at all; migrating them
+# would have manufactured an owner for something nobody has to own.
+# crates/kin-buildinfo/ needed none either, because all five of its sites were
+# in build.rs and `is_build_or_example` now excludes that by construction.
+# Everything else is a whole-file entry in the allowlist with an owner and a
+# staggered review date.
 
 QUERY_COMMANDS = {
     "locate.rs",
@@ -423,6 +464,35 @@ FN_DECL = re.compile(
 )
 
 
+def is_build_or_example(rel_path):
+    """Whether cargo compiles this path into something other than the product.
+
+    A build script runs on the developer's machine before the crate exists, and
+    an example is not linked into the library at all. Neither can be a query
+    answer BY CONSTRUCTION, which is a different kind of reason from every
+    other exclusion here: the rest are judgements about what a module does, and
+    this one is a fact about what cargo builds.
+
+    It matters because it decides which exemptions are real. Five of
+    kin-buildinfo's five reported sites are in `build.rs`, and two of
+    kin-parser's eight are in `examples/dump_parsed.rs`, so without this the
+    only way to quiet them is a crate-wide exemption that also covers the
+    crate's runtime code. That is a whole-directory exemption bought to silence
+    a build script, and it is how a directory entry earns a reason nobody can
+    argue with while hiding things nobody looked at.
+
+    Anchored to cargo's own layout rather than matched as a substring.
+    `crates/<crate>/build.rs` is a build script; `crates/<crate>/src/build.rs`
+    is an ordinary module and stays scanned. Likewise `crates/<crate>/examples/`
+    is cargo's directory, while a hypothetical `crates/<crate>/src/examples/` is
+    runtime code.
+    """
+    segments = rel_path.split("/")
+    if len(segments) < 3 or segments[0] != "crates":
+        return False
+    return segments[2] == "build.rs" or (len(segments) > 3 and segments[2] == "examples")
+
+
 def is_test_file(rel_path):
     # Skip standalone test directories. Anchored to whole path segments: a
     # substring test skipped any module whose name merely contained `test_`,
@@ -436,10 +506,11 @@ def is_test_file(rel_path):
         or rel_path.endswith("_test.rs")
     ):
         return True
-    # Skip ingestion/migration/projection boundary directories/files
-    for bdir in BOUNDARY_DIRS:
-        if rel_path.startswith(bdir) or rel_path == bdir:
-            return True
+
+    # Not a runtime path at all, so no exemption should ever have to cover it.
+    # A crate exemption was the only way to silence a build script before this.
+    if is_build_or_example(rel_path):
+        return True
 
     # For CLI commands, only scan query commands
     if "crates/kin-cli/src/commands/" in rel_path:
@@ -466,25 +537,133 @@ def scan_reaches(rel_path):
     return rel_path.startswith("crates/") and not is_test_file(rel_path)
 
 
-# Patterns to scan.
+# What the guard detects, and why it is not a list of spellings.
 #
-# The first group is the raw filesystem read / existence / traversal primitive
-# set shared with scripts/zero_file_search_guard.sh. Answering a semantic query
-# by probing the working tree is the violation the rule exists to stop, and it
-# does not require the `std::fs::` prefix to happen: `path.exists()`,
-# `path.try_exists()`, `File::open`, a bare `read_dir(`, or a `WalkDir`
-# traversal all read the tree just as directly. Spawning a subprocess is also
-# denied in answer modules: otherwise `rg`, `grep`, `find`, or a multiline
-# `git grep` builder can replace the semantic authority behind the guard's
-# back.
+# A deny-list of call spellings is always one spelling behind, and this guard
+# was. `PATTERNS` carried `\bstd::fs::[a-zA-Z0-9_]+`, which catches the
+# fully-qualified form by accident, through the module path rather than through
+# the primitive. `{` is not in that character class, so
+# `use std::fs::{self, OpenOptions};` matched nothing, and neither did the
+# `OpenOptions::new()...open(path)` it enables. That import is
+# crates/kin-projection/src/tree.rs line 13 verbatim, so the shape that evaded
+# the guard was the shape the codebase already writes.
+#
+# The fix is not a longer list. It is to detect the OPERATION, which in Rust
+# has exactly three syntactic forms, and to enumerate only where the language
+# leaves no choice:
+#
+#   1. A filesystem module named in the path. `std::fs::anything` is a
+#      filesystem operation whatever `anything` is, so NAMESPACE_REACH matches
+#      the MODULE and lets the item name be anything at all. That is complete
+#      over `std::fs` present and future: `std::fs::exists` (stabilised in
+#      1.81) needed no edit here, and neither will the next one.
+#
+#   2. A name the file imported out of such a module. `OpenOptions::new()`
+#      carries no filesystem marker, but the `use` that bound it does, so the
+#      guard READS each file's own use trees and denies what they bind. That is
+#      complete over types std has not shipped yet, and it is the only
+#      mechanism that survives an alias: `use std::fs::OpenOptions as Opener;`
+#      defeats every global spelling list and does not defeat this.
+#
+#   3. An inherent method on `Path`/`PathBuf`, which needs no import and so has
+#      neither a module path nor a binding to learn from. This is the one place
+#      enumeration is forced, and the set is closed by std rather than by our
+#      imagination: ten methods, verified against
+#      library/std/src/path.rs on rustc 1.96.0 (2026-09-03) with
+#      `verify-zero-file-search.py --audit-std`. SELF_TEST_CASES holds every
+#      one of them with a positive and a negative control and runs on every
+#      invocation, so the enumeration cannot silently shrink.
+#
+# Spawning a subprocess is denied in answer modules for the same reason:
+# otherwise `rg`, `grep`, `find`, or a multiline `git grep` builder replaces the
+# semantic authority behind the guard's back.
 #
 # Writes and directory creation ARE denied here, unlike in the shell guard,
-# because the module-qualified patterns below match all of `std::fs::` and the
-# named `fs::` calls include the mutating ones. Materialization is a projection
-# boundary rather than answer-by-search, so a write in an answer module is not
-# the violation this rule exists to stop. It is still a claim worth stating out
+# because matching the module rather than the item name catches all of
+# `std::fs`, mutating calls included. Materialization is a projection boundary
+# rather than answer-by-search, so a write in an answer module is not the
+# violation this rule exists to stop. It is still a claim worth stating out
 # loud, and stating it means an explicit allowlist pin naming the boundary
 # rather than a pattern that never looked.
+
+# Module paths whose contents reach the filesystem. The two lists below differ
+# on purpose, because they are consumed by two different mechanisms.
+#
+# NAMESPACE_REACH is matched textually against every scanned line, so it carries
+# only spellings that cannot be anything else. `ignore` and `tempfile` are
+# absent from it precisely because they are ordinary English words that appear
+# in identifiers and prose.
+#
+# FS_USE_ROOTS is matched against a PARSED `use` path, where a root segment is
+# unambiguous by construction, so it can afford single-word crate names.
+NAMESPACE_REACH = re.compile(
+    r"\b(?:std|core)::fs\b"
+    r"|\bstd::os::(?:unix|windows|wasi)::fs\b"
+    r"|\b(?:tokio|async_std|smol)::fs\b"
+    r"|\b(?:fs_err|fs2|fs_extra|filetime|walkdir)::"
+    r"|\bWalkDir\b"
+    r"|\bglob::glob\b"
+)
+
+FS_USE_ROOTS = (
+    "std::fs",
+    "std::os::unix::fs",
+    "std::os::windows::fs",
+    "std::os::wasi::fs",
+    "tokio::fs",
+    "async_std::fs",
+    "smol::fs",
+    "fs_err",
+    "fs2",
+    "fs_extra",
+    "filetime",
+    "walkdir",
+    "glob",
+    "ignore",
+    "notify",
+    "tempfile",
+)
+# `std::process` is deliberately NOT here, and the reason is measured rather
+# than assumed. Subprocess execution is already detected twice, at the import
+# by `process\s*(?:::|as)` and at the call by `Command::new(`, so learning its
+# bindings adds no coverage. It does add reports: in kin-daemon-spawn alone it
+# named 21 more lines, every one of them a `Command` or `Stdio` mentioned in a
+# type position rather than an execution. Pins for those would be ceremony, and
+# an allowlist full of ceremony trains readers to skim the entry that matters.
+
+# The public item names `use std::fs::*;` brings into scope. A glob binds no
+# name the parser can read off the declaration, so this is the fallback for
+# that one shape. Everything else resolves from the use tree itself and needs
+# no vocabulary, which is the whole point.
+FS_GLOB_VOCABULARY = (
+    "File",
+    "OpenOptions",
+    "DirBuilder",
+    "DirEntry",
+    "ReadDir",
+    "Metadata",
+    "Permissions",
+    "FileType",
+    "FileTimes",
+)
+
+# The closed set from form 3 above: `Path`/`PathBuf` inherent methods that
+# reach the filesystem. Extracted from the toolchain's own std source by
+# `--audit-std`, which is how the claim "this set is closed" stays checkable
+# rather than remembered.
+PATH_FS_METHODS = (
+    "canonicalize",
+    "exists",
+    "is_dir",
+    "is_file",
+    "is_symlink",
+    "metadata",
+    "read_dir",
+    "read_link",
+    "symlink_metadata",
+    "try_exists",
+)
+
 PATTERNS = [
     (re.compile(r'\.is_file\(\)'), "filesystem existence probe (is_file)"),
     (re.compile(r'\.is_dir\(\)'), "filesystem existence probe (is_dir)"),
@@ -495,7 +674,7 @@ PATTERNS = [
     (re.compile(r'\.metadata\(\)'), "filesystem metadata probe"),
     (re.compile(r'\bsymlink_metadata\b'), "filesystem metadata probe"),
     (re.compile(r'\bread_link\b'), "filesystem symlink read"),
-    (re.compile(r'\bFile::open\b'), "raw file handle open"),
+    (re.compile(r'\bFile::(?:open|create|create_new|options)\b'), "raw file handle open"),
     (re.compile(r'\bread_dir\('), "directory traversal (read_dir)"),
     (re.compile(r'\bWalkDir\b|\bwalkdir::'), "directory traversal (walkdir)"),
     (re.compile(r'\bglob::glob\b'), "filesystem glob"),
@@ -504,9 +683,181 @@ PATTERNS = [
     # namespace alias before it can hide a later `Alias::Command::new` call.
     # Bare Command::new covers an imported, unaliased constructor.
     (re.compile(r'\bCommand::new\s*\(|\bprocess\s*(?:::|\bas\b)'), "subprocess execution in answer authority"),
-    (re.compile(r'\bstd::fs::[a-zA-Z0-9_]+'), "std::fs API usage"),
-    (re.compile(r'(?<![_a-z])fs::(read|read_to_string|read_dir|metadata|write|copy|create_dir|create_dir_all|remove_file|remove_dir|remove_dir_all)\b'), "fs API usage"),
+    # Form 1. The module, not the item: complete over the whole surface of
+    # every filesystem module, including items that do not exist yet.
+    (NAMESPACE_REACH, "filesystem module namespace reach"),
+    # Retained beneath the namespace reach rather than folded into it. This
+    # catches a bare `fs::` alias in a file whose `use` the parser could not
+    # read, so the two mechanisms fail independently.
+    (re.compile(r'(?<![_a-z])fs::(read|read_to_string|read_dir|metadata|write|copy|create_dir|create_dir_all|remove_file|remove_dir|remove_dir_all|rename|set_permissions|hard_link|exists)\b'), "fs API usage"),
 ]
+
+# Deliberately NOT a pattern: a bare `symlink(` regex. It reads as the obvious
+# addition and it false-positives three times in this tree on
+# `TreeEntry::symlink(...)`, a graph type constructor that touches no
+# filesystem. Detecting the operation removes the need for it, because the real
+# call is `std::os::unix::fs::symlink`, which NAMESPACE_REACH already matches
+# through its module. SELF_TEST_CASES keeps both halves of that honest.
+
+
+USE_HEAD = re.compile(r"^\s*(?:pub(?:\s*\([^)]*\))?\s+)?use\s+(.*)$", re.S)
+USE_START = re.compile(r"^\s*(?:pub(?:\s*\([^)]*\))?\s+)?use\b")
+USE_ALIAS = re.compile(r"^(.*?)\s+as\s+([A-Za-z0-9_]+)$")
+
+
+def expand_use_tree(text):
+    """Yield (full path, bound name) for every leaf of one `use` declaration.
+
+    `text` is the declaration body after `use`, with its trailing `;` removed.
+    Nesting, `self`, `as` aliases and globs all resolve here, because the point
+    of reading the tree at all is to learn what a file actually bound rather
+    than to guess which spellings it might have used. `use std::fs::{self,
+    OpenOptions};` binds `fs` and `OpenOptions`; `use std::fs::File as F;`
+    binds `F`, which no list of spellings can know.
+    """
+    out = []
+
+    def members_of(body):
+        depth, current, members = 0, [], []
+        for ch in body:
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+            if ch == "," and depth == 0:
+                members.append("".join(current))
+                current = []
+                continue
+            current.append(ch)
+        if "".join(current).strip():
+            members.append("".join(current))
+        return members
+
+    def walk(prefix, body):
+        body = body.strip()
+        if not body:
+            return
+        members = members_of(body)
+        if len(members) > 1:
+            for member in members:
+                walk(prefix, member)
+            return
+
+        member = members[0].strip() if members else ""
+        if not member:
+            return
+
+        brace = member.find("{")
+        if brace >= 0:
+            close = member.rfind("}")
+            if close < brace:
+                return
+            head = member[:brace].strip().rstrip(":").strip()
+            joined = f"{prefix}::{head}" if prefix and head else (head or prefix)
+            walk(joined, member[brace + 1 : close])
+            return
+
+        alias = None
+        aliased = USE_ALIAS.match(member)
+        if aliased:
+            member, alias = aliased.group(1).strip(), aliased.group(2)
+        if member == "self":
+            full = prefix
+            name = alias or (prefix.split("::")[-1] if prefix else "")
+        else:
+            full = f"{prefix}::{member}" if prefix else member
+            name = alias or member.split("::")[-1]
+        if full:
+            out.append((full.lstrip(":"), name))
+
+    walk("", text)
+    return out
+
+
+def use_declarations(lexed):
+    """Yield (line index, declaration body) for every `use` item in a file.
+
+    Bounded with the same `item_span` the test-gate tracker uses, so a use tree
+    spanning lines is read whole. Read off the lexically stripped text, so a
+    `use` inside a comment or a string literal is not one.
+    """
+    n = len(lexed)
+    i = 0
+    while i < n:
+        if not USE_START.match(lexed[i][0]):
+            i += 1
+            continue
+        span = item_span(lexed, i)
+        if span is None:
+            i += 1
+            continue
+        body = " ".join(lexed[j][0] for j in range(span[0], span[1] + 1))
+        head = USE_HEAD.match(body)
+        if head:
+            yield i, head.group(1).strip().rstrip(";").strip()
+        i = span[1] + 1
+
+
+def rooted_in_filesystem(path):
+    """Whether a resolved `use` path names an item inside a filesystem module."""
+    return any(path == root or path.startswith(root + "::") for root in FS_USE_ROOTS)
+
+
+def filesystem_bindings(lexed):
+    """Names this file bound out of a filesystem module, as a deny set.
+
+    Derived from the file's own `use` declarations BEFORE any allowlist pin is
+    masked, and that ordering is the point. Pinning the import line is the
+    natural way to excuse `use std::fs::{self, OpenOptions};`, and if bindings
+    were read after masking, that one pin would silence every
+    `OpenOptions::new()` in the file forever. Read before, the pin buys silence
+    on its own line and nothing else.
+
+    A binding of `_` is skipped: `use std::os::unix::fs::PermissionsExt as _;`
+    imports a trait for its methods and names nothing a later line can spell.
+    The declaration itself still trips NAMESPACE_REACH, which is the honest
+    limit here: a trait extension makes its methods reachable with no syntactic
+    marker of their own, so the guard reports the import and whoever pins it
+    owns that trait's whole surface.
+
+    Only lines the scan reads contribute. An import inside `#[cfg(test)] mod
+    tests` binds nothing in a production build, and counting it would deny a
+    name across code that never sees it.
+    """
+    bindings = set()
+    scanned = {index for index, _ in scannable_lines(lexed)}
+    for index, body in use_declarations(lexed):
+        if index not in scanned:
+            continue
+        for path, name in expand_use_tree(body):
+            if not rooted_in_filesystem(path):
+                continue
+            if name == "*":
+                bindings.update(FS_GLOB_VOCABULARY)
+            elif name and name != "_":
+                bindings.add(name)
+    return bindings
+
+
+def binding_pattern(bindings):
+    """One compiled matcher for a file's filesystem bindings, or None.
+
+    A bound name is a path root or a type, never the tail of a field access, so
+    a preceding `.` disqualifies it. Without that, `use std::fs;` would deny
+    every `self.fs` in the file.
+
+    Matched against the lexically stripped `structure` rather than `code`, which
+    is the opposite choice from `PATTERNS` and is forced by what a binding is. A
+    bound NAME is an ordinary identifier, so it collides with English: with
+    `use std::fs;` in scope, matching literals reported the path
+    `"/sys/fs/cgroup"` four times, and with `use std::process;` in scope it
+    reported the word "process" inside an `eprintln!`. `PATTERNS` keeps literals
+    because its members are call shapes that cannot occur in prose by accident.
+    """
+    if not bindings:
+        return None
+    names = "|".join(re.escape(name) for name in sorted(bindings, key=len, reverse=True))
+    return re.compile(r"(?<![.\w])(?:" + names + r")\b")
 
 
 class LexState:
@@ -1075,6 +1426,10 @@ def scan_file(filepath, rel_path, exempt_fn_names=None, allowed_matches=None):
     lexed = lex_lines(lines)
     ranges = exempt_body_ranges(lines, exempt_fn_names, lexed)
 
+    # Read before masking, deliberately. See `filesystem_bindings`: a pin on the
+    # import line must not license every use of what that import bound.
+    bindings = binding_pattern(filesystem_bindings(lexed))
+
     for idx, line in scannable_lines(lexed):
         if any(lo <= idx <= hi for lo, hi in ranges):
             continue
@@ -1086,14 +1441,175 @@ def scan_file(filepath, rel_path, exempt_fn_names=None, allowed_matches=None):
         # line once with every primitive it tripped, so the violation count
         # tracks offending lines rather than pattern hits.
         descs = [desc for pattern, desc in PATTERNS if pattern.search(scan_line)]
+        # Both, and the conjunction carries the whole meaning. `structure` has
+        # literal contents blanked, so a name that only ever appears inside a
+        # string is not an operation. `scan_line` has the validated pins masked,
+        # so a name a boundary pin already declared is not reported twice. A
+        # site has to survive both to be a use of the binding this file made.
+        if bindings is not None and bindings.search(lexed[idx][0]) and bindings.search(scan_line):
+            descs.append("filesystem name bound by this file's own `use`")
         if descs:
             violations.append((idx + 1, line.strip(), ", ".join(dict.fromkeys(descs))))
 
     return violations
 
 
+# One case per primitive the guard claims, plus the negatives that keep the
+# claim from being satisfied by a matcher that reports everything.
+#
+# This is what makes the residual enumeration checkable. Forms 1 and 2 are
+# complete by construction and need no inventory; form 3, the `Path` inherent
+# methods, is enumerated because the language leaves no alternative, and this
+# table is what stops that enumeration silently shrinking. Deleting a pattern
+# turns a positive case red. Widening one until it matches prose turns a
+# negative case red. Both run on every invocation, so both grade the pull
+# request that would introduce them rather than main a release later.
+#
+# Fields: (label, source line, this file's fs bindings, must be reported).
+SELF_TEST_CASES = [
+    # Form 3: the closed Path/PathBuf set, one case each.
+    ("Path::exists", "if path.exists() {", (), True),
+    ("Path::try_exists", "if path.try_exists().unwrap_or(false) {", (), True),
+    ("Path::is_file", "if path.is_file() {", (), True),
+    ("Path::is_dir", "if path.is_dir() {", (), True),
+    ("Path::is_symlink", "if path.is_symlink() {", (), True),
+    ("Path::metadata", "let m = path.metadata()?;", (), True),
+    ("Path::symlink_metadata", "let m = symlink_metadata(path)?;", (), True),
+    ("Path::canonicalize", "let p = path.canonicalize()?;", (), True),
+    ("Path::read_link", "let t = read_link(path)?;", (), True),
+    ("Path::read_dir", "for e in read_dir(path)? {", (), True),
+    # Form 1: the module, whatever the item is.
+    ("qualified fs call", "let s = std::fs::read_to_string(p)?;", (), True),
+    ("grouped fs import", "use std::fs::{self, OpenOptions};", (), True),
+    ("bare fs module import", "use std::fs;", (), True),
+    ("std::fs item that did not exist in 1.80",
+     "if std::fs::exists(p)? {", (), True),
+    ("os-specific fs module", "std::os::unix::fs::symlink(target, dest)?;", (), True),
+    ("third-party fs crate", "use fs2::FileExt;", (), True),
+    ("async fs module", "let b = tokio::fs::read(p).await?;", (), True),
+    ("walkdir traversal", "for e in WalkDir::new(root) {", (), True),
+    ("glob", "for p in glob::glob(\"**/*.rs\")? {", (), True),
+    ("subprocess", "Command::new(\"rg\").arg(needle).output()?;", (), True),
+    # Form 2: names this file bound, including the alias no list can hold.
+    ("imported constructor", "let f = OpenOptions::new().read(true).open(p)?;",
+     ("OpenOptions",), True),
+    ("aliased constructor", "let f = Opener::new().read(true).open(p)?;",
+     ("Opener",), True),
+    ("imported File", "let f = File::create(p)?;", ("File",), True),
+    ("bare fs alias call", "fs::set_permissions(p, perms)?;", ("fs",), True),
+    # Negative controls. A deny set that reports these is matching prose, and a
+    # run where every case passes because everything matches proves nothing.
+    ("graph symlink constructor", "TreeEntry::symlink(record.body_hash),", (), False),
+    ("path join is not IO", "let p = root.join(\"kin\").join(name);", (), False),
+    ("compile-time include", "const H: &str = include_str!(\"index.html\");", (), False),
+    ("reader over a pipe", "let reader = BufReader::new(stdin);", (), False),
+    ("field named fs", "self.fs_state = FsState::Ready;", ("fs",), False),
+    ("prose mentioning a file", "// read the manifest from the graph, not the tree",
+     (), False),
+]
+
+
+def line_is_reported(line, bindings=()):
+    """Whether the scan's matcher would report this line. One code path only.
+
+    The self-test asks the question through the same two matchers `scan_file`
+    uses rather than restating them, so a case cannot pass against a copy of
+    the deny set that the scan no longer consults.
+    """
+    structure, code = split_code(line, LexState())
+    if any(pattern.search(code) for pattern, _ in PATTERNS):
+        return True
+    bound = binding_pattern(set(bindings))
+    return bound is not None and bound.search(structure) is not None
+
+
+def self_test():
+    """Check the deny set against SELF_TEST_CASES, returning a list of errors."""
+    errors = []
+    for label, line, bindings, want in SELF_TEST_CASES:
+        got = line_is_reported(line, bindings)
+        if got != want:
+            errors.append(
+                f"  deny-set self-test {label!r}: "
+                f"{'missed a primitive it claims to detect' if want else 'reported a line that touches no filesystem'}"
+                f" -> {line.strip()!r}"
+            )
+    covered = sum(1 for _, _, _, want in SELF_TEST_CASES if want)
+    if covered < len(PATH_FS_METHODS):
+        errors.append(
+            f"  deny-set self-test has {covered} positive cases for "
+            f"{len(PATH_FS_METHODS)} enumerated Path methods; the inventory "
+            "cannot be smaller than what it claims to cover"
+        )
+    return errors
+
+
+def audit_std():
+    """Re-derive the closed `Path` set from the toolchain's own std source.
+
+    Not a CI gate: it needs the `rust-src` component, and a check that skips
+    when a component is missing reports nothing and looks like a pass. It is
+    the lane tool that makes PATH_FS_METHODS checkable rather than remembered,
+    and the date and rustc version of the last run are recorded beside that
+    constant. Run it when a toolchain bump lands.
+    """
+    import subprocess
+
+    sysroot = subprocess.run(
+        ["rustc", "--print", "sysroot"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    version = subprocess.run(
+        ["rustc", "--version"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    source = os.path.join(sysroot, "lib/rustlib/src/rust/library/std/src/path.rs")
+    if not os.path.exists(source):
+        print(f"rust-src is not installed; {source} is missing.")
+        print("Install it with `rustup component add rust-src` and re-run.")
+        return 2
+
+    with open(source, "r", encoding="utf-8") as handle:
+        raw = handle.read().split("\n")
+    # Doc comments carry examples full of `fs::`, and an example is not a call.
+    code = "\n".join("" if re.match(r"\s*//", line) else line for line in raw)
+
+    found = set()
+    for match in re.finditer(r"\n    pub fn ([a-z_0-9]+)\s*[(<]", code):
+        tail = code[match.end() :]
+        stop = tail.find("\n    pub fn ")
+        body = tail[:stop] if stop > 0 else tail[:2000]
+        if re.search(r"\bfs::", body):
+            found.add(match.group(1))
+
+    if not found:
+        # The positive control. An extraction that finds nothing would confirm
+        # any inventory at all, which is the trap this whole guard exists to
+        # avoid, so it is a failure rather than a clean sheet.
+        print(f"AUDIT FAILED: found no fs-reaching Path methods in {source}.")
+        print("The extraction is broken, not the inventory.")
+        return 1
+
+    declared = set(PATH_FS_METHODS)
+    print(f"{version}\n{source}")
+    print(f"std declares {len(found)} fs-reaching Path/PathBuf methods.")
+    missing = sorted(found - declared)
+    extra = sorted(declared - found)
+    for name in missing:
+        print(f"  MISSING from PATH_FS_METHODS: {name}")
+    for name in extra:
+        print(f"  no longer in std: {name}")
+    uncovered = [n for n in sorted(found) if not line_is_reported(f"let _ = path.{n}();")]
+    for name in uncovered:
+        print(f"  NOT MATCHED by any pattern: {name}")
+    if missing or extra or uncovered:
+        return 1
+    print(f"AUDIT PASSED: all {len(found)} are declared and all are matched.")
+    return 0
+
+
 def main():
     policies, allowlist_errors = load_allowlist()
+    deny_set_errors = self_test()
+    expiry_warnings, expiry_summary = expiry_report()
     total_violations = 0
     scanned = 0
     whole_file_exempt = 0
@@ -1148,13 +1664,33 @@ def main():
         f"{whole_file_exempt} exempt whole-file)."
     )
 
+    # Printed on every run, red or green. An approaching expiry is not a verdict
+    # about this tree, it is a schedule, and a schedule nobody is shown is how 47
+    # entries came to share two dates without anyone noticing.
+    if expiry_summary:
+        print(expiry_summary)
+    if expiry_warnings:
+        print("\nAllowlist expiry WARNING (not a failure, yet):")
+        print("\n".join(expiry_warnings))
+
     if total_violations > 0:
         print(f"Verification FAILED: Found {total_violations} zero-file-search violations.")
     if allowlist_errors:
         report_allowlist_errors(allowlist_errors)
-    if total_violations or allowlist_errors:
+    if deny_set_errors:
+        # Last, and separate from the scan's own verdict. A scan is only worth
+        # its deny set, so a broken deny set has to be reported as its own
+        # failure rather than folded into a violation count that would read as
+        # a clean tree.
+        print("\nDeny-set self-test FAILED:")
+        print("\n".join(deny_set_errors))
+    if total_violations or allowlist_errors or deny_set_errors:
         sys.exit(1)
 
+    print(
+        f"Deny-set self-test passed: {len(SELF_TEST_CASES)} cases, "
+        f"{sum(1 for c in SELF_TEST_CASES if not c[3])} of them negative controls."
+    )
     print("Verification PASSED: Zero File-Search Invariant holds.")
     sys.exit(0)
 
@@ -1170,4 +1706,6 @@ def report_allowlist_errors(errors):
 
 
 if __name__ == "__main__":
+    if "--audit-std" in sys.argv[1:]:
+        sys.exit(audit_std())
     main()

--- a/scripts/verify-zero-file-search.py
+++ b/scripts/verify-zero-file-search.py
@@ -1509,6 +1509,49 @@ SELF_TEST_CASES = [
 ]
 
 
+# The LEARNER behind form 2, exercised over real `use` declarations.
+#
+# This table exists because the four form-2 cases above could not catch the
+# learner's deletion. They hand their bindings in as a literal tuple, so they
+# exercise `binding_pattern` and never `filesystem_bindings`, and an independent
+# review of kin#1458 proved the consequence rather than arguing it: with
+# `filesystem_bindings` stubbed to return an empty set, both guards stayed green
+# over the whole tree, all 30 cases above still passed, and a planted
+# `OpenOptions::new().read(true).open(p)` in a file whose entry pins its import
+# went silent. The one mechanism that closes FIR-3151 had no check anywhere that
+# failed when it was removed, which is precisely the class this guard exists to
+# stop, reproduced inside the fix for it.
+#
+# `scripts/falsify-zero-file-search.py` could not host this, for two independent
+# reasons. A probe that carries its own `use` is reported on that import line by
+# NAMESPACE_REACH whether or not the learner ran, so it passes with the learner
+# gone and proves nothing. And `Falsify guards` carries
+# `github.event_name != 'pull_request'`, so it never grades a pull request at
+# all. `self_test()` runs inside the scan, which `fast-gate-lint` runs on every
+# pull request, so this is the only surface that fails on the commit that breaks
+# it rather than on main a release later.
+#
+# Cases are the learner's own decision branches, not one happy path.
+BINDING_LEARNER_CASES = [
+    # The alias no global spelling list can hold. This is the whole argument for
+    # reading use trees, so it is the first thing that has to break.
+    ("alias", "use std::fs::OpenOptions as Opener;\n", {"Opener"}),
+    # `self` beside an item, which is the FIR-3151 import verbatim in shape.
+    ("self beside an item", "use std::fs::{self, File};\n", {"fs", "File"}),
+    ("third-party fs crate", "use fs2::FileExt;\n", {"FileExt"}),
+    # A glob binds no name the declaration names, so the vocabulary is the
+    # fallback for that one shape.
+    ("glob", "use std::fs::*;\n", set(FS_GLOB_VOCABULARY)),
+    # `as _` imports a trait for its methods and binds nothing a later line can
+    # spell. The learner must return nothing here and leave the import to
+    # NAMESPACE_REACH, which is the honest limit recorded on the function.
+    ("trait imported as _", "use std::os::unix::fs::PermissionsExt as _;\n", set()),
+    # Negative control. A learner that returned every name it saw, or that
+    # returned its input unfiltered, would satisfy every case above.
+    ("not a filesystem module", "use std::collections::HashMap;\n", set()),
+]
+
+
 def line_is_reported(line, bindings=()):
     """Whether the scan's matcher would report this line. One code path only.
 
@@ -1524,8 +1567,24 @@ def line_is_reported(line, bindings=()):
 
 
 def self_test():
-    """Check the deny set against SELF_TEST_CASES, returning a list of errors."""
+    """Check the deny set and the binding learner, returning a list of errors.
+
+    Two tables, because they fail for different reasons. SELF_TEST_CASES asks
+    whether the MATCHERS still recognise each primitive.
+    BINDING_LEARNER_CASES asks whether the learner that feeds one of those
+    matchers still reads a `use` tree at all, which no case in the first table
+    can answer.
+    """
     errors = []
+    for label, line, want in BINDING_LEARNER_CASES:
+        got = filesystem_bindings(lex_lines([line]))
+        if got != want:
+            errors.append(
+                f"  binding learner {label!r}: {line.strip()!r} bound "
+                f"{sorted(got)}, want {sorted(want)}. Form 2 of the deny set is "
+                "whatever this function returns, so a wrong answer here is a "
+                "silent hole rather than a failing pattern"
+            )
     for label, line, bindings, want in SELF_TEST_CASES:
         got = line_is_reported(line, bindings)
         if got != want:
@@ -1688,8 +1747,10 @@ def main():
         sys.exit(1)
 
     print(
-        f"Deny-set self-test passed: {len(SELF_TEST_CASES)} cases, "
-        f"{sum(1 for c in SELF_TEST_CASES if not c[3])} of them negative controls."
+        f"Deny-set self-test passed: {len(SELF_TEST_CASES)} matcher cases "
+        f"({sum(1 for c in SELF_TEST_CASES if not c[3])} negative controls) and "
+        f"{len(BINDING_LEARNER_CASES)} binding-learner cases "
+        f"({sum(1 for c in BINDING_LEARNER_CASES if not c[2])} negative controls)."
     )
     print("Verification PASSED: Zero File-Search Invariant holds.")
     sys.exit(0)

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -54,9 +54,9 @@
     },
     {
       "file": "crates/kin-cli/src/commands/spec.rs",
-      "reason": "Known violation under repair, not a boundary claim. Unlike every other entry here, these reads ARE the answer authority: `kin spec list` and `kin spec show` resolve their result by walking and parsing .kin/specs/*.json, which is exactly what the Zero File-Search Authority Rule forbids on a query path. The entry exists so the violation is visible, owned, and dated rather than invisible, which it was until this module entered the scanned query set: nothing had ever reported it. It is not evidence the path is graph-backed and must not be read as one. The reason it cannot simply be fixed is storage, not wiring: the pinned registry crates carry no home for a spec. kin_model::Spec is a bare data struct, GraphStore composes EntityStore, ChangeStore, WorkStore, ReviewStore, VerificationStore, ProvenanceStore and SessionStore and none of them has a spec method, and kin-db imports SpecId without using it. Mapping a spec onto a WorkItem would drop constraints, affected systems, validation requirements and the free-string scope, so the faithful fix is a SpecStore in kin-model and kin-db, which is a bottom-up registry publish. Tracked on the internal board for the command and for the store substrate; both pins and this entry come out when the query path reads graph truth. Pinned to the seven exact expressions rather than the whole file, so the debt cannot grow: any newly added filesystem primitive in this module fails the guard",
+      "reason": "Known violation under repair, not a boundary claim. Unlike every other entry here, these reads ARE the answer authority: `kin spec list` and `kin spec show` resolve their result by walking and parsing .kin/specs/*.json, which is exactly what the Zero File-Search Authority Rule forbids on a query path. The entry exists so the violation is visible, owned, and dated rather than invisible, which it was until this module entered the scanned query set: nothing had ever reported it. It is not evidence the path is graph-backed and must not be read as one. The reason it cannot simply be fixed is storage, not wiring: the pinned registry crates carry no home for a spec. kin_model::Spec is a bare data struct, GraphStore composes EntityStore, ChangeStore, WorkStore, ReviewStore, VerificationStore, ProvenanceStore and SessionStore and none of them has a spec method, and kin-db imports SpecId without using it. Mapping a spec onto a WorkItem would drop constraints, affected systems, validation requirements and the free-string scope, so the faithful fix is a SpecStore in kin-model and kin-db, which is a bottom-up registry publish. Tracked on the internal board for the command and for the store substrate; both pins and this entry come out when the query path reads graph truth. Pinned to the seven exact expressions rather than the whole file, so the debt cannot grow: any newly added filesystem primitive in this module fails the guard. Re-dated from 2026-10-31 to 2027-01-29 on 2026-09-03. The original date was set while neither zero-file-search guard graded a pull request, so it was a tracking date rather than a merge blocker. kin#1448 moved both guards into fast-gate-lint, which carries the required \"Fast gate lint and policy\" context and no job-level if, so from that landing the expiry blocks every kin pull request on the day it fires, whatever that pull request touches. The fix is the SpecStore train described above: kin-model, then kin-db, then a registry publish, carrying a GraphSnapshot format version, which is not schedulable against the old date. Measured on 2026-09-03 against the current pins: still no SpecStore in kin-model 0.7.23 or kin-db 0.7.96, and kin-db still imports SpecId at types.rs:15 without using it. The new date is kin-cli's own review day under the staggering this guard now recommends, so it is not a day any other owner's entries share.",
       "owner": "kin-cli",
-      "expiration": "2026-10-31",
+      "expiration": "2027-01-29",
       "allow_match": [
         "fs::create_dir_all(&specs_dir)?;",
         "fs::write(&spec_file, &json)?;",
@@ -64,7 +64,8 @@
         "let mut entries: Vec<_> = fs::read_dir(specs_dir)?",
         "let content = fs::read_to_string(entry.path())?;",
         "if !spec_file.exists() {",
-        "let content = fs::read_to_string(&spec_file)?;"
+        "let content = fs::read_to_string(&spec_file)?;",
+        "use std::fs;"
       ]
     },
     {
@@ -276,7 +277,34 @@
         "fs::read_to_string(path).ok()",
         "let _ = fs::write(serving_path(kin_root), body);",
         "let _ = fs::remove_file(serving_path(kin_root));",
-        "let raw = fs::read_to_string(serving_path(kin_root)).ok()?;"
+        "let raw = fs::read_to_string(serving_path(kin_root)).ok()?;",
+        "&& fs::rename(&announced, kin_root.join(APPROACHING_COMMIT_FILE_NAME)).is_err()",
+        "&& fs::rename(&tmp, kin_root.join(KILL_RECORD_FILE_NAME)).is_err()",
+        "&& fs::rename(&tmp, kin_root.join(TRANSACTION_FILE_NAME)).is_err()",
+        "FileExt::lock_shared(&file)?;",
+        "_file: File,",
+        "_root: File,",
+        "fn open_windows_regular_nofollow(path: &Path) -> std::io::Result<File> {",
+        "fn open_windows_root_guard(path: &Path) -> std::io::Result<File> {",
+        {
+          "expr": "fn same_file_object(left: &fs::Metadata, right: &fs::Metadata) -> bool {",
+          "count": 2
+        },
+        "fn windows_file_identity(file: &File) -> std::io::Result<((u32, u64), u32)> {",
+        "let Ok(mut log) = OpenOptions::new()",
+        {
+          "expr": "let file = OpenOptions::new()",
+          "count": 2
+        },
+        "let mut options = OpenOptions::new();",
+        "use fs2::FileExt;",
+        "use std::fs::{self, File, OpenOptions};",
+        "use std::os::unix::fs::MetadataExt as _;",
+        "use std::os::unix::fs::OpenOptionsExt as _;",
+        {
+          "expr": "use std::os::windows::fs::OpenOptionsExt as _;",
+          "count": 2
+        }
       ]
     },
     {
@@ -324,7 +352,8 @@
         "reexec_self"
       ],
       "allow_match": [
-        "file: std::fs::File,"
+        "file: std::fs::File,",
+        "use fs2::FileExt;"
       ]
     },
     {
@@ -334,6 +363,15 @@
       "expiration": "2026-12-31",
       "allow_fn": [
         "try_acquire_repository_runtime_authority"
+      ],
+      "allow_match": [
+        "Err(error) if error.kind() == fs2::lock_contended_error().kind() => {",
+        "file: File,",
+        "fn acquire_lifecycle_coordination(kin_root: &Path, deadline: Instant) -> std::io::Result<File> {",
+        "fn stamp_owner(file: &mut File, owner_stamp: &str) {",
+        "let file = OpenOptions::new()",
+        "use fs2::FileExt;",
+        "use std::fs::{File, OpenOptions};"
       ]
     },
     {
@@ -386,7 +424,11 @@
       ],
       "allow_match": [
         "use std::process::{Child, Command, ExitStatus, Output, Stdio};",
-        "let _ = std::fs::remove_file(&self.path);"
+        "let _ = std::fs::remove_file(&self.path);",
+        "file: File,",
+        "use fs2::FileExt;",
+        "use std::fs::{File, OpenOptions};",
+        "use std::os::unix::fs::{MetadataExt as _, OpenOptionsExt as _, PermissionsExt as _};"
       ]
     },
     {
@@ -748,7 +790,11 @@
       "expiration": "2026-12-31",
       "allow_match": [
         "std::fs::File",
-        "std::fs::create_dir_all(out_dir)"
+        "std::fs::create_dir_all(out_dir)",
+        "stream: BufWriter::new(File::create(out_dir.join(\"transcript.jsonl\"))?),",
+        "stream: BufWriter<File>,",
+        "trace: BufWriter::new(File::create(out_dir.join(\"kin-trace.jsonl\"))?),",
+        "trace: BufWriter<File>,"
       ]
     },
     {
@@ -813,7 +859,21 @@
         "for child in fs::read_dir(&directory).map_err(|error| io(&directory, error))? {",
         "fs::symlink_metadata(child.path()).map_err(|error| io(child.path(), error))?;",
         "std::fs::File::open(&directory)",
-        "fs::remove_dir_all(path).map_err(|error| io(path, error))"
+        "fs::remove_dir_all(path).map_err(|error| io(path, error))",
+        "fn executable_bit(_metadata: &fs::Metadata) -> bool {",
+        "fn executable_bit(metadata: &fs::Metadata) -> bool {",
+        "fs::rename(&source, &backup).map_err(|error| io(&source, error))?;",
+        "fs::rename(&source, &destination).map_err(|error| io(&destination, error))",
+        "fs::rename(&staged, &destination).map_err(|error| io(&destination, error))?;",
+        "fs::set_permissions(path, fs::Permissions::from_mode(mode)).map_err(|error| io(path, error))",
+        "if let Err(error) = fs::rename(&transaction.stage_root, root) {",
+        "let mut file = OpenOptions::new()",
+        "std::os::unix::fs::symlink(PathBuf::from(target), destination)",
+        "use std::fs::{self, OpenOptions};",
+        {
+          "expr": "use std::os::unix::fs::PermissionsExt as _;",
+          "count": 2
+        }
       ]
     },
     {
@@ -860,6 +920,240 @@
           "count": 2
         }
       ]
+    },
+    {
+      "file": "crates/kin-core/src/assistant.rs",
+      "reason": "Assistant integration boundary: discovers, reads and writes the assistant configuration files Kin manages on the operator's machine. The guard reports 42 sites here, dominated by existence probes and `std::fs` reads and writes against those config paths. It resolves no locate, search, context, trace, review or xref result. Migrated from BOUNDARY_DIRS on 2026-09-03, where this path carried no owner, no expiry and no reason field. Whole-file preserves exactly the scope it already had rather than re-arguing it; narrowing to expression pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
+      "owner": "kin-core",
+      "expiration": "2027-02-26"
+    },
+    {
+      "file": "crates/kin-core/src/assistant_sync.rs",
+      "reason": "Managed assistant-doc sync for AGENTS.md, CLAUDE.md, CODEX.md, GEMINI.md and their siblings, per the module's own doc. It writes Kin-generated content inside managed blocks while preserving everything around them, which is a materialization boundary: the content comes from Kin, the file is the output. Migrated from BOUNDARY_DIRS on 2026-09-03, where this path carried no owner, no expiry and no reason field. Whole-file preserves exactly the scope it already had rather than re-arguing it; narrowing to expression pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
+      "owner": "kin-core",
+      "expiration": "2027-02-26"
+    },
+    {
+      "file": "crates/kin-core/src/config.rs",
+      "reason": "The semantic repository's own config file, read and written at a path the caller already validated. It never resolves a path by searching and answers no query. Migrated from BOUNDARY_DIRS on 2026-09-03, where this path carried no owner, no expiry and no reason field. Whole-file preserves exactly the scope it already had rather than re-arguing it; narrowing to expression pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
+      "owner": "kin-core",
+      "expiration": "2027-02-26"
+    },
+    {
+      "file": "crates/kin-core/src/config/windows.rs",
+      "reason": "The Windows half of the same config writer, and the identical boundary as config.rs beside it. Split out because publishing a file atomically shares no code between the two platforms: the Unix writer holds a directory descriptor and publishes with `renameat2`. Every call here writes or proves the repository's own config file at a path the caller already validated, never resolves one by searching. Migrated from BOUNDARY_DIRS on 2026-09-03, where this path carried no owner, no expiry and no reason field. Whole-file preserves exactly the scope it already had rather than re-arguing it; narrowing to expression pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
+      "owner": "kin-core",
+      "expiration": "2027-02-26"
+    },
+    {
+      "file": "crates/kin-core/src/dependencies.rs",
+      "reason": "Cross-repo dependency detection from manifest files, per the module's own doc: it parses Cargo.toml, package.json and go.mod to discover external dependencies. That is a manifest ingestion boundary rather than a graph answer, and whether this should resolve from the spine instead is the open question `deps.rs` is scanned to keep visible. Migrated from BOUNDARY_DIRS on 2026-09-03, where this path carried no owner, no expiry and no reason field. Whole-file preserves exactly the scope it already had rather than re-arguing it; narrowing to expression pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
+      "owner": "kin-core",
+      "expiration": "2027-02-26"
+    },
+    {
+      "file": "crates/kin-core/src/git_init.rs",
+      "reason": "Exact, fail-closed Git repository admission, per the module's own doc: Git is consulted only at this explicit ingestion boundary. Reading a Git repository from disk is the whole point of an import boundary, and it runs before graph truth for that repository exists. Migrated from BOUNDARY_DIRS on 2026-09-03, where this path carried no owner, no expiry and no reason field. Whole-file preserves exactly the scope it already had rather than re-arguing it; narrowing to expression pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
+      "owner": "kin-core",
+      "expiration": "2027-02-26"
+    },
+    {
+      "file": "crates/kin-core/src/init.rs",
+      "reason": "Repository conversion, end to end, and the largest of these at 102 reported sites. It runs before any graph exists, on the source tree and on the staging directories it mints itself, and its output is the .kin repository rather than an answer to a query. Migrated from BOUNDARY_DIRS on 2026-09-03, where this path carried no owner, no expiry and no reason field. Whole-file preserves exactly the scope it already had rather than re-arguing it; narrowing to expression pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
+      "owner": "kin-core",
+      "expiration": "2027-02-26"
+    },
+    {
+      "file": "crates/kin-core/src/init_attempt.rs",
+      "reason": "The post-mortem for an interrupted init, and the same boundary as init_staging.rs beside it. It reads only the staging directories init itself minted in the repository's parent, to report where a killed conversion stopped and how much disk it is holding. It answers no locate, search, context, trace, review or xref query, reads no repository content, and runs before any graph exists. Migrated from BOUNDARY_DIRS on 2026-09-03, where this path carried no owner, no expiry and no reason field. Whole-file preserves exactly the scope it already had rather than re-arguing it; narrowing to expression pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
+      "owner": "kin-core",
+      "expiration": "2027-02-26"
+    },
+    {
+      "file": "crates/kin-core/src/init_staging.rs",
+      "reason": "Init's own staging directories, and nothing else. It runs before any graph exists, on paths init itself minted, and its whole output is whether a directory this process created still needs removing. It answers no query, and the directory it enumerates is the repository's parent, never repository content. Migrated from BOUNDARY_DIRS on 2026-09-03, where this path carried no owner, no expiry and no reason field. Whole-file preserves exactly the scope it already had rather than re-arguing it; narrowing to expression pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
+      "owner": "kin-core",
+      "expiration": "2027-02-26"
+    },
+    {
+      "file": "crates/kin-core/src/layout.rs",
+      "reason": "The on-disk shape of a .kin repository: where its directories are and whether they are present. Eight sites, all existence probes and path resolution against the repository's own layout rather than against repository content. Migrated from BOUNDARY_DIRS on 2026-09-03, where this path carried no owner, no expiry and no reason field. Whole-file preserves exactly the scope it already had rather than re-arguing it; narrowing to expression pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
+      "owner": "kin-core",
+      "expiration": "2027-02-26"
+    },
+    {
+      "file": "crates/kin-core/src/manifest.rs",
+      "reason": "The repository manifest file, read and written at the layout's own path. Four sites, all against that one file. Migrated from BOUNDARY_DIRS on 2026-09-03, where this path carried no owner, no expiry and no reason field. Whole-file preserves exactly the scope it already had rather than re-arguing it; narrowing to expression pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
+      "owner": "kin-core",
+      "expiration": "2027-02-26"
+    },
+    {
+      "file": "crates/kin-core/src/registry.rs",
+      "reason": "The cross-repo Kin registry at `<managed Kin home>/registry.toml`, per the module's own doc, which lets MCP servers and cross-repo queries discover Kin repositories on disk. The registry file is the boundary; what it returns is a list of repository roots, not a semantic answer about any repository's contents. Migrated from BOUNDARY_DIRS on 2026-09-03, where this path carried no owner, no expiry and no reason field. Whole-file preserves exactly the scope it already had rather than re-arguing it; narrowing to expression pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
+      "owner": "kin-core",
+      "expiration": "2027-02-26"
+    },
+    {
+      "file": "crates/kin-core/src/shims.rs",
+      "reason": "Graph-projection command shims: when Kin launches an assistant or shell against an exact workspace projection, this writes a directory of small wrapper executables for it to find. It only writes, and what it writes is generated by Kin. Migrated from BOUNDARY_DIRS on 2026-09-03, where this path carried no owner, no expiry and no reason field. Whole-file preserves exactly the scope it already had rather than re-arguing it; narrowing to expression pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
+      "owner": "kin-core",
+      "expiration": "2027-02-26"
+    },
+    {
+      "file": "crates/kin-core/src/sync_state.rs",
+      "reason": "Persisted sync state per remote in `.kin/sync_state.json`, per the module's own doc. Two sites, both reading and writing that one Kin-owned file. Migrated from BOUNDARY_DIRS on 2026-09-03, where this path carried no owner, no expiry and no reason field. Whole-file preserves exactly the scope it already had rather than re-arguing it; narrowing to expression pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
+      "owner": "kin-core",
+      "expiration": "2027-02-26"
+    },
+    {
+      "file": "crates/kin-core/src/tree.rs",
+      "reason": "Working-tree inspection for admission and reconcile, and the second largest at 144 sites, overwhelmingly metadata and file-type probes. It is the input boundary that tells Kin what the tree currently holds so the graph can be built from or compared against it. It is also the file in this set closest to an answer path, which is why the expiry matters: this is the one to narrow to pins first. Migrated from BOUNDARY_DIRS on 2026-09-03, where this path carried no owner, no expiry and no reason field. Whole-file preserves exactly the scope it already had rather than re-arguing it; narrowing to expression pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
+      "owner": "kin-core",
+      "expiration": "2027-02-26"
+    },
+    {
+      "file": "crates/kin-git/src/lossless.rs",
+      "reason": "The lossless Git migration boundary, per the module's own doc: it preserves Git as an exact external format without making it an authority path inside Kin. Capturing a Git repository from disk is the entire point of an import boundary. Migrated from BOUNDARY_DIRS on 2026-09-03, where this path carried no owner, no expiry and no reason field. Whole-file preserves exactly the scope it already had rather than re-arguing it; narrowing to expression pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
+      "owner": "kin-git",
+      "expiration": "2027-03-31"
+    },
+    {
+      "file": "crates/kin-git/src/admission_blockers.rs",
+      "reason": "Runs before any graph exists, on the source Git repository, and produces only refusals. Nothing it reads reaches a query answer, and its whole output is a list of reasons admission cannot start. Migrated from BOUNDARY_DIRS on 2026-09-03, where this path carried no owner, no expiry and no reason field. Whole-file preserves exactly the scope it already had rather than re-arguing it; narrowing to expression pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
+      "owner": "kin-git",
+      "expiration": "2027-03-31"
+    },
+    {
+      "file": "crates/kin-git/src/preflight.rs",
+      "reason": "Read-only authority preflight for one exact Git workspace migration, per the module's own doc: it proves a checkout matches its committed seed before admission. It refuses or proceeds; it never produces a result a user queried for. Migrated from BOUNDARY_DIRS on 2026-09-03, where this path carried no owner, no expiry and no reason field. Whole-file preserves exactly the scope it already had rather than re-arguing it; narrowing to expression pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
+      "owner": "kin-git",
+      "expiration": "2027-03-31"
+    },
+    {
+      "file": "crates/kin-git/src/repository_export.rs",
+      "reason": "Exact Git projection for repository-v6 authority, per the module's own doc: imported Git objects are copied byte-for-byte from graph-owned source CAS. This materializes graph-owned history back out as Git, which is an output boundary. Migrated from BOUNDARY_DIRS on 2026-09-03, where this path carried no owner, no expiry and no reason field. Whole-file preserves exactly the scope it already had rather than re-arguing it; narrowing to expression pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
+      "owner": "kin-git",
+      "expiration": "2027-03-31"
+    },
+    {
+      "file": "crates/kin-ranking/src/ltr.rs",
+      "reason": "The gradient-boosted ranking model's own serialized weights, loaded from and saved to a model file. Two sites, both against that file. The ranking it then performs reads graph results, never the filesystem. Migrated from BOUNDARY_DIRS on 2026-09-03, where this path carried no owner, no expiry and no reason field. Whole-file preserves exactly the scope it already had rather than re-arguing it; narrowing to expression pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
+      "owner": "kin-ranking",
+      "expiration": "2027-04-30"
+    },
+    {
+      "file": "crates/kin-cli/src/daemon_client.rs",
+      "reason": "HTTP client and lifecycle helpers for the kin daemon, per the module's own doc: CLI commands use it to query the daemon's live graph instead of opening a snapshot directly. The 122 reported sites are daemon lifecycle rather than answers: the socket and port records, the binary it re-execs, and the subprocess that starts it. The answers themselves come back over HTTP from the graph. Migrated from BOUNDARY_DIRS on 2026-09-03, where this path carried no owner, no expiry and no reason field. Whole-file preserves exactly the scope it already had rather than re-arguing it; narrowing to expression pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-01-29"
+    },
+    {
+      "file": "crates/kin-cli/src/profile.rs",
+      "reason": "Local CLI profile and environment probing. Eight sites, five of them subprocess execution for environment discovery, none of them reading repository content. Migrated from BOUNDARY_DIRS on 2026-09-03, where this path carried no owner, no expiry and no reason field. Whole-file preserves exactly the scope it already had rather than re-arguing it; narrowing to expression pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-01-29"
+    },
+    {
+      "file": "crates/kin-cli/src/main.rs",
+      "reason": "The CLI entry point: argument dispatch, and the process launches that dispatch implies. Ten sites, eight of them subprocess execution. It routes to the command modules rather than resolving any answer itself, and the query commands it routes to are scanned. Migrated from BOUNDARY_DIRS on 2026-09-03, where this path carried no owner, no expiry and no reason field. Whole-file preserves exactly the scope it already had rather than re-arguing it; narrowing to expression pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-01-29"
+    },
+    {
+      "file": "crates/kin-migrate/src/bounded_process.rs",
+      "reason": "Bounded, tree-contained execution for migration metadata subprocesses, per the module's own doc. The subprocess IS the product here: it drains stdout and stderr into byte-bounded sinks and terminates descendants. It runs no search tool on Kin's behalf and answers no query. Converted from the whole-directory BOUNDARY_DIRS entry `crates/kin-migrate/` on 2026-09-03, which carried no owner, no expiry and no reason. That directory covered 8 .rs files, 8 of them on the scanned runtime path, and only 4 contain any filesystem primitive at all, so the exemption was several times wider than anything it protected. Every other file in that crate is now scanned by default, including any added later.",
+      "owner": "kin-migrate",
+      "expiration": "2027-05-28"
+    },
+    {
+      "file": "crates/kin-migrate/src/executor.rs",
+      "reason": "Exact in-place Git migration, per the module's own doc, delegating to the same atomic repository-v6 admission boundary as `kin init` so there is one Git-to-Kin authority path. Migration is explicitly allowed to read files as an ingestion boundary. Converted from the whole-directory BOUNDARY_DIRS entry `crates/kin-migrate/` on 2026-09-03, which carried no owner, no expiry and no reason. That directory covered 8 .rs files, 8 of them on the scanned runtime path, and only 4 contain any filesystem primitive at all, so the exemption was several times wider than anything it protected. Every other file in that crate is now scanned by default, including any added later.",
+      "owner": "kin-migrate",
+      "expiration": "2027-05-28"
+    },
+    {
+      "file": "crates/kin-migrate/src/scanner.rs",
+      "reason": "Pre-migration scanning of the source repository. It reads the tree being migrated, which is the input side of an ingestion boundary, and produces no query result. Converted from the whole-directory BOUNDARY_DIRS entry `crates/kin-migrate/` on 2026-09-03, which carried no owner, no expiry and no reason. That directory covered 8 .rs files, 8 of them on the scanned runtime path, and only 4 contain any filesystem primitive at all, so the exemption was several times wider than anything it protected. Every other file in that crate is now scanned by default, including any added later.",
+      "owner": "kin-migrate",
+      "expiration": "2027-05-28"
+    },
+    {
+      "file": "crates/kin-migrate/src/finalize.rs",
+      "reason": "Shared onboarding finalization for `kin init` and `kin migrate`, per the module's own doc: it persists the .kidx read index and the registry entry. One site, on that output path. Converted from the whole-directory BOUNDARY_DIRS entry `crates/kin-migrate/` on 2026-09-03, which carried no owner, no expiry and no reason. That directory covered 8 .rs files, 8 of them on the scanned runtime path, and only 4 contain any filesystem primitive at all, so the exemption was several times wider than anything it protected. Every other file in that crate is now scanned by default, including any added later.",
+      "owner": "kin-migrate",
+      "expiration": "2027-05-28"
+    },
+    {
+      "file": "crates/kin-index/src/repository.rs",
+      "reason": "Exact repository membership discovery, per the module's own doc: it admits every regular file and symbolic link, including configuration, vendored trees, binaries and unsupported languages. Walking the tree is how graph membership is built, which the rule allows explicitly as ingestion. It is also the largest unowned surface of the six directories, at 45 sites, and a defect here mislabels graph truth rather than answering from the tree. Converted from the whole-directory BOUNDARY_DIRS entry `crates/kin-index/` on 2026-09-03, which carried no owner, no expiry and no reason. That directory covered 36 .rs files, 14 of them on the scanned runtime path, and only 4 contain any filesystem primitive at all, so the exemption was several times wider than anything it protected. Every other file in that crate is now scanned by default, including any added later.",
+      "owner": "kin-index",
+      "expiration": "2027-06-25"
+    },
+    {
+      "file": "crates/kin-index/src/watcher.rs",
+      "reason": "The filesystem watcher that tells the index what changed. Watching paths is the trigger for re-ingestion, not an answer to a query. Converted from the whole-directory BOUNDARY_DIRS entry `crates/kin-index/` on 2026-09-03, which carried no owner, no expiry and no reason. That directory covered 36 .rs files, 14 of them on the scanned runtime path, and only 4 contain any filesystem primitive at all, so the exemption was several times wider than anything it protected. Every other file in that crate is now scanned by default, including any added later.",
+      "owner": "kin-index",
+      "expiration": "2027-06-25"
+    },
+    {
+      "file": "crates/kin-index/src/pipeline.rs",
+      "reason": "The graph build and update pipeline. Five sites, on the ingestion path that turns files into graph-owned entities. Converted from the whole-directory BOUNDARY_DIRS entry `crates/kin-index/` on 2026-09-03, which carried no owner, no expiry and no reason. That directory covered 36 .rs files, 14 of them on the scanned runtime path, and only 4 contain any filesystem primitive at all, so the exemption was several times wider than anything it protected. Every other file in that crate is now scanned by default, including any added later.",
+      "owner": "kin-index",
+      "expiration": "2027-06-25"
+    },
+    {
+      "file": "crates/kin-index/src/support.rs",
+      "reason": "Coverage and support reporting, per the module's own doc: it walks a directory tree, classifies every file and summarises how many fall into each bucket. It reports on ingestion coverage rather than answering a semantic query, and it returns counts rather than file contents. Converted from the whole-directory BOUNDARY_DIRS entry `crates/kin-index/` on 2026-09-03, which carried no owner, no expiry and no reason. That directory covered 36 .rs files, 14 of them on the scanned runtime path, and only 4 contain any filesystem primitive at all, so the exemption was several times wider than anything it protected. Every other file in that crate is now scanned by default, including any added later.",
+      "owner": "kin-index",
+      "expiration": "2027-06-25"
+    },
+    {
+      "file": "crates/kin-registry/src/atomic_file.rs",
+      "reason": "Crash-safe publication of registry artifacts, per the module's own doc: stage bytes in the destination directory, durably flush, then replace with one atomic rename. Publication is a write boundary, and all 46 sites here are that one pattern. Converted from the whole-directory BOUNDARY_DIRS entry `crates/kin-registry/` on 2026-09-03, which carried no owner, no expiry and no reason. That directory covered 7 .rs files, 7 of them on the scanned runtime path, and only 4 contain any filesystem primitive at all, so the exemption was several times wider than anything it protected. Every other file in that crate is now scanned by default, including any added later.",
+      "owner": "kin-registry",
+      "expiration": "2027-07-30"
+    },
+    {
+      "file": "crates/kin-registry/src/lib.rs",
+      "reason": "Package serving for the KinLab platform, per the module's own doc, layered as blob store, manifest store and per-ecosystem protocol adapter. It serves packages, not repository semantics, and answers no locate, search, context, trace, review or xref query. Converted from the whole-directory BOUNDARY_DIRS entry `crates/kin-registry/` on 2026-09-03, which carried no owner, no expiry and no reason. That directory covered 7 .rs files, 7 of them on the scanned runtime path, and only 4 contain any filesystem primitive at all, so the exemption was several times wider than anything it protected. Every other file in that crate is now scanned by default, including any added later.",
+      "owner": "kin-registry",
+      "expiration": "2027-07-30"
+    },
+    {
+      "file": "crates/kin-registry/src/oci.rs",
+      "reason": "The OCI Distribution Specification adapter, per the module's own doc. Same boundary as lib.rs above: an artifact protocol served over HTTP. Converted from the whole-directory BOUNDARY_DIRS entry `crates/kin-registry/` on 2026-09-03, which carried no owner, no expiry and no reason. That directory covered 7 .rs files, 7 of them on the scanned runtime path, and only 4 contain any filesystem primitive at all, so the exemption was several times wider than anything it protected. Every other file in that crate is now scanned by default, including any added later.",
+      "owner": "kin-registry",
+      "expiration": "2027-07-30"
+    },
+    {
+      "file": "crates/kin-registry/src/storage_lock.rs",
+      "reason": "Cross-process advisory locks for registry storage transactions, per the module's own doc, keyed on the shared storage path because a registry root can be mounted by several daemon processes. The lock file is the boundary and it holds no repository content. Converted from the whole-directory BOUNDARY_DIRS entry `crates/kin-registry/` on 2026-09-03, which carried no owner, no expiry and no reason. That directory covered 7 .rs files, 7 of them on the scanned runtime path, and only 4 contain any filesystem primitive at all, so the exemption was several times wider than anything it protected. Every other file in that crate is now scanned by default, including any added later.",
+      "owner": "kin-registry",
+      "expiration": "2027-07-30"
+    },
+    {
+      "file": "crates/kin-runtime/src/exec.rs",
+      "reason": "Running a command in a materialized workspace, which is this crate's product rather than a query path. All three sites are subprocess execution; the crate reads no repository file. Converted from the whole-directory BOUNDARY_DIRS entry `crates/kin-runtime/` on 2026-09-03, which carried no owner, no expiry and no reason. That directory covered 7 .rs files, 7 of them on the scanned runtime path, and only 3 contain any filesystem primitive at all, so the exemption was several times wider than anything it protected. Every other file in that crate is now scanned by default, including any added later.",
+      "owner": "kin-runtime",
+      "expiration": "2027-08-27"
+    },
+    {
+      "file": "crates/kin-runtime/src/run.rs",
+      "reason": "The run surface over the same execution boundary. Two sites, both subprocess execution. Converted from the whole-directory BOUNDARY_DIRS entry `crates/kin-runtime/` on 2026-09-03, which carried no owner, no expiry and no reason. That directory covered 7 .rs files, 7 of them on the scanned runtime path, and only 3 contain any filesystem primitive at all, so the exemption was several times wider than anything it protected. Every other file in that crate is now scanned by default, including any added later.",
+      "owner": "kin-runtime",
+      "expiration": "2027-08-27"
+    },
+    {
+      "file": "crates/kin-runtime/src/workspace.rs",
+      "reason": "The materialized workspace a command runs inside. One site, on preparing that workspace rather than reading it for an answer. Converted from the whole-directory BOUNDARY_DIRS entry `crates/kin-runtime/` on 2026-09-03, which carried no owner, no expiry and no reason. That directory covered 7 .rs files, 7 of them on the scanned runtime path, and only 3 contain any filesystem primitive at all, so the exemption was several times wider than anything it protected. Every other file in that crate is now scanned by default, including any added later.",
+      "owner": "kin-runtime",
+      "expiration": "2027-08-27"
+    },
+    {
+      "file": "crates/kin-parser/src/todos.rs",
+      "reason": "Inline TODO/FIXME/HACK extraction, per the module's own doc, and the one genuine recursive source-tree walk among the six directories: read_dir, recurse on is_dir, read_to_string every file with a matching extension, depth-bounded. It is legal today and that was checked rather than assumed: both live callers, `work.rs:895` for `kin work todo-import` and `handlers/work.rs:570` for the agent-facing `kin_todo_import` MCP tool, persist every extracted marker through `create_work_item` and return counts, so the walk builds graph-owned truth, which the rule permits. It is one caller away from illegal: the day something returns the extracted list instead of importing it, this walk becomes the answer. That is exactly why it needs an owner and a date rather than a crate-wide silence. Converted from the whole-directory BOUNDARY_DIRS entry `crates/kin-parser/` on 2026-09-03, which carried no owner, no expiry and no reason. That directory covered 33 .rs files, 20 of them on the scanned runtime path, and only 1 contain any filesystem primitive at all, so the exemption was several times wider than anything it protected. Every other file in that crate is now scanned by default, including any added later.",
+      "owner": "kin-parser",
+      "expiration": "2027-09-24"
     }
   ]
 }

--- a/scripts/zero_file_search_guard.sh
+++ b/scripts/zero_file_search_guard.sh
@@ -46,17 +46,54 @@ authority_files=(
 # Raw filesystem read / existence / traversal primitives. Subprocess creation
 # is denied wholesale in answer modules so dynamic or multiline rg/grep/find/
 # git-grep builders cannot bypass a line-local executable-name pattern.
-deny_re='\.is_file\(\)|\.is_dir\(\)|\.exists\(\)|\.try_exists\(\)|\.is_symlink\(\)|\.canonicalize\(\)|\.metadata\(\)|symlink_metadata|read_link|Command::new[[:space:]]*\(|process[[:space:]]*(::|as([[:space:]]|$))|std::fs::(read|read_to_string|read_dir|metadata|File)|[^_a-z]fs::(read|read_to_string|read_dir|metadata)|File::open|read_dir\(|WalkDir|walkdir::|glob::glob'
+#
+# The filesystem half matches the MODULE, not the item name. It used to read
+# `std::fs::(read|read_to_string|read_dir|metadata|File)`, an enumeration of
+# five functions, and `OpenOptions` was in neither that alternation nor the
+# Python checker's: a read written with the builder shape passed both guards
+# green in `locate.rs`, the flagship answer module. Naming five items out of a
+# module is always one item behind, and `std::fs::exists` stabilising in 1.81
+# would have been the next miss. `std::fs` on its own is complete over that
+# module forever, and it costs nothing here because none of the ten answer
+# modules imports it.
+#
+# This guard has no parser, so it cannot do what the Python checker does and
+# learn a file's bindings from its own `use` trees. It does not have to: you
+# cannot bind an fs name without a `use` line, and a `use` line always names
+# the module. So the type names below are belt to the namespace reach's braces,
+# and the two together close the same class the checker closes with a parser.
+deny_re='\.is_file\(\)|\.is_dir\(\)|\.exists\(\)|\.try_exists\(\)|\.is_symlink\(\)|\.canonicalize\(\)|\.metadata\(\)|symlink_metadata|read_link|Command::new[[:space:]]*\(|process[[:space:]]*(::|as([[:space:]]|$))|(std|core)::fs|std::os::(unix|windows|wasi)::fs|(tokio|async_std|smol)::fs|(fs_err|fs2|fs_extra|filetime|walkdir)::|[^_a-z]fs::[a-zA-Z_]|File::(open|create|create_new|options)|OpenOptions|DirBuilder|DirEntry|ReadDir|read_dir\(|WalkDir|glob::glob'
 
 # Per-file justified allowlist (input/output boundaries, not the answer). A new
 # or different primitive in the same file still trips the guard.
+#
+# One expression PER LINE, and more than one per file is allowed. It used to be
+# a single string, which was not a policy decision, it was the shape the deny
+# set happened to need: nothing else was reported, so nothing else had to be
+# declared. Widening the deny set from five enumerated `std::fs` functions to
+# the module surfaced the cursor cache's own write and delete in
+# `locate_cursor.rs`, two boundary calls sitting one line apart from a read that
+# was declared, invisible for as long as the guard only watched five names.
+# Each expression is still counted and must occur exactly once.
 allow_for() {
   case "$1" in
-    locate.rs)             printf '%s' 'let marker_present = tel::consent_marker_path(layout.root()).exists();' ;;
-    locate_cursor.rs)      printf '%s' 'std::fs::read_to_string(&path)' ;;
-    locate_debug.rs)       printf '%s' 'std::fs::read_to_string(path)' ;;
-    contextbench_locate.rs) printf '%s' 'std::fs::read_to_string(&task_file)' ;;
-    *)                     printf '%s' '' ;;
+    locate.rs)
+      printf '%s\n' 'let marker_present = tel::consent_marker_path(layout.root()).exists();'
+      ;;
+    locate_cursor.rs)
+      # The paging-cursor cache, read, written and cleared. It holds a locate
+      # continuation token, never repository content, and no locate result is
+      # derived from it: a miss restarts paging rather than answering.
+      printf '%s\n' 'std::fs::read_to_string(&path)' \
+                    'let _ = std::fs::write(&path, cursor);' \
+                    'let _ = std::fs::remove_file(&path);'
+      ;;
+    locate_debug.rs)
+      printf '%s\n' 'std::fs::read_to_string(path)'
+      ;;
+    contextbench_locate.rs)
+      printf '%s\n' 'std::fs::read_to_string(&task_file)'
+      ;;
   esac
 }
 
@@ -101,10 +138,25 @@ for rel in "${authority_files[@]}"; do
   file="$repo_root/$rel"
   [[ -f "$file" ]] || continue
   base="$(basename "$rel")"
-  allow="$(allow_for "$base")"
   read -r test_start test_end <<<"$(test_module_span "$file")"
 
-  if [[ -n "$allow" ]]; then
+  # Read into an array rather than a single string. `while read` rather than
+  # `mapfile`, because the CI image and this fleet's macOS boxes do not agree on
+  # bash 4.
+  allow_list=()
+  while IFS= read -r allow_expr; do
+    [[ -n "$allow_expr" ]] && allow_list+=("$allow_expr")
+  done < <(allow_for "$base")
+
+  # Everything outside the test module, before it and after it alike, with the
+  # original line numbers preserved.
+  region="$(awk -v s="$test_start" -v e="$test_end" \
+    'NR < s || NR > e { print NR ":" $0 }' "$file")"
+  scan_region="$region"
+
+  # An empty array is unbound under `set -u` on bash 3.2, so expand it guarded.
+  pin_failed=0
+  for allow in ${allow_list[@]+"${allow_list[@]}"}; do
     allow_hits="$(grep -F -o -- "$allow" "$file" || true)"
     allow_count=0
     if [[ -n "$allow_hits" ]]; then
@@ -114,17 +166,10 @@ for rel in "${authority_files[@]}"; do
       violations+=(
         "$rel: allowlist expression occurs $allow_count times (want exactly 1): $allow"
       )
+      pin_failed=1
       continue
     fi
-  fi
-
-  # Everything outside the test module, before it and after it alike, with the
-  # original line numbers preserved.
-  region="$(awk -v s="$test_start" -v e="$test_end" \
-    'NR < s || NR > e { print NR ":" $0 }' "$file")"
-  scan_region="$region"
-  if [[ -n "$allow" ]]; then
-    scan_region="$(printf '%s\n' "$region" | awk -v needle="$allow" '
+    scan_region="$(printf '%s\n' "$scan_region" | awk -v needle="$allow" '
       {
         pos = index($0, needle)
         if (pos > 0) {
@@ -133,7 +178,9 @@ for rel in "${authority_files[@]}"; do
         print
       }
     ')"
-  fi
+  done
+  [[ "$pin_failed" -eq 0 ]] || continue
+
   hits="$(printf '%s\n' "$scan_region" | grep -E "$deny_re" || true)"
   [[ -n "$hits" ]] || continue
   while IFS= read -r hit; do


### PR DESCRIPTION
Both guards tested for one spelling of a filesystem read rather than for filesystem access.
FIR-3151 proved that on hosted CI: an `OpenOptions` read planted in `locate.rs`, the flagship
answer module, passed both guards green. This makes them detect the operation, and retires
`BOUNDARY_DIRS` (FIR-3149) while it is in the same file.

The scan goes from 219 files to 264. The allowlist goes from 47 entries to 86, and every exemption
in the repository now carries an owner, a reason and a date.

## The design call, because a longer list would be one spelling behind again

Filesystem access in Rust has three syntactic forms, and only the third leaves no alternative to
enumeration.

1. **A filesystem module in the path.** The pattern now matches the MODULE and lets the item name
   be anything, so it is complete over `std::fs` forever. `std::fs::exists` stabilised in 1.81 and
   would have been the next miss; it needs no edit under this shape. This alone fixes the ticket's
   repro, because `{` stops mattering.
2. **A name the file imported out of such a module.** `OpenOptions::new()` carries no filesystem
   marker, but the `use` that bound it does, so the guard reads each file's own use trees and denies
   what they bind. Complete over types std has not shipped yet, and the only mechanism that survives
   an alias: `use std::fs::OpenOptions as Opener;` defeats every global spelling list.
3. **`Path`/`PathBuf` inherent methods**, which need no import. Ten of them, closed by std rather
   than by our imagination, and checked rather than asserted.

A concrete win for the design over enumeration: the naive `symlink(` pattern is not needed at all.
The real call is `std::os::unix::fs::symlink`, matched through its module, so the three
`TreeEntry::symlink` false positives the measurement found never arise.

### Making the residual enumeration testable

`--audit-std` re-derives form 3 from the toolchain's own source, with a positive control so an
extraction that finds nothing is a failure rather than a clean sheet:

```
$ python3 scripts/verify-zero-file-search.py --audit-std
rustc 1.96.0 (ac68faa20 2026-05-25)
.../lib/rustlib/src/rust/library/std/src/path.rs
std declares 10 fs-reaching Path/PathBuf methods.
AUDIT PASSED: all 10 are declared and all are matched.
```

That needs `rust-src`, so it is a lane tool, not a gate: a check that skips when a component is
missing reports nothing and looks like a pass. What runs on **every** invocation, and so grades this
PR through `fast-gate-lint`, is a 30-case self-test with 24 positives and **6 negative controls**:

```
Deny-set self-test passed: 30 cases, 6 of them negative controls.
```

## Falsification: blind before, red after, both guards

Every probe is a real use of a primitive planted in `crates/kin-cli/src/commands/locate.rs`. Each
runs twice, against the guards on `origin/main` and against this branch's, because a guard that is
red now proves nothing without the pair. Files were copied first and restored from the copy.

```
probe                                                BEFORE (origin/main)   AFTER (this PR)
------------------------------------------------------------------------------------------------
FIR-3151 repro: grouped import + OpenOptions read    py:blind/sh:blind      py:RED/sh:RED
alias bypass: OpenOptions imported under another name py:RED/sh:blind       py:RED/sh:RED
File::create                                         py:RED/sh:RED          py:RED/sh:RED
os-specific fs module: symlink                       py:blind/sh:blind      py:RED/sh:RED
fs::set_permissions through a bare fs alias          py:RED/sh:blind        py:RED/sh:RED
third-party fs crate: fs2 file locking               py:RED/sh:RED          py:RED/sh:RED
async fs module: tokio::fs                           py:RED/sh:RED          py:RED/sh:RED
std::fs item that did not exist in 1.80              py:RED/sh:blind        py:RED/sh:RED

NEGATIVE graph symlink constructor is not a filesystem call ok (silent)
NEGATIVE path building is not IO                     ok (silent)

restore: diff clean (rc=0)
```

Read honestly: two of eight were blind in both guards, the shell guard was blind to four of eight,
and several "RED before" rows were red only at the `use` line, caught by accident because
`std::fs::OpenOptions` happens to match a pattern written for `std::fs::<function>`.

**That accident is exactly what a pin removes**, and the import is exactly the line a reviewer pins.
So this is the arm that justifies reading use trees at all:

```
planted in crates/kin-cli/src/commands/locate.rs
  import: use std::fs::{self, OpenOptions};
  call  : let mut f = OpenOptions::new().read(true).open(path).ok()?;
  and the import is PINNED in the allowlist both guards read.

BEFORE (origin/main)     rc=0  blind to the call
AFTER (this PR)          rc=1  REPORTS THE CALL
      Line 32952: let mut f = OpenOptions::new().read(true).open(path).ok()?; (filesystem name bound by this file's own `use`)
```

`rc=0` on the left: one pin on one import line and the old guard sees nothing. Bindings are
therefore derived before pin masking, so a pin buys silence on its own line and nothing else.

### Two false positives found and fixed before this was ready

The first cut reported 114 lines. Bindings were matched with string literals intact, so
`use std::fs;` reported `"/sys/fs/cgroup"` four times and `use std::process;` reported the word
"process" in an `eprintln!`. Bindings are ordinary identifiers and collide with English, so they are
now matched against lexically stripped text. And `std::process` is deliberately out of binding
learning: subprocess execution is already caught at the import and at the call, so it added no
coverage and 21 reported lines that were `Command` in a type position. 114 became 50, all real.

### What FIR-3151 cost

50 sites in 7 files, all 7 already carrying entries, so 46 new pins and zero new entries. Widening
the shell guard also surfaced two things nobody had seen:

```
$ bash scripts/zero_file_search_guard.sh .
Zero File-Search guard FAILED: raw filesystem access in answer paths:
  crates/kin-cli/src/commands/locate_cursor.rs:31:            let _ = std::fs::write(&path, cursor);
  crates/kin-cli/src/commands/locate_cursor.rs:36:            let _ = std::fs::remove_file(&path);
```

The cursor cache's own write and delete, one line from a read that was already declared, invisible
for as long as the guard watched five function names. Declaring them meant teaching `allow_for` to
carry more than one expression per file.

## FIR-3149: retire BOUNDARY_DIRS, all four steps

34 exemptions carrying no owner, no expiry and no reason, against 47 that carry all three, and the
only mechanism here that exempted code not yet written. Two numbers the ticket did not have:

**Five of the 28 per-file paths hide nothing at all.** Zero sites in
`kin-core/src/{env_registry,federation,lib,ref_view}.rs` and `kin-cli/src/backend.rs`. Migrating
them would have manufactured an owner for something nobody has to own. They are simply scanned now.

**The six directories were three and a half times wider than anything they protected.**

| directory | .rs files | on the scanned path | files with any fs primitive | sites |
| -- | --: | --: | --: | --: |
| `crates/kin-registry/` | 7 | 7 | 4 | 65 |
| `crates/kin-index/` | 36 | 14 | 4 | 64 |
| `crates/kin-migrate/` | 8 | 8 | 4 | 13 |
| `crates/kin-runtime/` | 7 | 7 | 3 | 6 |
| `crates/kin-parser/` | 33 | 20 | 1 | 6 |
| `crates/kin-buildinfo/` | 2 | 1 | **0** | **0** |
| total | 93 | 56 | **16** | 154 |

`kin-buildinfo` drops to zero once the walk stops treating `build.rs` as a runtime path, so the
entire crate exemption existed to silence a build script. Only 16 files needed an entry, not 56.

`crates/kin-parser/src/todos.rs` is the close call and it was checked, not assumed: a real recursive
source walk, legal today because both live callers persist every marker through `create_work_item`
and return counts. It is one caller away from illegal, which is why it needs an owner rather than a
crate-wide silence.

### FIR-3149 falsification

```
target                                         BEFORE     AFTER      want
----------------------------------------------------------------------------------
kin-migrate/ (was a directory exemption)       blind      RED        RED
kin-index/ (was a directory exemption)         blind      RED        RED
kin-registry/ (was a directory exemption)      blind      RED        RED
kin-buildinfo/ (was a directory exemption)     blind      RED        RED
kin-runtime/ (never counted by any ticket)     blind      RED        RED
kin-parser/ (never counted by any ticket)      blind      RED        RED
kin-core per-file path hiding zero sites       blind      RED        RED
kin-cli per-file path hiding zero sites        blind      RED        RED
NEGATIVE build script is not a runtime path    RED        blind      silent
NEGATIVE example is not a runtime path         blind      blind      silent

working tree outside scripts/: clean
```

The build-script row is worth reading twice: RED before, silent now, so the walk change is a real
behaviour change in the intended direction rather than a no-op.

## Two additions requested alongside

**`spec.rs` moves off 2026-10-31** to 2027-01-29, with the reason written into the entry. The
original date was set while neither guard graded a pull request, so it was a tracking date; kin#1448
turned it into a merge blocker by moving both guards into `fast-gate-lint`. Its fix needs the
FIR-1830 SpecStore train across kin-model, kin-db and a registry publish.

**An expiry now warns before it fires**, and the next expiry prints on every run. Falsified in three
arms on a copy, with the real allowlist never touched:

```
ARM 1 unmodified copy:  PASSED, no warning block
ARM 2 one entry at 20 days out:
  Allowlist expiry WARNING (not a failure, yet):
    1 exemption(s) expire 2026-09-23, in 20 day(s), owned by kin-cli:
  Verification PASSED ... rc=0   (a warning is not a failure)
ARM 3 same entry back-dated:
  Allowlist validation FAILED: ... exemption expired 2026-09-02 (owner: kin-cli)
  rc=1
```

I used **45 days rather than the 14 that was suggested**, deliberately. Two weeks is not a runway
for the case that motivated the check: `spec.rs` needs a three-repo publish train, so a 14-day
warning would fire and be ignored, which is worse than no warning. One constant to change if you
disagree.

**On whether 47 entries sharing two dates is itself the defect: yes.** Stagger by owner, not by add
date. An expiry is a re-justification appointment and the owner keeps it, so a date per owner means
the day means something and the worst a single day costs is one owner's review. The 39 entries here
stagger across nine owner days rather than joining 2026-12-31, which would have made that day's 45
failures into 84. **The pre-existing 45 are not re-dated** here; that is ten owners' judgement and
not this PR's ticket. The summary line now prints the cliff on every run.

## Verification

```
$ bin/kin-precheck kin        (from the lane worktree, through heavy-slot)
kin-precheck: repo=kin tree=.../worktrees/guardprimitive-kin sha=f793c7aa4 branch=chore/lane-guardprimitive-kin DIRTY
kin-precheck: 20 gates enumerated from the check job of .github/workflows/ci.yml
...
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
PASS     node-test                            node --test <15 file(s) named by the check job>
kin-precheck: 20 gates ran, 20 passed, 0 failed, on kin f793c7aa470ef5e27776247eda69fe57470e348b DIRTY
```

The repo's own falsification harness, run against a copy rather than the checkout:

```
$ python3 scripts/falsify-zero-file-search.py <copy>
Falsifying 25 answer modules at up to 4 sites each
... every module ok at every site; cfg tracker, brace desync, counted-pin slack,
    reground pins and every deny-set probe ok ...
Every enforced answer module fails its guards when poisoned, at every site.
harness rc=0
```

## Notes for the reviewer

- **FIR-3151 is marked Done**, closed by kin#1452, which touched neither guard. The gap it describes
  was still live on this tree, so there is no closing trailer here and someone should decide whether
  that ticket reopens.
- **FIR-2282 is untouched** and is the other half of this class. This PR makes the shell guard's deny
  set complete; it does not make its coverage complete, since `authority_files` is still an opt-in
  list of ten kin-cli modules that cannot reach another crate by construction.
- Two honest limits are recorded in the code: a trait extension imported from a filesystem crate
  makes its methods reachable with no syntactic marker of their own, so the guard reports the import
  and whoever pins it owns that trait's surface; and a re-export through another module is a
  cross-file resolution this guard cannot do.
