### PR TITLE
Carry relation-only pending enrichment across a branch switch

### DIFF
--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -114,7 +114,7 @@ pub use tree::{
 };
 pub use workspace_carry::{
     plan_workspace_carry, WorkspaceCarry, WorkspaceCarryConflict, WorkspaceCarryConflictKind,
-    WorkspaceCarryPlan,
+    WorkspaceCarryPlan, WorkspaceSemanticCarryRefusal,
 };
 pub use workspace_semantics::diff_workspace_semantics;
 

--- a/crates/kin-core/src/workspace_carry.rs
+++ b/crates/kin-core/src/workspace_carry.rs
@@ -41,12 +41,29 @@
 //! so carried work keeps its semantics instead of degrading into tree-only
 //! bytes. A precondition that does not hold fails closed as a conflict rather
 //! than publishing a graph nobody observed.
+//!
+//! Relations get one rule the tree side does not need, because relations are
+//! derived continuously and trees are not. A pending relation delta whose
+//! subject the destination does not hold **at all** is not a conflict: the
+//! destination branch simply never observed that edge, usually because its head
+//! predates the enrichment pass that derived it, so there is no destination
+//! state for the replay to discard. The pending observation installs. A
+//! destination that holds the subject as a *different edge* is a real conflict
+//! and still refuses, and the refusal says which edge and how many.
+//!
+//! Rule 5 closes the loop and is a property of the whole plan rather than of any
+//! one entry: no relation may leave here pointing at a node the same plan does
+//! not hold. Entities and relations replay independently, so a pending entity
+//! retirement can strand a destination edge into that entity, and every
+//! downstream consumer then refuses at the storage layer naming an id no query
+//! returns. An edge into a node the plan retired states nothing that can be
+//! read, so [`plan_workspace_carry`] retires it in the same plan and reports it.
 
 use std::collections::{BTreeMap, HashMap};
 
 use kin_model::{
-    Entity, EntityDelta, EntityId, Relation, RelationDelta, RelationId, RepoPath, ResolvedTree,
-    TreeDelta, WorkspaceSemanticOverlay,
+    Entity, EntityDelta, EntityId, GraphNodeId, Relation, RelationDelta, RelationId, RelationKind,
+    RepoPath, ResolvedTree, TreeDelta, WorkspaceSemanticOverlay,
 };
 
 use crate::{KinError, Result};
@@ -121,14 +138,26 @@ pub struct WorkspaceCarryPlan {
     /// Paths the destination already tracked at identical content, so they are
     /// tracked members after the transition rather than pending work.
     pub absorbed: Vec<RepoPath>,
+    /// Relations this plan retired because the plan itself does not hold one of
+    /// their endpoints, in id order. Carrying them would hand a graph with a
+    /// dangling edge to the storage layer, which refuses it naming an entity no
+    /// query returns; they state nothing readable, so the caller reports the
+    /// count rather than the ids.
+    pub retired_relations: Vec<RelationId>,
 }
 
 /// The outcome of planning a carry: either the exact destination state, or
 /// every reason the transition must refuse.
+///
+/// The two refusals are kept apart because they read differently to a caller.
+/// [`Self::Refused`] is about paths on disk and names each one;
+/// [`Self::SemanticallyRefused`] is about graph subjects and names counts and
+/// kinds, because there is no path to point at.
 #[derive(Debug, Clone)]
 pub enum WorkspaceCarry {
     Carried(Box<WorkspaceCarryPlan>),
     Refused(Vec<WorkspaceCarryConflict>),
+    SemanticallyRefused(WorkspaceSemanticCarryRefusal),
 }
 
 /// Plan the replay of one workspace's pending state onto a destination branch.
@@ -239,8 +268,30 @@ pub fn plan_workspace_carry(
             "replay pending workspace state onto the destination tree: {error}"
         ))
     })?;
-    let entities = replay_entities(pending_overlay.entity_deltas(), destination_entities)?;
-    let relations = replay_relations(pending_overlay.relation_deltas(), destination_relations)?;
+    // Both replays report into one refusal, so a caller learns everything the
+    // destination cannot take in one message rather than one entry per retry.
+    let mut refused = WorkspaceSemanticCarryRefusal::default();
+    let entities = replay_entities(
+        pending_overlay.entity_deltas(),
+        destination_entities,
+        &mut refused,
+    );
+    let mut relations = replay_relations(
+        pending_overlay.relation_deltas(),
+        destination_relations,
+        &mut refused,
+    );
+    if !refused.is_empty() {
+        return Ok(WorkspaceCarry::SemanticallyRefused(refused));
+    }
+
+    // Rule 5, decided once over the finished plan. Entities and relations
+    // replayed independently above, so this is the only place that can see a
+    // retired entity and a surviving edge into it at the same time.
+    let retired_relations = unadmitted_endpoints(&relations, &entities, &tree);
+    for relation_id in &retired_relations {
+        relations.remove(relation_id);
+    }
 
     Ok(WorkspaceCarry::Carried(Box::new(WorkspaceCarryPlan {
         tree,
@@ -248,7 +299,36 @@ pub fn plan_workspace_carry(
         relations,
         carried,
         absorbed,
+        retired_relations,
     })))
+}
+
+/// Every relation the finished plan holds whose endpoint the same plan does not.
+///
+/// Only `Entity` and `Artifact` endpoints are decidable from a carry plan: the
+/// plan owns exactly those two node populations. Tests, contracts, work items,
+/// verification runs and external references live in tables this planner never
+/// sees, so kin-db validates those and this does not pretend to.
+fn unadmitted_endpoints(
+    relations: &HashMap<RelationId, Relation>,
+    entities: &HashMap<EntityId, Entity>,
+    tree: &ResolvedTree,
+) -> Vec<RelationId> {
+    let mut retired = relations
+        .values()
+        .filter(|relation| {
+            [relation.src, relation.dst]
+                .into_iter()
+                .any(|node| match node {
+                    GraphNodeId::Entity(entity_id) => !entities.contains_key(&entity_id),
+                    GraphNodeId::Artifact(artifact_id) => tree.get(&artifact_id).is_none(),
+                    _ => false,
+                })
+        })
+        .map(|relation| relation.id)
+        .collect::<Vec<_>>();
+    retired.sort_unstable();
+    retired
 }
 
 /// Whether the destination's own members leave room for a path at all.
@@ -288,86 +368,194 @@ fn path_shape_conflict(
         .then_some(WorkspaceCarryConflictKind::PathIsADestinationDirectory)
 }
 
+/// Every pending semantic entry the destination cannot take, kept until both
+/// replays have run so one refusal can say how much work is pending and of what
+/// kind.
+///
+/// The stranger who found this refusal read "commit the pending work" and had no
+/// way to learn that the pending work was sixty-eight relation deltas a
+/// background sweep had derived. Counting them here is the whole difference
+/// between a mystery and a one-command fix.
+///
+/// This is a refusal rather than an error, and it is typed so its caller can say
+/// so. Returned as a plain error it reached a client as an HTTP 500 with an
+/// internal invariant in the body, which is how a designed refusal ends up
+/// reading like a crash.
+#[derive(Debug, Clone, Default)]
+pub struct WorkspaceSemanticCarryRefusal {
+    /// Names of the entities the destination holds in another state.
+    pub entities: Vec<String>,
+    /// Kinds of the edges the destination holds as a *different* edge. A
+    /// relation the destination does not hold at all never lands here, because
+    /// it is not a conflict.
+    pub relations: Vec<RelationKind>,
+}
+
+impl WorkspaceSemanticCarryRefusal {
+    pub fn is_empty(&self) -> bool {
+        self.entities.is_empty() && self.relations.is_empty()
+    }
+
+    /// The refusal, naming the pending work, its kinds, and both commands that
+    /// clear it.
+    pub fn reason(&self) -> String {
+        let mut clauses = Vec::new();
+        if !self.relations.is_empty() {
+            let mut counts = BTreeMap::new();
+            for kind in &self.relations {
+                *counts.entry(format!("{kind:?}")).or_insert(0_usize) += 1;
+            }
+            let breakdown = counts
+                .into_iter()
+                .map(|(kind, count)| format!("{count} {kind}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            clauses.push(format!(
+                "{} pending relation {} ({breakdown})",
+                self.relations.len(),
+                plural(self.relations.len(), "delta", "deltas")
+            ));
+        }
+        if !self.entities.is_empty() {
+            let mut named = self.entities.clone();
+            named.sort();
+            named.dedup();
+            clauses.push(format!(
+                "{} pending entity {} ({})",
+                self.entities.len(),
+                plural(self.entities.len(), "delta", "deltas"),
+                named.join(", ")
+            ));
+        }
+        format!(
+            "this workspace holds pending work the destination branch cannot take: {}. The \
+             destination holds those subjects in a state this pending work was never planned \
+             against, so replaying them would discard one side or the other. Run `kin commit` to \
+             publish the pending work, or `kin stash push --yes` to set it aside",
+            clauses.join(" and ")
+        )
+    }
+}
+
+const fn plural(count: usize, one: &'static str, many: &'static str) -> &'static str {
+    if count == 1 {
+        one
+    } else {
+        many
+    }
+}
+
+/// Whether two relations describe the same edge.
+///
+/// Identity for the carry precondition is the edge itself: which node points at
+/// which, under which kind. `confidence`, `origin`, `created_in`,
+/// `import_source` and `evidence` are derivation quality, republished
+/// continuously by parser reconciliation and the asynchronous enrichment worker
+/// outside the compare-and-swap. Two sides that observed the same edge with
+/// different evidence have not disagreed about anything a switch can lose, so
+/// requiring byte equality there refuses on the writer's tick rather than on the
+/// caller's work.
+fn same_edge(left: &Relation, right: &Relation) -> bool {
+    left.id == right.id && left.kind == right.kind && left.src == right.src && left.dst == right.dst
+}
+
 /// Replay the overlay's entity deltas onto the destination's live entities.
 ///
-/// An addition the destination already holds identically is absorbed, matching
-/// rule 2 one layer up. Every other precondition mismatch fails closed: the
-/// alternative is publishing a workspace whose semantics no observation
-/// produced.
+/// An addition or a change the destination already holds identically is
+/// absorbed, matching rule 2 one layer up. Every other precondition mismatch is
+/// recorded as a conflict: the alternative is publishing a workspace whose
+/// semantics no observation produced. An entity payload is authored truth rather
+/// than derived evidence, so this keeps the strict equality that relations
+/// relax.
 fn replay_entities(
     deltas: &[EntityDelta],
     destination: &HashMap<EntityId, Entity>,
-) -> Result<HashMap<EntityId, Entity>> {
+    refused: &mut WorkspaceSemanticCarryRefusal,
+) -> HashMap<EntityId, Entity> {
     let mut entities = destination.clone();
     for delta in deltas {
         match delta {
             EntityDelta::Added { new } => match entities.get(&new.id) {
                 Some(held) if held == new => {}
-                Some(_) => return Err(semantic_replay_conflict("entity", &new.name)),
+                Some(_) => refused.entities.push(new.name.clone()),
                 None => {
                     entities.insert(new.id, new.clone());
                 }
             },
-            EntityDelta::Modified { old, new } => {
-                if entities.get(&old.id) != Some(old) {
-                    return Err(semantic_replay_conflict("entity", &old.name));
+            EntityDelta::Modified { old, new } => match entities.get(&old.id) {
+                Some(held) if held == old => {
+                    entities.insert(new.id, new.clone());
                 }
-                entities.insert(new.id, new.clone());
-            }
-            EntityDelta::Removed { old } => {
-                if entities.get(&old.id) != Some(old) {
-                    return Err(semantic_replay_conflict("entity", &old.name));
+                // The destination already holds exactly what this change
+                // produces, so there is nothing left to replay.
+                Some(held) if held == new => {}
+                Some(_) | None => refused.entities.push(old.name.clone()),
+            },
+            EntityDelta::Removed { old } => match entities.get(&old.id) {
+                Some(held) if held == old => {
+                    entities.remove(&old.id);
                 }
-                entities.remove(&old.id);
-            }
+                Some(_) => refused.entities.push(old.name.clone()),
+                // Already retired on the destination, so this pending work is
+                // work the destination has done.
+                None => {}
+            },
         }
     }
-    Ok(entities)
+    entities
 }
 
-/// Replay the overlay's relation deltas under the same precondition as
-/// [`replay_entities`].
+/// Replay the overlay's relation deltas onto the destination's live relations.
+///
+/// Same shape as [`replay_entities`], with the two cases that make a derived
+/// edge different from an authored entity kept apart deliberately:
+///
+/// * the destination holds this relation id as a **different edge**, which is a
+///   real conflict and refuses, naming the kind, and
+/// * the destination **does not hold it at all**, which is not a conflict. Its
+///   head predates the pass that derived the edge, so there is no destination
+///   state a replay could discard and the pending observation installs.
+///
+/// Conflating those two is the defect a stranger hit on v0.7.0: after a
+/// background sweep derived sixty-eight relation deltas, every branch switch
+/// refused until a commit published them, because each `Modified` delta over an
+/// edge the destination had never seen took the conflict path.
 fn replay_relations(
     deltas: &[RelationDelta],
     destination: &HashMap<RelationId, Relation>,
-) -> Result<HashMap<RelationId, Relation>> {
+    refused: &mut WorkspaceSemanticCarryRefusal,
+) -> HashMap<RelationId, Relation> {
     let mut relations = destination.clone();
     for delta in deltas {
         match delta {
             RelationDelta::Added { new } => match relations.get(&new.id) {
-                Some(held) if held == new => {}
-                Some(_) => return Err(semantic_replay_conflict("relation", &render_relation(new))),
+                Some(held) if same_edge(held, new) => {
+                    relations.insert(new.id, new.clone());
+                }
+                Some(_) => refused.relations.push(new.kind),
                 None => {
                     relations.insert(new.id, new.clone());
                 }
             },
-            RelationDelta::Modified { old, new } => {
-                if relations.get(&old.id) != Some(old) {
-                    return Err(semantic_replay_conflict("relation", &render_relation(old)));
+            RelationDelta::Modified { old, new } => match relations.get(&old.id) {
+                Some(held) if same_edge(held, old) || same_edge(held, new) => {
+                    relations.insert(new.id, new.clone());
                 }
-                relations.insert(new.id, new.clone());
-            }
-            RelationDelta::Removed { old } => {
-                if relations.get(&old.id) != Some(old) {
-                    return Err(semantic_replay_conflict("relation", &render_relation(old)));
+                Some(_) => refused.relations.push(old.kind),
+                None => {
+                    relations.insert(new.id, new.clone());
                 }
-                relations.remove(&old.id);
-            }
+            },
+            RelationDelta::Removed { old } => match relations.get(&old.id) {
+                Some(held) if same_edge(held, old) => {
+                    relations.remove(&old.id);
+                }
+                Some(_) => refused.relations.push(old.kind),
+                None => {}
+            },
         }
     }
-    Ok(relations)
-}
-
-fn render_relation(relation: &Relation) -> String {
-    format!("{:?}", relation.kind)
-}
-
-fn semantic_replay_conflict(noun: &str, name: &str) -> KinError {
-    KinError::Other(format!(
-        "pending {noun} {name} cannot be replayed onto the destination branch, which holds it in a \
-         state this pending work was never planned against; commit the pending work or set it \
-         aside with `kin stash push` before switching branches"
-    ))
+    relations
 }
 
 #[cfg(test)]
@@ -421,16 +609,14 @@ mod tests {
                 .iter()
                 .map(|conflict| (conflict.path.to_string(), conflict.kind))
                 .collect(),
-            WorkspaceCarry::Carried(_) => panic!("expected a refusal"),
+            other => panic!("expected a path refusal, got {other:?}"),
         }
     }
 
     fn carried(carry: &WorkspaceCarry) -> &WorkspaceCarryPlan {
         match carry {
             WorkspaceCarry::Carried(plan) => plan,
-            WorkspaceCarry::Refused(conflicts) => {
-                panic!("expected a carry, refused with {conflicts:?}")
-            }
+            other => panic!("expected a carry, refused with {other:?}"),
         }
     }
 
@@ -715,6 +901,406 @@ mod tests {
             carried(&back).tree,
             pending,
             "switching away and back reproduces the pending tree byte for byte"
+        );
+    }
+}
+
+/// The stranger-run reproduction of the two v0.7.0 branch-switch defects, and
+/// the contract that replaced them.
+///
+/// Kept in its own module so the fixtures that build a semantic overlay do not
+/// crowd the tree-only fixtures above, and so a reader chasing either defect
+/// lands on the whole story in one place.
+#[cfg(test)]
+mod semantic_carry_tests {
+    use super::*;
+    use kin_model::{
+        entity::Entity, ArtifactId, EntityKind, EntityMetadata, EntityRole, FilePathId,
+        FingerprintAlgorithm, GraphNodeId, Hash256, LanguageId, LocatedEntry, RelationKind,
+        RelationOrigin, SemanticFingerprint, TreeEntry, Visibility,
+    };
+
+    fn path(value: &str) -> RepoPath {
+        RepoPath::from_bytes(value.as_bytes().to_vec()).expect("repository path")
+    }
+
+    fn entry(body: &str) -> TreeEntry {
+        TreeEntry::blob(
+            Hash256::from_bytes(kin_blobs::digest_bytes(body.as_bytes())),
+            false,
+        )
+    }
+
+    fn tree(members: &[(u128, &str, &str)]) -> ResolvedTree {
+        let deltas = members
+            .iter()
+            .map(|(id, at, body)| TreeDelta::Added {
+                artifact_id: ArtifactId(uuid::Uuid::from_u128(*id)),
+                new: LocatedEntry::new(path(at), entry(body)),
+            })
+            .collect::<Vec<_>>();
+        ResolvedTree::default()
+            .apply(&deltas)
+            .expect("build fixture tree")
+    }
+
+    fn entity_id(value: u128) -> EntityId {
+        EntityId(uuid::Uuid::from_u128(value))
+    }
+
+    fn relation_id(value: u128) -> RelationId {
+        RelationId(uuid::Uuid::from_u128(value))
+    }
+
+    fn entity(id: u128, name: &str, file: &str) -> Entity {
+        Entity {
+            id: entity_id(id),
+            kind: EntityKind::Function,
+            name: name.to_string(),
+            language: LanguageId::Python,
+            fingerprint: SemanticFingerprint {
+                algorithm: FingerprintAlgorithm::V1TreeSitter,
+                ast_hash: Hash256::from_bytes([1; 32]),
+                signature_hash: Hash256::from_bytes([2; 32]),
+                behavior_hash: Hash256::from_bytes([3; 32]),
+                equivalence_hash: Hash256::from_bytes([0; 32]),
+                stability_score: 1.0,
+            },
+            file_origin: Some(FilePathId::new(file)),
+            span: None,
+            signature: format!("def {name}()"),
+            visibility: Visibility::Public,
+            role: EntityRole::Source,
+            doc_summary: None,
+            metadata: EntityMetadata::default(),
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        }
+    }
+
+    fn relation(id: u128, src: u128, dst: u128, kind: RelationKind) -> Relation {
+        Relation {
+            id: relation_id(id),
+            kind,
+            src: GraphNodeId::Entity(entity_id(src)),
+            dst: GraphNodeId::Entity(entity_id(dst)),
+            confidence: 0.5,
+            origin: RelationOrigin::Parsed,
+            created_in: None,
+            import_source: None,
+            evidence: Vec::new(),
+        }
+    }
+
+    /// The same edge one enrichment pass later: the LSP worker resolved the
+    /// type, so origin and confidence move and the edge itself does not.
+    fn enriched(relation: &Relation) -> Relation {
+        Relation {
+            confidence: 1.0,
+            origin: RelationOrigin::Lsp,
+            ..relation.clone()
+        }
+    }
+
+    fn entities(members: &[Entity]) -> HashMap<EntityId, Entity> {
+        members
+            .iter()
+            .map(|entity| (entity.id, entity.clone()))
+            .collect()
+    }
+
+    fn relations(members: &[Relation]) -> HashMap<RelationId, Relation> {
+        members
+            .iter()
+            .map(|relation| (relation.id, relation.clone()))
+            .collect()
+    }
+
+    fn overlay(
+        entity_deltas: Vec<EntityDelta>,
+        relation_deltas: Vec<RelationDelta>,
+    ) -> WorkspaceSemanticOverlay {
+        WorkspaceSemanticOverlay::new(entity_deltas, relation_deltas)
+            .expect("build a fixture workspace semantic overlay")
+    }
+
+    fn carried(carry: &WorkspaceCarry) -> &WorkspaceCarryPlan {
+        match carry {
+            WorkspaceCarry::Carried(plan) => plan,
+            other => panic!("expected a carry, refused with {other:?}"),
+        }
+    }
+
+    /// Defect 1, the one that stopped the stranger: background enrichment
+    /// leaves relation-only pending state, and every switch refuses until a
+    /// commit publishes it.
+    ///
+    /// The workspace edited `parsing.py`, a member both branches hold
+    /// byte-identically, so rule 4 carries the tree side. The enrichment worker
+    /// then upgraded one `UsesType` edge over that member from a parsed guess
+    /// to an LSP-resolved fact, which is a relation-only `Modified` delta. On
+    /// v0.7.0 that alone refused the switch with `pending relation UsesType
+    /// cannot be replayed onto the destination branch`.
+    #[test]
+    fn an_enrichment_upgrade_over_a_member_both_branches_hold_carries() {
+        let base = tree(&[(1, "parsing.py", "base"), (2, "storage.py", "shared")]);
+        let pending = tree(&[(1, "parsing.py", "edited"), (2, "storage.py", "shared")]);
+        let destination = tree(&[(1, "parsing.py", "base"), (2, "storage.py", "shared")]);
+
+        let parse = entity(10, "parse", "parsing.py");
+        let store = entity(11, "store", "storage.py");
+        let edge = relation(20, 10, 11, RelationKind::UsesType);
+
+        let carry = plan_workspace_carry(
+            &base,
+            &pending,
+            &overlay(
+                Vec::new(),
+                vec![RelationDelta::Modified {
+                    old: edge.clone(),
+                    new: enriched(&edge),
+                }],
+            ),
+            &destination,
+            &entities(&[parse, store]),
+            &relations(std::slice::from_ref(&edge)),
+        )
+        .expect("a relation-only enrichment upgrade must not refuse the switch");
+
+        let plan = carried(&carry);
+        assert_eq!(
+            plan.relations.get(&edge.id),
+            Some(&enriched(&edge)),
+            "the enriched edge must arrive on the destination in its enriched form"
+        );
+        assert!(plan.retired_relations.is_empty());
+    }
+
+    /// Defect 1, probe 3: a five-word untracked markdown file, with the same
+    /// relation-only enrichment pending behind it. The file is the only tree
+    /// work, so nothing about it can conflict, and the switch still refused on
+    /// v0.7.0 because the overlay went through the same replay.
+    ///
+    /// The destination does not hold the edge, which is the shape that actually
+    /// refused: its head predates the sweep that derived it. A first draft of
+    /// this test gave the destination the edge, and it passed with the defect
+    /// reinstated, which is a test that cannot fail for what it claims to cover.
+    #[test]
+    fn a_lone_untracked_file_carries_while_enrichment_is_pending() {
+        let base = tree(&[(1, "parsing.py", "base")]);
+        let pending = tree(&[
+            (1, "parsing.py", "base"),
+            (2, "notes.md", "five words here"),
+        ]);
+        let destination = tree(&[(1, "parsing.py", "base"), (3, "export.py", "only there")]);
+
+        let parse = entity(10, "parse", "parsing.py");
+        let edge = relation(20, 10, 10, RelationKind::References);
+
+        let carry = plan_workspace_carry(
+            &base,
+            &pending,
+            &overlay(
+                Vec::new(),
+                vec![RelationDelta::Modified {
+                    old: edge.clone(),
+                    new: enriched(&edge),
+                }],
+            ),
+            &destination,
+            &entities(&[parse]),
+            &relations(&[]),
+        )
+        .expect("an untracked file plus pending enrichment must not refuse the switch");
+
+        let plan = carried(&carry);
+        assert_eq!(
+            plan.carried
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            vec!["notes.md".to_string()]
+        );
+        assert_eq!(plan.relations.get(&edge.id), Some(&enriched(&edge)));
+    }
+
+    /// The destination branch never observed the edge at all, because its head
+    /// predates the enrichment pass. Carrying the pending work means installing
+    /// it, and both endpoints are present, so nothing is invented.
+    #[test]
+    fn an_enrichment_upgrade_the_destination_never_observed_carries() {
+        let base = tree(&[(1, "parsing.py", "base")]);
+        let pending = tree(&[(1, "parsing.py", "edited")]);
+        let destination = tree(&[(1, "parsing.py", "base")]);
+
+        let parse = entity(10, "parse", "parsing.py");
+        let store = entity(11, "store", "parsing.py");
+        let edge = relation(20, 10, 11, RelationKind::UsesType);
+
+        let carry = plan_workspace_carry(
+            &base,
+            &pending,
+            &overlay(
+                Vec::new(),
+                vec![RelationDelta::Modified {
+                    old: edge.clone(),
+                    new: enriched(&edge),
+                }],
+            ),
+            &destination,
+            &entities(&[parse, store]),
+            &relations(&[]),
+        )
+        .expect("a destination that never observed the edge must not refuse the switch");
+
+        assert_eq!(
+            carried(&carry).relations.get(&edge.id),
+            Some(&enriched(&edge))
+        );
+    }
+
+    /// Defect 2, the wedge: pending work retires an entity, the destination
+    /// holds an edge into it, and nothing retires that edge. On v0.7.0 the plan
+    /// carried the orphan through, kin-db's preflight refused the resulting
+    /// transaction with `has unadmitted source endpoint entity:<id>`, and
+    /// commit, stash push and branch switch then all refused at once naming an
+    /// entity `kin graph inspect` says does not exist.
+    ///
+    /// A plan may not hand that shape downstream. The edge into a retired
+    /// entity is retired in the same plan and counted.
+    #[test]
+    fn an_edge_into_an_entity_the_pending_work_retires_is_retired_with_it() {
+        let base = tree(&[(1, "storage.py", "base"), (2, "reporting.py", "shared")]);
+        let pending = tree(&[(1, "storage.py", "edited"), (2, "reporting.py", "shared")]);
+        let destination = tree(&[(1, "storage.py", "base"), (2, "reporting.py", "shared")]);
+
+        let gone = entity(10, "grand_total", "storage.py");
+        let report = entity(11, "format_report", "reporting.py");
+        let orphaning = relation(20, 11, 10, RelationKind::UsesType);
+
+        let carry = plan_workspace_carry(
+            &base,
+            &pending,
+            &overlay(vec![EntityDelta::Removed { old: gone.clone() }], Vec::new()),
+            &destination,
+            &entities(&[gone.clone(), report]),
+            &relations(std::slice::from_ref(&orphaning)),
+        )
+        .expect("retiring an entity must not refuse the switch");
+
+        let plan = carried(&carry);
+        assert!(
+            !plan.entities.contains_key(&gone.id),
+            "the pending removal still retires the entity"
+        );
+        assert!(
+            !plan.relations.contains_key(&orphaning.id),
+            "the edge into the retired entity must not survive the plan"
+        );
+        assert_eq!(plan.retired_relations, vec![orphaning.id]);
+        assert_eq!(
+            unadmitted_endpoints(&plan.relations, &plan.entities, &plan.tree),
+            Vec::<RelationId>::new(),
+            "no relation in a carry plan may point at a node the plan does not hold"
+        );
+    }
+
+    /// A relation whose endpoint artifact the pending work removes is the same
+    /// class one node kind over, and it is retired the same way.
+    #[test]
+    fn an_edge_into_an_artifact_the_pending_work_removes_is_retired_with_it() {
+        let base = tree(&[(1, "storage.py", "base"), (2, "reporting.py", "shared")]);
+        let pending = tree(&[(2, "reporting.py", "shared")]);
+        let destination = tree(&[(1, "storage.py", "base"), (2, "reporting.py", "shared")]);
+
+        let report = entity(11, "format_report", "reporting.py");
+        let into_artifact = Relation {
+            dst: GraphNodeId::Artifact(ArtifactId(uuid::Uuid::from_u128(1))),
+            ..relation(20, 11, 11, RelationKind::References)
+        };
+
+        let carry = plan_workspace_carry(
+            &base,
+            &pending,
+            &overlay(Vec::new(), Vec::new()),
+            &destination,
+            &entities(&[report]),
+            &relations(std::slice::from_ref(&into_artifact)),
+        )
+        .expect("removing a member must not refuse the switch");
+
+        let plan = carried(&carry);
+        assert_eq!(plan.retired_relations, vec![into_artifact.id]);
+        assert!(!plan.relations.contains_key(&into_artifact.id));
+    }
+
+    /// The refusal that remains has to say what it is refusing on. The stranger
+    /// read `commit the pending work` and had no way to learn that the pending
+    /// work was 68 relation deltas from a background sweep.
+    #[test]
+    fn a_refusal_names_the_pending_work_its_kinds_and_the_command_that_clears_it() {
+        let base = tree(&[(1, "parsing.py", "base")]);
+        let pending = tree(&[(1, "parsing.py", "edited")]);
+        let destination = tree(&[(1, "parsing.py", "base")]);
+
+        let parse = entity(10, "parse", "parsing.py");
+        let store = entity(11, "store", "parsing.py");
+        let mine = relation(20, 10, 11, RelationKind::UsesType);
+        let theirs = Relation {
+            kind: RelationKind::Calls,
+            ..mine.clone()
+        };
+        let second = relation(21, 11, 10, RelationKind::References);
+        let second_theirs = Relation {
+            kind: RelationKind::Implements,
+            ..second.clone()
+        };
+
+        let carry = plan_workspace_carry(
+            &base,
+            &pending,
+            &overlay(
+                Vec::new(),
+                vec![
+                    RelationDelta::Modified {
+                        old: mine.clone(),
+                        new: enriched(&mine),
+                    },
+                    RelationDelta::Modified {
+                        old: second.clone(),
+                        new: enriched(&second),
+                    },
+                ],
+            ),
+            &destination,
+            &entities(&[parse, store]),
+            &relations(&[theirs, second_theirs]),
+        )
+        .expect("a semantic conflict is a refusal, not an error");
+        let WorkspaceCarry::SemanticallyRefused(refusal) = &carry else {
+            panic!(
+                "a destination holding a different edge under the same id is a real conflict, got \
+                 {carry:?}"
+            );
+        };
+        let error = refusal.reason();
+
+        assert!(
+            error.contains("2 pending relation deltas"),
+            "the refusal must count the pending work: {error}"
+        );
+        assert!(
+            error.contains("UsesType") && error.contains("References"),
+            "the refusal must name the kinds it is refusing on: {error}"
+        );
+        assert!(
+            error.contains("kin commit"),
+            "the refusal must name the command that publishes the pending work: {error}"
+        );
+        assert!(
+            error.contains("kin stash push --yes"),
+            "the refusal must name the command that sets the pending work aside: {error}"
         );
     }
 }

--- a/crates/kin-daemon/src/commit_deltas.rs
+++ b/crates/kin-daemon/src/commit_deltas.rs
@@ -1037,6 +1037,121 @@ mod tests {
         assert!(graph.to_snapshot().relations.is_empty());
     }
 
+    /// A per-path checkout retires the edges into every entity it discards, in
+    /// the same delta that discards them.
+    ///
+    /// The class this locks: an edit adds an entity, background enrichment mints
+    /// an edge into it from a file outside the selection, and the checkout drops
+    /// the entity. An edge left pointing at it is an orphan, and kin-db then
+    /// refuses every later transaction and every later snapshot naming an entity
+    /// `kin graph inspect` reports as not found. A stranger driving the v0.7.0
+    /// release reached that state and had commit, `kin stash push` and
+    /// `kin branch switch` all refuse at once.
+    ///
+    /// The `apply_transaction_delta` at the end is the positive control: it is
+    /// the same admission check the daemon runs, so a delta that stranded the
+    /// edge fails here rather than passing quietly.
+    #[test]
+    fn selected_checkout_retires_the_edges_into_every_entity_it_discards() {
+        let selected = RepoPath::from_utf8("src").unwrap();
+        let discarded_id = EntityId::new();
+        let outside_id = EntityId::new();
+        let selected_artifact = ArtifactId::new();
+        let outside_artifact = ArtifactId::new();
+        let entry = TreeEntry::blob(Hash256::from_bytes([0x41; 32]), false);
+        let tree = resolved_tree(vec![
+            (
+                selected_artifact,
+                RepoPath::from_utf8("src/lib.rs").unwrap(),
+                entry.clone(),
+            ),
+            (
+                outside_artifact,
+                RepoPath::from_utf8("other/mod.rs").unwrap(),
+                entry,
+            ),
+        ]);
+        let discarded = make_entity_with_id(
+            discarded_id,
+            "grand_total",
+            "src/lib.rs",
+            LanguageId::Rust,
+            [0x42; 32],
+        );
+        let outside = make_entity_with_id(
+            outside_id,
+            "format_report",
+            "other/mod.rs",
+            LanguageId::Rust,
+            [0x43; 32],
+        );
+        // Enrichment derived this after the edit, from a file the checkout does
+        // not touch into one it does.
+        let inbound = relation(
+            RelationId::new(),
+            GraphNodeId::Entity(outside_id),
+            GraphNodeId::Entity(discarded_id),
+            RelationKind::UsesType,
+        );
+
+        let graph = InMemoryGraph::new();
+        graph
+            .apply_transaction_delta(&TransactionDelta {
+                tree_deltas: kin_core::exact_tree_correction(&ResolvedTree::default(), &tree)
+                    .unwrap(),
+                entity_deltas: vec![
+                    kin_model::EntityDelta::Added {
+                        new: discarded.clone(),
+                    },
+                    kin_model::EntityDelta::Added {
+                        new: outside.clone(),
+                    },
+                ],
+                relation_deltas: vec![kin_model::RelationDelta::Added {
+                    new: inbound.clone(),
+                }],
+                ..TransactionDelta::default()
+            })
+            .unwrap();
+
+        // The change being restored predates the edit, so it never held the
+        // entity or the edge into it.
+        let target = ResolvedGraphState {
+            entities: HashMap::from([(outside_id, outside.clone())]),
+            relations: HashMap::new(),
+            entity_revisions: Default::default(),
+            tree: tree.clone(),
+            entity_tombstones: Default::default(),
+            relation_tombstones: Default::default(),
+            external_references: HashMap::new(),
+        };
+
+        let delta =
+            compute_selected_checkout_delta(&graph, &selected, &target, &tree, &tree).unwrap();
+        assert!(delta.tree_deltas.is_empty());
+        assert_eq!(
+            delta.entity_deltas,
+            vec![kin_model::EntityDelta::Removed { old: discarded }],
+            "the checkout discards the entity the edit introduced"
+        );
+        assert_eq!(
+            delta.relation_deltas,
+            vec![kin_model::RelationDelta::Removed {
+                old: inbound.clone()
+            }],
+            "and retires the edge into it in the same delta"
+        );
+
+        graph.apply_transaction_delta(&delta).unwrap();
+        let after = graph.to_snapshot();
+        assert!(!after.entities.contains_key(&discarded_id));
+        assert!(after.relations.is_empty());
+        assert!(
+            after.entities.contains_key(&outside_id),
+            "the entity outside the selection is untouched"
+        );
+    }
+
     /// A path selection does not scope the external-reference domain, so a
     /// spliced edge to an external endpoint survives exactly when the graph
     /// already holds that reference. The absent case must drop the edge rather

--- a/crates/kin-daemon/src/error.rs
+++ b/crates/kin-daemon/src/error.rs
@@ -20,6 +20,38 @@ pub fn workspace_generation_exhausted(
     )
 }
 
+/// Add the recovery to a refusal whose message names a graph node no query
+/// returns, and leave every other refusal alone.
+///
+/// kin-db refuses any transaction, and any snapshot, holding a relation whose
+/// endpoint the graph does not have. Its message names two uuids and nothing
+/// else, and the entity uuid it names is one `kin graph inspect` reports as not
+/// found, because it genuinely is not there. A caller meeting that has no way to
+/// know the state is recoverable at all. A first-time user hit exactly this on
+/// the v0.7.0 release: commit, `kin stash push` and `kin branch switch` refused
+/// at once, each naming an entity no query returned, and finding the sequence
+/// below by hand cost twenty minutes.
+///
+/// The clause is attached innermost, so `cause_first` renders it directly after
+/// the storage message it explains rather than behind the step description.
+pub fn name_stranded_endpoint_recovery(error: anyhow::Error) -> anyhow::Error {
+    const MARKERS: [&str; 3] = [
+        "unadmitted source endpoint",
+        "unadmitted destination endpoint",
+        "relation removal must be explicit",
+    ];
+    let message = format!("{error:#}");
+    if !MARKERS.iter().any(|marker| message.contains(marker)) {
+        return error;
+    }
+    error.context(
+        "recovery: the graph holds an edge into a node it no longer has, which is why the id in \
+         this message resolves to nothing. Run `kin daemon stop`, then `kin commit` until `kin \
+         diff HEAD WORKSPACE` reports no pending relations. Every file body on disk is intact \
+         throughout, and this is worth reporting: no command should leave that edge behind",
+    )
+}
+
 /// Render an error chain with its root cause as the headline.
 ///
 /// `{error:#}` prints the outermost context first, which on the repository
@@ -175,7 +207,54 @@ pub type Result<T> = std::result::Result<T, DaemonError>;
 
 #[cfg(test)]
 mod tests {
-    use super::cause_first;
+    use super::{cause_first, name_stranded_endpoint_recovery};
+
+    /// The wedge a stranger hit on the v0.7.0 release: a storage refusal naming
+    /// a relation and an entity, where the entity is one `kin graph inspect`
+    /// reports as not found. The refusal now carries the sequence that clears
+    /// it, and it lands directly after the storage message rather than behind
+    /// the internal step description.
+    #[test]
+    fn a_refusal_naming_a_node_no_query_returns_carries_its_recovery() {
+        let raw = anyhow::anyhow!(
+            "storage error: transaction relation faf90068 has unadmitted source endpoint \
+             entity:d1f10112"
+        );
+        let named =
+            name_stranded_endpoint_recovery(raw).context("apply branch-switch daemon preflight");
+        let rendered = cause_first(&named);
+
+        assert!(
+            rendered.contains("kin daemon stop"),
+            "the refusal must name the recovery: {rendered}"
+        );
+        assert!(
+            rendered.contains("kin commit"),
+            "the refusal must name what drains the pending relations: {rendered}"
+        );
+        let recovery_at = rendered
+            .find("recovery:")
+            .expect("the recovery clause is present");
+        let step_at = rendered
+            .find("apply branch-switch")
+            .expect("the step description is present");
+        assert!(
+            recovery_at < step_at,
+            "the recovery belongs beside the message it explains, not behind the step: {rendered}"
+        );
+    }
+
+    /// The clause is attached only to the refusal it explains. A guard that
+    /// fires on everything would append a graph recovery to a bad path, an
+    /// unreadable file, and every other refusal in the crate.
+    #[test]
+    fn an_unrelated_refusal_is_left_exactly_as_it_was() {
+        let raw = anyhow::anyhow!("provide a UTF-8 path or --path-hex");
+        assert_eq!(
+            cause_first(&name_stranded_endpoint_recovery(raw)),
+            "provide a UTF-8 path or --path-hex"
+        );
+    }
 
     #[test]
     fn the_root_cause_leads_and_the_steps_that_reached_it_follow() {

--- a/crates/kin-daemon/src/repository_branch.rs
+++ b/crates/kin-daemon/src/repository_branch.rs
@@ -1143,13 +1143,38 @@ fn plan_switch_carry(
         &target_state.entities,
         &target_state.relations,
     )
-    .context("plan pending workspace state against the branch being switched to")?
+    .with_context(|| format!("plan pending workspace state against {name}"))?
     {
         kin_core::WorkspaceCarry::Carried(plan) => Ok(Some(plan)),
         kin_core::WorkspaceCarry::Refused(conflicts) => {
             Err(pending_state_conflict(workspace, name, &conflicts, policy))
         }
+        kin_core::WorkspaceCarry::SemanticallyRefused(refusal) => Err(pending_semantics_conflict(
+            workspace, name, &refusal, policy,
+        )),
     }
+}
+
+/// Refuse a switch whose pending graph work the destination cannot take.
+///
+/// The tree-side twin above names each blocked path, because a path is what the
+/// caller edited. This one has no path to name: the pending work is entity and
+/// relation deltas a background pass derived, so it names how many there are and
+/// of what kind. It is a conflict rather than an internal error, which is what
+/// this refusal used to reach clients as, with the graph invariant in the body
+/// and no count anywhere.
+fn pending_semantics_conflict(
+    workspace: &kin_model::WorkspaceState,
+    name: &RefName,
+    refusal: &kin_core::WorkspaceSemanticCarryRefusal,
+    policy: TransitionPolicy,
+) -> anyhow::Error {
+    branch_conflict(format!(
+        "workspace {} cannot move onto {name}: {}, {}",
+        workspace.workspace_id,
+        refusal.reason(),
+        transition_remedy(policy)
+    ))
 }
 
 /// Refuse a switch that would lose pending work, naming every blocked path.
@@ -1183,6 +1208,12 @@ fn pending_state_conflict(
 /// came along, and needs the absorbed case named separately: those paths are
 /// tracked members of the branch now rather than pending work, which is a real
 /// change in what a later commit would publish.
+///
+/// Retired edges are reported for the same reason and are the one clause that is
+/// a loss rather than a move. An edge into a node the transition retired cannot
+/// be read by any query, so keeping it would only hand a dangling endpoint to
+/// the storage layer, but a graph that quietly holds fewer edges than it did is
+/// exactly the thing this product must never do without saying so.
 fn render_carried(plan: &kin_core::WorkspaceCarryPlan) -> String {
     let mut clauses = Vec::new();
     if !plan.carried.is_empty() {
@@ -1197,6 +1228,12 @@ fn render_carried(plan: &kin_core::WorkspaceCarryPlan) -> String {
             "{} pending path(s) already tracked at identical content on this branch: {}",
             plan.absorbed.len(),
             render_paths(&plan.absorbed)
+        ));
+    }
+    if !plan.retired_relations.is_empty() {
+        clauses.push(format!(
+            "{} relation(s) retired because this transition removed an endpoint they pointed at",
+            plan.retired_relations.len()
         ));
     }
     if clauses.is_empty() {
@@ -1380,9 +1417,11 @@ fn preflight_switch_delta(
         ));
     }
     let preflight = kin_db::InMemoryGraph::from_snapshot(state.graph.to_snapshot())
+        .map_err(|error| crate::error::name_stranded_endpoint_recovery(anyhow::Error::new(error)))
         .context("prepare branch-switch daemon graph preflight")?;
     preflight
         .apply_transaction_delta(delta)
+        .map_err(|error| crate::error::name_stranded_endpoint_recovery(anyhow::Error::new(error)))
         .context("apply branch-switch daemon graph preflight")?;
     let snapshot = preflight.to_snapshot();
     if snapshot.resolved_tree != *desired_tree

--- a/crates/kin-daemon/src/repository_checkout.rs
+++ b/crates/kin-daemon/src/repository_checkout.rs
@@ -841,6 +841,9 @@ fn classify_daemon_checkout_error(
 }
 
 fn checkout_error_for_status(status: StatusCode, error: anyhow::Error) -> CheckoutCommandError {
+    // Every checkout refusal funnels through here, so one call names the
+    // recovery for the whole command rather than four classifiers repeating it.
+    let error = crate::error::name_stranded_endpoint_recovery(error);
     match status {
         StatusCode::BAD_REQUEST => CheckoutCommandError::BadRequest(error),
         StatusCode::CONFLICT => CheckoutCommandError::Conflict(error),


### PR DESCRIPTION
## What this fixes

Two defects a first-time user hit driving a full version-control session on the released v0.7.0
bytes. The first stopped them: **`kin branch switch` refuses over any relation-only pending state**,
which background enrichment produces constantly, so the documented promise that uncommitted work
rides across a switch held only for an empty workspace. The second is the wedge behind it: a plan
could hand the storage layer an edge into an entity the same plan retired, after which commit,
`kin stash push` and `kin branch switch` all refused at once, each naming an entity
`kin graph inspect` reports as not found.

## Reproduction, measured before any code change

Four probes against `plan_workspace_carry` at `4d1dfa5af`, over the exact shapes the stranger drove.
Two passed and two failed:

```
$ cargo test -p kin-core --lib switchfix_probe -- --nocapture

running 4 tests
PROBE B: carried
PROBE A: carried

thread 'probe_c_destination_never_observed_the_edge' panicked:
PROBE C refused (semantic): pending relation UsesType cannot be replayed onto the destination
branch, which holds it in a state this pending work was never planned against; commit the pending
work or set it aside with `kin stash push` before switching branches

thread 'probe_d_orphan_relation_survives_the_plan' panicked:
PROBE D: plan carried. orphan relation 00000000-...-000000000014 still in plan = true; its source
endpoint entity 00000000-...-00000000000a absent from plan = true. kin-db then refuses with
`transaction relation ...014 has unadmitted source endpoint entity:...00a`

test result: FAILED. 2 passed; 2 failed; 857 filtered out
```

PROBE C's string is character-for-character the refusal the user hit.

The measurement refuted my going-in hypothesis, which is why it ran first. I expected the blocker to
be an enrichment *upgrade*, the same edge held by both sides with different `origin` and
`confidence`. That is PROBE A and it already carried. Fixing what I assumed would have shipped a
change that fixed nothing.

## Mechanism

`replay_relations` required, for a `RelationDelta::Modified`, that
`destination.get(&old.id) == Some(old)`. That test is false two ways and the code treated them the
same: the destination holds the id as a **different edge**, a real conflict, or the destination
**does not hold it at all**, which is not a conflict. The second case is the whole outage. The
destination branch's head predates the enrichment pass that derived the edge, so there is no
destination state a replay could discard. `Removed` had the mirror defect.

Separately, entities and relations replay independently and nothing checked endpoints afterwards, so
a pending `EntityDelta::Removed` could strand a destination edge into that entity. `switch` feeds the
plan to `preflight_switch_delta`, and kin-db refuses the whole transaction naming an id no query
returns.

## The change

`replay_relations` keeps the two cases apart. A different edge under the same id still refuses; an
edge the destination never observed installs. Relation identity for that precondition is now the edge
itself (`id`, `kind`, `src`, `dst`); `confidence`, `origin`, `created_in`, `import_source` and
`evidence` are derivation quality the enrichment worker republishes outside the compare-and-swap, so
requiring byte equality there refused on the writer's tick rather than on the caller's work. Entities
keep strict equality, since an entity payload is authored truth, and gain only the two cases that are
already done: a change the destination already holds and a retirement it already made.

`WorkspaceCarryPlan` gains `retired_relations`, and the planner ends with one endpoint-integrity pass
over its finished state. That pass is the only place that can see a retired entity and a surviving
edge into it together. `render_carried` reports the retired count on the switch line, because an edge
into a node the transition retired reads as nothing, but a graph that holds fewer edges than it did
must never go unsaid.

The remaining refusal is typed rather than an internal error, so it reaches a client as a conflict
rather than a 500, and it names the work:

```
workspace <id> cannot move onto refs/heads/main: this workspace holds pending work the destination
branch cannot take: 2 pending relation deltas (1 References, 1 UsesType). ... Run `kin commit` to
publish the pending work, or `kin stash push --yes` to set it aside, before switching branches
```

`name_stranded_endpoint_recovery` attaches the recovery to any refusal naming an unadmitted endpoint
or a dangling relation, and to nothing else. It is wired at both branch-switch preflight sites and at
`checkout_error_for_status`, the single funnel every checkout refusal passes through.

## Tests and falsification

Six new tests in `crates/kin-core/src/workspace_carry.rs` (`semantic_carry_tests`), one in
`crates/kin-daemon/src/commit_deltas.rs`, two in `crates/kin-daemon/src/error.rs`. Crate tests so
`ci.yml` grades them on this PR rather than acceptance grading them on main after landing.

Each was falsified by breaking exactly what it guards. Eight arms, each applied to a pristine copy
and reverted after:

| Mutation | Expected | Got |
|---|---|---|
| M1 `replay_relations` `Modified`/`None` back to a conflict | RED | RED |
| M2 `unadmitted_endpoints` returns nothing | RED | RED |
| M3 the refusal stops counting the pending work | RED | RED |
| M4 `same_edge` compares only the id | RED | RED |
| M5 `same_edge` never matches | RED | RED |
| M6 `relation_touches_selected` ignores the destination endpoint | RED | RED |
| M7 the recovery clause is never attached | RED | RED |
| M8 the recovery clause is attached to everything | RED | RED |

M1 caught a bad test of mine, which is worth stating. The first draft of
`a_lone_untracked_file_carries_while_enrichment_is_pending` gave the destination the edge, so it took
the `same_edge` path and stayed green with the defect reinstated. It could not fail for what it
claimed to cover. Rewritten so the destination lacks the edge, the shape that actually refused, it
goes red under M1 beside its sibling. M7 and M8 are a deliberate pair: one proves the clause
attaches, the other proves it does not attach to everything.

## Verification

Every cargo invocation through `.kin-coord/bin/heavy-slot.sh`, gates by absolute path with
`--repo-dir`.

```
$ bin/kin-precheck kin --repo-dir kin=<lane worktree>
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 4d1dfa5af54ccb1c6faae177b77b5149ba3df4e7 DIRTY
```

```
$ cargo test -p kin-core
test result: ok. 862 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 19.90s
(plus 7 further test binaries, all ok)

$ cargo test -p kin-daemon --lib
test result: ok. 1417 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 226.28s

$ cargo fmt --all -- --check        clean
$ cargo clippy --all-targets --all-features -- <90 allow words from .github/clippy-allowed-lints.txt>
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 41s
```

Rebased onto `origin/main` at `573235b98` and re-run: workspace_carry 19/19, `error::` 4/4,
`commit_deltas::tests::selected_checkout` 4/4. Nothing here touches `state.rs`.

## Limits

`kin commit` and `kin stash push` refusals do not carry the recovery clause yet; the helper is in
place and each needs one call. The original `kin checkout` orphan was seen once in a transcript and
neither the reporter nor I could reproduce it, so the checkout test is a regression lock on the class
rather than a reproduction. Nothing here was driven end to end against a real daemon: both classes
are decided in the planner.

Separately recorded for a ticket and not touched here: in the same session a merge left every file
body byte-exact and silently dropped about a third of the graph's edges, `kin daemon sweep` recovered
171 to 211 of 271 in seven seconds, nothing runs that sweep automatically, and `kin graph validate`
called the degraded graph clean.
