### PR TITLE
Stop the stranded-stage row calling an unreadable directory clean (FIR-3146)

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -2028,15 +2028,27 @@ fn stranded_init_stage_check_for(roots: &[PathBuf]) -> HealthCheck {
 
 /// Survey every scan root once, keeping each stage the first time it is seen.
 ///
-/// The roots overlap by construction: a working directory and its parent both
-/// name the parent's staging when the run happens one level down. Deduplicated
-/// on the owner record's path, which is unique per stage.
+/// Deduplicated on the owner record's path, which is unique per stage. The
+/// roots are a directory and its parent, so they hold disjoint entries today
+/// and the dedupe is insurance against a caller that passes overlapping roots
+/// rather than against the pair `staging_scan_roots` returns.
+///
+/// A root that could not be read is recorded, not dropped. Reporting a parent
+/// as clean because `read_dir` refused it would be the false negative this row
+/// exists to end, and it is the parent, one level up from where an operator
+/// stands, that these stages strand in.
 pub(crate) fn survey_stranded_stages(roots: &[PathBuf]) -> kin_core::StrandedStageSurvey {
     let mut survey = kin_core::StrandedStageSurvey::default();
     let mut seen = std::collections::BTreeSet::new();
     for root in roots {
-        let Ok(found) = kin_core::survey_orphaned_repository_stages(root) else {
-            continue;
+        let found = match kin_core::survey_orphaned_repository_stages(root) {
+            Ok(found) => found,
+            Err(error) => {
+                survey
+                    .unreadable
+                    .push(format!("{}: {error}", root.display()));
+                continue;
+            }
         };
         survey.live += found.live;
         for stage in found.stages {
@@ -2072,14 +2084,32 @@ pub fn stranded_stage_scan_roots() -> Vec<PathBuf> {
 /// owner lock, a private owner record and stage directory owned by this user,
 /// the exact recorded stage path, and a matching device and inode. A stage a
 /// live `kin init` holds is never touched.
+///
+/// That owner lock is host-local, so the proof holds on local storage and not
+/// on a shared mount, where a stage another machine is still writing can read
+/// as abandoned. FIR-3155 carries the fix, a host identifier on the owner
+/// record.
+///
+/// Refuses rather than returning zero when no root could be examined at all. A
+/// caller reading only the exit status would otherwise take "I could not look"
+/// for "there was nothing there".
 pub fn reclaim_stranded_stages(json: bool) -> anyhow::Result<()> {
-    let roots = stranded_stage_scan_roots();
+    reclaim_stranded_stages_in(&stranded_stage_scan_roots(), json)
+}
+
+/// [`reclaim_stranded_stages`] against explicit roots.
+///
+/// Split out so the refusal below is reachable from a test. Resolving the roots
+/// from `env::current_dir` is process-global state, and a test that changed the
+/// working directory to drive this would reach every other test running beside
+/// it in the same binary.
+pub(crate) fn reclaim_stranded_stages_in(roots: &[PathBuf], json: bool) -> anyhow::Result<()> {
     let mut recovered = 0usize;
     let mut bytes = 0u64;
     let mut retained = 0usize;
     let mut live = 0usize;
     let mut failures: Vec<String> = Vec::new();
-    for root in &roots {
+    for root in roots {
         match kin_core::reclaim_orphaned_repository_stages(root) {
             Ok(outcome) => {
                 recovered += outcome.recovered;
@@ -2091,6 +2121,17 @@ pub fn reclaim_stranded_stages(json: bool) -> anyhow::Result<()> {
             // thing an operator must not read as "nothing was stranded there".
             Err(error) => failures.push(format!("{}: {error}", root.display())),
         }
+    }
+    // Fail loud. `recovered == 0` beside a failure for every root is not a clean
+    // parent, and the summary sentence below says "nothing to reclaim here",
+    // which is the one thing this must not tell a script that reads only the
+    // exit status.
+    if failures.len() == roots.len() && !roots.is_empty() {
+        anyhow::bail!(
+            "kin doctor --reclaim-staging: no directory could be examined, so this run says \
+             nothing about what is stranded here: {}",
+            failures.join("; ")
+        );
     }
     if json {
         println!(
@@ -2117,18 +2158,22 @@ pub fn reclaim_stranded_stages(json: bool) -> anyhow::Result<()> {
     if !json {
         if retained > 0 {
             let (noun, pronoun) = if retained == 1 {
-                ("stage", "it")
+                ("store", "it")
             } else {
-                ("stages", "them")
+                ("stores", "them")
             };
             println!(
-                "  {retained} further staging {noun} left alone, because this run could not prove \
+                "  {retained} further staged {noun} left alone, because this run could not prove \
                  {pronoun} unused."
             );
         }
         if live > 0 {
-            let verb = if live == 1 { "is" } else { "are" };
-            println!("  {live} staging {verb} owned by a `kin init` running right now.");
+            let (noun, verb) = if live == 1 {
+                ("store", "is")
+            } else {
+                ("stores", "are")
+            };
+            println!("  {live} staged {noun} {verb} owned by a `kin init` running right now.");
         }
         for failure in &failures {
             println!("  could not be examined, {failure}");
@@ -5964,6 +6009,83 @@ mod tests {
         let quiet = stranded_init_stage_check_for(&[clean.path().to_path_buf()]);
         assert!(matches!(quiet.status, HealthStatus::Healthy), "{quiet:?}");
         assert!(quiet.manual_fix.is_none(), "{quiet:?}");
+    }
+
+    /// A scan root the process cannot read is reported, not reported as clean.
+    ///
+    /// The row used to drop the error and fall through to Healthy, printing
+    /// "no crashed `kin init` left a staged store beside this directory" about
+    /// a directory it had never managed to open. The reclaim beside it already
+    /// refused to do that, so the two surfaces disagreed on the same machine.
+    ///
+    /// The clean tempdir above is the control for the Healthy arm; this one is
+    /// the control for the other direction, so neither reading is an accident.
+    #[cfg(unix)]
+    #[test]
+    fn a_scan_root_that_cannot_be_read_is_reported_rather_than_read_as_clean() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let sealed = directory.path().join("sealed");
+        std::fs::create_dir(&sealed).unwrap();
+        std::fs::set_permissions(&sealed, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let check = stranded_init_stage_check_for(std::slice::from_ref(&sealed));
+        // Restored before any assertion, so a failing assertion still leaves a
+        // directory the tempdir can remove.
+        std::fs::set_permissions(&sealed, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        assert!(matches!(check.status, HealthStatus::Degraded), "{check:?}");
+        assert!(
+            check.detail.contains(&sealed.display().to_string()),
+            "{}",
+            check.detail
+        );
+        assert!(
+            check
+                .detail
+                .contains("does not say whether anything is stranded"),
+            "{}",
+            check.detail
+        );
+    }
+
+    /// A reclaim that could examine nothing refuses, rather than exiting clean.
+    ///
+    /// `main` exits non-zero only on `Err`, so returning `Ok(())` after every
+    /// root failed would tell a script that reads the exit status that the disk
+    /// was examined and found clean. The human summary in that case even prints
+    /// "nothing to reclaim here", which is the one sentence this must never say
+    /// about a directory it could not open.
+    ///
+    /// The readable tempdir is the control: a genuinely clean parent still
+    /// succeeds, so this is not a refusal that fires on everything.
+    #[cfg(unix)]
+    #[test]
+    fn a_reclaim_that_could_examine_nothing_refuses_rather_than_reporting_clean() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let sealed = directory.path().join("sealed");
+        std::fs::create_dir(&sealed).unwrap();
+        std::fs::set_permissions(&sealed, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let refused = reclaim_stranded_stages_in(std::slice::from_ref(&sealed), false);
+        std::fs::set_permissions(&sealed, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        let error = refused.expect_err("a root that could not be examined is not a clean parent");
+        let message = error.to_string();
+        assert!(message.contains(&sealed.display().to_string()), "{message}");
+        assert!(
+            message.contains("no directory could be examined"),
+            "{message}"
+        );
+
+        let clean = tempfile::tempdir().unwrap();
+        assert!(
+            reclaim_stranded_stages_in(&[clean.path().to_path_buf()], false).is_ok(),
+            "a readable empty parent still succeeds"
+        );
     }
 
     /// The reading a user needed BEFORE the commit that killed their daemon.

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -1299,10 +1299,12 @@ enum Command {
         /// Delete the staged stores a crashed `kin init` left beside this
         /// directory and its parent
         ///
-        /// Removes only a stage whose owner is provably gone and whose
-        /// destination repository was never created. Bare `kin doctor` is the
-        /// dry run: it names every stage this would take, with its size, and
-        /// deletes nothing.
+        /// Removes only a stage no live `kin init` on this machine owns and
+        /// whose destination repository was never created. The lock that proves
+        /// that is host-local, so run this on local storage: on a shared mount a
+        /// stage another machine is still writing can read as abandoned. Bare
+        /// `kin doctor` is the dry run: it names every stage this would take,
+        /// with its size, and deletes nothing.
         #[arg(long = "reclaim-staging", default_value_t = false)]
         reclaim_staging: bool,
     },

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -2523,6 +2523,14 @@ pub struct StrandedStageSurvey {
     /// Candidates a live initializer holds right now. Counted, not listed: an
     /// init running beside you is the healthy case and is not a finding.
     pub live: usize,
+    /// Directories this pass could not read at all, each with its reason.
+    ///
+    /// Carried rather than dropped, and reported by
+    /// [`stranded_stage_doctor_row`] as a finding of its own. A root that could
+    /// not be scanned is the one thing an operator must not read as "nothing
+    /// was stranded there", and the unreadable root is most plausibly the
+    /// parent directory, which is exactly where these stages strand.
+    pub unreadable: Vec<String>,
 }
 
 impl StrandedStageSurvey {
@@ -2539,8 +2547,10 @@ impl StrandedStageSurvey {
     }
 
     /// Whether anything here is worth an operator's attention.
+    ///
+    /// A root this pass could not read counts, because not knowing is a finding.
     pub fn is_empty(&self) -> bool {
-        self.stages.is_empty()
+        self.stages.is_empty() && self.unreadable.is_empty()
     }
 }
 
@@ -2593,7 +2603,7 @@ enum StageScanAction {
 
 /// What one pass of [`scan_repository_init_stages`] did.
 #[cfg(unix)]
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct StageScanOutcome {
     recovered: usize,
     retained: usize,
@@ -2731,11 +2741,14 @@ fn measure_stage_tree(root: &Path) -> (u64, bool, Option<std::time::SystemTime>)
                 complete = false;
                 continue;
             };
-            record_time(&metadata, &mut newest);
             let file_type = metadata.file_type();
+            // After the symlink skip, not before. A symlink contributes no
+            // bytes, so letting its mtime set the newest time would date the
+            // measurement by an entry the measurement does not count.
             if file_type.is_symlink() {
                 continue;
             }
+            record_time(&metadata, &mut newest);
             if file_type.is_dir() {
                 pending.push(path);
             } else if file_type.is_file() {
@@ -3118,8 +3131,15 @@ fn scan_repository_init_stages(
         }
         // Measured under the lock that proved the stage abandoned, and before
         // the claim that destroys it, so the number an operator is told came
-        // back is the number that was there.
-        let (bytes, _, _) = measure_stage_tree(&owned_root);
+        // back is the number that was there. Only where a caller reads it:
+        // `ReclaimedStages` has no bytes field and the destination-bound reaper
+        // discards the outcome's, so measuring there would put a second full
+        // walk of a staged store on `kin init`'s own path, beside the one
+        // `remove_dir_all` is about to do anyway.
+        let bytes = match scope {
+            StageScanScope::Unbound => measure_stage_tree(&owned_root).0,
+            StageScanScope::Destination(_) => 0,
+        };
         if owned_root == stage_root {
             if let Err(error) = rename_directory_noreplace(&stage_root, &reap_root) {
                 debug!(
@@ -3262,6 +3282,10 @@ pub fn survey_orphaned_repository_stages(staging_parent: &Path) -> Result<Strand
         Ok(StrandedStageSurvey {
             stages: outcome.stages,
             live: outcome.skipped,
+            // A single-root survey answers an unreadable root with `Err`. The
+            // list is for a caller aggregating several roots, which is where
+            // one failing must not silence the others.
+            unreadable: Vec::new(),
         })
     }
 }
@@ -3272,6 +3296,11 @@ pub fn survey_orphaned_repository_stages(staging_parent: &Path) -> Result<Strand
 /// Each stage is measured and removed under the same owner lock that proved it
 /// abandoned, so a live initializer arriving mid-pass is never raced and the
 /// bytes reported back are the bytes that were there.
+///
+/// That lock is host-local, so this proves the owner gone on local storage and
+/// not on a shared mount, where a stage another machine is still writing can
+/// read as abandoned. FIR-3155 carries the fix, a host identifier on the owner
+/// record; until it lands, every surface that offers this says so.
 pub fn reclaim_orphaned_repository_stages(
     staging_parent: &Path,
 ) -> Result<ReclaimedStrandedStages> {
@@ -3370,28 +3399,93 @@ fn describe_stranded_stage(stage: &StrandedRepositoryStage) -> String {
 /// init` reclaims a stage only at that stage's own recorded destination, and the
 /// stages that strand are the ones nobody ever initializes again.
 pub fn stranded_stage_doctor_row(survey: &StrandedStageSurvey) -> Option<(String, String)> {
-    if survey.stages.is_empty() {
+    if survey.is_empty() {
         return None;
     }
+    // A root this pass could not read is a finding on its own, not a silence.
+    // It is most plausibly the parent directory, which is exactly where these
+    // stages strand, so reporting the parent as clean because it could not be
+    // opened would be the false negative this row exists to end.
+    let unreadable = match survey.unreadable.len() {
+        0 => String::new(),
+        1 => format!(
+            "one directory beside this one could not be read, so this run does not say whether \
+             anything is stranded there: {}",
+            survey.unreadable[0]
+        ),
+        count => format!(
+            "{count} directories beside this one could not be read, so this run does not say \
+             whether anything is stranded there: {}",
+            survey.unreadable.join(", ")
+        ),
+    };
+    if survey.stages.is_empty() {
+        return Some((
+            unreadable,
+            "make those directories readable and run `kin doctor` again".to_string(),
+        ));
+    }
+
     let reclaimable = survey.reclaimable().collect::<Vec<_>>();
-    let held_back = survey.stages.len() - reclaimable.len();
-    if reclaimable.is_empty() {
-        let (noun, verb, pronoun) = if held_back == 1 {
-            ("stage", "was", "it")
+    let held_back = survey
+        .stages
+        .iter()
+        .filter(|stage| stage.verdict != StrandedStageVerdict::Reclaimable)
+        .collect::<Vec<_>>();
+    let describe = |stages: &[&StrandedRepositoryStage]| {
+        stages
+            .iter()
+            .map(|stage| describe_stranded_stage(stage))
+            .collect::<Vec<_>>()
+            .join("; ")
+    };
+    let mut detail = if reclaimable.is_empty() {
+        let (noun, verb, pronoun) = if held_back.len() == 1 {
+            ("store", "was", "it")
         } else {
-            ("stages", "were", "them")
+            ("stores", "were", "them")
         };
-        let detail = format!(
-            "{held_back} repository staging {noun} beside this directory {verb} left by an \
-             interrupted `kin init`, and this run could not prove {pronoun} unused: {}",
-            survey
-                .stages
-                .iter()
-                .map(describe_stranded_stage)
-                .collect::<Vec<_>>()
-                .join("; ")
-        );
-        let fix = format!(
+        format!(
+            "{} staged {noun} beside this directory {verb} left by an interrupted `kin init`, and \
+             this run could not prove {pronoun} unused: {}",
+            held_back.len(),
+            describe(&held_back)
+        )
+    } else {
+        let (run, verb) = if reclaimable.len() == 1 {
+            ("run", "is")
+        } else {
+            ("runs", "are")
+        };
+        format!(
+            "{} of staging from {} crashed `kin init` {run} {verb} reclaimable: {}",
+            crate::init_attempt::human_bytes(survey.reclaimable_bytes()),
+            reclaimable.len(),
+            describe(&reclaimable)
+        )
+    };
+    // Described rather than counted. A bare "1 more was left alone" tells an
+    // operator a directory exists and nothing about which one, how much disk it
+    // holds, or why this run declined it, which is the whole of what they came
+    // to the row for.
+    if !reclaimable.is_empty() && !held_back.is_empty() {
+        let (noun, pronoun) = if held_back.len() == 1 {
+            ("store", "it")
+        } else {
+            ("stores", "them")
+        };
+        detail.push_str(&format!(
+            ". This run also left {} further staged {noun} alone, because it could not prove \
+             {pronoun} unused: {}",
+            held_back.len(),
+            describe(&held_back)
+        ));
+    }
+    if !unreadable.is_empty() {
+        detail.push_str(&format!(". Separately, {unreadable}"));
+    }
+    let fix = if reclaimable.is_empty() {
+        format!(
             "delete {} by hand once no `kin init` is running here",
             survey
                 .stages
@@ -3399,40 +3493,15 @@ pub fn stranded_stage_doctor_row(survey: &StrandedStageSurvey) -> Option<(String
                 .map(|stage| stage.stage_path.display().to_string())
                 .collect::<Vec<_>>()
                 .join(" ")
-        );
-        return Some((detail, fix));
-    }
-    let total = survey.reclaimable_bytes();
-    let (run_noun, run_verb) = if reclaimable.len() == 1 {
-        ("run", "is")
+        )
     } else {
-        ("runs", "are")
+        // Names the machine, because the owner lock this proof rests on is
+        // host-local and the sentence used to promise more than that. FIR-3155.
+        "run `kin doctor --reclaim-staging` here, which removes only a stage no live `kin init` on \
+         this machine owns; a later `kin init` will not, because orphan recovery runs only at a \
+         stage's own recorded destination"
+            .to_string()
     };
-    let mut detail = format!(
-        "{} of staging from {} crashed `kin init` {run_noun} {run_verb} reclaimable: {}",
-        crate::init_attempt::human_bytes(total),
-        reclaimable.len(),
-        reclaimable
-            .iter()
-            .map(|stage| describe_stranded_stage(stage))
-            .collect::<Vec<_>>()
-            .join("; ")
-    );
-    if held_back > 0 {
-        let (noun, pronoun) = if held_back == 1 {
-            ("stage", "it")
-        } else {
-            ("stages", "them")
-        };
-        detail.push_str(&format!(
-            "; {held_back} further staging {noun} sat beside {pronoun} that this run could not \
-             prove unused"
-        ));
-    }
-    let fix = "run `kin doctor --reclaim-staging` here, which removes only a stage whose owner is \
-               provably gone; a later `kin init` will not, because orphan recovery runs only at a \
-               stage's own recorded destination"
-        .to_string();
     Some((detail, fix))
 }
 
@@ -4850,6 +4919,67 @@ mod tests {
         assert!(!stage_root.exists());
     }
 
+    /// The destination-bound reaper inside `kin init` measures nothing.
+    ///
+    /// `ReclaimedStages` has no bytes field and
+    /// `recover_orphaned_repository_stages` discards the outcome's, so
+    /// measuring on that path would put a second full walk of a staged store on
+    /// `kin init`'s own path, beside the one `remove_dir_all` is about to do
+    /// anyway. Asserted on the scan's own outcome, because the wrapper's return
+    /// type cannot show it.
+    ///
+    /// The unbound arm is the control: same stage, same bytes on disk, and a
+    /// caller that does read the number. Without it a scan that had stopped
+    /// measuring altogether would pass.
+    #[cfg(unix)]
+    #[test]
+    fn the_destination_bound_reaper_measures_nothing_the_caller_reads() {
+        fn strand_with_a_body(parent: &Path) -> PathBuf {
+            let repository = parent.join("repository");
+            std::fs::create_dir(&repository).unwrap();
+            let (stage_root, _) =
+                strand_repository_stage(parent, &repository.join(".kin")).unwrap();
+            std::fs::write(stage_root.join("body"), vec![0_u8; 65536]).unwrap();
+            repository.join(".kin")
+        }
+        fn scan_until_no_skip(parent: &Path, scope: StageScanScope<'_>) -> StageScanOutcome {
+            let mut outcome =
+                scan_repository_init_stages(parent, scope, StageScanAction::Reclaim).unwrap();
+            for _ in 0..40 {
+                if outcome.skipped == 0 {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(25));
+                outcome =
+                    scan_repository_init_stages(parent, scope, StageScanAction::Reclaim).unwrap();
+            }
+            outcome
+        }
+
+        let bound_dir = tempfile::tempdir().unwrap();
+        let bound_parent = bound_dir.path().canonicalize().unwrap();
+        let destination = strand_with_a_body(&bound_parent);
+        let bound = scan_until_no_skip(&bound_parent, StageScanScope::Destination(&destination));
+        assert_eq!(bound.recovered, 1, "the bound arm still reclaims");
+        assert_eq!(
+            bound.bytes_recovered, 0,
+            "and walks nothing for a number its caller drops"
+        );
+
+        let unbound_dir = tempfile::tempdir().unwrap();
+        let unbound_parent = unbound_dir.path().canonicalize().unwrap();
+        strand_with_a_body(&unbound_parent);
+        let unbound = scan_until_no_skip(&unbound_parent, StageScanScope::Unbound);
+        assert_eq!(
+            unbound.recovered, 1,
+            "the unbound arm reclaims the same way"
+        );
+        assert!(
+            unbound.bytes_recovered >= 65536,
+            "and does measure, because an operator reads the number: {unbound:?}"
+        );
+    }
+
     /// A stage whose destination exists now is named and left alone.
     ///
     /// The other half of the destination proof. Something else owns that
@@ -4908,6 +5038,7 @@ mod tests {
                 verdict: StrandedStageVerdict::Reclaimable,
             }],
             live: 0,
+            unreadable: Vec::new(),
         };
 
         let (detail, fix) =
@@ -4929,6 +5060,108 @@ mod tests {
             stranded_stage_doctor_row(&StrandedStageSurvey::default()).is_none(),
             "a clean parent is not a finding"
         );
+    }
+
+    /// A stage this pass declined is described, not just counted.
+    ///
+    /// The mixed case used to end in a bare "1 further staging stage sat beside
+    /// it", which tells an operator a directory exists and nothing about which
+    /// one, how much disk it holds, or why this run left it. That is the half
+    /// of the row they came for, and the pronoun pointed at the reclaimable
+    /// stage the same sentence had just said was provably unused.
+    #[test]
+    fn a_stage_the_row_declines_is_described_rather_than_counted() {
+        let survey = StrandedStageSurvey {
+            stages: vec![
+                stub_stage(
+                    "/scratchpad/.kin.init-11111111-1111-4111-8111-111111111111",
+                    1_610_612_736,
+                    StrandedStageVerdict::Reclaimable,
+                ),
+                stub_stage(
+                    "/scratchpad/.kin.init-22222222-2222-4222-8222-222222222222",
+                    4096,
+                    StrandedStageVerdict::Unprovable(
+                        "its filesystem identity is not provable".to_string(),
+                    ),
+                ),
+            ],
+            live: 0,
+            unreadable: Vec::new(),
+        };
+
+        let (detail, _) = stranded_stage_doctor_row(&survey).expect("a finding");
+        assert!(detail.contains(".kin.init-22222222"), "{detail}");
+        assert!(
+            detail.contains("its filesystem identity is not provable"),
+            "{detail}"
+        );
+        assert!(detail.contains("4.0 KB"), "{detail}");
+        // The reclaimable one is still the headline, and the declined one is
+        // not counted into the number that comes back.
+        assert!(detail.contains("1.5 GB of staging"), "{detail}");
+        assert_eq!(survey.reclaimable_bytes(), 1_610_612_736);
+    }
+
+    /// A directory this pass could not read is a finding, not a clean bill.
+    ///
+    /// The unreadable root is most plausibly the parent, which is exactly where
+    /// these stages strand, so answering "nothing is stranded here" because
+    /// `read_dir` refused is the false negative this row exists to end.
+    #[test]
+    fn a_root_that_could_not_be_read_is_a_finding_rather_than_silence() {
+        let survey = StrandedStageSurvey {
+            stages: Vec::new(),
+            live: 0,
+            unreadable: vec!["/scratchpad: permission denied".to_string()],
+        };
+        assert!(!survey.is_empty(), "not knowing is not the same as clean");
+
+        let (detail, fix) =
+            stranded_stage_doctor_row(&survey).expect("an unreadable root is a finding on its own");
+        assert!(
+            detail.contains("/scratchpad: permission denied"),
+            "{detail}"
+        );
+        assert!(
+            detail.contains("does not say whether anything is stranded"),
+            "{detail}"
+        );
+        assert!(fix.contains("readable"), "{fix}");
+
+        // And it rides along with a real stage rather than replacing it.
+        let both = StrandedStageSurvey {
+            stages: vec![stub_stage(
+                "/scratchpad/.kin.init-11111111-1111-4111-8111-111111111111",
+                4096,
+                StrandedStageVerdict::Reclaimable,
+            )],
+            live: 0,
+            unreadable: vec!["/elsewhere: permission denied".to_string()],
+        };
+        let (detail, fix) = stranded_stage_doctor_row(&both).expect("a finding");
+        assert!(detail.contains(".kin.init-11111111"), "{detail}");
+        assert!(detail.contains("/elsewhere: permission denied"), "{detail}");
+        assert!(fix.contains("kin doctor --reclaim-staging"), "{fix}");
+    }
+
+    /// One stranded stage, built for the row's wording rather than from disk.
+    fn stub_stage(
+        path: &str,
+        bytes: u64,
+        verdict: StrandedStageVerdict,
+    ) -> StrandedRepositoryStage {
+        StrandedRepositoryStage {
+            stage_path: PathBuf::from(path),
+            owner_path: PathBuf::from(format!("{path}.owner")),
+            destination_path: Some(PathBuf::from("/scratchpad/redis-full/.kin")),
+            bytes,
+            bytes_complete: true,
+            last_written: Some(
+                std::time::SystemTime::now() - std::time::Duration::from_secs(2 * 24 * 60 * 60),
+            ),
+            verdict,
+        }
     }
 
     /// Also asserts a reap, so it is bound to the platform that reaps.

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -88,9 +88,10 @@ pub use init::{
     init, init_adopting, init_replica, init_replica_adopting, initialize_repository_authority,
     prepare_repository_layout_at, prepare_repository_layout_with_origin, publish_repository_layout,
     publish_repository_layout_linearized, reclaim_orphaned_repository_stages,
-    survey_orphaned_repository_stages, InitResult, PreparedRepositoryInit, PublishedRepository,
-    ReclaimedStrandedStages, RepositoryBootstrap, RepositoryIdentityOrigin, RepositoryPublication,
-    StrandedRepositoryStage, StrandedStageSurvey, StrandedStageVerdict,
+    stranded_stage_doctor_row, survey_orphaned_repository_stages, InitResult,
+    PreparedRepositoryInit, PublishedRepository, ReclaimedStrandedStages, RepositoryBootstrap,
+    RepositoryIdentityOrigin, RepositoryPublication, StrandedRepositoryStage, StrandedStageSurvey,
+    StrandedStageVerdict,
 };
 pub use layout::KinLayout;
 pub use manifest::KinManifest;


### PR DESCRIPTION
Five findings from the review of #1461, all in the surfaces that PR added rather than in the proof
underneath them. Nothing here changes what is reaped or how abandonment is decided: liveness is still
the free owner lock and nothing else, and every existing test still grades it.

## A directory the scan could not read was reported as clean

`survey_stranded_stages` dropped the error and fell through, so on a parent the process can traverse
but not open, `kin doctor` printed "no crashed `kin init` left a staged store beside this directory"
and stayed `Healthy` about a directory it had never managed to read. The reclaim twenty lines below
already refused to do that, in a comment arguing against the line above it, so the two surfaces
disagreed on the same machine. The unreadable root is most plausibly the parent, one level up from
where an operator stands, which is exactly where these stages strand. It is recorded on the survey
now and reported by the row as a finding of its own.

## A reclaim that examined nothing exited zero

With every root failing, `recovered` stayed 0 and the summary printed "nothing to reclaim here", the
same sentence a genuinely clean parent gets, and `main` exits non-zero only on `Err`. A script
reading the exit status took "I could not look" for "there was nothing there". It refuses now, naming
every root it could not examine. Split into `reclaim_stranded_stages_in` so that refusal is reachable
from a test without the test changing the process-wide working directory.

## The destination-bound reaper measured a tree and threw the number away

`ReclaimedStages` has no bytes field, so every `kin init` that reclaimed an orphaned stage walked
that whole staged store, up to 400,000 entries, for a value nobody read, immediately before
`remove_dir_all` walked it again to delete it. Measurement is gated on the scope that reads it now,
and asserted on the scan's own outcome, because the wrapper's return type cannot show it.

## A stage the row declined was counted, not described

The mixed case ended in a bare "1 further staging stage sat beside it": an operator learned a
directory exists and nothing about which one, how much disk it holds, or why this run left it. The
pronoun also pointed at the reclaimable stage the same sentence had just called provably unused. It
describes them now, the way the all-declined branch already did.

## Wording

"staging stage" stuttered in three strings and now reads "staged store". Two surfaces promised
"removes only a stage whose owner is provably gone" without naming the precondition: the lock that
proof rests on is `flock`, which is host-local, so on a shared mount a stage another machine is still
writing can read as abandoned. The help text, the doc comments and the row's fix line now say "no
live `kin init` on this machine owns" and name local storage. FIR-3155 carries the real fix, a host
identifier on the owner record.

Also: a symlink's mtime no longer dates a measurement that does not count its bytes, and
`stranded_stage_doctor_row` is re-exported from `lib.rs` beside the two functions that produce its
input.

## Falsification

One arm per new test, each run against the full suite, both files restored from byte-compared copies
between arms. Every arm failed exactly one test.

| Mutation | Went red |
|---|---|
| an unreadable root stops counting as a finding (`is_empty` ignores it) | `a_root_that_could_not_be_read_is_a_finding_rather_than_silence` (1 failed, 87 passed) |
| the doctor row swallows a scan error again | `a_scan_root_that_cannot_be_read_is_reported_rather_than_read_as_clean` (1 failed, 173 passed) |
| a reclaim that examined nothing returns `Ok` | `a_reclaim_that_could_examine_nothing_refuses_rather_than_reporting_clean` (1 failed, 174 passed) |
| the destination-bound scope measures the tree again | `the_destination_bound_reaper_measures_nothing_the_caller_reads` (1 failed, 87 passed) |
| declined stages go back to a bare count | `a_stage_the_row_declines_is_described_rather_than_counted` (1 failed, 87 passed) |

Output tails are in `.kin-coord/logs/initstage-fu-falsify-*.log` on the umbrella, and the scripts
that produced them are `.kin-coord/initstage-falsify2.sh` and `initstage-falsify3.sh`. Both restore
from a copy taken before the first mutation and assert the restored files are byte-identical, rather
than using `git checkout`.

## Local gate run

```
$ bin/kin-precheck kin --repo-dir kin=<lane worktree>
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 543e9f765b4273c55b20f1f02f9cabd2ad00a058
```

Follow-up to #1461. Related: FIR-3155.
