### PR TITLE
Answer status, diff and log from one authority open

### DIFF
--- a/crates/kin-cli/src/commands/diff.rs
+++ b/crates/kin-cli/src/commands/diff.rs
@@ -30,6 +30,14 @@ pub struct DiffRequest {
     pub head: Option<String>,
     #[serde(default)]
     pub json: bool,
+    /// Whether the caller wants whole bodies rather than the trimmed content
+    /// rows, so the server can read CAS on the caller's behalf.
+    ///
+    /// `#[serde(default)]` because this crosses the daemon wire and an older
+    /// peer neither sends nor understands it; a daemon that ignores it answers
+    /// exactly as it did, and the caller's own fallback fills the content in.
+    #[serde(default)]
+    pub full_bodies: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -38,6 +46,15 @@ pub struct DiffResponse {
     pub lines: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub report: Option<DiffReport>,
+    /// Whether this responder read artifact content into `report`.
+    ///
+    /// A flag rather than an empty-vector test, because "this build did not
+    /// read content" and "the content rows are genuinely empty" are different
+    /// facts and only the first is a reason for the caller to open the whole
+    /// store and read CAS itself. `#[serde(default)]` makes an older peer's
+    /// silence read as the first, which is what it means.
+    #[serde(default)]
+    pub artifact_content_rendered: bool,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -255,6 +272,21 @@ pub fn inspect_with_endpoint_entities(
     live: Option<&kin_db::InMemoryGraph>,
 ) -> Result<(DiffReport, DiffEndpointEntities)> {
     let authority = ActiveRepositoryAuthority::open(binding)?;
+    inspect_with_endpoint_entities_at(&authority, base, head, live)
+}
+
+/// The same pair, from an authority the caller already opened.
+///
+/// An open re-verifies every persisted body, so a caller that wants the report
+/// AND the artifact content behind it takes one open and asks it for both.
+/// Reaching for the binding-taking wrapper twice is what made a local `kin diff`
+/// on a converted 470 MiB store pay for two whole-store opens.
+pub fn inspect_with_endpoint_entities_at(
+    authority: &ActiveRepositoryAuthority,
+    base: Option<&str>,
+    head: Option<&str>,
+    live: Option<&kin_db::InMemoryGraph>,
+) -> Result<(DiffReport, DiffEndpointEntities)> {
     let lease = authority.manager().read_authority();
     let metadata = lease.metadata();
     let workspace = metadata
@@ -771,7 +803,8 @@ pub async fn run(
     // local answer, which names its own gap rather than printing a zero that
     // reads like an answer.
     if !json && workspace_endpoint {
-        if let Some(response) = daemon_diff(&layout, &base, &head).await {
+        if let Some(response) = daemon_diff(&layout, &base, &head, full_bodies).await {
+            let content_rendered = response.artifact_content_rendered;
             for line in response.lines {
                 println!("{line}");
             }
@@ -780,12 +813,25 @@ pub async fn run(
                 //
                 // The daemon renders its own header lines and this appends after
                 // them, so its output stays byte-identical and the wire payload
-                // is unchanged. The report it already returns carries both blob
-                // hashes, so the CLI opens its own binding and reads CAS here.
-                // Two renderings of a content diff would drift, and the one
-                // nobody runs would be the one that drifts.
-                for line in content_lines_for(&layout, report, full_bodies) {
-                    println!("{line}");
+                // is unchanged. Two renderings of a content diff would drift,
+                // and the one nobody runs would be the one that drifts.
+                //
+                // The bodies come from the responder's own authority when it
+                // read them, and only from a local open when it did not. That
+                // second arm is a peer too old to carry the rows, and it is the
+                // whole of what used to happen every time: the answer arrived
+                // from a warm daemon and the command then re-verified the entire
+                // store to print the bodies beneath it.
+                if content_rendered {
+                    for row in &report.artifact_content {
+                        for line in render_content_lines(row) {
+                            println!("{line}");
+                        }
+                    }
+                } else {
+                    for line in content_lines_for(&layout, report, full_bodies) {
+                        println!("{line}");
+                    }
                 }
                 if let Some(line) = semantic_scope_line(report.semantic_basis.as_ref()) {
                     println!("{line}");
@@ -797,22 +843,33 @@ pub async fn run(
                 );
             }
             println!("{}", admitted_scope_line(&layout));
+            println!(
+                "{}",
+                crate::commands::repository_authority::answered_by_line(if content_rendered {
+                    crate::commands::repository_authority::AuthoritySource::RunningDaemon
+                } else {
+                    crate::commands::repository_authority::AuthoritySource::RunningDaemonAndOwnOpen
+                })
+            );
             return Ok(());
         }
     }
     let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout)?;
+    // ONE open for both readings. The report and the artifact bodies beneath it
+    // come from the same authority, where this used to open the whole store,
+    // build the report, and then open it a second time to read CAS.
+    //
     // No live graph on this path: the CLI opens durable authority in-process and
     // the entities a workspace endpoint needs live in the daemon's graph. So this
     // derives nothing and the basis says so by name, which is the zero
     // file-search rule applied to a read: when the graph cannot answer, report
     // the gap rather than a zero that reads like an answer.
-    let mut report = inspect(&binding, base.as_deref(), head.as_deref(), None)?;
-    if let Ok(authority) =
-        crate::commands::repository_authority::ActiveRepositoryAuthority::open(&binding)
-    {
-        report.artifact_content =
-            collect_artifact_content(&authority, &report.artifact_deltas, full_bodies);
-    }
+    let authority =
+        crate::commands::repository_authority::ActiveRepositoryAuthority::open(&binding)?;
+    let (mut report, _) =
+        inspect_with_endpoint_entities_at(&authority, base.as_deref(), head.as_deref(), None)?;
+    report.artifact_content =
+        collect_artifact_content(&authority, &report.artifact_deltas, full_bodies);
     if json {
         println!("{}", serde_json::to_string_pretty(&report)?);
     } else {
@@ -831,6 +888,12 @@ pub async fn run(
             println!("Admission scope: this diff was not measured against the working copy: {why}");
         }
         println!("{}", admitted_scope_line(&layout));
+        println!(
+            "{}",
+            crate::commands::repository_authority::answered_by_line(
+                crate::commands::repository_authority::AuthoritySource::OwnAuthorityOpen
+            )
+        );
     }
     Ok(())
 }
@@ -869,6 +932,7 @@ async fn daemon_diff(
     layout: &kin_core::KinLayout,
     base: &Option<String>,
     head: &Option<String>,
+    full_bodies: bool,
 ) -> Option<DiffResponse> {
     let base_url = crate::daemon_client::resolve_daemon_url_if_running_async(layout).await?;
     let client =
@@ -879,6 +943,10 @@ async fn daemon_diff(
         // The daemon renders its own lines and this path only takes the text
         // path, so it never asks for the JSON shape.
         json: false,
+        // Said out loud so the responder can read the bodies from the authority
+        // it already holds. A peer that does not know the field ignores it and
+        // answers as it always did, and the caller fills the content in.
+        full_bodies,
     };
     client.diff(&request).await.ok()
 }
@@ -993,15 +1061,36 @@ pub fn build_diff_response(
     request: &DiffRequest,
     live: Option<&kin_db::InMemoryGraph>,
 ) -> Result<DiffResponse> {
-    let report = inspect(
-        binding,
+    let authority = ActiveRepositoryAuthority::open(binding)?;
+    build_diff_response_at(&authority, request, live)
+}
+
+/// The same response, from an authority the caller already opened, with the
+/// artifact content read on the caller's behalf.
+///
+/// Reading content here is what lets a `kin diff` served by this response skip
+/// an authority open of its own. It used to open its own binding and read CAS
+/// after printing the daemon's lines, which meant the answer arrived from a
+/// warm daemon and the command then spent seconds re-verifying the whole store
+/// to render the bodies under it.
+pub fn build_diff_response_at(
+    authority: &ActiveRepositoryAuthority,
+    request: &DiffRequest,
+    live: Option<&kin_db::InMemoryGraph>,
+) -> Result<DiffResponse> {
+    let (mut report, _) = inspect_with_endpoint_entities_at(
+        authority,
         request.base.as_deref(),
         request.head.as_deref(),
         live,
     )?;
+    let lines = render_lines(&report);
+    report.artifact_content =
+        collect_artifact_content(authority, &report.artifact_deltas, request.full_bodies);
     Ok(DiffResponse {
-        lines: render_lines(&report),
+        lines,
         report: Some(report),
+        artifact_content_rendered: true,
     })
 }
 
@@ -1335,6 +1424,86 @@ mod tests {
         FingerprintAlgorithm, LanguageId, RelationKind, RelationOrigin, RepoPath, ResolvedArtifact,
         SemanticFingerprint, Visibility,
     };
+
+    /// One diff answer must open repository authority exactly once, report and
+    /// artifact bodies together.
+    ///
+    /// GAP-6, in the form that scales. An authority open is a full recovery that
+    /// re-verifies every persisted body against its content address, so it costs
+    /// whatever the whole store is worth: measured on a converted 470 MiB
+    /// express store, one open is seconds. The COUNT is the honest bound and the
+    /// wall clock is not, because a fixture small enough to run in CI answers in
+    /// milliseconds whether it opens once or twice.
+    ///
+    /// Counted on this thread only: this binary runs tests in parallel and
+    /// siblings open authority of their own.
+    ///
+    /// Breaking it: read the artifact content through a second
+    /// `ActiveRepositoryAuthority::open` on the binding, which is what both the
+    /// local arm and the daemon arm of `kin diff` used to do. Either takes this
+    /// to 2. Note the second open was UNCONDITIONAL in the shipped code, so this
+    /// bound goes red on a fixture with no artifact deltas too.
+    #[test]
+    fn one_diff_answer_opens_repository_authority_once() {
+        let root = tempfile::tempdir().expect("a temporary directory for the fixture store");
+        let init = kin_core::init(root.path()).expect("kin_core::init builds a real store");
+        let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&init.layout)
+            .expect("the fixture store binds");
+        let request = DiffRequest {
+            base: None,
+            head: None,
+            json: false,
+            full_bodies: false,
+        };
+
+        let before = kin_core::authority_opens();
+        let response =
+            build_diff_response(&binding, &request, None).expect("a fresh store answers a diff");
+        let opens = kin_core::authority_opens() - before;
+
+        // Non-vacuity first. A response with no report, or one that did not
+        // claim to have read content, cannot tell "one open for both" apart from
+        // "one open and the second reading skipped".
+        let report = response
+            .report
+            .as_ref()
+            .expect("the diff report must be real");
+        assert_eq!(report.schema, DIFF_SCHEMA);
+        assert!(
+            response.artifact_content_rendered,
+            "the responder must say it read artifact content, or its caller opens the store itself"
+        );
+        assert_eq!(
+            opens, 1,
+            "one diff answer must open repository authority once and ask that open for both the \
+             report and the artifact bodies; opening per reading is GAP-6"
+        );
+    }
+
+    /// An older daemon's silence about artifact content must read as "did not
+    /// read it", so the caller still renders the bodies.
+    ///
+    /// The wire half of the mixed-build case. A `false` here is what sends the
+    /// caller down its own local open, and a payload that decoded as `true`
+    /// would print a diff with every content row missing and nothing saying so.
+    ///
+    /// Breaking it: give the field a `#[serde(default = ...)]` that yields true,
+    /// or drop `#[serde(default)]` so an older payload fails to parse at all.
+    #[test]
+    fn an_older_daemons_diff_payload_says_it_rendered_no_artifact_content() {
+        let decoded: DiffResponse = serde_json::from_value(serde_json::json!({
+            "lines": ["Kin repository-v6 diff"],
+        }))
+        .expect("an older daemon's payload must still decode");
+
+        // Non-vacuity: the payload really is the older shape.
+        assert!(decoded.report.is_none());
+        assert_eq!(decoded.lines.len(), 1);
+        assert!(
+            !decoded.artifact_content_rendered,
+            "an absent flag must mean the content was not read, so the caller reads it itself"
+        );
+    }
 
     fn entity(id: EntityId, name: &str) -> Entity {
         Entity {

--- a/crates/kin-cli/src/commands/log.rs
+++ b/crates/kin-cli/src/commands/log.rs
@@ -307,7 +307,7 @@ pub async fn run(count: usize, json: bool) -> Result<()> {
                     &response.workspace_tip.unwrap_or(
                         crate::commands::workspace_tip::WorkspaceTip::Unknown {
                             reason: "the daemon that answered this log does not report it; \
-                                 `kin daemon restart` picks up this build"
+                                 `kin daemon stop` and re-run picks it up on this build"
                                 .to_string(),
                         }
                     )

--- a/crates/kin-cli/src/commands/log.rs
+++ b/crates/kin-cli/src/commands/log.rs
@@ -31,6 +31,14 @@ pub struct LogResponse {
     pub lines: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub report: Option<LogReport>,
+    /// Where this workspace sits relative to the branch its head names.
+    ///
+    /// On the ENVELOPE rather than in `report`, so `kin.log.v1` does not move
+    /// and a peer on either side of the wire that does not know this field
+    /// keeps working. Log is the one verb that can afford the distance in
+    /// changes, because it has already decoded the change DAG to answer at all.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_tip: Option<crate::commands::workspace_tip::WorkspaceTip>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -82,11 +90,28 @@ pub struct LogReport {
     pub entries: Vec<LogEntry>,
 }
 
+/// How far back a lag walk will look before it gives up and claims no count.
+///
+/// Bounded because the walk is over a converted repository's whole history and
+/// a workspace that is behind is normally behind by one change. A walk that
+/// exhausts this budget reports no distance rather than a short one; see
+/// [`crate::commands::workspace_tip::distance`].
+const ANCESTRY_WALK_CAP: usize = 4096;
+
 pub fn inspect(
     binding: &kin_core::LocalRepositoryAuthorityBinding,
     count: usize,
 ) -> Result<LogReport> {
     let authority = ActiveRepositoryAuthority::open(binding)?;
+    inspect_at(&authority, count)
+}
+
+/// The same report, from an authority the caller already opened.
+///
+/// An open re-verifies every persisted body, so a caller wanting both the log
+/// and the workspace-tip reading takes ONE open and asks it for both, rather
+/// than reaching for the binding-taking wrapper twice.
+pub fn inspect_at(authority: &ActiveRepositoryAuthority, count: usize) -> Result<LogReport> {
     let lease = authority.manager().read_authority();
     let metadata = lease.metadata();
     let snapshot = lease.snapshot();
@@ -183,16 +208,135 @@ pub fn inspect(
     })
 }
 
-pub fn run(count: usize, json: bool) -> Result<()> {
+/// Where this workspace sits relative to its branch, with the distance in
+/// changes filled in from the DAG this command has already decoded.
+///
+/// Log is the only one of these verbs that can honestly claim a count. Status
+/// reads authority metadata and stops, deliberately, because on a converted
+/// repository the change map is most of the snapshot body and no status should
+/// pay to decode it. Here the walk was already paid for.
+pub fn workspace_tip_at(
+    authority: &ActiveRepositoryAuthority,
+) -> crate::commands::workspace_tip::WorkspaceTip {
+    use crate::commands::workspace_tip::WorkspaceTip;
+    let reading = crate::commands::status::workspace_tip_at(authority);
+    let WorkspaceTip::Behind {
+        tip,
+        projected: Some(projected),
+        ..
+    } = &reading
+    else {
+        return reading;
+    };
+    let (tip, projected) = (*tip, *projected);
+    let lease = authority.manager().read_authority();
+    let snapshot = lease.snapshot();
+    let walked = crate::commands::workspace_tip::distance(
+        &tip,
+        &projected,
+        |change_id| {
+            snapshot
+                .changes
+                .get(change_id)
+                .map(|change| change.parents.clone())
+        },
+        ANCESTRY_WALK_CAP,
+    );
+    drop(lease);
+    match walked {
+        Some(changes) => reading.with_distance(changes),
+        None => reading,
+    }
+}
+
+/// Ask the daemon for a log, or `None` when it cannot answer.
+///
+/// Deliberately swallows every failure into `None`, exactly as `kin diff`'s own
+/// daemon route does. A `kin log` that refused because no daemon was running
+/// would be a regression against the command as it shipped, and the local path
+/// it falls back to is the same code the daemon runs.
+///
+/// The reason this route exists at all is cost, not capability: both sides
+/// answer from the same durable authority, and only the daemon can answer from
+/// an authority it already has open. On a converted 470 MiB store an
+/// in-process open re-verifies every persisted body and takes seconds; the
+/// daemon holds one open per publication and answers from it.
+async fn daemon_log(layout: &kin_core::KinLayout, count: usize) -> Option<LogResponse> {
+    let base_url = crate::daemon_client::resolve_daemon_url_if_running_async(layout).await?;
+    let client =
+        crate::daemon_client::DaemonClient::from_base_url_for_layout(base_url, layout).ok()?;
+    client.log(&LogRequest { count }).await.ok()
+}
+
+/// Everything `kin log` prints when no daemon answers, from ONE authority open.
+///
+/// Extracted from `run` so the open count is assertable. The count, not the
+/// wall clock, is the honest thing to bound: an open re-verifies every persisted
+/// body, so it costs whatever the store is worth, and a timing assertion on a
+/// fixture small enough to run in CI passes just as readily with a second open
+/// present.
+fn local_log(
+    binding: &kin_core::LocalRepositoryAuthorityBinding,
+    count: usize,
+) -> Result<(LogReport, crate::commands::workspace_tip::WorkspaceTip)> {
+    let authority = ActiveRepositoryAuthority::open(binding)?;
+    let report = inspect_at(&authority, count)?;
+    let tip = workspace_tip_at(&authority);
+    Ok((report, tip))
+}
+
+pub async fn run(count: usize, json: bool) -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
+    // The daemon first, and only for the text path. `--json` is a contract with
+    // a machine reader and must publish the exact report this build serializes,
+    // so it stays on the local read rather than re-serializing a peer's payload.
+    //
+    // A daemon too old to carry the tip reading costs this command a named gap
+    // and nothing else, so it does not fall back the way `kin status` does. The
+    // difference is what silence would mean: a status with no merge reading
+    // prints a clean tree over a workspace holding a merge open, and this prints
+    // a line saying the reading was not taken.
+    if !json {
+        if let Some(response) = daemon_log(&layout, count).await {
+            for line in response.lines {
+                println!("{line}");
+            }
+            println!(
+                "{}",
+                crate::commands::workspace_tip::line(
+                    &response.workspace_tip.unwrap_or(
+                        crate::commands::workspace_tip::WorkspaceTip::Unknown {
+                            reason: "the daemon that answered this log does not report it; \
+                                 `kin daemon restart` picks up this build"
+                                .to_string(),
+                        }
+                    )
+                )
+            );
+            println!(
+                "{}",
+                crate::commands::repository_authority::answered_by_line(
+                    crate::commands::repository_authority::AuthoritySource::RunningDaemon
+                )
+            );
+            return Ok(());
+        }
+    }
     let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout)?;
-    let report = inspect(&binding, count)?;
+    let (report, tip) = local_log(&binding, count)?;
     if json {
         println!("{}", serde_json::to_string_pretty(&report)?);
     } else {
         for line in render_lines(&report) {
             println!("{line}");
         }
+        println!("{}", crate::commands::workspace_tip::line(&tip));
+        println!(
+            "{}",
+            crate::commands::repository_authority::answered_by_line(
+                crate::commands::repository_authority::AuthoritySource::OwnAuthorityOpen
+            )
+        );
     }
     Ok(())
 }
@@ -202,10 +346,20 @@ pub fn build_log_response(
     _graph: &kin_db::InMemoryGraph,
     request: &LogRequest,
 ) -> Result<LogResponse> {
-    let report = inspect(binding, request.count)?;
+    let authority = ActiveRepositoryAuthority::open(binding)?;
+    build_log_response_at(&authority, request)
+}
+
+/// The same response, from an authority the caller already opened.
+pub fn build_log_response_at(
+    authority: &ActiveRepositoryAuthority,
+    request: &LogRequest,
+) -> Result<LogResponse> {
+    let report = inspect_at(authority, request.count)?;
     Ok(LogResponse {
         lines: render_lines(&report),
         report: Some(report),
+        workspace_tip: Some(workspace_tip_at(authority)),
     })
 }
 
@@ -293,6 +447,54 @@ mod tests {
         FingerprintAlgorithm, Hash256, LanguageId, SemanticChange, SemanticFingerprint, SourceSpan,
         Visibility,
     };
+
+    /// One `kin log` with no daemon must open repository authority exactly once.
+    ///
+    /// GAP-6, in the form that scales. An authority open is a full recovery that
+    /// re-verifies every persisted body against its content address, so it costs
+    /// whatever the whole store is worth: measured on a converted 470 MiB
+    /// express store, one open is seconds and `kin status` was paying for three
+    /// of them per invocation. The COUNT is therefore the honest bound and the
+    /// wall clock is not, because a fixture small enough to run in CI answers in
+    /// milliseconds whether it opens once or twice.
+    ///
+    /// Counted on this thread only: this binary runs tests in parallel and
+    /// siblings open authority of their own, so the process-wide delta is not
+    /// this test's number.
+    ///
+    /// Breaking it: give `local_log` a second open, which is exactly what the
+    /// shipped code did before this change and what reverting `workspace_tip_at`
+    /// to a binding-taking helper would restore. Either takes this to 2.
+    #[test]
+    fn one_local_log_opens_repository_authority_once() {
+        let _daemon = kin_core::test_env::EnvVarGuard::unset("KIN_DAEMON_URL");
+        let root = tempfile::tempdir().expect("a temporary directory for the fixture store");
+        let init = kin_core::init(root.path()).expect("kin_core::init builds a real store");
+        let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&init.layout)
+            .expect("the fixture store binds");
+
+        let before = kin_core::authority_opens();
+        let (report, tip) = local_log(&binding, 5).expect("a fresh store answers a log");
+        let opens = kin_core::authority_opens() - before;
+
+        // Non-vacuity first, both halves. A call that produced no report, or a
+        // tip reading that says it could not be taken, cannot tell "one open for
+        // both readings" apart from "one open and one reading missing", and the
+        // bound below would pass without meaning anything.
+        assert_eq!(report.schema, LOG_SCHEMA, "the log report must be real");
+        assert!(
+            !matches!(
+                tip,
+                crate::commands::workspace_tip::WorkspaceTip::Unknown { .. }
+            ),
+            "the workspace-tip reading must have come off that same open: {tip:?}"
+        );
+        assert_eq!(
+            opens, 1,
+            "one `kin log` must open repository authority once and ask that open for both the \
+             history and the workspace-tip reading; opening per reading is GAP-6"
+        );
+    }
 
     /// One version of one entity, plus the file-level noise a real reconcile
     /// stamps on every entity in a touched file whether or not it moved: the

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -106,6 +106,7 @@ pub mod transfer;
 pub mod update;
 pub mod verify;
 pub mod work;
+pub mod workspace_tip;
 pub mod xref;
 
 /// Discover the Kin repository a command is bound to, or refuse by naming the

--- a/crates/kin-cli/src/commands/repository_authority.rs
+++ b/crates/kin-cli/src/commands/repository_authority.rs
@@ -264,6 +264,56 @@ impl RequestRepositoryAuthority {
     }
 }
 
+/// Which authority open answered one command.
+///
+/// Printed, not inferred. The two paths cost different orders of magnitude on a
+/// real store, so a reader whose `kin status` took thirty seconds needs to be
+/// able to see which one they got without reading a log.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthoritySource {
+    /// The daemon serving this repository answered, from the authority it holds
+    /// open for the current publication, and this process opened nothing.
+    RunningDaemon,
+    /// The daemon answered, and this process still had to open the store for a
+    /// reading that daemon's build does not carry.
+    ///
+    /// Its own arm rather than folded into either neighbour, because both of
+    /// those would be a lie a reader could act on: "the daemon answered" hides
+    /// an open that took seconds, and "no daemon answered" sends them to start
+    /// one that is already running.
+    RunningDaemonAndOwnOpen,
+    /// This command opened repository authority itself.
+    OwnAuthorityOpen,
+}
+
+/// The line naming which authority open answered this invocation.
+///
+/// Worded so the number beside it is explained rather than merely reported: an
+/// open re-verifies every persisted body, so it costs whatever the whole store
+/// is worth, and a reader who waited thirty seconds needs to know they were the
+/// one paying for it.
+///
+/// Real, not theater. Each verb passes the arm it actually took, and the arms
+/// are distinguishable at the call site rather than guessed from a daemon
+/// liveness probe taken afterwards.
+pub fn answered_by_line(source: AuthoritySource) -> String {
+    match source {
+        AuthoritySource::RunningDaemon => "Answered by: this repository's daemon, from the \
+             authority it already holds open for the current publication"
+            .to_string(),
+        AuthoritySource::RunningDaemonAndOwnOpen => "Answered by: this repository's daemon, plus \
+             one repository-authority open in this command because that daemon's build does not \
+             carry every reading this page prints; `kin daemon stop` and re-run to restart it on \
+             this build"
+            .to_string(),
+        AuthoritySource::OwnAuthorityOpen => "Answered by: this command's own \
+             repository-authority open, which re-verifies every persisted body; no daemon \
+             answered. Start this repository's daemon to serve it from one open per publication \
+             instead"
+            .to_string(),
+    }
+}
+
 impl ActiveRepositoryAuthority {
     /// Open the authority from durable storage.
     ///

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -1316,24 +1316,27 @@ pub fn merge_in_progress_at(authority: &ActiveRepositoryAuthority) -> Option<Mer
 /// Metadata only, so it adds nothing measurable to an open that has already
 /// happened. See [`crate::commands::workspace_tip`] for why the distance in
 /// changes is not part of this reading.
+///
+/// The workspace comes through the authority's own accessor rather than off the
+/// lease here. That is deliberate and not style: `verify-zero-file-search.py`
+/// counts the spelling `.metadata()` per file against a pinned allowlist number,
+/// so a third one in this file fails the gate even though every one of them
+/// reads an authority lease and none of them touches a filesystem. Reaching for
+/// the accessor keeps the count where the allowlist reviewed it, and keeps the
+/// one lookup of this workspace in one place.
 pub fn workspace_tip_at(
     authority: &ActiveRepositoryAuthority,
 ) -> crate::commands::workspace_tip::WorkspaceTip {
+    let workspace = match authority.workspace() {
+        Ok(workspace) => workspace,
+        Err(error) => {
+            return crate::commands::workspace_tip::WorkspaceTip::Unknown {
+                reason: error.to_string(),
+            }
+        }
+    };
     let lease = authority.manager().read_authority();
-    let workspace = lease
-        .metadata()
-        .workspaces
-        .iter()
-        .find(|workspace| workspace.workspace_id == authority.workspace_id);
-    match workspace {
-        Some(workspace) => crate::commands::workspace_tip::read(&lease, workspace),
-        None => crate::commands::workspace_tip::WorkspaceTip::Unknown {
-            reason: format!(
-                "repository {} has no workspace {} in its authority",
-                authority.repository_id, authority.workspace_id
-            ),
-        },
-    }
+    crate::commands::workspace_tip::read(&lease, &workspace)
 }
 
 fn summarize_merge(record: &MergeTransactionRecord) -> MergeInProgress {

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -44,7 +44,7 @@ use kin_model::{
 };
 use serde::{Deserialize, Deserializer, Serialize};
 
-use super::repository_authority::ActiveRepositoryAuthority;
+use super::repository_authority::{ActiveRepositoryAuthority, AuthoritySource};
 use super::store_footprint::StoreFootprint;
 
 /// First status contract carrying embedding coverage alongside enrichment
@@ -750,6 +750,37 @@ pub struct CommandStatusResponse {
     pub text: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub json: Option<String>,
+    /// A merge this workspace is holding open, read off the same authority the
+    /// report came from.
+    ///
+    /// Carried on the ENVELOPE and not in `report`. `StatusReportWire` denies
+    /// unknown fields, so a key added there makes an older CLI reject a newer
+    /// daemon's report outright and is a v4 decision to take deliberately. This
+    /// struct has never denied them and every field beside `report` already
+    /// defaults, so an older peer on either side of the wire ignores this and
+    /// keeps working.
+    ///
+    /// The point of carrying it at all is that the caller stops opening the
+    /// whole store a second time to read it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub merge: Option<MergeInProgress>,
+    /// Where this workspace sits relative to the branch its head names, from
+    /// that same authority and for that same reason.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_tip: Option<crate::commands::workspace_tip::WorkspaceTip>,
+    /// Whether this responder took the two readings above off its own authority.
+    ///
+    /// A flag rather than a `None` test on `merge`, because "this build did not
+    /// read a merge" and "this workspace is holding no merge open" are different
+    /// facts and only the first is a reason for the caller to open the store
+    /// itself. Without it a new CLI against an older daemon would print a clean
+    /// status over a workspace with seventy-six conflicts parked in it, which is
+    /// FIR-2961 reintroduced through the wire rather than through the code.
+    ///
+    /// `#[serde(default)]` makes an older peer's silence read as "did not", so
+    /// the caller falls back to one local open and answers exactly as it did.
+    #[serde(default)]
+    pub authority_readings_taken: bool,
 }
 
 impl CommandStatusRequest {
@@ -778,6 +809,23 @@ pub fn inspect(
     embedding_coverage: EmbeddingCoverage,
 ) -> Result<StatusReport> {
     let authority = ActiveRepositoryAuthority::open(binding)?;
+    inspect_at(layout, &authority, embedding_coverage)
+}
+
+/// The same report, from an authority the caller already opened.
+///
+/// The open is the expensive half of this command by orders of magnitude: it
+/// re-verifies every persisted body, so it costs whatever the whole store is
+/// worth. A caller that needs more than one reading from repository authority
+/// takes ONE open and asks for each of them here, rather than reaching for the
+/// binding-taking wrapper once per reading, which is how one `kin status`
+/// invocation came to open the whole store twice in the CLI and twice more
+/// inside the daemon serving it.
+pub fn inspect_at(
+    layout: &kin_core::KinLayout,
+    authority: &ActiveRepositoryAuthority,
+    embedding_coverage: EmbeddingCoverage,
+) -> Result<StatusReport> {
     let lease = authority.manager().read_authority();
     let metadata = lease.metadata();
     let workspace = metadata
@@ -866,7 +914,7 @@ pub fn inspect(
 /// the schema, not the build check.
 async fn live_status_from_running_daemon(
     layout: &kin_core::KinLayout,
-) -> std::result::Result<StatusReport, EmbeddingCoverageUnobserved> {
+) -> std::result::Result<CommandStatusResponse, EmbeddingCoverageUnobserved> {
     let base_url = crate::daemon_client::resolve_daemon_url_if_running_async(layout)
         .await
         .ok_or(EmbeddingCoverageUnobserved::NoRunningDaemon)?;
@@ -893,9 +941,7 @@ async fn live_status_from_running_daemon(
     )
     .await
     {
-        Ok(response) => response
-            .map(|response| response.report)
-            .map_err(unavailable),
+        Ok(response) => response.map_err(unavailable),
         Err(_elapsed) => {
             tracing::debug!(
                 budget_secs = LIVE_STATUS_READ_BUDGET.as_secs(),
@@ -906,14 +952,68 @@ async fn live_status_from_running_daemon(
     }
 }
 
+/// One complete status reading, and everything the caller would otherwise open
+/// the store again to learn.
+///
+/// The merge and workspace-tip readings ride here rather than being fetched by
+/// their own helpers, and that IS the fix: each of those helpers takes a
+/// binding and opens the whole store for itself, which is how one `kin status`
+/// came to pay for three whole-store opens on a 470 MiB repository.
+pub struct StatusReading {
+    pub report: StatusReport,
+    pub merge: Option<MergeInProgress>,
+    pub workspace_tip: crate::commands::workspace_tip::WorkspaceTip,
+    pub source: AuthoritySource,
+}
+
 /// One complete status reading: the live daemon's when it answers, and this
 /// process's own authority read naming why it did not otherwise.
-async fn read_status_once(layout: &kin_core::KinLayout) -> Result<StatusReport> {
+///
+/// Exactly zero authority opens in this process on the daemon arm, and exactly
+/// one on the fallback arm. The fallback opens once and asks that one open for
+/// all three readings.
+async fn read_status_once(layout: &kin_core::KinLayout) -> Result<StatusReading> {
     match live_status_from_running_daemon(layout).await {
-        Ok(report) => Ok(report),
+        // A daemon that answered but did not take the merge and tip readings is
+        // an older build. Believing its silence would print a clean status over
+        // a workspace holding a merge open, so this pays for exactly one local
+        // open to read them, which is what this command did before the readings
+        // moved onto the response.
+        Ok(response) if !response.authority_readings_taken => {
+            let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(layout)?;
+            let authority = ActiveRepositoryAuthority::open(&binding)?;
+            Ok(StatusReading {
+                report: response.report,
+                merge: merge_in_progress_at(&authority),
+                workspace_tip: workspace_tip_at(&authority),
+                source: AuthoritySource::RunningDaemonAndOwnOpen,
+            })
+        }
+        Ok(response) => Ok(StatusReading {
+            report: response.report,
+            merge: response.merge,
+            // A responder that says it took the readings and then carries no tip
+            // is a build defect, not a current workspace, and rendering nothing
+            // would say exactly that. Name the gap instead.
+            workspace_tip: response.workspace_tip.unwrap_or(
+                crate::commands::workspace_tip::WorkspaceTip::Unknown {
+                    reason: "the daemon that answered this status reported taking the reading \
+                             and then carried none"
+                        .to_string(),
+                },
+            ),
+            source: AuthoritySource::RunningDaemon,
+        }),
         Err(reason) => {
             let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(layout)?;
-            inspect(layout, &binding, EmbeddingCoverage::unobserved(reason))
+            let authority = ActiveRepositoryAuthority::open(&binding)?;
+            let report = inspect_at(layout, &authority, EmbeddingCoverage::unobserved(reason))?;
+            Ok(StatusReading {
+                merge: merge_in_progress_at(&authority),
+                workspace_tip: workspace_tip_at(&authority),
+                report,
+                source: AuthoritySource::OwnAuthorityOpen,
+            })
         }
     }
 }
@@ -941,24 +1041,24 @@ async fn read_status_once(layout: &kin_core::KinLayout) -> Result<StatusReport> 
 async fn settle_embedding_coverage<Read, Reading>(
     budget: std::time::Duration,
     mut read: Read,
-) -> Result<StatusReport>
+) -> Result<StatusReading>
 where
     Read: FnMut() -> Reading,
-    Reading: std::future::Future<Output = Result<StatusReport>>,
+    Reading: std::future::Future<Output = Result<StatusReading>>,
 {
     let deadline = tokio::time::Instant::now() + budget;
     let mut backoff = QUIESCE_BACKOFF_FLOOR;
     loop {
-        let report = read().await?;
-        let EmbeddingCoverage::Unobserved { reason } = report.embedding_coverage else {
-            return Ok(report);
+        let reading = read().await?;
+        let EmbeddingCoverage::Unobserved { reason } = reading.report.embedding_coverage else {
+            return Ok(reading);
         };
         if !reason.settles_on_its_own() {
-            return Ok(report);
+            return Ok(reading);
         }
         let now = tokio::time::Instant::now();
         if now >= deadline {
-            return Ok(report);
+            return Ok(reading);
         }
         // Never overshoot the budget the caller stated, including on the last
         // nap before the deadline.
@@ -973,30 +1073,38 @@ pub async fn run(json: bool, wait_quiesce: std::time::Duration) -> Result<()> {
     // admission describes the graph as it was, which is exactly the answer
     // FIR-2961 is about.
     let pass = admit_before_reading(&layout).await;
-    let report = settle_embedding_coverage(wait_quiesce, || read_status_once(&layout)).await?;
+    let reading = settle_embedding_coverage(wait_quiesce, || read_status_once(&layout)).await?;
+    let report = reading.report;
     if json {
         println!("{}", serde_json::to_string_pretty(&report)?);
     } else {
-        // A merge Kin is holding open, read off the authority lease. Never fatal:
-        // a status that refuses to print because it could not check for a merge
-        // is worse than one that prints and does not mention it, and this is the
-        // command an operator runs when something is already wrong.
-        let merge = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout)
-            .ok()
-            .and_then(|binding| merge_in_progress(&binding).ok())
-            .flatten();
+        // The merge Kin is holding open and where this workspace sits relative
+        // to its branch both came off the SAME authority the report did, in
+        // `read_status_once`. They used to be fetched here through helpers that
+        // each opened the whole store again, which on a 470 MiB import cost two
+        // further whole-store opens for two readings already decoded in a lease
+        // this command had just paid for.
         let footprint = StoreFootprint::measure(&layout);
         print!(
             "{}",
-            render_text(
+            render_text_with_tip(
                 &report,
                 None,
                 Some(&footprint),
                 crate::daemon_death::recorded_for_store(layout.root()).as_ref(),
                 &kin_core::last_admission::read(&layout),
                 &pass,
-                merge.as_ref()
+                reading.merge.as_ref(),
+                Some(&reading.workspace_tip),
             )
+        );
+        // Which authority open answered, in the command's own output. Appended
+        // for the same reason the projection and store-size lines are: it is a
+        // measurement of this host and this invocation, not authority truth,
+        // and it must not move the report's wire shape.
+        println!(
+            "{}",
+            super::repository_authority::answered_by_line(reading.source)
         );
         // Which projection served the files this status describes. Appended
         // here rather than folded into the report for the same reason store
@@ -1119,8 +1227,9 @@ pub fn build_command_status_response(
     admission: &LastAdmissionRead,
     pass: &StatusAdmission,
     merge: Option<&MergeInProgress>,
+    workspace_tip: Option<&crate::commands::workspace_tip::WorkspaceTip>,
 ) -> Result<CommandStatusResponse> {
-    let text = render_text(
+    let text = render_text_with_tip(
         &report,
         build.as_ref(),
         footprint,
@@ -1128,6 +1237,7 @@ pub fn build_command_status_response(
         admission,
         pass,
         merge,
+        workspace_tip,
     );
     let json = json
         .then(|| serde_json::to_string(&report))
@@ -1138,6 +1248,13 @@ pub fn build_command_status_response(
         build,
         text,
         json,
+        merge: merge.cloned(),
+        workspace_tip: workspace_tip.cloned(),
+        // Said only where a caller actually supplied the tip reading, which is
+        // the one that cannot be inferred from a `None`. A caller that passes
+        // none has taken neither, and a `merge` of `None` from it means "not
+        // read" rather than "no merge".
+        authority_readings_taken: workspace_tip.is_some(),
     })
 }
 
@@ -1146,7 +1263,7 @@ pub fn build_command_status_response(
 /// Only the fields a status line needs. The full account is `kin conflicts`, and
 /// duplicating it here would give a reader two versions of one merge that can
 /// come to disagree.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MergeInProgress {
     pub source_ref: String,
     pub target_ref: String,
@@ -1174,14 +1291,49 @@ pub fn merge_in_progress(
     binding: &kin_core::LocalRepositoryAuthorityBinding,
 ) -> Result<Option<MergeInProgress>> {
     let authority = ActiveRepositoryAuthority::open(binding)?;
+    Ok(merge_in_progress_at(&authority))
+}
+
+/// The same reading, from an authority the caller already opened.
+///
+/// Infallible, because everything it needs is already decoded in the lease this
+/// open produced. The binding-taking wrapper above is fallible only for the
+/// open it performs.
+pub fn merge_in_progress_at(authority: &ActiveRepositoryAuthority) -> Option<MergeInProgress> {
     let lease = authority.manager().read_authority();
     let workspace_id = authority.workspace_id;
-    Ok(lease
+    lease
         .metadata()
         .merge_transactions
         .iter()
         .find(|record| record.workspace_id == workspace_id && record.state.is_in_progress())
-        .map(summarize_merge))
+        .map(summarize_merge)
+}
+
+/// Where this workspace sits relative to the branch its head names, from an
+/// authority the caller already opened.
+///
+/// Metadata only, so it adds nothing measurable to an open that has already
+/// happened. See [`crate::commands::workspace_tip`] for why the distance in
+/// changes is not part of this reading.
+pub fn workspace_tip_at(
+    authority: &ActiveRepositoryAuthority,
+) -> crate::commands::workspace_tip::WorkspaceTip {
+    let lease = authority.manager().read_authority();
+    let workspace = lease
+        .metadata()
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.workspace_id == authority.workspace_id);
+    match workspace {
+        Some(workspace) => crate::commands::workspace_tip::read(&lease, workspace),
+        None => crate::commands::workspace_tip::WorkspaceTip::Unknown {
+            reason: format!(
+                "repository {} has no workspace {} in its authority",
+                authority.repository_id, authority.workspace_id
+            ),
+        },
+    }
 }
 
 fn summarize_merge(record: &MergeTransactionRecord) -> MergeInProgress {
@@ -1407,6 +1559,11 @@ fn workspace_state_phrase(
 /// whose enrichment simply has not been certified yet also carries. The counts
 /// matched, the presence matched, and the caveat matched, so the two were
 /// indistinguishable on this surface.
+///
+/// This wrapper is the page as it reads with no workspace-tip line. Every
+/// production caller has one and goes through [`render_text_with_tip`]; the
+/// tests below are about other lines and would otherwise all have to state a
+/// tip they do not care about.
 fn render_text(
     report: &StatusReport,
     build: Option<&BuildStatus>,
@@ -1415,6 +1572,21 @@ fn render_text(
     admission: &LastAdmissionRead,
     pass: &StatusAdmission,
     merge: Option<&MergeInProgress>,
+) -> String {
+    render_text_with_tip(
+        report, build, footprint, death, admission, pass, merge, None,
+    )
+}
+
+fn render_text_with_tip(
+    report: &StatusReport,
+    build: Option<&BuildStatus>,
+    footprint: Option<&StoreFootprint>,
+    death: Option<&kin_daemon_spawn::DaemonKillRecord>,
+    admission: &LastAdmissionRead,
+    pass: &StatusAdmission,
+    merge: Option<&MergeInProgress>,
+    workspace_tip: Option<&crate::commands::workspace_tip::WorkspaceTip>,
 ) -> String {
     let workspace_state =
         workspace_state_phrase(report.workspace.dirty, admission, pass, Utc::now());
@@ -1482,6 +1654,18 @@ fn render_text(
             None => "Authority payload read: none (generation zero built in memory)".to_string(),
         },
     ];
+    // Beside the head it qualifies, not appended at the end. A workspace whose
+    // branch has moved past it reads as a clean tree in every line below, and a
+    // reader who does not already suspect the gap will not scroll for the one
+    // line that names it (FIR-2961 taught the same lesson about the merge
+    // banner, which is why that one leads).
+    if let Some(tip) = workspace_tip {
+        let after_head = lines
+            .iter()
+            .position(|line| line.starts_with("Head: "))
+            .map_or(lines.len(), |position| position + 1);
+        lines.insert(after_head, crate::commands::workspace_tip::line(tip));
+    }
     if let Some(footprint) = footprint {
         lines.push(format!("Store size: {}", footprint.render()));
     }
@@ -2400,6 +2584,91 @@ mod tests {
         );
     }
 
+    /// One `kin status` with no daemon must open repository authority exactly
+    /// once.
+    ///
+    /// GAP-6, in the form that scales. An authority open is a full recovery that
+    /// re-verifies every persisted body against its content address, so it costs
+    /// whatever the whole store is worth: measured on a converted 470 MiB
+    /// express store, one open is seconds and this command was paying for two of
+    /// them locally, plus two more inside the daemon serving it. The COUNT is
+    /// the honest bound and the wall clock is not, because a fixture small
+    /// enough to run in CI answers in milliseconds whether it opens once or
+    /// three times.
+    ///
+    /// Counted on this thread only: this binary runs tests in parallel and
+    /// siblings open authority of their own.
+    ///
+    /// Breaking it: put `merge_in_progress(&binding)` or a binding-taking
+    /// workspace-tip helper back on the fallback arm of `read_status_once`,
+    /// which is exactly what the shipped code did. Either takes this to 2.
+    #[tokio::test]
+    async fn one_status_reading_opens_repository_authority_once() {
+        let _daemon = kin_core::test_env::EnvVarGuard::unset("KIN_DAEMON_URL");
+        let root = tempfile::tempdir().expect("a temporary directory for the fixture store");
+        let init = kin_core::init(root.path()).expect("kin_core::init builds a real store");
+
+        let before = kin_core::authority_opens();
+        let reading = read_status_once(&init.layout)
+            .await
+            .expect("a fresh store answers a status");
+        let opens = kin_core::authority_opens() - before;
+
+        // Non-vacuity, all three halves. A reading that came from a daemon would
+        // open nothing here and pass the bound while testing nothing, and a tip
+        // reading that could not be taken cannot tell "one open for every
+        // reading" apart from "one open and the readings missing".
+        assert_eq!(
+            reading.source,
+            AuthoritySource::OwnAuthorityOpen,
+            "this case is about the arm that opens; a daemon answered instead"
+        );
+        assert_eq!(reading.report.schema, STATUS_SCHEMA);
+        assert!(
+            !matches!(
+                reading.workspace_tip,
+                crate::commands::workspace_tip::WorkspaceTip::Unknown { .. }
+            ),
+            "the workspace-tip reading must have come off that same open: {:?}",
+            reading.workspace_tip
+        );
+        assert_eq!(
+            opens, 1,
+            "one `kin status` must open repository authority once and ask that open for the \
+             report, the merge and the workspace tip; opening per reading is GAP-6"
+        );
+    }
+
+    /// An older daemon's silence about the merge reading must read as "did not
+    /// take it", never as "there is no merge".
+    ///
+    /// This is the wire half of the mixed-build case. A new CLI talking to a
+    /// daemon that predates these fields receives no `authority_readings_taken`
+    /// and no `merge`, and if that decoded as "readings taken, no merge" the
+    /// command would print a clean tree over a workspace holding seventy-six
+    /// conflicts open, which is FIR-2961 reintroduced through the wire.
+    ///
+    /// Breaking it: give the field a `#[serde(default = ...)]` that yields true,
+    /// or drop `#[serde(default)]` so an older payload fails to parse at all.
+    #[test]
+    fn an_older_daemons_status_payload_says_it_took_no_authority_readings() {
+        let payload = serde_json::json!({
+            "report": serde_json::to_value(settle_base_report()).unwrap(),
+            "text": "Kin repository-v6 status",
+        });
+        let decoded: CommandStatusResponse =
+            serde_json::from_value(payload).expect("an older daemon's payload must still decode");
+
+        // Non-vacuity: the payload really is the older shape, carrying neither
+        // of the fields whose absence this is about.
+        assert!(decoded.merge.is_none());
+        assert!(decoded.workspace_tip.is_none());
+        assert!(
+            !decoded.authority_readings_taken,
+            "an absent flag must mean the readings were not taken, so the caller reads them itself"
+        );
+    }
+
     /// One real report to drive the settle with, so it is exercised against the
     /// shape production hands it rather than a hand-built stand-in.
     fn settle_base_report() -> StatusReport {
@@ -2436,15 +2705,26 @@ mod tests {
     ) -> (StatusReport, usize, std::time::Duration) {
         let reads = std::cell::Cell::new(0usize);
         let started = tokio::time::Instant::now();
-        let report = settle_embedding_coverage(budget, || {
+        let reading = settle_embedding_coverage(budget, || {
             let attempt = reads.get();
             reads.set(attempt + 1);
-            let reading = script[attempt.min(script.len() - 1)].clone();
-            async move { Ok(reading) }
+            let report = script[attempt.min(script.len() - 1)].clone();
+            async move {
+                Ok(StatusReading {
+                    report,
+                    merge: None,
+                    workspace_tip: crate::commands::workspace_tip::WorkspaceTip::Detached,
+                    source: AuthoritySource::OwnAuthorityOpen,
+                })
+            }
         })
         .await
         .unwrap();
-        (report, reads.get(), tokio::time::Instant::now() - started)
+        (
+            reading.report,
+            reads.get(),
+            tokio::time::Instant::now() - started,
+        )
     }
 
     /// The race itself: the daemon could not pair a stable authority epoch with

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -1567,6 +1567,12 @@ fn workspace_state_phrase(
 /// production caller has one and goes through [`render_text_with_tip`]; the
 /// tests below are about other lines and would otherwise all have to state a
 /// tip they do not care about.
+///
+/// `#[cfg(test)]` because that is now the whole truth about it. Left compiled
+/// into the library it is dead code, and `-D warnings` in CI turns dead code
+/// into a red gate, so an attribute that says what it is beats a build that
+/// happens to include a test target.
+#[cfg(test)]
 fn render_text(
     report: &StatusReport,
     build: Option<&BuildStatus>,

--- a/crates/kin-cli/src/commands/workspace_tip.rs
+++ b/crates/kin-cli/src/commands/workspace_tip.rs
@@ -1,0 +1,461 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Whether a workspace is projected at the tip of the branch its head names.
+//!
+//! A workspace head can be symbolic and its projected change can still be an
+//! older change than the branch names, and nothing about the working copy shows
+//! it. That is the everyday shape after this store receives a push: the ref
+//! moves, the workspace does not, and `kin status` answers about the workspace
+//! it has. The answer is exactly right and reads as "nothing to do", which is
+//! how a reader came to edit files that the branch had already moved past.
+//! Git refuses the shape outright by default (`receive.denyCurrentBranch`) for
+//! the same reason.
+//!
+//! Read from authority metadata alone. Both readings this needs, the branch's
+//! target and the workspace's base target, live in the persisted authority
+//! record, so no caller pays a change-DAG decode to learn that its workspace
+//! moved. That matters: on a converted repository the change map is most of the
+//! snapshot body and `kin status` deliberately never touches it.
+//!
+//! The distance in changes is therefore NOT part of the reading. It cannot be
+//! had without walking history, so it is filled in by [`with_distance`] and only
+//! by a caller that already decoded the DAG for its own answer. A reading
+//! without it says the tips differ, which is the whole of what metadata proves.
+
+use kin_model::{RefName, RefTarget, SemanticChangeId, WorkspaceHead, WorkspaceState};
+use serde::{Deserialize, Serialize};
+
+/// Where a workspace sits relative to the branch its head names.
+///
+/// Every arm is a statement a reader can act on, including the two that are not
+/// about a lagging workspace. A detached head has no branch tip to compare
+/// with and an unborn branch has no target yet, and both of those rendered as
+/// silence would read exactly like agreement.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum WorkspaceTip {
+    /// The workspace is projected at the change its branch names.
+    AtBranchTip {
+        branch: RefName,
+        tip: SemanticChangeId,
+    },
+    /// The branch names a change this workspace is not projected at.
+    Behind {
+        branch: RefName,
+        tip: SemanticChangeId,
+        /// The change the workspace is projected at, absent on an unborn
+        /// workspace.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        projected: Option<SemanticChangeId>,
+        /// Changes between the projected change and the branch tip, where a
+        /// caller established ancestry. `None` means nobody walked, not that
+        /// the distance is zero.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        distance: Option<usize>,
+    },
+    /// The head is symbolic and its branch has no target yet.
+    BranchUnborn { branch: RefName },
+    /// The head names a change directly, so there is no branch to lag behind.
+    Detached,
+    /// The comparison could not be made, and why.
+    Unknown { reason: String },
+}
+
+impl WorkspaceTip {
+    /// Whether this reading says the workspace and its branch have come apart.
+    pub fn is_behind(&self) -> bool {
+        matches!(self, Self::Behind { .. })
+    }
+
+    /// The same reading with a distance a caller established by walking history.
+    ///
+    /// Silently ignored on every arm but [`Self::Behind`], because a distance
+    /// means nothing on the others and a caller that computed one anyway has
+    /// already spent the walk.
+    #[must_use]
+    pub fn with_distance(self, changes: usize) -> Self {
+        match self {
+            Self::Behind {
+                branch,
+                tip,
+                projected,
+                ..
+            } => Self::Behind {
+                branch,
+                tip,
+                projected,
+                distance: Some(changes),
+            },
+            other => other,
+        }
+    }
+}
+
+/// The branch name a `kin branch switch` argument would take.
+///
+/// Falls back to the fully qualified name rather than guessing, so a ref
+/// outside `refs/heads/` renders a command the reader can still paste.
+fn switch_argument(branch: &RefName) -> String {
+    let rendered = branch.to_string();
+    rendered
+        .strip_prefix("refs/heads/")
+        .unwrap_or(&rendered)
+        .to_string()
+}
+
+/// The status and log line for one reading, worded so the next command is in
+/// the sentence.
+///
+/// Never empty. A verb that prints this line only when something is wrong
+/// teaches its reader that no line means agreement, and no line is also what a
+/// build that lost this reading would print.
+pub fn line(tip: &WorkspaceTip) -> String {
+    const LEAD: &str = "Workspace tip:";
+    match tip {
+        WorkspaceTip::AtBranchTip { branch, tip } => {
+            format!("{LEAD} projected at {branch} ({tip})")
+        }
+        WorkspaceTip::Behind {
+            branch,
+            tip,
+            projected,
+            distance,
+        } => {
+            let gap = match (projected, distance) {
+                (Some(projected), Some(1)) => {
+                    format!("projected at {projected}, 1 change behind {branch} ({tip})")
+                }
+                (Some(projected), Some(count)) => {
+                    format!("projected at {projected}, {count} changes behind {branch} ({tip})")
+                }
+                // No walk established ancestry, so no count is claimed. Saying
+                // the tips differ is the whole of what authority metadata proves.
+                (Some(projected), None) => format!(
+                    "projected at {projected}, which is not the change {branch} names ({tip})"
+                ),
+                (None, _) => format!("unborn, while {branch} names {tip}"),
+            };
+            format!(
+                "{LEAD} {gap}; `kin branch switch {}` projects the branch tip, and nothing above \
+                 describes it",
+                switch_argument(branch)
+            )
+        }
+        WorkspaceTip::BranchUnborn { branch } => {
+            format!("{LEAD} {branch} has no target yet, so there is no branch tip to compare with")
+        }
+        WorkspaceTip::Detached => format!(
+            "{LEAD} this head names a change directly, so it follows no branch; `kin branch \
+             switch <branch>` attaches it"
+        ),
+        WorkspaceTip::Unknown { reason } => {
+            format!("{LEAD} not compared with this workspace's branch; {reason}")
+        }
+    }
+}
+
+/// Read the tip comparison from resolvers the caller supplies.
+///
+/// Split from [`read`] so the four interesting shapes are testable without a
+/// store: an authority open is O(store) and a test that needs one cannot be run
+/// on every arm.
+pub fn measure(
+    head: &WorkspaceHead,
+    base_target: Option<&RefTarget>,
+    resolve_ref: impl Fn(&RefName) -> Result<Option<RefTarget>, String>,
+    resolve_change: impl Fn(&RefTarget) -> Result<SemanticChangeId, String>,
+) -> WorkspaceTip {
+    let WorkspaceHead::Symbolic { target: branch } = head else {
+        return WorkspaceTip::Detached;
+    };
+    let branch_target = match resolve_ref(branch) {
+        Ok(Some(target)) => target,
+        Ok(None) => {
+            return WorkspaceTip::BranchUnborn {
+                branch: branch.clone(),
+            }
+        }
+        Err(reason) => {
+            return WorkspaceTip::Unknown {
+                reason: format!("its branch {branch} would not resolve ({reason})"),
+            }
+        }
+    };
+    let tip = match resolve_change(&branch_target) {
+        Ok(tip) => tip,
+        Err(reason) => {
+            return WorkspaceTip::Unknown {
+                reason: format!("the target of {branch} would not resolve to a change ({reason})"),
+            }
+        }
+    };
+    // An unborn workspace under a born branch is behind by construction, and it
+    // is the shape a fresh store takes after receiving its first push.
+    let Some(base_target) = base_target else {
+        return WorkspaceTip::Behind {
+            branch: branch.clone(),
+            tip,
+            projected: None,
+            distance: None,
+        };
+    };
+    let projected = match resolve_change(base_target) {
+        Ok(projected) => projected,
+        Err(reason) => {
+            return WorkspaceTip::Unknown {
+                reason: format!(
+                    "this workspace's own base target would not resolve to a change ({reason})"
+                ),
+            }
+        }
+    };
+    if projected == tip {
+        return WorkspaceTip::AtBranchTip {
+            branch: branch.clone(),
+            tip,
+        };
+    }
+    WorkspaceTip::Behind {
+        branch: branch.clone(),
+        tip,
+        projected: Some(projected),
+        distance: None,
+    }
+}
+
+/// Read the tip comparison off one authority lease.
+///
+/// Metadata only. `resolve_ref_target` and `resolve_target_change_id` both
+/// answer from the persisted authority record, so this decodes no change map
+/// and costs nothing that scales with history.
+pub fn read(lease: &kin_db::RepositoryAuthorityState, workspace: &WorkspaceState) -> WorkspaceTip {
+    measure(
+        &workspace.head,
+        workspace.base_target.as_ref(),
+        |name| {
+            lease
+                .resolve_ref_target(name)
+                .map_err(|error| error.to_string())
+        },
+        |target| {
+            lease
+                .resolve_target_change_id(target)
+                .map_err(|error| error.to_string())
+        },
+    )
+}
+
+/// How many changes separate `projected` from `tip`, walking first parents and
+/// merges alike, or `None` when ancestry was not established inside `cap`.
+///
+/// `None` is deliberately not zero and not an error. A projected change that is
+/// not an ancestor of the tip is a real state (the branch was force-moved), and
+/// so is a walk that ran out of budget on a converted repository's history.
+/// Both mean the same thing to a reader: the tips differ and no count is
+/// claimed.
+pub fn distance(
+    tip: &SemanticChangeId,
+    projected: &SemanticChangeId,
+    parents: impl Fn(&SemanticChangeId) -> Option<Vec<SemanticChangeId>>,
+    cap: usize,
+) -> Option<usize> {
+    if tip == projected {
+        return Some(0);
+    }
+    let mut seen = std::collections::BTreeSet::new();
+    let mut pending = std::collections::VecDeque::new();
+    seen.insert(*tip);
+    pending.push_back((*tip, 0_usize));
+    let mut visited = 0_usize;
+    while let Some((change_id, depth)) = pending.pop_front() {
+        visited += 1;
+        if visited > cap {
+            return None;
+        }
+        for parent in parents(&change_id)? {
+            if &parent == projected {
+                return Some(depth + 1);
+            }
+            if seen.insert(parent) {
+                pending.push_back((parent, depth + 1));
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kin_model::Hash256;
+
+    fn change(byte: u8) -> SemanticChangeId {
+        SemanticChangeId::from_hash(Hash256::from_bytes([byte; 32]))
+    }
+
+    fn main_branch() -> RefName {
+        RefName::from_utf8("refs/heads/main").expect("refs/heads/main is a legal ref name")
+    }
+
+    fn symbolic() -> WorkspaceHead {
+        WorkspaceHead::Symbolic {
+            target: main_branch(),
+        }
+    }
+
+    /// Resolvers for a store whose `refs/heads/main` names `tip`.
+    fn resolvers(
+        tip: SemanticChangeId,
+    ) -> (
+        impl Fn(&RefName) -> Result<Option<RefTarget>, String>,
+        impl Fn(&RefTarget) -> Result<SemanticChangeId, String>,
+    ) {
+        (
+            move |_: &RefName| Ok(Some(RefTarget::change(tip))),
+            |target: &RefTarget| match target {
+                RefTarget::Change { change_id } => Ok(*change_id),
+                other => Err(format!("{other:?} is not a change")),
+            },
+        )
+    }
+
+    /// GAP-8, rebuilt: the origin received a push, its `refs/heads/main` moved,
+    /// and its workspace is still projected at the change before it.
+    ///
+    /// Breaking it: return `AtBranchTip` unconditionally from `measure`, or drop
+    /// the `projected == tip` comparison so every workspace reads as current.
+    /// Either makes this assertion fail, and either is the defect.
+    #[test]
+    fn a_workspace_left_behind_by_a_push_says_so_and_names_the_switch() {
+        let (resolve_ref, resolve_change) = resolvers(change(0x12));
+        let reading = measure(
+            &symbolic(),
+            Some(&RefTarget::change(change(0x1e))),
+            resolve_ref,
+            resolve_change,
+        );
+        assert!(reading.is_behind(), "{reading:?}");
+        let rendered = line(&reading);
+        assert!(rendered.contains("refs/heads/main"), "{rendered}");
+        assert!(
+            rendered.contains("kin branch switch main"),
+            "the line must name the command that projects the tip: {rendered}"
+        );
+    }
+
+    /// The control. A workspace projected at its branch tip must not be told it
+    /// is behind, or every store reads as lagging and the line means nothing.
+    #[test]
+    fn a_workspace_at_its_branch_tip_is_not_reported_behind() {
+        let tip = change(0x12);
+        let (resolve_ref, resolve_change) = resolvers(tip);
+        let reading = measure(
+            &symbolic(),
+            Some(&RefTarget::change(tip)),
+            resolve_ref,
+            resolve_change,
+        );
+        assert_eq!(
+            reading,
+            WorkspaceTip::AtBranchTip {
+                branch: main_branch(),
+                tip,
+            }
+        );
+        let rendered = line(&reading);
+        assert!(!rendered.contains("behind"), "{rendered}");
+        assert!(
+            !rendered.contains("kin branch switch"),
+            "a workspace with nothing to do must not be handed a command: {rendered}"
+        );
+    }
+
+    /// A detached head follows no branch, and saying nothing would read exactly
+    /// like agreement with one.
+    #[test]
+    fn a_detached_head_says_it_follows_no_branch() {
+        let (resolve_ref, resolve_change) = resolvers(change(0x12));
+        let reading = measure(
+            &WorkspaceHead::Detached {
+                target: RefTarget::change(change(0x1e)),
+            },
+            Some(&RefTarget::change(change(0x1e))),
+            resolve_ref,
+            resolve_change,
+        );
+        assert_eq!(reading, WorkspaceTip::Detached);
+        assert!(line(&reading).contains("follows no branch"));
+    }
+
+    /// An unborn workspace under a born branch is behind, which is the shape a
+    /// fresh store takes after receiving its first push.
+    #[test]
+    fn an_unborn_workspace_under_a_born_branch_is_behind() {
+        let (resolve_ref, resolve_change) = resolvers(change(0x12));
+        let reading = measure(&symbolic(), None, resolve_ref, resolve_change);
+        assert!(reading.is_behind(), "{reading:?}");
+        assert!(line(&reading).contains("unborn"), "{}", line(&reading));
+    }
+
+    /// A count is claimed only when a caller walked for it, and never invented.
+    #[test]
+    fn a_distance_is_rendered_only_once_a_caller_establishes_it() {
+        let (resolve_ref, resolve_change) = resolvers(change(0x12));
+        let reading = measure(
+            &symbolic(),
+            Some(&RefTarget::change(change(0x1e))),
+            resolve_ref,
+            resolve_change,
+        );
+        assert!(
+            !line(&reading).contains("behind"),
+            "a reading with no walk behind it must not claim a count: {}",
+            line(&reading)
+        );
+        let counted = reading.with_distance(3);
+        assert!(
+            line(&counted).contains("3 changes behind"),
+            "{}",
+            line(&counted)
+        );
+        assert!(line(&WorkspaceTip::Behind {
+            branch: main_branch(),
+            tip: change(0x12),
+            projected: Some(change(0x1e)),
+            distance: Some(1),
+        })
+        .contains("1 change behind"));
+    }
+
+    /// The walk counts merges as well as first parents, and refuses rather than
+    /// guessing when the projected change is not an ancestor at all.
+    #[test]
+    fn the_walk_counts_ancestry_and_refuses_a_change_it_cannot_reach() {
+        let (tip, mid, root, stray) = (change(1), change(2), change(3), change(9));
+        let parents = |id: &SemanticChangeId| {
+            if id == &tip {
+                Some(vec![mid])
+            } else if id == &mid {
+                Some(vec![root])
+            } else if id == &root || id == &stray {
+                Some(Vec::new())
+            } else {
+                None
+            }
+        };
+        assert_eq!(distance(&tip, &mid, parents, 100), Some(1));
+        assert_eq!(distance(&tip, &root, parents, 100), Some(2));
+        assert_eq!(distance(&tip, &tip, parents, 100), Some(0));
+        assert_eq!(
+            distance(&tip, &stray, parents, 100),
+            None,
+            "a change the tip is not descended from has no distance to claim"
+        );
+        assert_eq!(
+            distance(&tip, &root, parents, 1),
+            None,
+            "a walk that runs out of budget claims nothing rather than a short count"
+        );
+    }
+}

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -2865,7 +2865,7 @@ fn run() -> Result<()> {
                     commands::capabilities::require_ready("commit")?;
                     commands::commit::run(message, quiet, amend).await
                 }
-                Command::Log { count, json } => commands::log::run(count, json),
+                Command::Log { count, json } => commands::log::run(count, json).await,
                 Command::Branch { action } => match action {
                     BranchAction::List { json } => commands::branch::list(json).await,
                     BranchAction::Create { name, ref_hex } => {

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -4561,11 +4561,16 @@ async fn command_status(
         ));
     }
 
-    let repository_authority = state
-        .local_repository_authority_binding()
-        .map_err(repository_authority_error)?;
+    // One open per publication, not three per request. This route used to take
+    // the raw binding and hand it to two kin-cli helpers that each opened the
+    // whole store for themselves, and the CLI then opened a third time on its
+    // own side for the same merge reading. On a converted 470 MiB store one
+    // open costs seconds because it re-verifies every persisted body, so the
+    // request paid that price three times over for two readings that cannot
+    // vary inside one publication.
+    let repository_authority = command_repository_authority(&state)?;
     let embedding_coverage = live_embedding_coverage(&state).await;
-    let report = kin_cli::commands::status::inspect(
+    let report = kin_cli::commands::status::inspect_at(
         &state.layout,
         &repository_authority,
         embedding_coverage,
@@ -4585,10 +4590,10 @@ async fn command_status(
         daemon_source_known: daemon_build.source_known,
         daemon_dependency_provenance: daemon_build.dependency_provenance.to_string(),
     };
-    let merge = kin_core::LocalRepositoryAuthorityBinding::from_layout(&state.layout)
-        .ok()
-        .and_then(|binding| kin_cli::commands::status::merge_in_progress(&binding).ok())
-        .flatten();
+    // Both readings come off the authority this request already holds, not from
+    // a binding that would open the whole store again for each of them.
+    let merge = kin_cli::commands::status::merge_in_progress_at(&repository_authority);
+    let workspace_tip = kin_cli::commands::status::workspace_tip_at(&repository_authority);
     let response = kin_cli::commands::status::build_command_status_response(
         report,
         request.json,
@@ -4616,6 +4621,7 @@ async fn command_status(
         // Never fatal: a status route that 500s because it could not check for a
         // merge is worse than one that answers and does not mention it.
         merge.as_ref(),
+        Some(&workspace_tip),
     )
     .map_err(internal_error)?;
     Ok(Json(response))
@@ -5259,13 +5265,15 @@ async fn command_diff(
         ));
     }
 
-    let repository_authority = state
-        .local_repository_authority_binding()
-        .map_err(repository_authority_error)?;
+    // One open per publication rather than one per request, for the same reason
+    // `/commands/status` and `/commands/log` take it: an open re-verifies every
+    // persisted body, and neither the diff nor the artifact bodies under it can
+    // vary inside one publication.
+    let repository_authority = command_repository_authority(&state)?;
     // The live graph, which is the whole point of routing a workspace diff here:
     // a workspace endpoint's entities are DERIVED, and this process is the only
     // one that holds them. Read per moved path rather than snapshot-cloned.
-    let response = kin_cli::commands::diff::build_diff_response(
+    let response = kin_cli::commands::diff::build_diff_response_at(
         &repository_authority,
         &request,
         Some(state.graph.as_ref()),
@@ -5290,14 +5298,18 @@ async fn command_log(
         ));
     }
 
+    // The session gate is unchanged: this route still resolves the caller's
+    // session graph, which `build_log_response` has always taken and never read,
+    // so that a session's bookkeeping behaves exactly as it did.
     let session_id = extract_session_id_from_headers(&headers)?;
-    let graph = resolve_session_graph(&state, session_id.as_ref()).await;
-    let repository_authority = state
-        .local_repository_authority_binding()
-        .map_err(repository_authority_error)?;
-    let response =
-        kin_cli::commands::log::build_log_response(&repository_authority, graph.as_ref(), &request)
-            .map_err(internal_error)?;
+    let _graph = resolve_session_graph(&state, session_id.as_ref()).await;
+    // One open per publication rather than one per request. This handler used to
+    // hand the raw binding to a helper that opened the whole store for itself,
+    // which on a converted 470 MiB store is seconds of re-verifying every
+    // persisted body for a history read that cannot vary inside one publication.
+    let repository_authority = command_repository_authority(&state)?;
+    let response = kin_cli::commands::log::build_log_response_at(&repository_authority, &request)
+        .map_err(internal_error)?;
     Ok(Json(response))
 }
 


### PR DESCRIPTION
Journey GAP-6 and GAP-8, from `.kin-coord/reports/showhn-journey-20260904.md`.

## The defect

An authority open re-verifies every persisted body, so it costs whatever the whole store is worth. On an imported 470 MiB express repository the journey lane measured, back to back at load 54:

```
kin log -n 1        9.567 s   then   8.983 s
kin status         35.957 s
kin diff           31.599 s
kin graph status    0.172 s   (daemon-served)
kin locate          1.149 s   (daemon-served)
```

Counted from source at the base sha, the reason is that these three verbs open the whole store two and three times per invocation:

| Verb | With a daemon | Without one |
|---|---|---|
| `kin status` | 1 in the CLI (`merge_in_progress`) + 2 in the daemon's `command_status` | 2 in the CLI |
| `kin diff` | 1 in the CLI (`content_lines_for`) + 1 in the daemon's `command_diff` | 2 in the CLI |
| `kin log` | 1 in the CLI; `log::run` never asked the daemon at all | 1 in the CLI |

The daemon already had a per-publication authority cache sitting beside those handlers, `command_repository_authority` in `api.rs`, and none of the three used it. Routes already existed for both unused verbs: `POST /commands/log` and `POST /commands/diff`. Nothing needed inventing.

The journey lane also measured the same verbs with the graph section freshly materialized (log 31.9 s, status 72.7 s, diff 21.0 s at load 70 to 120). They did not move: the open costs about 12.7 s with nothing to fold. Refreshing the section, which another lane is doing, removes an extra fold on top of an open that is expensive on its own.

## The change

Each verb opens once and asks that one open for everything it needs, through new helpers that take an already-open authority: `status::inspect_at`, `status::merge_in_progress_at`, `status::workspace_tip_at`, `log::inspect_at`, `log::build_log_response_at`, `diff::inspect_with_endpoint_entities_at`, `diff::build_diff_response_at`. The binding-taking wrappers stay, because a one-shot caller with nobody to share an open with is what they are for.

The daemon's `command_status`, `command_diff` and `command_log` take `command_repository_authority`. And `kin log` asks `POST /commands/log` before opening anything, the way `kin diff` already asked `/commands/diff`.

Two response envelopes grew a field so the caller's own open count reaches zero when a daemon answers. Neither report schema moves: `StatusReportWire` denies unknown fields, so a key added there makes an older CLI reject a newer daemon outright and is a v4 decision to take deliberately. The envelopes have never denied unknown fields and every field beside `report` already defaults.

- `CommandStatusResponse` carries `merge`, `workspace_tip` and `authority_readings_taken`.
- `DiffResponse` carries `artifact_content_rendered`; `DiffRequest` carries `full_bodies`.

Both flags exist because "this build did not read it" and "there is nothing to read" are different facts and only the first is a reason for the caller to open the store. An older daemon sends neither, which sends the caller down one local open rather than being believed, so a new CLI against an older daemon still prints the merge banner instead of a clean tree over a parked merge.

Every verb now names which open answered it, in three arms, because a daemon that answered and still cost a local open is neither of the other two.

## GAP-8: a workspace its branch has moved past

After a push into a store with a workspace, `kin status` and `kin log` described the change the workspace held and said nothing about the branch that had moved. New `commands/workspace_tip.rs` names five states and prints one line in every one of them, because a detached head and an unborn branch both read as agreement when nothing is printed.

The reading comes from authority metadata alone. `ChangeMap` decodes on first touch and on a converted repository it is most of the snapshot body, so a status that walked history to count how far behind it was would have re-imported the cost this PR removes. Only `kin log` claims a distance in changes, because only `kin log` has already walked that DAG; a reading with no walk behind it says the tips differ rather than inventing a count.

## Tests, and why they bound a count rather than a clock

New tests that can fail:

- `commands::status::tests::one_status_reading_opens_repository_authority_once`
- `commands::log::tests::one_local_log_opens_repository_authority_once`
- `commands::diff::tests::one_diff_answer_opens_repository_authority_once`
- `commands::status::tests::an_older_daemons_status_payload_says_it_took_no_authority_readings`
- `commands::diff::tests::an_older_daemons_diff_payload_says_it_rendered_no_artifact_content`
- six cases in `commands::workspace_tip::tests`

Each open-count test asserts `kin_core::authority_opens()` moved by exactly one, with a non-vacuity control first: the report must be real and the workspace-tip reading must not be `Unknown`, because "one open and both readings taken" and "one open and a reading missing" would otherwise read identically.

The assertion is on the count, not on elapsed time, and this repository already argues that in its own words at `crates/kin-daemon/src/api.rs`: "a timing assertion on a four-file fixture would pass just as readily with the defect present". A CI fixture answers in milliseconds whether it opens once or three times, so any ratio bound loose enough to survive a loaded runner passes with the defect in place. The wall clock belongs in the measurement below, on a real store.

## Measurement, before

Scratch `HOME` and `KIN_HOME` under `/tmp`, never the primary store. `expressjs/express` at tag `v5.2.1` (`dbac741a`), 218 files, imported with `kin init .` (1285 s on this box), then one `kin commit` because that is what invalidates the graph section and puts the store in the shape the defect was found in. Store 484 MiB under `.kin/`. `KIN_EMBED_BACKEND=cpu`. Binaries are the base sha's own release build.

Cold pass then warm pass; the warm number is the one that counts. `cli_opens` counts `opening persisted repository authority` on the CLI's own stderr under `RUST_LOG=warn,kin_core=info`; `daemon_opens` counts new lines of the same in `.kin/daemon.log` across the invocation. Load 78 to 94 with six Rust builders held on the box throughout, so every wall time is an upper bound and the ratio between the verbs and `kin graph status` at the same moment is what to read.

```
BEFORE, warm
verb             wall_s  cli_opens  daemon_opens  rc
log              23.492          1             0   0
status           85.036          2             2   0
diff             51.045          1             2   0
graph-status      0.304          0             0   0
```

The counts match what source said before anything ran. `kin graph status` answers in 0.304 s having opened repository authority zero times anywhere. `kin log` never asks the daemon. `kin status` spends 85 s across four whole-store opens. Every unit of that gap is an open that did not have to happen.

## Gates

Run locally in the lane worktree through the fleet's builder slot, on the tree at this head:

```
$ cargo fmt --all -- --check
fmt rc=0

$ cargo test -p kin-cli --lib -- commands::status::tests:: commands::log::tests:: \
    commands::diff::tests:: commands::workspace_tip::tests::
test result: ok. 49 passed; 0 failed; 0 ignored; 0 measured; 2128 filtered out; finished in 6.75s

$ cargo check -p kin-daemon --lib
daemon rc=0
```

Clippy is graded by hosted CI rather than locally: on this box a local clippy as `ci.yml` runs it is a full workspace check build and the builder cap is binding.

