### PR TITLE
FIR-3203: held authority variants measured over the peak acceptance, not for landing

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -937,6 +937,43 @@ fn command_repository_authority(
 fn cached_authority_admission_entry(
     state: &DaemonState,
 ) -> Result<HeldAdmission, (StatusCode, String)> {
+    admission_entry(state, InstallWriter::No)
+}
+
+/// Whether an admission-pair load may leave its manager installed as the held
+/// writer. Only the publishing tick may, because only the publishing tick has a
+/// drop for it; a reader that installed one would leave a decoded change map
+/// resident with nothing to forget it, which is the held design's floor by the
+/// back door (found by the reviewer at `62220167e`: the untracked-refresh probe,
+/// the catch-up planner and the open-merge checks all read the pair and none
+/// publishes).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum InstallWriter {
+    No,
+    Yes,
+}
+
+/// The admission pair for the publishing tick. The one entry that installs the
+/// writer, so the publication that follows in the same tick reuses the open;
+/// `exact_tree_admission` forgets it on every return that does not publish and
+/// the publication drops it itself.
+pub(crate) fn cached_authority_admission_for_publication(
+    state: &DaemonState,
+) -> Result<
+    (
+        kin_model::RootBundle,
+        Option<kin_index::ResolvedAdmissionMatcher>,
+    ),
+    (StatusCode, String),
+> {
+    let admission = admission_entry(state, InstallWriter::Yes)?;
+    Ok((admission.roots, admission.policy))
+}
+
+fn admission_entry(
+    state: &DaemonState,
+    install: InstallWriter,
+) -> Result<HeldAdmission, (StatusCode, String)> {
     let backend = state.local_repository_backend().ok_or_else(|| {
         repository_authority_error("local daemon is missing its startup storage capability")
     })?;
@@ -959,11 +996,10 @@ fn cached_authority_admission_entry(
         return Ok(admission);
     }
 
-    // The writer slot is consulted before anything opens: after a publication
-    // the daemon performed itself, the manager it published through is already
-    // at this publication, and reading the admission pair out of it costs no
-    // open. A daemon that has published nothing yet pays one open here, which
-    // then serves the publication that follows.
+    // An installed writer at this label costs nothing to read through. Otherwise
+    // one local open serves this load, and whether it outlives this function is
+    // the caller's kind: the publishing tick keeps it for the publication that
+    // follows and drops it itself; every reader lets it go here.
     let manager = match state.projection_authority.reuse_writer(&published) {
         Some(manager) => manager,
         None => {
@@ -978,13 +1014,16 @@ fn cached_authority_admission_entry(
                     .map_err(|error| repository_authority_error(error.to_string()))?,
             );
             state.projection_authority.record_load();
-            state
-                .projection_authority
-                .install_writer(published.clone(), Arc::clone(&manager));
+            if install == InstallWriter::Yes {
+                state
+                    .projection_authority
+                    .install_writer(published.clone(), Arc::clone(&manager));
+            }
             manager
         }
     };
     let admission = admission_values_from(state, &manager, published)?;
+    drop(manager);
     state
         .projection_authority
         .install_admission(admission.clone());
@@ -38788,6 +38827,63 @@ mod tests {
         (bare, roots)
     }
 
+    /// The publishing tick's yield to an open merge returns before any
+    /// publication, after its admission pair has installed the writer. That
+    /// return must forget the writer: a merge stays open for as long as a person
+    /// takes to resolve it, and a manager left installed there is a decoded
+    /// change map resident for the whole of that time.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial_test::serial(repository_commit)]
+    async fn a_tick_that_yields_to_an_open_merge_holds_no_writer() {
+        let (state, _layout, repository, _, _) = universal_branch_test_state("yield-open-merge");
+        let path = repository.join("selected/compose.yaml");
+        std::fs::write(&path, b"services:\n  api:\n    image: main-conflict\n").unwrap();
+        let app = router(Arc::clone(&state));
+        commit_through_api(
+            &app,
+            kin_model::OperationId::new(),
+            "create a real conflict",
+        )
+        .await;
+        let response = crate::repository_merge::execute(
+            &state,
+            &kin_cli::commands::merge::MergeRequest {
+                source: kin_model::RefName::branch(b"feature").unwrap(),
+                operation_id: kin_model::OperationId::new(),
+                actor: AuthorId::new("yield-merge-test"),
+            },
+        )
+        .unwrap_or_else(|refusal| {
+            panic!(
+                "fixture merge refused: {}",
+                axum::response::IntoResponse::into_response(refusal).status()
+            )
+        });
+        assert!(matches!(
+            response.report.unwrap().outcome,
+            kin_cli::commands::merge::MergeOutcome::Conflicted
+        ));
+        assert!(
+            cached_authority_has_open_merge(&state).unwrap(),
+            "the fixture must hold a durable open merge"
+        );
+        std::fs::write(&path, b"services:\n  api:\n    image: hand-authored\n").unwrap();
+        let observation =
+            std::iter::once(RepoPath::from_utf8("selected/compose.yaml").unwrap()).collect();
+        let yielded = crate::loop_runner::ambient_admission_for_test(&state, &observation).unwrap();
+        assert!(
+            yielded,
+            "the tick must yield to the open merge, or this proves nothing"
+        );
+        assert!(
+            !state.projection_authority.holds_writer(),
+            "a tick that yielded to an open merge must not keep the manager its admission pair \
+             installed"
+        );
+        drop(app);
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     #[serial_test::serial(repository_commit)]
@@ -43921,20 +44017,26 @@ mod tests {
             opens
         };
         // What the persist flush does after a publication: the enrichment
-        // publish and the read-index finalization read the held manager, and
-        // the finalization forgets it.
+        // publish resolves the write authority (one open, since the publication
+        // dropped its own), the read-index finalization reads that same manager,
+        // and the finalization forgets it. One open for the flush's two
+        // consumers, not one each.
         let finalize = |state: &Arc<DaemonState>| {
             let generation = state
                 .snapshot_generation
                 .load(std::sync::atomic::Ordering::SeqCst);
             let before = kin_core::authority_opens();
+            let for_enrichment =
+                held_write_authority(state).expect("the enrichment publish resolves the writer");
+            drop(for_enrichment);
             state
                 .load_committed_authority_graph(generation)
                 .expect("the finalization reads the committed graph");
             assert_eq!(
                 kin_core::authority_opens() - before,
                 1,
-                "the flush opens once for its own scope, after the publication's manager is gone"
+                "the flush's enrichment publish and finalization must share one open, after the \
+                 publication's manager is gone"
             );
             assert!(
                 !state.projection_authority.holds_writer(),
@@ -44009,6 +44111,75 @@ mod tests {
         assert!(
             !state.projection_authority.holds_writer(),
             "a publication that moved nothing must not keep its manager either"
+        );
+    }
+
+    /// Readers of the admission pair install nothing. Five call sites read the
+    /// pair and never publish (the untracked-refresh probe, the catch-up planner,
+    /// the open-merge checks); if any of them left the manager it opened in the
+    /// writer slot, an idle daemon would carry a decoded change map that nothing
+    /// forgets, which is the held design's floor by the back door.
+    #[cfg(unix)]
+    #[test]
+    fn readers_of_the_admission_pair_install_no_writer() {
+        let state = test_state();
+        install_repository_file(&state, "src/lib.py", b"def handler():\n    return 1\n");
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let loads_before = state.projection_authority.loads();
+
+        cached_authority_admission(&state).expect("the pair resolves");
+        assert!(
+            state.projection_authority.loads() > loads_before,
+            "the fixture's first read must load, or the assertions below prove nothing"
+        );
+        assert!(
+            !state.projection_authority.holds_writer(),
+            "cached_authority_admission must not install the writer"
+        );
+        cached_authority_has_open_merge(&state).expect("the merge check resolves");
+        assert!(!state.projection_authority.holds_writer());
+        refuse_commit_during_open_merge(&state).expect("no merge is open");
+        assert!(!state.projection_authority.holds_writer());
+        crate::loop_runner::current_authority_admission(&state)
+            .expect("the loop's reader resolves");
+        assert!(
+            !state.projection_authority.holds_writer(),
+            "the loop's plain reader must not install the writer"
+        );
+    }
+
+    /// A publishing tick that returns without publishing holds nothing either.
+    /// The admission pair's open is installed for the publication that would
+    /// follow; when nothing moved, no publication follows and no drop runs, so
+    /// the tick's own scope has to forget it. The yield-to-open-merge and
+    /// yield-to-commit returns share this scope.
+    #[cfg(unix)]
+    #[test]
+    fn a_publishing_tick_that_moves_nothing_holds_nothing_after() {
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let working = state.layout.working_dir().to_path_buf();
+        std::fs::create_dir_all(working.join("src")).unwrap();
+        std::fs::write(working.join("src/lib.py"), "def a():\n    return 1\n").unwrap();
+        let observation =
+            std::collections::BTreeSet::from([RepoPath::from_utf8("src/lib.py").unwrap()]);
+        assert!(!crate::loop_runner::ambient_admission_for_test(&state, &observation).unwrap());
+        assert!(!state.projection_authority.holds_writer());
+        // The same bytes again: the tick plans, finds nothing to move, and
+        // returns before any publication.
+        let opens_before = kin_core::authority_opens();
+        assert!(!crate::loop_runner::ambient_admission_for_test(&state, &observation).unwrap());
+        assert!(
+            !state.projection_authority.holds_writer(),
+            "a tick that published nothing must not keep the manager its admission pair opened"
+        );
+        assert!(
+            kin_core::authority_opens() - opens_before <= 1,
+            "a no-op tick costs at most the admission pair's own open"
         );
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -136,7 +136,7 @@ const MAX_AUTHORITY_PUBLICATION_RECORD_BYTES: u64 = 1024 * 1024;
 /// whether an already-loaded authority may be reused, and every answer served
 /// still comes from repository-v6 graph truth.
 #[derive(Clone, PartialEq, Eq)]
-enum LocalPublicationIdentity {
+pub(crate) enum LocalPublicationIdentity {
     /// The repository has persisted no authority yet, so its authority is the
     /// unpublished generation-zero state.
     Unpublished,
@@ -239,6 +239,11 @@ pub(crate) struct ProjectionAuthorityCache {
     /// The refs routes' envelope, keyed on the same publication identity as
     /// every slot above it.
     ref_metadata: std::sync::Mutex<Option<HeldRefMetadata>>,
+    /// The manager this daemon publishes through, kept across publications so an
+    /// edit costs no whole-store open; see [`HeldWriteAuthority`]. The
+    /// admission slot above is derived from it, so after a publication both are
+    /// relabelled together and the next reconcile tick opens nothing.
+    writer: std::sync::Mutex<Option<HeldWriteAuthority>>,
     /// Serializes misses so a burst of concurrent cold requests pays for one
     /// full load rather than one per request.
     load_gate: std::sync::Mutex<()>,
@@ -286,6 +291,33 @@ struct HeldRefMetadata {
     /// for [`HeldProjectionAuthority::published`] and for the same reason.
     published: LocalPublicationIdentity,
     metadata: Arc<kin_db::PersistedRepositoryAuthority>,
+}
+
+/// The authority this daemon publishes through, held across publications.
+///
+/// A publication used to open the persisted authority, commit through it and
+/// drop it, and the open is O(store): kin-db decodes the change map (93.8 percent
+/// of a 1051 MiB body on a converted psf/requests), and because every
+/// publication moves the generation the durable history-validation record never
+/// matches, so every such open also replays the whole history, which clones
+/// every change. One tracked-file edit cost the stranger's daemon 3.6 GiB of
+/// resident set that way before any commit ran (FIR-3203).
+///
+/// After its own commit the manager's in-memory state IS the durable successor,
+/// so the next publication can go through it with no open at all, as long as
+/// nothing else wrote in between. The label says which publication this manager
+/// is at. It is taken under the commit-point lock the freeze holds, so it cannot
+/// name a publication that landed after this manager's own; a reuse reads the
+/// durable record first and misses the moment any other writer moved it. If a
+/// writer moves it between that read and the commit, kin-db's successor
+/// compare-and-swap refuses the commit with a generation mismatch and the slot
+/// is forgotten, so a stale manager can never overwrite a foreign publication.
+struct HeldWriteAuthority {
+    /// Read strictly before the load, or under the freeze of the commit this
+    /// manager performed, for the reason [`HeldProjectionAuthority::published`]
+    /// gives.
+    published: LocalPublicationIdentity,
+    manager: Arc<RepositoryAuthorityManager<LocalFileBackend>>,
 }
 
 #[derive(Clone)]
@@ -409,12 +441,176 @@ impl ProjectionAuthorityCache {
         });
     }
 
+    fn reuse_writer(
+        &self,
+        published: &LocalPublicationIdentity,
+    ) -> Option<Arc<RepositoryAuthorityManager<LocalFileBackend>>> {
+        lock_recover(&self.writer)
+            .as_ref()
+            .filter(|held| &held.published == published)
+            .map(|held| Arc::clone(&held.manager))
+    }
+
+    fn install_writer(
+        &self,
+        published: LocalPublicationIdentity,
+        manager: Arc<RepositoryAuthorityManager<LocalFileBackend>>,
+    ) {
+        *lock_recover(&self.writer) = Some(HeldWriteAuthority { published, manager });
+    }
+
+    /// Forget the held writer. Taken on any refused publication, so the next
+    /// one starts from a fresh open of whatever authority holds now.
+    pub(crate) fn forget_writer(&self) {
+        *lock_recover(&self.writer) = None;
+    }
+
+    /// Whether a writer is held right now. A test reads this beside
+    /// [`Self::loads`] to tell "reused" from "never loaded".
+    #[cfg(test)]
+    pub(crate) fn holds_writer(&self) -> bool {
+        lock_recover(&self.writer).is_some()
+    }
+
     fn invalidate(&self) {
         *lock_recover(&self.held) = None;
         *lock_recover(&self.query) = None;
         *lock_recover(&self.command) = None;
         *lock_recover(&self.ref_metadata) = None;
+        *lock_recover(&self.writer) = None;
     }
+}
+
+/// The authority this daemon publishes through, at the publication local storage
+/// holds right now: the held one when its label still matches, otherwise one
+/// fresh open, which is then held.
+///
+/// Same shape as the three reader resolvers above and deliberately so: read the
+/// publication, try the slot, take the load gate, re-read under it because the
+/// publication may have moved while this caller waited, try again, and only then
+/// pay for the open. The difference is what the slot holds: the manager itself,
+/// because a publication needs a writer and not a value read out of one.
+pub(crate) fn held_write_authority(
+    state: &DaemonState,
+) -> Result<Arc<RepositoryAuthorityManager<LocalFileBackend>>, (StatusCode, String)> {
+    let backend = state.local_repository_backend().ok_or_else(|| {
+        repository_authority_error("local daemon is missing its startup storage capability")
+    })?;
+    let binding = state
+        .local_repository_authority_binding()
+        .map_err(repository_authority_error)?;
+    let repository_id = binding.repository_id().clone();
+
+    let published = read_local_publication_identity(&backend, &repository_id)?;
+    if let Some(manager) = state.projection_authority.reuse_writer(&published) {
+        return Ok(manager);
+    }
+
+    let _load = lock_recover(&state.projection_authority.load_gate);
+    let published = read_local_publication_identity(&backend, &repository_id)?;
+    if let Some(manager) = state.projection_authority.reuse_writer(&published) {
+        return Ok(manager);
+    }
+    let context =
+        crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(state)
+            .map_err(|error| repository_authority_error(error.to_string()))?;
+    let manager = Arc::new(
+        context
+            .open()
+            .map_err(|error| repository_authority_error(error.to_string()))?,
+    );
+    state.projection_authority.record_load();
+    state
+        .projection_authority
+        .install_writer(published, Arc::clone(&manager));
+    tracing::debug!(
+        repository = %repository_id,
+        loads = state.projection_authority.loads(),
+        "write repository authority loaded"
+    );
+    Ok(manager)
+}
+
+/// The admission pair and open-merge summary, read out of one already-open
+/// manager. What [`cached_authority_admission_entry`] installs on a miss and what
+/// a publication reinstalls under its freeze, so the two cannot compute them
+/// differently.
+fn admission_values_from(
+    state: &DaemonState,
+    manager: &RepositoryAuthorityManager<LocalFileBackend>,
+    published: LocalPublicationIdentity,
+) -> Result<HeldAdmission, (StatusCode, String)> {
+    let binding = state
+        .local_repository_authority_binding()
+        .map_err(repository_authority_error)?;
+    let workspace_id = binding.workspace_id();
+    let lease = manager.read_authority();
+    let roots = lease.roots().clone();
+    let open_merge = crate::repository_merge_state::open_merge_summary(&lease, workspace_id);
+    drop(lease);
+    let policy = manager
+        .workspace_admission_snapshot(binding.repository_id(), &workspace_id)
+        .map_err(|error| repository_authority_error(error.to_string()))?
+        .map(|snapshot| snapshot.matcher);
+    Ok(HeldAdmission {
+        published,
+        roots,
+        policy,
+        open_merge,
+    })
+}
+
+/// The publication identity local storage holds, read the instant after the
+/// commit that produced it.
+///
+/// A plain file read and no backend lock. The first version read this under
+/// kin-db's commit-point freeze so no other writer could move the record between
+/// the commit and the read, and derived the admission pair there too; that
+/// deadlocked, because the pair's matcher resolves rule sources through the
+/// backend whose flock the freeze holds, and the freeze variant of the commit
+/// also deep-clones the whole successor state, 2.7 GiB on a converted
+/// psf/requests, per publication. So the identity is read after a plain commit
+/// instead. The window is the instant between two statements of this process; a
+/// foreign writer landing in it labels a manager one generation behind with the
+/// foreign identity, the next admission plans against that manager's roots, and
+/// kin-db's successor compare-and-swap refuses the commit with a generation
+/// mismatch, after which the slot is forgotten and the tick after reopens.
+/// Nothing stale is ever published.
+pub(crate) fn publication_identity_after_commit(
+    state: &DaemonState,
+) -> Result<LocalPublicationIdentity, (StatusCode, String)> {
+    let backend = state.local_repository_backend().ok_or_else(|| {
+        repository_authority_error("local daemon is missing its startup storage capability")
+    })?;
+    let repository_id = state
+        .local_repository_authority_binding()
+        .map_err(repository_authority_error)?
+        .repository_id()
+        .clone();
+    read_local_publication_identity(&backend, &repository_id)
+}
+
+/// Install `manager` as the held writer under the label read by
+/// [`publication_identity_after_commit`], and the admission pair derived from
+/// it.
+///
+/// The values come from the manager's own in-memory state, which only its own
+/// commits advance, so they describe the labelled publication whenever they are
+/// computed. Deriving them reaches the backend for rule sources, so nothing may
+/// hold the repository lock while this runs. If another writer publishes before
+/// this install, the label is already behind the durable record, the next
+/// reader misses it and reopens, and nothing stale is served.
+pub(crate) fn install_write_authority(
+    state: &DaemonState,
+    manager: &Arc<RepositoryAuthorityManager<LocalFileBackend>>,
+    published: LocalPublicationIdentity,
+) -> Result<(), (StatusCode, String)> {
+    let admission = admission_values_from(state, manager, published.clone())?;
+    state.projection_authority.install_admission(admission);
+    state
+        .projection_authority
+        .install_writer(published, Arc::clone(manager));
+    Ok(())
 }
 
 /// Refuse a storage namespace that is no longer the one this daemon pinned.
@@ -746,28 +942,32 @@ fn cached_authority_admission_entry(
         return Ok(admission);
     }
 
-    let context =
-        crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(state)
-            .map_err(|error| repository_authority_error(error.to_string()))?;
-    let authority = context
-        .open()
-        .map_err(|error| repository_authority_error(error.to_string()))?;
-    state.projection_authority.record_load();
-    let lease = authority.read_authority();
-    let roots = lease.roots().clone();
-    let open_merge =
-        crate::repository_merge_state::open_merge_summary(&lease, context.workspace_id());
-    drop(lease);
-    let policy = authority
-        .workspace_admission_snapshot(context.repository_id(), &context.workspace_id())
-        .map_err(|error| repository_authority_error(error.to_string()))?
-        .map(|snapshot| snapshot.matcher);
-    let admission = HeldAdmission {
-        published,
-        roots,
-        policy,
-        open_merge,
+    // The writer slot is consulted before anything opens: after a publication
+    // the daemon performed itself, the manager it published through is already
+    // at this publication, and reading the admission pair out of it costs no
+    // open. A daemon that has published nothing yet pays one open here, which
+    // then serves the publication that follows.
+    let manager = match state.projection_authority.reuse_writer(&published) {
+        Some(manager) => manager,
+        None => {
+            let context =
+                crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(
+                    state,
+                )
+                .map_err(|error| repository_authority_error(error.to_string()))?;
+            let manager = Arc::new(
+                context
+                    .open()
+                    .map_err(|error| repository_authority_error(error.to_string()))?,
+            );
+            state.projection_authority.record_load();
+            state
+                .projection_authority
+                .install_writer(published.clone(), Arc::clone(&manager));
+            manager
+        }
     };
+    let admission = admission_values_from(state, &manager, published)?;
     state
         .projection_authority
         .install_admission(admission.clone());
@@ -43637,6 +43837,360 @@ mod tests {
             "eight CONCURRENT admission reads racing into a COLD slot must pay one load between \
              them, not one each; the load gate is what makes that true, and this is the only \
              arm that can watch it go"
+        );
+    }
+
+    /// FIR-3203. One tracked-file edit publishes a workspace admission, and a
+    /// publication used to cost two whole-store opens on the reconcile tick (the
+    /// admission pair, because the previous publication moved the identity its
+    /// slot is keyed on, and then the publish itself) plus one more on the
+    /// persist flush. On a converted psf/requests each open decodes a 1051 MiB
+    /// change map and, with no durable validation proof for the generation the
+    /// last publication just produced, replays the whole history and clones
+    /// every change: that is the 3.6 GiB the stranger's daemon grew from one
+    /// edit before any commit ran. The daemon now opens once per edit: the
+    /// admission pair's open is held, the publication and the finalization
+    /// read through it, and the finalization forgets it, so nothing decoded
+    /// stays resident between edits.
+    ///
+    /// Counted at kin-core's own funnel, which every route into kin-db's
+    /// recovery passes through, so an open reintroduced through a different
+    /// wrapper still fails this. The counter is thread-local and is read on the
+    /// thread the admission ran on. Each admission runs under a deadline so a
+    /// lock held across a backend read (the freeze deadlock this fix once had)
+    /// is a named failure rather than a hung suite; the fixture carries a
+    /// `.gitignore` rule source so the admission pair does read a blob.
+    #[cfg(unix)]
+    #[test]
+    fn an_edit_costs_one_open_and_the_finalization_holds_nothing() {
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let working = state.layout.working_dir().to_path_buf();
+        std::fs::write(working.join(".gitignore"), b"*.pyc\n").unwrap();
+        let write = |body: &str| {
+            std::fs::create_dir_all(working.join("src")).unwrap();
+            std::fs::write(working.join("src/lib.py"), body).unwrap();
+        };
+        let observation = std::collections::BTreeSet::from([
+            RepoPath::from_utf8("src/lib.py").unwrap(),
+            RepoPath::from_utf8(".gitignore").unwrap(),
+        ]);
+        let admit = |state: &Arc<DaemonState>| -> u64 {
+            let (tx, rx) = std::sync::mpsc::channel();
+            let state = Arc::clone(state);
+            let observation = observation.clone();
+            std::thread::spawn(move || {
+                let before = kin_core::authority_opens();
+                let yielded = crate::loop_runner::ambient_admission_for_test(&state, &observation)
+                    .map_err(|error| error.to_string());
+                tx.send(yielded.map(|yielded| (yielded, kin_core::authority_opens() - before)))
+                    .ok();
+            });
+            let (yielded, opens) = rx
+                .recv_timeout(std::time::Duration::from_secs(120))
+                .expect(
+                    "the admission must finish: a publication that reaches the backend while it \
+                     still holds a repository lock deadlocks on its own flock",
+                )
+                .expect("the admission must publish");
+            assert!(!yielded, "the admission must publish rather than yield");
+            opens
+        };
+        // What the persist flush does after a publication: the enrichment
+        // publish and the read-index finalization read the held manager, and
+        // the finalization forgets it.
+        let finalize = |state: &Arc<DaemonState>| {
+            let generation = state
+                .snapshot_generation
+                .load(std::sync::atomic::Ordering::SeqCst);
+            let before = kin_core::authority_opens();
+            state
+                .load_committed_authority_graph(generation)
+                .expect("the finalization reads the committed graph");
+            assert_eq!(
+                kin_core::authority_opens() - before,
+                0,
+                "the finalization must read the manager the publication held, not open another"
+            );
+            assert!(
+                !state.projection_authority.holds_writer(),
+                "the finalization must forget the held writer so its decoded state is released"
+            );
+        };
+
+        write("def a():\n    return 1\n");
+        let generation_before = state
+            .snapshot_generation
+            .load(std::sync::atomic::Ordering::SeqCst);
+        let first = admit(&state);
+        assert!(
+            first >= 1,
+            "the first publication of a daemon's life pays for an open, or this counter is dead"
+        );
+        assert!(
+            state.projection_authority.holds_writer(),
+            "the open that served the publication is held until the finalization"
+        );
+        finalize(&state);
+
+        for round in 2..=4 {
+            write(&format!("def a():\n    return {round}\n"));
+            assert_eq!(
+                admit(&state),
+                1,
+                "edit {round} must cost exactly one whole-store open: the admission pair's, shared \
+                 with the publication; before this fix it cost two on the tick and one on the flush"
+            );
+            finalize(&state);
+        }
+        assert_eq!(
+            state
+                .snapshot_generation
+                .load(std::sync::atomic::Ordering::SeqCst)
+                - generation_before,
+            4,
+            "four edits must be four publications"
+        );
+    }
+
+    /// The held writer is behind the moment another writer publishes, and it
+    /// must never publish over that writer. The next edit reads the durable
+    /// publication first, misses the held label, and reopens; the fresh
+    /// authority then refuses the daemon's stale plan exactly as it did before
+    /// any writer was held, and the slot is forgotten so nothing stale survives
+    /// into the tick after.
+    #[cfg(unix)]
+    #[test]
+    fn a_publication_by_another_writer_is_never_overwritten_by_the_held_one() {
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let working = state.layout.working_dir().to_path_buf();
+        std::fs::create_dir_all(working.join("src")).unwrap();
+        std::fs::write(working.join("src/lib.py"), "def a():\n    return 1\n").unwrap();
+        let observation =
+            std::collections::BTreeSet::from([RepoPath::from_utf8("src/lib.py").unwrap()]);
+        assert!(!crate::loop_runner::ambient_admission_for_test(&state, &observation).unwrap());
+        assert!(state.projection_authority.holds_writer());
+
+        // A writer beside the daemon publishes a tree the daemon's graph has not
+        // seen, through a fresh open of the same store.
+        let context =
+            crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(&state)
+                .unwrap();
+        let foreign = context.open().unwrap();
+        let (roots, previous) = {
+            let lease = foreign.read_authority();
+            let previous = lease
+                .metadata()
+                .workspaces
+                .iter()
+                .find(|workspace| workspace.workspace_id == context.workspace_id())
+                .map(|workspace| workspace.tree.clone())
+                .unwrap_or_default();
+            (lease.roots().clone(), previous)
+        };
+        let foreign_hash = Hash256::from_bytes(state.blobs.write(b"foreign\n").unwrap().0);
+        std::fs::write(working.join("foreign.txt"), b"foreign\n").unwrap();
+        let mut artifacts = previous.artifacts_by_path().cloned().collect::<Vec<_>>();
+        artifacts.push(kin_model::ResolvedArtifact::new(
+            kin_model::ArtifactId::new(),
+            RepoPath::from_utf8("foreign.txt").unwrap(),
+            TreeEntry::blob(foreign_hash, false),
+        ));
+        let desired = kin_model::ResolvedTree::from_artifacts(artifacts).unwrap();
+        let admitted = crate::repository_commit::admitted_workspace_tree_for_test(
+            &working, roots, previous, desired,
+        );
+        crate::repository_commit::publish_workspace_tree_through(
+            state.blobs.as_ref(),
+            context.repository_id().clone(),
+            context.workspace_id(),
+            &foreign,
+            &admitted,
+            kin_model::OperationId::new(),
+            AuthorId::new("writer-beside-the-daemon"),
+        )
+        .unwrap()
+        .expect("the foreign publication must move authority");
+        let foreign_generation = foreign.read_authority().roots().generation;
+
+        // The daemon's next edit. Its held writer is one generation behind.
+        std::fs::write(working.join("src/lib.py"), "def a():\n    return 2\n").unwrap();
+        let opens_before = kin_core::authority_opens();
+        let error = crate::loop_runner::ambient_admission_for_test(&state, &observation)
+            .expect_err("a plan against a graph that is behind authority is refused");
+        assert!(
+            kin_core::authority_opens() - opens_before >= 1,
+            "the moved publication must be observed by a fresh open, not served from the held one"
+        );
+        assert!(
+            error.to_string().contains("authority"),
+            "the refusal names authority: {error}"
+        );
+        assert!(
+            !state.projection_authority.holds_writer(),
+            "a refused publication forgets the held writer"
+        );
+        // Nothing overwrote the foreign publication.
+        let reopened = context.open().unwrap();
+        let lease = reopened.read_authority();
+        assert_eq!(lease.roots().generation, foreign_generation);
+        assert!(
+            lease
+                .metadata()
+                .workspaces
+                .iter()
+                .find(|workspace| workspace.workspace_id == context.workspace_id())
+                .unwrap()
+                .tree
+                .artifact_at_path(&RepoPath::from_utf8("foreign.txt").unwrap())
+                .is_some(),
+            "the foreign writer's artifact must survive the daemon's refused publication"
+        );
+    }
+
+    /// The backstop for the one window the label cannot close: a foreign
+    /// publication landing between the daemon's identity read and its commit.
+    /// The held manager is then one generation behind but labelled current,
+    /// exactly the state that window produces, and the daemon's own
+    /// publication path must be REFUSED by kin-db's successor compare-and-swap,
+    /// must forget the held authority, and must not overwrite the foreign
+    /// publication. Built directly rather than raced: the window is two adjacent
+    /// statements wide and a test that waits for it proves nothing on time.
+    #[cfg(unix)]
+    #[test]
+    fn a_held_authority_that_fell_behind_is_refused_by_the_cas_and_forgotten() {
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let working = state.layout.working_dir().to_path_buf();
+        std::fs::create_dir_all(working.join("src")).unwrap();
+        std::fs::write(working.join("src/lib.py"), "def a():\n    return 1\n").unwrap();
+        let observation =
+            std::collections::BTreeSet::from([RepoPath::from_utf8("src/lib.py").unwrap()]);
+        assert!(!crate::loop_runner::ambient_admission_for_test(&state, &observation).unwrap());
+        assert!(state.projection_authority.holds_writer());
+
+        let context =
+            crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(&state)
+                .unwrap();
+        // The daemon's plan, as the tick makes it: against the held manager's
+        // roots and this workspace's tree, both at the held generation.
+        let held = held_write_authority(&state).expect("the held writer resolves");
+        let (held_roots, held_tree) = {
+            let lease = held.read_authority();
+            let tree = lease
+                .metadata()
+                .workspaces
+                .iter()
+                .find(|workspace| workspace.workspace_id == context.workspace_id())
+                .map(|workspace| workspace.tree.clone())
+                .unwrap_or_default();
+            (lease.roots().clone(), tree)
+        };
+        let held_generation = held_roots.generation;
+
+        // The foreign writer lands now, through its own open.
+        let foreign = context.open().unwrap();
+        let foreign_hash = Hash256::from_bytes(state.blobs.write(b"foreign\n").unwrap().0);
+        std::fs::write(working.join("foreign.txt"), b"foreign\n").unwrap();
+        let mut artifacts = held_tree.artifacts_by_path().cloned().collect::<Vec<_>>();
+        artifacts.push(kin_model::ResolvedArtifact::new(
+            kin_model::ArtifactId::new(),
+            RepoPath::from_utf8("foreign.txt").unwrap(),
+            TreeEntry::blob(foreign_hash, false),
+        ));
+        let foreign_desired = kin_model::ResolvedTree::from_artifacts(artifacts).unwrap();
+        crate::repository_commit::publish_workspace_tree_through(
+            state.blobs.as_ref(),
+            context.repository_id().clone(),
+            context.workspace_id(),
+            &foreign,
+            &crate::repository_commit::admitted_workspace_tree_for_test(
+                &working,
+                held_roots.clone(),
+                held_tree.clone(),
+                foreign_desired,
+            ),
+            kin_model::OperationId::new(),
+            AuthorId::new("writer-beside-the-daemon"),
+        )
+        .unwrap()
+        .expect("the foreign publication must move authority");
+        let foreign_generation = foreign.read_authority().roots().generation;
+        assert_eq!(foreign_generation, held_generation + 1);
+
+        // The window's exact product: the held manager, one generation behind,
+        // wearing the label the foreign publication produced.
+        let current = publication_identity_after_commit(&state).unwrap();
+        state
+            .projection_authority
+            .install_writer(current, Arc::clone(&held));
+
+        // The daemon publishes its own edit through the production path. The
+        // identity read matches the (mis)label, the held manager is reused, its
+        // plan checks pass against its own stale roots, and the commit reaches
+        // kin-db's compare-and-swap.
+        std::fs::write(working.join("src/lib.py"), "def a():\n    return 2\n").unwrap();
+        let edited_hash =
+            Hash256::from_bytes(state.blobs.write(b"def a():\n    return 2\n").unwrap().0);
+        let mut artifacts = held_tree.artifacts_by_path().cloned().collect::<Vec<_>>();
+        for artifact in &mut artifacts {
+            if artifact.path == RepoPath::from_utf8("src/lib.py").unwrap() {
+                artifact.entry = TreeEntry::blob(edited_hash, false);
+            }
+        }
+        let admitted = crate::repository_commit::admitted_workspace_tree_for_test(
+            &working,
+            held_roots,
+            held_tree,
+            kin_model::ResolvedTree::from_artifacts(artifacts).unwrap(),
+        );
+        let opens_before = kin_core::authority_opens();
+        let error = crate::loop_runner::publish_exact_workspace_tree(&state, &admitted)
+            .expect_err("a held manager behind the durable record must be refused");
+        assert_eq!(
+            kin_core::authority_opens() - opens_before,
+            0,
+            "the refusal comes from the compare-and-swap through the held manager, not from a \
+             fresh open that noticed the move"
+        );
+        let message = error.to_string();
+        assert!(
+            message.contains("generation"),
+            "the compare-and-swap names the generation: {message}"
+        );
+        assert!(
+            !state.projection_authority.holds_writer(),
+            "a refused publication forgets the held authority"
+        );
+
+        // Nothing overwrote the foreign publication, and the next resolver
+        // reopens from storage rather than serving the manager that fell behind.
+        let reopened = context.open().unwrap();
+        let lease = reopened.read_authority();
+        assert_eq!(lease.roots().generation, foreign_generation);
+        assert!(lease
+            .metadata()
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.workspace_id == context.workspace_id())
+            .unwrap()
+            .tree
+            .artifact_at_path(&RepoPath::from_utf8("foreign.txt").unwrap())
+            .is_some());
+        drop(lease);
+        let opens_before = kin_core::authority_opens();
+        let fresh = held_write_authority(&state).unwrap();
+        assert!(kin_core::authority_opens() - opens_before >= 1);
+        assert_eq!(
+            fresh.read_authority().roots().generation,
+            foreign_generation
         );
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -239,13 +239,14 @@ pub(crate) struct ProjectionAuthorityCache {
     /// The refs routes' envelope, keyed on the same publication identity as
     /// every slot above it.
     ref_metadata: std::sync::Mutex<Option<HeldRefMetadata>>,
-    /// The manager this daemon publishes through, held for the life of one
-    /// publication; see [`HeldWriteAuthority`]. The admission pair's open
-    /// installs it, the publication and the enrichment publish go through it,
-    /// and the read-index finalization forgets it, so one edit costs one
-    /// whole-store open rather than the two or three it cost before and nothing
-    /// decoded stays resident between edits. The admission slot above is derived
-    /// from it and relabelled with it.
+    /// The manager this daemon publishes through, held for one scope at a time;
+    /// see [`HeldWriteAuthority`]. On the reconcile tick the admission pair's
+    /// open installs it, the publication goes through it, and the publication
+    /// drops it. On the persist flush the enrichment publish installs it, the
+    /// read-index finalization reuses it and forgets it. Two whole-store opens
+    /// per edit rather than the three or four it cost before, and no manager
+    /// alive across the boundary between the two scopes. The admission slot
+    /// above is derived from it and relabelled with it.
     writer: std::sync::Mutex<Option<HeldWriteAuthority>>,
     /// Serializes misses so a burst of concurrent cold requests pays for one
     /// full load rather than one per request.
@@ -296,7 +297,7 @@ struct HeldRefMetadata {
     metadata: Arc<kin_db::PersistedRepositoryAuthority>,
 }
 
-/// The authority this daemon publishes through, held for one publication.
+/// The authority this daemon publishes through, held for one scope.
 ///
 /// A publication used to open the persisted authority, commit through it and
 /// drop it, and the open is O(store): kin-db decodes the change map (93.8 percent
@@ -306,10 +307,13 @@ struct HeldRefMetadata {
 /// every change. One tracked-file edit cost the stranger's daemon 3.6 GiB of
 /// resident set that way before any commit ran (FIR-3203).
 ///
-/// After its own commit the manager's in-memory state IS the durable successor,
-/// so every later reader of that publication can go through it with no open at
-/// all: the enrichment publish and then the read-index finalization, which is
-/// the last of them and forgets the slot.
+/// After its own commit the manager's in-memory state IS the durable successor.
+/// Readers inside the same scope go through it with no open at all; the scope
+/// ends with the publication on the tick, and with the read-index finalization
+/// on the persist flush, and each end forgets the slot. Holding it across the
+/// two was measured on a converted psf/requests: the flush's allocations
+/// stacked on the decoded successor and the edit-window peak rose 2 to 4 GiB
+/// above the pre-fix peak.
 ///
 /// The label says which publication this manager is at. It is read the instant
 /// after a plain commit, under no lock at all, so a foreign publication landing
@@ -43861,10 +43865,15 @@ mod tests {
     /// change map and, with no durable validation proof for the generation the
     /// last publication just produced, replays the whole history and clones
     /// every change: that is the 3.6 GiB the stranger's daemon grew from one
-    /// edit before any commit ran. The daemon now opens once per edit: the
-    /// admission pair's open is held, the publication and the finalization
-    /// read through it, and the finalization forgets it, so nothing decoded
-    /// stays resident between edits.
+    /// edit before any commit ran. The tick now opens once: the admission
+    /// pair's open is held for the publication and dropped the moment the
+    /// publication returns, so nothing decoded is alive when the persist flush
+    /// that follows does its own work. The flush opens once for its own scope
+    /// (the enrichment publish installs, the read-index finalization reuses and
+    /// forgets). Two opens per edit against three or four before, and no
+    /// manager alive across the boundary between them, which is where a held
+    /// manager stacked the flush's allocations on the decoded successor and put
+    /// the edit-window peak 2 to 4 GiB above the pre-fix peak on psf/requests.
     ///
     /// Counted at kin-core's own funnel, which every route into kin-db's
     /// recovery passes through, so an open reintroduced through a different
@@ -43875,7 +43884,7 @@ mod tests {
     /// `.gitignore` rule source so the admission pair does read a blob.
     #[cfg(unix)]
     #[test]
-    fn an_edit_costs_one_open_and_the_finalization_holds_nothing() {
+    fn an_edit_pays_one_open_for_its_pair_and_publish_and_holds_nothing_after() {
         let state = test_state();
         state
             .is_initialized
@@ -43924,8 +43933,8 @@ mod tests {
                 .expect("the finalization reads the committed graph");
             assert_eq!(
                 kin_core::authority_opens() - before,
-                0,
-                "the finalization must read the manager the publication held, not open another"
+                1,
+                "the flush opens once for its own scope, after the publication's manager is gone"
             );
             assert!(
                 !state.projection_authority.holds_writer(),
@@ -43943,8 +43952,8 @@ mod tests {
             "the first publication of a daemon's life pays for an open, or this counter is dead"
         );
         assert!(
-            state.projection_authority.holds_writer(),
-            "the open that served the publication is held until the finalization"
+            !state.projection_authority.holds_writer(),
+            "the publication's manager must not outlive the publication"
         );
         finalize(&state);
 
@@ -43965,6 +43974,41 @@ mod tests {
                 - generation_before,
             4,
             "four edits must be four publications"
+        );
+
+        // A publication with nothing to publish: the desired tree is the tree
+        // authority already holds. It returns `None`, and it must hold nothing
+        // afterwards either; the first shape of this returned early with the
+        // manager still installed and no finalization armed to forget it.
+        let context =
+            crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(&state)
+                .unwrap();
+        let (roots, tree) = {
+            let manager = held_write_authority(&state).unwrap();
+            let lease = manager.read_authority();
+            let tree = lease
+                .metadata()
+                .workspaces
+                .iter()
+                .find(|workspace| workspace.workspace_id == context.workspace_id())
+                .map(|workspace| workspace.tree.clone())
+                .unwrap_or_default();
+            (lease.roots().clone(), tree)
+        };
+        let unchanged = crate::repository_commit::admitted_workspace_tree_for_test(
+            &working,
+            roots,
+            tree.clone(),
+            tree,
+        );
+        assert_eq!(
+            crate::loop_runner::publish_exact_workspace_tree(&state, &unchanged).unwrap(),
+            None,
+            "a desired tree authority already holds publishes nothing"
+        );
+        assert!(
+            !state.projection_authority.holds_writer(),
+            "a publication that moved nothing must not keep its manager either"
         );
     }
 
@@ -43987,7 +44031,9 @@ mod tests {
         let observation =
             std::collections::BTreeSet::from([RepoPath::from_utf8("src/lib.py").unwrap()]);
         assert!(!crate::loop_runner::ambient_admission_for_test(&state, &observation).unwrap());
-        assert!(state.projection_authority.holds_writer());
+        // The publication drops its manager as it returns, so nothing is held
+        // here; the resolver below opens the one this test then holds.
+        assert!(!state.projection_authority.holds_writer());
 
         // A writer beside the daemon publishes a tree the daemon's graph has not
         // seen, through a fresh open of the same store.
@@ -44087,7 +44133,9 @@ mod tests {
         let observation =
             std::collections::BTreeSet::from([RepoPath::from_utf8("src/lib.py").unwrap()]);
         assert!(!crate::loop_runner::ambient_admission_for_test(&state, &observation).unwrap());
-        assert!(state.projection_authority.holds_writer());
+        // The publication drops its manager as it returns, so nothing is held
+        // here; the resolver below opens the one this test then holds.
+        assert!(!state.projection_authority.holds_writer());
 
         let context =
             crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(&state)

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -489,6 +489,15 @@ impl ProjectionAuthorityCache {
         lock_recover(&self.writer).is_some()
     }
 
+    /// Cold the admission values slot, which [`Self::invalidate`] leaves alone.
+    /// A test whose act must pay the admission pair's own open, and so install
+    /// the writer that open serves, takes this first; a slot a reader warmed at
+    /// the current label would otherwise satisfy the act and install nothing.
+    #[cfg(test)]
+    pub(crate) fn forget_admission(&self) {
+        *lock_recover(&self.admission) = None;
+    }
+
     fn invalidate(&self) {
         *lock_recover(&self.held) = None;
         *lock_recover(&self.query) = None;
@@ -38864,22 +38873,36 @@ mod tests {
             response.report.unwrap().outcome,
             kin_cli::commands::merge::MergeOutcome::Conflicted
         ));
-        assert!(
-            cached_authority_has_open_merge(&state).unwrap(),
-            "the fixture must hold a durable open merge"
-        );
+        // Nothing reads the admission pair between here and the act. A reader
+        // here would install the pair at the current label, the tick would then
+        // take the pair from the slot and install no writer, and the guard would
+        // have nothing to forget: a deleted guard passed this test exactly that
+        // way. The slot is colded outright, since a commit and a merge ran above,
+        // and the open the act pays is asserted as the proof that it installed.
+        state.projection_authority.forget_admission();
         std::fs::write(&path, b"services:\n  api:\n    image: hand-authored\n").unwrap();
         let observation =
             std::iter::once(RepoPath::from_utf8("selected/compose.yaml").unwrap()).collect();
+        let opens_before = kin_core::authority_opens();
         let yielded = crate::loop_runner::ambient_admission_for_test(&state, &observation).unwrap();
         assert!(
             yielded,
             "the tick must yield to the open merge, or this proves nothing"
         );
+        assert_eq!(
+            kin_core::authority_opens() - opens_before,
+            1,
+            "the tick's pair read must be the one open that installs the writer, or the guard \
+             below is untested"
+        );
         assert!(
             !state.projection_authority.holds_writer(),
             "a tick that yielded to an open merge must not keep the manager its admission pair \
              installed"
+        );
+        assert!(
+            cached_authority_has_open_merge(&state).unwrap(),
+            "the fixture must hold a durable open merge"
         );
         drop(app);
     }
@@ -44155,6 +44178,12 @@ mod tests {
     /// follow; when nothing moved, no publication follows and no drop runs, so
     /// the tick's own scope has to forget it. The yield-to-open-merge and
     /// yield-to-commit returns share this scope.
+    ///
+    /// The publication above this tick re-installs the admission values at the
+    /// label it produced, so a second tick would read the pair from the slot and
+    /// install no writer, and a deleted guard passed this test exactly that way.
+    /// The slot is colded first, and the one open the tick then pays is asserted
+    /// as the proof that it installed.
     #[cfg(unix)]
     #[test]
     fn a_publishing_tick_that_moves_nothing_holds_nothing_after() {
@@ -44171,15 +44200,18 @@ mod tests {
         assert!(!state.projection_authority.holds_writer());
         // The same bytes again: the tick plans, finds nothing to move, and
         // returns before any publication.
+        state.projection_authority.forget_admission();
         let opens_before = kin_core::authority_opens();
         assert!(!crate::loop_runner::ambient_admission_for_test(&state, &observation).unwrap());
+        assert_eq!(
+            kin_core::authority_opens() - opens_before,
+            1,
+            "the tick's pair read must be the one open that installs the writer, or the guard \
+             below is untested"
+        );
         assert!(
             !state.projection_authority.holds_writer(),
             "a tick that published nothing must not keep the manager its admission pair opened"
-        );
-        assert!(
-            kin_core::authority_opens() - opens_before <= 1,
-            "a no-op tick costs at most the admission pair's own open"
         );
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -239,10 +239,13 @@ pub(crate) struct ProjectionAuthorityCache {
     /// The refs routes' envelope, keyed on the same publication identity as
     /// every slot above it.
     ref_metadata: std::sync::Mutex<Option<HeldRefMetadata>>,
-    /// The manager this daemon publishes through, kept across publications so an
-    /// edit costs no whole-store open; see [`HeldWriteAuthority`]. The
-    /// admission slot above is derived from it, so after a publication both are
-    /// relabelled together and the next reconcile tick opens nothing.
+    /// The manager this daemon publishes through, held for the life of one
+    /// publication; see [`HeldWriteAuthority`]. The admission pair's open
+    /// installs it, the publication and the enrichment publish go through it,
+    /// and the read-index finalization forgets it, so one edit costs one
+    /// whole-store open rather than the two or three it cost before and nothing
+    /// decoded stays resident between edits. The admission slot above is derived
+    /// from it and relabelled with it.
     writer: std::sync::Mutex<Option<HeldWriteAuthority>>,
     /// Serializes misses so a burst of concurrent cold requests pays for one
     /// full load rather than one per request.
@@ -293,7 +296,7 @@ struct HeldRefMetadata {
     metadata: Arc<kin_db::PersistedRepositoryAuthority>,
 }
 
-/// The authority this daemon publishes through, held across publications.
+/// The authority this daemon publishes through, held for one publication.
 ///
 /// A publication used to open the persisted authority, commit through it and
 /// drop it, and the open is O(store): kin-db decodes the change map (93.8 percent
@@ -304,18 +307,28 @@ struct HeldRefMetadata {
 /// resident set that way before any commit ran (FIR-3203).
 ///
 /// After its own commit the manager's in-memory state IS the durable successor,
-/// so the next publication can go through it with no open at all, as long as
-/// nothing else wrote in between. The label says which publication this manager
-/// is at. It is taken under the commit-point lock the freeze holds, so it cannot
-/// name a publication that landed after this manager's own; a reuse reads the
-/// durable record first and misses the moment any other writer moved it. If a
-/// writer moves it between that read and the commit, kin-db's successor
-/// compare-and-swap refuses the commit with a generation mismatch and the slot
-/// is forgotten, so a stale manager can never overwrite a foreign publication.
+/// so every later reader of that publication can go through it with no open at
+/// all: the enrichment publish and then the read-index finalization, which is
+/// the last of them and forgets the slot.
+///
+/// The label says which publication this manager is at. It is read the instant
+/// after a plain commit, under no lock at all, so a foreign publication landing
+/// between the commit and the read DOES leave this manager one generation behind
+/// while wearing the current label; see
+/// [`publication_identity_after_commit`]. That window is closed by kin-db, not
+/// by this label: an ordinary reuse reads the durable record first and misses
+/// the moment any other writer moved it, and a manager that slipped through the
+/// window is refused at the commit by kin-db's successor compare-and-swap with a
+/// generation mismatch, after which the slot is forgotten. Either way a stale
+/// manager can never overwrite a foreign publication. The test that pins the
+/// second path is
+/// `a_held_authority_that_fell_behind_is_refused_by_the_cas_and_forgotten`.
 struct HeldWriteAuthority {
-    /// Read strictly before the load, or under the freeze of the commit this
-    /// manager performed, for the reason [`HeldProjectionAuthority::published`]
-    /// gives.
+    /// Read strictly before the load, or immediately after the commit this
+    /// manager performed. The first case is the reason
+    /// [`HeldProjectionAuthority::published`] gives; the second carries the
+    /// window this type's own documentation names, and kin-db's compare-and-swap
+    /// is what closes it.
     published: LocalPublicationIdentity,
     manager: Arc<RepositoryAuthorityManager<LocalFileBackend>>,
 }

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant, SystemTime};
 use kin_index::{
     FileClassification, FileClassifier, FileEvent, FileWatcher, IndexPipeline, IndexedAny,
 };
+use kin_model::layout::ParseCompleteness;
 use kin_model::{
     EntityFilter, EntityId, EntityStore, FilePathId, Hash256, RepoPath, ShallowTrackedFile,
     TransactionDelta, TreeDelta, TreeEntry,
@@ -2307,12 +2308,63 @@ pub(crate) struct LayoutBackfill {
     pub(crate) unreadable: usize,
     /// Artifacts another facet already owns, which this pass must not touch.
     pub(crate) other_facet: usize,
+    /// Artifacts whose graph entities disagree with a fresh parse of the bytes
+    /// the tree holds: published as `Partial` rather than `Full`, and owed a
+    /// re-derivation. Counted inside `published`.
+    pub(crate) stale: usize,
+    /// The host paths whose entities are owed a re-derivation, for the loop to
+    /// enqueue as ordinary `Changed` events.
+    pub(crate) rederive: Vec<PathBuf>,
 }
 
 impl LayoutBackfill {
     fn observed(&self) -> usize {
         self.already_published + self.published + self.unreadable + self.other_facet
     }
+}
+
+/// One entity's identity as a parse would reproduce it: what it is, what it is
+/// called, and exactly which bytes it spans. Two parses of the same bytes agree
+/// on every field; a parse of different bytes moves the span of everything after
+/// the edit.
+type ParsedSpanKey = (String, String, usize, usize);
+
+fn parsed_span_keys(entities: &[kin_model::Entity]) -> Vec<ParsedSpanKey> {
+    let mut keys = entities
+        .iter()
+        .filter(|entity| entity.role == kin_model::EntityRole::Source)
+        .filter_map(|entity| {
+            entity.span.as_ref().map(|span| {
+                (
+                    format!("{:?}", entity.kind),
+                    entity.name.clone(),
+                    span.start_byte,
+                    span.end_byte,
+                )
+            })
+        })
+        .collect::<Vec<_>>();
+    keys.sort();
+    keys
+}
+
+/// How many of the graph's source entities for one file a fresh parse of the
+/// tree's bytes does not reproduce.
+///
+/// Compared by kind, name and byte span rather than by id, because the
+/// reconciler keeps an entity's id stable across an edit that moves it
+/// (`stable_entity_ids` in kin-reconcile), so ids agree on a store that is
+/// fresh and disagree on one that is not, which is backwards for this question.
+/// Spans are the thing that goes stale, so spans are what is compared.
+pub(crate) fn spans_a_fresh_parse_does_not_reproduce(
+    held: &[kin_model::Entity],
+    fresh: &[kin_model::Entity],
+) -> usize {
+    let fresh_keys = parsed_span_keys(fresh);
+    parsed_span_keys(held)
+        .into_iter()
+        .filter(|key| fresh_keys.binary_search(key).is_err())
+        .count()
 }
 
 /// Publish the per-file parse observation for every admitted entity-source
@@ -2414,20 +2466,20 @@ pub(crate) fn backfill_missing_file_layouts(state: &DaemonState) -> Result<Layou
             continue;
         }
 
-        let completeness =
-            match pipeline.index_file_content_with_tests(&file_id, &content, body_hash) {
-                Ok(indexed) => indexed.indexed_file.file_layout.parse_completeness,
-                Err(error) => {
-                    debug!(
-                        file = %file_id,
-                        error = %error,
-                        "graph-owned source could not be indexed, so its parse observation stays \
-                         unpublished rather than being guessed"
-                    );
-                    report.unreadable += 1;
-                    continue;
-                }
-            };
+        let indexed = match pipeline.index_file_content_with_tests(&file_id, &content, body_hash) {
+            Ok(indexed) => indexed.indexed_file,
+            Err(error) => {
+                debug!(
+                    file = %file_id,
+                    error = %error,
+                    "graph-owned source could not be indexed, so its parse observation stays \
+                     unpublished rather than being guessed"
+                );
+                report.unreadable += 1;
+                continue;
+            }
+        };
+        let mut completeness = indexed.file_layout.parse_completeness;
 
         let mut entities = state.graph.query_entities(&EntityFilter {
             file_path: Some(file_id.clone()),
@@ -2440,6 +2492,30 @@ pub(crate) fn backfill_missing_file_layouts(state: &DaemonState) -> Result<Layou
                 .map(|span| span.start_byte)
                 .unwrap_or(usize::MAX)
         });
+        // The parse just taken is of the bytes the tree holds NOW. The entities
+        // the graph holds may have been derived from an earlier blob at this
+        // path: a daemon that admitted new bytes into the tree and died before
+        // it re-derived and published their entities leaves exactly that, and
+        // nothing else about the store says so (FIR-3201, the restart window of
+        // FIR-3208). Publishing `Full` here would certify those spans over
+        // bytes they do not describe. The observation is recorded as partial,
+        // with the count, and the path is handed back to the loop as an
+        // ordinary host event so the reconciler re-derives it through the same
+        // bounded admission an edit takes.
+        let stale = spans_a_fresh_parse_does_not_reproduce(&entities, &indexed.entities);
+        if stale > 0 {
+            if let Ok(host_path) =
+                kin_index::host_path_from_repo_path(state.layout.working_dir(), &artifact.path)
+            {
+                report.rederive.push(host_path);
+            }
+            report.stale += 1;
+            completeness = ParseCompleteness::Partial(format!(
+                "{stale} of {} entity span(s) the graph holds for this file were not derived from \
+                 the bytes the repository tree holds at this path; they are being re-derived",
+                entities.len()
+            ));
+        }
         let layout =
             kin_core::build_entity_file_layout(&file_id, &entities, content.len(), completeness);
         state.graph.upsert_file_layout(&layout)?;
@@ -2750,10 +2826,24 @@ pub async fn run_loop_armed(
                         already_published = report.already_published,
                         unreadable = report.unreadable,
                         other_facet = report.other_facet,
+                        stale = report.stale,
                         observed = report.observed(),
                         "published the per-file parse observation for admitted source files that \
                          carried none, so an enumeration over them can be certified"
                     );
+                    if !report.rederive.is_empty() {
+                        warn!(
+                            count = report.rederive.len(),
+                            "these paths hold entities a fresh parse of the tree's bytes does not \
+                             reproduce, so their spans describe an earlier state of the file; \
+                             their parse observation was published as partial and they are being \
+                             re-derived"
+                        );
+                        enqueue_file_events(
+                            &mut pending_events,
+                            report.rederive.into_iter().map(FileEvent::Changed),
+                        );
+                    }
                     state.bump_version();
                 }
                 Err(error) => {
@@ -3753,6 +3843,284 @@ mod tests {
     fn open_test_state(repo: &tempfile::TempDir) -> Arc<DaemonState> {
         let init = kin_core::init(repo.path()).unwrap();
         Arc::new(DaemonState::open(init.layout).unwrap())
+    }
+
+    /// Write `content` to `rel_path` in the working copy, admit it into the
+    /// repository tree through the real ambient admission, and re-derive its
+    /// entities and layout the way the loop does after an admission. Returns
+    /// the blob the tree now holds at the path.
+    ///
+    /// This is the settled state a healthy edit reaches: tree, entities and
+    /// layout all describe the same bytes.
+    fn admit_and_derive(state: &Arc<DaemonState>, rel_path: &str, content: &str) -> Hash256 {
+        let host_path = state.layout.working_dir().join(rel_path);
+        std::fs::create_dir_all(host_path.parent().unwrap()).unwrap();
+        std::fs::write(&host_path, content).unwrap();
+        let repo_path = RepoPath::from_utf8(rel_path).unwrap();
+        let observation = BTreeSet::from([repo_path.clone()]);
+        let yielded = ambient_admission_for_test(state, &observation).expect("admission runs");
+        assert!(!yielded, "the fixture admission must not yield to a commit");
+        derive_semantics(state, rel_path);
+        state
+            .graph
+            .get_tree_entry(&FilePathId::new(rel_path))
+            .unwrap()
+            .and_then(|entry| entry.blob_identity())
+            .expect("the tree holds a blob at the admitted path")
+    }
+
+    /// The enrichment half of one reconcile round for one path: what the loop
+    /// runs after `exact_tree_admission`, without the loop.
+    fn derive_semantics(state: &Arc<DaemonState>, rel_path: &str) {
+        let host_path = state.layout.working_dir().join(rel_path);
+        let mut reconciler =
+            kin_reconcile::Reconciler::new(state.layout.working_dir().to_path_buf());
+        let result = reconciler
+            .reconcile_file_change(
+                &FileEvent::Changed(host_path),
+                &state.blobs,
+                state.graph.as_ref(),
+            )
+            .expect("the reconciler derives the file");
+        let (outcome, delta) = result.into_parts();
+        assert!(
+            matches!(outcome, kin_reconcile::ReconcileOutcome::Updated { .. }),
+            "the fixture file must reconcile cleanly: {outcome:?}"
+        );
+        state.graph.apply_transaction_delta(&delta).unwrap();
+        state
+            .persist_projection_truth_from_reconcile(&reconciler, &outcome)
+            .unwrap();
+    }
+
+    fn file_coverage(state: &Arc<DaemonState>, rel_path: &str) -> serde_json::Value {
+        let args = HashMap::from([("path".to_string(), serde_json::json!(rel_path))]);
+        let result = kin_mcp::handlers::file_entities::handle_list_file_entities(
+            &args,
+            state.graph.as_ref(),
+        )
+        .expect("the enumeration answers");
+        let kin_mcp::types::ContentBlock::Text { text } = &result.content[0];
+        let payload: serde_json::Value = serde_json::from_str(text).unwrap();
+        payload[kin_mcp::handlers::file_entities::FILE_COVERAGE_KEY].clone()
+    }
+
+    /// Whether `kin graph status`'s parse census counts `rel_path` as a file that
+    /// produced an entity, read through the same kin-core function the census
+    /// renders from.
+    fn census_counts_file(state: &Arc<DaemonState>, rel_path: &str) -> bool {
+        let entities = state.graph.list_all_entities().unwrap();
+        let retained = kin_core::retained_parse::read(&state.layout);
+        let census = kin_core::reference_coverage::collect_parse_coverage_from(
+            &state.graph.resolved_tree(),
+            &entities,
+            &retained,
+        );
+        // The census counts a file when an entity names it as origin and the
+        // tree admits it as source, so the python row must be whole AND the
+        // file must be the one it counted.
+        census
+            .languages
+            .iter()
+            .any(|row| row.language == "python" && row.tracked > 0 && row.silent == 0)
+            && entities
+                .iter()
+                .any(|entity| entity.file_origin.as_ref().map(|id| id.0.as_str()) == Some(rel_path))
+    }
+
+    const TWO_FUNCTIONS: &str = "def alpha():\n    return 1\n\n\ndef beta():\n    return 2\n";
+    /// Different bytes from [`TWO_FUNCTIONS`] on purpose: the observation planner
+    /// refuses a transition in which one exact blob appears at two paths, because
+    /// a copy and a move-plus-replace cannot be told apart from the tree alone.
+    const TWO_OTHER_FUNCTIONS: &str =
+        "def gamma():\n    return 3\n\n\ndef delta():\n    return 4\n";
+    const SEVENTEEN_LINES: &str = "# 1\n# 2\n# 3\n# 4\n# 5\n# 6\n# 7\n# 8\n# 9\n# 10\n# 11\n# 12\n# 13\n# 14\n# 15\n# 16\n# 17\n";
+
+    /// FIR-3201, the window. A file is admitted and derived, so its enumeration
+    /// certifies. Seventeen lines are prepended on disk and ONE ambient
+    /// admission runs: the tree now holds the new blob and the entities still
+    /// carry the old spans. The layout must not stand over them: kin-db's
+    /// `apply_transaction_delta` retires every path-keyed facet for a tree
+    /// delta that invalidates the path before it publishes the new tree, so
+    /// the enumeration floors on `file_parsed_absent` until the reconciler
+    /// re-derives the file, after which it and the parse census agree again.
+    /// Pinned here, in kin's own pipeline, so a dependency that stopped
+    /// retiring would fail this rather than certify a stale span.
+    #[test]
+    fn a_replaced_blob_retires_its_layout_until_the_spans_are_re_derived() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        state.is_initialized.store(true, Ordering::Relaxed);
+        let path = "src/mod.py";
+
+        let first_blob = admit_and_derive(&state, path, TWO_FUNCTIONS);
+        let settled = file_coverage(&state, path);
+        assert_eq!(settled["parsed"], serde_json::json!("full"), "{settled}");
+        assert_eq!(
+            settled["certifies_enumeration"],
+            serde_json::json!(true),
+            "the settled fixture must certify, or the assertions below prove nothing: {settled}"
+        );
+        assert!(census_counts_file(&state, path));
+
+        // The edit lands on disk and the tree moves. Nothing re-derives yet.
+        let host_path = state.layout.working_dir().join(path);
+        std::fs::write(&host_path, format!("{SEVENTEEN_LINES}{TWO_FUNCTIONS}")).unwrap();
+        let observation = BTreeSet::from([RepoPath::from_utf8(path).unwrap()]);
+        assert!(!ambient_admission_for_test(&state, &observation).unwrap());
+        let second_blob = state
+            .graph
+            .get_tree_entry(&FilePathId::new(path))
+            .unwrap()
+            .and_then(|entry| entry.blob_identity())
+            .unwrap();
+        assert_ne!(first_blob, second_blob, "the tree must hold the new bytes");
+
+        // The window: new blob, old spans. The enumeration must not certify.
+        let window = file_coverage(&state, path);
+        assert_eq!(
+            window["parsed"],
+            serde_json::json!("absent"),
+            "a layout describing the replaced blob must not stand: {window}"
+        );
+        assert_eq!(
+            window["certifies_enumeration"],
+            serde_json::json!(false),
+            "stale spans were certified: {window}"
+        );
+        let stale_alpha = state
+            .graph
+            .query_entities(&EntityFilter {
+                file_path: Some(FilePathId::new(path)),
+                ..Default::default()
+            })
+            .unwrap()
+            .into_iter()
+            .find(|entity| entity.name == "alpha")
+            .expect("alpha is still held");
+        assert_eq!(
+            stale_alpha.span.as_ref().unwrap().start_byte,
+            0,
+            "the fixture's spans really are stale in the window, or the test proves nothing"
+        );
+
+        // Settled: the reconciler re-derives, and both surfaces agree again.
+        derive_semantics(&state, path);
+        let settled = file_coverage(&state, path);
+        assert_eq!(settled["parsed"], serde_json::json!("full"), "{settled}");
+        assert_eq!(
+            settled["certifies_enumeration"],
+            serde_json::json!(true),
+            "{settled}"
+        );
+        let fresh_alpha = state
+            .graph
+            .query_entities(&EntityFilter {
+                file_path: Some(FilePathId::new(path)),
+                ..Default::default()
+            })
+            .unwrap()
+            .into_iter()
+            .find(|entity| entity.name == "alpha")
+            .unwrap();
+        assert_eq!(
+            fresh_alpha.span.as_ref().unwrap().start_byte,
+            SEVENTEEN_LINES.len(),
+            "the re-derived span must move by exactly the prepended bytes"
+        );
+        assert!(census_counts_file(&state, path));
+    }
+
+    /// FIR-3201, the restart window (FIR-3208's shape). A daemon admitted new
+    /// bytes into the tree and died before it re-derived and published their
+    /// entities. The next daemon holds the new blob, the old entities and no
+    /// layout, and its backfill re-parses the tree's bytes to publish one.
+    /// Before this change it published `Full` over the old spans, which is the
+    /// exact 20:52:58 state the stranger read. Now it publishes `Partial` with
+    /// the count, and hands the path back for re-derivation.
+    ///
+    /// The control is a file whose entities a fresh parse reproduces exactly,
+    /// which must still get `Full`, or a backfill that floors everything passes.
+    #[test]
+    fn the_backfill_refuses_full_over_entities_a_fresh_parse_does_not_reproduce() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        state.is_initialized.store(true, Ordering::Relaxed);
+        let stale_path = "src/stale.py";
+        let fresh_path = "src/fresh.py";
+        admit_and_derive(&state, stale_path, TWO_FUNCTIONS);
+        admit_and_derive(&state, fresh_path, TWO_OTHER_FUNCTIONS);
+
+        // The tree moves to the new bytes with nothing re-derived: the dead
+        // daemon's admission. The layout goes with the blob it described, as it
+        // would have in that daemon, and the entities keep their old spans.
+        let host_path = state.layout.working_dir().join(stale_path);
+        std::fs::write(&host_path, format!("{SEVENTEEN_LINES}{TWO_FUNCTIONS}")).unwrap();
+        let observation = BTreeSet::from([RepoPath::from_utf8(stale_path).unwrap()]);
+        assert!(!ambient_admission_for_test(&state, &observation).unwrap());
+        // A restart loses every layout the backfill exists to republish.
+        state
+            .graph
+            .delete_file_layout(&FilePathId::new(fresh_path))
+            .unwrap();
+        assert!(state
+            .graph
+            .get_file_layout(&FilePathId::new(stale_path))
+            .unwrap()
+            .is_none());
+
+        let report = backfill_missing_file_layouts(&state).unwrap();
+        assert_eq!(report.published, 2, "{report:?}");
+        assert_eq!(report.stale, 1, "{report:?}");
+        assert_eq!(report.rederive.len(), 1, "{report:?}");
+        assert!(
+            report.rederive[0].ends_with(stale_path),
+            "the owed re-derivation names the stale path: {report:?}"
+        );
+
+        let stale_layout = state
+            .graph
+            .get_file_layout(&FilePathId::new(stale_path))
+            .unwrap()
+            .expect("a layout is published for the stale path");
+        let ParseCompleteness::Partial(reason) = &stale_layout.parse_completeness else {
+            panic!(
+                "a fresh parse the graph's spans disagree with must not publish Full: {:?}",
+                stale_layout.parse_completeness
+            );
+        };
+        // The module entity, `alpha` and `beta`: a prepend moves all three spans.
+        assert!(reason.contains("3 of 3 entity span(s)"), "{reason}");
+        let coverage = file_coverage(&state, stale_path);
+        assert_eq!(
+            coverage["parsed"],
+            serde_json::json!("partial"),
+            "{coverage}"
+        );
+        assert_eq!(coverage["certifies_enumeration"], serde_json::json!(false));
+
+        let fresh_layout = state
+            .graph
+            .get_file_layout(&FilePathId::new(fresh_path))
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            fresh_layout.parse_completeness,
+            ParseCompleteness::Full,
+            "the control's entities match a fresh parse and must certify"
+        );
+        assert_eq!(
+            file_coverage(&state, fresh_path)["certifies_enumeration"],
+            serde_json::json!(true)
+        );
+
+        // Settled: the owed re-derivation runs, and the file certifies again over
+        // spans that moved by the prepended bytes.
+        derive_semantics(&state, stale_path);
+        let coverage = file_coverage(&state, stale_path);
+        assert_eq!(coverage["parsed"], serde_json::json!("full"), "{coverage}");
+        assert_eq!(coverage["certifies_enumeration"], serde_json::json!(true));
+        assert!(census_counts_file(&state, stale_path));
     }
 
     /// FIR-2442. A dropped host event is disclosed through the reconcile health

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -488,40 +488,27 @@ pub(crate) fn publish_exact_workspace_tree(
     // tracked-file edit (FIR-3203); reusing it costs nothing.
     let authority = crate::api::held_write_authority(state)
         .map_err(|(_, message)| DaemonError::Io(std::io::Error::other(message)))?;
-    let published = crate::repository_commit::publish_workspace_tree_through(
-        state.blobs.as_ref(),
-        authority_context.repository_id().clone(),
-        authority_context.workspace_id(),
-        &authority,
-        admitted,
-        kin_model::OperationId::new(),
-        // The daemon's own loop is the actor here, and naming it is a statement
-        // rather than a stand-in: nobody typed a command, this publishes no
-        // history node and advances no ref, and the workspace transition it
-        // records was observed by the watcher. A person's identity would be the
-        // fabrication on this path, not the honest answer. Every path that mints
-        // a change a person authored takes that person's resolved identity from
-        // the caller instead.
-        kin_model::AuthorId::new(DAEMON_ADMISSION_ACTOR),
-    );
-    let admission = match published {
-        Ok(Some(published)) => published,
-        Ok(None) => return Ok(None),
-        Err(error) => {
-            // A refused publication says nothing certain about the held
-            // manager, and one refused because another writer moved authority
-            // says the manager is behind it. Either way the next publication
-            // starts from a fresh open of what storage holds now.
-            state.projection_authority.forget_writer();
-            return Err(error);
-        }
+    // Everything that runs while the tick's manager is alive, in one place, so
+    // that whichever path it returns by (published, nothing to publish, refused,
+    // or a label that could not be read) the manager is dropped and the slot
+    // forgotten exactly once below. An audit of the first shape of this found
+    // the no-op return and two `?` returns leaving the manager resident with no
+    // finalization armed to forget it, which is the held design's floor arriving
+    // through the back door.
+    let outcome = publish_through_held_authority(state, &authority_context, &authority, admitted);
+    // The admission pair keeps its relabelled values; the manager itself goes
+    // now, unconditionally. Measured on a converted psf/requests: a manager alive
+    // across the boundary between this publication and the persist flush that
+    // follows it holds the decoded successor while the flush's enrichment
+    // publish and read-index finalization allocate on top, and the edit-window
+    // peak landed 2 to 4 GiB above the pre-fix peak. Dropped here, the flush
+    // opens its own manager and frees it, exactly the pre-fix profile, with one
+    // open fewer per edit and the plan-time values shared.
+    drop(authority);
+    state.projection_authority.forget_writer();
+    let Some(admission) = outcome? else {
+        return Ok(None);
     };
-    // The label is read the instant after the commit; see
-    // `publication_identity_after_commit` for the window and its backstop.
-    let published = crate::api::publication_identity_after_commit(state)
-        .map_err(|(_, message)| DaemonError::Io(std::io::Error::other(message)))?;
-    crate::api::install_write_authority(state, &authority, published)
-        .map_err(|(_, message)| DaemonError::Io(std::io::Error::other(message)))?;
     // What this cost is what the reconcile tick is deciding whether to spend, so
     // it is measured here rather than modelled from the store's size.
     state.record_authority_publication(started.elapsed());
@@ -534,6 +521,48 @@ pub(crate) fn publish_exact_workspace_tree(
         "admitted exact workspace tree into repository authority"
     );
     Ok(Some(admission.receipt.generation))
+}
+
+/// The part of [`publish_exact_workspace_tree`] that runs while the tick's
+/// held manager is alive: publish through it, then read the label the
+/// publication produced and relabel the admission pair with it.
+///
+/// A refused publication says nothing certain about the held manager, and one
+/// refused because another writer moved authority says the manager is behind
+/// it; the caller forgets the manager on every return of this function, so no
+/// branch here has to.
+fn publish_through_held_authority(
+    state: &DaemonState,
+    authority_context: &crate::local_repository_authority::LocalRepositoryAuthorityContext,
+    authority: &Arc<kin_db::RepositoryAuthorityManager<kin_db::LocalFileBackend>>,
+    admitted: &crate::repository_commit::AdmittedWorkspaceTree,
+) -> Result<Option<crate::repository_commit::WorkspaceAdmissionResult>> {
+    let Some(admission) = crate::repository_commit::publish_workspace_tree_through(
+        state.blobs.as_ref(),
+        authority_context.repository_id().clone(),
+        authority_context.workspace_id(),
+        authority,
+        admitted,
+        kin_model::OperationId::new(),
+        // The daemon's own loop is the actor here, and naming it is a statement
+        // rather than a stand-in: nobody typed a command, this publishes no
+        // history node and advances no ref, and the workspace transition it
+        // records was observed by the watcher. A person's identity would be the
+        // fabrication on this path, not the honest answer. Every path that mints
+        // a change a person authored takes that person's resolved identity from
+        // the caller instead.
+        kin_model::AuthorId::new(DAEMON_ADMISSION_ACTOR),
+    )?
+    else {
+        return Ok(None);
+    };
+    // The label is read the instant after the commit; see
+    // `publication_identity_after_commit` for the window and its backstop.
+    let published = crate::api::publication_identity_after_commit(state)
+        .map_err(|(_, message)| DaemonError::Io(std::io::Error::other(message)))?;
+    crate::api::install_write_authority(state, authority, published)
+        .map_err(|(_, message)| DaemonError::Io(std::io::Error::other(message)))?;
+    Ok(Some(admission))
 }
 
 fn invalid_tree_transition(error: impl std::fmt::Display) -> DaemonError {

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -481,9 +481,18 @@ pub(crate) fn publish_exact_workspace_tree(
     let authority_context =
         crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(state)?;
     let started = Instant::now();
-    let Some(admission) = crate::repository_commit::publish_workspace_tree(
+    // Through the authority this daemon already holds at the current
+    // publication, which after the daemon's own last publication is the very
+    // manager that performed it. Opening one afresh is O(store) and, on a
+    // converted psf/requests, the 3.6 GiB the stranger's daemon grew from one
+    // tracked-file edit (FIR-3203); reusing it costs nothing.
+    let authority = crate::api::held_write_authority(state)
+        .map_err(|(_, message)| DaemonError::Io(std::io::Error::other(message)))?;
+    let published = crate::repository_commit::publish_workspace_tree_through(
         state.blobs.as_ref(),
-        &authority_context,
+        authority_context.repository_id().clone(),
+        authority_context.workspace_id(),
+        &authority,
         admitted,
         kin_model::OperationId::new(),
         // The daemon's own loop is the actor here, and naming it is a statement
@@ -494,10 +503,25 @@ pub(crate) fn publish_exact_workspace_tree(
         // a change a person authored takes that person's resolved identity from
         // the caller instead.
         kin_model::AuthorId::new(DAEMON_ADMISSION_ACTOR),
-    )?
-    else {
-        return Ok(None);
+    );
+    let admission = match published {
+        Ok(Some(published)) => published,
+        Ok(None) => return Ok(None),
+        Err(error) => {
+            // A refused publication says nothing certain about the held
+            // manager, and one refused because another writer moved authority
+            // says the manager is behind it. Either way the next publication
+            // starts from a fresh open of what storage holds now.
+            state.projection_authority.forget_writer();
+            return Err(error);
+        }
     };
+    // The label is read the instant after the commit; see
+    // `publication_identity_after_commit` for the window and its backstop.
+    let published = crate::api::publication_identity_after_commit(state)
+        .map_err(|(_, message)| DaemonError::Io(std::io::Error::other(message)))?;
+    crate::api::install_write_authority(state, &authority, published)
+        .map_err(|(_, message)| DaemonError::Io(std::io::Error::other(message)))?;
     // What this cost is what the reconcile tick is deciding whether to spend, so
     // it is measured here rather than modelled from the store's size.
     state.record_authority_publication(started.elapsed());

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -616,6 +616,34 @@ pub(crate) fn current_authority_admission(
         .map_err(|(_status, message)| DaemonError::Io(std::io::Error::other(message)))
 }
 
+/// [`current_authority_admission`] for the one caller that goes on to publish:
+/// the open this pays is kept as the held writer for the publication in the same
+/// tick. Every other reader takes the plain form, which keeps nothing.
+fn current_authority_admission_for_publication(
+    state: &DaemonState,
+) -> Result<(
+    kin_model::RootBundle,
+    Option<kin_index::ResolvedAdmissionMatcher>,
+)> {
+    crate::api::cached_authority_admission_for_publication(state)
+        .map_err(|(_status, message)| DaemonError::Io(std::io::Error::other(message)))
+}
+
+/// Forgets the held writer when it goes out of scope, so a publishing tick that
+/// returns without publishing (yielded to an open merge or a waiting commit,
+/// nothing to move, a refused mass deletion, any error) cannot leave the
+/// manager its admission pair installed resident. The publication drops the
+/// manager itself; a second forget is a no-op.
+struct HeldWriterScope<'a> {
+    state: &'a DaemonState,
+}
+
+impl Drop for HeldWriterScope<'_> {
+    fn drop(&mut self) {
+        self.state.projection_authority.forget_writer();
+    }
+}
+
 /// Measure host content graph truth does not carry, right now.
 ///
 /// The reconcile loop records this set as a side effect of a pass, and an
@@ -771,7 +799,12 @@ fn exact_tree_admission(
     // Publication compare-and-swaps on this bundle, so a repository that moves
     // while the host walk is running fails the whole admission instead of
     // having its desired tree replanned onto the newer authority.
-    let (expected_roots, policy) = current_authority_admission(state)?;
+    // Held for this tick only, whatever path it returns by. Bound before the
+    // read, because the read itself can fail after it installed the writer
+    // (deriving the admission values reaches the backend), and an error out of
+    // it must not leave the manager resident either.
+    let _writer_scope = HeldWriterScope { state };
+    let (expected_roots, policy) = current_authority_admission_for_publication(state)?;
     if publication == TreePublication::StandaloneUnlessACommitIsWaiting
         && crate::api::cached_authority_has_open_merge(state)
             .map_err(|(_, message)| DaemonError::Io(std::io::Error::other(message)))?

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -16,9 +16,9 @@ use kin_model::{
     compute_resolved_tree_hash, compute_semantic_change_id, AuthorId, ChangeOrigin,
     EffectiveAdmissionPolicyStamp, Hash256, ModelError, OperationId, RefExpectation, RefMutation,
     RefName, RefTarget, RefUpdatePolicy, RepoPath, RepositoryCommitOutcome,
-    RepositoryCommitReceipt, RepositoryTransaction, RootBundle, SemanticChange, SemanticChangeId,
-    SharedAdmissionPolicy, Timestamp, WorkspaceExpectation, WorkspaceHead, WorkspaceId,
-    WorkspaceMutation, WorkspaceSemanticDelta, REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+    RepositoryCommitReceipt, RepositoryId, RepositoryTransaction, RootBundle, SemanticChange,
+    SemanticChangeId, SharedAdmissionPolicy, Timestamp, WorkspaceExpectation, WorkspaceHead,
+    WorkspaceId, WorkspaceMutation, WorkspaceSemanticDelta, REPOSITORY_TRANSACTION_SCHEMA_VERSION,
 };
 
 use crate::commit_deltas::compute_deltas_vs_repository_authority;
@@ -692,10 +692,38 @@ pub(crate) fn publish_workspace_tree(
     operation_id: OperationId,
     actor: AuthorId,
 ) -> Result<Option<WorkspaceAdmissionResult>> {
-    let desired_tree = &admitted.desired_tree;
-    let repository_id = authority_context.repository_id().clone();
-    let workspace_id = authority_context.workspace_id();
     let authority = authority_context.open().map_err(DaemonError::Graph)?;
+    publish_workspace_tree_through(
+        blobs,
+        authority_context.repository_id().clone(),
+        authority_context.workspace_id(),
+        &authority,
+        admitted,
+        operation_id,
+        actor,
+    )
+}
+
+/// [`publish_workspace_tree`] through an authority the caller already holds
+/// open.
+///
+/// The daemon's reconcile loop publishes through one held manager across ticks
+/// (`api::held_write_authority`) so a tracked-file edit costs no whole-store
+/// open. The commit is the plain one, not `commit_repository_transaction_and_freeze`:
+/// the freeze variant hands back a deep clone of the whole successor state, which
+/// on a converted psf/requests is a decoded 2.7 GiB change map per publication.
+/// Measured, that clone alone put the daemon 5 GiB above the pre-fix peaks and
+/// over its own derived memory budget, which then shut it down under a commit.
+pub(crate) fn publish_workspace_tree_through(
+    blobs: &kin_blobs::BlobStore,
+    repository_id: RepositoryId,
+    workspace_id: WorkspaceId,
+    authority: &RepositoryAuthorityManager<LocalFileBackend>,
+    admitted: &AdmittedWorkspaceTree,
+    operation_id: OperationId,
+    actor: AuthorId,
+) -> Result<Option<WorkspaceAdmissionResult>> {
+    let desired_tree = &admitted.desired_tree;
     let lease = authority.read_authority();
     if lease.roots() != &admitted.expected_roots {
         return Err(invalid(
@@ -743,7 +771,7 @@ pub(crate) fn publish_workspace_tree(
             // Every rule file in the desired tree is measured here, changed or
             // not, because the policy is derived from the whole tree rather
             // than from what moved.
-            let source = read_publishable_source(blobs, &authority, hash).map_err(|error| {
+            let source = read_publishable_source(blobs, authority, hash).map_err(|error| {
                 ModelError::InvalidOperation(format!(
                     "{error}, while deriving the admitted workspace policy"
                 ))
@@ -757,7 +785,7 @@ pub(crate) fn publish_workspace_tree(
             Ok(length)
         },
         |hash| {
-            read_publishable_source(blobs, &authority, hash)
+            read_publishable_source(blobs, authority, hash)
                 .map(|source| source.body().to_vec())
                 .map_err(|error| {
                     ModelError::InvalidOperation(format!(
@@ -834,7 +862,7 @@ pub(crate) fn publish_workspace_tree(
     // source becomes durable. An unchanged rule source is already there and
     // needs no copy.
     for hash in source_hashes {
-        if let Some(body) = read_publishable_source(blobs, &authority, hash)?.body_to_publish() {
+        if let Some(body) = read_publishable_source(blobs, authority, hash)?.body_to_publish() {
             authority.save_source_blob(hash, body)?;
         }
     }

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -10659,15 +10659,15 @@ impl DaemonState {
                     )))
                 })?;
             drop(lease);
-            // This is the last reader of the generation the held writer
-            // published: the admission pair, the publication and the enrichment
-            // publish came before it on the same held manager. Forgetting it
-            // here bounds the manager's life to one publication, so its decoded
-            // change map (about 2.7 GiB on a converted psf/requests) does not
-            // stay resident between edits. Measured on that store, a manager
-            // held across edits kept the transient peaks about a gigabyte above
-            // the pre-fix peaks at a 12 GiB ceiling; one open per edit, against
-            // two or three before, is the bound this ships with.
+            // This is the last reader in the persist flush's scope: the
+            // enrichment publish installed the held manager, this reuses it,
+            // and forgetting it here ends the scope, so its decoded change map
+            // (about 2.7 GiB on a converted psf/requests) is not resident past
+            // the flush. The reconcile tick has its own scope and drops its
+            // manager the moment the publication returns; measured on that
+            // store, a manager alive across the two scopes stacked the flush's
+            // allocations on the decoded successor and put the edit-window peak
+            // 2 to 4 GiB above the pre-fix peak.
             self.projection_authority.forget_writer();
             Arc::new(kin_db::InMemoryGraph::from_snapshot(snapshot).map_err(DaemonError::from)?)
         };

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -10404,7 +10404,12 @@ impl DaemonState {
     /// against this one lease.
     fn publish_local_workspace_enrichment(&self, expected_generation: u64) -> Result<u64> {
         let binding = self.local_repository_authority_binding()?;
-        let authority = binding.open_manager().map_err(DaemonError::from)?;
+        // The manager this daemon last published through, when its publication
+        // is still the one storage holds; a fresh open only when it is not. An
+        // open here is O(store), and this runs on every persist flush after an
+        // edit (FIR-3203).
+        let authority = crate::api::held_write_authority(self)
+            .map_err(|(_, message)| DaemonError::Io(std::io::Error::other(message)))?;
         let workspace_id = binding.workspace_id();
         let lease = authority.read_authority();
         let observed_generation = lease.roots().generation;
@@ -10519,9 +10524,17 @@ impl DaemonState {
             sealed_observation: None,
             collaboration_delta: None,
         };
-        let receipt = authority
-            .commit_repository_transaction(transaction)
-            .map_err(DaemonError::from)?;
+        let receipt = match authority.commit_repository_transaction(transaction) {
+            Ok(receipt) => receipt,
+            Err(error) => {
+                self.projection_authority.forget_writer();
+                return Err(DaemonError::from(error));
+            }
+        };
+        let identity = crate::api::publication_identity_after_commit(self)
+            .map_err(|(_, message)| DaemonError::Io(std::io::Error::other(message)))?;
+        crate::api::install_write_authority(self, &authority, identity)
+            .map_err(|(_, message)| DaemonError::Io(std::io::Error::other(message)))?;
         self.record_repository_authority_commit(receipt.generation)?;
         info!(
             repo_id = self.cached_repo_id.as_str(),
@@ -10583,7 +10596,7 @@ impl DaemonState {
         Ok((delta, unpublishable))
     }
 
-    fn load_committed_authority_graph(
+    pub(crate) fn load_committed_authority_graph(
         &self,
         generation: u64,
     ) -> Result<Arc<kin_db::InMemoryGraph>> {
@@ -10619,7 +10632,12 @@ impl DaemonState {
             }
         } else {
             let binding = self.local_repository_authority_binding()?;
-            let authority = binding.open_manager().map_err(DaemonError::from)?;
+            // The manager this daemon just committed through, when its
+            // publication is still the one storage holds. Measured on a
+            // converted psf/requests: this open was one of seven a single
+            // `kin commit` paid, each decoding the change map (FIR-3203).
+            let authority = crate::api::held_write_authority(self)
+                .map_err(|(_, message)| DaemonError::Io(std::io::Error::other(message)))?;
             let lease = authority.read_authority();
             let observed_generation = lease.roots().generation;
             if observed_generation != generation {
@@ -10640,6 +10658,17 @@ impl DaemonState {
                         binding.workspace_id()
                     )))
                 })?;
+            drop(lease);
+            // This is the last reader of the generation the held writer
+            // published: the admission pair, the publication and the enrichment
+            // publish came before it on the same held manager. Forgetting it
+            // here bounds the manager's life to one publication, so its decoded
+            // change map (about 2.7 GiB on a converted psf/requests) does not
+            // stay resident between edits. Measured on that store, a manager
+            // held across edits kept the transient peaks about a gigabyte above
+            // the pre-fix peaks at a 12 GiB ceiling; one open per edit, against
+            // two or three before, is the bound this ships with.
+            self.projection_authority.forget_writer();
             Arc::new(kin_db::InMemoryGraph::from_snapshot(snapshot).map_err(DaemonError::from)?)
         };
         Ok(authority_graph)

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -1581,9 +1581,20 @@ fn merge_file_coverage_classes(
         Some("absent") | Some("partial") | Some("failed") => STATE_ABSENT,
         _ => STATE_UNKNOWN,
     };
+    // A full parse of bytes the tree no longer holds is not a present class. The
+    // handler publishes the provenance beside the parse state rather than folding
+    // it in, so a reader can see which of the two failed; the verdict sees one
+    // class, and it is absent when either does.
+    let spans_stale = coverage
+        .and_then(|coverage| coverage.get("span_provenance"))
+        .and_then(Value::as_str)
+        == Some("stale");
+    let parsed = if spans_stale { STATE_ABSENT } else { parsed };
     classes.insert("file_parsed".to_string(), json!(parsed));
     decided_by.push("file_parsed".to_string());
-    if parsed != STATE_PRESENT {
+    if spans_stale {
+        limits.push("file_spans_stale".to_string());
+    } else if parsed != STATE_PRESENT {
         // Name the cause when the answer carries one. `file_parsed_absent` is
         // true and says nothing: a file no adapter claims and a file whose
         // adapter fell over earn the same word, and only the second is evidence
@@ -1646,6 +1657,10 @@ fn file_entities_counted(payload: &Value) -> Option<Value> {
         .and_then(|coverage| coverage.get("parsed"))
         .and_then(Value::as_str)
         .unwrap_or("unknown");
+    let spans_stale = coverage
+        .and_then(|coverage| coverage.get("span_provenance"))
+        .and_then(Value::as_str)
+        == Some("stale");
 
     let mut counted = json!({
         "unit": "entities_in_file",
@@ -1656,8 +1671,12 @@ fn file_entities_counted(payload: &Value) -> Option<Value> {
     // Named in the order a reader acts on. A file the adapter never parsed is
     // the limiting factor whatever the paging did, because following every
     // cursor to the end still assembles a set the extractor never produced.
+    // Spans derived from bytes the tree no longer holds come next: the set is
+    // complete for a file that is not the one at the path any more.
     if parsed != "full" {
         counted["floor_reason"] = json!(format!("file_parsed_{parsed}"));
+    } else if spans_stale {
+        counted["floor_reason"] = json!("file_spans_stale");
     } else if shifted {
         counted["floor_reason"] = json!("enumeration_shifted");
     } else if !whole_file {

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -1857,7 +1857,7 @@ fn committed_introducing_change<G: GraphStore>(
 ///
 /// `None` means the entity carries no such stamp, which is an ordinary state and
 /// must never be escalated into a read failure.
-fn recorded_span_source_digest(entity: &Entity) -> Option<kin_blobs::Hash256> {
+pub(crate) fn recorded_span_source_digest(entity: &Entity) -> Option<kin_blobs::Hash256> {
     let serde_json::Value::String(hex) = entity.metadata.extra.get("blob_hash")? else {
         return None;
     };

--- a/crates/kin-mcp/src/handlers/file_entities.rs
+++ b/crates/kin-mcp/src/handlers/file_entities.rs
@@ -42,7 +42,9 @@ use kin_model::{entity::Entity, EntityKind, EntityRole, FilePathId, LanguageId, 
 use serde::Serialize;
 
 use crate::error::{McpError, Result};
-use crate::handlers::common::{entity_presentation_end_line, entity_presentation_start_line};
+use crate::handlers::common::{
+    entity_presentation_end_line, entity_presentation_start_line, recorded_span_source_digest,
+};
 use crate::types::ToolCallResult;
 
 /// The tool's registered name, spelled once so the registry, the dispatcher,
@@ -167,6 +169,96 @@ impl ParsedState {
     /// entity surface. Only a complete parse does.
     pub fn certifies_enumeration(self) -> bool {
         matches!(self, Self::Full)
+    }
+}
+
+/// Whether the spans this enumeration serves were derived from the bytes the
+/// repository tree holds at this path right now.
+///
+/// The entity table and the repository tree are updated in separate
+/// transactions: an admission publishes the exact tree first and the reconciler
+/// re-derives spans afterwards (`SpanCoherence` in [`crate::handlers::common`]).
+/// Between those two steps, and for as long as the second never runs, the graph
+/// holds the new blob at the path and the old spans into it. A layout that says
+/// `Full` describes the parse that produced those spans, not the bytes now at
+/// the path, so on its own it cannot license certifying them: on a converted
+/// psf/requests the stranger of FIR-3201 was served a module entity ending at
+/// line 921 of a 937-line file under `parsed: full` and no degradation.
+///
+/// Read from the same stamp `get_entity_source` checks before it slices a body:
+/// the entity's recorded source digest against the tree's blob at the path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpanProvenance {
+    /// Every entity carrying a digest was derived from the blob the tree holds,
+    /// and at least one carries a digest.
+    DigestVerified,
+    /// No entity records a digest, so the pair could not be checked. Honest
+    /// absence rather than a claim of coherence: entities admitted by paths that
+    /// do not stamp provenance, such as a Git import, arrive without one.
+    Unverified,
+    /// At least this many entities record a digest that is not the blob the
+    /// tree holds at this path. Their spans were provably derived from other
+    /// bytes, so the enumeration cannot be certified over them.
+    Stale { entities: usize },
+    /// The tree admits no blob at this path (a gitlink, or a path admitted at
+    /// no tier), so there is nothing to check the spans against.
+    NoTreeBlob,
+}
+
+impl SpanProvenance {
+    pub fn wire(self) -> &'static str {
+        match self {
+            Self::DigestVerified => "digest_verified",
+            Self::Unverified => "unverified",
+            Self::Stale { .. } => "stale",
+            Self::NoTreeBlob => "no_tree_blob",
+        }
+    }
+
+    /// How many entities were provably derived from other bytes.
+    pub fn stale_entities(self) -> usize {
+        match self {
+            Self::Stale { entities } => entities,
+            _ => 0,
+        }
+    }
+
+    /// Whether this reading permits certifying the enumeration. Only a provable
+    /// mismatch refuses: an unverified pair is the ordinary state of a converted
+    /// store and refusing it would floor every enumeration there.
+    pub fn permits_certification(self) -> bool {
+        !matches!(self, Self::Stale { .. })
+    }
+}
+
+/// Decide [`SpanProvenance`] for one file's entities against the blob the tree
+/// holds at its path.
+///
+/// One map lookup per entity and no store read: `tree_blob` is the tree entry
+/// the caller already resolved, and the digest is read off entity metadata the
+/// caller already holds.
+pub fn span_provenance(
+    entities: &[Entity],
+    tree_blob: Option<&kin_model::Hash256>,
+) -> SpanProvenance {
+    let Some(tree_blob) = tree_blob else {
+        return SpanProvenance::NoTreeBlob;
+    };
+    let mut verified = 0usize;
+    let mut stale = 0usize;
+    for entity in entities {
+        match recorded_span_source_digest(entity) {
+            Some(recorded) if recorded.as_bytes() == tree_blob.as_bytes() => verified += 1,
+            Some(_) => stale += 1,
+            None => {}
+        }
+    }
+    if stale > 0 {
+        SpanProvenance::Stale { entities: stale }
+    } else if verified > 0 && verified == entities.len() {
+        SpanProvenance::DigestVerified
+    } else {
+        SpanProvenance::Unverified
     }
 }
 
@@ -502,6 +594,15 @@ pub fn handle_list_file_entities<G: GraphStore>(
             .count()
     });
 
+    // The spans against the bytes. A layout certifies the parse that produced
+    // these spans; this certifies that the parse was of the bytes the tree holds
+    // now. Both have to hold before the enumeration is read as the file.
+    let tree_blob = store
+        .get_tree_entry(&file_id)
+        .map_err(McpError::graph)?
+        .and_then(|entry| entry.blob_identity());
+    let provenance = span_provenance(&entities, tree_blob.as_ref());
+
     let tier = tracking_tier(store, &file_id)?;
     let opaque_reason = opaque_reason(&path, tier);
     // Admission identity, resolved through the repository tree rather than
@@ -596,8 +697,15 @@ pub fn handle_list_file_entities<G: GraphStore>(
             // disclosure here and never a decider. `_kin.completeness` carries
             // the store-grain reading beside it, labelled as store-grain.
             "embedded": "not_measured_per_file",
+            // Whether the spans served here were derived from the bytes the tree
+            // holds at this path now. `stale` is a provable mismatch and refuses
+            // certification below; `unverified` is the ordinary state of a
+            // converted store and does not.
+            "span_provenance": provenance.wire(),
+            "stale_spans": provenance.stale_entities(),
             "whole_file_in_response": whole_file_in_response,
             "certifies_enumeration": parsed.certifies_enumeration()
+                && provenance.permits_certification()
                 && whole_file_in_response
                 && !enumeration_shifted,
         },
@@ -1370,5 +1478,175 @@ mod tests {
         assert_eq!(counted["returned"], serde_json::json!(3));
         assert_eq!(counted["exact"], serde_json::json!(false));
         assert_eq!(counted["floor_reason"], serde_json::json!("page_bounded"));
+    }
+
+    /// Stamp an entity with the source digest the reconciler records, so the
+    /// provenance check has something to compare against the tree.
+    fn stamped(mut entity: Entity, blob: [u8; 32]) -> Entity {
+        entity.metadata.extra.insert(
+            "blob_hash".into(),
+            serde_json::Value::String(kin_blobs::Hash256::from_bytes(blob).to_string()),
+        );
+        entity
+    }
+
+    /// FIR-3201. The tree holds blob B at the path and the entities record that
+    /// they were derived from blob A, while the layout still says `Full`: the
+    /// stranger's state on psf/requests, where a module entity ending at line
+    /// 921 of a 937-line file was served as certified. A full parse of other
+    /// bytes must not certify the enumeration, and the response must say why.
+    ///
+    /// The control is the same store with A == B, which must still certify, so
+    /// a fix that floors every enumeration fails here rather than passing.
+    #[test]
+    fn a_span_derived_from_other_bytes_cannot_certify_the_enumeration() {
+        // `admit` puts blob [7; 32] at the path.
+        let store = InMemoryGraph::new();
+        admit(&store, FILE);
+        for index in 0..3 {
+            store
+                .upsert_entity(&stamped(
+                    entity_at(&format!("export{index}"), FILE, index * 100),
+                    [8; 32],
+                ))
+                .unwrap();
+        }
+        store
+            .upsert_file_layout(&layout_for(FILE, ParseCompleteness::Full, 3))
+            .unwrap();
+
+        let payload = call(&store, &[("path", serde_json::json!(FILE))]).unwrap();
+        let coverage = &payload[FILE_COVERAGE_KEY];
+        assert_eq!(coverage["parsed"], serde_json::json!("full"), "{payload}");
+        assert_eq!(
+            coverage["span_provenance"],
+            serde_json::json!("stale"),
+            "{payload}"
+        );
+        assert_eq!(coverage["stale_spans"], serde_json::json!(3), "{payload}");
+        assert_eq!(
+            coverage["certifies_enumeration"],
+            serde_json::json!(false),
+            "a full parse of bytes the tree no longer holds must not certify: {payload}"
+        );
+        // The rows are still served: withholding graph truth teaches nothing.
+        assert_eq!(payload["total_in_file"], serde_json::json!(3));
+
+        // The control: the same store, digests that name the tree's own blob.
+        let store = InMemoryGraph::new();
+        admit(&store, FILE);
+        for index in 0..3 {
+            store
+                .upsert_entity(&stamped(
+                    entity_at(&format!("export{index}"), FILE, index * 100),
+                    [7; 32],
+                ))
+                .unwrap();
+        }
+        store
+            .upsert_file_layout(&layout_for(FILE, ParseCompleteness::Full, 3))
+            .unwrap();
+        let payload = call(&store, &[("path", serde_json::json!(FILE))]).unwrap();
+        let coverage = &payload[FILE_COVERAGE_KEY];
+        assert_eq!(
+            coverage["span_provenance"],
+            serde_json::json!("digest_verified"),
+            "{payload}"
+        );
+        assert_eq!(coverage["stale_spans"], serde_json::json!(0));
+        assert_eq!(
+            coverage["certifies_enumeration"],
+            serde_json::json!(true),
+            "spans derived from the tree's own blob must still certify: {payload}"
+        );
+    }
+
+    /// Entities with no recorded digest are the ordinary state of a store
+    /// converted from Git, and refusing them would floor every enumeration on
+    /// every such store. They stay certifiable and the reading says `unverified`
+    /// rather than pretending a check ran.
+    #[test]
+    fn an_unstamped_entity_is_reported_unverified_and_still_certifies() {
+        let store = store_with(2, Some(ParseCompleteness::Full));
+        let payload = call(&store, &[("path", serde_json::json!(FILE))]).unwrap();
+        let coverage = &payload[FILE_COVERAGE_KEY];
+        assert_eq!(
+            coverage["span_provenance"],
+            serde_json::json!("unverified"),
+            "{payload}"
+        );
+        assert_eq!(coverage["certifies_enumeration"], serde_json::json!(true));
+    }
+
+    /// One stale entity among verified ones is enough: the enumeration is one
+    /// answer, and one row derived from other bytes makes the whole of it
+    /// describe a file that is not at the path.
+    #[test]
+    fn one_stale_span_among_verified_ones_refuses_certification() {
+        let store = InMemoryGraph::new();
+        admit(&store, FILE);
+        store
+            .upsert_entity(&stamped(entity_at("fresh", FILE, 0), [7; 32]))
+            .unwrap();
+        store
+            .upsert_entity(&stamped(entity_at("stale", FILE, 100), [9; 32]))
+            .unwrap();
+        store
+            .upsert_file_layout(&layout_for(FILE, ParseCompleteness::Full, 2))
+            .unwrap();
+        let payload = call(&store, &[("path", serde_json::json!(FILE))]).unwrap();
+        let coverage = &payload[FILE_COVERAGE_KEY];
+        assert_eq!(coverage["span_provenance"], serde_json::json!("stale"));
+        assert_eq!(coverage["stale_spans"], serde_json::json!(1));
+        assert_eq!(coverage["certifies_enumeration"], serde_json::json!(false));
+    }
+
+    /// The one verdict a reader acts on. Stale spans under a `Full` layout must
+    /// reach it as an absent `file_parsed` class, a named limit, and a floor on
+    /// the count, so the envelope cannot compute `certified` over them the way
+    /// the stranger's envelope did.
+    #[test]
+    fn stale_spans_reach_the_verdict_as_an_absent_class_and_a_named_limit() {
+        let envelope = structural_authoritative_envelope();
+        let store = InMemoryGraph::new();
+        admit(&store, FILE);
+        store
+            .upsert_entity(&stamped(entity_at("moved", FILE, 0), [8; 32]))
+            .unwrap();
+        store
+            .upsert_file_layout(&layout_for(FILE, ParseCompleteness::Full, 1))
+            .unwrap();
+        let payload = call(&store, &[("path", serde_json::json!(FILE))]).unwrap();
+        let annotated = crate::envelope::finalize(
+            ToolCallResult::text(serde_json::to_string(&payload).unwrap()),
+            envelope,
+            TOOL_NAME,
+        );
+        let crate::types::ContentBlock::Text { text } = &annotated.content[0];
+        let value: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(
+            value["_kin"]["completeness"]["classes"]["file_parsed"],
+            serde_json::json!("absent"),
+            "{value}"
+        );
+        let limits = finalized_limits(&store, FILE);
+        assert!(
+            limits.split(',').any(|limit| limit == "file_spans_stale"),
+            "the limit must name the stale spans: {limits:?}"
+        );
+        assert_eq!(
+            value["_kin"]["completeness"]["counted"]["floor_reason"],
+            serde_json::json!("file_spans_stale"),
+            "{value}"
+        );
+        assert_eq!(
+            value["_kin"]["completeness"]["counted"]["exact"],
+            serde_json::json!(false)
+        );
+        assert_ne!(
+            value["_kin"]["verdict"]["state"],
+            serde_json::json!("certified"),
+            "a stale enumeration must not be certified: {value}"
+        );
     }
 }

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -101,6 +101,21 @@ fn file_enumeration_gap(payload: &Value) -> Option<String> {
         .and_then(Value::as_str)
         .map(|detail| format!(" ({detail})"))
         .unwrap_or_default();
+    // Provenance first: a full parse of other bytes is a stronger disqualifier
+    // than any parse state, because every row it produced describes a file that
+    // is no longer at this path.
+    if coverage.get("span_provenance").and_then(Value::as_str) == Some("stale") {
+        let stale = coverage
+            .get("stale_spans")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        return Some(format!(
+            "file_spans_stale: {stale} entity span(s) in this file were derived from bytes the \
+             repository tree no longer holds at this path, so the enumeration describes an \
+             earlier state of the file; the graph has admitted the new source and not yet \
+             re-derived these entities"
+        ));
+    }
     match parsed {
         "full" => {}
         "absent" => {


### PR DESCRIPTION
**Draft, not for landing.** This branch carries the FIR-3203 work of 2026-09-04/05, opened for the record
and for review: three variants of a held repository authority in the daemon, each measured on a converted
psf/requests against the before numbers, and each over the peak acceptance this work set for itself (every
peak at or under its before number within 0.2 GiB, at most 2 whole-store opens per edit). It also carries
FIR-3201, which lands separately and alone for v0.7.0 from the captain's lane (`33a9500ae` cherry-picked
onto `950fb0bf8` as `51f048988`); the FIR-3201 text below describes that same commit. The FIR-3203 fix path
that would make a held manager cheap enough to keep is in kin-db and is written out at the end.

Related: FIR-3203 (v0.7.0 blocking), FIR-3201.

## What a stranger saw

On public v0.6.7, brown arm, a live daemon on a converted psf/requests sat at 6.38 GiB and reached
10.0 GiB twenty seconds after ONE Python file edit landed on disk, with no kin command run. The
commit then needed 1.5 GiB more and was OOM-killed under the 12 GiB container ceiling. After the
next commit, `list_file_entities` certified the stale file as `parsed: full`, `freshness:
recorded`, no degradation, serving a module entity that ended at line 921 of a 937-line file.

## Measurement, taken before the fix

Harness `.kin-coord/reports/memfix-scratch/measure-edit-rss-v2.sh` (report
`.kin-coord/reports/showhn-memfix-20260904.md`, section 1). This worktree's parent `f6a29e329`,
release build, psf/requests at `dae7ef63` (the stranger's own clone), scratch `KIN_HOME`, CPU
embedder, this Mac (128 GiB, no cgroup, so the numbers are deltas and peaks, not a kill). RSS from a
2 s per-pid sampler on the repo daemon, in GiB (KiB over 2^30; raw KiB in
`memfix-scratch/measure/rss2-*/rss.tsv`); opens from the daemon's own INFO line `opening persisted
repository authority` with its `caller=` attribution.

| | fresh daemon | fresh daemon (second sample) | warm daemon (alive since its own commit) |
|---|---|---|---|
| `kin graph status` on a fresh daemon | 122 s, 4 whole-store opens | 107 s, 4 opens | |
| idle window, 30 s, nothing touched | 0 opens, 0 drift | 0 opens, 0 drift | 0 opens, 11.31 GiB flat |
| ONE tracked-file edit, no command run: opens inside 90 s | 2 | 2 | 3 |
| the edit's publication (`publish_workspace_admission`) | | | 64.5 s |
| the edit's RSS peak (above the idle floor) | 10.93 GiB (+0.6) | 11.78 GiB (+1.1) | 12.38 GiB (+1.1) |
| `kin commit` of that edit | 279 s, 6 opens, peak 12.74 GiB | 198 s, 5 opens, peak 11.27 GiB | 191 s, 5 opens, peak 13.24 GiB |
| 90 s after the commit | 1 open, peak 13.81 GiB | 1 open, peak 11.96 GiB | 1 open, peak 13.66 GiB |

A fresh daemon spawned by `kin commit` itself (the stranger's lean daemon) went 5.25 GiB at 30 s,
8.93 GiB when the commit returned, 12.38 GiB peak (12,978,800 KiB) in the post-commit publishes:
past the 12 GiB cgroup on its own. The per-edit opens are, by caller, `repository_commit.rs:524`
(the publish's own open), `api.rs:635` (the admission pair, whenever the last publication moved the
identity its slot is keyed on), `state.rs:10366` (the enrichment publish on the persist flush, which
opens the whole store even when it then has nothing to publish) and `state.rs:10581` (read-index
finalization).

## Mechanism, from source

Read in this tree and in the pinned `kin-db =0.7.101` source. Every one of those opens is O(store)
on a converted repository for three reasons in kin-db: `RepositoryAuthorityManager::open` replays
the whole history unless a durable history-validation record names the exact bytes, and the replay
begins with `snapshot.changes.values().cloned().collect()` (`repository.rs:2676`), which decodes the
change map AND clones every change; the record is bound only inside `open` (`bind_history_validation`,
private) and matches only the generation and snapshot digest it was bound for, so every publication
leaves the next open without a proof; and `compute_roots` runs `history_root` on every commit,
including a workspace-only admission that adds no change, forcing the decode through
`ChangeMap::force()` (`repository.rs:8361`, `change_map.rs:432`), after which `Clone for ChangeMap`
copies the entries (`change_map.rs:500-514`) and a successor state is a clone of its base. kin-db's
own module doc measures the change map at 93.8 percent of a 1051.5 MiB body on psf/requests at 6733
commits, retaining about 2.7x the file once decoded. kin-db is pinned, so what `kin` controls is how
many opens and publications an edit causes.

For FIR-3201: `parsed` reads only the layout facet, which on a converted store a once-per-daemon
backfill builds from the entities the graph already holds (`loop_runner.rs`, `backfill_missing_file_layouts`);
`freshness: recorded` is the clock the tree admission stamps; no verdict input can say a span is
older than the blob now at its path; and `kin graph status` counts a file when any entity names it
as origin, so a stale entity satisfies it exactly as a fresh one. Two records, not one record read
two ways. Full trace with citations: `.kin-coord/reports/memfix-scratch/fir3201-trace.md`.

## After the fix

Numbers from the release binaries of slot job 14's build, `kin 0.7.0 (10d650cc0...)`, the rebased tree
that ships. The test-only commit on top (`8031fc542`, `crates/kin-daemon/src/api.rs | 48 ++++----`, 40
insertions and 8 deletions, all inside `mod tests` plus one `#[cfg(test)]` method) changes no binary
byte, and neither does the comment-only commit `a4a93de91` (`crates/kin-daemon/src/api.rs | 45 ++++----`,
29 insertions and 16 deletions, no non-comment line touched). Same harness and stores as the before run
(`after-run.sh`; raw data `measure/rss2-after-fresh-*` and `rss2-after-warm-*`), GiB as KiB over 2^30
with the raw KiB beside each peak. Arm A is a fresh daemon on the tracked store: `kin graph status`, one
edit, `kin commit`. Arm B is a second edit against the same, now warm, daemon, then its commit.

| case | before, fresh daemon (`tracked-fresh`) | before, warm daemon (`tracked-warm`) | after, fresh daemon (arm A) | after, the same daemon warm (arm B) |
|---|---|---|---|---|
| `kin graph status` on a fresh daemon | 122 s, 4 opens | (attached) | 36 s, 4 opens | (attached) |
| idle floor before the edit | 10.24 to 10.37 GiB | 11.31 GiB flat | 8.43 GiB flat | 14.61 GiB flat (arm A's retained memory never came down) |
| no-op touch (same bytes rewritten, 30 s): opens, peak | (not measured) | (not measured) | 1 opens, peak 9.50 GiB | 1 opens, peak 15.69 GiB |
| ONE edit: whole-store opens inside the 90 s watch window | 2 | 3 | 3 | 2 |
| the edit's publication, edit to `admitted exact workspace tree` | 60 s or more | 64.5 s | 24 s | 20 s |
| edit-window RSS peak | 10.93 GiB (11,457,184 KiB) | **12.38 GiB** (12,985,648 KiB) | **14.08 GiB (14,763,280 KiB)** | **16.13 GiB (16,914,912 KiB)** |
| `kin commit` of the edit | 279 s, 6 opens | 191 s, 5 opens | 57 s, 2 opens, rc=0 | rc=1 after 30 s: the daemon shut itself down 5 s into the commit (below) |
| commit RSS peak | **12.74 GiB** (13,357,440 KiB) | **13.24 GiB** (13,884,608 KiB) | **16.76 GiB (17,571,408 KiB)** | **16.13 GiB (16,918,560 KiB)** |
| 90 s after the commit: opens, peak | 1 open, 13.81 GiB | 1 open, 13.66 GiB | 2 open(s), 15.69 GiB (16,448,768 KiB) | no daemon left to sample |

**The three variants against before, peak RSS in true GiB** (raw samples in `measure/rss2-*/rss.tsv`;
the held design and bounded life were measured on the same store earlier tonight, report section 1c):

| run | idle floor | edit-window peak | commit peak | 90 s after |
|---|---|---|---|---|
| before, fresh daemon (`tracked-fresh`) | 10.37 | 10.93 | 12.74 | 13.81 |
| before, warm daemon (`tracked-warm`) | 11.31 | **12.38** | **13.24** | 13.66 |
| held design, fresh (03:46Z) | 9.04 | 12.90 | 14.06 | 13.00 |
| held design, warm (03:51Z) | 13.00 | 13.01 | 14.36 | 14.36 |
| bounded life, fresh (04:08Z) | 9.80 | 14.53 | 15.62 | 15.63 |
| bounded life, warm (04:14Z) | 14.56 | 15.98 | 17.04 | 17.04 |
| per-tick scope, fresh (05:01Z, this head) | 8.43 | 14.08 | 16.76 | 15.69 |
| per-tick scope, warm (05:07Z, this head) | 14.61 | 16.13 | (daemon gone at 16.13) | (daemon gone) |

The held design came closest (about a gigabyte over on peaks, 2.4 GiB over on the warm floor); the two
scoped variants are worse than it on every peak, because each one keeps a manager alive across work that
used to run with the previous manager already dropped.


**Reading arm A, which fails the peak acceptance.** Opens: the daemon's start costs 4 (start, the
admission reader, the command slot, the flush's enrichment publish), a no-op touch costs 1 (the flush's
enrichment publish, a 1.1 GiB blip that freed), and the edit costs 3 inside the window: the tick's publish
at +1 s (its pair came warm from the slot, so the publish paid the open), the flush's enrichment publish
at the admission (+24 s), and the flush's finalization at +76 s, which missed the held label and opened
fresh. That miss is the first finding this run adds: the enrichment publish labels the writer with the
identity read right after its commit, but the snapshot persists asynchronously (`snapshot to storage
backend generation=14 committed=false` at 05:04:49.68, the finalization's open 0.2 ms later), so in
production the record the finalization reads is not the record the label was taken from, and the flush
pays two opens exactly as before; the crate test, whose persistence is synchronous, sees one. Memory:
the publication itself is now a 24 s blip (before, 64.5 s), but across the 53 s flush the RSS climbs from
9.27 to 13.01 GiB and stays there into the commit, where before the fix the enrichment publish's manager
died at its commit and the finalization opened its own, so the two never coexisted and the RSS returned
to the floor. Holding one manager across the enrichment publish and the finalization stacks them, the
same shape the bounded-life variant showed across the publication-to-flush boundary, now inside the flush
alone. The commit then peaks at 16.76 GiB from a 13.01 base. The floor is lower (8.43 against 10.24) and
every wall time is shorter (graph status 36 s against 122, publication 24 s against 64.5, commit 57 s
against 279), but the ticket is memory at a 12 GiB ceiling, so the peaks decide. **Arm B**, the same daemon warm: the no-op touch cost 1 open again, the edit cost 2 in the window (the
tick's publish reused the writer the no-op flush had left installed; the flush's publish at the admission
and its finalization at +48 s each opened, the finalization on the same label miss), the publication took
20 s, and the edit-window peak was 16.13 GiB from a 14.61 GiB floor, the floor itself being arm A's
retained memory that never came down. The warm commit did not complete: 5 s into it the daemon logged
`daemon idle timeout reached, shutting down idle_ms=4594` and drained its tasks while the commit was in
`plan_compute_deltas`, and the client reported `the daemon serving this repository (pid 66750) is gone; it
was commit in phase plan_compute_deltas for 17s, and its last beat 12s before it stopped reported a
resident set of 15.1 GiB`. That is the third finding of this run and it is not this branch's: the idle
monitor counted neither the ambient publications nor an in-flight commit as activity. It needs its own
ticket; the commit row for arm B is void, not a number.

**What this means for the landing.** The per-tick scope as measured does not meet the bar this PR
set for itself (every peak at or under its before number within 0.2 GiB, at most 2 opens per edit). The
flush scope has to be split back into two managers, or the finalization has to read the committed graph
without a whole-store manager alive beside the enrichment publish's, and the label the enrichment publish
installs has to be taken after the snapshot persists. Those are small changes but they need another
measured after-run, which does not fit tonight's cut. FIR-3201 is independent of all of it.


## Why the per-tick scope and not the zero-open one

Three shapes were measured on the same converted psf/requests store before this one was chosen,
and the records are in the report (`.kin-coord/reports/showhn-memfix-20260904.md`, section 1c).
The first held the manager across edits: zero opens per edit, a 24 s publication and a four times
faster commit, but a flat floor about 2.4 GiB above the before idle floor and transient peaks about
a gigabyte above the before peaks (12.90 vs 11.78 GiB in the edit window, 14.06 at the commit). The
second gave the manager a bounded life, from the tick's admission read through the flush's
finalization: one open per edit and a 22 s publication, but peaks of 14.53 GiB at the edit and
15.62 GiB at the commit, worse than both, because the flush's enrichment publish and read-index
finalization ran while the manager holding the decoded successor was still alive and stacked on it.
The stranger runs at a 12 GiB ceiling, so peaks bind, and the captain chose the shape that keeps
no manager alive across the publication-to-flush boundary: the tick's open serves the admission
pair and the publication and is dropped the moment the publication returns; the flush's open serves
the enrichment publish and the finalization and is dropped by the finalization. The zero-open held
design returns after the launch as a tune with its floor measured.

## The fix

**FIR-3203, `kin-daemon`.** A publishing tick opens the repository authority once and everything
the tick does goes through that one manager. `ProjectionAuthorityCache` gains a `writer` slot
holding the manager itself, labelled with the durable publication identity like the reader slots.
The admission entry is split: `cached_authority_admission_entry` stays a reader and never installs
anything, and `cached_authority_admission_for_publication`, called only by the ambient tick, derives
the admission pair and installs the manager it derived them from. `publish_exact_workspace_tree`
takes that manager back through `held_write_authority` (a label match, no open), publishes through
it with `publish_workspace_tree_through`, and drops and forgets it on every path out, including a
no-op tick, a refused publication and an error; a `Drop` guard bound in `exact_tree_admission`
before the admission read covers the paths that never reach the publication, such as a tick that
yields to an open merge. The persist flush is the second scope: `publish_local_workspace_enrichment`
opens once, publishes, relabels the writer with the identity its commit produced, and
`load_committed_authority_graph` reads the same manager for the read-index finalization and forgets
it. Each publication is a plain `commit_repository_transaction`; the freeze variant deep-cloned the
successor and raised every peak by about 5 GiB. A commit through a manager that fell behind in the
read-to-commit window is refused by kin-db's successor compare-and-swap (`generation mismatch`) and
forgotten. `publish_workspace_tree` keeps its opening signature for its other callers and delegates
to `publish_workspace_tree_through`.

Bound: whole-store authority opens per tracked-file edit go from two or three to at most two, one
per scope, and no manager is alive between the publication and the flush or between ticks, so the
decoded change map is never resident between edits. Publications per edit stay at one; what that one
publication still costs inside the pinned kin-db is one successor clone of the decoded change map,
named for kin-db in the report (section 5).

Tests (`crates/kin-daemon/src/api.rs`): `an_edit_pays_one_open_for_its_pair_and_publish_and_holds_nothing_after`
counts `kin_core::authority_opens()`, the thread-local funnel every route into kin-db's recovery
passes through, across four real ambient admissions of a real edited file with the flush run between
them: each edit's pair and publication cost exactly one open and hold nothing after, the flush costs
exactly one open and holds nothing after, a no-op publication holds nothing, and the generation
advances by four. `a_held_authority_that_fell_behind_is_refused_by_the_cas_and_forgotten` installs the
held manager under a label a foreign publication produced, the exact product of the read-to-commit
window, publishes through the production path with zero opens, and asserts kin-db's compare-and-swap
refuses it naming the generation, the slot is forgotten and the foreign artifact survives.
`a_publication_by_another_writer_is_never_overwritten_by_the_held_one` publishes out of band through a
second manager and asserts the daemon's next edit reopens, is refused and forgets the writer. Those two
are NOT byte-identical to the versions earlier rounds ran: each carries one inverted precondition, the
`holds_writer()` the held design asserted after a publication is `!holds_writer()` under the per-tick
scope, and the CAS test installs the stale manager itself. `readers_of_the_admission_pair_install_no_writer`,
`a_publishing_tick_that_moves_nothing_holds_nothing_after` and
`a_tick_that_yields_to_an_open_merge_holds_no_writer` pin the three paths that leaked the writer in
earlier rounds (a reader, a no-op tick, a yield).

**FIR-3201, `kin-mcp` and `kin-daemon`.** `list_file_entities` compares each entity's recorded
source digest with the blob the tree holds at the path (the rule `get_entity_source` already applies
before slicing a body) and publishes `file_coverage.span_provenance` (`digest_verified`,
`unverified`, `stale`, `no_tree_blob`) and `stale_spans`; a provable mismatch refuses
`certifies_enumeration` and reaches the verdict as an absent `file_parsed` class with the limit
`file_spans_stale`. An unstamped store (a Git import stamps no digest) stays certifiable and says
`unverified`. The live-daemon window between a tree move and the re-derivation was already covered: kin-db's
`apply_transaction_delta` retires every path-keyed facet, the layout included, before it publishes
the new tree (`graph.rs:8845-8870`), which the falsification of a retirement function I had added
proved by staying green; the function is dropped and the window test stays as the guard. The
stranger's `full` came from the restart: the daemon that admitted the bytes was killed, the next one
started with the new tree, the old entities and no layouts, and its backfill published `Full` over
the old spans. The layout backfill compares its fresh
parse of the tree bytes with the graph's entities by kind, name and byte span, publishes `Partial`
with the count when they disagree, and hands the path back to the loop for re-derivation, so the
settled state agrees with the parse census again.

## Falsification

Every new test was broken by breaking the behaviour it guards. Arms from
`.kin-coord/reports/memfix-scratch/slot-job14.log` (04:41Z to 04:53Z, on the pushed head `10d650cc0`,
the test objects rebuilt after every restore, the worktree read clean afterwards). Each row names the
test the arm must break and the assertion that went red.

| arm | mutation | test | result |
|---|---|---|---|
| handler-certification | `&& provenance.permits_certification()` removed from `certifies_enumeration` | `a_span_derived_from_other_bytes_cannot_certify_the_enumeration`, `one_stale_span_among_verified_ones_refuses_certification` | red, `file_entities.rs:1526` and `:1600` |
| envelope-class | `spans_stale` no longer forces `file_parsed` absent | `stale_spans_reach_the_verdict_as_an_absent_class_and_a_named_limit` | red, `file_entities.rs:1627`, `file_parsed: present` |
| daemon-backfill | `spans_a_fresh_parse_does_not_reproduce` result multiplied by zero | `the_backfill_refuses_full_over_entities_a_fresh_parse_does_not_reproduce` | red, `loop_runner.rs:4160`, report `stale: 0, rederive: []` |
| writer-reuse | `held_write_authority` opens on every call | `an_edit_pays_one_open_for_its_pair_and_publish_and_holds_nothing_after` | red, `api.rs:44028` ("the flush's enrichment publish and finalization must share one open, after the publication's manager is gone") |
| keep-writer-after-refusal | the unconditional forget after the publication removed | `a_held_authority_that_fell_behind_is_refused_by_the_cas_and_forgotten` | red, `api.rs:44400` |
| never-forget | `forget_writer()` removed from the finalization | `an_edit_pays_one_open_for_its_pair_and_publish_and_holds_nothing_after` | red, `api.rs:44041` |
| never-drop | the publication keeps its manager | `an_edit_pays_one_open_for_its_pair_and_publish_and_holds_nothing_after` | red, `api.rs:44111` |
| skip-forget-on-noop | the no-op return inside the publication keeps the held writer | `an_edit_pays_one_open_for_its_pair_and_publish_and_holds_nothing_after` | red, `api.rs:44111` |
| reader-installs | `cached_authority_admission_entry` installs the writer | `readers_of_the_admission_pair_install_no_writer` | red, `api.rs:44138` |
| no-tick-scope | the `HeldWriterScope` binding deleted from `exact_tree_admission` (`loop_runner.rs:806`) | `a_tick_that_yields_to_an_open_merge_holds_no_writer`, `a_publishing_tick_that_moves_nothing_holds_nothing_after` | VOID in job 14 (anchor failed, see below); at `8031fc542` with the mutation shown applied: red on both, `api.rs:38898` (yield) and `api.rs:44212` (no-op), the `!holds_writer()` assertions |

**Reading the table.** A red arm is its own proof that the mutation applied: the same test was green
unmutated minutes earlier in the same job, and the panic names the guarded assertion, so the only way to
red was the mutated line. A green arm is the suspect kind, and job 14 had two, both on the guard-binding
arm: its mutation anchor still named the one-line guard comment from before the rebase, the tree since
`10d650cc0` carries a four-line comment there, the Python assert failed silently inside the job's filter,
and the test ran unmutated. Those two rows were VOID, not survivals, and are not cited. The blindness
itself is real and was found by the reviewer (`reviewmemfix`) with a hand-deleted binding: neither test's
tick ever installed a writer. The yield test's setup read `cached_authority_has_open_merge` through the
reader entry, which installed the admission values at the current label; the no-op test's second tick
inherited the values `publish_through_held_authority` re-installs at the label its publication produced.
Either way the tick's publishing entry returned from `reuse_admission` before `install_writer`, so the
guard had nothing to forget. The empty-deltas path is real, though: with nothing to move,
`exact_tree_admission` skips the publish block (`loop_runner.rs:975`) and the guard is the only release.
The fix is test-only, on top as `8031fc542`: a `#[cfg(test)]` `forget_admission` colds the values slot
before each act (`invalidate()` leaves that slot alone), the pair read moves after the act in the yield
test, and both tests assert the one open the tick then pays as the proof that it installed. The arm was
rerun on that head with a corrected anchor and the applied mutation's `git diff --stat` printed before the
test (`slot-job-yield2.log`, 05:05Z to 05:08Z): red on both tests, at the `!holds_writer()` assertion of each
(`api.rs:38898`, `api.rs:44212`); both tests green unmutated before and after on the same job.

```
### 2. ARM no-tick-scope: HeldWriterScope binding deleted (loop_runner.rs:806), on the yield test and the no-op tick test
### mutated crates/kin-daemon/src/loop_runner.rs:  1 file changed, 1 insertion(+), 1 deletion(-)
test api::tests::a_publishing_tick_that_moves_nothing_holds_nothing_after ... FAILED
test api::tests::a_tick_that_yields_to_an_open_merge_holds_no_writer ... FAILED
thread 'api::tests::a_publishing_tick_that_moves_nothing_holds_nothing_after' (320091867) panicked at crates/kin-daemon/src/api.rs:44212:9:
thread 'api::tests::a_tick_that_yields_to_an_open_merge_holds_no_writer' (320091868) panicked at crates/kin-daemon/src/api.rs:38898:9:
test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 1421 filtered out; finished in 2.87s
error: test failed, to rerun pass `-p kin-daemon --lib`
ARM no-tick-scope cargo exit=101
### restored crates/kin-daemon/src/loop_runner.rs; worktree: 0 dirty paths (expect 0)
### 3. both tests again on the restored tree
```

Two arms from earlier rounds are retired with the code they mutated: `values-under-freeze` (red after
120.93 s in slot job 7, the production deadlock reproduced; the freeze is gone from the design) and
`daemon-retire` (GREEN in slot job 4: kin-db's `apply_transaction_delta` already retires the layout,
`graph.rs:8845-8870`, so the function was dropped rather than the test). Two arms were void in slot
job 12 and repaired before job 14: `writer-reuse` (its test then modelled the flush without the
publication's manager gone) and `keep-writer-after-refusal` (it now removes the unconditional forget
the CAS path relies on).

### Raw arm tails, verbatim from `slot-job14.log` (mutation applied by `falsify-fir3201.sh` / `falsify-fir3203.sh`, then the command's tail, then the restore)

```
### 2. falsification FIR-3201
### ARM handler-certification: mutated crates/kin-mcp/src/handlers/file_entities.rs
thread 'handlers::file_entities::tests::one_stale_span_among_verified_ones_refuses_certification' (319482645) panicked at crates/kin-mcp/src/handlers/file_entities.rs:1600:9:
assertion `left == right` failed
thread 'handlers::file_entities::tests::a_span_derived_from_other_bytes_cannot_certify_the_enumeration' (319482644) panicked at crates/kin-mcp/src/handlers/file_entities.rs:1526:9:
assertion `left == right` failed: a full parse of bytes the tree no longer holds must not certify: {"entities":[{"end_byte":40,"end_line":3,"id":"c66b9756-a605-4d0b-87bc-ae78a85c8814","kind":"function
test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 917 filtered out; finished in 0.01s
ARM handler-certification cargo exit=101
### ARM handler-certification: restored crates/kin-mcp/src/handlers/file_entities.rs
### ARM envelope-class: mutated crates/kin-mcp/src/envelope.rs
test handlers::file_entities::tests::stale_spans_reach_the_verdict_as_an_absent_class_and_a_named_limit ... FAILED
thread 'handlers::file_entities::tests::stale_spans_reach_the_verdict_as_an_absent_class_and_a_named_limit' (319489985) panicked at crates/kin-mcp/src/handlers/file_entities.rs:1627:9:
assertion `left == right` failed: {"_kin":{"completeness":{"bound":"at_least","classes":{"embeddings_store_wide":"unknown","file_enriched":"absent","file_parsed":"present","graph":"present"},"counted"
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 918 filtered out; finished in 0.01s
ARM envelope-class cargo exit=101
### ARM envelope-class: restored crates/kin-mcp/src/envelope.rs
### ARM daemon-backfill: mutated crates/kin-daemon/src/loop_runner.rs
test loop_runner::tests::the_backfill_refuses_full_over_entities_a_fresh_parse_does_not_reproduce ... FAILED
thread 'loop_runner::tests::the_backfill_refuses_full_over_entities_a_fresh_parse_does_not_reproduce' (319532690) panicked at crates/kin-daemon/src/loop_runner.rs:4160:9:
assertion `left == right` failed: LayoutBackfill { already_published: 0, published: 2, unreadable: 0, other_facet: 0, stale: 0, rederive: [] }
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1422 filtered out; finished in 1.04s
ARM daemon-backfill cargo exit=101
### ARM daemon-backfill: restored crates/kin-daemon/src/loop_runner.rs
### ALL ARMS DONE; worktree status:
### 3. falsification FIR-3203
### ARM writer-reuse: held_write_authority opens on every call
test api::tests::an_edit_pays_one_open_for_its_pair_and_publish_and_holds_nothing_after ... FAILED
test api::tests::a_publication_by_another_writer_is_never_overwritten_by_the_held_one ... ok
thread 'api::tests::an_edit_pays_one_open_for_its_pair_and_publish_and_holds_nothing_after' (319565489) panicked at crates/kin-daemon/src/api.rs:44028:13:
assertion `left == right` failed: the flush's enrichment publish and finalization must share one open, after the publication's manager is gone
test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 1421 filtered out; finished in 1.21s
ARM writer-reuse cargo exit=101
### restored crates/kin-daemon/src/api.rs
### ARM keep-writer-after-refusal: the unconditional forget removed; the CAS test must see the refused manager retained
test api::tests::a_held_authority_that_fell_behind_is_refused_by_the_cas_and_forgotten ... FAILED
thread 'api::tests::a_held_authority_that_fell_behind_is_refused_by_the_cas_and_forgotten' (319576586) panicked at crates/kin-daemon/src/api.rs:44400:9:
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1422 filtered out; finished in 0.86s
ARM keep-writer-after-refusal cargo exit=101
### restored crates/kin-daemon/src/loop_runner.rs
### ARM never-forget: forget_writer removed from the finalization
test api::tests::an_edit_pays_one_open_for_its_pair_and_publish_and_holds_nothing_after ... FAILED
thread 'api::tests::an_edit_pays_one_open_for_its_pair_and_publish_and_holds_nothing_after' (319592174) panicked at crates/kin-daemon/src/api.rs:44041:13:
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1422 filtered out; finished in 0.71s
ARM never-forget cargo exit=101
### restored crates/kin-daemon/src/state.rs
### ARM never-drop: the publication keeps its manager
test api::tests::an_edit_pays_one_open_for_its_pair_and_publish_and_holds_nothing_after ... FAILED
thread 'api::tests::an_edit_pays_one_open_for_its_pair_and_publish_and_holds_nothing_after' (319622365) panicked at crates/kin-daemon/src/api.rs:44111:9:
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1422 filtered out; finished in 1.12s
ARM never-drop cargo exit=101
### restored crates/kin-daemon/src/loop_runner.rs
### ARM skip-forget-on-noop: the no-op return keeps the held writer
test api::tests::an_edit_pays_one_open_for_its_pair_and_publish_and_holds_nothing_after ... FAILED
thread 'api::tests::an_edit_pays_one_open_for_its_pair_and_publish_and_holds_nothing_after' (319658124) panicked at crates/kin-daemon/src/api.rs:44111:9:
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1422 filtered out; finished in 1.06s
ARM skip-forget-on-noop cargo exit=101
### restored crates/kin-daemon/src/loop_runner.rs
### ARM reader-installs: cached_authority_admission_entry installs the writer
test api::tests::readers_of_the_admission_pair_install_no_writer ... FAILED
thread 'api::tests::readers_of_the_admission_pair_install_no_writer' (319678697) panicked at crates/kin-daemon/src/api.rs:44138:9:
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1422 filtered out; finished in 0.68s
ARM reader-installs cargo exit=101
### restored crates/kin-daemon/src/api.rs
### ARM no-tick-scope: HeldWriterScope removed from exact_tree_admission
test api::tests::a_publishing_tick_that_moves_nothing_holds_nothing_after ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1422 filtered out; finished in 0.69s
ARM no-tick-scope cargo exit=0
### restored crates/kin-daemon/src/loop_runner.rs
### ARM skip-forget-on-yield: HeldWriterScope removed; the yield-to-open-merge return keeps the writer
test api::tests::a_tick_that_yields_to_an_open_merge_holds_no_writer ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1422 filtered out; finished in 2.74s
ARM skip-forget-on-yield cargo exit=0
### restored crates/kin-daemon/src/loop_runner.rs
### worktree after falsification: 0 dirty paths (expect 8)
```

## The real fix path

Every variant paid for the same thing: a whole-store authority open on a converted repository decodes
the change map and replays history, and a manager kept alive to avoid the next open keeps the decoded
map resident, so the win on opens is bought with the floor and the peaks. The order that gets the daemon
under a 12 GiB ceiling on this store is kin-db first, then kin:

1. **kin-db: bind a history-validation record after every commit**, not only inside `open`
   (`bind_history_validation` is private to `open` and matches only the generation and snapshot digest it
   was bound for, `repository.rs:2565-2680`), so a proof-less open after a publication stops replaying the
   whole history and stops the `snapshot.changes.values().cloned().collect()` at `repository.rs:2676`.
2. **kin-db: memoize `history_root`** so `compute_roots` on a workspace-only admission that adds no change
   does not force the change map through `ChangeMap::force()` (`repository.rs:8361`, `change_map.rs:432`),
   and give `ChangeMap` a shared or copy-on-write body so a successor state is not a deep copy of ~2.7 GiB
   (`change_map.rs:500-514`).
3. **Only then, kin: hold the manager.** With an open that no longer replays and a successor that no longer
   copies, the held design (zero opens per edit, a 4x faster commit) is the shape to ship, its floor
   measured on this store, with two kin-side fixes from tonight's run folded in: split the flush back into a
   manager per publication so the enrichment publish's state never coexists with the finalization's load,
   and take the writer's label after the snapshot persists (the `committed=false` window above), so the
   finalization's label match holds in production and not only in the crate test.

Until 1 and 2 land, kin-db is pinned at `=0.7.101` in this tree and the daemon's per-edit cost stays what
the before table shows.

## What was run locally

Per the captain's speed rule for tonight: targeted crate tests and `cargo fmt --all -- --check`
only. Clippy and the full workspace are graded by hosted CI, and so is everything a check-run on this
PR shows; nothing below restates a green context the PR surface already carries.

All through `.kin-coord/bin/heavy-slot.sh memfix kin -- bash .kin-coord/reports/memfix-scratch/slot-job.sh`
on the committed tree at `10d650cc0` (`slot-job14.log`, 04:41Z to 04:53Z):

```
cargo test -p kin-mcp --lib file_entities
test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 896 filtered out; finished in 0.02s

cargo test -p kin-daemon --lib -- <the nine tests below>
test api::tests::a_publishing_tick_that_moves_nothing_holds_nothing_after ... ok
test api::tests::readers_of_the_admission_pair_install_no_writer ... ok
test api::tests::a_publication_by_another_writer_is_never_overwritten_by_the_held_one ... ok
test loop_runner::tests::a_replaced_blob_retires_its_layout_until_the_spans_are_re_derived ... ok
test api::tests::a_held_authority_that_fell_behind_is_refused_by_the_cas_and_forgotten ... ok
test loop_runner::tests::the_backfill_refuses_full_over_entities_a_fresh_parse_does_not_reproduce ... ok
test api::tests::an_edit_pays_one_open_for_its_pair_and_publish_and_holds_nothing_after ... ok
test api::tests::the_admission_pair_costs_one_open_per_publication ... ok
test api::tests::a_tick_that_yields_to_an_open_merge_holds_no_writer ... ok
test api::tests::a_publication_by_another_writer_is_never_overwritten_by_the_held_one ... ok
test api::tests::a_publishing_tick_that_moves_nothing_holds_nothing_after ... ok
test api::tests::a_tick_that_yields_to_an_open_merge_holds_no_writer ... ok
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 1414 filtered out; finished in 4.29s
```

Short slot job on the test-only head `8031fc542` (`slot-job-yield2.log`, `bash slot-job-yield.sh` through the same
`heavy-slot.sh`): fmt, both guard tests unmutated, the guard-binding arm on both (tails above), both again on the restored tree:

```
### slot-job-yield start 2026-09-05T05:05:23Z head=8031fc542 dirty=0
### fmt rc=0
test api::tests::a_publishing_tick_that_moves_nothing_holds_nothing_after ... ok
test api::tests::a_tick_that_yields_to_an_open_merge_holds_no_writer ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 1421 filtered out; finished in 2.87s
### yield test rc=0
test api::tests::a_publishing_tick_that_moves_nothing_holds_nothing_after ... ok
test api::tests::a_tick_that_yields_to_an_open_merge_holds_no_writer ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 1421 filtered out; finished in 2.76s
### restored yield test rc=0
```

Not run locally, by the captain's rule: clippy, `bin/kin-precheck`, `bin/kin-parity`, the full workspace
suite. Hosted CI grades them on the PR.
