### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.6.8] - 2026-09-04
+## [0.7.0] - 2026-09-05
 
 ### Changed
 
 - Say which half of readiness refused, and how long it waited (#1486)
+- Read every release page before planning promotions (#1488)
+- Report unavailable enrichment after language-server installation (#1490)
+- Count semantic changes, not every hash a read surface prints (#1492)
+- First-contact truth follow-ups: the model fetch and the replayed graph sample (#1491)
+- Accept the release's own receipt as a stranger-run link (#1495)
+- Support native commit amend with exact head leases (#1496)
+- Support authored files in durable merge resolution (#1498)
+- Clone native repository history and exact source bodies (#1497)
+- Report entity change by content, not by artifact (#1493)
+- Parse a session's bytes where the session publishes them (#1499)
 
 
 ## [0.6.7] - 2026-09-04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3052,7 +3052,7 @@ dependencies = [
 
 [[package]]
 name = "kin-agent"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3081,14 +3081,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "age",
  "anyhow",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3185,7 +3185,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "cap-fs-ext",
  "cap-std",
@@ -3220,7 +3220,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon-spawn"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "fs2",
  "libc",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "cap-std",
  "chrono",
@@ -3367,7 +3367,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3419,7 +3419,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3454,7 +3454,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "base64 0.23.0",
  "hex",
@@ -3485,7 +3485,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3535,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "kin-notifier-macos"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "block2",
  "objc2 0.6.4",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "kin-notify"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3603,7 +3603,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "kin-model",
  "serde",
@@ -3612,7 +3612,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3632,7 +3632,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -3665,7 +3665,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "base64 0.23.0",
  "chrono",
@@ -3686,7 +3686,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3702,7 +3702,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3735,7 +3735,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3750,7 +3750,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.8"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -93,7 +93,7 @@ toml_edit = "0.25"
 tempfile = { workspace = true }
 unicode-normalization = "0.1"
 unicode-ident = "1"
-kin-spine = { version = "0.6.8", path = "../kin-spine" }
+kin-spine = { version = "0.7.0", path = "../kin-spine" }
 
 [dev-dependencies]
 kin-core = { workspace = true, features = ["test-support"] }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "kin-model",
  "serde",

--- a/packages/boundary-contracts/package.json
+++ b/packages/boundary-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kin/boundary-contracts",
-  "version": "0.6.8",
+  "version": "0.7.0",
   "private": false,
   "description": "Shared contracts for Kin ecosystem boundaries.",
   "type": "module",

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.6.8",
+  "version": "0.7.0",
   "mcpName": "ai.kinlab/kin",
   "description": "Start Kin's MCP server, the system of record for AI-written software, through an npm-friendly wrapper.",
   "type": "module",

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.6.8",
+  "version": "0.7.0",
   "description": "Canonical installer and launcher for Kin, the system of record for AI-written software. Provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary

Moves kin from 0.6.8 to 0.7.0 in lockstep across every file the release train reads. Version bump only, in one commit. The edits are version fields, the two lockfiles and the changelog section.

v0.6.8 was staged on main by the automated train (`7bd3678cb Release Kin v0.6.8 (#1487)`) but never tagged. The newest real tag is `v0.6.7`. So 0.7.0 absorbs the un-tagged 0.6.8 entries: the `## [0.7.0]` changelog section is generated from the merged pull requests between `v0.6.7` and `HEAD` (12 first-parent commits, 11 notes; the bump commit itself is filtered out by the generator's own rule) using `releaseNotes`, `removeChangelogSection` and `upsertChangelogSection` from `scripts/prepare-release.mjs`, the same functions release-train.yml's branch-writer step runs, and the stale `## [0.6.8]` stub is removed. No prose was written by hand.

## What moved

`git grep -n '0\.6\.8'` before any edit hit exactly 8 files, 31 lines. Every hit was a release-version surface. No dependency pin for an unrelated crate happened to read 0.6.8, so nothing was left alone by exception.

| File | Lines | Decision |
|---|---|---|
| `Cargo.toml` | 1 | workspace version, `[workspace.package]` |
| `crates/kin-cli/Cargo.toml` | 1 | `kin-spine` path-version pin, the one internal dependency not on `workspace = true` |
| `Cargo.lock` | 24 | all 24 are local `kin-*` packages with no `source =` line (every `[[package]]` block parsed); regenerated by cargo, see below |
| `fuzz/Cargo.lock` | 1 | the detached fuzz workspace's `kin-parser` entry; regenerated by cargo |
| `packages/kin/package.json` | 1 | npm version |
| `packages/kin-mcp/package.json` | 1 | npm version |
| `packages/boundary-contracts/package.json` | 1 | npm version |
| `CHANGELOG.md` | 1 | `## [0.6.8]` stub replaced by the generated `## [0.7.0] - 2026-09-05` section |

## Mechanism, from source

- `scripts/release-intent.mjs` (the mint's readiness gate, which release-tag.yml copies alone into `$RUNNER_TEMP`) asserts: workspace version == every npm manifest version (its `--npm` default names exactly the three above), == the `kin-spine` pin in `crates/kin-cli/Cargo.toml`, == every local `kin-*` entry in `Cargo.lock` without a `source =` line, == `fuzz/Cargo.lock`'s `kin-parser`, and a non-empty `## [version]` changelog section for a stable release.
- `scripts/check-release-version.mjs` is the `Release version gate` job (ci.yml:82-105). Its `if:` only fires for head ref `automation/release-next` or a `release:automated` label, so it does not run on this PR. The equivalent local run is pasted below.
- `scripts/prepare-release.mjs` is the train's generator for these same eight paths (release-train.yml:424 lists them as the only paths a release branch may touch).
- The candidate branch is derived, not hardcoded: `scripts/select-release-candidate.py:190-191` returns `release/v{version}-candidate`, and the mint reads its version live from `Cargo.toml` at the candidate sha (`release-tag.yml:244`). The same tree-wide grep hit zero files under `.github/workflows/`, so no workflow carries the old version.

## Lockfiles regenerated by cargo, never by hand

Root, through the fleet slot from the umbrella root:

```
KIN_EMBED_BACKEND=cpu .kin-coord/bin/heavy-slot.sh bump070 kin -- env KIN_EMBED_BACKEND=cpu cargo build --workspace
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 20s
heavy-slot: bump070 command exit rc=0 at 2026-09-05T00:38:33Z
```

Resulting `Cargo.lock` diff, every changed line:

```
  24 -version = "0.6.8"
  24 +version = "0.7.0"
```

Detached fuzz workspace (`fuzz/Cargo.toml` declares its own `[workspace]`), resolution only:

```
$ cargo metadata --manifest-path fuzz/Cargo.toml --format-version 1 >/dev/null
     Locking 1 package to latest compatible version
    Updating kin-parser v0.6.8 (<worktree>/crates/kin-parser) -> v0.7.0
rc=0
fuzz/Cargo.lock:668  name = "kin-parser"
fuzz/Cargo.lock:669  version = "0.7.0"
```

Resulting `fuzz/Cargo.lock` diff: that one version line and nothing else.

## Guard runs and falsification

Natural red, before the lockfiles were regenerated (source files already at 0.7.0):

```
$ node scripts/release-intent.mjs
  workspace version : 0.7.0
  npm packages      : kin-mcp@0.7.0, kin@0.7.0, boundary-contracts@0.7.0
  kin-spine pin     : 0.7.0
  local lock entries: 24
  changelog section : present
  newest tag        : v0.6.7
  tag v0.7.0       : absent
  FAIL: Cargo.lock local package kin-agent is 0.6.8, workspace is 0.7.0
  [... one FAIL per local kin-* package, 24 lines ...]
  FAIL: fuzz/Cargo.lock local package kin-parser is 0.6.8, workspace is 0.7.0
  => should_tag=false
v0.7.0 is staged but release surfaces are out of sync. Refusing to tag.
EXIT=1
```

Planted red, after the root lockfile was regenerated: `packages/kin/package.json` reverted to 0.6.8 by hand, guard run, restored.

```
  npm packages      : kin-mcp@0.7.0, kin@0.6.8, boundary-contracts@0.7.0
  FAIL: npm manifest packages/kin/package.json is 0.6.8, workspace is 0.7.0 [...]
  FAIL: fuzz/Cargo.lock local package kin-parser is 0.6.8, workspace is 0.7.0
  => should_tag=false
EXIT=1
```

(The npm FAIL line is truncated at the guard's own trailing clause, which carries a dash this repo's prose rules exclude. The fuzz line is the detached lockfile still pending at that moment, the natural state.)

```
```

Green, after both lockfiles:

```
$ node scripts/release-intent.mjs
Kin release-intent gate
  workspace version : 0.7.0
  npm packages      : kin-mcp@0.7.0, kin@0.7.0, boundary-contracts@0.7.0
  kin-spine pin     : 0.7.0
  local lock entries: 24
  changelog section : present
  newest tag        : v0.6.7
  tag v0.7.0       : absent
  stranded paths    : 0
  => should_tag=true
v0.7.0 is a coherent release. Ready to tag.
EXIT=0
```

`check-release-version.mjs` on the commit (base defaults to `HEAD^`, the pre-bump main head):

```
$ node scripts/check-release-version.mjs                # no label: the gate assumes patch, and refuses
Kin release version gate
  base              : f6a29e3294949acbd792341388bbc6ca9fb5f833
  workspace version : 0.6.8 -> 0.7.0
  requested bump    : patch (expected 0.6.9)
  changed paths     : 8
  release paths     : 6
    - Cargo.lock
    - Cargo.toml
    - crates/kin-cli/Cargo.toml
    - packages/boundary-contracts/package.json
    - packages/kin-mcp/package.json
    - packages/kin/package.json
  FAIL: patch release intent requires 0.6.9, but the workspace moved from 0.6.8 to 0.7.0
EXIT=1

$ node scripts/check-release-version.mjs --labels release:minor
  requested bump    : minor (expected 0.7.0)
  changed paths     : 8
  release paths     : 6
EXIT=0
```

(`CHANGELOG.md` and `fuzz/Cargo.lock` are the two changed paths the gate classifies as non-release, by its own `classifyPath` rules for markdown and `fuzz/` segments. The intent is minor: 0.6.8 to 0.7.0.)

The guards' own suites, as ci.yml's `npm launcher tests` job runs them:

```
$ node --test ./scripts/check-release-version.test.mjs ./scripts/release-intent.test.mjs ./scripts/prepare-release.test.mjs
# tests 32
# pass 32
# fail 0
EXIT=0

$ python3 scripts/falsify-release-version-guards.py
the release version guards rejected all 11 poisoned trees:
  [11 mutation -> catching-test rows]
EXIT=0
```

## Inner loop run locally (through heavy-slot, `RUSTFLAGS="-D warnings"` as in ci.yml, `KIN_EMBED_BACKEND=cpu`)

Per the captain's speed rule for tonight, `bin/kin-precheck` and `bin/kin-parity` were not run locally. Hosted CI grades the full workspace.

```
$ cargo fmt --all -- --check
(no output)
rc=0    started 2026-09-05T01:17:25Z, done by 01:17:32Z
```

Clippy is graded by hosted CI (the `Fast gate lint and policy` context), per the captain's tightened speed rule for tonight. A local run with the same allow list and `RUSTFLAGS="-D warnings"` was already in this lane's slot when the rule tightened and was allowed to finish:

```
$ cargo clippy --all-targets --all-features -- $allows    # 45 lints from .github/clippy-allowed-lints.txt, as ci.yml
    Checking kin-daemon v0.7.0 (<worktree>/crates/kin-daemon)
    Checking kin-integration-tests v0.7.0 (<worktree>/tests/integration)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4m 08s
warning: the following packages contain code that will be rejected by a future version of Rust: block v0.1.6
rc=0
```

`cargo test -p kin-cli` ran in the same slot before the rule tightened (this PR adds no tests, so a targeted run had nothing new to falsify, and hosted CI's `Fast gate build and tests` is the grader). It was stopped at 01:40:17Z to free the slot. The partial result is reported here in full:

```
$ cargo test -p kin-cli            # started 01:21:41Z, stopped 01:40:17Z (SIGTERM to the slot wrapper)
34 test binaries ran, in cargo's order from the lib unit tests through tests/init_non_tty_output.rs
2604 passed, 4 failed, 0 ignored
every binary before init_non_tty_output: ok
tests/init_non_tty_output.rs: FAILED. 9 passed; 4 failed; finished in 22.08s
```

Every failure sits in that one binary, the one executing when the stop signal arrived. Three of them panicked in the harness's own cleanup (`tests/common/mod.rs:1353`) with `process-group watcher cleanup failed with status signal: 15 (SIGTERM)`, which is the stop itself. The fourth, `the_enrichment_note_carries_a_cause_the_daemon_reported`, failed fourteen seconds before the stop at its positive-control assertion (`init_non_tty_output.rs:255`): the `kin init` stderr it captured carried `refusing to bind the parent store at /Users/troyfortinjr/GitHub/kin-ecosystem/.kin across the repository boundary at <this lane's worktree>` instead of the enrichment note. That is a property of running the test with its cwd inside a lane worktree nested under the umbrella's own `.kin` store, a condition of this shared box, and nothing in this diff touches store binding. A hosted runner checks out a plain tree with no parent store. If hosted CI disagrees, that is one more push.

Lane report: `.kin-coord/reports/bump070-20260905.md` in the umbrella workspace.
