### PR TITLE
Refuse a commit while a merge transaction is open (FIR-3171)

### DIFF
--- a/crates/kin-cli/tests/repository_merge_resolution.rs
+++ b/crates/kin-cli/tests/repository_merge_resolution.rs
@@ -901,6 +901,68 @@ fn a_second_merge_while_one_is_in_progress_is_refused() {
     assert!(record.state.is_in_progress());
 }
 
+/// A commit cannot publish around a parked merge. Forced admission advances
+/// the workspace generation, so allowing the commit would make the recorded
+/// restore point stale and strand every resolution already carried by it.
+#[test]
+fn a_commit_while_a_merge_is_in_progress_is_refused_before_admission() {
+    let root = tempdir().expect("temp root");
+    let repo = conflicting_repository(root.path());
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    let layout = initialize_kin_repo(&runtime, &repo);
+
+    parked_merge(
+        &run_kin(&runtime, &repo, &["merge", "feature"]),
+        "kin merge",
+    );
+    let main_before = branch_change(&layout, "main");
+    let parked = persisted_record(&layout).expect("the merge is parked");
+    let parked_hash = hex::encode(parked.hash.as_bytes());
+    let hand_authored = b"pub fn hand_authored_resolution(value: u64) {}\n";
+    fs::write(repo.join("src/lib.rs"), hand_authored).expect("write a hand-authored resolution");
+
+    let refused = run_kin(
+        &runtime,
+        &repo,
+        &["commit", "-m", "hand-authored merge resolution"],
+    );
+    assert!(
+        !refused.status.success(),
+        "commit must not publish around an open merge: stdout={} stderr={}",
+        String::from_utf8_lossy(&refused.stdout),
+        String::from_utf8_lossy(&refused.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&refused.stderr);
+    assert!(
+        stderr.contains("HTTP 409 Conflict"),
+        "the open transaction is a conflict rather than a daemon fault: {stderr}"
+    );
+    assert!(
+        stderr.contains(&parked_hash),
+        "the refusal names the exact merge transaction: {stderr}"
+    );
+    assert!(
+        stderr.contains("kin resolve --do-continue") && stderr.contains("kin resolve --abort"),
+        "the refusal names both ways out of the open transaction: {stderr}"
+    );
+
+    assert_eq!(
+        branch_change(&layout, "main"),
+        main_before,
+        "the refused commit does not move the target branch"
+    );
+    assert_eq!(
+        persisted_record(&layout),
+        Some(parked),
+        "the refusal happens before admission and leaves the exact merge record intact"
+    );
+    assert_eq!(
+        fs::read(repo.join("src/lib.rs")).expect("read the authored resolution"),
+        hand_authored,
+        "the refusal preserves the operator's working-copy resolution"
+    );
+}
+
 /// Settling names one identity at a time, and a name that matches nothing is
 /// refused rather than quietly settling the wrong conflict.
 #[test]

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -223,8 +223,9 @@ pub(crate) struct ProjectionAuthorityCache {
     held: std::sync::Mutex<Option<HeldProjectionAuthority>>,
     query: std::sync::Mutex<Option<HeldQueryAuthority>>,
     command: std::sync::Mutex<Option<HeldCommandAuthority>>,
-    /// The admission pair every reconcile task needs, which is not a fourth
-    /// wrapper over the authority but two small values read out of one.
+    /// The admission values every reconcile task needs, plus the small
+    /// open-merge summary a commit gate needs. This is not a fourth wrapper
+    /// over the authority, only values read out of one.
     ///
     /// `current_authority_admission` wants a root bundle and a compiled
     /// admission matcher, and neither can differ between tasks inside one
@@ -277,6 +278,7 @@ struct HeldAdmission {
     published: LocalPublicationIdentity,
     roots: kin_model::RootBundle,
     policy: Option<kin_index::ResolvedAdmissionMatcher>,
+    open_merge: Option<crate::repository_merge_state::OpenMergeSummary>,
 }
 
 impl ProjectionAuthorityCache {
@@ -336,30 +338,15 @@ impl ProjectionAuthorityCache {
         });
     }
 
-    fn reuse_admission(
-        &self,
-        published: &LocalPublicationIdentity,
-    ) -> Option<(
-        kin_model::RootBundle,
-        Option<kin_index::ResolvedAdmissionMatcher>,
-    )> {
+    fn reuse_admission(&self, published: &LocalPublicationIdentity) -> Option<HeldAdmission> {
         lock_recover(&self.admission)
             .as_ref()
             .filter(|held| &held.published == published)
-            .map(|held| (held.roots.clone(), held.policy.clone()))
+            .cloned()
     }
 
-    fn install_admission(
-        &self,
-        published: LocalPublicationIdentity,
-        roots: kin_model::RootBundle,
-        policy: Option<kin_index::ResolvedAdmissionMatcher>,
-    ) {
-        *lock_recover(&self.admission) = Some(HeldAdmission {
-            published,
-            roots,
-            policy,
-        });
+    fn install_admission(&self, admission: HeldAdmission) {
+        *lock_recover(&self.admission) = Some(admission);
     }
 
     fn reuse_command(
@@ -616,15 +603,9 @@ fn command_repository_authority(
 /// at 2.205 seconds, which is what one open costs warm there. Neither value it
 /// reads can differ between tasks inside one publication, so the cost was paid
 /// per arrival for an answer that could not vary.
-pub(crate) fn cached_authority_admission(
+fn cached_authority_admission_entry(
     state: &DaemonState,
-) -> Result<
-    (
-        kin_model::RootBundle,
-        Option<kin_index::ResolvedAdmissionMatcher>,
-    ),
-    (StatusCode, String),
-> {
+) -> Result<HeldAdmission, (StatusCode, String)> {
     let backend = state.local_repository_backend().ok_or_else(|| {
         repository_authority_error("local daemon is missing its startup storage capability")
     })?;
@@ -634,8 +615,8 @@ pub(crate) fn cached_authority_admission(
     let repository_id = binding.repository_id().clone();
 
     let published = read_local_publication_identity(&backend, &repository_id)?;
-    if let Some(pair) = state.projection_authority.reuse_admission(&published) {
-        return Ok(pair);
+    if let Some(admission) = state.projection_authority.reuse_admission(&published) {
+        return Ok(admission);
     }
 
     let _load = lock_recover(&state.projection_authority.load_gate);
@@ -643,8 +624,8 @@ pub(crate) fn cached_authority_admission(
     // waited, and the label installed below must be the one taken before the
     // open it describes.
     let published = read_local_publication_identity(&backend, &repository_id)?;
-    if let Some(pair) = state.projection_authority.reuse_admission(&published) {
-        return Ok(pair);
+    if let Some(admission) = state.projection_authority.reuse_admission(&published) {
+        return Ok(admission);
     }
 
     let context =
@@ -654,20 +635,73 @@ pub(crate) fn cached_authority_admission(
         .open()
         .map_err(|error| repository_authority_error(error.to_string()))?;
     state.projection_authority.record_load();
-    let roots = authority.read_authority().roots().clone();
+    let lease = authority.read_authority();
+    let roots = lease.roots().clone();
+    let open_merge =
+        crate::repository_merge_state::open_merge_summary(&lease, context.workspace_id());
+    drop(lease);
     let policy = authority
         .workspace_admission_snapshot(context.repository_id(), &context.workspace_id())
         .map_err(|error| repository_authority_error(error.to_string()))?
         .map(|snapshot| snapshot.matcher);
+    let admission = HeldAdmission {
+        published,
+        roots,
+        policy,
+        open_merge,
+    };
     state
         .projection_authority
-        .install_admission(published, roots.clone(), policy.clone());
+        .install_admission(admission.clone());
     tracing::debug!(
         repository = %repository_id,
         loads = state.projection_authority.loads(),
         "admission pair loaded"
     );
-    Ok((roots, policy))
+    Ok(admission)
+}
+
+pub(crate) fn cached_authority_admission(
+    state: &DaemonState,
+) -> Result<
+    (
+        kin_model::RootBundle,
+        Option<kin_index::ResolvedAdmissionMatcher>,
+    ),
+    (StatusCode, String),
+> {
+    let admission = cached_authority_admission_entry(state)?;
+    Ok((admission.roots, admission.policy))
+}
+
+fn refuse_commit_during_open_merge(state: &DaemonState) -> Result<(), (StatusCode, String)> {
+    let admission = cached_authority_admission_entry(state)?;
+    let Some(open_merge) = admission.open_merge else {
+        return Ok(());
+    };
+    let resolved_count = open_merge.conflict_count - open_merge.unresolved_count;
+    let completion = if open_merge.unresolved_count == 0 {
+        "publish it with `kin resolve --do-continue`".to_string()
+    } else {
+        format!(
+            "settle its remaining {} conflict(s) with `kin resolve`, then publish it with `kin \
+             resolve --do-continue`",
+            open_merge.unresolved_count
+        )
+    };
+    Err((
+        StatusCode::CONFLICT,
+        format!(
+            "commit refused: merge transaction {} for {} into {} is still open ({} of {} \
+             conflict(s) settled); {completion}, or abandon it with `kin resolve --abort` before \
+             committing",
+            open_merge.transaction,
+            open_merge.source_ref,
+            open_merge.target_ref,
+            resolved_count,
+            open_merge.conflict_count,
+        ),
+    ))
 }
 
 /// Hand a command helper an authority this daemon already resolved.
@@ -6163,6 +6197,10 @@ async fn command_commit(
         state.coordination_gate.lock(),
     )
     .await;
+    // A merge record is bound to the workspace generation that opened it.
+    // Refuse before forced admission can advance that generation and strand
+    // resolutions already persisted on the transaction.
+    refuse_commit_during_open_merge(&state)?;
     // The admission derives the exact tree from the working copy but does not
     // publish it. This commit's own transaction carries that tree transition
     // beside the semantic change, so one repository-authority successor is

--- a/crates/kin-daemon/src/repository_merge_state.rs
+++ b/crates/kin-daemon/src/repository_merge_state.rs
@@ -54,6 +54,41 @@ pub(crate) fn workspace_merge_record(
         .find(|record| record.workspace_id == workspace_id)
 }
 
+/// What a caller needs to refuse around an open merge without carrying the
+/// record: the transaction to name, the two refs it binds, and how much of it
+/// is already settled.
+#[derive(Clone)]
+pub(crate) struct OpenMergeSummary {
+    pub(crate) transaction: String,
+    pub(crate) source_ref: String,
+    pub(crate) target_ref: String,
+    pub(crate) unresolved_count: usize,
+    pub(crate) conflict_count: usize,
+}
+
+/// The merge a workspace still holds open, summarized from an authority lease.
+///
+/// Takes the lease rather than the metadata a caller has already read, so the
+/// accessor stays in this module. Every `.metadata()` here reads a repository-v6
+/// authority lease and returns graph-owned truth, which is the justification
+/// this module carries; the daemon RPC surface is scanned in full because it is
+/// the answer authority, and moving one accessor into the module that owns
+/// merge state is the cheaper of the two ways to keep both statements true.
+pub(crate) fn open_merge_summary(
+    lease: &kin_db::AuthorityReadLease<kin_db::RepositoryAuthorityState>,
+    workspace_id: WorkspaceId,
+) -> Option<OpenMergeSummary> {
+    workspace_merge_record(lease.metadata(), workspace_id)
+        .filter(|record| record.state.is_in_progress())
+        .map(|record| OpenMergeSummary {
+            transaction: record.hash.to_string(),
+            source_ref: record.binding.source_ref.to_string(),
+            target_ref: record.binding.target_ref.to_string(),
+            unresolved_count: record.unresolved().count(),
+            conflict_count: record.entries.len(),
+        })
+}
+
 pub(crate) fn commit_and_freeze_exact(
     manager: &RepositoryAuthorityManager<LocalFileBackend>,
     transaction: RepositoryTransaction,

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -695,13 +695,13 @@
     },
     {
       "file": "crates/kin-daemon/src/repository_merge_state.rs",
-      "reason": "Repository authority lease accessor, not a filesystem probe. Every `.metadata()` in this module is called on a repository-v6 authority lease and returns graph-owned authority metadata: the workspace set, ref state, and operation receipts. It shares a method name with the filesystem metadata probe in the shared deny set, which is the only reason it appears here. The module carries no raw filesystem primitive at all: no read, open, traversal, existence probe, or subprocess. Pinned by exact occurrence count instead of exempting the surrounding function bodies, so every planning and replay path in the module stays scanned and any new `.metadata()` call, filesystem or not, fails the guard until it is re-justified.",
+      "reason": "Repository authority lease accessor, not a filesystem probe. Every `.metadata()` in this module is called on a repository-v6 authority lease and returns graph-owned authority metadata: the workspace set, ref state, and operation receipts. It shares a method name with the filesystem metadata probe in the shared deny set, which is the only reason it appears here. The module carries no raw filesystem primitive at all: no read, open, traversal, existence probe, or subprocess. The third is `open_merge_summary`, which reads the merge-transaction set so the daemon's commit gate can refuse around an open merge; it lives here rather than on the RPC surface because that surface is scanned in full as the answer authority, and moving one lease accessor is cheaper than widening its exemption. Pinned by exact occurrence count instead of exempting the surrounding function bodies, so every planning and replay path in the module stays scanned and any new `.metadata()` call, filesystem or not, fails the guard until it is re-justified.",
       "owner": "kin-daemon",
       "expiration": "2026-12-31",
       "allow_match": [
         {
           "expr": ".metadata()",
-          "count": 2
+          "count": 3
         }
       ]
     },


### PR DESCRIPTION
Refuses `kin commit` while a merge transaction is open, before forced admission can advance the
workspace generation the transaction is bound to. FIR-3171 part one.

## The defect

The v0.6.6 stranger parked a twenty-conflict merge, hand-authored a resolution into the working
copy, and ran `kin commit` to take it. Kin accepted it:

```
$ kin commit -m "hand-authored merge resolution"
Created semantic change 5a6e6de0... on branch 'refs/heads/main' (7 entities, 0 relations, 1 artifacts)
exit 0
```

An ordinary single-parent commit published onto `refs/heads/main` while an unresolved merge
transaction was held against `refs/heads/main`. They then settled all twenty conflicts and the
publish failed:

```
$ kin resolve --do-continue
Error: ... HTTP 409 Conflict and published nothing: workspace 0dd72637-... has moved since this
merge opened, so publishing it would not be the merge that was resolved; abandon it with
`kin resolve --abort` and merge again
```

Twenty settled conflicts, gone. Git refuses the same commit outright with "you have unmerged paths".

## The mechanism

`command_commit` forced filesystem admission before it dispatched repository commit planning. A
merge record is bound to the workspace generation that opened it, so a successful unrelated commit
advanced that generation and made the parked transaction stale. The refusal has to run after the
command coordination gate is taken and before forced admission, which is where this puts it.

The open-merge summary rides in the existing publication-keyed authority admission cache rather than
in a second authority open, so a commit on a repository with no open merge pays nothing new. The
structural counter that proves one complete authority open per publication still passes; it is named
in the evidence below because it is the test that would catch a regression here.

The refusal names the exact transaction, how many of its conflicts are settled, and both ways out.

## Evidence

Every command below ran through the fleet heavy slot against this branch's worktree. Local gate
output is quoted rather than described, because hosted CI does not run any of it.

### The regression fails without the fix

The mutation removes the guard call itself, not an assertion. `crates/kin-daemon/src/api.rs:6222`,
`refuse_commit_during_open_merge(&state)?;`, replaced by a comment. The build proves the mutation
landed rather than being absorbed by a second defence:

```
warning: function `refuse_commit_during_open_merge` is never used
   --> crates/kin-daemon/src/api.rs:696:4
```

```
.kin-coord/bin/heavy-slot.sh vcsedge kin -- bash -c 'cargo build -p kin-daemon --bin kin-daemon \
  && cargo test -p kin-cli --test repository_merge_resolution \
  a_commit_while_a_merge_is_in_progress_is_refused_before_admission -- --nocapture'
```

2026-09-04T16:13:02Z, rc=101:

```
thread 'a_commit_while_a_merge_is_in_progress_is_refused_before_admission' panicked at
crates/kin-cli/tests/repository_merge_resolution.rs:929:5:
commit must not publish around an open merge: stdout=Created semantic change
a38f1506151e5c0af720d7c7844565aba3f7c99d168ea3819c7cb8ffe4dc5afe on branch 'refs/heads/main'
(2 entities, 0 relations, 1 artifacts)
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 25 filtered out; finished in 6.12s
```

The unguarded daemon published a single-parent change onto the merge's own target branch, which is
the reported defect exactly.

### The regression passes with it, and so does the whole merge suite

The guard was restored by the inverse edit rather than by `git checkout --`, and
`git status --porcelain` printed nothing afterwards, so the tree went back to exactly these bytes.
The daemon was rebuilt between the two arms on purpose: the CLI fixture's compatibility probe keys
on commit build identity and will accept a previously built daemon when only dirty source differs,
so a CLI-only rerun would have graded the old bytes.

```
.kin-coord/bin/heavy-slot.sh vcsedge kin -- bash -c 'cargo build -p kin-daemon --bin kin-daemon \
  && cargo test -p kin-cli --test repository_merge_resolution -- --nocapture'
```

2026-09-04T16:15:37Z, rc=0:

```
test a_commit_while_a_merge_is_in_progress_is_refused_before_admission ... ok
test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 25.10s
```

That suite covers the new refusal beside restart durability, stale identity, concurrent settlement,
completion, abort, path collision and the non-user semantic move.

### Whole crates

`cargo test -p kin-daemon` (2026-09-04T15:17:03Z) exited 0 with the daemon library reporting 1,368
passed, 0 failed and 3 ignored measurement cases, and every daemon integration binary passing.
`cargo test -p kin-cli` (15:22:41Z) exited 0 across the library and every CLI integration binary.
The structural counter that would catch a second authority open,
`the_admission_pair_costs_one_open_per_publication`, passed on its own at 15:11:02Z: the open-merge
summary rides in the existing publication-keyed cache, so a commit on a repository with no open
merge pays nothing new.

### Parity, both runs

`bin/kin-parity` resolved and printed the tree before grading it: checkout
`.kin-coord/worktrees/vcsedge-kin`, head `13bdf2f9738c4898e98bb22b8002faba3036b789`, branch
`chore/lane-vcsedge-kin`, `dirty False`. Release build exited 0 in 696.0s and the binary stamps the
checkout's own HEAD.

First run, 15:53:29Z:

```
kin-parity: magic       PASS                          26 pass / 0 fail / 0 unreadable
kin-parity: brownfield  FAIL                  479.0s  10 pass / 1 fail / 1 unreadable
kin-parity: firstrun    PASS-WITH-ALLOWANCES  104.6s   9 pass / 2 fail / 0 unreadable
kin-parity: FINAL FAIL in 1435.0s  (NON-CITABLE)
```

Both first-run failures are on parity's own allowance list by name (FIR-2580, and FIR-2501 for the
FIR-2554 doctor projection row), as is brownfield check 4 (FIR-2464). The one unallowed red was
brownfield check 9, FIR-2639: "2 staging path(s) survived the re-run unreferenced".

That check is load-sensitive, not this change. It PASSED at this exact head 28 minutes earlier in
another lane's run (`.kin-coord/parity/20260904T152544Z/parity.log:119`) and at
`48f84cd7f206a31464509cd5a135bc0e3e71cd27` on 09-03 (`20260903T002908Z/parity.log:592`), both times
with the sentence "the re-run reclaimed 2.8 MB of staging and said so; nothing is left beside the
repository". The failing run carried a kin-daemon build and a 26-test CLI suite in a second builder
slot while brownfield ran. The check kills `kin init` mid-ladder on a poll and asserts on what the
re-run reclaims, which is exactly the shape that moves under CPU contention.

Second run, same binaries, `--skip-build --only brownfield`, 16:18:08Z, rc=0:

```
CHECK 9 FIR-2639 PASS trend-unknown the re-run reclaimed 2.8 MB of staging and said so; nothing is
  left beside the repository
kin-parity: brownfield  PASS-WITH-ALLOWANCES  423.0s  11 pass / 0 fail / 1 unreadable
kin-parity: FINAL PASS-WITH-ALLOWANCES in 423.5s  (NON-CITABLE)  allowances: brownfield/4 FIR-2464
```

Both runs are here rather than only the second, because a reader who sees only the pass cannot tell
a flake that was chased down from one that was never seen.

### Precheck, and the gate it caught

The first run, on the pre-repair commit, was red on one gate, and it was right:

```
FAIL     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py  (exit 1)
         | [VIOLATION] crates/kin-daemon/src/api.rs contains forbidden filesystem access:
         |   Line  650: lease.metadata(), (filesystem metadata probe)
         |   Line 8861: .metadata() (filesystem metadata probe)
         | Allowlist validation FAILED:
         |   entry crates/kin-daemon/src/api.rs allow_match '.metadata()' occurs 2 times in
         |   scanned code (want 1)
```

`lease.metadata()` reads a repository-v6 authority lease and returns graph-owned truth, not a
filesystem probe, but it shares a method name with one in the deny set, so the allowlist pins the
exact occurrence count per file and any new call has to be re-justified. This change had added the
second one to the daemon RPC surface.

The repair is in the diff, above, and it is not a bump on `api.rs`. That file's own allowlist reason
says it "is the answer authority every agent, editor, and CLI reaches, so it is scanned in full and
only the explicit IO-boundary bodies are excused". `repository_merge_state.rs` already carries a pin
whose reason is "Every `.metadata()` in this module is called on a repository-v6 authority lease and
returns graph-owned authority metadata", and it already owns `workspace_merge_record`, the function
this code was calling. So the accessor moved there as `open_merge_summary(lease, workspace_id)`,
`api.rs` dropped its local struct and now keeps one `.metadata()`, and the merge-state pin goes 2 to
3 with the third named in its reason. It takes no extra authority open: the existing lease is passed
through, and `record_authority_open()` is counted inside
`LocalRepositoryAuthorityContext::open` (`local_repository_authority.rs:64`).

The pin was falsified rather than trusted. At its pre-bump value the guard fails and names the new
call by count:

```
Allowlist validation FAILED:
  entry crates/kin-daemon/src/repository_merge_state.rs allow_match '.metadata()' occurs 3 times
  in scanned code (want 2)
```

and at 3 it passes with its own deny-set self-test green:

```
Deny-set self-test passed: 30 matcher cases (6 negative controls) and 6 binding-learner cases
(2 negative controls).
Verification PASSED: Zero File-Search Invariant holds.
```

The run of record, on this head, 2026-09-04T16:41:51Z, rc=0:

```
kin-precheck: repo=kin tree=.../worktrees/vcsedge-kin sha=b79320b3f22f4660704bc2bc78ebd7c216a1cfc7
              branch=chore/lane-vcsedge-kin
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin b79320b3f22f4660704bc2bc78ebd7c216a1cfc7
```

No unknown script and no DROP, so the gate list is enumerated from this tree's ci.yml rather than
remembered. The merge suite was re-run against the moved accessor and is 26 passed, 0 failed.

## Base

Opened from `chore/lane-vcsedge-kin` at `b79320b3f22f4660704bc2bc78ebd7c216a1cfc7`, a few commits
behind `origin/main` and sharing no file with anything that landed since it was cut. The falsification
arm and the crate runs quoted above were taken on `13bdf2f97`, the same change before the
zero-file-search repair moved one lease accessor between modules; the merge suite was re-run on this
head afterwards and precheck's run of record is on this head.

## What this does not do

This is part one. `kin resolve` still accepts no hand-authored body, so there is no
`--take-worktree` and no `git add` equivalent, and the stale-conflict guidance after an aborted
merge is unchanged. Those stay open on FIR-3171.
