### PR TITLE
Retire a deleted file's entities in the session admission that deletes it

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6097,26 +6097,27 @@ async fn reconcile_session_workspace(
         if graph_tree == observation.base().source_workspace.tree {
             // Entities retire with the paths that owned them, in the same
             // step as the tree moves, so the live graph never holds an entity
-            // authority just refused to carry. Derived here from the LIVE
-            // graph with the plan's vacated set, never copied from the plan:
-            // the plan's delta was diffed against authority, and the live graph
-            // can already hold newer payloads for these entities from an
-            // earlier session's readmission. kin-db checks a removal's old
-            // payload against the graph it lands on, so authority's payload
-            // applied here was refused after authority had already moved,
-            // leaving the two graphs holding different trees.
-            let live = crate::repository_commit::retire_semantics_on_vacated(
-                &state.graph.to_snapshot(),
-                &vacated,
-            )
-            .map_err(repository_commit_error)?;
-            let retired_entity_deltas = live.entity_deltas().to_vec();
+            // authority just refused to carry. Read from the LIVE graph with
+            // the plan's vacated set, never copied from the plan: the plan's
+            // delta was diffed against authority, and the live graph can
+            // already hold newer payloads for these entities from an earlier
+            // session's readmission. kin-db checks a removal's old payload
+            // against the graph it lands on, so authority's payload applied
+            // here was refused after authority had already moved, leaving the
+            // two graphs holding different trees. Targeted reads rather than a
+            // snapshot of the whole store, which this path cannot afford.
+            let (retired_entity_deltas, retired_relation_deltas) =
+                crate::repository_commit::retire_live_semantics_on_vacated(
+                    state.graph.as_ref(),
+                    &vacated,
+                )
+                .map_err(repository_commit_error)?;
             state
                 .graph
                 .apply_transaction_delta(&TransactionDelta {
                     tree_deltas: observation.deltas().to_vec(),
                     entity_deltas: retired_entity_deltas.clone(),
-                    relation_deltas: live.relation_deltas().to_vec(),
+                    relation_deltas: retired_relation_deltas,
                     ..TransactionDelta::default()
                 })
                 .map_err(internal_error)?;

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6066,6 +6066,8 @@ async fn reconcile_session_workspace(
             &observation,
         )
         .map_err(repository_commit_error)?;
+        let retired_entity_deltas = plan.retired_entity_deltas.clone();
+        let retired_relation_deltas = plan.retired_relation_deltas.clone();
         let committed = crate::repository_commit::commit_session_workspace_admission(
             &state.layout,
             state.blobs.as_ref(),
@@ -6094,13 +6096,43 @@ async fn reconcile_session_workspace(
 
         let graph_tree = state.graph.resolved_tree();
         if graph_tree == observation.base().source_workspace.tree {
+            // Entities retire with the paths that owned them, in the same
+            // step as the tree moves, so the live graph never holds an entity
+            // authority just refused to carry.
             state
                 .graph
                 .apply_transaction_delta(&TransactionDelta {
                     tree_deltas: observation.deltas().to_vec(),
+                    entity_deltas: retired_entity_deltas.clone(),
+                    relation_deltas: retired_relation_deltas,
                     ..TransactionDelta::default()
                 })
                 .map_err(internal_error)?;
+            for delta in &retired_entity_deltas {
+                let kin_model::EntityDelta::Removed { old } = delta else {
+                    continue;
+                };
+                if let Some(file_id) = &old.file_origin {
+                    if let Err(error) = crate::loop_runner::clear_incompatible_facets_in(
+                        state.graph.as_ref(),
+                        file_id,
+                        crate::loop_runner::EnrichmentFacet::None,
+                    ) {
+                        warn!(
+                            file = %file_id,
+                            error = %error,
+                            "retired a vacated path's entities but could not clear every facet"
+                        );
+                    }
+                }
+                state.emit_event(DaemonEvent::EntityChanged {
+                    entity_id: old.id,
+                    node: None,
+                    change_type: crate::state::ChangeType::Deleted,
+                    file_path: old.file_origin.as_ref().map(|file| file.0.clone()),
+                    session_id: None,
+                });
+            }
         } else if graph_tree != *observation.desired_tree() {
             return Err((
                 StatusCode::CONFLICT,
@@ -35624,6 +35656,132 @@ mod tests {
             .resolved_tree()
             .artifact_at_path(&kin_model::RepoPath::from_utf8("pending.txt").unwrap())
             .is_none());
+    }
+
+    /// FIR-3209. A session that deletes an entity-owning file reconciles, the
+    /// file's entities are absent from every query afterwards, and the next
+    /// commit records the removal.
+    ///
+    /// kin-db refuses a transition that leaves an entity on a path the staged
+    /// tree no longer carries, and it names the remedy in its own message:
+    /// "carry its exact entity removal or relocation in the same delta". The
+    /// invariant is right and the session admission was the caller that owed
+    /// the removal, so an agent's `rm` of a source file could not reconcile at
+    /// all. The existing session-reconcile test deletes `delete.me`, a file with
+    /// no entities, which is why the suite was green over this.
+    ///
+    /// Falsify by restoring `semantic_delta: WorkspaceSemanticDelta::default()`
+    /// in `plan_session_workspace_admission`: the reconcile returns the 500 the
+    /// review's control probe measured, and `gone.rs` keeps its entity with no
+    /// file behind it.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial_test::serial(commit_phase_capture)]
+    async fn a_session_that_deletes_an_entity_source_file_retires_its_entities() {
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let state = Arc::new(DaemonState::open(initialized.layout).unwrap());
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        std::fs::write(repo.path().join("keep.rs"), b"pub fn keep() -> u32 { 1 }\n").unwrap();
+        std::fs::write(repo.path().join("gone.rs"), b"pub fn gone() -> u32 { 7 }\n").unwrap();
+        let app = router(Arc::clone(&state));
+        commit_through_api(&app, kin_model::OperationId::new(), "publish the fixtures").await;
+        let entities_at = |path: &str| {
+            state
+                .graph
+                .query_entities(&kin_db::EntityFilter {
+                    file_path: Some(kin_model::FilePathId::new(path)),
+                    ..Default::default()
+                })
+                .unwrap()
+        };
+        let gone_before = entities_at("gone.rs");
+        eprintln!(
+            "FIR-3209 measurement: before gone.rs entities={} keep.rs entities={}",
+            gone_before.len(),
+            entities_at("keep.rs").len()
+        );
+        assert_eq!(gone_before.len(), 1, "the fixture owns exactly one entity");
+        let gone_id = gone_before[0].id;
+
+        let session_dir = state.layout.root().join("runs/session-fir3209");
+        materialize_session_through_api(&app, &session_dir).await;
+        std::fs::remove_file(session_dir.join("gone.rs")).unwrap();
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::post("/reconcile")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({"session_dir": session_dir, "confirm_mass_deletion": false})
+                            .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 128 * 1024)
+            .await
+            .unwrap();
+        let body = String::from_utf8_lossy(&body).to_string();
+        eprintln!(
+            "FIR-3209 measurement: reconcile status={status} after gone.rs entities={} body={body}",
+            entities_at("gone.rs").len()
+        );
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "deleting a source file in a session is an ordinary edit and must reconcile: {body}"
+        );
+        let summary: kin_cli::commands::reconcile::ReconcileSummary =
+            serde_json::from_str(&body).unwrap();
+        assert_eq!(summary.removed, 1);
+
+        // Absent from every query, not only the by-path one the invariant is
+        // phrased in: by id, by name, and from the exact tree.
+        assert!(
+            entities_at("gone.rs").is_empty(),
+            "an entity must not outlive the path that owned it"
+        );
+        assert_eq!(entities_at("keep.rs").len(), 1, "the sibling is untouched");
+        assert!(state.graph.get_entity(&gone_id).unwrap().is_none());
+        assert!(state
+            .graph
+            .query_entities(&kin_db::EntityFilter {
+                name_pattern: Some("gone".to_string()),
+                ..Default::default()
+            })
+            .unwrap()
+            .is_empty());
+        assert!(state
+            .graph
+            .resolved_tree()
+            .artifact_at_path(&RepoPath::from_utf8("gone.rs".to_string()).unwrap())
+            .is_none());
+
+        // The next commit carries the removal into history.
+        let change_id =
+            commit_through_api(&app, kin_model::OperationId::new(), "commit the deletion").await;
+        let change = state.graph.get_change(&change_id).unwrap().unwrap();
+        assert!(
+            change.entity_deltas.iter().any(|delta| matches!(
+                delta,
+                kin_model::EntityDelta::Removed { old } if old.id == gone_id
+            )),
+            "the commit after the session must record the entity's removal: {:?}",
+            change.entity_deltas
+        );
+        assert!(
+            change
+                .tree_deltas
+                .iter()
+                .any(|delta| matches!(delta, kin_model::TreeDelta::Removed { .. })),
+            "and the file's removal beside it"
+        );
     }
 
     /// Changes in repository authority, read the way `kin log` reads them.

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6066,8 +6066,7 @@ async fn reconcile_session_workspace(
             &observation,
         )
         .map_err(repository_commit_error)?;
-        let retired_entity_deltas = plan.retired_entity_deltas.clone();
-        let retired_relation_deltas = plan.retired_relation_deltas.clone();
+        let vacated = plan.vacated.clone();
         let committed = crate::repository_commit::commit_session_workspace_admission(
             &state.layout,
             state.blobs.as_ref(),
@@ -6098,13 +6097,26 @@ async fn reconcile_session_workspace(
         if graph_tree == observation.base().source_workspace.tree {
             // Entities retire with the paths that owned them, in the same
             // step as the tree moves, so the live graph never holds an entity
-            // authority just refused to carry.
+            // authority just refused to carry. Derived here from the LIVE
+            // graph with the plan's vacated set, never copied from the plan:
+            // the plan's delta was diffed against authority, and the live graph
+            // can already hold newer payloads for these entities from an
+            // earlier session's readmission. kin-db checks a removal's old
+            // payload against the graph it lands on, so authority's payload
+            // applied here was refused after authority had already moved,
+            // leaving the two graphs holding different trees.
+            let live = crate::repository_commit::retire_semantics_on_vacated(
+                &state.graph.to_snapshot(),
+                &vacated,
+            )
+            .map_err(repository_commit_error)?;
+            let retired_entity_deltas = live.entity_deltas().to_vec();
             state
                 .graph
                 .apply_transaction_delta(&TransactionDelta {
                     tree_deltas: observation.deltas().to_vec(),
                     entity_deltas: retired_entity_deltas.clone(),
-                    relation_deltas: retired_relation_deltas,
+                    relation_deltas: live.relation_deltas().to_vec(),
                     ..TransactionDelta::default()
                 })
                 .map_err(internal_error)?;
@@ -35781,6 +35793,168 @@ mod tests {
                 .iter()
                 .any(|delta| matches!(delta, kin_model::TreeDelta::Removed { .. })),
             "and the file's removal beside it"
+        );
+    }
+
+    /// FIR-3209, the artifact half. A session that deletes a file another file
+    /// imports.
+    ///
+    /// The cross-file linker mints an artifact-to-artifact `Imports` edge that
+    /// no entity reaches, and kin-db validates every relation endpoint against
+    /// the staged artifact set, so retiring the file's entities alone left one
+    /// edge standing and the whole transaction was refused with "unadmitted
+    /// destination endpoint". Measured red by review1503's probe C at 03476033c.
+    ///
+    /// Falsify by dropping the `GraphNodeId::Artifact` arm from `departs` in
+    /// `retire_semantics_on_vacated`: the 500 returns with that message.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial_test::serial(commit_phase_capture)]
+    async fn a_session_that_deletes_an_imported_file_retires_its_artifact_edges() {
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let state = Arc::new(DaemonState::open(initialized.layout).unwrap());
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        std::fs::write(
+            repo.path().join("gone.ts"),
+            b"export function gone(): number { return 7; }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            repo.path().join("keep.ts"),
+            b"import { gone } from \"./gone\";\nexport function keep(): number { return gone(); }\n",
+        )
+        .unwrap();
+        let app = router(Arc::clone(&state));
+        commit_through_api(&app, kin_model::OperationId::new(), "publish the fixtures").await;
+        let gone_path = RepoPath::from_utf8("gone.ts".to_string()).unwrap();
+        let gone_artifact = state
+            .graph
+            .resolved_tree()
+            .artifact_at_path(&gone_path)
+            .map(|artifact| artifact.artifact_id)
+            .expect("the fixture is in the tree");
+        let gone_node = kin_model::GraphNodeId::Artifact(gone_artifact);
+        assert!(
+            !state
+                .graph
+                .get_all_relations_for_node(&gone_node)
+                .unwrap()
+                .is_empty(),
+            "the fixture only means something if the linker bound an edge to the artifact node"
+        );
+
+        let session_dir = state.layout.root().join("runs/session-fir3209-imported");
+        materialize_session_through_api(&app, &session_dir).await;
+        std::fs::remove_file(session_dir.join("gone.ts")).unwrap();
+        let summary = reconcile_session_through_api(&app, &session_dir).await;
+        assert_eq!(summary.removed, 1);
+
+        assert!(state
+            .graph
+            .resolved_tree()
+            .artifact_at_path(&gone_path)
+            .is_none());
+        assert!(
+            state
+                .graph
+                .get_all_relations_for_node(&gone_node)
+                .unwrap()
+                .is_empty(),
+            "no relation may outlive the artifact node it is bound to"
+        );
+        assert!(state
+            .graph
+            .query_entities(&kin_db::EntityFilter {
+                file_path: Some(kin_model::FilePathId::new("gone.ts")),
+                ..Default::default()
+            })
+            .unwrap()
+            .is_empty());
+        assert!(!state
+            .graph
+            .query_entities(&kin_db::EntityFilter {
+                file_path: Some(kin_model::FilePathId::new("keep.ts")),
+                ..Default::default()
+            })
+            .unwrap()
+            .is_empty());
+        commit_through_api(&app, kin_model::OperationId::new(), "commit the deletion").await;
+    }
+
+    /// FIR-3209, the split-brain half. Modify an entity-owning file in one
+    /// session, then delete it in the next.
+    ///
+    /// The first reconcile's readmission re-derives the path's entities into
+    /// the live graph only, so authority and the live graph now hold different
+    /// payloads for the same entity. A removal delta diffed against authority
+    /// and then applied to the live graph is refused there, "stale old payload
+    /// for removed entity", after authority has already committed, which left
+    /// the two graphs on different trees. Measured red by review1503's probe E
+    /// at 03476033c. Each graph now diffs itself with the same vacated set.
+    ///
+    /// Falsify by applying the plan's authority-derived deltas to the live
+    /// graph instead of the live-derived ones: the delete reconcile 500s with
+    /// that message after the authority commit is durable.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial_test::serial(commit_phase_capture)]
+    async fn a_session_that_deletes_a_file_an_earlier_session_modified_reconciles() {
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let state = Arc::new(DaemonState::open(initialized.layout).unwrap());
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        std::fs::write(repo.path().join("keep.rs"), b"pub fn keep() -> u32 { 1 }\n").unwrap();
+        std::fs::write(repo.path().join("gone.rs"), b"pub fn gone() -> u32 { 7 }\n").unwrap();
+        let app = router(Arc::clone(&state));
+        commit_through_api(&app, kin_model::OperationId::new(), "publish the fixtures").await;
+        let entities_at = |path: &str| {
+            state
+                .graph
+                .query_entities(&kin_db::EntityFilter {
+                    file_path: Some(kin_model::FilePathId::new(path)),
+                    ..Default::default()
+                })
+                .unwrap()
+        };
+        assert_eq!(entities_at("gone.rs").len(), 1);
+
+        let first = state.layout.root().join("runs/session-fir3209-modify");
+        materialize_session_through_api(&app, &first).await;
+        prepend_session_lines(&first.join("gone.rs"), 17);
+        let modified = reconcile_session_through_api(&app, &first).await;
+        assert_eq!(modified.semantic_files_enriched, 1);
+        assert_eq!(
+            entities_at("gone.rs")[0].span.as_ref().unwrap().start_line,
+            17,
+            "the live graph moved on; authority did not"
+        );
+
+        let second = state.layout.root().join("runs/session-fir3209-then-delete");
+        materialize_session_through_api(&app, &second).await;
+        std::fs::remove_file(second.join("gone.rs")).unwrap();
+        let deleted = reconcile_session_through_api(&app, &second).await;
+        assert_eq!(deleted.removed, 1);
+        assert!(entities_at("gone.rs").is_empty());
+        assert_eq!(entities_at("keep.rs").len(), 1);
+
+        // The two graphs must still be level: a third session materializes and
+        // the next commit carries the removal into history.
+        let change_id =
+            commit_through_api(&app, kin_model::OperationId::new(), "commit the deletion").await;
+        let change = state.graph.get_change(&change_id).unwrap().unwrap();
+        assert!(
+            change.entity_deltas.iter().any(|delta| matches!(
+                delta,
+                kin_model::EntityDelta::Removed { old }
+                    if old.file_origin.as_ref().is_some_and(|f| f.0 == "gone.rs")
+            )),
+            "history must record the removal: {:?}",
+            change.entity_deltas
         );
     }
 

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -231,11 +231,12 @@ pub struct SessionWorkspaceAdmissionPlan {
     pub previous_tree: kin_model::ResolvedTree,
     pub target_tree: kin_model::ResolvedTree,
     pub deltas: Vec<kin_model::TreeDelta>,
-    /// The entities and relations this admission retires because the paths
-    /// that owned them left the tree, carried in the same transaction as the
-    /// tree transition so the derived graph can follow authority exactly.
-    pub retired_entity_deltas: Vec<kin_model::EntityDelta>,
-    pub retired_relation_deltas: Vec<kin_model::RelationDelta>,
+    /// The paths this transition leaves with nothing at them, and the artifact
+    /// identities that held them. The transaction retires their semantics
+    /// against authority's own graph; the handler derives the live graph's
+    /// retirement from the live graph with the same set, because the two can
+    /// hold different payloads for the same entity and each must drop its own.
+    pub vacated: VacatedPaths,
     pub workspace_id: WorkspaceId,
     source_hashes: Vec<Hash256>,
     recovered_receipt: Option<RepositoryCommitReceipt>,
@@ -300,7 +301,7 @@ pub(crate) fn plan_session_workspace_admission(
     // session that deleted a source file could not reconcile at all, the
     // refusal surfaced as a 500, and the file's entities kept answering
     // queries with nothing on disk behind them.
-    let vacated = vacated_paths(&deltas);
+    let vacated = VacatedPaths::from_deltas(&deltas);
     let semantic_delta = if vacated.is_empty() {
         WorkspaceSemanticDelta::default()
     } else {
@@ -309,12 +310,10 @@ pub(crate) fn plan_session_workspace_admission(
             lease.workspace_graph_snapshot(&workspace_id)?
         };
         match snapshot {
-            Some(snapshot) => retire_entities_on_vacated_paths(&snapshot, &vacated)?,
+            Some(snapshot) => retire_semantics_on_vacated(&snapshot, &vacated)?,
             None => WorkspaceSemanticDelta::default(),
         }
     };
-    let retired_entity_deltas = semantic_delta.entity_deltas().to_vec();
-    let retired_relation_deltas = semantic_delta.relation_deltas().to_vec();
     let mut source_lengths = std::collections::BTreeMap::new();
     let (shared_policy, _) = SharedAdmissionPolicy::derive_from_tree_with_allowances(
         Some(&base.source_workspace.shared_admission_policy),
@@ -450,45 +449,82 @@ pub(crate) fn plan_session_workspace_admission(
         previous_tree: base.source_workspace.tree.clone(),
         target_tree: desired_tree.clone(),
         deltas,
-        retired_entity_deltas,
-        retired_relation_deltas,
+        vacated,
         workspace_id,
         source_hashes: source_hashes.into_iter().collect(),
         recovered_receipt,
     })
 }
 
-/// The repository paths a tree transition leaves with nothing at them.
+/// The paths a tree transition leaves with nothing at them, and the artifact
+/// identities that held them.
 ///
 /// A path some delta's old state held and no delta's new state holds. A
 /// modification keeps its path and a rename vacates only its old one, so a
-/// moved file retires its entities here and the enrichment that follows the
-/// publication re-derives them at the new path. Only UTF-8 paths are returned,
-/// because only those can own entities.
-fn vacated_paths(deltas: &[kin_model::TreeDelta]) -> BTreeSet<String> {
-    let kept = deltas
-        .iter()
-        .filter_map(|delta| delta.new_state().map(|new| new.path.clone()))
-        .collect::<BTreeSet<_>>();
-    deltas
-        .iter()
-        .filter_map(|delta| delta.old_state())
-        .filter(|old| !kept.contains(&old.path))
-        .filter_map(|old| old.path.as_utf8().map(str::to_string))
-        .collect()
+/// moved file retires its semantics here and the enrichment that follows the
+/// publication re-derives them at the new path. Paths are kept only in their
+/// UTF-8 rendering, because only those can own entities; artifact identities
+/// are kept for every vacated entry, because the cross-file linker binds
+/// relations to artifact nodes whatever the path is made of.
+#[derive(Debug, Clone, Default)]
+pub struct VacatedPaths {
+    pub paths: BTreeSet<String>,
+    pub artifacts: Vec<kin_model::ArtifactId>,
 }
 
-/// The canonical semantic transition that retires every entity authority holds
-/// on a vacated path, and every relation with such an entity at either end.
+impl VacatedPaths {
+    pub(crate) fn from_deltas(deltas: &[kin_model::TreeDelta]) -> Self {
+        let kept = deltas
+            .iter()
+            .filter_map(|delta| delta.new_state().map(|new| new.path.clone()))
+            .collect::<BTreeSet<_>>();
+        let mut vacated = Self::default();
+        for delta in deltas {
+            let Some(old) = delta.old_state() else {
+                continue;
+            };
+            if kept.contains(&old.path) {
+                continue;
+            }
+            vacated.artifacts.push(delta.artifact_id());
+            if let Some(path) = old.path.as_utf8() {
+                vacated.paths.insert(path.to_string());
+            }
+        }
+        vacated
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.artifacts.is_empty()
+    }
+}
+
+/// The canonical semantic transition that retires everything one graph holds
+/// on a vacated path: every entity the path owns, every relation with such an
+/// entity at either end, and every relation bound to the vacated artifact node
+/// itself.
 ///
-/// Derived by difference against the workspace's own authority graph rather
-/// than the daemon's live one, for the reason every other repository command
-/// plans its authority delta that way: the live graph carries enrichment that
-/// has not crossed the compare-and-swap, and a delta planned from it would ask
-/// authority to retract semantics it never held.
-fn retire_entities_on_vacated_paths(
+/// The last of those is the half a per-entity retirement misses. The
+/// cross-file linker mints file-level `Imports` and `Includes` edges between
+/// artifact nodes, which no entity reaches, and kin-db validates every relation
+/// endpoint against the staged artifact set on each transaction. One surviving
+/// edge fails the whole transaction with "unadmitted destination endpoint", so
+/// deleting a file another file imports could not reconcile at all until these
+/// were retired beside the entities. `retire_artifact_node_relations` in
+/// `loop_runner` is the same rule applied to the live graph by the watcher.
+///
+/// Called once per graph rather than once per transition, on purpose. The
+/// planner runs it on authority's workspace snapshot and the reconcile handler
+/// runs it on the live graph's, with the same vacated set, because the two can
+/// hold different payloads for the same entity: a readmission after an earlier
+/// session moves the live graph's spans and leaves authority's where the last
+/// commit put them. kin-db requires a removal's old payload to match the graph
+/// it is applied to exactly, so a delta derived against one graph and applied
+/// to the other is refused after authority has already moved, which splits the
+/// two. Each graph diffing itself is what keeps them level.
+pub(crate) fn retire_semantics_on_vacated(
     snapshot: &kin_db::GraphSnapshot,
-    vacated: &BTreeSet<String>,
+    vacated: &VacatedPaths,
 ) -> Result<WorkspaceSemanticDelta> {
     let mut desired_entities = snapshot.entities.clone();
     let mut retired = std::collections::HashSet::new();
@@ -496,16 +532,19 @@ fn retire_entities_on_vacated_paths(
         let owned_by_vacated = entity
             .file_origin
             .as_ref()
-            .is_some_and(|origin| vacated.contains(&origin.0));
+            .is_some_and(|origin| vacated.paths.contains(&origin.0));
         if owned_by_vacated {
             desired_entities.remove(entity_id);
             retired.insert(*entity_id);
         }
     }
-    let touches_retired = |node: &kin_model::GraphNodeId| matches!(node, kin_model::GraphNodeId::Entity(entity_id) if retired.contains(entity_id));
+    let departs = |node: &kin_model::GraphNodeId| match node {
+        kin_model::GraphNodeId::Entity(entity_id) => retired.contains(entity_id),
+        kin_model::GraphNodeId::Artifact(artifact_id) => vacated.artifacts.contains(artifact_id),
+        _ => false,
+    };
     let mut desired_relations = snapshot.relations.clone();
-    desired_relations
-        .retain(|_, relation| !touches_retired(&relation.src) && !touches_retired(&relation.dst));
+    desired_relations.retain(|_, relation| !departs(&relation.src) && !departs(&relation.dst));
     kin_core::diff_workspace_semantics(
         &snapshot.entities,
         &snapshot.relations,

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -231,6 +231,11 @@ pub struct SessionWorkspaceAdmissionPlan {
     pub previous_tree: kin_model::ResolvedTree,
     pub target_tree: kin_model::ResolvedTree,
     pub deltas: Vec<kin_model::TreeDelta>,
+    /// The entities and relations this admission retires because the paths
+    /// that owned them left the tree, carried in the same transaction as the
+    /// tree transition so the derived graph can follow authority exactly.
+    pub retired_entity_deltas: Vec<kin_model::EntityDelta>,
+    pub retired_relation_deltas: Vec<kin_model::RelationDelta>,
     pub workspace_id: WorkspaceId,
     source_hashes: Vec<Hash256>,
     recovered_receipt: Option<RepositoryCommitReceipt>,
@@ -288,6 +293,28 @@ pub(crate) fn plan_session_workspace_admission(
     }
 
     let authority = authority_context.open().map_err(DaemonError::Graph)?;
+    // An entity may not outlive the path that owns it. kin-db refuses a
+    // transition that leaves one on a path the staged tree no longer carries,
+    // and names the remedy in its own message: carry the exact removal in the
+    // same delta. This admission is the caller that owes it. Without this a
+    // session that deleted a source file could not reconcile at all, the
+    // refusal surfaced as a 500, and the file's entities kept answering
+    // queries with nothing on disk behind them.
+    let vacated = vacated_paths(&deltas);
+    let semantic_delta = if vacated.is_empty() {
+        WorkspaceSemanticDelta::default()
+    } else {
+        let snapshot = {
+            let lease = authority.read_authority();
+            lease.workspace_graph_snapshot(&workspace_id)?
+        };
+        match snapshot {
+            Some(snapshot) => retire_entities_on_vacated_paths(&snapshot, &vacated)?,
+            None => WorkspaceSemanticDelta::default(),
+        }
+    };
+    let retired_entity_deltas = semantic_delta.entity_deltas().to_vec();
+    let retired_relation_deltas = semantic_delta.relation_deltas().to_vec();
     let mut source_lengths = std::collections::BTreeMap::new();
     let (shared_policy, _) = SharedAdmissionPolicy::derive_from_tree_with_allowances(
         Some(&base.source_workspace.shared_admission_policy),
@@ -356,7 +383,7 @@ pub(crate) fn plan_session_workspace_admission(
             new_base_tree_hash: base.source_workspace.base_tree_hash,
             tree_deltas: deltas.clone(),
             new_tree_hash: tree_hash,
-            semantic_delta: WorkspaceSemanticDelta::default(),
+            semantic_delta,
             new_shared_admission_policy: shared_policy.clone(),
             new_admission_policy: EffectiveAdmissionPolicyStamp {
                 shared: shared_policy.stamp(),
@@ -423,10 +450,69 @@ pub(crate) fn plan_session_workspace_admission(
         previous_tree: base.source_workspace.tree.clone(),
         target_tree: desired_tree.clone(),
         deltas,
+        retired_entity_deltas,
+        retired_relation_deltas,
         workspace_id,
         source_hashes: source_hashes.into_iter().collect(),
         recovered_receipt,
     })
+}
+
+/// The repository paths a tree transition leaves with nothing at them.
+///
+/// A path some delta's old state held and no delta's new state holds. A
+/// modification keeps its path and a rename vacates only its old one, so a
+/// moved file retires its entities here and the enrichment that follows the
+/// publication re-derives them at the new path. Only UTF-8 paths are returned,
+/// because only those can own entities.
+fn vacated_paths(deltas: &[kin_model::TreeDelta]) -> BTreeSet<String> {
+    let kept = deltas
+        .iter()
+        .filter_map(|delta| delta.new_state().map(|new| new.path.clone()))
+        .collect::<BTreeSet<_>>();
+    deltas
+        .iter()
+        .filter_map(|delta| delta.old_state())
+        .filter(|old| !kept.contains(&old.path))
+        .filter_map(|old| old.path.as_utf8().map(str::to_string))
+        .collect()
+}
+
+/// The canonical semantic transition that retires every entity authority holds
+/// on a vacated path, and every relation with such an entity at either end.
+///
+/// Derived by difference against the workspace's own authority graph rather
+/// than the daemon's live one, for the reason every other repository command
+/// plans its authority delta that way: the live graph carries enrichment that
+/// has not crossed the compare-and-swap, and a delta planned from it would ask
+/// authority to retract semantics it never held.
+fn retire_entities_on_vacated_paths(
+    snapshot: &kin_db::GraphSnapshot,
+    vacated: &BTreeSet<String>,
+) -> Result<WorkspaceSemanticDelta> {
+    let mut desired_entities = snapshot.entities.clone();
+    let mut retired = std::collections::HashSet::new();
+    for (entity_id, entity) in &snapshot.entities {
+        let owned_by_vacated = entity
+            .file_origin
+            .as_ref()
+            .is_some_and(|origin| vacated.contains(&origin.0));
+        if owned_by_vacated {
+            desired_entities.remove(entity_id);
+            retired.insert(*entity_id);
+        }
+    }
+    let touches_retired = |node: &kin_model::GraphNodeId| matches!(node, kin_model::GraphNodeId::Entity(entity_id) if retired.contains(entity_id));
+    let mut desired_relations = snapshot.relations.clone();
+    desired_relations
+        .retain(|_, relation| !touches_retired(&relation.src) && !touches_retired(&relation.dst));
+    kin_core::diff_workspace_semantics(
+        &snapshot.entities,
+        &snapshot.relations,
+        &desired_entities,
+        &desired_relations,
+    )
+    .map_err(Into::into)
 }
 
 /// Persist session-observed immutable bodies and linearize the exact primary

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -469,7 +469,7 @@ pub(crate) fn plan_session_workspace_admission(
 #[derive(Debug, Clone, Default)]
 pub struct VacatedPaths {
     pub paths: BTreeSet<String>,
-    pub artifacts: Vec<kin_model::ArtifactId>,
+    pub artifacts: std::collections::HashSet<kin_model::ArtifactId>,
 }
 
 impl VacatedPaths {
@@ -486,7 +486,7 @@ impl VacatedPaths {
             if kept.contains(&old.path) {
                 continue;
             }
-            vacated.artifacts.push(delta.artifact_id());
+            vacated.artifacts.insert(delta.artifact_id());
             if let Some(path) = old.path.as_utf8() {
                 vacated.paths.insert(path.to_string());
             }
@@ -513,15 +513,16 @@ impl VacatedPaths {
 /// were retired beside the entities. `retire_artifact_node_relations` in
 /// `loop_runner` is the same rule applied to the live graph by the watcher.
 ///
-/// Called once per graph rather than once per transition, on purpose. The
-/// planner runs it on authority's workspace snapshot and the reconcile handler
-/// runs it on the live graph's, with the same vacated set, because the two can
-/// hold different payloads for the same entity: a readmission after an earlier
-/// session moves the live graph's spans and leaves authority's where the last
-/// commit put them. kin-db requires a removal's old payload to match the graph
-/// it is applied to exactly, so a delta derived against one graph and applied
-/// to the other is refused after authority has already moved, which splits the
-/// two. Each graph diffing itself is what keeps them level.
+/// This is the authority side only. The reconcile handler retires the same
+/// vacated set from the live graph with [`retire_live_semantics_on_vacated`],
+/// which reads that graph's own payloads through targeted queries, because the
+/// two graphs can hold different payloads for the same entity: a readmission
+/// after an earlier session moves the live graph's spans and leaves authority's
+/// where the last commit put them. kin-db requires a removal's old payload to
+/// match the graph it is applied to exactly, so a delta derived against one
+/// graph and applied to the other is refused after authority has already moved,
+/// which splits the two. Each graph deriving its own retirement is what keeps
+/// them level.
 pub(crate) fn retire_semantics_on_vacated(
     snapshot: &kin_db::GraphSnapshot,
     vacated: &VacatedPaths,
@@ -552,6 +553,54 @@ pub(crate) fn retire_semantics_on_vacated(
         &desired_relations,
     )
     .map_err(Into::into)
+}
+
+/// The live graph's own retirement of a vacated set, read through targeted
+/// queries rather than a snapshot of the whole store.
+///
+/// The first cut of this diffed `state.graph.to_snapshot()`, which deep-clones
+/// every sub-store and the change DAG on each vacating reconcile, on the exact
+/// path a one-file commit on a converted `psf/requests` already peaks past the
+/// stranger's memory ceiling. This reads only what leaves: the entities each
+/// vacated path owns, every relation bound to one of those entities, and every
+/// relation bound to a vacated artifact node, the same three reads the watcher's
+/// removal path makes. The payloads are the live graph's own, which is the whole
+/// point of deriving this here rather than carrying authority's delta over.
+pub(crate) fn retire_live_semantics_on_vacated(
+    graph: &kin_db::InMemoryGraph,
+    vacated: &VacatedPaths,
+) -> Result<(Vec<kin_model::EntityDelta>, Vec<kin_model::RelationDelta>)> {
+    use kin_model::EntityStore as _;
+    let mut entity_deltas = Vec::new();
+    let mut departing_relations = std::collections::HashMap::new();
+    for path in &vacated.paths {
+        let owned = graph.query_entities(&kin_model::EntityFilter {
+            file_path: Some(kin_model::FilePathId::new(path)),
+            ..Default::default()
+        })?;
+        for entity in owned {
+            for relation in
+                graph.get_all_relations_for_node(&kin_model::GraphNodeId::Entity(entity.id))?
+            {
+                departing_relations.insert(relation.id, relation);
+            }
+            entity_deltas.push(kin_model::EntityDelta::Removed { old: entity });
+        }
+    }
+    for artifact_id in &vacated.artifacts {
+        for relation in
+            graph.get_all_relations_for_node(&kin_model::GraphNodeId::Artifact(*artifact_id))?
+        {
+            departing_relations.insert(relation.id, relation);
+        }
+    }
+    let mut relation_deltas = departing_relations
+        .into_values()
+        .map(|old| kin_model::RelationDelta::Removed { old })
+        .collect::<Vec<_>>();
+    entity_deltas.sort_by_key(kin_model::EntityDelta::target_id);
+    relation_deltas.sort_by_key(kin_model::RelationDelta::target_id);
+    Ok((entity_deltas, relation_deltas))
 }
 
 /// Persist session-observed immutable bodies and linearize the exact primary


### PR DESCRIPTION
Closes FIR-3209, the mirror half of FIR-3200. Sits on `f6a29e329` (#1499's squash) and is
independent of #1501.

## Measurement, taken before the fix

Two Rust fixtures committed, a session workspace materialized, `gone.rs` deleted inside the
session directory, then `POST /reconcile`.

Broken:

```
FIR-3209 measurement: before gone.rs entities=1 keep.rs entities=1
FIR-3209 measurement: reconcile status=500 Internal Server Error after gone.rs entities=1
  body=Core error: repository authority commit outcome is indeterminate: commit repository
  projection authority: storage error: transaction leaves entity 0b2482f5-... on repository
  path gone.rs absent from the staged tree; carry its exact entity removal or relocation in
  the same delta
assertion `left == right` failed: deleting a source file in a session is an ordinary edit and
  must reconcile
  left: 500
 right: 200
test result: FAILED. 0 passed; 1 failed
```

The file is gone from disk and its entity is still in the graph, and the reconcile that
should have retired it returned 500. The review's independent control probe at 3c28603
measured the same thing (`.kin-coord/reports/review1499-logs/control-head.log`:
`after gone.rs entities=1 host_exists=false`).

Fixed:

```
FIR-3209 measurement: before gone.rs entities=1 keep.rs entities=1
FIR-3209 measurement: reconcile status=200 OK after gone.rs entities=0
  body={"schema":"kin.session-reconcile.v1",...,"removed":1,...}
test result: ok. 1 passed; 0 failed
```

Beyond the two printed lines the test asserts the entity is absent by path, by id and by
name, that the exact tree no longer carries the path, that the sibling file keeps its one
entity, and that the commit after the session records `EntityDelta::Removed` for the
retired entity beside `TreeDelta::Removed` for the file.

```
(assertions above, all green in the same run)
```

## Mechanism

`plan_session_workspace_admission` builds the session's workspace mutation with
`semantic_delta: WorkspaceSemanticDelta::default()`. kin-db refuses a transition that leaves
an entity on a path the staged tree no longer carries, and its message names the remedy:
"carry its exact entity removal or relocation in the same delta". The invariant is right and
the session admission was the caller that owed the removal, so an agent's `rm` of a source
file could not reconcile at all. The existing session-reconcile test deletes `delete.me`, a
file with no entities, which is why the suite was green over this.

## Fix

`plan_session_workspace_admission` now computes the paths the tree transition vacates: a
path some delta's old state held and no delta's new state holds, so a modification keeps its
path and a rename vacates only its old one. For those it reads the workspace's own authority
graph snapshot from the lease, the way checkout does, drops every entity owned by a vacated
path and every relation with such an entity at either end, and derives the canonical
transition with `kin_core::diff_workspace_semantics` against that snapshot. It is planned
against authority rather than the daemon's live graph for the reason every other repository
command plans its authority delta that way: the live graph carries enrichment that has not
crossed the compare-and-swap, and a delta planned from it would ask authority to retract
semantics it never held.

That delta rides the same workspace mutation as the tree transition, where the default sat.
The plan carries the retired entity and relation deltas out, and `reconcile_session_workspace`
applies them to the live graph in the same step as the tree deltas, clears the vacated
file's facets, and emits the `EntityChanged` deletions, so the derived graph follows
authority exactly and never holds an entity authority just refused to carry.

**Renames, stated rather than hidden.** A moved file retires its entities at the old path
here and #1499's readmission re-derives them at the new one. The end state is correct and
the ids are new rather than relocated. The ticket says "removal or relocation"; this is
removal. Relocation with identity preserved is a follow-up, not something to invent late on
a Friday.

## Falsification

Restore `semantic_delta: WorkspaceSemanticDelta::default()` in
`plan_session_workspace_admission`, which is exactly the line the fix replaced:

```
FIR-3209 measurement: before gone.rs entities=1 keep.rs entities=1
FIR-3209 measurement: reconcile status=500 Internal Server Error after gone.rs entities=1
  body=... transaction leaves entity 0b2482f5-... on repository path gone.rs absent from the
  staged tree; carry its exact entity removal or relocation in the same delta
assertion `left == right` failed: deleting a source file in a session is an ordinary edit and
  must reconcile
  left: 500
 right: 200
test result: FAILED. 0 passed; 1 failed
```

## Second head: what review found at 03476033c, and what changed

review1503 measured two HIGH red arms at the exact first head, both end to end
(`.kin-coord/reports/review1503-probes-ce.log`). Both are in this head as red-first crate
tests lifted from the review's own probes, with assertions added.

**The artifact half.** Deleting a file another file imports still returned 500:
`transaction relation ... has unadmitted destination endpoint artifact:...`. The first head
retired the path's entities and the relations touching them, and nothing else. The
cross-file linker mints artifact-to-artifact `Imports` edges that no entity reaches, and
kin-db validates every relation endpoint against the staged artifact set, so one surviving
edge fails the whole transaction. `VacatedPaths` now carries the vacated artifact ids beside
the paths, and `retire_semantics_on_vacated` also drops every relation bound to a vacated
artifact node, which is the rule `retire_artifact_node_relations` already applies to the live
graph in `loop_runner`. Test: `a_session_that_deletes_an_imported_file_retires_its_artifact_edges`.

**The split brain, which the first head introduced.** Modify an entity-owning file in one
session, delete it in the next: 500 with `stale old payload for removed entity` AFTER the
authority commit was durable. The first reconcile's readmission re-derives the path's
entities into the live graph only, so authority and the live graph hold different payloads
for the same entity; the first head diffed the removal against authority and then applied
that same delta to the live graph, where kin-db checks a removal's old payload against the
graph it lands on. Authority had moved and the live graph had not. The plan no longer carries
retired deltas at all, only the vacated set, and the handler derives the live graph's own
retirement from `state.graph.to_snapshot()` with that set, the way `plan_daemon_semantic_delta`
already keeps the daemon-side delta separate from the authority-side one for every other
repository command. Test: `a_session_that_deletes_a_file_an_earlier_session_modified_reconciles`.

Under the speed rule I did not re-run the two probes red myself; the review's run at the
exact head is the red measurement, and it is the same sequence these tests drive.

### Falsification of the second head

F1, drop the `GraphNodeId::Artifact` arm from `departs` in `retire_semantics_on_vacated`:

```
test api::tests::a_session_that_deletes_an_imported_file_retires_its_artifact_edges ... FAILED
panicked at crates/kin-daemon/src/api.rs:35379:9:
assertion `left == right` failed: Core error: repository authority commit outcome is indeterminate:
  commit repository projection authority: storage error: transaction relation 1f886c9e-... has
  unadmitted destination endpoint artifact:1ddf52b8-...
  left: 500
 right: 200
test result: FAILED. 0 passed; 1 failed
```

F2, carry the plan's authority-derived deltas and apply them to the live graph instead of the
live-derived ones (the first head's exact behaviour):

```
Run on the third head, below, after the second head's own attempt failed to apply its mutation (the anchor matched two sites and the script aborted; that run's 'ok' was on an unmutated tree and is not cited).
```

### Not covered here: the live working-copy admission (journey GAP-11)

This fix is in `plan_session_workspace_admission` and the reconcile handler, which is the
session path FIR-3209 names. It does not touch the ambient and `kin admit` path, which
publishes through `publish_exact_workspace_tree` with no semantic delta at all. That is why
journey step 10 sees the same kin-db refusal when an entity-bearing file is removed in the
working copy, until the commit's own planner retires the entities and records the deletion
correctly. Same class, one path over; `retire_semantics_on_vacated` is written to be reusable
there, and it is named as the follow-up rather than folded in tonight.

## Third head: review round two

Both HIGHs were answered at the root on the second head. Two more before landing, because they
sit on the exact path memfix is fighting, where a one-file commit on a converted `psf/requests`
already peaks at 12.38 GiB.

**R2-1, the live retirement deep-cloned the whole store.** The second head derived the live
graph's retirement by diffing `state.graph.to_snapshot()`, which clones every sub-store and the
change DAG on every vacating reconcile. `retire_live_semantics_on_vacated` now reads only what
leaves: `query_entities` by each vacated path, `get_all_relations_for_node` on each retired
entity node and on each vacated artifact node, the deltas built from the live graph's own
payloads and sorted the way `commit_deltas` sorts them. Those are the same three reads the
watcher's removal path makes. The property that mattered on the second head is kept: each graph
derives its own retirement, and nothing authority holds is ever applied as a removal's `old` to
the live graph.

**R2-2, the artifact set is a `HashSet`**, matching the entity side beside it.

### Round-two falsification on this head

F1, drop the `GraphNodeId::Artifact` arm from `departs` on the authority side:

```
test api::tests::a_session_that_deletes_an_imported_file_retires_its_artifact_edges ... FAILED
panicked at crates/kin-daemon/src/api.rs:35380:9:
assertion `left == right` failed: Core error: repository authority commit outcome is indeterminate:
  commit repository projection authority: storage error: transaction relation fa8610a5-... has
  unadmitted destination endpoint artifact:daced884-...
  left: 500
 right: 200
test result: FAILED. 0 passed; 1 failed
```

F2, carry the plan's authority-derived deltas and apply them to the live graph instead of the
live-derived ones, the second head's split brain restored:

```
test api::tests::a_session_that_deletes_a_file_an_earlier_session_modified_reconciles ... FAILED
panicked at crates/kin-daemon/src/api.rs:35379:9:
assertion `left == right` failed: storage error: transaction has stale old payload for removed entity 0b2482f5-d1ae-5079-932f-d4f3822e455e
  left: 500
 right: 200
test result: FAILED. 0 passed; 1 failed
```

### Carried as follow-ups, in the reviewer's words

R2-3, LOW: `None => WorkspaceSemanticDelta::default()` still silently skips when the workspace
graph snapshot is absent. Every sibling errors there; kin-db returns `Ok(None)` only when the
workspace id is absent from authority metadata, which the plan has already validated, so it is
probably unreachable, and if it is ever reached the caller gets the original 500 back from a
lower layer with nothing in the log explaining it.

R2-4, LOW: the facet sweep, `clear_incompatible_facets_in(.., EnrichmentFacet::None)`, runs
once per retired entity with its failure downgraded to a `warn!` where the sibling propagates.
kin-db's `apply_transaction_delta` already retires path-keyed enrichment for every removal
under the same entity lock, so the sweep is a redundant pass run N times for N entities;
harmless, and worth collapsing to one call per distinct `file_origin` or dropping.

R2-5, LOW: rename gets two answers from one repository. The watcher and the MCP planner
relocate with identity; the session path retires and re-derives with new ids. This is a live
divergence between surfaces rather than only deferred work, and the follow-up ticket should
say so.

## Gates

Speed rule in force: no local precheck and no local clippy; hosted CI grades both the full
workspace and clippy. Run locally on head `f47883e5db6ac3e1e2f24991a2b9831ad547244e`, one slot job with the tree
restored after each mutation:

```
cargo test -p kin-daemon --lib -- deletes_an_entity_source_file deletes_an_imported_file
    deletes_a_file_an_earlier_session_modified          3 passed; 0 failed (7.89s)
F1 and F2 above, each 0 passed; 1 failed at the quoted line
rustfmt --edition 2021 --check crates/kin-daemon/src/api.rs
    crates/kin-daemon/src/repository_commit.rs            clean
```

The two touched files were format-checked with rustfmt directly rather than through
`cargo fmt --all -- --check`, because every cargo invocation on this box queues behind the
builder cap; hosted CI runs the workspace form. The first head carried a full local precheck
(21 gates ran, 21 passed on 03476033c) and the full kin-daemon lib suite (1392 passed, 0
failed).

## Follow-ups, not in this PR

R2-3, R2-4 and R2-5 above, in the reviewer's words. Relocation with identity for a renamed
entity-owning file is R2-5's ticket. The live working-copy admission (journey GAP-11) is
described in the second-head section.
