### PR TITLE
Settle a merged graph after finalization applies its live delta

### DIFF
--- a/crates/kin-cli/tests/repository_merge_resolution.rs
+++ b/crates/kin-cli/tests/repository_merge_resolution.rs
@@ -2422,3 +2422,115 @@ fn authored_merge_accepts_in_place_input_and_preserves_unrelated_or_later_edits(
         b"keep this\n"
     );
 }
+
+/// FIR-3242. The census a merge records has to be a reading of the graph the
+/// merge left live.
+///
+/// `settle_merged_graph` ran from inside the publication path, and the
+/// publication path returns to `execute`, which is where
+/// `finalize_local_repository_commit` derives and applies the merged live
+/// entity and relation correction. The `create_change` calls above the settle
+/// install immutable history and revision lineage, not the merged entity and
+/// relation table, so the record carried this merge's timestamp and source over
+/// a reading of the PREVIOUS live relation set. Every later comparison is
+/// judged against that baseline, so a kind this merge introduced can disappear
+/// without the store ever having recorded that it existed.
+///
+/// Read off disk, with enrichment off, and needing no barrier: the merged tree
+/// holds a source file the target branch never had, so the merged graph holds
+/// strictly more entities than the graph before it, and a record written after
+/// finalization has to show that. A record written before finalization holds
+/// the pre-merge count instead, and nothing between the merge and this reading
+/// can move either side.
+#[test]
+fn a_published_merge_records_the_census_of_the_graph_it_finalized() {
+    let root = tempdir().expect("temp root");
+    let repo = disjoint_repository(root.path());
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    ok(
+        &run_kin_without_enrichment(&runtime, &repo, &["init", ".", "--json"]),
+        "kin init",
+    );
+    let layout = kin_core::KinLayout::discover(&repo).expect("discover exact layout");
+    assert!(
+        kin_core::relation_census::read(&layout)
+            .recorded()
+            .is_none(),
+        "the recorder runs at the end of a sweep and at the end of a commit, and this init is \
+         neither, so the record read below is the one this merge wrote and nothing else"
+    );
+
+    let merged = ok(
+        &run_kin_without_enrichment(&runtime, &repo, &["merge", "feature"]),
+        "kin merge",
+    );
+    assert!(
+        merged.contains("Merged refs/heads/feature into refs/heads/main"),
+        "the fixture has to publish rather than park, or nothing below is about a merge: {merged}"
+    );
+
+    let recorded = kin_core::relation_census::read(&layout)
+        .recorded()
+        .cloned()
+        .expect("a published merge records the baseline the next comparison is judged against");
+    let published = graph_at(&layout, &branch_change(&layout, "main"));
+    let published_entities = published
+        .entities
+        .values()
+        .filter(|entity| !kin_index::is_external_reference_target(entity))
+        .count() as u64;
+
+    assert_eq!(
+        recorded.entities,
+        Some(published_entities),
+        "the record has to describe the graph this merge published, and this one describes the \
+         graph before the merged live delta was applied: the merged tree holds {published_entities} \
+         entities and the record claims {:?}",
+        recorded.entities
+    );
+}
+
+/// FIR-3242. A parked merge settles nothing, because it published no merged
+/// graph.
+///
+/// A merge that parks its conflicts still writes a merge transaction record and
+/// finalizes like any other repository transition, so it reaches the same
+/// executor the settle now runs in. It composed no merged entity and relation
+/// table: a census recorded there would describe the unmerged graph under this
+/// merge's timestamp and source, and retiring every file's enrichment evidence
+/// would buy a full re-derivation for a merge that published nothing.
+///
+/// Green before the settle moved, because `open_conflicted_merge` reaches a
+/// `bail!` rather than the publication path the settle used to live in. This is
+/// the lock that keeps it green.
+#[test]
+fn a_parked_merge_records_no_census_because_it_published_no_merged_graph() {
+    let root = tempdir().expect("temp root");
+    let repo = conflicting_repository(root.path());
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    ok(
+        &run_kin_without_enrichment(&runtime, &repo, &["init", ".", "--json"]),
+        "kin init",
+    );
+    let layout = kin_core::KinLayout::discover(&repo).expect("discover exact layout");
+    assert!(
+        kin_core::relation_census::read(&layout)
+            .recorded()
+            .is_none(),
+        "the recorder runs at the end of a sweep and at the end of a commit, and this init is \
+         neither, so anything read below was written by the merge"
+    );
+
+    parked_merge(
+        &run_kin_without_enrichment(&runtime, &repo, &["merge", "feature"]),
+        "kin merge",
+    );
+
+    assert!(
+        kin_core::relation_census::read(&layout)
+            .recorded()
+            .is_none(),
+        "a parked merge composed no merged relation set, so it has none to record; a record \
+         written here would describe the graph before the merge and carry this merge's timestamp"
+    );
+}

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -1952,7 +1952,7 @@ fn graph_holds_language_server_relations(state: &DaemonState) -> bool {
 /// So the set is written once, after publication succeeds. Resume-after-kill
 /// degrades in the correct direction: a hard kill now re-sweeps, which is right,
 /// because a hard kill did not publish either.
-fn mark_files_enriched(state: &DaemonState, files: &[String]) {
+pub(crate) fn mark_files_enriched(state: &DaemonState, files: &[String]) {
     if files.is_empty() {
         return;
     }
@@ -2017,6 +2017,63 @@ pub(crate) fn retire_enrichment_marker(state: &DaemonState, files: &[String]) {
     if let Ok(bytes) = serde_json::to_vec(&snapshot) {
         let _ = std::fs::write(lsp_enriched_marker_path(state), bytes);
     }
+}
+
+/// Publish that the cold sweep this worker was running has ended.
+///
+/// Extracted from the worker's own tail so the daemon has one named place where
+/// a sweep finishes. Every caller of a sweep waits on `lsp_sweeps_completed`
+/// rather than on `lsp_sweep_running`, because polling `running` alone races
+/// the worker, so the two have to move together and this is where they do.
+///
+/// Marked complete even when the loop broke early on shutdown or a supervisor
+/// halt, which is the behaviour the tail already had: a waiter blocked on a
+/// counter that only advances on a clean finish would wait out its whole budget
+/// on a sweep that already stopped.
+pub(crate) fn complete_lsp_sweep(state: &DaemonState, files_blocked: u64) {
+    state
+        .lsp_sweep_running
+        .store(false, std::sync::atomic::Ordering::SeqCst);
+    state
+        .lsp_sweeps_completed
+        .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    state
+        .lsp_sweep_files_blocked
+        .store(files_blocked, std::sync::atomic::Ordering::SeqCst);
+    // A merge admitted while this pass ran could not be covered by it, because
+    // the pass had already taken its entity, file and target snapshot. Its
+    // demand waited here rather than being queued beside this one, so that a
+    // caller waiting on `lsp_sweeps_completed` could not see the wrong pass
+    // finish. Drained after the running flag clears, so the queue accepts it.
+    if state.take_pending_lsp_sweep() {
+        state.queue_lsp_sweep();
+    }
+}
+
+/// Retire every enrichment marker this store holds, because a merge changed
+/// what the files they name can bind to.
+///
+/// The marker means "the enrichment for this file is durable", and the sweep
+/// skips a marked file before it asks a language server anything. A merge makes
+/// that claim false for files nothing edited: a caller on one branch and its
+/// callee on the other produce an edge that exists only once the merge exists,
+/// and the caller's file is unchanged by the merge, was legitimately marked
+/// when it was swept, and is skipped by the sweep the merge queues. Retiring
+/// only the files the merge changed does not close it, because the answer that
+/// went stale is a cross-file one whose target moved elsewhere.
+///
+/// So the whole set goes. It costs the merge's own sweep one re-derivation of
+/// this store and is the cheap direction to be wrong in, the same asymmetry
+/// [`load_lsp_enriched_marker`] and [`retire_enrichment_marker`] are already
+/// built on: a wrong skip is silent and loses the answers, a wrong re-sweep
+/// only costs time.
+pub(crate) fn retire_enrichment_evidence_for_merge(state: &DaemonState) {
+    let Ok(marked) = state.lsp_enriched_files.lock() else {
+        return;
+    };
+    let files: Vec<String> = marked.iter().cloned().collect();
+    drop(marked);
+    retire_enrichment_marker(state, &files);
 }
 
 /// The batch size one embedding pass may use under a pressure verdict.
@@ -3220,7 +3277,7 @@ mod sweep_backfill_gate_tests {
 }
 
 /// Whether the sweep has already finished this file.
-fn file_already_enriched(state: &DaemonState, file: &str) -> bool {
+pub(crate) fn file_already_enriched(state: &DaemonState, file: &str) -> bool {
     state
         .lsp_enriched_files
         .lock()
@@ -5852,21 +5909,11 @@ pub async fn run_with_authority_on(
                         }
 
                         // Marked complete even when the loop broke early on
-                        // shutdown or a supervisor halt. A waiter blocked on a
-                        // counter that only advances on a clean finish would
-                        // wait out its whole budget on a sweep that already
-                        // stopped, and report a timeout for a pass that ended
-                        // seconds in. What was enriched is durable either way,
-                        // and the next sweep resumes from it.
-                        lsp_state
-                            .lsp_sweep_running
-                            .store(false, std::sync::atomic::Ordering::SeqCst);
-                        lsp_state
-                            .lsp_sweeps_completed
-                            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                        lsp_state
-                            .lsp_sweep_files_blocked
-                            .store(tally.blocked() as u64, std::sync::atomic::Ordering::SeqCst);
+                        // shutdown or a supervisor halt. What was enriched is
+                        // durable either way, and the next sweep resumes from
+                        // it. The reason the counters move together, and the
+                        // demand this drains, are on the function.
+                        complete_lsp_sweep(&lsp_state, tally.blocked() as u64);
                         // Published with the counts, so a caller reading a
                         // nonzero blocked count can also say which language it
                         // lost and what this process saw. Replaces the previous

--- a/crates/kin-daemon/src/repository_merge.rs
+++ b/crates/kin-daemon/src/repository_merge.rs
@@ -95,9 +95,13 @@ fn merge_enrichment(
 /// Settle the graph a merge just published: record what its relation set now
 /// holds, and converge the enrichment the merged tree implies.
 ///
-/// Called from both publication paths, because a merge settled through
-/// `kin resolve --continue` publishes the same kind of graph as one that
-/// composed cleanly and was missing the same edges.
+/// Called from both top-level executors, `execute` and `execute_resolve`,
+/// because a merge settled through `kin resolve --continue` publishes the same
+/// kind of graph as one that composed cleanly and was missing the same edges.
+/// From the executors and not from the publication paths beneath them, because
+/// the merged entity and relation table is installed by
+/// `finalize_local_repository_commit`, which the executors call after the
+/// publication returns; see the comment at that call site.
 ///
 /// The census is recorded for the reason the commit path records one: the
 /// relation set just moved and this process knows it finished, which is what
@@ -112,21 +116,41 @@ fn merge_enrichment(
 /// variant, and a store stamped with one reads as unreadable to any build that
 /// predates it, which trades a labelling nicety for a window where no lost kind
 /// can be detected at all.
-fn settle_merged_graph(state: &DaemonState) -> Option<String> {
+pub(crate) fn settle_merged_graph(state: &DaemonState) -> Option<String> {
     crate::background_work::record_relation_census(
         &state.layout,
         &state.graph,
         kin_core::relation_census::CensusSource::Commit,
     );
-    match merge_enrichment(
+    let enrichment = merge_enrichment(
         state.filesystem_reconcile_disabled(),
         crate::api::enrichment_unavailable_reason_for(state),
-    ) {
+    );
+    if !matches!(enrichment, MergeEnrichment::Silent) {
+        // Retired before the sweep is asked for, so the pass that answers this
+        // merge sees the retirement rather than skipping the files it names.
+        // Retired on the announcing row too: the evidence is equally stale
+        // there, and the sweep the line tells a reader to run is the one that
+        // would otherwise skip everything and report full coverage.
+        crate::daemon::retire_enrichment_evidence_for_merge(state);
+    }
+    match enrichment {
         MergeEnrichment::Sweep => {
-            // `false` here means a sweep is already running, which covers this
-            // merge as well as one queued now would.
-            state.queue_lsp_sweep();
-            None
+            if state.request_lsp_sweep_after_merge() {
+                return None;
+            }
+            // Not "a sweep is already running", which is the answer
+            // `queue_lsp_sweep` gives and which this used to read as coverage.
+            // `request_lsp_sweep_after_merge` records that case as demand the
+            // worker drains, so a `false` here is a channel that can never
+            // deliver: nothing later converges this graph on its own.
+            Some(
+                "Cross-file enrichment could not be queued for this merge (this daemon's \
+                 enrichment worker is not accepting work), so the merged graph holds only the \
+                 edges the two branches already carried; restart the daemon and run \
+                 `kin daemon sweep`"
+                    .to_string(),
+            )
         }
         MergeEnrichment::Silent => None,
         MergeEnrichment::Announce(line) => Some(line),
@@ -144,6 +168,16 @@ const RENDERED_CONFLICT_LIMIT: usize = 25;
 
 pub(crate) struct MergeExecution {
     response: MergeResponse,
+    /// Whether this execution published a merged graph.
+    ///
+    /// False for a merge that parked its conflicts. A parked merge writes a
+    /// merge transaction record and finalizes like any other repository
+    /// transition, so it reaches the same executor, but it composed no merged
+    /// entity and relation table and there is nothing about it to settle: a
+    /// census recorded there would describe the unmerged graph, and retiring
+    /// every file's enrichment evidence would cost a full re-derivation for a
+    /// merge that published nothing.
+    pub(crate) published_merged_graph: bool,
     /// Present only when the merge was published by `kin resolve --continue`,
     /// whose caller answers on the resolve wire rather than the merge one.
     pub(crate) resolve_response: Option<kin_cli::commands::resolve::ResolveResponse>,
@@ -264,7 +298,7 @@ pub(crate) fn execute(
         .map_err(|refusal| CommandRefusal::before_write(merge_bind_refusal(refusal)))?;
     let outcome = plan_and_publish(state, &authority, request)
         .map_err(|error| CommandRefusal::before_write(classify_merge_error(error)))?;
-    let execution = match outcome {
+    let mut execution = match outcome {
         MergeCommandOutcome::Commit(execution) => execution,
         MergeCommandOutcome::ReadOnly(response) => {
             drop(persistence);
@@ -302,6 +336,27 @@ pub(crate) fn execute(
     }
     if !finalization.graph_changed {
         state.invalidate_projection();
+    }
+
+    // Settled HERE, not inside the publication path, and the difference is the
+    // whole of what the record means. `plan_and_publish` installs the merge's
+    // immutable changes into the live query graph, which is history and
+    // revision lineage; the merged entity and relation table arrives only when
+    // `finalize_local_repository_commit` above derives the live correction and
+    // applies it. A census taken before that call carries this merge's
+    // timestamp and source over a reading of the PREVIOUS relation set, so
+    // every later comparison is judged against a baseline that never held the
+    // merge, and a kind this merge introduced can disappear without the store
+    // ever having recorded that it existed. The sweep is queued from here for
+    // the same reason: the worker snapshots every entity once when it starts,
+    // so one queued against the pre-finalization graph can snapshot old
+    // entities. Still inside the persistence and graph-authority locks, so no
+    // other command moves the graph between the finalization and this reading.
+    //
+    // A parked merge reaches here too. It finalizes like any other repository
+    // transition, and it composed no merged graph, so it settles nothing.
+    if execution.published_merged_graph {
+        execution.response.lines.extend(settle_merged_graph(state));
     }
 
     drop(persistence);
@@ -1437,8 +1492,6 @@ pub(crate) fn publish_resolved_merge(
         })?;
     }
 
-    let settled = settle_merged_graph(state);
-
     let resolved_count = terminated.entries.len();
     let report = kin_cli::commands::resolve::ResolveReport {
         schema: kin_cli::commands::resolve::RESOLVE_REPORT_SCHEMA.to_string(),
@@ -1454,6 +1507,7 @@ pub(crate) fn publish_resolved_merge(
     };
     let previous_tree = workspace.tree.clone();
     Ok(MergeExecution {
+        published_merged_graph: true,
         response: MergeResponse::default(),
         resolve_response: Some(kin_cli::commands::resolve::ResolveResponse {
             lines: {
@@ -1468,7 +1522,6 @@ pub(crate) fn publish_resolved_merge(
                     receipt.generation
                 )];
                 lines.extend(projections);
-                lines.extend(settled);
                 lines
             },
             mutated: matches!(receipt.outcome, RepositoryCommitOutcome::Committed),
@@ -2686,7 +2739,6 @@ fn publish(
             bail!("a parked merge must not reach the workspace publication path")
         }
     };
-    let settled = settle_merged_graph(state);
     let report = MergeReport {
         schema: MERGE_REPORT_SCHEMA.to_string(),
         authority: "repository-v6".to_string(),
@@ -2705,8 +2757,7 @@ fn publish(
         relation_delta_count: 0,
         tree_delta_count: 0,
     };
-    let mut lines = vec![line];
-    lines.extend(settled);
+    let lines = vec![line];
     Ok(MergeExecution {
         resolve_response: None,
         response: MergeResponse {
@@ -2717,6 +2768,7 @@ fn publish(
             authority_generation: Some(receipt.generation),
             idempotent: matches!(receipt.outcome, RepositoryCommitOutcome::IdempotentReplay),
         },
+        published_merged_graph: true,
         receipt,
         authority_freeze,
         daemon_delta,
@@ -2835,6 +2887,7 @@ fn open_conflicted_merge(
             authority_generation: Some(receipt.generation),
             idempotent: matches!(receipt.outcome, RepositoryCommitOutcome::IdempotentReplay),
         },
+        published_merged_graph: false,
         receipt,
         authority_freeze,
         daemon_delta: TransactionDelta::default(),
@@ -4447,6 +4500,110 @@ mod tests {
             census_path.exists(),
             "a merge moves the relation set and knows it finished, so it records the baseline \
              the next comparison is judged against, exactly as a commit does"
+        );
+    }
+
+    /// FIR-3242. A merge admitted while a sweep is running still gets a sweep.
+    ///
+    /// `queue_lsp_sweep` returns false while one is running, and this helper
+    /// read that as "an existing sweep covers this merge as well as one queued
+    /// now would". It does not. The running pass lists every entity and builds
+    /// its file grouping and its target index once at the top of the `Sweep`
+    /// arm, before this merge existed, so it cannot visit a file or reach an
+    /// endpoint the merge introduced, and finishing only cleared the running
+    /// flag. One sweep at a time is still right: a caller waits on
+    /// `lsp_sweeps_completed`, so two passes queued over one graph let a waiter
+    /// see the first finish and return over a graph the second is still
+    /// mutating. What the merge needs is for its demand to outlive that pass.
+    #[test]
+    fn a_merge_admitted_while_a_sweep_runs_gets_one_after_that_sweep_ends() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let (state, mut rx) = enriching_state(init.layout.clone());
+        state
+            .lsp_sweep_running
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+
+        assert_eq!(
+            settle_merged_graph(&state),
+            None,
+            "a daemon that can enrich converges silently, running pass or not"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "and one sweep at a time still holds: nothing is queued beside the pass already \
+             running, because a waiter would see the wrong one of the two finish"
+        );
+
+        crate::daemon::complete_lsp_sweep(&state, 0);
+
+        assert!(
+            matches!(rx.try_recv(), Ok(crate::state::LspEnrichmentMessage::Sweep)),
+            "the running pass could not see this merge, so ending it has to hand the worker the \
+             merge's own sweep; before this the request was dropped on the floor and the merged \
+             tree waited for a command nobody knew"
+        );
+    }
+
+    /// FIR-3242. A merge whose enrichment worker is gone names the gap.
+    ///
+    /// `queue_lsp_sweep` matched only `TrySendError::Full`, so a channel whose
+    /// receiver a supervisor halt had already dropped fell through to `true`,
+    /// and the merge published the silent convergence that never happened.
+    /// `lsp_enrichment_tx.is_some()` cannot see this: it establishes that a
+    /// sender exists, not that anything is left to receive. A closed channel is
+    /// the case where no later pass repairs the gap on its own, which is
+    /// exactly the row that has to speak.
+    #[test]
+    fn a_merge_whose_enrichment_worker_is_gone_names_the_gap_rather_than_reporting_convergence() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let (state, rx) = enriching_state(init.layout.clone());
+        drop(rx);
+
+        let Some(line) = settle_merged_graph(&state) else {
+            panic!("a merge with nothing left to run its sweep must not publish that gap quietly");
+        };
+        assert!(
+            line.contains("kin daemon sweep"),
+            "and it names its own recovery, which is the whole value of the line: {line}"
+        );
+    }
+
+    /// FIR-3242. A merge retires the enrichment evidence its own sweep skips.
+    ///
+    /// The marker means "the enrichment for this file is durable", and the
+    /// sweep skips a marked file before it asks a language server anything.
+    /// A merge makes that claim false for files nothing edited: the shape the
+    /// measurement's round 4 drove is a caller on one branch and its callee on
+    /// the other, so the caller's file is unchanged by the merge, was
+    /// legitimately marked when it was swept, and gains through the merge an
+    /// edge no pass before it could derive. Only the two reconcile paths retire
+    /// a marker, and a merge is neither, so the sweep the merge queues skips
+    /// the file and reports full coverage over work it did not do.
+    ///
+    /// Retiring costs that sweep one re-derivation and is the cheap direction
+    /// to be wrong in, the same asymmetry `load_lsp_enriched_marker` and
+    /// `retire_enrichment_marker` are already built on: a wrong skip is silent
+    /// and loses the answers, a wrong re-sweep only costs time.
+    #[test]
+    fn a_merge_retires_the_enrichment_evidence_its_own_sweep_would_skip() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let (state, _rx) = enriching_state(init.layout.clone());
+        crate::daemon::mark_files_enriched(&state, &["ledger/printing.py".to_string()]);
+        assert!(
+            crate::daemon::file_already_enriched(&state, "ledger/printing.py"),
+            "the fixture has to start marked, or the assertion below proves nothing"
+        );
+
+        settle_merged_graph(&state);
+
+        assert!(
+            !crate::daemon::file_already_enriched(&state, "ledger/printing.py"),
+            "a file the merge did not touch can still have gained a cross-file edge through it, \
+             and a sweep that skips the file cannot derive one; the evidence has to be retired so \
+             the merge's own sweep visits it"
         );
     }
 

--- a/crates/kin-daemon/src/repository_merge_state.rs
+++ b/crates/kin-daemon/src/repository_merge_state.rs
@@ -423,7 +423,7 @@ pub(crate) fn execute_resolve(
     // as a possible write.
     let authority = ActiveLocalRepositoryAuthority::open_bound(state)
         .map_err(|refusal| CommandRefusal::before_write(merge_bind_refusal(refusal)))?;
-    let execution = plan_resolution(state, &authority, request)
+    let mut execution = plan_resolution(state, &authority, request)
         .map_err(|error| CommandRefusal::before_write(classify_merge_error(error)))?;
     let finalization = state
         .finalize_local_repository_commit(
@@ -455,6 +455,21 @@ pub(crate) fn execute_resolve(
     if !finalization.graph_changed {
         state.invalidate_projection();
     }
+
+    // Settled after the finalization for the reason `repository_merge::execute`
+    // settles after its own: a merge published through `resolve --continue`
+    // reaches the live entity and relation table at exactly this call and not
+    // before it.
+    //
+    // A settlement and an abort reach here too, and neither composed a merged
+    // graph, so neither settles one.
+    if execution.published_merged_graph {
+        execution
+            .resolve_response
+            .lines
+            .extend(crate::repository_merge::settle_merged_graph(state));
+    }
+
     drop(persistence);
     drop(graph_mutation);
     Ok(execution.resolve_response)
@@ -463,6 +478,10 @@ pub(crate) fn execute_resolve(
 /// One resolution's outcome, carrying the merge execution the daemon finalizes.
 pub(crate) struct ResolveExecution {
     resolve_response: ResolveResponse,
+    /// Whether this execution published a merged graph. False for a settlement
+    /// and for an abort, which record decisions and restore a workspace without
+    /// composing one; see [`MergeExecution::published_merged_graph`].
+    published_merged_graph: bool,
     receipt: RepositoryCommitReceipt,
     authority_freeze: LocalRepositoryAuthorityFreeze,
     daemon_delta: TransactionDelta,
@@ -521,6 +540,7 @@ fn plan_resolution(
 
 fn into_resolve_execution(execution: MergeExecution) -> ResolveExecution {
     ResolveExecution {
+        published_merged_graph: execution.published_merged_graph,
         resolve_response: execution
             .resolve_response
             .expect("a merge execution reached through resolve carries its resolve response"),
@@ -1286,6 +1306,7 @@ fn record_execution(
     };
     let tree = workspace.tree;
     ResolveExecution {
+        published_merged_graph: false,
         resolve_response: ResolveResponse {
             lines,
             mutated: matches!(receipt.outcome, RepositoryCommitOutcome::Committed),

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -3176,6 +3176,17 @@ pub struct DaemonState {
     pub lsp_sweep_languages_skipped: std::sync::Mutex<Vec<SweepLanguageSkip>>,
     /// Set while a sweep is in flight.
     pub lsp_sweep_running: AtomicBool,
+    /// A sweep that was asked for while one was already running.
+    ///
+    /// The running pass lists every entity and builds its file grouping and its
+    /// target index once when it starts, so it cannot visit a file or reach an
+    /// endpoint that arrived after that. A merge admitted underneath it needs a
+    /// pass of its own, and queueing one immediately is not the answer: a caller
+    /// waits on `lsp_sweeps_completed`, so two passes over one graph let a
+    /// waiter see the first finish and return over a graph the second is still
+    /// mutating. One coalesced bit rather than a counter, because the demand is
+    /// "sweep the graph as it now stands" and two of those are one.
+    pub lsp_sweep_pending: AtomicBool,
     /// Files a sweep has finished enriching, so a later pass can skip them.
     ///
     /// An explicit marker rather than an inference from the graph. Two attempts
@@ -5293,6 +5304,7 @@ impl DaemonState {
             lsp_sweep_languages_skipped: std::sync::Mutex::new(Vec::new()),
             lsp_sweeps_completed: AtomicU64::new(0),
             lsp_sweep_running: AtomicBool::new(false),
+            lsp_sweep_pending: AtomicBool::new(false),
             lsp_enriched_files: std::sync::Mutex::new(std::collections::HashSet::new()),
             unpublished_enrichment: std::sync::Mutex::new(std::collections::HashSet::new()),
             cached_repo_id,
@@ -5661,6 +5673,7 @@ impl DaemonState {
             lsp_sweep_languages_skipped: std::sync::Mutex::new(Vec::new()),
             lsp_sweeps_completed: AtomicU64::new(0),
             lsp_sweep_running: AtomicBool::new(false),
+            lsp_sweep_pending: AtomicBool::new(false),
             lsp_enriched_files: std::sync::Mutex::new(std::collections::HashSet::new()),
             unpublished_enrichment: std::sync::Mutex::new(std::collections::HashSet::new()),
             cached_repo_id: repo_id.to_string(),
@@ -11139,15 +11152,64 @@ impl DaemonState {
             return false;
         }
         if let Some(ref tx) = self.lsp_enrichment_tx {
-            if let Err(tokio::sync::mpsc::error::TrySendError::Full(_)) =
-                tx.try_send(LspEnrichmentMessage::Sweep)
-            {
-                warn!("LSP enrichment channel full, sweep request dropped");
-                return false;
-            }
-            return true;
+            // Every arm named. `is_some` on the sender establishes that a
+            // sender exists, not that anything is left to receive, and matching
+            // only `Full` let a channel whose receiver a supervisor halt had
+            // already dropped fall through to `true`. A caller that took that
+            // answer reported a sweep it had not queued and could not queue.
+            return match tx.try_send(LspEnrichmentMessage::Sweep) {
+                Ok(()) => true,
+                Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                    warn!("LSP enrichment channel full, sweep request dropped");
+                    false
+                }
+                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                    warn!("LSP enrichment worker is gone, sweep request dropped");
+                    false
+                }
+            };
         }
         false
+    }
+
+    /// Ask for a sweep over the graph a merge just published, and answer
+    /// whether one is coming.
+    ///
+    /// [`Self::queue_lsp_sweep`] answers a different question, "is a sweep
+    /// running", and a merge cannot use that answer: the running pass took its
+    /// entity, file and target snapshot before this merge existed and cannot
+    /// visit the merged tree. So a refusal on that ground is recorded as demand
+    /// the worker drains when its pass ends, and only a channel that can never
+    /// deliver reads as no.
+    ///
+    /// The demand is published BEFORE the attempt to queue, so a pass that ends
+    /// between the two calls drains it at its tail rather than racing past it.
+    /// The cost of losing that race in the other direction is one redundant
+    /// sweep, which is the cheap direction to be wrong in; the cost of losing it
+    /// the way the ordering avoids is a merged graph nothing ever converges.
+    pub fn request_lsp_sweep_after_merge(&self) -> bool {
+        self.lsp_sweep_pending
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        if self
+            .lsp_sweep_running
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            return true;
+        }
+        if self.queue_lsp_sweep() {
+            self.lsp_sweep_pending
+                .store(false, std::sync::atomic::Ordering::SeqCst);
+            return true;
+        }
+        self.lsp_sweep_pending
+            .store(false, std::sync::atomic::Ordering::SeqCst);
+        false
+    }
+
+    /// Take the pending sweep demand, if there is one.
+    pub fn take_pending_lsp_sweep(&self) -> bool {
+        self.lsp_sweep_pending
+            .swap(false, std::sync::atomic::Ordering::SeqCst)
     }
 
     /// Return the current reconciliation status as a human-readable string.


### PR DESCRIPTION
FIR-3242.

A published merge recorded its relation census, and queued its convergence sweep, against the graph
as it stood BEFORE the merged live delta was applied. Two entities against three on a two-file
fixture. This settles both after the finalization that installs that delta, keeps a sweep request
the running pass cannot cover instead of dropping it, stops reading a dead enrichment channel as a
queued sweep, and retires the enrichment evidence the merge's own sweep would otherwise skip.

Follows kin #1523, which added the settle and the census. An independent source review of that
squash from source and raised three P1 convergence gaps
(`.kin-coord/reports/mergeedges-independent-review-20260905.md`). All three are real. A fourth fell
out of the second.

## Measured first, on the landed tree

Every arm below ran on `34d63ba76` plus the new tests and two behaviour-preserving seams the tests
need to call into (`mark_files_enriched` and `file_already_enriched` become `pub(crate)`, and the
sweep worker's three completion writes move verbatim into a named `complete_lsp_sweep`). Every arm
ran `cargo build -p kin-daemon --bin kin-daemon` first, because
`cargo test -p kin-cli --test <name>` does not rebuild the daemon and the harness reuses any daemon
binary whose build stamp is compatible.

| claim | falsifier | landed tree | after the fix | with the fix reverted |
|---|---|---|---|---|
| census and sweep see the pre-finalization graph | `a_published_merge_records_the_census_of_the_graph_it_finalized` | RED | ok | RED |
| a request made while a sweep runs is dropped | `a_merge_admitted_while_a_sweep_runs_gets_one_after_that_sweep_ends` | RED | ok | RED |
| a closed channel reads as a queued sweep | `a_merge_whose_enrichment_worker_is_gone_names_the_gap_rather_than_reporting_convergence` | RED | ok | RED |
| a durable marker lets the sweep skip merged-in work | `a_merge_retires_the_enrichment_evidence_its_own_sweep_would_skip` | RED | ok | RED |
| a parked merge must settle nothing (this PR's own hazard) | `a_parked_merge_records_no_census_because_it_published_no_merged_graph` | ok | ok | RED |

### The census arm, on the landed tree

```
thread 'a_published_merge_records_the_census_of_the_graph_it_finalized' panicked at
crates/kin-cli/tests/repository_merge_resolution.rs:2480:5:
assertion `left == right` failed: the record has to describe the graph this merge published, and
this one describes the graph before the merged live delta was applied: the merged tree holds 3
entities and the record claims Some(2)
  left: Some(2)
 right: Some(3)

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 35 filtered out; finished in 4.04s
```

The merged tree carries `src/feature.rs`, which the target branch never had, and the record written
by this merge does not know it exists.

### The other three, on the landed tree

```
test result: FAILED. 24 passed; 3 failed; 0 ignored; 0 measured; 1406 filtered out; finished in 2.26s

panicked at crates/kin-daemon/src/repository_merge.rs:4487:9:
the running pass could not see this merge, so ending it has to hand the worker the merge's own
sweep; before this the request was dropped on the floor and the merged tree waited for a command
nobody knew

panicked at crates/kin-daemon/src/repository_merge.rs:4512:13:
a merge with nothing left to run its sweep must not publish that gap quietly

panicked at crates/kin-daemon/src/repository_merge.rs:4551:9:
a file the merge did not touch can still have gained a cross-file edge through it, and a sweep
that skips the file cannot derive one; the evidence has to be retired so the merge's own sweep
visits it
```

The 24 that passed include `settling_a_merged_graph_queues_the_sweep_and_records_the_census`, the
control: on an idle channel the merge does queue its sweep, so the three failures are about the
states that test never entered.

## What changed

**Settle where the merged graph is live.** `plan_and_publish` installs the merge's immutable changes
into the live query graph, which is history and revision lineage; the merged entity and relation
table arrives only when `finalize_local_repository_commit` derives the live correction and applies
it, one call later in `execute`. Both settle calls move to the two top-level executors, after the
finalization and still inside the persistence and graph-authority locks. Queueing the sweep from
there is the second half of it, not a side effect: the worker snapshots every entity once when it
starts, so one queued against the pre-finalization graph can snapshot entities the merge already
replaced. `execute` still returns early for an already-up-to-date merge, which publishes nothing.

**Keep a request the running pass cannot cover.** `DaemonState` gains one coalesced
`lsp_sweep_pending` bit and `request_lsp_sweep_after_merge`. Queueing a second sweep beside the
running one was the alternative and it is wrong: a caller waits on `lsp_sweeps_completed`, so two
passes over one graph let a waiter see the first finish and return over a graph the second is still
mutating. The worker drains the bit at the tail of its pass. The demand is published before the
attempt to queue, so a pass that ends between the two calls drains it rather than racing past it.

**Name every send arm.** `queue_lsp_sweep` matched only `TrySendError::Full`, so a channel whose
receiver a supervisor halt had already dropped fell through to `true` and the merge reported a
convergence it had not queued and could not queue. A `false` is now a channel that can never
deliver, and the merge says so with its own recovery line.

**Settle nothing on a merge that published nothing.** A merge that PARKS its conflicts also
returns an execution with a receipt and finalizes like any other repository transition, so it
reaches the executor the settle moved into; the same holds for `ResolveAction::Settle` and
`ResolveAction::Abort`. Moved naively, a parked merge would have recorded a census of the UNMERGED
graph under this merge's timestamp and retired every file's enrichment evidence. `MergeExecution`
and `ResolveExecution` carry `published_merged_graph`, true only in `publish` and
`publish_resolved_merge`, and the settle is gated on it. That case was green before this PR, so its
lock is listed above with a green landed column and a red reverted one.

**Retire the evidence the merge's own sweep would skip.** The marker means "the enrichment for this
file is durable", and the sweep skips a marked file before it asks a language server anything. A
merge makes that false for files nothing edited: a caller on one branch and its callee on the other
produce an edge that exists only once the merge exists, and the caller's file is unchanged by the
merge and was legitimately marked when it was swept. Retiring only the changed files does not close
it, because the answer that went stale is a cross-file one whose target moved elsewhere. The whole
set goes, through the `retire_enrichment_marker` that already exists.

## Falsification

Each fix was reverted and the test written for it went red again.

```
# the merge settles before finalization again
assertion `left == right` failed: ... the merged tree holds 3 entities and the record claims Some(2)
  left: Some(2)
 right: Some(3)
test result: FAILED. 0 passed; 1 failed; 35 filtered out; finished in 4.05s

# complete_lsp_sweep stops draining the pending demand
the running pass could not see this merge, so ending it has to hand the worker the merge's own
sweep; before this the request was dropped on the floor and the merged tree waited for a command
nobody knew
test result: FAILED. 0 passed; 1 failed; 1432 filtered out; finished in 1.19s

# queue_lsp_sweep reports a closed channel as queued
a merge with nothing left to run its sweep must not publish that gap quietly
test result: FAILED. 0 passed; 1 failed; 1432 filtered out; finished in 1.02s

# the merge stops retiring the enrichment evidence
a file the merge did not touch can still have gained a cross-file edge through it, and a sweep
that skips the file cannot derive one; the evidence has to be retired so the merge's own sweep
visits it
test result: FAILED. 0 passed; 1 failed; 1432 filtered out; finished in 1.61s

# the settle stops asking whether a merged graph was published
a parked merge composed no merged relation set, so it has none to record; a record written here
would describe the graph before the merge and carry this merge's timestamp
test result: FAILED. 0 passed; 1 failed; 36 filtered out; finished in 3.99s
```

Backups by copy and restore by copy, never `git checkout -- <file>`, which restores HEAD. Every
mutated file was compared against its backup afterwards and matched byte for byte.

## Verification

Every command through the fleet's builder slot, at the committed head on a
clean tree.

```
cargo test -p kin-daemon --lib
test result: ok. 1430 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 285.67s

cargo test -p kin-cli --test repository_merge_resolution
test result: ok. 37 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 33.94s

cargo fmt --all -- --check
clean
```

`bin/kin-precheck kin --repo-dir kin=<this worktree>` at head `2f1c08095`, 0 behind main, is running as this PR opens; its `21 gates enumerated from the check job of .github/workflows/ci.yml` line and its tally follow in a comment.

One thing worth knowing for whoever runs these next: an arm that runs the whole `kin-daemon` lib
suite and then the merge integration file in ONE heavy slot fails two integration tests on
contention. Both pass alone and together in a whole-file run of their own, and one of them,
`an_untouched_entity_differs_between_branches_only_in_its_span`, performs no merge at all, so no
path this change touches is on it. Split the arms before believing a regression there.

`crates/kin-daemon/src/repository_merge_state.rs` is three lines at the resolve path's own
finalization seam. The resolve path carries the identical defect and there is no way to reach it
from the merge path; no open kin PR touches that file.

Report: `.kin-coord/reports/showhn-mergeedges2-20260905.md`.

