### PR TITLE
Give each hosted repository its own text-index directory (FIR-3253)

### DIFF
--- a/crates/kin-core/src/layout.rs
+++ b/crates/kin-core/src/layout.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
+use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
 
 use crate::error::KinError;
 
@@ -217,6 +220,33 @@ impl KinLayout {
     /// `.kin/kindb/text-index/` — Persistent tantivy text index directory.
     pub fn text_index_dir(&self) -> PathBuf {
         self.kindb_dir().join("text-index")
+    }
+
+    /// `.kin/kindb/text-index/hosted/<digest>/` — the persistent text index for
+    /// one hosted repository's served graph.
+    ///
+    /// A hosted daemon serves many repositories out of one layout, and a
+    /// persistent text index is a directory of segment files under one manifest
+    /// that names them. Two graphs pointed at one directory are two writers of
+    /// one image: each reclaims the segment files the other's manifest names,
+    /// and the load-time reconciliation then refuses an image whose segments
+    /// and manifest disagree. So the directory is per repository, and the
+    /// repository is what names it.
+    ///
+    /// The name is a digest and not the repository id, because a repository id
+    /// is not a path component. [`kin_model::RepositoryId`] refuses only the
+    /// empty string, ids over 255 bytes and control characters, so `../peer`,
+    /// `/etc/kin` and `a/b` are all valid ids and all escape or collide as
+    /// path components. A digest has none of those shapes: it is a fixed-length
+    /// string over `0-9a-f`, one per distinct id byte string, so `Kin` and
+    /// `kin` land apart and `a/b` and `a_b` land apart.
+    ///
+    /// 128 bits of SHA-256, which is a collision bound far beyond a fleet of
+    /// repository ids and short enough to read in a directory listing.
+    pub fn hosted_text_index_dir(&self, repo_id: &str) -> PathBuf {
+        self.text_index_dir()
+            .join("hosted")
+            .join(hosted_text_index_component(repo_id))
     }
 
     /// `.kin/stashes/` — Named overlay snapshots.
@@ -498,9 +528,99 @@ fn is_managed_kin_home(candidate: &Path) -> bool {
     false
 }
 
+/// The path component naming one hosted repository's text index.
+///
+/// Free-standing so a caller can name the component without a layout, and so
+/// the mapping has one definition: every hosted site derives its directory from
+/// this, and a second derivation elsewhere would be a second answer.
+fn hosted_text_index_component(repo_id: &str) -> String {
+    let digest = Sha256::digest(repo_id.as_bytes());
+    let mut component = String::with_capacity(32);
+    for byte in &digest[..16] {
+        // `write!` into a `String` cannot fail; the result is consumed so the
+        // formatting contract stays visible rather than being swallowed.
+        let _ = write!(component, "{byte:02x}");
+    }
+    component
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A repository id is not a path component, and this is where that is
+    /// enforced.
+    ///
+    /// `kin_model::RepositoryId::new` refuses only the empty string, ids over
+    /// 255 bytes and control characters, so every id below is a legal
+    /// repository id. Joined raw, the first three escape the directory the
+    /// hosted daemon owns and the last two collide with a sibling. Every one of
+    /// them has to land inside the hosted root, under a name made only of hex
+    /// digits.
+    #[test]
+    fn hosted_text_index_component_admits_no_path_shape() {
+        let layout = KinLayout::new(PathBuf::from("/repo/.kin"));
+        let hosted_root = layout.text_index_dir().join("hosted");
+        for repo_id in [
+            "../peer", "..", "/etc/kin", "a/b", "a_b", "kin", "Kin", "kin.", " kin",
+        ] {
+            let dir = layout.hosted_text_index_dir(repo_id);
+            let component = dir
+                .strip_prefix(&hosted_root)
+                .unwrap_or_else(|_| panic!("{repo_id:?} escaped the hosted text-index root"));
+            assert_eq!(
+                component.components().count(),
+                1,
+                "{repo_id:?} produced more than one path component"
+            );
+            let name = component.to_string_lossy();
+            assert_eq!(name.len(), 32, "{repo_id:?} produced {name:?}");
+            assert!(
+                name.chars()
+                    .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+                "{repo_id:?} produced {name:?}"
+            );
+        }
+    }
+
+    /// Ids that a filesystem or a careless sanitizer would fold together stay
+    /// apart.
+    ///
+    /// Case and delimiter folding are the two ways a per-repository directory
+    /// quietly becomes a shared one: `Kin` and `kin` are distinct repositories
+    /// on a case-sensitive store, and `a/b` and `a_b` are distinct
+    /// repositories that a slash-to-underscore rewrite would merge. A digest
+    /// over the exact id bytes folds neither.
+    #[test]
+    fn hosted_text_index_directories_separate_ids_a_sanitizer_would_fold() {
+        let layout = KinLayout::new(PathBuf::from("/repo/.kin"));
+        let ids = ["kin", "Kin", "KIN", "a/b", "a_b", "a-b", "../kin", "kin/"];
+        let directories: std::collections::HashSet<PathBuf> = ids
+            .iter()
+            .map(|repo_id| layout.hosted_text_index_dir(repo_id))
+            .collect();
+        assert_eq!(
+            directories.len(),
+            ids.len(),
+            "distinct repository ids must get distinct directories"
+        );
+    }
+
+    /// The same id names the same directory every time, in this process and in
+    /// the next one.
+    ///
+    /// A hosted pod reopens its store across restarts and a rebuilt index is
+    /// only reusable if the name is stable, so the mapping is pinned to a
+    /// literal rather than recomputed by the test. A change to the digest, its
+    /// truncation or the namespace fails here.
+    #[test]
+    fn hosted_text_index_directory_is_stable_for_an_id() {
+        let layout = KinLayout::new(PathBuf::from("/repo/.kin"));
+        assert_eq!(
+            layout.hosted_text_index_dir("kin"),
+            PathBuf::from("/repo/.kin/kindb/text-index/hosted/c1d6b0ba57d78fec8689f0877d805355")
+        );
+    }
 
     #[test]
     fn layout_paths() {

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -5415,7 +5415,13 @@ impl DaemonState {
         allowed_repo_ids: Option<HashSet<String>>,
         publication_control: Option<Arc<crate::publication_lease::PublicationControl>>,
     ) -> Result<Self> {
-        let text_index_path = layout.text_index_dir();
+        // Per repository, never the layout's one text-index directory. A hosted
+        // daemon serves many repositories through one layout, so a shared
+        // directory makes every repository's graph a writer of one segment
+        // image: each rebuild reclaims the files another repository's manifest
+        // names, and the load-time reconciliation refuses the result. See
+        // `KinLayout::hosted_text_index_dir` for why the component is a digest.
+        let text_index_path = layout.hosted_text_index_dir(repo_id);
         let (
             graph,
             generation,
@@ -8336,7 +8342,11 @@ impl DaemonState {
                     .as_ref()
                     .cloned()
                     .map(Arc::new);
-                let text_index_path = self.layout.text_index_dir();
+                // The same per-repository rule the hosted open takes. This is
+                // the site the five-repo spine root proof drives once per fleet
+                // repository, so a shared directory turns one proof into five
+                // writers of one image.
+                let text_index_path = self.layout.hosted_text_index_dir(repo_id);
                 let (query_snapshot, materialized_head) =
                     materialize_hosted_repository_snapshot(recovered.snapshot)?;
                 let graph = Arc::new(
@@ -11232,6 +11242,192 @@ mod tests {
         ));
         std::fs::remove_file(state.layout.kindb_vector_index_path()).unwrap();
         descriptor
+    }
+
+    /// How many times each repository is loaded in the isolation test.
+    ///
+    /// The failure it guards is two loads writing one on-disk image, so the
+    /// loads have to overlap. One round per repository would usually finish
+    /// before the next repository's thread started; several rounds keep every
+    /// repository writing for as long as the others are.
+    const HOSTED_LOAD_ISOLATION_ROUNDS: usize = 6;
+
+    /// A hosted daemon over one layout serving a five-repository fleet.
+    ///
+    /// Five because that is the fleet the hosted spine root proof loads, and
+    /// because the failure needs a repository to load against a directory some
+    /// OTHER repository is writing. Entity counts differ per repository on
+    /// purpose: a persistent text index reconciles its segment sums against its
+    /// manifest, so two repositories of equal size could disagree about which
+    /// documents are present while still agreeing about how many.
+    ///
+    /// Returns the temporary directories as well, because dropping either one
+    /// deletes the store under the daemon still holding it.
+    fn hosted_fleet_fixture() -> (
+        tempfile::TempDir,
+        tempfile::TempDir,
+        DaemonState,
+        Vec<(String, String)>,
+    ) {
+        let working = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(working.path()).unwrap().layout;
+        let storage = tempfile::tempdir().unwrap();
+
+        let fleet: Vec<(&str, usize)> = vec![
+            ("kin", 12),
+            ("kin-db", 31),
+            ("kin-vfs", 7),
+            ("kinlab", 23),
+            ("kin-editor", 45),
+        ];
+        let mut witnesses = Vec::new();
+        {
+            let seed = kin_db::LocalFileBackend::new(storage.path());
+            for (repo_id, entities) in &fleet {
+                let symbol_stem = repo_id.replace('-', "_");
+                let graph = kin_db::InMemoryGraph::new();
+                let mut owned = Vec::with_capacity(*entities);
+                for index in 0..*entities {
+                    owned.push(test_entity(
+                        &format!("{symbol_stem}_symbol_{index}"),
+                        &format!("src/{repo_id}/module_{index}.rs"),
+                    ));
+                }
+                graph.batch_upsert_entities(&owned).unwrap();
+                let (bytes, _) = graph.serialize_snapshot_borrowed().unwrap();
+                kin_db::StorageBackend::save_snapshot(
+                    &seed,
+                    repo_id,
+                    &bytes,
+                    kin_db::GENERATION_INIT,
+                )
+                .unwrap();
+                witnesses.push(((*repo_id).to_string(), format!("{symbol_stem}_symbol_0")));
+            }
+        }
+
+        let allowed: HashSet<String> = fleet
+            .iter()
+            .map(|(repo_id, _)| (*repo_id).to_string())
+            .collect();
+        let state = DaemonState::open_with_backend(
+            layout,
+            Box::new(kin_db::LocalFileBackend::new(storage.path())),
+            "kin",
+            Some(allowed),
+        )
+        .unwrap();
+
+        (working, storage, state, witnesses)
+    }
+
+    /// Every hosted repository's graph loads, and answers out of its own text
+    /// index, while its siblings load beside it.
+    ///
+    /// A hosted daemon serves the fleet out of one layout and loads its
+    /// repositories concurrently: the reload gate is sharded by repository id,
+    /// so two different repositories are meant to load at once, and readiness,
+    /// the spine root proof and ordinary served reads all drive loads at the
+    /// same time. Pointing all of them at one persistent text-index directory
+    /// makes them writers of one segment image. Each rebuild reclaims the
+    /// segment files another repository's manifest names and publishes its own
+    /// counts over them, and the load-time segment-versus-manifest
+    /// reconciliation then refuses the image rather than serving a corpus that
+    /// is half somebody else's.
+    ///
+    /// Concurrent rather than sequential on purpose. Sequential loads of one
+    /// shared directory are wasteful but consistent, because each rebuild
+    /// reclaims the previous one cleanly, so a sequential fixture passes over
+    /// the very directory this test exists to keep repositories out of.
+    /// Overlapping the loads is what makes two writers visible, and it is what
+    /// the daemon does.
+    ///
+    /// Both halves matter. The loads succeeding is what readiness needs; the
+    /// witness search is what a served read needs, and an index that answers a
+    /// sibling's documents can satisfy the first while failing the second.
+    #[test]
+    fn concurrent_hosted_repo_loads_each_serve_their_own_text_index() {
+        let (_working, _storage, state, witnesses) = hosted_fleet_fixture();
+        let state = &state;
+        let refusals: Mutex<Vec<String>> = Mutex::new(Vec::new());
+        let held: Mutex<Vec<(String, String, Arc<HostedRepoCacheEntry>)>> = Mutex::new(Vec::new());
+
+        std::thread::scope(|scope| {
+            for (repo_id, witness) in &witnesses {
+                let refusals = &refusals;
+                let held = &held;
+                scope.spawn(move || {
+                    for _ in 0..HOSTED_LOAD_ISOLATION_ROUNDS {
+                        match state.load_repo_graph(repo_id) {
+                            Ok(entry) => held
+                                .lock()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                .push((repo_id.clone(), witness.clone(), entry)),
+                            Err(error) => refusals
+                                .lock()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                .push(format!(
+                                    "load {repo_id} for the hosted spine root proof: {error}"
+                                )),
+                        }
+                    }
+                });
+            }
+        });
+
+        let refusals = refusals
+            .into_inner()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert!(
+            refusals.is_empty(),
+            "every hosted repository load must succeed; {} refused, first: {}",
+            refusals.len(),
+            refusals.first().map(String::as_str).unwrap_or("")
+        );
+
+        // Every graph that loaded still answers for its own repository, with
+        // all of them still open. A shared image can satisfy the loads above
+        // and fail here, because the corpus on disk is the last writer's.
+        let held = held
+            .into_inner()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert_eq!(
+            held.len(),
+            witnesses.len() * HOSTED_LOAD_ISOLATION_ROUNDS,
+            "every load must have produced a cache entry"
+        );
+        for (repo_id, witness, entry) in &held {
+            let hits = entry
+                .graph
+                .text_search(witness, 8)
+                .unwrap_or_else(|error| panic!("{repo_id} text search: {error}"));
+            assert!(
+                !hits.is_empty(),
+                "{repo_id}'s own text index must answer for {witness}"
+            );
+        }
+    }
+
+    /// Two hosted repositories never share a text-index directory, whatever
+    /// their ids look like.
+    ///
+    /// The load path takes the repository id as a string, so this is the
+    /// assertion that the directory a load writes is a function of the id and
+    /// of nothing else the id can be confused with.
+    #[test]
+    fn hosted_text_index_directories_are_disjoint_across_the_served_fleet() {
+        let working = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(working.path()).unwrap().layout;
+        let fleet = ["kin", "kin-db", "kin-vfs", "kinlab", "kin-editor"];
+        let directories: HashSet<std::path::PathBuf> = fleet
+            .iter()
+            .map(|repo_id| layout.hosted_text_index_dir(repo_id))
+            .collect();
+        assert_eq!(
+            directories.len(),
+            fleet.len(),
+            "each served repository must get its own text-index directory"
+        );
     }
 
     #[test]


### PR DESCRIPTION
FIR-3253. A hosted daemon built every repository's persistent text index at one shared path, so the five-repo readiness proof refused on 0.7.0 and production rolled back.

## The defect

`crates/kin-daemon/src/state.rs` built every hosted repository's graph with `from_snapshot_with_text_index(query_snapshot, self.layout.text_index_dir())` at both hosted sites: the hosted authority open in `open_with_backend_internal`, and `load_repo_graph`. One layout, one `text-index` directory, every repository id. A persistent text index is a directory of segment files under one manifest that names them, so every repository the daemon loads becomes a writer of one image.

Read in the dependencies rather than inferred. `kin-db 0.7.102` decides the index is current by comparing the persisted `graph_root_hash` against the snapshot's retrieval authority hash (`src/engine/graph.rs:2819`), and two repositories never agree on that hash, so every hosted load rebuilds the whole index and commits it into the shared directory. `kin-search 0.1.9` `write_mapped_streaming` (`src/mapped.rs:740`) publishes each segment file, then the manifest, then reclaims the generations the new manifest no longer names, so two writers read the same previous generations, rename onto the same names and publish their own counts over each other. `reconcile` (`src/mapped.rs:1376`) then refuses the image.

Loads of different repositories run concurrently by design: the reload gate shards by repository id, so it single-flights one repository and never two.

## Measurement, before any code change

**Sequential loads pass on the unfixed tree.** A fixture that loads the five fleet repositories one after another, twice, in the order the spine root proof drives them, is green unfixed, and stays green when every loaded graph is held open across the pass. Sequential rebuilds of one shared directory reclaim each other cleanly. So the fixture had to be concurrent, which is also the shape the daemon's per-repository reload gate produces.

**Positive control that the sharing is real.** Listing the text-index directory after each load, unfixed:

```
PROBE after-open:   index.bin.kinseg-1-0 ... index.bin.kinseg-62-0 index.bin.kinseg-manifest(1357)
PROBE after-kin-db: index.bin.kinseg-0-0 index.bin.kinseg-1-1 ... index.bin.kinseg-manifest(1581)
PROBE after-kin-vfs: index.bin.kinseg-1-2 index.bin.kinseg-21-0 index.bin.kinseg-33-0
  index.bin.kinseg-37-1 index.bin.kinseg-38-0 index.bin.kinseg-44-0 index.bin.kinseg-63-0
  index.bin.kinseg-manifest(1277)
```

Twenty-six segment files after `kin-db`, seven after `kin-vfs`. Each load reclaims the previous repository's files and publishes its own manifest over the same names.

**Concurrent loads reproduce production.** Five threads, one per fleet repository, six loads each, on the unfixed tree:

```
PROBE failures=17
PROBE load kin-db for the hosted spine root proof: Graph error: index error: corrupt text index at
  .../.kin/kindb/text-index/index.bin.kinseg-manifest: the segments hold 34 documents of 330 tokens
  with 0 documents of 0 tokens tombstoned, which is 34 of 330, and the manifest claims 31 of 310
  (rebuild needed)
PROBE load kin-vfs for the hosted spine root proof: Graph error: index error: corrupt text index at
  .../index.bin.kinseg-manifest: segment 5 gen 0: unreadable: No such file or directory (os error 2)
  (rebuild needed)
```

Seventeen of thirty loads refused, with the production message and the fixture's own counts: `31` is kin-db's entity count in the fixture, `34` is the mixed image.

## The fix

`KinLayout::hosted_text_index_dir(repo_id)` resolves to `.kin/kindb/text-index/hosted/<32 hex characters>`, the first 128 bits of SHA-256 over the exact repository id bytes. Both hosted sites take it. The local repository-v6 open in `open_with_repo_id` keeps `text_index_dir()`, because it serves one repository per layout and never shares.

The component is a digest and not the repository id because a repository id is not a path component. `RepositoryId::new` in kin-model 0.7.26 (`src/ids.rs:143`) refuses the empty string, ids over 255 bytes and control characters, and nothing else, so `../peer`, `/etc/kin` and `a/b` are all valid repository ids, and the load path takes the id as a `&str`. A digest is a fixed-length name over `0-9a-f`: it cannot escape the hosted root, and it folds neither case nor delimiters, so `Kin` and `kin` land apart and `a/b` and `a_b` land apart. Three tests in `kin-core` cover traversal, case and delimiter collisions, and pin the name so a change to the digest, its truncation or the namespace fails visibly.

## Falsification

**Arm A, the fix reverted.** Both hosted sites back to `layout.text_index_dir()`, five runs, red five for five with 15 to 18 refusals of 30:

```
every hosted repository load must succeed; 17 refused, first: load kin-vfs for the hosted spine root
  proof: Graph error: index error: corrupt text index at .../text-index/index.bin.kinseg-manifest:
  the segments hold 7 documents of 68 tokens with 0 documents of 0 tokens tombstoned, which is 7 of
  68, and the manifest claims 7 of 70 (rebuild needed)
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1427 filtered out; finished in 5.18s
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1427 filtered out; finished in 5.08s
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1427 filtered out; finished in 4.55s
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1427 filtered out; finished in 4.84s
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1427 filtered out; finished in 4.41s
```

**Arm B, the mapping broken without touching either call site.** `hosted_text_index_component` returns a constant, so every repository resolves to one directory again. Red three for three, which says the test binds to the per-repository mapping and not to the two lines that call it:

```
every hosted repository load must succeed; 15 refused, first: load kinlab ... corrupt text index at
  .../text-index/hosted/efeef5efdf70ae008ba00618ffe089da/index.bin.kinseg-manifest: the segments hold
  23 documents of 190 tokens ... and the manifest claims 23 of 184 (rebuild needed)
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1427 filtered out; finished in 4.96s
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1427 filtered out; finished in 4.66s
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1427 filtered out; finished in 4.73s
```

**Arm C, the property left in place.** The digest takes bytes 16..32 instead of 0..16: one directory per repository still, different name. The isolation test stays green and only the pinned-name test moves, which is the control against a vacuously red test:

```
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1427 filtered out; finished in 2.19s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1427 filtered out; finished in 2.05s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1427 filtered out; finished in 1.87s
--- layout tests under arm C ---
thread 'layout::tests::hosted_text_index_directory_is_stable_for_an_id' panicked at layout.rs:627:9:
assertion `left == right` failed
  left: "/repo/.kin/kindb/text-index/hosted/6112c2277d3896f34eb5f6c3e5f230d5"
 right: "/repo/.kin/kindb/text-index/hosted/c1d6b0ba57d78fec8689f0877d805355"
test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 863 filtered out; finished in 0.00s
```

The green direction was run eight consecutive times on the fixed tree, ok eight for eight.

## What this change does not address

The hosted authority open and a load of that same repository id resolve to the same directory, so the daemon's own long-lived graph and a served load of the same repository are still two handles over one image. I wrote a probe for it, one thread committing on the primary graph's text index against one thread reloading the same repository id, and it reported zero failures on the fixed tree and zero on the unfixed tree. A probe that cannot fail is not evidence, so I make no claim either way about that case, and it is not addressed here. Raised for a follow-up on FIR-3253.

## Verification

`cargo test -p kin-core --lib`: 865 passed, 0 failed, 1 ignored.
`cargo test -p kin-daemon --lib`: 1425 passed, 0 failed, 3 ignored.
`cargo fmt --all -- --check`: rc=0.
`cargo clippy --all-targets --all-features` with the 45 allows from `.github/clippy-allowed-lints.txt`: rc=0.

`bin/kin-precheck kin --repo-dir kin=<lane worktree>`:

```
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:check_private_repo_coupling.sh bash scripts/check_private_repo_coupling.sh
PASS     guard:check_runtime_boundaries.sh    bash scripts/check_runtime_boundaries.sh
PASS     guard:test-release-policy-gate.sh    bash scripts/test-release-policy-gate.sh
PASS     guard:test-windows-authority-legs.sh bash scripts/test-windows-authority-legs.sh
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:check-kin-vfs-compat.mjs       node scripts/check-kin-vfs-compat.mjs
PASS     guard:check-rc-build-drift.mjs       node scripts/check-rc-build-drift.mjs
PASS     guard:check-required-contexts.py     python3 scripts/check-required-contexts.py
PASS     guard:test-assertion-reachability.py python3 scripts/test-assertion-reachability.py
PASS     guard:test-guard-duplicate-release-run.py python3 scripts/test-guard-duplicate-release-run.py
PASS     guard:test-homebrew-release-gate.py  python3 scripts/test-homebrew-release-gate.py
PASS     guard:test-install-checksum.py       python3 scripts/test-install-checksum.py
PASS     guard:test-private-repo-coupling.py  python3 scripts/test-private-repo-coupling.py
PASS     guard:test-release-tag-evaluate-dispatch.py python3 scripts/test-release-tag-evaluate-dispatch.py
PASS     guard:test-release-workflow-authority.py python3 scripts/test-release-workflow-authority.py
PASS     guard:test-select-release-candidate.py python3 scripts/test-select-release-candidate.py
PASS     guard:verify-hydration-semantics.py  python3 scripts/verify-hydration-semantics.py
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
PASS     node-test                            node --test <15 file(s) named by the check job>
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 457b3545d77f396603c8d074464e848e1ed340d5
```

Every claim above whose only witness is this branch is quoted as the command's actual output. Acceptance grades main, not this pull request.
