### PR TITLE
Converge a merged graph's enrichment and let graph validate see a census gap

### DIFF
--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -433,7 +433,9 @@ pub fn execute_graph_command_for_store(
             census,
             kin_root,
         ),
-        GraphCommandRequest::Validate => build_graph_validate_response(authority, graph, kin_root),
+        GraphCommandRequest::Validate => {
+            build_graph_validate_response_with_census(authority, graph, census, kin_root)
+        }
         GraphCommandRequest::Inspect { name } => build_graph_inspect_response(graph, name),
         GraphCommandRequest::Source { entity } => {
             build_graph_source_response(authority, graph, entity)
@@ -1254,9 +1256,34 @@ fn append_health_notes(lines: &mut Vec<String>, notes: &[String]) {
     }
 }
 
+/// The validate renderer as every test in this module asks for it: about a
+/// graph with no store beside it, and so with no census to compare against.
+///
+/// A wrapper rather than a defaulted argument, for the reason the status
+/// wrapper above is one: a test that has no `.kin` directory keeps the spelling
+/// it had, and the store-aware path is the one that has to say which store it
+/// means.
+#[cfg(test)]
 fn build_graph_validate_response(
     authority: &super::repository_authority::RequestRepositoryAuthority,
     graph: &kin_db::InMemoryGraph,
+    kin_root: Option<&std::path::Path>,
+) -> Result<GraphCommandResponse> {
+    build_graph_validate_response_with_census(
+        authority,
+        graph,
+        &kin_core::relation_census::CensusContext {
+            previous: kin_core::relation_census::RelationCensusRead::Absent,
+            causes: Vec::new(),
+        },
+        kin_root,
+    )
+}
+
+fn build_graph_validate_response_with_census(
+    authority: &super::repository_authority::RequestRepositoryAuthority,
+    graph: &kin_db::InMemoryGraph,
+    census: &kin_core::relation_census::CensusContext,
     kin_root: Option<&std::path::Path>,
 ) -> Result<GraphCommandResponse> {
     // Validate renders the same parse-coverage section status does, so it reads
@@ -1377,6 +1404,37 @@ fn build_graph_validate_response(
         ));
     }
 
+    // The census this store last recorded, compared against the one this graph
+    // takes now.
+    //
+    // `validate` used to build no comparison at all and hand back
+    // `relation_census: None`, so the command a reader runs to ask "is my graph
+    // sound" was the one surface that never looked at the record kept for
+    // exactly that question. On the rc070 stranger run it printed
+    // "All integrity checks passed" over three separate states another Kin
+    // command refused as inconsistent, and over a merge result `kin doctor`'s
+    // own census row was calling stale in the same session. Both commands read
+    // one store; only one of them was reading this record.
+    //
+    // Measured entity-rooted and de-duplicated by relation id, which is the
+    // measurement `record_relation_census` writes and the one `kin graph status`
+    // prints. The whole-table walk above it counts a different population, and
+    // comparing that against this baseline would report movement no pass
+    // produced.
+    let (current_census, census_entities) = measure_relation_census_with_entities(graph)?;
+    let census_comparison = kin_core::relation_census::RelationCensusComparison::build(
+        &census.previous,
+        &current_census,
+        census.causes.clone(),
+    )
+    .with_current_entities(census_entities);
+    // A lost kind is an issue in its own right, so it withholds the all-clear
+    // and sets the command's non-zero exit rather than printing beneath it. An
+    // integrity pass over a graph missing a third of its edges is still a
+    // passing integrity pass, and saying so and nothing else is what let a
+    // degraded graph read as healthy.
+    issues.extend(census_comparison.loss_lines());
+
     issues.extend(health.critical_issues.clone());
 
     let mut lines = Vec::new();
@@ -1410,12 +1468,20 @@ fn build_graph_validate_response(
     // cannot check whether the edges that should exist do. So it says which
     // question it answered and prints the answer to the other one beside it,
     // rather than leaving a reader to assume the two are the same check.
+    //
+    // The census row is the nearest this command gets to the second question
+    // and is not the same as answering it: it says whether the edges this store
+    // used to hold are still here, never whether the edges the code implies were
+    // ever derived. The sentence names that boundary so a green census is not
+    // read as the completeness claim the line above disclaims.
     lines.push(String::new());
     lines.push(
-        "Integrity only: these checks say the edges present are coherent, not that the edges a \
-         reader expects exist."
+        "Integrity only: these checks say the edges present are coherent, and the census below \
+         says whether the edges this store already held are still here; neither says the edges a \
+         reader expects were ever derived."
             .to_string(),
     );
+    lines.push(census_comparison.summary_line());
     lines.extend(health.reference_edge_coverage.summary_lines());
     let unsupportable = health
         .reference_edge_coverage
@@ -1435,7 +1501,7 @@ fn build_graph_validate_response(
         error: (!issues.is_empty()).then(|| format!("{} issue(s) found", issues.len())),
         source: None,
         reference_edge_coverage: Some(health.reference_edge_coverage.clone()),
-        relation_census: None,
+        relation_census: Some(census_comparison),
         graph_section: None,
     })
 }
@@ -4018,6 +4084,137 @@ mod tests {
             repository_coverage_line(0, 0),
             "Repository coverage: no files admitted yet, so there is no coverage fraction to \
              report"
+        );
+    }
+
+    /// `kin graph validate` is the command a reader runs to ask whether the
+    /// graph is sound, and it was the one surface that never read the record
+    /// kept for exactly that question.
+    ///
+    /// On the rc070 stranger run it printed "All integrity checks passed" over
+    /// three separate states another Kin command refused as inconsistent, and
+    /// over a merge result whose relation census `kin doctor` was calling stale
+    /// in the same session. One store, two commands, and only one of them
+    /// looking at the record.
+    ///
+    /// Both arms share one fixture and differ only in whether `UsesType` still
+    /// has an edge. The control is what makes the second arm mean anything: a
+    /// build that stopped printing the all-clear at all would otherwise read as
+    /// a pass.
+    #[test]
+    fn graph_validate_refuses_the_all_clear_over_a_census_that_lost_ground() {
+        let temp = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(temp.path()).unwrap();
+        let layout = initialized.layout.clone();
+        let binding =
+            kin_core::LocalRepositoryAuthorityBinding::from_layout(&initialized.layout).unwrap();
+
+        let enriched = kin_db::InMemoryGraph::new();
+        let caller = test_entity("run_task");
+        let callee = test_entity("finalize");
+        let typed = test_entity("Payload");
+        for entity in [&caller, &callee, &typed] {
+            enriched.upsert_entity(entity).unwrap();
+        }
+        enriched
+            .upsert_relation(&test_relation(RelationKind::Calls, caller.id, callee.id))
+            .unwrap();
+        enriched
+            .upsert_relation(&test_relation(RelationKind::UsesType, caller.id, typed.id))
+            .unwrap();
+
+        let recorded = kin_core::relation_census::RelationCensus::new(
+            chrono::Utc::now(),
+            kin_core::relation_census::CensusSource::Sweep,
+            measure_relation_census(&enriched).unwrap(),
+            Vec::new(),
+        );
+        assert_eq!(
+            recorded.kinds.get("UsesType"),
+            Some(&1),
+            "the recorded census holds the kind that is about to be lost: {:?}",
+            recorded.kinds
+        );
+        kin_core::relation_census::write(&layout, &recorded).unwrap();
+
+        // The control. Integrity is sound and the census has lost nothing, so
+        // the all-clear is reachable and validate still says so.
+        let unchanged = build_graph_validate_response_with_census(
+            &pinned(&binding),
+            &enriched,
+            &kin_core::relation_census::CensusContext::for_layout(
+                &layout,
+                Vec::<(String, String)>::new(),
+            ),
+            None,
+        )
+        .unwrap();
+        assert!(unchanged.error.is_none(), "{:?}", unchanged.lines);
+        assert!(
+            unchanged
+                .lines
+                .iter()
+                .any(|line| line == "✓ All integrity checks passed."),
+            "{:?}",
+            unchanged.lines
+        );
+        assert!(
+            unchanged
+                .relation_census
+                .as_ref()
+                .is_some_and(|census| !census.reports_loss()),
+            "the control has to reach the census and find nothing, or the second arm proves \
+             only that some issue exists: {:?}",
+            unchanged.lines
+        );
+
+        // The kind is gone. Every integrity check above still passes: the one
+        // remaining edge points at entities that exist, no entity is duplicated
+        // and none is orphaned. That is exactly the state that used to answer
+        // "All integrity checks passed."
+        let stripped = kin_db::InMemoryGraph::new();
+        for entity in [&caller, &callee, &typed] {
+            stripped.upsert_entity(entity).unwrap();
+        }
+        stripped
+            .upsert_relation(&test_relation(RelationKind::Calls, caller.id, callee.id))
+            .unwrap();
+
+        let lost = build_graph_validate_response_with_census(
+            &pinned(&binding),
+            &stripped,
+            &kin_core::relation_census::CensusContext::for_layout(
+                &layout,
+                Vec::<(String, String)>::new(),
+            ),
+            None,
+        )
+        .unwrap();
+        let rendered = lost.lines.join("\n");
+        assert!(
+            lost.error.is_some(),
+            "a lost relation kind sets the command's non-zero exit: {rendered}"
+        );
+        assert!(
+            !lost
+                .lines
+                .iter()
+                .any(|line| line == "✓ All integrity checks passed."),
+            "the all-clear is withheld over a graph that lost a whole relation kind: {rendered}"
+        );
+        assert!(
+            lost.lines
+                .iter()
+                .any(|line| line.starts_with("✗ relation kind UsesType lost every edge it held")),
+            "the issue names the kind, because the reader's next action depends on which one \
+             went: {rendered}"
+        );
+        assert!(
+            lost.relation_census
+                .as_ref()
+                .is_some_and(|census| census.reports_loss()),
+            "validate publishes the comparison it judged on rather than only its verdict: \
+             {rendered}"
         );
     }
 

--- a/crates/kin-cli/tests/repository_merge_resolution.rs
+++ b/crates/kin-cli/tests/repository_merge_resolution.rs
@@ -404,6 +404,25 @@ fn path_colliding_repository(root: &Path) -> std::path::PathBuf {
     repo
 }
 
+/// Two branches touching disjoint files, so the merge composes cleanly and
+/// publishes rather than parking.
+fn disjoint_repository(root: &Path) -> std::path::PathBuf {
+    let repo = root.join("repo");
+    initialize_git_repo(&repo);
+
+    run_git(&repo, &["switch", "-c", "feature"]);
+    fs::write(repo.join("src/feature.rs"), b"pub fn feature() {}\n")
+        .expect("add a feature source file");
+    run_git(&repo, &["add", "--all"]);
+    run_git(&repo, &["commit", "-m", "feature work"]);
+
+    run_git(&repo, &["switch", "main"]);
+    fs::write(repo.join("src/trunk.rs"), b"pub fn trunk() {}\n").expect("add a trunk source file");
+    run_git(&repo, &["add", "--all"]);
+    run_git(&repo, &["commit", "-m", "main work"]);
+    repo
+}
+
 /// Every artifact identity claiming one path in the graph a change resolves to.
 fn artifacts_at_path(
     layout: &kin_core::KinLayout,
@@ -899,6 +918,42 @@ fn a_second_merge_while_one_is_in_progress_is_refused() {
     );
     let record = persisted_record(&layout).expect("the merge is still parked");
     assert!(record.state.is_in_progress());
+}
+
+/// A merge composes the union of two committed graphs, which is the edges the
+/// two branches already carried and not the graph the merged tree implies. A
+/// daemon that can enrich now converges that itself and says nothing, because
+/// having to know `kin daemon sweep` was the defect. A daemon that cannot
+/// enrich has nothing that will repair the gap later, so it has to say so, and
+/// this is the arm that runs with no language server on the host.
+#[test]
+fn a_merge_that_cannot_enrich_says_the_merged_graph_was_not_converged() {
+    let root = tempdir().expect("temp root");
+    let repo = disjoint_repository(root.path());
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    // The daemon serving every call below is the one this init starts, and it
+    // captures the enrichment lever at process start, so the lever goes here.
+    ok(
+        &run_kin_without_enrichment(&runtime, &repo, &["init", ".", "--json"]),
+        "kin init",
+    );
+
+    let merged = ok(
+        &run_kin_without_enrichment(&runtime, &repo, &["merge", "feature"]),
+        "kin merge",
+    );
+    assert!(
+        merged.contains("Merged refs/heads/feature into refs/heads/main"),
+        "the fixture has to publish rather than park, or the line below proves nothing: {merged}"
+    );
+    assert!(
+        merged.contains("Cross-file enrichment did not run for this merge"),
+        "a merge that could not converge its own graph has to say so: {merged}"
+    );
+    assert!(
+        merged.contains("kin daemon sweep"),
+        "and it names the recovery, which nothing in the product used to: {merged}"
+    );
 }
 
 /// A commit cannot publish around a parked merge. Forced admission advances

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -17610,13 +17610,25 @@ async fn lsp_sweep(
 /// rather than guessing, because an unfinished check is not evidence of a
 /// missing server.
 fn enrichment_unavailable(state: &DaemonState) -> Option<serde_json::Value> {
+    enrichment_unavailable_reason_for(state)
+        .map(|(reason, detail)| json!({ "reason": reason, "detail": detail }))
+}
+
+/// The same answer as the reason and detail this daemon holds, for callers that
+/// render it as prose rather than as a JSON field.
+///
+/// The state wiring lives here, once, so a second caller cannot come to read a
+/// different pair of fields than `/lsp/sweep` reads and report a different cause
+/// for the same daemon.
+pub(crate) fn enrichment_unavailable_reason_for(
+    state: &DaemonState,
+) -> Option<(&'static str, String)> {
     let readiness = kin_mcp::edge_coverage::published_language_server_readiness();
     enrichment_unavailable_reason(
         state.lsp_enrichment_tx.is_some(),
         state.lsp_enrichment_enabled,
         readiness.as_ref(),
     )
-    .map(|(reason, detail)| json!({ "reason": reason, "detail": detail }))
 }
 
 /// The decision behind [`enrichment_unavailable`], as a pure rule.

--- a/crates/kin-daemon/src/repository_merge.rs
+++ b/crates/kin-daemon/src/repository_merge.rs
@@ -37,6 +37,102 @@ use crate::local_repository_authority::{
 use crate::source_cas::read_publishable_source;
 use crate::state::{DaemonEvent, DaemonState};
 
+/// What a published merge should do about the cross-file enrichment its result
+/// needs.
+///
+/// A merge composes the three-way union of two committed graphs, and that union
+/// is exactly the edges the two branches already carried. It is not the graph
+/// the merged tree implies. An edge whose two ends arrive from different sides
+/// exists only once the merge exists, so no branch could ever have held it, and
+/// a branch committed before its own enrichment settled contributes less than
+/// its tree implies on top of that. Measured on the v0.7.0 bytes over a
+/// disjoint-file merge: the composer published the exact union every time, and
+/// a `kin daemon sweep` run straight after, over source nobody had touched,
+/// still added edges. Nothing queued that sweep. One is queued when the daemon
+/// starts and by `POST /lsp/sweep`, and a merge is neither, so the command that
+/// converges a merged graph was one a reader had no reason to know existed.
+///
+/// So the merge queues it, and the ordinary case is silent: converging without
+/// anybody typing the command is the whole point. The case that speaks is the
+/// one where the daemon cannot enrich at all, because there the merged graph
+/// holds only what the branches carried and no later pass repairs it on its
+/// own.
+#[derive(Debug, PartialEq, Eq)]
+enum MergeEnrichment {
+    /// Converge the merged tree in the background.
+    Sweep,
+    /// Nothing to converge from, and nothing to announce.
+    Silent,
+    /// Say the merged graph was not converged, and why.
+    Announce(String),
+}
+
+/// Decide from the two facts the daemon holds about its own enrichment.
+///
+/// Pure so every row is exercised without standing up a daemon, which is what
+/// the row that never speaks needs most: a rule that reported "enrichment did
+/// not run" on a graph-only store would be advice about a knob that store does
+/// not have.
+fn merge_enrichment(
+    reconcile_disabled: bool,
+    unavailable: Option<(&'static str, String)>,
+) -> MergeEnrichment {
+    if reconcile_disabled {
+        // Filesystem-derived relations cannot mutate graph-only authority, so
+        // there is no sweep to run and no gap a sweep would close.
+        return MergeEnrichment::Silent;
+    }
+    match unavailable {
+        Some((_, detail)) => MergeEnrichment::Announce(format!(
+            "Cross-file enrichment did not run for this merge ({detail}), so the merged graph \
+             holds only the edges the two branches already carried; run `kin daemon sweep` once \
+             a language server is available"
+        )),
+        None => MergeEnrichment::Sweep,
+    }
+}
+
+/// Settle the graph a merge just published: record what its relation set now
+/// holds, and converge the enrichment the merged tree implies.
+///
+/// Called from both publication paths, because a merge settled through
+/// `kin resolve --continue` publishes the same kind of graph as one that
+/// composed cleanly and was missing the same edges.
+///
+/// The census is recorded for the reason the commit path records one: the
+/// relation set just moved and this process knows it finished, which is what
+/// makes the record a baseline rather than a mid-flight sample.
+/// [`kin_core::relation_census::record`] refuses to advance a losing census, so
+/// a merge that lost ground leaves the older baseline standing rather than
+/// burying the loss under its own reading.
+///
+/// Recorded as [`CensusSource::Commit`](kin_core::relation_census::CensusSource)
+/// because that is what the source names: a change installed in the live graph,
+/// which is exactly what a published merge is. The alternative was a third
+/// variant, and a store stamped with one reads as unreadable to any build that
+/// predates it, which trades a labelling nicety for a window where no lost kind
+/// can be detected at all.
+fn settle_merged_graph(state: &DaemonState) -> Option<String> {
+    crate::background_work::record_relation_census(
+        &state.layout,
+        &state.graph,
+        kin_core::relation_census::CensusSource::Commit,
+    );
+    match merge_enrichment(
+        state.filesystem_reconcile_disabled(),
+        crate::api::enrichment_unavailable_reason_for(state),
+    ) {
+        MergeEnrichment::Sweep => {
+            // `false` here means a sweep is already running, which covers this
+            // merge as well as one queued now would.
+            state.queue_lsp_sweep();
+            None
+        }
+        MergeEnrichment::Silent => None,
+        MergeEnrichment::Announce(line) => Some(line),
+    }
+}
+
 const MERGE_REASON: &str = "publish exact repository-v6 semantic merge";
 const FAST_FORWARD_REASON: &str = "advance exact repository-v6 branch to a descendant";
 const OPEN_MERGE_REASON: &str = "open a durable repository-v6 merge transaction";
@@ -1341,6 +1437,8 @@ pub(crate) fn publish_resolved_merge(
         })?;
     }
 
+    let settled = settle_merged_graph(state);
+
     let resolved_count = terminated.entries.len();
     let report = kin_cli::commands::resolve::ResolveReport {
         schema: kin_cli::commands::resolve::RESOLVE_REPORT_SCHEMA.to_string(),
@@ -1370,6 +1468,7 @@ pub(crate) fn publish_resolved_merge(
                     receipt.generation
                 )];
                 lines.extend(projections);
+                lines.extend(settled);
                 lines
             },
             mutated: matches!(receipt.outcome, RepositoryCommitOutcome::Committed),
@@ -2587,6 +2686,7 @@ fn publish(
             bail!("a parked merge must not reach the workspace publication path")
         }
     };
+    let settled = settle_merged_graph(state);
     let report = MergeReport {
         schema: MERGE_REPORT_SCHEMA.to_string(),
         authority: "repository-v6".to_string(),
@@ -2605,10 +2705,12 @@ fn publish(
         relation_delta_count: 0,
         tree_delta_count: 0,
     };
+    let mut lines = vec![line];
+    lines.extend(settled);
     Ok(MergeExecution {
         resolve_response: None,
         response: MergeResponse {
-            lines: vec![line],
+            lines,
             mutated: matches!(receipt.outcome, RepositoryCommitOutcome::Committed),
             report: Some(report),
             operation_id: Some(receipt.operation_id),
@@ -4246,6 +4348,106 @@ mod tests {
         SharedAdmissionPolicy::derive_from_tree(None, &ResolvedTree::default(), |_| Ok(0))
             .unwrap()
             .0
+    }
+
+    /// A daemon that can enrich, with a channel a test can read the sweep off.
+    fn enriching_state(
+        layout: kin_core::KinLayout,
+    ) -> (
+        DaemonState,
+        tokio::sync::mpsc::Receiver<crate::state::LspEnrichmentMessage>,
+    ) {
+        let (tx, rx) = tokio::sync::mpsc::channel(8);
+        let mut state = DaemonState::open(layout).expect("open a repository-v6 daemon state");
+        state.lsp_enrichment_tx = Some(tx);
+        (state, rx)
+    }
+
+    // ── What a published merge does about the enrichment its result needs ──
+    //
+    // The composer publishes the three-way union of two committed graphs, and
+    // measured on the v0.7.0 bytes that union is exact. It is also not the graph
+    // the merged tree implies, and a `kin daemon sweep` run straight after a
+    // merge over untouched source added edges every time. Nothing queued that
+    // sweep, so the rows below are the whole of what a merge decides.
+
+    #[test]
+    fn a_merge_that_can_enrich_converges_its_result_without_saying_anything() {
+        assert_eq!(
+            merge_enrichment(false, None),
+            MergeEnrichment::Sweep,
+            "a daemon that can enrich converges the merged tree itself; the command that \
+             recovers those edges is one nobody should have to know"
+        );
+    }
+
+    #[test]
+    fn a_merge_that_cannot_enrich_says_so_and_names_the_cause() {
+        let MergeEnrichment::Announce(line) = merge_enrichment(
+            false,
+            Some((
+                "no_language_server",
+                "this daemon found no language server for any language it enriches".to_string(),
+            )),
+        ) else {
+            panic!("a daemon that cannot enrich must not publish the gap quietly");
+        };
+        assert!(
+            line.contains("this daemon found no language server for any language it enriches"),
+            "the cause the daemon holds is the whole value of the line: {line}"
+        );
+        assert!(
+            line.contains("kin daemon sweep"),
+            "a refusal names its own recovery, and this one did not exist in the product: {line}"
+        );
+    }
+
+    #[test]
+    fn a_graph_only_store_is_told_nothing_about_a_sweep_it_cannot_run() {
+        assert_eq!(
+            merge_enrichment(
+                true,
+                Some((
+                    "no_language_server",
+                    "this daemon found no language server".to_string(),
+                )),
+            ),
+            MergeEnrichment::Silent,
+            "filesystem-derived relations cannot mutate graph-only authority, so there is no \
+             gap here and advice about a knob this store does not have is noise"
+        );
+    }
+
+    /// The decision above is only worth anything if the publication path takes
+    /// it. This is the assertion the defect needed: after a merge settles its
+    /// graph, a sweep is on the enrichment channel with nobody having typed one.
+    #[test]
+    fn settling_a_merged_graph_queues_the_sweep_and_records_the_census() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let census_path = init.layout.kindb_relation_census_path();
+        assert!(
+            !census_path.exists(),
+            "the fixture has to start with no census, or the assertion below proves nothing"
+        );
+        let (state, mut rx) = enriching_state(init.layout.clone());
+
+        assert_eq!(
+            settle_merged_graph(&state),
+            None,
+            "a daemon that can enrich converges silently"
+        );
+
+        assert!(
+            matches!(rx.try_recv(), Ok(crate::state::LspEnrichmentMessage::Sweep)),
+            "a published merge has to ask for the sweep its result needs; before this it asked \
+             for nothing and the edges waited for a command nobody knew"
+        );
+        assert!(
+            census_path.exists(),
+            "a merge moves the relation set and knows it finished, so it records the baseline \
+             the next comparison is judged against, exactly as a commit does"
+        );
     }
 
     fn authority(init: &kin_core::InitResult) -> RepositoryAuthorityManager<LocalFileBackend> {


### PR DESCRIPTION
FIR-3242.

A stranger driving a full version-control session on the released v0.7.0 bytes reported that a
merge left every file byte-exact and silently degraded the semantic graph, that `kin daemon sweep`
recovered most of it in seven seconds, that nothing runs that sweep, and that `kin graph validate`
reported "All integrity checks passed" over the degraded graph. This closes the two halves that
reproduce, and records the third as refuted by measurement.

## What was measured first, on the released binary

`kin-macos-aarch64.tar.gz`, sha256 `54b1787bd6188172e641a7f4f3b2671e5738d44de5e503047956bbb8add4cd37`,
reporting `kin 0.7.0 (b4898be1141bf4e8a013e4912e358195d03a41f1)`. Scratch `KIN_HOME`,
`KIN_EMBED_BACKEND=cpu`, the binary by absolute path, a five-file Python ledger fixture with real
cross-file imports and calls. Counts are `kin graph status` rows, entity-to-entity and
all-excluding-CoChanges.

| round | shape | main | branch | base | merge published | after ONE sweep, no source change |
|---|---|---|---|---|---|---|
| 1 | disjoint files, unenriched | 33/41 | 39/49 | 26/32 | 46/58 | n/a |
| 2 | one branch committed under-enriched | 75/87 | | 72/84 | 82/**96** | 87/**101** |
| 3 | both sides fully swept | 96/112 | 100/116 | 87/101 | 109/127 | 109/127 |
| 4 | an edge neither branch could hold | 122/140 | 114/133 | 109/127 | 127/**146** | 129/**148** |

Rounds 1, 3 and 4 show the composer publishing the exact three-way union to the edge
(46 = 33 + 39 - 26; 109 = 96 + 100 - 87; 127 = 122 + 114 - 109). Rounds 2 and 4 show a sweep run
immediately after the merge, over source nobody had touched, still adding edges. Over both of those
under-derived states:

```
$ kin graph validate
Checked 39 entities, 148 relations

✓ All integrity checks passed.
$ kin doctor
  ✓ Relation census   ok   no relation kind has lost ground since the last recorded census
```

## Refuted: "a merge drops relations derived on one side"

Round 5 drove the exact hypothesis, a relation whose endpoint moved on the other side while this
side still relates to it. The merge does not drop it, it refuses:

```
$ kin merge movers
Merging refs/heads/movers into refs/heads/main left 2 unresolved conflict(s); the merge is held as
merge transaction d22bb50e78c2a637bd578008944cd7467dba72f4740853671e0a9d7392abee40
  - relation 9710c130-759d-9222-a76a-0eb061c5506a: one branch removed total in ledger/reporting.py,
    which the other branch still relates to
exit 8
```

That is `collect_dangling_endpoints`, and it is already the "publishes every relation of its result
or fails loud" behaviour. Nothing was changed there. A separate read-only reconstruction of the
stranger's own daemon log reached the same conclusion independently: the 271 baseline belongs to a
commit on a throwaway branch two operations before the merge, and across the last main commit and
the merge the named relation kinds actually rise.

## Fixed 1: a merge converges the graph it just published

`publish()` installed the merge change into the live query graph and returned. It never asked for
cross-file enrichment and never recorded a relation census. A sweep is queued in exactly two places,
at daemon startup and by `POST /lsp/sweep`, and a merge is neither, so the command that converges a
merged graph was one a reader had no reason to know existed.

Both publication paths now call one `settle_merged_graph`, the clean composition and the one settled
through `kin resolve --continue`, because a resolved merge is missing the same edges. It records the
census the way the commit path does, and queues the sweep. `record` refuses to advance a losing
census, so a merge that lost ground leaves the older baseline standing.

The ordinary case is silent, because converging without anybody typing the command is the point. A
daemon that cannot enrich says so and names its recovery. A graph-only store says nothing, because
filesystem-derived relations cannot mutate graph-only authority.

## Fixed 2: `kin graph validate` consults the census

It built no comparison and handed back `relation_census: None`, so the command a reader runs to ask
whether the graph is sound was the one surface that never read the record kept for that question,
while `kin doctor` read it from the same store in the same session. It now takes the census context
the daemon already passes in, measures through the same entity-rooted walk the recorder writes and
`kin graph status` prints, and puts every loss line into its issues. A lost kind withholds the
all-clear and sets the non-zero exit rather than printing beneath a pass.

## Tests, and the falsification of each

Every guard is a crate test, because kin's `Product Acceptance` job carries
`if: ${{ github.event_name != 'pull_request' }}` and so does not grade this PR.

- `kin-daemon` `settling_a_merged_graph_queues_the_sweep_and_records_the_census`: builds a daemon
  state over a real store with a readable enrichment channel, calls `settle_merged_graph`, asserts a
  `Sweep` is on the channel and the census record exists on disk.
- `kin-daemon` three decision rows: converges silently, says so when it cannot, silent on a
  graph-only store.
- `kin-cli` `graph_validate_refuses_the_all_clear_over_a_census_that_lost_ground`: records a census,
  then validates a graph that lost the `UsesType` edge. Every integrity check still passes on that
  graph, which is exactly the state that used to answer "All integrity checks passed". The control
  arm validates the unchanged graph and asserts the all-clear is still reachable.
- `kin-cli` integration `a_merge_that_cannot_enrich_says_the_merged_graph_was_not_converged`: real
  binaries, real daemon, `KIN_DAEMON_DISABLE_LSP=1`, a clean disjoint-file merge. Needs no language
  server on the host, which is what makes it deterministic in CI.

Falsification, one arm per behaviour, each red on the assertion it was written for:

```
# the merge stops asking for the sweep
panicked at crates/kin-daemon/src/repository_merge.rs:4434:
a published merge has to ask for the sweep its result needs; before this it asked for nothing and
the edges waited for a command nobody knew

# the merge stops recording the census, and an unavailable daemon stops speaking
test repository_merge::tests::a_merge_that_cannot_enrich_says_so_and_names_the_cause ... FAILED
test repository_merge::tests::settling_a_merged_graph_queues_the_sweep_and_records_the_census ... FAILED
test result: FAILED. 22 passed; 2 failed

# validate stops putting the census loss into its issues
test commands::graph::tests::graph_validate_refuses_the_all_clear_over_a_census_that_lost_ground ... FAILED
test result: FAILED. 0 passed; 1 failed
```

Green on the real build:

```
test result: ok. 24 passed; 0 failed  (kin-daemon repository_merge::tests)
test result: ok. 9 passed; 0 failed   (kin-cli commands::graph::tests::graph_validate*)
test result: ok. 1 passed; 0 failed   (kin-cli repository_merge_resolution, the no-enrichment merge)
```

### The integration arm was re-run against fresh bytes, because the first one was not

The first attempt at the integration arm passed, and that pass was worthless.
`cargo test -p kin-cli --test repository_merge_resolution` does not rebuild `kin-daemon`, and the
harness's `fresh_daemon_bin` reuses any daemon binary whose build stamp is compatible with the test
binary, so the broken source never reached the daemon under test. It finished in 4.40 s against the
108 s the honest run took, and it read as a weak test rather than an unbuilt one.

The real arm builds the daemon first:

```
$ cargo build -p kin-daemon --bin kin-daemon      # with Announce dropped to None
$ cargo test -p kin-cli --test repository_merge_resolution a_merge_that_cannot_enrich
test a_merge_that_cannot_enrich_says_the_merged_graph_was_not_converged ... FAILED
panicked at crates/kin-cli/tests/repository_merge_resolution.rs:949:
test result: FAILED. 0 passed; 1 failed

$ cargo build -p kin-daemon --bin kin-daemon      # restored
$ cargo test -p kin-cli --test repository_merge_resolution a_merge_that_cannot_enrich
test a_merge_that_cannot_enrich_says_the_merged_graph_was_not_converged ... ok
test result: ok. 1 passed; 0 failed
```

Recorded so the next reader of this suite does not spend the cycle: a kin-daemon source change is
graded by these tests only if `kin-daemon` is built before they run.

## One thing this does not fix

`kin doctor`'s relation census cannot catch this class either, and no change here makes it. The
census is a lost-ground detector, and a merge that under-derives while still adding edges on net
never loses ground on any kind, which is why every round above reports the census green over an
under-derived graph. The stranger's merge tripped it only because theirs netted a fall. That is why
`kin graph validate` had to be taught to read the census rather than the census being taught about
merges.

## Verification at the head sha

`bin/kin-precheck kin`, named by absolute path with `--repo-dir kin=<this worktree>`, through
`.kin-coord/bin/heavy-slot.sh mergeedges kin`, at head `e7024fc258e5558ed0d0731103e5aa52f4be1506`:

```
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
...
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:check_private_repo_coupling.sh bash scripts/check_private_repo_coupling.sh
PASS     guard:check_runtime_boundaries.sh    bash scripts/check_runtime_boundaries.sh
PASS     guard:test-release-policy-gate.sh    bash scripts/test-release-policy-gate.sh
PASS     guard:test-windows-authority-legs.sh bash scripts/test-windows-authority-legs.sh
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:check-kin-vfs-compat.mjs       node scripts/check-kin-vfs-compat.mjs
PASS     guard:check-rc-build-drift.mjs       node scripts/check-rc-build-drift.mjs
PASS     guard:check-required-contexts.py     python3 scripts/check-required-contexts.py
PASS     guard:test-assertion-reachability.py python3 scripts/test-assertion-reachability.py
PASS     guard:test-guard-duplicate-release-run.py python3 scripts/test-guard-duplicate-release-run.py
PASS     guard:test-homebrew-release-gate.py  python3 scripts/test-homebrew-release-gate.py
PASS     guard:test-install-checksum.py       python3 scripts/test-install-checksum.py
PASS     guard:test-private-repo-coupling.py  python3 scripts/test-private-repo-coupling.py
PASS     guard:test-release-tag-evaluate-dispatch.py python3 scripts/test-release-tag-evaluate-dispatch.py
PASS     guard:test-release-workflow-authority.py python3 scripts/test-release-workflow-authority.py
PASS     guard:test-select-release-candidate.py python3 scripts/test-select-release-candidate.py
PASS     guard:verify-hydration-semantics.py  python3 scripts/verify-hydration-semantics.py
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
PASS     node-test                            node --test <15 file(s) named by the check job>
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin e7024fc258e5558ed0d0731103e5aa52f4be1506
```

The three steps the check job runs that precheck deliberately does not are the language-server
provisioning step, which gates nothing; `release-policy-gate.sh`, which routes on pull-request
context a local run cannot supply truthfully; and `falsify-hydration-semantics.py`, which the check
job runs against a poisoned copy the workflow builds first.

### End to end, on release binaries built from this tree

`cargo build --release -p kin-cli -p kin-daemon` at head `e7024fc25`, then the round-2 shape driven
against those binaries: a branch committed before its own enrichment settled, merged into a fully
settled `main`. Scratch `KIN_HOME`, `KIN_EMBED_BACKEND=cpu`, `KIN_DAEMON_BIN` pointed at the same
build, binaries by absolute path.

```
--- census: main head, settled, pre-merge ---
Entities: 12 | Entity-to-entity relations: 32
All graph relations excluding CoChanges: 36

$ kin merge audit-trail
Merged refs/heads/audit-trail into refs/heads/main as change 0b6ffbf95617... (5 projected entries)
exit 0
--- waiting for the merge's own sweep to land ---
  t+1s All graph relations excluding CoChanges: 49
  t+4s All graph relations excluding CoChanges: 49
--- census: AFTER the merge, nobody typed sweep ---
Entities: 15 | Entity-to-entity relations: 43
All graph relations excluding CoChanges: 49

$ kin graph validate
Checked 15 entities, 49 relations

✓ All integrity checks passed.
Relation census: no relation kind has lost ground since 2026-09-05T09:52:33.461887+00:00
(enrichment sweep), which is what this row compares the histogram above against

--- the control: an explicit sweep must now add nothing ---
$ kin daemon sweep
  enriched 5/5 files
  cross-file enrichment complete (5/5 files)
exit 0
--- census: after an explicit kin daemon sweep ---
Entities: 15 | Entity-to-entity relations: 43
All graph relations excluding CoChanges: 49
```

The control is the whole assertion. On the released bytes, an explicit `kin daemon sweep` run
straight after this shape's merge ADDED edges, 96 to 101 in round 2 and 146 to 148 in round 4. On
this build it enriches all five files and adds none, because the merge already queued the sweep and
it had landed by the first reading. Fixture sizes differ between the two runs, so the totals are not
comparable across them; what is comparable, and is the claim, is whether a sweep after the merge
still has work to do.

The `Relation census:` row in the validate output above is the second fix on the wire. That row did
not exist on `kin graph validate` before this change, and it exits 0 here because nothing was lost,
which is the same rule that withholds the all-clear when something was.

Full report, with every command and every count:
`.kin-coord/reports/showhn-mergeedges-20260905.md`.
