### PR TITLE
Show the native VCS loop in the README from a real run

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,194 @@ Admission derives the semantic entities, not their vectors. Run `kin embed` to
 add local vector similarity over them, and confirm coverage with
 `kin graph status`.
 
+## Version control without Git
+
+Kin keeps a full change history with no Git underneath it. In an empty
+directory with no `.git`, the same binary records changes, branches, merges,
+and history, and Git never runs. This is that loop, with the output it printed
+on one real run of a build of `main`. `kin init`, `kin status`, and `kin diff`
+say more than is shown here; the lines below are theirs, unedited, with the
+rest trimmed.
+
+Start an empty repository and record a first change:
+
+```sh
+mkdir kin-demo && cd kin-demo
+kin init
+```
+
+```
+  Authority: repository-v6 (graph-owned)
+  Default ref: refs/heads/main
+  History: unborn (no synthetic commit)
+  Workspace: empty exact tree
+  Store size: 17.4 KiB under .kin/ (no Git object store here to compare against)
+```
+
+```sh
+cat > retry.py <<'PY'
+def backoff(attempt):
+    return min(2 ** attempt, 30)
+PY
+kin commit -m "Add the retry backoff"
+```
+
+```
+  starting the kin daemon for this repository; the first query after a start waits for it to load the graph
+  kin daemon ready in 1.8s
+Created semantic change f635b52070f2944aa1c8651fec50cfa62e1cc21c00760137f62f971a7c27642f on branch 'refs/heads/main' (2 entities, 0 relations, 1 artifacts)
+Recorded in Kin authority, not in git. `git status` stays dirty until you run `kin eject` or push this branch to a Kin remote.
+```
+
+The first commit starts the repository's daemon. Before that, right after
+`kin init`, `kin status` reports durable authority alone and says so on its
+`Tree:` line; once the daemon is up, every `kin status` measures the working
+copy. Who made the change comes from your Git identity when you have one, and
+otherwise from `default_author` in `.kin/config.toml`. Kin refuses to record a
+change attributed to nobody.
+
+Branch, change the function on the branch, and commit there:
+
+```sh
+kin branch create cap-backoff
+kin branch switch cap-backoff
+```
+
+```
+Created refs/heads/cap-backoff at change f635b52070f2944aa1c8651fec50cfa62e1cc21c00760137f62f971a7c27642f (authority generation 3)
+Switched to refs/heads/cap-backoff at change f635b52070f2944aa1c8651fec50cfa62e1cc21c00760137f62f971a7c27642f (1 projected entries, authority generation 4)
+```
+
+```sh
+cat > retry.py <<'PY'
+def backoff(attempt):
+    """Exponential backoff, capped at a minute."""
+    return min(2 ** attempt, 60)
+PY
+kin status
+```
+
+```
+Kin repository-v6 status
+Head: symbolic refs/heads/cap-backoff
+Tree: 198609d9406becdd1fb97f1f3d16d8d869dc382c38823f2b88aa75f72d927029 (1 artifacts, ahead of its base change as admitted 0s ago)
+Refs: 2, default refs/heads/main
+Durable semantic enrichment: present (2 entities, 0 relations, 1 changes at authority generation 5, workspace generation 3; completion not attested)
+Untracked host content: none, measured 0s ago
+```
+
+```sh
+kin commit -m "Raise the backoff cap to a minute"
+```
+
+```
+Created semantic change 64cce9085641a7eee86bd2b870567ac524835e2e80488f7e5444f7cf9b42c065 on branch 'refs/heads/cap-backoff' (2 entities, 0 relations, 1 artifacts)
+```
+
+Back on `main`, record a second change so the merge has two real parents, then
+merge the branch:
+
+```sh
+kin branch switch main
+cat > retry_test.py <<'PY'
+from retry import backoff
+
+def test_first_attempt_waits_one_second():
+    assert backoff(0) == 1
+PY
+kin commit -m "Add a first backoff test"
+kin merge cap-backoff
+```
+
+```
+Switched to refs/heads/main at change f635b52070f2944aa1c8651fec50cfa62e1cc21c00760137f62f971a7c27642f (1 projected entries, authority generation 7)
+Created semantic change 18abd82f3a295696fa4938fc078613c0abe4a3214dd6ec0eb81f8a7c1f747105 on branch 'refs/heads/main' (2 entities, 3 relations, 1 artifacts)
+Merged refs/heads/cap-backoff into refs/heads/main as change 4137af4647e6b838771d5e4ce98d8a604304b9d0a66fdb4e0931e828d6b75c9c (2 projected entries, authority generation 9)
+```
+
+The merge composed both sides by entity identity against their common base,
+with no line-level text merge, and published one change carrying both parents.
+`kin log` walks that history and `kin diff` shows what the merge brought in,
+as artifacts, as entities, and as lines:
+
+```sh
+kin log
+```
+
+```
+change 4137af4647e6b838771d5e4ce98d8a604304b9d0a66fdb4e0931e828d6b75c9c
+Author: Kin Demo <demo@example.com>
+Date:   2026-09-05T01:15:32.635348+00:00
+Origin: native
+Parents: 18abd82f3a295696fa4938fc078613c0abe4a3214dd6ec0eb81f8a7c1f747105 64cce9085641a7eee86bd2b870567ac524835e2e80488f7e5444f7cf9b42c065
+Deltas: entities=2 relations=0 tree=1 policy=false
+    Merge refs/heads/cap-backoff into refs/heads/main
+
+change 18abd82f3a295696fa4938fc078613c0abe4a3214dd6ec0eb81f8a7c1f747105
+Author: Kin Demo <demo@example.com>
+Date:   2026-09-05T01:15:32.339226+00:00
+Origin: native
+Parents: f635b52070f2944aa1c8651fec50cfa62e1cc21c00760137f62f971a7c27642f
+Deltas: entities=2 relations=3 tree=1 policy=false
+    Add a first backoff test
+
+change 64cce9085641a7eee86bd2b870567ac524835e2e80488f7e5444f7cf9b42c065
+Author: Kin Demo <demo@example.com>
+Date:   2026-09-05T01:15:31.791709+00:00
+Origin: native
+Parents: f635b52070f2944aa1c8651fec50cfa62e1cc21c00760137f62f971a7c27642f
+Deltas: entities=2 relations=0 tree=1 policy=false
+    Raise the backoff cap to a minute
+
+change f635b52070f2944aa1c8651fec50cfa62e1cc21c00760137f62f971a7c27642f
+Author: Kin Demo <demo@example.com>
+Date:   2026-09-05T01:15:30.609174+00:00
+Origin: native
+Deltas: entities=2 relations=0 tree=1 policy=true
+    Add the retry backoff
+```
+
+```sh
+kin diff HEAD~1 HEAD
+```
+
+```
+Kin repository-v6 diff
+Base: HEAD~1 (e5aa80af2498ad1d8f8c5a756f24467773a7f12c46039395deb691a0e09ff0bc)
+Head: HEAD 4137af4647e6b838771d5e4ce98d8a604304b9d0a66fdb4e0931e828d6b75c9c (f86d6f68558a54372da1c08cedd8549dd98733110e3f2db6193dc8314ba10c11)
+Artifacts: +0 ~1 -0
+Entities: +0 ~2 -0
+Relations: +0 ~0 -0
+M  retry.py -> retry.py [aab37f62-f986-4543-8187-4af2b8984e0a] blob 0ceda974a82e648bf6e6d40efccc9489eb4b73fa5ab3f0c5cfd35df4911cd524 mode=100644 -> blob c0b44cec88f49e73cc31f7f439ec1b10d9d73cfe1c414dc539106886d4747cce mode=100644
+E~ 0a69467a-63d6-5c34-ac35-632cefde30b7 retry -> retry
+E~ 6cd876cf-cc8a-50bd-94be-e0a2fde3208d backoff -> backoff
+   @@ -1,2 +1,3 @@
+    def backoff(attempt):
+   -    return min(2 ** attempt, 30)
+   +    """Exponential backoff, capped at a minute."""
+   +    return min(2 ** attempt, 60)
+```
+
+`HEAD~1` is the merge's first parent, the test commit, so the diff is exactly
+what `cap-backoff` contributed: one artifact, the two entities in it (the
+module and the function), and the lines. `kin checkout`, `kin stash`,
+`kin rollback`, `kin blame`, and `kin conflicts` with `kin resolve` round out
+the set, and `kin capabilities` prints where each one stands.
+[The CLI reference](docs/cli-reference.md#branches-merges-and-exact-trees) has
+every flag.
+
+Sharing a native repository between machines is still in progress, and public
+repository connection through KinLab is not a first-run flow yet. What the
+transfer commands do today: `kin clone` takes a KinLab locator or the HTTP
+endpoint of another machine's running Kin daemon, adopts that repository's
+identity into a fresh local workspace, and remembers the origin it came from.
+`kin push` sends your new changes to that saved origin one verified pack at a
+time, and refuses rather than forces when the remote has moved past you.
+`kin pull` admits what the origin has that you do not and moves your working
+tree onto it, and when uncommitted work stops the tree from following, it says
+so and keeps the history it received. Each of the three is exercised between two
+Kin daemons over HTTP by the test suite.
+
 ## Works with your agent
 
 Kin ships its own agent, and it is the path we recommend for agent work. `kin
@@ -568,6 +756,7 @@ live at [kinlab.ai/blog](https://kinlab.ai/blog) with a feed at
 ## Learn and contribute
 
 - [Quickstart and advanced configuration](docs/quickstart.md)
+- [CLI reference: every command, with its flags and defaults](docs/cli-reference.md)
 - [Store size and what drives it](docs/store-size.md)
 - [MCP tool reference](docs/mcp-tools.md)
 - [Language support and what each tier extracts](docs/language-support.md)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -680,7 +680,7 @@ kin conflicts [options]
 
 ### `kin resolve`
 
-Resolve repository-v6 merge conflicts Nine flags name a resolution and at least one is required, which is a group rather than a per-argument condition. `kin conflicts` is the read-only view of the same transaction, so nothing here has to accept an empty invocation in order to be inspectable.
+Resolve repository-v6 merge conflicts Ten flags name a resolution and at least one is required, which is a group rather than a per-argument condition. `kin conflicts` is the read-only view of the same transaction, so nothing here has to accept an empty invocation in order to be inspectable.
 
 ```
 kin resolve [options]
@@ -693,12 +693,43 @@ kin resolve [options]
 | `--base <selector>` |  | Keep the merge base version of a conflicting identity. Repeatable. |
 | `--remove <selector>` |  | Settle a conflicting identity by dropping it from the merge. Repeatable. |
 | `--keep-path <path=artifact>` |  | Settle a contested path by naming the artifact that keeps it. Repeatable. |
+| `--file <path> <file>` |  | Resolve a conflicted repository path using the exact bytes in FILE. Repeatable. |
 | `--all-ours` |  | Resolve all remaining conflicts keeping your version |
 | `--all-theirs` |  | Resolve all remaining conflicts keeping the incoming version |
 | `--do-continue`, `--continue` |  | Complete the merge after all conflicts are resolved. `--continue` is an accepted alias that the CLI parses but does not list in `--help`, so a reader coming from Git will find it works. |
 | `--abort` |  | Abort the merge and discard conflict state |
 | `--expect <hash>` |  | Require the merge transaction to still be the one this identity names |
 | `--json` |  | Emit the machine-readable merge transaction record |
+
+`--file` is the form for a conflict you settle by writing the merged file yourself, the way a
+Git user edits past conflict markers. It takes the repository path and a file holding the
+complete body you want, records those exact bytes, and derives the entities from them, so one
+call settles the artifact conflict and every entity conflict inside that file. `--all-ours` and
+`--all-theirs` are the other way to clear a file in one call, and they keep one side whole, which
+is rarely what a two-sided edit wants. A file that both branches changed on one run, and what
+settled it:
+
+```
+$ kin merge cap-backoff
+Merging refs/heads/cap-backoff into refs/heads/main left 3 unresolved conflict(s); the merge is held as merge transaction 7b942cddee6acda03d7fba308215e7b71cd20d08256e68cd9f04ec491b014817 (authority generation 8)
+  - artifact retry.py (18564001-2f7e-4247-92ef-ae4e61e36365): changed on both branches with different content
+  - entity retry in retry.py (0a69467a-63d6-5c34-ac35-632cefde30b7): changed on both branches with different content
+  - entity backoff in retry.py (6cd876cf-cc8a-50bd-94be-e0a2fde3208d): changed on both branches with different content
+Settle each conflict with `kin resolve`, then `kin resolve --continue`, or discard the merge with `kin resolve --abort`
+Exit 8: the merge is parked with conflicts; `kin conflicts` lists them
+
+$ kin resolve --file retry.py /tmp/retry-merged.py
+Settled 3 conflict(s); merge transaction 672a290099aa89f23566753a876674309b3b6e9fae39eb72b969794dffbb397e has 3 of 3 conflict(s) settled
+Publish the merge with `kin resolve --continue`
+
+$ kin resolve --continue
+Merged refs/heads/cap-backoff into refs/heads/main as change 6aa69c3b80300026f03afa8a4beecf3440beacebfb14445d2d17a257a28481c7 after settling 3 conflict(s) (1 projected entries, authority generation 10)
+```
+
+The merge exits 8 while it is parked, and nothing moves until `--continue`. A call carries up
+to 8 MiB of authored input; related files can be settled across separate calls, and a later
+`--ours` or `--theirs` for the same subject does not overwrite an authored body, though another
+`--file` for the path replaces it.
 
 ### `kin stash`
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -354,6 +354,24 @@ Save a new semantic change snapshot:
 kin commit -m "refactor: optimize user query path"
 ```
 
+### Branch and merge
+
+A branch is a ref over the same immutable history, and a merge composes both
+sides by entity identity against their common base rather than by line:
+
+```sh
+kin branch create cap-backoff   # a new ref at the current head
+kin branch switch cap-backoff   # move the workspace onto it; uncommitted work comes along
+kin commit -m "Raise the backoff cap to a minute"
+kin branch switch main
+kin merge cap-backoff           # one merge change carrying both parents
+```
+
+A merge that does not compose is parked as a durable conflict record rather
+than refused: `kin conflicts` shows it and `kin resolve` settles it. The
+[README runs this loop end to end](../README.md#version-control-without-git)
+in an empty directory, with the output of a real run.
+
 ### View history
 
 ```sh


### PR DESCRIPTION
Docs only. The README named no native VCS verb beyond `kin status` (journey lane GAP-1, measured at f6a29e329), and `docs/cli-reference.md` omitted `kin resolve --file`, the flag that settles a two-sided file conflict in one call.

## What changed

- `README.md`: a new "Version control without Git" section between "Shortest graph-backed path" and "Works with your agent". It runs `kin init`, a first commit, `kin branch create` and `switch`, an edit and `kin status` on the branch, a second commit, a switch back, a second change on `main`, `kin merge`, `kin log`, and `kin diff HEAD~1 HEAD`, with the output a build of this tree printed. Every output line is from the run below; `kin init`, `kin status`, and `kin diff` are trimmed to the lines that matter and the section says so. It carries the kinlab.ai marker verbatim ("Sharing a native repository between machines is still in progress") and one sentence each for `kin clone`, `kin push`, and `kin pull` from `crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json`.
- `README.md`: `docs/cli-reference.md` added to "Learn and contribute".
- `docs/quickstart.md`: a "Branch and merge" subsection in section 5, in the guide's own voice, ending with a link to `../README.md#version-control-without-git`. That link is what makes the link checker exercise the new anchor.
- `docs/cli-reference.md`: `--file <path> <file>` in the `kin resolve` table beside the other resolution flags, the flag count corrected from nine to ten (the binary's `--help` lists ten), and a worked example from a real parked conflict.

## The run behind the README section

Binary: `.kin-coord/bin/heavy-slot.sh readmeverbs kin -- cargo build --release -p kin-cli -p kin-daemon` at f6a29e329 (`Finished release profile [optimized] target(s) in 13m 00s`, wrapper rc=0). Scratch `KIN_HOME` under `/tmp`, `KIN_EMBED_BACKEND=cpu`, absolute binary path, `default_author` set to `Kin Demo <demo@example.com>` in `.kin/config.toml` after init so no personal address lands in the README. Seventeen commands, every one exit 0. The tail, with the absolute binary path shortened to `kin` and the stderr `KIN_EMBED_BACKEND` override warning dropped from each command:

```
$ kin branch switch main
Switched to refs/heads/main at change f635b52070f2944aa1c8651fec50cfa62e1cc21c00760137f62f971a7c27642f (1 projected entries, authority generation 7)
[rc=0]

# wrote retry_test.py on main

$ kin commit -m Add a first backoff test
Created semantic change 18abd82f3a295696fa4938fc078613c0abe4a3214dd6ec0eb81f8a7c1f747105 on branch 'refs/heads/main' (2 entities, 3 relations, 1 artifacts)
Recorded in Kin authority, not in git. `git status` stays dirty until you run `kin eject` or push this branch to a Kin remote.
[rc=0]

$ kin merge cap-backoff
Merged refs/heads/cap-backoff into refs/heads/main as change 4137af4647e6b838771d5e4ce98d8a604304b9d0a66fdb4e0931e828d6b75c9c (2 projected entries, authority generation 9)
[rc=0]

$ kin log
change 4137af4647e6b838771d5e4ce98d8a604304b9d0a66fdb4e0931e828d6b75c9c
Author: Kin Demo <demo@example.com>
Date:   2026-09-05T01:15:32.635348+00:00
Origin: native
Parents: 18abd82f3a295696fa4938fc078613c0abe4a3214dd6ec0eb81f8a7c1f747105 64cce9085641a7eee86bd2b870567ac524835e2e80488f7e5444f7cf9b42c065
Deltas: entities=2 relations=0 tree=1 policy=false
    Merge refs/heads/cap-backoff into refs/heads/main
...
[rc=0]

$ kin diff HEAD~1 HEAD
Kin repository-v6 diff
Authority generation: 9
Base: HEAD~1 (e5aa80af2498ad1d8f8c5a756f24467773a7f12c46039395deb691a0e09ff0bc)
Head: HEAD 4137af4647e6b838771d5e4ce98d8a604304b9d0a66fdb4e0931e828d6b75c9c (f86d6f68558a54372da1c08cedd8549dd98733110e3f2db6193dc8314ba10c11)
Artifacts: +0 ~1 -0
Entities: +0 ~2 -0
Relations: +0 ~0 -0
M  retry.py -> retry.py [aab37f62-f986-4543-8187-4af2b8984e0a] blob 0ceda974a82e648bf6e6d40efccc9489eb4b73fa5ab3f0c5cfd35df4911cd524 mode=100644 -> blob c0b44cec88f49e73cc31f7f439ec1b10d9d73cfe1c414dc539106886d4747cce mode=100644
E~ 0a69467a-63d6-5c34-ac35-632cefde30b7 retry -> retry
E~ 6cd876cf-cc8a-50bd-94be-e0a2fde3208d backoff -> backoff
   @@ -1,2 +1,3 @@
    def backoff(attempt):
   -    return min(2 ** attempt, 30)
   +    """Exponential backoff, capped at a minute."""
   +    return min(2 ** attempt, 60)
Admitted scope: both endpoints are admitted repository authority, so host content no admission has taken appears on neither side; graph truth was last admitted at 2026-09-05T01:15:32.993098+00:00 over 2 artifact(s).
[rc=0]

$ kin daemon stop
  kin-demo (pid 35841): stopped
All targeted Kin daemons stopped.
[rc=0]
```

## The run behind `kin resolve --file`

Same binary and environment. Both branches changed `backoff` in `retry.py`; the merge parked, one `--file` call settled the artifact and both entities in it, and `--continue` published the merge:

```
$ kin merge cap-backoff
Merging refs/heads/cap-backoff into refs/heads/main left 3 unresolved conflict(s); the merge is held as merge transaction 7b942cddee6acda03d7fba308215e7b71cd20d08256e68cd9f04ec491b014817 (authority generation 8)
  - artifact retry.py (18564001-2f7e-4247-92ef-ae4e61e36365): changed on both branches with different content
  - entity retry in retry.py (0a69467a-63d6-5c34-ac35-632cefde30b7): changed on both branches with different content
  - entity backoff in retry.py (6cd876cf-cc8a-50bd-94be-e0a2fde3208d): changed on both branches with different content
Settle each conflict with `kin resolve`, then `kin resolve --continue`, or discard the merge with `kin resolve --abort`
Exit 8: the merge is parked with conflicts; `kin conflicts` lists them
[rc=8]

$ kin resolve --file retry.py /tmp/readmeverbs/retry-merged.py
Settled 3 conflict(s); merge transaction 672a290099aa89f23566753a876674309b3b6e9fae39eb72b969794dffbb397e has 3 of 3 conflict(s) settled
Publish the merge with `kin resolve --continue`
[rc=0]

$ kin resolve --continue
Merged refs/heads/cap-backoff into refs/heads/main as change 6aa69c3b80300026f03afa8a4beecf3440beacebfb14445d2d17a257a28481c7 after settling 3 conflict(s) (1 projected entries, authority generation 10)
[rc=0]
```

The reference shows that command with `/tmp/retry-merged.py`; the output lines under it are verbatim.

## Guards

Docs only, no Rust touched, so `cargo test`, `cargo fmt --all -- --check`, and clippy had nothing to grade and did not run. What ran, in the lane worktree at this head:

```
$ lychee --config lychee.toml ./README.md ./CONTRIBUTING.md ./SECURITY.md ./docs/quickstart.md
🔍 93 Total (in 2s 568ms) 🔗 67 Unique ✅ 80 OK 🚫 0 Errors 👻 13 Excluded 🔀 3 Redirects
lychee rc=0
```

Falsification that the new anchor is really checked, not just present. A scratch copy of the quickstart with the fragment misspelt fails, naming the README anchor (`<wt>` is the worktree path):

```
 [ERROR] file:///<wt>/README.md#version-control-without-gitx (at 372:1) | Cannot find fragment
```

and the CI's own fixture fails naming its anchor, with the same lychee 0.24.2 the workflow pins:

```
 [ERROR] file:///<wt>/scripts/fixtures/public-doc-links/missing-anchor.md#anchor-that-does-not-exist (at 3:1) | Cannot find fragment
```

README language count, the awk from ci.yml's "Check the README language count against the adapter registry" step: `registry=14 readme_table=14`, and no prose count sentence matched. Em dashes in the diff: none. Release version strings in added lines: none.

## Two things the run showed, not changed here

1. After `kin init` in an empty directory the daemon `init` started does not stay up: `kin daemon status` two seconds later reports "worker daemon not running", and the first `kin status` after writing a file says "no daemon is running for this repository, so nothing admitted the working copy and this reports durable authority alone". The first `kin commit` starts a daemon and records the file. The README says so in one sentence rather than hiding it.
2. `kin commit` on a repository with no `.git` still prints "Recorded in Kin authority, not in git. `git status` stays dirty until you run `kin eject` or push this branch to a Kin remote." The README shows it verbatim.
