### PR TITLE
Declare the daemon's hosted start requirements in --compat-json

### DIFF
--- a/crates/kin-daemon/src/bin/kin-daemon.rs
+++ b/crates/kin-daemon/src/bin/kin-daemon.rs
@@ -57,6 +57,9 @@ fn usage(program: &str) {
     eprintln!(
         "  KIN_SUPERVISOR_IDLE_TIMEOUT_SECS  optional supervisor idle shutdown timeout; 0 disables"
     );
+    eprintln!(
+        "\n--compat-json also declares this build's hosted start requirements under\n  \"hosted_start_requirements\"; see docs/hosted-daemon-start.md"
+    );
 }
 
 fn parse_args() -> Result<Args, String> {
@@ -211,46 +214,40 @@ fn create_state(
         StorageMode::Local => Ok(DaemonState::open_with_repo_id(layout, Some(repo_id))?),
         #[cfg(feature = "gcs")]
         StorageMode::Gcs => {
-            let bucket = env::var("KIN_GCS_BUCKET")
-                .map_err(|_| "KIN_GCS_BUCKET env var required for --storage gcs")?;
-            let prefix = env::var("KIN_GCS_PREFIX")
+            use kin_daemon::hosted_start::{self, Stage};
+
+            // Every bind-stage requirement is admitted before the first object
+            // store call, so a misconfigured deployment fails on its own config
+            // rather than on a storage timeout that hides which value is wrong.
+            // Each message comes from the requirement's own declaration, which
+            // is what `--compat-json` prints, so the two cannot drift.
+            let bucket = hosted_start::GCS_BUCKET.require(Stage::Bind)?;
+            let prefix = hosted_start::GCS_PREFIX
+                .read()
                 .unwrap_or_default()
                 .trim_matches('/')
                 .to_string();
-            let runtime_reader_identity = env::var("KIN_RELEASE_DAEMON_DIGEST_INTERNAL").map_err(
-                |_| {
-                    "KIN_RELEASE_DAEMON_DIGEST_INTERNAL is required for GCS graph publication admission"
-                },
-            )?;
-            let daemon_auth_token = env::var("KIN_DAEMON_AUTH_TOKEN")
-                .ok()
-                .map(|token| token.trim().to_string())
-                .filter(|token| !token.is_empty());
-            if daemon_auth_token.is_none() {
-                return Err(
-                    "KIN_DAEMON_AUTH_TOKEN is required for the hosted publication-control API"
-                        .into(),
-                );
-            }
-            let publication_control_auth_token =
-                env::var("KIN_PUBLICATION_CONTROL_AUTH_TOKEN")
-                    .ok()
-                    .map(|token| token.trim().to_string())
-                    .filter(|token| !token.is_empty())
-                    .ok_or(
-                        "KIN_PUBLICATION_CONTROL_AUTH_TOKEN is required for hosted rollout administration",
-                    )?;
-            if daemon_auth_token.as_deref() == Some(publication_control_auth_token.as_str()) {
+            let runtime_reader_identity =
+                hosted_start::RELEASE_DAEMON_DIGEST.require(Stage::Bind)?;
+            let daemon_auth_token = hosted_start::DAEMON_AUTH_TOKEN
+                .require(Stage::Bind)?
+                .trim()
+                .to_string();
+            let publication_control_auth_token = hosted_start::PUBLICATION_CONTROL_AUTH_TOKEN
+                .require(Stage::Bind)?
+                .trim()
+                .to_string();
+            if daemon_auth_token == publication_control_auth_token {
                 return Err(
                     "KIN_PUBLICATION_CONTROL_AUTH_TOKEN must differ from KIN_DAEMON_AUTH_TOKEN"
                         .into(),
                 );
             }
-            let (backend, object_store) = open_gcs_backend(&bucket, prefix.clone())?;
             let fleet_repositories = parse_repo_id_list();
             if fleet_repositories.is_empty() || allowed_repo_ids.is_none() {
-                return Err("KIN_REPO_IDS is required for GCS graph publication fencing".into());
+                return Err(hosted_start::REPO_IDS.refusal(Stage::Bind).into());
             }
+            let (backend, object_store) = open_gcs_backend(&bucket, prefix.clone())?;
             let scope = if prefix.is_empty() {
                 format!("gcs://{bucket}/")
             } else {
@@ -303,10 +300,7 @@ fn create_state(
             )?;
             let spine_startup = if let Some(pending) = bootstrap {
                 let legacy_writer_drain_proof_sha256 =
-                    env::var("KIN_SPINE_LEGACY_DRAIN_PROOF_SHA256_INTERNAL")
-                        .ok()
-                        .map(|digest| digest.trim().to_string())
-                        .filter(|digest| !digest.is_empty());
+                    kin_daemon::hosted_start::SPINE_LEGACY_DRAIN_PROOF.read();
                 // The sequence itself lives on the state so the same bytes run
                 // under a test clock; see `complete_hosted_startup_rollout`.
                 runtime.block_on(state.complete_hosted_startup_rollout(
@@ -405,8 +399,8 @@ fn acquire_before_state<T>(
 
 #[cfg(feature = "gcs")]
 fn parse_repo_id_list() -> Vec<String> {
-    env::var("KIN_REPO_IDS")
-        .ok()
+    kin_daemon::hosted_start::REPO_IDS
+        .read()
         .map(|raw| {
             raw.split(',')
                 .map(str::trim)
@@ -653,6 +647,11 @@ async fn async_main() -> i32 {
                     "branch": build.branch,
                     "built_at": build.built_at,
                 },
+                // What this image needs before it can serve hosted, declared by
+                // the same table its start path refuses from. A deployment can
+                // grade its config against the image it pins instead of against
+                // a list typed after the last rollback.
+                "hosted_start_requirements": kin_daemon::hosted_start::declaration(),
             })
         );
         return 0;
@@ -1198,6 +1197,147 @@ mod tests {
         assert!(
             logged.contains("daemon is up and ready"),
             "expected info lifecycle log in the writer, got: {logged:?}"
+        );
+    }
+    /// The full hosted environment, from which one requirement at a time is
+    /// removed below. `KIN_GCS_ENDPOINT` points at a closed port on purpose:
+    /// with every requirement present, startup must get past every env check
+    /// and fail reaching for storage, which is what proves an arm's refusal
+    /// came from the missing value rather than from the fixture.
+    #[cfg(feature = "gcs")]
+    fn complete_hosted_environment() -> Vec<(&'static str, &'static str)> {
+        vec![
+            ("KIN_GCS_BUCKET", "fixture-bucket"),
+            ("KIN_GCS_PREFIX", "fixture"),
+            ("KIN_GCS_ENDPOINT", "http://127.0.0.1:9"),
+            (
+                "KIN_RELEASE_DAEMON_DIGEST_INTERNAL",
+                "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            ),
+            ("KIN_REPO_IDS", "kin,kin-db"),
+            ("KIN_DAEMON_AUTH_TOKEN", "ordinary-daemon-token"),
+            (
+                "KIN_PUBLICATION_CONTROL_AUTH_TOKEN",
+                "publication-admin-token",
+            ),
+        ]
+    }
+
+    /// Run `create_state` in GCS mode under an environment with `omitted`
+    /// removed, resolving the repo key space exactly as `async_main` does so
+    /// the allowlist argument tracks the environment rather than being faked.
+    #[cfg(feature = "gcs")]
+    fn hosted_startup_without(omitted: Option<&str>) -> String {
+        let mut environment = kin_core::test_env::EnvVarGuard::new();
+        for (name, value) in complete_hosted_environment() {
+            if Some(name) == omitted {
+                environment.apply::<_, &str>(name, None);
+            } else {
+                environment.apply(name, Some(value));
+            }
+        }
+        let repo_id = "kin";
+        let allowed = served_repo_key_space(&StorageMode::Gcs, repo_id)
+            .expect("the fixture allowlist must admit the served repo");
+        let repo = tempfile::tempdir().unwrap();
+        let layout = KinLayout::new(repo.path().join(".kin"));
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        match create_state(
+            layout,
+            &StorageMode::Gcs,
+            repo_id,
+            runtime.handle(),
+            allowed,
+        ) {
+            Ok(_) => panic!("the fixture endpoint is closed, so startup cannot succeed"),
+            Err(error) => error.to_string(),
+        }
+    }
+
+    /// Every requirement `--compat-json` declares as refused at bind actually
+    /// refuses the real start path, with the declared message.
+    ///
+    /// This is the arm that catches a declaration nothing enforces: add a row
+    /// with a `Stage::Bind` refusal that no code performs and its arm here
+    /// reaches the storage probe instead and fails.
+    ///
+    /// The companion direction, a refusal added without a declaration, is held
+    /// by `hosted_start::tests::the_hosted_start_path_reads_no_environment_of_its_own`.
+    #[cfg(feature = "gcs")]
+    #[test]
+    #[serial_test::serial]
+    fn every_declared_bind_requirement_refuses_startup() {
+        use kin_daemon::hosted_start::{Stage, HOSTED_START_REQUIREMENTS};
+
+        let bind_requirements: Vec<_> = HOSTED_START_REQUIREMENTS
+            .iter()
+            .filter(|requirement| requirement.enforced_at(Stage::Bind))
+            .collect();
+
+        // Positive control: an empty list would make the loop below vacuous.
+        assert!(
+            bind_requirements.len() >= 4,
+            "the declaration lists {} bind requirements, which is too few to be the real set",
+            bind_requirements.len()
+        );
+
+        // With nothing missing, startup must reach storage. If it refused here
+        // the fixture would be incomplete and every arm below would pass for
+        // the wrong reason.
+        let complete = hosted_startup_without(None);
+        for requirement in &bind_requirements {
+            let declared = requirement.refusal(Stage::Bind);
+            assert!(
+                !complete.contains(declared),
+                "a complete hosted environment still refused on {}: {complete}",
+                requirement.name
+            );
+        }
+
+        for requirement in &bind_requirements {
+            let refusal = hosted_startup_without(Some(requirement.name));
+            assert!(
+                refusal.contains(requirement.refusal(Stage::Bind)),
+                "removing {} produced {refusal:?}, not the refusal --compat-json declares: {:?}",
+                requirement.name,
+                requirement.refusal(Stage::Bind)
+            );
+        }
+    }
+
+    /// An empty value is not a set value. A deployment that renders a blank
+    /// into its config has not supplied the requirement, and startup says so
+    /// with the same message absence gets rather than carrying the blank into
+    /// publication fencing.
+    #[cfg(feature = "gcs")]
+    #[test]
+    #[serial_test::serial]
+    fn a_blank_hosted_requirement_refuses_like_an_absent_one() {
+        use kin_daemon::hosted_start::{Stage, RELEASE_DAEMON_DIGEST};
+
+        let mut environment = kin_core::test_env::EnvVarGuard::new();
+        for (name, value) in complete_hosted_environment() {
+            environment.apply(name, Some(value));
+        }
+        environment.apply(RELEASE_DAEMON_DIGEST.name, Some("   "));
+        let repo_id = "kin";
+        let allowed = served_repo_key_space(&StorageMode::Gcs, repo_id).unwrap();
+        let repo = tempfile::tempdir().unwrap();
+        let layout = KinLayout::new(repo.path().join(".kin"));
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let error = create_state(
+            layout,
+            &StorageMode::Gcs,
+            repo_id,
+            runtime.handle(),
+            allowed,
+        )
+        .err()
+        .expect("a blank reader identity must not start")
+        .to_string();
+        assert!(
+            error.contains(RELEASE_DAEMON_DIGEST.refusal(Stage::Bind)),
+            "{error}"
         );
     }
 }

--- a/crates/kin-daemon/src/hosted_start.rs
+++ b/crates/kin-daemon/src/hosted_start.rs
@@ -1,0 +1,762 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! What a hosted `kin-daemon` needs before it can serve, declared by the binary
+//! that enforces it.
+//!
+//! # Why this exists
+//!
+//! The hosted start path has grown a requirement per release, and each one
+//! reached production as a rollback rather than as a diff. A deployment cannot
+//! read a requirement out of an image, so the deployment's env list was
+//! hand-typed from a rollback narrative and was always one release behind the
+//! binary it configured. `kin-daemon --compat-json` now carries
+//! [`declaration`], so the config can be graded against the image it pins.
+//!
+//! The central `KIN_*` registry in `kin-core::env_registry` cannot answer this.
+//! It covers `KIN_*` names only, and `GOOGLE_CLOUD_PROJECT`, the variable whose
+//! absence produced the 2026-09-02 outage, is not one.
+//!
+//! # The shape of the declaration
+//!
+//! ```json
+//! "hosted_start_requirements": {
+//!   "schema": "kin.daemon.hosted-start.v1",
+//!   "features": { "gcs": true, "firestore": true },
+//!   "requirements": [
+//!     {
+//!       "name": "GOOGLE_CLOUD_PROJECT",
+//!       "kind": "env",
+//!       "required": true,
+//!       "introduced_in": "0.6.2",
+//!       "absence": "readiness-closed",
+//!       "consequence": "...",
+//!       "refusals": [{ "stage": "spine", "message": "..." }]
+//!     }
+//!   ]
+//! }
+//! ```
+//!
+//! `requirements` is sorted by name so a consumer can diff two images. `absence`
+//! is derived from the stages, never stored, so it cannot disagree with them.
+//!
+//! # The two stages, and why they are not one flag
+//!
+//! [`Stage::Bind`] refusals happen in `create_state` before any I/O: the process
+//! exits and nothing serves. [`Stage::Spine`] refusals happen in
+//! `DaemonState::hosted_spine_contract`, which is not on the bind path, so the
+//! daemon binds, loads the graph, and then answers 503 on `/readiness` forever.
+//! That second shape is what the 2026-09-02 rollout hit, and a declaration that
+//! called both of them "required" would not have told the grader that the
+//! failure arrives after a successful start.
+//!
+//! # The single source of truth
+//!
+//! Every hosted requirement is one [`HostedStartRequirement`] const below, and
+//! every refusal site reads its message from that const rather than spelling it
+//! again. The table and the enforcing code stay bound by tests that fail in
+//! opposite directions. `every_declared_bind_requirement_refuses_startup` (in
+//! the daemon binary) and `every_declared_spine_requirement_closes_the_hosted_contract`
+//! (in `state`) drive the real start path once per declared requirement and
+//! fail on a declaration nothing enforces.
+//! [`tests::the_hosted_start_path_reads_no_environment_of_its_own`] scans the
+//! enforcing source and fails on a refusal added without a row here.
+//!
+//! # Feature gates are start requirements too
+//!
+//! A build without the `firestore` feature refuses hosted service whatever the
+//! environment holds, because `create_spine_backend` cannot compare-and-swap a
+//! cursor-bound head. `features` in the declaration reports that, so a pin can
+//! be refused for a build that could never have served.
+
+use std::collections::BTreeMap;
+
+/// Whether a requirement carries a credential.
+///
+/// A `Secret` is never rendered with its value anywhere, and a deployment is
+/// expected to source it from a secret store rather than a config literal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Kind {
+    Env,
+    Secret,
+}
+
+impl Kind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Kind::Env => "env",
+            Kind::Secret => "secret",
+        }
+    }
+}
+
+/// Where in hosted startup a requirement is enforced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Stage {
+    /// `create_state`, before any object-store or Firestore traffic. The
+    /// process refuses to start.
+    Bind,
+    /// `DaemonState::hosted_spine_contract`, reached after the process is
+    /// already bound and serving liveness. Readiness stays closed instead.
+    Spine,
+}
+
+impl Stage {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Stage::Bind => "bind",
+            Stage::Spine => "spine",
+        }
+    }
+}
+
+/// What an operator sees when the requirement is absent. Derived from the
+/// stages a requirement is enforced at, so it can never contradict them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Absence {
+    /// The process exits during startup with the refusal on stderr.
+    RefusesToStart,
+    /// The process starts, binds, and answers 503 on `/readiness` with the
+    /// refusal as the reason. Liveness stays green, which is the shape that
+    /// reads as healthy to everything except the readiness gate.
+    ReadinessClosed,
+    /// Nothing refuses. The daemon takes a default and runs.
+    ///
+    /// Paired with `required: true` this is the dangerous class, and the whole
+    /// reason the declaration reports `required` separately from what enforces
+    /// it: the deployment must set the value because nothing in the binary will
+    /// tell it that it didn't.
+    Silent,
+}
+
+impl Absence {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Absence::RefusesToStart => "refuses-to-start",
+            Absence::ReadinessClosed => "readiness-closed",
+            Absence::Silent => "silent",
+        }
+    }
+}
+
+/// One environment variable or secret the hosted start path reads.
+#[derive(Debug, Clone, Copy)]
+pub struct HostedStartRequirement {
+    /// The environment variable name, exactly as the daemon reads it.
+    pub name: &'static str,
+    pub kind: Kind,
+    /// Whether a hosted deployment has to set this.
+    ///
+    /// Deliberately independent of [`Self::refusals`]. Some requirements are
+    /// needed and enforced; some are needed and enforced by nothing, which a
+    /// declaration that conflated the two could not say. Read it with
+    /// [`Self::absence`].
+    pub required: bool,
+    /// The first `kin` release whose hosted path refuses without this.
+    ///
+    /// A historical fact the running binary cannot derive, so it is recorded
+    /// here and held to a well-formed version no later than this build by
+    /// `introduced_in_is_a_released_version`. Read it as provenance for a
+    /// deployment's version floor, not as something the binary measured.
+    pub introduced_in: &'static str,
+    /// One line an operator can act on, naming what breaks and when.
+    pub consequence: &'static str,
+    /// Every stage that refuses without this, with the verbatim message that
+    /// stage prints. Empty for a requirement whose absence takes a default.
+    pub refusals: &'static [(Stage, &'static str)],
+}
+
+impl HostedStartRequirement {
+    /// The message the named stage prints when this is absent.
+    ///
+    /// Every refusal site calls this rather than spelling its message again,
+    /// so the declaration and the refusal cannot drift apart.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirement declares no refusal for that stage, which is a
+    /// programming error: a site that refuses must have a row saying so.
+    pub fn refusal(&self, stage: Stage) -> &'static str {
+        self.refusals
+            .iter()
+            .find(|(declared, _)| *declared == stage)
+            .map(|(_, message)| *message)
+            .unwrap_or_else(|| {
+                panic!(
+                    "{} refuses at {} with no declared message; add the stage to its \
+                     HostedStartRequirement",
+                    self.name,
+                    stage.as_str()
+                )
+            })
+    }
+
+    /// What an operator sees when this is absent, derived from the stages.
+    ///
+    /// A bind refusal dominates a spine one: a process that never starts cannot
+    /// go on to close readiness.
+    pub fn absence(&self) -> Absence {
+        if self.enforced_at(Stage::Bind) {
+            Absence::RefusesToStart
+        } else if self.enforced_at(Stage::Spine) {
+            Absence::ReadinessClosed
+        } else {
+            Absence::Silent
+        }
+    }
+
+    /// Required, and nothing in the binary refuses without it.
+    ///
+    /// These are the rows a deployment grade should read first: the binary
+    /// cannot defend itself against their absence, so the config is the only
+    /// thing standing between the fleet and a pod that starts wrong and looks
+    /// healthy doing it.
+    pub fn required_but_unenforced(&self) -> bool {
+        self.required && self.absence() == Absence::Silent
+    }
+
+    pub fn enforced_at(&self, stage: Stage) -> bool {
+        self.refusals.iter().any(|(declared, _)| *declared == stage)
+    }
+
+    /// Read this requirement, refusing at the named stage with the declared
+    /// message. An empty or untrimmed value counts as absent: a deployment that
+    /// renders a blank value has not set it.
+    pub fn require(&self, stage: Stage) -> Result<String, String> {
+        match std::env::var(self.name) {
+            Ok(value) if !value.trim().is_empty() => Ok(value),
+            _ => Err(self.refusal(stage).to_string()),
+        }
+    }
+
+    /// Read this requirement without refusing, for the optional ones.
+    pub fn read(&self) -> Option<String> {
+        std::env::var(self.name)
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The requirements themselves.
+// ---------------------------------------------------------------------------
+
+pub const STORAGE: HostedStartRequirement = HostedStartRequirement {
+    name: "KIN_STORAGE",
+    kind: Kind::Env,
+    required: true,
+    introduced_in: "0.6.0",
+    consequence: "the daemon runs in local mode and every requirement below is skipped. It opens \
+                  the pod's own disk instead of the bucket, builds an in-memory spine, needs no \
+                  credential, logs \"using in-memory spine backend (local dev mode)\", and serves. \
+                  Nothing refuses, because nothing at that point knows the deployment meant to be \
+                  hosted. `--storage gcs` on the command line sets the same mode",
+    refusals: &[],
+};
+
+pub const DAEMON_BIND_HOST: HostedStartRequirement = HostedStartRequirement {
+    name: "KIN_DAEMON_BIND_HOST",
+    kind: Kind::Env,
+    required: true,
+    introduced_in: "0.6.0",
+    consequence: "the daemon binds 127.0.0.1 and nothing outside the container can reach it. \
+                  Hosted wants 0.0.0.0, which then requires KIN_DAEMON_AUTH_TOKEN: a non-loopback \
+                  bind without one is refused",
+    refusals: &[],
+};
+
+pub const GCS_BUCKET: HostedStartRequirement = HostedStartRequirement {
+    name: "KIN_GCS_BUCKET",
+    kind: Kind::Env,
+    required: true,
+    introduced_in: "0.6.0",
+    consequence: "no hosted graph storage: the daemon exits during startup",
+    refusals: &[
+        (
+            Stage::Bind,
+            "KIN_GCS_BUCKET env var required for --storage gcs",
+        ),
+        (
+            Stage::Spine,
+            "KIN_GCS_BUCKET is required for hosted durable spine",
+        ),
+    ],
+};
+
+pub const GCS_PREFIX: HostedStartRequirement = HostedStartRequirement {
+    name: "KIN_GCS_PREFIX",
+    kind: Kind::Env,
+    required: true,
+    introduced_in: "0.6.2",
+    consequence: "the daemon binds and then holds /readiness at 503: the durable spine scope is \
+                  the bucket root, which is not an addressable fleet scope",
+    refusals: &[(
+        Stage::Spine,
+        "KIN_GCS_PREFIX is required for hosted durable spine",
+    )],
+};
+
+pub const RELEASE_DAEMON_DIGEST: HostedStartRequirement = HostedStartRequirement {
+    name: "KIN_RELEASE_DAEMON_DIGEST_INTERNAL",
+    kind: Kind::Env,
+    required: true,
+    introduced_in: "0.6.2",
+    consequence: "no reader admission identity, so publication fencing cannot name this process: \
+                  the daemon exits during startup",
+    refusals: &[(
+        Stage::Bind,
+        "KIN_RELEASE_DAEMON_DIGEST_INTERNAL is required for GCS graph publication admission",
+    )],
+};
+
+pub const DAEMON_AUTH_TOKEN: HostedStartRequirement = HostedStartRequirement {
+    name: "KIN_DAEMON_AUTH_TOKEN",
+    kind: Kind::Secret,
+    required: true,
+    introduced_in: "0.6.2",
+    consequence: "the hosted publication-control API would be unauthenticated: the daemon exits \
+                  during startup",
+    refusals: &[(
+        Stage::Bind,
+        "KIN_DAEMON_AUTH_TOKEN is required for the hosted publication-control API",
+    )],
+};
+
+pub const PUBLICATION_CONTROL_AUTH_TOKEN: HostedStartRequirement = HostedStartRequirement {
+    name: "KIN_PUBLICATION_CONTROL_AUTH_TOKEN",
+    kind: Kind::Secret,
+    required: true,
+    introduced_in: "0.6.2",
+    consequence: "no operator credential distinct from the ordinary daemon token, so a rollout \
+                  could be driven by any authenticated caller: the daemon exits during startup. \
+                  It must also differ from KIN_DAEMON_AUTH_TOKEN, which is refused separately",
+    refusals: &[(
+        Stage::Bind,
+        "KIN_PUBLICATION_CONTROL_AUTH_TOKEN is required for hosted rollout administration",
+    )],
+};
+
+pub const REPO_IDS: HostedStartRequirement = HostedStartRequirement {
+    name: "KIN_REPO_IDS",
+    kind: Kind::Env,
+    required: true,
+    introduced_in: "0.6.2",
+    consequence: "publication fencing has no fleet to fence: the daemon exits during startup. The \
+                  durable spine additionally requires exactly five canonical entries, and one \
+                  that omits the served repo id is refused by name",
+    refusals: &[
+        (
+            Stage::Bind,
+            "KIN_REPO_IDS is required for GCS graph publication fencing",
+        ),
+        (
+            Stage::Spine,
+            "KIN_REPO_IDS must name the exact hosted spine fleet",
+        ),
+    ],
+};
+
+pub const GOOGLE_CLOUD_PROJECT: HostedStartRequirement = HostedStartRequirement {
+    name: "GOOGLE_CLOUD_PROJECT",
+    kind: Kind::Env,
+    required: true,
+    introduced_in: "0.6.2",
+    consequence: "the daemon binds, loads the graph, and holds /readiness at 503 for as long as \
+                  it runs, because the durable Firestore spine has no project. Liveness stays \
+                  green throughout. A daemon before 0.6.2 does the opposite and must NOT be \
+                  given this: it silently builds the legacy spine instead",
+    refusals: &[(
+        Stage::Spine,
+        "GOOGLE_CLOUD_PROJECT is required for hosted durable spine",
+    )],
+};
+
+pub const SPINE_LEGACY_DRAIN_PROOF: HostedStartRequirement = HostedStartRequirement {
+    name: "KIN_SPINE_LEGACY_DRAIN_PROOF_SHA256_INTERNAL",
+    kind: Kind::Env,
+    required: false,
+    introduced_in: "0.6.2",
+    consequence: "the first hosted rollout cannot write the one-way legacy-migration seal, and \
+                  hosted spine reads stay refused until some rollout does. Needed once per \
+                  database, not once per deployment",
+    refusals: &[],
+};
+
+pub const FIRESTORE_DATABASE_ID: HostedStartRequirement = HostedStartRequirement {
+    name: "FIRESTORE_DATABASE_ID",
+    kind: Kind::Env,
+    required: false,
+    introduced_in: "0.6.2",
+    consequence: "the durable spine uses the project's (default) Firestore database",
+    refusals: &[],
+};
+
+pub const DAEMON_IDLE_TIMEOUT_SECS: HostedStartRequirement = HostedStartRequirement {
+    name: "KIN_DAEMON_IDLE_TIMEOUT_SECS",
+    kind: Kind::Env,
+    required: false,
+    introduced_in: "0.6.0",
+    consequence: "the daemon shuts itself down after an hour with no traffic. A hosted pod is \
+                  then restarted and pays its startup cost again; set 0 to disable",
+    refusals: &[],
+};
+
+pub const GCS_ENDPOINT: HostedStartRequirement = HostedStartRequirement {
+    name: "KIN_GCS_ENDPOINT",
+    kind: Kind::Env,
+    required: false,
+    introduced_in: "0.6.0",
+    consequence: "graph storage goes to real Google Cloud Storage. Set only to redirect at an \
+                  emulator, which the daemon then probes and refuses to start without",
+    refusals: &[],
+};
+
+pub const STORAGE_EMULATOR_HOST: HostedStartRequirement = HostedStartRequirement {
+    name: "STORAGE_EMULATOR_HOST",
+    kind: Kind::Env,
+    required: false,
+    introduced_in: "0.6.0",
+    consequence: "graph storage goes to real Google Cloud Storage. KIN_GCS_ENDPOINT takes \
+                  precedence over this when both are set",
+    refusals: &[],
+};
+
+/// Every hosted start requirement, in declaration order.
+///
+/// [`declaration`] sorts by name; this order is the reading order, grouped by
+/// what an operator sets together.
+pub const HOSTED_START_REQUIREMENTS: &[HostedStartRequirement] = &[
+    STORAGE,
+    DAEMON_BIND_HOST,
+    GCS_BUCKET,
+    GCS_PREFIX,
+    RELEASE_DAEMON_DIGEST,
+    DAEMON_AUTH_TOKEN,
+    PUBLICATION_CONTROL_AUTH_TOKEN,
+    REPO_IDS,
+    GOOGLE_CLOUD_PROJECT,
+    SPINE_LEGACY_DRAIN_PROOF,
+    FIRESTORE_DATABASE_ID,
+    DAEMON_IDLE_TIMEOUT_SECS,
+    GCS_ENDPOINT,
+    STORAGE_EMULATOR_HOST,
+];
+
+/// The schema name of the declaration block, versioned independently of the
+/// compat payload around it so a consumer can require a shape.
+pub const DECLARATION_SCHEMA: &str = "kin.daemon.hosted-start.v1";
+
+/// The `hosted_start_requirements` block `--compat-json` prints.
+///
+/// Requirements are sorted by name so two images can be diffed directly.
+pub fn declaration() -> serde_json::Value {
+    let sorted: BTreeMap<&str, &HostedStartRequirement> = HOSTED_START_REQUIREMENTS
+        .iter()
+        .map(|requirement| (requirement.name, requirement))
+        .collect();
+    let requirements: Vec<serde_json::Value> = sorted
+        .values()
+        .map(|requirement| {
+            let refusals: Vec<serde_json::Value> = requirement
+                .refusals
+                .iter()
+                .map(|(stage, message)| {
+                    serde_json::json!({ "stage": stage.as_str(), "message": message })
+                })
+                .collect();
+            serde_json::json!({
+                "name": requirement.name,
+                "kind": requirement.kind.as_str(),
+                "required": requirement.required,
+                "introduced_in": requirement.introduced_in,
+                "absence": requirement.absence().as_str(),
+                "required_but_unenforced": requirement.required_but_unenforced(),
+                "consequence": requirement.consequence,
+                "refusals": refusals,
+            })
+        })
+        .collect();
+    serde_json::json!({
+        "schema": DECLARATION_SCHEMA,
+        "features": {
+            "gcs": cfg!(feature = "gcs"),
+            "firestore": cfg!(feature = "firestore"),
+        },
+        "requirements": requirements,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The two enforcing sources, embedded at compile time rather than read
+    /// from disk, so the scan below cannot pass because a path was wrong.
+    const DAEMON_BIN_SOURCE: &str = include_str!("bin/kin-daemon.rs");
+    const STATE_SOURCE: &str = include_str!("state.rs");
+
+    fn declared_names() -> Vec<&'static str> {
+        HOSTED_START_REQUIREMENTS
+            .iter()
+            .map(|requirement| requirement.name)
+            .collect()
+    }
+
+    /// The body of a named function, from its signature to the next item at the
+    /// same indentation. Crude on purpose: it needs to bound a scan, not parse
+    /// Rust, and `every_hosted_env_read_is_declared` proves it found something.
+    fn function_body<'a>(source: &'a str, signature: &str) -> &'a str {
+        let start = source
+            .find(signature)
+            .unwrap_or_else(|| panic!("{signature} is no longer in the enforcing source"));
+        let rest = &source[start..];
+        let indent = signature.len() - signature.trim_start().len();
+        let closer = format!("\n{}}}", " ".repeat(indent));
+        let end = rest
+            .find(&closer)
+            .unwrap_or_else(|| panic!("{signature} has no closing brace at its own indentation"));
+        &rest[..end]
+    }
+
+    /// Every `env::var("NAME")` inside a span, however it is qualified.
+    fn env_reads(span: &str) -> Vec<String> {
+        let mut names = Vec::new();
+        let mut rest = span;
+        while let Some(at) = rest.find("env::var(\"") {
+            let after = &rest[at + "env::var(\"".len()..];
+            if let Some(close) = after.find('"') {
+                names.push(after[..close].to_string());
+                rest = &after[close..];
+            } else {
+                break;
+            }
+        }
+        names
+    }
+
+    /// The hosted start path reads its environment only through this registry.
+    ///
+    /// This is the arm that catches a refusal added without a declaration. A
+    /// raw `env::var` inside either enforcing function is a hosted requirement
+    /// no `--compat-json` consumer can see, so the seam is closed here rather
+    /// than left to review.
+    #[test]
+    fn the_hosted_start_path_reads_no_environment_of_its_own() {
+        // Positive control on the extractor itself. Without this, a broken
+        // matcher would report "no raw reads" for a function full of them.
+        assert_eq!(
+            env_reads("let a = env::var(\"KIN_ONE\"); let b = std::env::var(\"KIN_TWO\");"),
+            vec!["KIN_ONE".to_string(), "KIN_TWO".to_string()],
+            "the env-read extractor does not find reads it is pointed at"
+        );
+
+        for (label, span) in [
+            (
+                "create_state",
+                function_body(DAEMON_BIN_SOURCE, "fn create_state("),
+            ),
+            (
+                "hosted_spine_contract",
+                function_body(STATE_SOURCE, "    fn hosted_spine_contract(&self)"),
+            ),
+        ] {
+            // Positive control on the span. A `function_body` that grabbed the
+            // wrong text would make the assertion below pass vacuously.
+            assert!(
+                span.contains("hosted_start::"),
+                "{label} no longer reads its requirements from this registry, so this scan is \
+                 pointed at the wrong code"
+            );
+            assert!(
+                !span.contains("env::var("),
+                "{label} reads the environment directly: {:?}. Every hosted requirement must go \
+                 through a HostedStartRequirement, or --compat-json cannot declare it and a \
+                 deployment cannot know it needs it.",
+                env_reads(span)
+            );
+        }
+    }
+
+    /// Every `HostedStartRequirement` const in this file is in the list the
+    /// declaration renders. A const that is enforced but unlisted is invisible
+    /// to a consumer, which is the same failure with a different shape.
+    #[test]
+    fn every_declared_const_is_in_the_rendered_list() {
+        const THIS_SOURCE: &str = include_str!("hosted_start.rs");
+        let marker = ": HostedStartRequirement = HostedStartRequirement {";
+        let mut consts: Vec<&str> = Vec::new();
+        for line in THIS_SOURCE.lines() {
+            if let Some(head) = line.strip_prefix("pub const ") {
+                if let Some(name) = head.strip_suffix(marker) {
+                    consts.push(name);
+                }
+            }
+        }
+
+        // Positive control: the scan must find the consts this file defines.
+        assert!(
+            consts.contains(&"GOOGLE_CLOUD_PROJECT") && consts.contains(&"GCS_BUCKET"),
+            "the const scan is not reading this file's declarations: {consts:?}"
+        );
+        assert_eq!(
+            consts.len(),
+            HOSTED_START_REQUIREMENTS.len(),
+            "this file declares {} requirement consts but HOSTED_START_REQUIREMENTS lists {}. \
+             Every const must be listed or --compat-json will not carry it: {consts:?}",
+            consts.len(),
+            HOSTED_START_REQUIREMENTS.len()
+        );
+    }
+
+    /// A requirement that refuses at a stage carries that stage's message, and
+    /// the message names the variable. A refusal an operator cannot grep for is
+    /// the reason the deployment table was typed by hand.
+    #[test]
+    fn every_refusal_names_its_own_variable() {
+        for requirement in HOSTED_START_REQUIREMENTS {
+            for (stage, message) in requirement.refusals {
+                assert!(
+                    message.contains(requirement.name),
+                    "{} refuses at {} with a message that does not name it: {message}",
+                    requirement.name,
+                    stage.as_str()
+                );
+                assert_eq!(requirement.refusal(*stage), *message);
+            }
+        }
+    }
+
+    /// Anything the binary refuses without is required. The converse is not
+    /// asserted on purpose: `required_but_unenforced` names the rows where the
+    /// deployment is the only thing holding the invariant, and erasing that
+    /// distinction is what a single "required" flag would do.
+    #[test]
+    fn every_enforced_requirement_is_required() {
+        for requirement in HOSTED_START_REQUIREMENTS {
+            if !requirement.refusals.is_empty() {
+                assert!(
+                    requirement.required,
+                    "{} is refused at startup but declared optional",
+                    requirement.name
+                );
+            }
+            assert_eq!(
+                requirement.absence() == Absence::Silent,
+                requirement.refusals.is_empty(),
+                "{} derives an absence that disagrees with its refusals",
+                requirement.name
+            );
+        }
+    }
+
+    /// The rows a deployment grade must read first are exactly the ones this
+    /// fleet has been bitten by, and the set does not grow unnoticed.
+    #[test]
+    fn the_unenforced_requirements_are_the_known_ones() {
+        let mut unenforced: Vec<&str> = HOSTED_START_REQUIREMENTS
+            .iter()
+            .filter(|requirement| requirement.required_but_unenforced())
+            .map(|requirement| requirement.name)
+            .collect();
+        unenforced.sort_unstable();
+        assert_eq!(
+            unenforced,
+            vec!["KIN_DAEMON_BIND_HOST", "KIN_STORAGE"],
+            "the set of requirements nothing enforces has changed. Either the binary grew a \
+             refusal (good, drop the row from this list) or hosted grew a requirement only the \
+             config holds (say so here, so a grade can too)."
+        );
+    }
+
+    /// Names are unique, so a consumer keying on name cannot silently lose one.
+    #[test]
+    fn requirement_names_are_unique() {
+        let mut names = declared_names();
+        let total = names.len();
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(total, names.len(), "a requirement name is declared twice");
+    }
+
+    /// `introduced_in` is a well-formed version no later than this build. It
+    /// cannot be derived at runtime, so this holds it to the one property a
+    /// running binary can check: a requirement cannot have been introduced by a
+    /// release that does not exist yet.
+    #[test]
+    fn introduced_in_is_a_released_version() {
+        let parse = |value: &str| -> Vec<u64> {
+            value
+                .split('.')
+                .map(|part| {
+                    part.parse::<u64>()
+                        .unwrap_or_else(|_| panic!("{value} is not a dotted version"))
+                })
+                .collect()
+        };
+        let current = parse(env!("CARGO_PKG_VERSION"));
+        for requirement in HOSTED_START_REQUIREMENTS {
+            let introduced = parse(requirement.introduced_in);
+            assert_eq!(
+                introduced.len(),
+                3,
+                "{} names a non-semver introducing release {}",
+                requirement.name,
+                requirement.introduced_in
+            );
+            assert!(
+                introduced <= current,
+                "{} claims to have been introduced in {}, which is later than this build ({})",
+                requirement.name,
+                requirement.introduced_in,
+                env!("CARGO_PKG_VERSION")
+            );
+        }
+    }
+
+    /// The rendered block keeps the shape a consumer parses.
+    #[test]
+    fn the_declaration_renders_every_requirement_sorted() {
+        let rendered = declaration();
+        assert_eq!(rendered["schema"], DECLARATION_SCHEMA);
+        let requirements = rendered["requirements"]
+            .as_array()
+            .expect("requirements must be an array")
+            .clone();
+        assert_eq!(requirements.len(), HOSTED_START_REQUIREMENTS.len());
+
+        let names: Vec<&str> = requirements
+            .iter()
+            .map(|entry| entry["name"].as_str().expect("a name"))
+            .collect();
+        let mut sorted = names.clone();
+        sorted.sort_unstable();
+        assert_eq!(names, sorted, "requirements must render sorted by name");
+
+        for entry in &requirements {
+            for field in [
+                "name",
+                "kind",
+                "required",
+                "introduced_in",
+                "absence",
+                "required_but_unenforced",
+                "consequence",
+                "refusals",
+            ] {
+                assert!(!entry[field].is_null(), "{field} is missing from {entry}");
+            }
+        }
+
+        let project = requirements
+            .iter()
+            .find(|entry| entry["name"] == "GOOGLE_CLOUD_PROJECT")
+            .expect("the variable the outage turned on must be declared");
+        assert_eq!(project["absence"], "readiness-closed");
+        assert_eq!(project["required"], true);
+        assert_eq!(
+            project["refusals"][0]["message"],
+            "GOOGLE_CLOUD_PROJECT is required for hosted durable spine"
+        );
+    }
+}

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -123,6 +123,7 @@ pub mod daemon;
 pub mod error;
 pub mod gcs_endpoint;
 pub mod graph_only_members;
+pub mod hosted_start;
 pub mod lifecycle;
 mod local_repository_authority;
 pub mod loop_runner;

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -35,6 +35,7 @@ use tokio::sync::{Mutex as AsyncMutex, RwLock};
 use tracing::{debug, error, info, warn};
 
 use crate::error::{DaemonError, Result};
+use crate::hosted_start;
 use crate::session_registry::SessionCoordinator;
 
 /// Borrowed immutable history used to materialize a hosted repository ref.
@@ -5638,20 +5639,20 @@ impl DaemonState {
         if self.storage_backend.is_none() {
             return Err("hosted spine contract requested for a local daemon".to_string());
         }
-        let project_id = std::env::var("GOOGLE_CLOUD_PROJECT")
-            .map_err(|_| "GOOGLE_CLOUD_PROJECT is required for hosted durable spine".to_string())?;
-        if project_id.is_empty() || project_id.trim() != project_id {
+        // Each name and refusal comes from the hosted start registry, which is
+        // what `kin-daemon --compat-json` declares. A requirement enforced here
+        // and undeclared there is a deployment nobody can grade, so the two are
+        // one table; `hosted_start` holds the test that keeps them one.
+        let project_id = hosted_start::GOOGLE_CLOUD_PROJECT.require(hosted_start::Stage::Spine)?;
+        if project_id.trim() != project_id {
             return Err("GOOGLE_CLOUD_PROJECT must be non-empty and canonical".to_string());
         }
-        let bucket = std::env::var("KIN_GCS_BUCKET")
-            .map_err(|_| "KIN_GCS_BUCKET is required for hosted durable spine".to_string())?;
-        if bucket.is_empty() || bucket.trim() != bucket || bucket.contains('/') {
+        let bucket = hosted_start::GCS_BUCKET.require(hosted_start::Stage::Spine)?;
+        if bucket.trim() != bucket || bucket.contains('/') {
             return Err("KIN_GCS_BUCKET must be a canonical bucket name".to_string());
         }
-        let prefix = std::env::var("KIN_GCS_PREFIX")
-            .map_err(|_| "KIN_GCS_PREFIX is required for hosted durable spine".to_string())?;
-        if prefix.is_empty()
-            || prefix.trim() != prefix
+        let prefix = hosted_start::GCS_PREFIX.require(hosted_start::Stage::Spine)?;
+        if prefix.trim() != prefix
             || prefix.starts_with('/')
             || prefix.ends_with('/')
             || prefix.contains("//")
@@ -5661,7 +5662,11 @@ impl DaemonState {
         let mut fleet = self
             .allowed_repo_ids
             .as_ref()
-            .ok_or_else(|| "KIN_REPO_IDS must name the exact hosted spine fleet".to_string())?
+            .ok_or_else(|| {
+                hosted_start::REPO_IDS
+                    .refusal(hosted_start::Stage::Spine)
+                    .to_string()
+            })?
             .iter()
             .cloned()
             .collect::<Vec<_>>();
@@ -7458,10 +7463,9 @@ impl DaemonState {
             #[cfg(feature = "firestore")]
             {
                 let (scope, fleet) = self.hosted_spine_contract()?;
-                let project_id = std::env::var("GOOGLE_CLOUD_PROJECT").map_err(|_| {
-                    "GOOGLE_CLOUD_PROJECT is required for hosted durable spine".to_string()
-                })?;
-                let database_id = std::env::var("FIRESTORE_DATABASE_ID").ok();
+                let project_id =
+                    hosted_start::GOOGLE_CLOUD_PROJECT.require(hosted_start::Stage::Spine)?;
+                let database_id = hosted_start::FIRESTORE_DATABASE_ID.read();
                 info!(
                     project = %project_id,
                     database = database_id.as_deref().unwrap_or("(default)"),
@@ -18179,5 +18183,106 @@ mod tests {
         assert!(refused.contains("expired"), "{refused}");
         drop(bound);
         gate().expect("an unbound lease defends nothing");
+    }
+    /// The complete hosted spine contract, from which one requirement at a
+    /// time is removed below.
+    fn hosted_spine_fleet() -> [&'static str; HOSTED_SPINE_FLEET_SIZE] {
+        ["kin", "kin-db", "kin-lsp", "kin-model", "kin-search"]
+    }
+
+    fn hosted_state_for_contract(with_fleet: bool) -> (DaemonState, tempfile::TempDir) {
+        use kin_db::LocalFileBackend;
+
+        let storage = tempfile::tempdir().unwrap();
+        let repo_dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(repo_dir.path()).unwrap().layout;
+        let allowed = with_fleet.then(|| {
+            hosted_spine_fleet()
+                .into_iter()
+                .map(str::to_string)
+                .collect()
+        });
+        let state = DaemonState::open_with_backend(
+            layout,
+            Box::new(LocalFileBackend::new(storage.path())),
+            "kin",
+            allowed,
+        )
+        .unwrap();
+        (state, repo_dir)
+    }
+
+    /// Every requirement `--compat-json` declares as refused at the spine stage
+    /// actually closes the hosted spine contract, with the declared message.
+    ///
+    /// These are the ones that do not stop the process. The daemon binds, loads
+    /// the graph, keeps liveness green and holds `/readiness` at 503 for as long
+    /// as it runs, which is the shape the 2026-09-02 rollout hit. Declaring them
+    /// as merely "required" would have hidden that, so the stage is declared and
+    /// this is what proves the stage is real.
+    ///
+    /// Falsified in the other direction by
+    /// `hosted_start::tests::the_hosted_start_path_reads_no_environment_of_its_own`,
+    /// which refuses a refusal added here without a declaration.
+    #[test]
+    #[serial_test::serial]
+    fn every_declared_spine_requirement_closes_the_hosted_contract() {
+        let spine_requirements: Vec<_> = hosted_start::HOSTED_START_REQUIREMENTS
+            .iter()
+            .filter(|requirement| requirement.enforced_at(hosted_start::Stage::Spine))
+            .collect();
+
+        // Positive control: an empty list would make the loop below vacuous.
+        assert!(
+            spine_requirements.len() >= 3,
+            "the declaration lists {} spine requirements, which is too few to be the real set",
+            spine_requirements.len()
+        );
+
+        let complete: Vec<(&str, String)> = vec![
+            ("GOOGLE_CLOUD_PROJECT", "fixture-project".to_string()),
+            ("KIN_GCS_BUCKET", "fixture-bucket".to_string()),
+            ("KIN_GCS_PREFIX", "fixture-prefix".to_string()),
+            ("KIN_REPO_IDS", hosted_spine_fleet().join(",")),
+        ];
+
+        // With nothing missing the contract must hold, or every arm below would
+        // pass because the fixture was incomplete rather than because the
+        // requirement is enforced.
+        {
+            let mut environment = kin_core::test_env::EnvVarGuard::new();
+            for (name, value) in &complete {
+                environment.apply(name, Some(value.as_str()));
+            }
+            let (state, _repo) = hosted_state_for_contract(true);
+            state
+                .hosted_spine_contract()
+                .expect("the fixture must provision a complete hosted contract");
+        }
+
+        for requirement in &spine_requirements {
+            let mut environment = kin_core::test_env::EnvVarGuard::new();
+            for (name, value) in &complete {
+                if *name == requirement.name {
+                    environment.apply::<_, &str>(name, None);
+                } else {
+                    environment.apply(name, Some(value.as_str()));
+                }
+            }
+            // KIN_REPO_IDS reaches the contract through the allowlist the
+            // process was constructed with, not through a second read, so its
+            // absence is expressed the way startup expresses it.
+            let with_fleet = requirement.name != "KIN_REPO_IDS";
+            let (state, _repo) = hosted_state_for_contract(with_fleet);
+            let refusal = state
+                .hosted_spine_contract()
+                .expect_err("a missing hosted requirement must close the contract");
+            assert_eq!(
+                refusal,
+                requirement.refusal(hosted_start::Stage::Spine),
+                "removing {} produced a refusal --compat-json does not declare",
+                requirement.name
+            );
+        }
     }
 }

--- a/crates/kin-daemon/tests/compat_json_stdout.rs
+++ b/crates/kin-daemon/tests/compat_json_stdout.rs
@@ -81,4 +81,58 @@ async fn compat_json_stdout_is_pure_json_under_env_overrides() {
     assert!(parsed["build"]["dependency_provenance"].is_string());
     assert!(parsed["build"]["branch"].is_string());
     assert!(parsed["build"]["built_at"].is_string());
+
+    // The exact top-level key set. kin-infra reads this payload by name and
+    // records it verbatim as the evidence a hosted pin is graded against, so a
+    // key that quietly appears or disappears changes what that evidence means.
+    // Adding one is fine and this is where it is acknowledged.
+    let mut keys: Vec<&str> = parsed
+        .as_object()
+        .expect("the compat payload must be an object")
+        .keys()
+        .map(String::as_str)
+        .collect();
+    keys.sort_unstable();
+    assert_eq!(
+        keys,
+        vec![
+            "build",
+            "graph_snapshot_max_supported_version",
+            "graph_snapshot_min_supported_version",
+            "graph_snapshot_version",
+            "hosted_start_requirements",
+            "schema",
+            "supervisor_startup_capabilities",
+            "supervisor_startup_protocol",
+            "version",
+        ],
+        "the compat payload's top-level shape changed"
+    );
+
+    // The hosted declaration itself, from the real binary rather than from the
+    // in-process renderer, so the block a deployment reads off an image is the
+    // one under test.
+    let hosted = &parsed["hosted_start_requirements"];
+    assert_eq!(hosted["schema"], "kin.daemon.hosted-start.v1");
+    assert!(
+        hosted["features"]["gcs"].is_boolean() && hosted["features"]["firestore"].is_boolean(),
+        "the declaration must report the build features hosted service needs: {hosted}"
+    );
+    let requirements = hosted["requirements"]
+        .as_array()
+        .expect("the declaration must carry a requirements array");
+    let project = requirements
+        .iter()
+        .find(|entry| entry["name"] == "GOOGLE_CLOUD_PROJECT")
+        .unwrap_or_else(|| panic!("the declaration must name GOOGLE_CLOUD_PROJECT: {hosted}"));
+    assert_eq!(project["required"], true);
+    assert_eq!(
+        project["absence"], "readiness-closed",
+        "a missing project does not stop the process, it holds readiness shut, and a deployment \
+         reading this block has to be told which"
+    );
+    assert_eq!(
+        project["refusals"][0]["message"],
+        "GOOGLE_CLOUD_PROJECT is required for hosted durable spine"
+    );
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,9 @@ repository, and walks the everyday loop end to end. Once Kin is running, the
 - **[Environment variables](env-vars.md)** is the generated list of supported
   `KIN_*` variables, their defaults, and which ones change results rather than
   performance.
+- **[Hosted daemon start requirements](hosted-daemon-start.md)** explains the
+  `hosted_start_requirements` block `kin-daemon --compat-json` prints, which is
+  how a deployment reads what an image needs instead of tracking it by hand.
 - **[Language support](language-support.md)** states what semantic enrichment
   each language actually gets. No tier is implied beyond what extraction emits.
 - **[Store size](store-size.md)** explains what drives the size of `.kin/` and

--- a/docs/hosted-daemon-start.md
+++ b/docs/hosted-daemon-start.md
@@ -1,0 +1,88 @@
+# Hosted daemon start requirements
+
+A hosted `kin-daemon` needs more configuration than a local one, and the list has grown with every
+release. `kin-daemon --compat-json` now declares it, so a deployment can read what an image needs
+straight off the image instead of keeping a list in sync by hand.
+
+Run it against any build:
+
+```bash
+kin-daemon --compat-json | jq .hosted_start_requirements
+```
+
+## What the block says
+
+```json
+{
+  "schema": "kin.daemon.hosted-start.v1",
+  "features": { "gcs": true, "firestore": true },
+  "requirements": [
+    {
+      "name": "GOOGLE_CLOUD_PROJECT",
+      "kind": "env",
+      "required": true,
+      "introduced_in": "0.6.2",
+      "absence": "readiness-closed",
+      "required_but_unenforced": false,
+      "consequence": "the daemon binds, loads the graph, and holds /readiness at 503 ...",
+      "refusals": [
+        { "stage": "spine", "message": "GOOGLE_CLOUD_PROJECT is required for hosted durable spine" }
+      ]
+    }
+  ]
+}
+```
+
+`requirements` is sorted by name, so two images diff cleanly.
+
+`features` reports the cargo features the binary was built with. Both must be true for hosted
+service. A build without `firestore` refuses the durable spine whatever the environment holds,
+because it cannot compare-and-swap a cursor-bound head, and no amount of configuration fixes that.
+
+`absence` is the field to read first. It has three values.
+
+- `refuses-to-start` means the process exits during startup and prints the refusal on stderr.
+  Nothing serves, and the reason is in the pod's logs.
+- `readiness-closed` means the process starts, binds, loads the graph, and then holds `/readiness`
+  at 503 for as long as it runs. Liveness stays green. Everything except the readiness gate reads
+  this pod as healthy, which is why it gets its own value rather than being folded into "required".
+- `silent` means nothing refuses. The daemon takes a default and runs. Paired with `required: true`
+  this is the class to grade hardest, because the configuration is the only thing holding the
+  invariant and the binary will not tell anyone it is missing. `required_but_unenforced` is that
+  pair, precomputed.
+
+`refusals` carries the verbatim message each stage prints, so an operator can grep a log for the
+exact string and a deployment can show it before applying a change.
+
+`introduced_in` is the first `kin` release whose hosted path refuses without the requirement. It is
+a historical record the running binary cannot measure, so treat it as provenance for a version
+floor rather than as something the image proved. The binary does check that it is a well-formed
+version no later than itself.
+
+## Where the list comes from
+
+`crates/kin-daemon/src/hosted_start.rs` is the single table. Every refusal site reads its message
+from that table rather than spelling it again, so the declaration and the refusal cannot drift.
+Three tests hold the seam, and they fail in opposite directions:
+
+- `the_hosted_start_path_reads_no_environment_of_its_own` scans the two enforcing functions and
+  fails if either reads the environment outside the registry, which catches a requirement added
+  without a declaration.
+- `every_declared_bind_requirement_refuses_startup` runs the real start path once per declared
+  bind requirement, with that one value removed, and fails if the declared refusal does not appear.
+  That catches a declaration nothing enforces.
+- `every_declared_spine_requirement_closes_the_hosted_contract` does the same for the spine stage.
+
+## Why it exists
+
+Every hosted daemon release so far has added a start requirement, and each one reached production
+as a rollback rather than as a diff. A deployment cannot read a requirement out of an image, so the
+env list was typed by hand after the last outage and was always one release behind the binary it
+configured.
+
+The central `KIN_*` environment registry cannot answer this either. It covers `KIN_*` names only,
+and `GOOGLE_CLOUD_PROJECT`, whose absence produced the 2026-09-02 rollback, is not one of those.
+
+The consumer is kin-infra. `scripts/hosted-daemon-images.py record` already runs `--version` and
+`--compat-json` against an image and records the verbatim output, and this block is what lets that
+evidence grade a config rather than only name a version.


### PR DESCRIPTION
## The problem

Every hosted daemon release so far has added a start requirement, and each one reached production
as a rollback rather than as a diff. A deployment cannot read a requirement out of an image, so
kin-infra's env list was typed by hand after the last outage and was always one release behind the
binary it configured.

On 2026-09-02 a v0.6.3 image reached the daemon container, loaded the graph, logged
`GOOGLE_CLOUD_PROJECT is required for hosted durable spine`, answered 503 on `/readiness` for the
gate's 600 s and was rolled back, with the API 502 for eleven minutes.

## What this does

`kin-daemon --compat-json` grows a `hosted_start_requirements` block. **kin-infra's grade is the
intended consumer.** To be precise about what exists today: `scripts/hosted-daemon-images.py record`
already runs both `--version` and `--compat-json` against an image, but `row_from_reads`
(`:174-193`) keeps only the version line plus a derived `graphSnapshotRange`, and `validate_row`
(`:241`) refuses any other field. So nothing consumes this block yet. It is the input a future
grade reads, not something recorded today, and wiring it up is kin-infra's change to make.

The refusals lived in two files, so this adds the registry they both read.
`crates/kin-daemon/src/hosted_start.rs` holds one const per requirement, `create_state` and
`hosted_spine_contract` take their messages from it rather than spelling them again, and the
declaration renders from the same table.

Read off a real `--features gcs,firestore` binary built from this branch:

```
schema: kin.daemon.hosted-start.v1   features: {'firestore': True, 'gcs': True}

name                                           kind    req   since  absence           unenforced
FIRESTORE_DATABASE_ID                          env     False 0.6.2  silent            False
GOOGLE_CLOUD_PROJECT                           env     True  0.6.2  readiness-closed  False
KIN_DAEMON_AUTH_TOKEN                          secret  True  0.6.2  refuses-to-start  False
KIN_DAEMON_BIND_HOST                           env     True  0.6.0  silent            True
KIN_DAEMON_IDLE_TIMEOUT_SECS                   env     False 0.6.0  silent            False
KIN_GCS_BUCKET                                 env     True  0.6.0  refuses-to-start  False
KIN_GCS_ENDPOINT                               env     False 0.6.0  silent            False
KIN_GCS_PREFIX                                 env     True  0.6.2  readiness-closed  False
KIN_PUBLICATION_CONTROL_AUTH_TOKEN             secret  True  0.6.2  refuses-to-start  False
KIN_RELEASE_DAEMON_DIGEST_INTERNAL             env     True  0.6.2  refuses-to-start  False
KIN_REPO_IDS                                   env     True  0.6.2  refuses-to-start  False
KIN_SPINE_LEGACY_DRAIN_PROOF_SHA256_INTERNAL   env     False 0.6.2  silent            False
KIN_STORAGE                                    env     True  0.6.0  silent            True
STORAGE_EMULATOR_HOST                          env     False 0.6.0  silent            False
```

Each row also carries a `consequence` line and its `refusals` array with the verbatim message,
omitted above for width.

### Three absence values, not one required flag

The failures do not look alike, and a grade needs to tell them apart.

- `refuses-to-start` exits during startup with the refusal on stderr.
- `readiness-closed` binds, loads the graph, keeps liveness green and holds `/readiness` at 503 for
  as long as the process runs. That is the shape the rollback hit, and calling it merely "required"
  would not have told the grader the failure arrives after a successful start.
- `silent` means nothing refuses. Paired with `required` it names the rows only the config holds:
  `KIN_STORAGE` and `KIN_DAEMON_BIND_HOST` today, pinned by a test so the set cannot grow unnoticed.

`features` reports `gcs` and `firestore`, because a build without `firestore` refuses the durable
spine whatever the environment holds. A pin can now be refused for a build that could never have
served.

### A measurement that corrects a hand-typed floor

kin-infra sets `HOSTED_SPINE_MIN_VERSION = "0.6.3"` and attributes `GOOGLE_CLOUD_PROJECT` to
v0.6.3. The source says v0.6.2. Grepping each refusal string at each release tag, every one of
these landed in `a27c99bb9` (#1227), which v0.6.2 is the first tag to contain, and
`v0.6.2:crates/kin-daemon/src/state.rs:7141-7151` shows the hosted branch already calling
`hosted_spine_contract()`. Harmless today only because 0.6.2 was never deployed. It is also the
argument for this change: the floor was typed from a rollback narrative and is one release wrong.

## Tests, and how each was falsified

Three tests bind the declaration to the refusals and fail in opposite directions. Each was
falsified by breaking the behaviour it guards, with the red tail pasted below.

**Declare a requirement nothing refuses** (added a bind refusal no code performs):

```
test tests::every_declared_bind_requirement_refuses_startup ... FAILED
panicked at crates/kin-daemon/src/bin/kin-daemon.rs:1293:13:
removing KIN_FALSIFY_NOTHING_REFUSES produced "KIN_GCS_ENDPOINT points at http://127.0.0.1:9 but
nothing is listening there ...", not the refusal --compat-json declares:
"KIN_FALSIFY_NOTHING_REFUSES is required for the falsification arm"
test result: FAILED. 0 passed; 1 failed
```

**Add a refusal without declaring it** (raw `env::var` inside `hosted_spine_contract`):

```
test hosted_start::tests::the_hosted_start_path_reads_no_environment_of_its_own ... FAILED
panicked at crates/kin-daemon/src/hosted_start.rs:565:13:
hosted_spine_contract reads the environment directly: ["KIN_FALSIFY_UNDECLARED_READ"]. Every
hosted requirement must go through a HostedStartRequirement, or --compat-json cannot declare it
and a deployment cannot know it needs it.
test result: FAILED. 7 passed; 1 failed
```

**Remove a refusal the declaration claims** (defaulted `KIN_GCS_PREFIX` instead of refusing):

```
test state::tests::every_declared_spine_requirement_closes_the_hosted_contract ... FAILED
panicked at crates/kin-daemon/src/state.rs:18271:18:
a missing hosted requirement must close the contract: ("gcs://fixture-bucket/fallback",
["kin", "kin-db", "kin-lsp", "kin-model", "kin-search"])
test result: FAILED. 0 passed; 1 failed
```

Both behavioural arms first prove the complete fixture gets past every env check, so no arm can
pass because the fixture was short. The source scan carries an extractor self-test and asserts each
span actually contains `hosted_start::`, so a broken matcher or a mislocated span cannot pass it
silently.

## Behaviour changes

Three, all tightenings.

- An empty `KIN_GCS_BUCKET` or `KIN_RELEASE_DAEMON_DIGEST_INTERNAL` now refuses like an absent one.
  For the digest this moves an existing `validate_image_identity` refusal earlier with a clearer
  message rather than adding one.
- `KIN_REPO_IDS` is now checked before `open_gcs_backend`, so a misconfigured fleet fails on its
  config instead of on a storage timeout.
- An empty `GOOGLE_CLOUD_PROJECT` now reports "is required" rather than "must be non-empty and
  canonical". The canonicality check still fires for a value with whitespace, and no test in the
  repo asserted the old string for the empty case.

The existing compat-json fields are unchanged. kin-infra's `parse_compat` reads by key, never by
byte comparison, and `compat_json_stdout.rs` now asserts the exact top-level key set so one cannot
appear or disappear quietly.

## Limits

`introduced_in` is the one hand-written field: a running binary cannot measure which release first
refused without a variable. It is held only to the property a binary can check, a well-formed
version no later than itself. The values here were measured by grepping each refusal string at each
release tag.

The source scan covers `create_state` and `hosted_spine_contract`. A requirement introduced in a
third function would need its span added.

## Local verification

Run from the lane worktree at the pushed sha. Commands and their output tails:

```
$ bin/kin-precheck kin
kin-precheck: 20 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows>
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
... 20 rows ...
kin-precheck: 20 gates ran, 20 passed, 0 failed

$ cargo test -p kin-daemon --features gcs,firestore --locked --lib hosted_start::
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 1370 filtered out

$ cargo test -p kin-daemon --features gcs,firestore --locked --lib every_declared_spine
test result: ok. 1 passed; 0 failed

$ cargo test -p kin-daemon --features gcs,firestore --locked --bin kin-daemon
test result: ok. 14 passed; 0 failed

$ cargo test -p kin-daemon --locked --test compat_json_stdout
test result: ok. 6 passed; 0 failed
```

**What grades the feature-gated paths, stated exactly.** The `gcs,firestore` arm runs on main's
push, not on this pull request. The commands are `ci.yml:2593` and `:2598`, in the `feature-tests`
job (`:2500`), which carries `github.event_name != 'pull_request'` at `:2506`. The green
"Feature permutation tests (ubuntu-latest)/(macos-latest)" contexts on this PR come from the
fast-path job, whose log says "This job runs no tests. The feature permutations run on push to
main, after the merge, and not on this pull request."

So the runs above are local, which is why their output tails are pasted rather than described. This
matches the repo's shape: acceptance and the feature permutations grade main, and the fast gate is
admission. The reviewer reproduced them independently (14 passed on the bin, 9 on the lib) and
falsified the declaration arm by declaring a refusal nothing performs.

One note for whoever reads the payload next: `serde_json`'s `preserve_order` is off, so the new key
sorts into the middle of the document alphabetically rather than being appended. Inert today, since
every consumer reads by key.

Docs: `docs/hosted-daemon-start.md`, linked from `docs/README.md`, and `kin-daemon --help` names it
beside `--compat-json`.

Report: `.kin-coord/reports/daemonreq-20260904.md`.
