### PR TITLE
Parse a session's bytes where the session publishes them

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -35031,6 +35031,113 @@ mod tests {
         );
     }
 
+    /// FIR-3200. A session that publishes a file the parser cannot parse is
+    /// refused in words, and the bytes stay published.
+    ///
+    /// This is the arm I could not build a deterministic trigger for until
+    /// review found the defect underneath it. The daemon reconciles under
+    /// `ReconcilePolicy::FallbackToLkg`, so unparseable source comes back as
+    /// `ReconcileOutcome::BrokenAst`: last-known-good state retained, no
+    /// transaction derived, the file still answering at the positions its
+    /// previous parse recorded. Counting that as enrichment reproduced this
+    /// change's own defect one level down, on the most ordinary agent case there
+    /// is, a file caught mid-edit.
+    ///
+    /// So the trigger is the ordinary case: prepend the seventeen lines and
+    /// leave the file syntactically broken. The reconcile must name the file
+    /// rather than report a clean summary, and the tree must still carry the
+    /// bytes, because a parser never retracts membership.
+    ///
+    /// Falsify by restoring the unconditional `outcome.enriched += 1` outside
+    /// the applied-delta arm: this returns 200 with enriched 1 and failures 0
+    /// over a file whose span never moved.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial_test::serial(commit_phase_capture)]
+    async fn a_session_publishing_unparseable_source_is_refused_and_keeps_its_bytes() {
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let state = Arc::new(DaemonState::open(initialized.layout).unwrap());
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        std::fs::write(
+            repo.path().join("shifted.rs"),
+            b"pub fn shifted() -> u32 { 7 }\n",
+        )
+        .unwrap();
+
+        let app = router(Arc::clone(&state));
+        commit_through_api(&app, kin_model::OperationId::new(), "publish the fixture").await;
+        let before = published_start_line(&state, "shifted.rs");
+
+        let session_dir = state.layout.root().join("runs/session-fir3200-broken");
+        materialize_session_through_api(&app, &session_dir).await;
+        let session_file = session_dir.join("shifted.rs");
+        prepend_session_lines(&session_file, 17);
+        let mut broken = std::fs::read(&session_file).unwrap();
+        broken.extend_from_slice(b"pub fn half_written(\n");
+        std::fs::write(&session_file, &broken).unwrap();
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::post("/reconcile")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "session_dir": session_dir,
+                            "confirm_mass_deletion": false
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 128 * 1024)
+            .await
+            .unwrap();
+        let body = String::from_utf8_lossy(&body).to_string();
+
+        assert_eq!(
+            status,
+            StatusCode::CONFLICT,
+            "a reconcile that could not re-parse what it published must not read as a clean \
+             success: {body}"
+        );
+        let refusal: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(refusal["error"], "semantic_readmission_failed");
+        assert_eq!(refusal["files"], json!(["shifted.rs"]));
+        assert_eq!(refusal["summary"]["semantic_files_enriched"], json!(0));
+        assert_eq!(refusal["summary"]["semantic_enrichment_failures"], json!(1));
+
+        // Membership is not in doubt, and a parser may not retract it. The
+        // refusal is a report of a graph gap, never a rollback.
+        let tree = state.graph.resolved_tree();
+        let published = tree
+            .artifact_at_path(&RepoPath::from_utf8("shifted.rs".to_string()).unwrap())
+            .expect("the path stays in the exact tree");
+        let kin_model::TreeEntry::Blob { hash, .. } = published.entry else {
+            panic!("the fixture is a regular file");
+        };
+        assert_eq!(
+            state
+                .blobs
+                .read(&kin_blobs::Hash256::from_bytes(*hash.as_bytes()))
+                .expect("the published body is readable"),
+            broken,
+            "the refusal reports a gap in the graph and never retracts the bytes"
+        );
+        assert_eq!(
+            published_start_line(&state, "shifted.rs"),
+            before,
+            "an unparseable file keeps its last-known-good spans, which is what the refusal is \
+             telling the caller about"
+        );
+    }
+
     /// FIR-3200. The refusal a reconcile returns when its bytes published and
     /// their semantics did not.
     ///

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -35068,7 +35068,8 @@ mod tests {
             changes: Vec::new(),
         };
 
-        let (status, body) = semantic_readmission_refused(&summary, &["src/shifted.rs".to_string()]);
+        let (status, body) =
+            semantic_readmission_refused(&summary, &["src/shifted.rs".to_string()]);
 
         assert_eq!(
             status,
@@ -35166,7 +35167,6 @@ mod tests {
         assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
         serde_json::from_slice(&body).unwrap()
     }
-
 
     /// Changes in repository authority, read the way `kin log` reads them.
     #[cfg(unix)]

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6028,14 +6028,19 @@ async fn reconcile_session_workspace(
         ));
     }
 
-    let (authority_generation, workspace_generation, idempotent_replay) = if observation
-        .deltas()
-        .is_empty()
-    {
+    let (
+        authority_generation,
+        workspace_generation,
+        idempotent_replay,
+        semantic_enriched,
+        semantic_failures,
+    ) = if observation.deltas().is_empty() {
         (
             observation.base().authority_roots.generation,
             observation.base().source_workspace.generation,
             false,
+            0,
+            Vec::new(),
         )
     } else {
         let authority_context =
@@ -6098,6 +6103,22 @@ async fn reconcile_session_workspace(
             old_root_hash: Some(previous_tree_hash.to_string()),
             new_root_hash: desired_tree_hash.to_string(),
         });
+        // The exact tree is published and nothing has parsed it. Re-derive the
+        // semantic layer for the paths this publication moved, here, under the
+        // gate that published them.
+        //
+        // Leaving it to the next commit does not work, and that is the whole
+        // defect. A commit forces one complete admission, and that admission
+        // plans its transition from the working copy this publication has
+        // already made current, so the transition is empty and it returns before
+        // its own enrichment half ever runs. The bytes moved, the parse never
+        // happened, and every read surface kept answering at the positions the
+        // previous parse recorded. On a converted `psf/requests` an edit that
+        // prepended seventeen lines left the whole file answering seventeen
+        // lines short, under an envelope with nothing to report.
+        let readmitted =
+            crate::loop_runner::readmit_semantics_for_paths(&state, &published_paths(&observation))
+                .await;
         (
             committed.receipt.generation,
             observation
@@ -6106,11 +6127,13 @@ async fn reconcile_session_workspace(
                 .generation
                 .saturating_add(1),
             committed.idempotent_replay,
+            readmitted.enriched,
+            readmitted.failed,
         )
     };
 
     drop(graph_mutation);
-    Ok(Json(kin_cli::commands::reconcile::ReconcileSummary {
+    let summary = kin_cli::commands::reconcile::ReconcileSummary {
         schema: kin_cli::commands::reconcile::RECONCILE_SUMMARY_SCHEMA.to_string(),
         operation_id: observation.base().reconcile_operation_id,
         repository_id: observation.base().repository_id.clone(),
@@ -6126,10 +6149,68 @@ async fn reconcile_session_workspace(
         observed_materialized_artifacts: observation.observed_materialized_artifacts(),
         preserved_graph_only_artifacts: observation.preserved_graph_only_artifacts(),
         observed_body_bytes: observation.observed_body_bytes(),
-        semantic_files_enriched: 0,
-        semantic_enrichment_failures: 0,
+        semantic_files_enriched: semantic_enriched,
+        semantic_enrichment_failures: semantic_failures.len(),
         changes,
-    }))
+    };
+    if !semantic_failures.is_empty() {
+        return Err(semantic_readmission_refused(&summary, &semantic_failures));
+    }
+    Ok(Json(summary))
+}
+
+/// Every repository path one session publication moved.
+///
+/// Both sides of every delta. A rename's old path leaves the tree and its new
+/// path enters it, and the readmission skips whatever the tree no longer
+/// carries, so naming both sides costs nothing and misses nothing.
+fn published_paths(
+    observation: &kin_cli::commands::reconcile::SessionReconcileObservation,
+) -> std::collections::BTreeSet<RepoPath> {
+    let mut paths = std::collections::BTreeSet::new();
+    for delta in observation.deltas() {
+        if let Some(old) = delta.old_state() {
+            paths.insert(old.path.clone());
+        }
+        if let Some(new) = delta.new_state() {
+            paths.insert(new.path.clone());
+        }
+    }
+    paths
+}
+
+/// Refuse a reconcile whose exact tree published but whose semantics did not.
+///
+/// The bytes are durable before this is reached and a parser may not retract
+/// them, so this is not a rollback and the body says so outright: the tree
+/// moved, and the graph cannot answer about these files at the positions their
+/// new bytes hold. Returning it as a refusal rather than as a degradation block
+/// inside a 200 is what makes `kin reconcile` exit non-zero, because the CLI
+/// treats any non-success status as an error and prints the body; a caller that
+/// reads a clean summary and a zero has no way to learn that the file it just
+/// edited still answers at its old spans, which is the failure this whole change
+/// exists to end.
+///
+/// The complete summary travels inside the refusal, so nothing a success would
+/// have reported is lost by refusing.
+fn semantic_readmission_refused(
+    summary: &kin_cli::commands::reconcile::ReconcileSummary,
+    failed: &[String],
+) -> (StatusCode, String) {
+    let body = serde_json::json!({
+        "error": "semantic_readmission_failed",
+        "message": format!(
+            "the exact tree published as {} but {} of the files it moved could not be \
+             re-parsed, so the graph still answers about them at the positions their previous \
+             bytes held: {}",
+            summary.desired_tree_hash,
+            failed.len(),
+            failed.join(", ")
+        ),
+        "files": failed,
+        "summary": summary,
+    });
+    (StatusCode::CONFLICT, body.to_string())
 }
 
 fn session_reconcile_error(error: impl std::fmt::Display) -> (StatusCode, String) {
@@ -34854,6 +34935,238 @@ mod tests {
             "a refused commit must record no change at all"
         );
     }
+    /// FIR-3200. Read the published start line of the sole entity a path holds.
+    #[cfg(unix)]
+    fn published_start_line(state: &Arc<DaemonState>, path: &str) -> u32 {
+        let entities = state
+            .graph
+            .query_entities(&kin_db::EntityFilter {
+                file_path: Some(kin_model::FilePathId::new(path)),
+                ..Default::default()
+            })
+            .unwrap();
+        let spanned = entities
+            .iter()
+            .filter_map(|entity| entity.span.as_ref().map(|span| span.start_line))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            spanned.len(),
+            1,
+            "the fixture holds exactly one spanned entity at {path}, found {spanned:?}"
+        );
+        spanned[0]
+    }
+
+    /// FIR-3200 measurement. Reproduce the brownfield stranger's stale span:
+    /// an edit that arrives through a disposable session, the session reconcile
+    /// that publishes its exact tree, and the ordinary commit after it.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial_test::serial(commit_phase_capture)]
+    async fn a_commit_after_a_session_reconcile_republishes_the_moved_span() {
+        const PREPENDED_LINES: u32 = 17;
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let state = Arc::new(DaemonState::open(initialized.layout).unwrap());
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let host_path = repo.path().join("shifted.rs");
+        std::fs::write(&host_path, b"pub fn shifted() -> u32 { 7 }\n").unwrap();
+
+        let app = router(Arc::clone(&state));
+        commit_through_api(&app, kin_model::OperationId::new(), "publish the fixture").await;
+        let before = published_start_line(&state, "shifted.rs");
+        eprintln!("FIR-3200 measurement: committed start_line={before}");
+
+        let session_dir = state.layout.root().join("runs/session-fir3200");
+        materialize_session_through_api(&app, &session_dir).await;
+        prepend_session_lines(&session_dir.join("shifted.rs"), PREPENDED_LINES);
+        let summary = reconcile_session_through_api(&app, &session_dir).await;
+        eprintln!(
+            "FIR-3200 measurement: reconcile modified={} enriched={} after_reconcile_start_line={}",
+            summary.modified,
+            summary.semantic_files_enriched,
+            published_start_line(&state, "shifted.rs")
+        );
+        assert_eq!(
+            summary.semantic_files_enriched, 1,
+            "the reconcile must report the file it re-parsed rather than a hardcoded zero"
+        );
+        assert_eq!(summary.semantic_enrichment_failures, 0);
+
+        let commit = app
+            .clone()
+            .oneshot(
+                Request::post("/commands/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "operation_id": kin_model::OperationId::new(),
+                            "timestamp": Timestamp::now(),
+                            "author": "Test Author <test@example.invalid>",
+                            "message": "commit the session's edit"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let commit_status = commit.status();
+        let commit_body = axum::body::to_bytes(commit.into_body(), 128 * 1024)
+            .await
+            .unwrap();
+        eprintln!(
+            "FIR-3200 measurement: commit status={commit_status} body={}",
+            String::from_utf8_lossy(&commit_body)
+        );
+
+        let after = published_start_line(&state, "shifted.rs");
+        eprintln!("FIR-3200 measurement: after_commit start_line={after}");
+        assert_eq!(
+            after,
+            before + PREPENDED_LINES,
+            "the published span must move with the bytes the session changed"
+        );
+    }
+
+    /// FIR-3200. The refusal a reconcile returns when its bytes published and
+    /// their semantics did not.
+    ///
+    /// The shape is the whole point, so the shape is what is asserted: a status
+    /// the CLI turns into a non-zero exit, every file named, and the complete
+    /// summary carried inside so refusing costs a caller nothing a success would
+    /// have told them. A 200 with a degradation block would satisfy none of
+    /// that: `daemon_client::reconcile` returns `Ok` for any success status and
+    /// the caller reads a clean summary, which is the exact failure this change
+    /// exists to end.
+    ///
+    /// Falsify by returning `StatusCode::OK` from `semantic_readmission_refused`,
+    /// or by dropping `files` from its body: the first assertion goes red on the
+    /// status, the second on the name.
+    #[test]
+    fn a_reconcile_whose_semantics_did_not_publish_refuses_and_names_the_files() {
+        let summary = kin_cli::commands::reconcile::ReconcileSummary {
+            schema: kin_cli::commands::reconcile::RECONCILE_SUMMARY_SCHEMA.to_string(),
+            operation_id: kin_model::OperationId::new(),
+            repository_id: RepositoryId::new("refusal-shape".to_string()).unwrap(),
+            authority_generation: 7,
+            workspace_generation: 9,
+            previous_tree_hash: Hash256::from_bytes([0x11; 32]),
+            desired_tree_hash: Hash256::from_bytes([0x22; 32]),
+            idempotent_replay: false,
+            changed: true,
+            added: 0,
+            modified: 1,
+            removed: 0,
+            observed_materialized_artifacts: 1,
+            preserved_graph_only_artifacts: 0,
+            observed_body_bytes: 512,
+            semantic_files_enriched: 0,
+            semantic_enrichment_failures: 1,
+            changes: Vec::new(),
+        };
+
+        let (status, body) = semantic_readmission_refused(&summary, &["src/shifted.rs".to_string()]);
+
+        assert_eq!(
+            status,
+            StatusCode::CONFLICT,
+            "the CLI turns any non-success status into a non-zero exit; a 2xx here reads as a \
+             clean reconcile over a file that still answers at its old spans"
+        );
+        let refusal: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(refusal["error"], "semantic_readmission_failed");
+        assert_eq!(
+            refusal["files"],
+            json!(["src/shifted.rs"]),
+            "a reader cannot act on a count; the refusal has to name the file"
+        );
+        assert!(
+            refusal["message"]
+                .as_str()
+                .unwrap()
+                .contains("src/shifted.rs"),
+            "the sentence a person reads must name the file too: {body}"
+        );
+        assert_eq!(
+            refusal["summary"]["semantic_enrichment_failures"],
+            json!(1),
+            "refusing must not cost the caller what a success would have reported"
+        );
+        assert_eq!(refusal["summary"]["modified"], json!(1));
+    }
+
+    /// FIR-3200. Materialize a disposable session projection, the way
+    /// `kin exec` does before it runs anything.
+    #[cfg(unix)]
+    async fn materialize_session_through_api(app: &axum::Router, session_dir: &std::path::Path) {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::post("/commands/session-workspace")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "session_dir": session_dir.display().to_string(),
+                            "strategy": null,
+                            "scope": null
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 128 * 1024)
+            .await
+            .unwrap();
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+    }
+
+    /// FIR-3200. The edit shape the stranger arm hit: content prepended above
+    /// every declaration in the file, so a stale parse is visible as an offset
+    /// rather than as a missing entity.
+    #[cfg(unix)]
+    fn prepend_session_lines(session_file: &std::path::Path, lines: u32) {
+        let original = std::fs::read(session_file).unwrap();
+        let mut shifted = b"// prepended by the session\n".repeat(lines as usize);
+        shifted.extend_from_slice(&original);
+        std::fs::write(session_file, &shifted).unwrap();
+    }
+
+    /// FIR-3200. Admit one session's observation and return its summary.
+    #[cfg(unix)]
+    async fn reconcile_session_through_api(
+        app: &axum::Router,
+        session_dir: &std::path::Path,
+    ) -> kin_cli::commands::reconcile::ReconcileSummary {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::post("/reconcile")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "session_dir": session_dir,
+                            "confirm_mass_deletion": false
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 128 * 1024)
+            .await
+            .unwrap();
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        serde_json::from_slice(&body).unwrap()
+    }
+
 
     /// Changes in repository authority, read the way `kin log` reads them.
     #[cfg(unix)]
@@ -40562,7 +40875,14 @@ mod tests {
         assert_eq!(summary.preserved_graph_only_artifacts, 2);
         #[cfg(not(target_os = "macos"))]
         assert_eq!(summary.preserved_graph_only_artifacts, 1);
-        assert_eq!(summary.semantic_files_enriched, 0);
+        // Four of the five paths this observation moved carry a body the
+        // publication can re-index: `compose.yaml`, `assets/policy.unknown`,
+        // `bin/verify` and `notes/new.odd`. The symlink and the removal are
+        // skipped, because neither is source owned by its path. The zero this
+        // assertion used to carry was a literal in the handler rather than a
+        // measurement, and it read as "nothing needed parsing" over files that
+        // had just changed.
+        assert_eq!(summary.semantic_files_enriched, 4);
         assert_eq!(summary.semantic_enrichment_failures, 0);
 
         let authority = ActiveApiRepositoryAuthority::open(&state).unwrap();

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -8268,7 +8268,25 @@ pub(crate) async fn readmit_semantics_for_paths(
                     &reconciled,
                     ReconcileOutcome::Updated { .. } | ReconcileOutcome::FileRemoved { .. }
                 );
-                if should_apply {
+                // `BrokenAst` and `Conflict` retain last-known-good state and
+                // derive nothing, so the file keeps the spans its previous parse
+                // recorded. Counting either as enrichment would be this whole
+                // change's own defect one level down: a clean summary over a
+                // file that still answers at its old positions. The daemon
+                // reconciles under `ReconcilePolicy::FallbackToLkg`, so a
+                // syntactically broken file is the ordinary case rather than an
+                // edge, and it is exactly the case an agent produces mid-edit.
+                if !should_apply {
+                    warn!(
+                        file = %file_id,
+                        outcome = ?reconciled,
+                        "published bytes were read but no semantic transaction came back, so \
+                         this path still answers at the positions its previous parse recorded"
+                    );
+                    outcome.failed.push(file_id.0.clone());
+                    continue;
+                }
+                {
                     let derived_entities = !delta.entity_deltas.is_empty();
                     if let Err(error) = state.graph.apply_transaction_delta(&delta) {
                         warn!(
@@ -8314,8 +8332,8 @@ pub(crate) async fn readmit_semantics_for_paths(
                         }
                     }
                     graph_changed = true;
+                    outcome.enriched += 1;
                 }
-                outcome.enriched += 1;
             }
             Err(error) => {
                 warn!(

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -8249,7 +8249,8 @@ pub(crate) async fn readmit_semantics_for_paths(
             }
         }
 
-        if let Err(error) = clear_incompatible_facets(state, &file_id, EnrichmentFacet::EntitySource)
+        if let Err(error) =
+            clear_incompatible_facets(state, &file_id, EnrichmentFacet::EntitySource)
         {
             warn!(
                 file = %file_id,
@@ -8285,7 +8286,10 @@ pub(crate) async fn readmit_semantics_for_paths(
                     // The file's declarations just moved, so whatever a language
                     // server said about them was said at positions this delta
                     // retired.
-                    crate::daemon::retire_enrichment_marker(state, &[file_id.0.clone()]);
+                    crate::daemon::retire_enrichment_marker(
+                        state,
+                        std::slice::from_ref(&file_id.0),
+                    );
                     if let Err(error) =
                         state.persist_projection_truth_from_reconcile(&reconciler, &reconciled)
                     {

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -8095,6 +8095,244 @@ pub(crate) async fn sync_filesystem_with_graph_deferring_tree_publication(
     sync_filesystem_with_graph_publishing(state, TreePublication::DeferredToCaller).await
 }
 
+/// What re-deriving the semantic layer for one set of already-admitted paths
+/// produced.
+#[derive(Debug, Default)]
+pub(crate) struct SemanticReadmission {
+    /// Paths whose semantic layer was re-derived from the bytes graph authority
+    /// now holds.
+    pub(crate) enriched: usize,
+    /// Entity-source paths whose bytes moved and whose semantics could not be
+    /// re-derived, named so a caller can refuse in words rather than report a
+    /// count of zero.
+    pub(crate) failed: Vec<String>,
+}
+
+/// Re-derive the semantic layer for paths whose exact bytes are already graph
+/// authority.
+///
+/// [`sync_filesystem_with_graph_publishing_inner`] runs enrichment as the second
+/// half of admitting a transition it planned itself, and returns before that
+/// half when the transition is empty. A disposable session publishes a complete
+/// exact tree through a different route and parses none of it, so by the time
+/// the next commit forces an admission the working copy and the graph tree
+/// already agree, the transition really is empty, and the file whose bytes just
+/// moved is never offered to a parser. Its entities keep the spans they were
+/// parsed at, and every read surface serves those spans under an envelope with
+/// nothing to report. On a converted `psf/requests` an edit that prepended
+/// seventeen lines left every line number in the file seventeen short of the
+/// bytes on disk.
+///
+/// So the parse belongs where the bytes were published rather than at the commit
+/// after it. This is that half on its own, driven by a caller that already knows
+/// which paths its publication moved.
+///
+/// Content comes from the body the exact tree names, and the host is re-read
+/// only to prove it still holds that same body, which is the same
+/// [`host_entry_matches_graph`] guard the admission's own enrichment uses: bytes
+/// written after a publication may not enrich against the tree that publication
+/// established. A path the graph no longer carries, a symlink, a Gitlink and a
+/// path with no UTF-8 rendering are skipped rather than failed. None of them is
+/// source owned by that path, and the exact tree already records what each one
+/// is.
+///
+/// Failure is reported and never fatal here. Membership is durable before this
+/// runs and a parser may not retract it, which is the invariant stated beside
+/// the admission's own enrichment loop. What a re-parse it could not perform
+/// means for the reply is the caller's decision, not this function's.
+pub(crate) async fn readmit_semantics_for_paths(
+    state: &DaemonState,
+    paths: &BTreeSet<RepoPath>,
+) -> SemanticReadmission {
+    let mut outcome = SemanticReadmission::default();
+    if paths.is_empty() {
+        return outcome;
+    }
+    let working_dir = state.layout.working_dir();
+    let tree = state.graph.resolved_tree();
+    let enrichment_pipeline = IndexPipeline::new();
+    let mut reconciler = state.reconciler.write().await;
+    let mut graph_changed = false;
+
+    for repo_path in paths {
+        let Some(artifact) = tree.artifact_at_path(repo_path) else {
+            continue;
+        };
+        // Symlinks and Gitlinks are never parsed as source owned by the link
+        // path, which is the rule the layout backfill and the admission loop
+        // both apply.
+        let TreeEntry::Blob { hash, .. } = artifact.entry else {
+            continue;
+        };
+        let Some(file_id) = semantic_file_id(repo_path) else {
+            continue;
+        };
+        let Ok(host_path) = kin_index::host_path_from_repo_path(working_dir, repo_path) else {
+            continue;
+        };
+        // `TreeEntry` carries kin-model's hash and the blob store speaks
+        // kin-blobs', so the identity crosses that boundary by bytes.
+        let body_hash = kin_blobs::Hash256::from_bytes(*hash.as_bytes());
+        let content = match state.blobs.read(&body_hash) {
+            Ok(content) => content,
+            Err(error) => {
+                warn!(
+                    file = %file_id,
+                    error = %error,
+                    "the body this path's exact tree entry names is not readable, so its \
+                     semantics cannot be re-derived from graph-owned truth"
+                );
+                outcome.failed.push(file_id.0.clone());
+                continue;
+            }
+        };
+
+        let classification = FileClassifier::classify_with_content(&host_path, &content);
+        if classification != FileClassification::EntitySource {
+            match enrichment_pipeline.index_any_content(&file_id, &content, body_hash) {
+                Ok(indexed) => match persist_non_entity_enrichment(state, indexed) {
+                    Ok((persisted, cleanup)) => {
+                        for id in cleanup.removed_entities {
+                            state.emit_event(DaemonEvent::EntityChanged {
+                                entity_id: id,
+                                node: None,
+                                change_type: ChangeType::Deleted,
+                                file_path: Some(persisted.0.clone()),
+                                session_id: None,
+                            });
+                        }
+                        graph_changed = true;
+                        outcome.enriched += 1;
+                    }
+                    Err(error) => {
+                        warn!(
+                            file = %file_id,
+                            error = %error,
+                            "published bytes re-indexed but facet persistence failed"
+                        );
+                    }
+                },
+                Err(error) => warn!(
+                    file = %file_id,
+                    error = %error,
+                    "published bytes could not be re-indexed as a non-entity artifact"
+                ),
+            }
+            continue;
+        }
+
+        // The host is consulted for identity only. A working copy that no longer
+        // holds the published body is a path some other writer has moved past,
+        // and enriching from it would publish facets against a tree entry this
+        // publication did not establish.
+        match host_entry_matches_graph(state, &host_path, repo_path) {
+            Ok(true) => {}
+            Ok(false) => {
+                warn!(
+                    file = %file_id,
+                    "the host entry no longer matches the body this path's exact tree entry \
+                     names, so its semantics were left for the admission that observes those \
+                     bytes"
+                );
+                outcome.failed.push(file_id.0.clone());
+                continue;
+            }
+            Err(error) => {
+                warn!(
+                    file = %file_id,
+                    error = %error,
+                    "could not compare the host entry to graph authority before re-deriving \
+                     this path's semantics"
+                );
+                outcome.failed.push(file_id.0.clone());
+                continue;
+            }
+        }
+
+        if let Err(error) = clear_incompatible_facets(state, &file_id, EnrichmentFacet::EntitySource)
+        {
+            warn!(
+                file = %file_id,
+                error = %error,
+                "incompatible facet cleanup failed before re-deriving this path's semantics"
+            );
+        }
+
+        let event = FileEvent::Changed(host_path);
+        match reconciler.reconcile_file_change(&event, &state.blobs, state.graph.as_ref()) {
+            Ok(result) => {
+                let (reconciled, delta) = result.into_parts();
+                use kin_reconcile::ReconcileOutcome;
+                let should_apply = matches!(
+                    &reconciled,
+                    ReconcileOutcome::Updated { .. } | ReconcileOutcome::FileRemoved { .. }
+                );
+                if should_apply {
+                    let derived_entities = !delta.entity_deltas.is_empty();
+                    if let Err(error) = state.graph.apply_transaction_delta(&delta) {
+                        warn!(
+                            file = %file_id,
+                            error = %error,
+                            "re-derived semantics for published bytes but the transaction would \
+                             not apply"
+                        );
+                        outcome.failed.push(file_id.0.clone());
+                        continue;
+                    }
+                    if derived_entities {
+                        mark_enrichment_unpublished(state, &file_id);
+                    }
+                    // The file's declarations just moved, so whatever a language
+                    // server said about them was said at positions this delta
+                    // retired.
+                    crate::daemon::retire_enrichment_marker(state, &[file_id.0.clone()]);
+                    if let Err(error) =
+                        state.persist_projection_truth_from_reconcile(&reconciler, &reconciled)
+                    {
+                        warn!(
+                            file = %file_id,
+                            error = %error,
+                            "failed to persist projection truth after re-deriving semantics"
+                        );
+                    }
+                    if let ReconcileOutcome::FileRemoved {
+                        removed, file_id, ..
+                    } = &reconciled
+                    {
+                        for id in removed {
+                            state.emit_event(DaemonEvent::EntityChanged {
+                                entity_id: *id,
+                                node: None,
+                                change_type: ChangeType::Deleted,
+                                file_path: Some(file_id.0.clone()),
+                                session_id: None,
+                            });
+                        }
+                    }
+                    graph_changed = true;
+                }
+                outcome.enriched += 1;
+            }
+            Err(error) => {
+                warn!(
+                    file = %file_id,
+                    error = %error,
+                    "published bytes could not be re-parsed, so this path's entities still \
+                     answer at the positions they were parsed at"
+                );
+                outcome.failed.push(file_id.0.clone());
+            }
+        }
+    }
+
+    drop(reconciler);
+    if graph_changed {
+        state.mark_dirty();
+        state.bump_version();
+    }
+    outcome
+}
+
 async fn sync_filesystem_with_graph_publishing(
     state: &DaemonState,
     publication: TreePublication,


### PR DESCRIPTION
Closes the live-daemon half of FIR-3200. The restart window it does not close is FIR-3208.

## Measurement, taken before the fix

A one-line Rust fixture is committed, a disposable session workspace is materialized, 17
lines are prepended to the file inside the session dir (the shape `kin exec` produces),
`/reconcile` publishes it, then `/commands/commit` runs, then the published span is read
back out of the graph.

Broken:

```
committed start_line=0
reconcile modified=1 enriched=0 after_reconcile_start_line=0
commit status=200 OK body={"entity_count":0,"relation_count":0,"file_count":1}
after_commit start_line=0
assertion `left == right` failed: the published span must move with the bytes the session changed
  left: 0
 right: 17
```

Read the commit line. It returns **200 with `entity_count: 0` and `file_count: 1`**. The
tree delta is recorded and the semantic delta is not, so a function that now begins on line
17 keeps answering at line 0, and every read surface serves that under an envelope with
nothing to report. That is the brownfield stranger's finding on `psf/requests`, reproduced.

Fixed:

```
committed start_line=0
reconcile modified=1 enriched=1 after_reconcile_start_line=17
commit status=200 OK body={"entity_count":1,"relation_count":0,"file_count":1}
after_commit start_line=17
test result: ok. 1 passed
```

The span moves at the reconcile, before the commit runs at all, and the commit that follows
carries `entity_count: 1`, so the semantic change reaches history rather than being absent
from it.

## Mechanism

Three facts, read from source rather than inferred.

`reconcile_session_workspace` admits a session's exact tree and publishes it. Its summary
carried `semantic_files_enriched: 0` and `semantic_enrichment_failures: 0` as literals, and
those two were the only writers of those fields anywhere in the daemon. The publication
moved bytes and parsed none of them.

`command_commit` forces one complete admission through
`sync_filesystem_with_graph_deferring_tree_publication`.

That admission early-returns on an empty tree delta, and the whole semantic enrichment loop,
including `reconciler.reconcile_file_change`, sits below that return.

The first fact makes the tree delta empty for the third. The publication already made the
working copy current, so the commit's admission finds nothing to move, returns, and the file
whose bytes changed is never offered to a parser.

## Fix

The parse now happens where the bytes were published. `reconcile_session_workspace` calls
`readmit_semantics_for_paths` for the paths its publication moved, under the same gate that
published them, and reports the real counts in the two fields that were hardcoded.

The helper reads content from the body the exact tree names, and re-reads the host only to
prove it still holds that same body, which is the `host_entry_matches_graph` guard the
admission's own enrichment already uses. Symlinks, Gitlinks, paths the graph no longer
carries and paths with no UTF-8 rendering are skipped rather than failed, because none of
them is source owned by that path.

### Bytes stay published when a parse fails

This deliberately does not publish "tree and semantics or neither". `api.rs` and
`loop_runner.rs` both state the opposite invariant on this path: semantic parsing never
controls exact membership, and parser support never controls repository membership. Failing
closed would let an unsupported language or a parse failure block exact bytes from reaching
authority, which inverts the thesis that bytes are authority and semantics are derived. So
the bytes stay published and the gap is reported loudly instead.

### Why the refusal is a 409 and not a 200 with a degradation block

A reconcile that moved an entity-source file it could not re-parse returns 409 carrying the
file list, the real counts, and the complete summary inside the refusal body. Two reasons
for that shape rather than a success status. It makes `kin reconcile` exit non-zero with no
CLI change at all, because `daemon_client::reconcile` already turns any non-success status
into an error and prints the body; a caller that reads a clean summary and a zero has no way
to learn that the file it just edited still answers at its old spans. And
`ReconcileSummary` carries `#[serde(deny_unknown_fields)]`, so a degradation block could not
be added to it without changing the wire contract and `kin-cli` beside it.

## What this PR does not close

**FIR-3209, the mirror half, deliberately out of scope.** A session that REMOVES an
entity-source file cannot reconcile at all today: `/reconcile` returns 500 from
`commit_session_workspace_admission`, which refuses a transaction leaving an entity on a
repository path absent from the staged tree, and that runs before this readmission is
reached. Carrying the entity removal in the admission's own delta is `repository_commit.rs`
work and belongs in its own change. The existing suite is green over a delete only because
its fixture carries no entities.

**FIR-3208, the restart window.** A daemon that comes up between a session reconcile and the commit that
publishes it still reads the pre-edit span. Measured, not assumed:

```
a_daemon_reopened_after_a_session_reconcile_answers_at_the_moved_span
assertion failed: a reopened daemon must load the spans the session's bytes hold
  left: 0
 right: 17
```

It fails at the first read after the restart, before the commit is even reached. The reason
is structural: entities reach durable authority only inside a semantic change, a session
reconcile deliberately publishes the workspace tree with no history and no ref move, and a
derived-graph mutation that no change carries is gone when the next daemon replays that
history. A synchronous `save_snapshot` immediately after the re-derivation was probed and
did not change the result. Closing it needs a record that outlives the daemon and tells the
next commit it owes a parse, which is FIR-3208 and a stacked PR.

## Falsification

Two tails.

The fix's own inverse. Replace the `readmit_semantics_for_paths` call in
`reconcile_session_workspace` with `SemanticReadmission::default()`, the pair of zeros that
stood there before, which is exactly restoring the skip. The run stops at the reconcile's own
count, one assertion before the commit line:

```
FIR-3200 measurement: committed start_line=0
FIR-3200 measurement: reconcile modified=1 enriched=0 after_reconcile_start_line=0
assertion `left == right` failed: the reconcile must report the file it re-parsed rather than
a hardcoded zero
  left: 0
 right: 1
test result: FAILED. 0 passed; 1 failed
```

An earlier draft of this section quoted a tail that ran on to the commit line and the span
assertion. That is not what the procedure prints, because the enriched assertion fires first.
Corrected after review pointed it out.

The refusal, end to end. `a_session_publishing_unparseable_source_is_refused_and_keeps_its_bytes`
prepends the seventeen lines and leaves the file syntactically broken, which is the ordinary
agent case rather than a contrived one. It asserts 409, the file named, `enriched: 0`,
`failures: 1`, the published body still byte-identical in the tree, and the span still at its
last-known-good position. Falsify by restoring the unconditional `outcome.enriched += 1`
outside the applied-delta arm: it returns 200 with enriched 1 and failures 0 over a file
whose span never moved.

That test exists because review found the defect under it, and it is worth stating plainly.
`enriched` was incremented outside the applied-delta check, so a file coming back as
`BrokenAst` or `Conflict` derived nothing, kept its old spans, and was still counted as
enriched with zero failures. The daemon reconciles under `ReconcilePolicy::FallbackToLkg`, so
unparseable source is the common path, not an edge. That is this change's own defect one
level down, a clean summary over a file that still answers at its old positions, and it is
now counted and refused rather than reported as success.

The refusal's shape. `a_reconcile_whose_semantics_did_not_publish_refuses_and_names_the_files`
falsifies two ways: return `StatusCode::OK` from `semantic_readmission_refused` and the
status assertion goes red, drop `files` from its body and the naming assertion goes red.

## Gates

`bin/kin-precheck kin --repo-dir kin=<this worktree>`, run through the fleet builder slot at
23:18:30Z:

```
kin-precheck: repo=kin tree=.kin-coord/worktrees/commitfresh-kin
              sha=f2cc831e2869c15c22de41f4f7d90937742f0484
              branch=chore/lane-commitfresh-kin
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
21 PASS, 0 FAIL, exit rc=0
```

`cargo test -p kin-daemon --lib`: **1373 passed, 0 failed, 3 ignored**, 259s.

The tree is 5 commits behind origin/main. Nothing here touches `AGENTS.md` or
`docs/traps.md`, so no whole-tree claim rides on the base. Hosted CI is the gate of record
for the full workspace, and acceptance grades main rather than this PR.
