### PR TITLE
Take kin-db 0.7.102 and re-read its StorageBackend surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -152,7 +152,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -448,7 +448,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes 3.0.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -465,7 +465,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
  "winx",
 ]
 
@@ -1130,7 +1130,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1239,7 +1239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3295,9 +3295,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.101"
+version = "0.7.102"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "79b731269e751a17239f0cca406d8140bc4ef3e658a7e47f3d56ef872b997dbb"
+checksum = "a112df686bd7ba5433912c5dc9032a09dd915b387bde295196f1e17a73fc31b4"
 dependencies = [
  "bincode",
  "bstr",
@@ -4158,7 +4158,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5080,7 +5080,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5149,7 +5149,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5602,7 +5602,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5746,7 +5746,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6679,7 +6679,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ kin-lsp = { version = "=0.7.16", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.101", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.102", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.24", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-daemon/src/storage_delegate.rs
+++ b/crates/kin-daemon/src/storage_delegate.rs
@@ -62,7 +62,7 @@ use kin_db::{
 /// `storage_backend_surface_is_audited_against_the_pinned_kin_db` fails when
 /// the workspace pin moves past it, which is the only moment a method can have
 /// appeared.
-pub const AUDITED_KIN_DB_VERSION: &str = "0.7.101";
+pub const AUDITED_KIN_DB_VERSION: &str = "0.7.102";
 
 /// Wraps a [`StorageBackendDelegate`] so it can be handed anywhere a
 /// `Box<dyn StorageBackend>` is expected.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -619,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -819,9 +819,9 @@ checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
 dependencies = [
  "portable-atomic",
 ]
@@ -1001,7 +1001,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1121,9 +1121,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1147,7 +1147,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1398,9 +1398,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1411,9 +1411,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1421,22 +1421,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
Takes kin-db 0.7.102 in `Cargo.toml`, `Cargo.lock` and `fuzz/Cargo.lock`, byte for byte the three-file diff of #1502, plus the audit re-read that #1502 was missing. Replaces #1502. This is what puts FIR-3199 (kin-db #299, landing sha `87f5658`) inside v0.7.0.

## Why #1502 was red

`storage_backend_surface_is_audited_against_the_pinned_kin_db` (`crates/kin-daemon/src/storage_delegate.rs:292`) asserts the workspace pin equals `AUDITED_KIN_DB_VERSION`. It goes red on every pin bump by design, so that someone re-reads kin-db's `StorageBackend` trait before the bridge table can silently inherit a new defaulted method. #1502 moved the pin and not the constant.

## The re-read

kin-db's `crates/kin-db/src/storage/backend.rs` is byte-identical between the `v0.7.101` (5459419) and `v0.7.102` (87f5658) tags: `git diff 5459419 87f5658 -- crates/kin-db/src/storage/backend.rs` is empty. The trait declares 32 methods at both tags, with the same names, and kin-daemon's `storage_backend_surface!` table names exactly those 32 (name-by-name diff empty, first names as a control: `clear_deltas`, `compact_deltas`, `delete_overlay`). kin-db 0.7.102 differs from 0.7.101 only in `crates/kin-db/src/embed/mod.rs` (the FIR-3199 dispatch-line fix) and its own version. So the trait surface did not change, no row is added, and the one code change is `AUDITED_KIN_DB_VERSION` from `0.7.101` to `0.7.102`.

## Verification, per tonight's speed rule

No `bin/kin-precheck` and no `bin/kin-parity`; hosted CI grades the full workspace. Run locally through heavy-slot on the pushed tree, with `RUSTFLAGS="-D warnings"` as `ci.yml` sets it:

`cargo test -p kin-daemon --lib --locked storage_delegate` (the two audit tests, with the fix):

```
test storage_delegate::tests::storage_backend_surface_is_audited_against_the_pinned_kin_db ... ok
test storage_delegate::tests::the_bridged_method_roster_names_each_method_once ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 1392 filtered out; finished in 0.00s
```

`cargo test -p kin-daemon --lib --locked` (the crate's whole unit suite):

```
test result: ok. 1391 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 457.51s
```

`cargo fmt --all -- --check`: clean (rc 0).

`cargo clippy --all-targets --all-features -- $allows` with the 45-lint allow list from `.github/clippy-allowed-lints.txt`: rc 0, one future-incompatibility warning from the `block v0.1.6` dependency, no error. This run had already started when the rule changed to no local clippy, so it was left to finish; hosted CI grades clippy either way.

`git status` after the runs: only `Cargo.toml`, `Cargo.lock`, `fuzz/Cargo.lock` and `crates/kin-daemon/src/storage_delegate.rs` modified, so `--locked` held and the lock did not move.

## Falsification

Two arms, both restored to the byte-identical fixed file afterwards.

Mutant A, `AUDITED_KIN_DB_VERSION` back to `0.7.101` with the pin at `0.7.102` (this is #1502's exact red):

```
: AUDITED_KIN_DB_VERSION back to 0.7.101 with the pin at 0.7.102 ===
test storage_delegate::tests::the_bridged_method_roster_names_each_method_once ... ok
test storage_delegate::tests::storage_backend_surface_is_audited_against_the_pinned_kin_db ... FAILED
thread 'storage_delegate::tests::storage_backend_surface_is_audited_against_the_pinned_kin_db' (307572234) panicked at crates/kin-daemon/src/storage_delegate.rs:292:9:
assertion `left == right` failed: kin-db moved from 0.7.101 to 0.7.102 and the StorageBackend table in crates/kin-daemon/src/storage_delegate.rs has not been re-read. Count the trait's methods in `kin-db-0.7.102/src/storage/backend.rs`, add a row for anything new, then set AUDITED_KIN_DB_VERSION to 0.7.102. A method missing from that table is a capability every decorator in this crate reports as absent, with no error anywhere.
  left: "0.7.102"
 right: "0.7.101"
test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 1392 filtered out; finished in 0.07s
cargo rc=101
restored A: byte-identical to the fixed copy
```

Mutant B, one row left out of the table, two attempts, both under CI's `RUSTFLAGS="-D warnings"`, both restored byte for byte:

```
row dropped: supports_incremental_deltas (kin-db default: false)
error[E0407]: method `supports_incremental_deltas` is not a member of trait `StorageBackendDelegate`
    --> crates/kin-daemon/src/publication_lease.rs:3397:5
error: could not compile `kin-daemon` (lib test) due to 1 previous error
cargo rc=101

row dropped: with_source_blob_write_batch (kin-db default: a DefaultSourceBlobWriteBatch over self; no kin-daemon mention outside the bridge)
error: unused import: `SourceBlobWriteBatch`
error: could not compile `kin-daemon` (lib test) due to 1 previous error
cargo rc=101
```

So under CI's flags a row left out is caught before any test runs: by a decorator that overrides the method, or by the import the row alone used. A third arm that also drops the import, so the roster-count test is the only guard left, was queued and then withdrawn to free the builder queue (thirteen lanes waiting); it can be run on request. The assertion this PR changes is the version guard, and mutant A above is its red.
