### PR TITLE
Make the command surface opt-out, and give the two guards one answer-module list (FIR-2282)

### DIFF
--- a/scripts/falsify-zero-file-search.py
+++ b/scripts/falsify-zero-file-search.py
@@ -423,26 +423,36 @@ def probe_sites(lines):
     return sites
 
 
-def shell_guard_modules(root):
-    """The answer modules the shell guard lists, read from the script itself.
+def shell_guard_modules(root, flag="--list-enforced"):
+    """The answer modules the shell guard names, asked OF the shell guard.
 
-    Read rather than restated for the same reason as the Python list: a
-    harness that keeps its own copy of what it is supposed to cover will
-    eventually cover something else.
+    This used to parse an `authority_files=(...)` array out of the script. That
+    array is gone: FIR-2282 made the command surface opt-out, so the guard
+    derives its modules from the shared allowlist and there is no literal list
+    left to read. Asking it directly is better anyway, for the reason the array
+    was read rather than restated in the first place. A harness that keeps its
+    own copy of what it is supposed to cover will eventually cover something
+    else.
+
+    `--list-enforced` rather than `--list-scanned` on purpose: the enforced list
+    excludes modules whose declared boundary pins the shell guard defers to the
+    Python checker. Poisoning one of those would fail for the wrong reason.
     """
-    path = os.path.join(root, "scripts", "zero_file_search_guard.sh")
-    modules, collecting = set(), False
-    with open(path, "r", encoding="utf-8") as f:
-        for line in f:
-            if line.startswith("authority_files=("):
-                collecting = True
-                continue
-            if collecting:
-                if line.strip() == ")":
-                    break
-                entry = line.strip().strip('"')
-                if entry.startswith("$cmd_dir/"):
-                    modules.add(entry.split("/")[-1])
+    guard = os.path.join(root, "scripts", "zero_file_search_guard.sh")
+    result = subprocess.run(
+        ["bash", guard, flag, root], capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            f"::error::the shell guard refused to enumerate its modules "
+            f"({flag}, rc={result.returncode}): {result.stderr.strip()[:300]}"
+        )
+    modules = {line.strip() for line in result.stdout.split("\n") if line.strip()}
+    if not modules:
+        # The control. An empty set would silently make every module below
+        # "not in the shell guard's scope" and the harness would report a clean
+        # sheet over nothing, which is the failure mode it exists to catch.
+        raise SystemExit("::error::the shell guard enumerated zero answer modules")
     return modules
 
 
@@ -545,13 +555,19 @@ def main():
     exempt = whole_file_exempt(root)
     shell_modules = shell_guard_modules(root)
 
+    # Which modules each guard grades, asked of each guard rather than assumed.
+    # The command surface is opt-out since FIR-2282, so "scanned" is now the
+    # default and the interesting set is what remains after the allowlist.
+    policies = guard.load_allowlist()[0]
+    python_modules = guard.command_modules_scanned(policies)
+
     enforced, skipped = [], []
     cmd_dir = os.path.join(root, CMD_DIR)
     for name in sorted(os.listdir(cmd_dir)):
-        if name not in guard.QUERY_COMMANDS and name not in shell_modules:
+        if name not in python_modules and name not in shell_modules:
             continue
         rel = f"{CMD_DIR}/{name}"
-        python_scans = name in guard.QUERY_COMMANDS and rel not in exempt
+        python_scans = name in python_modules and rel not in exempt
         shell_scans = name in shell_modules
         if python_scans or shell_scans:
             enforced.append((rel, python_scans, shell_scans))
@@ -560,7 +576,7 @@ def main():
 
     if skipped:
         print("Not falsifiable — the allowlist exempts these answer modules entirely,")
-        print("so the guard never scans them despite their being listed as query commands:")
+        print("so neither guard scans them despite their being command modules:")
         for rel in skipped:
             print(f"  - {rel}")
         print()

--- a/scripts/falsify-zero-file-search.py
+++ b/scripts/falsify-zero-file-search.py
@@ -588,49 +588,110 @@ def main():
     py_guard = os.path.join(root, "scripts", "verify-zero-file-search.py")
     sh_guard = os.path.join(root, "scripts", "zero_file_search_guard.sh")
 
-    print(f"Falsifying {len(enforced)} answer modules at up to 4 sites each")
-    print("  py = Python checker, sh = shell guard, - = module not in that guard's scope\n")
+    # Batched by site, one guard run per site instead of one per module.
+    #
+    # FIR-2282 made the command surface opt-out, which took the enforced set from
+    # 25 modules to 59, and this loop used to run both guards once per module per
+    # site: 472 runs where it had been 200, at roughly 4.5s each. Measured, that
+    # is about 20 minutes for this section alone against a 30-minute job timeout,
+    # so widening coverage would have broken `Falsify guards` on main by clock
+    # rather than by verdict.
+    #
+    # Batching is the same trade the cfg-tracker probes below already make, and
+    # it costs the same thing: attribution. A guard that goes red names some
+    # files, and a module missing from that list could mean the probe was missed
+    # OR that an earlier probe's exclusion swallowed it. So a batch that is not
+    # unanimous is replayed one module at a time, which localises it exactly, and
+    # only a failing run pays for that.
+    #
+    # Each module keeps its own probe, its own site, and its own required
+    # report, so the per-module guarantee is unchanged. What changes is how many
+    # times the tree is walked to check them.
+    print(f"Falsifying {len(enforced)} answer modules at up to 4 sites each, batched by site")
+    print("  py = Python checker, sh = shell guard\n")
     failures = []
-    for rel, python_scans, shell_scans in enforced:
-        path = os.path.join(root, rel)
-        with open(path, "r", encoding="utf-8") as f:
-            original = f.read()
-        lines = original.split("\n")
-        marks = []
+
+    def poison_at(entries, label_wanted):
+        """Poison every entry at `label_wanted`; return {rel: original}."""
+        saved = {}
+        for rel, _, _ in entries:
+            path = os.path.join(root, rel)
+            with open(path, "r", encoding="utf-8") as handle:
+                original = handle.read()
+            saved[rel] = original
+            lines = original.split("\n")
+            sites = dict(probe_sites(lines))
+            idx = sites.get(label_wanted)
+            if idx is None:
+                continue
+            poisoned = lines[:idx] + [POISON] + lines[idx:]
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write("\n".join(poisoned))
+        return saved
+
+    def restore(saved):
+        for rel, original in saved.items():
+            with open(os.path.join(root, rel), "w", encoding="utf-8") as handle:
+                handle.write(original)
+
+    def verdicts_for(entries, label_wanted):
+        """{rel: (py, sh)} for one batched run at one site."""
+        saved = poison_at(entries, label_wanted)
         try:
-            for label, idx in probe_sites(lines):
-                poisoned = lines[:idx] + [POISON] + lines[idx:]
-                with open(path, "w", encoding="utf-8") as f:
-                    f.write("\n".join(poisoned))
-                cell = []
-                for tag, scans, cmd in (
-                    ("py", python_scans, [sys.executable, py_guard, root]),
-                    ("sh", shell_scans, ["bash", sh_guard, root]),
-                ):
-                    if not scans:
-                        cell.append("-")
-                        continue
-                    code, out = run(cmd)
-                    named = (
-                        scan_reported(out, rel)
-                        if tag == "py"
-                        else os.path.basename(rel) in out
-                    )
-                    if code == 0:
-                        failures.append(f"{rel} @ {label}: {tag} guard PASSED on a poisoned tree")
-                        cell.append("BLIND")
-                    elif not named:
-                        failures.append(
-                            f"{rel} @ {label}: {tag} guard failed but its scan never "
-                            "reported the file"
-                        )
-                        cell.append("UNNAMED")
-                    else:
-                        cell.append("ok")
-                marks.append(f"{label}=py:{cell[0]}/sh:{cell[1]}")
+            py_code, py_out = run([sys.executable, py_guard, root])
+            sh_code, sh_out = run(["bash", sh_guard, root])
         finally:
-            with open(path, "w", encoding="utf-8") as f:
-                f.write(original)
+            restore(saved)
+        out = {}
+        for rel, python_scans, shell_scans in entries:
+            lines = saved[rel].split("\n")
+            if label_wanted not in dict(probe_sites(lines)):
+                out[rel] = ("-", "-")
+                continue
+            py = "-"
+            if python_scans:
+                py = "ok" if (py_code != 0 and scan_reported(py_out, rel)) else (
+                    "BLIND" if py_code == 0 else "UNNAMED")
+            sh = "-"
+            if shell_scans:
+                sh = "ok" if (sh_code != 0 and os.path.basename(rel) in sh_out) else (
+                    "BLIND" if sh_code == 0 else "UNNAMED")
+            out[rel] = (py, sh)
+        return out
+
+    labels = ["eof", "quarter", "half", "last-prod"]
+    table = {rel: {} for rel, _, _ in enforced}
+    for label in labels:
+        batch = verdicts_for(enforced, label)
+        # Only the modules that did NOT come back ok are replayed, and only
+        # those are ambiguous. A module the guard NAMED was genuinely reported,
+        # whoever else was poisoned in the same run. A module it did not name is
+        # the open question: its own probe may have been missed, or an earlier
+        # snippet's over-wide exclusion may have swallowed it. Replaying exactly
+        # those answers it, and it keeps a failing run cheap: replaying all 67
+        # at every site took over ten minutes and is what a red build would have
+        # paid on every push.
+        unclear = [e for e in enforced if any(v not in ("ok", "-") for v in batch[e[0]])]
+        for entry in unclear:
+            batch.update(verdicts_for([entry], label))
+        for rel, pair in batch.items():
+            table[rel][label] = pair
+
+    for rel, python_scans, shell_scans in enforced:
+        marks = []
+        for label in labels:
+            py, sh = table[rel].get(label, ("-", "-"))
+            if py == "-" and sh == "-":
+                continue
+            marks.append(f"{label}=py:{py}/sh:{sh}")
+            for tag, verdict in (("py", py), ("sh", sh)):
+                if verdict == "BLIND":
+                    failures.append(f"{rel} @ {label}: {tag} guard PASSED on a poisoned tree")
+                elif verdict == "UNNAMED":
+                    failures.append(
+                        f"{rel} @ {label}: {tag} guard failed but its scan never "
+                        "reported the file"
+                    )
         print(f"  {os.path.basename(rel):24} {'  '.join(marks)}")
 
     # A module that was whole-file exempt has no falsification history at all:

--- a/scripts/verify-zero-file-search.py
+++ b/scripts/verify-zero-file-search.py
@@ -25,12 +25,14 @@ import os
 import sys
 import json
 import re
+import subprocess
 from datetime import date
 
 # Resolve paths relative to kin repo root
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 KIN_ROOT = os.path.abspath(sys.argv[1]) if len(sys.argv) > 1 else os.path.dirname(SCRIPT_DIR)
 ALLOWLIST_PATH = os.path.join(SCRIPT_DIR, "zero-file-search-allowlist.json")
+CMD_DIR = "crates/kin-cli/src/commands"
 
 # Every allowlist entry must carry these so each exemption has an accountable
 # owner and a date by which it is re-justified or removed.
@@ -393,63 +395,52 @@ def expiry_report(today=None):
 # Everything else is a whole-file entry in the allowlist with an owner and a
 # staggered review date.
 
-QUERY_COMMANDS = {
-    "locate.rs",
-    "search.rs",
-    "trace.rs",
-    "trace_data_flow.rs",
-    "xref.rs",
-    "review.rs",
-    "ref_lookup.rs",
-    # refs answers incoming-reference queries purely from graph relation edges;
-    # scanning it keeps that authority path free of any raw source-tree walk.
-    "refs.rs",
-    # Context-pack assembly is an answer authority, not an IO boundary.
-    "context.rs",
-    # rename derives its edit plan — the answer — from the graph's entity and
-    # reference relations, so it is an authority path even though applying the
-    # plan later writes files.
-    "rename.rs",
-    # deps answers a cross-repo dependency query. Whether it may answer it from
-    # manifests instead of the spine is an open decision; scanning it keeps the
-    # question visible instead of silent.
-    "deps.rs",
-    # Read-only analyses that answer from graph relations, history, and health
-    # records. None of them should need the working tree to produce an answer.
-    "blame.rs",
-    "impact.rs",
-    "dead_code.rs",
-    "overview.rs",
-    # health reports on the local install and graph state. Environment probes
-    # here are a diagnostic boundary, but repo-content reads would not be.
-    "health.rs",
-    # `kin graph validate`/`inspect`/`stats` report on graph integrity itself.
-    # A validation surface that decides its answer from the working tree states
-    # the filesystem's opinion of the graph rather than the graph's own, which
-    # is how the orphan count came to be computed by probing each entity's
-    # file_origin with `.exists()`. Orphan status now resolves against the
-    # graph-owned exact tree, and scanning this module is what keeps it there.
-    "graph.rs",
-    # The same graph data, rendered. A visualization that reads the tree would
-    # draw a picture of the projection while claiming to draw the graph.
-    "graph_viz.rs",
-    # Co-change answers from graph-owned CoChanges relations; the Git-format
-    # boundary that captures them lives in kin-git, not here.
-    "cochange.rs",
-    # History answers from recorded commits, not from re-reading the tree.
-    "history.rs",
-    # `kin mcp` is how agents reach Kin. It is a launcher today and carries no
-    # filesystem primitive at all, which is exactly why it belongs here: the
-    # agent-facing entry point should never become the one answer surface that
-    # nothing was watching.
-    "mcp.rs",
-    # `kin spec list`/`show` answer from graph-owned specs. The module was
-    # outside this set for as long as it answered by reading .kin/specs/*.json,
-    # so the guard reported the invariant holding over a surface that was
-    # breaking it. Coverage is half the fix: without the module scanned, a
-    # later reader could reintroduce the sidecar read and CI would stay green.
-    "spec.rs"
-}
+# QUERY_COMMANDS is gone, and its deletion is FIR-2282.
+#
+# It was an opt-in list of answer modules, so the command surface was exempt by
+# default: a module was scanned only if somebody remembered to name it. That is
+# the same polarity error BOUNDARY_DIRS was, pointing the other way. One
+# exempted by default, this one covered only by opt-in, and both report PASSED
+# when they under-cover.
+#
+# Measured on main at 8f1283293 before the change: 107 command modules, 22 named
+# here, 10 named in the shell guard's own list, and 82 covered by NEITHER. The
+# guard read 78k lines of the command surface and skipped 108k, so most of the
+# CLI was outside the gate that exists to hold the thesis on it.
+#
+# Two hand-maintained lists over one surface also drift, and these had.
+# `contextbench_locate.rs`, `locate_cursor.rs` and `locate_debug.rs` were
+# answer modules to the shell guard, with declared boundary pins, and did not
+# exist to this one. Nothing could report that, because nothing compared them.
+#
+# The commands directory is now scanned by default like every other crate, the
+# exemptions live in the allowlist with an owner and a date, and
+# `command_modules_scanned` below is the single notion of an answer module that
+# both guards read. `check_guard_seam` fails if the two ever disagree again.
+
+
+def command_modules_scanned(policies):
+    """Command modules the guards scan: everything not exempt whole-file.
+
+    THE shared definition. The shell guard derives its own list from the same
+    allowlist through `--list-scanned`, and `check_guard_seam` requires the two
+    to be identical, so this function is the only place the notion lives.
+    """
+    directory = os.path.join(KIN_ROOT, CMD_DIR)
+    if not os.path.isdir(directory):
+        return set()
+    scanned = set()
+    for name in sorted(os.listdir(directory)):
+        if not name.endswith(".rs"):
+            continue
+        rel = f"{CMD_DIR}/{name}"
+        if is_test_file(rel):
+            continue
+        policy = policies.get(rel)
+        if policy is not None and policy.whole_file:
+            continue
+        scanned.add(name)
+    return scanned
 
 # Matches a free or method function declaration, including the visibility,
 # constness, asyncness, unsafety and ABI a declaration may carry. `pub(crate)`
@@ -512,12 +503,6 @@ def is_test_file(rel_path):
     if is_build_or_example(rel_path):
         return True
 
-    # For CLI commands, only scan query commands
-    if "crates/kin-cli/src/commands/" in rel_path:
-        filename = os.path.basename(rel_path)
-        if filename not in QUERY_COMMANDS:
-            return True
-
     return False
 
 
@@ -525,14 +510,17 @@ def scan_reaches(rel_path):
     """Whether the walk would scan this path absent any allowlist policy.
 
     A pinned entry answers yes by construction: naming spans in a file forces it
-    to be scanned even inside a boundary directory. A whole-file entry for a path
-    the walk skips anyway answers no, and such an entry is inert. Eight of them
-    had accumulated on command modules outside the query set and on a file
-    already enumerated as a boundary, each reading like an enforced boundary
-    declaration while granting exactly nothing. Deciding this from the same walk
-    predicate the scan uses is what keeps the two from drifting: add a module to
-    QUERY_COMMANDS and its dormant whole-file exemption would begin to matter,
-    which is when it has to be re-justified rather than silently inherited.
+    to be scanned. A whole-file entry for a path the walk skips anyway answers
+    no, and such an entry is inert. Eight of them had accumulated on command
+    modules outside the old opt-in query set and on a file already enumerated as
+    a boundary, each reading like an enforced boundary declaration while granting
+    exactly nothing. Deciding this from the same walk predicate the scan uses is
+    what keeps the two from drifting.
+
+    Since the command surface became opt-out, this predicate is what makes a
+    dormant exemption impossible there rather than merely unlikely: every module
+    is reached, so an entry either excuses something real or is reported as inert
+    on the run that adds it.
     """
     return rel_path.startswith("crates/") and not is_test_file(rel_path)
 
@@ -1566,6 +1554,68 @@ def line_is_reported(line, bindings=()):
     return bound is not None and bound.search(structure) is not None
 
 
+def check_guard_seam(policies):
+    """Require both guards to agree on what an answer module is.
+
+    This is the check whose absence produced FIR-2282's quieter half. Two
+    hand-maintained opt-in lists covered the same directory, they had drifted to
+    different sets, and nothing anywhere compared them, so
+    `contextbench_locate.rs`, `locate_cursor.rs` and `locate_debug.rs` were
+    answer modules to one guard and did not exist to the other. Both lists are
+    now derived from this allowlist, which makes them agree today; this makes
+    them stay agreeing.
+
+    It runs the shell guard's OWN enumeration rather than reimplementing it.
+    A Python copy of that logic would be a third list to drift, and it would
+    pass while the shell guard did something else entirely, which is the shape
+    of every defect this file has been fixed for.
+    """
+    errors = []
+    guard = os.path.join(SCRIPT_DIR, "zero_file_search_guard.sh")
+    if not os.path.exists(guard):
+        return [f"  the shell guard is missing at {guard}, so the two guards' notion "
+                "of an answer module cannot be compared"]
+    try:
+        result = subprocess.run(
+            ["bash", guard, "--list-scanned", KIN_ROOT],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except Exception as error:  # noqa: BLE001 - reported, never swallowed
+        return [f"  could not run the shell guard's --list-scanned: {error}"]
+    if result.returncode != 0:
+        return [
+            "  the shell guard refused to enumerate its answer modules "
+            f"(rc={result.returncode}): {result.stderr.strip()[:200]}"
+        ]
+
+    theirs = {line.strip() for line in result.stdout.split("\n") if line.strip()}
+    ours = command_modules_scanned(policies)
+
+    # The control. Both sides empty would compare equal and prove nothing, which
+    # is exactly how an opt-in list reports PASSED over a surface it never read.
+    if not ours or not theirs:
+        return [
+            f"  the answer-module set is empty (python {len(ours)}, shell "
+            f"{len(theirs)}); an empty set compares equal to an empty set, so "
+            "this comparison would pass while neither guard read anything"
+        ]
+
+    for name in sorted(theirs - ours):
+        errors.append(
+            f"  {name} is an answer module to the shell guard and not to this "
+            "one. One list, two answers: give it an allowlist entry or remove "
+            "the shell guard's reason for scanning it"
+        )
+    for name in sorted(ours - theirs):
+        errors.append(
+            f"  {name} is an answer module to this guard and not to the shell "
+            "guard, so a raw read there is graded by only one of the two"
+        )
+    return errors
+
+
 def self_test():
     """Check the deny set and the binding learner, returning a list of errors.
 
@@ -1668,6 +1718,7 @@ def audit_std():
 def main():
     policies, allowlist_errors = load_allowlist()
     deny_set_errors = self_test()
+    seam_errors = check_guard_seam(policies)
     expiry_warnings, expiry_summary = expiry_report()
     total_violations = 0
     scanned = 0
@@ -1736,6 +1787,12 @@ def main():
         print(f"Verification FAILED: Found {total_violations} zero-file-search violations.")
     if allowlist_errors:
         report_allowlist_errors(allowlist_errors)
+    if seam_errors:
+        # Its own section. A seam failure is not a dirty tree and not a broken
+        # deny set: it says the two guards disagree about what they are guarding,
+        # which makes both their verdicts partial.
+        print("\nGuard seam FAILED (the two guards disagree on the answer-module set):")
+        print("\n".join(seam_errors))
     if deny_set_errors:
         # Last, and separate from the scan's own verdict. A scan is only worth
         # its deny set, so a broken deny set has to be reported as its own
@@ -1743,7 +1800,7 @@ def main():
         # a clean tree.
         print("\nDeny-set self-test FAILED:")
         print("\n".join(deny_set_errors))
-    if total_violations or allowlist_errors or deny_set_errors:
+    if total_violations or allowlist_errors or deny_set_errors or seam_errors:
         sys.exit(1)
 
     print(

--- a/scripts/verify-zero-file-search.py
+++ b/scripts/verify-zero-file-search.py
@@ -1529,7 +1529,17 @@ BINDING_LEARNER_CASES = [
     ("third-party fs crate", "use fs2::FileExt;\n", {"FileExt"}),
     # A glob binds no name the declaration names, so the vocabulary is the
     # fallback for that one shape.
-    ("glob", "use std::fs::*;\n", set(FS_GLOB_VOCABULARY)),
+    #
+    # The expectation is a LITERAL set, not `set(FS_GLOB_VOCABULARY)`. Written
+    # against the constant it was testing, both sides of the comparison moved
+    # together: dropping the glob branch was caught, and SHRINKING the
+    # vocabulary was not, because the case would have shrunk with it. That is
+    # the same self-referential shape as the defect this whole table exists to
+    # stop, one level down, and it was found by review rather than by the table.
+    # Naming the items here means removing one fails.
+    ("glob", "use std::fs::*;\n",
+     {"File", "OpenOptions", "DirBuilder", "DirEntry", "ReadDir", "Metadata",
+      "Permissions", "FileType", "FileTimes"}),
     # `as _` imports a trait for its methods and binds nothing a later line can
     # spell. The learner must return nothing here and leave the import to
     # NAMESPACE_REACH, which is the honest limit recorded on the function.

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -1373,21 +1373,32 @@
     },
     {
       "file": "crates/kin-cli/src/commands/locate_cursor.rs",
-      "reason": "The per-repo paging cursor for `kin locate --next`, per its own doc. It holds a continuation token, never repository content, and a miss restarts paging rather than answering. Already declared in the shell guard's own pins; this entry is what makes both guards agree it is a boundary. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "reason": "The per-repo paging cursor for `kin locate --next`, per its own doc. It holds a continuation token, never repository content, and a miss restarts paging rather than answering. Read, written and cleared here, and those three expressions are the whole of its filesystem surface. PINNED rather than whole-file, and that distinction is the correction this entry exists to record. `scripts/zero_file_search_guard.sh` enforced this module before FIR-2282, with these exact expressions declared in its own `allow_for`. A whole-file entry drops the path during that guard's enumeration, one step before the deferral logic, so the first cut of FIR-2282 left neither guard scanning it: a coverage REGRESSION inside the change that widens coverage, found by review. Pinning keeps both guards on every other line of the file, which is what the shell guard already had.",
       "owner": "kin-cli",
-      "expiration": "2027-06-18"
+      "expiration": "2027-06-18",
+      "allow_match": [
+        "std::fs::read_to_string(&path)",
+        "let _ = std::fs::write(&path, cursor);",
+        "let _ = std::fs::remove_file(&path);"
+      ]
     },
     {
       "file": "crates/kin-cli/src/commands/locate_debug.rs",
-      "reason": "`kin locate-debug`: the offline signal breakdown reader, per its own doc. Already declared in the shell guard's pins; this entry is the other half of that declaration. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "reason": "`kin locate-debug`: the offline signal-breakdown reader, per its own doc. The single read is the dump file an operator names on the command line, never repository content. PINNED rather than whole-file, and that distinction is the correction this entry exists to record. `scripts/zero_file_search_guard.sh` enforced this module before FIR-2282, with these exact expressions declared in its own `allow_for`. A whole-file entry drops the path during that guard's enumeration, one step before the deferral logic, so the first cut of FIR-2282 left neither guard scanning it: a coverage REGRESSION inside the change that widens coverage, found by review. Pinning keeps both guards on every other line of the file, which is what the shell guard already had.",
       "owner": "kin-cli",
-      "expiration": "2027-06-18"
+      "expiration": "2027-06-18",
+      "allow_match": [
+        "std::fs::read_to_string(path)"
+      ]
     },
     {
       "file": "crates/kin-cli/src/commands/contextbench_locate.rs",
-      "reason": "The benchmark task-input boundary: it reads the task file a benchmark run names. Already declared in the shell guard's pins; this entry is the other half. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "reason": "The benchmark task-input boundary: it reads the task file a benchmark run names. That file is the harness's input, not repository content, and no locate result derives from it. PINNED rather than whole-file, and that distinction is the correction this entry exists to record. `scripts/zero_file_search_guard.sh` enforced this module before FIR-2282, with these exact expressions declared in its own `allow_for`. A whole-file entry drops the path during that guard's enumeration, one step before the deferral logic, so the first cut of FIR-2282 left neither guard scanning it: a coverage REGRESSION inside the change that widens coverage, found by review. Pinning keeps both guards on every other line of the file, which is what the shell guard already had.",
       "owner": "kin-cli",
-      "expiration": "2027-06-18"
+      "expiration": "2027-06-18",
+      "allow_match": [
+        "std::fs::read_to_string(&task_file)"
+      ]
     },
     {
       "file": "crates/kin-cli/src/commands/status.rs",

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -1154,6 +1154,294 @@
       "reason": "Inline TODO/FIXME/HACK extraction, per the module's own doc, and the one genuine recursive source-tree walk among the six directories: read_dir, recurse on is_dir, read_to_string every file with a matching extension, depth-bounded. It is legal today and that was checked rather than assumed: both live callers, `work.rs:895` for `kin work todo-import` and `handlers/work.rs:570` for the agent-facing `kin_todo_import` MCP tool, persist every extracted marker through `create_work_item` and return counts, so the walk builds graph-owned truth, which the rule permits. It is one caller away from illegal: the day something returns the extracted list instead of importing it, this walk becomes the answer. That is exactly why it needs an owner and a date rather than a crate-wide silence. Converted from the whole-directory BOUNDARY_DIRS entry `crates/kin-parser/` on 2026-09-03, which carried no owner, no expiry and no reason. That directory covered 33 .rs files, 20 of them on the scanned runtime path, and only 1 contain any filesystem primitive at all, so the exemption was several times wider than anything it protected. Every other file in that crate is now scanned by default, including any added later.",
       "owner": "kin-parser",
       "expiration": "2027-09-24"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/setup.rs",
+      "reason": "The installer. `kin setup` writes MCP client configurations, installs binaries and language servers, and keeps an install ledger, which is the largest filesystem surface in the CLI at 445 reported sites and answers no locate, search, context, trace, review or xref query. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-04-23"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/update.rs",
+      "reason": "The updater: downloads, verifies and swaps the installed binaries, holding file locks over the install root. 359 sites, all install-time IO, and it resolves no semantic query. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-04-23"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/update_windows.rs",
+      "reason": "The Windows half of the updater, per its own doc: path binding and private preflight directories for candidate programs that are statically inspected and never launched. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-04-23"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/setup_verify.rs",
+      "reason": "Proves a written MCP client config can actually reach Kin, per its own doc (FIR-1882). The subprocess sites are that proof: it launches the client path it just wrote to confirm the wiring, rather than answering anything. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-04-23"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/language_server_release.rs",
+      "reason": "Installs a language server from its project's own release binaries, per its own doc, for a host carrying none of the toolchains the package route needs. Download and unpack IO. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-04-23"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/language_servers.rs",
+      "reason": "Reports which language servers this build enriches with and how to install them, per its own doc. The subprocess sites probe for installed servers. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-04-23"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/publish.rs",
+      "reason": "Release publication transport. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-04-23"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/release_orch.rs",
+      "reason": "The cross-repo release orchestrator, per its own doc: it drives a bottom-up publish wave across repositories. Subprocess and workspace IO, no query. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-04-23"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/release_cmd.rs",
+      "reason": "Release command surface. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-04-23"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/verify.rs",
+      "reason": "Release artifact verification, via subprocess. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-04-23"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/bench.rs",
+      "reason": "Benchmark harness entry point. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-06-18"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/bench_meta.rs",
+      "reason": "Benchmark metadata collection. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-06-18"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/init.rs",
+      "reason": "Clean-slate repository authority initialization, per its own doc: `kin init` captures a Git worktree as exact reachable history. It runs before graph truth for that repository exists, which is the ingestion boundary the rule allows explicitly. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-05-21"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/clone.rs",
+      "reason": "Exact Git transport followed by atomic repository-v6 admission, per its own doc. Ingestion boundary. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-05-21"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/eject.rs",
+      "reason": "Leaving Kin through one exact repository-v6 to Git projection, per its own doc, which adds that eject never treats working files or an ambient `.git/` as repository authority. Materialization out, not answer-by-search. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-05-21"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/git.rs",
+      "reason": "Exact repository-v6 projection into a new Git repository, per its own doc, which states Git is an interoperability projection and never an authority fallback. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-05-21"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/backup.rs",
+      "reason": "Store backup and restore IO over `.kin/`. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-05-21"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/admit.rs",
+      "reason": "Wire types and CLI transport for requesting one exact-tree admission, per its own doc. The single site is subprocess, not a read. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-05-21"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/commit.rs",
+      "reason": "The commit surface. Two of its three sites are the authority-lease `.metadata()` accessor rather than a filesystem probe, the collision FIR-3162 tracks; the third is subprocess. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-05-21"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/commit_progress.rs",
+      "reason": "What `kin commit` shows while the daemon commits, per its own doc. Progress rendering and the daemon's own progress file, never repository content. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-05-21"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/reconcile.rs",
+      "reason": "The explicit repository-v6 session observation boundary, and its own doc is the justification: it is the only runtime path permitted to observe editable session bytes, and it never answers a semantic query from the filesystem. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-05-21"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/projection.rs",
+      "reason": "Which of three ways Kin is showing graph truth as ordinary files, per its own doc. It reports on and manages projections; the graph stays the authority. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-05-21"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/prepared_state.rs",
+      "reason": "Prepared-state reuse and reopen bookkeeping over `.kin/`. Kin-owned state files, not repository content. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-05-21"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/daemon.rs",
+      "reason": "`kin daemon`: inspect and gracefully stop the daemon topology, per its own doc. Its sites are the daemon's own pid, port and socket records. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-06-18"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/session_run.rs",
+      "reason": "Runs a process inside an exact graph-derived session workspace, per its own doc: the daemon materializes repository-authority bodies and this launches into them. The subprocess IS the product. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-06-18"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/agent.rs",
+      "reason": "`kin agent`: runs a task through Kin's own agent loop, per its own doc, writing the run's output directory. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-06-18"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/assistant.rs",
+      "reason": "Assistant launch surface. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-06-18"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/assistant_adapter.rs",
+      "reason": "One adapter per assistant CLI in a registry, per its own doc, owning the launch program and capability profile. All three sites are that launch. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-06-18"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/auth.rs",
+      "reason": "Local credential storage and the token file it owns. No repository content and no query result. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-06-18"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/allow.rs",
+      "reason": "`kin allow`: records an explicit approval for one blocked sensitive artifact, per its own doc. It reads the named path to confirm the digest admission refused, which is an admission boundary. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-06-18"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/cache.rs",
+      "reason": "`kin cache`: inspects and bounds the on-disk embedding cache, per its own doc. The traversal is over `~/.kin/cache/embeddings`, which is Kin's own derived data, never repository source. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-06-18"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/telemetry.rs",
+      "reason": "Telemetry consent and the local consent marker. Opt-in and local-first. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-06-18"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/locate_telemetry.rs",
+      "reason": "Opt-in local telemetry for `kin locate`, per its own doc: default off, gated on an env var or a `.kin/telemetry/consent` marker. The marker check is the gate, not the answer. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-06-18"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/store_footprint.rs",
+      "reason": "What the store costs on disk beside the Git object store it was admitted from, per its own doc. It measures sizes; it reads no content and answers no semantic query. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-06-18"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/graph_export.rs",
+      "reason": "The consumer-facing projection of the live graph, per its own doc, which records that it replaced a render payload built by reading a snapshot off disk. The single remaining site is the export's own output path. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-06-18"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/managed_config_scope.rs",
+      "reason": "The scope boundary for managed-config discovery, per its own doc: managed MCP client configs are addressed from the home directory. Both sites canonicalize that scope so IO cannot escape it, which is the boundary enforcing itself. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-06-18"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/locate_cursor.rs",
+      "reason": "The per-repo paging cursor for `kin locate --next`, per its own doc. It holds a continuation token, never repository content, and a miss restarts paging rather than answering. Already declared in the shell guard's own pins; this entry is what makes both guards agree it is a boundary. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-06-18"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/locate_debug.rs",
+      "reason": "`kin locate-debug`: the offline signal breakdown reader, per its own doc. Already declared in the shell guard's pins; this entry is the other half of that declaration. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-06-18"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/contextbench_locate.rs",
+      "reason": "The benchmark task-input boundary: it reads the task file a benchmark run names. Already declared in the shell guard's pins; this entry is the other half. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-06-18"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/status.rs",
+      "reason": "Coherent repository-v6 status, and its own doc is the point: every count comes from one immutable authority lease and nothing here inspects checkout contents, Git or legacy sidecars. NOT a filesystem call. The reported `.metadata()` is `RepositoryAuthorityState::metadata()`, which returns the graph-owned repository-v6 authority envelope; this module reads workspace, alias, external-object or merge-transaction state out of it. It shares a method name with the filesystem metadata probe in the shared deny set, which is the only reason it appears here, and pinning by exact occurrence count rather than exempting the file keeps every other line scanned. Measured across the whole scan on 2026-09-04, 57 of 78 `.metadata()` hits are this in-memory accessor rather than a filesystem probe. Tracked as FIR-3162, which makes the pattern precise; these pins retire with it.",
+      "owner": "kin-cli",
+      "expiration": "2027-01-29",
+      "allow_match": [
+        {
+          "expr": ".metadata()",
+          "count": 2
+        }
+      ]
+    },
+    {
+      "file": "crates/kin-cli/src/commands/diff.rs",
+      "reason": "Exact repository-v6 diffs, per its own doc: one immutable authority lease and two graph-owned endpoint states. NOT a filesystem call. The reported `.metadata()` is `RepositoryAuthorityState::metadata()`, which returns the graph-owned repository-v6 authority envelope; this module reads workspace, alias, external-object or merge-transaction state out of it. It shares a method name with the filesystem metadata probe in the shared deny set, which is the only reason it appears here, and pinning by exact occurrence count rather than exempting the file keeps every other line scanned. Measured across the whole scan on 2026-09-04, 57 of 78 `.metadata()` hits are this in-memory accessor rather than a filesystem probe. Tracked as FIR-3162, which makes the pattern precise; these pins retire with it.",
+      "owner": "kin-cli",
+      "expiration": "2027-01-29",
+      "allow_match": [
+        ".metadata()"
+      ]
+    },
+    {
+      "file": "crates/kin-cli/src/commands/log.rs",
+      "reason": "Immutable repository-v6 history reads, per its own doc, which states it never asks Git or legacy branch sidecars. NOT a filesystem call. The reported `.metadata()` is `RepositoryAuthorityState::metadata()`, which returns the graph-owned repository-v6 authority envelope; this module reads workspace, alias, external-object or merge-transaction state out of it. It shares a method name with the filesystem metadata probe in the shared deny set, which is the only reason it appears here, and pinning by exact occurrence count rather than exempting the file keeps every other line scanned. Measured across the whole scan on 2026-09-04, 57 of 78 `.metadata()` hits are this in-memory accessor rather than a filesystem probe. Tracked as FIR-3162, which makes the pattern precise; these pins retire with it.",
+      "owner": "kin-cli",
+      "expiration": "2027-01-29",
+      "allow_match": [
+        ".metadata()"
+      ]
+    },
+    {
+      "file": "crates/kin-cli/src/commands/ref_grammar.rs",
+      "reason": "The one endpoint grammar every read surface speaks, per its own doc, shared by `kin diff`, `kin blame --ref` and `kin history --ref`. NOT a filesystem call. The reported `.metadata()` is `RepositoryAuthorityState::metadata()`, which returns the graph-owned repository-v6 authority envelope; this module reads workspace, alias, external-object or merge-transaction state out of it. It shares a method name with the filesystem metadata probe in the shared deny set, which is the only reason it appears here, and pinning by exact occurrence count rather than exempting the file keeps every other line scanned. Measured across the whole scan on 2026-09-04, 57 of 78 `.metadata()` hits are this in-memory accessor rather than a filesystem probe. Tracked as FIR-3162, which makes the pattern precise; these pins retire with it.",
+      "owner": "kin-cli",
+      "expiration": "2027-01-29",
+      "allow_match": [
+        {
+          "expr": ".metadata()",
+          "count": 3
+        }
+      ]
+    },
+    {
+      "file": "crates/kin-cli/src/commands/repository_authority.rs",
+      "reason": "Coherent read access to the active repository-v6 authority, per its own doc, used instead of reconstructing refs or workspace state from legacy sidecars. NOT a filesystem call. The reported `.metadata()` is `RepositoryAuthorityState::metadata()`, which returns the graph-owned repository-v6 authority envelope; this module reads workspace, alias, external-object or merge-transaction state out of it. It shares a method name with the filesystem metadata probe in the shared deny set, which is the only reason it appears here, and pinning by exact occurrence count rather than exempting the file keeps every other line scanned. Measured across the whole scan on 2026-09-04, 57 of 78 `.metadata()` hits are this in-memory accessor rather than a filesystem probe. Tracked as FIR-3162, which makes the pattern precise; these pins retire with it.",
+      "owner": "kin-cli",
+      "expiration": "2027-01-29",
+      "allow_match": [
+        {
+          "expr": ".metadata()",
+          "count": 2
+        }
+      ]
     }
   ]
 }

--- a/scripts/zero_file_search_guard.sh
+++ b/scripts/zero_file_search_guard.sh
@@ -23,25 +23,115 @@
 # Python checker rather than being duplicated here.
 #
 # Usage: zero_file_search_guard.sh [repo_root]
+#        zero_file_search_guard.sh --list-scanned [repo_root]
 # Exit: 0 when the answer paths are graph-clean, 1 on the first violation.
 set -euo pipefail
 
+# Two lists, two meanings, and the difference matters.
+#
+#   --list-scanned   every answer module, deferred ones included. This is the
+#                    notion of an answer module the Python checker's
+#                    `check_guard_seam` compares against, because a deferred
+#                    file is still an answer module; it is simply graded by the
+#                    other guard.
+#   --list-enforced  the modules THIS guard actually runs its deny set over.
+#                    scripts/falsify-zero-file-search.py poisons these, and
+#                    poisoning a deferred one would fail for the wrong reason.
+list_only=0
+if [[ "${1:-}" == "--list-scanned" ]]; then
+  list_only=1
+  shift
+elif [[ "${1:-}" == "--list-enforced" ]]; then
+  list_only=2
+  shift
+fi
+
 repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 cmd_dir="crates/kin-cli/src/commands"
+allowlist="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/zero-file-search-allowlist.json"
 
-# Answer-authority modules that must resolve results from graph truth alone.
-authority_files=(
-  "$cmd_dir/locate.rs"
-  "$cmd_dir/locate_cursor.rs"
-  "$cmd_dir/locate_debug.rs"
-  "$cmd_dir/contextbench_locate.rs"
-  "$cmd_dir/search.rs"
-  "$cmd_dir/context.rs"
-  "$cmd_dir/trace.rs"
-  "$cmd_dir/trace_data_flow.rs"
-  "$cmd_dir/review.rs"
-  "$cmd_dir/xref.rs"
-)
+# Answer-authority modules, DERIVED rather than listed.
+#
+# This was a hardcoded array of ten module names, and that was the FIR-2282
+# defect: an opt-in list on a surface of 107 modules, so a new command with a
+# raw filesystem fallback was outside the guard on the day it was written. It
+# was also the second such list. The Python checker kept its own, they covered
+# different sets, and nothing compared them, so `contextbench_locate.rs`,
+# `locate_cursor.rs` and `locate_debug.rs` were answer modules here and did not
+# exist over there.
+#
+# So: every module in the directory is an answer module, minus the ones the
+# shared allowlist exempts whole-file. That is the same list
+# `command_modules_scanned` builds in the Python checker, and its
+# `check_guard_seam` runs `--list-scanned` and fails when the two differ, so the
+# drift that produced this ticket cannot recur silently.
+#
+# A whole-file exemption is an entry with no `allow_match` and no `allow_fn`.
+# Read with awk rather than a JSON parser because this guard stays dependency
+# free, and the allowlist is machine-written with one key per line. The parse
+# carries its own control below: a run that resolves zero modules refuses
+# instead of reporting a clean sheet over nothing.
+allowlist_files() {
+  # $2 selects which kind: "whole" for entries with no pins, "pinned" for the
+  # rest. Both are read from the same entries in one pass so they cannot
+  # disagree about which bucket a file is in.
+  awk -v want="$2" '
+    /^    \{/                    { file=""; pinned=0; next }
+    /"file":/                    { if (match($0, /crates\/[^"]*/)) file=substr($0, RSTART, RLENGTH) }
+    /"allow_match"|"allow_fn"/   { pinned=1 }
+    /^    \}/                    {
+      if (file != "" && ((want == "whole" && pinned == 0) || (want == "pinned" && pinned == 1)))
+        print file
+      file=""; pinned=0
+    }
+  ' "$1"
+}
+
+exempt=" $(allowlist_files "$allowlist" whole | tr '\n' ' ') "
+
+# Files whose exemptions are expression pins or function bodies. This guard
+# cannot express those without a JSON parser it deliberately does not have, so
+# it DEFERS them to the Python checker, which grades them in full.
+#
+# Deferring rather than exempting, and counted out loud below, because a silent
+# skip is the defect this ticket exists to remove. A deferred file is still an
+# answer module: it appears in `--list-scanned`, the seam check compares it, and
+# the Python checker reports every line of it. What this guard gives up is only
+# its second opinion, and only where a boundary has already been declared and
+# reviewed.
+pinned=" $(allowlist_files "$allowlist" pinned | tr '\n' ' ') "
+
+# The test-file rule, stated to match `is_test_file` in the Python checker
+# exactly: a `test_` prefix or a `_test.rs` suffix. Both spellings, because the
+# checker skips both and the seam check compares the resulting sets.
+#
+# `test_subprocess.rs` is why the prefix half is here and it was found by that
+# seam check on its first run, not by reading. It is `#[cfg(test)] pub(crate)
+# mod test_subprocess;` in commands/mod.rs, so it does not exist in a production
+# build, and this guard would have scanned it while the checker skipped it.
+authority_files=()
+while IFS= read -r path; do
+  rel="${path#"$repo_root"/}"
+  base="${rel##*/}"
+  case "$base" in test_*) continue ;; *_test.rs) continue ;; esac
+  [[ "$exempt" == *" $rel "* ]] && continue
+  authority_files+=("$rel")
+done < <(find "$repo_root/$cmd_dir" -maxdepth 1 -name '*.rs' -type f | sort)
+
+# The control. A glob that matched nothing, or an allowlist parse that swallowed
+# every module, would otherwise print "answer paths are graph-clean" over an
+# empty set, which is the exact failure mode this ticket is about.
+if ((${#authority_files[@]} < 10)); then
+  echo "Zero File-Search guard REFUSES: resolved only ${#authority_files[@]} answer" >&2
+  echo "module(s) under $cmd_dir. That is fewer than this repository has ever had," >&2
+  echo "so the enumeration is broken rather than the tree being clean." >&2
+  exit 1
+fi
+
+if ((list_only == 1)); then
+  printf '%s\n' "${authority_files[@]##*/}"
+  exit 0
+fi
 
 # Raw filesystem read / existence / traversal primitives. Subprocess creation
 # is denied wholesale in answer modules so dynamic or multiline rg/grep/find/
@@ -133,11 +223,33 @@ test_module_span() {
   ' "$1"
 }
 
+enforced_files=()
+for rel in "${authority_files[@]}"; do
+  if [[ "$pinned" == *" $rel "* ]] && [[ -z "$(allow_for "${rel##*/}")" ]]; then
+    continue
+  fi
+  enforced_files+=("$rel")
+done
+
+if ((list_only == 2)); then
+  printf '%s\n' "${enforced_files[@]##*/}"
+  exit 0
+fi
+
 violations=()
+deferred=$(( ${#authority_files[@]} - ${#enforced_files[@]} ))
 for rel in "${authority_files[@]}"; do
   file="$repo_root/$rel"
   [[ -f "$file" ]] || continue
   base="$(basename "$rel")"
+  # Declared boundaries this guard cannot express, deferred to the Python
+  # checker. A file `allow_for` covers is NOT deferred: those pins are this
+  # guard's own and predate the shared list, and dropping them would quietly
+  # narrow coverage of the four core answer modules while this change claims to
+  # widen it.
+  if [[ "$pinned" == *" $rel "* ]] && [[ -z "$(allow_for "$base")" ]]; then
+    continue
+  fi
   read -r test_start test_end <<<"$(test_module_span "$file")"
 
   # Read into an array rather than a single string. `while read` rather than
@@ -150,8 +262,30 @@ for rel in "${authority_files[@]}"; do
 
   # Everything outside the test module, before it and after it alike, with the
   # original line numbers preserved.
-  region="$(awk -v s="$test_start" -v e="$test_end" \
-    'NR < s || NR > e { print NR ":" $0 }' "$file")"
+  # Everything outside the test module, plus the single-statement items a
+  # `#[cfg(test)]` gates on its own.
+  #
+  # The second half was found by widening this guard's coverage, not by reading:
+  # `setup_ledger.rs` carries `#[cfg(test)]` on line 25 and `use std::fs;` on 26,
+  # a test-only import of a production-looking module. `test_module_span` only
+  # recognises a `#[cfg(test)]` whose next item is a `mod`, so it walked past
+  # this one to the real test module at 768 and reported line 26 as a production
+  # filesystem import. The Python checker's cfg tracker already excluded it, so
+  # the two guards disagreed about one line of one file.
+  #
+  # Only a one-line statement is dropped, never an item with a body. A gated
+  # `fn` or `mod` keeps being scanned, which over-reports rather than
+  # under-reports, and over-reporting is the direction a reviewer can see.
+  region="$(awk -v s="$test_start" -v e="$test_end" '
+    NR >= s && NR <= e                              { next }
+    /^[[:space:]]*#\[cfg\(test\)\][[:space:]]*$/ { gate = 1; next }
+    gate && /^[[:space:]]*(\/\/|$)/                 { next }
+    gate {
+      gate = 0
+      if ($0 !~ /^[[:space:]]*mod / && $0 ~ /;[[:space:]]*$/) next
+    }
+                                                    { print NR ":" $0 }
+  ' "$file")"
   scan_region="$region"
 
   # An empty array is unbound under `set -u` on bash 3.2, so expand it guarded.
@@ -197,4 +331,5 @@ if ((${#violations[@]} > 0)); then
   exit 1
 fi
 
-echo "Zero File-Search guard passed: answer paths are graph-clean."
+echo "Zero File-Search guard passed: ${#authority_files[@]} answer modules are graph-clean" \
+     "($deferred with declared boundary pins deferred to verify-zero-file-search.py)."

--- a/scripts/zero_file_search_guard.sh
+++ b/scripts/zero_file_search_guard.sh
@@ -276,7 +276,40 @@ for rel in "${authority_files[@]}"; do
   # Only a one-line statement is dropped, never an item with a body. A gated
   # `fn` or `mod` keeps being scanned, which over-reports rather than
   # under-reports, and over-reporting is the direction a reviewer can see.
+  # Comments are stripped, because this guard had no lexer and the deny set is
+  # full of ordinary words. Measured: `// we deliberately avoid OpenOptions
+  # here`, `// the process as a whole is graph-owned` and a trailing
+  # `// OpenOptions is not used` each redden a REQUIRED context, in any of the
+  # 57 modules FIR-2282 newly covers, while the Python checker correctly ignores
+  # all three. A guard that fails on prose trains people to write around it.
+  #
+  # The stripper tracks double-quoted strings so a `//` inside a literal cannot
+  # truncate the code after it, and it carries block-comment state across lines.
+  # Every way it can be wrong is a FALSE POSITIVE: a char literal holding a quote
+  # leaves it believing it is inside a string, so it stops stripping and reports
+  # more, and a string spanning lines resets at the newline, where the only thing
+  # it could then hide is text inside a literal, which is not code. It never
+  # strips something it should have scanned.
   region="$(awk -v s="$test_start" -v e="$test_end" '
+    function strip(line,   i, n, ch, nx, out, in_str, esc) {
+      n = length(line); out = ""
+      for (i = 1; i <= n; i++) {
+        ch = substr(line, i, 1); nx = substr(line, i + 1, 1)
+        if (in_block) { if (ch == "*" && nx == "/") { in_block = 0; i++ } ; continue }
+        if (in_str) {
+          out = out ch
+          if (esc) esc = 0
+          else if (ch == "\\") esc = 1
+          else if (ch == "\"") in_str = 0
+          continue
+        }
+        if (ch == "\"") { in_str = 1; out = out ch; continue }
+        if (ch == "/" && nx == "/") break
+        if (ch == "/" && nx == "*") { in_block = 1; i++; continue }
+        out = out ch
+      }
+      return out
+    }
     NR >= s && NR <= e                              { next }
     /^[[:space:]]*#\[cfg\(test\)\][[:space:]]*$/ { gate = 1; next }
     gate && /^[[:space:]]*(\/\/|$)/                 { next }
@@ -284,7 +317,7 @@ for rel in "${authority_files[@]}"; do
       gate = 0
       if ($0 !~ /^[[:space:]]*mod / && $0 ~ /;[[:space:]]*$/) next
     }
-                                                    { print NR ":" $0 }
+                                                    { print NR ":" strip($0) }
   ' "$file")"
   scan_region="$region"
 


### PR DESCRIPTION
The command surface was exempt by default: a module was scanned only if somebody remembered to name
it in `QUERY_COMMANDS`. That is the same polarity error `BOUNDARY_DIRS` was, pointing the other way.
One exempted by default, this one covered only by opt-in, and both report PASSED when they
under-cover. This inverts it and gives the two guards one answer-module list.

## Measured on main at 8f1283293 before changing anything

```
command modules on main: 107
  python guard QUERY_COMMANDS: 22
  shell guard authority_files: 10
  covered by NEITHER: 82
```

The guard read 78k lines of the command surface and skipped 108k, so most of the CLI sat outside the
gate that exists to hold the thesis on it. The ticket says 73 of 95; it has grown since.

**And the two lists had drifted, which no one could see.** `contextbench_locate.rs`,
`locate_cursor.rs` and `locate_debug.rs` were answer modules to the shell guard, with declared
boundary pins, and did not exist to the Python checker. Nothing compared them, so nothing reported it.

## What this does

Both lists are gone. The directory is scanned by default like every other crate, exemptions live in
the allowlist with an owner and a date, and `command_modules_scanned` is the single notion of an
answer module. The shell guard derives the same set from the same allowlist through
`--list-scanned`, and `check_guard_seam` runs that enumeration and fails when the two differ.

**The seam check earned itself on its first run.** It caught `test_subprocess.rs`: the Python checker
skips it on the `test_` prefix rule and the shell guard would have scanned it. It is
`#[cfg(test)] pub(crate) mod` in `commands/mod.rs`, so it does not exist in a production build and
the checker was right. Found by the check, not by reading.

Widening the shell guard surfaced a second disagreement it could not have seen before:
`setup_ledger.rs` carries `#[cfg(test)]` on line 25 and `use std::fs;` on 26, and `test_module_span`
only recognises a `#[cfg(test)]` whose next item is a `mod`, so it reported a test-only import as
production. The region filter now drops a single-statement item a `#[cfg(test)]` gates, and only
that; anything with a body stays scanned, which over-reports rather than under-reports.

## Cost

44 entries. **40 modules report nothing and take none.** Three files carry 851 of the 1193 real
sites and are one thing, the installer and updater family.

The scan reads 314 files, up from 266. PR-time cost, measured because the required context runs this
on every kin PR: **3.7s to 4.4s** for the Python checker alone; the pair with the shell guard costs 6.6s to 7.0s.

## Five entries are pinned rather than whole-file, and the distinction is the point

`diff.rs`, `log.rs`, `status.rs`, `ref_grammar.rs` and `repository_authority.rs` are read surfaces
whose only reported sites are `lease.metadata()`, the repository authority envelope chained into
`.workspaces` and `.aliases`. That is not a filesystem call. A whole-file entry there would declare
five answer surfaces to be filesystem boundaries when they touch no filesystem at all, which is the
overclaiming kin#1452 landed to correct, on the modules the thesis cares most about.

The pins say what the sites actually are, following the `graph_section.rs` precedent, and name
FIR-3162 so they have a retirement path. Measured across the whole scan, **57 of 78 `.metadata()`
hits are that in-memory accessor**. The pattern is deliberately NOT weakened here: a receiver-name
exclusion could blind the guard to a real `path.metadata()`, and that is a deny-set precision
problem rather than this ticket's polarity problem.

## Falsification

The ticket's acceptance is one sentence: a planted raw `std::fs` read in a previously unlisted
command module must red the guard. Each target ran against `origin/main`'s guards and this branch's.

```
A. a raw read in a previously unlisted command module

  module                     BEFORE py/sh     AFTER py/sh
  ------------------------------------------------------------
  refs.rs                    RED/blind        RED/RED
  rename.rs                  RED/blind        RED/RED
  blame.rs                   RED/blind        RED/RED
  graph.rs                   RED/blind        RED/RED
  work.rs                    blind/blind      RED/RED
  checkout.rs                blind/blind      RED/RED
  merge.rs                   blind/blind      RED/RED
  notify.rs                  blind/blind      RED/RED
  setup_ledger.rs            blind/blind      RED/RED
  mod.rs                     blind/blind      RED/RED

B. the seam check: make the two guards disagree
  drop refs.rs from the shell list only:  rc=1  seam names it  ok

C. the shell guard's enumeration control
  glob that matches nothing:  rc=1  refuses  ok

D. negative controls
  cfg(test)-gated import     py=silent    sh=silent    ok
  authority lease accessor   py=reported  sh=reported  (expected: FIR-3162)

working tree outside scripts/: clean
unmutated python guard: rc=0
```

Six of ten were blind in both guards; four were red in Python and blind in the shell guard.

## The harness would have timed out, so it is batched now

This is the part worth reviewing carefully. Going from 25 enforced modules to 67 took the harness's
inner loop to 472 guard runs at ~4.5s each, about twenty minutes for that section alone against the
**thirty-minute timeout** on `Falsify guards`. Widening coverage would have broken that job by clock
rather than by verdict, which is the quietest way to lose a guard.

It is batched by site now: poison every enforced module at one site, run each guard once, require
every module to be named. Four sites, eight guard runs, and each module keeps its own probe, its own
site and its own required report. Same trade the cfg-tracker probes already make.

Batching costs attribution, so a non-unanimous batch replays the modules that did not come back ok.
Only those are ambiguous. **Falsified both ways:** with the Python guard blinded to exactly one
module, the harness fails rc=1 reporting `refs.rs @ eof: py guard failed but its scan never reported
the file` at all four sites and blames no other module. On a clean tree it passes over all 67 with
zero BLIND or UNNAMED.

Clean run 4m29s, failing run 4m03s, both inside the budget and both broader than the fifteen minutes
twenty-five modules used to cost.

`scripts/falsify-zero-file-search.py` also now asks each guard which modules it grades instead of
parsing an array that no longer exists, and the shell guard grew `--list-enforced` for it, because
the seam's list includes deferred modules and poisoning one of those would fail for the wrong reason.

## Verification

```
kin-precheck: repo=kin tree=.../authorityopt-kin sha=c94d3710ae95f12b3ed50b70078d001467ae45f3 branch=chore/lane-authorityopt-kin
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin c94d3710ae95f12b3ed50b70078d001467ae45f3
```

Clean tree, not DIRTY.

## Note for the reviewer

The 39 whole-file entries preserve today's effective scope rather than re-arguing 39 exemptions in
one night, which is the treatment FIR-3149 gave the `BOUNDARY_DIRS` paths, and each reason says so
explicitly rather than claiming the module was audited. The expiries stagger across four dates by
subsystem, because putting 44 on kin-cli's single review day would rebuild the cliff the expiry
warning exists to report.

---

## Review round 1: a coverage regression, found and fixed

An opus review held this PR on one defect, and it was the right catch.

`locate_cursor.rs`, `locate_debug.rs` and `contextbench_locate.rs` were given **whole-file** entries.
The shell guard drops whole-file paths during enumeration, one step before the deferral logic whose
own comment promises a declared boundary is still an answer module. So on main that guard enforced
all three with counted pins, and at the previous head **neither guard scanned them**. The harness
reported nothing, because a module in neither guard's set is not a module it probes. A coverage
regression inside the change that widens coverage.

The entries' own reasons carried the contradiction in one paragraph: that the shell guard already
declared these pins, and that the module was never scanned before.

They are pinned now, on the five expressions `allow_for()` already declares. **70 answer modules**,
both guards green, and a poison in each reds both.

Three more from the same review:

**The shell guard had no comment lexer**, so prose reddened a required context. Measured:
`// we deliberately avoid OpenOptions here`, `// the process as a whole is graph-owned`, and a
trailing `// OpenOptions is not used` each fail it in any of the 60 newly covered modules, while the
Python checker ignores all three. It strips comments now, tracking string state so a `//` inside a
literal cannot truncate the code after it. Every way the stripper can be wrong is a false positive.
Falsified both ways:

```
  sh_rc=0  silent  // we deliberately avoid OpenOptions here
  sh_rc=0  silent      // the process as a whole is graph-owned
  sh_rc=0  silent  fn __c() { let x = 1; } // OpenOptions is not used
  sh_rc=0  silent  /* a block comment naming OpenOptions */
  sh_rc=1  RED     fn __r(p: &Path) -> bool { std::fs::read_to_string(p).is_ok() }
  sh_rc=1  RED     fn __o(p: &Path) -> bool { OpenOptions::new().read(true).open(p).is_ok() }
  sh_rc=1  RED     fn __s(p: &Path) -> bool { let _u = "http://x"; std::fs::read(p).is_ok() }
```

**The glob binding-learner case expected `set(FS_GLOB_VOCABULARY)`**, so both sides of the comparison
moved together: dropping the glob branch was caught, shrinking the vocabulary was not. It names the
nine items literally now, and removing one fails the self-test (proved by removing `OpenOptions`).

**`Falsify guards` carries `github.event_name != 'pull_request'`**, so the batching rewrite has no
witness on this pull request. Main's push run is what grades it. Locally it passes over 70 modules
with zero BLIND or UNNAMED in 4m41s, and with the Python guard blinded to one module it fails naming
only that module.

Re-verified: `21 gates ran, 21 passed, 0 failed`. Main moved one commit (the 0.6.7 bump), it touches
none of these files, and `git merge-tree` is clean, so the head is left alone rather than rebased.

