### PR TITLE
Cover relations in the durability block

### DIFF
--- a/crates/kin-cli/tests/live_graph_durability_disclosure.rs
+++ b/crates/kin-cli/tests/live_graph_durability_disclosure.rs
@@ -1136,12 +1136,17 @@ fn a_file_written_while_no_daemon_watched_is_admitted_by_the_next_one() {
         "the disclosure has to say what it means for an answer: {behind}"
     );
     let durability = durability(&locate);
-    assert!(
-        !durability["note"]
-            .as_str()
-            .is_some_and(|note| note.contains("records everything answering here")),
+    assert_ne!(
+        durability["state"],
+        serde_json::json!("recorded"),
         "durability may not report an all-clear over a repository holding an unadmitted \
          module: {durability}"
+    );
+    assert!(
+        durability["note"]
+            .as_str()
+            .is_some_and(|note| note.contains("covers admitted content only")),
+        "the durability note has to say the reading is qualified: {durability}"
     );
 
     second.stop();

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -841,6 +841,19 @@ pub struct HealthResponse {
     /// means the live graph is entirely uncommitted.
     #[serde(default)]
     pub durable_entity_count: Option<u64>,
+    /// Relations in the live query graph.
+    ///
+    /// The half the entity pair above could not answer. A store whose entity
+    /// counts were level published an all-clear over 3,438 relations a
+    /// language-server sweep had written into the live graph and no commit
+    /// carried, because nothing on this endpoint counted them (FIR-3202).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub graph_relation_count: Option<usize>,
+    /// Relations durable repository authority carried at the same levelling as
+    /// `durable_entity_count`. Absent, never zero, when this daemon has never
+    /// levelled.
+    #[serde(default)]
+    pub durable_relation_count: Option<u64>,
     pub graph_loaded: bool,
     pub reconciliation_status: String,
     pub repo_id: String,
@@ -2861,6 +2874,11 @@ async fn mcp_graph_status_with_stable_authority(
                     // open and at commit, and neither can run while this fence
                     // is held.
                     durable_entity_count: state.durable_entity_count(),
+                    // The relation half, under that same fence and levelled at
+                    // those same two moments. Without it the block built from
+                    // this observation certifies an entity layer and says
+                    // nothing about the edges answering beside it (FIR-3202).
+                    durable_relation_count: state.durable_relation_count(),
                 }
             }),
             Err(std::sync::TryLockError::WouldBlock) => None,
@@ -3772,6 +3790,10 @@ async fn health(
     let uptime_seconds = state.started_at.elapsed().as_secs();
     let graph = Arc::clone(&state.graph);
     let entity_count = graph.entity_count();
+    // Read off the same graph handle at the same instant as the entity count,
+    // so the pair a caller subtracts against the durable readings below
+    // describes one graph rather than two.
+    let relation_count = graph.relation_count();
     let graph_loaded = entity_count > 0;
     let external_session_count = state
         .coordinator
@@ -3871,6 +3893,8 @@ async fn health(
         uptime_seconds,
         graph_entity_count: Some(entity_count),
         durable_entity_count: state.durable_entity_count(),
+        graph_relation_count: Some(relation_count),
+        durable_relation_count: state.durable_relation_count(),
         graph_loaded,
         reconciliation_status: state.reconciliation_status_str().to_string(),
         repo_id: primary_repo_id(&state),
@@ -6568,6 +6592,10 @@ fn command_commit_after_admission(
     // live graph rather than from the plan, because a plan's `entity_count` is
     // the size of its delta and this is the size of the whole.
     state.record_durable_entity_count(graph.entity_count() as u64);
+    // The relation half of the same levelling, from the same live graph at the
+    // same instant. Recording one counter and not the other would publish a
+    // difference no observation produced (FIR-3202).
+    state.record_durable_relation_count(graph.relation_count() as u64);
     // The relation set just moved and the change is installed, so this is the
     // baseline the next `kin graph status` compares against. Recorded after the
     // install rather than from the plan, for the reason the entity count above
@@ -8460,6 +8488,11 @@ async fn measure_untracked_host_content(state: &Arc<DaemonState>) {
 async fn daemon_health_snapshot(state: &Arc<DaemonState>) -> serde_json::Value {
     measure_untracked_host_content(state).await;
     let entity_count = state.graph.entity_count();
+    // Both live counts off one graph handle before anything else runs, so the
+    // envelope's durability block subtracts a pair from one instant. The
+    // relation half is what makes that block cover the whole graph rather than
+    // the entity layer alone (FIR-3202).
+    let relation_count = state.graph.relation_count();
     serde_json::json!({
         "initialized": state
             .is_initialized
@@ -8467,6 +8500,8 @@ async fn daemon_health_snapshot(state: &Arc<DaemonState>) -> serde_json::Value {
         "graph_loaded": entity_count > 0,
         "graph_entity_count": entity_count as u64,
         "durable_entity_count": state.durable_entity_count(),
+        "graph_relation_count": relation_count as u64,
+        "durable_relation_count": state.durable_relation_count(),
         "graph_generation": state
             .snapshot_generation
             .load(std::sync::atomic::Ordering::Relaxed),
@@ -39085,6 +39120,203 @@ mod tests {
         assert_eq!(
             authority.graph.relation_count(),
             state.graph.relation_count()
+        );
+    }
+
+    /// One committed relation over two committed entities, so both durability
+    /// axes are level with authority through the real MCP transaction path,
+    /// which is the levelling `finalize_committed_transaction` records.
+    async fn state_levelled_by_a_relation_commit() -> (Arc<DaemonState>, Entity, Entity) {
+        let state = test_state();
+        let mut caller = test_entity("caller", "src/lib.rs");
+        caller.file_origin = None;
+        caller.span = None;
+        let mut callee = test_entity("callee", "src/lib.rs");
+        callee.file_origin = None;
+        callee.span = None;
+        install_repository_entities(&state, vec![caller.clone(), callee.clone()]);
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let session_id = mcp_test_session(&state);
+
+        let begin = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_transaction_begin",
+            serde_json::json!({ "session_id": session_id, "scope": "file:src/lib.rs" }),
+        )
+        .await;
+        let begin_json: serde_json::Value = serde_json::from_str(&mcp_result_text(&begin)).unwrap();
+        let tx_id = begin_json["transaction_id"].as_str().unwrap().to_string();
+        let _stage = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_transaction_stage",
+            serde_json::json!({
+                "transaction_id": tx_id,
+                "operations": [{
+                    "verb": "add",
+                    "target": "",
+                    "payload": { "Relation": {
+                        "from": caller.id, "to": callee.id, "kind": RelationKind::Calls }},
+                    "description": ""
+                }]
+            }),
+        )
+        .await;
+        let commit = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_transaction_commit",
+            serde_json::json!({ "transaction_id": tx_id }),
+        )
+        .await;
+        assert_ne!(
+            commit.is_error,
+            Some(true),
+            "commit failed: {}",
+            mcp_result_text(&commit)
+        );
+        (state, caller, callee)
+    }
+
+    /// The durability block every daemon-built envelope is decorated from,
+    /// read off the production health snapshot rather than a hand-built body.
+    async fn durability_block(state: &Arc<DaemonState>) -> kin_mcp::envelope::Durability {
+        kin_mcp::Envelope::daemon()
+            .with_health(&daemon_health_snapshot(state).await)
+            .durability
+            .expect("a daemon that counted its graph carries a durability block")
+    }
+
+    /// FIR-3202. The stranger's shape, driven through the sweep's own write
+    /// path: entities level with authority, then a language-server enrichment
+    /// pass installs a relation into the live graph and commits nothing.
+    ///
+    /// Before the fix this block read `recorded`, `live_only_entities: 0` and
+    /// "2 entities, 0 uncommitted; durable repository authority records
+    /// everything answering here" both before and after the sweep, byte for
+    /// byte, while the live relation count went from 1 to 2. On the brown arm
+    /// the same block said the same sentence over 3,438 swept relations.
+    #[tokio::test]
+    async fn a_relation_the_sweep_wrote_and_no_commit_carries_is_reported_uncommitted() {
+        let (state, caller, callee) = state_levelled_by_a_relation_commit().await;
+        let relations_before = state.graph.relation_count();
+
+        let published = crate::daemon::install_lsp_relations(
+            &state,
+            &[kin_model::Relation {
+                id: kin_model::RelationId::new(),
+                kind: RelationKind::References,
+                src: kin_model::GraphNodeId::Entity(caller.id),
+                dst: kin_model::GraphNodeId::Entity(callee.id),
+                confidence: 1.0,
+                origin: kin_model::RelationOrigin::Lsp,
+                created_in: None,
+                import_source: None,
+                evidence: Vec::new(),
+            }],
+        );
+        assert_eq!(
+            state.graph.relation_count(),
+            relations_before + 1,
+            "the fixture has to put a relation in the live graph, or it measures nothing: {published:?}"
+        );
+
+        let block = durability_block(&state).await;
+        assert_eq!(
+            block.live_only_relations,
+            Some(1),
+            "the swept relation belongs to no committed change and the count has to say so: {}",
+            block.note
+        );
+        assert_eq!(
+            block.live_only_entities,
+            Some(0),
+            "no entity moved, and the entity axis must not borrow the relation reading: {}",
+            block.note
+        );
+        assert_eq!(block.state, "live_uncommitted", "{}", block.note);
+        assert!(
+            block
+                .note
+                .contains("0 entities and 1 relations are uncommitted"),
+            "the note states the uncommitted count of each: {}",
+            block.note
+        );
+        assert!(
+            !block.note.contains("everything"),
+            "no sentence over one axis may claim the whole graph: {}",
+            block.note
+        );
+    }
+
+    /// The control. Right after a commit that captured every live relation, the
+    /// same block reads level on both axes, so the disclosure above is a
+    /// reading and not a fixture that always fires.
+    #[tokio::test]
+    async fn a_commit_that_carries_every_live_relation_reads_recorded_on_both_axes() {
+        let (state, _caller, _callee) = state_levelled_by_a_relation_commit().await;
+        assert!(
+            state.graph.relation_count() > 0,
+            "the control has to hold a relation, or a zero here proves nothing"
+        );
+
+        let block = durability_block(&state).await;
+        assert_eq!(block.state, "recorded", "{}", block.note);
+        assert_eq!(block.live_only_entities, Some(0), "{}", block.note);
+        assert_eq!(block.live_only_relations, Some(0), "{}", block.note);
+        assert_eq!(
+            block.live_relations,
+            Some(state.graph.relation_count() as u64)
+        );
+        assert_eq!(block.durable_relations, block.live_relations);
+    }
+
+    /// The same two readings on the graph-status path, which samples its own
+    /// counters under the embedding fence rather than reading `/health`.
+    #[tokio::test]
+    async fn graph_status_carries_the_durable_relation_count_beside_the_live_one() {
+        let (state, caller, callee) = state_levelled_by_a_relation_commit().await;
+        let level = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_graph_status",
+            serde_json::json!({}),
+        )
+        .await;
+        let level: serde_json::Value = serde_json::from_str(&mcp_result_text(&level)).unwrap();
+        assert_eq!(
+            level["durable_relation_count"], level["relation_count"],
+            "level after the commit: {level}"
+        );
+
+        crate::daemon::install_lsp_relations(
+            &state,
+            &[kin_model::Relation {
+                id: kin_model::RelationId::new(),
+                kind: RelationKind::UsesType,
+                src: kin_model::GraphNodeId::Entity(caller.id),
+                dst: kin_model::GraphNodeId::Entity(callee.id),
+                confidence: 1.0,
+                origin: kin_model::RelationOrigin::Lsp,
+                created_in: None,
+                import_source: None,
+                evidence: Vec::new(),
+            }],
+        );
+        let swept = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_graph_status",
+            serde_json::json!({}),
+        )
+        .await;
+        let swept: serde_json::Value = serde_json::from_str(&mcp_result_text(&swept)).unwrap();
+        assert_eq!(
+            swept["relation_count"].as_u64(),
+            level["relation_count"].as_u64().map(|count| count + 1),
+            "the sweep moved the live count: {swept}"
+        );
+        assert_eq!(
+            swept["durable_relation_count"], level["durable_relation_count"],
+            "nothing levelled, so the durable count must not move: {swept}"
         );
     }
 

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -3469,7 +3469,7 @@ const ENRICHMENT_WRITE_BATCH: usize = 256;
 /// the graph is the truth being written to, and it is the only surface that can
 /// separate "never written" from "written, then a later step failed".
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-struct EnrichmentWrite {
+pub(crate) struct EnrichmentWrite {
     /// Relations the graph holds afterwards, counted from the graph.
     published: usize,
     /// Relations this write was asked to publish.
@@ -3647,7 +3647,7 @@ fn held_relation_ids(
     held
 }
 
-fn install_lsp_relations(
+pub(crate) fn install_lsp_relations(
     state: &DaemonState,
     relations: &[kin_model::Relation],
 ) -> EnrichmentWrite {

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -2416,6 +2416,12 @@ fn finalize_committed_transaction(
     // that this commit did not publish, and reading the live count here would
     // record those as durable.
     state.record_durable_entity_count(authority.graph.entity_count() as u64);
+    // The relation half, from the authority graph for the reason the entity
+    // count is taken from it: an ambient admission or an enrichment sweep may
+    // already have added relations to the live graph that this commit did not
+    // publish, and reading the live count here would record those as durable
+    // (FIR-3202).
+    state.record_durable_relation_count(authority.graph.relation_count() as u64);
     let layouts = timed_finalize_step("rebuild_changed_layouts", || {
         if planned_layouts.is_empty() && committed.file_count > 0 {
             rebuild_changed_layouts(state, &authority, &committed.change)

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -2730,6 +2730,20 @@ pub struct DaemonState {
     /// `u64::MAX` rather than an `Option` so the sentinel and the counter share
     /// one atomic read; [`Self::durable_entity_count`] is the only reader.
     durable_entity_count: AtomicU64,
+    /// Relations durable repository authority carried at that same levelling,
+    /// or `u64::MAX` when this daemon never levelled (FIR-3202).
+    ///
+    /// The counter above answers half the question. A language-server
+    /// enrichment sweep writes its relations into the live graph with
+    /// `upsert_relation` and records nothing, exactly as ambient admission does
+    /// for entities, so a store whose entity counts were level served
+    /// `861 entities, 0 uncommitted; durable repository authority records
+    /// everything answering here` while 3,438 swept relations answered every
+    /// query and no committed change carried any of them. Recorded at the same
+    /// two moments and read under the same fences as the entity count, because
+    /// two counters levelled at different instants would publish a difference
+    /// nobody observed.
+    durable_relation_count: AtomicU64,
     pub blobs: Arc<BlobStore>,
     /// Why the derived ingestion CAS could not be hydrated from graph
     /// Why a persisted local or hosted vector artifact was not installed when
@@ -5146,6 +5160,9 @@ impl DaemonState {
         // Baseline for the shutdown anti-wipe guard: the entity count loaded
         // from the on-disk snapshot. Read before `graph` is moved into the state.
         let loaded_entity_count = graph.entity_count();
+        // The relation half of the durability baseline, read from the same
+        // snapshot at the same instant so the two describe one graph.
+        let loaded_relation_count = graph.relation_count();
 
         let coordination_events = CoordinationEventLog::open(&layout, &cached_repo_id)?;
         let coordination_event_persist_failures = coordination_events.persisted_failure_count();
@@ -5262,6 +5279,7 @@ impl DaemonState {
             cached_workspace_id: Some(workspace_id),
             is_shutdown: AtomicBool::new(false),
             durable_entity_count: AtomicU64::new(loaded_entity_count as u64),
+            durable_relation_count: AtomicU64::new(loaded_relation_count as u64),
             persisted_entity_count: AtomicU64::new(loaded_entity_count as u64),
             mass_deletion_blocked: AtomicBool::new(false),
             retired_graph_only_members: Default::default(),
@@ -5502,8 +5520,10 @@ impl DaemonState {
         let persisted_vfs_version = Self::load_persisted_vfs_version(&layout);
 
         // Baseline for the shutdown anti-wipe guard (entity count loaded from
-        // the backend snapshot).
+        // the backend snapshot), and beside it the relation count from the same
+        // snapshot at the same instant.
         let loaded_entity_count = graph.entity_count();
+        let loaded_relation_count = graph.relation_count();
         let spine_disabled = Self::spine_disabled_from_env();
 
         let coordination_events = CoordinationEventLog::open(&layout, repo_id)?;
@@ -5621,6 +5641,7 @@ impl DaemonState {
             cached_workspace_id: None,
             is_shutdown: AtomicBool::new(false),
             durable_entity_count: AtomicU64::new(loaded_entity_count as u64),
+            durable_relation_count: AtomicU64::new(loaded_relation_count as u64),
             persisted_entity_count: AtomicU64::new(loaded_entity_count as u64),
             mass_deletion_blocked: AtomicBool::new(false),
             retired_graph_only_members: Default::default(),
@@ -10678,6 +10699,32 @@ impl DaemonState {
         // clamping is the only way a real store could ever be read as "never
         // levelled". A repository with `u64::MAX` entities does not exist.
         self.durable_entity_count
+            .store(count.min(u64::MAX - 1), Ordering::Relaxed);
+    }
+
+    /// How many relations durable repository authority carried at that same
+    /// levelling, or `None` when this daemon never levelled (FIR-3202).
+    ///
+    /// `None` is a real answer here for the reason it is for entities: a daemon
+    /// that never levelled cannot say how much of its live relation set is
+    /// recorded, and zero would report all of it as uncommitted.
+    pub fn durable_relation_count(&self) -> Option<u64> {
+        match self.durable_relation_count.load(Ordering::Relaxed) {
+            u64::MAX => None,
+            count => Some(count),
+        }
+    }
+
+    /// Record that the live query graph now carries every relation durable
+    /// authority carries, and how many that is.
+    ///
+    /// Called from the same two levelling paths as
+    /// [`Self::record_durable_entity_count`] and from nowhere else. A path that
+    /// levels one counter and not the other publishes a difference no
+    /// observation produced, which is the shape of wrong answer the block this
+    /// feeds exists to refuse.
+    pub fn record_durable_relation_count(&self, count: u64) {
+        self.durable_relation_count
             .store(count.min(u64::MAX - 1), Ordering::Relaxed);
     }
 

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -524,15 +524,34 @@ const DURABILITY_UNKNOWN: &str = "unknown";
 /// work was in the graph and never committed. The entities went with the
 /// daemon; the payloads it read were all true and all silent about it.
 ///
-/// Nothing here is fabricated. `live_only_entities` is a difference between two
-/// counts the daemon observed, and when the two cannot be reconciled the state
-/// is `unknown` with no count rather than a number the reader would act on.
+/// Nothing here is fabricated. Each `live_only_*` field is a difference between
+/// two counts the daemon observed, and when either pair cannot be reconciled the
+/// state is `unknown` with no differences at all rather than numbers the reader
+/// would act on.
+///
+/// It counts relations beside entities because counting entities alone
+/// published a false all-clear over a graph half of which was uncommitted
+/// (FIR-3202). A language-server enrichment sweep writes relations straight into
+/// the live query graph and records nothing durable, exactly as continuous host
+/// admission does for entities, so a store whose entity counts were level
+/// reported `861 entities, 0 uncommitted; durable repository authority records
+/// everything answering here` while 3,438 swept relations answered every query
+/// and belonged to no committed change; an unrelated one-line docstring commit
+/// later folded them in as `entities=0 relations=3438`. Every count in that
+/// block was right. The scope was not: it covered one of the two things a graph
+/// is made of, and its note claimed both.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Durability {
-    /// `recorded` when durable authority carries every entity the selected
-    /// graph holds, `live_uncommitted` when it carries fewer, `unknown` when
-    /// the daemon reported no durable observation or the two counts cannot be
+    /// `recorded` when durable authority carries every entity AND every relation
+    /// the selected graph holds, `live_uncommitted` when it carries fewer of
+    /// either, `unknown` when the daemon reported no durable observation for one
+    /// of them, reported no relation reading at all, or either pair cannot be
     /// reconciled.
+    ///
+    /// One word over two readings, the most pessimistic winning, for the reason
+    /// [`crate::verdict::Verdict`] carries one verdict over its inputs: two
+    /// state words that can disagree is two answers to one question, and which
+    /// one a caller acts on becomes a matter of which key it happened to read.
     pub state: String,
     /// Entities in the live query graph that answered this call.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -546,8 +565,159 @@ pub struct Durability {
     /// that this number could not be derived.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub live_only_entities: Option<u64>,
+    /// Relations in the live query graph that answered this call.
+    ///
+    /// Absent when the runtime reported no relation reading, which is not zero.
+    /// A store holding no relations and a runtime that never counted them are
+    /// different answers, and only the first of them can be certified.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub live_relations: Option<u64>,
+    /// Relations durable repository authority carried when this daemon last
+    /// levelled its query graph with authority.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub durable_relations: Option<u64>,
+    /// How many of `live_relations` no committed change carries. Absent under
+    /// the same rule as `live_only_entities` above, and for the same reason.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub live_only_relations: Option<u64>,
     /// One line an agent can act on without reading the counts.
     pub note: String,
+}
+
+/// The four readings [`Durability::observe`] reduces to one state.
+///
+/// A struct rather than four positional arguments. Two of them are
+/// `Option<u64>` and all four are counts of two different things, so a caller
+/// that transposed a pair would publish a durable relation count as a durable
+/// entity count and nothing in the type system would catch it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct DurabilityCounts {
+    /// Entities in the live query graph that answered this call.
+    pub live_entities: u64,
+    /// Entities durable authority carried at the last levelling, or `None` when
+    /// this daemon has never levelled. `None` is not zero.
+    pub durable_entities: Option<u64>,
+    /// Relations in the live query graph, or `None` when the runtime reported no
+    /// relation reading at all. `None` is not zero.
+    pub live_relations: Option<u64>,
+    /// Relations durable authority carried at the last levelling, or `None` on
+    /// the same rule as `durable_entities`.
+    pub durable_relations: Option<u64>,
+}
+
+/// One count pair's reading, before the two pairs are reduced to one state.
+///
+/// Five readings and not three, because the two that cannot yield a number
+/// arrive for different reasons and send a reader to different levers: a daemon
+/// that never levelled needs `kin status`, and a live graph below durable
+/// authority is a store that lost edges.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Axis {
+    /// Durable authority carries exactly what the live graph holds.
+    Level,
+    /// Durable authority carries fewer, by this many.
+    Uncommitted(u64),
+    /// This daemon has never levelled this axis with durable authority.
+    Unlevelled,
+    /// Durable authority carries MORE than the live graph holds, so the
+    /// difference is not a count of uncommitted work and `recorded` here would
+    /// be the false all-clear this object exists to prevent.
+    Unreconciled { live: u64, durable: u64 },
+    /// Nothing measured this axis at all.
+    Unobserved,
+}
+
+impl Axis {
+    fn observe(live: Option<u64>, durable: Option<u64>) -> Self {
+        let Some(live) = live else {
+            return Self::Unobserved;
+        };
+        let Some(durable) = durable else {
+            return Self::Unlevelled;
+        };
+        if durable > live {
+            return Self::Unreconciled { live, durable };
+        }
+        match live - durable {
+            0 => Self::Level,
+            live_only => Self::Uncommitted(live_only),
+        }
+    }
+
+    /// The difference, or `None` when this reading cannot yield one.
+    fn live_only(self) -> Option<u64> {
+        match self {
+            Self::Level => Some(0),
+            Self::Uncommitted(live_only) => Some(live_only),
+            Self::Unlevelled | Self::Unreconciled { .. } | Self::Unobserved => None,
+        }
+    }
+
+    /// This axis's clause in an `unknown` note: its count when it has one, and
+    /// otherwise why it does not.
+    ///
+    /// The axis that DID reconcile still states its number. A reader told only
+    /// that the relations could not be read loses the entity reading that was
+    /// fine, and a reader told only that the entity reading is fine has been
+    /// handed the all-clear this object exists to refuse.
+    fn clause(self, subject: &str) -> String {
+        match self {
+            Self::Level => format!("0 of the {subject} are uncommitted"),
+            Self::Uncommitted(live_only) => {
+                format!("{live_only} of the {subject} are uncommitted")
+            }
+            Self::Unlevelled => format!(
+                "how many of the {subject} are uncommitted is unknown, because this daemon has \
+                 not levelled its query graph with durable repository authority"
+            ),
+            Self::Unreconciled { live, durable } => format!(
+                "how many of the {subject} are uncommitted is unknown, because durable authority \
+                 carries {durable} of them and the live graph holds only {live}"
+            ),
+            Self::Unobserved => format!(
+                "how many {subject} are uncommitted is unknown, because nothing measured them"
+            ),
+        }
+    }
+}
+
+/// What answered, as the lead clause of every note this object writes.
+///
+/// Always both counts, because the note has to state the scope it is about to
+/// make a claim over. The block that named only its entity count is the one that
+/// claimed "everything answering here" over a graph whose relations it had never
+/// read.
+fn live_lead(live_entities: Option<u64>, live_relations: Option<u64>) -> String {
+    match (live_entities, live_relations) {
+        (Some(entities), Some(relations)) => {
+            format!("{entities} entities and {relations} relations answered here")
+        }
+        (Some(entities), None) => {
+            format!("{entities} entities answered here and no relation reading reached this answer")
+        }
+        (None, Some(relations)) => {
+            format!("{relations} relations answered here and no entity reading reached this answer")
+        }
+        (None, None) => "this graph answered".to_string(),
+    }
+}
+
+/// Why an observation could not be reduced to numbers, one clause per axis.
+///
+/// The two axes are joined rather than one winning, and the one case that is
+/// written out whole is both axes unlevelled, because there the clauses are the
+/// same sentence twice and a reader skims a note that repeats itself.
+fn unknown_cause(entities: Axis, relations: Axis) -> String {
+    if entities == Axis::Unlevelled && relations == Axis::Unlevelled {
+        return "how many of the entities and relations are uncommitted is unknown, because this \
+                daemon has not levelled its query graph with durable repository authority"
+            .to_string();
+    }
+    format!(
+        "{}, and {}",
+        entities.clause("entities"),
+        relations.clause("relations")
+    )
 }
 
 /// How far graph truth is behind the working copy this daemon watches.
@@ -842,66 +1012,79 @@ impl GraphFreshness {
 }
 
 impl Durability {
-    /// Derive the durability state from the two counts the daemon observed.
+    /// Derive the durability state from the counts the daemon observed.
     ///
-    /// `durable` is `None` when the daemon has never levelled its query graph
-    /// with durable authority and therefore has nothing to report; that is
-    /// `unknown`, not zero. A durable count ABOVE the live count is also
-    /// `unknown`: the live graph has dropped entities authority still carries,
-    /// so the difference is not a count of uncommitted work and reporting
-    /// `recorded` there would be the false all-clear this object exists to
-    /// prevent.
-    pub fn observe(live: u64, durable: Option<u64>) -> Self {
-        let Some(durable) = durable else {
+    /// Two pairs, one state, and the pessimistic reading wins. A `None` durable
+    /// count is a daemon that has never levelled that axis and therefore has
+    /// nothing to report; that is `unknown`, not zero. A durable count ABOVE the
+    /// live one is also `unknown`: the live graph has dropped objects authority
+    /// still carries, so the difference is not a count of uncommitted work and
+    /// reporting `recorded` there would be the false all-clear this object
+    /// exists to prevent. An absent live RELATION count is `unknown` too, and
+    /// that is the FIR-3202 rule stated as code: an answer that never counted
+    /// the relations cannot certify that they are recorded, and reading its
+    /// silence as an all-clear is exactly what the entity-only block did.
+    ///
+    /// Neither `live_only_*` field survives `unknown`. Both go, not just the one
+    /// whose pair failed, because `state` is the field a caller branches on and
+    /// FIR-2820 is the record of what happens when a withdrawn claim leaves a
+    /// number standing beside it. The four raw counts stay on the wire, so a
+    /// reader loses nothing it could not subtract for itself.
+    pub fn observe(counts: DurabilityCounts) -> Self {
+        let entities = Axis::observe(Some(counts.live_entities), counts.durable_entities);
+        let relations = Axis::observe(counts.live_relations, counts.durable_relations);
+        let lead = live_lead(Some(counts.live_entities), counts.live_relations);
+        let (Some(live_only_entities), Some(live_only_relations)) =
+            (entities.live_only(), relations.live_only())
+        else {
             return Self {
                 state: DURABILITY_UNKNOWN.to_string(),
-                live_entities: Some(live),
-                durable_entities: None,
+                live_entities: Some(counts.live_entities),
+                durable_entities: counts.durable_entities,
                 live_only_entities: None,
-                note: "This daemon has not levelled its query graph with durable repository \
-                       authority, so whether these entities are recorded is unknown. Run `kin \
-                       status` to read durable authority directly."
-                    .to_string(),
-            };
-        };
-        if durable > live {
-            return Self {
-                state: DURABILITY_UNKNOWN.to_string(),
-                live_entities: Some(live),
-                durable_entities: Some(durable),
-                live_only_entities: None,
+                live_relations: counts.live_relations,
+                durable_relations: counts.durable_relations,
+                live_only_relations: None,
                 note: format!(
-                    "The live query graph holds {live} entities and durable authority carries \
-                     {durable}, so this answer cannot say how much of it is recorded. Run `kin \
-                     status` to read durable authority directly."
+                    "{lead}; {}. Run `kin status` to read durable authority directly.",
+                    unknown_cause(entities, relations)
                 ),
             };
-        }
-        let live_only = live - durable;
-        if live_only == 0 {
+        };
+        if live_only_entities == 0 && live_only_relations == 0 {
             return Self {
                 state: DURABILITY_RECORDED.to_string(),
-                live_entities: Some(live),
-                durable_entities: Some(durable),
+                live_entities: Some(counts.live_entities),
+                durable_entities: counts.durable_entities,
                 live_only_entities: Some(0),
+                live_relations: counts.live_relations,
+                durable_relations: counts.durable_relations,
+                live_only_relations: Some(0),
+                // Not "everything". The claim names the two things this block
+                // counted, because the sentence it replaces made a whole-graph
+                // promise out of a one-axis reading.
                 note: format!(
-                    "{live} entities, 0 uncommitted; durable repository authority records \
-                     everything answering here."
+                    "{lead}; 0 entities and 0 relations are uncommitted, and durable repository \
+                     authority records every entity and relation answering here."
                 ),
             };
         }
         Self {
             state: DURABILITY_LIVE_UNCOMMITTED.to_string(),
-            live_entities: Some(live),
-            durable_entities: Some(durable),
-            live_only_entities: Some(live_only),
+            live_entities: Some(counts.live_entities),
+            durable_entities: counts.durable_entities,
+            live_only_entities: Some(live_only_entities),
+            live_relations: counts.live_relations,
+            durable_relations: counts.durable_relations,
+            live_only_relations: Some(live_only_relations),
             note: format!(
-                "{live} entities, {live_only} uncommitted; {} is recorded yet, and the \
-                 uncommitted work is lost when this daemon exits. Commit to record it.",
-                if durable == 0 {
-                    "nothing you wrote"
+                "{lead}; {live_only_entities} entities and {live_only_relations} relations are \
+                 uncommitted, and {} recorded yet. The uncommitted work is lost when this daemon \
+                 exits. Commit to record it.",
+                if counts.durable_entities == Some(0) && counts.durable_relations == Some(0) {
+                    "nothing you wrote is"
                 } else {
-                    "not all of what you wrote"
+                    "not all of what you wrote is"
                 }
             ),
         }
@@ -909,9 +1092,10 @@ impl Durability {
 
     /// Restate this reading over a store the working copy has outrun.
     ///
-    /// [`Self::observe`] compares two ENTITY counts, so it answers a question
-    /// about what a commit carries and is structurally unable to see a file no
-    /// admission has taken. A store holding unadmitted host paths therefore
+    /// [`Self::observe`] compares counts the graph already holds, so it answers
+    /// a question about what a commit carries and is structurally unable to see
+    /// a file no admission has taken. A store holding unadmitted host paths
+    /// therefore
     /// reached `recorded` and said "durable repository authority records
     /// everything answering here" over a repository holding a 140-line module
     /// the graph had never met (FIR-2499). The counts are left exactly as
@@ -934,10 +1118,7 @@ impl Durability {
     /// one clause before the note explained that no such number was derivable.
     /// The lead now states the live count, which is a fact, and nothing else.
     pub fn qualified_by(mut self, behind: &GraphBehind) -> Self {
-        let counts = match self.live_entities {
-            Some(live) => format!("{live} entities answered here"),
-            None => "this graph answered".to_string(),
-        };
+        let counts = live_lead(self.live_entities, self.live_relations);
         // Two readings and two sentences, for the same reason the limiting
         // factor carries two: a measured count and no measurement at all send a
         // reader to different levers, and one of them is `kin admit`.
@@ -957,7 +1138,12 @@ impl Durability {
             )
         };
         self.state = DURABILITY_UNKNOWN.to_string();
+        // Both differences, for the reason the state is one word: a withdrawn
+        // claim that leaves a number standing beside it is the FIR-2820 failure,
+        // and there is nothing about a relation count that makes it the
+        // exception.
         self.live_only_entities = None;
+        self.live_only_relations = None;
         self
     }
 
@@ -1825,16 +2011,17 @@ impl Envelope {
     /// its own entity and embedding observations here. Fields that only
     /// `/health` knows stay absent rather than being borrowed from HEAD.
     ///
-    /// `durable_entity_count` is the one durable reading graph status carries
-    /// itself, because the question it answers is about the selected graph and
-    /// not about HEAD. `None` reaches [`Durability::observe`] as `unknown`.
+    /// `counts` carries the durable readings graph status supplies itself,
+    /// because the question they answer is about the selected graph and not
+    /// about HEAD. A `None` in either durable field reaches
+    /// [`Durability::observe`] as `unknown`, and so does an unread relation
+    /// count.
     pub fn with_selected_graph_observation(
         mut self,
-        entity_count: u64,
+        counts: DurabilityCounts,
         embeddings_indexed: u64,
         embeddings_pending: u64,
         embeddings_total: u64,
-        durable_entity_count: Option<u64>,
     ) -> Self {
         let complete = embeddings_pending == 0 && embeddings_indexed == embeddings_total;
         self.runtime = Runtime::RepoDaemon;
@@ -1860,7 +2047,7 @@ impl Envelope {
             graph_body_gap_paths: None,
         });
         self.graph_as_of = None;
-        let durability = Durability::observe(entity_count, durable_entity_count);
+        let durability = Durability::observe(counts);
         // Requalified rather than replaced. This runs on the graph-status path,
         // which may set durability after `with_health` has already read the
         // reconcile block, and a plain assignment there would restore the
@@ -1870,7 +2057,7 @@ impl Envelope {
             None => durability,
         });
         self.graph_state = GraphState {
-            entity_count: Some(entity_count),
+            entity_count: Some(counts.live_entities),
             ..GraphState::default()
         };
         // The selected report replaces HEAD-scoped health observations, but it
@@ -2137,17 +2324,26 @@ impl Envelope {
         if let Some(value) = health.get("initialized").and_then(Value::as_bool) {
             self.graph_state.initialized = Some(value);
         }
-        // Derived from the pair rather than reported by the daemon, because the
+        // Derived from the pairs rather than reported by the daemon, because the
         // live count is the one this envelope already carries and deriving it
-        // here keeps the two numbers from describing different instants. A
-        // daemon that reports no live count has nothing to compare against, so
+        // here keeps the numbers from describing different instants. A daemon
+        // that reports no live entity count has nothing to compare against, so
         // the object stays absent instead of asserting `unknown` about a graph
         // it never measured.
+        //
+        // The relation counts are read straight off the body rather than kept in
+        // `graph_state`, which is a HEAD entity observation and has no relation
+        // field. A body that carries neither leaves both `None`, which
+        // [`Durability::observe`] reads as `unknown` rather than as zero: a
+        // daemon too old to publish a relation count is a daemon this answer
+        // cannot certify (FIR-3202).
         if let Some(live) = self.graph_state.entity_count {
-            self.durability = Some(Durability::observe(
-                live,
-                health.get("durable_entity_count").and_then(Value::as_u64),
-            ));
+            self.durability = Some(Durability::observe(DurabilityCounts {
+                live_entities: live,
+                durable_entities: health.get("durable_entity_count").and_then(Value::as_u64),
+                live_relations: health.get("graph_relation_count").and_then(Value::as_u64),
+                durable_relations: health.get("durable_relation_count").and_then(Value::as_u64),
+            }));
         }
         // Read after the counts, and applied to them. The reconcile block is
         // the only place a response can learn that the host holds content the
@@ -2927,8 +3123,19 @@ mod tests {
         }
     }
 
-    /// The four states a durability observation can be in, including the two
-    /// that must refuse to name a number.
+    /// A level pair on both axes, for the tests below whose subject is
+    /// something other than durability.
+    fn level_counts(entities: u64, relations: u64) -> DurabilityCounts {
+        DurabilityCounts {
+            live_entities: entities,
+            durable_entities: Some(entities),
+            live_relations: Some(relations),
+            durable_relations: Some(relations),
+        }
+    }
+
+    /// The states a durability observation can be in, including the three that
+    /// must refuse to name a number.
     ///
     /// `durable > live` is the one worth writing down. The live graph has
     /// dropped entities authority still carries, so the difference is not a
@@ -2938,42 +3145,175 @@ mod tests {
     /// while authority still holds them.
     #[test]
     fn durability_names_a_count_only_when_the_two_counts_can_be_reconciled() {
-        let uncommitted = Durability::observe(14, Some(0));
+        let uncommitted = Durability::observe(DurabilityCounts {
+            live_entities: 14,
+            durable_entities: Some(0),
+            live_relations: Some(20),
+            durable_relations: Some(0),
+        });
         assert_eq!(uncommitted.state, "live_uncommitted");
         assert_eq!(uncommitted.live_only_entities, Some(14));
+        assert_eq!(uncommitted.live_only_relations, Some(20));
         assert!(
-            uncommitted.note.contains("14 entities, 14 uncommitted")
-                && uncommitted.note.contains("nothing you wrote"),
+            uncommitted
+                .note
+                .contains("14 entities and 20 relations are uncommitted")
+                && uncommitted.note.contains("nothing you wrote is"),
             "an empty durable authority means none of it is recorded: {}",
             uncommitted.note
         );
 
-        let partly = Durability::observe(14, Some(9));
+        let partly = Durability::observe(DurabilityCounts {
+            live_entities: 14,
+            durable_entities: Some(9),
+            live_relations: Some(20),
+            durable_relations: Some(11),
+        });
         assert_eq!(partly.state, "live_uncommitted");
         assert_eq!(partly.live_only_entities, Some(5));
+        assert_eq!(partly.live_only_relations, Some(9));
         assert!(
-            partly.note.contains("not all of what you wrote"),
+            partly.note.contains("not all of what you wrote is"),
             "a nonempty durable authority records some of it: {}",
             partly.note
         );
 
-        let recorded = Durability::observe(14, Some(14));
+        let recorded = Durability::observe(level_counts(14, 20));
         assert_eq!(recorded.state, "recorded");
         assert_eq!(recorded.live_only_entities, Some(0));
+        assert_eq!(recorded.live_only_relations, Some(0));
 
-        let unmeasured = Durability::observe(14, None);
+        let unmeasured = Durability::observe(DurabilityCounts {
+            live_entities: 14,
+            durable_entities: None,
+            live_relations: Some(20),
+            durable_relations: None,
+        });
         assert_eq!(unmeasured.state, "unknown");
         assert_eq!(
             unmeasured.live_only_entities, None,
             "an unlevelled daemon must not report 14 uncommitted entities it cannot see"
         );
+        assert_eq!(unmeasured.live_only_relations, None);
 
-        let shrunk = Durability::observe(9, Some(14));
+        let shrunk = Durability::observe(DurabilityCounts {
+            live_entities: 9,
+            durable_entities: Some(14),
+            live_relations: Some(20),
+            durable_relations: Some(20),
+        });
         assert_eq!(
             shrunk.state, "unknown",
             "a live graph below durable authority cannot be read as recorded"
         );
         assert_eq!(shrunk.live_only_entities, None);
+    }
+
+    /// FIR-3202. The stranger's shape: entities level, relations swept in and
+    /// never committed, and a block that counted only the first of the two.
+    ///
+    /// The counts are the ones the brown arm produced. What shipped over them
+    /// was `state: recorded`, `live_only_entities: 0` and a note reading
+    /// "861 entities, 0 uncommitted; durable repository authority records
+    /// everything answering here", while the 3,438 relations answering every
+    /// query belonged to no committed change.
+    #[test]
+    fn relations_a_commit_does_not_carry_are_never_read_as_recorded() {
+        let swept = Durability::observe(DurabilityCounts {
+            live_entities: 861,
+            durable_entities: Some(861),
+            live_relations: Some(3438),
+            durable_relations: Some(0),
+        });
+
+        assert_eq!(
+            swept.live_only_relations,
+            Some(3438),
+            "the count is the whole disclosure: {}",
+            swept.note
+        );
+        assert_eq!(swept.live_only_entities, Some(0));
+        assert_eq!(
+            swept.state, "live_uncommitted",
+            "a level entity count cannot certify a relation set no commit carries: {}",
+            swept.note
+        );
+        assert!(
+            swept
+                .note
+                .contains("0 entities and 3438 relations are uncommitted"),
+            "the note has to state the uncommitted count of each: {}",
+            swept.note
+        );
+        assert!(
+            !swept.note.contains("everything"),
+            "no sentence here may claim a scope this block does not cover: {}",
+            swept.note
+        );
+    }
+
+    /// The relation axis refuses on its own terms, and each refusal names what
+    /// it could not read.
+    ///
+    /// Three inputs, one per refusal, because two refusals that can both catch
+    /// one input hide each other's absence.
+    #[test]
+    fn an_unreadable_relation_axis_withdraws_the_whole_reading() {
+        let unlevelled = Durability::observe(DurabilityCounts {
+            live_entities: 12,
+            durable_entities: Some(12),
+            live_relations: Some(30),
+            durable_relations: None,
+        });
+        assert_eq!(unlevelled.state, "unknown");
+        assert_eq!(
+            unlevelled.live_only_entities, None,
+            "the state a caller branches on moved, so the number beside it goes with it"
+        );
+        assert!(
+            unlevelled
+                .note
+                .contains("has not levelled its query graph with durable repository authority"),
+            "{}",
+            unlevelled.note
+        );
+
+        // The rc0547b shape: edges gone while the entity count held. A
+        // difference is not derivable from it, and `recorded` over it is the
+        // all-clear this object exists to refuse.
+        let lost = Durability::observe(DurabilityCounts {
+            live_entities: 783,
+            durable_entities: Some(783),
+            live_relations: Some(1268),
+            durable_relations: Some(1279),
+        });
+        assert_eq!(lost.state, "unknown");
+        assert_eq!(lost.live_only_relations, None);
+        assert!(
+            lost.note
+                .contains("durable authority carries 1279 of them and the live graph holds only")
+                && lost.note.contains("0 of the entities are uncommitted"),
+            "the axis that did reconcile still states its number: {}",
+            lost.note
+        );
+
+        // A runtime that published no relation count at all. Silence is not
+        // zero, and reading it as one is the defect with the counts removed.
+        let unobserved = Durability::observe(DurabilityCounts {
+            live_entities: 12,
+            durable_entities: Some(12),
+            live_relations: None,
+            durable_relations: None,
+        });
+        assert_eq!(unobserved.state, "unknown");
+        assert_eq!(unobserved.live_relations, None);
+        assert!(
+            unobserved
+                .note
+                .contains("no relation reading reached this answer"),
+            "{}",
+            unobserved.note
+        );
     }
 
     /// The generic tool path takes its envelope from `/health`, so the fold
@@ -2983,12 +3323,15 @@ mod tests {
         let env = Envelope::daemon().with_health(&serde_json::json!({
             "graph_entity_count": 22,
             "durable_entity_count": 0,
+            "graph_relation_count": 31,
+            "durable_relation_count": 0,
         }));
         let durability = env
             .durability
             .expect("a measured live count carries durability");
         assert_eq!(durability.state, "live_uncommitted");
         assert_eq!(durability.live_only_entities, Some(22));
+        assert_eq!(durability.live_only_relations, Some(31));
 
         // A daemon that reports no durable reading is unknown, not recorded.
         let unlevelled = Envelope::daemon()
@@ -2996,6 +3339,24 @@ mod tests {
             .durability
             .expect("a measured live count carries durability");
         assert_eq!(unlevelled.state, "unknown");
+
+        // FIR-3202. A body that carries the entity pair and no relation reading
+        // is a daemon this answer cannot certify, because the relations
+        // answering beside those entities were never counted. Reading that
+        // silence as zero is the defect with the numbers taken out.
+        let entities_only = Envelope::daemon()
+            .with_health(&serde_json::json!({
+                "graph_entity_count": 22,
+                "durable_entity_count": 22,
+            }))
+            .durability
+            .expect("a measured live count carries durability");
+        assert_eq!(
+            entities_only.state, "unknown",
+            "a level entity pair is not an all-clear over unread relations: {}",
+            entities_only.note
+        );
+        assert_eq!(entities_only.live_only_entities, None);
 
         // And a runtime that measured no live count has nothing to compare, so
         // the object stays absent rather than asserting anything.
@@ -3013,6 +3374,8 @@ mod tests {
         let env = Envelope::daemon().with_health(&serde_json::json!({
             "graph_entity_count": 51,
             "durable_entity_count": 51,
+            "graph_relation_count": 51,
+            "durable_relation_count": 51,
             "reconcile": {
                 "untracked_path_count": 1,
                 "untracked_paths_sample": ["notekeeper/search.py"],
@@ -3038,7 +3401,7 @@ mod tests {
         assert!(
             !durability
                 .note
-                .contains("records everything answering here"),
+                .contains("records every entity and relation answering here"),
             "the all-clear this reading cannot make: {}",
             durability.note
         );
@@ -3078,19 +3441,21 @@ mod tests {
             .with_health(&serde_json::json!({
                 "graph_entity_count": 51,
                 "durable_entity_count": 51,
+                "graph_relation_count": 51,
+                "durable_relation_count": 51,
                 "reconcile": {
                     "untracked_path_count": 2,
                     "untracked_paths_sample": ["notekeeper/search.py"],
                     "last_admission_success_at": "2026-08-20T13:00:00Z",
                 },
             }))
-            .with_selected_graph_observation(51, 51, 0, 51, Some(51));
+            .with_selected_graph_observation(level_counts(51, 51), 51, 0, 51);
 
         let durability = env.durability.expect("graph status reports the counts");
         assert!(
             !durability
                 .note
-                .contains("records everything answering here"),
+                .contains("records every entity and relation answering here"),
             "the graph-status reading restored an all-clear over a behind store: {}",
             durability.note
         );
@@ -3132,7 +3497,7 @@ mod tests {
         });
         let env = Envelope::daemon()
             .with_working_copy_health(&health)
-            .with_selected_graph_observation(6, 6, 0, 6, Some(6));
+            .with_selected_graph_observation(level_counts(6, 6), 6, 0, 6);
 
         assert_eq!(
             env.graph_state.entity_count,
@@ -3160,7 +3525,7 @@ mod tests {
         // has to reach the same reading or the fix depends on a call sequence
         // nobody is holding still.
         let reversed = Envelope::daemon()
-            .with_selected_graph_observation(6, 6, 0, 6, Some(6))
+            .with_selected_graph_observation(level_counts(6, 6), 6, 0, 6)
             .with_working_copy_health(&health)
             .durability
             .expect("graph status reports the counts");
@@ -3181,7 +3546,7 @@ mod tests {
                     "untracked_observed_age_seconds": 0,
                 },
             }))
-            .with_selected_graph_observation(6, 6, 0, 6, Some(6));
+            .with_selected_graph_observation(level_counts(6, 6), 6, 0, 6);
 
         assert!(env.behind.is_none(), "nothing unadmitted is nothing to say");
         let durability = env.durability.expect("graph status reports the counts");
@@ -3205,6 +3570,8 @@ mod tests {
         let env = Envelope::daemon().with_health(&serde_json::json!({
             "graph_entity_count": 51,
             "durable_entity_count": 51,
+            "graph_relation_count": 51,
+            "durable_relation_count": 51,
             "reconcile": { "untracked_path_count": 0 },
         }));
 
@@ -3345,6 +3712,8 @@ mod tests {
         let env = Envelope::daemon().with_health(&serde_json::json!({
             "graph_entity_count": 51,
             "durable_entity_count": 51,
+            "graph_relation_count": 51,
+            "durable_relation_count": 51,
             "reconcile": {
                 "untracked_path_count": 0,
                 "untracked_observation_not_applicable": true,
@@ -3373,6 +3742,8 @@ mod tests {
         let env = Envelope::daemon().with_health(&serde_json::json!({
             "graph_entity_count": 6,
             "durable_entity_count": 6,
+            "graph_relation_count": 6,
+            "durable_relation_count": 6,
             "reconcile": {
                 "untracked_path_count": 1,
                 "untracked_paths_sample": ["linkgraph/predicates.py"],
@@ -3386,8 +3757,10 @@ mod tests {
             durability.note
         );
         assert!(
-            durability.note.contains("6 entities answered here"),
-            "the live count is a fact and stays: {}",
+            durability
+                .note
+                .contains("6 entities and 6 relations answered here"),
+            "the live counts are facts and stay: {}",
             durability.note
         );
     }
@@ -3400,6 +3773,8 @@ mod tests {
         let env = Envelope::daemon().with_health(&serde_json::json!({
             "graph_entity_count": 51,
             "durable_entity_count": 51,
+            "graph_relation_count": 51,
+            "durable_relation_count": 51,
             // Stamped: a measured zero is the all-clear, an unstamped one is the
             // disclosure the test below this asserts.
             "reconcile": {
@@ -3414,7 +3789,7 @@ mod tests {
         assert!(
             durability
                 .note
-                .contains("records everything answering here"),
+                .contains("records every entity and relation answering here"),
             "{}",
             durability.note
         );
@@ -5067,7 +5442,7 @@ mod tests {
             assert!(!trusted);
             assert!(reason.contains("degraded"), "{reason}");
 
-            let selected = flagged.with_selected_graph_observation(4, 4, 0, 4, Some(4));
+            let selected = flagged.with_selected_graph_observation(level_counts(4, 4), 4, 0, 4);
             assert_eq!(
                 selected.degraded.hydration_semantics_stale,
                 Some(true),
@@ -5189,7 +5564,7 @@ mod tests {
         };
         let selected = Envelope::daemon()
             .with_hydration_semantics_observation(Some(&standing))
-            .with_selected_graph_observation(4, 4, 0, 4, Some(4));
+            .with_selected_graph_observation(level_counts(4, 4), 4, 0, 4);
 
         let observation = selected
             .hydration_semantics

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -5488,6 +5488,18 @@ pub struct GraphStatusReport {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub durable_entity_count: Option<u64>,
     pub relation_count: usize,
+    /// Relations durable repository authority carried when the daemon last
+    /// levelled this graph with authority (FIR-3202).
+    ///
+    /// Beside `relation_count` for the reason `durable_entity_count` is beside
+    /// `entity_count`, and added because that pair on its own was the whole
+    /// disclosure. A language-server enrichment sweep writes relations into the
+    /// live query graph and records nothing durable, so a store whose entity
+    /// counts were level published an all-clear over 3,438 relations that
+    /// belonged to no committed change. Absent, not zero, when the daemon has
+    /// never levelled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub durable_relation_count: Option<u64>,
     pub embedding_source: GraphStatusEmbeddingSource,
     pub embeddings_indexed: usize,
     pub embeddings_pending: usize,
@@ -5535,6 +5547,8 @@ struct GraphStatusReportWire {
     #[serde(default)]
     durable_entity_count: Option<u64>,
     relation_count: usize,
+    #[serde(default)]
+    durable_relation_count: Option<u64>,
     embedding_source: GraphStatusEmbeddingSource,
     embeddings_indexed: usize,
     embeddings_pending: usize,
@@ -5567,6 +5581,7 @@ impl<'de> Deserialize<'de> for GraphStatusReport {
             entity_count: wire.entity_count,
             durable_entity_count: wire.durable_entity_count,
             relation_count: wire.relation_count,
+            durable_relation_count: wire.durable_relation_count,
             embedding_source: wire.embedding_source,
             embeddings_indexed: wire.embeddings_indexed,
             embeddings_pending: wire.embeddings_pending,
@@ -5796,6 +5811,11 @@ pub struct GraphStatusObservation {
     /// levelled this graph with authority (FIR-2421). `None` when it never has,
     /// which is not zero.
     pub durable_entity_count: Option<u64>,
+    /// Relations durable repository authority carried at that same levelling
+    /// (FIR-3202). `None` on the same rule as the entity count above, and read
+    /// under the same fence, so the pair a caller subtracts describes one
+    /// instant.
+    pub durable_relation_count: Option<u64>,
 }
 
 pub fn handle_daemon_graph_status_observation(
@@ -5812,6 +5832,7 @@ pub fn handle_daemon_graph_status_observation(
         entity_count: observation.entity_count,
         durable_entity_count: observation.durable_entity_count,
         relation_count: observation.relation_count,
+        durable_relation_count: observation.durable_relation_count,
         embedding_source: GraphStatusEmbeddingSource::SelectedGraph,
         embeddings_indexed: observation.embeddings_indexed,
         embeddings_pending: observation.embeddings_pending,
@@ -5851,6 +5872,7 @@ pub fn handle_daemon_graph_status_stale_observation(
         entity_count: observation.entity_count,
         durable_entity_count: observation.durable_entity_count,
         relation_count: observation.relation_count,
+        durable_relation_count: observation.durable_relation_count,
         embedding_source: GraphStatusEmbeddingSource::SelectedGraph,
         embeddings_indexed: observation.embeddings_indexed,
         embeddings_pending: observation.embeddings_pending,
@@ -11271,6 +11293,7 @@ mod tests {
             embeddings_total: embeddings.total,
             embedding_index_keys: None,
             durable_entity_count: None,
+            durable_relation_count: None,
         };
         let result =
             handle_daemon_graph_status_observation(GraphStatusScope::TemporalSession, observation)
@@ -11312,6 +11335,7 @@ mod tests {
                 embeddings_total: 2,
                 embedding_index_keys: None,
                 durable_entity_count: None,
+                durable_relation_count: None,
             },
         )
         .expect_err("the direct daemon boundary must reject impossible coverage");
@@ -11343,6 +11367,7 @@ mod tests {
                 embeddings_total: 49,
                 embedding_index_keys: Some(89),
                 durable_entity_count: None,
+                durable_relation_count: None,
             },
         )
         .expect("a stale-but-covered graph is a reportable observation");
@@ -11364,6 +11389,7 @@ mod tests {
                 embeddings_total: 49,
                 embedding_index_keys: Some(49),
                 durable_entity_count: None,
+                durable_relation_count: None,
             },
         )
         .unwrap();
@@ -11383,6 +11409,7 @@ mod tests {
                 embeddings_total: 12,
                 embedding_index_keys: None,
                 durable_entity_count: None,
+                durable_relation_count: None,
             },
         )
         .unwrap();
@@ -11410,6 +11437,7 @@ mod tests {
                 embeddings_total: 10,
                 embedding_index_keys: Some(9),
                 durable_entity_count: None,
+                durable_relation_count: None,
             },
         )
         .expect_err("an index below its own covered keys is not a reportable observation");

--- a/crates/kin-mcp/src/server.rs
+++ b/crates/kin-mcp/src/server.rs
@@ -1552,8 +1552,9 @@ fn finalize_daemon_graph_status(
         u64::try_from(report.embeddings_indexed),
         u64::try_from(report.embeddings_pending),
         u64::try_from(report.embeddings_total),
+        u64::try_from(report.relation_count),
     );
-    let (Ok(entity_count), Ok(indexed), Ok(pending), Ok(total)) = counts else {
+    let (Ok(entity_count), Ok(indexed), Ok(pending), Ok(total), Ok(relation_count)) = counts else {
         return envelope::finalize(
             ToolCallResult::error(
                 "daemon kin_graph_status counters do not fit the stdio response envelope",
@@ -1583,11 +1584,15 @@ fn finalize_daemon_graph_status(
     };
     let mut selected_env = base_env
         .with_selected_graph_observation(
-            entity_count,
+            envelope::DurabilityCounts {
+                live_entities: entity_count,
+                durable_entities: report.durable_entity_count,
+                live_relations: Some(relation_count),
+                durable_relations: report.durable_relation_count,
+            },
             indexed,
             pending,
             total,
-            report.durable_entity_count,
         )
         .with_memory_pressure(pressure_refusal.as_ref());
     if let Some(stale) = report.stale.as_ref() {
@@ -2032,7 +2037,17 @@ mod tests {
             embedding_coverage,
         );
         let env = Envelope::daemon()
-            .with_selected_graph_observation(1, 1, 0, 1, Some(1))
+            .with_selected_graph_observation(
+                envelope::DurabilityCounts {
+                    live_entities: 1,
+                    durable_entities: Some(1),
+                    live_relations: Some(0),
+                    durable_relations: Some(0),
+                },
+                1,
+                0,
+                1,
+            )
             .with_memory_pressure(refusal.as_ref());
         let result = envelope::finalize(
             ToolCallResult::text(


### PR DESCRIPTION
FIR-3202. The `_kin.durability` block counted entities only and its note claimed the whole graph. It now counts relations from the same authority at the same two levelling moments, publishes one state over both axes with the pessimistic reading winning, and writes a note that states both counts and the uncommitted count of each.

## The defect, measured before any code change

Stranger evidence (brown arm): `{"durable_entities": 861, "live_entities": 861, "live_only_entities": 0, "note": "861 entities, 0 uncommitted; durable repository authority records everything answering here."}` while 3,438 relations from the language-server enrichment sweep sat live-only and uncommitted until an unrelated docstring commit folded them in (`entities=0 relations=3438`).

Reproduced on the unmodified tree with a temporary kin-daemon test that opens a real store, commits two entities and a `Calls` relation through the real MCP transaction path, then upserts one `Lsp`-origin relation into the live graph with no commit, reading the block off the production `daemon_health_snapshot`:

```
FIR3202 AFTER-COMMIT live_entities=2 live_relations=1 durable_entities=Some(2) durability={"state":"recorded","live_entities":2,"durable_entities":2,"live_only_entities":0,"note":"2 entities, 0 uncommitted; durable repository authority records everything answering here."}
FIR3202 AFTER-SWEEP  live_entities=2 live_relations=2 durable_entities=Some(2) durability={"state":"recorded","live_entities":2,"durable_entities":2,"live_only_entities":0,"note":"2 entities, 0 uncommitted; durable repository authority records everything answering here."}
```

The relation count moved from 1 to 2; the block did not move by a byte.

## The mechanism, from source

- `Durability::observe(live: u64, durable: Option<u64>)` (`crates/kin-mcp/src/envelope.rs`) subtracted two entity counts and wrote the note from the difference. Its two callers, `Envelope::with_health` and `Envelope::with_selected_graph_observation`, handed it entity counts only.
- The daemon's durable side existed for entities only: `DaemonState::durable_entity_count` (`crates/kin-daemon/src/state.rs`), recorded at open from the loaded snapshot and after a commit installs authority onto the live graph (`api.rs` HTTP commit path, `mcp_commit.rs::finalize_committed_transaction`).
- The graph-status observation already sampled `relation_count: selected_graph.relation_count()` under the embedding fence; it never reached `observe`. `/health` and the health snapshot carried no relation count at all.
- The enrichment sweep writes with `state.graph.upsert_relation(relation)` (`daemon.rs::install_lsp_relations`) and records nothing durable, exactly as ambient admission does for entities.

## The fix

- `Durability` gains `live_relations`, `durable_relations`, `live_only_relations`. `observe` takes a `DurabilityCounts` struct, reduces each axis to level / uncommitted by N / never levelled / durable above live / unobserved, and publishes one state: `recorded` only when both axes are level, `live_uncommitted` when either carries fewer, `unknown` when either cannot yield a number. `unknown` publishes neither `live_only_*` field (the FIR-2820 invariant, now over both axes); the raw counts stay on the wire. An absent relation reading is `unknown`, not zero.
- Notes state both counts and each uncommitted count; no arm says "everything". Recorded now reads `N entities and M relations answered here; 0 entities and 0 relations are uncommitted, and durable repository authority records every entity and relation answering here.` The behind-working-copy requalification leads with both counts, clears both differences, and still carries no "uncommitted" (which `working_copy_freshness_repro.py::grade_durability_withholds_the_all_clear` refuses).
- `DaemonState.durable_relation_count` mirrors the entity counter: same `u64::MAX` sentinel, initialised at both open sites from `graph.relation_count()` of the loaded snapshot, recorded after the HTTP commit installs the change (live graph, as the entity count there) and after `install_authority_graph` in `finalize_committed_transaction` (authority graph, for the reason the entity count is taken from it).
- `/health` (`HealthResponse`), `daemon_health_snapshot` and the graph-status observation publish `graph_relation_count` and `durable_relation_count`; `GraphStatusReport` and its `deny_unknown_fields` wire struct carry `durable_relation_count`; the stdio finalizer hands both to `with_selected_graph_observation`.
- `packages/boundary-contracts` carries no `_kin` envelope schema (36 schemas, all VFS, SCM, transfer and hosted tool-call shapes; `git grep durability packages/boundary-contracts` is empty), so the contract stays where it is: the Rust serde shape and the wire struct, both changed here with crate tests. Captain accepted that default.

## `_kin.verdict`

Unchanged, by reading rather than assumption. `Verdict::compute` (`verdict.rs`) takes seven inputs (`absence_gate`, `edge_coverage`, `withheld_candidates`, `degradations`, `cross_repo`, `completeness`, `graph_freshness`); none reads `durability`, and `Durability::is_live_uncommitted()` has no caller outside tests. Live-only relations therefore reach the verdict exactly as live-only entities do today: not at all. The verdict answers whether an answer can be acted on; durability answers whether the substrate survives the process. A swept relation answers correctly right now, so it does not make counts a floor or an absence unsafe; it makes the answer perishable, and the block says so. Folding durability into the verdict would turn every uncommitted working session into `inconclusive`, which is the always-firing disclosure the FIR-2421 tests call noise. That is a design decision over both axes together, not one to take on the relation half.

## Tests

- `crates/kin-mcp/src/envelope.rs`: `relations_a_commit_does_not_carry_are_never_read_as_recorded` (the 861/3438 shape), `an_unreadable_relation_axis_withdraws_the_whole_reading` (never levelled, durable above live, unobserved; one input per refusal), the existing observe and `with_health` tests extended over both axes plus an entities-only health body that must read `unknown`.
- `crates/kin-daemon/src/api.rs`: `a_relation_the_sweep_wrote_and_no_commit_carries_is_reported_uncommitted` drives `daemon::install_lsp_relations` (the sweep's own write path, widened to `pub(crate)` for this) over a store levelled by a real MCP transaction commit and asserts `live_only_relations == Some(1)`, `live_only_entities == Some(0)`, `live_uncommitted`, and a note stating `0 entities and 1 relations are uncommitted`; `a_commit_that_carries_every_live_relation_reads_recorded_on_both_axes` is the positive control; `graph_status_carries_the_durable_relation_count_beside_the_live_one` covers the fence-sampled path.

## Falsification

Each mutation was applied to the committed fix, graded, and reverted with `git checkout -- <file>` (script refuses a dirty `crates/`). Run 2026-09-05T01:28:37Z through `heavy-slot.sh durability kin -- bash .kin-coord/reports/.durability-patches/falsify.sh`.

**A. `with_health` stops reading the relation pair** (`live_relations: None, durable_relations: None`). Red on the count:

```
test api::tests::a_relation_the_sweep_wrote_and_no_commit_carries_is_reported_uncommitted ... FAILED
assertion `left == right` failed: the swept relation belongs to no committed change and the count has to say so: 2 entities answered here and no relation reading reached this answer; 0 of the entities are uncommitted, and how many relations are uncommitted is unknown, because nothing measured them. Run `kin status` to read durable authority directly.
  left: None
 right: Some(1)
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1396 filtered out; finished in 3.72s
test envelope::tests::with_health_derives_durability_from_the_live_and_durable_counts ... FAILED
  left: "unknown"
 right: "live_uncommitted"
```

**C. `observe` treats the relation axis as always level** (`Axis::observe(counts.live_relations, counts.live_relations)`). Red on the count in both crates, and the note printed is the old false all-clear over the new sentence:

```
test envelope::tests::relations_a_commit_does_not_carry_are_never_read_as_recorded ... FAILED
assertion `left == right` failed: the count is the whole disclosure: 861 entities and 3438 relations answered here; 0 entities and 0 relations are uncommitted, and durable repository authority records every entity and relation answering here.
  left: Some(0)
 right: Some(3438)
test api::tests::a_relation_the_sweep_wrote_and_no_commit_carries_is_reported_uncommitted ... FAILED
  left: Some(0)
 right: Some(1)
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1396 filtered out; finished in 3.03s
```

**B. The MCP commit levels entities and not relations** (`record_durable_relation_count` removed from `finalize_committed_transaction`). The first run of this arm passed the two daemon filters as one quoted argument, matched no test, and exited 0 on `0 passed; 0 failed; 1397 filtered out`, which is a check that cannot fail; caught by reading the tail. Rerun with the filters split, plus a filter control on the restored tree:

```
running 2 tests
test api::tests::graph_status_carries_the_durable_relation_count_beside_the_live_one ... FAILED
test api::tests::a_commit_that_carries_every_live_relation_reads_recorded_on_both_axes ... FAILED
assertion `left == right` failed: level after the commit: {"authority":"repo-daemon","authority_epoch":2,"completion_attested":false,"durable_entity_count":2,"durable_relation_count":0,"embedding_source":"selected_graph","embeddings_indexed":0,"embeddings_pending":4,"embeddings_total":4,"entity_count":2,"relation_count":1,"sampling":"point_in_time_selected_graph","schema":"kin.graph-status.v1","scope":"head","view":"daemon_selected_graph"}
  left: Number(0)
 right: Number(1)
assertion `left == right` failed: 2 entities and 1 relations answered here; 0 entities and 1 relations are uncommitted, and not all of what you wrote is recorded yet. The uncommitted work is lost when this daemon exits. Commit to record it.
  left: "live_uncommitted"
 right: "recorded"
test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 1395 filtered out; finished in 2.33s
```

Filter control on the restored tree, same two filters: `running 2 tests` ... `test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 1395 filtered out; finished in 3.32s`. Run 2026-09-05T01:58:16Z on rust-heavy-b through `heavy-slot.sh durability kin -- bash .kin-coord/reports/.durability-patches/falsify-b.sh`. The positive control is therefore a reading, not a fixture that always passes: with the MCP commit levelling entities and not relations, the control reports the one relation as uncommitted, which is exactly what a levelling gap on one axis should look like.


## Verification run on this box

Per the captain's speed rule tonight, hosted CI is the full-workspace grader; locally only the touched crates, fmt and clippy ran, all through `heavy-slot.sh durability kin` (per-lane target, `KIN_EMBED_BACKEND=cpu`).

- `cargo fmt --all -- --check`: clean (exit 0), run in the worktree.
- `heavy-slot.sh durability kin -- cargo test -p kin-mcp --lib` (2026-09-05T01:16:35Z):
  `test result: ok. 895 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 19.80s`
- `heavy-slot.sh durability kin -- cargo test -p kin-daemon --lib -- durability relation_the_sweep commit_that_carries graph_status_carries_the_durable mcp_transaction_commit_lands`:
  `test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 1392 filtered out; finished in 3.11s`
  (the three new tests, the existing transaction-lands-relation test, and the hosted vector durability test).
- Full `cargo test -p kin-daemon --lib` on the restored tree after the falsification reverts (2026-09-05T01:43:57Z, started before the tightened rule arrived and let finish):
  `test result: ok. 1394 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 382.51s`
- Clippy: NOT run locally, by the captain's rule tonight; the `Fast gate lint and policy` context on this PR grades it. `bin/kin-precheck` and `bin/kin-parity`: not run locally, same rule; hosted CI is the full-workspace grader.


Report: `.kin-coord/reports/showhn-durability-20260904.md`.
