### PR TITLE
chore(deps): take kin-db 0.7.99, re-audit StorageBackend bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3289,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.96"
+version = "0.7.99"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "41bce744e7356004b6fd20c90160b574541bad99ce7c72434a193fa01257dc5e"
+checksum = "ff013aeff1ef286d8b2e94f7b5b05c34eea0e67feb88791e3bbdab085be34e0d"
 dependencies = [
  "bincode",
  "bstr",
@@ -3433,9 +3433,9 @@ dependencies = [
 
 [[package]]
 name = "kin-lsp"
-version = "0.7.13"
+version = "0.7.15"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "52dc1c2bb5ea9d02e67986f5d352b4b9cc9f4fafb1892e5e17dc3bb0afa674e1"
+checksum = "d18327f9d339f945a8672200af0aa001cf5bdc05c205b1fcad82a5e207fd6b53"
 dependencies = [
  "kin-model",
  "serde",
@@ -3508,9 +3508,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.23"
+version = "0.7.25"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "f8fa9147250a6ed0344f4b4d6e9503972f3a119d8034e26a23728b2d5baa62a2"
+checksum = "98ff1636777b36969b9723a20d8dd337a0e17261747fdb27eefd9a500cdff566"
 dependencies = [
  "chrono",
  "gix-hash",
@@ -3763,9 +3763,9 @@ dependencies = [
 
 [[package]]
 name = "kin-vector"
-version = "0.1.12"
+version = "0.2.0"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "455de2428eef80e8496e1963a24a8469ca3c15702dc4bfb46bd5182e1f3bdda3"
+checksum = "2c279bb634aa149fca1e862d4d0e43345409fa2103ecfd644f767ca5f3e51bb2"
 dependencies = [
  "fs2",
  "hashbrown 0.15.5",
@@ -6671,7 +6671,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ pretty_assertions = "1"
 serial_test = "4"
 
 # Internal crates
-kin-model = { version = "=0.7.23", registry = "kin" }
+kin-model = { version = "=0.7.25", registry = "kin" }
 kin-blobs = { version = "=0.1.5", registry = "kin" }
 kin-core = { path = "crates/kin-core" }
 kin-parser = { path = "crates/kin-parser" }
@@ -152,13 +152,13 @@ kin-daemon-spawn = { path = "crates/kin-daemon-spawn" }
 kin-mcp = { path = "crates/kin-mcp" }
 kin-spine = { path = "crates/kin-spine" }
 kin-registry = { path = "crates/kin-registry" }
-kin-lsp = { version = "=0.7.13", registry = "kin" }
+kin-lsp = { version = "=0.7.15", registry = "kin" }
 # Cross-platform base: NO "metal" here. `[workspace.dependencies]` entries cannot be
 # `[target.'cfg(...)']`-gated, so listing "metal" here forces the macOS-only kin-infer/metal
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.96", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.99", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.24", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-daemon/src/storage_delegate.rs
+++ b/crates/kin-daemon/src/storage_delegate.rs
@@ -62,7 +62,7 @@ use kin_db::{
 /// `storage_backend_surface_is_audited_against_the_pinned_kin_db` fails when
 /// the workspace pin moves past it, which is the only moment a method can have
 /// appeared.
-pub const AUDITED_KIN_DB_VERSION: &str = "0.7.96";
+pub const AUDITED_KIN_DB_VERSION: &str = "0.7.99";
 
 /// Wraps a [`StorageBackendDelegate`] so it can be handed anywhere a
 /// `Box<dyn StorageBackend>` is expected.


### PR DESCRIPTION
Takes the same registry pins the dependency wave (#1444) moves: kin-db 0.7.96 -> 0.7.99, kin-lsp 0.7.13 -> 0.7.15, kin-model 0.7.23 -> 0.7.25 (kin-vector 0.1.12 -> 0.2.0 transitively through kin-db). #1444 fails `Fast gate test shard (3)` on `storage_backend_surface_is_audited_against_the_pinned_kin_db`, a deliberate tripwire in `crates/kin-daemon/src/storage_delegate.rs` that fires on any kin-db pin move until a human re-reads kin-db's `StorageBackend` trait and confirms the forwarding table is still complete.

I read it. kin-db 0.7.96 and 0.7.99's `src/storage/backend.rs`, the file that defines the trait, are byte-for-byte identical: same 32 methods, nothing added or renamed. kin-db 0.7.97-0.7.99 (kin-db#289, #294, #296) changed a persisted-identity test, added v3 kvec container read support, and moved the kin-vector pin, none of which touch `StorageBackend`. So this is not a dependency defect and not a missing table row, it's an unbumped literal. This PR bumps `AUDITED_KIN_DB_VERSION` to "0.7.99" alongside the pin moves, since the literal and the pin have to move together or the test fails in the other direction.

Testing:
- Reproduced #1444's failure locally on this exact dependency graph before the fix (same panic and assertion text as CI).
- `cargo test -p kin-daemon storage_delegate::` green after the fix (both audit tests).
- `cargo test -p kin-daemon` green (full crate suite).
- `bin/kin-precheck kin` green (fmt, clippy, 3 nextest shards, doctests, guards).
