### PR TITLE
Read every release page before planning promotions

### DIFF
--- a/scripts/release-promotion-plan.mjs
+++ b/scripts/release-promotion-plan.mjs
@@ -282,15 +282,16 @@ export async function buildPlan({
   if (!repository) {
     throw new Error('no repository given; set GITHUB_REPOSITORY');
   }
-  const releases = await api('/releases?per_page=100');
-  // A full page is a refusal, not an answer. A promoter that silently read
-  // only the newest hundred releases would go quiet exactly when the list
-  // grew past them, and it would look identical to a healthy rail.
-  if (Array.isArray(releases) && releases.length === 100) {
-    throw new Error(
-      'the release listing filled a whole page, so it may be truncated; page ' +
-      'it before trusting this sweep',
-    );
+  const releases = [];
+  // Read the complete listing before judging any release. A full final page
+  // needs one more request to distinguish it from a truncated listing.
+  for (let page = 1; ; page += 1) {
+    const entries = await api(`/releases?per_page=100&page=${page}`);
+    if (!Array.isArray(entries)) {
+      throw new Error(`release listing page ${page} did not come back as an array`);
+    }
+    releases.push(...entries);
+    if (entries.length < 100) break;
   }
   const candidates = selectCandidates(releases);
   log(`${candidates.length} published stable release(s) are not GitHub Latest`);

--- a/scripts/release-promotion-plan.test.mjs
+++ b/scripts/release-promotion-plan.test.mjs
@@ -355,32 +355,61 @@ test('buildPlan turns an unresolvable tag into a wait, not a failure', async () 
   assert.match(plan.waiting[0].reason, /HTTP 404 Not Found/);
 });
 
-// The one read that must NOT fail soft. A truncated listing looks exactly like
-// a short one, and a promoter that silently read only the newest hundred
-// releases would go quiet at the moment the list outgrew them.
-test('buildPlan refuses a release listing that filled a whole page', async () => {
-  await assert.rejects(
-    buildPlan({
+for (const count of [99, 100, 101, 200, 201]) {
+  test(`buildPlan reads all ${count} releases before planning promotions`, async () => {
+    const releases = Array.from({ length: count }, (_, index) =>
+      release({ tag_name: `v1.0.${index}` }),
+    );
+    const pages = [];
+    const plan = await buildPlan({
       repository: 'firelock-ai/kin',
-      api: stubApi({ '/releases?': Array.from({ length: 100 }, () => release()) }),
-      judge: async () => ({}),
+      api: async (path) => {
+        if (path.startsWith('/releases?')) {
+          const page = Number(new URL(path, 'https://api.github.com').searchParams.get('page') ?? 1);
+          pages.push(page);
+          assert.ok(page <= Math.floor(count / 100) + 1, 'listing must stop at its terminal page');
+          return releases.slice((page - 1) * 100, page * 100);
+        }
+        return stubApi(listing())(path);
+      },
+      judge: async () => ({ stranger: { driver: { endpoint: 'account' } } }),
       now: NOW,
-    }),
-    /filled a whole page/,
-  );
-  // The control: ninety-nine is an answer, and it must be read as one.
-  const short = await buildPlan({
-    repository: 'firelock-ai/kin',
-    api: stubApi({
-      '/releases?': Array.from({ length: 99 }, () => release()),
-      '/git/ref/tags/': { object: { type: 'commit', sha: 'a'.repeat(40) } },
-      '/issues?': [],
-    }),
-    judge: async () => ({ stranger: { driver: { endpoint: 'account' } } }),
-    now: NOW,
+    });
+    assert.deepEqual(plan.promote.map((entry) => entry.tag), releases.map((entry) => entry.tag_name));
+    assert.deepEqual(pages, Array.from({ length: Math.floor(count / 100) + 1 }, (_, index) => index + 1));
   });
-  assert.equal(short.promote.length, 99);
-});
+}
+
+for (const [name, secondPage, reason] of [
+  ['unreadable', new Error('GET release page 2 failed: HTTP 503'), /GET release page 2 failed: HTTP 503/],
+  ['malformed', { message: 'not a listing' }, /release listing page 2 did not come back as an array/],
+]) {
+  test(`buildPlan refuses a later page that is ${name} before judging a partial listing`, async () => {
+    let judgements = 0;
+    await assert.rejects(
+      buildPlan({
+        repository: 'firelock-ai/kin',
+        api: async (path) => {
+          if (path.startsWith('/releases?')) {
+            const page = Number(new URL(path, 'https://api.github.com').searchParams.get('page') ?? 1);
+            if (page === 1) return Array.from({ length: 100 }, () => release());
+            assert.equal(page, 2);
+            if (secondPage instanceof Error) throw secondPage;
+            return secondPage;
+          }
+          return stubApi(listing())(path);
+        },
+        judge: async () => {
+          judgements += 1;
+          return {};
+        },
+        now: NOW,
+      }),
+      reason,
+    );
+    assert.equal(judgements, 0, 'an incomplete listing must not reach the proof gate');
+  });
+}
 
 test('buildPlan finds the open alarm by its exact title and nothing else', async () => {
   const withIssue = await buildPlan({


### PR DESCRIPTION
The promotion sweep fails once the repository has 100 releases. Run [33913668045](https://github.com/firelock-ai/kin/actions/runs/33913668045) stopped at the full-page guard while the live listing contained exactly 100 entries and an empty second page. This prevents the sweep from clearing first-contact notices or updating its proof alarm.

Read every release page before judging candidates. Full pages trigger another request, including the empty terminal page when the total is a multiple of 100. An unreadable or malformed later page still refuses the sweep before any proof judgement.

Validation:

- The complete `Validate automatic release policy` command block from `.github/workflows/ci.yml` passed, including all four Python validators and 263 Node tests.
- Both changed files pass `node --check`; `git diff --check` passes.
- Boundary tests cover 99, 100, 101, 200 and 201 releases, including all returned tags and the terminal page. Later-page error tests prove incomplete listings never reach the proof gate.

Actual output tail from the complete release-policy block:

```text
ℹ tests 263
ℹ suites 0
ℹ pass 263
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
RELEASE_POLICY_RC=0
```

The focused suite was falsified by temporarily restoring the original full-page refusal, then by stopping after the first page, then by discarding fetched entries. Each mutation changed production code. The exact edited bytes were restored after each arm.

```text
$ node --test scripts/release-promotion-plan.test.mjs scripts/read-promotion-plan.test.mjs
original full-page refusal: exit=1, tests=41, pass=35, fail=6
stop after page one:        exit=1, tests=41, pass=35, fail=6
discard fetched entries:   exit=1, tests=41, pass=31, fail=10
restored implementation:   exit=0, tests=41, pass=41, fail=0
```

The original-refusal and page-one mutations each fail the 100, 101, 200 and 201 boundary cases plus both later-page refusal cases. Discarding entries also fails the 99-release control. No release or production workflow was dispatched. This PR is held as a draft for review before landing.
