### PR TITLE
Use shared history snapshots for repository operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3295,9 +3295,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.102"
+version = "0.7.103"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "a112df686bd7ba5433912c5dc9032a09dd915b387bde295196f1e17a73fc31b4"
+checksum = "82eff0bcc9a6b69bb06bde1e771695abe9d3b93ea53a67a1f32e0176a7aa0e09"
 dependencies = [
  "bincode",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ kin-lsp = { version = "=0.7.16", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.102", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.103", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.24", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-daemon/src/storage_delegate.rs
+++ b/crates/kin-daemon/src/storage_delegate.rs
@@ -62,7 +62,7 @@ use kin_db::{
 /// `storage_backend_surface_is_audited_against_the_pinned_kin_db` fails when
 /// the workspace pin moves past it, which is the only moment a method can have
 /// appeared.
-pub const AUDITED_KIN_DB_VERSION: &str = "0.7.102";
+pub const AUDITED_KIN_DB_VERSION: &str = "0.7.103";
 
 /// Wraps a [`StorageBackendDelegate`] so it can be handed anywhere a
 /// `Box<dyn StorageBackend>` is expected.


### PR DESCRIPTION
Repository operations can retain repeated copies of immutable change history. Pin kin-db 0.7.103 so snapshots share that history and full validation borrows change payloads while preserving replay and admission checks. The implementation landed in firelock-ai/kin-db#300.

The manifest and lock use the published registry package and checksum. Update the storage delegation audit version after checking that the published StorageBackend trait is unchanged and all 32 delegated methods still match. Both audit assertions remain intact. This PR changes no Kin runtime algorithm.

Validation:

- All 48 hosted check runs at `6243f5d9` have concluded with success or intentionally skipped contexts. Product Acceptance remains a main-push gate.
- A clean, isolated checkout of `a6df0dc6` with a fresh Cargo home passed locked registry resolution and a cold release build of kin and kin-daemon. All external dependencies resolved from registries; the downloaded kin-db source and checksum matched the published package. This measurement build predates the audit-version-only correction.
- Local precheck on that same checkout reported `21 gates ran, 21 passed, 0 failed`. The checkout and committed lock stayed clean.
- At corrected head `6243f5d9`, the targeted command `cargo test --locked -p kin-daemon --lib storage_delegate::tests:: -- --nocapture` reported `2 passed; 0 failed; 0 ignored; 0 measured; 1428 filtered out`, exit 0. The earlier hosted failure of the preserved version assertion is its negative control.

Real-process memory acceptance remains open. On the preserved tracked-history fixture, the published v0.7.0 baseline peaked at 16.406 GiB for the fresh commit/post phase and 16.411 GiB warm. The candidate's first fresh run peaked at 15.051 GiB; its warm attempt was refused before measurement because the recorded daemon had exited. A second pair, with immediate automatic warm transition, passed both status and commit commands and peaked at 13.229 GiB fresh and 13.088 GiB warm. All figures are raw daemon RSS KiB divided by 1048576. The variation between fresh runs and growth during idle/no-op phases preclude a general savings claim. The no-watch/untracked control and a documented bound remain open. These measurements use sealed candidate bytes, not released bytes, and the issue is not closed.

Refs FIR-3203. Landing remains held for release composition until the v0.7.1 candidate is fixed; this change is assigned to the subsequent release.
