### PR TITLE
Carry a session's unpaid parse across a restart

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6138,10 +6138,7 @@ async fn reconcile_session_workspace(
         // between this publication and its commit read the pre-edit span back,
         // and a synchronous snapshot immediately after the re-derivation did not
         // change that. The commit that publishes is what settles the record.
-        crate::semantic_debt::record(
-            state.layout.root(),
-            &crate::semantic_debt::owed_by(observation.deltas()),
-        );
+        crate::semantic_debt::record(&state, &crate::semantic_debt::owed_by(observation.deltas()));
         let readmitted =
             crate::loop_runner::readmit_semantics_for_paths(&state, &published_paths(&observation))
                 .await;
@@ -6436,7 +6433,7 @@ async fn command_commit(
             // is still owed. Settled here rather than at the drain because a
             // crash between the two would otherwise clear the record for work no
             // change carried, which is the loss the record exists to prevent.
-            crate::semantic_debt::settle_all(state.layout.root());
+            crate::semantic_debt::settle_all(&state);
             Ok(response)
         }
         Err(error) => {
@@ -35204,6 +35201,93 @@ mod tests {
         );
     }
 
+    /// FIR-3208. A drain that is not a commit settles nothing.
+    ///
+    /// The record exists because a re-derivation lives in the derived graph and
+    /// dies with the daemon that performed it; only a commit puts it in
+    /// history. So a drain at startup pays the parse and must leave the record
+    /// standing, or the next restart before a commit reads the pre-edit span
+    /// with nothing left to say otherwise.
+    ///
+    /// Falsify by moving `settle_all` into `drain_semantic_debt`: the first
+    /// assertion on the record goes red, and the second reopen reads the
+    /// pre-edit span with no record to pay it from.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial_test::serial(commit_phase_capture)]
+    async fn a_drain_without_a_commit_leaves_the_record_standing() {
+        const PREPENDED_LINES: u32 = 17;
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let layout = initialized.layout.clone();
+        let state = Arc::new(DaemonState::open(initialized.layout).unwrap());
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        std::fs::write(
+            repo.path().join("shifted.rs"),
+            b"pub fn shifted() -> u32 { 7 }\n",
+        )
+        .unwrap();
+        let app = router(Arc::clone(&state));
+        commit_through_api(&app, kin_model::OperationId::new(), "publish the fixture").await;
+        let before = published_start_line(&state, "shifted.rs");
+        let session_dir = layout.root().join("runs/session-fir3208-standing");
+        materialize_session_through_api(&app, &session_dir).await;
+        prepend_session_lines(&session_dir.join("shifted.rs"), PREPENDED_LINES);
+        reconcile_session_through_api(&app, &session_dir).await;
+        drop(app);
+        drop(state);
+
+        // First restart: the drain pays the parse, and the record stands.
+        let reopened = Arc::new(DaemonState::open(layout.clone()).unwrap());
+        crate::loop_runner::drain_semantic_debt(&reopened)
+            .await
+            .unwrap();
+        assert_eq!(
+            published_start_line(&reopened, "shifted.rs"),
+            before + PREPENDED_LINES
+        );
+        assert!(
+            !crate::semantic_debt::outstanding(&reopened).is_empty(),
+            "a drain pays the parse in the derived graph; only a commit may settle the record"
+        );
+        drop(reopened);
+
+        // Second restart, still no commit: the derived graph is stale again
+        // and the record is what makes that recoverable.
+        let again = Arc::new(DaemonState::open(layout).unwrap());
+        again
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            published_start_line(&again, "shifted.rs"),
+            before,
+            "nothing durable carried the parse across the restart"
+        );
+        crate::loop_runner::drain_semantic_debt(&again)
+            .await
+            .unwrap();
+        assert_eq!(
+            published_start_line(&again, "shifted.rs"),
+            before + PREPENDED_LINES,
+            "the standing record pays it again"
+        );
+
+        // The commit is what settles it.
+        let again_app = router(Arc::clone(&again));
+        commit_through_api(
+            &again_app,
+            kin_model::OperationId::new(),
+            "commit the session's edit",
+        )
+        .await;
+        assert!(
+            crate::semantic_debt::outstanding(&again).is_empty(),
+            "a commit that reached authority settles the whole record"
+        );
+    }
+
     /// FIR-3208. One unrelated edit must not settle a debt nothing has paid.
     ///
     /// The commit that carries an admission clears the whole record once its
@@ -35402,7 +35486,7 @@ mod tests {
         };
         drop(tree);
         crate::semantic_debt::record(
-            state.layout.root(),
+            &state,
             &[crate::semantic_debt::SemanticDebt {
                 path: "shifted.rs".to_string(),
                 body: hash.to_string(),

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6129,6 +6129,19 @@ async fn reconcile_session_workspace(
         // previous parse recorded. On a converted `psf/requests` an edit that
         // prepended seventeen lines left the whole file answering seventeen
         // lines short, under an envelope with nothing to report.
+        // Record what this publication owes a parser before parsing any of it,
+        // and leave the record standing after. Re-deriving here fixes the live
+        // daemon and nothing more: entities reach durable authority only inside
+        // a semantic change, this publication deliberately writes no history,
+        // and a derived-graph mutation no change carries is gone when the next
+        // daemon replays that history. Measured, not assumed. A daemon reopened
+        // between this publication and its commit read the pre-edit span back,
+        // and a synchronous snapshot immediately after the re-derivation did not
+        // change that. The commit that publishes is what settles the record.
+        crate::semantic_debt::record(
+            state.layout.root(),
+            &crate::semantic_debt::owed_by(observation.deltas()),
+        );
         let readmitted =
             crate::loop_runner::readmit_semantics_for_paths(&state, &published_paths(&observation))
                 .await;
@@ -6167,7 +6180,11 @@ async fn reconcile_session_workspace(
         changes,
     };
     if !semantic_failures.is_empty() {
-        return Err(semantic_readmission_refused(&summary, &semantic_failures));
+        let named = semantic_failures
+            .iter()
+            .map(|failure| failure.path.clone())
+            .collect::<Vec<_>>();
+        return Err(semantic_readmission_refused(&summary, &named));
     }
     Ok(Json(summary))
 }
@@ -6413,6 +6430,13 @@ async fn command_commit(
                 &state.layout,
                 state.graph.resolved_tree().len() as u64,
             );
+            // This transaction reached authority, and a commit derives its
+            // change from the live graph, so every parse the admission above put
+            // back into that graph is in history now. Nothing the record named
+            // is still owed. Settled here rather than at the drain because a
+            // crash between the two would otherwise clear the record for work no
+            // change carried, which is the loss the record exists to prevent.
+            crate::semantic_debt::settle_all(state.layout.root());
             Ok(response)
         }
         Err(error) => {
@@ -6645,10 +6669,22 @@ fn refuse_a_successor_that_records_nothing(
 /// they can see. On 0.5.52 it reached them as `HTTP 500 Internal Server Error:
 /// Core error: ...` (FIR-2664). Everything else stays an internal error.
 fn commit_admission_error(error: crate::error::DaemonError) -> (StatusCode, String) {
-    match projection_blocked_refusal(&error) {
-        Some(refusal) => refusal,
-        None => internal_error(error),
+    if let Some(refusal) = projection_blocked_refusal(&error) {
+        return refusal;
     }
+    // A parse this daemon could not perform over bytes that are already durable
+    // authority. The store is intact and nothing needs repairing, so answering
+    // it as an internal error would send a reader to the daemon for a file they
+    // can see. It is a refusal in words, naming the files, exactly as the
+    // reconcile that first owed the parse refuses.
+    if let crate::error::DaemonError::SemanticReadmissionFailed(message) = &error {
+        let body = serde_json::json!({
+            "error": "semantic_readmission_failed",
+            "message": message,
+        });
+        return (StatusCode::CONFLICT, body.to_string());
+    }
+    internal_error(error)
 }
 
 /// The worded refusal for a blocked projection, when `error` is one.
@@ -35089,6 +35125,326 @@ mod tests {
             after,
             before + PREPENDED_LINES,
             "the published span must move with the bytes the session changed"
+        );
+    }
+
+    /// FIR-3200, the reopen arm. The session that makes the edit and the commit
+    /// that publishes it are routinely separated by a daemon restart, which is
+    /// what makes where the parse happens matter rather than merely when. A
+    /// daemon that comes up after the session reconcile must load a graph whose
+    /// spans already match its own tree, with nothing left owed to it.
+    ///
+    /// Falsify it the way its sibling falsifies: replace the
+    /// `readmit_semantics_for_paths` call in `reconcile_session_workspace` with
+    /// `SemanticReadmission::default()`, the pair of zeros that stood there
+    /// before, and this reopens onto a graph seventeen lines behind its bytes.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial_test::serial(commit_phase_capture)]
+    async fn a_daemon_reopened_after_a_session_reconcile_answers_at_the_moved_span() {
+        const PREPENDED_LINES: u32 = 17;
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let layout = initialized.layout.clone();
+        let state = Arc::new(DaemonState::open(initialized.layout).unwrap());
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        std::fs::write(
+            repo.path().join("shifted.rs"),
+            b"pub fn shifted() -> u32 { 7 }\n",
+        )
+        .unwrap();
+
+        let app = router(Arc::clone(&state));
+        commit_through_api(&app, kin_model::OperationId::new(), "publish the fixture").await;
+        let before = published_start_line(&state, "shifted.rs");
+
+        let session_dir = layout.root().join("runs/session-fir3200-reopen");
+        materialize_session_through_api(&app, &session_dir).await;
+        prepend_session_lines(&session_dir.join("shifted.rs"), PREPENDED_LINES);
+        let summary = reconcile_session_through_api(&app, &session_dir).await;
+        assert_eq!(summary.semantic_files_enriched, 1);
+        assert_eq!(summary.semantic_enrichment_failures, 0);
+
+        // The daemon dies here, between the session's edit and the commit that
+        // publishes it. Whatever the readmission derived has to be on disk
+        // already for the next one to load it.
+        drop(app);
+        drop(state);
+        let reopened = Arc::new(DaemonState::open(layout).unwrap());
+        reopened
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        // The seam the reconcile loop drives once per daemon life, before it
+        // answers anything. Called directly here because this test drives the
+        // daemon's HTTP surface rather than its loop, and what is being asserted
+        // is that the record carries the parse across the restart, not that a
+        // background task eventually fires.
+        crate::loop_runner::drain_semantic_debt(&reopened)
+            .await
+            .unwrap();
+        assert_eq!(
+            published_start_line(&reopened, "shifted.rs"),
+            before + PREPENDED_LINES,
+            "a reopened daemon must load the spans the session's bytes hold"
+        );
+
+        let reopened_app = router(Arc::clone(&reopened));
+        commit_through_api(
+            &reopened_app,
+            kin_model::OperationId::new(),
+            "commit the session's edit after a restart",
+        )
+        .await;
+        assert_eq!(
+            published_start_line(&reopened, "shifted.rs"),
+            before + PREPENDED_LINES,
+            "the commit after a restart must not move the span back"
+        );
+    }
+
+    /// FIR-3208. One unrelated edit must not settle a debt nothing has paid.
+    ///
+    /// The commit that carries an admission clears the whole record once its
+    /// transaction reaches authority. An admission that drained only when its
+    /// own transition was empty would therefore let a one-line edit somewhere
+    /// else discard a parse another file was still owed, and the file would stay
+    /// stale with the record saying it was settled.
+    ///
+    /// Found by reading the settle point rather than from a failure, and it is
+    /// the same mistake the empty-delta return made in the first place: a
+    /// conclusion drawn from the wrong question. The admission's own transition
+    /// says what THIS pass moved, never what an earlier one left owing.
+    ///
+    /// Falsify by moving the `drain_semantic_debt` call back inside the
+    /// `exact_admission.deltas.is_empty()` arm: this commit then has a non-empty
+    /// transition of its own, never drains, settles the record anyway, and the
+    /// span stays where the pre-edit parse left it.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial_test::serial(commit_phase_capture)]
+    async fn an_unrelated_edit_does_not_settle_a_debt_nothing_paid() {
+        const PREPENDED_LINES: u32 = 17;
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let layout = initialized.layout.clone();
+        let state = Arc::new(DaemonState::open(initialized.layout).unwrap());
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        std::fs::write(
+            repo.path().join("shifted.rs"),
+            b"pub fn shifted() -> u32 { 7 }\n",
+        )
+        .unwrap();
+
+        let app = router(Arc::clone(&state));
+        commit_through_api(&app, kin_model::OperationId::new(), "publish the fixture").await;
+        let before = published_start_line(&state, "shifted.rs");
+
+        let session_dir = layout.root().join("runs/session-fir3208-unrelated");
+        materialize_session_through_api(&app, &session_dir).await;
+        prepend_session_lines(&session_dir.join("shifted.rs"), PREPENDED_LINES);
+        reconcile_session_through_api(&app, &session_dir).await;
+
+        // The restart is what makes the debt matter: the publication's own
+        // re-derivation lives in the derived graph, and the next daemon rebuilds
+        // that from a history this publication deliberately did not write.
+        drop(app);
+        drop(state);
+        let reopened = Arc::new(DaemonState::open(layout).unwrap());
+        reopened
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        // A commit whose own transition is non-empty and has nothing to do with
+        // the file that is owed a parse.
+        std::fs::write(
+            repo.path().join("unrelated.rs"),
+            b"pub fn unrelated() -> u32 { 9 }\n",
+        )
+        .unwrap();
+        let reopened_app = router(Arc::clone(&reopened));
+        commit_through_api(
+            &reopened_app,
+            kin_model::OperationId::new(),
+            "commit an unrelated file",
+        )
+        .await;
+
+        assert_eq!(
+            published_start_line(&reopened, "shifted.rs"),
+            before + PREPENDED_LINES,
+            "a commit that settles the record must first pay what it settles"
+        );
+    }
+
+    /// FIR-3208. An unparseable file does not block the commit.
+    ///
+    /// Source the parser cannot read is the file's own state, and retaining
+    /// last-known-good is the designed answer to it rather than a fault. An
+    /// agent mid-edit produces exactly this, so refusing every commit until the
+    /// syntax is fixed would leave a caller unable to record anything at all,
+    /// which is worse than the stale spans this record exists to prevent. The
+    /// commit records the bytes and the file keeps the spans its last readable
+    /// version produced, which is what this seam did for such a file before any
+    /// of this existed.
+    ///
+    /// Falsify by dropping the `unparseable` partition in `drain_semantic_debt`
+    /// and refusing on every failure: this commit then 409s and a caller with one
+    /// half-written file can record nothing.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial_test::serial(commit_phase_capture)]
+    async fn an_unparseable_file_keeps_its_spans_and_does_not_block_the_commit() {
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let layout = initialized.layout.clone();
+        let state = Arc::new(DaemonState::open(initialized.layout).unwrap());
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        std::fs::write(
+            repo.path().join("shifted.rs"),
+            b"pub fn shifted() -> u32 { 7 }\n",
+        )
+        .unwrap();
+
+        let app = router(Arc::clone(&state));
+        commit_through_api(&app, kin_model::OperationId::new(), "publish the fixture").await;
+        let before = published_start_line(&state, "shifted.rs");
+
+        let session_dir = layout.root().join("runs/session-fir3208-broken");
+        materialize_session_through_api(&app, &session_dir).await;
+        let session_file = session_dir.join("shifted.rs");
+        prepend_session_lines(&session_file, 17);
+        let mut broken = std::fs::read(&session_file).unwrap();
+        broken.extend_from_slice(b"pub fn half_written(\n");
+        std::fs::write(&session_file, &broken).unwrap();
+        // The reconcile refuses, because the caller who just published these
+        // bytes is the one who needs to know their semantics did not follow.
+        let refusal = app
+            .clone()
+            .oneshot(
+                Request::post("/reconcile")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({"session_dir": session_dir, "confirm_mass_deletion": false})
+                            .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(refusal.status(), StatusCode::CONFLICT);
+
+        // The commit after it does not refuse. The caller has been told once,
+        // the bytes are durable, and blocking them buys nothing.
+        drop(app);
+        drop(state);
+        let reopened = Arc::new(DaemonState::open(layout).unwrap());
+        reopened
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let reopened_app = router(Arc::clone(&reopened));
+        commit_through_api(
+            &reopened_app,
+            kin_model::OperationId::new(),
+            "commit a half-written file",
+        )
+        .await;
+        assert_eq!(
+            published_start_line(&reopened, "shifted.rs"),
+            before,
+            "an unparseable file keeps its last readable version's spans"
+        );
+    }
+
+    /// FIR-3208. A drain failure that is NOT the file's own fault refuses the
+    /// commit.
+    ///
+    /// The two halves have to be told apart or the split is meaningless. This
+    /// failure is transient and the caller can retry it; letting it through would
+    /// settle the record unpaid and reproduce the stale spans silently, which is
+    /// the whole class the record exists to close.
+    ///
+    /// The trigger is graph-owned rather than contrived: the record names a body
+    /// the exact tree still carries, and the CAS cannot produce it. That is the
+    /// shape of a store whose ingestion CAS was pruned under it.
+    ///
+    /// Falsify by treating every drain failure as unparseable: this commit then
+    /// succeeds and settles a record nothing paid.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial_test::serial(commit_phase_capture)]
+    async fn a_drain_failure_that_is_not_the_file_refuses_the_commit() {
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let state = Arc::new(DaemonState::open(initialized.layout).unwrap());
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        std::fs::write(
+            repo.path().join("shifted.rs"),
+            b"pub fn shifted() -> u32 { 7 }\n",
+        )
+        .unwrap();
+        let app = router(Arc::clone(&state));
+        commit_through_api(&app, kin_model::OperationId::new(), "publish the fixture").await;
+
+        let repo_path = RepoPath::from_utf8("shifted.rs".to_string()).unwrap();
+        let tree = state.graph.resolved_tree();
+        let kin_model::TreeEntry::Blob { hash, .. } =
+            tree.artifact_at_path(&repo_path).unwrap().entry
+        else {
+            panic!("the fixture is a regular file");
+        };
+        drop(tree);
+        crate::semantic_debt::record(
+            state.layout.root(),
+            &[crate::semantic_debt::SemanticDebt {
+                path: "shifted.rs".to_string(),
+                body: hash.to_string(),
+            }],
+        );
+        let body_hash = kin_blobs::Hash256::from_bytes(*hash.as_bytes());
+        state.blobs.delete(&body_hash).unwrap();
+
+        std::fs::write(repo.path().join("other.rs"), b"pub fn other() -> u32 { 1 }\n").unwrap();
+        let response = app
+            .clone()
+            .oneshot(
+                Request::post("/commands/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "operation_id": kin_model::OperationId::new(),
+                            "timestamp": Timestamp::now(),
+                            "author": "Test Author <test@example.invalid>",
+                            "message": "commit while a debt cannot be paid"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 128 * 1024)
+            .await
+            .unwrap();
+        let body = String::from_utf8_lossy(&body).to_string();
+        assert_eq!(
+            status,
+            StatusCode::CONFLICT,
+            "a drain failure the caller can retry must refuse rather than settle unpaid: {body}"
+        );
+        let refusal: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(refusal["error"], "semantic_readmission_failed");
+        assert!(
+            refusal["message"].as_str().unwrap().contains("shifted.rs"),
+            "the refusal names the path it could not pay: {body}"
         );
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -35411,7 +35411,11 @@ mod tests {
         let body_hash = kin_blobs::Hash256::from_bytes(*hash.as_bytes());
         state.blobs.delete(&body_hash).unwrap();
 
-        std::fs::write(repo.path().join("other.rs"), b"pub fn other() -> u32 { 1 }\n").unwrap();
+        std::fs::write(
+            repo.path().join("other.rs"),
+            b"pub fn other() -> u32 { 1 }\n",
+        )
+        .unwrap();
         let response = app
             .clone()
             .oneshot(

--- a/crates/kin-daemon/src/error.rs
+++ b/crates/kin-daemon/src/error.rs
@@ -114,6 +114,17 @@ pub enum DaemonError {
     #[error("{0}")]
     RepoOwnedByAnotherDaemon(String),
 
+    /// Paths whose exact bytes are already durable authority and whose
+    /// semantics could not be re-derived from them.
+    ///
+    /// Typed rather than folded into [`Io`](Self::Io) because the two need
+    /// different answers. Membership is not in doubt here and nothing needs
+    /// repairing; what the caller has to say is that the graph will answer
+    /// about these files at positions their bytes no longer hold, and it has to
+    /// name them.
+    #[error("{0}")]
+    SemanticReadmissionFailed(String),
+
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 }

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -143,6 +143,7 @@ mod repository_rename;
 mod repository_rollback;
 mod repository_stash;
 mod repository_tag;
+mod semantic_debt;
 pub mod session_registry;
 pub mod source_body_memo;
 mod source_cas;

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -2479,6 +2479,12 @@ pub async fn run_loop_armed(
     // Owed once per daemon life, and independent of the catch-up window: the
     // paths it recovers are exactly the ones whose host modification time puts
     // them outside that window, which is why the window cannot see them.
+    // The semantic debt one previous daemon left, owed once per daemon life and
+    // before this loop answers anything. A path whose bytes reached authority
+    // without a parse is a wrong answer this daemon is able to know about, and
+    // waiting for the next commit to drain it would serve the previous parse to
+    // every query in between.
+    let mut semantic_debt_drain_owed = true;
     let mut enrichment_repair_owed = true;
     // Owed once per daemon life for the same reason and on the same schedule:
     // a store converted from Git carries entities whose parse observation was
@@ -2645,6 +2651,17 @@ pub async fn run_loop_armed(
         // answered every query as an absence, and a store that has been in that
         // state deserves the count said out loud rather than repaired in
         // silence.
+        if semantic_debt_drain_owed {
+            semantic_debt_drain_owed = false;
+            if let Err(error) = drain_semantic_debt(&state).await {
+                warn!(
+                    error = %error,
+                    "a path whose bytes reached authority without a parse could not be re-parsed \
+                     at startup, so it still answers at the positions its previous bytes held"
+                );
+            }
+        }
+
         if enrichment_repair_owed {
             enrichment_repair_owed = false;
             match plan_unpublished_enrichment_repair(&state) {
@@ -8102,6 +8119,72 @@ pub(crate) async fn sync_filesystem_with_graph_deferring_tree_publication(
     sync_filesystem_with_graph_publishing(state, TreePublication::DeferredToCaller).await
 }
 
+/// Re-derive the semantics every recorded debt still owes, and refuse in words
+/// if any of them cannot be.
+///
+/// Entries a later transition overtook are settled here rather than re-parsed:
+/// the tree no longer names the body they were recorded for, so the admission
+/// that moved it enriched the path already. What survives that filter is settled
+/// only by the commit that publishes it, because a commit is the transaction
+/// that makes a parse durable and a crash before one would otherwise clear the
+/// record for work nothing carried.
+pub(crate) async fn drain_semantic_debt(state: &DaemonState) -> Result<()> {
+    let recorded = crate::semantic_debt::outstanding(state.layout.root());
+    if recorded.is_empty() {
+        return Ok(());
+    }
+    let (owed, spent) = crate::semantic_debt::partition_against_tree(state, &recorded);
+    crate::semantic_debt::settle(state.layout.root(), &spent);
+    if owed.is_empty() {
+        return Ok(());
+    }
+    info!(
+        paths = owed.len(),
+        "re-deriving the semantics for paths whose bytes reached authority without them"
+    );
+    let readmitted = readmit_semantics_for_paths(state, &owed).await;
+    let (unparseable, unresolved): (Vec<_>, Vec<_>) = readmitted
+        .failed
+        .into_iter()
+        .partition(|failure| failure.unparseable);
+    // Source the parser cannot read is the file's own state, and retaining
+    // last-known-good is the designed answer to it rather than a fault. An agent
+    // mid-edit produces exactly this, and refusing the commit until the syntax is
+    // fixed would leave a caller unable to record anything at all, which is a
+    // worse outcome than the spans this seam exists to keep current. So it is
+    // said out loud and the commit proceeds, which is what this file already did
+    // for such a path before any of this existed.
+    if !unparseable.is_empty() {
+        warn!(
+            files = unparseable
+                .iter()
+                .map(|failure| failure.path.as_str())
+                .collect::<Vec<_>>()
+                .join(", "),
+            "these paths could not be parsed, so they keep the spans their last readable \
+             version produced; the commit records their bytes either way"
+        );
+    }
+    if unresolved.is_empty() {
+        return Ok(());
+    }
+    // Everything else is this daemon failing at something it should have
+    // managed, and a caller can retry it. Letting one through would settle the
+    // record unpaid and reproduce the stale spans silently, which is the whole
+    // class this record exists to close.
+    Err(DaemonError::SemanticReadmissionFailed(format!(
+        "the bytes for {} of these paths are durable authority and their semantics could not be \
+         re-derived from them, so the graph still answers about them at the positions their \
+         previous bytes held: {}",
+        unresolved.len(),
+        unresolved
+            .iter()
+            .map(|failure| failure.path.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    )))
+}
+
 /// What re-deriving the semantic layer for one set of already-admitted paths
 /// produced.
 #[derive(Debug, Default)]
@@ -8112,7 +8195,40 @@ pub(crate) struct SemanticReadmission {
     /// Entity-source paths whose bytes moved and whose semantics could not be
     /// re-derived, named so a caller can refuse in words rather than report a
     /// count of zero.
-    pub(crate) failed: Vec<String>,
+    pub(crate) failed: Vec<SemanticFailure>,
+}
+
+/// One path whose semantics did not follow its bytes, and whether the file
+/// itself is the reason.
+///
+/// The distinction decides what a caller may do about it. Source the parser
+/// cannot read is the file's own state, and falling back to last-known-good is
+/// the designed answer rather than a fault: an agent mid-edit produces it
+/// constantly, and refusing every commit until the syntax is fixed would be a
+/// worse outcome than the stale spans this seam exists to prevent. Everything
+/// else is this daemon failing at something it should have managed, and a caller
+/// can retry it.
+#[derive(Debug, Clone)]
+pub(crate) struct SemanticFailure {
+    pub(crate) path: String,
+    /// The parser read the file and could not make sense of it.
+    pub(crate) unparseable: bool,
+}
+
+impl SemanticFailure {
+    fn unparseable(path: String) -> Self {
+        Self {
+            path,
+            unparseable: true,
+        }
+    }
+
+    fn unresolved(path: String) -> Self {
+        Self {
+            path,
+            unparseable: false,
+        }
+    }
 }
 
 /// Re-derive the semantic layer for paths whose exact bytes are already graph
@@ -8189,7 +8305,9 @@ pub(crate) async fn readmit_semantics_for_paths(
                     "the body this path's exact tree entry names is not readable, so its \
                      semantics cannot be re-derived from graph-owned truth"
                 );
-                outcome.failed.push(file_id.0.clone());
+                outcome
+                    .failed
+                    .push(SemanticFailure::unresolved(file_id.0.clone()));
                 continue;
             }
         };
@@ -8241,7 +8359,9 @@ pub(crate) async fn readmit_semantics_for_paths(
                      names, so its semantics were left for the admission that observes those \
                      bytes"
                 );
-                outcome.failed.push(file_id.0.clone());
+                outcome
+                    .failed
+                    .push(SemanticFailure::unresolved(file_id.0.clone()));
                 continue;
             }
             Err(error) => {
@@ -8251,7 +8371,9 @@ pub(crate) async fn readmit_semantics_for_paths(
                     "could not compare the host entry to graph authority before re-deriving \
                      this path's semantics"
                 );
-                outcome.failed.push(file_id.0.clone());
+                outcome
+                    .failed
+                    .push(SemanticFailure::unresolved(file_id.0.clone()));
                 continue;
             }
         }
@@ -8290,7 +8412,12 @@ pub(crate) async fn readmit_semantics_for_paths(
                         "published bytes were read but no semantic transaction came back, so \
                          this path still answers at the positions its previous parse recorded"
                     );
-                    outcome.failed.push(file_id.0.clone());
+                    outcome.failed.push(if matches!(reconciled, ReconcileOutcome::BrokenAst { .. })
+                    {
+                        SemanticFailure::unparseable(file_id.0.clone())
+                    } else {
+                        SemanticFailure::unresolved(file_id.0.clone())
+                    });
                     continue;
                 }
                 {
@@ -8302,7 +8429,9 @@ pub(crate) async fn readmit_semantics_for_paths(
                             "re-derived semantics for published bytes but the transaction would \
                              not apply"
                         );
-                        outcome.failed.push(file_id.0.clone());
+                        outcome
+                            .failed
+                            .push(SemanticFailure::unresolved(file_id.0.clone()));
                         continue;
                     }
                     if derived_entities {
@@ -8349,7 +8478,9 @@ pub(crate) async fn readmit_semantics_for_paths(
                     "published bytes could not be re-parsed, so this path's entities still \
                      answer at the positions they were parsed at"
                 );
-                outcome.failed.push(file_id.0.clone());
+                outcome
+                    .failed
+                    .push(SemanticFailure::unresolved(file_id.0.clone()));
             }
         }
     }
@@ -8542,6 +8673,25 @@ async fn sync_filesystem_with_graph_publishing_inner(
     // Recorded before anything below can fail, so a pass that dies part way
     // through enrichment still hands the deferral back to be closed.
     *deferred_out = exact_admission.deferred_tree.take();
+    // Drain what earlier publications owe a parser, on both paths and before the
+    // empty-transition conclusion below.
+    //
+    // On the empty path this is the whole point: an empty transition means the
+    // working copy and the graph agree about bytes, not that the graph agrees
+    // with itself, and returning without asking is what let a commit record a
+    // tree delta with no entity delta over a file whose declarations had all
+    // moved.
+    //
+    // On the non-empty path it matters for a different reason. This pass parses
+    // the paths ITS OWN transition moved, which need not include a path some
+    // earlier publication left owing, and the commit that carries this admission
+    // settles the whole record once its transaction reaches authority. Draining
+    // only on the empty path would let one unrelated edit clear a debt nothing
+    // had paid.
+    if let Err(error) = drain_semantic_debt(state).await {
+        drop(graph_mutation);
+        return Err(error);
+    }
     if exact_admission.deltas.is_empty() {
         drop(graph_mutation);
         return Ok(());

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -2653,6 +2653,12 @@ pub async fn run_loop_armed(
         // silence.
         if semantic_debt_drain_owed {
             semantic_debt_drain_owed = false;
+            // Under the gate every other graph-authority mutation takes,
+            // including the tick below, commit and checkout. The drain applies
+            // entity transactions to the live graph, and a mutation outside
+            // the gate can interleave with a commit planning its change from
+            // that same graph.
+            let _coordination = state.coordination_gate.lock().await;
             if let Err(error) = drain_semantic_debt(&state).await {
                 warn!(
                     error = %error,
@@ -3907,6 +3913,86 @@ mod tests {
             std::env::var_os("KIN_ALLOW_MASS_DELETION"),
             mass_delete_before,
             "graph-only mode must not set or clear the mass-deletion escape hatch"
+        );
+    }
+
+    /// FIR-3208. A daemon start pays the semantic debt a previous daemon left,
+    /// before the loop answers anything.
+    ///
+    /// The record is the only thing carrying a parse across a restart, and a
+    /// commit is the only other drain, so a loop that skipped this at startup
+    /// would serve the previous parse to every query until someone committed.
+    /// The store is put into exactly the shape a session publication leaves:
+    /// the exact tree published on its own, nothing parsed, the record naming
+    /// what is owed.
+    ///
+    /// Falsify by removing the once-per-life drain from `run_loop_armed`: the
+    /// span never moves and the poll below runs out.
+    #[tokio::test]
+    async fn a_daemon_start_pays_the_semantic_debt_a_previous_daemon_left() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let host = repo.path().join("shifted.rs");
+        let original = b"pub fn shifted() -> u32 { 7 }\n".to_vec();
+        std::fs::write(&host, &original).unwrap();
+        sync_filesystem_with_graph(&state).await.unwrap();
+        let start_line = |state: &DaemonState| -> Option<u32> {
+            state
+                .graph
+                .query_entities(&EntityFilter {
+                    file_path: Some(FilePathId::new("shifted.rs")),
+                    ..Default::default()
+                })
+                .unwrap()
+                .into_iter()
+                .find_map(|entity| entity.span.map(|span| span.start_line))
+        };
+        assert_eq!(start_line(&state), Some(0));
+
+        let mut shifted = b"// prepended\n".repeat(17);
+        shifted.extend_from_slice(&original);
+        std::fs::write(&host, &shifted).unwrap();
+        let admission = exact_tree_admission(&state, None, TreePublication::Standalone).unwrap();
+        assert!(!admission.deltas.is_empty(), "the bytes moved");
+        crate::semantic_debt::record(&state, &crate::semantic_debt::owed_by(&admission.deltas));
+        let recorded = crate::semantic_debt::outstanding(&state);
+        let (owed, _) = crate::semantic_debt::partition_against_tree(&state, &recorded);
+        assert_eq!(owed.len(), 1, "the tree carries the body the record names");
+        assert_eq!(
+            start_line(&state),
+            Some(0),
+            "nothing has parsed the new bytes yet; that is the debt"
+        );
+
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        let mut handle = tokio::spawn(run_loop(
+            Arc::clone(&state),
+            LoopConfig::default(),
+            cancel_rx,
+        ));
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while start_line(&state) != Some(17) {
+            assert!(
+                !handle.is_finished(),
+                "the loop exited before paying the debt a previous daemon left"
+            );
+            assert!(
+                Instant::now() < deadline,
+                "the loop never re-derived the path a previous daemon left owing; span is {:?}",
+                start_line(&state)
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        cancel_tx.send(true).unwrap();
+        tokio::time::timeout(Duration::from_secs(30), &mut handle)
+            .await
+            .expect("the loop exits on shutdown")
+            .expect("the loop task must not panic")
+            .expect("the loop exits cleanly");
+        assert!(
+            !crate::semantic_debt::outstanding(&state).is_empty(),
+            "a startup drain pays the parse in the derived graph and leaves the record for the \
+             commit that makes it durable"
         );
     }
 
@@ -8129,12 +8215,12 @@ pub(crate) async fn sync_filesystem_with_graph_deferring_tree_publication(
 /// that makes a parse durable and a crash before one would otherwise clear the
 /// record for work nothing carried.
 pub(crate) async fn drain_semantic_debt(state: &DaemonState) -> Result<()> {
-    let recorded = crate::semantic_debt::outstanding(state.layout.root());
+    let recorded = crate::semantic_debt::outstanding(state);
     if recorded.is_empty() {
         return Ok(());
     }
     let (owed, spent) = crate::semantic_debt::partition_against_tree(state, &recorded);
-    crate::semantic_debt::settle(state.layout.root(), &spent);
+    crate::semantic_debt::settle(state, &spent);
     if owed.is_empty() {
         return Ok(());
     }

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -8412,12 +8412,13 @@ pub(crate) async fn readmit_semantics_for_paths(
                         "published bytes were read but no semantic transaction came back, so \
                          this path still answers at the positions its previous parse recorded"
                     );
-                    outcome.failed.push(if matches!(reconciled, ReconcileOutcome::BrokenAst { .. })
-                    {
-                        SemanticFailure::unparseable(file_id.0.clone())
-                    } else {
-                        SemanticFailure::unresolved(file_id.0.clone())
-                    });
+                    outcome.failed.push(
+                        if matches!(reconciled, ReconcileOutcome::BrokenAst { .. }) {
+                            SemanticFailure::unparseable(file_id.0.clone())
+                        } else {
+                            SemanticFailure::unresolved(file_id.0.clone())
+                        },
+                    );
                     continue;
                 }
                 {

--- a/crates/kin-daemon/src/semantic_debt.rs
+++ b/crates/kin-daemon/src/semantic_debt.rs
@@ -52,7 +52,7 @@
 //! would clear the record for a parse the next crash could still lose.
 
 use std::collections::BTreeSet;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use kin_model::{RepoPath, TreeEntry};
 use serde::{Deserialize, Serialize};
@@ -71,8 +71,13 @@ pub(crate) struct SemanticDebt {
 }
 
 /// Ingestion IO: the record of what is owed, under the store root.
-fn marker_path(root: &Path) -> PathBuf {
-    root.join("semantic-debt.json")
+///
+/// The root is read from the daemon's own layout here rather than taken as a
+/// parameter, the way the sibling markers in `loop_runner` and `daemon` read
+/// it, so the only path this module ever opens is a constant join under a root
+/// the daemon bound at open and nothing a caller passes can reach the join.
+fn marker_path(state: &DaemonState) -> PathBuf {
+    state.layout.root().join("semantic-debt.json")
 }
 
 /// Every path one publication moved, paired with the body it published there.
@@ -106,20 +111,20 @@ pub(crate) fn owed_by(deltas: &[kin_model::TreeDelta]) -> Vec<SemanticDebt> {
 /// recoverable; a store that cannot write it is no worse off than one built
 /// before this existed, and refusing a durable publication over it would trade a
 /// recoverable gap for an unrecoverable refusal.
-pub(crate) fn record(root: &Path, owed: &[SemanticDebt]) {
+pub(crate) fn record(state: &DaemonState, owed: &[SemanticDebt]) {
     if owed.is_empty() {
         return;
     }
-    let mut entries = outstanding(root);
+    let mut entries = outstanding(state);
     entries.retain(|entry| !owed.iter().any(|fresh| fresh.path == entry.path));
     entries.extend_from_slice(owed);
-    write(root, &entries);
+    write(state, &entries);
 }
 
 /// Read the record. An unreadable or unparseable one is treated as empty and
 /// said out loud, because the alternative is refusing every commit on the store.
-pub(crate) fn outstanding(root: &Path) -> Vec<SemanticDebt> {
-    let marker = marker_path(root);
+pub(crate) fn outstanding(state: &DaemonState) -> Vec<SemanticDebt> {
+    let marker = marker_path(state);
     let Ok(bytes) = std::fs::read(&marker) else {
         return Vec::new();
     };
@@ -170,17 +175,17 @@ pub(crate) fn partition_against_tree(
 }
 
 /// Drop the named paths from the record and rewrite it.
-pub(crate) fn settle(root: &Path, paths: &[String]) {
+pub(crate) fn settle(state: &DaemonState, paths: &[String]) {
     if paths.is_empty() {
         return;
     }
-    let mut entries = outstanding(root);
+    let mut entries = outstanding(state);
     let before = entries.len();
     entries.retain(|entry| !paths.contains(&entry.path));
     if entries.len() == before {
         return;
     }
-    write(root, &entries);
+    write(state, &entries);
 }
 
 /// Clear the whole record.
@@ -191,8 +196,8 @@ pub(crate) fn settle(root: &Path, paths: &[String]) {
 /// owed. The coordination gate spans both the publication that records a debt
 /// and the commit that clears it, so nothing can be recorded in between and lost
 /// here.
-pub(crate) fn settle_all(root: &Path) {
-    let marker = marker_path(root);
+pub(crate) fn settle_all(state: &DaemonState) {
+    let marker = marker_path(state);
     match std::fs::remove_file(&marker) {
         Ok(()) => debug!(
             marker = %marker.display(),
@@ -208,12 +213,12 @@ pub(crate) fn settle_all(root: &Path) {
     }
 }
 
-fn write(root: &Path, entries: &[SemanticDebt]) {
+fn write(state: &DaemonState, entries: &[SemanticDebt]) {
     if entries.is_empty() {
-        settle_all(root);
+        settle_all(state);
         return;
     }
-    let marker = marker_path(root);
+    let marker = marker_path(state);
     match serde_json::to_vec(entries) {
         Ok(bytes) => {
             if let Err(error) = std::fs::write(&marker, bytes) {

--- a/crates/kin-daemon/src/semantic_debt.rs
+++ b/crates/kin-daemon/src/semantic_debt.rs
@@ -154,12 +154,12 @@ pub(crate) fn partition_against_tree(
             spent.push(entry.path.clone());
             continue;
         };
-        let still_owed = tree
-            .artifact_at_path(&repo_path)
-            .is_some_and(|artifact| match artifact.entry {
-                TreeEntry::Blob { hash, .. } => hash.to_string() == entry.body,
-                _ => false,
-            });
+        let still_owed =
+            tree.artifact_at_path(&repo_path)
+                .is_some_and(|artifact| match artifact.entry {
+                    TreeEntry::Blob { hash, .. } => hash.to_string() == entry.body,
+                    _ => false,
+                });
         if still_owed {
             owed.insert(repo_path);
         } else {

--- a/crates/kin-daemon/src/semantic_debt.rs
+++ b/crates/kin-daemon/src/semantic_debt.rs
@@ -1,0 +1,230 @@
+//! Paths whose exact bytes reached authority without their semantics, recorded
+//! against the body identity the parse is owed for.
+//!
+//! # Why this exists
+//!
+//! A disposable session publishes a complete exact tree of its own. The bytes
+//! become graph authority, and nothing parses them, so the derived graph keeps
+//! answering about those files at the positions the previous parse recorded.
+//! The commit that follows cannot notice: it forces one complete admission,
+//! that admission plans its transition from a working copy the publication has
+//! already made current, finds it empty, and returns before its own enrichment
+//! half ever runs. On a converted `psf/requests` an edit that prepended
+//! seventeen lines left the whole file answering seventeen lines short, under an
+//! envelope with nothing to report.
+//!
+//! The publication re-derives the semantics on the spot, which fixes the live
+//! daemon. It does not survive a restart. Entities reach durable authority only
+//! inside a semantic change, a session reconcile deliberately publishes the
+//! workspace tree with no history and no ref move, and a derived-graph mutation
+//! that no change carries is gone when the next daemon replays that history.
+//! Measured rather than assumed: a daemon reopened between the session's edit
+//! and its commit read the pre-edit span back, and a synchronous
+//! `save_snapshot` immediately after the re-derivation did not change that.
+//!
+//! So something has to outlive the daemon and tell the next commit it owes a
+//! parse. That is what this file records.
+//!
+//! # Why it is bound to a hash
+//!
+//! A path alone cannot say whether the debt is still real. The working copy
+//! moves on, other writers publish over the same path, and a commit lands. A
+//! path plus the body the parse is owed for answers all three: an entry whose
+//! tree entry no longer names that body has been overtaken by a later
+//! transition, and the admission that observed that transition already enriched
+//! it. Settling those costs nothing and re-parsing them would be waste that
+//! grows with the age of the store.
+//!
+//! # Why a file under the store root
+//!
+//! Every read and write here is ingestion IO at an explicit boundary, never a
+//! semantic answer: the record says which paths are owed a parse, and the parse
+//! itself reads graph-owned CAS. The two durable markers that already serve this
+//! path, `unpublished-enrichment.json` and the LSP-enriched marker, are sidecar
+//! JSON under the same root, and the graph exposes no general metadata surface
+//! to hang a third one from.
+//!
+//! # Who settles it
+//!
+//! The commit that publishes, and only after its transaction reaches authority.
+//! A commit derives its change from the live graph, so everything the drain put
+//! back into that graph reaches history with it. Settling at the drain instead
+//! would clear the record for a parse the next crash could still lose.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use kin_model::{RepoPath, TreeEntry};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+use crate::state::DaemonState;
+
+/// One path owed a parse, and the body it is owed for.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SemanticDebt {
+    /// The repository path, in its UTF-8 rendering. A path with no UTF-8
+    /// rendering carries no semantic identity and is never recorded.
+    pub(crate) path: String,
+    /// Hex of the body hash the parse is owed for.
+    pub(crate) body: String,
+}
+
+/// Ingestion IO: the record of what is owed, under the store root.
+fn marker_path(root: &Path) -> PathBuf {
+    root.join("semantic-debt.json")
+}
+
+/// Every path one publication moved, paired with the body it published there.
+///
+/// Removals and the vacated half of a rename carry no body to parse and are
+/// skipped, as are symlinks and Gitlinks, which are never source owned by the
+/// link path.
+pub(crate) fn owed_by(deltas: &[kin_model::TreeDelta]) -> Vec<SemanticDebt> {
+    let mut owed = Vec::new();
+    for delta in deltas {
+        let Some(new) = delta.new_state() else {
+            continue;
+        };
+        let TreeEntry::Blob { hash, .. } = new.entry else {
+            continue;
+        };
+        let Some(path) = new.path.as_utf8() else {
+            continue;
+        };
+        owed.push(SemanticDebt {
+            path: path.to_string(),
+            body: hash.to_string(),
+        });
+    }
+    owed
+}
+
+/// Merge `owed` into the record, replacing any earlier entry for the same path.
+///
+/// A failed write is reported and never fatal. The record makes a loss
+/// recoverable; a store that cannot write it is no worse off than one built
+/// before this existed, and refusing a durable publication over it would trade a
+/// recoverable gap for an unrecoverable refusal.
+pub(crate) fn record(root: &Path, owed: &[SemanticDebt]) {
+    if owed.is_empty() {
+        return;
+    }
+    let mut entries = outstanding(root);
+    entries.retain(|entry| !owed.iter().any(|fresh| fresh.path == entry.path));
+    entries.extend_from_slice(owed);
+    write(root, &entries);
+}
+
+/// Read the record. An unreadable or unparseable one is treated as empty and
+/// said out loud, because the alternative is refusing every commit on the store.
+pub(crate) fn outstanding(root: &Path) -> Vec<SemanticDebt> {
+    let marker = marker_path(root);
+    let Ok(bytes) = std::fs::read(&marker) else {
+        return Vec::new();
+    };
+    match serde_json::from_slice::<Vec<SemanticDebt>>(&bytes) {
+        Ok(entries) => entries,
+        Err(error) => {
+            warn!(
+                marker = %marker.display(),
+                error = %error,
+                "the semantic-debt record will not parse, so a path whose bytes moved without \
+                 their semantics stays stale until it is edited again"
+            );
+            Vec::new()
+        }
+    }
+}
+
+/// Split a record into what is still owed and what a later transition overtook.
+///
+/// Owed means the tree still names the exact body the debt was recorded for. A
+/// path the tree no longer carries, or carries at a different body, has been
+/// through an admission that enriched it, and the entry is spent.
+pub(crate) fn partition_against_tree(
+    state: &DaemonState,
+    entries: &[SemanticDebt],
+) -> (BTreeSet<RepoPath>, Vec<String>) {
+    let tree = state.graph.resolved_tree();
+    let mut owed = BTreeSet::new();
+    let mut spent = Vec::new();
+    for entry in entries {
+        let Ok(repo_path) = RepoPath::from_utf8(entry.path.clone()) else {
+            spent.push(entry.path.clone());
+            continue;
+        };
+        let still_owed = tree
+            .artifact_at_path(&repo_path)
+            .is_some_and(|artifact| match artifact.entry {
+                TreeEntry::Blob { hash, .. } => hash.to_string() == entry.body,
+                _ => false,
+            });
+        if still_owed {
+            owed.insert(repo_path);
+        } else {
+            spent.push(entry.path.clone());
+        }
+    }
+    (owed, spent)
+}
+
+/// Drop the named paths from the record and rewrite it.
+pub(crate) fn settle(root: &Path, paths: &[String]) {
+    if paths.is_empty() {
+        return;
+    }
+    let mut entries = outstanding(root);
+    let before = entries.len();
+    entries.retain(|entry| !paths.contains(&entry.path));
+    if entries.len() == before {
+        return;
+    }
+    write(root, &entries);
+}
+
+/// Clear the whole record.
+///
+/// Called once a commit's transaction reaches authority. A commit derives its
+/// change from the live graph, so every parse the drain put back into that graph
+/// is in history by the time this runs, and nothing the record named is still
+/// owed. The coordination gate spans both the publication that records a debt
+/// and the commit that clears it, so nothing can be recorded in between and lost
+/// here.
+pub(crate) fn settle_all(root: &Path) {
+    let marker = marker_path(root);
+    match std::fs::remove_file(&marker) {
+        Ok(()) => debug!(
+            marker = %marker.display(),
+            "a commit published every re-derived parse, so the semantic-debt record is spent"
+        ),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => warn!(
+            marker = %marker.display(),
+            error = %error,
+            "could not clear the semantic-debt record; the next commit re-parses paths that are \
+             already published, which costs time and loses nothing"
+        ),
+    }
+}
+
+fn write(root: &Path, entries: &[SemanticDebt]) {
+    if entries.is_empty() {
+        settle_all(root);
+        return;
+    }
+    let marker = marker_path(root);
+    match serde_json::to_vec(entries) {
+        Ok(bytes) => {
+            if let Err(error) = std::fs::write(&marker, bytes) {
+                warn!(
+                    marker = %marker.display(),
+                    error = %error,
+                    "could not persist the semantic-debt record, so a daemon restart before the \
+                     next commit would leave these paths answering at their previous positions"
+                );
+            }
+        }
+        Err(error) => warn!(error = %error, "could not encode the semantic-debt record"),
+    }
+}

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -573,6 +573,17 @@
       ]
     },
     {
+      "file": "crates/kin-daemon/src/semantic_debt.rs",
+      "reason": "Semantic-debt record boundary. Three primitives on one bookkeeping file at <kin_root>/semantic-debt.json: one read of what is owed, one rewrite when an entry is recorded or settled, and one removal when a commit settles the whole record. It names repository paths whose exact bytes reached authority without a parse, and nothing else. No repository content is read here and no query answer derives from it: what the record names is decided against graph truth by partition_against_tree before anything acts on it, and the parse it triggers reads the body the exact tree names from graph-owned CAS rather than from the filesystem. An absent or unparseable record degrades to the behaviour that existed before it, a path answering at the positions its previous parse recorded, rather than to a wrong answer this daemon believes. It is a file rather than in-memory state for the same reason the unpublished-enrichment marker beside it is: the fact it carries is only ever read by a LATER process. A session reconcile publishes the workspace tree with no history and no ref move, entities reach durable authority only inside a semantic change, so the re-derivation it triggers has nothing to ride and dies with the daemon that performed it. Measured, not assumed: a daemon reopened between a session's edit and its commit read the pre-edit span back, and a synchronous snapshot immediately after the re-derivation did not change that. Function-scoped so the rest of the module stays scanned, and the module holds no other filesystem call.",
+      "owner": "kin-daemon",
+      "expiration": "2027-09-24",
+      "allow_fn": [
+        "outstanding",
+        "write",
+        "settle_all"
+      ]
+    },
+    {
       "file": "crates/kin-daemon/src/loop_runner.rs",
       "reason": "Host event ingestion boundary. The excused bodies are the file watcher's admission path: reading a host file or symlink target and its mode so the change can be admitted into the graph as exact tree state, and comparing a host entry against what the graph already holds so an unchanged file is not re-admitted. Reading the working tree is the entire job of an ingestion boundary, and the result is written into graph truth rather than returned as an answer. The remaining two are repository binding, which precedes any graph consult: recognizing a bare git layout, and resolving a path relative to the bound root. The helper that canonicalized a host parent while preserving its leaf moved to kin-index, which is a declared ingestion boundary, so the watcher and this runner decide repository containment by one rule instead of two. The cfg-gated executable-bit helper is the pair that carries a count of two. Function-scoped so the rest of the runner stays scanned. Two further bodies are operational state beside the pid and port files, the same class as the sweep's own enrichment marker in daemon.rs: one records the repository paths this daemon derived entities for and could not have published, the other reads that record back on the next open. Neither reads repository content and neither answers a query. What the record names is decided against graph truth before anything acts on it, which is the point: without it a file whose entities died with the daemon that derived them stays admitted and unqueryable forever (FIR-2606).",
       "owner": "kin-daemon",


### PR DESCRIPTION
Closes FIR-3208. Sits on top of #1499, which landed at 23:40:02Z as `f6a29e329` and closed
the live-daemon half of FIR-3200; this branch is rebased onto that squash and carries only
its own two commits.

## What #1499 left open, and why it could not close it there

#1499 makes a session's publication parse the bytes it moves, under the gate that published
them. That fixes a live daemon and nothing more. Measured:

```
a_daemon_reopened_after_a_session_reconcile_answers_at_the_moved_span
assertion failed: a reopened daemon must load the spans the session's bytes hold
  left: 0
 right: 17
```

It fails at the first read after the restart, before the commit is even reached. The reason
is structural rather than incidental. Entities reach durable authority only inside a
semantic change; a session reconcile deliberately publishes the workspace tree with no
history and no ref move, which is what keeps a session's edit pending until someone commits
it; so there is no change for the re-derived semantics to ride, and the next daemon rebuilds
from a history that never carried them. A synchronous `save_snapshot` immediately after the
re-derivation was probed and did not change the result, so the snapshot is not the carrier
either.

Closing it needs something that outlives the daemon and tells the next commit it owes a
parse.

## The record

`crates/kin-daemon/src/semantic_debt.rs`. One entry per path, carrying the body hash the
parse is owed for, persisted under the store root beside the two markers that already serve
this path, `unpublished-enrichment.json` and the LSP-enriched marker.

Bound to a hash, not to a path alone, because a path alone cannot say whether the debt is
still real. The working copy moves on, other writers publish over the same path, a commit
lands. Path plus body answers all three: an entry whose tree entry no longer names that body
was overtaken by a later transition, and the admission that observed that transition already
enriched it. Those settle for free instead of being re-parsed forever.

Written at the publication. Drained by the commit's admission. Settled only when the
commit's transaction reaches authority, because a commit derives its change from the live
graph, so everything the drain put back into that graph is in history by then. Settling at
the drain instead would clear the record for a parse the next crash could still lose.

Also drained once per daemon life by the reconcile loop, before it answers anything. A path
whose bytes reached authority without a parse is a wrong answer this daemon can know about,
and waiting for the next commit would serve the previous parse to every query in between.

### Ingestion IO

Every filesystem call this adds is ingestion IO at an explicit boundary and none of it is a
semantic answer. `semantic_debt::outstanding` reads the record, `record` and `settle` rewrite
it, `settle_all` removes it. The record says which paths are owed a parse; the parse itself
reads graph-owned CAS through the exact tree, never the filesystem, and the host is touched
only by the existing `host_entry_matches_graph` identity guard.

## A hole I put in this myself, and the test that would have caught it

I first put the drain inside the `deltas.is_empty()` arm, mirroring the early return it
replaces. That is wrong, and wrong in the same shape as the original defect.

The commit settles the whole record on success. An admission whose own transition is
non-empty would skip the drain and settle anyway, so one unrelated one-line edit would
discard a parse another file was still owed, and that file would stay stale with the record
claiming it was paid. The admission's own transition says what THIS pass moved; it never says
what an earlier one left owing. Drawing a conclusion from the wrong question is exactly what
the empty-delta early return was doing in the first place.

The drain now runs on both paths, before the empty-transition conclusion. I found this by
reading the settle point rather than from a failure, so
`an_unrelated_edit_does_not_settle_a_debt_nothing_paid` is the test it should have failed on:
publish through a session, restart so the record is the only thing carrying the parse, edit
an unrelated file, commit, and assert the first file's span still moved.

## Refusal, and the one failure that is not one

The two halves of a drain failure get different answers, and the difference is the point.

**Source the parser cannot read is reported, and the commit proceeds.** That is the file's
own state, and retaining last-known-good is the designed answer to it rather than a fault:
the daemon reconciles under `ReconcilePolicy::FallbackToLkg` and an agent mid-edit produces
half-written source constantly. Refusing every commit until the syntax is fixed would leave
a caller unable to record anything at all, which is worse than the stale spans this record
exists to prevent, and it would be a regression against what this seam already did for such
a file. It is reported as a `warn` line naming the paths rather than in the commit response,
because `CommandCommitResponse` has no field for it and widening that wire shape for a log
line is not worth it; say so if you disagree and I will add the field.

**Everything else refuses**, through `DaemonError::SemanticReadmissionFailed`, which
`commit_admission_error` answers as 409 naming the files rather than as a 500. The store is
intact and nothing needs repairing; what the caller has to be told is that the graph will
answer about those files at positions their bytes no longer hold, and a transient failure is
something they can retry. Letting one through would settle the record unpaid and reproduce
the stale spans silently, which is the whole class this record closes.

A parse never retracts membership either way, which is the invariant #1499 cites and this
keeps.

### Follow-up, to be ticketed

`settle_all` clears the whole record when a commit reaches authority, so a permanently
unparseable path is settled without ever being paid. That matches today's behaviour for such
a file exactly, and it is no worse, but the better shape is for the admission to hand the
paid set up to the commit so an unpaid entry survives and the next successful parse pays it.
That is more plumbing than the rest of this PR and it is deliberately not in it. Filed as
FIR-3215.

## What review found on the first head, and what changed

**CodeQL raised three `rust/path-injection` alerts** on the module's three filesystem calls,
all through a `marker_path(root: &Path)` that joined a constant onto a root the caller
passed. Review read them as false positives, and they were, but a PR cannot land red and
there is no suppression idiom in-tree. The module now reads `state.layout.root()` inside
`marker_path` and every function takes `&DaemonState`, which is exactly the shape of the
sibling `unpublished_enrichment_marker_path` in `loop_runner.rs` that raises nothing. The
only path this module ever opens is a constant join under a root the daemon bound at open,
and nothing a caller passes can reach the join. The zero-file-search allowlist entry names
functions, not signatures, so it holds unchanged.

**The startup drain mutated the graph outside the coordination gate.** The tick takes
`coordination_gate` before its own admission, and so do commit and checkout; the
once-per-life drain ran before that lock. It now holds the gate for its own scope. Nothing
else holds it at that point in the iteration, and the drain takes the reconciler lock after
the gate in the same order the tick does.

**Two of the guarantees had no test that could fail.** Review removed the startup drain and
moved `settle_all` into the drain, and nothing went red, because the existing reopen test
called the drain directly. Two tests now stand where those mutations bite.
`a_daemon_start_pays_the_semantic_debt_a_previous_daemon_left` puts a store into the shape a
session publication leaves (exact tree published on its own, nothing parsed, the record
naming what is owed), spawns `run_loop`, and polls the span to 17 under a 30-second deadline;
`run_loop_armed` performs no complete sync of its own at startup, so the once-per-life block
is the only thing that can pay it. `a_drain_without_a_commit_leaves_the_record_standing`
drains after a restart, asserts the record stands, restarts again without a commit, reads
the pre-edit span back, pays it again from the standing record, and only then commits and
asserts the record is settled.

## Falsification

Six mutations, one per guarantee, each applied alone with the tree restored before the next.
What follows for each is the mutation and the run's own output, ending in the assertion line
the run printed; nothing below is paraphrased.

All six from one run at 01:05Z to 01:14Z, log `.kin-coord/reports/commitfresh-1501-falsify.log`, each mutation applied alone and the tree restored before the next; the same six tests pass together on the unmutated tree (`6 passed; 0 failed`, 8.07s).

**M1: drop the `semantic_debt::record` call in `reconcile_session_workspace`.**

```
test api::tests::a_daemon_reopened_after_a_session_reconcile_answers_at_the_moved_span ... FAILED
panicked at crates/kin-daemon/src/api.rs:35183:9:
assertion `left == right` failed: a reopened daemon must load the spans the session's bytes hold
  left: 0
 right: 17
test result: FAILED. 0 passed; 1 failed
```

**M2: move the drain call back inside the `deltas.is_empty()` arm.**

```
test api::tests::an_unrelated_edit_does_not_settle_a_debt_nothing_paid ... FAILED
panicked at crates/kin-daemon/src/api.rs:35358:9:
assertion `left == right` failed: a commit that settles the record must first pay what it settles
  left: 0
 right: 17
test result: FAILED. 0 passed; 1 failed
```

**M3: remove the once-per-life drain from `run_loop_armed`.**

```
test loop_runner::tests::a_daemon_start_pays_the_semantic_debt_a_previous_daemon_left ... FAILED
panicked at crates/kin-daemon/src/loop_runner.rs:3962:13:
the loop never re-derived the path a previous daemon left owing; span is Some(0)
test result: FAILED. 0 passed; 1 failed; finished in 32.07s
```

**M4: call `settle_all` inside `drain_semantic_debt`.**

```
test api::tests::a_drain_without_a_commit_leaves_the_record_standing ... FAILED
panicked at crates/kin-daemon/src/api.rs:35251:9:
a drain pays the parse in the derived graph; only a commit may settle the record
test result: FAILED. 0 passed; 1 failed
```

**M5: partition every failure as not unparseable, so every drain failure refuses.**

```
test api::tests::an_unparseable_file_keeps_its_spans_and_does_not_block_the_commit ... FAILED
panicked at crates/kin-daemon/src/api.rs:36816:9:
assertion `left == right` failed: {"error":"semantic_readmission_failed","message":"the bytes for 1 of these paths are durable authority and their semantics could not be re-derived from them, so the graph still answers about them at the positions their previous bytes held: shifted.rs"}
  left: 409
 right: 200
test result: FAILED. 0 passed; 1 failed
```

**M6: partition every failure as unparseable, so no drain failure refuses.**

```
test api::tests::a_drain_failure_that_is_not_the_file_refuses_the_commit ... FAILED
panicked at crates/kin-daemon/src/api.rs:35524:9:
assertion `left == right` failed: a drain failure the caller can retry must refuse rather than settle unpaid: {"change_id":"b1cff0fa...","branch":"refs/heads/main","entity_count":1,"relation_count":0,"file_count":1}
  left: 200
 right: 409
test result: FAILED. 0 passed; 1 failed
```

 Its trigger is
graph-owned rather than contrived, a record naming a body the exact tree still carries that
the CAS can no longer produce, which is the shape of a store whose ingestion CAS was pruned
under it.

## Gates

Speed rule in force: no local precheck. Run through the fleet builder slot on head
`f81a6c962d8984c32f20126b88965bcd0a86068e`:

```
cargo fmt --all -- --check                      fmt check rc=0
cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
                                                clippy rc=0
cargo test -p kin-daemon --lib -- semantic_debt reopened_after_a_session unrelated_edit
    drain_without_a_commit unparseable_file_keeps drain_failure_that_is_not
                                                6 passed; 0 failed (8.07s)
cargo test -p kin-daemon --lib semantic         33 passed; 0 failed (restructure alone, 76d1c53f6)
```

The full kin-daemon lib suite last ran green on the previous head at 1395 passed, 0 failed;
hosted CI grades the full workspace on this one. The falsification arms above ran on this
head's tree between the restructure and the commit.

CodeQL: watched on this head until `Analyze (rust)` concluded; its verdict is posted as a
comment once it lands.
