### PR TITLE
Accept the release's own receipt as a stranger-run link

### DIFF
--- a/docs/release-bot.md
+++ b/docs/release-bot.md
@@ -213,10 +213,14 @@ there are two honest sets of bytes: the preflight judges the rc-build archives,
 and `release.yml` rebuilds at the tag, so the archive a developer downloads is
 never a preflight leg. With only the first link, the released-byte proof of any
 release could never lift that release's own pending notice. The release receipt
-is held to the same standard: its `kin.commit`, and every artifact's, must be
-the candidate, so a release whose provenance describes another build refuses
-rather than being passed over. An archive in neither receipt is still a stranger
-that ran on some other build, and it is still refused.
+is a trusted release receipt, not signature-verified proof: other jobs verify
+the asset's attestation and the gate does not, so it trusts the record as one
+the release chain wrote and holds it to the same standard as the preflight. Its
+`kin.commit`, and every artifact's, must be the candidate, so a release whose
+provenance describes another build refuses rather than being passed over, and
+a receipt that cannot be read refuses rather than reading as absent. An archive
+in neither receipt is still a stranger that ran on some other build, and it is
+still refused.
 
 The driver takes its credential from `KIN_STRANGER_ANTHROPIC_API_KEY`, exported
 as `ANTHROPIC_API_KEY`. No harness change was needed: `driver_env_argv` unsets

--- a/docs/release-bot.md
+++ b/docs/release-bot.md
@@ -203,6 +203,21 @@ release still becomes GitHub Latest. A partial record is still refused rather
 than accepted, because a record that overstates its own coverage is worse than
 no record.
 
+**A stranger record is linked to its candidate by one of two receipts, and both
+are the release chain's own.** `stranger.env` names the archive sha256 the
+stranger ran, and `scripts/check-release-proof-artifacts.mjs` accepts that
+archive when it appears among the preflight legs for that commit, or among
+`artifacts[].archive.sha256` in the `release-provenance.json` asset of the
+release whose tag resolves to that commit. Two receipts rather than one because
+there are two honest sets of bytes: the preflight judges the rc-build archives,
+and `release.yml` rebuilds at the tag, so the archive a developer downloads is
+never a preflight leg. With only the first link, the released-byte proof of any
+release could never lift that release's own pending notice. The release receipt
+is held to the same standard: its `kin.commit`, and every artifact's, must be
+the candidate, so a release whose provenance describes another build refuses
+rather than being passed over. An archive in neither receipt is still a stranger
+that ran on some other build, and it is still refused.
+
 The driver takes its credential from `KIN_STRANGER_ANTHROPIC_API_KEY`, exported
 as `ANTHROPIC_API_KEY`. No harness change was needed: `driver_env_argv` unsets
 that variable on exactly one branch, the local endpoint, and the endpoint

--- a/scripts/check-release-proof-artifacts.mjs
+++ b/scripts/check-release-proof-artifacts.mjs
@@ -20,10 +20,21 @@
 // The gate reads the proof loop's own records, not a summary of them. A
 // preflight record names, per leg, the commit that leg judged and the archive
 // sha256 it judged there. A stranger run.env names the archive sha256 the
-// stranger actually ran. Requiring the stranger's archive to appear among the
-// preflight's legs is what links the two: it proves the stranger ran on the
-// bytes the preflight judged FOR THIS COMMIT, rather than on some other build
-// that merely also exists. Two independent existence checks would not.
+// stranger actually ran. Requiring the stranger's archive to appear in a record
+// the release chain wrote FOR THIS COMMIT is what links the two, rather than
+// two independent existence checks, which would let a stranger run on some
+// other build that merely also exists satisfy this candidate.
+//
+// There are two such records and the gate accepts either, because there are two
+// sets of bytes a stranger can honestly run and both belong to this commit. The
+// preflight's legs are the rc-build archives the machine proof judged. The
+// release's own release-provenance.json names the archives release.yml built
+// and published AT THE TAG, which are different bytes by construction: the tag
+// build is a fresh one, so the archive a developer downloads is never a
+// preflight leg. Requiring the preflight link alone therefore made the
+// released-byte proof of any release unable to lift that release's own pending
+// notice, which is what v0.6.7 measured on 2026-09-04: three complete arms on
+// the public Linux aarch64 archive, refused as "not on these bytes".
 
 import process from 'node:process';
 import { realpathSync } from 'node:fs';
@@ -72,6 +83,10 @@ export const REFERENCE_DRIVER_ENDPOINT = 'account';
 // the same literal, and the authority suite pins the two together so they
 // cannot drift into a bridge that resolves somewhere nothing was ever proven.
 export const BUMP_BRANCH = 'automation/release-next';
+// The release's own signed receipt. release.yml writes and attests it onto
+// every release beside a sha256 sidecar, and it is the second record that can
+// link a stranger run to this candidate's bytes.
+export const PROVENANCE_ASSET = 'release-provenance.json';
 
 const COMMIT_SHA = /^[0-9a-f]{40}$/;
 const ARCHIVE_SHA = /^[0-9a-f]{64}$/;
@@ -282,7 +297,13 @@ export function describeDriver(driver) {
   );
 }
 
-export function judgeStranger(env, sha, archives) {
+// The bytes a stranger record claims, and whether it finished claiming them.
+//
+// Split out of judgeStranger so main() can read them without judging anything
+// else: which receipt has to be fetched depends on the archive, and fetching
+// the release provenance for every candidate would put a network read on the
+// ordinary path that the preflight legs already answer.
+export function readStrangerArchive(env, sha) {
   const where = evidencePath(sha, STRANGER_RECORD);
   const archive = env?.archive_sha256;
   if (!archive) {
@@ -297,11 +318,32 @@ export function judgeStranger(env, sha, archives) {
       'complete and its verdict is unknown',
     );
   }
-  if (!archives.includes(archive)) {
+  return archive;
+}
+
+// `provenance` is the release receipt, and its three states are distinct on
+// purpose. null means it was never consulted, because the preflight legs
+// already answered or because a caller is judging without a transport, and the
+// refusal then names only the legs. A receipt with a tag means a release of
+// this commit was found and read. A receipt whose tag is null means the search
+// ran and no published release of this commit carries one, which a refusal has
+// to say out loud rather than reporting as though only the preflight was ever
+// asked.
+export function judgeStranger(env, sha, archives, provenance = null) {
+  const where = evidencePath(sha, STRANGER_RECORD);
+  const archive = readStrangerArchive(env, sha);
+  if (!archives.includes(archive) && !(provenance?.archives ?? []).includes(archive)) {
+    let shipped = '';
+    if (provenance) {
+      shipped = provenance.tag === null
+        ? `, and no published release of ${sha} carries a ${PROVENANCE_ASSET}`
+        : `, and release ${provenance.tag} shipped ` +
+          `(${provenance.archives.join(', ')})`;
+    }
     throw new Error(
       `${where} ran archive sha256 ${archive}, which no preflight leg for ` +
-      `${sha} judged (${archives.join(', ')}); the stranger ran, but not on ` +
-      'these bytes',
+      `${sha} judged (${archives.join(', ')})${shipped}; the stranger ran, ` +
+      'but not on these bytes',
     );
   }
 
@@ -401,6 +443,190 @@ export async function fetchEvidence(
     );
   }
   return response.text();
+}
+
+// One authenticated read of the GitHub API, in the shape the two readers below
+// need. Written beside fetchEvidence rather than folded into it because that
+// function reads a file off a branch and reports a 404 as a flag a caller may
+// act on, while these read the release surface and treat every non-OK answer
+// the same way: fail closed, because a release we could not read is not a
+// release that agrees with us.
+function apiHeaders(token, accept) {
+  const headers = {
+    accept,
+    'user-agent': 'kin-release-proof-gate',
+    'x-github-api-version': '2022-11-28',
+  };
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+async function apiRead(url, what, { token, fetchImpl = fetch } = {}, accept) {
+  let response;
+  try {
+    response = await fetchImpl(url, { headers: apiHeaders(token, accept) });
+  } catch (cause) {
+    throw new Error(`could not reach GitHub to ${what}: ${cause.message}`, { cause });
+  }
+  if (!response.ok) {
+    throw new Error(
+      `could not ${what}: HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+  return response;
+}
+
+const apiJson = async (url, what, options) =>
+  (await apiRead(url, what, options, 'application/vnd.github+json')).json();
+
+// Resolve a tag to the commit it names, dereferencing an annotated tag. The
+// same two steps scripts/release-promotion-plan.mjs takes, and written here
+// rather than imported from it: release-tag.yml runs THIS FILE ALONE out of
+// $RUNNER_TEMP (`git show refs/remotes/origin/main:scripts/...` into a temp
+// path), so a relative import of a sibling script would not exist there and the
+// gate would fail to load on a release night.
+//
+// A tag that resolves to no commit sha answers null rather than throwing,
+// because the caller is searching a listing for the ONE tag that names this
+// candidate: a ref it cannot resolve is not that tag, and refusing the whole
+// judgement over an unrelated malformed ref would make an old tag able to hold
+// every future release.
+async function resolveReleaseTagCommit(tag, options) {
+  const base = `https://api.github.com/repos/${options.repository}`;
+  const ref = await apiJson(
+    `${base}/git/ref/tags/${encodeURIComponent(tag)}`,
+    `resolve the tag ${tag} of ${options.repository}`,
+    options,
+  );
+  let sha = ref?.object?.sha;
+  if (ref?.object?.type === 'tag' && COMMIT_SHA.test(sha ?? '')) {
+    sha = (
+      await apiJson(
+        `${base}/git/tags/${sha}`,
+        `dereference the annotated tag ${tag} of ${options.repository}`,
+        options,
+      )
+    )?.object?.sha;
+  }
+  return COMMIT_SHA.test(sha ?? '') ? sha : null;
+}
+
+// What a release's own receipt says about the bytes it shipped.
+//
+// Two statements have to agree before this record links anything, and they are
+// independent. The release's TAG must resolve to the candidate, which is the
+// caller's half. The record itself must say it is about that commit, which is
+// this half: `kin.commit` at the top and `kin.commit` on every artifact. A
+// release whose tag points at this candidate while its provenance describes
+// another build is REFUSED rather than skipped, because a receipt that
+// disagrees with the release carrying it is evidence of tampering and not of
+// absence, and quietly moving on to the next release would let the disagreement
+// pick the answer.
+export function judgeReleaseProvenance(record, sha, tag) {
+  const where = `${PROVENANCE_ASSET} on release ${tag}`;
+  if (!record || typeof record !== 'object' || Array.isArray(record)) {
+    throw new Error(`${where} did not parse as a release provenance record`);
+  }
+  const commit = record?.kin?.commit;
+  if (commit !== sha) {
+    throw new Error(
+      `${where} records commit ${commit ?? '<none>'}, not ${sha}; the release ` +
+      'exists but its provenance is about a different build',
+    );
+  }
+  const artifacts = Array.isArray(record.artifacts) ? record.artifacts : [];
+  const archives = [];
+  artifacts.forEach((artifact, index) => {
+    const name = artifact?.artifact ?? artifact?.target ?? `artifact ${index}`;
+    const built = artifact?.kin?.commit;
+    if (built !== sha) {
+      throw new Error(
+        `${where} artifact "${name}" records commit ${built ?? '<none>'}, not ` +
+        `${sha}; the record exists but that artifact is about a different build`,
+      );
+    }
+    const archive = artifact?.archive?.sha256;
+    if (typeof archive !== 'string' || !ARCHIVE_SHA.test(archive)) {
+      throw new Error(
+        `${where} artifact "${name}" records no archive sha256, so nothing ` +
+        'can link a stranger run to the bytes it shipped',
+      );
+    }
+    archives.push(archive);
+  });
+  if (archives.length === 0) {
+    throw new Error(
+      `${where} lists no artifacts, so it names no released bytes`,
+    );
+  }
+  return { tag, commit, archives };
+}
+
+// Find the release of this candidate and read the bytes it shipped.
+//
+// Newest first, which is the order GitHub lists releases in, stopping at the
+// first release whose tag resolves to the candidate. A re-tag of the same
+// commit publishes a NEWER release, and the bytes on offer are that one's, so
+// taking the newest match is reading the current answer rather than guessing
+// between two.
+//
+// Draft releases are skipped because nothing about them is a claim yet, and a
+// release carrying no PROVENANCE_ASSET is skipped BEFORE its tag is resolved,
+// which is what keeps the cost of this search at one extra request in the
+// ordinary case: the candidate's own release is at the top of the listing.
+// Returning a receipt whose tag is null rather than throwing is deliberate, so
+// the caller's refusal can name both the legs it checked and the release
+// surface it searched.
+export async function findReleaseProvenance(sha, options = {}) {
+  const { repository } = options;
+  const base = `https://api.github.com/repos/${repository}`;
+  for (let page = 1; ; page += 1) {
+    const releases = await apiJson(
+      `${base}/releases?per_page=100&page=${page}`,
+      `list the releases of ${repository}`,
+      options,
+    );
+    if (!Array.isArray(releases)) {
+      throw new Error(
+        `release listing page ${page} of ${repository} did not come back as ` +
+        `an array, so no release can be resolved to ${sha}`,
+      );
+    }
+    for (const release of releases) {
+      if (release?.draft === true) continue;
+      const tag = typeof release?.tag_name === 'string' ? release.tag_name : '';
+      if (!tag) continue;
+      const asset = (Array.isArray(release?.assets) ? release.assets : []).find(
+        (entry) => entry?.name === PROVENANCE_ASSET && typeof entry?.url === 'string',
+      );
+      if (!asset) continue;
+      if ((await resolveReleaseTagCommit(tag, options)) !== sha) continue;
+      const response = await apiRead(
+        asset.url,
+        `read ${PROVENANCE_ASSET} from release ${tag}`,
+        options,
+        'application/octet-stream',
+      );
+      const text = await response.text();
+      let record;
+      try {
+        record = JSON.parse(text);
+      } catch (cause) {
+        throw new Error(
+          `${PROVENANCE_ASSET} on release ${tag} is not valid JSON: ${cause.message}`,
+          { cause },
+        );
+      }
+      return judgeReleaseProvenance(record, sha, tag);
+    }
+    // A full final page is indistinguishable from a truncated listing without
+    // one more request, which is the same reason buildPlan pages this way.
+    if (releases.length < 100) {
+      return { tag: null, commit: null, archives: [] };
+    }
+  }
 }
 
 // The bridge for tags cut before the candidate became a main commit.
@@ -635,17 +861,27 @@ export async function main({
     return { sha, archives, archive: null, stranger };
   }
 
-  const { archive, arms, driver } = judgeStranger(
-    parseRunEnv(strangerText),
-    sha,
-    archives,
-  );
-  const stranger = { state: 'complete', arms, archive, driver };
+  const record = parseRunEnv(strangerText);
+  // Read the bytes the record names before deciding which receipt has to
+  // answer for them. A stranger run on the candidate's rc-build archive is
+  // linked by the preflight legs already in hand and costs no request; only a
+  // run on other bytes reaches the release's own provenance, which is the
+  // released-byte case this gate used to refuse outright.
+  const provenance = archives.includes(readStrangerArchive(record, sha))
+    ? null
+    : await findReleaseProvenance(sha, options);
+  const { archive, arms, driver } = judgeStranger(record, sha, archives, provenance);
+  const link = provenance === null ? 'preflight' : 'release-provenance';
+  const stranger = { state: 'complete', arms, archive, driver, link };
 
   log(
     `Verified release proof artifacts for ${sha}: preflight PASS across ` +
     `${archives.length} leg(s), stranger completed ${arms.join(', ')} on archive sha256 ${archive}, ` +
-    `driven ${describeDriver(driver)}`,
+    `linked to this candidate by ${
+      provenance === null
+        ? 'a preflight leg'
+        : `release ${provenance.tag}'s ${PROVENANCE_ASSET}`
+    }, driven ${describeDriver(driver)}`,
   );
   return { sha, archives, archive, stranger };
 }

--- a/scripts/check-release-proof-artifacts.mjs
+++ b/scripts/check-release-proof-artifacts.mjs
@@ -31,10 +31,8 @@
 // release's own release-provenance.json names the archives release.yml built
 // and published AT THE TAG, which are different bytes by construction: the tag
 // build is a fresh one, so the archive a developer downloads is never a
-// preflight leg. Requiring the preflight link alone therefore made the
-// released-byte proof of any release unable to lift that release's own pending
-// notice, which is what v0.6.7 measured on 2026-09-04: three complete arms on
-// the public Linux aarch64 archive, refused as "not on these bytes".
+// preflight leg. With the preflight link alone, a stranger run on released
+// bytes can never lift that release's own pending notice.
 
 import process from 'node:process';
 import { realpathSync } from 'node:fs';
@@ -83,9 +81,11 @@ export const REFERENCE_DRIVER_ENDPOINT = 'account';
 // the same literal, and the authority suite pins the two together so they
 // cannot drift into a bridge that resolves somewhere nothing was ever proven.
 export const BUMP_BRANCH = 'automation/release-next';
-// The release's own signed receipt. release.yml writes and attests it onto
-// every release beside a sha256 sidecar, and it is the second record that can
-// link a stranger run to this candidate's bytes.
+// The release's own receipt, and the second record that can link a stranger
+// run to this candidate's bytes. release.yml publishes it onto every release
+// beside a sha256 sidecar and other jobs verify its attestation; nothing in
+// this gate does, so it counts here as a trusted release receipt, a record the
+// release chain wrote, and never as signature-verified proof.
 export const PROVENANCE_ASSET = 'release-provenance.json';
 
 const COMMIT_SHA = /^[0-9a-f]{40}$/;

--- a/scripts/check-release-proof-artifacts.test.mjs
+++ b/scripts/check-release-proof-artifacts.test.mjs
@@ -16,6 +16,7 @@ import {
   LEGACY_DRIVER_ENDPOINT_FIELD,
   PREFLIGHT_RECORD,
   PREFLIGHT_SCHEMA,
+  PROVENANCE_ASSET,
   REFERENCE_DRIVER_ENDPOINT,
   REQUIRE_MODES,
   STRANGER_RECORD,
@@ -23,6 +24,7 @@ import {
   evidencePath,
   fetchEvidence,
   judgePreflight,
+  judgeReleaseProvenance,
   judgeStranger,
   main,
   parseRunEnv,
@@ -573,9 +575,16 @@ test('require preflight still judges a stranger record that exists', async () =>
       require: 'preflight',
       env: {},
       log: () => {},
+      // Three reads now, not two. A stranger record naming bytes no preflight
+      // leg judged sends the gate to the release surface for a second receipt,
+      // and this candidate has no release: an empty listing is what says so.
+      // Without the route the stub's default 404 would fail closed and this
+      // assertion would pass on a transport error instead of on the refusal it
+      // is about.
       fetchImpl: stubFetch({
         [PREFLIGHT_RECORD]: ok(JSON.stringify(preflightRecord())),
         [STRANGER_RECORD]: ok(strangerRecordText({ archive_sha256: ARCHIVE_UNJUDGED })),
+        '/releases?': jsonOk([]),
       }),
     }),
     /the stranger ran, but not on these bytes/,
@@ -966,6 +975,329 @@ test('main holds on absence when no commit to bridge from is given', async () =>
     /the proof loop has not recorded this candidate/,
   );
   assert.equal(bridged, false);
+});
+
+// ── the release's own receipt ─────────────────────────────────────────────
+//
+// The second link, and the reason there had to be one. A preflight leg judges
+// an rc-build archive; release.yml rebuilds at the tag, so the archive a
+// developer downloads from a release is never a preflight leg. Requiring the
+// preflight link alone made the released-byte proof of any release unable to
+// lift that release's own pending notice. Measured on v0.6.7 on 2026-09-04:
+// three complete arms on the public Linux aarch64 archive
+// f23d321d3ab5bc425063aa50ba2e70a9f0efcbfe164521fcaf343b4efff4d2c0, refused as
+// "not on these bytes" while release-provenance.json for that exact commit
+// listed it as artifacts[1].archive.sha256.
+
+// Bytes that exist only in the release, never among the preflight legs, which
+// is the whole shape of the case.
+const RELEASED_ARCHIVE = '4'.repeat(64);
+const RELEASE_TAG = 'v9.9.9';
+const ASSET_URL = `https://api.github.com/repos/${REPO}/releases/assets/1`;
+
+// Shaped on the real v0.6.7 asset: schema_version 2, the commit at kin.commit
+// rather than at a top-level `commit`, and repeated on every artifact beside
+// the archive sha256 the release shipped.
+const provenanceRecord = (over = {}) => ({
+  schema_version: 2,
+  release_tag: RELEASE_TAG,
+  kin: { commit: SHA, cargo_lock_sha256: '0'.repeat(64) },
+  artifacts: [
+    {
+      artifact: 'kin-linux-aarch64',
+      target: 'aarch64-unknown-linux-musl',
+      kin: { commit: SHA },
+      archive: { name: 'kin-linux-aarch64.tar.gz', sha256: RELEASED_ARCHIVE, size_bytes: 1 },
+    },
+  ],
+  ...over,
+});
+
+const releaseListing = (over = {}) => [
+  {
+    tag_name: RELEASE_TAG,
+    draft: false,
+    assets: [
+      { name: 'checksums-sha256.txt', url: `${ASSET_URL}0` },
+      { name: PROVENANCE_ASSET, url: ASSET_URL },
+    ],
+    ...over,
+  },
+];
+
+// Every route main() needs to reach the release receipt. Overridable one at a
+// time so each refusal below changes exactly one thing.
+const releaseRoutes = ({
+  stranger = strangerRecordText({ archive_sha256: RELEASED_ARCHIVE }),
+  listing = releaseListing(),
+  ref = jsonOk({ object: { type: 'commit', sha: SHA } }),
+  asset = ok(JSON.stringify(provenanceRecord())),
+} = {}) => ({
+  [PREFLIGHT_RECORD]: ok(JSON.stringify(preflightRecord())),
+  [STRANGER_RECORD]: ok(stranger),
+  '/releases/assets/': asset,
+  '/releases?': jsonOk(listing),
+  '/git/ref/tags/': ref,
+});
+
+test('main accepts a stranger run on the bytes the release of that commit shipped', async () => {
+  const lines = [];
+  const result = await main({
+    sha: SHA,
+    repository: REPO,
+    env: {},
+    log: (line) => lines.push(line),
+    fetchImpl: stubFetch(releaseRoutes()),
+  });
+  // The preflight legs do not contain these bytes and are not supposed to.
+  assert.equal(preflightRecord().legs.some((leg) => leg.result.archive.sha256 === RELEASED_ARCHIVE), false);
+  assert.equal(result.archive, RELEASED_ARCHIVE);
+  assert.equal(result.stranger.state, 'complete');
+  assert.equal(result.stranger.link, 'release-provenance');
+  assert.deepEqual(result.stranger.arms, ['green', 'brown', 'vcs']);
+  assert.match(lines.join('\n'), new RegExp(`linked to this candidate by release ${RELEASE_TAG}`));
+});
+
+// The preflight link is untouched, and it still answers without asking the
+// release surface anything. A second receipt that got consulted on the ordinary
+// path would put a network read, and a network failure, in front of every
+// release the gate already proves.
+test('main links a run on preflight bytes without reading the release surface', async () => {
+  let asked = '';
+  const result = await main({
+    sha: SHA,
+    repository: REPO,
+    env: {},
+    log: () => {},
+    fetchImpl: async (url) => {
+      if (url.includes('/releases') || url.includes('/git/ref/tags/')) {
+        asked = url;
+      }
+      return stubFetch({
+        [PREFLIGHT_RECORD]: ok(JSON.stringify(preflightRecord())),
+        [STRANGER_RECORD]: ok(strangerRecordText()),
+      })(url);
+    },
+  });
+  assert.equal(result.archive, ARCHIVE_A);
+  assert.equal(result.stranger.link, 'preflight');
+  assert.equal(asked, '', `the gate read ${asked} when the preflight legs already answered`);
+});
+
+// Neither receipt names these bytes, so the stranger ran on some other build
+// and this candidate is not proven. The refusal must name BOTH sets it checked,
+// or a reader is sent to look at half of what was consulted.
+test('main refuses a run on bytes neither the preflight nor the release names', async () => {
+  await assert.rejects(
+    main({
+      sha: SHA,
+      repository: REPO,
+      env: {},
+      log: () => {},
+      fetchImpl: stubFetch(
+        releaseRoutes({ stranger: strangerRecordText({ archive_sha256: ARCHIVE_UNJUDGED }) }),
+      ),
+    }),
+    (error) => {
+      assert.match(error.message, /the stranger ran, but not on these bytes/);
+      assert.match(error.message, new RegExp(`no preflight leg for ${SHA} judged`));
+      assert.match(error.message, new RegExp(`release ${RELEASE_TAG} shipped`));
+      return true;
+    },
+  );
+});
+
+// A release whose tag resolves to this candidate while its own receipt is about
+// another build is tampering, not absence, so it refuses rather than being
+// skipped in favour of the next release.
+test('main refuses a release provenance that is about another commit', async () => {
+  await assert.rejects(
+    main({
+      sha: SHA,
+      repository: REPO,
+      env: {},
+      log: () => {},
+      fetchImpl: stubFetch(
+        releaseRoutes({
+          asset: ok(JSON.stringify(provenanceRecord({ kin: { commit: OTHER_SHA } }))),
+        }),
+      ),
+    }),
+    /records commit b{40}, not a{40}; the release exists but its provenance is about a different build/,
+  );
+  // The same refusal one level down: the top of the record agrees while the
+  // artifact carrying the bytes does not.
+  await assert.rejects(
+    main({
+      sha: SHA,
+      repository: REPO,
+      env: {},
+      log: () => {},
+      fetchImpl: stubFetch(
+        releaseRoutes({
+          asset: ok(
+            JSON.stringify(
+              provenanceRecord({
+                artifacts: [
+                  {
+                    artifact: 'kin-linux-aarch64',
+                    kin: { commit: OTHER_SHA },
+                    archive: { sha256: RELEASED_ARCHIVE },
+                  },
+                ],
+              }),
+            ),
+          ),
+        }),
+      ),
+    }),
+    /artifact "kin-linux-aarch64" records commit b{40}, not a{40}/,
+  );
+});
+
+// A real release of this exact commit, read successfully, that simply does not
+// ship the bytes the stranger ran. Existence of a receipt is not the test; the
+// archive appearing in it is.
+test('main refuses when the release of the candidate ships other bytes', async () => {
+  await assert.rejects(
+    main({
+      sha: SHA,
+      repository: REPO,
+      env: {},
+      log: () => {},
+      fetchImpl: stubFetch(
+        releaseRoutes({
+          asset: ok(
+            JSON.stringify(
+              provenanceRecord({
+                artifacts: [
+                  {
+                    artifact: 'kin-linux-x86_64',
+                    kin: { commit: SHA },
+                    archive: { sha256: ARCHIVE_B },
+                  },
+                ],
+              }),
+            ),
+          ),
+        }),
+      ),
+    }),
+    (error) => {
+      assert.match(error.message, /the stranger ran, but not on these bytes/);
+      assert.match(error.message, new RegExp(`release ${RELEASE_TAG} shipped \\(${ARCHIVE_B}\\)`));
+      return true;
+    },
+  );
+});
+
+// No release of this candidate at all. The refusal has to say the release
+// surface was searched and came back empty, rather than reporting as though
+// only the preflight was ever asked.
+test('main names the empty release surface when nothing shipped these bytes', async () => {
+  await assert.rejects(
+    main({
+      sha: SHA,
+      repository: REPO,
+      env: {},
+      log: () => {},
+      fetchImpl: stubFetch(
+        releaseRoutes({
+          stranger: strangerRecordText({ archive_sha256: ARCHIVE_UNJUDGED }),
+          listing: [],
+        }),
+      ),
+    }),
+    new RegExp(`no published release of ${SHA} carries a ${PROVENANCE_ASSET}`),
+  );
+});
+
+// Fails closed, the same way an unreadable evidence record does. A release
+// listing that could not be read must not be reported as a listing with no
+// release in it: this search can only ever ADD an acceptance, and an answer we
+// could not read must not be turned into a sentence about what exists.
+test('main fails closed when the release surface cannot be read', async () => {
+  await assert.rejects(
+    main({
+      sha: SHA,
+      repository: REPO,
+      env: {},
+      log: () => {},
+      fetchImpl: stubFetch({
+        [PREFLIGHT_RECORD]: ok(JSON.stringify(preflightRecord())),
+        [STRANGER_RECORD]: ok(strangerRecordText({ archive_sha256: RELEASED_ARCHIVE })),
+        '/releases?': { ok: false, status: 502, statusText: 'Bad Gateway' },
+      }),
+    }),
+    /could not list the releases of firelock-ai\/kin: HTTP 502 Bad Gateway/,
+  );
+});
+
+// A draft is not published, so nothing about it is a claim yet, and a release
+// carrying no receipt cannot be the second link. Both are skipped rather than
+// read, and the search goes on to the release that can answer.
+//
+// The draft's own receipt is about another build and sits at its own asset URL,
+// so a gate that stopped skipping drafts would take it FIRST, being newest, and
+// refuse. Without that the draft would carry the same bytes as the release
+// below it and the test would pass either way.
+test('findReleaseProvenance skips a draft and a release with no receipt', async () => {
+  const result = await main({
+    sha: SHA,
+    repository: REPO,
+    env: {},
+    log: () => {},
+    fetchImpl: stubFetch({
+      // First, because the stub answers on the first fragment that matches and
+      // the shared '/releases/assets/' route below would otherwise swallow this
+      // URL and hand the draft the good record.
+      '/releases/assets/1-draft': ok(
+        JSON.stringify(provenanceRecord({ kin: { commit: OTHER_SHA } })),
+      ),
+      ...releaseRoutes({
+        listing: [
+          {
+            tag_name: 'v9.9.9-draft',
+            draft: true,
+            assets: [{ name: PROVENANCE_ASSET, url: `${ASSET_URL}-draft` }],
+          },
+          {
+            tag_name: 'v9.9.8',
+            draft: false,
+            assets: [{ name: 'checksums-sha256.txt', url: `${ASSET_URL}-other` }],
+          },
+          ...releaseListing(),
+        ],
+      }),
+    }),
+  });
+  assert.equal(result.stranger.link, 'release-provenance');
+});
+
+test('judgeReleaseProvenance refuses a record that is not one', () => {
+  throwsWith(
+    () => judgeReleaseProvenance(null, SHA, RELEASE_TAG),
+    /did not parse as a release provenance record/,
+  );
+  throwsWith(
+    () => judgeReleaseProvenance([], SHA, RELEASE_TAG),
+    /did not parse as a release provenance record/,
+  );
+  throwsWith(
+    () => judgeReleaseProvenance(provenanceRecord({ artifacts: [] }), SHA, RELEASE_TAG),
+    /lists no artifacts, so it names no released bytes/,
+  );
+  throwsWith(
+    () =>
+      judgeReleaseProvenance(
+        provenanceRecord({
+          artifacts: [{ artifact: 'kin-linux-aarch64', kin: { commit: SHA }, archive: {} }],
+        }),
+        SHA,
+        RELEASE_TAG,
+      ),
+    /records no archive sha256/,
+  );
 });
 
 test('the gate runs from a copy reached through a symlinked directory', () => {

--- a/scripts/check-release-proof-artifacts.test.mjs
+++ b/scripts/check-release-proof-artifacts.test.mjs
@@ -1274,6 +1274,129 @@ test('findReleaseProvenance skips a draft and a release with no receipt', async 
   assert.equal(result.stranger.link, 'release-provenance');
 });
 
+// A release whose tag resolves to some other commit is not this candidate's,
+// whatever its receipt says. The foreign receipt here claims the candidate at
+// kin.commit and lists the very archive the stranger ran, so a gate that
+// stopped comparing the tag's commit would read it and ACCEPT. The candidate's
+// own release is absent, so the right answer is a refusal, and the foreign
+// asset must never be fetched at all; the tag ref must, or the skip was never
+// exercised.
+test('findReleaseProvenance skips a release whose tag resolves to another commit', async () => {
+  const seen = [];
+  const foreignAsset = `${ASSET_URL}-foreign`;
+  await assert.rejects(
+    main({
+      sha: SHA,
+      repository: REPO,
+      env: {},
+      log: () => {},
+      fetchImpl: async (url) => {
+        seen.push(url);
+        return stubFetch({
+          [foreignAsset]: ok(JSON.stringify(provenanceRecord())),
+          '/git/ref/tags/v9.9.10': jsonOk({ object: { type: 'commit', sha: OTHER_SHA } }),
+          ...releaseRoutes({
+            listing: [
+              {
+                tag_name: 'v9.9.10',
+                draft: false,
+                assets: [{ name: PROVENANCE_ASSET, url: foreignAsset }],
+              },
+            ],
+          }),
+        })(url);
+      },
+    }),
+    new RegExp(`no published release of ${SHA} carries a ${PROVENANCE_ASSET}`),
+  );
+  assert.equal(
+    seen.some((url) => url.includes('/git/ref/tags/v9.9.10')),
+    true,
+    'the foreign tag was never resolved, so the skip was not exercised',
+  );
+  assert.equal(seen.includes(foreignAsset), false, "the foreign release's receipt was read");
+});
+
+// A receipt the release surface says exists and then does not serve. Fails
+// closed in BOTH require modes, with the transport answer in the message and
+// without the absence flag: the flag is what lets a caller widen on a missing
+// stranger record, and a missing release receipt must never be read that way,
+// or "we could not tell" becomes "no receipt, so judge on the preflight alone".
+test('main fails closed when the release provenance asset is missing', async () => {
+  for (const requireMode of REQUIRE_MODES) {
+    await assert.rejects(
+      main({
+        sha: SHA,
+        repository: REPO,
+        require: requireMode,
+        env: {},
+        log: () => {},
+        fetchImpl: stubFetch(
+          releaseRoutes({ asset: { ok: false, status: 404, statusText: 'Not Found' } }),
+        ),
+      }),
+      (error) => {
+        assert.match(
+          error.message,
+          new RegExp(`could not read ${PROVENANCE_ASSET} from release ${RELEASE_TAG}: HTTP 404 Not Found`),
+        );
+        assert.doesNotMatch(
+          error.message,
+          /has not recorded this candidate|does not exist on the release-evidence branch/,
+        );
+        assert.equal(
+          error.evidenceAbsent,
+          undefined,
+          `under require ${requireMode} a missing receipt wore the absence flag a caller may act on`,
+        );
+        return true;
+      },
+    );
+  }
+});
+
+// A rejected request, as distinct from an HTTP failure above: the listing
+// never answered at all. It refuses with the release-surface context in the
+// message, so an operator reading a blocked promotion sees which read died
+// rather than a bare socket error.
+test('main fails closed when the release listing cannot be reached', async () => {
+  await assert.rejects(
+    main({
+      sha: SHA,
+      repository: REPO,
+      env: {},
+      log: () => {},
+      fetchImpl: async (url) => {
+        if (url.includes('/releases?')) {
+          throw new Error('socket hang up');
+        }
+        return stubFetch(releaseRoutes())(url);
+      },
+    }),
+    /could not reach GitHub to list the releases of firelock-ai\/kin: socket hang up/,
+  );
+});
+
+// The same door for a transport failure on the asset alone: the listing and
+// the tag answered, the bytes did not arrive. Not agreement, not absence.
+test('main fails closed when the release provenance asset cannot be reached', async () => {
+  await assert.rejects(
+    main({
+      sha: SHA,
+      repository: REPO,
+      env: {},
+      log: () => {},
+      fetchImpl: async (url) => {
+        if (url.includes('/releases/assets/')) {
+          throw new Error('socket hang up');
+        }
+        return stubFetch(releaseRoutes())(url);
+      },
+    }),
+    new RegExp(`could not reach GitHub to read ${PROVENANCE_ASSET} from release ${RELEASE_TAG}: socket hang up`),
+  );
+});
+
 test('judgeReleaseProvenance refuses a record that is not one', () => {
   throwsWith(
     () => judgeReleaseProvenance(null, SHA, RELEASE_TAG),


### PR DESCRIPTION
## What this fixes

A preflight leg judges an rc-build archive. `release.yml` rebuilds fresh bytes at the tag, so the archive a developer downloads from a published release is by construction never a preflight leg. The gate required the stranger's archive to appear among the preflight legs and nothing else, so the released-byte proof of any release could never lift that release's own "First-contact proof pending" notice. v0.6.7 is the release that measured it.

This is the sweep's `clearNotice` path, not a promotion: v0.6.7 is already GitHub Latest with `prerelease=false`, and what it still carries is the stale notice behind `<!-- kin-first-contact-proof -->`.

## Measurement, before any code change

The judge run the way `release-promote.yml` runs it (`scripts/release-promotion-plan.mjs` calls `main()` with `require: 'all'`, the tag's resolved commit, `GITHUB_REPOSITORY` and a `GH_TOKEN`), reproduced directly against the candidate with a read-only token:

```
$ GH_TOKEN="$(gh auth token)" GITHUB_REPOSITORY=firelock-ai/kin \
    CANDIDATE_SHA=073a0ed79801ebc75204d810b2b3ee2aa40dcd23 \
    KIN_RELEASE_REQUIRE=all \
    node scripts/check-release-proof-artifacts.mjs
::error::evidence/073a0ed79801ebc75204d810b2b3ee2aa40dcd23/stranger.env ran archive sha256 f23d321d3ab5bc425063aa50ba2e70a9f0efcbfe164521fcaf343b4efff4d2c0, which no preflight leg for 073a0ed79801ebc75204d810b2b3ee2aa40dcd23 judged (24556533d0219ebeb0a699d50187e2ec158ce61f79cd0ea81ecf3b17424baa6f, 2812f064f339e483fb11f29176ffe8c7a783905930761a80927db4026f3693ff, 0d053ab07964cc714563c34e43dd8f8f58a75a080c36c728b8d93532f6983229); the stranger ran, but not on these bytes
RC=1
```

The record is on the evidence branch and it is complete. `evidence/073a0ed79801ebc75204d810b2b3ee2aa40dcd23/` on `release-evidence` carries `preflight.json` (57997 bytes) and `stranger.env` (1441 bytes), and the stranger record names `archive_sha256=f23d321d...`, `arms=green,brown,vcs`, `arms_complete=green,brown,vcs`, `arms_incomplete=` (empty), `finished_at=2026-09-04T21:06:38Z`, `driver_endpoint=account`, `run_id=rc067-073a0ed7`. Every refusal in the gate except the archive link is satisfied.

The release's own receipt names those exact bytes. `release-provenance.json`, an asset of the v0.6.7 release, is `schema_version` 2 and carries `kin.commit = 073a0ed79801ebc75204d810b2b3ee2aa40dcd23` with:

```
artifacts[0] x86_64-unknown-linux-musl   e533d54149a3c93004c3a67233581c7b4ef4c2865f775a3eac3b04863531c602
artifacts[1] aarch64-unknown-linux-musl  f23d321d3ab5bc425063aa50ba2e70a9f0efcbfe164521fcaf343b4efff4d2c0
artifacts[2] x86_64-apple-darwin         d2406707dacb0b40603e350cec23743ac58402819635916d842b2ce60d9f8284
artifacts[3] aarch64-apple-darwin        a41aabfc73d7219ea0ef55368765a7be15adfe7e3d432188486cc131dcfbbdf1
artifacts[4] x86_64-pc-windows-msvc      dceea9b9674ff55170583ee205119d25314ca66e8eda283ed4d82cd078db1507
```

`artifacts[1].archive.sha256` is exactly the archive the stranger ran, and every `artifacts[].kin.commit` is the candidate. Note that the commit lives at `kin.commit`, not at a top-level `commit`; `signer_workflow` is on the sibling `release-promotion.json`, which names the same commit, `release_tag` v0.6.7 and `release_workflow_run_id` 33908420337.

After the change, the same command:

```
Verified release proof artifacts for 073a0ed79801ebc75204d810b2b3ee2aa40dcd23: preflight PASS across 3 leg(s), stranger completed green, brown, vcs on archive sha256 f23d321d3ab5bc425063aa50ba2e70a9f0efcbfe164521fcaf343b4efff4d2c0, linked to this candidate by release v0.6.7's release-provenance.json, driven on the account endpoint
RC=0
```

## What changed

`scripts/check-release-proof-artifacts.mjs`, +266/-15. A stranger archive is accepted when it appears among the preflight legs, unchanged, **or** among `artifacts[].archive.sha256` in the `release-provenance.json` of the release whose tag resolves to the candidate. `findReleaseProvenance` lists releases newest first, skips drafts and releases carrying no receipt before resolving anything, resolves each remaining tag the two-step way `release-promotion-plan.mjs` does (lightweight ref, then dereference an annotated tag), and stops at the first release that resolves to the candidate. `judgeReleaseProvenance` then requires the record's own `kin.commit`, and every artifact's, to be the candidate. `readStrangerArchive` is split out of `judgeStranger` so `main()` can decide whether a second receipt is needed at all.

The tag resolution is written in the file rather than imported from `release-promotion-plan.mjs` on purpose: `release-tag.yml` runs this file **alone** out of `$RUNNER_TEMP` (`git show refs/remotes/origin/main:scripts/check-release-proof-artifacts.mjs > "$gate"`), so a relative import of a sibling script would not exist there and the gate would fail to load on a release night.

Kept, all of it: an unreadable record, missing arms, repeated arms, an undeclared arm, a missing driver key that claims to answer, an archive in neither receipt, and a provenance about another sha. The release surface is read only when the preflight legs did not answer, so the ordinary path takes no extra request. An unreadable release listing fails closed rather than being reported as a listing with no release in it, since this search can only ever add an acceptance and an answer nobody could read must not become a sentence about what exists.

`scripts/check-release-proof-artifacts.test.mjs`, +332. Eight new cases plus one existing fixture updated: `require preflight still judges a stranger record that exists` now needs a third route, because a record naming bytes no preflight leg judged sends the gate to the release surface, and without a `/releases?` route the stub's default 404 would fail closed and that assertion would pass on a transport error instead of on the refusal it is about. Its assertion is unchanged.

`docs/release-bot.md`, +15. One paragraph in the stranger section naming both receipts and why there are two.

## Falsification

Every new test broken at the behaviour it guards, then the tree restored. Full transcript, red tails first:

```
### MUTANT: M1 the release receipt no longer links anything
not ok 52 - main accepts a stranger run on the bytes the release of that commit shipped
not ok 59 - findReleaseProvenance skips a draft and a release with no receipt
# tests 61
# pass 59
# fail 2

### MUTANT: M2 judgeReleaseProvenance stops checking the record's own commit
not ok 55 - main refuses a release provenance that is about another commit
# tests 61
# pass 60
# fail 1

### MUTANT: M3 judgeReleaseProvenance stops checking each artifact's commit
not ok 55 - main refuses a release provenance that is about another commit
# tests 61
# pass 60
# fail 1

### MUTANT: M4 an unreadable release listing is swallowed as no release
not ok 55 - main refuses a release provenance that is about another commit
not ok 58 - main fails closed when the release surface cannot be read
# tests 61
# pass 59
# fail 2

### MUTANT: M5 the refusal stops naming what the release shipped
not ok 54 - main refuses a run on bytes neither the preflight nor the release names
not ok 56 - main refuses when the release of the candidate ships other bytes
not ok 57 - main names the empty release surface when nothing shipped these bytes
# tests 61
# pass 58
# fail 3

### MUTANT: M6 the release surface is read even when a preflight leg answered
not ok 26 - main proceeds when both records exist for the exact candidate
not ok 31 - require preflight still judges a stranger record that exists
not ok 36 - a complete run reports its state and its driver to the caller
not ok 46 - main bridges a landed commit to the candidate that was proven
not ok 48 - main answers from the direct key without asking about pull requests
not ok 49 - main bridges when the direct key is absent and a commit is given
not ok 53 - main links a run on preflight bytes without reading the release surface
# tests 61
# pass 54
# fail 7

### MUTANT: M7 a draft release is treated as a published claim
not ok 59 - findReleaseProvenance skips a draft and a release with no receipt
# tests 61
# pass 60
# fail 1

### RESTORED, control run:
# tests 61
# pass 61
# fail 0
```

M4 reddening test 55 as well is the point of that mutation: swallowing the read failure swallows the tampering refusal with it. The draft case only falsifies because the draft's own receipt is about another build and sits at its own asset URL, so a gate that stopped skipping drafts takes it first, being newest, and refuses.

Green tail, the three node suites CI runs on this file's behalf:

```
$ node --test scripts/check-release-proof-artifacts.test.mjs \
    scripts/release-promotion-plan.test.mjs scripts/read-promotion-plan.test.mjs
# tests 102
# pass 102
# fail 0
# skipped 0
# todo 0
```

`python3 scripts/test-release-workflow-authority.py` also passes on this tree.

These suites run on this pull request through `Fast gate lint and policy`, so the guard is graded before the change merges rather than by acceptance on main afterwards.


## Second head, d6cb5630534ab4ff8b122e6fe7f7e86809529a51

Review found the first head unproven on three arms and asked for two wording changes. Tests and comments only, no logic change in the gate.

Three new tests. A release whose tag resolves to another commit is skipped even when its receipt claims the candidate at `kin.commit` and lists the stranger's archive, and the test asserts the foreign tag ref was resolved (the skip was exercised) and the foreign asset was never fetched. A provenance asset 404 refuses in both require modes with the HTTP answer in the message, does not carry the `evidenceAbsent` flag a caller may widen on, and never reads as "has not recorded this candidate". A rejected request on the listing, and one on the asset, each refuse with the release-surface context ("could not reach GitHub to list the releases of firelock-ai/kin: socket hang up", and the same for reading the asset from the release).

Falsification, tree restored between mutants:

```
### MUTANT: M8 the tag is resolved but its commit is never compared to the candidate
not ok 60 - findReleaseProvenance skips a release whose tag resolves to another commit
# tests 64 / pass 63 / fail 1

### MUTANT: M9 a missing receipt is skipped as though the release carried none
not ok 61 - main fails closed when the release provenance asset is missing
# tests 64 / pass 63 / fail 1

### MUTANT: M10 an unreachable receipt is skipped as though the release carried none
not ok 61 - main fails closed when the release provenance asset is missing
not ok 62 - main fails closed when the release provenance asset cannot be reached
# tests 64 / pass 62 / fail 2

### MUTANT: M11 a 404 on the release surface wears the absence flag
not ok 61 - main fails closed when the release provenance asset is missing
# tests 64 / pass 63 / fail 1

### MUTANT: M12 apiRead stops catching a rejected request (no release-surface context)
not ok 62 - main fails closed when the release listing cannot be reached
not ok 63 - main fails closed when the release provenance asset cannot be reached
# tests 65 / pass 63 / fail 2

### RESTORED, control run:
# tests 65 / pass 65 / fail 0
```

Green tail, the three node suites: `# tests 106 / pass 106 / fail 0`.

Wording. The gate's source comments now describe the durable behaviour only; the v0.6.7 chronology stays in this body. The asset is named a trusted release receipt in the comments and in `docs/release-bot.md`: other jobs verify its attestation and this gate does not, so it is trusted as a record the release chain wrote, never as signature-verified proof. The accept line already said "linked to this candidate by release v0.6.7's release-provenance.json" and claims nothing about a signature.
