### PR TITLE
Qualify the first-contact answers Kin cannot certify

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -1267,7 +1267,9 @@ fn check_projection_mode() -> HealthCheck {
         }
     };
     let cwd = env::current_dir().unwrap_or_default();
-    let repo_root = kin_core::KinLayout::discover(&cwd)
+    let layout = kin_core::KinLayout::discover(&cwd);
+    let inside_repository = layout.is_some();
+    let repo_root = layout
         .map(|layout| layout.root().to_path_buf())
         .unwrap_or(cwd);
     let report = crate::commands::projection::report_for(
@@ -1278,7 +1280,7 @@ fn check_projection_mode() -> HealthCheck {
     );
     let outside = probe_outside_repo(home_dir().ok().as_deref(), report.shim.engaged);
     let hook = probe_shell_hook(&kin_home, detect_shell(), &report.shim.path);
-    projection_mode_check_for(&report, env::consts::OS, &outside, &hook)
+    projection_mode_check_for_context(&report, env::consts::OS, &outside, &hook, inside_repository)
 }
 
 /// Whether Kin's own shell hook is live in the shell that started this process.
@@ -1939,6 +1941,35 @@ fn projection_mode_check_for(
              available here"
         },
     )
+}
+
+/// Qualify the projection row by whether this doctor run has a repository to
+/// project. Kept as a separate seam so first-contact context can be tested
+/// without asking a fixture to discover the process working directory.
+fn projection_mode_check_for_context(
+    report: &crate::commands::projection::ProjectionReport,
+    os: &str,
+    outside: &OutsideRepoProbe,
+    hook: &ShellHook,
+    inside_repository: bool,
+) -> HealthCheck {
+    let check = projection_mode_check_for(report, os, outside, hook);
+    if !inside_repository && hook.is_live() && matches!(check.status, HealthStatus::Stale) {
+        return HealthCheck::new(
+            "projection_mode",
+            "Projection in force",
+            HealthStatus::Unsupported,
+            format!(
+                "this command is not inside a Kin repository, so there is no repository root for \
+                 the live shell hook to project; the hook itself is live; underlying probe: {}",
+                check.detail
+            ),
+        )
+        .with_platform_note(
+            "Run `kin doctor` from inside the Kin repository whose projection you want to check.",
+        );
+    }
+    check
 }
 
 /// Report staging an interrupted `kin init` left on disk, and where it stopped.
@@ -7975,6 +8006,37 @@ mod tests {
                 .is_some_and(|fix| fix.contains("new interactive shell")),
             "the no-hook fix is still the shell, and it is still the right one: {stale:?}"
         );
+    }
+
+    /// Outside a Kin repository there is no graph-backed root for a live hook
+    /// to project. That is expected context, not a stale install.
+    #[test]
+    fn a_live_hook_outside_a_repository_is_not_an_attention_row() {
+        let mut unbound = correctly_hooked_report();
+        unbound.live.unengaged_here_only = false;
+
+        let outside = projection_mode_check_for_context(
+            &unbound,
+            "macos",
+            &not_probed(),
+            &hook_live(),
+            false,
+        );
+        assert!(
+            matches!(outside.status, HealthStatus::Unsupported),
+            "outside a repository no projection can be in force, got {:?}: {}",
+            outside.status,
+            outside.detail
+        );
+        assert!(!needs_attention(&outside));
+        assert!(outside.detail.contains("not inside a Kin repository"));
+
+        // The falsification control: the same probe from inside a repository
+        // is still stale because its bound root is not serving this process.
+        let inside =
+            projection_mode_check_for_context(&unbound, "macos", &not_probed(), &hook_live(), true);
+        assert!(matches!(inside.status, HealthStatus::Stale));
+        assert!(needs_attention(&inside));
     }
 
     /// The negative controls for the green above. Each one removes a single

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -13196,7 +13196,7 @@ fn readiness_line(report: &crate::commands::health::HealthReport) -> ReadinessLi
     } else {
         "Each row above carries the fix it needs."
     };
-    let sentence = if waiting.len() == 1 {
+    let mut sentence = if waiting.len() == 1 {
         format!("1 check needs attention: {}. {advice}", labels.join(", "))
     } else {
         format!(
@@ -13205,6 +13205,28 @@ fn readiness_line(report: &crate::commands::health::HealthReport) -> ReadinessLi
             labels.join(", ")
         )
     };
+    let pending = waiting
+        .iter()
+        .filter(|check| matches!(check.status, HealthStatus::Pending))
+        .map(|check| check.label.as_str())
+        .collect::<Vec<_>>();
+    if !pending.is_empty() {
+        sentence.push_str(&format!(
+            " Pending rows are expected first-run work: {}.",
+            pending.join(", ")
+        ));
+    }
+    let degraded = waiting
+        .iter()
+        .filter(|check| matches!(check.status, HealthStatus::Degraded))
+        .map(|check| check.label.as_str())
+        .collect::<Vec<_>>();
+    if !degraded.is_empty() {
+        sentence.push_str(&format!(
+            " Degraded rows are host limits: {}.",
+            degraded.join(", ")
+        ));
+    }
     ReadinessLine {
         ready: false,
         severe,
@@ -14161,14 +14183,7 @@ pub async fn doctor(fix: bool, install_language_servers: bool, json: bool) -> Re
     println!();
     print_human_report(&after);
 
-    let still_manual: Vec<&crate::commands::health::HealthCheck> = after
-        .checks
-        .iter()
-        .filter(|c| {
-            !matches!(c.status, crate::commands::health::HealthStatus::Healthy)
-                && c.manual_fix.is_some()
-        })
-        .collect();
+    let still_manual = manual_attention_checks(&after);
     if !still_manual.is_empty() {
         println!();
         println!("Still needs manual steps:");
@@ -14182,6 +14197,19 @@ pub async fn doctor(fix: bool, install_language_servers: bool, json: bool) -> Re
     print_unfinished_repairs(&unfinished);
 
     fix_verdict(&unfinished)
+}
+
+/// Rows the post-fix footer may truthfully call manual work.
+fn manual_attention_checks(
+    report: &crate::commands::health::HealthReport,
+) -> Vec<&crate::commands::health::HealthCheck> {
+    report
+        .checks
+        .iter()
+        .filter(|check| {
+            crate::commands::health::needs_attention(check) && check.manual_fix.is_some()
+        })
+        .collect()
 }
 
 /// Start the daemon for the repo containing the current directory, if any.
@@ -15870,6 +15898,18 @@ mod tests {
             "the printed count must be the tally: tally={attention}, line={}",
             line.sentence
         );
+        assert!(
+            line.sentence
+                .contains("Pending rows are expected first-run work: Embedding model"),
+            "the footer must distinguish expected warming from a broken install: {}",
+            line.sentence
+        );
+        assert!(
+            line.sentence
+                .contains("Degraded rows are host limits: Memory floor"),
+            "the footer must distinguish a host limit from a broken install: {}",
+            line.sentence
+        );
         // The control that keeps the assertion above from passing for any
         // report at all: turn the three rows healthy and the line has to stop
         // counting entirely.
@@ -15896,6 +15936,25 @@ mod tests {
             readiness_line(&ready).ready,
             "{}",
             readiness_line(&ready).sentence
+        );
+    }
+
+    /// The post-fix manual list must use the same attention predicate as the
+    /// summary. An unsupported row can carry a way to opt into an optional
+    /// surface, but that does not make it unfinished repair work.
+    #[test]
+    fn the_post_fix_manual_list_excludes_not_applicable_rows() {
+        let mut optional = check("editor", "Editor extension", HealthStatus::Unsupported);
+        optional.manual_fix = Some("install the optional editor extension".to_string());
+        let mut pending = check("embedding_model", "Embedding model", HealthStatus::Pending);
+        pending.manual_fix = Some("allow the first model download".to_string());
+        let report = HealthReport::from_checks("linux".to_string(), vec![optional, pending]);
+
+        let rows = manual_attention_checks(&report);
+        assert_eq!(
+            rows.iter().map(|row| row.id.as_str()).collect::<Vec<_>>(),
+            vec!["embedding_model"],
+            "not-applicable rows must not reappear under 'Still needs manual steps'"
         );
     }
 

--- a/crates/kin-mcp/src/agent_belt.rs
+++ b/crates/kin-mcp/src/agent_belt.rs
@@ -229,7 +229,7 @@ fn short_descriptions() -> BTreeMap<&'static str, &'static str> {
         ),
         (
             "get_context_pack",
-            "Assemble a bundle around one entity within a token budget: the focal body plus the signatures of what it depends on, optionally its tests and transitive dependencies. Call it instead of several get_entity_source reads.",
+            "Assemble a token-bounded bundle from one entity, several entities, or a plain-language question: focal bodies plus dependency signatures and connecting routes. Call it instead of several get_entity_source and traversal reads.",
         ),
         (
             "get_entity_source",
@@ -381,6 +381,7 @@ fn schema_keep_lists() -> BTreeMap<&'static str, &'static [&'static str]> {
                 "depth",
                 "include_body",
                 "compact",
+                "limit_per_step",
                 "max_response_chars",
                 "max_chars",
             ] as &[&str],
@@ -415,7 +416,14 @@ fn schema_keep_lists() -> BTreeMap<&'static str, &'static [&'static str]> {
         ),
         (
             "get_context_pack",
-            &["entity_id", "depth", "token_budget", "max_chars"] as &[&str],
+            &[
+                "entity_id",
+                "entities",
+                "question",
+                "depth",
+                "token_budget",
+                "max_chars",
+            ] as &[&str],
         ),
         ("kin_provenance_query", &["entity_id", "limit"] as &[&str]),
         // Both, written out rather than left absent. The tool registers exactly
@@ -672,6 +680,18 @@ fn tool_property_descriptions() -> BTreeMap<(&'static str, &'static str), &'stat
         (
             ("trace_data_flow", "direction"),
             "Which way to walk: `calls` for callees, `callers` for callers, `both` merges.",
+        ),
+        (
+            ("trace_data_flow", "limit_per_step"),
+            "Edges kept per hop. Raise it for a node `clipped_steps` reports as cut.",
+        ),
+        (
+            ("get_context_pack", "entities"),
+            "Several focal entity names or UUIDs when the question is about how they connect.",
+        ),
+        (
+            ("get_context_pack", "question"),
+            "A plain-language question resolved to one or more focal entities before packing.",
         ),
         (
             ("trace_path", "direction"),
@@ -1400,6 +1420,206 @@ mod tests {
         assert!(
             problems.is_empty(),
             "agent-default trimmed a knob a shipped acceptance check reads: {problems:#?}"
+        );
+    }
+
+    /// Every remediation or invocation alternative the agent-facing response
+    /// names must be present in the schema that same agent receives.
+    ///
+    /// The first-contact run was told to widen `limit_per_step`, but the belt
+    /// had removed that property. It also left `question` and `entities` in
+    /// `get_context_pack`'s input alternatives after removing both property
+    /// definitions, producing a schema that described only one of its three
+    /// valid ways to call the tool.
+    #[test]
+    fn agent_default_advertises_every_answer_recovery_and_input_alternative() {
+        let served = served_agent_default();
+        let properties = |name: &str| {
+            served
+                .tools
+                .iter()
+                .find(|tool| tool.name == name)
+                .unwrap_or_else(|| panic!("agent-default does not serve {name}"))
+                .input_schema["properties"]
+                .as_object()
+                .unwrap_or_else(|| panic!("{name} has no property map"))
+        };
+
+        let trace = properties("trace_data_flow");
+        assert!(
+            trace.contains_key("limit_per_step"),
+            "trace remediation tells this profile to widen limit_per_step, so its served schema \
+             must advertise the knob: {:?}",
+            trace.keys().collect::<Vec<_>>()
+        );
+
+        let context = properties("get_context_pack");
+        for alternative in ["entity_id", "entities", "question"] {
+            assert!(
+                context.contains_key(alternative),
+                "get_context_pack names `{alternative}` as a valid input alternative but the \
+                 served property map omits it: {:?}",
+                context.keys().collect::<Vec<_>>()
+            );
+        }
+    }
+
+    /// Every property name a schema requires, directly or inside an `anyOf`,
+    /// `oneOf` or `allOf` branch. Combinator branches only: a nested object's
+    /// own `required` names ITS properties, not the tool's.
+    fn required_property_names(schema: &serde_json::Value) -> Vec<(&str, bool)> {
+        let mut names = Vec::new();
+        if let Some(required) = schema.get("required").and_then(|value| value.as_array()) {
+            names.extend(
+                required
+                    .iter()
+                    .filter_map(|value| value.as_str())
+                    .map(|name| (name, false)),
+            );
+        }
+        for combinator in ["anyOf", "oneOf", "allOf"] {
+            let Some(branches) = schema.get(combinator).and_then(|value| value.as_array()) else {
+                continue;
+            };
+            for branch in branches {
+                names.extend(
+                    required_property_names(branch)
+                        .into_iter()
+                        .map(|(name, _)| (name, true)),
+                );
+            }
+        }
+        names
+    }
+
+    /// Every backtick-quoted identifier in `text`. Multi-word phrases and
+    /// quoted values are not identifiers and are left alone.
+    fn backticked_identifiers(text: &str) -> Vec<&str> {
+        text.split('`')
+            .skip(1)
+            .step_by(2)
+            .filter(|token| {
+                !token.is_empty()
+                    && token
+                        .chars()
+                        .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+                    && token.starts_with(|ch: char| ch.is_ascii_alphabetic() || ch == '_')
+            })
+            .collect()
+    }
+
+    /// A short property description may not introduce an identifier the tool's
+    /// own registered contract never uses.
+    ///
+    /// This belt shortens a vetted description; it does not get to write a new
+    /// claim. The `limit_per_step` short form in this bundle first shipped
+    /// naming `truncated_steps`, a response field that exists nowhere in Kin,
+    /// while the real disclosure is `clipped_steps` carrying `fanout_truncated`
+    /// and `fanout_dropped`. To the agent reading it, an invented field name is
+    /// indistinguishable from a real one, and the remediation it anchors is
+    /// unfollowable.
+    ///
+    /// The haystack is the tool's WHOLE registered definition, description and
+    /// schema together, so an enum value and a response field both count as
+    /// vetted. Scoped to the per-tool table, which is where a description can
+    /// name a fact about one tool; the shared table's entries are written to be
+    /// true of every tool that takes the property.
+    #[test]
+    fn no_short_property_description_names_an_identifier_the_tool_never_publishes() {
+        let registered = crate::tools::tool_definitions();
+        let mut checked = 0usize;
+        let mut unknown: Vec<String> = Vec::new();
+
+        for ((tool, property), short) in tool_property_descriptions() {
+            let definition = registered
+                .tools
+                .iter()
+                .find(|candidate| candidate.name == tool)
+                .unwrap_or_else(|| {
+                    panic!("tool_property_descriptions() names unregistered tool {tool}")
+                });
+            let contract = serde_json::to_string(&definition.input_schema)
+                .expect("a registered schema serializes");
+            for token in backticked_identifiers(short) {
+                checked += 1;
+                if contract.contains(token) || definition.description.contains(token) {
+                    continue;
+                }
+                unknown.push(format!("{tool}.{property} names `{token}`"));
+            }
+        }
+
+        assert!(
+            unknown.is_empty(),
+            "these short property descriptions name identifiers absent from the tool's own \
+             registered description and schema, so an agent is told to read a field that does \
+             not exist: {unknown:?}"
+        );
+        assert!(
+            checked >= 10,
+            "the sweep read {checked} backticked identifiers out of the per-tool table, so it is \
+             not reaching the text it grades"
+        );
+    }
+
+    /// A served schema must not require a property it does not define.
+    ///
+    /// [`trim_schema`] filters `properties` and the top-level `required` against
+    /// the keep list and touches nothing else, so a constraint nested in a
+    /// combinator keeps naming a property the trim removed. `get_context_pack`
+    /// shipped exactly that on all three belt profiles: its `anyOf` offers
+    /// `entity_id`, `entities` and `question`, and the keep list defined only
+    /// the first, so two of the three documented ways to call the tool were
+    /// required by the schema and absent from it.
+    ///
+    /// A sweep rather than those two names, because the next keep-list edit that
+    /// drops a constrained property is the same defect, and a test naming the
+    /// properties of the last one stays green through it.
+    #[test]
+    fn no_belt_profile_serves_a_schema_that_requires_a_property_it_does_not_define() {
+        let mut names_read = 0usize;
+        let mut branch_names_read = 0usize;
+        let mut missing: Vec<String> = Vec::new();
+
+        for (profile, names) in [
+            ("agent-default", crate::tools::agent_default_tool_names()),
+            ("agent-query", crate::tools::agent_query_tool_names()),
+            ("agent-search", crate::tools::agent_search_tool_names()),
+        ] {
+            let allowed: std::collections::HashSet<String> =
+                names.iter().map(|name| (*name).to_string()).collect();
+            for tool in crate::tools::served_tools_list(Some(&allowed), true).tools {
+                let defined: std::collections::HashSet<&str> = tool.input_schema["properties"]
+                    .as_object()
+                    .map(|properties| properties.keys().map(String::as_str).collect())
+                    .unwrap_or_default();
+                for (required, from_branch) in required_property_names(&tool.input_schema) {
+                    names_read += 1;
+                    if from_branch {
+                        branch_names_read += 1;
+                    }
+                    if !defined.contains(required) {
+                        missing.push(format!("{profile}/{}: `{required}`", tool.name));
+                    }
+                }
+            }
+        }
+
+        assert!(
+            missing.is_empty(),
+            "these served schemas require a property their own `properties` map does not define, \
+             so the profile advertises a way to call the tool it never describes: {missing:?}; add \
+             the property to that tool's entry in schema_keep_lists()"
+        );
+        // Anti-vacuity. A top-level `required` cannot fail this, because
+        // `trim_schema` filters that list too, so the sweep is only grading the
+        // class while it reads combinator branches. Reading none means the
+        // schemas moved out from under it, not that they are clean.
+        assert!(
+            branch_names_read >= 3,
+            "the sweep read {names_read} required names across three profiles and only \
+             {branch_names_read} of them from an anyOf/oneOf/allOf branch, which is the only \
+             place this defect can live"
         );
     }
 

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -771,6 +771,21 @@ pub enum GraphFreshness {
     /// succeeded in this daemon's life. An answer taken over that store is
     /// answering from a graph nothing in this process ever brought level.
     NoAdmissionRecorded,
+    /// The selected graph could not be sampled live, so this response replays
+    /// an earlier observation whose age and failure mode are known.
+    ///
+    /// This is deliberately distinct from the admission clock above. The
+    /// selected graph may be stale even when HEAD was admitted seconds ago,
+    /// and copying that unrelated clock onto this answer would report the
+    /// opposite of what the status producer observed.
+    Stale {
+        basis: String,
+        reason: String,
+        settled_age_ms: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        observed_authority_epoch: Option<u64>,
+        live_attempts: u32,
+    },
 }
 
 impl GraphFreshness {
@@ -812,6 +827,16 @@ impl GraphFreshness {
                  unmeasured and an answer here cannot be read as covering current code"
                     .to_string(),
             ),
+            Self::Stale {
+                reason,
+                settled_age_ms,
+                live_attempts,
+                ..
+            } => Some(format!(
+                "selected_graph_sample_stale: the selected graph could not be sampled live after \
+                 {live_attempts} attempt(s) because {reason}; these counters replay an observation \
+                 from {settled_age_ms} ms earlier"
+            )),
         }
     }
 }
@@ -1874,6 +1899,25 @@ impl Envelope {
         // is, and dropping it here would leave graph status carrying the
         // compatibility boolean with none of the direction an agent acts on.
         // `self.hydration_semantics` is deliberately not reassigned.
+        self
+    }
+
+    /// Replace an unrelated HEAD admission clock with the selected graph's own
+    /// stale-sample disclosure.
+    pub fn with_selected_graph_staleness(
+        mut self,
+        reason: impl Into<String>,
+        settled_age_ms: u64,
+        observed_authority_epoch: Option<u64>,
+        live_attempts: u32,
+    ) -> Self {
+        self.freshness = Some(GraphFreshness::Stale {
+            basis: "selected_graph_sample".to_string(),
+            reason: reason.into(),
+            settled_age_ms,
+            observed_authority_epoch,
+            live_attempts,
+        });
         self
     }
 
@@ -4286,6 +4330,187 @@ mod tests {
                 .count(),
             1,
             "reconciliation must not repeat the negative reason"
+        );
+    }
+
+    /// First-contact impact answers keep both kinds of uncertainty after the
+    /// response ladder cuts rows: the host content the graph has not admitted,
+    /// and the explicit lower bound on graph-observed covering tests.
+    #[test]
+    fn impact_bounds_and_working_copy_caveats_survive_response_budgeting() {
+        let entity_id = |index: usize| format!("9b9f577c-2cb3-43fd-a59b-ced58218{index:04}");
+        let impacts = (0..120)
+            .map(|index| {
+                json!({
+                    "entity_id": entity_id(index),
+                    "consumer_count": 0,
+                    "strong_consumer_count": 0,
+                    "proven_consumer_count": 0,
+                    "contract_consumer_count": 0,
+                    "consumer_files": [format!("src/feature_{index}.rs")],
+                    "covering_tests": 0,
+                    "covering_tests_bound": "graph_observed_lower_bound",
+                    "consumers_migrated_in_diff": 0,
+                    "call_shapes": {},
+                })
+            })
+            .collect::<Vec<_>>();
+        let payload = ToolCallResult::text(
+            json!({
+                "affected_callers": [],
+                "affected_dependents": [],
+                "affected_contract_consumers": [],
+                "affected_tests": [],
+                "affected_work_items": [],
+                "affected_annotations": [],
+                "changed_ids": (0..120).map(entity_id).collect::<Vec<_>>(),
+                "unreviewed_agent_changes": [],
+                "actor_attribution": [],
+                "entity_impacts": impacts,
+                "edge_coverage": {
+                    "scope": "language",
+                    "language": "Rust",
+                    "requested_classes": ["calls", "imports", "references"],
+                    "classes": {
+                        "calls": "present",
+                        "imports": "present",
+                        "references": "present"
+                    },
+                    "reference_enrichment": "present",
+                    "budget_exhausted": false
+                }
+            })
+            .to_string(),
+        );
+        let envelope = ready_daemon_envelope().with_working_copy_health(&json!({
+            "reconcile": {
+                "untracked_path_count": 17,
+                "untracked_paths_sample": ["src/not_admitted.rs"],
+                "untracked_observed_age_seconds": 0,
+                "last_admission_success_at": "2026-09-04T14:00:00Z"
+            }
+        }));
+        let budget = ResponseBudget {
+            max_chars: 5_000,
+            ..ResponseBudget::default()
+        };
+        let annotated = finalize_bounded(payload, envelope, "impact_analysis", &budget);
+        let final_payload = annotated_value(&annotated);
+        assert_eq!(final_payload[ENVELOPE_KEY]["response"]["bounded"], true);
+
+        let kept = final_payload["entity_impacts"]
+            .as_array()
+            .expect("impact rows survive the budget floor");
+        assert!(
+            !kept.is_empty(),
+            "a cut must not turn impact into no impact"
+        );
+        assert!(kept.iter().all(|row| {
+            row[crate::handlers::review::COVERING_TESTS_BOUND_KEY]
+                == json!(crate::handlers::review::COVERING_TESTS_BOUND)
+        }));
+
+        let negative = &final_payload[crate::negative::NEGATIVE_KEY];
+        assert_eq!(negative["safe_to_conclude_absent"], false);
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(reason.contains("graph_behind_working_tree"), "{reason}");
+        assert!(reason.contains("response_bounded"), "{reason}");
+    }
+
+    /// The first-contact answer a stranger's agent actually receives: a prose
+    /// question, a full page of nearest neighbours, and complete embedding
+    /// coverage so nothing else in the response can be what refuses.
+    ///
+    /// The served instructions tell an agent to read `_kin.verdict` first, so
+    /// proving the absence gate built a block is half the contract. This proves
+    /// the block reaches the one field the reader acts on. It matters here more
+    /// than on other tools because `qualifies_populated_answers` excludes
+    /// `semantic_locate`, so a populated page reached the verdict with the
+    /// absence gate silent, and a silent input leaves every other reading to
+    /// certify the answer on its own.
+    ///
+    /// The shape is the COMPACT surface, because that is the one `agent-default`
+    /// asks for on its agents' behalf: no `results` array, no `degradations`,
+    /// and `query` inserted after projection rather than carried by
+    /// `CompactLocate` itself. A guard reading `query` only where the full shape
+    /// puts it would be absent from every response an agent sees.
+    #[test]
+    fn a_prose_locate_page_of_neighbours_never_certifies_on_the_compact_surface() {
+        let page = |all_fallback: bool| {
+            let mut payload = json!({
+                "query": "password hashing and session token expiry",
+                "granularity": "entity",
+                "routing": "fused-v1",
+                "page": 0,
+                "surface": "compact",
+                "entities": [
+                    {
+                        "id": "00000000-0000-0000-0000-0000000000aa",
+                        "name": "Hit",
+                        "kind": "struct",
+                        "file": "src/search.rs",
+                        "line": 12,
+                        "score": 0.41
+                    },
+                    {
+                        "id": "00000000-0000-0000-0000-0000000000ab",
+                        "name": "build_match_query",
+                        "kind": "function",
+                        "file": "src/search.rs",
+                        "line": 88,
+                        "score": 0.39
+                    }
+                ],
+                "files": ["src/search.rs"],
+                "total_ranked": 40,
+                "ranked_by": "vector similarity over graph bodies",
+                "semantic_coverage": {
+                    "indexed": 100,
+                    "total": 100,
+                    "pending": 0,
+                    "complete": true
+                }
+            });
+            if all_fallback {
+                payload["all_fallback"] = json!(true);
+            }
+            annotated_value(&finalize(
+                ToolCallResult::text(payload.to_string()),
+                ready_daemon_envelope(),
+                "semantic_locate",
+            ))
+        };
+
+        let neighbours = page(true);
+        let verdict = &neighbours[ENVELOPE_KEY]["verdict"];
+        assert_eq!(verdict["state"], "inconclusive", "{neighbours}");
+        assert_eq!(verdict["safe_to_conclude_absent"], false, "{neighbours}");
+        let factor = verdict["limiting_factor"]
+            .as_str()
+            .expect("an inconclusive verdict names what limited it");
+        assert!(factor.contains("relevance_floor_unmeasured"), "{factor}");
+        assert_eq!(
+            neighbours[crate::negative::NEGATIVE_KEY]["kind"],
+            "relevance_unverified",
+            "{neighbours}"
+        );
+        assert!(
+            crate::verdict::disagreements(&neighbours).is_empty(),
+            "a response may not contradict its own verdict: {neighbours}"
+        );
+
+        // The control that stops the assertions above passing for any locate
+        // answer at all, and that pins the repair's scope: the same page whose
+        // ranking DID name what the query asked for keeps its certified verdict
+        // and carries no absence object.
+        let named = page(false);
+        assert_eq!(
+            named[ENVELOPE_KEY]["verdict"]["state"], "certified",
+            "{named}"
+        );
+        assert!(
+            named.get(crate::negative::NEGATIVE_KEY).is_none(),
+            "a ranking that named the query's symbol needs no relevance caveat: {named}"
         );
     }
 

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -5422,6 +5422,15 @@ pub enum GraphStatusStaleReason {
     SelectedGraphChanging,
 }
 
+impl GraphStatusStaleReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::EmbeddingCoverageChanging => "embedding_coverage_changing",
+            Self::SelectedGraphChanging => "selected_graph_changing",
+        }
+    }
+}
+
 /// The disclosure that makes a replayed reading honest.
 ///
 /// Present exactly when `sampling` is [`GraphStatusSampling::LastSettledSelectedGraph`],
@@ -5651,7 +5660,7 @@ impl GraphStatusReport {
         &self,
         envelope: &crate::envelope::Envelope,
     ) -> std::result::Result<(), String> {
-        use crate::envelope::{Runtime, ENVELOPE_VERSION};
+        use crate::envelope::{GraphFreshness, Runtime, ENVELOPE_VERSION};
 
         if envelope.envelope_version != ENVELOPE_VERSION {
             return Err(format!(
@@ -5708,6 +5717,32 @@ impl GraphStatusReport {
                 "_kin semantic_coverage.note must be present exactly when coverage is incomplete"
                     .to_string(),
             );
+        }
+        match (&self.stale, &envelope.freshness) {
+            (
+                Some(stale),
+                Some(GraphFreshness::Stale {
+                    basis,
+                    reason,
+                    settled_age_ms,
+                    observed_authority_epoch,
+                    live_attempts,
+                }),
+            ) if basis == "selected_graph_sample"
+                && reason == stale.reason.as_str()
+                && *settled_age_ms == stale.settled_age_ms
+                && *observed_authority_epoch == stale.observed_authority_epoch
+                && *live_attempts == stale.live_attempts => {}
+            (Some(_), _) => {
+                return Err(
+                    "_kin freshness does not carry the exact stale selected-graph observation"
+                        .to_string(),
+                );
+            }
+            (None, Some(GraphFreshness::Stale { .. })) => {
+                return Err("_kin freshness marks a point-in-time selected graph stale".to_string());
+            }
+            (None, _) => {}
         }
         Ok(())
     }

--- a/crates/kin-mcp/src/handlers/review.rs
+++ b/crates/kin-mcp/src/handlers/review.rs
@@ -43,7 +43,9 @@ radius, answering \"if I change this, what else might break?\", from the graph i
 call instead of hand-tracing callers. Pair it with semantic_diff (what changed) or use \
 semantic_review when you want diff + impact + risk together in a single report. \
 Per-entity counts separate `consumer_count` (every inbound edge) from \
-`proven_consumer_count` (only edges resolved above `name_only`). This response carries \
+`proven_consumer_count` (only edges resolved above `name_only`). `covering_tests` is a \
+graph-observed lower bound, labeled beside every count rather than a claim about every \
+test in the working copy. This response carries \
 counts and buckets rather than ranked paths: the per-hop ranked report, where every step \
 carries its own `resolution` and a confidence score, is produced only by \
 `kin impact --json` on the CLI and is not reachable from here. Read a used/unused claim \
@@ -56,6 +58,17 @@ build cannot produce, or on a graph holding none of them, an empty blast radius 
 the query could not observe what it was asked about rather than that nothing depends on \
 the change. Check it before reading a zero consumer count as safe to change.";
 
+/// The field a serialized impact row carries beside `covering_tests`, and the
+/// one value it takes.
+///
+/// Named once rather than spelled at each surface. The budget-survival test in
+/// [`crate::envelope`] builds its impact rows by hand, so a literal there would
+/// go on asserting a spelling this producer had renamed, and the pair would
+/// drift with both halves green.
+pub(crate) const COVERING_TESTS_BOUND_KEY: &str = "covering_tests_bound";
+/// See [`COVERING_TESTS_BOUND_KEY`].
+pub(crate) const COVERING_TESTS_BOUND: &str = "graph_observed_lower_bound";
+
 /// The blast-radius buckets of an [`kin_review::ImpactReport`] that serialize as
 /// arrays of raw entities, paired with their key in the response object.
 const IMPACT_ENTITY_BUCKETS: [&str; 4] = [
@@ -65,8 +78,7 @@ const IMPACT_ENTITY_BUCKETS: [&str; 4] = [
     "affected_tests",
 ];
 
-/// Give every entity in an impact response the same 1-based `start_line` /
-/// `end_line` fields its sibling surfaces emit.
+/// Add the presentation fields and explicit bounds an impact response needs.
 ///
 /// `ImpactReport` holds raw `Entity` values, so serializing it exposes only the
 /// nested `span`, whose rows are the graph's 0-based tree-sitter positions. An
@@ -101,6 +113,24 @@ fn annotate_impact_presentation_lines(
             object.insert(
                 "end_line".to_string(),
                 serde_json::json!(entity_presentation_end_line(entity)),
+            );
+        }
+    }
+
+    let Some(entity_impacts) = result
+        .get_mut("entity_impacts")
+        .and_then(serde_json::Value::as_array_mut)
+    else {
+        return;
+    };
+    for row in entity_impacts {
+        let Some(object) = row.as_object_mut() else {
+            continue;
+        };
+        if object.contains_key("covering_tests") {
+            object.insert(
+                COVERING_TESTS_BOUND_KEY.to_string(),
+                serde_json::json!(COVERING_TESTS_BOUND),
             );
         }
     }
@@ -1145,7 +1175,17 @@ mod tests {
             changed_ids: vec![],
             unreviewed_agent_changes: vec![],
             actor_attribution: vec![],
-            entity_impacts: vec![],
+            entity_impacts: vec![kin_review::EntityImpact {
+                entity_id: direct.id,
+                consumer_count: 0,
+                strong_consumer_count: 0,
+                proven_consumer_count: 0,
+                contract_consumer_count: 0,
+                consumer_files: vec![],
+                covering_tests: 0,
+                consumers_migrated_in_diff: 0,
+                call_shapes: kin_review::impact::ConsumerCallShapeSummary::default(),
+            }],
         };
 
         let mut value = serde_json::to_value(&report).unwrap();
@@ -1168,6 +1208,14 @@ mod tests {
             rows[1]["start_line"].is_null(),
             "an entity with no span has no line to report: {}",
             rows[1]
+        );
+
+        let coverage = &value["entity_impacts"][0];
+        assert_eq!(coverage["covering_tests"], 0);
+        assert_eq!(
+            coverage[COVERING_TESTS_BOUND_KEY], COVERING_TESTS_BOUND,
+            "a zero must say beside the number that missing local-variable property edges can \
+             make it a false negative: {coverage}"
         );
     }
 

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -1334,6 +1334,40 @@ fn locate_ranking_names_nothing(payload: &Value) -> bool {
         })
 }
 
+/// True when locate returned only fallback neighbours for a prose query.
+///
+/// `all_fallback` is computed over the full retained ranking, so this reads the
+/// producer's observation rather than guessing from one page. A prose query
+/// does not name a symbol whose absence can be checked. The relevant fact is
+/// instead that the ranking has no calibrated floor saying any returned row
+/// answers the concept the caller described.
+///
+/// This gate replaced one that deliberately said the opposite, and that
+/// argument is answered rather than dropped. It held that `all_fallback` fires
+/// on prose queries whose top hits are correct, so a qualifier there is one an
+/// agent learns to ignore. True of the [`locate_ranking_names_nothing`] wording
+/// beside it, which asserts a named symbol was not found and would be a false
+/// statement over a correct hit. It is not true of this one, which asserts only
+/// that the ranking publishes no measured relevance threshold. That sentence is
+/// exactly as true over a correct top hit as over a wrong one, which is the
+/// whole reason the answer cannot be certified: nothing in the response can
+/// tell the two apart. So the block says `relevance_unverified` and
+/// `nearest_neighbors_only`, never that the concept is absent.
+///
+/// Answered HERE, at the absence gate, and not by folding the producer's
+/// `query_shape` degradation into the run-quality verdict. That exemption is
+/// correct and stays: the run lost no capability, embeddings ranked, and
+/// [`describes_advice_not_run_quality`] keeps a query's shape out of a verdict
+/// about how well the query ran. How far the returned rows can be trusted is
+/// this gate's question, not that one's.
+fn locate_relevance_unverified(payload: &Value) -> bool {
+    let Some(query) = payload.get("query").and_then(Value::as_str) else {
+        return false;
+    };
+    !query_names_a_symbol(query)
+        && payload.get("all_fallback").and_then(Value::as_bool) == Some(true)
+}
+
 /// The wire word for the one embedding verdict, so the absence object and the
 /// completeness block publish the same vocabulary for the same fact.
 fn embedding_state_word(coverage: &crate::envelope::SemanticCoverage) -> &'static str {
@@ -2002,6 +2036,14 @@ fn unnamed_ranking_consequence() -> &'static str {
      settle that with find_references or semantic_search, which resolve a name directly."
 }
 
+/// The consequence for a prose locate page containing fallback neighbours.
+fn unverified_relevance_consequence() -> &'static str {
+    "Inspect the returned code before treating these nearest neighbours as relevant. The ranking \
+     has no calibrated relevance floor and returns candidates from any non-empty index, so do not \
+     conclude the concept is absent or present from this page alone. Refine the query or confirm \
+     the behavior through a graph surface that answers a concrete entity or relation question."
+}
+
 /// The kind the payload reports for its focal entity, whichever shape carries
 /// it: `find_references` nests the focal under `focal_entity`, `trace_data_flow`
 /// reports it flat as `focal_kind`.
@@ -2302,6 +2344,7 @@ pub fn negative_for(
     // this reports rather than filters, and a weak-but-real hit is never dropped
     // to hide a wrong one.
     let ranking_names_nothing = tool == "semantic_locate" && locate_ranking_names_nothing(payload);
+    let relevance_unverified = tool == "semantic_locate" && locate_relevance_unverified(payload);
     // Whether this response asserts that something is NOT there. An answer with
     // rows asserts nothing of the kind, and still gets qualified: the gates
     // below decide how far its rows can be trusted as the whole set, which is
@@ -2312,7 +2355,7 @@ pub fn negative_for(
     // readings of one question are how a caveat about absences came to ride on
     // an answer with rows (FIR-2496).
     let claims_absence = answer_claims_absence(tool, payload);
-    if !claims_absence && !qualifies_populated_answers(tool) {
+    if !claims_absence && !qualifies_populated_answers(tool) && !relevance_unverified {
         return None;
     }
 
@@ -2510,6 +2553,16 @@ pub fn negative_for(
              candidate set rather than an enumeration of the graph, so the name may belong to an \
              entity this query never ranked; observed substrate state: {trust_reason}"
         );
+    } else if relevance_unverified {
+        kind = "relevance_unverified";
+        subject = "the query described a concept and every returned row is a nearest neighbour; \
+                   this ranking publishes no measured relevance floor";
+        trustworthy = false;
+        trust_reason = format!(
+            "relevance_floor_unmeasured: every ranked row was a fallback neighbour and the \
+             response publishes no calibrated threshold establishing that any row answers the \
+             concept; observed substrate state: {trust_reason}"
+        );
     }
     if tool == "graph_neighborhood" {
         // The emitted edge array is capped by the caller's `limit`, and a
@@ -2620,6 +2673,8 @@ pub fn negative_for(
 
     let interpretation = if ranking_names_nothing {
         "unnamed_ranking"
+    } else if relevance_unverified {
+        "nearest_neighbors_only"
     } else if spec.always {
         "qualified_verdicts"
     } else if claims_absence {
@@ -2627,13 +2682,15 @@ pub fn negative_for(
     } else {
         "qualified_answer"
     };
-    if !claims_absence {
+    if !claims_absence && !relevance_unverified {
         kind = "qualified_answer";
         subject = "this answer returned rows, so it asserts no absence; the verdict below says \
                    how far those rows can be trusted as the whole set";
     }
     let consequence = if ranking_names_nothing {
         unnamed_ranking_consequence().to_string()
+    } else if relevance_unverified {
+        unverified_relevance_consequence().to_string()
     } else if claims_absence {
         absence_advice_consequence(tool, spec.always, trustworthy, &trust_reason)
     } else {
@@ -6926,20 +6983,39 @@ mod tests {
     }
 
     #[test]
-    fn prose_query_over_fallback_hits_is_not_qualified_as_unnamed() {
-        // `all_fallback` fires on natural-language queries whose top hits are
-        // correct, so it cannot be the whole rule. A qualifier that fired there
-        // too is one an agent learns to ignore.
-        let mut payload = empty_fused_locate_page("merge queue captain lane arbitration");
-        payload["entities"] = json!([fused_locate_hit("submit_to_queue")]);
-        payload["total_ranked"] = json!(3);
+    fn prose_query_over_fallback_hits_refuses_to_certify_relevance() {
+        // The exact first-contact shape: a natural-language concept the
+        // repository does not contain still gets a full page because locate is
+        // a nearest-neighbour ranking. Complete embedding coverage says every
+        // candidate could rank. It does not provide a calibrated relevance
+        // floor, so it cannot turn the neighbours into a certified answer.
+        let mut payload = empty_fused_locate_page("password hashing and session token expiry");
+        payload["entities"] = json!([
+            fused_locate_hit("Hit"),
+            fused_locate_hit("Link"),
+            fused_locate_hit("build_match_query"),
+            fused_locate_hit("SearchError"),
+        ]);
+        payload["total_ranked"] = json!(40);
         payload["all_fallback"] = json!(true);
-        assert!(negative_for(
+        let negative = negative_for(
             "semantic_locate",
             &payload,
-            &semantic_authoritative_envelope()
+            &semantic_authoritative_envelope(),
         )
-        .is_none());
+        .expect("fallback-only prose rankings must qualify their relevance");
+        assert_eq!(negative["kind"], json!("relevance_unverified"));
+        assert_eq!(negative["interpretation"], json!("nearest_neighbors_only"));
+        assert_eq!(negative["trust"], json!("inconclusive"));
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(reason.contains("relevance_floor_unmeasured"), "{reason}");
+        let advice = negative["advice"].as_str().unwrap();
+        assert!(
+            advice.contains("Inspect the returned code")
+                && advice.contains("do not conclude the concept is absent"),
+            "{advice}"
+        );
     }
 
     #[test]

--- a/crates/kin-mcp/src/server.rs
+++ b/crates/kin-mcp/src/server.rs
@@ -1581,7 +1581,7 @@ fn finalize_daemon_graph_status(
             );
         }
     };
-    let selected_env = base_env
+    let mut selected_env = base_env
         .with_selected_graph_observation(
             entity_count,
             indexed,
@@ -1590,6 +1590,14 @@ fn finalize_daemon_graph_status(
             report.durable_entity_count,
         )
         .with_memory_pressure(pressure_refusal.as_ref());
+    if let Some(stale) = report.stale.as_ref() {
+        selected_env = selected_env.with_selected_graph_staleness(
+            stale.reason.as_str(),
+            stale.settled_age_ms,
+            stale.observed_authority_epoch,
+            stale.live_attempts,
+        );
+    }
     let enveloped = envelope::finalize(result, selected_env, "kin_graph_status");
     if let Err(error) = daemon_delegate::parse_graph_status_report(&enveloped) {
         return envelope::finalize(
@@ -1788,6 +1796,75 @@ mod tests {
         assert_eq!(coverage.pending, 1);
         assert_eq!(coverage.total, 2);
         assert!(!coverage.complete);
+    }
+
+    /// A replayed status sample must own the envelope's freshness reading.
+    ///
+    /// The first-contact run received counters from 359601 ms earlier beside
+    /// `_kin.freshness.state=recorded` and `age_seconds=6`, because the latter
+    /// came from HEAD admission health. A reader scanning the standard envelope
+    /// therefore saw a fresh-looking status over an empty past graph.
+    #[test]
+    fn replayed_graph_status_marks_the_standard_envelope_stale() {
+        let stale_result = ToolCallResult::text(
+            serde_json::json!({
+                "schema": "kin.graph-status.v1",
+                "view": "daemon_selected_graph",
+                "scope": "head",
+                "authority": "repo-daemon",
+                "sampling": "last_settled_selected_graph",
+                "authority_epoch": 7,
+                "entity_count": 0,
+                "durable_entity_count": 0,
+                "relation_count": 0,
+                "embedding_source": "selected_graph",
+                "embeddings_indexed": 0,
+                "embeddings_pending": 0,
+                "embeddings_total": 0,
+                "completion_attested": false,
+                "stale": {
+                    "reason": "embedding_coverage_changing",
+                    "settled_age_ms": 359601,
+                    "observed_authority_epoch": 8,
+                    "live_attempts": 3,
+                    "note": "the live sample was abandoned while embedding coverage changed"
+                }
+            })
+            .to_string(),
+        );
+        let admission_health = serde_json::json!({
+            "reconcile": {
+                "untracked_path_count": 0,
+                "untracked_observed_age_seconds": 0,
+                "last_admission_success_at": "2026-09-04T14:00:00Z",
+                "last_admission_success_age_seconds": 6
+            }
+        });
+        let enveloped = finalize_daemon_graph_status(
+            stale_result,
+            Envelope::daemon().with_working_copy_health(&admission_health),
+            &[],
+            2,
+        );
+        let report = daemon_delegate::parse_graph_status_report(&enveloped)
+            .expect("the stdio contract validates")
+            .expect("the status call succeeds");
+        let freshness = serde_json::to_value(
+            report
+                .response_envelope
+                .expect("stdio status carries an envelope")
+                .freshness
+                .expect("a replayed sample carries freshness"),
+        )
+        .unwrap();
+        assert_eq!(freshness["state"], "stale");
+        assert_eq!(freshness["basis"], "selected_graph_sample");
+        assert_eq!(freshness["settled_age_ms"], 359601);
+        assert_eq!(freshness["live_attempts"], 3);
+        assert!(
+            freshness.get("age_seconds").is_none(),
+            "the unrelated six-second admission clock must not survive: {freshness}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
A stranger's first questions get answers Kin cannot back, and each one reads as confident. This
bundle makes six of those surfaces state their own limits. It changes no answer that was already
honest, and it does not widen what Kin can prove.

## What was wrong, and where

**An absent concept received a certified answer.** `qualifies_populated_answers` excludes
`semantic_locate`, so a populated locate page gets no `negative` block, the absence gate reads
`Silent`, and a silent input certifies nothing but refuses nothing either. The daemon does record an
`all_fallback` degradation, and `describes_advice_not_run_quality` deliberately filters it out of the
run-quality verdict, correctly: the run lost no capability. The result was that
`semantic_locate("password hashing and session token expiry")` on a repository with no auth code came
back with four confident neighbours and `_kin.verdict.state: certified`, `limiting_factor: null`.

Answered at the absence gate, which is the seam that owns "how far can these rows be trusted", rather
than by folding a query's shape into a verdict about how well the query ran. A fallback-only page for
a prose query now carries `kind: relevance_unverified`, `interpretation: nearest_neighbors_only` and a
`relevance_floor_unmeasured` reason, and the `_kin` verdict follows it to `inconclusive`. It does not
say the concept is absent, because nothing in the response can tell an absent concept from a correct
neighbour, and that is the whole reason it cannot be certified.

This replaces a test that asserted the opposite. Its argument was that `all_fallback` fires on prose
queries whose top hits are correct, so a qualifier there is one an agent learns to ignore. That holds
against the `unnamed_ranking` wording, which asserts a named symbol was not found and would be false
over a correct hit. It does not hold against this one, which asserts only that the ranking publishes
no measured relevance threshold, a sentence equally true either way. The argument is now answered in
the code rather than deleted with the test.

**A schema required properties it did not define.** `trim_schema` filters `properties` and the
top-level `required` against the keep list and touches nothing else, so `get_context_pack` shipped an
`anyOf` offering `entity_id`, `entities` and `question` while defining only the first, on all three
belt profiles. Two of its three documented ways to be called were required by the served schema and
absent from it. Separately, the clipped-chain remediation tells a caller to widen `limit_per_step`
while the belt had trimmed that property away, so the advice was unfollowable and a five-wide cap
could not be raised through the advertised schema at any budget.

**Status replayed an unrelated clock.** `kin_graph_status` can answer from the last settled sample
when a live one cannot be taken. The counters said so under `stale`, while `_kin.freshness` still
carried the HEAD admission clock, so a six-minute-old `entity_count: 0` sat beside
`state: recorded, age_seconds: 6`. `_kin.freshness` now carries the selected graph's own stale
observation, and the stdio contract rejects any response where the two disagree in either direction.

**A covering-test count read as a claim about the working copy.** `entity_impacts[].covering_tests` is
a graph-observed lower bound, and nothing beside the number said so, so a `0` from a missing
local-variable property edge published as a confident zero. Every serialized row now carries
`covering_tests_bound: graph_observed_lower_bound`, through one annotation seam that serves both the
direct impact response and the impact nested inside `semantic_review`. **This is disclosure, not a
repair: the number is still 0.** The enrichment gap under it is untouched.

**A correct install looked broken.** Outside a Kin repository there is no root for a live shell hook
to project, and the projection row still read `Stale` and counted toward `needs_attention`. The
post-fix footer derived its own attention predicate rather than calling the one the summary uses, so
`unsupported` rows the summary correctly called not applicable reappeared under "Still needs manual
steps". The readiness line now also names which rows are expected first-run work and which are host
limits.

**Uncertainty had to survive a budgeted cut.** The budget already excludes `_kin` and `negative` and
rebuilds the verdict on any pass that cut rows. What was missing was a regression holding that
property over a first-contact impact response, so the working-copy-behind caveat, the response-bounded
factor and the new covering-test bound are all asserted after 120 rows are cut to a 5,000-character
ceiling.

## Two things found while verifying the fixes

The `limit_per_step` short description told agents to read `truncated_steps`, a response field that
exists nowhere in Kin; the real disclosure is `clipped_steps`, carrying `fanout_truncated` and
`fanout_dropped`. A fix for "no nonexistent parameters shown to users" had shipped a nonexistent field
name of its own. Corrected, and the class now has a check rather than a spot fix:
`no_short_property_description_names_an_identifier_the_tool_never_publishes` asserts that every
backtick-quoted identifier in the per-tool short-description table appears in that tool's own
registered description or schema. It passes over the whole table, so that was the only one.

The schema defect is likewise answered by a sweep rather than by naming two properties:
`no_belt_profile_serves_a_schema_that_requires_a_property_it_does_not_define` walks all three belt
profiles and asserts no served schema requires a property its own `properties` map omits, with an
anti-vacuity control that fails if it stops reading combinator branches, which is the only place the
defect can live.

## Verification

Claims hosted CI does not itself check are recorded here as the command and its output, never as
prose. Eight new tests, one rewritten and two extended, were falsified across fourteen pairings, one
mutant at a time, each mutant the exact reverse of a product change; files were restored from text held
in memory and the tree proved byte-identical afterwards.

Every gate below ran on this branch's head `6c530a366d1dd34182f2a1416929c806ec0a0ca7`, through
`.kin-coord/bin/heavy-slot.sh answertruth kin` from the umbrella root, each printing the worktree and
target it resolved before grading.

```text
$ heavy-slot.sh answertruth kin -- cargo fmt --all -- --check
heavy-slot: answertruth command exit rc=0 at 2026-09-04T17:00:19Z

$ heavy-slot.sh answertruth kin -- cargo test -p kin-mcp
kin-lane: run lane=answertruth repo=kin worktree=.../worktrees/answertruth-kin
   target=.../cargo-target/answertruth-kin embed=cpu
test result: ok. 891 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 20.42s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
heavy-slot: answertruth command exit rc=0 at 2026-09-04T17:01:23Z

$ heavy-slot.sh answertruth kin -- cargo test -p kin-cli
running 2145 tests
test result: ok. 2144 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 165.30s
(2989 passed, 0 failed across every binary in the crate)
heavy-slot: answertruth command exit rc=0 at 2026-09-04T17:13:31Z

$ heavy-slot.sh answertruth kin -- bin/kin-precheck kin --repo-dir kin=<this worktree>
kin-precheck: repo=kin tree=.../worktrees/answertruth-kin sha=6c530a366d1dd34182f2a1416929c806ec0a0ca7 branch=chore/lane-answertruth-kin
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 6c530a366d1dd34182f2a1416929c806ec0a0ca7
heavy-slot: answertruth command exit rc=0 at 2026-09-04T17:15:42Z
```

`kin-precheck` names the three check-job steps it deliberately does not reproduce, so the 21 is a stated
subset rather than a claim to have run the whole job: the language-server provisioning script, the
release policy gate whose failure routing needs GitHub event context that a local run cannot supply
truthfully, and the hydration falsification that only means anything against the poisoned copy the
workflow builds first.

`bin/kin-parity` ran on the same tree before the rebase, at `a77b7c857` dirty, and the rebase took in
only `ci.yml`, `release-cut.yml`, `crates/kin-spine/src/firestore.rs`, `docs/release-bot.md` and two
release scripts, none of which this bundle touches:

```text
kin-parity: build       release        1023.5s
kin-parity: magic       PASS            166.4s  26 pass / 0 fail / 0 unreadable
kin-parity: brownfield  PASS-WITH-ALLOWANCES  400.4s  11 pass / 0 fail / 1 unreadable
kin-parity: firstrun    PASS-WITH-ALLOWANCES  106.2s  9 pass / 1 fail / 1 unreadable
kin-parity: FINAL PASS-WITH-ALLOWANCES in 1698.4s  (NON-CITABLE)
            allowances: firstrun/9 FIR-2580, firstrun/3 FIR-2501, brownfield/4 FIR-2464
heavy-slot: answertruth command exit rc=0 at 2026-09-04T16:59:04Z
```

All three allowances are pre-existing tracked tickets and none names a file in this bundle.

Falsification, fourteen pairings, thirteen red:

```text
MUTANT: the absence gate stops qualifying a fallback-only prose page
  prose_query_over_fallback_hits_refuses_to_certify_relevance                  FAILED  rc=101
  a_prose_locate_page_of_neighbours_never_certifies_on_the_compact_surface     FAILED  rc=101
MUTANT: the belt trims limit_per_step back out of the trace schema
  agent_default_advertises_every_answer_recovery_and_input_alternative         FAILED  rc=101
MUTANT: the context-pack keep list returns to its shipped form
  no_belt_profile_serves_a_schema_that_requires_a_property_it_does_not_define  FAILED  rc=101
  agent_default_advertises_every_answer_recovery_and_input_alternative         FAILED  rc=101
MUTANT: impact rows stop carrying the covering-test bound
  impact_rows_carry_one_based_presentation_lines_beside_the_raw_span           FAILED  rc=101
  impact_bounds_and_working_copy_caveats_survive_response_budgeting            ok      rc=0    SURVIVED
MUTANT: the replayed sample stops owning the envelope's freshness
  replayed_graph_status_marks_the_standard_envelope_stale                      FAILED  rc=101
MUTANT: a budgeted cut stops downgrading the verdict and the absence object
  impact_bounds_and_working_copy_caveats_survive_response_budgeting            FAILED  rc=101
MUTANT: the projection row stops reading whether a repository is here
  a_live_hook_outside_a_repository_is_not_an_attention_row                     FAILED  rc=101
MUTANT: the post-fix manual footer returns to its own predicate
  the_post_fix_manual_list_excludes_not_applicable_rows                        FAILED  rc=101
MUTANT: the readiness line stops naming expected first-run work
  the_printed_count_is_the_tally_and_both_come_from_one_predicate              FAILED  rc=101
MUTANT: the short description names a response field again
  no_short_property_description_names_an_identifier_the_tool_never_publishes   FAILED  rc=101
MUTANT: the producer renames the value the hand-built fixture spells
  impact_bounds_and_working_copy_caveats_survive_response_budgeting            FAILED  rc=101
```

The survivor is a wrong pairing in the harness, not a test that cannot fail, and it is left in the
record rather than removed. The budget test builds its impact rows by hand, so deleting the producer's
annotation leaves the field present in that fixture. What that test guards is that a budgeted cut does
not strip the caveats from the rows it kept, and the mutant targeting exactly that, removing
`crate::verdict::mark_response_bounded` from the budget loop, turns it red. The other half, that the
producer adds the bound at all, is guarded by `impact_rows_carry_one_based_presentation_lines_beside_the_raw_span`,
which the first mutant does turn red. The key and its value are now one constant read by the producer
and both tests, so a rename cannot let the hand-built fixture drift green.

## What this does not fix

Three things, stated so nothing downstream reads more into this than it says.

`covering_tests: 0` for a genuinely covered entity is still `0`. The label beside it,
`covering_tests_bound: graph_observed_lower_bound`, says the number is a graph-observed lower bound
and not a claim about every test in the working copy. The enrichment gap that produces the zero,
coverage resolving through a constructor call but not through property access on an inferred local,
is untouched here.

A stranger report also names `impact_analysis` as telling a caller to widen `limit_per_step`. That
half is unclaimed. The only advice in this repository naming that parameter is `spine_clipping_gap`,
gated on `spine_clipped_steps`, and only `trace_data_flow` publishes that field
(`crates/kin-mcp/src/handlers/entities.rs:4086`). Nothing here changes `impact_analysis`, and the
report should not be read as covering it.

A prose locate page now qualifies its relevance whether or not its top hit is correct, because no
field in the response separates the two. That is a deliberate widening of when the caveat appears,
and it is the price of not certifying what cannot be certified.

## One thing this bundle is next to but does not fix

`bin/kin-parity`'s firstrun suite carries an allowance, FIR-2501 with its own ticket FIR-2554, saying
`kin doctor`'s projection row cannot go green under Kin's own shell hook: the hook strips the preload
from every `kin` invocation on purpose, and the row measures whether the shim is loaded into the doctor
process, which is the one process the hook exists to keep unshimmed. That is the inside-a-repository
half of the row this bundle touches. Nothing here changes it. The new branch is gated on
`!inside_repository`, and parity reproduced the identical allowance after the change.

## Landing note

`Product Acceptance` carries `if: ${{ github.event_name != 'pull_request' }}`, so it reports
`skipped` here and main's own push run is the grader for these changes.
