### PR TITLE
Render the stranger's two-stage command everywhere a reader is told to type it

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -813,9 +813,11 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${RECORDED:-}" = true ]; then
-            echo "### First contact measured for \`${CANDIDATE}\`" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "The three arms completed and the record is on its way to the evidence branch." >> "$GITHUB_STEP_SUMMARY"
+            {
+              echo "### First contact measured for \`${CANDIDATE}\`"
+              echo ""
+              echo "The three arms completed and the record is on its way to the evidence branch."
+            } >> "$GITHUB_STEP_SUMMARY"
             echo "::notice::stranger completed for ${CANDIDATE}"
           else
             {
@@ -827,10 +829,13 @@ jobs:
               echo "what a first-time user meets."
               echo ""
               echo "To measure it, run the stranger locally against the archive or the published"
-              echo "npm bytes, which is the ordinary path:"
+              echo "npm bytes, which is the ordinary path. Two stages, both taking the same"
+              echo "\`--run\` id; the two \`run\` lines are alternatives, not a sequence:"
               echo ""
               echo '```'
-              echo "bin/kin-stranger run --npm <version>      # what a stranger who types the install line gets"
+              echo "bin/kin-stranger prepare --run <id> --arms green,brown,vcs"
+              echo "bin/kin-stranger run --run <id> --archive <path> --candidate-sha <sha>   # the candidate bytes"
+              echo "bin/kin-stranger run --run <id> --npm <version>     # or the published npm bytes instead"
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
             echo "::notice::stranger left no record for ${CANDIDATE}; first contact stays pending and nothing is held"

--- a/docs/release-bot.md
+++ b/docs/release-bot.md
@@ -169,11 +169,20 @@ gh secret set KIN_STRANGER_ANTHROPIC_API_KEY --repo firelock-ai/kin
 decision, 2026-09-04: "the damn smoke should never block release it is a nice to
 have ONLY ... it should be mainly run locally not in the CI." The ordinary way to
 measure first contact is `bin/kin-stranger` from the umbrella, against the
-candidate archive before a tag or the published npm bytes after one:
+candidate archive before a tag or the published npm bytes after one.
+
+It is two stages and both take the same `--run` id. `prepare` builds or reuses the
+image and creates one container per arm; `run` drives both phases against whichever
+source you name. `run` refuses without a run id, so the one-line form does not work
+and never did. Archive mode also refuses without a candidate sha unless the archive's
+own `.provenance.json` names one, and it refuses AFTER staging the archive into the
+container, so leaving it out costs a prepared run. npm mode needs no sha. The two
+`run` lines below are alternatives, not a sequence:
 
 ```
-bin/kin-stranger run --archive <path>   # the release-candidate bytes
-bin/kin-stranger run --npm <version>    # what a stranger who types the install line gets
+bin/kin-stranger prepare --run <id> --arms green,brown,vcs
+bin/kin-stranger run --run <id> --archive <path> --candidate-sha <sha>   # the candidate bytes
+bin/kin-stranger run --run <id> --npm <version>     # or the published npm bytes instead
 ```
 
 The hosted job in `release-cut.yml` is a convenience that runs the same tool on a

--- a/scripts/test-select-release-candidate.py
+++ b/scripts/test-select-release-candidate.py
@@ -41,6 +41,7 @@ SELECTOR_PATH = ROOT / "scripts" / "select-release-candidate.py"
 CUT_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "release-cut.yml"
 RELEASE_TAG_PATH = ROOT / ".github" / "workflows" / "release-tag.yml"
 RC_BUILD_PATH = ROOT / ".github" / "workflows" / "rc-build.yml"
+RELEASE_BOT_DOC = ROOT / "docs" / "release-bot.md"
 REPO = "firelock-ai/kin"
 VERSION = "0.6.5"
 NEWEST = "a" * 40
@@ -993,6 +994,119 @@ class TriggerTests(unittest.TestCase):
 # ---------------------------------------------------------------------------
 # Contracts against the mint and the workflow.
 # ---------------------------------------------------------------------------
+
+
+class StrangerCommandRenderingTests(unittest.TestCase):
+    """Every public instruction renders the two-stage form, and nothing renders the old one.
+
+    `bin/kin-stranger run` REFUSES without `--run <id>`, and the run id comes from
+    `prepare`, so a one-line `run --archive <path>` is not a shortcut, it is a
+    command that cannot work. Two places told a reader to type exactly that:
+    `docs/release-bot.md` and the summary `release-cut.yml` writes when the
+    hosted stranger leaves no record. Both were added by this lane on
+    2026-09-04 and both were wrong the moment they shipped.
+
+    The rendering lives in two files that cannot share a string, one Markdown
+    and one shell heredoc, so the coupling is asserted here instead.
+    """
+
+    #: The one shape a reader may be handed. `prepare` first, and every `run`
+    #: carrying the same `--run` id.
+    PREPARE = "bin/kin-stranger prepare --run"
+    RUN = "bin/kin-stranger run --run"
+
+    def rendered_lines(self, text: str) -> list[str]:
+        """Every kin-stranger command line in a file, stripped of shell quoting."""
+
+        lines = []
+        for raw in text.splitlines():
+            stripped = raw.strip()
+            # A workflow renders its lines through `echo "..."`; a doc renders
+            # them bare. Take the payload either way.
+            match = re.fullmatch(r"""echo ["'](.*)["']""", stripped)
+            if match:
+                stripped = match.group(1)
+            if "bin/kin-stranger " in stripped and not stripped.startswith("#"):
+                lines.append(stripped)
+        return lines
+
+    def command_lines(self, text: str) -> list[str]:
+        """Only the lines that render a command, not prose that names the tool."""
+
+        return [
+            line
+            for line in self.rendered_lines(text)
+            if re.search(r"bin/kin-stranger (prepare|run|resume) ", line)
+        ]
+
+    def test_the_doc_and_the_cut_summary_render_the_same_block(self) -> None:
+        doc = self.command_lines(RELEASE_BOT_DOC.read_text(encoding="utf-8"))
+        cut = self.command_lines(CUT_WORKFLOW_PATH.read_text(encoding="utf-8"))
+        # The summary renders the same three lines the doc does. Anything the
+        # workflow renders beyond them belongs to the standby job or to the job
+        # actually driving the tool, which are not this assertion's business.
+        self.assertTrue(doc, "docs/release-bot.md renders no kin-stranger command at all")
+        for line in doc:
+            self.assertIn(
+                line,
+                cut,
+                "the cut summary and the doc have drifted; a reader is handed two "
+                f"different commands for the same job: {line!r}",
+            )
+
+    def test_every_rendered_run_carries_a_run_id(self) -> None:
+        """The defect itself. `run` without `--run` is refused by the tool."""
+
+        for path in (RELEASE_BOT_DOC, CUT_WORKFLOW_PATH, SELECTOR_PATH):
+            for line in self.command_lines(path.read_text(encoding="utf-8")):
+                if "bin/kin-stranger run" not in line:
+                    continue
+                self.assertIn(
+                    self.RUN,
+                    line,
+                    f"{path.name} renders a run with no --run id, which the tool "
+                    f"refuses: {line!r}",
+                )
+
+    def test_a_rendered_run_is_always_preceded_by_a_prepare(self) -> None:
+        """A run id has to come from somewhere, and `prepare` is the only source."""
+
+        for path in (RELEASE_BOT_DOC, CUT_WORKFLOW_PATH):
+            lines = self.command_lines(path.read_text(encoding="utf-8"))
+            seen_prepare = False
+            for line in lines:
+                if line.startswith(self.PREPARE):
+                    seen_prepare = True
+                    continue
+                if line.startswith(self.RUN):
+                    self.assertTrue(
+                        seen_prepare,
+                        f"{path.name} renders a run before any prepare, so the run "
+                        f"id it names was never created: {line!r}",
+                    )
+
+    def test_the_selector_still_renders_the_two_stage_form(self) -> None:
+        """The positive control, and the shape the other two were corrected to.
+
+        `stranger_command` has rendered prepare-then-run since it was written.
+        If this ever goes red the needles above are wrong rather than the tree.
+        """
+
+        command = selector.stranger_command(VERSION, MIDDLE, 34_000_000_001)
+        rendered = command.splitlines()
+        self.assertTrue(
+            any(line.startswith(self.PREPARE) for line in rendered),
+            f"the selector stopped rendering a prepare line: {command}",
+        )
+        self.assertTrue(
+            any(line.startswith(self.RUN) for line in rendered),
+            f"the selector stopped rendering a run with a run id: {command}",
+        )
+        self.assertLess(
+            next(i for i, l in enumerate(rendered) if l.startswith(self.PREPARE)),
+            next(i for i, l in enumerate(rendered) if l.startswith(self.RUN)),
+            f"the selector renders run before prepare: {command}",
+        )
 
 
 class ContractTests(unittest.TestCase):


### PR DESCRIPTION
## What this fixes

`bin/kin-stranger run` refuses without a `--run` id, and the id comes from `prepare`. Two places told a reader to type the one-line form, so both were commands that cannot work:

```
docs/release-bot.md:175      bin/kin-stranger run --archive <path>
release-cut.yml summary      bin/kin-stranger run --npm <version>
```

This lane added both on 2026-09-04 and both were wrong the moment they shipped. The two renderings that were already correct, `stranger_command` in the selector and the `stranger-standby` summary, both render prepare then run and served as the positive control.

## The second defect, found only by running it

Cold-executing the corrected sequence against the real v0.6.6 archive refused again:

```
REFUSED: no candidate commit for this archive run: --candidate-sha was not given and the
archive's provenance carries no kin commit.
RC=65
```

Archive mode needs `--candidate-sha` unless the archive's own `.provenance.json` names a commit, and it refuses **after** staging the archive into the container, so omitting it costs a prepared run rather than failing at the door. Confirmed in the harness source at the refusal site, which is guarded on `[ "$mode" = archive ]`, so npm mode is exempt.

Reading would not have caught this. Running what we publish did.

## What every public instruction renders now

Identical in the doc and in the workflow summary, word for word:

```
bin/kin-stranger prepare --run <id> --arms green,brown,vcs
bin/kin-stranger run --run <id> --archive <path> --candidate-sha <sha>   # the candidate bytes
bin/kin-stranger run --run <id> --npm <version>     # or the published npm bytes instead
```

The doc also says why: `run` refuses without a run id, archive mode refuses without a sha and does so after staging, npm mode needs neither, and the two `run` lines are alternatives rather than a sequence.

## Cold execution, recorded

Run from a `kin-ecosystem` worktree at `cb4967dd3` (carries the landed harness fix), against `kin-linux-aarch64.tar.gz` downloaded from the v0.6.6 GitHub Release with its `.sha256` verified (`shasum -a 256 -c` prints OK).

```
bin/kin-stranger prepare --run rc066-strangermint-smoke-1603 --arms green
  RC=0, 1s
  "prepared. Next: kin-stranger run --run rc066-strangermint-smoke-1603 --archive <path> | --npm <version>"

bin/kin-stranger run --run rc066-strangermint-smoke-1603 \
  --archive /tmp/strangermint-v066/kin-linux-aarch64.tar.gz \
  --candidate-sha 7d4ba06633a735e8af23909b8097801e5233f930 --arms green --smoke
  archive sha256 c1245cfe... verified against its .sha256
  candidate_sha 7d4ba06633a735e8af23909b8097801e5233f930
  green launched, run root /Users/Shared/kin-stranger/rc066-strangermint-smoke-1603
```

`prepare`'s own next-step line renders the same two-stage form this PR writes into the docs, which is an independent confirmation of the shape. Exploration run, never publishable: `--arms green` alone is a subset and `--smoke` swaps in a plumbing mission. No gpu lock was requested at any point. Wall time and final rc go in a comment when the arm finishes.

## Falsification

Four arms, each red on the exact behavior, all files restored byte-identical, suite green after.

```
ARM 1  the doc returns to the prior one-line form
       FAIL test_every_rendered_run_carries_a_run_id
       AssertionError: 'bin/kin-stranger run --run' not found in 'bin/kin-stranger run --archive <path> ...'
ARM 2  the doc drops its prepare line
       FAIL test_a_rendered_run_is_always_preceded_by_a_prepare
       AssertionError: release-bot.md renders a run before any prepare, so the run id it names was never created
ARM 3  the cut summary drifts from the doc
       FAIL test_the_doc_and_the_cut_summary_render_the_same_block
       FAIL test_every_rendered_run_carries_a_run_id
ARM 4  the positive control loses its prepare line
       FAIL test_the_selector_still_renders_the_two_stage_form
```

The doc and the workflow cannot share a string, one being Markdown and one a shell heredoc, so the coupling is asserted in the test rather than in the source.

## Sweep, with a positive control

```
$ git grep -nE 'kin-stranger run --(archive|npm)' -- .      # the prior form
rc=1, no hits

$ git grep -c 'kin-stranger run --run' -- .                 # the correct form, so the search sees these files
release-cut.yml:4  release-bot.md:2  select-release-candidate.py:1  test-select-release-candidate.py:1
```

No README or other markdown renders the command.

## Gates

```
python3 scripts/test-select-release-candidate.py     Ran 75 tests, OK   (was 71)
python3 scripts/test-release-workflow-authority.py   green
actionlint .github/workflows/release-cut.yml         clean
```

actionlint also flagged SC2129 on three ungrouped redirects this lane added in its previous change; grouped, and the lint is clean. `bin/kin-precheck kin` is running as this opens; its tail goes in a comment.
