### PR TITLE
Preserve prepared binding preflight through storage decorators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3295,9 +3295,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.103"
+version = "0.7.104"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "82eff0bcc9a6b69bb06bde1e771695abe9d3b93ea53a67a1f32e0176a7aa0e09"
+checksum = "cddb9f8689824e1884b1cbc234e105865571a1a266ec2c702983f6f61412e818"
 dependencies = [
  "bincode",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ kin-lsp = { version = "=0.7.16", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.103", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.104", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.24", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-daemon/src/source_body_memo.rs
+++ b/crates/kin-daemon/src/source_body_memo.rs
@@ -459,6 +459,15 @@ impl StorageBackend for SourceBodyMemoBackend {
         )
     }
 
+    fn load_prepared_workspace_graph_binding(
+        &self,
+        repo_id: &str,
+        workspace_id: &str,
+    ) -> Result<Option<Vec<u8>>, KinDbError> {
+        self.inner
+            .load_prepared_workspace_graph_binding(repo_id, workspace_id)
+    }
+
     fn load_prepared_workspace_graph(
         &self,
         repo_id: &str,
@@ -562,6 +571,8 @@ mod tests {
         cursor_reads: std::sync::Arc<AtomicU64>,
         snapshot_reads: std::sync::Arc<AtomicU64>,
         recovery_reads: std::sync::Arc<AtomicU64>,
+        prepared_bindings: std::sync::Arc<Mutex<HashMap<(String, String), Vec<u8>>>>,
+        prepared_binding_reads: std::sync::Arc<AtomicU64>,
     }
 
     impl CountingBackend {
@@ -574,6 +585,20 @@ mod tests {
     }
 
     impl StorageBackend for CountingBackend {
+        fn load_prepared_workspace_graph_binding(
+            &self,
+            repo_id: &str,
+            workspace_id: &str,
+        ) -> Result<Option<Vec<u8>>, KinDbError> {
+            self.prepared_binding_reads.fetch_add(1, Ordering::SeqCst);
+            Ok(self
+                .prepared_bindings
+                .lock()
+                .unwrap()
+                .get(&(repo_id.to_string(), workspace_id.to_string()))
+                .cloned())
+        }
+
         fn load_snapshot(
             &self,
             _repo_id: &str,
@@ -875,6 +900,63 @@ mod tests {
         assert_eq!(backend.body_reads.load(Ordering::SeqCst), 5);
         memo.load_source_blob("kin", digest(3)).unwrap().unwrap();
         assert_eq!(backend.body_reads.load(Ordering::SeqCst), 5);
+    }
+
+    #[test]
+    fn prepared_binding_reads_cross_both_decorators_without_becoming_body_cache_entries() {
+        use crate::storage_delegate::{DelegatingBackend, StorageBackendDelegate};
+
+        struct PassThrough(SourceBodyMemoBackend);
+        impl StorageBackendDelegate for PassThrough {
+            fn delegate(&self) -> &dyn StorageBackend {
+                &self.0
+            }
+        }
+
+        let (backend, memo) = fixture();
+        let key = ("repo-a".to_string(), "workspace-a".to_string());
+        backend
+            .prepared_bindings
+            .lock()
+            .unwrap()
+            .insert(key.clone(), b"first-binding".to_vec());
+        assert_eq!(
+            memo.load_prepared_workspace_graph_binding("repo-a", "workspace-a")
+                .unwrap(),
+            Some(b"first-binding".to_vec())
+        );
+
+        let decorated = DelegatingBackend::new(PassThrough(memo));
+        assert_eq!(
+            decorated
+                .load_prepared_workspace_graph_binding("repo-a", "workspace-a")
+                .unwrap(),
+            Some(b"first-binding".to_vec())
+        );
+        backend
+            .prepared_bindings
+            .lock()
+            .unwrap()
+            .insert(key, b"replacement-binding".to_vec());
+        assert_eq!(
+            decorated
+                .load_prepared_workspace_graph_binding("repo-a", "workspace-a")
+                .unwrap(),
+            Some(b"replacement-binding".to_vec())
+        );
+        for (repo, workspace) in [("repo-b", "workspace-a"), ("repo-a", "workspace-b")] {
+            assert_eq!(
+                decorated
+                    .load_prepared_workspace_graph_binding(repo, workspace)
+                    .unwrap(),
+                None
+            );
+        }
+        assert_eq!(decorated.decorator().0.resident_bytes(), 0);
+        assert_eq!(backend.prepared_binding_reads.load(Ordering::SeqCst), 5);
+        assert_eq!(backend.body_reads.load(Ordering::SeqCst), 0);
+        assert_eq!(backend.snapshot_reads.load(Ordering::SeqCst), 0);
+        assert_eq!(backend.recovery_reads.load(Ordering::SeqCst), 0);
     }
 
     /// The regression that started this work, pinned on the new decorator.

--- a/crates/kin-daemon/src/storage_delegate.rs
+++ b/crates/kin-daemon/src/storage_delegate.rs
@@ -62,7 +62,7 @@ use kin_db::{
 /// `storage_backend_surface_is_audited_against_the_pinned_kin_db` fails when
 /// the workspace pin moves past it, which is the only moment a method can have
 /// appeared.
-pub const AUDITED_KIN_DB_VERSION: &str = "0.7.103";
+pub const AUDITED_KIN_DB_VERSION: &str = "0.7.104";
 
 /// Wraps a [`StorageBackendDelegate`] so it can be handed anywhere a
 /// `Box<dyn StorageBackend>` is expected.
@@ -168,6 +168,11 @@ storage_backend_surface! {
         journal_sha256: &str,
         validator_version: u32,
     ) -> Result<bool, KinDbError>;
+    fn load_prepared_workspace_graph_binding(
+        &self,
+        repo_id: &str,
+        workspace_id: &str,
+    ) -> Result<Option<Vec<u8>>, KinDbError>;
     fn load_prepared_workspace_graph(
         &self,
         repo_id: &str,
@@ -311,8 +316,8 @@ mod tests {
         );
         assert_eq!(
             BRIDGED_STORAGE_BACKEND_METHODS.len(),
-            32,
-            "kin-db {AUDITED_KIN_DB_VERSION} declares 32 StorageBackend methods"
+            33,
+            "kin-db {AUDITED_KIN_DB_VERSION} declares 33 StorageBackend methods"
         );
     }
 }


### PR DESCRIPTION
Prepared snapshot binding hints disappeared when storage was wrapped by the daemon decorators, so a backend could not reject an ineligible prepared artifact before loading its payload. Forward the optional binding read through both decorators and pin kin-db 0.7.104. Eligible artifacts and backends without the hint retain the full validation path.

The regression exercises both real decorators, changed bindings, repository/workspace isolation, and zero source-body cache growth. The published dependency checksum and source identity were verified.

Verification against commit 8c310a7ecf72553d13f1ba8e45948d59aa27acb8 used an isolated checkout, registry-only dependencies and the committed lock:

```text
cargo build --release --locked --bin kin --bin kin-daemon
exit 0; both binary versions identify 8c310a7ecf72553d13f1ba8e45948d59aa27acb8

cargo test --locked -p kin-daemon --lib source_body_memo::tests:: -- --nocapture
test result: ok. 10 passed; 0 failed
cargo test --locked -p kin-daemon --lib storage_delegate::tests:: -- --nocapture
test result: ok. 2 passed; 0 failed

cargo test --locked -p kin-daemon --lib source_body_memo::tests::prepared_binding_reads_cross_both_decorators_without_becoming_body_cache_entries -- --exact --nocapture
Omit memo forwarding: compiled; assertion failed at source_body_memo.rs:914, left None, right Some(first-binding); exit 101
Omit delegate forwarding: compiled; assertion failed at source_body_memo.rs:930, left None, right Some(first-binding); exit 101
Restored source: 10 memo tests and 2 delegate tests passed again

kin-precheck kin --repo-dir kin=<isolated exact-commit checkout> --no-fetch
21 gates ran, 21 passed, 0 failed, on kin 8c310a7ecf72553d13f1ba8e45948d59aa27acb8
```

Local parity has not run because acceptance cleanup still contains a numeric-PID signalling fallback being repaired separately. Memory measurement and final main/released-byte acceptance remain open; this change does not close the performance finding by itself.

Tracks FIR-3203.
