### PR TITLE
Refuse to certify a file enumeration over spans of other bytes

### DIFF
--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant, SystemTime};
 use kin_index::{
     FileClassification, FileClassifier, FileEvent, FileWatcher, IndexPipeline, IndexedAny,
 };
+use kin_model::layout::ParseCompleteness;
 use kin_model::{
     EntityFilter, EntityId, EntityStore, FilePathId, Hash256, RepoPath, ShallowTrackedFile,
     TransactionDelta, TreeDelta, TreeEntry,
@@ -2307,12 +2308,63 @@ pub(crate) struct LayoutBackfill {
     pub(crate) unreadable: usize,
     /// Artifacts another facet already owns, which this pass must not touch.
     pub(crate) other_facet: usize,
+    /// Artifacts whose graph entities disagree with a fresh parse of the bytes
+    /// the tree holds: published as `Partial` rather than `Full`, and owed a
+    /// re-derivation. Counted inside `published`.
+    pub(crate) stale: usize,
+    /// The host paths whose entities are owed a re-derivation, for the loop to
+    /// enqueue as ordinary `Changed` events.
+    pub(crate) rederive: Vec<PathBuf>,
 }
 
 impl LayoutBackfill {
     fn observed(&self) -> usize {
         self.already_published + self.published + self.unreadable + self.other_facet
     }
+}
+
+/// One entity's identity as a parse would reproduce it: what it is, what it is
+/// called, and exactly which bytes it spans. Two parses of the same bytes agree
+/// on every field; a parse of different bytes moves the span of everything after
+/// the edit.
+type ParsedSpanKey = (String, String, usize, usize);
+
+fn parsed_span_keys(entities: &[kin_model::Entity]) -> Vec<ParsedSpanKey> {
+    let mut keys = entities
+        .iter()
+        .filter(|entity| entity.role == kin_model::EntityRole::Source)
+        .filter_map(|entity| {
+            entity.span.as_ref().map(|span| {
+                (
+                    format!("{:?}", entity.kind),
+                    entity.name.clone(),
+                    span.start_byte,
+                    span.end_byte,
+                )
+            })
+        })
+        .collect::<Vec<_>>();
+    keys.sort();
+    keys
+}
+
+/// How many of the graph's source entities for one file a fresh parse of the
+/// tree's bytes does not reproduce.
+///
+/// Compared by kind, name and byte span rather than by id, because the
+/// reconciler keeps an entity's id stable across an edit that moves it
+/// (`stable_entity_ids` in kin-reconcile), so ids agree on a store that is
+/// fresh and disagree on one that is not, which is backwards for this question.
+/// Spans are the thing that goes stale, so spans are what is compared.
+pub(crate) fn spans_a_fresh_parse_does_not_reproduce(
+    held: &[kin_model::Entity],
+    fresh: &[kin_model::Entity],
+) -> usize {
+    let fresh_keys = parsed_span_keys(fresh);
+    parsed_span_keys(held)
+        .into_iter()
+        .filter(|key| fresh_keys.binary_search(key).is_err())
+        .count()
 }
 
 /// Publish the per-file parse observation for every admitted entity-source
@@ -2414,20 +2466,20 @@ pub(crate) fn backfill_missing_file_layouts(state: &DaemonState) -> Result<Layou
             continue;
         }
 
-        let completeness =
-            match pipeline.index_file_content_with_tests(&file_id, &content, body_hash) {
-                Ok(indexed) => indexed.indexed_file.file_layout.parse_completeness,
-                Err(error) => {
-                    debug!(
-                        file = %file_id,
-                        error = %error,
-                        "graph-owned source could not be indexed, so its parse observation stays \
-                         unpublished rather than being guessed"
-                    );
-                    report.unreadable += 1;
-                    continue;
-                }
-            };
+        let indexed = match pipeline.index_file_content_with_tests(&file_id, &content, body_hash) {
+            Ok(indexed) => indexed.indexed_file,
+            Err(error) => {
+                debug!(
+                    file = %file_id,
+                    error = %error,
+                    "graph-owned source could not be indexed, so its parse observation stays \
+                     unpublished rather than being guessed"
+                );
+                report.unreadable += 1;
+                continue;
+            }
+        };
+        let mut completeness = indexed.file_layout.parse_completeness;
 
         let mut entities = state.graph.query_entities(&EntityFilter {
             file_path: Some(file_id.clone()),
@@ -2440,6 +2492,30 @@ pub(crate) fn backfill_missing_file_layouts(state: &DaemonState) -> Result<Layou
                 .map(|span| span.start_byte)
                 .unwrap_or(usize::MAX)
         });
+        // The parse just taken is of the bytes the tree holds NOW. The entities
+        // the graph holds may have been derived from an earlier blob at this
+        // path: a daemon that admitted new bytes into the tree and died before
+        // it re-derived and published their entities leaves exactly that, and
+        // nothing else about the store says so (FIR-3201, the restart window of
+        // FIR-3208). Publishing `Full` here would certify those spans over
+        // bytes they do not describe. The observation is recorded as partial,
+        // with the count, and the path is handed back to the loop as an
+        // ordinary host event so the reconciler re-derives it through the same
+        // bounded admission an edit takes.
+        let stale = spans_a_fresh_parse_does_not_reproduce(&entities, &indexed.entities);
+        if stale > 0 {
+            if let Ok(host_path) =
+                kin_index::host_path_from_repo_path(state.layout.working_dir(), &artifact.path)
+            {
+                report.rederive.push(host_path);
+            }
+            report.stale += 1;
+            completeness = ParseCompleteness::Partial(format!(
+                "{stale} of {} entity span(s) the graph holds for this file were not derived from \
+                 the bytes the repository tree holds at this path; they are being re-derived",
+                entities.len()
+            ));
+        }
         let layout =
             kin_core::build_entity_file_layout(&file_id, &entities, content.len(), completeness);
         state.graph.upsert_file_layout(&layout)?;
@@ -2750,10 +2826,24 @@ pub async fn run_loop_armed(
                         already_published = report.already_published,
                         unreadable = report.unreadable,
                         other_facet = report.other_facet,
+                        stale = report.stale,
                         observed = report.observed(),
                         "published the per-file parse observation for admitted source files that \
                          carried none, so an enumeration over them can be certified"
                     );
+                    if !report.rederive.is_empty() {
+                        warn!(
+                            count = report.rederive.len(),
+                            "these paths hold entities a fresh parse of the tree's bytes does not \
+                             reproduce, so their spans describe an earlier state of the file; \
+                             their parse observation was published as partial and they are being \
+                             re-derived"
+                        );
+                        enqueue_file_events(
+                            &mut pending_events,
+                            report.rederive.into_iter().map(FileEvent::Changed),
+                        );
+                    }
                     state.bump_version();
                 }
                 Err(error) => {
@@ -3753,6 +3843,284 @@ mod tests {
     fn open_test_state(repo: &tempfile::TempDir) -> Arc<DaemonState> {
         let init = kin_core::init(repo.path()).unwrap();
         Arc::new(DaemonState::open(init.layout).unwrap())
+    }
+
+    /// Write `content` to `rel_path` in the working copy, admit it into the
+    /// repository tree through the real ambient admission, and re-derive its
+    /// entities and layout the way the loop does after an admission. Returns
+    /// the blob the tree now holds at the path.
+    ///
+    /// This is the settled state a healthy edit reaches: tree, entities and
+    /// layout all describe the same bytes.
+    fn admit_and_derive(state: &Arc<DaemonState>, rel_path: &str, content: &str) -> Hash256 {
+        let host_path = state.layout.working_dir().join(rel_path);
+        std::fs::create_dir_all(host_path.parent().unwrap()).unwrap();
+        std::fs::write(&host_path, content).unwrap();
+        let repo_path = RepoPath::from_utf8(rel_path).unwrap();
+        let observation = BTreeSet::from([repo_path.clone()]);
+        let yielded = ambient_admission_for_test(state, &observation).expect("admission runs");
+        assert!(!yielded, "the fixture admission must not yield to a commit");
+        derive_semantics(state, rel_path);
+        state
+            .graph
+            .get_tree_entry(&FilePathId::new(rel_path))
+            .unwrap()
+            .and_then(|entry| entry.blob_identity())
+            .expect("the tree holds a blob at the admitted path")
+    }
+
+    /// The enrichment half of one reconcile round for one path: what the loop
+    /// runs after `exact_tree_admission`, without the loop.
+    fn derive_semantics(state: &Arc<DaemonState>, rel_path: &str) {
+        let host_path = state.layout.working_dir().join(rel_path);
+        let mut reconciler =
+            kin_reconcile::Reconciler::new(state.layout.working_dir().to_path_buf());
+        let result = reconciler
+            .reconcile_file_change(
+                &FileEvent::Changed(host_path),
+                &state.blobs,
+                state.graph.as_ref(),
+            )
+            .expect("the reconciler derives the file");
+        let (outcome, delta) = result.into_parts();
+        assert!(
+            matches!(outcome, kin_reconcile::ReconcileOutcome::Updated { .. }),
+            "the fixture file must reconcile cleanly: {outcome:?}"
+        );
+        state.graph.apply_transaction_delta(&delta).unwrap();
+        state
+            .persist_projection_truth_from_reconcile(&reconciler, &outcome)
+            .unwrap();
+    }
+
+    fn file_coverage(state: &Arc<DaemonState>, rel_path: &str) -> serde_json::Value {
+        let args = HashMap::from([("path".to_string(), serde_json::json!(rel_path))]);
+        let result = kin_mcp::handlers::file_entities::handle_list_file_entities(
+            &args,
+            state.graph.as_ref(),
+        )
+        .expect("the enumeration answers");
+        let kin_mcp::types::ContentBlock::Text { text } = &result.content[0];
+        let payload: serde_json::Value = serde_json::from_str(text).unwrap();
+        payload[kin_mcp::handlers::file_entities::FILE_COVERAGE_KEY].clone()
+    }
+
+    /// Whether `kin graph status`'s parse census counts `rel_path` as a file that
+    /// produced an entity, read through the same kin-core function the census
+    /// renders from.
+    fn census_counts_file(state: &Arc<DaemonState>, rel_path: &str) -> bool {
+        let entities = state.graph.list_all_entities().unwrap();
+        let retained = kin_core::retained_parse::read(&state.layout);
+        let census = kin_core::reference_coverage::collect_parse_coverage_from(
+            &state.graph.resolved_tree(),
+            &entities,
+            &retained,
+        );
+        // The census counts a file when an entity names it as origin and the
+        // tree admits it as source, so the python row must be whole AND the
+        // file must be the one it counted.
+        census
+            .languages
+            .iter()
+            .any(|row| row.language == "python" && row.tracked > 0 && row.silent == 0)
+            && entities
+                .iter()
+                .any(|entity| entity.file_origin.as_ref().map(|id| id.0.as_str()) == Some(rel_path))
+    }
+
+    const TWO_FUNCTIONS: &str = "def alpha():\n    return 1\n\n\ndef beta():\n    return 2\n";
+    /// Different bytes from [`TWO_FUNCTIONS`] on purpose: the observation planner
+    /// refuses a transition in which one exact blob appears at two paths, because
+    /// a copy and a move-plus-replace cannot be told apart from the tree alone.
+    const TWO_OTHER_FUNCTIONS: &str =
+        "def gamma():\n    return 3\n\n\ndef delta():\n    return 4\n";
+    const SEVENTEEN_LINES: &str = "# 1\n# 2\n# 3\n# 4\n# 5\n# 6\n# 7\n# 8\n# 9\n# 10\n# 11\n# 12\n# 13\n# 14\n# 15\n# 16\n# 17\n";
+
+    /// FIR-3201, the window. A file is admitted and derived, so its enumeration
+    /// certifies. Seventeen lines are prepended on disk and ONE ambient
+    /// admission runs: the tree now holds the new blob and the entities still
+    /// carry the old spans. The layout must not stand over them: kin-db's
+    /// `apply_transaction_delta` retires every path-keyed facet for a tree
+    /// delta that invalidates the path before it publishes the new tree, so
+    /// the enumeration floors on `file_parsed_absent` until the reconciler
+    /// re-derives the file, after which it and the parse census agree again.
+    /// Pinned here, in kin's own pipeline, so a dependency that stopped
+    /// retiring would fail this rather than certify a stale span.
+    #[test]
+    fn a_replaced_blob_retires_its_layout_until_the_spans_are_re_derived() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        state.is_initialized.store(true, Ordering::Relaxed);
+        let path = "src/mod.py";
+
+        let first_blob = admit_and_derive(&state, path, TWO_FUNCTIONS);
+        let settled = file_coverage(&state, path);
+        assert_eq!(settled["parsed"], serde_json::json!("full"), "{settled}");
+        assert_eq!(
+            settled["certifies_enumeration"],
+            serde_json::json!(true),
+            "the settled fixture must certify, or the assertions below prove nothing: {settled}"
+        );
+        assert!(census_counts_file(&state, path));
+
+        // The edit lands on disk and the tree moves. Nothing re-derives yet.
+        let host_path = state.layout.working_dir().join(path);
+        std::fs::write(&host_path, format!("{SEVENTEEN_LINES}{TWO_FUNCTIONS}")).unwrap();
+        let observation = BTreeSet::from([RepoPath::from_utf8(path).unwrap()]);
+        assert!(!ambient_admission_for_test(&state, &observation).unwrap());
+        let second_blob = state
+            .graph
+            .get_tree_entry(&FilePathId::new(path))
+            .unwrap()
+            .and_then(|entry| entry.blob_identity())
+            .unwrap();
+        assert_ne!(first_blob, second_blob, "the tree must hold the new bytes");
+
+        // The window: new blob, old spans. The enumeration must not certify.
+        let window = file_coverage(&state, path);
+        assert_eq!(
+            window["parsed"],
+            serde_json::json!("absent"),
+            "a layout describing the replaced blob must not stand: {window}"
+        );
+        assert_eq!(
+            window["certifies_enumeration"],
+            serde_json::json!(false),
+            "stale spans were certified: {window}"
+        );
+        let stale_alpha = state
+            .graph
+            .query_entities(&EntityFilter {
+                file_path: Some(FilePathId::new(path)),
+                ..Default::default()
+            })
+            .unwrap()
+            .into_iter()
+            .find(|entity| entity.name == "alpha")
+            .expect("alpha is still held");
+        assert_eq!(
+            stale_alpha.span.as_ref().unwrap().start_byte,
+            0,
+            "the fixture's spans really are stale in the window, or the test proves nothing"
+        );
+
+        // Settled: the reconciler re-derives, and both surfaces agree again.
+        derive_semantics(&state, path);
+        let settled = file_coverage(&state, path);
+        assert_eq!(settled["parsed"], serde_json::json!("full"), "{settled}");
+        assert_eq!(
+            settled["certifies_enumeration"],
+            serde_json::json!(true),
+            "{settled}"
+        );
+        let fresh_alpha = state
+            .graph
+            .query_entities(&EntityFilter {
+                file_path: Some(FilePathId::new(path)),
+                ..Default::default()
+            })
+            .unwrap()
+            .into_iter()
+            .find(|entity| entity.name == "alpha")
+            .unwrap();
+        assert_eq!(
+            fresh_alpha.span.as_ref().unwrap().start_byte,
+            SEVENTEEN_LINES.len(),
+            "the re-derived span must move by exactly the prepended bytes"
+        );
+        assert!(census_counts_file(&state, path));
+    }
+
+    /// FIR-3201, the restart window (FIR-3208's shape). A daemon admitted new
+    /// bytes into the tree and died before it re-derived and published their
+    /// entities. The next daemon holds the new blob, the old entities and no
+    /// layout, and its backfill re-parses the tree's bytes to publish one.
+    /// Before this change it published `Full` over the old spans, which is the
+    /// exact 20:52:58 state the stranger read. Now it publishes `Partial` with
+    /// the count, and hands the path back for re-derivation.
+    ///
+    /// The control is a file whose entities a fresh parse reproduces exactly,
+    /// which must still get `Full`, or a backfill that floors everything passes.
+    #[test]
+    fn the_backfill_refuses_full_over_entities_a_fresh_parse_does_not_reproduce() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        state.is_initialized.store(true, Ordering::Relaxed);
+        let stale_path = "src/stale.py";
+        let fresh_path = "src/fresh.py";
+        admit_and_derive(&state, stale_path, TWO_FUNCTIONS);
+        admit_and_derive(&state, fresh_path, TWO_OTHER_FUNCTIONS);
+
+        // The tree moves to the new bytes with nothing re-derived: the dead
+        // daemon's admission. The layout goes with the blob it described, as it
+        // would have in that daemon, and the entities keep their old spans.
+        let host_path = state.layout.working_dir().join(stale_path);
+        std::fs::write(&host_path, format!("{SEVENTEEN_LINES}{TWO_FUNCTIONS}")).unwrap();
+        let observation = BTreeSet::from([RepoPath::from_utf8(stale_path).unwrap()]);
+        assert!(!ambient_admission_for_test(&state, &observation).unwrap());
+        // A restart loses every layout the backfill exists to republish.
+        state
+            .graph
+            .delete_file_layout(&FilePathId::new(fresh_path))
+            .unwrap();
+        assert!(state
+            .graph
+            .get_file_layout(&FilePathId::new(stale_path))
+            .unwrap()
+            .is_none());
+
+        let report = backfill_missing_file_layouts(&state).unwrap();
+        assert_eq!(report.published, 2, "{report:?}");
+        assert_eq!(report.stale, 1, "{report:?}");
+        assert_eq!(report.rederive.len(), 1, "{report:?}");
+        assert!(
+            report.rederive[0].ends_with(stale_path),
+            "the owed re-derivation names the stale path: {report:?}"
+        );
+
+        let stale_layout = state
+            .graph
+            .get_file_layout(&FilePathId::new(stale_path))
+            .unwrap()
+            .expect("a layout is published for the stale path");
+        let ParseCompleteness::Partial(reason) = &stale_layout.parse_completeness else {
+            panic!(
+                "a fresh parse the graph's spans disagree with must not publish Full: {:?}",
+                stale_layout.parse_completeness
+            );
+        };
+        // The module entity, `alpha` and `beta`: a prepend moves all three spans.
+        assert!(reason.contains("3 of 3 entity span(s)"), "{reason}");
+        let coverage = file_coverage(&state, stale_path);
+        assert_eq!(
+            coverage["parsed"],
+            serde_json::json!("partial"),
+            "{coverage}"
+        );
+        assert_eq!(coverage["certifies_enumeration"], serde_json::json!(false));
+
+        let fresh_layout = state
+            .graph
+            .get_file_layout(&FilePathId::new(fresh_path))
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            fresh_layout.parse_completeness,
+            ParseCompleteness::Full,
+            "the control's entities match a fresh parse and must certify"
+        );
+        assert_eq!(
+            file_coverage(&state, fresh_path)["certifies_enumeration"],
+            serde_json::json!(true)
+        );
+
+        // Settled: the owed re-derivation runs, and the file certifies again over
+        // spans that moved by the prepended bytes.
+        derive_semantics(&state, stale_path);
+        let coverage = file_coverage(&state, stale_path);
+        assert_eq!(coverage["parsed"], serde_json::json!("full"), "{coverage}");
+        assert_eq!(coverage["certifies_enumeration"], serde_json::json!(true));
+        assert!(census_counts_file(&state, stale_path));
     }
 
     /// FIR-2442. A dropped host event is disclosed through the reconcile health

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -1581,9 +1581,20 @@ fn merge_file_coverage_classes(
         Some("absent") | Some("partial") | Some("failed") => STATE_ABSENT,
         _ => STATE_UNKNOWN,
     };
+    // A full parse of bytes the tree no longer holds is not a present class. The
+    // handler publishes the provenance beside the parse state rather than folding
+    // it in, so a reader can see which of the two failed; the verdict sees one
+    // class, and it is absent when either does.
+    let spans_stale = coverage
+        .and_then(|coverage| coverage.get("span_provenance"))
+        .and_then(Value::as_str)
+        == Some("stale");
+    let parsed = if spans_stale { STATE_ABSENT } else { parsed };
     classes.insert("file_parsed".to_string(), json!(parsed));
     decided_by.push("file_parsed".to_string());
-    if parsed != STATE_PRESENT {
+    if spans_stale {
+        limits.push("file_spans_stale".to_string());
+    } else if parsed != STATE_PRESENT {
         // Name the cause when the answer carries one. `file_parsed_absent` is
         // true and says nothing: a file no adapter claims and a file whose
         // adapter fell over earn the same word, and only the second is evidence
@@ -1646,6 +1657,10 @@ fn file_entities_counted(payload: &Value) -> Option<Value> {
         .and_then(|coverage| coverage.get("parsed"))
         .and_then(Value::as_str)
         .unwrap_or("unknown");
+    let spans_stale = coverage
+        .and_then(|coverage| coverage.get("span_provenance"))
+        .and_then(Value::as_str)
+        == Some("stale");
 
     let mut counted = json!({
         "unit": "entities_in_file",
@@ -1656,8 +1671,12 @@ fn file_entities_counted(payload: &Value) -> Option<Value> {
     // Named in the order a reader acts on. A file the adapter never parsed is
     // the limiting factor whatever the paging did, because following every
     // cursor to the end still assembles a set the extractor never produced.
+    // Spans derived from bytes the tree no longer holds come next: the set is
+    // complete for a file that is not the one at the path any more.
     if parsed != "full" {
         counted["floor_reason"] = json!(format!("file_parsed_{parsed}"));
+    } else if spans_stale {
+        counted["floor_reason"] = json!("file_spans_stale");
     } else if shifted {
         counted["floor_reason"] = json!("enumeration_shifted");
     } else if !whole_file {

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -1857,7 +1857,7 @@ fn committed_introducing_change<G: GraphStore>(
 ///
 /// `None` means the entity carries no such stamp, which is an ordinary state and
 /// must never be escalated into a read failure.
-fn recorded_span_source_digest(entity: &Entity) -> Option<kin_blobs::Hash256> {
+pub(crate) fn recorded_span_source_digest(entity: &Entity) -> Option<kin_blobs::Hash256> {
     let serde_json::Value::String(hex) = entity.metadata.extra.get("blob_hash")? else {
         return None;
     };

--- a/crates/kin-mcp/src/handlers/file_entities.rs
+++ b/crates/kin-mcp/src/handlers/file_entities.rs
@@ -42,7 +42,9 @@ use kin_model::{entity::Entity, EntityKind, EntityRole, FilePathId, LanguageId, 
 use serde::Serialize;
 
 use crate::error::{McpError, Result};
-use crate::handlers::common::{entity_presentation_end_line, entity_presentation_start_line};
+use crate::handlers::common::{
+    entity_presentation_end_line, entity_presentation_start_line, recorded_span_source_digest,
+};
 use crate::types::ToolCallResult;
 
 /// The tool's registered name, spelled once so the registry, the dispatcher,
@@ -167,6 +169,96 @@ impl ParsedState {
     /// entity surface. Only a complete parse does.
     pub fn certifies_enumeration(self) -> bool {
         matches!(self, Self::Full)
+    }
+}
+
+/// Whether the spans this enumeration serves were derived from the bytes the
+/// repository tree holds at this path right now.
+///
+/// The entity table and the repository tree are updated in separate
+/// transactions: an admission publishes the exact tree first and the reconciler
+/// re-derives spans afterwards (`SpanCoherence` in [`crate::handlers::common`]).
+/// Between those two steps, and for as long as the second never runs, the graph
+/// holds the new blob at the path and the old spans into it. A layout that says
+/// `Full` describes the parse that produced those spans, not the bytes now at
+/// the path, so on its own it cannot license certifying them: on a converted
+/// psf/requests the stranger of FIR-3201 was served a module entity ending at
+/// line 921 of a 937-line file under `parsed: full` and no degradation.
+///
+/// Read from the same stamp `get_entity_source` checks before it slices a body:
+/// the entity's recorded source digest against the tree's blob at the path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpanProvenance {
+    /// Every entity carrying a digest was derived from the blob the tree holds,
+    /// and at least one carries a digest.
+    DigestVerified,
+    /// No entity records a digest, so the pair could not be checked. Honest
+    /// absence rather than a claim of coherence: entities admitted by paths that
+    /// do not stamp provenance, such as a Git import, arrive without one.
+    Unverified,
+    /// At least this many entities record a digest that is not the blob the
+    /// tree holds at this path. Their spans were provably derived from other
+    /// bytes, so the enumeration cannot be certified over them.
+    Stale { entities: usize },
+    /// The tree admits no blob at this path (a gitlink, or a path admitted at
+    /// no tier), so there is nothing to check the spans against.
+    NoTreeBlob,
+}
+
+impl SpanProvenance {
+    pub fn wire(self) -> &'static str {
+        match self {
+            Self::DigestVerified => "digest_verified",
+            Self::Unverified => "unverified",
+            Self::Stale { .. } => "stale",
+            Self::NoTreeBlob => "no_tree_blob",
+        }
+    }
+
+    /// How many entities were provably derived from other bytes.
+    pub fn stale_entities(self) -> usize {
+        match self {
+            Self::Stale { entities } => entities,
+            _ => 0,
+        }
+    }
+
+    /// Whether this reading permits certifying the enumeration. Only a provable
+    /// mismatch refuses: an unverified pair is the ordinary state of a converted
+    /// store and refusing it would floor every enumeration there.
+    pub fn permits_certification(self) -> bool {
+        !matches!(self, Self::Stale { .. })
+    }
+}
+
+/// Decide [`SpanProvenance`] for one file's entities against the blob the tree
+/// holds at its path.
+///
+/// One map lookup per entity and no store read: `tree_blob` is the tree entry
+/// the caller already resolved, and the digest is read off entity metadata the
+/// caller already holds.
+pub fn span_provenance(
+    entities: &[Entity],
+    tree_blob: Option<&kin_model::Hash256>,
+) -> SpanProvenance {
+    let Some(tree_blob) = tree_blob else {
+        return SpanProvenance::NoTreeBlob;
+    };
+    let mut verified = 0usize;
+    let mut stale = 0usize;
+    for entity in entities {
+        match recorded_span_source_digest(entity) {
+            Some(recorded) if recorded.as_bytes() == tree_blob.as_bytes() => verified += 1,
+            Some(_) => stale += 1,
+            None => {}
+        }
+    }
+    if stale > 0 {
+        SpanProvenance::Stale { entities: stale }
+    } else if verified > 0 && verified == entities.len() {
+        SpanProvenance::DigestVerified
+    } else {
+        SpanProvenance::Unverified
     }
 }
 
@@ -502,6 +594,15 @@ pub fn handle_list_file_entities<G: GraphStore>(
             .count()
     });
 
+    // The spans against the bytes. A layout certifies the parse that produced
+    // these spans; this certifies that the parse was of the bytes the tree holds
+    // now. Both have to hold before the enumeration is read as the file.
+    let tree_blob = store
+        .get_tree_entry(&file_id)
+        .map_err(McpError::graph)?
+        .and_then(|entry| entry.blob_identity());
+    let provenance = span_provenance(&entities, tree_blob.as_ref());
+
     let tier = tracking_tier(store, &file_id)?;
     let opaque_reason = opaque_reason(&path, tier);
     // Admission identity, resolved through the repository tree rather than
@@ -596,8 +697,15 @@ pub fn handle_list_file_entities<G: GraphStore>(
             // disclosure here and never a decider. `_kin.completeness` carries
             // the store-grain reading beside it, labelled as store-grain.
             "embedded": "not_measured_per_file",
+            // Whether the spans served here were derived from the bytes the tree
+            // holds at this path now. `stale` is a provable mismatch and refuses
+            // certification below; `unverified` is the ordinary state of a
+            // converted store and does not.
+            "span_provenance": provenance.wire(),
+            "stale_spans": provenance.stale_entities(),
             "whole_file_in_response": whole_file_in_response,
             "certifies_enumeration": parsed.certifies_enumeration()
+                && provenance.permits_certification()
                 && whole_file_in_response
                 && !enumeration_shifted,
         },
@@ -1370,5 +1478,175 @@ mod tests {
         assert_eq!(counted["returned"], serde_json::json!(3));
         assert_eq!(counted["exact"], serde_json::json!(false));
         assert_eq!(counted["floor_reason"], serde_json::json!("page_bounded"));
+    }
+
+    /// Stamp an entity with the source digest the reconciler records, so the
+    /// provenance check has something to compare against the tree.
+    fn stamped(mut entity: Entity, blob: [u8; 32]) -> Entity {
+        entity.metadata.extra.insert(
+            "blob_hash".into(),
+            serde_json::Value::String(kin_blobs::Hash256::from_bytes(blob).to_string()),
+        );
+        entity
+    }
+
+    /// FIR-3201. The tree holds blob B at the path and the entities record that
+    /// they were derived from blob A, while the layout still says `Full`: the
+    /// stranger's state on psf/requests, where a module entity ending at line
+    /// 921 of a 937-line file was served as certified. A full parse of other
+    /// bytes must not certify the enumeration, and the response must say why.
+    ///
+    /// The control is the same store with A == B, which must still certify, so
+    /// a fix that floors every enumeration fails here rather than passing.
+    #[test]
+    fn a_span_derived_from_other_bytes_cannot_certify_the_enumeration() {
+        // `admit` puts blob [7; 32] at the path.
+        let store = InMemoryGraph::new();
+        admit(&store, FILE);
+        for index in 0..3 {
+            store
+                .upsert_entity(&stamped(
+                    entity_at(&format!("export{index}"), FILE, index * 100),
+                    [8; 32],
+                ))
+                .unwrap();
+        }
+        store
+            .upsert_file_layout(&layout_for(FILE, ParseCompleteness::Full, 3))
+            .unwrap();
+
+        let payload = call(&store, &[("path", serde_json::json!(FILE))]).unwrap();
+        let coverage = &payload[FILE_COVERAGE_KEY];
+        assert_eq!(coverage["parsed"], serde_json::json!("full"), "{payload}");
+        assert_eq!(
+            coverage["span_provenance"],
+            serde_json::json!("stale"),
+            "{payload}"
+        );
+        assert_eq!(coverage["stale_spans"], serde_json::json!(3), "{payload}");
+        assert_eq!(
+            coverage["certifies_enumeration"],
+            serde_json::json!(false),
+            "a full parse of bytes the tree no longer holds must not certify: {payload}"
+        );
+        // The rows are still served: withholding graph truth teaches nothing.
+        assert_eq!(payload["total_in_file"], serde_json::json!(3));
+
+        // The control: the same store, digests that name the tree's own blob.
+        let store = InMemoryGraph::new();
+        admit(&store, FILE);
+        for index in 0..3 {
+            store
+                .upsert_entity(&stamped(
+                    entity_at(&format!("export{index}"), FILE, index * 100),
+                    [7; 32],
+                ))
+                .unwrap();
+        }
+        store
+            .upsert_file_layout(&layout_for(FILE, ParseCompleteness::Full, 3))
+            .unwrap();
+        let payload = call(&store, &[("path", serde_json::json!(FILE))]).unwrap();
+        let coverage = &payload[FILE_COVERAGE_KEY];
+        assert_eq!(
+            coverage["span_provenance"],
+            serde_json::json!("digest_verified"),
+            "{payload}"
+        );
+        assert_eq!(coverage["stale_spans"], serde_json::json!(0));
+        assert_eq!(
+            coverage["certifies_enumeration"],
+            serde_json::json!(true),
+            "spans derived from the tree's own blob must still certify: {payload}"
+        );
+    }
+
+    /// Entities with no recorded digest are the ordinary state of a store
+    /// converted from Git, and refusing them would floor every enumeration on
+    /// every such store. They stay certifiable and the reading says `unverified`
+    /// rather than pretending a check ran.
+    #[test]
+    fn an_unstamped_entity_is_reported_unverified_and_still_certifies() {
+        let store = store_with(2, Some(ParseCompleteness::Full));
+        let payload = call(&store, &[("path", serde_json::json!(FILE))]).unwrap();
+        let coverage = &payload[FILE_COVERAGE_KEY];
+        assert_eq!(
+            coverage["span_provenance"],
+            serde_json::json!("unverified"),
+            "{payload}"
+        );
+        assert_eq!(coverage["certifies_enumeration"], serde_json::json!(true));
+    }
+
+    /// One stale entity among verified ones is enough: the enumeration is one
+    /// answer, and one row derived from other bytes makes the whole of it
+    /// describe a file that is not at the path.
+    #[test]
+    fn one_stale_span_among_verified_ones_refuses_certification() {
+        let store = InMemoryGraph::new();
+        admit(&store, FILE);
+        store
+            .upsert_entity(&stamped(entity_at("fresh", FILE, 0), [7; 32]))
+            .unwrap();
+        store
+            .upsert_entity(&stamped(entity_at("stale", FILE, 100), [9; 32]))
+            .unwrap();
+        store
+            .upsert_file_layout(&layout_for(FILE, ParseCompleteness::Full, 2))
+            .unwrap();
+        let payload = call(&store, &[("path", serde_json::json!(FILE))]).unwrap();
+        let coverage = &payload[FILE_COVERAGE_KEY];
+        assert_eq!(coverage["span_provenance"], serde_json::json!("stale"));
+        assert_eq!(coverage["stale_spans"], serde_json::json!(1));
+        assert_eq!(coverage["certifies_enumeration"], serde_json::json!(false));
+    }
+
+    /// The one verdict a reader acts on. Stale spans under a `Full` layout must
+    /// reach it as an absent `file_parsed` class, a named limit, and a floor on
+    /// the count, so the envelope cannot compute `certified` over them the way
+    /// the stranger's envelope did.
+    #[test]
+    fn stale_spans_reach_the_verdict_as_an_absent_class_and_a_named_limit() {
+        let envelope = structural_authoritative_envelope();
+        let store = InMemoryGraph::new();
+        admit(&store, FILE);
+        store
+            .upsert_entity(&stamped(entity_at("moved", FILE, 0), [8; 32]))
+            .unwrap();
+        store
+            .upsert_file_layout(&layout_for(FILE, ParseCompleteness::Full, 1))
+            .unwrap();
+        let payload = call(&store, &[("path", serde_json::json!(FILE))]).unwrap();
+        let annotated = crate::envelope::finalize(
+            ToolCallResult::text(serde_json::to_string(&payload).unwrap()),
+            envelope,
+            TOOL_NAME,
+        );
+        let crate::types::ContentBlock::Text { text } = &annotated.content[0];
+        let value: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(
+            value["_kin"]["completeness"]["classes"]["file_parsed"],
+            serde_json::json!("absent"),
+            "{value}"
+        );
+        let limits = finalized_limits(&store, FILE);
+        assert!(
+            limits.split(',').any(|limit| limit == "file_spans_stale"),
+            "the limit must name the stale spans: {limits:?}"
+        );
+        assert_eq!(
+            value["_kin"]["completeness"]["counted"]["floor_reason"],
+            serde_json::json!("file_spans_stale"),
+            "{value}"
+        );
+        assert_eq!(
+            value["_kin"]["completeness"]["counted"]["exact"],
+            serde_json::json!(false)
+        );
+        assert_ne!(
+            value["_kin"]["verdict"]["state"],
+            serde_json::json!("certified"),
+            "a stale enumeration must not be certified: {value}"
+        );
     }
 }

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -101,6 +101,21 @@ fn file_enumeration_gap(payload: &Value) -> Option<String> {
         .and_then(Value::as_str)
         .map(|detail| format!(" ({detail})"))
         .unwrap_or_default();
+    // Provenance first: a full parse of other bytes is a stronger disqualifier
+    // than any parse state, because every row it produced describes a file that
+    // is no longer at this path.
+    if coverage.get("span_provenance").and_then(Value::as_str) == Some("stale") {
+        let stale = coverage
+            .get("stale_spans")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        return Some(format!(
+            "file_spans_stale: {stale} entity span(s) in this file were derived from bytes the \
+             repository tree no longer holds at this path, so the enumeration describes an \
+             earlier state of the file; the graph has admitted the new source and not yet \
+             re-derived these entities"
+        ));
+    }
     match parsed {
         "full" => {}
         "absent" => {


### PR DESCRIPTION
FIR-3201. A stranger on a converted psf/requests committed a 17-line edit and `list_file_entities` served the module entity at its pre-edit span as `parsed: full`, `freshness: recorded`, no degradation; nine minutes and one daemon restart later the same call said `parsed: absent` while `kin graph status` said python 37/37.

`parsed` read only the layout facet, which a once-per-daemon backfill builds from the entities the graph already holds; `freshness: recorded` is a clock the tree admission stamps; and no verdict input could say a span was older than the blob now at its path.

`list_file_entities` now compares each entity's recorded source digest against the tree's blob at the path, the same rule `get_entity_source` applies before slicing a body, and publishes `span_provenance` and `stale_spans` beside `parsed`. A provable mismatch refuses certification and reaches the verdict as an absent `file_parsed` class with the limit `file_spans_stale`; an unstamped store stays certifiable and says `unverified`. A tree transition that replaces a path's blob retires that path's layout before the tree moves, so the window between admission and re-derivation reads `parsed: absent` instead of certifying the old spans. The layout backfill compares its fresh parse of the tree bytes with the graph's entities by kind, name and span, publishes `Partial` with the count when they disagree, and hands the path back to the loop for re-derivation.

## Provenance

This is lane memfix's commit `33a9500ae` (patch id `22ba8a81e12cf0ad43c6cccc6def9da36cd2be4e`, identical here) cherry-picked onto `950fb0bf8`. The FIR-3203 half of that branch measured over its memory acceptance on the release build and is held back as a draft for the record, so the FIR-3201 fix lands alone.

## Verification on this tree (51f048988), through the fleet's builder slot

```
cargo test -p kin-mcp --lib file_entities
test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 896 filtered out; finished in 0.02s

cargo test -p kin-daemon --lib -- loop_runner::tests::a_replaced_blob_retires_its_layout_until_the_spans_are_re_derived loop_runner::tests::the_backfill_refuses_full_over_entities_a_fresh_parse_does_not_reproduce
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 1415 filtered out; finished in 1.56s

cargo fmt --all -- --check
rc=0
```

Not run locally, by the cut's speed rule: clippy, precheck, parity, the full workspace suite. Hosted CI grades them here.

## Falsification on this tree, each arm restored from a byte copy

Each arm mutates the guarded behaviour, prints the applied diff stat, runs the test named for it, and restores the file. Red is the required result.

```
ARM handler-certification: mutated crates/kin-mcp/src/handlers/file_entities.rs
mutation applied:  1 file changed, 1 deletion(-)
test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 917 filtered out; finished in 0.01s
ARM handler-certification cargo exit=101

ARM envelope-class: mutated crates/kin-mcp/src/envelope.rs
mutation applied:  1 file changed, 1 insertion(+), 1 deletion(-)
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 918 filtered out; finished in 0.01s
ARM envelope-class cargo exit=101

ARM daemon-backfill: mutated crates/kin-daemon/src/loop_runner.rs
mutation applied:  1 file changed, 1 insertion(+), 1 deletion(-)
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1416 filtered out; finished in 1.29s
ARM daemon-backfill cargo exit=101
```
