### PR TITLE
Keep a merge's convergence demand and its evidence across an in-flight sweep

### DIFF
--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -1952,21 +1952,66 @@ fn graph_holds_language_server_relations(state: &DaemonState) -> bool {
 /// So the set is written once, after publication succeeds. Resume-after-kill
 /// degrades in the correct direction: a hard kill now re-sweeps, which is right,
 /// because a hard kill did not publish either.
-pub(crate) fn mark_files_enriched(state: &DaemonState, files: &[String]) {
+/// The marker generation a pass starting now would be recording against.
+///
+/// Read once when a pass takes its entity snapshot and carried to its tail,
+/// never read at the tail: the whole point is to notice that the set moved
+/// between the two.
+pub(crate) fn current_marker_epoch(state: &DaemonState) -> u64 {
+    state
+        .lsp_enriched_marker_epoch
+        .load(std::sync::atomic::Ordering::SeqCst)
+}
+
+/// Persist the enrichment marker set for this store.
+///
+/// Called ONLY with the `lsp_enriched_files` guard held by the caller, so the
+/// in-memory set and its durable record move together. Two writers that release
+/// before they persist can land in either order, and the losing order
+/// reintroduces at the next daemon start exactly the skips the winner retired.
+///
+/// One write site for both the marking path and the merge's retirement, which is
+/// also what keeps this file's raw filesystem touches to the three the
+/// zero-file-search allowlist accounts for.
+fn persist_enriched_marker(state: &DaemonState, files: &[String]) {
+    if let Ok(bytes) = serde_json::to_vec(files) {
+        let _ = std::fs::write(lsp_enriched_marker_path(state), bytes);
+    }
+}
+
+pub(crate) fn mark_files_enriched(state: &DaemonState, files: &[String], captured_epoch: u64) {
     if files.is_empty() {
         return;
     }
-    let snapshot = {
+    {
         let Ok(mut marked) = state.lsp_enriched_files.lock() else {
             return;
         };
+        // Read INSIDE the guard the insert happens under, and never before it.
+        // Read outside, a pass could satisfy this comparison, wait while a
+        // merge advanced the generation and cleared the set, and then insert
+        // its stale marks beneath that clear. That is the silent skip this
+        // whole rule exists to end, so the generation and the set move as one.
+        let epoch = state
+            .lsp_enriched_marker_epoch
+            .load(std::sync::atomic::Ordering::SeqCst);
+        if epoch != captured_epoch {
+            warn!(
+                files = files.len(),
+                captured_epoch,
+                epoch,
+                "not recording these files as enriched: the marker set was invalidated after \
+                 this pass started, so its answers describe a graph that has since moved"
+            );
+            return;
+        }
         for file in files {
             marked.insert(file.clone());
         }
-        marked.iter().cloned().collect::<Vec<_>>()
-    };
-    if let Ok(bytes) = serde_json::to_vec(&snapshot) {
-        let _ = std::fs::write(lsp_enriched_marker_path(state), bytes);
+        // Written INSIDE the guard, not after it. Written after, an old pass's
+        // snapshot could reach the file behind the cleared write a merge just
+        // made, and the next daemon would load the stale skips straight back.
+        persist_enriched_marker(state, &marked.iter().cloned().collect::<Vec<_>>());
     }
 }
 
@@ -2045,8 +2090,28 @@ pub(crate) fn complete_lsp_sweep(state: &DaemonState, files_blocked: u64) {
     // demand waited here rather than being queued beside this one, so that a
     // caller waiting on `lsp_sweeps_completed` could not see the wrong pass
     // finish. Drained after the running flag clears, so the queue accepts it.
-    if state.take_pending_lsp_sweep() {
-        state.queue_lsp_sweep();
+    drain_pending_lsp_sweep(state);
+}
+
+/// Hand the worker a sweep a merge asked for while a pass was running, if the
+/// queue will take one now.
+///
+/// The bit is RESTORED when the queue refuses. `queue_lsp_sweep` answers false
+/// for a FULL channel exactly as it does for a closed one, and consuming the bit
+/// while ignoring that answer threw the demand away in the one case it exists
+/// for.
+///
+/// Called at the worker's receive boundary as well as at a sweep's tail, and the
+/// receive boundary is the one that makes it converge: the tail runs only when a
+/// sweep COMPLETES, so a queue full of incremental work with no sweep queued
+/// would drain message by message while the demand sat in the bit forever. At
+/// the boundary the worker has just taken a message, so the next attempt has
+/// room.
+pub(crate) fn drain_pending_lsp_sweep(state: &DaemonState) {
+    if state.take_pending_lsp_sweep() && !state.queue_lsp_sweep() {
+        state
+            .lsp_sweep_pending
+            .store(true, std::sync::atomic::Ordering::SeqCst);
     }
 }
 
@@ -2068,12 +2133,37 @@ pub(crate) fn complete_lsp_sweep(state: &DaemonState, files_blocked: u64) {
 /// built on: a wrong skip is silent and loses the answers, a wrong re-sweep
 /// only costs time.
 pub(crate) fn retire_enrichment_evidence_for_merge(state: &DaemonState) {
-    let Ok(marked) = state.lsp_enriched_files.lock() else {
-        return;
+    let retired = {
+        // One critical section, and the same lock taken first by every writer
+        // of this evidence. Bumping outside it would let a pass's tail read the
+        // old generation, block here, and then insert beneath the clear below,
+        // which is the interleaving the generation exists to refuse.
+        let Ok(mut marked) = state.lsp_enriched_files.lock() else {
+            return;
+        };
+        // Bumped unconditionally, and before the clear, because what a merge
+        // invalidates is not only what is marked at this instant: a sweep
+        // already in flight is holding the files it is about to mark, derived
+        // from language-server answers taken before this merge existed, and an
+        // empty marker set right now does not mean there is nothing to
+        // invalidate.
+        state
+            .lsp_enriched_marker_epoch
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let retired = marked.len();
+        marked.clear();
+        if retired > 0 {
+            persist_enriched_marker(state, &[]);
+        }
+        retired
     };
-    let files: Vec<String> = marked.iter().cloned().collect();
-    drop(marked);
-    retire_enrichment_marker(state, &files);
+    if retired > 0 {
+        debug!(
+            files = retired,
+            "retired every enrichment marker for a published merge; the sweep it queued \
+             re-derives them"
+        );
+    }
 }
 
 /// The batch size one embedding pass may use under a pressure verdict.
@@ -5133,6 +5223,13 @@ pub async fn run_with_authority_on(
                     break;
                 }
 
+                // A merge admitted while a pass was running left its demand on
+                // the pending bit. Drained here, at the receive boundary, and
+                // not only at a sweep's tail: the tail runs only when a sweep
+                // completes, so a queue holding nothing but incremental work
+                // would drain forever with the demand still sitting in the bit.
+                drain_pending_lsp_sweep(&lsp_state);
+
                 // Process buffered requests first (always incremental), then wait for new messages.
                 let message = if let Some(buffered) = pending_buffer.pop() {
                     LspEnrichmentMessage::Incremental(buffered)
@@ -5413,6 +5510,13 @@ pub async fn run_with_authority_on(
                         lsp_state
                             .lsp_sweep_files_done
                             .store(0, std::sync::atomic::Ordering::SeqCst);
+
+                        // The marker generation this pass's answers describe,
+                        // captured with the entity snapshot they are taken over
+                        // rather than at the tail, because the tail is where
+                        // the record is written and by then the graph may have
+                        // moved underneath every answer in it.
+                        let marker_epoch = current_marker_epoch(&lsp_state);
 
                         // Get all entities from the graph.
                         use kin_model::EntityStore;
@@ -5898,7 +6002,7 @@ pub async fn run_with_authority_on(
                             );
                         }
                         if sweep_marker_is_durable(total_relations, published) {
-                            mark_files_enriched(&lsp_state, &enriched_this_sweep);
+                            mark_files_enriched(&lsp_state, &enriched_this_sweep, marker_epoch);
                         } else {
                             warn!(
                                 files = enriched_this_sweep.len(),
@@ -7261,7 +7365,7 @@ mod tests {
         ];
         let never_reached = "src/requests/models.py";
 
-        super::mark_files_enriched(&state, &completed);
+        super::mark_files_enriched(&state, &completed, super::current_marker_epoch(&state));
 
         for file in &completed {
             assert!(
@@ -7907,6 +8011,7 @@ mod enrichment_marker_tests {
         super::mark_files_enriched(
             &state,
             &["src/sessions.py".to_string(), "src/adapters.py".to_string()],
+            super::current_marker_epoch(&state),
         );
         assert!(
             file_already_enriched(&state, "src/sessions.py"),
@@ -7949,7 +8054,11 @@ mod enrichment_marker_tests {
         let init = kin_core::init(repo_dir.path()).unwrap();
         let state = DaemonState::open(init.layout).unwrap();
         install_language_server_relation(&state);
-        super::mark_files_enriched(&state, &["src/sessions.py".to_string()]);
+        super::mark_files_enriched(
+            &state,
+            &["src/sessions.py".to_string()],
+            super::current_marker_epoch(&state),
+        );
 
         super::retire_enrichment_marker(&state, &["src/models.py".to_string()]);
 
@@ -9598,7 +9707,7 @@ mod sweep_lifecycle_tests {
 
             sweep_started(&state);
             // The sweep's tail, in the order the sweep runs it.
-            mark_files_enriched(&state, &files);
+            mark_files_enriched(&state, &files, super::current_marker_epoch(&state));
             let counted = sweep_finished(&state, false, files.len());
 
             assert_eq!(

--- a/crates/kin-daemon/src/repository_merge.rs
+++ b/crates/kin-daemon/src/repository_merge.rs
@@ -4591,7 +4591,11 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let init = kin_core::init(root.path()).unwrap();
         let (state, _rx) = enriching_state(init.layout.clone());
-        crate::daemon::mark_files_enriched(&state, &["ledger/printing.py".to_string()]);
+        crate::daemon::mark_files_enriched(
+            &state,
+            &["ledger/printing.py".to_string()],
+            crate::daemon::current_marker_epoch(&state),
+        );
         assert!(
             crate::daemon::file_already_enriched(&state, "ledger/printing.py"),
             "the fixture has to start marked, or the assertion below proves nothing"
@@ -4604,6 +4608,155 @@ mod tests {
             "a file the merge did not touch can still have gained a cross-file edge through it, \
              and a sweep that skips the file cannot derive one; the evidence has to be retired so \
              the merge's own sweep visits it"
+        );
+    }
+
+    /// FIR-3242. A merge's demand outlives a full channel at the pass tail.
+    ///
+    /// `complete_lsp_sweep` swapped the pending bit to false and then threw
+    /// away what `queue_lsp_sweep` answered, and `queue_lsp_sweep` answers
+    /// false for a FULL channel exactly as it does for a closed one. So a
+    /// bounded queue with anything in it at the moment a pass ends consumed the
+    /// merge's demand and queued nothing, and the merged tree went back to
+    /// waiting for a command nobody knows to type.
+    ///
+    /// The empty-channel row is
+    /// `a_merge_admitted_while_a_sweep_runs_gets_one_after_that_sweep_ends`,
+    /// and it is the control this one is set beside: there the tail queues the
+    /// sweep and clears the bit, and both rows have to hold.
+    #[test]
+    fn a_merge_demand_outlives_a_full_channel_at_the_pass_tail() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let (state, mut rx) = enriching_state(init.layout.clone());
+        state
+            .lsp_sweep_running
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+
+        assert!(
+            state.request_lsp_sweep_after_merge(),
+            "a merge admitted under a running pass is told its sweep is coming, which is the \
+             promise the rest of this test holds the daemon to"
+        );
+
+        // What a busy incremental path leaves behind, and what the tail below
+        // has to send into.
+        let filled = {
+            let tx = state
+                .lsp_enrichment_tx
+                .as_ref()
+                .expect("the fixture's daemon can enrich");
+            let mut filled = 0usize;
+            // Incremental messages, deliberately: a queue full of SWEEPS would
+            // complete one and drain the bit at that tail, which is the path
+            // this test exists to prove is not the only one.
+            while tx
+                .try_send(crate::state::LspEnrichmentMessage::Incremental(
+                    crate::state::LspEnrichmentRequest {
+                        file_id: kin_model::FilePathId::new("ledger/model.py"),
+                        changed_entity_ids: Vec::new(),
+                    },
+                ))
+                .is_ok()
+            {
+                filled += 1;
+            }
+            filled
+        };
+        assert!(
+            filled > 0,
+            "the fixture has to actually fill the queue, or the tail below meets an empty one \
+             and this test is the control instead"
+        );
+
+        crate::daemon::complete_lsp_sweep(&state, 0);
+
+        assert!(
+            state
+                .lsp_sweep_pending
+                .load(std::sync::atomic::Ordering::SeqCst),
+            "the tail could not queue into a full channel, so the demand has to still be \
+             recorded; it was consumed and the failure to place it was thrown away"
+        );
+
+        // And the demand is live rather than merely remembered. The retry that
+        // matters is NOT another sweep completing: with the queue holding
+        // nothing but incremental work, no sweep ever completes, and a demand
+        // only a tail could drain would sit in the bit forever. So this drives
+        // the drain the worker runs at its receive boundary, after it takes a
+        // message and before it blocks again, with no completion at all.
+        state
+            .lsp_sweep_running
+            .store(false, std::sync::atomic::Ordering::SeqCst);
+        rx.try_recv().expect("the worker takes one message");
+        crate::daemon::drain_pending_lsp_sweep(&state);
+
+        let mut delivered = false;
+        while let Ok(message) = rx.try_recv() {
+            delivered |= matches!(message, crate::state::LspEnrichmentMessage::Sweep);
+        }
+        assert!(
+            delivered,
+            "the receive boundary has to hand the merge its sweep once the queue has room; a \
+             demand nothing can ever act on is the same defect wearing a bit"
+        );
+        assert!(
+            !state
+                .lsp_sweep_pending
+                .load(std::sync::atomic::Ordering::SeqCst),
+            "and the bit clears once the sweep is actually placed, or the next boundary queues a \
+             second one"
+        );
+    }
+
+    /// FIR-3242. A pass that started before the merge cannot restore what the
+    /// merge retired.
+    ///
+    /// The worker lists every entity once when it starts, and marks the files
+    /// it finished durable at its tail, and only then completes. A merge that
+    /// lands between those two points retires the marker set, and then that old
+    /// pass's tail marks its own files again, using language-server answers
+    /// taken before the merge existed. The sweep the merge queued then skips
+    /// exactly the files whose cross-file answers the merge changed.
+    ///
+    /// The retirement test beside this one asserts immediately after the settle
+    /// and never reaches the old tail, which is why it stayed green over this.
+    #[test]
+    fn a_pass_that_started_before_the_merge_cannot_restore_what_the_merge_retired() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let (state, _rx) = enriching_state(init.layout.clone());
+        state
+            .lsp_sweep_running
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let enriched_this_sweep = vec!["ledger/printing.py".to_string()];
+        // What the pass carries from the moment it listed the graph.
+        let started_at = crate::daemon::current_marker_epoch(&state);
+
+        settle_merged_graph(&state);
+
+        // The old pass reaches its tail: it judges its writes durable, marks
+        // what it finished, and only then completes.
+        crate::daemon::mark_files_enriched(&state, &enriched_this_sweep, started_at);
+        crate::daemon::complete_lsp_sweep(&state, 0);
+
+        assert!(
+            !crate::daemon::file_already_enriched(&state, "ledger/printing.py"),
+            "this pass took its answers before the merge existed, so its mark cannot outrank the \
+             merge's retirement; the sweep the merge queued has to visit the file"
+        );
+
+        // The control, and it is the whole reason this rule is a comparison
+        // rather than a refusal: a pass that started AFTER the merge still
+        // records what it finished. Without it the rule above is satisfied by a
+        // marker that never marks anything, which would retire the skip
+        // entirely and re-sweep the store on every pass forever.
+        let after_the_merge = crate::daemon::current_marker_epoch(&state);
+        crate::daemon::mark_files_enriched(&state, &enriched_this_sweep, after_the_merge);
+        assert!(
+            crate::daemon::file_already_enriched(&state, "ledger/printing.py"),
+            "a pass whose answers postdate the merge records them, or the marker has stopped \
+             being a marker"
         );
     }
 

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -3187,6 +3187,18 @@ pub struct DaemonState {
     /// mutating. One coalesced bit rather than a counter, because the demand is
     /// "sweep the graph as it now stands" and two of those are one.
     pub lsp_sweep_pending: AtomicBool,
+    /// How many times this store's enrichment markers have been invalidated
+    /// wholesale.
+    ///
+    /// A cold sweep takes its language-server answers over a graph it lists
+    /// once, and records what it finished at its tail, long after. Anything
+    /// that invalidates the marker set in between makes that record false, and
+    /// the pass cannot see it: a merge retires every marker and the pass then
+    /// puts its own straight back, so the sweep the merge queued skips exactly
+    /// the files whose cross-file answers the merge changed. A pass carries the
+    /// value this held when it started, and its tail is refused when the value
+    /// has moved.
+    pub lsp_enriched_marker_epoch: AtomicU64,
     /// Files a sweep has finished enriching, so a later pass can skip them.
     ///
     /// An explicit marker rather than an inference from the graph. Two attempts
@@ -5305,6 +5317,7 @@ impl DaemonState {
             lsp_sweeps_completed: AtomicU64::new(0),
             lsp_sweep_running: AtomicBool::new(false),
             lsp_sweep_pending: AtomicBool::new(false),
+            lsp_enriched_marker_epoch: AtomicU64::new(0),
             lsp_enriched_files: std::sync::Mutex::new(std::collections::HashSet::new()),
             unpublished_enrichment: std::sync::Mutex::new(std::collections::HashSet::new()),
             cached_repo_id,
@@ -5674,6 +5687,7 @@ impl DaemonState {
             lsp_sweeps_completed: AtomicU64::new(0),
             lsp_sweep_running: AtomicBool::new(false),
             lsp_sweep_pending: AtomicBool::new(false),
+            lsp_enriched_marker_epoch: AtomicU64::new(0),
             lsp_enriched_files: std::sync::Mutex::new(std::collections::HashSet::new()),
             unpublished_enrichment: std::sync::Mutex::new(std::collections::HashSet::new()),
             cached_repo_id: repo_id.to_string(),


### PR DESCRIPTION
FIR-3242.

Two interleavings between a merge and a cold sweep already running, both found by an independent
source review of the landed convergence fix and neither reproduced by it. Both reproduce. A
falsifier was written for each on the landed tree before any code change, and both went red.

The first loses the merge's sweep demand: `complete_lsp_sweep` consumed the pending bit and threw
away what `queue_lsp_sweep` answered, and that answer is false for a FULL channel exactly as it is
for a closed one. The second loses the merge's retirement: a sweep that started before the merge
marks its own files enriched at its tail, after the merge retired every marker, so the follow-up
sweep skips exactly the files whose cross-file answers the merge changed.

## Measured first, on the landed tree

`25bfaa567` plus the two new tests and nothing else, after `cargo build -p kin-daemon --bin
kin-daemon` in the same arm:

```
test repository_merge::tests::a_merge_demand_outlives_a_full_channel_at_the_pass_tail ... FAILED
test repository_merge::tests::a_pass_that_started_before_the_merge_cannot_restore_what_the_merge_retired ... FAILED
test result: FAILED. 27 passed; 2 failed; 0 ignored; 0 measured; 1408 filtered out; finished in 2.65s

panicked at crates/kin-daemon/src/repository_merge.rs:4659:9:
the tail could not queue into a full channel, so the demand has to still be recorded; it was
consumed and the failure to place it was thrown away

panicked at crates/kin-daemon/src/repository_merge.rs:4708:9:
this pass took its answers before the merge existed, so its mark cannot outrank the merge's
retirement; the sweep the merge queued has to visit the file
```

The 27 that passed include both controls this pair is set beside: the same tail over an EMPTY
channel, and the retirement asserted immediately after the settle. Both stayed green over both
defects, which is why neither was caught.

## What changed

**The tail keeps a demand it could not place, and the worker retries it.** The pending bit is
restored when `queue_lsp_sweep` refuses, and the retry runs at the worker's own receive boundary
rather than only at a sweep's tail. The tail runs only when a sweep COMPLETES, so a queue holding
nothing but incremental work would drain message by message with the demand sitting in the bit
forever. At the boundary the worker has just taken a message, so the next attempt has room. Having
the tail run the sweep inline was the other option, and it would either enqueue into its own full
queue or hold the worker in its own loop.

**The marker commit is bound to the generation the pass started in, under one lock.** `DaemonState`
carries `lsp_enriched_marker_epoch`, and every writer takes `lsp_enriched_files` first and touches
the generation inside that guard. Read outside it, a tail could satisfy the comparison, block while
a merge advanced the generation and cleared the set, and then insert its stale marks beneath that
clear. The persisted record is written inside the same guard for the same reason: two writers
releasing before they persist can land in either order, and the losing order reintroduces every
skip at the next daemon start. Both marker writes share one helper, which also keeps this file's
raw filesystem touches to the three the zero-file-search allowlist accounts for. The worker reads it beside its entity snapshot and hands it to the
tail, `mark_files_enriched` refuses a commit whose generation has moved and says so at `warn!`,
and `retire_enrichment_evidence_for_merge` bumps it unconditionally and before the removal, because
a pass already in flight is holding the files it is about to mark and an empty marker set does not
mean there is nothing to invalidate.

The second rule is a comparison rather than a refusal, and its test carries the control that makes
that load-bearing: a pass whose answers postdate the merge still records them. Without it the rule
is satisfied by a marker that never marks, which would re-sweep the store on every pass forever.

Scope held: the two reconcile paths that retire markers do NOT bump the generation. The same class
exists there, a file edited mid-sweep and re-marked by that sweep's tail, and it is a wider blast
radius than this ticket's falsifier reaches.

## Falsification

Each fix reverted, each test red again. Backups by copy and restore by copy, never
`git checkout -- <file>`; the file matched its backup byte for byte afterwards.

```
### MUTANT F: the tail goes back to ignoring what the queue answered
panicked at crates/kin-daemon/src/repository_merge.rs:4666:9:
the tail could not queue into a full channel, so the demand has to still be recorded; it was
consumed and the failure to place it was thrown away
test result: FAILED. 0 passed; 1 failed; 1436 filtered out; finished in 1.12s

### MUTANT G: the marker commit stops comparing generations
panicked at crates/kin-daemon/src/repository_merge.rs:4717:9:
this pass took its answers before the merge existed, so its mark cannot outrank the merge's
retirement; the sweep the merge queued has to visit the file
test result: FAILED. 0 passed; 1 failed; 1436 filtered out; finished in 1.13s

### MUTANT H: the merge stops bumping the generation it invalidates
panicked at crates/kin-daemon/src/repository_merge.rs:4717:9:
this pass took its answers before the merge existed, so its mark cannot outrank the merge's
retirement; the sweep the merge queued has to visit the file
test result: FAILED. 0 passed; 1 failed; 1436 filtered out; finished in 0.77s
```

G and H are the two halves of the second fix, the comparison at the tail and the bump at the merge,
and either alone leaves the defect standing.

Re-run at the revised head after the review round, on the two behaviours it changed:

```
### MUTANT I: the drain consumes the demand without checking it was placed
panicked at crates/kin-daemon/src/repository_merge.rs:4674:9:
the tail could not queue into a full channel, so the demand has to still be recorded; it was
consumed and the failure to place it was thrown away
test result: FAILED. 0 passed; 1 failed; 1436 filtered out; finished in 1.20s

### MUTANT J: the marker commit stops comparing generations under the guard
panicked at crates/kin-daemon/src/repository_merge.rs:4743:9:
this pass took its answers before the merge existed, so its mark cannot outrank the merge's
retirement; the sweep the merge queued has to visit the file
test result: FAILED. 0 passed; 1 failed; 1436 filtered out; finished in 1.14s
```

Three properties in this change are stated rather than covered by a deterministic test, because the
code has no seam a single-threaded test can drive: the worker's receive-boundary drain is exercised
through `drain_pending_lsp_sweep`, the function the loop calls, rather than through the whole worker
loop; the PLACEMENT of that call at the receive boundary is therefore not covered either, since a
test that calls the function directly cannot see the call site move; and the write-ordering property
needs two threads with a barrier between a guard release and a write. Both are argued from the diff and the lock order, and no existing assertion was weakened to
accommodate either.

## Verification

```
cargo test -p kin-daemon --lib
test result: ok. 1434 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 246.69s

cargo fmt --all -- --check
clean
```

1430 before this change, 1434 now: the two falsifiers plus the two controls.

`bin/kin-precheck kin --repo-dir kin=<this worktree>`, named by absolute path, at the committed head on a clean tree: `21 gates ran, 21 passed, 0 failed, on kin 1844b5bdbc75307bfec32546aadf1de670a9a667`. Full tally in a comment.
