### PR TITLE
Count semantic changes, not every hash a read surface prints

### DIFF
--- a/crates/kin-cli/src/commands/ref_grammar.rs
+++ b/crates/kin-cli/src/commands/ref_grammar.rs
@@ -268,35 +268,42 @@ pub(crate) fn parse_change_id(input: &str) -> Result<SemanticChangeId> {
 
 /// The one change whose id starts with `prefix`, or a refusal that says why not.
 ///
-/// The candidate set is the authority snapshot's own change map, which both
-/// callers already hold a lease on. That map IS the repository's history, so a
-/// prefix is matched against every change kin holds rather than against the
-/// slice reachable from one branch: an id an operator read out of
+/// `candidates` is the authority snapshot's own change map, which both callers
+/// already hold a lease on. That map IS the repository's history, so a prefix is
+/// matched against every change kin holds rather than against the slice
+/// reachable from one branch: an id an operator read out of
 /// `kin history --ref <branch>` resolves here whatever branch they are standing
 /// on. Nothing on disk is consulted; the ids come from graph-owned authority.
+///
+/// It arrives as an iterator of ids rather than as the lease itself so that the
+/// refusal below can be graded on a collision that was CONSTRUCTED. Change ids
+/// are hashes, so two of a small repository's own ids sharing four hexadecimal
+/// characters is a one-in-tens-of-thousands accident, and a check that waits for
+/// one is a check that never runs. Taking the ids alone lets the tests below
+/// hand this two that collide by construction, which is the only reason the
+/// ambiguity arm is graded at all.
 ///
 /// Ambiguity is refused rather than resolved to whichever candidate came first.
 /// Picking one would be the worst outcome available: it answers, it looks right,
 /// and it silently describes a different point in history than the operator
 /// meant.
 fn resolve_change_prefix(
-    lease: &kin_db::AuthorityReadLease<kin_db::RepositoryAuthorityState>,
+    candidates: impl Iterator<Item = SemanticChangeId>,
     original: &str,
     prefix: &str,
 ) -> Result<SemanticChangeId> {
-    let mut matches = Vec::new();
-    for change_id in lease.snapshot().changes.keys() {
-        if change_id.to_string().starts_with(prefix) {
-            matches.push(*change_id);
-            if matches.len() > AMBIGUITY_PREVIEW {
-                break;
-            }
-        }
-    }
-    // Sorted so an ambiguity refusal names the same candidates in the same order
-    // every run. A HashMap's iteration order is not stable and an error message
-    // that reshuffles between two runs of one command reads like two different
-    // failures.
+    // Every match is collected before any is named, and the sort is what makes
+    // the refusal reproducible. The early exit this used to take once
+    // `AMBIGUITY_PREVIEW` candidates were in hand ran BEFORE that sort, so which
+    // ids a refusal named came from the change map's iteration order, which a
+    // HashMap does not promise: two runs of one command could name two different
+    // sets and read like two different failures. The filter is a string prefix
+    // over a set bounded by the repository's own history, so collecting it whole
+    // costs nothing worth that ambiguity, and it makes the count an exact number
+    // rather than a floor.
+    let mut matches: Vec<SemanticChangeId> = candidates
+        .filter(|change_id| change_id.to_string().starts_with(prefix))
+        .collect();
     matches.sort();
     match matches.len() {
         0 => Err(ref_error(
@@ -310,14 +317,21 @@ fn resolve_change_prefix(
         count => {
             let preview = matches
                 .iter()
+                .take(AMBIGUITY_PREVIEW)
                 .map(|candidate| candidate.to_string()[..12].to_string())
                 .collect::<Vec<_>>()
                 .join(", ");
+            let unnamed = count.saturating_sub(AMBIGUITY_PREVIEW);
+            let elision = if unnamed == 0 {
+                String::new()
+            } else {
+                format!(", and {unnamed} more")
+            };
             Err(ref_error(
                 original,
                 format!(
-                    "'{prefix}' is ambiguous: at least {count} semantic changes begin with it \
-                     ({preview}); use more characters"
+                    "'{prefix}' is ambiguous: {count} semantic changes begin with it \
+                     ({preview}{elision}); use more characters"
                 ),
             ))
         }
@@ -510,7 +524,7 @@ where
             parse_change_id(value).map_err(|error| ref_error(original, error.to_string()))?
         } else if is_change_prefix(value) {
             let (lease, _) = authority.parts(original)?;
-            resolve_change_prefix(lease, original, value)?
+            resolve_change_prefix(lease.snapshot().changes.keys().copied(), original, value)?
         } else {
             return Err(ref_error(
                 original,
@@ -600,7 +614,8 @@ where
 
     if is_change_prefix(core) {
         let (lease, _) = authority.parts(original)?;
-        let change_id = resolve_change_prefix(lease, original, core)?;
+        let change_id =
+            resolve_change_prefix(lease.snapshot().changes.keys().copied(), original, core)?;
         return resolve_present_change(graph, original, change_id);
     }
 
@@ -726,5 +741,143 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// A full-width change id that starts with `prefix` and is padded with `fill`.
+    ///
+    /// Built rather than mined. Two of a three-commit repository's own ids
+    /// sharing four hexadecimal characters is a one-in-tens-of-thousands
+    /// accident, so a test that seeds a fixture and hopes for a collision is a
+    /// test that almost never reaches the code it was written for. These ids are
+    /// never stored or replayed; they exist only to be matched against a prefix,
+    /// which is the whole of what the function under test does.
+    ///
+    /// The padding runs to the full width rather than sitting in the last
+    /// character on purpose: a refusal previews twelve characters of each
+    /// candidate, so ids that differ only in their sixty-fourth would preview
+    /// identically and an assertion that both were named would hold over a
+    /// message that named one of them twice.
+    fn id_with_prefix(prefix: &str, fill: char) -> SemanticChangeId {
+        let mut hex = String::from(prefix);
+        while hex.len() < CHANGE_ID_HEX {
+            hex.push(fill);
+        }
+        parse_change_id(&hex).expect("constructed a full-width change id")
+    }
+
+    /// Ambiguity is refused, and the refusal says which selector and how many.
+    ///
+    /// This is the arm an operator meets when a short id they typed names more
+    /// than one point in history. Resolving it would be the worst outcome
+    /// available: it answers, it looks right, and it describes a change the
+    /// operator did not mean. `kin diff`, `kin blame --ref` and
+    /// `kin history --ref` all reach this through `resolve`, and the test above
+    /// pins that they hold no resolver of their own, so a refusal here is their
+    /// refusal.
+    #[test]
+    fn an_ambiguous_short_prefix_is_refused_naming_the_selector_and_the_count() {
+        let first = id_with_prefix("adfc", 'a');
+        let second = id_with_prefix("adfc", 'b');
+        let other = id_with_prefix("beef", 'c');
+
+        let error = resolve_change_prefix([first, other, second].into_iter(), "adfc", "adfc")
+            .expect_err("two changes begin with adfc, so it names no single point in history");
+        let message = format!("{error:#}");
+
+        assert!(
+            message.contains("'adfc'"),
+            "the refusal must quote the selector the operator typed, or they cannot tell \
+             which endpoint to lengthen: {message}"
+        );
+        assert!(
+            message.contains("2 semantic changes"),
+            "the refusal must say how many changes the prefix matches: {message}"
+        );
+        for candidate in [first, second] {
+            assert!(
+                message.contains(&candidate.to_string()[..12]),
+                "the refusal must name candidate {candidate} so the operator can pick one: \
+                 {message}"
+            );
+        }
+    }
+
+    /// The positive control: a prefix that names one change still resolves.
+    ///
+    /// Without it, a `resolve_change_prefix` that refused every prefix outright
+    /// would pass the ambiguity test above, and the widening FIR-3015 landed
+    /// would be gone with nothing red.
+    #[test]
+    fn a_unique_short_prefix_still_resolves() {
+        let first = id_with_prefix("adfc", 'a');
+        let second = id_with_prefix("adfc", 'b');
+        let other = id_with_prefix("beef", 'c');
+
+        let resolved = resolve_change_prefix([first, other, second].into_iter(), "beef", "beef")
+            .expect("exactly one change begins with beef");
+        assert_eq!(resolved, other);
+    }
+
+    /// A prefix nothing begins with is a different refusal from an ambiguous one.
+    ///
+    /// One says lengthen what you typed and the other says kin does not hold it.
+    /// Collapsing them would send an operator hunting for a longer id that does
+    /// not exist.
+    #[test]
+    fn a_prefix_no_change_begins_with_is_refused_as_absent_rather_than_ambiguous() {
+        let error =
+            resolve_change_prefix([id_with_prefix("adfc", 'a')].into_iter(), "dead", "dead")
+                .expect_err("no change begins with dead");
+        let message = format!("{error:#}");
+        assert!(
+            message.contains("no semantic change") && message.contains("'dead'"),
+            "an absent prefix must say kin holds nothing under it: {message}"
+        );
+        assert!(
+            !message.contains("ambiguous"),
+            "an absent prefix is not an ambiguous one: {message}"
+        );
+    }
+
+    /// One command, one refusal, whatever order the change map hands its keys in.
+    ///
+    /// The candidate ids come from a `HashMap`'s keys, whose iteration order is
+    /// not promised between two runs of one binary. This used to stop collecting
+    /// at `AMBIGUITY_PREVIEW` matches BEFORE sorting them, so the set a refusal
+    /// named was whichever ones iteration reached first and two runs could print
+    /// two different failures for one command. Six candidates, so the elision
+    /// arm is exercised too.
+    #[test]
+    fn an_ambiguous_refusal_reads_the_same_whatever_order_the_candidates_arrive_in() {
+        let ids: Vec<SemanticChangeId> = "abcdef"
+            .chars()
+            .map(|tail| id_with_prefix("adfc", tail))
+            .collect();
+        let mut reversed = ids.clone();
+        reversed.reverse();
+
+        let forward = format!(
+            "{:#}",
+            resolve_change_prefix(ids.iter().copied(), "adfc", "adfc")
+                .expect_err("six changes begin with adfc")
+        );
+        let backward = format!(
+            "{:#}",
+            resolve_change_prefix(reversed.into_iter(), "adfc", "adfc")
+                .expect_err("six changes begin with adfc")
+        );
+
+        assert_eq!(
+            forward, backward,
+            "the refusal must not depend on key order"
+        );
+        assert!(
+            forward.contains("6 semantic changes"),
+            "the count is exact, not a floor: {forward}"
+        );
+        assert!(
+            forward.contains("and 2 more"),
+            "a refusal that names only {AMBIGUITY_PREVIEW} of 6 must say so: {forward}"
+        );
     }
 }

--- a/scripts/acceptance/ref_grammar_repro.py
+++ b/scripts/acceptance/ref_grammar_repro.py
@@ -53,12 +53,15 @@ by the early ones.
                grammar that refused with a generic sentence would leave an
                operator no way to tell which of two endpoints was the bad one
   short_prefix a four-character prefix off a real change id resolves when it is
-               unique and is refused, naming itself, when it is not. Both arms
-               are graded every run, because which one applies is a property of
-               the fixture's own ids. An ambiguity-only check would have read
-               UNREADABLE four runs in five, and gate.py fails an unallowed
-               UNREADABLE, so it would have been red for a reason that has
-               nothing to do with the product
+               unique and is refused, naming itself and the count, when it is
+               not. Which arm the fixture reaches is a property of its own ids
+               and not something this suite gets to choose, and in practice that
+               is the unique arm: change ids are hashes, so a small repository's
+               own ids colliding on four hexadecimal characters is a
+               one-in-tens-of-thousands accident. The ambiguity refusal is
+               graded where a collision can be CONSTRUCTED rather than waited
+               for, in `crates/kin-cli/src/commands/ref_grammar.rs`, over the
+               same resolver `kin diff` calls
 
 Exit status is 0 when every check passed, 1 when one failed, 2 when none failed
 but one could not be read, and 3 when the run could not be set up. `--self-test`
@@ -309,13 +312,21 @@ def grade_refusal_names_the_selector(selector, text):
 def grade_short_prefix(prefix, text, matches):
     """A short prefix resolves when it is unique and is refused when it is not.
 
-    Both arms are graded in every run, because which one applies is a property
-    of the fixture's own change ids and not something the suite gets to choose.
-    Written as one grader rather than as an ambiguity check with an UNREADABLE
-    escape: three changes collide on four hex characters about one run in five,
-    so an ambiguity-only check would have spent four runs in five reporting that
-    it could not be read, and `gate.py` fails an UNREADABLE that carries no
-    allowance. A check that usually cannot answer is a check nobody trusts.
+    Both arms stay graded, and which one applies is a property of the fixture's
+    own change ids rather than something the suite gets to choose. In practice
+    the unique arm is the one that runs. Change ids are hashes, so this
+    fixture's own ids colliding on four hexadecimal characters is a
+    one-in-tens-of-thousands accident, not the one run in five this docstring
+    used to claim, and that wrong estimate is what licensed counting every
+    64-character hash the read surfaces printed as a change. `kin blame` prints
+    an entity revision id beside every change id and both render as 64 lowercase
+    hexadecimal characters, so a prefix matching one change and one revision was
+    reported here as two changes, and `kin diff` resolving the one change it
+    actually matched was graded as picking one silently. That is the FAIL run
+    33912645879 carried on prefix 'adfc'. The count now comes from
+    `semantic_change_ids`, which reads the column rather than the shape, and the
+    ambiguity refusal itself is graded deterministically in `ref_grammar.rs`
+    over a collision that is constructed.
     """
     if matches < 1:
         return UNREADABLE, (
@@ -351,6 +362,141 @@ HEX64 = re.compile(r"\b[0-9a-f]{64}\b")
 # self-test so the two cannot drift apart.
 FABRICATED_12 = "deadbeefcafe"
 FABRICATED_64 = "de" * 32
+
+
+# One real `kin blame biggest` stdout, from the same three-commit fixture this
+# suite seeds. Every line is byte-identical to what the binary printed except the
+# dashed rule under the header, shortened from 140 dashes to 78 to fit the line
+# budget; it carries no hash and the parse never reads it. The rest is verbatim
+# because the whole point of the parse below is what this text looks like: two
+# 64-character lowercase hashes side by side on every row, of which only the
+# second names a point in history.
+SELFTEST_BLAME = """\
+Blame for 'biggest' (Function, python) at \
+8ebcb1c67bf9594c608b24f8afec74d044e70ed2e1017fd50f8fc082d31e6c80:
+
+REVISION                              CHANGE                                \
+TIMESTAMP             AUTHOR           MESSAGE
+------------------------------------------------------------------------------
+57b4b3287a9093c8512b6e5abe0725527937e2eae25e10145698819635bb2d1a  \
+c4e634b2c431293236ab9106fbcd73d7090492bff1fb3127e186287cc0f22fa8  \
+2026-09-04T20:46:47.514820+00:00  ref-grammar-repro <repro@example.invalid>  \
+Add ledger line parsing
+7f051ba60cb46b2c0c8a6ff2516400f5022705a1f83f6e60eb602fdaed8763e1  \
+29872726c5c10df27ba4d239f560c8dce2910a587db5f95eadddd616fbebdad2  \
+2026-09-04T20:46:47.757698+00:00  ref-grammar-repro <repro@example.invalid>  \
+Add a biggest() helper
+1a9b0a6264099818e713a3030f052b801afd7ac6a9542398c5026bf54798c027  \
+8ebcb1c67bf9594c608b24f8afec74d044e70ed2e1017fd50f8fc082d31e6c80  \
+2026-09-04T20:46:47.991667+00:00  ref-grammar-repro <repro@example.invalid>  \
+Key biggest() on the amount column
+
+3 version(s) found.
+
+State at 8ebcb1c67bf9594c608b24f8afec74d044e70ed2e1017fd50f8fc082d31e6c80:
+  Signature: def biggest(rows)
+  Visibility: Public
+  File: ledger.py
+"""
+
+# The three semantic changes that blame text names, newest first, and the three
+# entity revision ids printed beside them. Both lists are read off the text
+# above by eye; the self-test proves the parse agrees and that the revision ids
+# really are in there, so neither list can quietly go stale.
+SELFTEST_CHANGE_IDS = [
+    "8ebcb1c67bf9594c608b24f8afec74d044e70ed2e1017fd50f8fc082d31e6c80",
+    "29872726c5c10df27ba4d239f560c8dce2910a587db5f95eadddd616fbebdad2",
+    "c4e634b2c431293236ab9106fbcd73d7090492bff1fb3127e186287cc0f22fa8",
+]
+SELFTEST_REVISION_IDS = [
+    "1a9b0a6264099818e713a3030f052b801afd7ac6a9542398c5026bf54798c027",
+    "7f051ba60cb46b2c0c8a6ff2516400f5022705a1f83f6e60eb602fdaed8763e1",
+    "57b4b3287a9093c8512b6e5abe0725527937e2eae25e10145698819635bb2d1a",
+]
+
+
+def selftest_log_json(change_ids):
+    """A `kin log --json` payload carrying `change_ids`, newest first.
+
+    Built rather than pasted because the real report is a few hundred lines of
+    root hashes and workspace state this parse never reads, and a literal that
+    large hides the four bytes that matter. The byte-array shape IS the product's
+    shape: `change_id` serializes as the bytes behind its `Hash256`, which is why
+    the parse cannot simply read a hex string. The live half is exercised for
+    real on every run of this suite, against whatever the binary actually emits.
+    """
+    return json.dumps({
+        "schema": "kin.log.v1",
+        "entries": [
+            {"change_id": [int(value[index:index + 2], 16)
+                           for index in range(0, len(value), 2)]}
+            for value in change_ids
+        ],
+    })
+
+
+def hex_change_id(value):
+    """One change id as lowercase hexadecimal, whatever `kin log --json` sent.
+
+    `change_id` serializes as the byte array behind its `Hash256`. A hex string
+    is accepted too, so a later change to that serialization is read rather than
+    silently dropped.
+    """
+    if isinstance(value, str):
+        return value.lower()
+    return "".join("%02x" % byte for byte in value)
+
+
+def change_ids_from_log_json(text):
+    """The change ids `kin log --json` names, newest first.
+
+    Read from the JSON report rather than from the human rendering. The
+    rendering is prose, and a regular expression over prose cannot tell a change
+    id from any other 64-character hash printed beside it. That is not a
+    hypothetical: it is the defect these two functions exist to end.
+    """
+    report = json.loads(text)
+    return [hex_change_id(entry["change_id"]) for entry in report.get("entries", [])]
+
+
+def change_ids_from_blame(text):
+    """The change ids `kin blame` names, in the order it prints them.
+
+    Blame prints a REVISION id and a CHANGE id side by side and both render as
+    64 lowercase hexadecimal characters, because `EntityRevisionId` and
+    `SemanticChangeId` are each a `Hash256`. A `findall` over the row takes both
+    and calls both changes. That is how this suite came to report `kin diff`
+    resolving an ambiguous prefix on run 33912645879: the second "change" was an
+    entity revision id, which names no point in history, and the one change the
+    prefix really matched was resolved correctly.
+
+    So the column decides rather than the shape. A row carrying two ids is
+    `revision  change`; a header line carrying one carries the change it is
+    reporting at.
+    """
+    ids = []
+    for line in (text or "").splitlines():
+        found = HEX64.findall(line)
+        if len(found) >= 2:
+            ids.append(found[1])
+        elif len(found) == 1:
+            ids.append(found[0])
+    return ids
+
+
+def semantic_change_ids(log_json_text, blame_text):
+    """Every semantic change id these two surfaces name, newest first, deduped.
+
+    Two surfaces on purpose, which is unchanged: a parse that keys on one
+    surface is a check that cannot fail the day that surface changes how it
+    prints. What changed is that each surface is now read where it says what a
+    value IS, rather than scanned for values that look alike.
+    """
+    ids = []
+    for value in change_ids_from_log_json(log_json_text) + change_ids_from_blame(blame_text):
+        if value not in ids:
+            ids.append(value)
+    return ids
 
 
 class Suite(object):
@@ -426,23 +572,22 @@ class Suite(object):
         return self._printed_id
 
     def changes(self):
-        """Every full change id this fixture holds, newest first.
+        """Every semantic change id this fixture's read surfaces name, newest first.
 
         Read from `kin log` AND `kin blame`, because a parse that keys on one
         surface printing full ids is a check that cannot fail the day that
         surface starts abbreviating the way `kin history` already does. blame.rs
-        prints `change.id` unabbreviated, so it is the backstop; the union is
-        deduplicated and an empty one is reported rather than proceeded on.
+        prints `change.id` unabbreviated, so it is the backstop.
+
+        stdout only, and `--json` for the log half. `answer()` folds stderr in so
+        a refusal can be graded, and stderr here carries tracing warnings that
+        are not the product's answer to anything.
         """
         if self._changes is not None:
             return self._changes
-        seen = []
-        for args in (["log", "-n", "20"], ["blame", "biggest"]):
-            _, text = self.answer(args)
-            for value in HEX64.findall(text):
-                if value not in seen:
-                    seen.append(value)
-        self._changes = seen
+        _, log_out, _ = self.kin_run(["log", "-n", "20", "--json"])
+        _, blame_out, _ = self.kin_run(["blame", "biggest"])
+        self._changes = semantic_change_ids(log_out, blame_out)
         return self._changes
 
     def measured(self):
@@ -645,6 +790,21 @@ def self_test():
               % (name, "ok" if ok else "BROKEN", want, status,
                  "" if ok else (" detail=%s" % (got[1] if isinstance(got, tuple) else ""))))
 
+    def expect_value(name, got, want):
+        """Like expect(), for a parse that returns a value rather than a verdict.
+
+        Prints both values on a break, because "expected=True got=False" over a
+        list of change ids tells a reader nothing about which id moved.
+        """
+        nonlocal ran, broken
+        ran += 1
+        ok = got == want
+        if not ok:
+            broken += 1
+        print("SELFTEST %s %s%s"
+              % (name, "ok" if ok else "BROKEN",
+                 "" if ok else (" expected=%r got=%r" % (want, got))))
+
     printed = "1971f659d7aa"
 
     # printed_id: the literal refusal must FAIL, the fixed answer must PASS.
@@ -721,6 +881,34 @@ def self_test():
            FAIL)
     expect("short_prefix/no-match-is-unreadable", grade_short_prefix("abcd", "", 0), UNREADABLE)
 
+    # The change set the short_prefix count is taken from. `matches` is the only
+    # input to that grader the product does not hand it directly, and reading it
+    # wrong is what made run 33912645879 red over correct behaviour, so the parse
+    # is graded here against real product text rather than trusted.
+    log_json = selftest_log_json(SELFTEST_CHANGE_IDS)
+    expect_value("change_set/names-changes-not-revisions",
+                 semantic_change_ids(log_json, SELFTEST_BLAME), SELFTEST_CHANGE_IDS)
+    # CONTROL: the revision ids ARE in that text. Without this, the case above is
+    # satisfied by a parse searching for something that is not there at all,
+    # which is the shape of every check that cannot fail.
+    expect_value("change_set/CONTROL-the-revision-ids-are-in-the-text",
+                 [value in SELFTEST_BLAME for value in SELFTEST_REVISION_IDS],
+                 [True, True, True])
+    # CONTROL: the parse this replaced. Six values where three are changes is the
+    # defect itself, written down, so a revert to `HEX64.findall` over the whole
+    # line goes red here rather than one acceptance run in thirteen thousand.
+    expect_value("change_set/CONTROL-a-findall-over-the-row-counts-six",
+                 len(set(HEX64.findall(SELFTEST_BLAME))), 6)
+    # `check_short_prefix` takes its prefix off index 0 and `measured()` takes
+    # its full-id forms off the same, so newest-first is load-bearing.
+    expect_value("change_set/log-json-leads-with-the-newest-change",
+                 semantic_change_ids(log_json, SELFTEST_BLAME)[0], SELFTEST_CHANGE_IDS[0])
+    # Blame is the backstop: with the log half empty it still names every change
+    # and still names no revision.
+    expect_value("change_set/blame-alone-is-a-backstop",
+                 sorted(semantic_change_ids(selftest_log_json([]), SELFTEST_BLAME)),
+                 sorted(SELFTEST_CHANGE_IDS))
+
     gate_ran, gate_broken = check_the_gate_reads_this_suites_report()
     ran += gate_ran
     broken += gate_broken
@@ -730,7 +918,7 @@ def self_test():
         return 1
     # A self-test that graded nothing is a failure, not a pass. The floor is the
     # count of expect() calls above, so deleting one has to be deliberate.
-    if ran < 24:
+    if ran < 29:
         print("SELFTEST %s BROKEN only %d case(s) ran; the self-test lost coverage"
               % (TICKET, ran))
         return 1


### PR DESCRIPTION
Product Acceptance went red on main (run 33912645879, alarm kin#1489) for `kin diff` behaving
correctly. `ref_grammar:short_prefix FAIL FIR-3015 prefix 'adfc' matches 2 changes and kin diff
resolved it anyway, so it picked one without saying which`. It did not. The second "change" was an
entity revision id.

## Why the grader was wrong

`kin diff` resolves its endpoint through `ref_grammar::resolve` (`diff.rs:518-519`), once, and a
test in `ref_grammar.rs` pins that it holds no parser of its own. That resolver already refuses an
ambiguous prefix, and it scans `lease.snapshot().changes`, of which `kin log` walks a subset
(`log.rs:101-150`). So two ids `kin log` printed sharing a prefix would both be seen and the
command would have refused. In that run it exited 0.

The count came from `Suite.changes()`, which collected every `\b[0-9a-f]{64}\b` out of `kin log`
and `kin blame`. `blame.rs:134-137` prints `revision.revision_id` in the first column, and
`EntityRevisionId` is a `Hash256` (kin-model 0.7.26 `ids.rs:265`), so it renders exactly like a
change id. A prefix matching one change and one revision was counted as two changes.

Reproduced locally against a debug `kin` at a73168325, on the same three-commit fixture the suite
seeds:

```
GRADER changes() count=6
REAL change ids from kin log: 3
NOT-A-CHANGE values the grader counted: 3
  dea088e2f946e3840295deb68696b0b011a7f27e269bf5b07efac01d9ad1dfb6
  8e7cdfc3fb62bd65fabe66dbc94743c173258a3d738682a5bbd9f28b6226001c
  dc19e52b30ea6593ad5a9f9f8be50e4573ade1bf0a8ec87c0f9ed24112a6ca61
  $ kin diff dea0 HEAD -> rc=1
DIFF revision-prefix dea0 -> rc=1
  $ kin diff dea088e2f946e3840295deb68696b0b011a7f27e269bf5b07efac01d9ad1dfb6 HEAD -> rc=1
DIFF full revision id -> rc=1
```

`kin diff` refuses a revision id at four characters and at sixty-four. There was nothing to fix in
the product's answer.

After this change, same probe, fresh fixture:

```
AFTER changes() count=3
naive findall over the SAME blame stdout: 6 values
values the old parse would have counted as changes and this one does not: 3
  REVISION 3b902f48088f3302a87f1aeba867ab77b9b7bd1c255fcde3d1e25a40ffeaf11b
  REVISION 404c860bc72d0d5edb8a2af1ffd223dd341670f58606e326204235c7f59457ba
  REVISION 703b4dc4a180e03d25a7b1bf1a5b198933dc50442151fe711827ee41ad7144bd
```

## What changed

`scripts/acceptance/ref_grammar_repro.py` reads each surface where it says what a value IS.
`kin log -n 20 --json` names `change_id`; on a blame row the column decides rather than the shape.
stdout only, because `answer()` folds stderr in and stderr carries tracing warnings. Both surfaces
stay, so a parse keyed on one still cannot pass the day that surface changes how it prints.

`crates/kin-cli/src/commands/ref_grammar.rs` gains the tests the ambiguity arm never had.
`resolve_change_prefix` takes an iterator of change ids rather than the authority lease, because
change ids are hashes and a test that seeds a repository and waits for two of them to collide on
four hexadecimal characters runs about once in tens of thousands of runs. Two behaviours change,
both in the refusal and neither in what resolves: collecting stopped at the preview width BEFORE
the sort, so which candidates a refusal named came out of HashMap iteration order and one command
could print two different failures; every match is collected now, which also makes the count exact
rather than a floor, with the remainder reported.

The docstrings that licensed the old parse are corrected. They put three change ids colliding on
four hexadecimal characters at one run in five. It is nearer one in tens of thousands, so the
fixture reaches the unique arm and the ambiguity refusal is graded where a collision can be built.

## Falsification

Each arm was applied, built and run, then reverted.

Resolve the first candidate instead of refusing:

```
test commands::ref_grammar::tests::a_unique_short_prefix_still_resolves ... ok
test commands::ref_grammar::tests::an_ambiguous_short_prefix_is_refused_naming_the_selector_and_the_count ... FAILED
test commands::ref_grammar::tests::an_ambiguous_refusal_reads_the_same_whatever_order_the_candidates_arrive_in ... FAILED
test result: FAILED. 6 passed; 2 failed
```

Refuse every prefix, which is the control that the two above are not satisfied by a resolver that
refuses everything:

```
---- commands::ref_grammar::tests::a_unique_short_prefix_still_resolves stdout ----
exactly one change begins with beef: cannot resolve 'beef': FALSIFICATION ARM: refuse every prefix
test result: FAILED. 7 passed; 1 failed
```

Restore the early exit before the sort:

```
---- ...an_ambiguous_refusal_reads_the_same_whatever_order_the_candidates_arrive_in stdout ----
the count is exact, not a floor: cannot resolve 'adfc': 'adfc' is ambiguous: 5 semantic changes
begin with it (adfc00000000, adfc00000000, adfc00000000, adfc00000000, and 1 more); use more characters
test result: FAILED. 7 passed; 1 failed
```

Restore `HEX64.findall` over the whole blame row, which is the parse this replaces:

```
SELFTEST change_set/names-changes-not-revisions BROKEN
  expected=['8ebcb1c6...', '29872726...', 'c4e634b2...']
  got=['8ebcb1c6...', '29872726...', 'c4e634b2...', '57b4b328...', '7f051ba6...', '1a9b0a62...']
SELFTEST change_set/blame-alone-is-a-backstop BROKEN
SELFTEST FIR-3015 30 case(s), 2 broken
rc=1
```

Restored, both green:

```
running 8 tests
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 2141 filtered out

SELFTEST FIR-3015 30 case(s), 0 broken
```

Live suite against locally built `kin` and `kin-daemon`:

```
CHECK printed_id FIR-3015 PASS FIR-3015 kin diff resolves the id kin history printed (b23c13f8c390) and still refuses a fabricated one, naming it (deadbeefcafe)
CHECK relative FIR-3015 PASS FIR-3015 kin diff walks parent hops (HEAD~1 answers) and refuses a hop past the root (HEAD~99)
CHECK parity FIR-3015 PASS FIR-3015 both surfaces agree on all 12 measured form(s): 10 resolved by each, 2 refused by each
CHECK refusal_names_it FIR-3015 PASS FIR-3015 the refusal names the endpoint that failed: dededede...
CHECK short_prefix FIR-3015 PASS FIR-3015 the unique 4-character prefix 'b23c' resolves
```

FIR-3015.
