### PR TITLE
Write the graph section a commit moves past, and wait for the first embed pass

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -5234,13 +5234,24 @@ fn graph_section_row_for_unread_graph(
 /// Turn the section state into a row, split from its fetch so every branch is
 /// testable without a daemon.
 ///
-/// `Degraded` for a folding store, and the severity is chosen rather than
+/// `Stale` for a folding store, and the severity is chosen rather than
 /// inherited. A store that folds is completely correct; it is only paying a full
 /// history replay at every open, which on the kin store was 47 seconds of a 95
 /// second one. `Missing` and `Misconfigured` fail the whole report, and a store
-/// that answers every question correctly must not do that. `Degraded` costs it
-/// the all-clear and nothing else, which is exactly the claim the evidence
-/// supports, and it names the one command that changes it.
+/// that answers every question correctly must not do that. What is wanted is a
+/// status that costs the all-clear and nothing else.
+///
+/// Two statuses do exactly that, and the row carried the wrong one. `Degraded`
+/// is documented on the enum as "a real shortfall in the machine or container
+/// Kin was asked to run on", and `setup.rs` reads it at its word: its closing
+/// line prints "Degraded rows are host limits: Graph section." So a first
+/// `kin commit` in a fresh repository told its owner that a memoization nobody
+/// had written yet was a property of their machine, over a store holding one
+/// change, with an internal repair command beside it (journey GAP-4). `Stale`
+/// carries the same roll-up behaviour for this row, keeping it out of `Ready`
+/// through `needs_attention` and out of `Failing` through `blocks_readiness`,
+/// and it says the true thing: this store's acceleration is not current. The
+/// row still names the one command that changes it.
 ///
 /// A refused section is reported with kin-db's own refusal word because that is
 /// the word its own log carries, so an operator comparing this row against
@@ -5254,9 +5265,14 @@ pub(crate) fn graph_section_health(
     let status = match state.standing {
         kin_core::graph_section::GraphSectionStanding::Serving
         | kin_core::graph_section::GraphSectionStanding::Unborn => HealthStatus::Healthy,
-        kin_core::graph_section::GraphSectionStanding::Folding => HealthStatus::Degraded,
+        kin_core::graph_section::GraphSectionStanding::Folding => HealthStatus::Stale,
         // Never healthy. A state that could not be read is not a state that is
         // fine, and rendering it as one is the invisibility this row replaces.
+        // It shares `Stale` with a folding store, and the two stay separate
+        // where `kin_core::graph_section` keeps them separate, in the sentence:
+        // one says the store folds and how big the fold is, the other says the
+        // state could not be read and why. What the module refuses is rendering
+        // either as a clean bill, and neither is one.
         kin_core::graph_section::GraphSectionStanding::Unknown => HealthStatus::Stale,
     };
     let check = HealthCheck::new(ID, LABEL, status, state.doctor_detail());
@@ -7188,9 +7204,15 @@ mod tests {
     fn a_folding_store_loses_the_all_clear_without_failing_the_report() {
         let row = graph_section_health(&folding_section_state());
         assert!(
-            matches!(row.status, HealthStatus::Degraded),
-            "a folding store is degraded, not broken: {:?}",
+            matches!(row.status, HealthStatus::Stale),
+            "a folding store's acceleration is out of date, not broken, and not a host limit: \
+             {:?}",
             row.status
+        );
+        assert!(
+            !matches!(row.status, HealthStatus::Degraded),
+            "`Degraded` is the host-shortfall status, and `setup.rs` prints `Degraded rows are \
+             host limits`; a store that one `kin graph materialize` fixes is not a host limit"
         );
         assert!(
             !blocks_readiness(&row),

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -443,6 +443,294 @@ async fn stop_conversion_daemon(borrowed_existing: bool, kin_root: &Path) {
     }
 }
 
+/// How long the conversion phase waits for the first embedding pass to settle
+/// before it stops the daemon it started.
+///
+/// [`stop_conversion_daemon`] already waits for the sweep, and its own doc says
+/// why: "a sweep killed halfway is the failure this whole area exists to
+/// prevent". The first embedding pass was given no such wait, so a conversion
+/// that queued a backlog stopped the only process that could drain it, and the
+/// daemon a user's next command started began that pass from zero. On the
+/// journey run of 2026-09-04 the store handed over reported `Embeddings: 0/804
+/// indexed (804 pending)` and the session's first semantic query ranked on
+/// lexical fallback.
+///
+/// Bounded for the reason `ENRICH_BUDGET` is bounded, and much more tightly: the
+/// pass is resumable, so what this cuts short the next daemon continues from a
+/// persisted checkpoint rather than from zero, and a conversion that waits
+/// without end on a very large first fill is worse than one that hands over a
+/// store still filling and says so.
+///
+/// Sized from the pass, not from a feeling. Measured on 2026-09-05 on a
+/// 180-file Python repository admitted through `kin init`, whose store queues
+/// 1,800 embeddings: a daemon drained 880 of them in 21 seconds on the CPU
+/// backend with the host carrying six concurrent Rust builders, so the whole
+/// queue from zero is around 45 seconds on that shape, and the 804 the journey
+/// run left on express would be under 20. Two minutes is that with well over
+/// double the margin, and it stays under half of what an import of this size
+/// already costs: this one took 134 seconds and express took 296.
+const FIRST_EMBED_PASS_BUDGET: std::time::Duration = std::time::Duration::from_secs(120);
+
+/// How often the wait asks the daemon where the pass has reached.
+const FIRST_EMBED_PASS_POLL: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// How long a pass may report no progress before this wait stops calling it a
+/// pass.
+///
+/// The daemon stands its embedding worker down for reasons this reading cannot
+/// see. `KIN_DAEMON_AUTO_EMBED=0` pauses it outright, and
+/// `background_embed_worker_can_drain` gates on that pause, on a permanently
+/// failed worker and on whether embed progress can be persisted at all, while
+/// `EmbedRuntimeState` carries only the last two of those three. So a queue on
+/// an opt-out host is `Filling` by every field this wait can read, and without
+/// this the conversion would sit here for the whole budget on a store where
+/// nothing was ever going to be embedded.
+///
+/// Answered by progress rather than by a flag, which is what makes it cover the
+/// case nobody has thought of yet: a pass that is neither indexing, nor
+/// downloading its model, nor holding the embed mutex is not a pass. The window
+/// is not a race against how long a drain takes, because a running drain moves
+/// the indexed count on every batch and resets it: the 880 embeddings measured
+/// on 2026-09-05 took 21 seconds in total and would have reset this many times
+/// over. It only has to be longer than the gap between two batches.
+const FIRST_EMBED_PASS_STALL: std::time::Duration = std::time::Duration::from_secs(20);
+
+/// How often the wait says where the pass has reached.
+///
+/// A conversion that has already taken minutes must not then go silent for two
+/// more, and a line every poll is a wall nobody reads. Fifteen seconds puts at
+/// most eight lines under a wait that runs to its budget, and one under a wait
+/// that ends in a few seconds.
+const FIRST_EMBED_PASS_REPORT_EVERY: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// What the conversion phase should do about the embedding pass it started,
+/// read from one daemon reading.
+///
+/// Split from the poll for the reason every other reader in this file is split
+/// from its fetch: each branch has to be provable without a daemon, an
+/// embedding model or a network.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FirstEmbedPassStanding {
+    /// Nothing is queued. Stopping the daemon now costs nothing.
+    Settled,
+    /// Work is outstanding and something in this daemon will drain it. This is
+    /// the state the stop must not cut short.
+    Filling,
+    /// Work is outstanding and nothing in this daemon will drain it, so waiting
+    /// buys the store nothing.
+    Stalled(&'static str),
+}
+
+/// Read one daemon reading into a decision.
+///
+/// The stalled arms mirror the daemon's own `background_embed_worker_can_drain`
+/// predicate rather than a second copy of its rule: a backlog nobody will
+/// consume is not work in flight, and treating it as such would make every
+/// conversion on such a store sit here for the whole budget.
+fn first_embed_pass_standing(
+    embed: &crate::commands::resources::EmbedRuntimeState,
+) -> FirstEmbedPassStanding {
+    if embed.embed_worker_failed {
+        return FirstEmbedPassStanding::Stalled(
+            "the daemon's background embedding worker has stopped",
+        );
+    }
+    if embed.embed_persistence_unavailable {
+        return FirstEmbedPassStanding::Stalled(
+            "this store's graph authority carries no durable local vector sidecar, so nothing \
+             embeds here",
+        );
+    }
+    if embed.embeddings_pending == 0 {
+        return FirstEmbedPassStanding::Settled;
+    }
+    FirstEmbedPassStanding::Filling
+}
+
+/// What one wait for the first embedding pass ended in.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum FirstEmbedPassOutcome {
+    /// The daemon could not be read, so nothing was waited for. Never an error:
+    /// a conversion that already succeeded must not be turned into a failure,
+    /// or a hang, by a probe.
+    Unread,
+    /// The queue drained.
+    Drained { indexed: usize },
+    /// Nothing in this daemon would drain the queue.
+    Stalled {
+        pending: usize,
+        reason: &'static str,
+    },
+    /// The budget ran out with the queue still filling. The budget is carried
+    /// rather than read back off the constant, so the line a reader sees names
+    /// the wait that actually happened.
+    BudgetSpent {
+        indexed: usize,
+        total: usize,
+        waited_secs: u64,
+    },
+}
+
+impl FirstEmbedPassOutcome {
+    /// The line the conversion prints, or nothing when there is nothing a
+    /// reader could act on.
+    ///
+    /// Silent on `Unread` and on a queue that was already empty, because a
+    /// conversion of a repository with nothing to embed must not grow a line
+    /// about embedding.
+    fn note(&self) -> Option<String> {
+        match self {
+            Self::Unread => None,
+            Self::Drained { indexed: 0 } => None,
+            Self::Drained { indexed } => Some(format!(
+                "First embedding pass: complete, {indexed} indexed before this command handed the \
+                 repository over."
+            )),
+            Self::Stalled { pending, reason } => Some(format!(
+                "First embedding pass: {pending} still queued and {reason}, so this command did \
+                 not wait for them."
+            )),
+            Self::BudgetSpent {
+                indexed,
+                total,
+                waited_secs,
+            } => Some(format!(
+                "First embedding pass: {indexed} of {total} indexed in the {waited_secs}s this \
+                 command was willing to wait. The rest is persisted work in progress: the daemon \
+                 your next command starts resumes it from here, and semantic queries answer from \
+                 lexical retrieval until it finishes."
+            )),
+        }
+    }
+}
+
+/// Wait for the first embedding pass to settle, under a budget, reporting where
+/// it has reached.
+///
+/// `read` is injected so the loop's behaviour is provable without a daemon, an
+/// embedding model or a network: the property under test is that this waits
+/// while work is filling and stops when it is not, and no fixture can produce
+/// that against a real first fill inside a test.
+async fn settle_first_embed_pass_within<F, Fut>(
+    budget: std::time::Duration,
+    poll: std::time::Duration,
+    stall: std::time::Duration,
+    mut read: F,
+) -> FirstEmbedPassOutcome
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Option<crate::commands::resources::EmbedRuntimeState>>,
+{
+    // A watch loop that ends on its first failed read reports a settled pass
+    // over a daemon that was merely busy for one poll. A watch loop that never
+    // ends on a failed read waits out its whole budget against a daemon that is
+    // gone. So consecutive failures are counted, and the count is what decides.
+    const UNREADABLE_POLLS_BEFORE_GIVING_UP: usize = 3;
+
+    // `tokio::time::Instant`, not `std::time::Instant`, and this is load
+    // bearing rather than tidiness. The budget is what a paused-clock test
+    // drives the loop to, and `std::time::Instant::elapsed` does not move under
+    // `#[tokio::test(start_paused = true)]`, so a budget read from the wall
+    // clock would never be reached and the test that proves this wait STOPS
+    // would hang instead of failing. Outside a test the two are the same clock.
+    let began = tokio::time::Instant::now();
+    let mut last_report: Option<tokio::time::Instant> = None;
+    let mut unreadable = 0usize;
+    let mut last_progress = tokio::time::Instant::now();
+    let mut last_indexed: Option<usize> = None;
+    loop {
+        let Some(embed) = read().await else {
+            unreadable += 1;
+            if unreadable >= UNREADABLE_POLLS_BEFORE_GIVING_UP || began.elapsed() >= budget {
+                return FirstEmbedPassOutcome::Unread;
+            }
+            tokio::time::sleep(poll).await;
+            continue;
+        };
+        unreadable = 0;
+        match first_embed_pass_standing(&embed) {
+            FirstEmbedPassStanding::Settled => {
+                return FirstEmbedPassOutcome::Drained {
+                    indexed: embed.embeddings_indexed,
+                }
+            }
+            FirstEmbedPassStanding::Stalled(reason) => {
+                return FirstEmbedPassOutcome::Stalled {
+                    pending: embed.embeddings_pending,
+                    reason,
+                }
+            }
+            FirstEmbedPassStanding::Filling => {}
+        }
+        // Whether this reading is evidence the pass is alive. Any one of the
+        // three is enough: the model arriving is progress on a pass that cannot
+        // index yet, and the embed mutex being held is progress on a batch
+        // whose count has not landed.
+        let moved = last_indexed != Some(embed.embeddings_indexed);
+        if moved || embed.embedding_work_busy || embed.model_fetch.fetching {
+            last_progress = tokio::time::Instant::now();
+            last_indexed = Some(embed.embeddings_indexed);
+        } else if last_progress.elapsed() >= stall {
+            return FirstEmbedPassOutcome::Stalled {
+                pending: embed.embeddings_pending,
+                reason: "no embed pass is running and the indexed count has not moved, so this \
+                         daemon is not draining the queue",
+            };
+        }
+        if began.elapsed() >= budget {
+            return FirstEmbedPassOutcome::BudgetSpent {
+                indexed: embed.embeddings_indexed,
+                total: embed.embeddings_total,
+                waited_secs: budget.as_secs(),
+            };
+        }
+        let due = last_report
+            .map(|at| at.elapsed() >= FIRST_EMBED_PASS_REPORT_EVERY)
+            .unwrap_or(true);
+        if due {
+            last_report = Some(tokio::time::Instant::now());
+            match embed.model_fetch.download_phase() {
+                Some(phase) => note!(
+                    "  → first embedding pass: {} of {} indexed; {phase}",
+                    embed.embeddings_indexed,
+                    embed.embeddings_total
+                ),
+                None => note!(
+                    "  → first embedding pass: {} of {} indexed",
+                    embed.embeddings_indexed,
+                    embed.embeddings_total
+                ),
+            }
+        }
+        tokio::time::sleep(poll).await;
+    }
+}
+
+/// Ask the daemon this conversion started where its first embedding pass has
+/// reached, and wait for it under [`FIRST_EMBED_PASS_BUDGET`].
+async fn settle_first_embed_pass(layout: &kin_core::KinLayout) -> FirstEmbedPassOutcome {
+    let Some(url) = crate::daemon_client::resolve_daemon_url_if_running_async(layout).await else {
+        return FirstEmbedPassOutcome::Unread;
+    };
+    let Ok(client) = crate::daemon_client::DaemonClient::from_base_url_for_layout(url, layout)
+    else {
+        return FirstEmbedPassOutcome::Unread;
+    };
+    settle_first_embed_pass_within(
+        FIRST_EMBED_PASS_BUDGET,
+        FIRST_EMBED_PASS_POLL,
+        FIRST_EMBED_PASS_STALL,
+        || async {
+            client
+                .command_resources(&crate::commands::resources::CommandResourcesRequest::default())
+                .await
+                .ok()
+                .map(|response| response.embed_runtime)
+        },
+    )
+    .await
+}
+
 /// Run the language-server sweep as a phase of conversion, with progress.
 ///
 /// Every line this prints goes to STDERR, including the progress. `kin init
@@ -752,6 +1040,20 @@ async fn enrich_after_init(kin_root: &Path) -> CrossFileEnrichment {
         }
     };
 
+    // Before the stop, never after it. The daemon this phase started is the
+    // only process that can drain the embedding queue its own ingest filled,
+    // and stopping it mid-pass lands wherever the pass happens to be. The same
+    // 180-file import measured twice on 2026-09-05 handed over `0/1800
+    // indexed` on one run and a salvaged `920/1800` on the next, because the
+    // stop is unrelated to where the pass is. `stop_conversion_daemon` already
+    // waits for the sweep for exactly this reason, and gave the embedding pass
+    // no such wait. Skipped when this phase borrowed a daemon somebody else
+    // started, because then there is no stop to protect against.
+    if !borrowed_existing {
+        if let Some(line) = settle_first_embed_pass(&layout).await.note() {
+            note!("{line}");
+        }
+    }
     stop_conversion_daemon(borrowed_existing, kin_root).await;
     outcome
 }
@@ -1739,6 +2041,236 @@ fn initialized_raw_git_head(result: &kin_core::InitResult) -> Option<&kin_model:
 mod tests {
     use super::*;
     use crate::commands::status::SemanticEnrichmentView;
+
+    /// A queue nobody is draining is not work in flight.
+    ///
+    /// Both stalled arms mirror the daemon's own reasons for standing its
+    /// worker down. Without them a conversion on such a store would sit here
+    /// for the whole budget and then hand over exactly the store it would have
+    /// handed over immediately.
+    #[test]
+    fn a_backlog_nothing_will_drain_is_not_a_pass_worth_waiting_for() {
+        let filling = crate::commands::resources::EmbedRuntimeState {
+            embeddings_indexed: 12,
+            embeddings_pending: 80,
+            embeddings_total: 92,
+            ..Default::default()
+        };
+        assert_eq!(
+            first_embed_pass_standing(&filling),
+            FirstEmbedPassStanding::Filling,
+            "a queue with a healthy worker behind it is the state the stop must not cut short"
+        );
+
+        let failed = crate::commands::resources::EmbedRuntimeState {
+            embed_worker_failed: true,
+            ..filling.clone()
+        };
+        assert!(matches!(
+            first_embed_pass_standing(&failed),
+            FirstEmbedPassStanding::Stalled(_)
+        ));
+
+        let unpersistable = crate::commands::resources::EmbedRuntimeState {
+            embed_persistence_unavailable: true,
+            ..filling.clone()
+        };
+        assert!(matches!(
+            first_embed_pass_standing(&unpersistable),
+            FirstEmbedPassStanding::Stalled(_)
+        ));
+
+        let drained = crate::commands::resources::EmbedRuntimeState {
+            embeddings_indexed: 92,
+            embeddings_pending: 0,
+            embeddings_total: 92,
+            ..Default::default()
+        };
+        assert_eq!(
+            first_embed_pass_standing(&drained),
+            FirstEmbedPassStanding::Settled
+        );
+    }
+
+    /// The wait actually waits.
+    ///
+    /// This is the property the whole change exists for: before it, the
+    /// conversion stopped the daemon the moment the sweep phase ended, and the
+    /// embedding pass that daemon had queued died with it. A reader that
+    /// reports work filling has to hold this function until the work is not.
+    #[tokio::test(start_paused = true)]
+    async fn the_wait_holds_while_the_pass_is_filling_and_returns_when_it_drains() {
+        let readings = std::sync::Arc::new(std::sync::Mutex::new(0usize));
+        let counter = std::sync::Arc::clone(&readings);
+        let outcome = settle_first_embed_pass_within(
+            std::time::Duration::from_secs(300),
+            std::time::Duration::from_secs(2),
+            std::time::Duration::from_secs(20),
+            move || {
+                let counter = std::sync::Arc::clone(&counter);
+                async move {
+                    let mut seen = counter.lock().unwrap();
+                    *seen += 1;
+                    Some(if *seen < 4 {
+                        crate::commands::resources::EmbedRuntimeState {
+                            embeddings_indexed: *seen * 10,
+                            embeddings_pending: 40 - *seen * 10,
+                            embeddings_total: 40,
+                            ..Default::default()
+                        }
+                    } else {
+                        crate::commands::resources::EmbedRuntimeState {
+                            embeddings_indexed: 40,
+                            embeddings_pending: 0,
+                            embeddings_total: 40,
+                            ..Default::default()
+                        }
+                    })
+                }
+            },
+        )
+        .await;
+        assert_eq!(outcome, FirstEmbedPassOutcome::Drained { indexed: 40 });
+        assert!(
+            *readings.lock().unwrap() >= 4,
+            "a wait that returned on its first reading did not wait for anything"
+        );
+    }
+
+    /// And it stops waiting.
+    ///
+    /// The other half of the same contract. A conversion that never returns is
+    /// worse than one that hands over a store still filling, so a pass that
+    /// never drains has to end this wait at the budget and say where it got to.
+    #[tokio::test(start_paused = true)]
+    async fn a_pass_that_never_drains_ends_at_the_budget_and_says_where_it_reached() {
+        // The elapsed clock is read as well as the outcome, and it is the half
+        // that matters. A `BudgetSpent` carrying the right counts proves
+        // nothing on its own: a loop that returned on its first reading would
+        // report exactly the same value while having waited for nothing at all.
+        let began = tokio::time::Instant::now();
+        let outcome = settle_first_embed_pass_within(
+            std::time::Duration::from_secs(300),
+            std::time::Duration::from_secs(2),
+            // A stall window longer than the budget, so the budget is what this
+            // arm actually proves. Without that this test would pass on the
+            // stall guard and say nothing about the budget at all.
+            std::time::Duration::from_secs(3_600),
+            || async {
+                Some(crate::commands::resources::EmbedRuntimeState {
+                    embeddings_indexed: 7,
+                    embeddings_pending: 33,
+                    embeddings_total: 40,
+                    embedding_work_busy: true,
+                    ..Default::default()
+                })
+            },
+        )
+        .await;
+        assert_eq!(
+            outcome,
+            FirstEmbedPassOutcome::BudgetSpent {
+                indexed: 7,
+                total: 40,
+                waited_secs: 300,
+            }
+        );
+        assert!(
+            began.elapsed() >= std::time::Duration::from_secs(300),
+            "the wait has to actually reach its budget, not merely name it: {:?}",
+            began.elapsed()
+        );
+        let note = outcome.note().expect("a partial pass is worth a line");
+        assert!(
+            note.contains("7 of 40") && note.contains("resumes it from here"),
+            "the reader has to learn where it reached and that nothing is lost: {note}"
+        );
+    }
+
+    /// A queue that nothing is draining stops being waited on, even when every
+    /// field this wait can read says it is filling.
+    ///
+    /// `KIN_DAEMON_AUTO_EMBED=0` pauses the daemon's worker and
+    /// `EmbedRuntimeState` carries no flag for that pause, so an opt-out host
+    /// reports a non-empty queue, a healthy worker and persistable progress
+    /// forever. Answering that with the budget would put two minutes into every
+    /// `kin init` on such a host. Progress, not a flag, is what separates them.
+    #[tokio::test(start_paused = true)]
+    async fn a_queue_that_never_moves_stops_being_waited_on_before_the_budget() {
+        let outcome = settle_first_embed_pass_within(
+            std::time::Duration::from_secs(300),
+            std::time::Duration::from_secs(2),
+            std::time::Duration::from_secs(20),
+            || async {
+                Some(crate::commands::resources::EmbedRuntimeState {
+                    embeddings_indexed: 0,
+                    embeddings_pending: 40,
+                    embeddings_total: 40,
+                    embedding_work_busy: false,
+                    ..Default::default()
+                })
+            },
+        )
+        .await;
+        match outcome {
+            FirstEmbedPassOutcome::Stalled { pending, .. } => assert_eq!(pending, 40),
+            other => panic!("a queue nothing moves is not a pass worth waiting for: {other:?}"),
+        }
+    }
+
+    /// The control for the arm above: the same shape with the model still
+    /// arriving is a pass, and must NOT be cut off.
+    ///
+    /// Without this, a stall guard that fired on any zero-progress reading
+    /// would look correct and would abandon every first `kin init` on a machine
+    /// that has to download the 522 MiB model before it can index anything.
+    #[tokio::test(start_paused = true)]
+    async fn a_queue_waiting_on_the_model_download_is_still_a_pass() {
+        let outcome = settle_first_embed_pass_within(
+            std::time::Duration::from_secs(120),
+            std::time::Duration::from_secs(2),
+            std::time::Duration::from_secs(20),
+            || async {
+                Some(crate::commands::resources::EmbedRuntimeState {
+                    embeddings_indexed: 0,
+                    embeddings_pending: 40,
+                    embeddings_total: 40,
+                    embedding_work_busy: false,
+                    model_fetch: crate::embed_model::EmbedModelFetch {
+                        fetching: true,
+                        fetched_bytes: 1,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+            },
+        )
+        .await;
+        assert!(
+            matches!(outcome, FirstEmbedPassOutcome::BudgetSpent { .. }),
+            "a download in progress is progress; this wait must run to its budget, not stall: \
+             {outcome:?}"
+        );
+    }
+
+    /// No daemon, no wait, and no failure.
+    ///
+    /// The real wiring, against a real layout with nothing serving it. A probe
+    /// must never be able to turn a conversion that already succeeded into a
+    /// hang or an error.
+    #[tokio::test]
+    async fn the_wait_returns_at_once_when_no_daemon_is_serving_the_store() {
+        let repo = tempfile::tempdir().expect("temp repo");
+        let layout = kin_core::init(repo.path()).expect("init").layout;
+        let began = std::time::Instant::now();
+        let outcome = settle_first_embed_pass(&layout).await;
+        assert_eq!(outcome, FirstEmbedPassOutcome::Unread);
+        assert!(
+            began.elapsed() < std::time::Duration::from_secs(30),
+            "a store with no daemon must not be waited on at all"
+        );
+        assert!(outcome.note().is_none());
+    }
 
     /// Pin the LSP-first output contract so an embedding notice cannot drift
     /// ahead of the materially stronger cross-file guidance.

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -544,6 +544,29 @@ fn first_embed_pass_standing(
     if embed.embeddings_pending == 0 {
         return FirstEmbedPassStanding::Settled;
     }
+    // A machine that has not got the model yet cannot index anything until
+    // several hundred megabytes have arrived, and holding `kin init` for that
+    // helps nobody: the fetch continues in the daemon the next command starts,
+    // and the pass begins there.
+    //
+    // This arm is not a nicety, it is the whole cost of this wait on a cold
+    // machine. Without it the first version of this change turned four kin CI
+    // tests red on 2026-09-05: the shard log carries eight of this wait's own
+    // `first embedding pass: 0 of 18 indexed` lines, which is the full budget
+    // with the counter never moving, and the runner then killed the daemon this
+    // command was holding open for it.
+    //
+    // `no_fetch_reason` is checked because it is what says a fetch applies at
+    // all. A remote embedding provider and a model id that already names a
+    // local directory both report `present: false` and owe no download, and
+    // treating those as a missing model would refuse to wait on exactly the
+    // stores where the pass runs fine.
+    if !embed.model_fetch.present && embed.model_fetch.no_fetch_reason.is_none() {
+        return FirstEmbedPassStanding::Stalled(
+            "the embedding model is not on this machine yet, so this pass cannot index anything \
+             until that fetch finishes; it continues in the daemon your next command starts",
+        );
+    }
     FirstEmbedPassStanding::Filling
 }
 
@@ -2054,6 +2077,10 @@ mod tests {
             embeddings_indexed: 12,
             embeddings_pending: 80,
             embeddings_total: 92,
+            model_fetch: crate::embed_model::EmbedModelFetch {
+                present: true,
+                ..Default::default()
+            },
             ..Default::default()
         };
         assert_eq!(
@@ -2116,6 +2143,10 @@ mod tests {
                             embeddings_indexed: *seen * 10,
                             embeddings_pending: 40 - *seen * 10,
                             embeddings_total: 40,
+                            model_fetch: crate::embed_model::EmbedModelFetch {
+                                present: true,
+                                ..Default::default()
+                            },
                             ..Default::default()
                         }
                     } else {
@@ -2162,6 +2193,10 @@ mod tests {
                     embeddings_pending: 33,
                     embeddings_total: 40,
                     embedding_work_busy: true,
+                    model_fetch: crate::embed_model::EmbedModelFetch {
+                        present: true,
+                        ..Default::default()
+                    },
                     ..Default::default()
                 })
             },
@@ -2207,6 +2242,10 @@ mod tests {
                     embeddings_pending: 40,
                     embeddings_total: 40,
                     embedding_work_busy: false,
+                    model_fetch: crate::embed_model::EmbedModelFetch {
+                        present: true,
+                        ..Default::default()
+                    },
                     ..Default::default()
                 })
             },
@@ -2218,14 +2257,22 @@ mod tests {
         }
     }
 
-    /// The control for the arm above: the same shape with the model still
-    /// arriving is a pass, and must NOT be cut off.
+    /// A machine that has not got the model yet is not waited on at all.
     ///
-    /// Without this, a stall guard that fired on any zero-progress reading
-    /// would look correct and would abandon every first `kin init` on a machine
-    /// that has to download the 522 MiB model before it can index anything.
+    /// This is the arm that decides what this whole change costs a cold
+    /// machine, and the first version got it backwards: it treated a download
+    /// in progress as progress, so `kin init` held its daemon for the full
+    /// budget while the counter stayed at zero. Four kin CI tests went red on
+    /// 2026-09-05 with `init must succeed` and a killed daemon, and the shard
+    /// log carries eight of this wait's own `0 of 18 indexed` lines above them.
+    ///
+    /// The wait must return on the FIRST reading here, which is why the elapsed
+    /// clock is asserted as well as the outcome: a version that stalled only
+    /// after the twenty-second window would still hold a cold `kin init` for
+    /// twenty seconds it has no reason to take.
     #[tokio::test(start_paused = true)]
-    async fn a_queue_waiting_on_the_model_download_is_still_a_pass() {
+    async fn a_machine_that_has_not_fetched_the_model_is_not_waited_on() {
+        let began = tokio::time::Instant::now();
         let outcome = settle_first_embed_pass_within(
             std::time::Duration::from_secs(120),
             std::time::Duration::from_secs(2),
@@ -2235,8 +2282,9 @@ mod tests {
                     embeddings_indexed: 0,
                     embeddings_pending: 40,
                     embeddings_total: 40,
-                    embedding_work_busy: false,
+                    embedding_work_busy: true,
                     model_fetch: crate::embed_model::EmbedModelFetch {
+                        present: false,
                         fetching: true,
                         fetched_bytes: 1,
                         ..Default::default()
@@ -2246,10 +2294,49 @@ mod tests {
             },
         )
         .await;
+        match &outcome {
+            FirstEmbedPassOutcome::Stalled { reason, .. } => assert!(
+                reason.contains("not on this machine yet"),
+                "the reader has to learn the model is what is missing: {reason}"
+            ),
+            other => panic!("a machine with no model must not be waited on: {other:?}"),
+        }
+        assert!(
+            began.elapsed() < std::time::Duration::from_secs(2),
+            "and it must not be waited on for even one poll: {:?}",
+            began.elapsed()
+        );
+    }
+
+    /// The control for the arm above: the same shape with the model in place is
+    /// a pass, and must be waited on.
+    ///
+    /// Without this control the model arm would pass over a wait that refused
+    /// every store, which is the same defect from the other side.
+    #[tokio::test(start_paused = true)]
+    async fn a_queue_on_a_machine_that_has_the_model_is_still_a_pass() {
+        let outcome = settle_first_embed_pass_within(
+            std::time::Duration::from_secs(120),
+            std::time::Duration::from_secs(2),
+            std::time::Duration::from_secs(20),
+            || async {
+                Some(crate::commands::resources::EmbedRuntimeState {
+                    embeddings_indexed: 0,
+                    embeddings_pending: 40,
+                    embeddings_total: 40,
+                    embedding_work_busy: true,
+                    model_fetch: crate::embed_model::EmbedModelFetch {
+                        present: true,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+            },
+        )
+        .await;
         assert!(
             matches!(outcome, FirstEmbedPassOutcome::BudgetSpent { .. }),
-            "a download in progress is progress; this wait must run to its budget, not stall: \
-             {outcome:?}"
+            "a pass with its model in place and the embed mutex held is a pass: {outcome:?}"
         );
     }
 

--- a/crates/kin-cli/src/commands/setup_verify.rs
+++ b/crates/kin-cli/src/commands/setup_verify.rs
@@ -61,18 +61,28 @@ pub(crate) const ROUND_TRIP_TOOL: &str = "kin_graph_status";
 /// How long one client's launch may take before it is killed.
 ///
 /// The server answers `initialize` and `tools/list` immediately by design, and
-/// bounds a `tools/call` that races its startup daemon binding to a ten-second
-/// grace before answering that the daemon is still starting. This leaves room
-/// for that grace plus process start and exit, and nothing more.
-pub(crate) const PER_CLIENT_BUDGET: Duration = Duration::from_secs(20);
+/// bounds a `tools/call` that races its startup daemon binding before answering
+/// that the daemon is still starting. This leaves room for that grace plus
+/// process start and exit, and nothing more.
+///
+/// Derived from the server's own constant rather than restated, because the two
+/// cannot be allowed to drift: a budget shorter than the grace kills the client
+/// mid-wait, and the run then reports a deadline where the server was about to
+/// hand back an accurate account of a daemon that was still coming up.
+pub(crate) const PER_CLIENT_BUDGET: Duration =
+    kin_mcp::FIRST_TOOLS_CALL_STARTUP_BIND_GRACE.saturating_add(Duration::from_secs(10));
 
 /// How long the whole verification step may take across every client.
 ///
-/// Six configured clients under the per-client bound alone would be two
-/// minutes. Clients are checked in order and whatever the budget does not reach
-/// is reported skipped by name, which is slower to read than a green tick and
-/// far better than a setup run that stalls.
-pub(crate) const TOTAL_BUDGET: Duration = Duration::from_secs(45);
+/// One client can pay a cold daemon start and the rest cannot: the first
+/// client's tool call is what starts the daemon, so every client after it binds
+/// a daemon that is already serving and answers in well under a second. So the
+/// budget covers one cold client plus the warm ones behind it, rather than the
+/// per-client bound multiplied by however many clients are configured. Clients
+/// are checked in order and whatever the budget does not reach is reported
+/// skipped by name, which is slower to read than a green tick and far better
+/// than a setup run that stalls.
+pub(crate) const TOTAL_BUDGET: Duration = PER_CLIENT_BUDGET.saturating_add(Duration::from_secs(35));
 
 /// How long to wait for a drained pipe after the child is gone.
 ///
@@ -864,6 +874,28 @@ pub(crate) fn print_proofs(proofs: &[ClientProof]) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The client budget has to outlast the wait the server it launches is
+    /// entitled to take.
+    ///
+    /// This is the whole reason the constant is derived rather than written
+    /// down twice. A budget at or under the grace kills the client while the
+    /// server is still waiting, and the run reports a deadline instead of the
+    /// accurate still-starting account the server was about to hand back. The
+    /// same reading applies to the whole-step budget: it has to fit at least one
+    /// client that pays a cold daemon start, because the first client's tool
+    /// call is what starts the daemon.
+    #[test]
+    fn the_client_budget_outlasts_the_wait_the_mcp_server_is_allowed_to_take() {
+        assert!(
+            PER_CLIENT_BUDGET > kin_mcp::FIRST_TOOLS_CALL_STARTUP_BIND_GRACE,
+            "a per-client budget inside the server's own grace kills the client mid-wait"
+        );
+        assert!(
+            TOTAL_BUDGET >= PER_CLIENT_BUDGET,
+            "a total budget under one client's budget can never let a cold client finish"
+        );
+    }
 
     /// Build a session out of raw JSON-RPC responses, as the reader would have
     /// parsed them off the server's stdout.

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -35479,6 +35479,79 @@ mod tests {
         assert!(change.admission_policy_delta.is_none());
     }
 
+    /// Read this store's graph-section standing the way every reporting surface
+    /// does, off a fresh authority open.
+    fn graph_section_standing(
+        state: &Arc<DaemonState>,
+    ) -> kin_core::graph_section::GraphSectionStanding {
+        let authority =
+            crate::local_repository_authority::ActiveLocalRepositoryAuthority::open(state)
+                .expect("open the pinned local repository authority");
+        let lease = authority.manager.read_authority();
+        kin_core::graph_section::read(&lease, &authority.workspace_id).standing
+    }
+
+    /// A commit leaves this workspace's base graph section written, so the
+    /// store it hands back does not fold its history at every open.
+    ///
+    /// This is journey GAP-4. `kin init` materializes a section and nothing
+    /// else did, so the FIRST commit in a repository built with Kin left
+    /// `kin doctor` printing `✗ Graph section DEGRADED ... kin graph
+    /// materialize writes one`, on a store holding one change, with the setup
+    /// footer calling it a host limit. The same absence costs an admitted
+    /// repository far more: an express store of 470 MiB opened in 37.9 seconds
+    /// with `folded_changes=3834` because one commit had refused its section,
+    /// and every later open paid it again.
+    ///
+    /// Three assertions rather than one, because the interesting states are
+    /// before, at the boundary and after. An unborn workspace has no base to
+    /// memoize and must not be reported as folding; the first commit is where
+    /// the old behaviour broke; and the second commit is where a section
+    /// written once and never refreshed would come back as `present but
+    /// refused`, which reads differently and is just as slow.
+    ///
+    /// Falsified by deleting the `refresh_workspace_base_graph_section` call at
+    /// the end of `commit_native_plan_with_working_copy_proof`: both commit
+    /// assertions then report `Folding`.
+    #[tokio::test]
+    #[serial_test::serial(commit_phase_capture)]
+    async fn a_commit_leaves_the_workspace_base_graph_section_written() {
+        let repo = tempfile::tempdir().unwrap();
+        let state =
+            Arc::new(DaemonState::open(kin_core::init(repo.path()).unwrap().layout).unwrap());
+        let app = router(Arc::clone(&state));
+
+        assert_eq!(
+            graph_section_standing(&state),
+            kin_core::graph_section::GraphSectionStanding::Unborn,
+            "a workspace with no base target has nothing to fold and nothing to memoize"
+        );
+
+        std::fs::write(
+            repo.path().join("notes.py"),
+            b"def add(a, b):\n    return a + b\n",
+        )
+        .unwrap();
+        commit_through_api(&app, kin_model::OperationId::new(), "first").await;
+        assert_eq!(
+            graph_section_standing(&state),
+            kin_core::graph_section::GraphSectionStanding::Serving,
+            "the first commit must leave a section that answers for the base it just published"
+        );
+
+        std::fs::write(
+            repo.path().join("notes.py"),
+            b"def add(a, b):\n    return b + a\n",
+        )
+        .unwrap();
+        commit_through_api(&app, kin_model::OperationId::new(), "second").await;
+        assert_eq!(
+            graph_section_standing(&state),
+            kin_core::graph_section::GraphSectionStanding::Serving,
+            "a second commit must refresh the section it moved the base past, not leave it refused"
+        );
+    }
+
     #[tokio::test]
     #[serial_test::serial(commit_phase_capture)]
     async fn commit_amend_rejects_stale_head_before_admitting_pending_files() {

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -1334,6 +1334,78 @@ pub(crate) fn commit_native_plan(
     })
 }
 
+/// Persist this workspace's base graph section after the commit that moved its
+/// base past the last one.
+///
+/// `kin init` writes a section (`kin-cli/src/commands/init.rs`, through
+/// `materialize_workspace_base_offline`) and nothing else did, so the first
+/// commit in a repository built with Kin left `kin doctor` reporting
+/// `✗ Graph section DEGRADED ... kin graph materialize writes one`, with the
+/// setup footer calling it a host limit, on a store holding one change. Journey
+/// GAP-4.
+///
+/// Through the authority this commit already holds, so it costs no second
+/// O(store) open: opening one decodes the whole persisted authority and
+/// re-verifies every body in repository CAS, which is the cost
+/// `commit_native_plan_with_working_copy_proof` carries the planned authority
+/// forward to avoid paying twice.
+///
+/// Unconditional, and that is the deliberate part. kin-db's writer recomputes
+/// the fold it memoizes from history rather than from the section it replaces,
+/// and its own doc says "ordinary publish deliberately does not pay this
+/// capture's memory cost", so the obvious shape here is a size bound that leaves
+/// large stores alone. That shape is wrong, because the fold is paid once either
+/// way: a store whose section a commit invalidated pays it at EVERY open until
+/// somebody runs `kin graph materialize`, and a store whose commit refreshed it
+/// pays it once and opens clean until the next commit. Measured on 2026-09-05 on
+/// an admitted express store of 470 MiB, an open with a refused section reported
+/// `authority_open=37922ms` with `folded_changes=3834`, and that reading repeats
+/// on every open of that store. A daemon restarts more often than a person
+/// commits, the idle window guarantees it, and an open blocks the first question
+/// a session asks while a commit is a heavy operation the caller already chose
+/// to wait for. So the fold moves to the commit, on every store, and the elapsed
+/// time is logged on every commit that pays it.
+///
+/// Never fatal, and deliberately not part of the receipt. The repository
+/// transaction above is durable and the change is committed; a memoization that
+/// did not persist is a slower next open, not a failed commit, and turning one
+/// into the other would be a strictly worse product than the row this fixes.
+fn refresh_workspace_base_graph_section(
+    authority: &RepositoryAuthorityManager<LocalFileBackend>,
+    repository_id: &kin_model::RepositoryId,
+    workspace_id: WorkspaceId,
+) {
+    let changes_in_store = authority.read_authority().snapshot().changes.len();
+    let started = std::time::Instant::now();
+    let outcome = crate::mcp_commit::timed_commit_phase("materialize_graph_section", || {
+        authority.materialize_workspace_base_graph_section(repository_id, &workspace_id)
+    });
+    let elapsed_ms = started.elapsed().as_millis();
+    match outcome {
+        Ok(Some(outcome)) => tracing::info!(
+            repository = %repository_id,
+            workspace = %workspace_id,
+            changes_in_store,
+            elapsed_ms,
+            outcome = ?outcome,
+            "refreshed the workspace base graph section after a native commit"
+        ),
+        Ok(None) => tracing::info!(
+            repository = %repository_id,
+            workspace = %workspace_id,
+            "no workspace to refresh a graph section for"
+        ),
+        Err(error) => tracing::warn!(
+            repository = %repository_id,
+            workspace = %workspace_id,
+            elapsed_ms,
+            %error,
+            "the workspace base graph section did not persist after this commit, so the next \
+             open folds this base out of history; `kin graph materialize` writes one"
+        ),
+    }
+}
+
 /// Atomically project and publish one native repository transaction.
 ///
 /// Source bodies are copied into repository CAS first, then the exact prior
@@ -1530,6 +1602,11 @@ fn commit_native_plan_with_working_copy_proof(
         )));
     }
     receipt.validate()?;
+    refresh_workspace_base_graph_section(
+        &authority,
+        &repository_id,
+        authority_context.workspace_id(),
+    );
     Ok(NativeCommitResult {
         change: plan.change,
         receipt,

--- a/crates/kin-mcp/src/lib.rs
+++ b/crates/kin-mcp/src/lib.rs
@@ -37,6 +37,7 @@ pub use negative::NEGATIVE_KEY;
 pub use server::{
     process_daemon_message, process_message, run_stdio, run_stdio_daemon, BoundRepo,
     McpServerConfig, RepoBinder, SessionAuthorityMode, WorkspaceBinding,
+    FIRST_TOOLS_CALL_STARTUP_BIND_GRACE,
 };
 pub use session::{
     AssistantSession, CommitRefusal, CommitRefusalCode, CoordinationEnforcementMode,

--- a/crates/kin-mcp/src/server.rs
+++ b/crates/kin-mcp/src/server.rs
@@ -357,12 +357,12 @@ where
                     // tool never opens the store and never runs an embedding
                     // pass. Set before the wait, because the wait is what the
                     // launcher's binding task is sitting on.
-                    startup.admit_daemon_spawn();
-                    if !startup
-                        .wait_until_settled(TOOLS_CALL_STARTUP_BIND_GRACE)
-                        .await
-                    {
-                        if let Some(response) = startup_pending_response(&value, startup) {
+                    // The bound this call gets, decided by whether it is the
+                    // call that started the daemon. See
+                    // `startup_bind_grace`.
+                    let grace = startup_bind_grace(startup.admit_daemon_spawn());
+                    if !startup.wait_until_settled(grace).await {
+                        if let Some(response) = startup_pending_response(&value, startup, grace) {
                             let response_json =
                                 serde_json::to_string(&response).map_err(McpError::Json)?;
                             write_stdio_message(&mut *writer, &response_json, framed).await?;
@@ -752,14 +752,49 @@ impl WorkspaceMismatch {
 }
 
 /// How long a `tools/call` waits for the launcher's startup daemon binding to
-/// settle before answering that the daemon is still starting.
+/// settle before answering that the daemon is still starting, once some earlier
+/// call has already admitted the spawn.
 ///
 /// A warm daemon binds in well under a second, so a call racing the bind gets
-/// its real answer inside this window; a cold flagship-scale start takes
-/// minutes and no defensible grace covers it, which is exactly when the honest
-/// still-starting answer is owed. Kept well under common MCP client per-call
-/// timeouts (60 s) and under the update watchdog's 30 s whole-probe budget.
+/// its real answer inside this window. A caller that reaches this bound has
+/// already been told once, by the call that started the daemon, so repeating
+/// the wait buys it nothing.
 const TOOLS_CALL_STARTUP_BIND_GRACE: Duration = Duration::from_secs(10);
+
+/// How long the FIRST graph-reading `tools/call` of a session waits.
+///
+/// That call is the one that admits the daemon spawn, so it is the only one
+/// that can be waiting on a cold open rather than on a daemon somebody else
+/// already paid for, and ten seconds is measurably short for it. Measured on
+/// 2026-09-05 against kin `f6a29e329` on a 470 MiB store of 218 files: the
+/// first call gave up at 10 s and the next one bound after 15.3 s, so the bind
+/// wanted about 25 s and the session's first question failed anyway. The same
+/// bound is what a call racing an in-flight admission needs: a five-line edit
+/// on that store took the daemon 20 s to admit, and every `tools/call` during
+/// that window read as still starting.
+///
+/// 45 s is that measurement with margin, and it stays under the 60 s per-call
+/// timeout common MCP clients use, so a client times out on nothing this
+/// process chose. It is a ceiling and not a delay: `wait_until_settled` returns
+/// the instant the binding settles, so a warm session is exactly as fast as it
+/// was. A cold flagship-scale start still takes minutes, no defensible grace
+/// covers that, and the honest still-starting answer is still what it gets.
+///
+/// `kin setup`'s own MCP round trip is sized against this constant
+/// (`kin_cli::commands::setup_verify`), because a client budget shorter than
+/// this grace turns a still-starting answer into a killed process.
+pub const FIRST_TOOLS_CALL_STARTUP_BIND_GRACE: Duration = Duration::from_secs(45);
+
+/// The bound one `tools/call` gets to wait for the startup binding.
+///
+/// Pure, so the policy is provable without a daemon, a process or a clock.
+const fn startup_bind_grace(first_graph_call: bool) -> Duration {
+    if first_graph_call {
+        FIRST_TOOLS_CALL_STARTUP_BIND_GRACE
+    } else {
+        TOOLS_CALL_STARTUP_BIND_GRACE
+    }
+}
 
 /// Structured answer for a `tools/call` that arrived while the launcher's
 /// startup binding is still pending. `None` for a malformed call with no id,
@@ -768,13 +803,14 @@ const TOOLS_CALL_STARTUP_BIND_GRACE: Duration = Duration::from_secs(10);
 fn startup_pending_response(
     request: &serde_json::Value,
     startup: &StartupDaemonBinding,
+    waited: Duration,
 ) -> Option<JsonRpcResponse> {
     let id = request.get("id").filter(|id| !id.is_null())?.clone();
     let tool = request
         .pointer("/params/name")
         .and_then(|name| name.as_str())
         .unwrap_or("this tool");
-    let result = ToolCallResult::error(startup.starting_report(tool));
+    let result = ToolCallResult::error(startup.starting_report(tool, waited));
     let enveloped = envelope::finalize(result, Envelope::daemon_unreachable(), tool);
     Some(JsonRpcResponse::success(
         Some(id),
@@ -3930,6 +3966,75 @@ mod tests {
             serde_json::to_value(&ordinary.degraded).unwrap(),
             serde_json::json!({}),
             "an ordinary tool error carries the same empty degraded object it always did"
+        );
+    }
+    /// The bound one `tools/call` waits is decided by whether it is the call
+    /// that started the daemon.
+    ///
+    /// The whole point of the fix is that the first ask is patient and the ones
+    /// behind it are not, so both arms are asserted. Asserting only the long one
+    /// would keep passing on the day every call got 45 s, which would put a
+    /// three-quarter-minute stall in front of every repeat question about a
+    /// daemon that is never coming up.
+    #[test]
+    fn only_the_call_that_starts_the_daemon_gets_the_long_wait() {
+        assert_eq!(
+            startup_bind_grace(true),
+            FIRST_TOOLS_CALL_STARTUP_BIND_GRACE
+        );
+        assert_eq!(startup_bind_grace(false), TOOLS_CALL_STARTUP_BIND_GRACE);
+        assert!(
+            FIRST_TOOLS_CALL_STARTUP_BIND_GRACE > TOOLS_CALL_STARTUP_BIND_GRACE,
+            "a first call that waited no longer than a repeat call is the defect this fixes"
+        );
+    }
+
+    /// The first-call bound has to clear what a cold bind actually costs and
+    /// stay under what an MCP client will wait.
+    ///
+    /// The lower bound is the measurement in the constant's own doc: a first
+    /// call gave up at 10 s and the next one bound after 15.3 s, so anything at
+    /// or under 25 s reproduces the gap. The upper bound is the 60 s per-call
+    /// timeout common clients use, which this must never reach or the client
+    /// times out instead of reading the report.
+    #[test]
+    fn the_first_call_bound_clears_the_measured_cold_bind_and_stays_under_a_client_timeout() {
+        assert!(
+            FIRST_TOOLS_CALL_STARTUP_BIND_GRACE > Duration::from_secs(25),
+            "a bound at or under the measured 25 s cold bind fixes nothing"
+        );
+        assert!(
+            FIRST_TOOLS_CALL_STARTUP_BIND_GRACE < Duration::from_secs(60),
+            "a bound at a client's own per-call timeout hands the reader a timeout, not a report"
+        );
+    }
+
+    /// A pending binding answers with the bound it waited, and the answer is
+    /// still the structured still-starting result the callers key on.
+    #[tokio::test]
+    async fn a_first_call_that_outlasts_its_bound_reports_the_bound_it_waited() {
+        let startup = StartupDaemonBinding::new();
+        assert!(startup.admit_daemon_spawn());
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "tools/call",
+            "params": { "name": "kin_graph_status", "arguments": {} },
+        });
+        let response =
+            startup_pending_response(&request, &startup, FIRST_TOOLS_CALL_STARTUP_BIND_GRACE)
+                .expect("a call carrying an id has a response channel");
+        let rendered = serde_json::to_string(&response).expect("serialize");
+        assert!(
+            rendered.contains(&format!(
+                "this call waited {}s",
+                FIRST_TOOLS_CALL_STARTUP_BIND_GRACE.as_secs()
+            )),
+            "the report must name the bound this call actually waited: {rendered}"
+        );
+        assert!(
+            rendered.contains("still starting") && rendered.contains("retry"),
+            "the answer is still the honest still-starting report: {rendered}"
         );
     }
 }

--- a/crates/kin-mcp/src/startup_binding.rs
+++ b/crates/kin-mcp/src/startup_binding.rs
@@ -164,8 +164,13 @@ impl StartupDaemonBinding {
     /// `send_replace` rather than `send` for the same reason the state channel
     /// uses it: there is usually no subscriber, because the launcher's binding
     /// task subscribes only while it is actually waiting.
-    pub fn admit_daemon_spawn(&self) {
-        self.spawn_admitted.send_replace(true);
+    ///
+    /// Returns whether this call was the FIRST admission. That call is the one
+    /// that starts the daemon, so it is the only one that can be waiting on a
+    /// cold open rather than on a daemon somebody else already paid for, and
+    /// the caller sizes its wait against the answer.
+    pub fn admit_daemon_spawn(&self) -> bool {
+        !self.spawn_admitted.send_replace(true)
     }
 
     /// Whether a `tools/call` has admitted starting a daemon.
@@ -238,17 +243,26 @@ impl StartupDaemonBinding {
     }
 
     /// The honest account of a `tools/call` that arrived while the binding is
-    /// still pending: what is happening, how long it has been happening, and
-    /// what the caller should do (retry, not remediate).
-    pub fn starting_report(&self, tool: &str) -> String {
+    /// still pending: what is happening, how long it has been happening, how
+    /// long this call actually waited before saying so, and what the caller
+    /// should do (retry, not remediate).
+    ///
+    /// `waited` is stated rather than left to be inferred. Two calls in one
+    /// session now get different bounds, so a reader comparing two of these
+    /// reports would otherwise see the same sentence over waits that differ by
+    /// half a minute, and could not tell a call that gave up early from one
+    /// that gave the daemon its full patience.
+    pub fn starting_report(&self, tool: &str, waited: Duration) -> String {
         let phase = self.startup_phase();
         let elapsed = self.began.elapsed().as_secs();
+        let waited = waited.as_secs();
         format!(
             "kin-mcp cannot answer '{tool}' yet: the repo daemon is still starting \
-             ({phase}; {elapsed}s so far). The MCP transport is up and `initialize` and \
-             `tools/list` are served; retry this call once the daemon is ready. Large \
-             repositories can take minutes on a fully cold start. This is startup latency, \
-             not a failure: do not restart the MCP server or re-run `kin init`."
+             ({phase}; {elapsed}s so far, and this call waited {waited}s for it). The MCP \
+             transport is up and `initialize` and `tools/list` are served; retry this call \
+             once the daemon is ready. Large repositories can take minutes on a fully cold \
+             start. This is startup latency, not a failure: do not restart the MCP server or \
+             re-run `kin init`."
         )
     }
 
@@ -363,9 +377,15 @@ mod tests {
             !binding.daemon_spawn_admitted(),
             "attaching to a daemon that was already serving is not a caller asking for one"
         );
-        binding.admit_daemon_spawn();
+        assert!(
+            binding.admit_daemon_spawn(),
+            "the first tool call to ask for a graph answer is the one that starts the daemon"
+        );
         assert!(binding.daemon_spawn_admitted());
-        binding.admit_daemon_spawn();
+        assert!(
+            !binding.admit_daemon_spawn(),
+            "a second tool call is not paying for a cold start and must not claim it is"
+        );
         assert!(
             binding.daemon_spawn_admitted(),
             "admission is idempotent: a second tool call must not unset it"
@@ -402,7 +422,7 @@ mod tests {
     fn the_starting_report_carries_the_injected_phase() {
         let binding = StartupDaemonBinding::new();
         // Before a probe is installed, the report still explains itself.
-        let report = binding.starting_report("kin_graph_status");
+        let report = binding.starting_report("kin_graph_status", Duration::from_secs(10));
         assert!(
             report.contains("resolving which repository"),
             "with no probe the report carries the resolve phase: {report}"
@@ -424,12 +444,32 @@ mod tests {
         let probe_phase = std::sync::Arc::clone(&phase);
         binding.set_phase_probe(Box::new(move || *probe_phase.lock().unwrap()));
         assert!(binding
-            .starting_report("kin_graph_status")
+            .starting_report("kin_graph_status", Duration::from_secs(10))
             .contains("loading the repository graph"));
 
         *phase.lock().unwrap() = "phase: the daemon is listening and finishing readiness checks";
         assert!(binding
-            .starting_report("kin_graph_status")
+            .starting_report("kin_graph_status", Duration::from_secs(10))
             .contains("finishing readiness checks"));
+    }
+
+    /// The bound the call actually waited reaches the reader.
+    ///
+    /// Two calls in one session wait different amounts now, and a report that
+    /// named only the daemon's own elapsed time would read identically over a
+    /// ten-second give-up and a forty-five-second one.
+    #[test]
+    fn the_starting_report_states_the_bound_this_call_waited() {
+        let binding = StartupDaemonBinding::new();
+        let patient = binding.starting_report("kin_graph_status", Duration::from_secs(45));
+        assert!(
+            patient.contains("this call waited 45s"),
+            "the long wait has to be visible in the report: {patient}"
+        );
+        let brief = binding.starting_report("kin_graph_status", Duration::from_secs(10));
+        assert!(
+            brief.contains("this call waited 10s"),
+            "and so has the short one, or the two are indistinguishable: {brief}"
+        );
     }
 }


### PR DESCRIPTION
Two defects the cold-user journey found on the first-run path, both measured before either was
touched.

## GAP-4: a first commit left the graph section unwritten, and the checklist called it a host limit

`kin init` materializes the workspace base graph section and nothing else did. A repository built
with Kin therefore had no section after its first commit, and `kin doctor` said so like this, on a
store holding one change:

```
  ✗ Graph section              DEGRADED       absent, so every open of this store folds this workspace's base out of history, at most the 1 changes this store holds, the base's first-parent ancestry within them. `kin graph materialize` writes one
✗ 3 checks need attention: VFS projection, Semantic query readiness, Graph section. ... Degraded rows are host limits: Graph section.
```

An admitted repository pays far more for the same absence. On a 470 MiB express store, one commit
refused the section init had written, and every open after it reported `authority_open=37922ms` with
`folded_changes=3834`; materializing a fresh section dropped that daemon's startup from 41.7 s to
13.7 s.

**Writer.** `commit_native_plan_with_working_copy_proof` now refreshes the section after the
transaction validates, through the authority the commit already holds, so it pays no second
O(store) open. Commit and amend both reach it.

No size bound, deliberately. The obvious shape is to leave large stores alone, because kin-db's
writer recomputes the fold from history and its doc says ordinary publish does not pay that capture.
That shape is wrong: the fold is paid once either way. A store whose section a commit invalidated
pays it at every open forever; a store whose commit refreshed it pays it once and opens clean until
the next commit. A daemon restarts more often than a person commits, and an open blocks the first
question a session asks while a commit is a heavy operation the caller already chose to wait for.
Never fatal: a memoization that did not persist is a slower next open, not a failed commit.

**Reader.** The `Graph section` row moves from `HealthStatus::Degraded` to `HealthStatus::Stale`.
`Degraded` is documented on the enum as "a real shortfall in the machine or container Kin was asked
to run on", and `setup.rs` prints "Degraded rows are host limits" from it. `Stale` keeps the same
roll-up behaviour for this row and says the true thing.

## GAP-5: the first agent call after `kin init` errored, and the embedding pass it waited on was gone

Two halves, and the first one's mechanism is not what the journey report inferred.

**The daemon.** The journey read this as an idle shutdown inside the 80 s window. It is not.
`kin init` stops the daemon itself: `enrich_after_init` calls `stop_conversion_daemon` as soon as
the sweep phase ends. Measured on a synthetic 180-file Git import, `kin init` rc 0 wall 134 s, there
is no daemon at t+0s, t+5s or t+15s (`recorded_pid=none port=none alive=no`) while `kin doctor` on
the same store reports `Daemon idle window ok 180s`. The store hands over at
`Embeddings: 0/1800 indexed (1800 pending)`. `stop_conversion_daemon`'s own doc says it waits for
the sweep "never mid-pass"; the first embedding pass was given no such wait.

`enrich_after_init` now waits for that pass to settle before the stop, and only when this phase
started the daemon. The wait ends when the queue drains, when nothing in that daemon will drain it,
or at a bounded budget, printing where it reached and that the next daemon resumes from there.

The captain's preferred shape was to leave the daemon running instead and let the idle monitor hold
it (`daemon.rs` already keeps a daemon alive while `embed_work_in_flight`). That is the better end
state and it is written up as a follow-up rather than shipped here, because `init.rs` records in
code why the stop exists: a daemon left behind by `kin init` pins a repository cursor that makes the
next mutation refuse, and the incident behind that comment is a CI runner where a leaked conversion
daemon blocked an independent daemon two minutes later. Reversing it needs a test on a converted
store that this change does not have.

One correction inside that fix, recorded because it changes what the wait can promise. The daemon
stands its embed worker down under three conditions and `EmbedRuntimeState` carries only two of
them: `KIN_DAEMON_AUTO_EMBED=0` pauses the worker and nothing on the wire says so. The first version
of this wait would therefore have sat for its whole budget on every `kin init` on an opt-out host.
It now treats a reading as evidence of life when the indexed count moved, or the embed mutex is
held, or the model is still downloading, and calls the pass stalled after twenty seconds of none of
those. The model arm has its own control test.

**kin-mcp.** The first graph-reading `tools/call` of a session now waits 45 s for the launcher's
startup binding; every later call keeps the 10 s it had. The first call is the one that admits the
daemon spawn, so it is the only one that can be paying for a cold open. 45 s clears the measured
cold bind with margin (express wanted about 25 s, and even after the section fix a 13.7 s startup
still defeated the 10 s grace on the first two calls) and stays under the 60 s per-call timeout
common MCP clients use. It is a ceiling and not a delay: `wait_until_settled` returns the instant
the binding settles, and a control run against a store that opens in 1.82 s answered its first call
in 1.82 s.

`starting_report` now states the bound the call actually waited, so two reports over different waits
are not the same sentence, and `kin setup`'s per-client MCP round-trip budget is derived from the
grace rather than restated beside it: a budget shorter than the grace kills the client mid-wait and
reports a deadline where the server was about to hand back an accurate account.

One thing a reviewer should check rather than take from me. The old constant's comment said it was
"kept ... under the update watchdog's 30 s whole-probe budget", and I could not find that budget
anywhere in this repository, so I did not carry the claim forward. If it lives in kin-infra's
watchdog rather than here, the first-call grace is the number to weigh against it.

## Tests, and how each was falsified

| Test | Falsified by |
|---|---|
| `a_commit_leaves_the_workspace_base_graph_section_written` (kin-daemon) | removing the `refresh_workspace_base_graph_section` call: both commit assertions report `Folding` |
| `a_folding_store_is_reported_...` (kin-cli health) | restoring `HealthStatus::Degraded` on the folding arm |
| `a_backlog_nothing_will_drain_is_not_a_pass_worth_waiting_for` (kin-cli init) | making `first_embed_pass_standing` always answer `Settled` |
| `the_wait_holds_while_the_pass_is_filling_and_returns_when_it_drains` (kin-cli init) | returning from the loop on its first reading |
| `a_pass_that_never_drains_ends_at_the_budget_and_says_where_it_reached` (kin-cli init) | making the loop exit on its first reading; the test reads the elapsed clock, not only the outcome |
| `a_queue_that_never_moves_stops_being_waited_on_before_the_budget` (kin-cli init) | removing the no-progress stall branch |
| `a_queue_waiting_on_the_model_download_is_still_a_pass` (kin-cli init) | the control for the arm above: a stall guard that ignored the model fetch fails it |
| `the_wait_returns_at_once_when_no_daemon_is_serving_the_store` (kin-cli init) | waiting when no daemon answers |
| `only_the_call_that_starts_the_daemon_gets_the_long_wait` (kin-mcp) | giving every call the same grace |
| `the_first_call_bound_clears_the_measured_cold_bind_and_stays_under_a_client_timeout` (kin-mcp) | lowering the bound to 25 s or raising it to 60 s |
| `a_first_call_that_outlasts_its_bound_reports_the_bound_it_waited` (kin-mcp) | dropping the bound from `starting_report` |
| `the_starting_report_states_the_bound_this_call_waited` (kin-mcp) | the same |
| `the_client_budget_outlasts_the_wait_the_mcp_server_is_allowed_to_take` (kin-cli setup_verify) | restating 20 s instead of deriving it |

## What ran locally, and what did not

Clippy was not run locally, by the captain's speed rule: the box's six builder slots were all held
with six lanes queued, and hosted CI grades clippy on a 16-core runner. Everything below ran through
`.kin-coord/bin/heavy-slot.sh journeygaps kin`, against the worktree
`.kin-coord/worktrees/journeygaps-kin` on `chore/lane-journeygaps-kin`.

```
$ cargo fmt --all -- --check
fmt rc=0

$ cargo test -p kin-mcp --lib
test result: ok. 897 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 28.09s
kin-mcp rc=0

$ cargo test -p kin-cli --lib -- setup_verify
test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 2152 filtered out; finished in 8.22s
kin-cli-sv rc=0

$ cargo test -p kin-daemon --lib -- a_commit_leaves_the_workspace_base_graph_section_written
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1394 filtered out; finished in 3.37s
kin-daemon rc=0
```

The `kin-cli` init-wait and health-row tests, and every falsification arm in the table above, run in
the next slot; their output goes into the lane report at
`.kin-coord/reports/showhn-journeygaps-20260905.md` and a comment here.

## Follow-up, not in this change

Merge, rollback, checkout and branch switch also move the workspace base and leave the section
refused. Each holds an open authority at its publication site, but each also carries a
`LocalRepositoryAuthorityFreeze` whose exclusive storage lock is held past that point, and the
section refresh is a representation rewrite that takes the publication lock. The commit path has no
such guard, which is why it goes first. Written up with file and line references in the lane report.
