### PR TITLE
Publish one cross-repo edge per identity so the hosted daemon can publish its spine

### DIFF
--- a/crates/kin-spine/src/xref.rs
+++ b/crates/kin-spine/src/xref.rs
@@ -329,6 +329,26 @@ pub(crate) fn materialized_edges(
         }
     }
 
+    // One durable edge per (src_repo, src_entity, dst_repo, dst_entity). A source entity
+    // that imports the same symbol twice, or reaches one target through both an exact and
+    // an ambiguous resolution, yields identical identities, and the publication validator
+    // refuses a duplicate. Keep one edge per identity, the highest confidence seen, in a
+    // deterministic order.
+    edges.sort_by(|left, right| {
+        left.src_repo
+            .cmp(&right.src_repo)
+            .then_with(|| left.src_entity.cmp(&right.src_entity))
+            .then_with(|| left.dst_repo.cmp(&right.dst_repo))
+            .then_with(|| left.dst_entity.cmp(&right.dst_entity))
+            .then_with(|| right.confidence.total_cmp(&left.confidence))
+    });
+    edges.dedup_by(|later, kept| {
+        later.src_repo == kept.src_repo
+            && later.src_entity == kept.src_entity
+            && later.dst_repo == kept.dst_repo
+            && later.dst_entity == kept.dst_entity
+    });
+
     edges
 }
 
@@ -1251,6 +1271,62 @@ mod tests {
             matches!(results[0].1, ResolveResult::NotFound),
             "import naming kin_db must not bind a kin-vfs name collision, got {:?}",
             results[0].1
+        );
+    }
+
+    #[test]
+    fn materialized_edges_keep_one_edge_per_identity_with_the_highest_confidence() {
+        let source_entity = EntityId::new();
+        let target_entity = EntityId::new();
+        let import = |name: &str| UnresolvedImport {
+            source_repo: "kin".to_string(),
+            source_entity,
+            imported_name: name.to_string(),
+            imported_kind: Some(EntityKind::Class),
+            candidate_repos: vec!["kin-db".to_string()],
+            language: Some("rust".to_string()),
+            reference_fingerprint: None,
+            import_source: None,
+        };
+        let imports = vec![import("Graph"), import("Graph"), import("Graph")];
+        let resolutions = vec![
+            (
+                0usize,
+                ResolveResult::Resolved {
+                    target_repo: "kin-db".to_string(),
+                    target_entity,
+                    confidence: 0.6,
+                },
+            ),
+            (
+                1usize,
+                ResolveResult::Ambiguous {
+                    candidates: vec![("kin-db".to_string(), target_entity, 0.9)],
+                },
+            ),
+            (
+                2usize,
+                ResolveResult::Resolved {
+                    target_repo: "kin-db".to_string(),
+                    target_entity,
+                    confidence: 0.7,
+                },
+            ),
+        ];
+
+        let edges = materialized_edges(&imports, &resolutions);
+
+        assert_eq!(
+            edges.len(),
+            1,
+            "one identity must publish as one edge: {edges:?}"
+        );
+        assert_eq!(edges[0].src_entity, source_entity);
+        assert_eq!(edges[0].dst_entity, target_entity);
+        assert!(
+            (edges[0].confidence - 0.9).abs() < f32::EPSILON,
+            "the kept edge carries the highest confidence: {}",
+            edges[0].confidence
         );
     }
 }


### PR DESCRIPTION
Resolves the production refusal in FIR-3167: the v0.6.6 daemon loaded every hosted repo and then refused to publish with `prepare GCS-bound durable spine publication: serialization error: publication for repo kin contains a duplicate cross-repo edge`, so it never became Ready and the hop rolled back.

## Mechanism

`SpineIndex::derive_cross_repo_edges` builds edges through `xref::materialized_edges`, which pushed one `CrossRepoEdge` per resolution. A source entity that imports the same symbol twice, or reaches one target through both an exact and an ambiguous resolution, yields two edges whose identity `(src_repo, src_entity, dst_repo, dst_entity)` is identical. `RepoSpinePublication::into_canonical` (the validator added in #1227 on 2026-08-29) refuses a duplicate identity, so every daemon built since #1227 fails on a store whose imports have that shape; the Aug 27 daemon production runs (d6b61e55) predates the validator and publishes.

## Fix

`materialized_edges` now sorts by identity, then confidence descending, and deduplicates by identity, so one edge per identity survives carrying the highest confidence seen, in a deterministic order. The validator is unchanged and still refuses a hand-built duplicate.

## Test and falsification

`materialized_edges_keep_one_edge_per_identity_with_the_highest_confidence`: three resolutions (exact 0.6, ambiguous 0.9, exact 0.7) from one source entity to one target yield exactly one edge at 0.9. With the dedupe block removed the test goes red:

```
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 116 filtered out
ARM rc=101 (must be non-zero)
```

## Gates run locally (heavy-slot, lane worktree spinecap-kin)

```
cargo fmt -p kin-spine -- --check          FMT_OK
cargo clippy -p kin-spine --all-targets --all-features -- <ci allow list, 45 lints>   rc=0
cargo test -p kin-spine                     117 passed; 0 failed / 19 passed; 0 failed
```

The full `bin/kin-precheck kin` gate list was not run locally; hosted CI is the gate of record.

## After landing

The kin-build trigger publishes `kin-ecosystem/kin-daemon:<this squash>`; record its row in kin-infra (`hosted-daemon-images.py record`) and re-run the hop with the snapshot copy refreshed. The second outage in FIR-3167 (the old daemon not passing its startup probe under kinlab #409's promotion) is not addressed here.
