### PR TITLE
Serve a local daemon's refs read from the cached authority (FIR-3180)

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -518,6 +518,15 @@ fn local_repository_ref_metadata(
         .map_err(repository_authority_error)?
         .repository_id()
         .clone();
+    // The pinned-namespace probe runs before the reuse check, exactly as the
+    // three sibling resolvers run it, so a `.kin/kindb` replaced under the
+    // daemon cannot keep being answered from the envelope of the store it
+    // replaced. It decodes no snapshot and takes no repository lock.
+    if let Err(error) = confirm_pinned_projection_namespace(&backend, &repository_id) {
+        state.projection_authority.invalidate();
+        return Err(error);
+    }
+
     let published = read_local_publication_identity(&backend, &repository_id)?;
     if let Some(metadata) = state.projection_authority.reuse_ref_metadata(&published) {
         return Ok(metadata);
@@ -526,6 +535,14 @@ fn local_repository_ref_metadata(
     // The authority open itself is already cached and gated one layer down, so
     // this reaches a full open only when that slot misses too.
     let authority = projection_repository_authority(state)?;
+    // Re-check after that open. A burst of concurrent cold requests is
+    // serialized by the gate inside `projection_repository_authority` and then
+    // released one at a time into the clone below, and the clone is O(history);
+    // whoever loses the race takes the envelope the winner installed instead of
+    // cloning a second copy of it.
+    if let Some(metadata) = state.projection_authority.reuse_ref_metadata(&published) {
+        return Ok(metadata);
+    }
     let metadata = {
         let lease = authority.manager.read_authority();
         lease
@@ -22867,6 +22884,11 @@ mod tests {
             "publish a second change so the refs slot must invalidate",
         )
         .await;
+        // Counted AFTER the commit, not before it. A commit opens authority for
+        // its own reasons, so a count taken before it is satisfied by the
+        // commit's open and says nothing about the read. This one moves only if
+        // the refs read itself reloaded.
+        let after_commit = state.projection_authority.loads();
         let (status, after) = repo_route(Arc::clone(&state), &path).await;
         assert_eq!(
             status,
@@ -22874,15 +22896,15 @@ mod tests {
             "the read after a publication must answer: {}",
             String::from_utf8_lossy(&after)
         );
-        assert!(
-            state.projection_authority.loads() > before,
-            "a refs read after a publication must open the authority again rather than serve \
-             the publication before it"
-        );
         assert_ne!(
             after, first,
             "the refs read after a publication still returns the pre-commit head, so the slot \
              is pinned rather than keyed on the publication"
+        );
+        assert_eq!(
+            state.projection_authority.loads(),
+            after_commit + 1,
+            "the refs read after a publication must itself reload the authority exactly once"
         );
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -236,6 +236,9 @@ pub(crate) struct ProjectionAuthorityCache {
     /// that function at one instant, serialized at 2.2 seconds per open
     /// because an open is O(store).
     admission: std::sync::Mutex<Option<HeldAdmission>>,
+    /// The refs routes' envelope, keyed on the same publication identity as
+    /// every slot above it.
+    ref_metadata: std::sync::Mutex<Option<HeldRefMetadata>>,
     /// Serializes misses so a burst of concurrent cold requests pays for one
     /// full load rather than one per request.
     load_gate: std::sync::Mutex<()>,
@@ -268,6 +271,21 @@ struct HeldCommandAuthority {
     /// [`HeldProjectionAuthority::published`] and for the same reason.
     published: LocalPublicationIdentity,
     authority: Arc<kin_cli::commands::repository_authority::ActiveRepositoryAuthority>,
+}
+
+/// The repository authority envelope a refs read answers from.
+///
+/// Held as an `Arc` rather than rebuilt, because the envelope carries an
+/// operation log and a receipt per change, so cloning it is O(history) and
+/// paying that per request is the same defect one layer down from the open it
+/// replaces. The hosted arm already hands out `Arc<PersistedRepositoryAuthority>`
+/// out of its generation-bound cache entry; this is the local arm's equivalent.
+#[derive(Clone)]
+struct HeldRefMetadata {
+    /// Read strictly before the authority it came out of was loaded, exactly as
+    /// for [`HeldProjectionAuthority::published`] and for the same reason.
+    published: LocalPublicationIdentity,
+    metadata: Arc<kin_db::PersistedRepositoryAuthority>,
 }
 
 #[derive(Clone)]
@@ -370,10 +388,32 @@ impl ProjectionAuthorityCache {
         });
     }
 
+    fn reuse_ref_metadata(
+        &self,
+        published: &LocalPublicationIdentity,
+    ) -> Option<Arc<kin_db::PersistedRepositoryAuthority>> {
+        lock_recover(&self.ref_metadata)
+            .as_ref()
+            .filter(|held| &held.published == published)
+            .map(|held| Arc::clone(&held.metadata))
+    }
+
+    fn install_ref_metadata(
+        &self,
+        published: LocalPublicationIdentity,
+        metadata: Arc<kin_db::PersistedRepositoryAuthority>,
+    ) {
+        *lock_recover(&self.ref_metadata) = Some(HeldRefMetadata {
+            published,
+            metadata,
+        });
+    }
+
     fn invalidate(&self) {
         *lock_recover(&self.held) = None;
         *lock_recover(&self.query) = None;
         *lock_recover(&self.command) = None;
+        *lock_recover(&self.ref_metadata) = None;
     }
 }
 
@@ -444,6 +484,67 @@ fn projection_repository_authority(
         "projection repository authority loaded"
     );
     Ok(authority)
+}
+
+/// The repository authority envelope a local daemon's refs routes answer from.
+///
+/// Blocking: reads storage metadata and, on a publication change, loads the
+/// complete durable authority. Callers run it on a blocking thread.
+///
+/// This exists because `/repos/{repo_id}/refs` used to reach
+/// [`ActiveApiRepositoryAuthority::open`] directly on every request, and an
+/// open reads the durable publication in full, so the read was proportional to
+/// whole-repository size rather than to the ref set it returns. Measured on
+/// 2026-09-04 against a `kin init` store of firelock-ai/kin itself (2864
+/// changes, 111 refs, a 21685-byte response): ten cold reads had a median of
+/// 39.33 s and ten warm reads on the same daemon a median of 44.63 s, which is
+/// the same distribution because there was nothing to warm into. The hosted
+/// route in front of it refuses at 12 s.
+///
+/// The envelope is cached per durable publication rather than per request, in
+/// the same [`ProjectionAuthorityCache`] and against the same publication
+/// identity as the three authority wrappers beside it, so it inherits their
+/// invalidation contract instead of adding a second one. The label is read
+/// before the load it describes, which at worst costs one spurious reload and
+/// never serves a publication that has moved.
+fn local_repository_ref_metadata(
+    state: &DaemonState,
+) -> Result<Arc<kin_db::PersistedRepositoryAuthority>, (StatusCode, String)> {
+    let backend = state.local_repository_backend().ok_or_else(|| {
+        repository_authority_error("local daemon is missing its startup storage capability")
+    })?;
+    let repository_id = state
+        .local_repository_authority_binding()
+        .map_err(repository_authority_error)?
+        .repository_id()
+        .clone();
+    let published = read_local_publication_identity(&backend, &repository_id)?;
+    if let Some(metadata) = state.projection_authority.reuse_ref_metadata(&published) {
+        return Ok(metadata);
+    }
+
+    // The authority open itself is already cached and gated one layer down, so
+    // this reaches a full open only when that slot misses too.
+    let authority = projection_repository_authority(state)?;
+    let metadata = {
+        let lease = authority.manager.read_authority();
+        lease
+            .snapshot()
+            .repository_authority
+            .as_ref()
+            .ok_or_else(|| {
+                (
+                    StatusCode::FAILED_DEPENDENCY,
+                    "snapshot has no repository-v6 authority envelope".to_string(),
+                )
+            })?
+            .clone()
+    };
+    let metadata = Arc::new(metadata);
+    state
+        .projection_authority
+        .install_ref_metadata(published, Arc::clone(&metadata));
+    Ok(metadata)
 }
 
 /// Resolve the repository-v6 authority the MCP query tools read source from.
@@ -14743,6 +14844,19 @@ async fn repository_ref_metadata(
             });
     }
 
+    // The daemon's own repository answers from the publication-keyed cache. Any
+    // other id falls through to the snapshot path, which is where the refusal
+    // that names the served identity lives.
+    if repo_id == state.cached_repo_id {
+        // `block_in_place` rather than an inline call, because a publication
+        // change still pays a full open here and this route is reached from the
+        // async request path; the same wrapper the rest of the daemon uses to
+        // keep liveness answering through a blocking step.
+        return crate::lifecycle::without_blocking_runtime_worker(|| {
+            local_repository_ref_metadata(state)
+        });
+    }
+
     let snapshot = repository_authority_snapshot(state, repo_id).await?;
     Ok(Arc::new(repository_metadata(&snapshot)?.clone()))
 }
@@ -22676,6 +22790,99 @@ mod tests {
         assert!(
             detail.contains("authority envelope"),
             "the refusal must name the missing envelope, got: {detail}"
+        );
+    }
+
+    /// A refs read costs one durable-authority open per publication, not one
+    /// per request (FIR-3180).
+    ///
+    /// `/repos/{repo_id}/refs` reached [`ActiveApiRepositoryAuthority::open`]
+    /// on every request, and an open reads the durable publication in full, so
+    /// the read was proportional to whole-repository size rather than to the
+    /// ref set it returns. Measured on 2026-09-04 against a `kin init` store of
+    /// firelock-ai/kin itself, 2864 changes and 111 refs answering in 21685
+    /// bytes: ten cold reads had a median of 39.33 s and ten warm reads on the
+    /// same daemon a median of 44.63 s, the same distribution because there was
+    /// nothing to warm into. The hosted route in front of it refuses at 12 s.
+    ///
+    /// Two arms, because they fail differently. Reuse proves the slot is
+    /// consulted at all. Invalidation proves it is keyed on the publication
+    /// rather than pinned for the life of the process, which is how this kind
+    /// of cache turns a latency fix into a correctness bug: a refs read that
+    /// keeps answering from the publication before a commit is worse than a
+    /// slow one.
+    ///
+    /// Every response is asserted OK before any count is read. A count that did
+    /// not move reads the same whether reuse worked or every request failed
+    /// early, and only one of those is the property.
+    #[tokio::test]
+    async fn a_refs_read_costs_one_authority_open_per_publication() {
+        let state = test_state();
+        install_repository_file(&state, "src/lib.py", b"def handler():\n    return 1\n");
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let repo_id = state.cached_repo_id.clone();
+        let path = format!("/repos/{repo_id}/refs");
+        let app = router(Arc::clone(&state));
+
+        // Warm the publication once, so the count below measures reuse rather
+        // than the first load every path has to pay.
+        let (status, first) = repo_route(Arc::clone(&state), &path).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "the fixture must answer a refs read: {}",
+            String::from_utf8_lossy(&first)
+        );
+        let before = state.projection_authority.loads();
+
+        for call in 1..=8 {
+            let (status, body) = repo_route(Arc::clone(&state), &path).await;
+            assert_eq!(
+                status,
+                StatusCode::OK,
+                "reuse call {call} failed: {}",
+                String::from_utf8_lossy(&body)
+            );
+            assert_eq!(
+                body, first,
+                "reuse call {call} returned different bytes at one publication, so the reads \
+                 being counted are not the identical read this covers"
+            );
+        }
+        assert_eq!(
+            state.projection_authority.loads(),
+            before,
+            "eight refs reads at one publication must open the durable authority zero further \
+             times; each open reads the whole publication and re-verifies every CAS body"
+        );
+
+        // A publication moves the identity the slot is keyed on, so the next
+        // read must reload and must answer from the new publication.
+        install_repository_file(&state, "src/next.py", b"def added():\n    return 2\n");
+        commit_through_api(
+            &app,
+            kin_model::OperationId::new(),
+            "publish a second change so the refs slot must invalidate",
+        )
+        .await;
+        let (status, after) = repo_route(Arc::clone(&state), &path).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "the read after a publication must answer: {}",
+            String::from_utf8_lossy(&after)
+        );
+        assert!(
+            state.projection_authority.loads() > before,
+            "a refs read after a publication must open the authority again rather than serve \
+             the publication before it"
+        );
+        assert_ne!(
+            after, first,
+            "the refs read after a publication still returns the pre-commit head, so the slot \
+             is pinned rather than keyed on the publication"
         );
     }
 


### PR DESCRIPTION
FIR-3180. **The production 504 is on the hosted arm and this PR does not close it.** Do not close
FIR-3180 on this PR. What closes it is the image hop: production runs `d6b61e550` = kin **0.6.1**,
and the hosted reuse landed in **0.6.2**. Reading the first call inside `repo_refs` at each tag,
`git show <tag>:crates/kin-daemon/src/api.rs`: `v0.6.1` (line 11763) calls
`repository_authority_snapshot`; `v0.6.2` (14691), `v0.6.3`, `v0.6.5`, `v0.6.7` and `origin/main`
all call `repository_ref_metadata`. Measured from inside the cluster at 02:21Z, production
`/repos/kin/refs` answered 200 in 38.94, 38.58 and 39.62 s on three consecutive reads, which is the
local before-median of 39.33 s to the second, and its log carries one `loaded graph from storage
backend` at startup and none since, because 0.6.1's per-request cost is
`RepositoryAuthorityManager::open`, not `load_repo_graph`.

This PR fixes the same defect on the **local** arm, which no release has fixed.

## What the read path does

`repo_refs` calls `repository_ref_metadata`, which splits by capability. The hosted arm
(`storage_backend.is_some()`) answers from the generation-bound cache: warm and unchanged, that is a
map read plus one `probe_repo_publication`, which on `GcsBackend` is a scoped list of delta objects
plus a head on the snapshot object, with no body download and no authority open. The local arm fell
through to `repository_authority_snapshot` and `ActiveApiRepositoryAuthority::open`, whose own doc
says it "reads the durable publication in full", on every request, with nothing caching it between
requests.

## Numbers, by arm

Store for both runs: `kin init --no-enrich` over a single-branch clone of firelock-ai/kin at
`ae8214296867870acb271db96c75bc0e75a9613b`, 992 files, 2864 changes, 33628 entities, 7.6 GiB under
`.kin/`. Every sample HTTP 200, 21685 bytes, 111 refs. Timings are curl `%{time_total}`, gated on
`/readiness`, with a positive control asserting a non-empty `refs` array before any timing is kept.

**Local arm, warm, ten reads on one daemon.** This is the arm the change is about.

| | min | median | mean | max | load avg |
|---|---|---|---|---|---|
| before, `da356723b` | 37.35 s | 44.63 s | 45.04 s | 61.87 s | 19 to 39 |
| after, this branch | 0.001 s | **0.001 s** | 0.002 s | 0.004 s | 82.17 |

A median of 1.2 milliseconds against 44.6 seconds, on a box four times busier than the before run.

**Local arm, cold, ten daemon starts, one timed read each.**

| | min | median | mean | max | load avg |
|---|---|---|---|---|---|
| before, `da356723b` | 34.20 s | 39.33 s | 39.84 s | 48.45 s | 17 to 34 |
| after, this branch | 78.72 s | 127.10 s | 125.19 s | 165.30 s | 57 to 131 |

**The cold rows are not comparable.** The box carried 47 cargo and rustc processes and about twenty
lanes throughout the after run. Structurally the cold path now does strictly less work than before,
one envelope clone instead of a full snapshot clone plus an envelope clone, so the difference is
contention. The cold row is published rather than dropped so nobody has to take that on trust.

The read path is byte-identical between `da356723b` and this PR's base `f6a29e329`, checked function
by function on `repo_refs`, `repository_ref_metadata`, `repository_authority_snapshot` and
`projection_repository_authority`, so the before numbers carry to the base.

**A cold first read still pays one full open.** Nothing populates `ProjectionAuthorityCache` at
startup: `projection_repository_authority` has three callers and all three are request paths. So a
restarted local daemon's first refs read still costs one open, and that is the request that would
504. Warm-on-start is a named follow-up, not in this PR, and it is local-arm only: a hosted daemon
already pre-loads its own repo's cache entry with authority and cursor before the state is visible
(`state.rs:5650`).

Two corrections for the ticket. The 315 bytes in it is the response size, not the work: these reads
returned 21685 bytes for the same 40 s, so the cost tracks the publication being opened, not the
payload. And `/health` answers 200 while the daemon is still loading repository authority, after
which every graph route refuses in under a millisecond with `daemon_opening`; a measurement gated on
`/health` times a 0.0007 s 503 and reports the defect fixed.

## The change

The envelope is held per durable publication in the `ProjectionAuthorityCache` that already holds
three other authority wrappers, keyed on the same `LocalPublicationIdentity` and cleared by the same
`invalidate`, so the refs read inherits that invalidation contract rather than adding a second one.
It is an `Arc` because the envelope carries an operation log and a receipt per change, so cloning it
per request is the same defect one layer down. The label is read before the load it describes, which
at worst costs one spurious reload and never serves a publication that has moved. The pinned
namespace is probed before the reuse check, as the three siblings do, and the slot is re-checked
after the open so a burst of cold requests pays one envelope clone rather than one each.

## Test and its falsification

`a_refs_read_costs_one_authority_open_per_publication`, two arms: eight reads at one publication add
zero authority opens, and a read after a commit adds exactly one and returns different bytes. The
second arm counts loads from **after** the commit, because a commit opens authority for its own
reasons and a count taken before it is satisfied by the commit's open.

Falsified on this exact head by bypassing the new branch with
`if false && repo_id == state.cached_repo_id`, run through heavy-slot, with the tree restored from a
pristine copy under a trap afterwards:

```
armed: the cached branch is bypassed
thread 'api::tests::a_refs_read_costs_one_authority_open_per_publication' panicked at
crates/kin-daemon/src/api.rs:22871:9:
assertion `left == right` failed: eight refs reads at one publication must open the durable
authority zero further times; each open reads the whole publication and re-verifies every CAS body
  left: 9
 right: 1
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1394 filtered out; finished in 1.97s
falsification test exit rc=101 (non-zero is the expected result)
restored api.rs from the pristine copy
```

Left 9 against right 1 is eight refs reads each paying their own authority open, which is the defect.

An earlier falsification attempt patched the other occurrence of the same line, in
`repository_authority_snapshot` rather than in `repository_ref_metadata`, and passed green while
proving nothing. That is why the run above prints the branch it armed.

## What ran locally

Per tonight's speed rule, no `bin/kin-precheck`, no `bin/kin-parity`, and no local clippy; hosted CI
grades clippy and the full workspace. Everything below ran through
`.kin-coord/bin/heavy-slot.sh refsmeasure kin`, with `RUSTFLAGS=-D warnings`.

```
$ cargo fmt --all -- --check
(exited 0 with no output)

$ cargo test -p kin-daemon --lib
test result: ok. 1392 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 213.03s

$ cargo test -p kin-daemon --lib a_refs_read_costs_one_authority_open_per_publication -- --nocapture
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1394 filtered out; finished in 2.39s
```

The full-crate run above was taken on `315f7f620`; the targeted run and fmt were re-taken on this
head after the review fixes. Clippy on this head is graded by hosted CI.

## Not in this PR

`repo_history`, `repo_files` and the other local-arm routes still reach
`repository_authority_snapshot` and pay a full open per request. Same defect, same fix shape.
