### PR TITLE
Answer hosted readiness from the cached spine authority proof (FIR-3255)

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -4078,6 +4078,13 @@ async fn health(
     }))
 }
 
+/// An authority answer at least this slow is reported even when it succeeds.
+///
+/// The tightest probe timeout the hosted deployment configures is the readiness
+/// probe's `timeoutSeconds: 1`, so a probe answered more slowly than this was
+/// already a timeout on the prober's side whatever this daemon returned.
+const READINESS_SLOW_ANSWER: Duration = Duration::from_secs(1);
+
 /// GET /readiness — returns 200 when initialized, 503 otherwise.
 /// An initialized daemon has either loaded a snapshot or completed at least
 /// one reconciliation cycle. An empty but initialized workspace is ready.
@@ -4096,17 +4103,43 @@ async fn readiness(State(state): State<Arc<DaemonState>>) -> impl IntoResponse {
     // Option keeps a branch that never consulted the gate from ever printing a
     // measured-looking zero for it.
     let mut authority_wait: Option<Duration> = None;
+    let mut authority_refusal: Option<String> = None;
     let hosted_spine_ready = if initialized && hosted {
+        // Start the pass that keeps the authority proof current, then read that
+        // proof. Establishing it here instead is what starved the kubelet on
+        // 2026-09-05; `DaemonState::hosted_readiness_spine_authority` carries
+        // the measurement and what the probe still refuses on.
+        state.start_hosted_spine_authority_refresh_cadence();
         let started = Instant::now();
-        let ready = state.acquire_spine_read_authority().await.is_some();
+        let answer = state.hosted_readiness_spine_authority().await;
         authority_wait = Some(started.elapsed());
-        ready
+        match answer {
+            Ok(()) => true,
+            Err(reason) => {
+                authority_refusal = Some(reason);
+                false
+            }
+        }
     } else {
         true
     };
     let warming = state.spine_warming() || (initialized && !hosted_spine_ready);
 
     if initialized && hosted_spine_ready {
+        // A success slower than the probe's own timeout is invisible to the
+        // prober: Kubernetes records a timeout and nothing else. On 2026-09-05 a
+        // hosted pod answered `{"ready":true,"warming":false}` after 175.7 s and
+        // its log said nothing about it, because only the refusal branch below
+        // reported its waits. So report them here too, and only here: an
+        // unconditional line would print on every probe for the life of the pod
+        // and bury the one case that matters.
+        if let Some(waited) = authority_wait.filter(|waited| *waited >= READINESS_SLOW_ANSWER) {
+            tracing::warn!(
+                authority_wait_ms = waited.as_millis() as u64,
+                spine_gate_wait_ms = state.last_spine_gate_read_wait().as_millis() as u64,
+                "readiness answered ready more slowly than a probe timeout"
+            );
+        }
         (
             StatusCode::OK,
             Json(ReadinessResponse {
@@ -4155,6 +4188,7 @@ async fn readiness(State(state): State<Arc<DaemonState>>) -> impl IntoResponse {
                     refused_on = "hosted spine authority",
                     authority_wait_ms = waited.as_millis() as u64,
                     spine_gate_wait_ms = state.last_spine_gate_read_wait().as_millis() as u64,
+                    reason = authority_refusal.as_deref().unwrap_or("unreported"),
                     "readiness refused"
                 ),
             }
@@ -45338,6 +45372,14 @@ mod tests {
     /// The environment guard is returned so it lives as long as the state;
     /// dropping it restores the variables.
     fn hosted_test_state() -> (Arc<DaemonState>, kin_core::test_env::EnvVarGuard) {
+        hosted_test_state_over(Arc::new(kin_spine::test_support::FakeSpineStore::cold()))
+    }
+
+    /// The same fixture over a caller-supplied durable store, so a test can
+    /// measure or charge what the store is asked for.
+    fn hosted_test_state_over(
+        spine_store: Arc<dyn kin_spine::SpineStore>,
+    ) -> (Arc<DaemonState>, kin_core::test_env::EnvVarGuard) {
         const READER: &str =
             "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         let fleet = vec![
@@ -45395,9 +45437,7 @@ mod tests {
             .unwrap(),
         );
         state.install_hosted_durable_spine_for_test(Arc::new(
-            kin_spine::FirestoreSpineBackend::with_store(Arc::new(
-                kin_spine::test_support::FakeSpineStore::cold(),
-            )),
+            kin_spine::FirestoreSpineBackend::with_store(spine_store),
         ));
         assert!(
             state.hosted_spine_readiness_required(),
@@ -45405,6 +45445,203 @@ mod tests {
              exercise nothing FIR-3179 is about"
         );
         (state, environment)
+    }
+
+    /// A durable spine store that delegates every call and can be given the
+    /// cost a real durable read has.
+    ///
+    /// `load_repo_publications` is the read the cache hydration makes, exactly
+    /// one per hydration, so counting it counts hydrations and charging it
+    /// charges them. The charge starts at zero so the fixture can publish and
+    /// admit at full speed, and is armed only for the pass under test.
+    struct MeasuredSpineStore {
+        inner: Arc<kin_spine::test_support::FakeSpineStore>,
+        durable_reads: std::sync::atomic::AtomicUsize,
+        charge_ms: std::sync::atomic::AtomicU64,
+    }
+
+    impl MeasuredSpineStore {
+        fn cold() -> Self {
+            Self {
+                inner: Arc::new(kin_spine::test_support::FakeSpineStore::cold()),
+                durable_reads: std::sync::atomic::AtomicUsize::new(0),
+                charge_ms: std::sync::atomic::AtomicU64::new(0),
+            }
+        }
+
+        fn durable_reads(&self) -> usize {
+            self.durable_reads.load(std::sync::atomic::Ordering::SeqCst)
+        }
+
+        fn charge_each_durable_read(&self, cost: Duration) {
+            self.charge_ms.store(
+                u64::try_from(cost.as_millis()).unwrap_or(u64::MAX),
+                std::sync::atomic::Ordering::SeqCst,
+            );
+        }
+
+        fn charge(&self) {
+            self.durable_reads
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let charge = self.charge_ms.load(std::sync::atomic::Ordering::SeqCst);
+            if charge > 0 {
+                std::thread::sleep(Duration::from_millis(charge));
+            }
+        }
+    }
+
+    impl kin_spine::SpineStore for MeasuredSpineStore {
+        fn load_repo_publications(
+            &self,
+        ) -> std::result::Result<Vec<kin_spine::LoadedRepoPublication>, kin_spine::SpineError>
+        {
+            self.charge();
+            self.inner.load_repo_publications()
+        }
+
+        fn load_rollout_fence(
+            &self,
+        ) -> std::result::Result<Option<kin_spine::LoadedSpineRolloutFence>, kin_spine::SpineError>
+        {
+            self.inner.load_rollout_fence()
+        }
+
+        fn advance_rollout_fence(
+            &self,
+            fence: kin_spine::SpineRolloutFence,
+        ) -> std::result::Result<kin_spine::SpineRolloutFenceCommit, kin_spine::SpineError>
+        {
+            self.inner.advance_rollout_fence(fence)
+        }
+
+        fn legacy_migration_complete(&self) -> std::result::Result<bool, kin_spine::SpineError> {
+            self.inner.legacy_migration_complete()
+        }
+
+        fn complete_legacy_migration(
+            &self,
+            rollout_fence: &kin_spine::LoadedSpineRolloutFence,
+            writer_drain: &kin_spine::LegacySpineWriterDrainAttestation,
+        ) -> std::result::Result<(), kin_spine::SpineError> {
+            self.inner
+                .complete_legacy_migration(rollout_fence, writer_drain)
+        }
+
+        fn prepare_repo_publication(
+            &self,
+            publication: kin_spine::RepoSpinePublication,
+        ) -> std::result::Result<kin_spine::PreparedStorePublication, kin_spine::SpineError>
+        {
+            self.inner.prepare_repo_publication(publication)
+        }
+
+        fn prepare_repo_publication_bound(
+            &self,
+            publication: kin_spine::RepoSpinePublication,
+            expected_rollout_fence: &kin_spine::SpineRolloutFenceEvidence,
+        ) -> std::result::Result<kin_spine::PreparedStorePublication, kin_spine::SpineError>
+        {
+            self.inner
+                .prepare_repo_publication_bound(publication, expected_rollout_fence)
+        }
+
+        fn commit_repo_publication(
+            &self,
+            prepared: &kin_spine::PreparedStorePublication,
+        ) -> std::result::Result<kin_spine::RepoPublicationCommit, kin_spine::SpineError> {
+            self.inner.commit_repo_publication(prepared)
+        }
+
+        fn load_repo_publication(
+            &self,
+            repo_id: &str,
+        ) -> std::result::Result<Option<kin_spine::LoadedRepoPublication>, kin_spine::SpineError>
+        {
+            self.inner.load_repo_publication(repo_id)
+        }
+
+        fn cleanup_repo_publications(
+            &self,
+            active_head: &kin_spine::RepoPublicationHead,
+            max_rows: usize,
+        ) -> std::result::Result<kin_spine::RepoPublicationCleanupProgress, kin_spine::SpineError>
+        {
+            self.inner.cleanup_repo_publications(active_head, max_rows)
+        }
+
+        fn load_repos(
+            &self,
+        ) -> std::result::Result<Vec<kin_spine::LoadedRepo>, kin_spine::SpineError> {
+            self.inner.load_repos()
+        }
+
+        fn load_edges(
+            &self,
+        ) -> std::result::Result<Vec<kin_spine::CrossRepoEdge>, kin_spine::SpineError> {
+            self.inner.load_edges()
+        }
+
+        fn write_entity(
+            &self,
+            entry: &kin_spine::EntityEntry,
+            root_hash: &str,
+        ) -> std::result::Result<(), kin_spine::SpineError> {
+            self.inner.write_entity(entry, root_hash)
+        }
+
+        fn delete_repo_entities(
+            &self,
+            repo_id: &str,
+        ) -> std::result::Result<(), kin_spine::SpineError> {
+            self.inner.delete_repo_entities(repo_id)
+        }
+
+        fn write_edge(
+            &self,
+            edge: &kin_spine::CrossRepoEdge,
+        ) -> std::result::Result<(), kin_spine::SpineError> {
+            self.inner.write_edge(edge)
+        }
+
+        fn delete_repo_edges(
+            &self,
+            repo_id: &str,
+        ) -> std::result::Result<(), kin_spine::SpineError> {
+            self.inner.delete_repo_edges(repo_id)
+        }
+    }
+
+    /// A hosted daemon that has completed its startup rollout: its reader is
+    /// admitted and its cursor/root authority proof is cached. That is the
+    /// state a production pod is in for every probe after the first, and the
+    /// only state in which the readiness handler's authority half runs at all.
+    async fn admitted_hosted_test_state() -> (
+        Arc<DaemonState>,
+        Arc<MeasuredSpineStore>,
+        kin_core::test_env::EnvVarGuard,
+    ) {
+        let store = Arc::new(MeasuredSpineStore::cold());
+        let (state, environment) =
+            hosted_test_state_over(Arc::clone(&store) as Arc<dyn kin_spine::SpineStore>);
+        let control = Arc::clone(
+            state
+                .publication_control
+                .as_ref()
+                .expect("the hosted fixture carries publication control"),
+        );
+        let pending = control
+            .bootstrap_runtime_if_absent()
+            .expect("bootstrap the fleet control record")
+            .expect("an absent control record leaves one pending startup rollout");
+        state
+            .complete_hosted_startup_rollout(
+                &control,
+                pending,
+                Some(format!("sha256:{}", "b".repeat(64))),
+            )
+            .await
+            .expect("the hosted startup rollout must complete");
+        (state, store, environment)
     }
 
     fn capturing_warnings() -> (CapturedLog, tracing::subscriber::DefaultGuard) {
@@ -45604,6 +45841,122 @@ mod tests {
             "a ready daemon must not log a refusal. The probe runs every few \
              seconds for the life of the pod, so an unconditional line would \
              bury the one case that matters. Captured output was: {logged:?}"
+        );
+    }
+
+    // ── A probe is a report, not an authority transition ──────────────────
+    //
+    // FIR-3255. On 2026-09-05 a hosted pod ran the full spine authority proof
+    // on every readiness probe: one durable cache hydration plus a whole-fleet
+    // double-collect that loads every repository graph and recomputes every
+    // root. Fifty-one of those ran back to back between 12:16:22Z and
+    // 12:25:15Z, median 10.46 s, with a 92 microsecond median gap, because the
+    // hydration takes one process-wide lock and the probes queued behind one
+    // another. The kubelet allows 3 s on the startup probe and 1 s on the
+    // readiness probe. End-to-end answers took 141 s, 156 s and 175.7 s, every
+    // one of them `{"ready":true,"warming":false}`, and the pod never went
+    // Ready. The 0.6.1 daemon, whose readiness read two atomics, passed the
+    // same probes on the same fleet.
+    //
+    // These three are a set. The first fails if a probe re-establishes the
+    // proof. The second fails if the cheap answer stopped being an honest one.
+    // The third fails if taking the refresh off the probe path left nothing
+    // keeping the proof current.
+
+    /// The probe must answer from the proof this process already holds.
+    ///
+    /// The bound is 2 s: under the looser of the two probe timeouts with room
+    /// for a loaded CI box, and five times under the cost charged below, so it
+    /// cannot pass on timing luck.
+    #[tokio::test]
+    async fn a_hosted_readiness_probe_answers_without_a_durable_spine_refresh() {
+        let (state, store, _environment) = admitted_hosted_test_state().await;
+        store.charge_each_durable_read(Duration::from_secs(10));
+        let durable_reads_before = store.durable_reads();
+
+        let started = Instant::now();
+        let status = call_readiness_handler(Arc::clone(&state)).await;
+        let elapsed = started.elapsed();
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "an admitted hosted reader holding a current authority proof must report ready"
+        );
+        // Timing first, because the timing is what the kubelet sees.
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "readiness took {elapsed:?}. The kubelet allows 3 s on the startup probe and \
+             1 s on the readiness probe, so a probe that pays the authority proof times \
+             out on every one of them and the pod never becomes Ready."
+        );
+        assert_eq!(
+            store.durable_reads(),
+            durable_reads_before,
+            "the probe hydrated the durable spine cache. Establishing authority is what \
+             the publication and rollout paths do; a probe reports it."
+        );
+    }
+
+    /// Cheap is not the same as permissive: an active rollout still refuses.
+    #[tokio::test]
+    async fn a_hosted_readiness_probe_refuses_while_a_rollout_holds_the_fleet() {
+        let (state, _store, _environment) = admitted_hosted_test_state().await;
+        assert_eq!(
+            call_readiness_handler(Arc::clone(&state)).await,
+            StatusCode::OK,
+            "the fixture must be ready first, or the refusal below proves nothing"
+        );
+
+        let control = Arc::clone(
+            state
+                .publication_control
+                .as_ref()
+                .expect("the hosted fixture carries publication control"),
+        );
+        control
+            .acquire_rollout(crate::publication_lease::AcquireRolloutLeaseRequest {
+                scope: control.scope().to_string(),
+                repositories: control.fleet_repositories().to_vec(),
+                previous_repositories: None,
+                holder: "readiness-rollout-honesty".to_string(),
+                request_id: "readiness-rollout-honesty-1".to_string(),
+                ttl_seconds: crate::publication_lease::DEFAULT_ROLLOUT_LEASE_SECONDS,
+                bootstrap_reader: None,
+            })
+            .expect("acquire a rollout over the admitted fleet");
+
+        assert_eq!(
+            call_readiness_handler(state).await,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "a pod whose fleet authority is being rolled must not report ready; the \
+             cached proof it holds is exactly the one the rollout is replacing"
+        );
+    }
+
+    /// Something has to keep the proof current once the probe stops doing it.
+    #[tokio::test]
+    async fn readiness_starts_the_background_hosted_spine_authority_refresh() {
+        let (state, store, _environment) = admitted_hosted_test_state().await;
+        // Production sleeps a minute between passes. A test cannot wait that
+        // long, and waiting would prove nothing the interval itself decides.
+        state.set_hosted_spine_refresh_interval_for_test(Duration::from_millis(50));
+        let durable_reads_before = store.durable_reads();
+
+        assert_eq!(
+            call_readiness_handler(Arc::clone(&state)).await,
+            StatusCode::OK
+        );
+
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while store.durable_reads() == durable_reads_before && Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        assert!(
+            store.durable_reads() > durable_reads_before,
+            "no background pass re-proved the hosted spine authority. Without one, a \
+             reader that nobody queries proves its authority once, at admission, and \
+             never learns that a sibling published."
         );
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -33577,6 +33577,10 @@ mod tests {
         /// Wall-clock delay a source read holds for, used to prove the read is
         /// not running on the thread driving the request future.
         blob_read_delay: Option<Duration>,
+        /// Wall-clock cost every source publication cursor probe pays, so a
+        /// readiness probe's per-repository reads are measured rather than
+        /// assumed free.
+        cursor_probe_delay: Option<Duration>,
     }
 
     #[derive(Clone)]
@@ -33689,6 +33693,19 @@ mod tests {
                 .cursor_probes
                 .entry(repo_id.to_string())
                 .or_default() += 1;
+        }
+
+        fn charge_each_cursor_probe(&self, cost: Duration) {
+            self.0.lock().unwrap().cursor_probe_delay = Some(cost);
+        }
+
+        fn cursor_probe_delay(&self) -> Option<Duration> {
+            self.0.lock().unwrap().cursor_probe_delay
+        }
+
+        /// Every cursor probe this backend has served, across every repository.
+        fn total_cursor_probes(&self) -> usize {
+            self.0.lock().unwrap().cursor_probes.values().sum()
         }
 
         fn cursor_probes(&self, repo_id: &str) -> usize {
@@ -33896,6 +33913,9 @@ mod tests {
             // Count the probe before parking on any rendezvous, so a blocked
             // probe still shows up in `cursor_probes`.
             self.faulting.record_cursor_probe(repo_id);
+            if let Some(cost) = self.faulting.cursor_probe_delay() {
+                std::thread::sleep(cost);
+            }
             if let Some(block) = self.faulting.cursor_probe_block_for(repo_id) {
                 block.arrive_and_wait();
             }
@@ -45372,14 +45392,23 @@ mod tests {
     /// The environment guard is returned so it lives as long as the state;
     /// dropping it restores the variables.
     fn hosted_test_state() -> (Arc<DaemonState>, kin_core::test_env::EnvVarGuard) {
-        hosted_test_state_over(Arc::new(kin_spine::test_support::FakeSpineStore::cold()))
+        let (state, _backend_root, _meters, environment) =
+            hosted_test_state_over(Arc::new(kin_spine::test_support::FakeSpineStore::cold()));
+        (state, environment)
     }
 
     /// The same fixture over a caller-supplied durable store, so a test can
-    /// measure or charge what the store is asked for.
+    /// measure or charge what the store is asked for. The storage root comes
+    /// back too, so a test can advance a repository's source publication the
+    /// way a sibling writer does.
     fn hosted_test_state_over(
         spine_store: Arc<dyn kin_spine::SpineStore>,
-    ) -> (Arc<DaemonState>, kin_core::test_env::EnvVarGuard) {
+    ) -> (
+        Arc<DaemonState>,
+        std::path::PathBuf,
+        HostedProbeMeters,
+        kin_core::test_env::EnvVarGuard,
+    ) {
         const READER: &str =
             "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         let fleet = vec![
@@ -45421,15 +45450,22 @@ mod tests {
         let repo = tempfile::tempdir().unwrap();
         let repo = Box::leak(Box::new(repo));
         let initialized = kin_core::init(repo.path()).unwrap();
-        let store = Arc::new(crate::publication_lease::InMemoryPublicationControlStore::default());
+        let control_store = Arc::new(MeasuredControlStore::new());
         let control = Arc::new(
-            crate::publication_lease::PublicationControl::new(scope, READER, fleet.clone(), store)
-                .unwrap(),
+            crate::publication_lease::PublicationControl::new(
+                scope,
+                READER,
+                fleet.clone(),
+                Arc::clone(&control_store)
+                    as Arc<dyn crate::publication_lease::PublicationControlStore>,
+            )
+            .unwrap(),
         );
+        let (counting_backend, cursor_probes) = RepoFaultBackend::new(backend_root.path());
         let state = Arc::new(
             DaemonState::open_with_backend_and_publication_control(
                 initialized.layout,
-                Box::new(kin_db::LocalFileBackend::new(backend_root.path())),
+                Box::new(counting_backend),
                 "kin",
                 Some(fleet.iter().cloned().collect()),
                 control,
@@ -45444,7 +45480,42 @@ mod tests {
             "the fixture must put readiness on the hosted half, or these tests \
              exercise nothing FIR-3179 is about"
         );
-        (state, environment)
+        (
+            state,
+            backend_root.path().to_path_buf(),
+            HostedProbeMeters {
+                control: control_store,
+                cursor_probes,
+            },
+            environment,
+        )
+    }
+
+    /// Everything a hosted probe reads, counted and chargeable: the durable
+    /// spine store, the publication-control record, and every repository's
+    /// source publication cursor.
+    struct HostedProbeMeters {
+        control: Arc<MeasuredControlStore>,
+        cursor_probes: FaultSwitch,
+    }
+
+    /// Publish a newer source snapshot for one repository, exactly as a sibling
+    /// writer does, and leave the committed spine head where it is.
+    fn advance_repo_source_publication(backend_root: &std::path::Path, repo_id: &str) {
+        let graph = kin_db::InMemoryGraph::new();
+        graph
+            .upsert_entity(&test_entity(
+                &format!("{}_advanced_entity", repo_id.replace('-', "_")),
+                "src/advanced.rs",
+            ))
+            .unwrap();
+        kin_db::StorageBackend::save_snapshot(
+            &kin_db::LocalFileBackend::new(backend_root),
+            repo_id,
+            &graph.to_snapshot().to_bytes().unwrap(),
+            kin_db::GENERATION_INIT + 1,
+        )
+        .unwrap();
     }
 
     /// A durable spine store that delegates every call and can be given the
@@ -45456,34 +45527,71 @@ mod tests {
     /// admit at full speed, and is armed only for the pass under test.
     struct MeasuredSpineStore {
         inner: Arc<kin_spine::test_support::FakeSpineStore>,
-        durable_reads: std::sync::atomic::AtomicUsize,
-        charge_ms: std::sync::atomic::AtomicU64,
+        hydration_reads: std::sync::atomic::AtomicUsize,
+        point_reads: std::sync::atomic::AtomicUsize,
+        hydration_charge_ms: std::sync::atomic::AtomicU64,
+        point_charge_ms: std::sync::atomic::AtomicU64,
+        fail_next_hydration: std::sync::atomic::AtomicBool,
     }
 
     impl MeasuredSpineStore {
         fn cold() -> Self {
             Self {
                 inner: Arc::new(kin_spine::test_support::FakeSpineStore::cold()),
-                durable_reads: std::sync::atomic::AtomicUsize::new(0),
-                charge_ms: std::sync::atomic::AtomicU64::new(0),
+                hydration_reads: std::sync::atomic::AtomicUsize::new(0),
+                point_reads: std::sync::atomic::AtomicUsize::new(0),
+                hydration_charge_ms: std::sync::atomic::AtomicU64::new(0),
+                point_charge_ms: std::sync::atomic::AtomicU64::new(0),
+                fail_next_hydration: std::sync::atomic::AtomicBool::new(false),
             }
         }
 
-        fn durable_reads(&self) -> usize {
-            self.durable_reads.load(std::sync::atomic::Ordering::SeqCst)
+        /// Reads that pull every entity row: the durable cache hydration.
+        fn hydration_reads(&self) -> usize {
+            self.hydration_reads
+                .load(std::sync::atomic::Ordering::SeqCst)
         }
 
-        fn charge_each_durable_read(&self, cost: Duration) {
-            self.charge_ms.store(
+        /// Reads that pull one document or one small collection.
+        fn point_reads(&self) -> usize {
+            self.point_reads.load(std::sync::atomic::Ordering::SeqCst)
+        }
+
+        /// Fail the next durable cache hydration once, leaving every identity
+        /// this fleet publishes exactly where it is.
+        fn fail_next_hydration(&self) {
+            self.fail_next_hydration
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+
+        fn charge_each_hydration(&self, cost: Duration) {
+            self.hydration_charge_ms.store(
                 u64::try_from(cost.as_millis()).unwrap_or(u64::MAX),
                 std::sync::atomic::Ordering::SeqCst,
             );
         }
 
-        fn charge(&self) {
-            self.durable_reads
+        fn charge_each_point_read(&self, cost: Duration) {
+            self.point_charge_ms.store(
+                u64::try_from(cost.as_millis()).unwrap_or(u64::MAX),
+                std::sync::atomic::Ordering::SeqCst,
+            );
+        }
+
+        fn charge_hydration(&self) {
+            self.hydration_reads
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            let charge = self.charge_ms.load(std::sync::atomic::Ordering::SeqCst);
+            Self::sleep_for(&self.hydration_charge_ms);
+        }
+
+        fn charge_point_read(&self) {
+            self.point_reads
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Self::sleep_for(&self.point_charge_ms);
+        }
+
+        fn sleep_for(charge_ms: &std::sync::atomic::AtomicU64) {
+            let charge = charge_ms.load(std::sync::atomic::Ordering::SeqCst);
             if charge > 0 {
                 std::thread::sleep(Duration::from_millis(charge));
             }
@@ -45495,14 +45603,33 @@ mod tests {
             &self,
         ) -> std::result::Result<Vec<kin_spine::LoadedRepoPublication>, kin_spine::SpineError>
         {
-            self.charge();
+            self.charge_hydration();
+            if self
+                .fail_next_hydration
+                .swap(false, std::sync::atomic::Ordering::SeqCst)
+            {
+                return Err(kin_spine::SpineError::Backend(
+                    "injected durable cache hydration failure".to_string(),
+                ));
+            }
             self.inner.load_repo_publications()
+        }
+
+        fn load_repo_heads(
+            &self,
+        ) -> std::result::Result<
+            std::collections::BTreeMap<String, (kin_spine::RepoPublicationHead, String)>,
+            kin_spine::SpineError,
+        > {
+            self.charge_point_read();
+            self.inner.load_repo_heads()
         }
 
         fn load_rollout_fence(
             &self,
         ) -> std::result::Result<Option<kin_spine::LoadedSpineRolloutFence>, kin_spine::SpineError>
         {
+            self.charge_point_read();
             self.inner.load_rollout_fence()
         }
 
@@ -45557,6 +45684,7 @@ mod tests {
             repo_id: &str,
         ) -> std::result::Result<Option<kin_spine::LoadedRepoPublication>, kin_spine::SpineError>
         {
+            self.charge_hydration();
             self.inner.load_repo_publication(repo_id)
         }
 
@@ -45611,6 +45739,102 @@ mod tests {
         }
     }
 
+    /// A publication-control store that counts and charges every durable
+    /// record read, so a probe's control-plane cost is measured rather than
+    /// assumed.
+    struct MeasuredControlStore {
+        inner: crate::publication_lease::InMemoryPublicationControlStore,
+        record_reads: std::sync::atomic::AtomicUsize,
+        charge_ms: std::sync::atomic::AtomicU64,
+    }
+
+    impl MeasuredControlStore {
+        fn new() -> Self {
+            Self {
+                inner: crate::publication_lease::InMemoryPublicationControlStore::default(),
+                record_reads: std::sync::atomic::AtomicUsize::new(0),
+                charge_ms: std::sync::atomic::AtomicU64::new(0),
+            }
+        }
+
+        fn record_reads(&self) -> usize {
+            self.record_reads.load(std::sync::atomic::Ordering::SeqCst)
+        }
+
+        fn charge_each_record_read(&self, cost: Duration) {
+            self.charge_ms.store(
+                u64::try_from(cost.as_millis()).unwrap_or(u64::MAX),
+                std::sync::atomic::Ordering::SeqCst,
+            );
+        }
+    }
+
+    impl crate::publication_lease::PublicationControlStore for MeasuredControlStore {
+        fn load(
+            &self,
+        ) -> std::result::Result<
+            Option<crate::publication_lease::StoredPublicationControlRecord>,
+            crate::publication_lease::PublicationControlError,
+        > {
+            self.record_reads
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let charge = self.charge_ms.load(std::sync::atomic::Ordering::SeqCst);
+            if charge > 0 {
+                std::thread::sleep(Duration::from_millis(charge));
+            }
+            self.inner.load()
+        }
+
+        fn create(
+            &self,
+            record: &crate::publication_lease::PublicationControlRecord,
+        ) -> std::result::Result<
+            crate::publication_lease::PublicationRecordVersion,
+            crate::publication_lease::PublicationControlError,
+        > {
+            self.inner.create(record)
+        }
+
+        fn update(
+            &self,
+            expected: &crate::publication_lease::PublicationRecordVersion,
+            record: &crate::publication_lease::PublicationControlRecord,
+        ) -> std::result::Result<
+            crate::publication_lease::PublicationRecordVersion,
+            crate::publication_lease::PublicationControlError,
+        > {
+            self.inner.update(expected, record)
+        }
+
+        fn capture_authority(
+            &self,
+            repositories: &[String],
+        ) -> std::result::Result<
+            Vec<crate::publication_lease::RepositoryAuthorityCapture>,
+            crate::publication_lease::PublicationControlError,
+        > {
+            self.inner.capture_authority(repositories)
+        }
+
+        fn fence_authority(
+            &self,
+            capture: &crate::publication_lease::RepositoryAuthorityCapture,
+        ) -> std::result::Result<
+            crate::publication_lease::RepositoryAuthorityFence,
+            crate::publication_lease::PublicationControlError,
+        > {
+            self.inner.fence_authority(capture)
+        }
+
+        fn verify_authority_fence(
+            &self,
+            capture: &crate::publication_lease::RepositoryAuthorityCapture,
+            fence: &crate::publication_lease::RepositoryAuthorityFence,
+        ) -> std::result::Result<(), crate::publication_lease::PublicationControlError> {
+            self.inner.verify_authority_fence(capture, fence)
+        }
+    }
+
     /// A hosted daemon that has completed its startup rollout: its reader is
     /// admitted and its cursor/root authority proof is cached. That is the
     /// state a production pod is in for every probe after the first, and the
@@ -45618,10 +45842,12 @@ mod tests {
     async fn admitted_hosted_test_state() -> (
         Arc<DaemonState>,
         Arc<MeasuredSpineStore>,
+        std::path::PathBuf,
+        HostedProbeMeters,
         kin_core::test_env::EnvVarGuard,
     ) {
         let store = Arc::new(MeasuredSpineStore::cold());
-        let (state, environment) =
+        let (state, backend_root, meters, environment) =
             hosted_test_state_over(Arc::clone(&store) as Arc<dyn kin_spine::SpineStore>);
         let control = Arc::clone(
             state
@@ -45641,7 +45867,7 @@ mod tests {
             )
             .await
             .expect("the hosted startup rollout must complete");
-        (state, store, environment)
+        (state, store, backend_root, meters, environment)
     }
 
     fn capturing_warnings() -> (CapturedLog, tracing::subscriber::DefaultGuard) {
@@ -45863,45 +46089,79 @@ mod tests {
     // The third fails if taking the refresh off the probe path left nothing
     // keeping the proof current.
 
-    /// The probe must answer from the proof this process already holds.
+    /// The probe must answer from the proof this process already holds, at a
+    /// cost that is counted rather than assumed.
     ///
-    /// The bound is 2 s: under the looser of the two probe timeouts with room
-    /// for a loaded CI box, and five times under the cost charged below, so it
-    /// cannot pass on timing luck.
-    #[tokio::test]
+    /// Every read the probe makes is charged here, not just the hydration: the
+    /// publication-control record, the active Firestore fence, the committed
+    /// heads, and every repository's source publication cursor. The per-repo
+    /// cursor charge is deliberately the largest, because it is the one the
+    /// probe issues five at a time: served in series those ten reads alone
+    /// would cost two seconds, so a bound of 1.5 s fails a serial
+    /// implementation and passes a concurrent one.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn a_hosted_readiness_probe_answers_without_a_durable_spine_refresh() {
-        let (state, store, _environment) = admitted_hosted_test_state().await;
-        store.charge_each_durable_read(Duration::from_secs(10));
-        let durable_reads_before = store.durable_reads();
+        let (state, store, _backend_root, meters, _environment) =
+            admitted_hosted_test_state().await;
+        store.charge_each_hydration(Duration::from_secs(10));
+        store.charge_each_point_read(Duration::from_millis(20));
+        meters
+            .control
+            .charge_each_record_read(Duration::from_millis(20));
+        meters
+            .cursor_probes
+            .charge_each_cursor_probe(Duration::from_millis(200));
+        let hydrations_before = store.hydration_reads();
+        let point_reads_before = store.point_reads();
+        let record_reads_before = meters.control.record_reads();
+        let cursor_probes_before = meters.cursor_probes.total_cursor_probes();
 
         let started = Instant::now();
         let status = call_readiness_handler(Arc::clone(&state)).await;
         let elapsed = started.elapsed();
+
+        let hydrations = store.hydration_reads() - hydrations_before;
+        let point_reads = store.point_reads() - point_reads_before;
+        let record_reads = meters.control.record_reads() - record_reads_before;
+        let cursor_probes = meters.cursor_probes.total_cursor_probes() - cursor_probes_before;
+        println!(
+            "readiness probe cost: {elapsed:?}, {hydrations} hydration(s), \
+             {point_reads} spine point read(s), {record_reads} control record read(s), \
+             {cursor_probes} source cursor probe(s)"
+        );
 
         assert_eq!(
             status,
             StatusCode::OK,
             "an admitted hosted reader holding a current authority proof must report ready"
         );
-        // Timing first, because the timing is what the kubelet sees.
-        assert!(
-            elapsed < Duration::from_secs(2),
-            "readiness took {elapsed:?}. The kubelet allows 3 s on the startup probe and \
-             1 s on the readiness probe, so a probe that pays the authority proof times \
-             out on every one of them and the pod never becomes Ready."
-        );
         assert_eq!(
-            store.durable_reads(),
-            durable_reads_before,
+            hydrations, 0,
             "the probe hydrated the durable spine cache. Establishing authority is what \
              the publication and rollout paths do; a probe reports it."
+        );
+        assert!(
+            elapsed < Duration::from_millis(1500),
+            "readiness took {elapsed:?} for {point_reads} spine point reads, {record_reads} \
+             control record reads and {cursor_probes} source cursor probes. The kubelet \
+             allows 3 s on the startup probe and 1 s on the readiness probe, and ten \
+             cursor probes served in series would cost 2 s of that on their own."
+        );
+        assert!(
+            point_reads <= 4 && record_reads <= 4 && cursor_probes <= 12,
+            "the probe made {point_reads} spine point reads, {record_reads} control record \
+             reads and {cursor_probes} source cursor probes. Two complete bundle \
+             observations of one heads read and one cursor read per repository, plus the \
+             admission and runtime-authority record reads and the active fence, is the \
+             whole budget; anything past it is a read nobody accounted for."
         );
     }
 
     /// Cheap is not the same as permissive: an active rollout still refuses.
     #[tokio::test]
     async fn a_hosted_readiness_probe_refuses_while_a_rollout_holds_the_fleet() {
-        let (state, _store, _environment) = admitted_hosted_test_state().await;
+        let (state, _store, _backend_root, _meters, _environment) =
+            admitted_hosted_test_state().await;
         assert_eq!(
             call_readiness_handler(Arc::clone(&state)).await,
             StatusCode::OK,
@@ -45937,11 +46197,12 @@ mod tests {
     /// Something has to keep the proof current once the probe stops doing it.
     #[tokio::test]
     async fn readiness_starts_the_background_hosted_spine_authority_refresh() {
-        let (state, store, _environment) = admitted_hosted_test_state().await;
+        let (state, store, _backend_root, _meters, _environment) =
+            admitted_hosted_test_state().await;
         // Production sleeps a minute between passes. A test cannot wait that
         // long, and waiting would prove nothing the interval itself decides.
         state.set_hosted_spine_refresh_interval_for_test(Duration::from_millis(50));
-        let durable_reads_before = store.durable_reads();
+        let hydrations_before = store.hydration_reads();
 
         assert_eq!(
             call_readiness_handler(Arc::clone(&state)).await,
@@ -45949,14 +46210,144 @@ mod tests {
         );
 
         let deadline = Instant::now() + Duration::from_secs(30);
-        while store.durable_reads() == durable_reads_before && Instant::now() < deadline {
+        while store.hydration_reads() == hydrations_before && Instant::now() < deadline {
             tokio::time::sleep(Duration::from_millis(25)).await;
         }
         assert!(
-            store.durable_reads() > durable_reads_before,
+            store.hydration_reads() > hydrations_before,
             "no background pass re-proved the hosted spine authority. Without one, a \
              reader that nobody queries proves its authority once, at admission, and \
              never learns that a sibling published."
+        );
+    }
+
+    // ── A cheap answer is still an exact one ──────────────────────────────
+    //
+    // FIR-3255, second round. An independent source review found that reusing a
+    // cached proof on the strength of the reader admission, the rollout fence
+    // and the fleet's NAMES is weaker than the baseline it replaced. An ordinary
+    // publication lease advances a committed head while the admitted rollout
+    // evidence stays exactly where it is, so a proof built against a superseded
+    // generation passes every one of those checks. And a failed revalidation
+    // left the previous proof installed, so a process that had already
+    // determined its authority was invalid went on certifying reads from it.
+    //
+    // These three are the review's three shapes.
+
+    /// A source publication that moves past the proof must refuse.
+    #[tokio::test]
+    async fn a_hosted_readiness_probe_refuses_a_repository_whose_source_advanced() {
+        let (state, _store, backend_root, _meters, _environment) =
+            admitted_hosted_test_state().await;
+        assert_eq!(
+            call_readiness_handler(Arc::clone(&state)).await,
+            StatusCode::OK,
+            "the fixture must be ready first, or the refusal below proves nothing"
+        );
+
+        // Everything the cheap path used to check stays exactly as it is: the
+        // reader admission, the rollout fence evidence, the active Firestore
+        // fence and the fleet's names. Only one repository's source publication
+        // moves, and its committed spine head stays at the old cursor.
+        advance_repo_source_publication(&backend_root, "kin-db");
+
+        assert_eq!(
+            call_readiness_handler(Arc::clone(&state)).await,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "a proof built against a superseded generation must not certify readiness. \
+             The rollout fence does not move for an ordinary publication, so nothing \
+             but the repository's own durable identity can catch this."
+        );
+        assert!(
+            state.ensure_spine().is_none(),
+            "and the full pass must agree: a repository whose source cursor is ahead of \
+             its committed spine head cannot be proved, so the refusal above is the \
+             cheap path reaching the same verdict the expensive one does"
+        );
+    }
+
+    /// A failed authority pass must refuse until one succeeds.
+    ///
+    /// The failure is inside the pass itself and every durable identity stays
+    /// exactly where it is, so the identity binding above cannot catch this
+    /// one. Only invalidating the proof the failed pass was revalidating can.
+    #[tokio::test]
+    async fn a_hosted_readiness_probe_refuses_after_the_authority_proof_fails() {
+        let (state, store, _backend_root, _meters, _environment) =
+            admitted_hosted_test_state().await;
+        assert_eq!(
+            call_readiness_handler(Arc::clone(&state)).await,
+            StatusCode::OK
+        );
+
+        store.fail_next_hydration();
+        assert!(
+            state.ensure_spine().is_none(),
+            "the authority pass must fail, or this test proves nothing about what \
+             readiness does after it fails"
+        );
+
+        assert_eq!(
+            call_readiness_handler(Arc::clone(&state)).await,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "a process that has already determined it cannot revalidate its authority \
+             must not answer ready from the proof that pass was revalidating"
+        );
+        assert_eq!(
+            call_readiness_handler(Arc::clone(&state)).await,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "and it must keep refusing, not recover by being asked twice"
+        );
+
+        // Repair. One successful pass installs a proof again and readiness
+        // comes back, which is what makes the refusal above a hold rather than
+        // a permanent fault.
+        assert!(
+            state.ensure_spine().is_some(),
+            "the pass must succeed once the injected failure is spent"
+        );
+        assert_eq!(
+            call_readiness_handler(state).await,
+            StatusCode::OK,
+            "readiness must return as soon as a pass succeeds"
+        );
+    }
+
+    /// A refresh in flight must not become a licence to certify.
+    ///
+    /// Hydration replaces the whole cached index before the proof that follows
+    /// it can fail, so between those two points the process holds a new cache
+    /// beside an old proof whose fleet names still match. A probe in that window
+    /// must answer from durable identity, not from the names.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn a_hosted_readiness_probe_refuses_while_a_failing_refresh_holds_the_cache() {
+        let (state, store, backend_root, _meters, _environment) =
+            admitted_hosted_test_state().await;
+        assert_eq!(
+            call_readiness_handler(Arc::clone(&state)).await,
+            StatusCode::OK
+        );
+
+        advance_repo_source_publication(&backend_root, "kin-db");
+        // Long enough that the probe below lands inside the hydration rather
+        // than after the pass has finished and cleared the proof.
+        store.charge_each_hydration(Duration::from_secs(3));
+        let refreshing = Arc::clone(&state);
+        let pass = tokio::task::spawn_blocking(move || refreshing.ensure_spine().is_some());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let probed = call_readiness_handler(Arc::clone(&state)).await;
+        let proved = pass.await.expect("the authority pass must not panic");
+
+        assert_eq!(
+            probed,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "the probe answered ready while a refresh held a replaced cache beside a \
+             proof for a generation that had already been superseded"
+        );
+        assert!(
+            !proved,
+            "the pass itself must fail, or the window under test never existed"
         );
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -45532,6 +45532,9 @@ mod tests {
         hydration_charge_ms: std::sync::atomic::AtomicU64,
         point_charge_ms: std::sync::atomic::AtomicU64,
         fail_next_hydration: std::sync::atomic::AtomicBool,
+        /// Runs on every committed-head read, so a test can move durable state
+        /// while a probe is between its two bundle observations.
+        on_head_read: std::sync::Mutex<Option<Box<dyn Fn() + Send + Sync>>>,
     }
 
     impl MeasuredSpineStore {
@@ -45543,6 +45546,7 @@ mod tests {
                 hydration_charge_ms: std::sync::atomic::AtomicU64::new(0),
                 point_charge_ms: std::sync::atomic::AtomicU64::new(0),
                 fail_next_hydration: std::sync::atomic::AtomicBool::new(false),
+                on_head_read: std::sync::Mutex::new(None),
             }
         }
 
@@ -45555,6 +45559,10 @@ mod tests {
         /// Reads that pull one document or one small collection.
         fn point_reads(&self) -> usize {
             self.point_reads.load(std::sync::atomic::Ordering::SeqCst)
+        }
+
+        fn on_head_read(&self, hook: Box<dyn Fn() + Send + Sync>) {
+            *self.on_head_read.lock().unwrap() = Some(hook);
         }
 
         /// Fail the next durable cache hydration once, leaving every identity
@@ -45622,6 +45630,13 @@ mod tests {
             kin_spine::SpineError,
         > {
             self.charge_point_read();
+            // Clone the hook out before calling it, so a hook that touches this
+            // store does not deadlock on its own lock.
+            let hook = self.on_head_read.lock().unwrap().take();
+            if let Some(hook) = hook {
+                hook();
+                *self.on_head_read.lock().unwrap() = Some(hook);
+            }
             self.inner.load_repo_heads()
         }
 
@@ -45746,6 +45761,10 @@ mod tests {
         inner: crate::publication_lease::InMemoryPublicationControlStore,
         record_reads: std::sync::atomic::AtomicUsize,
         charge_ms: std::sync::atomic::AtomicU64,
+        /// Refuse every record read past this many, counted from the arming.
+        /// Zero means never.
+        refuse_reads_past: std::sync::atomic::AtomicUsize,
+        reads_since_arming: std::sync::atomic::AtomicUsize,
     }
 
     impl MeasuredControlStore {
@@ -45754,11 +45773,23 @@ mod tests {
                 inner: crate::publication_lease::InMemoryPublicationControlStore::default(),
                 record_reads: std::sync::atomic::AtomicUsize::new(0),
                 charge_ms: std::sync::atomic::AtomicU64::new(0),
+                refuse_reads_past: std::sync::atomic::AtomicUsize::new(0),
+                reads_since_arming: std::sync::atomic::AtomicUsize::new(0),
             }
         }
 
         fn record_reads(&self) -> usize {
             self.record_reads.load(std::sync::atomic::Ordering::SeqCst)
+        }
+
+        /// Serve `allowed` more record reads, then refuse every one after
+        /// them, so a probe's pre-bundle reads succeed and its post-bundle
+        /// reads find the admission gone.
+        fn refuse_record_reads_past(&self, allowed: usize) {
+            self.reads_since_arming
+                .store(0, std::sync::atomic::Ordering::SeqCst);
+            self.refuse_reads_past
+                .store(allowed, std::sync::atomic::Ordering::SeqCst);
         }
 
         fn charge_each_record_read(&self, cost: Duration) {
@@ -45781,6 +45812,20 @@ mod tests {
             let charge = self.charge_ms.load(std::sync::atomic::Ordering::SeqCst);
             if charge > 0 {
                 std::thread::sleep(Duration::from_millis(charge));
+            }
+            let allowed = self
+                .refuse_reads_past
+                .load(std::sync::atomic::Ordering::SeqCst);
+            if allowed > 0 {
+                let served = self
+                    .reads_since_arming
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                    + 1;
+                if served > allowed {
+                    return Err(crate::publication_lease::PublicationControlError::Missing(
+                        "injected publication-control record read failure".to_string(),
+                    ));
+                }
             }
             self.inner.load()
         }
@@ -46152,8 +46197,9 @@ mod tests {
             "the probe made {point_reads} spine point reads, {record_reads} control record \
              reads and {cursor_probes} source cursor probes. Two complete bundle \
              observations of one heads read and one cursor read per repository, plus the \
-             admission and runtime-authority record reads and the active fence, is the \
-             whole budget; anything past it is a read nobody accounted for."
+             admission, runtime-authority and active-fence reads taken on BOTH sides of \
+             that bundle, is the whole budget; anything past it is a read nobody \
+             accounted for."
         );
     }
 
@@ -46310,6 +46356,72 @@ mod tests {
             call_readiness_handler(state).await,
             StatusCode::OK,
             "readiness must return as soon as a pass succeeds"
+        );
+    }
+
+    /// A rollout that begins WHILE the bundle is read must refuse.
+    ///
+    /// The heads and the cursors do not move here, so both bundle observations
+    /// agree and the identity comparison passes. Only re-reading the control
+    /// authority after the bundle can catch it.
+    #[tokio::test]
+    async fn a_hosted_readiness_probe_refuses_a_fence_that_moves_during_the_bundle() {
+        let (state, store, _backend_root, _meters, _environment) =
+            admitted_hosted_test_state().await;
+        assert_eq!(
+            call_readiness_handler(Arc::clone(&state)).await,
+            StatusCode::OK,
+            "the fixture must be ready first, or the refusal below proves nothing"
+        );
+
+        let fake = Arc::clone(&store.inner);
+        let fired = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let armed = Arc::clone(&fired);
+        store.on_head_read(Box::new(move || {
+            if armed.swap(true, std::sync::atomic::Ordering::SeqCst) {
+                return;
+            }
+            // Between the probe's two bundle observations: advance the durable
+            // rollout fence's revision and nothing else.
+            let mut fence = fake.rollout_fence_state.lock().unwrap();
+            if let Some((revision, _)) = fence.as_mut() {
+                *revision += 1;
+            }
+        }));
+
+        assert_eq!(
+            call_readiness_handler(state).await,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "the control authority moved while the identity bundle was being read, and a \
+             probe that reads it only before the bundle answers through exactly that"
+        );
+        assert!(
+            fired.load(std::sync::atomic::Ordering::SeqCst),
+            "the hook never ran, so nothing moved and this test proved nothing"
+        );
+    }
+
+    /// An admission that lapses WHILE the bundle is read must refuse.
+    #[tokio::test]
+    async fn a_hosted_readiness_probe_refuses_an_admission_lost_during_the_bundle() {
+        let (state, _store, _backend_root, meters, _environment) =
+            admitted_hosted_test_state().await;
+        assert_eq!(
+            call_readiness_handler(Arc::clone(&state)).await,
+            StatusCode::OK,
+            "the fixture must be ready first, or the refusal below proves nothing"
+        );
+
+        // The probe reads the control record twice before the bundle, for the
+        // admission and the runtime authority. Serve exactly those two and
+        // refuse everything after, which is the post-bundle pair.
+        meters.control.refuse_record_reads_past(2);
+
+        assert_eq!(
+            call_readiness_handler(state).await,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "a probe whose durable admission stopped answering while it read the identity \
+             bundle must not report ready on the strength of the read it made first"
         );
     }
 

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1770,6 +1770,16 @@ struct HostedSpineAuthorityProof {
     repositories: BTreeMap<String, HostedSpineRepoAuthorityProof>,
 }
 
+/// The durable control-plane authority a cached proof is read under: the
+/// admitted fence evidence, the active Firestore fence with the store revision
+/// that carried it, and the registered fleet.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HostedControlAuthority {
+    durable: kin_spine::SpineRolloutFenceEvidence,
+    active_fence: kin_spine::LoadedSpineRolloutFence,
+    registered: std::collections::BTreeSet<String>,
+}
+
 /// Why a cached hosted authority proof cannot answer, and whether re-proving it
 /// now would help.
 #[derive(Debug, Clone)]
@@ -6880,6 +6890,48 @@ impl DaemonState {
         ))
     }
 
+    /// The durable control-plane authority a cached proof is read under: the
+    /// admitted fence evidence, the active Firestore fence with the revision
+    /// that carried it, and the registered fleet.
+    ///
+    /// Read once before the identity bundle and once after, and required to be
+    /// identical, so a rollout or an admission change DURING the bundle reads
+    /// cannot be answered through.
+    fn read_hosted_control_authority(
+        &self,
+        control: &crate::publication_lease::PublicationControl,
+        backend: &dyn kin_spine::SpineBackend,
+    ) -> std::result::Result<HostedControlAuthority, CachedAuthorityRefusal> {
+        control
+            .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
+            .map_err(|error| {
+                CachedAuthorityRefusal::blocked(format!(
+                    "hosted spine reader is not durably admitted: {error}"
+                ))
+            })?;
+        let durable = match control.runtime_spine_authority().map_err(|error| {
+            CachedAuthorityRefusal::blocked(format!("load hosted spine runtime authority: {error}"))
+        })? {
+            crate::publication_lease::RuntimeSpineAuthority::Completed(evidence) => evidence,
+            crate::publication_lease::RuntimeSpineAuthority::RolloutActive(blocking) => {
+                return Err(CachedAuthorityRefusal::blocked(format!(
+                    "hosted spine {blocking}; cached authority is not readable"
+                )))
+            }
+        };
+        let active_fence = without_blocking_runtime_worker(|| backend.active_rollout_fence())
+            .map_err(|error| {
+                CachedAuthorityRefusal::blocked(format!(
+                    "load active Firestore spine fence: {error}"
+                ))
+            })?;
+        Ok(HostedControlAuthority {
+            durable,
+            active_fence,
+            registered: backend.registered_repo_ids().into_iter().collect(),
+        })
+    }
+
     /// Prove the cached hosted authority against durable identity, with no
     /// hydration and no graph load.
     ///
@@ -6894,6 +6946,12 @@ impl DaemonState {
     /// rollout evidence stays exactly where it is, so a check that stops at the
     /// fleet's names certifies a proof built against a generation that has
     /// already been superseded.
+    ///
+    /// The control-plane authority is read on BOTH sides of the identity bundle
+    /// and required to be identical. Reading it only before would answer a probe
+    /// through a rollout that began, or an admission that lapsed, while the
+    /// heads and cursors were being read; the full proof re-reads its fence at
+    /// the end for the same reason.
     ///
     /// What it does NOT re-establish is the graph root, because it does not have
     /// to: the root was fully validated against an immutable source cursor, and
@@ -6912,27 +6970,11 @@ impl DaemonState {
         let Some(control) = self.publication_control.as_ref() else {
             return Ok(());
         };
-        control
-            .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
-            .map_err(|error| {
-                CachedAuthorityRefusal::blocked(format!(
-                    "hosted spine reader is not durably admitted: {error}"
-                ))
-            })?;
-        let durable = match control.runtime_spine_authority().map_err(|error| {
-            CachedAuthorityRefusal::blocked(format!("load hosted spine runtime authority: {error}"))
-        })? {
-            crate::publication_lease::RuntimeSpineAuthority::Completed(evidence) => evidence,
-            crate::publication_lease::RuntimeSpineAuthority::RolloutActive(blocking) => {
-                return Err(CachedAuthorityRefusal::blocked(format!(
-                    "hosted spine {blocking}; cached authority is not readable"
-                )))
-            }
-        };
+        let before = self.read_hosted_control_authority(control, backend)?;
         let expected = self
             .expected_hosted_spine_rollout_fence()
             .map_err(CachedAuthorityRefusal::blocked)?;
-        if expected != durable {
+        if expected != before.durable {
             return Err(CachedAuthorityRefusal::blocked(
                 "cached hosted spine evidence differs from the GCS publication-control record"
                     .to_string(),
@@ -6949,24 +6991,18 @@ impl DaemonState {
                     self.spine_unavailable_reason()
                 ))
             })?;
-        let active = without_blocking_runtime_worker(|| backend.active_rollout_fence()).map_err(
-            |error| {
-                CachedAuthorityRefusal::blocked(format!(
-                    "load active Firestore spine fence: {error}"
-                ))
-            },
-        )?;
-        if active != cached.rollout_fence || active.evidence() != durable {
+        if before.active_fence != cached.rollout_fence
+            || before.active_fence.evidence() != before.durable
+        {
             return Err(CachedAuthorityRefusal::blocked(
                 "cached hosted spine proof differs from active Firestore authority".to_string(),
             ));
         }
-        let registered = backend.registered_repo_ids();
-        if cached.repositories.len() != registered.len()
+        if cached.repositories.len() != before.registered.len()
             || cached
                 .repositories
                 .keys()
-                .any(|repo_id| !registered.contains(repo_id))
+                .any(|repo_id| !before.registered.contains(repo_id))
         {
             return Err(CachedAuthorityRefusal::blocked(
                 "cached hosted spine proof does not cover the exact registered fleet".to_string(),
@@ -6993,6 +7029,16 @@ impl DaemonState {
                     proved.identity.source_cursor,
                 )));
             }
+        }
+        // Close the bracket. Everything the answer rests on must still be what
+        // it was when the bundle reads started.
+        let after = self.read_hosted_control_authority(control, backend)?;
+        if after != before {
+            return Err(CachedAuthorityRefusal::superseded(
+                "hosted control-plane authority moved while the durable identity bundle was \
+                 being read"
+                    .to_string(),
+            ));
         }
         Ok(())
     }

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1683,6 +1683,17 @@ const HOSTED_REPO_RELOAD_ATTEMPTS: usize = 3;
 /// siblings. It is never on a request path; the readiness probe reads the proof
 /// this pass maintains and never waits for it.
 const HOSTED_SPINE_AUTHORITY_REFRESH_INTERVAL: Duration = Duration::from_secs(60);
+
+/// How soon the background pass retries after a failed one, doubling up to
+/// [`HOSTED_SPINE_AUTHORITY_REFRESH_INTERVAL`].
+///
+/// A failed pass invalidates the cached proof, so the daemon reports unready
+/// until a pass succeeds. Waiting a whole minute to retry would turn a single
+/// transient durable read into a minute out of service; retrying in a second
+/// turns it into a second. It is also the floor between passes when a probe
+/// wakes one, so a persistent drift cannot turn the probe back into the thing
+/// that drives a continuous refresh.
+const HOSTED_SPINE_AUTHORITY_RETRY_FLOOR: Duration = Duration::from_secs(1);
 const HOSTED_SPINE_FLEET_SIZE: usize = 5;
 const HOSTED_SPINE_CURSOR_CAS_REQUIRED: &str =
     "hosted persistent spine is unavailable until its durable backend can stage rows and compare-and-swap a head bound to the exact source publication cursor";
@@ -1729,17 +1740,69 @@ struct SpineGraphCapture {
     relations: Vec<kin_model::Relation>,
 }
 
+/// One repository's durable identity, as a caller can read it without loading
+/// a graph or a single entity row: the committed spine head with the store
+/// revision that carried it, and the GCS source publication cursor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HostedRepoDurableIdentity {
+    head: kin_spine::RepoPublicationHead,
+    head_revision: String,
+    source_cursor: kin_spine::SpineSourceCursor,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct HostedSpineRepoAuthorityProof {
     durable_head_cursor: kin_spine::SpineSourceCursor,
     current_source_cursor: kin_spine::SpineSourceCursor,
     root_hash: String,
+    /// The exact durable identity this proof was built against.
+    ///
+    /// A cursor and a root hash do not pin a publication on their own. The head
+    /// also carries its publication id and its manifest and metadata digests,
+    /// and an identity check that compares less than all of it can accept a
+    /// different publication that happens to sit at the same cursor.
+    identity: HostedRepoDurableIdentity,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct HostedSpineAuthorityProof {
     rollout_fence: kin_spine::LoadedSpineRolloutFence,
     repositories: BTreeMap<String, HostedSpineRepoAuthorityProof>,
+}
+
+/// Why a cached hosted authority proof cannot answer, and whether re-proving it
+/// now would help.
+#[derive(Debug, Clone)]
+pub(crate) struct CachedAuthorityRefusal {
+    reason: String,
+    /// The durable identity moved under the proof, or the proof is gone. A
+    /// fresh pass can install one for the identity that is there now.
+    ///
+    /// A lost admission or an active rollout is not this: re-proving cannot fix
+    /// either, and waking the background pass for them would run it back to
+    /// back for as long as the condition lasts, which is the behaviour this
+    /// whole path exists to remove from the probe.
+    superseded: bool,
+}
+
+impl CachedAuthorityRefusal {
+    fn blocked(reason: String) -> Self {
+        Self {
+            reason,
+            superseded: false,
+        }
+    }
+
+    fn superseded(reason: String) -> Self {
+        Self {
+            reason,
+            superseded: true,
+        }
+    }
+
+    pub(crate) fn into_reason(self) -> String {
+        self.reason
+    }
 }
 
 fn hosted_spine_authority_vector_is_stable(
@@ -2951,6 +3014,15 @@ pub struct DaemonState {
     /// current has been started. It is started once, by whichever hosted
     /// request route runs first, and never again.
     hosted_spine_refresh_cadence_started: AtomicBool,
+    /// Wakes that pass when a probe observes that durable identity moved under
+    /// the cached proof, so readiness returns on the next successful pass
+    /// rather than at the end of the interval.
+    hosted_spine_refresh_wake: Arc<tokio::sync::Notify>,
+    /// Tickets handed to authority passes, and the highest ticket whose result
+    /// has been applied. Two passes can overlap, and without an order an older
+    /// one that finishes second overwrites the newer one's result.
+    hosted_spine_authority_pass_seq: AtomicU64,
+    hosted_spine_authority_applied_seq: AtomicU64,
     /// Test-only escape hatch for process-local spine behavior. Production
     /// hosted states have no corresponding field or bypass: they remain held
     /// until the durable backend owns cursor-bound publication CAS.
@@ -5293,6 +5365,9 @@ impl DaemonState {
             #[cfg(test)]
             hosted_spine_refresh_interval_for_test: Mutex::new(None),
             hosted_spine_refresh_cadence_started: AtomicBool::new(false),
+            hosted_spine_refresh_wake: Arc::new(tokio::sync::Notify::new()),
+            hosted_spine_authority_pass_seq: AtomicU64::new(0),
+            hosted_spine_authority_applied_seq: AtomicU64::new(0),
             #[cfg(test)]
             hosted_in_memory_spine_allowed: AtomicBool::new(false),
             #[cfg(test)]
@@ -5666,6 +5741,9 @@ impl DaemonState {
             #[cfg(test)]
             hosted_spine_refresh_interval_for_test: Mutex::new(None),
             hosted_spine_refresh_cadence_started: AtomicBool::new(false),
+            hosted_spine_refresh_wake: Arc::new(tokio::sync::Notify::new()),
+            hosted_spine_authority_pass_seq: AtomicU64::new(0),
+            hosted_spine_authority_applied_seq: AtomicU64::new(0),
             #[cfg(test)]
             hosted_in_memory_spine_allowed: AtomicBool::new(false),
             #[cfg(test)]
@@ -6245,6 +6323,13 @@ impl DaemonState {
                     selected_fence.evidence()
                 ));
             }
+            // The committed heads are read before the collection and again
+            // after it, and the attempt restarts unless both reads agree. The
+            // collector below stabilizes the per-repository cursors and roots;
+            // stabilizing only one of the two sources still lets a bundle mix
+            // two fleet instants, which is the same A-out/B-in mistake one
+            // level up.
+            let selected_heads = self.committed_head_identities(spine)?;
             // A single sequential collection can accept a fleet vector that
             // never existed at one instant: A can match then advance before B
             // advances into the expected value. Snapshot cursors are monotonic,
@@ -6252,6 +6337,9 @@ impl DaemonState {
             // collections. The same helper is driven by the A-out/B-in mutant.
             let repositories =
                 collect_stable_hosted_spine_authority_vector(&fleet, 1, |repo_id| {
+                    let Some((head, head_revision)) = selected_heads.get(repo_id) else {
+                        return Ok(None);
+                    };
                     let loaded = self.load_repo_graph(repo_id).map_err(|error| {
                         format!("load {repo_id} for hosted spine root proof: {error}")
                     })?;
@@ -6273,10 +6361,21 @@ impl DaemonState {
                     {
                         return Ok(None);
                     }
+                    // The durable head must say the same thing this process's
+                    // cache says. A head that disagrees is a cache the proof
+                    // would otherwise bind to the wrong publication.
+                    if head.source_cursor != durable_head_cursor || head.root_hash != root_hash {
+                        return Ok(None);
+                    }
                     Ok(Some(HostedSpineRepoAuthorityProof {
                         durable_head_cursor,
                         current_source_cursor,
                         root_hash,
+                        identity: HostedRepoDurableIdentity {
+                            head: head.clone(),
+                            head_revision: head_revision.clone(),
+                            source_cursor: current_source_cursor,
+                        },
                     }))
                 })?;
             let Some(repositories) = repositories else {
@@ -6289,6 +6388,9 @@ impl DaemonState {
                     "hosted spine committed heads do not expose one complete exact-fleet edge authority"
                         .to_string(),
                 );
+            }
+            if self.committed_head_identities(spine)? != selected_heads {
+                continue 'attempt;
             }
             let observed_fence = spine
                 .active_rollout_fence()
@@ -6309,18 +6411,54 @@ impl DaemonState {
     ) -> std::result::Result<(), String> {
         #[cfg(test)]
         self.spine_backend_hydrations.fetch_add(1, Ordering::SeqCst);
-        spine
+        let ticket = self
+            .hosted_spine_authority_pass_seq
+            .fetch_add(1, Ordering::SeqCst)
+            + 1;
+        let refreshed = spine
             .refresh_committed_publications()
-            .map_err(|error| format!("refresh committed hosted spine heads: {error}"))?;
-        // Always rebuild the proof through the real double-collect path. A
-        // cached single-pass shortcut can accept an A-out/B-in fleet vector
-        // that never existed at one instant.
-        let proof = self.validate_hosted_spine_authority(spine)?;
-        *self
+            .map_err(|error| format!("refresh committed hosted spine heads: {error}"))
+            // Always rebuild the proof through the real double-collect path. A
+            // cached single-pass shortcut can accept an A-out/B-in fleet vector
+            // that never existed at one instant.
+            .and_then(|()| self.validate_hosted_spine_authority(spine));
+        // A FAILED pass clears the proof. Leaving the previous one installed
+        // is how a process that has already determined its authority is
+        // invalid goes on certifying reads from it: the caller records the
+        // error and returns None, but every cached-authority reader still
+        // finds a `Some` proof whose fleet names and rollout fence are intact
+        // and answers yes. Hydration can also have replaced the cache before
+        // validation failed, so the surviving proof would then describe a
+        // generation the cache no longer holds.
+        let mut cached = self
             .hosted_spine_authority_proof
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(proof);
-        Ok(())
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // Read and write the applied ticket under the proof lock, so a pass
+        // that started earlier and finished later reports its own result and
+        // leaves a newer pass's state alone.
+        let stale = self
+            .hosted_spine_authority_applied_seq
+            .load(Ordering::SeqCst)
+            >= ticket;
+        if !stale {
+            self.hosted_spine_authority_applied_seq
+                .store(ticket, Ordering::SeqCst);
+        }
+        match refreshed {
+            Ok(proof) => {
+                if !stale {
+                    *cached = Some(proof);
+                }
+                Ok(())
+            }
+            Err(error) => {
+                if !stale {
+                    *cached = None;
+                }
+                Err(error)
+            }
+        }
     }
 
     /// Construct the durable hosted backend without acquiring a GCS
@@ -6627,48 +6765,178 @@ impl DaemonState {
             .ok_or_else(|| "spine is disabled or has not been initialized".to_string())
     }
 
+    /// The committed spine heads, read from the durable store.
+    fn committed_head_identities(
+        &self,
+        spine: &dyn kin_spine::SpineBackend,
+    ) -> std::result::Result<BTreeMap<String, (kin_spine::RepoPublicationHead, String)>, String>
+    {
+        without_blocking_runtime_worker(|| spine.committed_head_identities())
+            .map_err(|error| format!("read durable committed spine heads: {error}"))
+    }
+
+    /// Probe every named repository's GCS source publication cursor at once.
+    ///
+    /// One point read per repository, issued together rather than in series. A
+    /// readiness probe runs every few seconds against a one-second timeout, and
+    /// five sequential object reads is five round trips of latency it has no
+    /// reason to pay one after another.
+    ///
+    /// A read that FAILS is an error, never an absence: a repository whose
+    /// metadata could not be read is unknown, not unpublished, and folding the
+    /// two together lets a broken object store read as a moved cursor.
+    fn probe_fleet_publication_cursors(
+        &self,
+        repo_ids: &[String],
+    ) -> std::result::Result<BTreeMap<String, kin_spine::SpineSourceCursor>, String> {
+        without_blocking_runtime_worker(|| {
+            std::thread::scope(|scope| {
+                let probes = repo_ids
+                    .iter()
+                    .map(|repo_id| {
+                        scope.spawn(move || (repo_id, self.probe_repo_publication(repo_id)))
+                    })
+                    .collect::<Vec<_>>();
+                let mut observed = BTreeMap::new();
+                for probe in probes {
+                    let (repo_id, result) = probe
+                        .join()
+                        .map_err(|_| "a hosted publication cursor probe panicked".to_string())?;
+                    let cursor = result.map_err(|error| {
+                        format!("probe {repo_id} source publication cursor: {error}")
+                    })?;
+                    let Some(cursor) = cursor else {
+                        return Err(format!(
+                            "repo {repo_id} has no source publication cursor to bind authority to"
+                        ));
+                    };
+                    observed.insert(
+                        repo_id.clone(),
+                        Self::snapshot_cursor_for_spine(Some(cursor)),
+                    );
+                }
+                Ok(observed)
+            })
+        })
+    }
+
+    /// One observation of the fleet's durable identity: committed spine heads
+    /// and GCS source publication cursors, with no graph load and no row read.
+    fn observe_hosted_fleet_identity(
+        &self,
+        spine: &dyn kin_spine::SpineBackend,
+        repo_ids: &[String],
+    ) -> std::result::Result<BTreeMap<String, HostedRepoDurableIdentity>, String> {
+        let heads = self.committed_head_identities(spine)?;
+        let cursors = self.probe_fleet_publication_cursors(repo_ids)?;
+        let mut identity = BTreeMap::new();
+        for repo_id in repo_ids {
+            let Some((head, head_revision)) = heads.get(repo_id) else {
+                return Err(format!(
+                    "repo {repo_id} has no committed durable spine head"
+                ));
+            };
+            let Some(source_cursor) = cursors.get(repo_id) else {
+                return Err(format!(
+                    "repo {repo_id} was not probed for its source cursor"
+                ));
+            };
+            identity.insert(
+                repo_id.clone(),
+                HostedRepoDurableIdentity {
+                    head: head.clone(),
+                    head_revision: head_revision.clone(),
+                    source_cursor: *source_cursor,
+                },
+            );
+        }
+        Ok(identity)
+    }
+
+    /// The same observation, taken twice and required to agree.
+    ///
+    /// Stabilizing one source is not enough. The bundle spans two stores, and a
+    /// writer that advances a GCS cursor between the head read and the cursor
+    /// read produces a vector that never existed at any instant, which is the
+    /// A-out/B-in shape the full proof's double collection refuses one level
+    /// up. Both halves are therefore collected twice and compared whole.
+    fn observe_stable_hosted_fleet_identity(
+        &self,
+        spine: &dyn kin_spine::SpineBackend,
+        repo_ids: &[String],
+    ) -> std::result::Result<BTreeMap<String, HostedRepoDurableIdentity>, String> {
+        let mut last_movement = String::new();
+        for attempt in 1..=HOSTED_REPO_RELOAD_ATTEMPTS {
+            let selected = self.observe_hosted_fleet_identity(spine, repo_ids)?;
+            let observed = self.observe_hosted_fleet_identity(spine, repo_ids)?;
+            if selected == observed {
+                return Ok(selected);
+            }
+            last_movement =
+                format!("hosted fleet durable identity moved during observation attempt {attempt}");
+        }
+        Err(format!(
+            "{last_movement}; it did not stabilize after {HOSTED_REPO_RELOAD_ATTEMPTS} attempts"
+        ))
+    }
+
     /// Prove the cached hosted authority against durable identity, with no
     /// hydration and no graph load.
     ///
     /// The reuse is conditional on identity, never on age: the durable reader
     /// admission, the runtime spine authority, the admitted fence evidence, the
-    /// active Firestore fence and the registered fleet must all still be the
-    /// ones the cached proof was built under. Any drift, and any error reading
-    /// them, refuses. What it does NOT re-establish is the per-repository
-    /// cursor and root equality that `validate_hosted_spine_authority` proves
-    /// by loading every repo graph twice; that pass stays exactly as it is, on
-    /// the paths that establish authority rather than on the paths that report
-    /// it.
+    /// active Firestore fence, the registered fleet, and then the exact durable
+    /// identity of every repository the proof was built against, must all still
+    /// be what they were. Any drift, and any error reading them, refuses.
     ///
-    /// Callers hold the publication read gate, so a writer cannot install a new
-    /// committed generation between this proof and the answer it authorizes.
+    /// Names are not identity, and the rollout fence is not identity either. An
+    /// ordinary publication lease advances a committed head while the admitted
+    /// rollout evidence stays exactly where it is, so a check that stops at the
+    /// fleet's names certifies a proof built against a generation that has
+    /// already been superseded.
+    ///
+    /// What it does NOT re-establish is the graph root, because it does not have
+    /// to: the root was fully validated against an immutable source cursor, and
+    /// this check proves that both the committed head and the source cursor are
+    /// still the exact ones it was validated at. Recomputing it would mean
+    /// loading every repository graph on every probe, which is the cost this
+    /// whole path exists to remove.
+    ///
+    /// Callers hold the publication read gate, so a writer in this process
+    /// cannot install a new committed generation between this proof and the
+    /// answer it authorizes.
     fn assert_cached_hosted_spine_authority(
         &self,
         backend: &dyn kin_spine::SpineBackend,
-    ) -> std::result::Result<(), String> {
+    ) -> std::result::Result<(), CachedAuthorityRefusal> {
         let Some(control) = self.publication_control.as_ref() else {
             return Ok(());
         };
         control
             .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
-            .map_err(|error| format!("hosted spine reader is not durably admitted: {error}"))?;
-        let durable = match control
-            .runtime_spine_authority()
-            .map_err(|error| format!("load hosted spine runtime authority: {error}"))?
-        {
+            .map_err(|error| {
+                CachedAuthorityRefusal::blocked(format!(
+                    "hosted spine reader is not durably admitted: {error}"
+                ))
+            })?;
+        let durable = match control.runtime_spine_authority().map_err(|error| {
+            CachedAuthorityRefusal::blocked(format!("load hosted spine runtime authority: {error}"))
+        })? {
             crate::publication_lease::RuntimeSpineAuthority::Completed(evidence) => evidence,
             crate::publication_lease::RuntimeSpineAuthority::RolloutActive(blocking) => {
-                return Err(format!(
+                return Err(CachedAuthorityRefusal::blocked(format!(
                     "hosted spine {blocking}; cached authority is not readable"
-                ))
+                )))
             }
         };
-        let expected = self.expected_hosted_spine_rollout_fence()?;
+        let expected = self
+            .expected_hosted_spine_rollout_fence()
+            .map_err(CachedAuthorityRefusal::blocked)?;
         if expected != durable {
-            return Err(
+            return Err(CachedAuthorityRefusal::blocked(
                 "cached hosted spine evidence differs from the GCS publication-control record"
                     .to_string(),
-            );
+            ));
         }
         let cached = self
             .hosted_spine_authority_proof
@@ -6676,14 +6944,22 @@ impl DaemonState {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone()
             .ok_or_else(|| {
-                "hosted spine has no completed cursor/root authority proof".to_string()
+                CachedAuthorityRefusal::superseded(format!(
+                    "hosted spine has no completed cursor/root authority proof: {}",
+                    self.spine_unavailable_reason()
+                ))
             })?;
-        let active = without_blocking_runtime_worker(|| backend.active_rollout_fence())
-            .map_err(|error| format!("load active Firestore spine fence: {error}"))?;
+        let active = without_blocking_runtime_worker(|| backend.active_rollout_fence()).map_err(
+            |error| {
+                CachedAuthorityRefusal::blocked(format!(
+                    "load active Firestore spine fence: {error}"
+                ))
+            },
+        )?;
         if active != cached.rollout_fence || active.evidence() != durable {
-            return Err(
+            return Err(CachedAuthorityRefusal::blocked(
                 "cached hosted spine proof differs from active Firestore authority".to_string(),
-            );
+            ));
         }
         let registered = backend.registered_repo_ids();
         if cached.repositories.len() != registered.len()
@@ -6692,9 +6968,31 @@ impl DaemonState {
                 .keys()
                 .any(|repo_id| !registered.contains(repo_id))
         {
-            return Err(
+            return Err(CachedAuthorityRefusal::blocked(
                 "cached hosted spine proof does not cover the exact registered fleet".to_string(),
-            );
+            ));
+        }
+        let repo_ids = cached.repositories.keys().cloned().collect::<Vec<_>>();
+        let observed = self
+            .observe_stable_hosted_fleet_identity(backend, &repo_ids)
+            .map_err(CachedAuthorityRefusal::superseded)?;
+        for (repo_id, proved) in &cached.repositories {
+            let Some(current) = observed.get(repo_id) else {
+                return Err(CachedAuthorityRefusal::superseded(format!(
+                    "repo {repo_id} has no durable identity to bind the cached proof to"
+                )));
+            };
+            if current != &proved.identity {
+                return Err(CachedAuthorityRefusal::superseded(format!(
+                    "repo {repo_id} durable identity moved under the cached proof: committed head \
+                     publication {} at source cursor {:?}, proof built against publication {} at \
+                     source cursor {:?}",
+                    current.head.publication_id,
+                    current.source_cursor,
+                    proved.identity.head.publication_id,
+                    proved.identity.source_cursor,
+                )));
+            }
         }
         Ok(())
     }
@@ -6709,7 +7007,8 @@ impl DaemonState {
     ) -> std::result::Result<SpineAuthorityReadGuard<'_>, String> {
         let publication_gate = self.spine_refresh_gate.read().await;
         let backend = self.initialized_spine_backend()?;
-        self.assert_cached_hosted_spine_authority(backend)?;
+        self.assert_cached_hosted_spine_authority(backend)
+            .map_err(CachedAuthorityRefusal::into_reason)?;
         Ok(SpineAuthorityReadGuard {
             backend,
             _publication_gate: publication_gate,
@@ -6747,7 +7046,20 @@ impl DaemonState {
             return Err(self.spine_unavailable_reason());
         }
         let backend = self.initialized_spine_backend()?;
-        self.assert_cached_hosted_spine_authority(backend)
+        match self.assert_cached_hosted_spine_authority(backend) {
+            Ok(()) => Ok(()),
+            Err(refusal) => {
+                if refusal.superseded {
+                    // Re-prove now rather than at the end of the interval, so
+                    // Ready comes back on the next successful pass instead of a
+                    // minute later. The pass keeps its own floor between runs,
+                    // so a drift that persists cannot turn the probe back into
+                    // the thing that drives a continuous refresh.
+                    self.hosted_spine_refresh_wake.notify_one();
+                }
+                Err(refusal.into_reason())
+            }
+        }
     }
 
     /// How long the background authority refresh sleeps between passes.
@@ -6792,10 +7104,35 @@ impl DaemonState {
         {
             return;
         }
-        let state = Arc::clone(self);
+        // The pass holds a WEAK reference and takes a strong one only while it
+        // is working. A background task that owns the daemon state keeps every
+        // graph, cache and index it holds alive for as long as the task runs,
+        // which is forever, and it cannot notice that the state it exists to
+        // maintain has gone.
+        let wake = Arc::clone(&self.hosted_spine_refresh_wake);
+        let state = Arc::downgrade(self);
         runtime.spawn(async move {
+            // `Some` only while a pass is failing, and it doubles from the
+            // retry floor up to the interval. A failed pass invalidates the
+            // cached proof, so the daemon reports unready until one succeeds:
+            // waiting a whole interval to retry would turn one transient
+            // durable read into a minute out of service.
+            let mut retry: Option<Duration> = None;
             loop {
-                tokio::time::sleep(state.hosted_spine_authority_refresh_interval()).await;
+                let (interval, floor) = {
+                    let Some(state) = state.upgrade() else { return };
+                    let interval = state.hosted_spine_authority_refresh_interval();
+                    (interval, HOSTED_SPINE_AUTHORITY_RETRY_FLOOR.min(interval))
+                };
+                tokio::select! {
+                    () = tokio::time::sleep(retry.unwrap_or(interval)) => {}
+                    () = wake.notified() => {
+                        // A probe saw durable identity move. Re-prove soon, but
+                        // never faster than the floor.
+                        tokio::time::sleep(floor).await;
+                    }
+                }
+                let Some(state) = state.upgrade() else { return };
                 let started = Instant::now();
                 let refreshed = {
                     let _publication_gate = state.spine_refresh_gate.read().await;
@@ -6803,18 +7140,26 @@ impl DaemonState {
                 };
                 let elapsed_ms = started.elapsed().as_millis() as u64;
                 if refreshed {
+                    retry = None;
                     debug!(
                         elapsed_ms,
                         "hosted spine authority refreshed on the background cadence"
                     );
                 } else {
+                    retry = Some(
+                        retry
+                            .map_or(floor, |backoff| backoff.saturating_mul(2))
+                            .min(interval),
+                    );
                     warn!(
                         elapsed_ms,
+                        retry_in_ms = retry.unwrap_or(interval).as_millis() as u64,
                         reason = %state.spine_unavailable_reason(),
-                        "background hosted spine authority refresh failed; the probe answer \
-                         still follows the durable admission, rollout and evidence checks"
+                        "background hosted spine authority refresh failed; the cached proof is \
+                         invalidated and readiness refuses until a pass succeeds"
                     );
                 }
+                drop(state);
             }
         });
     }
@@ -12336,12 +12681,36 @@ mod tests {
         );
     }
 
+    /// A committed head whose every field moves with the generation and root
+    /// under test, so the A-out/B-in control still discriminates now that the
+    /// proof carries the whole head identity rather than three fields of it.
+    fn hosted_repo_head(generation: u64, root_hash: &str) -> kin_spine::RepoPublicationHead {
+        kin_spine::RepoPublicationHead {
+            schema_version: kin_spine::REPO_PUBLICATION_SCHEMA_VERSION,
+            repo_id: "fixture".to_string(),
+            source_cursor: kin_spine::SpineSourceCursor::from_backend_generation(generation),
+            root_hash: root_hash.to_string(),
+            phase: kin_spine::RepoPublicationPhase::Edges,
+            publication_id: format!("{root_hash}-{generation}"),
+            manifest_sha256: format!("manifest-{root_hash}-{generation}"),
+            metadata_sha256: format!("metadata-{root_hash}-{generation}"),
+            entity_count: 1,
+            edge_count: 0,
+            resolution_roots: BTreeMap::new(),
+        }
+    }
+
     fn hosted_repo_proof(generation: u64, root_hash: &str) -> HostedSpineRepoAuthorityProof {
         let cursor = kin_spine::SpineSourceCursor::from_backend_generation(generation);
         HostedSpineRepoAuthorityProof {
             durable_head_cursor: cursor,
             current_source_cursor: cursor,
             root_hash: root_hash.to_string(),
+            identity: HostedRepoDurableIdentity {
+                head: hosted_repo_head(generation, root_hash),
+                head_revision: format!("rev-{generation}"),
+                source_cursor: cursor,
+            },
         }
     }
 

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1672,6 +1672,17 @@ const SPINE_GRAPH_CAPTURE_ATTEMPTS: usize = 3;
 /// constant while still allowing unrelated repositories to reload in parallel.
 const HOSTED_REPO_RELOAD_GATE_SHARDS: usize = 64;
 const HOSTED_REPO_RELOAD_ATTEMPTS: usize = 3;
+
+/// How often a hosted reader re-proves its spine authority in the background.
+///
+/// One pass hydrates the whole durable cache and then double-collects the fleet,
+/// loading every repository graph and recomputing every root. A five-repo
+/// production fleet measured a 10.46 s median for one of them on 2026-09-05, so
+/// this interval has to be long enough that the pod is mostly idle between
+/// passes and short enough that a reader nobody queries still tracks its
+/// siblings. It is never on a request path; the readiness probe reads the proof
+/// this pass maintains and never waits for it.
+const HOSTED_SPINE_AUTHORITY_REFRESH_INTERVAL: Duration = Duration::from_secs(60);
 const HOSTED_SPINE_FLEET_SIZE: usize = 5;
 const HOSTED_SPINE_CURSOR_CAS_REQUIRED: &str =
     "hosted persistent spine is unavailable until its durable backend can stage rows and compare-and-swap a head bound to the exact source publication cursor";
@@ -2931,6 +2942,15 @@ pub struct DaemonState {
     #[cfg(test)]
     #[cfg_attr(not(feature = "firestore"), allow(dead_code))]
     spine_backend_hydrations: AtomicUsize,
+    /// Shortens the background refresh interval so a test can watch the pass
+    /// actually run. `None`, and every production build, uses
+    /// [`HOSTED_SPINE_AUTHORITY_REFRESH_INTERVAL`].
+    #[cfg(test)]
+    hosted_spine_refresh_interval_for_test: Mutex<Option<Duration>>,
+    /// Whether the background pass that keeps the hosted spine authority proof
+    /// current has been started. It is started once, by whichever hosted
+    /// request route runs first, and never again.
+    hosted_spine_refresh_cadence_started: AtomicBool,
     /// Test-only escape hatch for process-local spine behavior. Production
     /// hosted states have no corresponding field or bypass: they remain held
     /// until the durable backend owns cursor-bound publication CAS.
@@ -5271,6 +5291,9 @@ impl DaemonState {
             #[cfg(test)]
             spine_backend_hydrations: AtomicUsize::new(0),
             #[cfg(test)]
+            hosted_spine_refresh_interval_for_test: Mutex::new(None),
+            hosted_spine_refresh_cadence_started: AtomicBool::new(false),
+            #[cfg(test)]
             hosted_in_memory_spine_allowed: AtomicBool::new(false),
             #[cfg(test)]
             hosted_durable_spine_for_test: Mutex::new(None),
@@ -5640,6 +5663,9 @@ impl DaemonState {
             spine_backend_constructions: AtomicUsize::new(0),
             #[cfg(test)]
             spine_backend_hydrations: AtomicUsize::new(0),
+            #[cfg(test)]
+            hosted_spine_refresh_interval_for_test: Mutex::new(None),
+            hosted_spine_refresh_cadence_started: AtomicBool::new(false),
             #[cfg(test)]
             hosted_in_memory_spine_allowed: AtomicBool::new(false),
             #[cfg(test)]
@@ -6584,6 +6610,95 @@ impl DaemonState {
         })
     }
 
+    /// The already-initialized backend, or the reason it cannot be read.
+    ///
+    /// A recovery-only process opened its primary graph before the GCS
+    /// generation fence completed, so it must never serve a cached view as
+    /// current authority even though a backend exists.
+    fn initialized_spine_backend(
+        &self,
+    ) -> std::result::Result<&dyn kin_spine::SpineBackend, String> {
+        if self.hosted_restart_required() {
+            return Err(self.spine_unavailable_reason());
+        }
+        self.spine
+            .get()
+            .map(AsRef::as_ref)
+            .ok_or_else(|| "spine is disabled or has not been initialized".to_string())
+    }
+
+    /// Prove the cached hosted authority against durable identity, with no
+    /// hydration and no graph load.
+    ///
+    /// The reuse is conditional on identity, never on age: the durable reader
+    /// admission, the runtime spine authority, the admitted fence evidence, the
+    /// active Firestore fence and the registered fleet must all still be the
+    /// ones the cached proof was built under. Any drift, and any error reading
+    /// them, refuses. What it does NOT re-establish is the per-repository
+    /// cursor and root equality that `validate_hosted_spine_authority` proves
+    /// by loading every repo graph twice; that pass stays exactly as it is, on
+    /// the paths that establish authority rather than on the paths that report
+    /// it.
+    ///
+    /// Callers hold the publication read gate, so a writer cannot install a new
+    /// committed generation between this proof and the answer it authorizes.
+    fn assert_cached_hosted_spine_authority(
+        &self,
+        backend: &dyn kin_spine::SpineBackend,
+    ) -> std::result::Result<(), String> {
+        let Some(control) = self.publication_control.as_ref() else {
+            return Ok(());
+        };
+        control
+            .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
+            .map_err(|error| format!("hosted spine reader is not durably admitted: {error}"))?;
+        let durable = match control
+            .runtime_spine_authority()
+            .map_err(|error| format!("load hosted spine runtime authority: {error}"))?
+        {
+            crate::publication_lease::RuntimeSpineAuthority::Completed(evidence) => evidence,
+            crate::publication_lease::RuntimeSpineAuthority::RolloutActive(blocking) => {
+                return Err(format!(
+                    "hosted spine {blocking}; cached authority is not readable"
+                ))
+            }
+        };
+        let expected = self.expected_hosted_spine_rollout_fence()?;
+        if expected != durable {
+            return Err(
+                "cached hosted spine evidence differs from the GCS publication-control record"
+                    .to_string(),
+            );
+        }
+        let cached = self
+            .hosted_spine_authority_proof
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+            .ok_or_else(|| {
+                "hosted spine has no completed cursor/root authority proof".to_string()
+            })?;
+        let active = without_blocking_runtime_worker(|| backend.active_rollout_fence())
+            .map_err(|error| format!("load active Firestore spine fence: {error}"))?;
+        if active != cached.rollout_fence || active.evidence() != durable {
+            return Err(
+                "cached hosted spine proof differs from active Firestore authority".to_string(),
+            );
+        }
+        let registered = backend.registered_repo_ids();
+        if cached.repositories.len() != registered.len()
+            || cached
+                .repositories
+                .keys()
+                .any(|repo_id| !registered.contains(repo_id))
+        {
+            return Err(
+                "cached hosted spine proof does not cover the exact registered fleet".to_string(),
+            );
+        }
+        Ok(())
+    }
+
     /// Guard an already-initialized spine for side-effect-free diagnostics.
     /// Hosted health must never warm, hydrate, or publish, but it also must not
     /// report an unadmitted cached generation as healthy. The durable reader
@@ -6593,73 +6708,115 @@ impl DaemonState {
         &self,
     ) -> std::result::Result<SpineAuthorityReadGuard<'_>, String> {
         let publication_gate = self.spine_refresh_gate.read().await;
-        // Health reads the already-constructed backend rather than entering
-        // `ensure_spine_initialized`, so it needs the recovery-only refusal of
-        // its own. Without it a recovery process that repaired durable state
-        // would report a cached view as current authority over a primary graph
-        // that predates the fence.
-        if self.hosted_restart_required() {
-            return Err(self.spine_unavailable_reason());
-        }
-        let backend = self
-            .spine
-            .get()
-            .map(AsRef::as_ref)
-            .ok_or_else(|| "spine is disabled or has not been initialized".to_string())?;
-        if let Some(control) = self.publication_control.as_ref() {
-            control
-                .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
-                .map_err(|error| format!("hosted spine reader is not durably admitted: {error}"))?;
-            let durable = match control
-                .runtime_spine_authority()
-                .map_err(|error| format!("load hosted spine runtime authority: {error}"))?
-            {
-                crate::publication_lease::RuntimeSpineAuthority::Completed(evidence) => evidence,
-                crate::publication_lease::RuntimeSpineAuthority::RolloutActive(blocking) => {
-                    return Err(format!(
-                        "hosted spine {blocking}; cached authority is not readable"
-                    ))
-                }
-            };
-            let expected = self.expected_hosted_spine_rollout_fence()?;
-            if expected != durable {
-                return Err(
-                    "cached hosted spine evidence differs from the GCS publication-control record"
-                        .to_string(),
-                );
-            }
-            let cached = self
-                .hosted_spine_authority_proof
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .clone()
-                .ok_or_else(|| {
-                    "hosted spine has no completed cursor/root authority proof".to_string()
-                })?;
-            let active = without_blocking_runtime_worker(|| backend.active_rollout_fence())
-                .map_err(|error| format!("load active Firestore spine fence: {error}"))?;
-            if active != cached.rollout_fence || active.evidence() != durable {
-                return Err(
-                    "cached hosted spine proof differs from active Firestore authority".to_string(),
-                );
-            }
-            let registered = backend.registered_repo_ids();
-            if cached.repositories.len() != registered.len()
-                || cached
-                    .repositories
-                    .keys()
-                    .any(|repo_id| !registered.contains(repo_id))
-            {
-                return Err(
-                    "cached hosted spine proof does not cover the exact registered fleet"
-                        .to_string(),
-                );
-            }
-        }
+        let backend = self.initialized_spine_backend()?;
+        self.assert_cached_hosted_spine_authority(backend)?;
         Ok(SpineAuthorityReadGuard {
             backend,
             _publication_gate: publication_gate,
         })
+    }
+
+    /// Answer one hosted readiness probe. Nothing here hydrates the durable
+    /// cache or loads a repository graph.
+    ///
+    /// A probe is a report, not an authority transition. Establishing authority
+    /// costs one full durable cache hydration plus a whole-fleet double-collect
+    /// that loads every repository graph and recomputes every root; on a
+    /// five-repo production fleet on 2026-09-05 that measured a 10.46 s median,
+    /// against a 3 s startup-probe timeout and a 1 s readiness-probe timeout.
+    /// Worse, the hydration takes one process-wide lock, so probes did not even
+    /// overlap: they queued, and end-to-end readiness answers took 141 s, 156 s
+    /// and 175.7 s while the answer itself was `ready: true`. The pod never went
+    /// Ready and the rollout was reverted.
+    ///
+    /// So the probe reads the proof that the authority transitions establish and
+    /// [`Self::start_hosted_spine_authority_refresh_cadence`] keeps current, and
+    /// it re-proves durable identity every time so a lost admission, an active
+    /// rollout or drifted evidence still refuses.
+    pub(crate) async fn hosted_readiness_spine_authority(&self) -> std::result::Result<(), String> {
+        let gate_started = Instant::now();
+        let _publication_gate = self.spine_refresh_gate.read().await;
+        self.spine_gate_read_wait_micros.store(
+            u64::try_from(gate_started.elapsed().as_micros()).unwrap_or(u64::MAX),
+            Ordering::Relaxed,
+        );
+        // The refusal `ensure_spine_initialized` would have reached first. A
+        // build or configuration that cannot construct the hosted backend must
+        // not report ready on the strength of a proof cached before it broke.
+        if self.hosted_persistent_spine_blocked() {
+            return Err(self.spine_unavailable_reason());
+        }
+        let backend = self.initialized_spine_backend()?;
+        self.assert_cached_hosted_spine_authority(backend)
+    }
+
+    /// How long the background authority refresh sleeps between passes.
+    fn hosted_spine_authority_refresh_interval(&self) -> Duration {
+        #[cfg(test)]
+        if let Some(interval) = *self
+            .hosted_spine_refresh_interval_for_test
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+        {
+            return interval;
+        }
+        HOSTED_SPINE_AUTHORITY_REFRESH_INTERVAL
+    }
+
+    /// Start the one background pass that keeps the hosted spine authority
+    /// proof current, if it is not already running.
+    ///
+    /// Idempotent, so a request route may call it unconditionally. It exists
+    /// because the readiness probe used to be what refreshed this proof: taking
+    /// that off the probe path without putting it anywhere would leave a reader
+    /// that nobody queries proving its authority once, at admission, and never
+    /// again.
+    ///
+    /// A failed pass does not by itself make this daemon unready. The three
+    /// conditions a probe must refuse on, a lost durable admission, an active
+    /// rollout and drifted evidence, are re-read on every probe and decide the
+    /// answer; flapping a serving pod out of the fleet over one transient
+    /// durable read would take out the whole pool on a blip.
+    pub(crate) fn start_hosted_spine_authority_refresh_cadence(self: &Arc<Self>) {
+        if !self.hosted_spine_readiness_required() {
+            return;
+        }
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            // Nothing to spawn on. Leave the flag clear so a later caller that
+            // does have a runtime still starts the pass.
+            return;
+        };
+        if self
+            .hosted_spine_refresh_cadence_started
+            .swap(true, Ordering::SeqCst)
+        {
+            return;
+        }
+        let state = Arc::clone(self);
+        runtime.spawn(async move {
+            loop {
+                tokio::time::sleep(state.hosted_spine_authority_refresh_interval()).await;
+                let started = Instant::now();
+                let refreshed = {
+                    let _publication_gate = state.spine_refresh_gate.read().await;
+                    state.ensure_spine().is_some()
+                };
+                let elapsed_ms = started.elapsed().as_millis() as u64;
+                if refreshed {
+                    debug!(
+                        elapsed_ms,
+                        "hosted spine authority refreshed on the background cadence"
+                    );
+                } else {
+                    warn!(
+                        elapsed_ms,
+                        reason = %state.spine_unavailable_reason(),
+                        "background hosted spine authority refresh failed; the probe answer \
+                         still follows the durable admission, rollout and evidence checks"
+                    );
+                }
+            }
+        });
     }
 
     /// Refuse hosted operation unless the deployed bytes and configuration can
@@ -7198,6 +7355,16 @@ impl DaemonState {
             .spine_initialization_test_hook
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = hook;
+    }
+
+    /// Shorten the background authority refresh interval for a test that has
+    /// to watch the pass run. Production has no such override.
+    #[cfg(test)]
+    pub(crate) fn set_hosted_spine_refresh_interval_for_test(&self, interval: Duration) {
+        *self
+            .hosted_spine_refresh_interval_for_test
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(interval);
     }
 
     #[cfg(all(test, feature = "embeddings"))]

--- a/crates/kin-spine/src/backend.rs
+++ b/crates/kin-spine/src/backend.rs
@@ -164,6 +164,30 @@ pub trait SpineBackend: Send + Sync {
         ))
     }
 
+    /// Read every committed repository head from the DURABLE store, without
+    /// its entity rows, as one coherent whole-fleet observation.
+    ///
+    /// This is the cheap identity read. `source_cursor`, `root_hash` and
+    /// `registered_repo_ids` all answer from this process's cache and cannot
+    /// say whether durable authority moved underneath it;
+    /// `refresh_committed_publications` can say, but it loads every row to do
+    /// it. A caller that only needs to know whether an identity is still the
+    /// one it proved against takes this.
+    ///
+    /// This is ONE observation, deliberately. A caller proving that identity has
+    /// not moved must collect the complete bundle it cares about, these heads
+    /// and whatever else it reads, twice and compare, because stabilizing one
+    /// source alone still lets two instants mix.
+    ///
+    /// Backends must opt in explicitly, exactly as they do for publication.
+    fn committed_head_identities(
+        &self,
+    ) -> Result<BTreeMap<String, (RepoPublicationHead, String)>, SpineError> {
+        Err(SpineError::Backend(
+            "durable committed head identities are unsupported by this backend".to_string(),
+        ))
+    }
+
     /// Stage immutable rows for one cursor-bound repository publication.
     ///
     /// Backends must opt in explicitly. Hosted callers treat the default error

--- a/crates/kin-spine/src/firestore.rs
+++ b/crates/kin-spine/src/firestore.rs
@@ -1176,6 +1176,12 @@ impl SpineBackend for FirestoreSpineBackend {
         FirestoreSpineBackend::complete_legacy_migration(self, writer_drain)
     }
 
+    fn committed_head_identities(
+        &self,
+    ) -> Result<BTreeMap<String, (RepoPublicationHead, String)>, SpineError> {
+        self.store.load_repo_heads()
+    }
+
     fn refresh_committed_publications(&self) -> Result<(), SpineError> {
         self.hydrate()
     }
@@ -3561,6 +3567,12 @@ impl SpineStore for FirestoreStore {
             return Ok(RepoPublicationCommit::Conflict(conflict));
         }
         self.commit_head_and_rollout_fence(prepared)
+    }
+
+    fn load_repo_heads(
+        &self,
+    ) -> Result<BTreeMap<String, (RepoPublicationHead, String)>, SpineError> {
+        self.list_repo_heads()
     }
 
     fn load_repo_publications(&self) -> Result<Vec<LoadedRepoPublication>, SpineError> {

--- a/crates/kin-spine/src/store.rs
+++ b/crates/kin-spine/src/store.rs
@@ -418,6 +418,22 @@ pub trait SpineStore: Send + Sync {
         ))
     }
 
+    /// Load every committed repository head WITHOUT its entity rows.
+    ///
+    /// The head carries the whole durable identity of a publication: its source
+    /// cursor, its root hash, its publication id and its digests. Loading the
+    /// rows as well is what makes [`Self::load_repo_publications`] expensive,
+    /// and a caller that only needs to know whether an identity moved must not
+    /// pay for them. The second element is the store's own revision token for
+    /// that head, which the existing head read already carries.
+    fn load_repo_heads(
+        &self,
+    ) -> Result<BTreeMap<String, (RepoPublicationHead, String)>, SpineError> {
+        Err(SpineError::Backend(
+            "durable committed repository heads are unsupported by this store".to_string(),
+        ))
+    }
+
     /// Load only publications reachable from committed repository heads.
     fn load_repo_publications(&self) -> Result<Vec<LoadedRepoPublication>, SpineError> {
         Err(SpineError::Backend(

--- a/crates/kin-spine/src/test_support.rs
+++ b/crates/kin-spine/src/test_support.rs
@@ -905,6 +905,26 @@ impl SpineStore for FakeSpineStore {
         })
     }
 
+    fn load_repo_heads(
+        &self,
+    ) -> Result<BTreeMap<String, (RepoPublicationHead, String)>, SpineError> {
+        if !self.atomicity_available.load(Ordering::SeqCst) {
+            return Err(SpineError::Backend(
+                "injected atomic publication unavailable".to_string(),
+            ));
+        }
+        Ok(self
+            .publication_state
+            .lock()
+            .unwrap()
+            .heads
+            .iter()
+            .map(|(repo_id, (revision, head))| {
+                (repo_id.clone(), (head.clone(), revision.to_string()))
+            })
+            .collect())
+    }
+
     fn load_repo_publications(&self) -> Result<Vec<LoadedRepoPublication>, SpineError> {
         if !self.atomicity_available.load(Ordering::SeqCst) {
             return Err(SpineError::Backend(


### PR DESCRIPTION
FIR-3255.

A hosted `/readiness` probe ran the full durable spine authority proof, so the pod starved under the
kubelet's 3 s startup-probe timeout and never went Ready. This answers the probe from the authority
proof the process already holds and moves the refresh to a background cadence.

## Measured first

Production hop of kin-daemon `5645ed233` (0.7.1). Pod `kin-daemon-c854b974-lfhcm`, started
12:10:00Z, API listening 12:15:51Z, initialization complete 12:16:01Z, reader admitted and lease
released 12:16:05Z. `/health` answered instantly. `/readiness` did not.

Counting the two `kin_spine::firestore` cache lines out of the pod log:

```
starts 56 ends 55
first start 2026-09-05T12:14:44.290869+00:00 last end 2026-09-05T12:25:15.640155+00:00
n durations 55
min 8.35 max 14.29 mean 10.64 median 10.57
gap end->next start: min 0.000041 max 21.737974 median 0.000092  (n=55)
steady-state n=51 min 8.35 max 14.29 mean 10.65 median 10.46
```

Read the gap line first. The median time between one refresh finishing and the next starting is 92
microseconds: from 12:16:22Z to 12:25:15Z the pod ran 51 back-to-back full cache refreshes with no
idle time at all. Every one reported the same `repos=5 entities=41496 edges=1489`, so no refresh in
that window found anything new. Alongside them, `loaded repo graph from storage backend` ran 50 to 63
times a minute against 5 to 6 refreshes, which is about ten graph loads per refresh on a five-repo
fleet, not five.

kubelet's side: startup probe 503 x32 from 12:10:10Z to 12:15:20Z, which is the bootstrap and is
expected, then `Startup probe failed: ... context deadline exceeded (Client.Timeout exceeded while
awaiting headers)` x26 from 12:16:03Z to 12:20:14Z. The startup probe allows `timeoutSeconds: 3`, the
readiness probe `timeoutSeconds: 1`. Against a 10.46 s median both are hopeless by construction.
End-to-end answers, all of them eventually succeeding: 141 s at 12:26:10Z and 156 s at 12:27:05Z
through the API-server proxy, and 175.7 s from 12:24:43Z to 12:27:39Z on one direct GET with a 600 s
budget, every one returning `{"ready":true,"warming":false}`. The proof succeeds; the proof is the
cost, and 175 s is the queue on top of it: `active_request_count` climbed from 8 at 12:19Z to 18 at
12:26Z.

## The mechanism

Every probe ran the full authority proof inline, because `readiness` awaited
`acquire_spine_read_authority`, which called `ensure_spine`, which on a hosted daemon calls
`refresh_hosted_spine_authority` unconditionally. That does two expensive things: it re-hydrates the
entire committed spine cache from Firestore, and it re-proves the whole fleet by loading every
repository graph and recomputing every root. The hydrate takes a process-wide mutex, so concurrent
probes could not even overlap; they queued, each paying its own 10.46 s median in turn.

Read at the deployed sha `5645ed233`:

- `crates/kin-daemon/src/api.rs:4089` `readiness`, awaiting the authority at `api.rs:4101` whenever
  initialized and hosted. No cached branch, no fast path.
- `crates/kin-daemon/src/state.rs:6533` `acquire_spine_read_authority`: publication read gate,
  `assert_runtime_admitted`, then `ensure_spine()`.
- `state.rs:6495` `ensure_spine`: when `storage_backend.is_some()`, calls
  `refresh_hosted_spine_authority` on every call, consulting no cache, timestamp or generation first.
- `state.rs:6253` `refresh_hosted_spine_authority`: `refresh_committed_publications()`, then
  `validate_hosted_spine_authority`.
- Cost A. `crates/kin-spine/src/firestore.rs:1179` `refresh_committed_publications` is
  `self.hydrate()`. `firestore.rs:1023` `hydrate` takes `refresh_write_lock` on its first line
  (`firestore.rs:1024`) and logs the two lines counted above (`firestore.rs:1026`, `1146`). That
  mutex is the serialization behind the 92 microsecond median gap.
- Cost B. `state.rs:6175` `validate_hosted_spine_authority` drives
  `collect_stable_hosted_spine_authority_vector` (`state.rs:1741`), which iterates the fleet twice
  per attempt (`state.rs:1749-1775`), calling `load_repo_graph` (`state.rs:8329`) each time. Ten
  graph loads and ten root-hash computations per probe, which is the ten-per-refresh ratio measured
  above and the independent confirmation those bursts are this collector.

At `d6b61e55` (0.6.1, the arm that passes the same probes on the same fleet) the whole handler was
two atomic reads and no spine call at all (`api.rs:3272` there). The commit that put the authority on
the probe path is `a27c99bb9`, "Repair and compose the durable spine compare-and-swap, publication
lease and stage TTL" (#1227, 2026-08-29), found with
`git log -S "acquire_spine_read_authority().await.is_some()"` and placed by `git merge-base
--is-ancestor` after `d6b61e55` and before `HEAD`.

## The fix

Three commits. The first takes the proof off the probe path. The second, after an independent source
review, binds what the probe answers from to current durable identity and stops a failed pass from
leaving a proof behind. Everything is in `kin-daemon` apart from one read-only seam in `kin-spine`, a
workspace member of this repository reached by a path dependency.
`validate_hosted_spine_authority`'s double collection and the exact-fleet control are unchanged, so
the A-out/B-in mutants stay red against a single-pass shortcut.

### The probe reports authority instead of establishing it

`readiness` calls `DaemonState::hosted_readiness_spine_authority`, which takes the publication read
gate and records its wait as before, refuses when `hosted_persistent_spine_blocked`, resolves the
already-constructed backend, and runs `assert_cached_hosted_spine_authority`. No hydration and no
graph load.

That predicate is the cached-authority check lifted out of `acquire_initialized_spine_read_authority`
so both callers share one implementation. The reuse is conditional on identity, never on age: the
durable reader admission, the runtime spine authority, the admitted fence evidence, the active
Firestore fence, the registered fleet, and then the exact durable identity of every repository the
proof was built against must all still be what they were, and any drift, or any error reading them,
refuses.

### The bundle is bracketed by its control authority

The cheap answer read the durable admission, the runtime spine authority and the active Firestore
fence BEFORE it observed the identity bundle, and then answered with no re-read. A rollout that
began, or an admission that lapsed, while the committed heads and source cursors were being read was
answered through: neither moves the heads or the cursors, so both bundle observations agree and the
identity comparison passes. The full authority pass re-reads its fence at the end for exactly this
reason.

Those three reads now bracket the bundle. The pre-bundle values are compared with the proof as
before, and the post-bundle values must equal the pre-bundle ones, including the store revision that
carried the active fence and the registered fleet, or the probe refuses and wakes the background
pass. Nothing hydrates on either side.

### Names are not identity

The first commit stopped at the fleet's names, and that is weaker than the baseline it replaced. An
ordinary publication lease advances a committed head while the admitted rollout evidence stays
exactly where it is (`publication_lease.rs` refuses Rollout leases, not Publication ones), so a proof
built against a superseded generation passed every check.

The probe now observes the complete durable bundle, the committed spine heads and every repository's
source publication cursor, twice, and requires the two observations to agree before comparing them
with the identity the proof carries. Stabilizing one source is not enough: the bundle spans two
stores, and a writer that advances a GCS cursor between the head read and the cursor read produces a
vector that never existed at any instant, which is the A-out/B-in shape one level up. Identity
equality is the whole `RepoPublicationHead`, publication id and manifest and metadata digests
included, plus the store revision that carried it.

The graph root is not recomputed, and does not need to be. It was fully validated against an
immutable source cursor, and this check proves that both the committed head and the source cursor are
still the exact ones it was validated at. Recomputing it would mean loading every repository graph on
every probe, which is the cost this whole change exists to remove.

The read that makes this affordable is new: `SpineStore::load_repo_heads`, reached through
`SpineBackend::committed_head_identities`, reads committed heads WITHOUT their entity rows. Both
default to a loud error, so a backend opts in explicitly. `FirestoreStore` implements it through the
`list_repo_heads` listing it already had, which is what `load_repo_publications` calls before it goes
on to pull every row per head; pulling those rows is the ten-second cost, and an identity check must
not pay it.

### A failed pass must not leave a proof behind

`refresh_hosted_spine_authority` installed the proof only on success, so a failure left the previous
one in place. The caller recorded the error and returned `None`, but every cached-authority reader
still found a `Some` proof whose names and fence were intact and answered yes, after the process had
already determined its authority was invalid. Hydration can also replace the cached index before the
validation after it fails, leaving a proof that describes a generation the cache no longer holds.

A failed pass now clears the proof. Every pass takes a ticket first and the result is applied only if
no later pass has already applied one, read and written under the proof lock, so an older pass
finishing second cannot overwrite newer state.

### The background pass

`start_hosted_spine_authority_refresh_cadence` starts one pass per process that runs the full refresh
every 60 s under the publication read gate. It exists because the probe was what refreshed the proof;
taking that off the probe path without putting it anywhere would leave a reader nobody queries
proving its authority once, at admission, and never learning that a sibling published. Sixty seconds
because one pass measured a 10.46 s median on the production fleet.

It retries at 1 s doubling to the interval while it fails, because a failed pass now invalidates the
proof and the daemon reports unready until one succeeds: a whole interval of backoff would turn one
transient durable read into a minute out of service. A probe that refuses because identity moved
wakes it, so Ready returns on the next successful pass rather than at the end of the interval, and
never faster than the retry floor, so a persistent drift cannot turn the probe back into the thing
that drives a continuous refresh. Only a superseded refusal wakes it; a lost admission or an active
rollout cannot be fixed by re-proving. It holds a weak reference to the daemon state and takes a
strong one only while working, so it neither keeps the state alive forever nor outlives it.

### Three properties

**Started exactly once.** `hosted_spine_refresh_cadence_started.swap(true, SeqCst)` is a
compare-and-swap, not a check-then-set, and the spawn happens only for the caller that observed
`false`. It runs on the daemon's own runtime through `Handle::try_current().spawn`, so it ends when
the runtime does. With no runtime the flag is left clear and a later caller can still start it.

**A probe never waits for the cadence, and never softens because of it.** Both take the read side of
the gate, so they overlap. `active_rollout_fence` (`firestore.rs:1162`) is a bare store read that
does not take the hydrate mutex, and `registered_repo_ids` reads a cache that
`replace_committed_repo_publications` builds whole and swaps in under a write lock rather than
mutating in place, so a mid-hydrate probe sees the old fleet or the new one and never a torn one.

**The first hydration completes before the first ready answer,** and not by timing.
`admit_hosted_spine_rollout_fence` runs `refresh_hosted_spine_authority` before it calls
`admit_reader`, and `release_hosted_spine_rollout` runs it again. Until `admit_reader` has
checkpointed, the `hosted_reader_admission` middleware (`api.rs:1937`) answers every probe itself
with 503 and the handler never runs.

### Slow successes are logged too

`READINESS_SLOW_ANSWER` is 1 s, the tightest probe timeout the deployment configures, and an answer
at least that slow reports its authority and gate waits even when it returns 200. Without it the
175.7 s `ready: true` leaves no line in the pod log at all. It is deliberately not unconditional: a
line on every probe for the life of the pod would bury the case that matters.

### The publication gate is left as it is

The one wait left on the probe path is the publication read gate, which was already there: main's
`acquire_spine_read_authority` awaits the same gate first. Its write side is taken by rollout
transitions, where refusing is right, and by exactly two authenticated control-plane routes, spine
ingest (`api.rs:17561`) and cross-repo edge refresh (`api.rs:17592`), both explicit writes by this
pod. Nothing on a timer takes it: `daemon.rs`, `loop_runner.rs` and `background_work.rs` contain no
reference to `spine_refresh_gate`, `ingest_repo_into_spine` or `refresh_all_cross_repo_edges`, so
neither the embedding worker nor the reconcile loop can hold it, and the gate is a process-local
`RwLock` so another pod's publication cannot hold this pod's. The pod log agrees: `published
exact-fleet cross-repo edges through durable spine head CAS` appears exactly once, at 12:14:43Z,
before the API listened, and after `daemon initialization complete` at 12:16:01Z the only recurring
lines in nine minutes are the hydrations, their graph loads, the bounded cleanup sweeps and one
transient Firestore retry at 12:20:18Z. That pod also logs `filesystem watcher and reconciliation
loop disabled`.

## What the probe costs now

Measured, not assumed. The fixture charges every read the probe makes and counts it, and the test
prints both:

```
readiness probe cost: 640.083833ms, 0 hydration(s), 4 spine point read(s),
4 control record read(s), 10 source cursor probe(s)
```

| read | count | charge in the test |
|---|---|---|
| durable cache hydration | 0 | 10 s |
| spine point reads (2 committed-head listings, 2 active fence reads) | 4 | 20 ms each |
| publication-control record reads (admission and runtime authority, on both sides) | 4 | 20 ms each |
| source publication cursor probes (5 per bundle observation, 2 observations) | 10 | 200 ms each |

Eighteen reads, up from fifteen before the bracket: the three control-plane reads are taken on both
sides of the bundle rather than only before it. That measured 640 ms against 555 ms without the
bracket. The cursor charge is deliberately the largest,
because those are the reads the probe issues five at a time in one scoped join: served in series the
ten of them would cost 2 s on their own, so the test's 1.5 s bound fails a serial implementation and
passes a concurrent one. The concurrency is proved by the bound, not asserted in prose.

Production reasoning. The charges above are a test instrument, not a latency prediction; what carries
over is the shape. Eighteen reads, of which ten are issued in two concurrent batches, is ten
sequential round trips against a single object store and a single document store, where the removed
work was a full committed-cache hydration plus ten repository graph loads and ten root-hash
computations, measured at a 10.46 s median on the production fleet. The readiness probe allows 1 s
and needs 12 consecutive failures to flip the pod out of service, and the startup probe allows 3 s,
so an occasional round trip over budget costs one failure out of twelve rather than a rollout.

The publication-control record reads stay as they are. Folding each side's pair into one load parsed
twice needs a new method on `PublicationControl`, and it saves two point reads out of eighteen.

## Falsification

Five arms, each reverting one half on the final tree, each red on its own test and nothing else. All
through the fleet heavy-slot wrapper, `cargo test -p kin-daemon --lib readiness -- --nocapture`.
Backups by copy, never `git checkout -- <file>`.

Whole tree, green: `test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 1432 filtered out`.

**Arm A**, the readiness handler's authority call put back to
`state.acquire_spine_read_authority().await.is_some()`, which is exactly what `origin/main` does:

```
readiness probe cost: 12.393962584s, 1 hydration(s), 6 spine point read(s),
1 control record read(s), 10 source cursor probe(s)
thread 'api::tests::a_hosted_readiness_probe_answers_without_a_durable_spine_refresh'
panicked at crates/kin-daemon/src/api.rs:46133:9:
assertion `left == right` failed: the probe hydrated the durable spine cache. Establishing
authority is what the publication and rollout paths do; a probe reports it.
  left: 1
 right: 0
```

12.39 s in a test against the 10.46 s median measured in production. The test uses no seam that
`main` lacks, so this is the red it shows there.

**Arm B**, deleting `state.start_hosted_spine_authority_refresh_cadence();` from the handler:

```
thread 'api::tests::readiness_starts_the_background_hosted_spine_authority_refresh'
panicked at crates/kin-daemon/src/api.rs:46215:9:
no background pass re-proved the hosted spine authority. Without one, a reader that nobody
queries proves its authority once, at admission, and never learns that a sibling published.
```

**Arm C**, removing the per-repository identity binding from the cached predicate:

```
thread 'api::tests::a_hosted_readiness_probe_refuses_a_repository_whose_source_advanced'
panicked at crates/kin-daemon/src/api.rs:46254:9:
assertion `left == right` failed: a proof built against a superseded generation must not certify
readiness. The rollout fence does not move for an ordinary publication, so nothing but the
repository's own durable identity can catch this.
  left: 200
 right: 503

thread 'api::tests::a_hosted_readiness_probe_refuses_while_a_failing_refresh_holds_the_cache'
panicked at crates/kin-daemon/src/api.rs:46342:9:
assertion `left == right` failed: the probe answered ready while a refresh held a replaced cache
beside a proof for a generation that had already been superseded
  left: 200
 right: 503

readiness probe cost: 68.393792ms, 0 hydration(s), 1 spine point read(s),
2 control record read(s), 0 source cursor probe(s)
```

The cost line under that arm is the second half of the evidence: the binding is exactly the two
committed-head listings and the ten cursor probes, and without it they are not made.

**Arm D**, leaving a failed pass's proof installed:

```
thread 'api::tests::a_hosted_readiness_probe_refuses_after_the_authority_proof_fails'
panicked at crates/kin-daemon/src/api.rs:46290:9:
assertion `left == right` failed: a process that has already determined it cannot revalidate its
authority must not answer ready from the proof that pass was revalidating
  left: 200
 right: 503
```

That test earns its place the hard way. Its first version advanced a repository's source cursor and
then failed the pass, and arm D PASSED it, because the identity binding was catching the same input
one step earlier. It now fails the hydration inside the pass with every durable identity left exactly
where it is, which only the invalidation can catch, and it ends by clearing the injection and
proving that one successful pass brings Ready back, so the refusal is a hold rather than a fault.

**Arm E**, removing the post-bundle re-read so the control authority is read only before the bundle:

```
thread 'api::tests::a_hosted_readiness_probe_refuses_a_fence_that_moves_during_the_bundle'
panicked at crates/kin-daemon/src/api.rs:46392:9:
assertion `left == right` failed: the control authority moved while the identity bundle was
being read, and a probe that reads it only before the bundle answers through exactly that
  left: 200
 right: 503

thread 'api::tests::a_hosted_readiness_probe_refuses_an_admission_lost_during_the_bundle'
panicked at crates/kin-daemon/src/api.rs:46420:9:
assertion `left == right` failed: a probe whose durable admission stopped answering while it
read the identity bundle must not report ready on the strength of the read it made first
  left: 200
 right: 503

readiness probe cost: 566.64675ms, 0 hydration(s), 3 spine point read(s),
2 control record read(s), 10 source cursor probe(s)
```

Both shapes move something the bundle observations cannot see: the first advances the durable rollout
fence's store revision from a hook on the committed-head read, between the two observations, leaving
the heads and every cursor exactly where they are; the second serves the probe's two pre-bundle
record reads and refuses every read after them. Neither changes the bundle, so only the post-bundle
re-read can catch either, and the cost line under the arm shows the three reads it removes.

The exact-fleet A-out/B-in control is extended rather than left behind: the proof now carries the
whole committed head, and the control's fixture builds a head whose publication id and digests move
with the generation under test, so it still discriminates.

## Verification

`cargo test -p kin-daemon -p kin-spine --lib`, through the fleet heavy-slot wrapper, rc=0:

```
test result: ok. 1448 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 314.05s
test result: ok. 118 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

`bin/kin-precheck kin --repo-dir kin=<worktree>`, by absolute path through the same wrapper, rc=0.
Every gate line was PASS; the tally names the sha it graded, and that sha is this PR's head:

```
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 23c2dddee9cbc2fcee0ed25602c53e7fcf094b92
```

`cargo fmt -- --check` and `cargo clippy --all-targets --all-features` with the repository's 45-entry
allow list are two of those 21 gates and both passed.
