### PR TITLE
Gate the stale-span certification tests to unix beside their helper

### DIFF
--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -3852,6 +3852,7 @@ mod tests {
     ///
     /// This is the settled state a healthy edit reaches: tree, entities and
     /// layout all describe the same bytes.
+    #[cfg(unix)]
     fn admit_and_derive(state: &Arc<DaemonState>, rel_path: &str, content: &str) -> Hash256 {
         let host_path = state.layout.working_dir().join(rel_path);
         std::fs::create_dir_all(host_path.parent().unwrap()).unwrap();
@@ -3871,6 +3872,7 @@ mod tests {
 
     /// The enrichment half of one reconcile round for one path: what the loop
     /// runs after `exact_tree_admission`, without the loop.
+    #[cfg(unix)]
     fn derive_semantics(state: &Arc<DaemonState>, rel_path: &str) {
         let host_path = state.layout.working_dir().join(rel_path);
         let mut reconciler =
@@ -3893,6 +3895,7 @@ mod tests {
             .unwrap();
     }
 
+    #[cfg(unix)]
     fn file_coverage(state: &Arc<DaemonState>, rel_path: &str) -> serde_json::Value {
         let args = HashMap::from([("path".to_string(), serde_json::json!(rel_path))]);
         let result = kin_mcp::handlers::file_entities::handle_list_file_entities(
@@ -3908,6 +3911,7 @@ mod tests {
     /// Whether `kin graph status`'s parse census counts `rel_path` as a file that
     /// produced an entity, read through the same kin-core function the census
     /// renders from.
+    #[cfg(unix)]
     fn census_counts_file(state: &Arc<DaemonState>, rel_path: &str) -> bool {
         let entities = state.graph.list_all_entities().unwrap();
         let retained = kin_core::retained_parse::read(&state.layout);
@@ -3928,12 +3932,15 @@ mod tests {
                 .any(|entity| entity.file_origin.as_ref().map(|id| id.0.as_str()) == Some(rel_path))
     }
 
+    #[cfg(unix)]
     const TWO_FUNCTIONS: &str = "def alpha():\n    return 1\n\n\ndef beta():\n    return 2\n";
     /// Different bytes from [`TWO_FUNCTIONS`] on purpose: the observation planner
     /// refuses a transition in which one exact blob appears at two paths, because
     /// a copy and a move-plus-replace cannot be told apart from the tree alone.
+    #[cfg(unix)]
     const TWO_OTHER_FUNCTIONS: &str =
         "def gamma():\n    return 3\n\n\ndef delta():\n    return 4\n";
+    #[cfg(unix)]
     const SEVENTEEN_LINES: &str = "# 1\n# 2\n# 3\n# 4\n# 5\n# 6\n# 7\n# 8\n# 9\n# 10\n# 11\n# 12\n# 13\n# 14\n# 15\n# 16\n# 17\n";
 
     /// FIR-3201, the window. A file is admitted and derived, so its enumeration
@@ -3946,6 +3953,7 @@ mod tests {
     /// re-derives the file, after which it and the parse census agree again.
     /// Pinned here, in kin's own pipeline, so a dependency that stopped
     /// retiring would fail this rather than certify a stale span.
+    #[cfg(unix)]
     #[test]
     fn a_replaced_blob_retires_its_layout_until_the_spans_are_re_derived() {
         let repo = tempfile::tempdir().unwrap();
@@ -4041,6 +4049,7 @@ mod tests {
     ///
     /// The control is a file whose entities a fresh parse reproduces exactly,
     /// which must still get `Full`, or a backfill that floors everything passes.
+    #[cfg(unix)]
     #[test]
     fn the_backfill_refuses_full_over_entities_a_fresh_parse_does_not_reproduce() {
         let repo = tempfile::tempdir().unwrap();


### PR DESCRIPTION
The Windows authority tests job went red on main at `b4898be11` (#1515): `cargo test --no-run --target x86_64-pc-windows-msvc -p kin-daemon --no-default-features --lib` failed with E0425 at `loop_runner.rs:3861`, `:3970` and `:4060`, because the two stale-span certification tests and their helpers call `ambient_admission_for_test`, which is compiled only under `cfg(all(test, unix))`. That job runs only on pushes to main (`if: github.event_name != 'pull_request'`), so #1515 never compiled it.

This gates the nine items the tests consist of (four helpers, three fixtures, two tests) to unix beside the helper. Nothing else in the module references them, so the Windows build carries no dead code and no new warning.

## Verification


Both trees checked with `cargo check --tests --locked --target x86_64-pc-windows-gnu -p kin-daemon --no-default-features --lib` (the msvc target's `ring` build script wants the MSVC toolchain, which this box lacks; `cfg(unix)` is false on both Windows targets, so the gnu target answers the same question).

Control, the unpatched tree (`51f048988`, the same `loop_runner.rs` as `b4898be11`):

```
### 2026-09-05T05:42:59Z tree 51f048988 dirty=0
error[E0425]: cannot find function `ambient_admission_for_test` in this scope
error[E0425]: cannot find function `ambient_admission_for_test` in this scope
error[E0425]: cannot find function `ambient_admission_for_test` in this scope
For more information about this error, try `rustc --explain E0425`.
error: could not compile `kin-daemon` (lib test) due to 3 previous errors
rc_wincheck=101
### end 2026-09-05T05:44:05Z
```

The fix (`22b9e6017`):

```
### 2026-09-05T05:43:00Z tree 22b9e6017 dirty=0
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 41s
rc_wincheck=0
### end 2026-09-05T05:44:41Z
```

The two tests still run on unix, and the tree is formatted:

```
cargo test -p kin-daemon --lib -- loop_runner::tests::a_replaced_blob_retires_its_layout_until_the_spans_are_re_derived loop_runner::tests::the_backfill_refuses_full_over_entities_a_fresh_parse_does_not_reproduce
running 2 tests
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 1415 filtered out; finished in 1.86s
cargo fmt --all -- --check
rc=0
```

Not this PR's problem to solve tonight, but ticketed: the class is a main-only test job a pull request cannot see, and the check that closes it is a `cargo check --tests` for a Windows target on the pull request.
