### PR TITLE
Say which half of readiness refused, and how long it waited

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -3880,11 +3880,13 @@ async fn readiness(State(state): State<Arc<DaemonState>>) -> impl IntoResponse {
     let initialized = state
         .is_initialized
         .load(std::sync::atomic::Ordering::Relaxed);
+    let authority_started = Instant::now();
     let hosted_spine_ready = if initialized && state.hosted_spine_readiness_required() {
         state.acquire_spine_read_authority().await.is_some()
     } else {
         true
     };
+    let authority_wait = authority_started.elapsed();
     let warming = state.spine_warming() || (initialized && !hosted_spine_ready);
 
     if initialized && hosted_spine_ready {
@@ -3896,6 +3898,34 @@ async fn readiness(State(state): State<Arc<DaemonState>>) -> impl IntoResponse {
             }),
         )
     } else {
+        // Say which half refused, and how long the authority check spent
+        // waiting, because a refusal that says nothing is how a rollout gets
+        // read as a broken daemon.
+        //
+        // On 2026-09-04 a hosted daemon bound port 4219 at 464 s into its
+        // start, then failed its rollout 134 s later having never reported
+        // ready. Nothing in that pod's log said whether it was still
+        // uninitialized or whether the spine authority was refusing, and
+        // Kubernetes records only the status code, so the post-mortem could
+        // name a mechanism and not confirm it. This is the line that would
+        // have answered it.
+        //
+        // WARN rather than DEBUG on purpose: a hosted daemon that cannot
+        // serve is the operator's problem whether or not anyone raised the
+        // log level first, and this stops as soon as the daemon is ready.
+        tracing::warn!(
+            initialized,
+            hosted_spine_ready,
+            warming,
+            refused_on = if !initialized {
+                "initialization"
+            } else {
+                "hosted spine authority"
+            },
+            authority_wait_ms = authority_wait.as_millis() as u64,
+            spine_gate_wait_ms = state.last_spine_gate_read_wait().as_millis() as u64,
+            "readiness refused"
+        );
         (
             StatusCode::SERVICE_UNAVAILABLE,
             Json(ReadinessResponse {
@@ -42766,6 +42796,138 @@ mod tests {
         assert!(
             !readiness.warming,
             "an idle daemon must not claim to be warming"
+        );
+    }
+
+    // ── A refusal has to say what refused ────────────────────────────────
+    //
+    // Kubernetes records the status code and nothing else. On 2026-09-04 a
+    // hosted daemon bound its port at 464 s, failed its rollout 134 s later
+    // without ever reporting ready, and the pod log carried no line saying
+    // whether it was still uninitialized or whether the spine authority was
+    // refusing. The post-mortem could name a mechanism and not confirm it.
+    //
+    // These two tests are a pair on purpose. The first fails if the line is
+    // removed or stops naming which half refused. The second fails if the
+    // line is emitted unconditionally, which would satisfy the first while
+    // making the log useless and noisy on every healthy probe.
+
+    /// Collects formatted tracing output so a test can assert on it.
+    #[derive(Clone)]
+    struct CapturedLog(Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl CapturedLog {
+        fn new() -> Self {
+            Self(Arc::new(std::sync::Mutex::new(Vec::new())))
+        }
+
+        fn text(&self) -> String {
+            String::from_utf8_lossy(
+                &self
+                    .0
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner),
+            )
+            .into_owned()
+        }
+    }
+
+    impl std::io::Write for CapturedLog {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'writer> tracing_subscriber::fmt::MakeWriter<'writer> for CapturedLog {
+        type Writer = CapturedLog;
+
+        fn make_writer(&'writer self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    #[tokio::test]
+    async fn a_refused_readiness_says_which_half_refused() {
+        let captured = CapturedLog::new();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(captured.clone())
+            .with_max_level(tracing::Level::WARN)
+            .with_ansi(false)
+            .finish();
+        // `set_default` is thread-local and `#[tokio::test]` runs the future on
+        // this thread, so the handler below writes into `captured`.
+        let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+
+        // `test_state()` opens a real repo, and `DaemonState::open` sets
+        // `is_initialized` from whether a snapshot loaded, so the fixture
+        // arrives ready. Put it back to the state a starting daemon is in, so
+        // the first half is what refuses.
+        let state = test_state();
+        state
+            .is_initialized
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+        let response = router(state)
+            .oneshot(Request::get("/readiness").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        let logged = captured.text();
+        assert!(
+            logged.contains("readiness refused"),
+            "a 503 from /readiness must say so in the log; Kubernetes keeps only \
+             the status code, so an unlogged refusal is an unanswerable rollout \
+             failure. Captured output was: {logged:?}"
+        );
+        assert!(
+            logged.contains("refused_on=\"initialization\""),
+            "the refusal must name which half refused, so a reader does not have \
+             to guess between initialization and the spine authority. Captured \
+             output was: {logged:?}"
+        );
+        assert!(
+            logged.contains("spine_gate_wait_ms="),
+            "the refusal must report how long the authority check waited for the \
+             publication gate, which is the measurement that separates a slow \
+             open from starvation behind the refresh passes. Captured output \
+             was: {logged:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_ready_daemon_logs_no_readiness_refusal() {
+        let captured = CapturedLog::new();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(captured.clone())
+            .with_max_level(tracing::Level::WARN)
+            .with_ansi(false)
+            .finish();
+        let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let response = router(state)
+            .oneshot(Request::get("/readiness").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let logged = captured.text();
+        assert!(
+            !logged.contains("readiness refused"),
+            "a ready daemon must not log a refusal. The probe runs every few \
+             seconds for the life of the pod, so an unconditional line would \
+             bury the one case that matters. Captured output was: {logged:?}"
         );
     }
 

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -2961,6 +2961,18 @@ pub struct DaemonState {
     /// The backend independently keeps a pass-wide incomplete lease; this gate
     /// prevents daemon request paths from racing that lease with a new ingest.
     spine_refresh_gate: tokio::sync::RwLock<()>,
+    /// How long the most recent reader waited to take `spine_refresh_gate`,
+    /// in microseconds. Written by `acquire_spine_read_authority`, read by
+    /// `/readiness` so a refusal can say whether it was waiting on this lock.
+    ///
+    /// It exists because the alternative is guessing. On 2026-09-04 a hosted
+    /// daemon bound its port at 464 s, then failed its rollout without ever
+    /// reporting ready, and nothing on the daemon side recorded why: the
+    /// refresh passes that hold this gate for write ran back to back for the
+    /// whole window, and a tokio RwLock is write-preferring, but no evidence
+    /// separated that from the rest of the authority check. One relaxed store
+    /// on a path that already awaits a lock is cheap enough to keep always on.
+    spine_gate_read_wait_micros: std::sync::atomic::AtomicU64,
     /// Maps repo_id to a lazily-loaded graph. Graphs are loaded from the
     /// storage backend on first access. Only active when `storage_backend`
     /// is `Some` (cloud / multi-repo mode).
@@ -5211,6 +5223,7 @@ impl DaemonState {
             #[cfg(all(test, feature = "embeddings"))]
             vector_checkpoint_reopen_test_hook: Mutex::new(None),
             spine_refresh_gate: tokio::sync::RwLock::new(()),
+            spine_gate_read_wait_micros: std::sync::atomic::AtomicU64::new(0),
             repo_graphs: RwLock::new(HashMap::new()),
             repo_graph_load_gates: hosted_repo_reload_gates(),
             repo_graph_load_gate_hasher: RandomState::new(),
@@ -5569,6 +5582,7 @@ impl DaemonState {
             #[cfg(all(test, feature = "embeddings"))]
             vector_checkpoint_reopen_test_hook: Mutex::new(None),
             spine_refresh_gate: tokio::sync::RwLock::new(()),
+            spine_gate_read_wait_micros: std::sync::atomic::AtomicU64::new(0),
             repo_graphs: RwLock::new(HashMap::new()), // populated below
             repo_graph_load_gates: hosted_repo_reload_gates(),
             repo_graph_load_gate_hasher: RandomState::new(),
@@ -6444,7 +6458,12 @@ impl DaemonState {
     /// read. Hosted and local writers use the same gate, so the proof cannot be
     /// invalidated in the gap between readiness and response construction.
     pub(crate) async fn acquire_spine_read_authority(&self) -> Option<SpineAuthorityReadGuard<'_>> {
+        let gate_started = Instant::now();
         let publication_gate = self.spine_refresh_gate.read().await;
+        self.spine_gate_read_wait_micros.store(
+            u64::try_from(gate_started.elapsed().as_micros()).unwrap_or(u64::MAX),
+            Ordering::Relaxed,
+        );
         if let Some(control) = self.publication_control.as_ref() {
             if let Err(error) =
                 control.assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
@@ -7059,6 +7078,15 @@ impl DaemonState {
     /// Whether a complete lazy spine initialization pass is in progress.
     pub fn spine_warming(&self) -> bool {
         self.spine_warming.load(Ordering::Relaxed)
+    }
+
+    /// How long the most recent `acquire_spine_read_authority` waited for the
+    /// publication gate. Zero before the first acquisition, and a diagnostic
+    /// rather than an input to any decision: readiness reports it so a refused
+    /// probe says whether the authority check was blocked on the refresh
+    /// passes that hold that gate for write.
+    pub fn last_spine_gate_read_wait(&self) -> Duration {
+        Duration::from_micros(self.spine_gate_read_wait_micros.load(Ordering::Relaxed))
     }
 
     #[cfg(test)]


### PR DESCRIPTION
## Why

Kubernetes records a probe's status code and nothing else. So a daemon that answers 503 on `/readiness` tells an operator exactly one thing: it is not ready.

On 2026-09-04 that was not enough. KinLab promotion run [33886343178](https://github.com/firelock-ai/kinlab/actions/runs/33886343178) rolled a hosted daemon that bound port 4219 at 464 seconds into its start, then failed its rollout 134 seconds later having never reported ready. The pod log carries no line saying whether it was still uninitialized or whether the spine authority was refusing:

```
15:09:28Z     container started
15:17:12.992Z INFO kin_daemon::api: daemon API server listening port=4219
15:19:27.064Z error: deployment "kin-daemon" exceeded its progress deadline
15:19:28Z     Replicas: 1 desired | 1 updated | 1 total | 0 available | 1 unavailable
```

Kubelet aggregates repeated probe events, so the last recorded probe result is 15:14:56Z and nothing on record says what `/readiness` answered after the API bound. The post-mortem could name a mechanism and could not confirm it. This is the line that would have answered it.

## What

The refusal branch of `readiness` logs one line naming which half said no, with two durations:

```
WARN kin_daemon::api: readiness refused initialized=false hosted_spine_ready=true warming=false
     refused_on="initialization" authority_wait_ms=0 spine_gate_wait_ms=0
```

The gate wait has to be recorded where it happens, so `acquire_spine_read_authority` stores it in one relaxed atomic immediately after taking the publication gate and `readiness` reads it back. That is a single store on a path that already awaits a lock.

It is worth having as its own number rather than folded into the total. The periodic hosted refresh passes (`ingest_repo_into_spine_under_publication`, `refresh_all_hosted_cross_repo_edges_with_before_commit_hook`, `refresh_all_cross_repo_edges_under_publication`) hold that same `RwLock` for write, and a tokio `RwLock` is write-preferring, so a readiness probe queued behind them is a specific and checkable explanation rather than a guess. In the run above those passes ran back to back with no idle gap from 15:15:21Z until SIGTERM at 15:19:41Z.

Nothing decides anything on these numbers. They are reported, not consulted, and readiness returns exactly what it returned before.

WARN rather than DEBUG: a hosted daemon that cannot serve is the operator's problem whether or not anyone raised the log level first, and the line stops as soon as the daemon is ready.

## The tests are a pair, deliberately

`a_refused_readiness_says_which_half_refused` captures the formatted tracing output through a `MakeWriter` and fails if the line is missing, stops naming which half refused, or drops the gate wait.

`a_ready_daemon_logs_no_readiness_refusal` fails if a ready daemon logs a refusal at all.

Without the second, an unconditional line would satisfy the first while emitting a warning every few seconds for the life of every healthy pod, burying the one case that matters. Neither test is worth much alone.

One fixture detail, because it bit: `test_state()` opens a real repo and `DaemonState::open` sets `is_initialized` from whether a snapshot loaded, so the fixture arrives ready. The first run of the new test failed on that rather than on the behaviour, asserting a 503 from a state that was already 200. It now sets the flag back by hand with a comment saying why.

## Falsification

CI runs the tests; it does not run these. Each arm breaks one thing, alone, and was checked for **which** assertion fired.

```
ARM A  the tracing line deleted entirely
       a_refused_readiness_says_which_half_refused ... FAILED
       a_ready_daemon_logs_no_readiness_refusal ... ok
       "a 503 from /readiness must say so in the log; Kubernetes keeps only the status code, so an
        unlogged refusal is an unanswerable rollout failure."
       captured output contained no readiness line at all

ARM B  the line emitted on the ready branch too
       a_refused_readiness_says_which_half_refused ... ok
       a_ready_daemon_logs_no_readiness_refusal ... FAILED
       "a ready daemon must not log a refusal. The probe runs every few seconds for the life of the
        pod, so an unconditional line would bury the one case that matters."
       captured: readiness refused initialized=true hosted_spine_ready=true ...

ARM C  the refused_on field dropped
       a_refused_readiness_says_which_half_refused ... FAILED
       "the refusal must name which half refused, so a reader does not have to guess between
        initialization and the spine authority."
       captured: readiness refused initialized=false hosted_spine_ready=true warming=false
                 authority_wait_ms=0 spine_gate_wait_ms=0

ARM D  spine_gate_wait_ms dropped
       a_refused_readiness_says_which_half_refused ... FAILED
       "the refusal must report how long the authority check waited for the publication gate, which
        is the measurement that separates a slow open from starvation behind the refresh passes."
       captured: readiness refused initialized=false hosted_spine_ready=true warming=false
                 refused_on="initialization" authority_wait_ms=0

CONTROL  restored
       test result: ok. 6 passed; 0 failed
```

Each arm was confirmed to have compiled before its red was believed (`error[E` and `could not compile` both zero, one test binary executed). An earlier pair of arms edited by regex over the braced block did **not** compile, and `cargo test` gives a compile failure and an assertion failure the same exit code 101, so they read as red while proving nothing. They were redone with the block matched as an exact literal.

Green on this branch, through the fleet's builder slot:

```
$ cargo test -p kin-daemon readiness
test api::tests::a_ready_daemon_logs_no_readiness_refusal ... ok
test api::tests::a_refused_readiness_says_which_half_refused ... ok
test api::tests::readiness_returns_200_when_initialized ... ok
test api::tests::readiness_returns_200_for_initialized_empty_repository ... ok
test api::tests::readiness_reports_the_warming_state_it_is_in ... ok
test api::tests::readiness_is_answered_while_a_blocking_warm_up_holds_the_runtime ... ok
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 1367 filtered out

$ cargo fmt --all -- --check
(clean)
```

FIR-3167, FIR-3179.
