### PR TITLE
Pair the seam's declared schema version with the contract

### DIFF
--- a/packages/boundary-contracts/src/index.d.ts
+++ b/packages/boundary-contracts/src/index.d.ts
@@ -774,7 +774,7 @@ export interface HostedRepositoryTransferRefusal {
  */
 export interface HostedRepositoryTransferSeam {
   protocol: "kin-repository-v6-fast-forward";
-  schemaVersion: 4;
+  schemaVersion: 5;
   routeTemplate: string;
   authorizationScheme: "Bearer";
   orgScoped: true;

--- a/packages/boundary-contracts/test/contracts.test.js
+++ b/packages/boundary-contracts/test/contracts.test.js
@@ -692,6 +692,30 @@ test('the hosted transfer seam is one contract three implementations read', asyn
   );
   assert.ok(version, 'the Rust schema version constant must remain readable');
   assert.equal(Number(version[1]), seam.schemaVersion);
+
+  // The seam's own declared literal, which nothing paired with the contract
+  // until now. kin#1512 bumped the four snake_case `schema_version` literals in
+  // the declarations and left this camelCase one at 4, so a TypeScript consumer
+  // read 4 where both the contract and the runtime said 5, and every suite
+  // stayed green. Read out of the interface rather than restated here, so a
+  // second hand-typed copy cannot drift with the first.
+  const seamInterface = declarations.match(
+    /export interface HostedRepositoryTransferSeam \{([\s\S]*?)\n\}/
+  );
+  assert.ok(
+    seamInterface,
+    'HostedRepositoryTransferSeam must remain declared, or this pairing is reading nothing'
+  );
+  const declaredSeamVersion = seamInterface[1].match(/\n  schemaVersion: (\d+);/);
+  assert.ok(
+    declaredSeamVersion,
+    'HostedRepositoryTransferSeam must declare schemaVersion as a literal, so a consumer reads the number rather than `number`'
+  );
+  assert.equal(
+    Number(declaredSeamVersion[1]),
+    seam.schemaVersion,
+    'the declared seam schemaVersion and the contract disagree, so a TypeScript consumer reads a version the runtime does not send'
+  );
 });
 
 test('the hosted transfer route is built from the contract, and refuses what it cannot address', async () => {


### PR DESCRIPTION
`index.d.ts` declared `HostedRepositoryTransferSeam.schemaVersion: 4` while the contract beside it
and the runtime both said 5, so a TypeScript consumer read a version the daemon does not send. This
fixes the declaration and adds the assertion that would have caught it.

kin#1512 moved the transfer schema from 4 to 5 and bumped the four snake_case `schema_version`
literals in the declarations. It missed this camelCase one. Found by kinlab's transfer5 lane, not by
any check.

## Why nothing caught it

`packages/boundary-contracts/test/contracts.test.js` is thorough about this seam and still had a
hole. It pins the Rust `REPOSITORY_TRANSFER_SCHEMA_VERSION` to the JSON `schemaVersion`, and it pins
three declared interfaces to the export envelope's exact key list and order. No assertion ever read
the seam interface's own declared literal, so the Rust said 5, the JSON said 5, the declarations said
4, and every suite stayed green.

## The pairing

It reads the literal out of the interface rather than restating the number beside it, which is the
reason the rest of this file gives for reading sources instead of copying them: a second hand-typed
copy agrees with nothing and drifts with the first. Two guards come with it, so a hit means
something. The interface must still be declared, or the regex is reading an empty string. And
`schemaVersion` must still be a literal rather than `number`, because widening the type is the other
way this pairing could stop meaning anything while staying green.

## Verification

```
$ cd packages/boundary-contracts && node --test
ℹ tests 19
ℹ pass 19
ℹ fail 0
```

Falsified by setting the declaration back to `schemaVersion: 4`:

```
mutated rc=1
AssertionError [ERR_ASSERTION]: the declared seam schemaVersion and the contract disagree, so a
TypeScript consumer reads a version the runtime does not send
```

Reverted, `rc=0` again, and `git status --porcelain` empty.

No released binary carries the wrong declaration, so this is a documentation-of-record fix rather
than a runtime one. The suite runs inside the required `Fast gate lint and policy` context.
