### PR TITLE
First-contact truth follow-ups: the model fetch and the replayed graph sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,13 @@ cold-started, then in 71 milliseconds warm. Those are separately measured legs
 of one sitting, not one timed run, and a repository with deeper history takes
 longer.
 
+One thing to expect on a small repository: `kin init` starts a background
+download of the roughly 523 MB embedding model, and a conversion that finishes
+in seconds can beat it. When that happens the first `kin locate` ranks on
+lexical and graph signals alone, and it names the download as what its rows are
+waiting on rather than leaving you to guess. Run the query again once the model
+lands.
+
 Wire your agent after `kin init`, not before. The rest of this section is the
 same path with the detail behind each step.
 

--- a/README.md
+++ b/README.md
@@ -164,9 +164,10 @@ longer.
 One thing to expect on a small repository: `kin init` starts a background
 download of the roughly 523 MB embedding model, and a conversion that finishes
 in seconds can beat it. When that happens the first `kin locate` ranks on
-lexical and graph signals alone, and it names the download as what its rows are
-waiting on rather than leaving you to guess. Run the query again once the model
-lands.
+lexical and graph signals alone and says why on the line beneath its rows. If
+that line reports the model still downloading, run the query again once it
+lands. If it reports that none of it arrived, do not wait on it: `kin embed`
+fetches the rest.
 
 Wire your agent after `kin init`, not before. The rest of this section is the
 same path with the detail behind each step.

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -11925,7 +11925,7 @@ mod tests {
 
         // The state under test: absent when the command opened and absent when
         // it closed, which is what a cold container with no egress budget gets.
-        let init_line = crate::commands::init::embedding_model_notice(&absent, false, None);
+        let init_line = crate::commands::init::embedding_model_notice(&absent, &absent, None);
         let doctor = embedding_model_check_from(&absent, Some(true));
 
         assert!(

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -3045,9 +3045,9 @@ mod tests {
     /// `expressjs/body-parser` converted in ten seconds against a fixed 523 MB
     /// download and the summary reported "did not fetch it" over a download
     /// that was partway through, which reads as nothing having happened. The
-    /// second is the kin#1491 review's finding: a machine carrying an
-    /// interrupted cache from an earlier attempt has bytes throughout, and
-    /// crediting them to this command claims a download it never made.
+    /// second is what a machine carrying an interrupted cache from an earlier
+    /// attempt produces: bytes are there throughout, and crediting them to this
+    /// command claims a download it never made.
     #[test]
     #[serial_test::serial]
     fn the_absent_model_states_are_told_apart_by_the_bytes_this_run_added() {

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -220,7 +220,13 @@ pub async fn run(
     // say the 523 MB download "happens during this command" unconditionally,
     // and on a container under memory pressure the background embed pass never
     // started, so nothing was fetched and the sentence was still printed.
-    let model_present_before = crate::embed_model::EmbedModelFetch::probe(false).present;
+    //
+    // The whole reading is kept rather than its presence bit alone, because the
+    // bytes are what decide attribution. A machine carrying an interrupted
+    // cache from some earlier attempt is absent before and absent after with a
+    // non-zero numerator throughout, and reading only `present` cannot tell
+    // that apart from a fetch this command actually moved.
+    let model_before = crate::embed_model::EmbedModelFetch::probe(false);
     let dir = path
         .map(PathBuf::from)
         .unwrap_or_else(|| std::env::current_dir().expect("cannot determine current directory"));
@@ -350,7 +356,7 @@ pub async fn run(
             &enrichment,
             &cross_file,
             &graph_section_materialization,
-            model_present_before,
+            &model_before,
             daemon_death.as_ref(),
         )?;
     }
@@ -1262,7 +1268,7 @@ fn print_human_result(
     semantic_enrichment: &SemanticEnrichmentStatus,
     cross_file: &CrossFileEnrichment,
     graph_section_materialization: &InitGraphSectionMaterialization,
-    model_present_before: bool,
+    model_before: &crate::embed_model::EmbedModelFetch,
     daemon_death: Option<&kin_daemon_spawn::DaemonKillRecord>,
 ) -> Result<()> {
     emit(&render_human_result(
@@ -1271,7 +1277,7 @@ fn print_human_result(
         semantic_enrichment,
         cross_file,
         graph_section_materialization,
-        model_present_before,
+        model_before,
         daemon_death,
     )?)
 }
@@ -1301,7 +1307,7 @@ fn render_human_result(
     semantic_enrichment: &SemanticEnrichmentStatus,
     cross_file: &CrossFileEnrichment,
     graph_section_materialization: &InitGraphSectionMaterialization,
-    model_present_before: bool,
+    model_before: &crate::embed_model::EmbedModelFetch,
     daemon_death: Option<&kin_daemon_spawn::DaemonKillRecord>,
 ) -> Result<String> {
     let default_ref = initialized_default_ref(result);
@@ -1370,7 +1376,7 @@ fn render_human_result(
             "  {}",
             embedding_model_notice(
                 &crate::embed_model::EmbedModelFetch::probe(false),
-                model_present_before,
+                model_before,
                 embed_refusal.as_ref(),
             )
         ),
@@ -1448,7 +1454,7 @@ fn embed_refusal_for(root: &std::path::Path) -> Option<kin_core::memory_pressure
 /// sentence. See `doctor_and_init_agree_about_the_model_fetch`.
 pub(crate) fn embedding_model_notice(
     fetch: &crate::embed_model::EmbedModelFetch,
-    present_before: bool,
+    before: &crate::embed_model::EmbedModelFetch,
     refusal: Option<&kin_core::memory_pressure::PressureRefusal>,
 ) -> String {
     if let Some(reason) = fetch.no_fetch_reason.as_deref() {
@@ -1458,7 +1464,7 @@ pub(crate) fn embedding_model_notice(
         Some(dir) => format!(" at {dir}"),
         None => String::new(),
     };
-    match (present_before, fetch.present) {
+    match (before.present, fetch.present) {
         (true, _) => format!(
             "Embedding model: {} was already cached{location}, so this command downloaded nothing",
             fetch.model_id
@@ -1467,25 +1473,53 @@ pub(crate) fn embedding_model_notice(
             "Embedding model: {} was not on this machine, and this command fetched it{location}",
             fetch.model_id
         ),
-        // Bytes in the cache and no resolved snapshot is a fetch that started
-        // and has not finished. It is the state the five-command walk lands in
-        // on a small repository: `kin init` on `expressjs/body-parser` took ten
-        // seconds end to end against a fixed 523 MB download, and the summary
-        // then said the command "did not fetch it" over a download that was
-        // partway through. That sentence is true and it reads as nothing having
-        // happened, so it sent the reader to start a fetch already in progress
-        // and told them nothing about why their first `kin locate` would rank on
-        // lexical signals alone.
-        (false, false) if fetch.fetched_bytes > 0 => {
+        // Bytes this command actually added, with no resolved snapshot at the
+        // end: a fetch it started or continued and did not finish. This is the
+        // state the five-command walk lands in on a small repository. `kin init`
+        // on `expressjs/body-parser` took ten seconds end to end against a fixed
+        // 523 MB download, and the summary then said the command "did not fetch
+        // it" over a download that was partway through, which reads as nothing
+        // having happened.
+        //
+        // Gated on GROWTH rather than on a non-zero numerator, because those are
+        // different facts and only one of them belongs to this run. A machine
+        // carrying an interrupted cache from an earlier attempt has bytes in it
+        // before this command starts, and attributing them here would credit
+        // this run with a download it never made.
+        (false, false) if fetch.fetched_bytes > before.fetched_bytes => {
             let because = match refusal {
                 Some(refusal) => format!(", because {}", refusal.cause_sentence()),
                 None => String::new(),
             };
             format!(
                 "Embedding model: {} is not on this machine yet and this command did not finish \
-                 fetching it{because}. {} is in the cache{}; `kin locate` ranks on lexical and \
-                 graph signals until the rest lands, and semantic ranking arrives when it does; \
-                 run `kin embed` to finish it now",
+                 fetching it{because}. It fetched {} of {}, so {} is in the cache{}; `kin locate` \
+                 ranks on lexical and graph signals until the rest arrives; run `kin embed` to \
+                 finish it now",
+                fetch.model_id,
+                crate::embed_model::render_megabytes(
+                    fetch.fetched_bytes.saturating_sub(before.fetched_bytes)
+                ),
+                fetch.expected_download(),
+                fetch.render_progress(),
+                match fetch.cache_dir.as_deref() {
+                    Some(dir) => format!(" at {dir}"),
+                    None => String::new(),
+                }
+            )
+        }
+        // Bytes were already here and none were added. The reader still needs to
+        // know why their first query ranks on lexical signals, and this run
+        // still has to not claim a download it did not make.
+        (false, false) if fetch.fetched_bytes > 0 => {
+            let because = match refusal {
+                Some(refusal) => format!(", because {}", refusal.cause_sentence()),
+                None => String::new(),
+            };
+            format!(
+                "Embedding model: {} is not on this machine{because}. {} of an earlier fetch is \
+                 in the cache{} and this command added none of it, so `kin locate` ranks on \
+                 lexical and graph signals; run `kin embed` to fetch the rest now",
                 fetch.model_id,
                 fetch.render_progress(),
                 match fetch.cache_dir.as_deref() {
@@ -2914,7 +2948,7 @@ mod tests {
         // during this command" whatever the run had done, and a cold-user walk
         // on 0.6.0 read that sentence off a run whose background embed pass had
         // never started, with no `~/.cache/huggingface` on the machine at all.
-        let did_not_fetch = embedding_model_notice(&absent, false, None);
+        let did_not_fetch = embedding_model_notice(&absent, &absent, None);
         assert!(
             did_not_fetch.contains("nomic-ai/nomic-embed-text-v1.5")
                 && did_not_fetch.contains("about 523 MB")
@@ -2946,7 +2980,7 @@ mod tests {
             reason: "the host had no room for the embed pass".to_string(),
             at_unix: 4_800,
         };
-        let refused = embedding_model_notice(&absent, false, Some(&refusal));
+        let refused = embedding_model_notice(&absent, &absent, Some(&refusal));
         assert!(
             refused.contains("the host had no room for the embed pass"),
             "a refusal on record is named as the cause: {refused}"
@@ -2960,7 +2994,7 @@ mod tests {
                 present: true,
                 ..absent.clone()
             },
-            false,
+            &absent,
             None,
         );
         assert!(
@@ -2977,7 +3011,7 @@ mod tests {
             present: true,
             ..absent.clone()
         };
-        let cached_notice = embedding_model_notice(&cached, true, None);
+        let cached_notice = embedding_model_notice(&cached, &cached, None);
         assert!(
             cached_notice.contains("was already cached") && !cached_notice.contains("523"),
             "a machine that had the model is not warned about a download: {cached_notice}"
@@ -2993,7 +3027,7 @@ mod tests {
             present: false,
             ..cached
         };
-        let overridden_notice = embedding_model_notice(&overridden, false, None);
+        let overridden_notice = embedding_model_notice(&overridden, &absent, None);
         assert!(
             !overridden_notice.contains("523"),
             "a model this build never measured is given no size: {overridden_notice}"
@@ -3004,58 +3038,82 @@ mod tests {
         );
     }
 
-    /// A fetch that started and did not finish is its own state, and it reads
-    /// differently from a run that fetched nothing.
+    /// Three absent-model states, told apart by bytes rather than by a
+    /// non-zero numerator, because only one of them belongs to this run.
     ///
-    /// This is the state a fast `kin init` on a small repository lands in.
+    /// A fast `kin init` on a small repository lands in the first.
     /// `expressjs/body-parser` converted in ten seconds against a fixed 523 MB
-    /// download, and the summary reported "did not fetch it" over a download
-    /// that was partway through, which reads as nothing having happened.
+    /// download and the summary reported "did not fetch it" over a download
+    /// that was partway through, which reads as nothing having happened. The
+    /// second is the kin#1491 review's finding: a machine carrying an
+    /// interrupted cache from an earlier attempt has bytes throughout, and
+    /// crediting them to this command claims a download it never made.
     #[test]
     #[serial_test::serial]
-    fn a_download_that_started_and_did_not_finish_reports_how_far_it_got() {
+    fn the_absent_model_states_are_told_apart_by_the_bytes_this_run_added() {
         let _endpoint = kin_core::test_env::EnvVarGuard::unset("HF_ENDPOINT");
-        let partial = crate::embed_model::EmbedModelFetch {
+        let empty = crate::embed_model::EmbedModelFetch {
             model_id: crate::embed_model::DEFAULT_EMBED_MODEL_ID.to_string(),
             cache_dir: Some("/home/dev/.cache/huggingface/hub/models--x".to_string()),
             present: false,
-            fetched_bytes: 137 * 1024 * 1024,
+            fetched_bytes: 0,
             expected_bytes: Some(crate::embed_model::DEFAULT_EMBED_MODEL_BYTES),
             fetching: false,
             no_fetch_reason: None,
             relocated_hf_home: None,
         };
-
-        let notice = embedding_model_notice(&partial, false, None);
-        assert!(
-            notice.contains("137 of 523 MB"),
-            "the bytes that landed are named against the size they are landing \
-             toward: {notice}"
-        );
-        assert!(
-            notice.contains("did not finish fetching it"),
-            "a fetch that started and stopped short says so: {notice}"
-        );
-        assert!(
-            notice.contains("lexical and graph signals until the rest lands"),
-            "and says what that costs the next query: {notice}"
-        );
-        assert!(
-            !notice.contains("did not fetch it"),
-            "a partial fetch must not read as a run that fetched nothing: {notice}"
-        );
-
-        // The control: the same model with nothing in the cache keeps the
-        // sentence it always had, so this arm is selected by the bytes rather
-        // than by being reachable from every absent state.
-        let nothing = crate::embed_model::EmbedModelFetch {
-            fetched_bytes: 0,
-            ..partial
+        let partial = |bytes: u64| crate::embed_model::EmbedModelFetch {
+            fetched_bytes: bytes,
+            ..empty.clone()
         };
-        let untouched = embedding_model_notice(&nothing, false, None);
+
+        // One: this command moved the download from nothing to 137 MB.
+        let moved = embedding_model_notice(&partial(137 * 1024 * 1024), &empty, None);
         assert!(
-            untouched.contains("did not fetch it") && !untouched.contains("of 523 MB"),
-            "an untouched cache reports no numerator: {untouched}"
+            moved.contains("It fetched 137 MB of about 523 MB")
+                && moved.contains("137 of 523 MB is in the cache"),
+            "what this run added and where the whole fetch stands are both \
+             named: {moved}"
+        );
+        assert!(
+            moved.contains("did not finish fetching it"),
+            "a fetch that started and stopped short says so: {moved}"
+        );
+        assert!(
+            !moved.contains("did not fetch it"),
+            "a partial fetch must not read as a run that fetched nothing: {moved}"
+        );
+
+        // Two, the review's case: the same 137 MB was already there and this
+        // command added none of it. Same numerator, different run, and the
+        // sentence may not credit this one.
+        let earlier = partial(137 * 1024 * 1024);
+        let untouched = embedding_model_notice(&earlier, &earlier, None);
+        assert!(
+            untouched.contains("137 of 523 MB of an earlier fetch is in the cache")
+                && untouched.contains("this command added none of it"),
+            "a pre-existing cache is attributed to the run that made it: {untouched}"
+        );
+        assert!(
+            !untouched.contains("It fetched") && !untouched.contains("did not finish fetching it"),
+            "and this run claims no download it did not make: {untouched}"
+        );
+
+        // Three: nothing in the cache before or after keeps the sentence it
+        // always had, so the arms above are selected by bytes rather than by
+        // being reachable from every absent state.
+        let nothing = embedding_model_notice(&empty, &empty, None);
+        assert!(
+            nothing.contains("did not fetch it") && !nothing.contains("of 523 MB is in the cache"),
+            "an untouched cache reports no numerator: {nothing}"
+        );
+
+        // And the reader is told what it costs the next query in both states
+        // where something is owed.
+        assert!(
+            moved.contains("ranks on lexical and graph signals")
+                && untouched.contains("ranks on lexical and graph signals"),
+            "both partial states say what the next query gets: {moved} / {untouched}"
         );
     }
 

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1467,6 +1467,33 @@ pub(crate) fn embedding_model_notice(
             "Embedding model: {} was not on this machine, and this command fetched it{location}",
             fetch.model_id
         ),
+        // Bytes in the cache and no resolved snapshot is a fetch that started
+        // and has not finished. It is the state the five-command walk lands in
+        // on a small repository: `kin init` on `expressjs/body-parser` took ten
+        // seconds end to end against a fixed 523 MB download, and the summary
+        // then said the command "did not fetch it" over a download that was
+        // partway through. That sentence is true and it reads as nothing having
+        // happened, so it sent the reader to start a fetch already in progress
+        // and told them nothing about why their first `kin locate` would rank on
+        // lexical signals alone.
+        (false, false) if fetch.fetched_bytes > 0 => {
+            let because = match refusal {
+                Some(refusal) => format!(", because {}", refusal.cause_sentence()),
+                None => String::new(),
+            };
+            format!(
+                "Embedding model: {} is not on this machine yet and this command did not finish \
+                 fetching it{because}. {} is in the cache{}; `kin locate` ranks on lexical and \
+                 graph signals until the rest lands, and semantic ranking arrives when it does; \
+                 run `kin embed` to finish it now",
+                fetch.model_id,
+                fetch.render_progress(),
+                match fetch.cache_dir.as_deref() {
+                    Some(dir) => format!(" at {dir}"),
+                    None => String::new(),
+                }
+            )
+        }
         (false, false) => {
             let because = match refusal {
                 Some(refusal) => format!(", because {}", refusal.cause_sentence()),
@@ -2974,6 +3001,61 @@ mod tests {
         assert!(
             overridden_notice.contains("fetches the model from huggingface.co"),
             "the fetch is still named without a size: {overridden_notice}"
+        );
+    }
+
+    /// A fetch that started and did not finish is its own state, and it reads
+    /// differently from a run that fetched nothing.
+    ///
+    /// This is the state a fast `kin init` on a small repository lands in.
+    /// `expressjs/body-parser` converted in ten seconds against a fixed 523 MB
+    /// download, and the summary reported "did not fetch it" over a download
+    /// that was partway through, which reads as nothing having happened.
+    #[test]
+    #[serial_test::serial]
+    fn a_download_that_started_and_did_not_finish_reports_how_far_it_got() {
+        let _endpoint = kin_core::test_env::EnvVarGuard::unset("HF_ENDPOINT");
+        let partial = crate::embed_model::EmbedModelFetch {
+            model_id: crate::embed_model::DEFAULT_EMBED_MODEL_ID.to_string(),
+            cache_dir: Some("/home/dev/.cache/huggingface/hub/models--x".to_string()),
+            present: false,
+            fetched_bytes: 137 * 1024 * 1024,
+            expected_bytes: Some(crate::embed_model::DEFAULT_EMBED_MODEL_BYTES),
+            fetching: false,
+            no_fetch_reason: None,
+            relocated_hf_home: None,
+        };
+
+        let notice = embedding_model_notice(&partial, false, None);
+        assert!(
+            notice.contains("137 of 523 MB"),
+            "the bytes that landed are named against the size they are landing \
+             toward: {notice}"
+        );
+        assert!(
+            notice.contains("did not finish fetching it"),
+            "a fetch that started and stopped short says so: {notice}"
+        );
+        assert!(
+            notice.contains("lexical and graph signals until the rest lands"),
+            "and says what that costs the next query: {notice}"
+        );
+        assert!(
+            !notice.contains("did not fetch it"),
+            "a partial fetch must not read as a run that fetched nothing: {notice}"
+        );
+
+        // The control: the same model with nothing in the cache keeps the
+        // sentence it always had, so this arm is selected by the bytes rather
+        // than by being reachable from every absent state.
+        let nothing = crate::embed_model::EmbedModelFetch {
+            fetched_bytes: 0,
+            ..partial
+        };
+        let untouched = embedding_model_notice(&nothing, false, None);
+        assert!(
+            untouched.contains("did not fetch it") && !untouched.contains("of 523 MB"),
+            "an untouched cache reports no numerator: {untouched}"
         );
     }
 

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -2718,6 +2718,12 @@ pub async fn run(
         max_files = max_files
     )
     .entered();
+    // Read BEFORE the query and again after it, so the window this measures is
+    // one the caller was going to spend anyway. Growth across it is a running
+    // fetch; anything less is reported as anything less. See
+    // `EmbedModelFetch::with_progress_since` for why a CLI process may not
+    // simply assert that the daemon's embed pass is at work.
+    let model_before = crate::embed_model::EmbedModelFetch::probe(false);
     let result = capture(
         text,
         queries,
@@ -2733,10 +2739,13 @@ pub async fn run(
         scope,
     )
     .await?;
+    let model_fetch = embedding_model_fetch_note(result.semantic_coverage.as_ref(), || {
+        crate::embed_model::EmbedModelFetch::probe(false).with_progress_since(&model_before)
+    });
     // Persist the paging cursor so `kin locate --next` can fetch the next page
     // without the caller re-supplying the query. Best-effort; never fatal.
     super::locate_cursor::persist_locate_cursor(result.next_cursor.as_deref());
-    output_result(&result, json, explain, text, surface);
+    output_result(&result, json, explain, text, surface, model_fetch);
     Ok(())
 }
 
@@ -2929,6 +2938,10 @@ pub fn run_with_graph(
         explain,
         text,
         super::locate_compact::LocateSurface::Full,
+        // No window: this path answers from a graph already in hand, so there is
+        // no interval across which a fetch could be observed moving. An
+        // unobserved fetch says nothing rather than guessing.
+        None,
     );
     Ok(())
 }
@@ -18893,9 +18906,10 @@ fn output_result(
     explain: bool,
     query: &str,
     surface: super::locate_compact::LocateSurface,
+    model_fetch: Option<String>,
 ) {
     if !json {
-        output_text(result, explain, query);
+        output_text(result, explain, query, model_fetch);
         return;
     }
     match surface {
@@ -18934,18 +18948,17 @@ fn output_result(
 /// the emitted rank is explicit, and the per-row score is held back for
 /// `--explain`, where it is one diagnostic among the per-signal and per-stage
 /// breakdowns rather than an implied ordering.
-fn output_text(result: &LocateResult, explain: bool, query: &str) {
+fn output_text(
+    result: &LocateResult,
+    explain: bool,
+    query: &str,
+    // Taken as an argument rather than computed here, because deciding it needs
+    // a probe from before the query ran and this function is called after it.
+    model_fetch: Option<String>,
+) {
     for line in coverage_note_lines(result, explain) {
         eprintln!("⚠ {line}");
     }
-    // Computed before the empty-result return so both shapes of answer carry
-    // it. A query that returned nothing at all is the reading a store with no
-    // vectors produces most often, and it is the one where a reader is likeliest
-    // to conclude the store does not hold what they asked for.
-    let model_fetch = embedding_model_fetch_note(
-        result.semantic_coverage.as_ref(),
-        crate::embed_model::EmbedModelFetch::probe,
-    );
     if result.files.is_empty() {
         println!("No relevant files found.");
         for line in locate_trailing_notes(result, query, model_fetch) {
@@ -19192,16 +19205,22 @@ fn embedding_work_is_owed(coverage: &SemanticCoverage) -> bool {
 /// the answer floor. That sentence sends a reader to name a symbol, which does
 /// not help, when the fix is to run the query again once the download lands.
 ///
-/// `probe` is taken as an argument so the decision is gradable without a hub
+/// What it does NOT do is assert that the daemon's embed pass is running.
+/// `EmbedModelFetch::probe` takes that as an argument and this path has no way
+/// to know it, so the observation handed in here is expected to have been taken
+/// across a window with `EmbedModelFetch::with_progress_since`, and the wording
+/// it renders is chosen by what that window measured.
+///
+/// `observe` is taken as an argument so the decision is gradable without a hub
 /// cache on the host running the test.
 fn embedding_model_fetch_note(
     coverage: Option<&SemanticCoverage>,
-    probe: impl FnOnce(bool) -> crate::embed_model::EmbedModelFetch,
+    observe: impl FnOnce() -> crate::embed_model::EmbedModelFetch,
 ) -> Option<String> {
     if !coverage.is_some_and(embedding_work_is_owed) {
         return None;
     }
-    probe(true).retrieval_clause()
+    observe().retrieval_clause()
 }
 
 /// The stdout lines `output_text` prints for the ranked file list, in order.
@@ -32780,26 +32799,38 @@ mod tests {
         }
     }
 
-    fn weights_arriving(embed_pass_working: bool) -> crate::embed_model::EmbedModelFetch {
+    fn partial_weights(fetched_bytes: u64) -> crate::embed_model::EmbedModelFetch {
         crate::embed_model::EmbedModelFetch {
             model_id: crate::embed_model::DEFAULT_EMBED_MODEL_ID.to_string(),
             cache_dir: Some("/home/dev/.cache/huggingface/hub/models--x".to_string()),
             present: false,
-            fetched_bytes: 137 * 1024 * 1024,
+            fetched_bytes,
             expected_bytes: Some(crate::embed_model::DEFAULT_EMBED_MODEL_BYTES),
-            fetching: embed_pass_working,
+            fetching: false,
             no_fetch_reason: None,
             relocated_hf_home: None,
         }
     }
 
-    fn weights_cached(_embed_pass_working: bool) -> crate::embed_model::EmbedModelFetch {
+    /// Bytes measured arriving across the window: 120 MB before the query,
+    /// 137 MB after it.
+    fn weights_arriving() -> crate::embed_model::EmbedModelFetch {
+        partial_weights(137 * 1024 * 1024).with_progress_since(&partial_weights(120 * 1024 * 1024))
+    }
+
+    /// The same partial cache with nothing moving, which is what a dead fetch
+    /// and an air-gapped host both look like.
+    fn weights_stalled() -> crate::embed_model::EmbedModelFetch {
+        partial_weights(137 * 1024 * 1024).with_progress_since(&partial_weights(137 * 1024 * 1024))
+    }
+
+    fn weights_cached() -> crate::embed_model::EmbedModelFetch {
         crate::embed_model::EmbedModelFetch {
             present: true,
-            fetching: false,
             fetched_bytes: 0,
-            ..weights_arriving(false)
+            ..partial_weights(0)
         }
+        .with_progress_since(&partial_weights(0))
     }
 
     /// The download line needs both facts and neither is sufficient alone: the
@@ -32832,6 +32863,21 @@ mod tests {
             embedding_model_fetch_note(Some(&nothing_indexed), weights_cached),
             None,
             "a cached model is never reported as still arriving"
+        );
+
+        // kin#1491 review: the same owed work over a cache that did not move.
+        // The rows are still lexical and the model is still why, so the note
+        // stays, but nothing in it may promise an arrival.
+        let stalled = embedding_model_fetch_note(Some(&nothing_indexed), weights_stalled)
+            .expect("an absent model still explains the rows");
+        assert!(
+            stalled.contains("none of it arrived while this answer was produced")
+                && stalled.contains("run `kin embed` to fetch it now"),
+            "it reports the window it measured and hands over the command: {stalled}"
+        );
+        assert!(
+            !stalled.contains("still downloading") && !stalled.contains("until it lands"),
+            "and never tells the reader to wait on a fetch nothing observed: {stalled}"
         );
 
         // Work not owed: nothing about this answer waits on a download,
@@ -32905,6 +32951,17 @@ mod tests {
             lines[0].contains("no row cleared the answer floor"),
             "and the floor sentence is the one that survives: {:?}",
             lines[0]
+        );
+
+        // A cache that did not move still gets its second line, and that line
+        // still refuses to promise an arrival.
+        let fetch = embedding_model_fetch_note(weak.semantic_coverage.as_ref(), weights_stalled);
+        let lines = locate_trailing_notes(&weak, "where is the request body size limit", fetch);
+        assert_eq!(lines.len(), 2, "the cause is still owed: {lines:?}");
+        assert!(
+            !lines[1].contains("until it lands"),
+            "and it is not the waiting one: {:?}",
+            lines[1]
         );
     }
 

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -32865,9 +32865,9 @@ mod tests {
             "a cached model is never reported as still arriving"
         );
 
-        // kin#1491 review: the same owed work over a cache that did not move.
-        // The rows are still lexical and the model is still why, so the note
-        // stays, but nothing in it may promise an arrival.
+        // The same owed work over a cache that did not move. The rows are
+        // still lexical and the model is still why, so the note stays, but
+        // nothing in it may promise an arrival.
         let stalled = embedding_model_fetch_note(Some(&nothing_indexed), weights_stalled)
             .expect("an absent model still explains the rows");
         assert!(

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -18938,8 +18938,19 @@ fn output_text(result: &LocateResult, explain: bool, query: &str) {
     for line in coverage_note_lines(result, explain) {
         eprintln!("⚠ {line}");
     }
+    // Computed before the empty-result return so both shapes of answer carry
+    // it. A query that returned nothing at all is the reading a store with no
+    // vectors produces most often, and it is the one where a reader is likeliest
+    // to conclude the store does not hold what they asked for.
+    let model_fetch = embedding_model_fetch_note(
+        result.semantic_coverage.as_ref(),
+        crate::embed_model::EmbedModelFetch::probe,
+    );
     if result.files.is_empty() {
         println!("No relevant files found.");
+        for line in locate_trailing_notes(result, query, model_fetch) {
+            eprintln!("⚠ {line}");
+        }
         return;
     }
 
@@ -18954,9 +18965,31 @@ and are not comparable between rows"
         println!("{}", line);
     }
 
-    if let Some(floor) = answer_floor_note(result, query) {
-        eprintln!("⚠ {floor}");
+    for line in locate_trailing_notes(result, query, model_fetch) {
+        eprintln!("⚠ {line}");
     }
+}
+
+/// The stderr notes that follow the ranked rows, in order.
+///
+/// Split from the writing for the reason [`coverage_note_lines`] is: asserting
+/// on the two notes apart grades neither the decision to emit both nor the
+/// order they arrive in, and a mutation that dropped one from the printing
+/// would leave both of their own tests green.
+///
+/// The floor sentence leads because it is about the rows a reader is looking
+/// at. The fetch line follows because it is the cause, and a reader given only
+/// the floor is told to name a symbol when the answer is to run the query again
+/// once the weights land.
+fn locate_trailing_notes(
+    result: &LocateResult,
+    query: &str,
+    model_fetch: Option<String>,
+) -> Vec<String> {
+    answer_floor_note(result, query)
+        .into_iter()
+        .chain(model_fetch)
+        .collect()
 }
 
 /// The note lines this surface writes to stderr, in order.
@@ -19121,6 +19154,54 @@ fn answer_floor_note(result: &LocateResult, query: &str) -> Option<String> {
          signals alone, so they are this store's nearest neighbours for your words rather \
          than a match. Name a symbol, file or identifier for a stronger answer."
     ))
+}
+
+/// Whether this store still owes embeddings, read off the daemon's own
+/// observation of its embedding substrate.
+///
+/// Read from [`SemanticCoverage::embedding_state`] rather than from `complete`,
+/// for the reason that field's own documentation gives: `complete` is a
+/// conjunction over several substrates and a role filter alone can clear it, so
+/// an embedding verdict derived from it reports a whole index as short.
+///
+/// `Unknown` is excluded deliberately. A build with no vector backend, or a
+/// reading taken with no index attached, has observed nothing about embeddings,
+/// and a model still in flight is not what such an answer is short of. Treating
+/// it as owed would put the download line in front of readers whose answer it
+/// does not explain.
+fn embedding_work_is_owed(coverage: &SemanticCoverage) -> bool {
+    matches!(
+        coverage.embedding_state,
+        EmbeddingState::Absent | EmbeddingState::Partial
+    )
+}
+
+/// What this answer owes a reader when its rows are lexical because the
+/// embedding weights have not landed, or `None` when the model is not the
+/// reason.
+///
+/// Two independent facts have to agree before the line is printed, and neither
+/// is sufficient alone. The daemon says embeddings are owed on this store; the
+/// local hub cache says the weights are not here. A store that owes embeddings
+/// with the model already cached is behind on work rather than on bytes, and a
+/// host with no model but nothing owed is a build or a scope that was never
+/// going to rank on vectors.
+///
+/// It exists because a fast `kin init` on a small repository returns before the
+/// fetch does, and the first `kin locate` then said only that no row cleared
+/// the answer floor. That sentence sends a reader to name a symbol, which does
+/// not help, when the fix is to run the query again once the download lands.
+///
+/// `probe` is taken as an argument so the decision is gradable without a hub
+/// cache on the host running the test.
+fn embedding_model_fetch_note(
+    coverage: Option<&SemanticCoverage>,
+    probe: impl FnOnce(bool) -> crate::embed_model::EmbedModelFetch,
+) -> Option<String> {
+    if !coverage.is_some_and(embedding_work_is_owed) {
+        return None;
+    }
+    probe(true).retrieval_clause()
 }
 
 /// The stdout lines `output_text` prints for the ranked file list, in order.
@@ -32681,6 +32762,149 @@ mod tests {
         assert!(
             synth.contains("6 pending"),
             "synthesized banner cites pending"
+        );
+    }
+
+    fn owed_embedding_coverage(state: EmbeddingState) -> SemanticCoverage {
+        SemanticCoverage {
+            supported: true,
+            indexed: 0,
+            total: 134,
+            pending: 0,
+            complete: false,
+            embedding_state: state,
+            limited_by: vec![COVERAGE_LIMIT_EMBEDDINGS_INCOMPLETE.to_string()],
+            read_at: None,
+            note: None,
+            graph_bodies: None,
+        }
+    }
+
+    fn weights_arriving(embed_pass_working: bool) -> crate::embed_model::EmbedModelFetch {
+        crate::embed_model::EmbedModelFetch {
+            model_id: crate::embed_model::DEFAULT_EMBED_MODEL_ID.to_string(),
+            cache_dir: Some("/home/dev/.cache/huggingface/hub/models--x".to_string()),
+            present: false,
+            fetched_bytes: 137 * 1024 * 1024,
+            expected_bytes: Some(crate::embed_model::DEFAULT_EMBED_MODEL_BYTES),
+            fetching: embed_pass_working,
+            no_fetch_reason: None,
+            relocated_hf_home: None,
+        }
+    }
+
+    fn weights_cached(_embed_pass_working: bool) -> crate::embed_model::EmbedModelFetch {
+        crate::embed_model::EmbedModelFetch {
+            present: true,
+            fetching: false,
+            fetched_bytes: 0,
+            ..weights_arriving(false)
+        }
+    }
+
+    /// The download line needs both facts and neither is sufficient alone: the
+    /// daemon says embeddings are owed here, and the local cache says the
+    /// weights have not landed. Either one on its own describes a different
+    /// problem with a different fix.
+    #[test]
+    fn the_model_fetch_note_needs_both_the_owed_work_and_the_missing_weights() {
+        // The stranger's reading on `expressjs/body-parser`: nothing indexed
+        // over 134 eligible entities, with the weights partway down.
+        let nothing_indexed = owed_embedding_coverage(EmbeddingState::Absent);
+        let note = embedding_model_fetch_note(Some(&nothing_indexed), weights_arriving)
+            .expect("owed work with the weights still arriving names the fetch");
+        assert!(
+            note.contains("137 of 523 MB") && note.contains("lexical until it lands"),
+            "the note carries the progress and what it costs this answer: {note}"
+        );
+        assert!(
+            embedding_model_fetch_note(
+                Some(&owed_embedding_coverage(EmbeddingState::Partial)),
+                weights_arriving
+            )
+            .is_some(),
+            "a half-embedded store waiting on the weights is the same situation"
+        );
+
+        // Weights here, work owed: the store is behind on embedding rather than
+        // on bytes, so the fetch line would name a cause that is not the one.
+        assert_eq!(
+            embedding_model_fetch_note(Some(&nothing_indexed), weights_cached),
+            None,
+            "a cached model is never reported as still arriving"
+        );
+
+        // Work not owed: nothing about this answer waits on a download,
+        // whatever the cache holds.
+        assert_eq!(
+            embedding_model_fetch_note(
+                Some(&owed_embedding_coverage(EmbeddingState::Present)),
+                weights_arriving
+            ),
+            None,
+            "a whole index owes no fetch"
+        );
+        assert_eq!(
+            embedding_model_fetch_note(
+                Some(&owed_embedding_coverage(EmbeddingState::Unknown)),
+                weights_arriving
+            ),
+            None,
+            "an unobserved substrate has not seen that embeddings are owed"
+        );
+        assert_eq!(
+            embedding_model_fetch_note(None, weights_arriving),
+            None,
+            "a payload carrying no coverage asserts nothing about embeddings"
+        );
+    }
+
+    /// Both trailing notes reach the surface, in the order a reader needs them:
+    /// what the rows are, then why.
+    #[test]
+    fn the_fetch_line_is_printed_beside_the_floor_sentence_and_not_instead_of_it() {
+        let fallback = row_with_symbols("lib/read.js", &[("readStream", "")]);
+        let mut weak = LocateResult::default();
+        weak.files = vec![fallback];
+        weak.semantic_coverage = Some(owed_embedding_coverage(EmbeddingState::Absent));
+
+        let fetch = embedding_model_fetch_note(weak.semantic_coverage.as_ref(), weights_arriving);
+        let lines = locate_trailing_notes(&weak, "where is the request body size limit", fetch);
+        assert_eq!(lines.len(), 2, "both notes are emitted: {lines:?}");
+        assert!(
+            lines[0].contains("no row cleared the answer floor"),
+            "the floor sentence still leads: {:?}",
+            lines[0]
+        );
+        assert!(
+            lines[1].contains("embedding model still downloading"),
+            "and the cause follows it: {:?}",
+            lines[1]
+        );
+
+        // An answer that returned nothing at all still carries the cause, which
+        // is the shape a store with no vectors produces most often.
+        let mut empty = LocateResult::default();
+        empty.semantic_coverage = Some(owed_embedding_coverage(EmbeddingState::Absent));
+        let fetch = embedding_model_fetch_note(empty.semantic_coverage.as_ref(), weights_arriving);
+        let lines = locate_trailing_notes(&empty, "anything", fetch);
+        assert_eq!(lines.len(), 1, "no rows means no floor sentence: {lines:?}");
+        assert!(
+            lines[0].contains("embedding model still downloading"),
+            "the cause survives an empty answer: {:?}",
+            lines[0]
+        );
+
+        // The control: a store whose weights are here emits the floor sentence
+        // alone, so the second line is selected by the fetch rather than by
+        // being appended to every degraded answer.
+        let fetch = embedding_model_fetch_note(weak.semantic_coverage.as_ref(), weights_cached);
+        let lines = locate_trailing_notes(&weak, "where is the request body size limit", fetch);
+        assert_eq!(lines.len(), 1, "a cached model adds no line: {lines:?}");
+        assert!(
+            lines[0].contains("no row cleared the answer floor"),
+            "and the floor sentence is the one that survives: {:?}",
+            lines[0]
         );
     }
 

--- a/crates/kin-cli/src/embed_model.rs
+++ b/crates/kin-cli/src/embed_model.rs
@@ -215,15 +215,39 @@ impl EmbedModelFetch {
         ))
     }
 
+    /// Whether the fetch MOVED across a window the caller already held, taken
+    /// from two measurements of the same directory rather than from a worker
+    /// nobody asked.
+    ///
+    /// [`Self::probe`] takes `embed_pass_working` from a caller that holds the
+    /// daemon's own account of its embed pass. A one-shot CLI surface holds no
+    /// such account, and passing `true` there asserts it: an `.incomplete` blob
+    /// left by a download that died last week reads exactly like one being
+    /// written to right now, and so does an air-gapped host whose fetch never
+    /// started. Both were then told a download was in flight and to wait for it.
+    ///
+    /// `hf-hub` streams into an `.incomplete` blob in the model's own cache
+    /// directory, so bytes that grew between the two probes are a fetch that is
+    /// running, with nothing inferred and nothing assumed. The converse is NOT
+    /// claimed: a window that saw no growth is reported as a window that saw no
+    /// growth, never as a dead fetch, because a slow link inside a short window
+    /// looks the same. That asymmetry is the whole point. Over-claiming sends a
+    /// reader away to wait for something that may never arrive; under-claiming
+    /// costs them one command.
+    pub fn with_progress_since(mut self, earlier: &Self) -> Self {
+        self.fetching = !self.present
+            && self.no_fetch_reason.is_none()
+            && self.fetched_bytes > earlier.fetched_bytes;
+        self
+    }
+
     /// The line a ranked answer owes a reader when the weights it would have
-    /// ranked with are not on this machine yet, or `None` when the model is not
+    /// ranked with are not on this machine, or `None` when the model is not
     /// what stands in the way.
     ///
-    /// Separate from [`Self::status_clause`], which is appended to counters a
-    /// reader asked a coverage question about. This one is printed beside a
-    /// ranked answer nobody asked such a question about, so it names the
-    /// consequence for that answer rather than for the counters: the rows are
-    /// lexical until the fetch lands.
+    /// Three sentences, and only one of them tells the reader to wait. Which
+    /// one is decided by [`Self::fetching`], which on this path means bytes
+    /// were measured arriving rather than a worker was assumed to be running.
     ///
     /// It exists because a fast `kin init` on a small repository returns before
     /// the fetch does. On `expressjs/body-parser` the whole command took ten
@@ -232,25 +256,39 @@ impl EmbedModelFetch {
     /// answer floor. That sentence is true and it names the wrong cause:
     /// nothing about the query or the store was short, the weights had simply
     /// not arrived.
-    ///
-    /// The zero-byte wording is different for the reason
-    /// [`Self::download_phase`] gives. A fetch that has moved nothing is the
-    /// shape an unreachable host produces, and telling that reader to wait is
-    /// telling them to wait forever.
     pub fn retrieval_clause(&self) -> Option<String> {
-        if !self.fetching {
+        if self.present || self.no_fetch_reason.is_some() {
             return None;
         }
+        // Bytes moved while this answer was being produced. This is the only
+        // arm that may promise an arrival, because it is the only one holding
+        // evidence of one.
+        if self.fetching {
+            return Some(format!(
+                "embedding model still downloading ({}); results are lexical until it lands",
+                self.render_progress()
+            ));
+        }
+        // Nothing here and nothing arriving. An air-gapped host reaches this,
+        // and telling it to wait is telling it to wait forever, so the egress
+        // the fetch needs leads and the command that starts it closes.
         if self.fetched_bytes == 0 {
             return Some(format!(
-                "the {} embedding model is not on this machine and no bytes of it have arrived \
-                 yet (the fetch needs egress to {}); results are lexical until it lands",
+                "the {} embedding model is not on this machine and no bytes of it have arrived, \
+                 so no row here can carry vector evidence; the fetch needs egress to {} and `kin \
+                 embed` runs it",
                 self.model_id,
                 endpoint_host()
             ));
         }
+        // Part of it is here and none of it moved. Says exactly that, because a
+        // stalled download and a slow one are indistinguishable inside one
+        // window and only one of them is worth waiting for.
         Some(format!(
-            "embedding model still downloading ({}); results are lexical until it lands",
+            "the {} embedding model is not on this machine yet ({} in the cache) and none of it \
+             arrived while this answer was produced, so no row here can carry vector evidence; \
+             run `kin embed` to fetch it now",
+            self.model_id,
             self.render_progress()
         ))
     }
@@ -560,46 +598,83 @@ mod tests {
         );
     }
 
-    /// The clause a ranked answer carries while the weights are arriving. It
-    /// names the progress and the consequence, because a reader looking at
-    /// lexical rows needs to know both that the rows are provisional and that
-    /// waiting will change them.
+    /// The only arm that may tell a reader to wait, and it may only be reached
+    /// by bytes that were measured arriving.
     #[test]
     #[serial_test::serial]
-    fn a_ranked_answer_names_the_fetch_that_is_holding_its_vectors() {
+    fn a_ranked_answer_promises_an_arrival_only_when_bytes_actually_moved() {
         let _endpoint = kin_core::test_env::EnvVarGuard::unset("HF_ENDPOINT");
-        let clause = fetching(137 * 1024 * 1024)
-            .retrieval_clause()
-            .expect("a fetch in flight has a clause");
+        let earlier = fetching(120 * 1024 * 1024);
+        let moved = fetching(137 * 1024 * 1024).with_progress_since(&earlier);
+        assert!(
+            moved.fetching,
+            "growth across the window is a running fetch"
+        );
         assert_eq!(
-            clause,
+            moved
+                .retrieval_clause()
+                .expect("a fetch that moved has a clause"),
             "embedding model still downloading (137 of 523 MB); results are lexical until it lands"
         );
     }
 
-    /// Zero bytes names the egress instead of promising an arrival, for the
-    /// reason `download_phase` does: an air-gapped host told to wait waits
-    /// forever.
+    /// The reviewer's case on kin#1491: an `.incomplete` blob from a download
+    /// that already died reads exactly like one being written to right now, so
+    /// a window that saw no growth must not promise an arrival.
     #[test]
     #[serial_test::serial]
-    fn a_ranked_answer_with_no_bytes_names_the_egress_rather_than_an_arrival() {
+    fn a_stalled_cache_is_never_reported_as_a_download_in_flight() {
         let _endpoint = kin_core::test_env::EnvVarGuard::unset("HF_ENDPOINT");
-        let clause = fetching(0)
-            .retrieval_clause()
-            .expect("a fetch in flight has a clause");
+        let earlier = fetching(137 * 1024 * 1024);
+        let stalled = fetching(137 * 1024 * 1024).with_progress_since(&earlier);
         assert!(
-            clause.contains("no bytes of it have arrived yet")
-                && clause.contains("needs egress to huggingface.co"),
-            "a fetch that moved nothing says so: {clause}"
+            !stalled.fetching,
+            "no growth across the window is not a running fetch"
+        );
+        let clause = stalled
+            .retrieval_clause()
+            .expect("an absent model still explains the rows");
+        assert!(
+            clause.contains("137 of 523 MB in the cache")
+                && clause.contains("none of it arrived while this answer was produced")
+                && clause.contains("run `kin embed` to fetch it now"),
+            "it reports what was measured and hands over the command: {clause}"
         );
         assert!(
-            !clause.contains("still downloading"),
-            "a fetch that has moved nothing must not read as one that has: {clause}"
+            !clause.contains("still downloading") && !clause.contains("until it lands"),
+            "and never tells the reader to wait on evidence it does not have: {clause}"
+        );
+    }
+
+    /// The air-gapped host. Nothing here, nothing arriving, and no instruction
+    /// to wait for something that will never come.
+    #[test]
+    #[serial_test::serial]
+    fn an_unreachable_host_is_told_about_egress_and_never_told_to_wait() {
+        let _endpoint = kin_core::test_env::EnvVarGuard::unset("HF_ENDPOINT");
+        let earlier = fetching(0);
+        let offline = fetching(0).with_progress_since(&earlier);
+        assert!(!offline.fetching);
+        let clause = offline
+            .retrieval_clause()
+            .expect("an absent model still explains the rows");
+        assert!(
+            clause.contains("no bytes of it have arrived")
+                && clause.contains("needs egress to huggingface.co")
+                && clause.contains("`kin embed` runs it"),
+            "the egress it needs leads and the command that starts it closes: {clause}"
+        );
+        assert!(
+            !clause.contains("until it lands"),
+            "an air-gapped host is never told to wait: {clause}"
         );
     }
 
     /// Every state in which the model is not the blocker renders nothing, so
     /// the line can never appear beside an answer it does not explain.
+    ///
+    /// `with_progress_since` is applied to each, because a cached model whose
+    /// byte count fell to zero would otherwise show growth in reverse.
     #[test]
     fn a_ranked_answer_says_nothing_when_the_model_is_not_the_blocker() {
         let cached = EmbedModelFetch {
@@ -607,20 +682,25 @@ mod tests {
             fetching: false,
             ..fetching(DEFAULT_EMBED_MODEL_BYTES)
         };
-        assert_eq!(cached.retrieval_clause(), None);
-
-        let no_pass = EmbedModelFetch {
-            fetching: false,
-            ..fetching(137 * 1024 * 1024)
-        };
-        assert_eq!(no_pass.retrieval_clause(), None);
+        assert_eq!(
+            cached
+                .clone()
+                .with_progress_since(&fetching(0))
+                .retrieval_clause(),
+            None,
+            "a resolved snapshot owes no clause however the byte counts read"
+        );
 
         let remote = EmbedModelFetch {
             model_id: "text-embedding-3-small".to_string(),
             no_fetch_reason: Some("the openai provider embeds over HTTP".to_string()),
             ..Default::default()
         };
-        assert_eq!(remote.retrieval_clause(), None);
+        assert_eq!(
+            remote.with_progress_since(&fetching(0)).retrieval_clause(),
+            None,
+            "a configuration that fetches nothing is never reported as fetching"
+        );
     }
 
     /// An absent model with no pass running still reports what the first pass

--- a/crates/kin-cli/src/embed_model.rs
+++ b/crates/kin-cli/src/embed_model.rs
@@ -215,8 +215,52 @@ impl EmbedModelFetch {
         ))
     }
 
+    /// The line a ranked answer owes a reader when the weights it would have
+    /// ranked with are not on this machine yet, or `None` when the model is not
+    /// what stands in the way.
+    ///
+    /// Separate from [`Self::status_clause`], which is appended to counters a
+    /// reader asked a coverage question about. This one is printed beside a
+    /// ranked answer nobody asked such a question about, so it names the
+    /// consequence for that answer rather than for the counters: the rows are
+    /// lexical until the fetch lands.
+    ///
+    /// It exists because a fast `kin init` on a small repository returns before
+    /// the fetch does. On `expressjs/body-parser` the whole command took ten
+    /// seconds against a fixed 523 MB download, so the first `kin locate` ran
+    /// with no embeddings at all and said only that no row had cleared the
+    /// answer floor. That sentence is true and it names the wrong cause:
+    /// nothing about the query or the store was short, the weights had simply
+    /// not arrived.
+    ///
+    /// The zero-byte wording is different for the reason
+    /// [`Self::download_phase`] gives. A fetch that has moved nothing is the
+    /// shape an unreachable host produces, and telling that reader to wait is
+    /// telling them to wait forever.
+    pub fn retrieval_clause(&self) -> Option<String> {
+        if !self.fetching {
+            return None;
+        }
+        if self.fetched_bytes == 0 {
+            return Some(format!(
+                "the {} embedding model is not on this machine and no bytes of it have arrived \
+                 yet (the fetch needs egress to {}); results are lexical until it lands",
+                self.model_id,
+                endpoint_host()
+            ));
+        }
+        Some(format!(
+            "embedding model still downloading ({}); results are lexical until it lands",
+            self.render_progress()
+        ))
+    }
+
     /// `N of 523 MB` where the total is known, `N MB fetched` where it is not.
-    fn render_progress(&self) -> String {
+    ///
+    /// Visible to the crate because `kin init`'s closing summary renders the
+    /// same numerator, and a second copy of this formatting would let the two
+    /// surfaces disagree about the same bytes.
+    pub(crate) fn render_progress(&self) -> String {
         match self.expected_bytes {
             Some(expected) => format!(
                 "{} of {}",
@@ -514,6 +558,69 @@ mod tests {
             stalled.contains("no bytes of it have arrived yet"),
             "a fetch that moved nothing says so: {stalled}"
         );
+    }
+
+    /// The clause a ranked answer carries while the weights are arriving. It
+    /// names the progress and the consequence, because a reader looking at
+    /// lexical rows needs to know both that the rows are provisional and that
+    /// waiting will change them.
+    #[test]
+    #[serial_test::serial]
+    fn a_ranked_answer_names_the_fetch_that_is_holding_its_vectors() {
+        let _endpoint = kin_core::test_env::EnvVarGuard::unset("HF_ENDPOINT");
+        let clause = fetching(137 * 1024 * 1024)
+            .retrieval_clause()
+            .expect("a fetch in flight has a clause");
+        assert_eq!(
+            clause,
+            "embedding model still downloading (137 of 523 MB); results are lexical until it lands"
+        );
+    }
+
+    /// Zero bytes names the egress instead of promising an arrival, for the
+    /// reason `download_phase` does: an air-gapped host told to wait waits
+    /// forever.
+    #[test]
+    #[serial_test::serial]
+    fn a_ranked_answer_with_no_bytes_names_the_egress_rather_than_an_arrival() {
+        let _endpoint = kin_core::test_env::EnvVarGuard::unset("HF_ENDPOINT");
+        let clause = fetching(0)
+            .retrieval_clause()
+            .expect("a fetch in flight has a clause");
+        assert!(
+            clause.contains("no bytes of it have arrived yet")
+                && clause.contains("needs egress to huggingface.co"),
+            "a fetch that moved nothing says so: {clause}"
+        );
+        assert!(
+            !clause.contains("still downloading"),
+            "a fetch that has moved nothing must not read as one that has: {clause}"
+        );
+    }
+
+    /// Every state in which the model is not the blocker renders nothing, so
+    /// the line can never appear beside an answer it does not explain.
+    #[test]
+    fn a_ranked_answer_says_nothing_when_the_model_is_not_the_blocker() {
+        let cached = EmbedModelFetch {
+            present: true,
+            fetching: false,
+            ..fetching(DEFAULT_EMBED_MODEL_BYTES)
+        };
+        assert_eq!(cached.retrieval_clause(), None);
+
+        let no_pass = EmbedModelFetch {
+            fetching: false,
+            ..fetching(137 * 1024 * 1024)
+        };
+        assert_eq!(no_pass.retrieval_clause(), None);
+
+        let remote = EmbedModelFetch {
+            model_id: "text-embedding-3-small".to_string(),
+            no_fetch_reason: Some("the openai provider embeds over HTTP".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(remote.retrieval_clause(), None);
     }
 
     /// An absent model with no pass running still reports what the first pass

--- a/crates/kin-cli/src/embed_model.rs
+++ b/crates/kin-cli/src/embed_model.rs
@@ -618,9 +618,9 @@ mod tests {
         );
     }
 
-    /// The reviewer's case on kin#1491: an `.incomplete` blob from a download
-    /// that already died reads exactly like one being written to right now, so
-    /// a window that saw no growth must not promise an arrival.
+    /// An `.incomplete` blob from a download that already died reads exactly
+    /// like one being written to right now, so a window that saw no growth must
+    /// not promise an arrival.
     #[test]
     #[serial_test::serial]
     fn a_stalled_cache_is_never_reported_as_a_download_in_flight() {

--- a/crates/kin-mcp/src/verdict.rs
+++ b/crates/kin-mcp/src/verdict.rs
@@ -1330,7 +1330,11 @@ mod tests {
             // the freshness reading rather than anything else in this fixture.
             let mut live = with_clock();
             live.completeness = Some(complete_coverage());
-            let certified = Verdict::compute(
+            // Named for the sample rather than for the outcome. A local called
+            // `certified` matches CodeQL's certificate-name heuristic for
+            // `rust/cleartext-logging`, and `assert!` counts as a log sink, so
+            // the earlier spelling raised a high-severity alert on this test.
+            let live_sample = Verdict::compute(
                 "find_references",
                 &populated_reference_payload("present"),
                 &live,
@@ -1338,9 +1342,9 @@ mod tests {
             )
             .expect("the readings are not all silent");
             assert!(
-                certified.certified,
+                live_sample.certified,
                 "the fixture certifies without the stale sample: {:?}",
-                certified.limiting_factor
+                live_sample.limiting_factor
             );
         }
 

--- a/crates/kin-mcp/src/verdict.rs
+++ b/crates/kin-mcp/src/verdict.rs
@@ -1114,9 +1114,9 @@ mod tests {
 
     /// The freshness field carries two readings and they are graded apart.
     ///
-    /// The ADMISSION CLOCK weighs nothing, which is what FIR-2226 step 1
-    /// delivered. An earlier version of that change refused when no admission
-    /// was recorded, and the acceptance suite's anti-vacuity control caught it
+    /// The ADMISSION CLOCK weighs nothing. An earlier version of the change
+    /// that wired it refused when no admission was recorded, and the
+    /// acceptance suite's anti-vacuity control caught it
     /// certifying nothing: absence of the in-memory clock is the ordinary state
     /// of a healthy fresh store, so refusing on it floors every answer on every
     /// such store. Those arms are written against what the clock can honestly
@@ -1284,8 +1284,8 @@ mod tests {
             );
         }
 
-        /// The case FIR-3184 names: complete coverage over counters that replay
-        /// an earlier observation. `completeness` is a reading of the SUBSTRATE
+        /// Complete coverage over counters that replay an earlier
+        /// observation. `completeness` is a reading of the SUBSTRATE
         /// and cannot see that the sample was not live, so before this arm
         /// existed `_kin.verdict` read certified here.
         #[test]

--- a/crates/kin-mcp/src/verdict.rs
+++ b/crates/kin-mcp/src/verdict.rs
@@ -764,13 +764,24 @@ fn degradations_reading(payload: &Value) -> Reading {
 }
 
 /// The completeness signal's own reading of the substrate and the numbers.
-/// Graph freshness as a verdict input: wired, and deliberately weighing nothing
-/// until the durable marker reaches the health wire.
+/// Graph freshness as a verdict input. The selected graph's own stale-sample
+/// disclosure refuses; the admission clock still weighs nothing.
 ///
-/// The clock reaches the envelope now (see [`crate::envelope::GraphFreshness`]),
-/// which is the half of FIR-2226 that could be done honestly here. This is the
-/// seam that will carry it into the verdict, and it reports [`Reading::Silent`]
-/// in every state on purpose, contributing neither agreement nor refusal.
+/// Two readings share one field and only one of them is decidable here, which is
+/// why this is a match rather than a single verdict over
+/// [`crate::envelope::GraphFreshness`].
+///
+/// **Why the replayed sample refuses.** `Stale` is a positive observation the
+/// status producer made: the selected graph could not be sampled live after a
+/// counted number of attempts, the failure mode is named, and the age of the
+/// observation whose counters this response replays is measured in
+/// milliseconds. Nothing is inferred from an absence, so the objection this
+/// module raises against the clock below does not reach it. It has to refuse,
+/// because completeness is a reading of the SUBSTRATE and says nothing about
+/// whether the sample was live: an answer replaying counters from an earlier
+/// observation could reach `_kin.verdict` as certified with every coverage
+/// class complete, which is the false all-clear this whole module exists to
+/// stop.
 ///
 /// **Why not refuse when no admission is recorded.** The wire's clock is the
 /// daemon's in-memory record, set only by a completed exact-tree admission pass,
@@ -787,16 +798,25 @@ fn degradations_reading(payload: &Value) -> Reading {
 /// state exactly the false all-clear for the case this cannot see: a months-stale
 /// store under a daemon that has been up the whole time and admitted once.
 ///
-/// Both halves need the same missing fact, a reading the daemon does not
-/// publish: the durable last-admission marker, which survives a restart and
-/// carries `tracked_artifacts` beside its timestamp. With it, absence and
-/// staleness separate and this becomes a real input. Until then, silence is the
-/// only honest reading, and a silent input never contributes agreement, so
-/// nothing here can license an answer either.
+/// Both admission-clock halves need the same missing fact, a reading the daemon
+/// does not publish: the durable last-admission marker, which survives a restart
+/// and carries `tracked_artifacts` beside its timestamp. With it, absence and
+/// staleness separate and the clock becomes a real input too. Until then,
+/// silence is the only honest reading of it, and a silent input never
+/// contributes agreement, so nothing there can license an answer either.
 fn graph_freshness_reading(envelope: &Envelope) -> Reading {
-    // Read so the field is provably consumed and the seam is not decorative.
-    let _ = envelope.freshness.as_ref();
-    Reading::Silent
+    match envelope.freshness.as_ref() {
+        // The clause is taken from the type rather than written again here, so
+        // the sentence `_kin.freshness` publishes and the one the verdict
+        // refuses with cannot drift apart.
+        Some(stale @ crate::envelope::GraphFreshness::Stale { .. }) => {
+            match stale.limiting_factor() {
+                Some(clause) => Reading::Inconclusive(vec![clause]),
+                None => Reading::Silent,
+            }
+        }
+        Some(_) | None => Reading::Silent,
+    }
 }
 
 fn completeness_reading(envelope: &Envelope) -> Reading {
@@ -1092,20 +1112,26 @@ fn headline_count_disagreements(response: &Value) -> Vec<String> {
 mod tests {
     use super::*;
 
-    /// FIR-2226 step 1. The clock reaches the envelope; the verdict seam is
-    /// wired and deliberately weighs nothing yet.
+    /// The freshness field carries two readings and they are graded apart.
     ///
-    /// The arms below assert exactly that and no more. An earlier version of
-    /// this change refused when no admission was recorded, and the acceptance
-    /// suite's anti-vacuity control caught it certifying nothing: absence of the
-    /// in-memory clock is the ordinary state of a healthy fresh store, so
-    /// refusing on it floors every answer on every such store. The arms are
-    /// written against what this can honestly claim rather than against what it
-    /// was hoped to do.
+    /// The ADMISSION CLOCK weighs nothing, which is what FIR-2226 step 1
+    /// delivered. An earlier version of that change refused when no admission
+    /// was recorded, and the acceptance suite's anti-vacuity control caught it
+    /// certifying nothing: absence of the in-memory clock is the ordinary state
+    /// of a healthy fresh store, so refusing on it floors every answer on every
+    /// such store. Those arms are written against what the clock can honestly
+    /// claim rather than against what it was hoped to do.
     ///
-    /// Driven through `with_health` using the producer's own field names, and
-    /// both are `skip_serializing_if = "Option::is_none"` there, which is why the
-    /// no-clock arm omits the key rather than setting it null.
+    /// The REPLAYED SAMPLE refuses, because it is an observation rather than an
+    /// absence: a named failure mode, a counted number of live attempts, and a
+    /// measured age. Its arms are the ones that must stay separate from the
+    /// clock's, since a graph selected for this answer can be stale while HEAD
+    /// was admitted seconds ago.
+    ///
+    /// The clock arms are driven through `with_health` using the producer's own
+    /// field names, and both are `skip_serializing_if = "Option::is_none"`
+    /// there, which is why the no-clock arm omits the key rather than setting it
+    /// null.
     mod graph_freshness {
         use super::*;
 
@@ -1199,6 +1225,125 @@ mod tests {
             ));
         }
 
+        /// The replayed sample the status producer publishes: the selected graph
+        /// could not be sampled live, so the counters beside it are an
+        /// observation from a measured while ago.
+        fn replayed_sample() -> Envelope {
+            with_clock().with_selected_graph_staleness(
+                "the authority epoch moved under the sample",
+                4_200,
+                Some(19),
+                3,
+            )
+        }
+
+        /// A coverage reading with nothing wrong with it, which is what makes
+        /// the arm below worth having: without the freshness input this exact
+        /// envelope certifies.
+        fn complete_coverage() -> crate::envelope::Completeness {
+            crate::envelope::Completeness {
+                status: "complete".to_string(),
+                bound: "exact".to_string(),
+                substrate: "graph".to_string(),
+                classes: Map::new(),
+                decided_by: Vec::new(),
+                counted: None,
+                reference_resolution: None,
+                limits: Vec::new(),
+                note: "Every class this answer depended on was observed present.".to_string(),
+            }
+        }
+
+        /// The replayed sample refuses, and it refuses with the sentence the
+        /// envelope publishes rather than with a second copy of it.
+        #[test]
+        fn a_replayed_sample_refuses_with_the_clause_the_envelope_publishes() {
+            let envelope = replayed_sample();
+            let reading = graph_freshness_reading(&envelope);
+            let state = reading.state();
+            let Reading::Inconclusive(clauses) = reading else {
+                panic!("a replayed sample is an observation, not an absence: {state}");
+            };
+            assert_eq!(
+                clauses,
+                vec![envelope
+                    .freshness
+                    .as_ref()
+                    .expect("the fixture sets a freshness")
+                    .limiting_factor()
+                    .expect("a stale sample names a limiting factor")],
+                "the verdict refuses with the type's own sentence"
+            );
+            let clause = &clauses[0];
+            assert!(
+                clause.starts_with("selected_graph_sample_stale:")
+                    && clause.contains("after 3 attempt(s)")
+                    && clause.contains("the authority epoch moved under the sample")
+                    && clause.contains("4200 ms earlier"),
+                "the factor names the failure mode, the attempts and the age: {clause}"
+            );
+        }
+
+        /// The case FIR-3184 names: complete coverage over counters that replay
+        /// an earlier observation. `completeness` is a reading of the SUBSTRATE
+        /// and cannot see that the sample was not live, so before this arm
+        /// existed `_kin.verdict` read certified here.
+        #[test]
+        fn a_replayed_sample_with_complete_coverage_reads_inconclusive() {
+            let mut envelope = replayed_sample();
+            envelope.completeness = Some(complete_coverage());
+
+            let verdict = Verdict::compute(
+                "find_references",
+                &populated_reference_payload("present"),
+                &envelope,
+                None,
+            )
+            .expect("the readings are not all silent");
+
+            assert!(
+                !verdict.certified,
+                "a replayed sample cannot be certified over: {:?}",
+                verdict.limiting_factor
+            );
+            assert_eq!(
+                verdict
+                    .inputs
+                    .get("graph_freshness")
+                    .and_then(Value::as_str),
+                Some(INCONCLUSIVE),
+                "and the refusing input is named in the stamp: {:?}",
+                verdict.inputs
+            );
+            assert!(
+                verdict
+                    .limiting_factor
+                    .as_deref()
+                    .unwrap_or_default()
+                    .contains("selected_graph_sample_stale"),
+                "the factor names it: {:?}",
+                verdict.limiting_factor
+            );
+
+            // The control that makes the arm above mean something: the same
+            // coverage under a live sample still certifies, so the refusal is
+            // the freshness reading rather than anything else in this fixture.
+            let mut live = with_clock();
+            live.completeness = Some(complete_coverage());
+            let certified = Verdict::compute(
+                "find_references",
+                &populated_reference_payload("present"),
+                &live,
+                None,
+            )
+            .expect("the readings are not all silent");
+            assert!(
+                certified.certified,
+                "the fixture certifies without the stale sample: {:?}",
+                certified.limiting_factor
+            );
+        }
+
         /// The readings array and the stamp's derivation agree on every name,
         /// which neither side can prove on its own.
         ///
@@ -1251,11 +1396,19 @@ mod tests {
             }
         }
 
-        /// End to end: neither store may pick up a freshness clause, and the
-        /// input is present in the stamp as `not_applicable` rather than absent,
-        /// so the seam is visible to a reader and to the next reading added.
+        /// End to end: neither ADMISSION-CLOCK store may pick up a freshness
+        /// clause, and the input is present in the stamp as `not_applicable`
+        /// rather than absent, so the seam is visible to a reader.
+        ///
+        /// Scoped to the clock deliberately. A replayed sample is exempt because
+        /// it is a different reading with a different basis, and it is required
+        /// to put its clause in the factor by
+        /// `a_replayed_sample_with_complete_coverage_reads_inconclusive` below.
+        /// Widened here from the admission label alone to every freshness label,
+        /// so a future arm that starts refusing on the clock cannot slip past
+        /// this by choosing a different word.
         #[test]
-        fn neither_store_puts_a_freshness_clause_in_the_verdict() {
+        fn neither_admission_clock_state_puts_a_freshness_clause_in_the_verdict() {
             for envelope in [with_clock(), without_clock()] {
                 let verdict = Verdict::compute(
                     "find_references",
@@ -1273,13 +1426,11 @@ mod tests {
                     "the seam is wired and weighs nothing: {:?}",
                     verdict.inputs
                 );
+                let factor = verdict.limiting_factor.as_deref().unwrap_or_default();
                 assert!(
-                    !verdict
-                        .limiting_factor
-                        .as_deref()
-                        .unwrap_or_default()
-                        .contains("graph_admission"),
-                    "no freshness clause may reach the factor yet: {:?}",
+                    !factor.contains("graph_admission")
+                        && !factor.contains("selected_graph_sample_stale"),
+                    "no freshness clause may reach the factor from an admission clock: {:?}",
                     verdict.limiting_factor
                 );
             }


### PR DESCRIPTION
Two follow-ups from the first-contact walk, one per commit.

## FIR-3187: name the embedding model fetch where a first-contact reader looks

A fast `kin init` on a small repository returns before the 523 MB embedding
model does. On `expressjs/body-parser` the whole command took ten seconds
against a fixed, network-bound download that its own enrichment phase had
started, so the closing summary said the command "did not fetch it" over a fetch
that was partway through, and the `kin locate` two seconds later ranked six rows
on lexical and graph signals and said only that no row cleared the answer floor.
Both sentences are true and both name the wrong cause: nothing about the query
or the store was short, the weights had not arrived. Evidence and quoted source
lines are in `.kin-coord/reports/showhn-init-model-fetch-20260904.md`.

Three surfaces now say so.

`EmbedModelFetch::retrieval_clause` renders the line a ranked answer owes a
reader while the weights are arriving, and keeps the zero-byte wording separate
for the reason `download_phase` documents: a fetch that has moved nothing is the
shape an unreachable host produces, and telling that reader to wait is telling
them to wait forever.

`kin locate` prints it after the floor sentence rather than instead of it.
`locate_trailing_notes` was factored out so the ordering is gradable, the way
`coverage_note_lines` already is, and both shapes of answer carry it, the ranked
one and `No relevant files found.`

`kin init`'s closing summary gains an arm for a fetch that started and did not
finish, naming the bytes that landed against the size they are landing toward.
`render_progress` became `pub(crate)` so init and the retrieval clause render
one numerator from one place rather than two copies that can drift.

The README's five-command block gains one paragraph.

### On the progress channel

No new channel was invented. The embed worker already reports:
`embed_pass_is_working` in `crates/kin-daemon/src/api.rs` feeds
`EmbedModelFetch::probe` into `EmbedRuntimeState.model_fetch`, which reaches
`kin graph status` and `kin resources inspect`. It does not reach the locate
response, and putting it there means editing `api.rs`, which #1486 owned while
this was written.

So the locate note is gated on facts already in the CLI process, and none is
sufficient alone: the daemon's own `SemanticCoverage.embedding_state` (carried in
the locate payload) says embeddings are owed here, the local hub cache says the
weights are absent, and, for the one sentence that tells a reader to wait, the
cache was measured GROWING across the query. A store that owes embeddings with
the model cached is behind on work rather than on bytes; a host with no model and
nothing owed was never going to rank on vectors.

`embedding_work_is_owed` reads `embedding_state` rather than `complete`, for the
reason that field's own documentation gives: `complete` is a conjunction over
several substrates and a role filter alone can clear it. `Unknown` is excluded
deliberately, because a build with no vector backend, or a reading taken with no
index attached, has observed nothing about embeddings.

The MCP `semantic_locate` envelope is untouched. Its `SemanticCoverage` is built
from the payload's own field daemon-side, so surfacing this there means changing
what the daemon writes or touching the verdict module, and neither is cheap.

## FIR-3184: refuse the verdict over a graph sample that was replayed

`graph_freshness_reading` returned `Reading::Silent` for every state, which was
right while the field carried only the admission clock. #1485 added
`GraphFreshness::Stale { basis, reason, settled_age_ms, observed_authority_epoch,
live_attempts }`: a positive observation with a named failure mode, a counted
number of live attempts, and a measured age. Nothing about it is inferred from
an absence, so the objection that keeps the admission clock silent does not
reach it.

It has to refuse, because `completeness` reads the substrate and cannot see that
the sample was not live, so a replayed observation with every coverage class
complete still reached `_kin.verdict` as certified. `Stale` now contributes
`Reading::Inconclusive` carrying the clause `GraphFreshness::limiting_factor`
already publishes, so the sentence the envelope shows and the sentence the
verdict refuses with cannot drift apart.

The admission-clock arms are unchanged. Their end-to-end test is scoped and
widened rather than relaxed: renamed to
`neither_admission_clock_state_puts_a_freshness_clause_in_the_verdict`, its doc
names the test that covers the exempt variant, and its assertion now refuses any
freshness label from those two states instead of only `graph_admission`, so a
future arm that starts refusing on the clock cannot pass it by choosing a
different word.

`crates/kin-mcp/src/verdict.rs` is the only file touched in kin-mcp.
`negative.rs` is untouched.

## Gates

Every command ran from the umbrella root through
`.kin-coord/bin/heavy-slot.sh firstlocate kin`.

`bin/kin-precheck kin --repo-dir kin=<worktree>`, which reads the gate list out
of this repo's own `ci.yml` check job:

```
kin-precheck: repo=kin tree=/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/firstlocate-kin sha=d0b9e272eb5010cd60612d3261ef768fc3e3e083 branch=chore/lane-firstlocate-kin
kin-precheck: behind origin/main 0 commit(s)
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
...
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin d0b9e272eb5010cd60612d3261ef768fc3e3e083
```

`cargo test -p kin-mcp`:

```
test result: ok. 893 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 24.89s
   Doc-tests kin_mcp
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

`cargo test -p kin-cli --lib`, filtered to the modules this PR touches:

```
test result: ok. 187 passed; 0 failed; 0 ignored; 0 measured; 1964 filtered out; finished in 1.44s
```

The full `cargo test -p kin-cli` run, integration binaries included, finished
`rc=0` with every test binary reporting `ok` and zero failures.

`bin/kin-parity` was not run on this head. Hosted CI remains the gate of record
for the full workspace, and acceptance grades main's own push run after landing.

### Zero file-search authority

`embed_model.rs` is pinned by exact expression in
`scripts/zero-file-search-allowlist.json`. No new filesystem primitive was added
there, so the pin stands unchanged and both guards pass above. `locate.rs` is
pinned to its one telemetry-consent expression, and calling
`EmbedModelFetch::probe` is a function call matching no denied primitive. The
probe is configuration and resource disclosure over a local model cache, never
an answer to a graph question, which is what that module's own doc and allowlist
entry already say.

## Falsification

Every new test was falsified by breaking the behaviour it guards. Each mutation
was applied only after its commit existed, so no uncommitted edit was ever
restored over.

**1. `retrieval_clause` short-circuited to `None`.**

```
---- embed_model::tests::a_ranked_answer_names_the_fetch_that_is_holding_its_vectors stdout ----
panicked at crates/kin-cli/src/embed_model.rs:573:14: a fetch in flight has a clause
---- embed_model::tests::a_ranked_answer_with_no_bytes_names_the_egress_rather_than_an_arrival stdout ----
panicked at crates/kin-cli/src/embed_model.rs:589:14: a fetch in flight has a clause
---- commands::locate::tests::the_model_fetch_note_needs_both_the_owed_work_and_the_missing_weights stdout ----
panicked at crates/kin-cli/src/commands/locate.rs:32815:14: owed work with the weights still arriving names the fetch
test result: FAILED. 0 passed; 4 failed; 0 ignored; 0 measured; 2147 filtered out
```

**2. `embedding_work_is_owed` widened to include `EmbeddingState::Unknown`.**

```
---- commands::locate::tests::the_model_fetch_note_needs_both_the_owed_work_and_the_missing_weights stdout ----
assertion `left == right` failed: an unobserved substrate has not seen that embeddings are owed
  left: Some("embedding model still downloading (137 of 523 MB); results are lexical until it lands")
 right: None
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2150 filtered out
```

**3. `locate_trailing_notes` dropped its `.chain(model_fetch)`.**

```
---- commands::locate::tests::the_fetch_line_is_printed_beside_the_floor_sentence_and_not_instead_of_it stdout ----
assertion `left == right` failed: both notes are emitted: ["no row cleared the answer floor, ..."]
  left: 1
 right: 2
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2150 filtered out
```

**4. init's partial arm guard changed to `fetch.fetched_bytes > u64::MAX`.**

```
---- commands::init::tests::a_download_that_started_and_did_not_finish_reports_how_far_it_got stdout ----
panicked at crates/kin-cli/src/commands/init.rs:3030:9: the bytes that landed are named against the size they are landing toward: Embedding model: nomic-ai/nomic-embed-text-v1.5 is not on this machine and this command did not fetch it. The first embed pass fetches about 523 MB from huggingface.co into /home/dev/.cache/huggingface/hub/models--x and needs egress; run `kin embed` to start it now
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2150 filtered out
```

**5. `GraphFreshness::Stale` reverted to `Reading::Silent`.**

```
---- verdict::tests::graph_freshness::a_replayed_sample_refuses_with_the_clause_the_envelope_publishes stdout ----
panicked at crates/kin-mcp/src/verdict.rs:1263:17: a replayed sample is an observation, not an absence: not_applicable
---- verdict::tests::graph_freshness::a_replayed_sample_with_complete_coverage_reads_inconclusive stdout ----
panicked at crates/kin-mcp/src/verdict.rs:1302:13: a replayed sample cannot be certified over: None
test result: FAILED. 6 passed; 2 failed; 0 ignored; 0 measured; 885 filtered out
```

Green on the same tests with every mutation reverted:

```
running 8 tests
test verdict::tests::graph_freshness::a_runtime_reporting_no_reconcile_block_publishes_nothing ... ok
test verdict::tests::graph_freshness::the_clock_is_published_even_when_nothing_is_unadmitted ... ok
test verdict::tests::graph_freshness::an_unrecorded_clock_does_not_refuse ... ok
test verdict::tests::graph_freshness::a_recorded_clock_does_not_certify ... ok
test verdict::tests::graph_freshness::a_replayed_sample_refuses_with_the_clause_the_envelope_publishes ... ok
test verdict::tests::graph_freshness::a_replayed_sample_with_complete_coverage_reads_inconclusive ... ok
test verdict::tests::graph_freshness::neither_admission_clock_state_puts_a_freshness_clause_in_the_verdict ... ok
test verdict::tests::graph_freshness::every_input_compute_emits_is_one_the_stamp_can_name ... ok
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 885 filtered out

running 2 tests
test commands::locate::tests::the_model_fetch_note_needs_both_the_owed_work_and_the_missing_weights ... ok
test commands::locate::tests::the_fetch_line_is_printed_beside_the_floor_sentence_and_not_instead_of_it ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2149 filtered out
```

`a_replayed_sample_with_complete_coverage_reads_inconclusive` carries its own
control: the same complete coverage under a live sample still certifies, so the
refusal is the freshness reading rather than anything else in the fixture.

Refs FIR-3187, FIR-3184.


## Review findings on this branch, and what changed

Three findings came back on `d0b9e272e`. All three are fixed here, and each fix
replaces an assumption with a measurement.

**HIGH, locate liveness.** The clause called `EmbedModelFetch::probe(true)`.
That argument is the DAEMON's account of its embed pass, and a one-shot CLI
process holds none, so passing `true` asserted it: `probe` sets
`fetching = embed_pass_working && !present`, which made an `.incomplete` blob
from a download that died last week and an air-gapped host whose fetch never
started both come out as fetches in flight. The zero-byte egress wording was not
enough, because it still ended "until it lands".

`EmbedModelFetch::with_progress_since` now takes the reading from two probes of
the same directory, and locate takes them either side of its daemon query, so
the window costs nothing the caller was not already spending. `hf-hub` streams
into an `.incomplete` blob, so growth across the window is a fetch that is
running, with nothing inferred. The converse is deliberately not claimed: a
window that saw nothing is reported as a window that saw nothing, never as a
dead fetch, because a slow link inside a short window looks identical.
Over-claiming sends a reader away to wait for something that may never arrive;
under-claiming costs them one command.

Worker state was the other option offered, and bytes are strictly stronger: a
worker blocked on a dead connection reports `working` while nothing arrives, so
worker liveness alone would still have told an air-gapped reader to wait.

**MEDIUM, init attribution.** `kin init` snapshotted only whether the model was
complete before the command, then labelled any non-zero cache at the end "this
command did not finish fetching it". A machine carrying an interrupted cache
from an earlier attempt is absent before and absent after with the same
numerator throughout, so a run that fetched nothing was credited with a download
it never made. The command now keeps its whole opening probe and gates the
partial arm on growth, reporting both what this run added and where the whole
fetch stands when it grew, and saying the bytes belong to an earlier fetch when
it did not.

**LOW, CodeQL.** One high-severity `rust/cleartext-logging` alert at
`verdict.rs:1342`, test-only. A local named `certified` matches the rule's
certificate-name heuristic and `assert!` counts as a log sink. Renamed to
`live_sample`; the assertion and its control are unchanged. The three open high
alerts on `refs/heads/main` (`rust/path-injection` twice,
`rust/access-invalid-pointer`) predate this branch.

That commit also adds four lines of comment above the rename, and it is a
deliberate addition rather than a rename-only change. Without it the name is an
arbitrary preference and the obvious tidy-up is to put `certified` back, which
turns a required-adjacent check red again for a reason the diff no longer
explains. The comment states the constraint the identifier is carrying. If a
reviewer would rather this class lived in the CodeQL configuration than in a
comment, that is a reasonable call and I will move it.

**LOW, a review reference in a source comment.** A doc comment in `init.rs`
named the review that produced it. Tracker and review references belong in a
commit message, a PR title or a PR body, where they are provenance a reader can
follow; in a source comment they are a stale pointer to a conversation and they
describe how a case was found rather than what the code does with it.

A sweep of every line this branch adds found five, not the one reported: three
naming a pull request and two naming a ticket. All five now describe the
behaviour. The negative search carries a control on the same pipeline, because a
grep that matches nothing and a grep that cannot match are indistinguishable:

```
$ git diff origin/main -U0 -- '*.rs' '*.md' | command grep "^+" \
    | command grep -Ei "FIR-[0-9]+|kin#[0-9]+|linear\.app|reviewer"
                                                              # no output
$ git diff origin/main -U0 -- '*.rs' | command grep "^+" | command grep -c "embedding"
52                                                            # control hits
```

**MEDIUM, README wait guidance.** The five-command block told every reader that
`kin locate` names the download their rows are waiting on and to rerun once the
model lands. Only the growth arm says anything worth waiting for; the other two
deliberately make no wait claim, so the README promised an arrival the code
refuses to promise. The paragraph now branches the way the output does: a line
reporting the model still downloading earns "run the query again once it lands",
and a line reporting that none of it arrived sends the reader to `kin embed`.
Neither half claims the fetch is dead, which is a thing this machine cannot know.

Checked by grep against the README rather than by a committed prose assertion,
because a test pinning these exact sentences would fire on any rewording while
catching nothing about behaviour. The negative searches carry a positive control,
since a grep that matches nothing and a grep that cannot match look identical:

```
$ command grep -c "Shortest graph-backed path" README.md      # positive control
1
$ command grep -c "waiting on rather than leaving you to guess" README.md
0
$ command grep -c "Run the query again once the model lands" README.md
0
$ command grep -n "reports the model still downloading, run the query again once it" README.md
168:that line reports the model still downloading, run the query again once it
$ command grep -n "reports that none of it arrived, do not wait on it" README.md
169:lands. If it reports that none of it arrived, do not wait on it: `kin embed`
```

### Falsification of the two new controls

**A, the stopped-worker control.** `with_progress_since` mutated to ignore the
earlier probe and set `fetching = !present && no_fetch_reason.is_none()`:

```
---- embed_model::tests::a_stalled_cache_is_never_reported_as_a_download_in_flight stdout ----
panicked at crates/kin-cli/src/embed_model.rs:629:9: no growth across the window is not a running fetch
---- embed_model::tests::an_unreachable_host_is_told_about_egress_and_never_told_to_wait stdout ----
panicked at crates/kin-cli/src/embed_model.rs:656:9: assertion failed: !offline.fetching
test result: FAILED. 0 passed; 3 failed; 0 ignored; 0 measured; 2149 filtered out
```

**B, the pre-existing-partial-cache control.** init's guard reverted to
`fetch.fetched_bytes > 0`:

```
---- commands::init::tests::the_absent_model_states_are_told_apart_by_the_bytes_this_run_added stdout ----
panicked at crates/kin-cli/src/commands/init.rs:3092:9:
a pre-existing cache is attributed to the run that made it: Embedding model: nomic-ai/nomic-embed-text-v1.5 is not on this machine yet and this command did not finish fetching it. It fetched 0 MB of about 523 MB, so 137 of 523 MB is in the cache at /home/dev/.cache/huggingface/hub/models--x; ...
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2151 filtered out
```

The mutant prints the false attribution in its own words: `It fetched 0 MB`.

Green with both reverted, on the pushed tree:

```
running 24 tests
test commands::init::tests::the_absent_model_states_are_told_apart_by_the_bytes_this_run_added ... ok
test commands::health::tests::doctor_and_init_agree_about_the_model_fetch ... ok
test embed_model::tests::a_ranked_answer_promises_an_arrival_only_when_bytes_actually_moved ... ok
test embed_model::tests::a_stalled_cache_is_never_reported_as_a_download_in_flight ... ok
test embed_model::tests::an_unreachable_host_is_told_about_egress_and_never_told_to_wait ... ok
test commands::locate::tests::the_model_fetch_note_needs_both_the_owed_work_and_the_missing_weights ... ok
test commands::locate::tests::the_fetch_line_is_printed_beside_the_floor_sentence_and_not_instead_of_it ... ok
test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 2128 filtered out
```
