### PR TITLE
Finish the first-contact record after a release is promoted (FIR-3152)

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -647,6 +647,23 @@ jobs:
     needs: select
     if: needs.select.outputs.decision == 'stranger' && vars.KIN_STRANGER_RUNNER != ''
     runs-on: ${{ vars.KIN_STRANGER_RUNNER }}
+    # The stranger never reddens this rail. Founder decision, 2026-09-04: "the
+    # damn smoke should never block release it is a nice to have ONLY ... it
+    # should be mainly run locally not in the CI." A driver that ran out of
+    # limit, a runner that went offline, a container that could not start: none
+    # of those is a fact about the candidate, and a red cut run for any of them
+    # is a rail that looks broken while behaving exactly as designed. The
+    # stranger's home is `bin/kin-stranger` against the archive or the published
+    # npm bytes; this hosted job is the optional convenience.
+    #
+    # `continue-on-error` has TWO axes and only one of them is wanted here. It
+    # keeps the run green, and it ALSO masks `needs.stranger.result` to
+    # 'success' for every downstream job, including a stranger that failed. So
+    # `publish-stranger` below keys on this job's own `recorded` output instead,
+    # which is written only after a record exists on disk. Gating it on
+    # `.result` under this flag would publish nothing over a failed arm and
+    # report success for doing it.
+    continue-on-error: true
     # Three concurrent arms plus image and container setup. The arms run
     # concurrently, so the wall clock is one phase 1 plus one phase 2, not three
     # of each.
@@ -785,6 +802,40 @@ jobs:
           echo "recorded=true" >> "$GITHUB_OUTPUT"
           echo "stranger record at ${record}"
 
+      # Whatever happened, the cut's own record says so. A job that is allowed
+      # to fail quietly is a job nobody reads, and "pending" is the answer this
+      # rail acts on everywhere else, so it is the word used here too.
+      - name: Say what the stranger left behind
+        if: always()
+        env:
+          RECORDED: ${{ steps.run.outputs.recorded }}
+          CANDIDATE: ${{ needs.select.outputs.candidate }}
+        run: |
+          set -euo pipefail
+          if [ "${RECORDED:-}" = true ]; then
+            echo "### First contact measured for \`${CANDIDATE}\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "The three arms completed and the record is on its way to the evidence branch." >> "$GITHUB_STEP_SUMMARY"
+            echo "::notice::stranger completed for ${CANDIDATE}"
+          else
+            {
+              echo "### First contact stays PENDING for \`${CANDIDATE}\`"
+              echo ""
+              echo "The hosted stranger did not leave a record this cycle, and that does not hold"
+              echo "the release. The tag, the GitHub release and Latest all move on the machine"
+              echo "preflight alone, and the release carries a notice saying nobody has measured"
+              echo "what a first-time user meets."
+              echo ""
+              echo "To measure it, run the stranger locally against the archive or the published"
+              echo "npm bytes, which is the ordinary path:"
+              echo ""
+              echo '```'
+              echo "bin/kin-stranger run --npm <version>      # what a stranger who types the install line gets"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::notice::stranger left no record for ${CANDIDATE}; first contact stays pending and nothing is held"
+          fi
+
       - name: Upload the stranger record
         if: success()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
@@ -797,7 +848,11 @@ jobs:
   publish-stranger:
     name: Publish the candidate's stranger record
     needs: [select, stranger]
-    if: needs.select.outputs.decision == 'stranger' && needs.stranger.result == 'success'
+    # `outputs.recorded`, never `result`. The stranger job is
+    # continue-on-error, which masks its result to 'success' even when it
+    # failed, so a `.result` gate here would run this publisher over an arm
+    # that produced no record.
+    if: needs.select.outputs.decision == 'stranger' && needs.stranger.outputs.recorded == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: release-tag

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -148,6 +148,43 @@ jobs:
             echo "${tag} is GitHub Latest"
           done < <(node scripts/read-promotion-plan.mjs promotions)
 
+      # The other half of finishing the record, and the half that had no owner
+      # until 2026-09-04. A release that is ALREADY Latest and whose stranger
+      # record has now landed still carries the pending notice on its body, so
+      # it goes on telling every reader that nobody measured it. That is a false
+      # claim in the same direction the strip above exists to prevent; it just
+      # arrives by a different door now that release.yml promotes rather than
+      # holds.
+      #
+      # Deliberately NOT the promote path. These releases are already Latest, so
+      # there is nothing to flip, the npm ordering check would compare against
+      # whatever npm serves today rather than at their publication, and
+      # `--latest` on an older tag would be a rollback.
+      - name: Take the pending notice out of a release the stranger has now measured
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KIN_PROMOTION_PLAN: ${{ runner.temp }}/promotion-plan.json
+        run: |
+          set -euo pipefail
+          while IFS=$'\t' read -r tag driver; do
+            [ -n "$tag" ] || continue
+            echo "::notice::first-contact proof landed for ${tag}, driven on the ${driver} endpoint; taking its pending notice out"
+            gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json body --jq '.body' \
+              | node scripts/read-promotion-plan.mjs strip-notice > "$RUNNER_TEMP/measured-body.md"
+            gh release edit "$tag" --repo "$GITHUB_REPOSITORY" \
+              --notes-file "$RUNNER_TEMP/measured-body.md"
+
+            # Read it back. An edit returning 200 is not the same fact as a body
+            # that no longer carries the marker, and this loop's whole job is
+            # that the body stops making a claim that is no longer true.
+            if gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json body --jq '.body' \
+              | grep -qF 'kin-first-contact-proof'; then
+              echo "::error::${tag} still carries the first-contact pending notice after the strip"
+              exit 1
+            fi
+            echo "${tag} no longer claims its first contact is pending"
+          done < <(node scripts/read-promotion-plan.mjs notice-clears)
+
       # The alarm runs whatever the promotion did, because the releases it
       # reports are exactly the ones the promotion could NOT touch.
       - name: Report releases still waiting for first-contact proof

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2440,20 +2440,24 @@ jobs:
       # a bridged answer can only ever shape a refusal; it can no longer admit
       # one.
       #
-      # WHY THIS GATE READS `preflight` AND STILL BLOCKS LATEST.
+      # WHY THIS GATE READS `preflight` AND BLOCKS NOTHING.
       #
       # `require: preflight` does not lower this job's bar. It changes what an
       # ABSENT stranger record does: instead of throwing here, it comes back as
       # a reported pending state that the steps below act on. Every other
       # stranger failure -- unreadable, about another build, an incomplete arm,
-      # bytes no preflight leg judged -- still throws exactly as before.
+      # bytes no preflight leg judged -- still throws exactly as before. That
+      # narrowing is the whole of it, and it is why a relaxed gate cannot be
+      # used to ship a record that is WRONG rather than one that is missing.
       #
-      # The distinction the release chain now makes is between a tag and Latest.
-      # A tag is an artifact somebody must name to install. Latest is what an
-      # installer resolves when a stranger types the install line, so Latest is
-      # the claim of first-contact coverage and Latest is where the stranger
-      # record is required. A pending release is published, installable, and
-      # marked prerelease until its record lands.
+      # What the pending state buys is a label, not a hold. Until 2026-09-04
+      # Latest was where the stranger record was required, on the reasoning that
+      # Latest is what an installer resolves and so is the claim of first-contact
+      # coverage. Holding there put the line in the wrong place: it kept a
+      # finished, installable release out of every default install path for want
+      # of a driver nobody could summon. A pending release is now published,
+      # installable, promoted, and carries a notice on its own body saying
+      # nobody has measured what a first-time user meets.
       - name: Require proof-loop artifacts for the tagged candidate
         id: proof
         env:

--- a/docs/release-bot.md
+++ b/docs/release-bot.md
@@ -165,6 +165,25 @@ gh variable set KIN_STRANGER_RUNNER --repo firelock-ai/kin --body '<runner label
 gh secret set KIN_STRANGER_ANTHROPIC_API_KEY --repo firelock-ai/kin
 ```
 
+**The stranger's home is a local run, and the hosted job is optional.** Founder
+decision, 2026-09-04: "the damn smoke should never block release it is a nice to
+have ONLY ... it should be mainly run locally not in the CI." The ordinary way to
+measure first contact is `bin/kin-stranger` from the umbrella, against the
+candidate archive before a tag or the published npm bytes after one:
+
+```
+bin/kin-stranger run --archive <path>   # the release-candidate bytes
+bin/kin-stranger run --npm <version>    # what a stranger who types the install line gets
+```
+
+The hosted job in `release-cut.yml` is a convenience that runs the same tool on a
+runner the fleet owns when `KIN_STRANGER_RUNNER` names one. It carries
+`continue-on-error: true` and can never redden a cut run, because a driver out of
+limit or an offline runner is not a fact about the candidate. Whatever it does,
+it writes a summary line naming the state, and `publish-stranger` keys on that
+job's own `recorded` output rather than on its result, since `continue-on-error`
+masks a failed job's result to success for everything downstream.
+
 With the variable unset the cut still selects, arms and preflights, and the
 `stranger-standby` job prints the exact local command with all three arms named
 and raises a warning. The mint tags either way. What a missing `stranger.env`

--- a/scripts/read-promotion-plan.mjs
+++ b/scripts/read-promotion-plan.mjs
@@ -30,6 +30,18 @@ export function renderPromotions(plan) {
     .join('\n');
 }
 
+// The releases that are already Latest and only carry a stale pending notice.
+//
+// A separate list rather than a flag on the promotion lines, because the two
+// need different work done to them and a workflow reading one list would have
+// to branch on a column to avoid flipping GitHub Latest onto an older tag.
+// Same tab-separated shape, so the workflow reads it the same way.
+export function renderNoticeClears(plan) {
+  return (plan.clearNotice ?? [])
+    .map((entry) => `${entry.tag}\t${entry.driver ?? 'unrecorded'}`)
+    .join('\n');
+}
+
 // action, issue number and title on one tab-separated line, with the body
 // written to its own file. The title travels with the decision because the
 // alarm's title is the only thing that makes a second run update the first
@@ -89,6 +101,8 @@ async function readStdin() {
 export async function run(argv) {
   const [command, ...rest] = argv;
   switch (command) {
+    case 'notice-clears':
+      return `${renderNoticeClears(readPlan())}\n`;
     case 'promotions':
       return `${renderPromotions(readPlan())}\n`;
     case 'alarm': {
@@ -103,7 +117,7 @@ export async function run(argv) {
     default:
       throw new Error(
         `unknown command ${JSON.stringify(command ?? '')}; this reader knows ` +
-        'promotions, alarm and strip-notice',
+        'promotions, notice-clears, alarm and strip-notice',
       );
   }
 }

--- a/scripts/read-promotion-plan.test.mjs
+++ b/scripts/read-promotion-plan.test.mjs
@@ -96,6 +96,49 @@ test('stripPendingNotice returns the original body byte for byte', () => {
   assert.equal(stripPendingNotice(written), notes);
 });
 
+// The coupling the fixtures above cannot provide.
+//
+// Every other test here builds its own notice text, so `stripPendingNotice`
+// is only ever asked to strip a shape this FILE invented. release.yml is what
+// actually writes the notice, and its wording changed on 2026-09-04 when the
+// sentence claiming the release stays a prerelease became false. Nothing would
+// have gone red if that edit had also broken the strip: the stripper would
+// simply stop matching in production, a promoted release would keep claiming
+// its proof is pending forever, and every test here would still pass.
+//
+// So read the real heredoc out of the workflow and strip THAT.
+test('stripPendingNotice strips the notice release.yml actually writes', () => {
+  const workflow = fs.readFileSync(
+    path.join(import.meta.dirname, '..', '.github', 'workflows', 'release.yml'),
+    'utf8',
+  );
+  const lines = workflow.split('\n');
+  const open = lines.findIndex((line) => line.includes("<<NOTE"));
+  assert.notEqual(open, -1, 'release.yml no longer writes the notice with a <<NOTE heredoc');
+  const indent = lines[open].length - lines[open].trimStart().length;
+  const body = [];
+  for (let i = open + 1; i < lines.length; i += 1) {
+    if (lines[i].trim() === 'NOTE') break;
+    body.push(lines[i].slice(indent));
+  }
+
+  // The guard this file's own history argues for. An extraction that silently
+  // found nothing would make every assertion below compare two empty-ish
+  // values and pass, which is the shape that reports a green harness over a
+  // fixture that never built.
+  assert.ok(body.length >= 2, `extracted ${body.length} notice line(s) from release.yml`);
+  assert.ok(
+    body.some((line) => line.includes('First-contact proof pending')),
+    `the extracted block is not the notice: ${JSON.stringify(body)}`,
+  );
+
+  const notice = body.join('\n').replace('${marker}', PENDING_MARKER);
+  assert.ok(notice.includes(PENDING_MARKER), 'the extracted notice carries no marker to key on');
+
+  const notes = '## Notes\n\n> a quote the author wrote\n';
+  assert.equal(stripPendingNotice(`${notice}\n${notes}`), notes);
+});
+
 test('run refuses a command it does not know rather than doing nothing', async () => {
   await assert.rejects(run(['publish']), /unknown command "publish"/);
   await assert.rejects(run([]), /unknown command ""/);

--- a/scripts/release-promotion-plan.mjs
+++ b/scripts/release-promotion-plan.mjs
@@ -43,6 +43,18 @@ export const PENDING_MARKER = '<!-- kin-first-contact-proof -->';
 // first and short enough that a forgotten one is found the same day.
 export const DEFAULT_ALARM_AFTER_MINUTES = 360;
 
+// How long a release that is ALREADY Latest may go unmeasured before it is
+// worth an issue. Longer than the held threshold on purpose, because the two
+// states are not equally urgent and one alarm for both would be noise.
+//
+// A held release is stuck: nothing reaches an installer until somebody acts,
+// and six hours is the right impatience. A promoted release shipped. Its only
+// gap is that nobody has measured what a first-time user meets, and under the
+// rule of 2026-09-03 that gap is expected on every release the stranger has
+// not reached yet. Alarming on it inside a day would ring on every healthy
+// release and train every reader to skim the one issue that matters.
+export const DEFAULT_PROMOTED_ALARM_AFTER_MINUTES = 1440;
+
 const STABLE_TAG = /^v\d+\.\d+\.\d+$/;
 
 // Which releases this promoter is even allowed to touch.
@@ -60,7 +72,18 @@ export function selectCandidates(releases) {
     .filter((release) => release && typeof release.tag_name === 'string')
     .filter((release) => STABLE_TAG.test(release.tag_name))
     .filter((release) => release.draft !== true)
-    .filter((release) => release.prerelease === true)
+    // Either shape this chain can leave behind. Keying on the prerelease flag
+    // ALONE is what went blind on 2026-09-04: once release.yml stopped holding
+    // Latest, no release was ever a prerelease again, this sweep selected
+    // nothing, and both the notice-stripping and the alarm went quiet with no
+    // signal that they had. v0.6.6 was the first release to sit in exactly that
+    // state. A notice-bearing release is this chain's business whether or not
+    // it is still held.
+    .filter(
+      (release) =>
+        release.prerelease === true ||
+        (typeof release.body === 'string' && release.body.includes(PENDING_MARKER)),
+    )
     .map((release) => ({
       tag: release.tag_name,
       publishedAt: release.published_at ?? null,
@@ -69,6 +92,12 @@ export function selectCandidates(releases) {
       // reported and never promoted: the promoter finishes what the release
       // chain started and does not overrule a person.
       held: typeof release.body === 'string' && release.body.includes(PENDING_MARKER),
+      // Already GitHub Latest. Such a release needs its notice taken out and
+      // nothing else: flipping it again would move Latest onto whatever tag
+      // this sweep happened to reach, which for an older release is a
+      // rollback, and asserting it IS Latest afterwards would fail on any
+      // release but the newest.
+      promoted: release.prerelease !== true,
     }));
 }
 
@@ -79,18 +108,33 @@ function minutesSince(iso, now) {
   return (now - then) / 60000;
 }
 
-// Turn one judgement per candidate into the three lists the workflow acts on.
+// Turn one judgement per candidate into the four lists the workflow acts on.
 //
-// A judgement is `{ tag, publishedAt, held, proven, reason }`. `proven` true
-// means the full gate passed for that tag's commit. `proven` false with a
-// reason is every other answer, and the reason is carried verbatim into the
-// alarm, because "which record was missing" is the first thing a reader needs
-// and a generic "not proven" sends them to read three logs.
+// A judgement is `{ tag, publishedAt, held, promoted, proven, reason }`.
+// `proven` true means the full gate passed for that tag's commit. `proven`
+// false with a reason is every other answer, and the reason is carried
+// verbatim into the alarm, because "which record was missing" is the first
+// thing a reader needs and a generic "not proven" sends them to read three
+// logs.
+//
+// A proven candidate goes to ONE of two lists, and the split is not cosmetic.
+// `promote` is a release still held as a prerelease: it needs the npm ordering
+// checks, the notice taken out, the flip to Latest, and the readback.
+// `clearNotice` is a release that is already Latest and only carries a stale
+// notice: it needs the notice taken out and nothing else. Running the promote
+// path on one of those would move GitHub Latest onto whichever tag the sweep
+// reached, which for anything but the newest release is a rollback.
 export function planPromotion(
   judgements,
-  { now = Date.now(), alarmAfterMinutes = DEFAULT_ALARM_AFTER_MINUTES, openIssue = null } = {},
+  {
+    now = Date.now(),
+    alarmAfterMinutes = DEFAULT_ALARM_AFTER_MINUTES,
+    promotedAlarmAfterMinutes = DEFAULT_PROMOTED_ALARM_AFTER_MINUTES,
+    openIssue = null,
+  } = {},
 ) {
   const promote = [];
+  const clearNotice = [];
   const waiting = [];
   const foreign = [];
   for (const judgement of judgements ?? []) {
@@ -104,22 +148,31 @@ export function planPromotion(
       continue;
     }
     if (judgement.proven === true) {
-      promote.push({ tag: judgement.tag, driver: judgement.driver ?? null });
+      const entry = { tag: judgement.tag, driver: judgement.driver ?? null };
+      (judgement.promoted === true ? clearNotice : promote).push(entry);
       continue;
     }
     waiting.push({
       tag: judgement.tag,
       reason: judgement.reason || 'the proof gate gave no reason',
       minutes: minutesSince(judgement.publishedAt, now),
+      promoted: judgement.promoted === true,
     });
   }
 
-  // Alarm only on a release that has waited past the threshold. A release
+  // Alarm only on a release that has waited past its own threshold. A release
   // whose publication time cannot be read counts as overdue rather than as
   // fresh: an unreadable timestamp must not buy silence.
-  const overdue = waiting.filter(
-    (entry) => entry.minutes === null || entry.minutes >= alarmAfterMinutes,
-  );
+  //
+  // Two thresholds, because the two waiting states are not the same finding. A
+  // held release is stuck and six hours is the right impatience. A promoted one
+  // shipped and is merely unmeasured, which since 2026-09-04 is the normal
+  // state of every release the stranger has not reached, so it gets a day
+  // before it is worth anybody's attention.
+  const overdue = waiting.filter((entry) => {
+    const threshold = entry.promoted ? promotedAlarmAfterMinutes : alarmAfterMinutes;
+    return entry.minutes === null || entry.minutes >= threshold;
+  });
   let alarm = 'none';
   if (overdue.length > 0) {
     alarm = openIssue ? 'update' : 'open';
@@ -129,7 +182,7 @@ export function planPromotion(
     // closing on it would reopen the alarm an hour later.
     alarm = 'close';
   }
-  return { promote, waiting, foreign, overdue, alarm };
+  return { promote, clearNotice, waiting, foreign, overdue, alarm };
 }
 
 // One gate refusal, rendered safely into one Markdown table cell.
@@ -155,22 +208,36 @@ function tableCell(text) {
     .trim();
 }
 
-export function buildBody(overdue, { alarmAfterMinutes = DEFAULT_ALARM_AFTER_MINUTES } = {}) {
+export function buildBody(
+  overdue,
+  {
+    alarmAfterMinutes = DEFAULT_ALARM_AFTER_MINUTES,
+    promotedAlarmAfterMinutes = DEFAULT_PROMOTED_ALARM_AFTER_MINUTES,
+  } = {},
+) {
+  // The `state` column is the whole point of this table now. Before
+  // 2026-09-04 every row meant the same thing, a release stuck off Latest, and
+  // the prose above could say so once. Two states share this alarm today and
+  // they need different things done about them, so a body that described only
+  // the held one would misreport whichever row a reader happened to act on.
   const lines = [
-    `These releases are published, are not GitHub Latest, and have been waiting more than ${alarmAfterMinutes} minutes for first-contact proof.`,
+    'These published releases have not been through the green, brown and vcs stranger arms, so none of them may be described as first-contact proven.',
     '',
-    'Each one cleared the machine preflight on its own bytes. None has been through the green, brown and vcs stranger arms, so none may be described as first-contact proven, and none will become Latest until its `stranger.env` lands under its commit on the `release-evidence` branch.',
+    `A release still **held** off GitHub Latest is stuck and appears here after ${alarmAfterMinutes} minutes. One that is already **Latest** shipped on its machine preflight alone under the rule of 2026-09-03 and appears here after ${promotedAlarmAfterMinutes} minutes, because nobody has measured what a first-time user meets and its release body still says so.`,
     '',
-    '| tag | waiting | what the gate said |',
-    '| --- | --- | --- |',
+    '| tag | state | waiting | what the gate said |',
+    '| --- | --- | --- | --- |',
   ];
   for (const entry of overdue) {
     const waited = entry.minutes === null ? 'unknown' : `${Math.floor(entry.minutes)} min`;
-    lines.push(`| \`${entry.tag}\` | ${waited} | ${tableCell(entry.reason)} |`);
+    const state = entry.promoted ? 'Latest, unmeasured' : 'held, not Latest';
+    lines.push(`| \`${entry.tag}\` | ${state} | ${waited} | ${tableCell(entry.reason)} |`);
   }
   lines.push(
     '',
-    'To clear one: run the stranger on that candidate with all three arms, let it publish, and the promoter takes Latest on its next tick. A local-model run is allowed and is a weaker stranger; the record says which driver produced it and every reader of this rail is told.',
+    'To clear one: run the stranger on that candidate with all three arms and let it publish. `bin/kin-stranger` against the archive or the published npm bytes is the ordinary way to do that, and the hosted job is optional. On its next tick the promoter takes a held release to Latest, and takes the pending notice out of one that is already Latest.',
+    '',
+    'A local-model run is allowed and is a weaker stranger; the record says which driver produced it and every reader of this rail is told.',
     '',
     'This issue closes itself when no published release is waiting.',
   );

--- a/scripts/release-promotion-plan.test.mjs
+++ b/scripts/release-promotion-plan.test.mjs
@@ -10,6 +10,7 @@ import test from 'node:test';
 import {
   ALARM_TITLE,
   DEFAULT_ALARM_AFTER_MINUTES,
+  DEFAULT_PROMOTED_ALARM_AFTER_MINUTES,
   PENDING_MARKER,
   buildBody,
   buildPlan,
@@ -34,9 +35,13 @@ const release = (over = {}) => ({
 test('selectCandidates takes exactly the shape this design creates', () => {
   const picked = selectCandidates([
     release(),
-    // Already Latest. Nothing to do, and promoting it again would be a no-op
-    // that still rewrites its body.
+    // Already Latest AND still carrying the notice. Since 2026-09-04 that is
+    // the ordinary state of every release the stranger has not reached, and it
+    // is this chain's business: the notice has to come out when the record
+    // lands. Keying on the prerelease flag alone made this invisible.
     release({ tag_name: 'v0.6.4', prerelease: false }),
+    // Already Latest and carrying NO notice. A finished release, nothing owed.
+    release({ tag_name: 'v0.6.3', prerelease: false, body: 'clean release notes' }),
     // A draft is not published, so it is not a claim yet.
     release({ tag_name: 'v0.6.6', draft: true }),
     // A prerelease TAG is meant to stay a prerelease. Promoting one would be
@@ -45,8 +50,79 @@ test('selectCandidates takes exactly the shape this design creates', () => {
     // Not a version tag at all.
     release({ tag_name: 'nightly' }),
   ]);
-  assert.deepEqual(picked.map((entry) => entry.tag), ['v0.6.5']);
+  assert.deepEqual(picked.map((entry) => entry.tag), ['v0.6.5', 'v0.6.4']);
   assert.equal(picked[0].held, true);
+  assert.equal(picked[0].promoted, false);
+  assert.equal(picked[1].held, true);
+  assert.equal(picked[1].promoted, true);
+});
+
+test('a promoted release carrying no notice is not this sweep\'s business', () => {
+  // The guard against the opposite overreach. Widening the filter to catch
+  // promoted releases must not make every finished release in the listing a
+  // candidate, or the sweep would resolve and judge every tag kin has ever cut
+  // on every tick.
+  const picked = selectCandidates([
+    release({ tag_name: 'v0.6.3', prerelease: false, body: 'clean release notes' }),
+    release({ tag_name: 'v0.6.2', prerelease: false, body: '' }),
+    release({ tag_name: 'v0.6.1', prerelease: false, body: null }),
+  ]);
+  assert.deepEqual(picked, []);
+});
+
+test('a proven release that is already Latest is cleared, never re-promoted', () => {
+  // The rollback this split exists to prevent. The promote path ends in
+  // `gh release edit --latest` plus an assertion that the tag IS Latest, so
+  // running it on an older already-promoted release would move Latest
+  // backwards and then fail the readback.
+  const plan = planPromotion([
+    { tag: 'v0.6.6', held: true, promoted: true, proven: true, driver: 'account', publishedAt: ago(30) },
+    { tag: 'v0.5.9', held: true, promoted: false, proven: true, driver: 'local', publishedAt: ago(30) },
+  ], { now: NOW });
+  assert.deepEqual(plan.clearNotice.map((e) => e.tag), ['v0.6.6']);
+  assert.deepEqual(plan.promote.map((e) => e.tag), ['v0.5.9']);
+});
+
+test('an unmeasured release that is already Latest still reaches the alarm', () => {
+  // The gap FIR-3152 names. Before this, nothing was ever held, so nothing was
+  // ever waiting, and the alarm could not fire at all. v0.6.6 was the first
+  // release to sit in exactly this state.
+  const promoted = {
+    tag: 'v0.6.6',
+    held: true,
+    promoted: true,
+    proven: false,
+    reason: 'stranger.env does not exist',
+    publishedAt: ago(DEFAULT_PROMOTED_ALARM_AFTER_MINUTES + 1),
+  };
+  const plan = planPromotion([promoted], { now: NOW });
+  assert.deepEqual(plan.overdue.map((e) => e.tag), ['v0.6.6']);
+  assert.equal(plan.alarm, 'open');
+  assert.equal(plan.waiting[0].promoted, true);
+});
+
+test('a promoted release gets a longer fuse than a held one', () => {
+  // Two states, two impatiences. A held release is stuck; a promoted one
+  // shipped and is merely unmeasured, which is now the normal state of every
+  // release the stranger has not reached. One threshold for both would ring on
+  // every healthy release six hours after it shipped.
+  const at = (minutes, over) => ({
+    tag: 'v0.9.9', held: true, proven: false, reason: 'no stranger.env',
+    publishedAt: ago(minutes), ...over,
+  });
+  const between = DEFAULT_ALARM_AFTER_MINUTES + 1;
+  assert.equal(between < DEFAULT_PROMOTED_ALARM_AFTER_MINUTES, true, 'the two thresholds must differ');
+
+  assert.deepEqual(
+    planPromotion([at(between, { promoted: true })], { now: NOW }).overdue.map((e) => e.tag),
+    [],
+    'a promoted release inside its own window is not overdue',
+  );
+  assert.deepEqual(
+    planPromotion([at(between, { promoted: false })], { now: NOW }).overdue.map((e) => e.tag),
+    ['v0.9.9'],
+    'a held release past the held threshold is overdue',
+  );
 });
 
 test('selectCandidates refuses a listing it cannot read rather than returning nothing', () => {
@@ -164,24 +240,25 @@ test('buildBody renders a gate refusal into one table cell whatever it contains'
       .find((line) => line.startsWith('| `v1.0.0`'));
 
   // A bare pipe: one escape, one cell.
-  assert.equal(row('a | b'), '| `v1.0.0` | 400 min | a \\| b |');
+  assert.equal(row('a | b'), '| `v1.0.0` | held, not Latest | 400 min | a \\| b |');
 
   // A backslash BEFORE a pipe. Escaping the pipe alone turns this into a
   // literal backslash followed by an unescaped delimiter, and the row silently
   // gains a column. Both characters have to be escaped in one pass.
-  assert.equal(row('a\\|b'), '| `v1.0.0` | 400 min | a\\\\\\|b |');
+  assert.equal(row('a\\|b'), '| `v1.0.0` | held, not Latest | 400 min | a\\\\\\|b |');
 
   // A newline inside a table row ends the row.
-  assert.equal(row('line one\nline two'), '| `v1.0.0` | 400 min | line one line two |');
+  assert.equal(row('line one\nline two'), '| `v1.0.0` | held, not Latest | 400 min | line one line two |');
 
-  // Every rendered row has exactly the four pipes of a three-column row, so a
-  // cell can never smuggle in a fifth.
+  // Every rendered row has exactly the five pipes of a four-column row, so a
+  // cell can never smuggle in a sixth. The count moved with the `state` column
+  // this alarm gained; the property it guards did not.
   for (const reason of ['a | b', 'a\\|b', 'line one\nline two', '|||', '\\\\']) {
     const rendered = row(reason);
     const unescaped = rendered.replace(/\\./g, '');
     assert.equal(
       unescaped.split('|').length - 1,
-      4,
+      5,
       `reason ${JSON.stringify(reason)} rendered ${JSON.stringify(rendered)}`,
     );
   }

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -882,10 +882,12 @@ EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
         "stranger-standby": "Report the stranger a runner cannot take",
         "report": "Report the cut's decision",
     },
-    # The second tier of the proof contract. A tag now mints on the machine
-    # preflight alone and the release is published as a prerelease; this sweep
-    # is what takes it to GitHub Latest once its stranger record lands, and what
-    # alarms while it has not. None of its jobs runs on a pull_request or
+    # The far end of the proof contract. A tag mints on the machine preflight
+    # alone and the release is published AND promoted; this sweep is what
+    # finishes the record afterwards, taking the pending notice back out once a
+    # stranger record lands, promoting the older shape that was held as a
+    # prerelease, and alarming while neither has happened. None of its jobs
+    # runs on a pull_request or
     # merge_group event, so none can claim a required context; it is registered
     # here because this census is what would otherwise let a new workflow's job
     # NAME appear unreviewed.
@@ -1153,8 +1155,17 @@ def require(content: str, needle: str, context: str) -> None:
 #
 # The contract now has two tiers, and these assertions are what stop the tiers
 # collapsing back into one in either direction. Collapsing UP puts the outage
-# back. Collapsing DOWN promotes a release to GitHub Latest with no first-contact
-# proof, which is the 2026-08-20 failure this whole gate exists for.
+# back: a release the stranger cannot reach is held off Latest indefinitely
+# while every machine signal is green.
+#
+# Collapsing DOWN is subtler than it was, because promoting without a stranger
+# record is now the INTENDED behaviour. What must not collapse is the label. The
+# 2026-08-20 failure was a release promoted to Latest with no PREFLIGHT record
+# and no stranger run on its bytes, and nothing anywhere saying so; the machine
+# proof is still required and the missing first-contact record still has to be
+# stated on the release, in the mint's summary and in the promote summary. A
+# release that is unmeasured and silent about it is the failure. A release that
+# is unmeasured and says so is the design.
 #
 # Every assertion reads active lines, never raw text, because each of these
 # files carries prose ABOUT the thing being asserted and a check satisfied by
@@ -1230,6 +1241,56 @@ def assert_the_mint_lists_preflight_only_candidates(release_tag: str) -> None:
             "release-tag.yml computes a stranger state and reads it back "
             "nowhere, so a release minted without first-contact proof is "
             "indistinguishable from one that has it"
+        )
+
+
+def assert_the_hosted_stranger_never_reddens_the_rail(release_cut: str) -> None:
+    """A nice-to-have must not be able to fail a release run.
+
+    Founder decision, 2026-09-04: "the damn smoke should never block release it
+    is a nice to have ONLY ... it should be mainly run locally not in the CI."
+    A driver out of limit, an offline runner or a container that would not start
+    is not a fact about the candidate, and a red cut run for any of them is a
+    rail that looks broken while behaving exactly as designed.
+
+    The second half is the trap that makes the first half dangerous.
+    `continue-on-error` masks `needs.<job>.result` to 'success' for every
+    downstream job, including one whose upstream failed. The record publisher
+    therefore has to key on the stranger job's own output, which is written only
+    after a record exists on disk. Keyed on `.result` under this flag it would
+    run over a failed arm and publish nothing while reporting success.
+    """
+
+    jobs = workflow_job_blocks(release_cut)
+    for name in ("stranger", "publish-stranger"):
+        if name not in jobs:
+            raise AssertionError(f"release-cut.yml no longer declares a {name} job")
+    block = jobs["stranger"]
+    if "continue-on-error: true" not in block:
+        raise AssertionError(
+            "release-cut.yml's stranger job can redden the cut run; it is a "
+            "nice-to-have and must carry continue-on-error: true"
+        )
+
+    publisher = "\n".join(active_lines(jobs["publish-stranger"].split("\n    steps:", 1)[0]))
+    if "needs.stranger.result" in publisher:
+        raise AssertionError(
+            "publish-stranger keys on needs.stranger.result, which "
+            "continue-on-error masks to 'success' even for a failed stranger, "
+            "so it would publish over an arm that produced no record"
+        )
+    if "needs.stranger.outputs.recorded == 'true'" not in publisher:
+        raise AssertionError(
+            "publish-stranger must key on the stranger job's own recorded "
+            f"output, which is written only after a record exists: {publisher}"
+        )
+
+    # Silence is the other way a nice-to-have becomes invisible. A job allowed
+    # to fail has to say what it left behind, in the word this rail acts on.
+    if "pending" not in "\n".join(active_lines(block)).lower():
+        raise AssertionError(
+            "release-cut.yml's stranger job never names the pending state, so a "
+            "cycle that measured nothing leaves no record saying so"
         )
 
 
@@ -16909,6 +16970,23 @@ def main() -> None:
             '            echo "| first contact | recorded |"\n',
             1,
         ): assert_the_mint_records_the_state_it_tagged_on(mutant),
+    )
+    assert_the_hosted_stranger_never_reddens_the_rail(release_cut)
+    expect_assertion(
+        "the hosted stranger can fail a cut run again",
+        "must carry continue-on-error: true",
+        lambda mutant=release_cut.replace("    continue-on-error: true\n", "", 1): (
+            assert_the_hosted_stranger_never_reddens_the_rail(mutant)
+        ),
+    )
+    expect_assertion(
+        "the record publisher trusts a result continue-on-error has masked",
+        "which continue-on-error masks",
+        lambda mutant=release_cut.replace(
+            "needs.stranger.outputs.recorded == 'true'",
+            "needs.stranger.result == 'success'",
+            1,
+        ): assert_the_hosted_stranger_never_reddens_the_rail(mutant),
     )
     assert_the_stranger_labels_a_release_and_never_holds_it(release)
     assert_latest_claims_gate_on_promotion(release)


### PR DESCRIPTION
## What this fixes

FIR-3152, plus the founder's ruling that the stranger must never block a release.

The promoter went blind the moment `release.yml` stopped holding Latest, and nothing said so. `selectCandidates` keyed on `prerelease === true`, which was how a held release was recognised. Once no release was ever a prerelease again, the sweep selected nothing, the pending notice was never stripped, and the missing-proof alarm could not fire because nothing was ever waiting. **v0.6.6 is the first release in exactly that state and it sits there now**, carrying a notice saying nobody measured it, with no path that would ever take the notice back out.

## Two states, two actions

A proven candidate now goes to one of two lists, and the split is not cosmetic.

`promote` is a release still held as a prerelease: npm ordering checks, notice out, flip to Latest, readback. Unchanged.

`clearNotice` is a release already Latest whose record has since landed: notice out, nothing else. Running the promote path on one of those would end in `gh release edit --latest` on whichever tag the sweep reached, which for anything but the newest release is a rollback, and would then fail its own readback assertion.

## The alarm gets a second threshold, not a second issue

A held release is stuck and six hours is the right impatience. A promoted one shipped and is merely unmeasured, which since 2026-09-04 is the normal state of every release the stranger has not reached. One threshold for both would ring on every healthy release six hours after it shipped and train every reader to skim the one issue that matters. Held stays at 360 minutes, promoted gets 1440, and the alarm body gained a `state` column because a table whose rows mean two different things has to say which is which.

## The strip is now coupled to its writer

Every fixture in `read-promotion-plan.test.mjs` built its own copy of the notice text. `release.yml` could reword it, `stripPendingNotice` could stop matching, and the whole suite would stay green while a promoted release kept claiming its proof was pending forever. That wording did change, in #1455. The new case reads the `<<NOTE` heredoc out of the workflow and strips that.

It also asserts the extraction found a notice before comparing anything, because an extraction that silently found nothing would compare two empty values and pass. That is the shape this fleet catalogued at `docs/traps.md` after it printed PASS over a fixture that never built.

## The hosted stranger can no longer redden the rail

Founder, 2026-09-04: "the damn smoke should never block release it is a nice to have ONLY ... it should be mainly run locally not in the CI."

`release-cut.yml`'s stranger job takes `continue-on-error: true` and writes a summary line naming the state whatever happened. A driver out of limit, an offline runner or a container that would not start is not a fact about the candidate.

**The trap that makes that dangerous, handled:** `continue-on-error` masks `needs.<job>.result` to `success` for every downstream job, including one whose upstream failed. `publish-stranger` gated on `needs.stranger.result == 'success'`, so under the flag alone it would have run over a failed arm and published nothing while reporting success. It now keys on the stranger job's own `recorded` output, which is written only after a record exists on disk.

`docs/release-bot.md` now documents `bin/kin-stranger run --archive` and `--npm` as the ordinary path with the hosted job as the optional convenience. The umbrella's `docs/fleet-operations.md` gets the same in a companion PR.

## Falsification

Every new arm was broken and went red on the exact behavior. Files restored byte-identical afterwards, suites green again.

```
ARM 1  release.yml's notice drifts from what the stripper matches
       not ok - stripPendingNotice strips the notice release.yml actually writes
ARM 2  the heredoc extraction finds nothing (the vacuous-pass shape)
       not ok - error: 'release.yml no longer writes the notice with a <<NOTE heredoc'
ARM 3  selectCandidates keyed on the prerelease flag alone again (the original bug)
       not ok - selectCandidates takes exactly the shape this design creates
ARM 4  an already-Latest release sent down the promote path (the rollback)
       not ok - a proven release that is already Latest is cleared, never re-promoted
ARM 5  one threshold for both states
       not ok - a promoted release gets a longer fuse than a held one
```

Arms 6 and 7 live in the authority suite as `expect_assertion` arms and run on every invocation: removing `continue-on-error` from the stranger job, and pointing `publish-stranger` back at `needs.stranger.result`.

## Gates run locally

```
node --test release-promotion-plan + read-promotion-plan   # tests 35  pass 35  fail 0   (was 30)
python3 scripts/test-release-workflow-authority.py         green, including the two new arms
ruby -ryaml                                                release-cut, release-promote, release.yml all parse
```

`bin/kin-precheck kin` is running as this opens; its tail goes in a comment. No Rust is touched.
