### PR TITLE
Use scoped cooperative shutdown in acceptance fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1022,6 +1022,9 @@ jobs:
       - name: Check the flake quarantine
         run: python3 scripts/check-quarantine.py
 
+      - name: Test acceptance fixture cleanup safety
+        run: python3 scripts/acceptance/test_fixture_shutdown.py
+
       # Here rather than in `check`, for the reason the step above records: a
       # script step in `check` is a gate `bin/kin-precheck` enumerates and must
       # classify by name, and one wired there without the matching umbrella

--- a/scripts/acceptance/brownfield_repro.py
+++ b/scripts/acceptance/brownfield_repro.py
@@ -672,32 +672,42 @@ class Suite(object):
             else:
                 print("kin-brownfield-repro: fixture %s: no npm on PATH; "
                       "require() targets will not resolve" % name)
+        self.fixtures[name] = path
         rc, out, err = self.kin_run(["init", "."], path)
         if rc != 0:
             raise ProbeError("kin init failed in %s: %s" % (path, (err or out)[-300:]))
-        self.fixtures[name] = path
         return path
 
     def shutdown(self):
-        """Stop the per-fixture daemons this run started.
-
-        Each fixture is a throwaway repository, so its daemon has nothing to serve
-        once the run ends; leaving them alive leaks one process per fixture per run
-        and holds the fixture's files against removal.
-        """
-        stopped = []
+        """Ask the product to stop and retire each fixture's current worker."""
+        res = Result("cleanup", "CLEANUP", "fixture workers stopped and endpoints retired")
+        if not self.fixtures:
+            res.ok("no fixtures were created")
         for path in self.fixtures.values():
-            pid_file = os.path.join(path, ".kin", "daemon.pid")
-            if not os.path.exists(pid_file):
+            # Without this boundary, repo discovery could select a parent repo.
+            if not os.path.isfile(os.path.join(path, ".kin", "manifest.json")):
+                res.bad("%s: fixture manifest missing; stop was not attempted" % path)
                 continue
             try:
-                with open(pid_file) as handle:
-                    pid = int(handle.read().strip())
-                os.kill(pid, 15)
-                stopped.append(pid)
-            except (ValueError, OSError):
-                continue
-        return stopped
+                rc, out, err = self.kin_run(["daemon", "stop", "--json"], path, timeout=60)
+                report = json.loads(out) if rc == 0 else {}
+                stopped = report.get("stopped") if isinstance(report, dict) else None
+                succeeded = (rc == 0 and isinstance(stopped, list)
+                             and report.get("schema") == "kin.daemon-stop.v1"
+                             and report.get("scope") == "current-repo"
+                             and report.get("all_stopped") is True
+                             and report.get("endpoints_retired", not stopped) is True
+                             and all(isinstance(row, dict)
+                                     and row.get("result") in ("stopped", "not-running")
+                                     and "preserved_endpoint" not in row for row in stopped))
+                detail = "%s: kin daemon stop --json rc=%s; %s %s" % (path, rc, out.strip(), err.strip())
+                if succeeded:
+                    res.ok(detail)
+                else:
+                    res.bad(detail)
+            except Exception as exc:
+                res.bad("%s: cooperative stop failed: %s: %s" % (path, type(exc).__name__, exc))
+        return res
 
     # ------------------------------------------------------------ status probes
 
@@ -2374,46 +2384,52 @@ def main(argv):
             prior = None
 
     results = []
-    for check_id, fn in CHECKS:
-        if wanted and check_id not in wanted:
-            continue
-        try:
-            res = fn(suite)
-        except ProbeError as exc:
-            res = Result(check_id, "?", "probe failure")
-            res.unknown(str(exc)[:300])
-        except Exception as exc:
-            res = Result(check_id, "?", "harness failure")
-            res.unknown("%s: %s" % (type(exc).__name__, str(exc)[:300]))
-        # A check that falls off its own end returns None, and None then blows up
-        # three stages later on an attribute nobody can trace back to the check
-        # that caused it. Measured: a rebase moved one check's `return res` onto
-        # the next check's tail, `--only 10` ran the surviving one and stayed
-        # green, and the full run died in the reporter with a traceback naming
-        # the reporter. Name the check instead, and never report it as a pass.
-        if res is None:
-            res = Result(check_id, "?", "harness failure")
-            res.unknown("check_%s returned no Result, so it fell off its own "
-                        "end; a check that reports nothing is never a pass"
-                        % check_id)
-        results.append(res)
-        res.prior = None if prior is None else prior.get(res.id)
-        res.trend = trend_of(res.status, res.prior)
-        marker = res.status
-        if res.trend == "regression":
-            marker = "%s REGRESSION-from-%s-in-%s" % (res.status, res.prior, prior_label)
-        elif res.trend == "fixed":
-            marker = "%s fixed-since-%s" % (res.status, prior_label)
-        elif res.trend == "unknown":
-            marker = "%s trend-unknown" % res.status
-        print("CHECK %s %s %s %s" % (res.id, res.ticket, marker, res.detail))
-        if opts.verbose:
-            for a in res.asserts:
-                print("      %-11s %s" % (a["status"], a["detail"]))
+    try:
+        for check_id, fn in CHECKS:
+            if wanted and check_id not in wanted:
+                continue
+            try:
+                res = fn(suite)
+            except ProbeError as exc:
+                res = Result(check_id, "?", "probe failure")
+                res.unknown(str(exc)[:300])
+            except Exception as exc:
+                res = Result(check_id, "?", "harness failure")
+                res.unknown("%s: %s" % (type(exc).__name__, str(exc)[:300]))
+            # A check that falls off its own end returns None, and None then blows up
+            # three stages later on an attribute nobody can trace back to the check
+            # that caused it. Measured: a rebase moved one check's `return res` onto
+            # the next check's tail, `--only 10` ran the surviving one and stayed
+            # green, and the full run died in the reporter with a traceback naming
+            # the reporter. Name the check instead, and never report it as a pass.
+            if res is None:
+                res = Result(check_id, "?", "harness failure")
+                res.unknown("check_%s returned no Result, so it fell off its own "
+                            "end; a check that reports nothing is never a pass"
+                            % check_id)
+            results.append(res)
+            res.prior = None if prior is None else prior.get(res.id)
+            res.trend = trend_of(res.status, res.prior)
+            marker = res.status
+            if res.trend == "regression":
+                marker = "%s REGRESSION-from-%s-in-%s" % (res.status, res.prior, prior_label)
+            elif res.trend == "fixed":
+                marker = "%s fixed-since-%s" % (res.status, prior_label)
+            elif res.trend == "unknown":
+                marker = "%s trend-unknown" % res.status
+            print("CHECK %s %s %s %s" % (res.id, res.ticket, marker, res.detail))
+            if opts.verbose:
+                for a in res.asserts:
+                    print("      %-11s %s" % (a["status"], a["detail"]))
 
-    stopped = suite.shutdown()
-    if stopped:
-        print("kin-brownfield-repro: stopped %d fixture daemon(s)" % len(stopped))
+    finally:
+        cleanup = suite.shutdown()
+        if not results:
+            selection = Result("selection", "HARNESS", "no acceptance check ran")
+            selection.bad("the check selection produced no results")
+            results.append(selection)
+        results.append(cleanup)
+        print("CHECK %s %s %s %s" % (cleanup.id, cleanup.ticket, cleanup.status, cleanup.detail))
 
     failed = [r for r in results if r.status == FAIL]
     unread = [r for r in results if r.status == UNREADABLE]
@@ -2442,8 +2458,10 @@ def main(argv):
                       handle, indent=2)
         print("kin-brownfield-repro: json %s" % opts.json_out)
 
-    if not opts.keep and not opts.workdir:
+    if cleanup.status == PASS and not opts.keep and not opts.workdir:
         shutil.rmtree(workdir, ignore_errors=True)
+    elif cleanup.status != PASS:
+        print("kin-brownfield-repro: cleanup failed; run root kept at %s" % workdir)
 
     if failed:
         return 1

--- a/scripts/acceptance/magic_repro.py
+++ b/scripts/acceptance/magic_repro.py
@@ -219,30 +219,40 @@ class Suite(object):
                 path = os.path.join(self.workdir,
                                     "%s-%s-%d" % (name, self.run_id, attempt))
             os.makedirs(path)
-            getattr(self, "_build_" + name)(path)
             self.fixtures[name] = path
+            getattr(self, "_build_" + name)(path)
         return self.fixtures[name]
 
     def shutdown(self):
-        """Stop the per-fixture daemons this run started.
-
-        Each fixture is a fresh repository, so its daemon has nothing to serve
-        once the run ends; leaving them alive leaks one process per fixture per
-        run and holds the fixture's files against removal.
-        """
-        stopped = []
+        """Ask the product to stop and retire each fixture's current worker."""
+        res = Result("cleanup", "CLEANUP", "fixture workers stopped and endpoints retired")
+        if not self.fixtures:
+            res.ok("no fixtures were created")
         for path in self.fixtures.values():
-            pid_file = os.path.join(path, ".kin", "daemon.pid")
-            if not os.path.exists(pid_file):
+            # Without this boundary, repo discovery could select a parent repo.
+            if not os.path.isfile(os.path.join(path, ".kin", "manifest.json")):
+                res.bad("%s: fixture manifest missing; stop was not attempted" % path)
                 continue
             try:
-                with open(pid_file) as handle:
-                    pid = int(handle.read().strip())
-                os.kill(pid, 15)
-                stopped.append(pid)
-            except (ValueError, OSError):
-                continue
-        return stopped
+                rc, out, err = self.kin_run(["daemon", "stop", "--json"], path, timeout=60)
+                report = json.loads(out) if rc == 0 else {}
+                stopped = report.get("stopped") if isinstance(report, dict) else None
+                succeeded = (rc == 0 and isinstance(stopped, list)
+                             and report.get("schema") == "kin.daemon-stop.v1"
+                             and report.get("scope") == "current-repo"
+                             and report.get("all_stopped") is True
+                             and report.get("endpoints_retired", not stopped) is True
+                             and all(isinstance(row, dict)
+                                     and row.get("result") in ("stopped", "not-running")
+                                     and "preserved_endpoint" not in row for row in stopped))
+                detail = "%s: kin daemon stop --json rc=%s; %s %s" % (path, rc, out.strip(), err.strip())
+                if succeeded:
+                    res.ok(detail)
+                else:
+                    res.bad(detail)
+            except Exception as exc:
+                res.bad("%s: cooperative stop failed: %s: %s" % (path, type(exc).__name__, exc))
+        return res
 
     def _write(self, repo, rel, text):
         full = os.path.join(repo, rel)
@@ -3910,44 +3920,50 @@ def main(argv):
             print("kin-magic-repro: tips file unreadable (%s): %s" % (opts.tips, exc))
 
     results = []
-    for check_id, fn in CHECKS:
-        if wanted and check_id not in wanted:
-            continue
-        try:
-            res = fn(suite)
-        except Exception as exc:
-            res = Result(check_id, "?", "harness failure")
-            res.unknown("%s: %s" % (type(exc).__name__, str(exc)[:200]))
-        # A check that falls off the end returns None, which is legal Python and
-        # survives every syntax check, then dies four lines down dereferencing
-        # `res.id` with an AttributeError that names neither the check nor the
-        # cause. It happened here: a conflict resolution truncated one check's
-        # tail, the file still parsed, and the suite crashed after fourteen
-        # green checks. Name it as this check's own UNREADABLE instead, so the
-        # run reports which check is broken and still grades the rest.
-        if res is None:
-            res = Result(check_id, "?", "harness failure")
-            res.unknown("check %s returned no Result, so it falls off the end of its "
-                        "own body; a check that returns None cannot be graded"
-                        % check_id)
-        results.append(res)
-        res.prior = None if prior is None else prior.get(res.id)
-        res.trend = trend_of(res.status, res.prior)
-        marker = res.status
-        if res.trend == "regression":
-            marker = "%s REGRESSION-from-%s-in-%s" % (res.status, res.prior, prior_label)
-        elif res.trend == "fixed":
-            marker = "%s fixed-since-%s" % (res.status, prior_label)
-        elif res.trend == "unknown":
-            marker = "%s trend-unknown" % res.status
-        print("CHECK %s %s %s %s" % (res.id, res.ticket, marker, res.detail))
-        if opts.verbose:
-            for a in res.asserts:
-                print("      %-11s %s" % (a["status"], a["detail"]))
+    try:
+        for check_id, fn in CHECKS:
+            if wanted and check_id not in wanted:
+                continue
+            try:
+                res = fn(suite)
+            except Exception as exc:
+                res = Result(check_id, "?", "harness failure")
+                res.unknown("%s: %s" % (type(exc).__name__, str(exc)[:200]))
+            # A check that falls off the end returns None, which is legal Python and
+            # survives every syntax check, then dies four lines down dereferencing
+            # `res.id` with an AttributeError that names neither the check nor the
+            # cause. It happened here: a conflict resolution truncated one check's
+            # tail, the file still parsed, and the suite crashed after fourteen
+            # green checks. Name it as this check's own UNREADABLE instead, so the
+            # run reports which check is broken and still grades the rest.
+            if res is None:
+                res = Result(check_id, "?", "harness failure")
+                res.unknown("check %s returned no Result, so it falls off the end of its "
+                            "own body; a check that returns None cannot be graded"
+                            % check_id)
+            results.append(res)
+            res.prior = None if prior is None else prior.get(res.id)
+            res.trend = trend_of(res.status, res.prior)
+            marker = res.status
+            if res.trend == "regression":
+                marker = "%s REGRESSION-from-%s-in-%s" % (res.status, res.prior, prior_label)
+            elif res.trend == "fixed":
+                marker = "%s fixed-since-%s" % (res.status, prior_label)
+            elif res.trend == "unknown":
+                marker = "%s trend-unknown" % res.status
+            print("CHECK %s %s %s %s" % (res.id, res.ticket, marker, res.detail))
+            if opts.verbose:
+                for a in res.asserts:
+                    print("      %-11s %s" % (a["status"], a["detail"]))
 
-    stopped = suite.shutdown()
-    if stopped:
-        print("kin-magic-repro: stopped %d fixture daemon(s)" % len(stopped))
+    finally:
+        cleanup = suite.shutdown()
+        if not results:
+            selection = Result("selection", "HARNESS", "no acceptance check ran")
+            selection.bad("the check selection produced no results")
+            results.append(selection)
+        results.append(cleanup)
+        print("CHECK %s %s %s %s" % (cleanup.id, cleanup.ticket, cleanup.status, cleanup.detail))
 
     failed = [r for r in results if r.status == FAIL]
     unread = [r for r in results if r.status == UNREADABLE]
@@ -3971,8 +3987,10 @@ def main(argv):
                       handle, indent=2)
         print("kin-magic-repro: json %s" % opts.json_out)
 
-    if not opts.keep and not opts.workdir:
+    if cleanup.status == PASS and not opts.keep and not opts.workdir:
         shutil.rmtree(workdir, ignore_errors=True)
+    elif cleanup.status != PASS:
+        print("kin-magic-repro: cleanup failed; run root kept at %s" % workdir)
 
     if failed:
         return 1

--- a/scripts/acceptance/test_fixture_shutdown.py
+++ b/scripts/acceptance/test_fixture_shutdown.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Exercise fixture cleanup with synthetic stop responses and no processes."""
+import contextlib
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+def load(name):
+    spec = importlib.util.spec_from_file_location(name, Path(__file__).with_name(name + ".py"))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULES = [load("magic_repro"), load("brownfield_repro")]
+GATE = load("gate")
+
+
+def response(**changes):
+    payload = {"schema": "kin.daemon-stop.v1", "scope": "current-repo",
+               "stopped": [{"result": "stopped"}], "all_stopped": True,
+               "endpoints_retired": True}
+    payload.update(changes)
+    return json.dumps(payload)
+
+
+class FixtureShutdownTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="fixture-shutdown-test-")
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.kill = mock.patch("os.kill").start()
+        self.addCleanup(mock.patch.stopall)
+        mock.patch("subprocess.Popen", side_effect=AssertionError("unexpected process")).start()
+
+    def suite(self, module, pids=("424242",)):
+        suite = module.Suite.__new__(module.Suite)
+        suite.fixtures = {}
+        for index, pid in enumerate(pids):
+            path = self.root / module.__name__ / str(index)
+            (path / ".kin").mkdir(parents=True, exist_ok=True)
+            (path / ".kin" / "manifest.json").write_text("{}")
+            if pid is not None:
+                (path / ".kin" / "daemon.pid").write_text(pid)
+            suite.fixtures[str(index)] = str(path)
+        suite.kin_run = mock.Mock(return_value=(0, response(), ""))
+        return suite
+
+    def test_foreign_or_reused_pid_never_authorizes_a_signal(self):
+        for module in MODULES:
+            with self.subTest(suite=module.__name__):
+                suite = self.suite(module)
+                result = suite.shutdown()
+                self.kill.assert_not_called()
+                suite.kin_run.assert_called_once_with(
+                    ["daemon", "stop", "--json"], next(iter(suite.fixtures.values())), timeout=60)
+                self.assertEqual(result.status, module.PASS)
+
+    def test_stop_does_not_depend_on_pid_file(self):
+        for module in MODULES:
+            for pid in (None, "not a pid"):
+                with self.subTest(suite=module.__name__, pid=pid):
+                    suite = self.suite(module, (pid,))
+                    result = suite.shutdown()
+                    self.assertEqual(suite.kin_run.call_count, 1)
+                    self.assertEqual(result.status, module.PASS)
+                    self.kill.assert_not_called()
+
+    def test_refusals_are_failures_and_remaining_fixtures_are_attempted(self):
+        cases = [(1, response(), "command failed"), (1, response(all_stopped=False), "identity mismatch"),
+                 (-9, "", "timeout"), (0, "not JSON", ""),
+                 (0, response(endpoints_retired=False), ""),
+                 (0, response(scope="home"), ""),
+                 (0, response(all_stopped=False), ""),
+                 (0, response(stopped=[{"result": "signal-failed"}]), ""),
+                 (0, response(stopped=[{"result": "stopped", "preserved_endpoint": {}}]), ""),
+                 (1, response(stopped=[{"result": "stopped"}, {"result": "timeout"}], all_stopped=False), "partial stop"),
+                 (0, response(stopped=[], schema="wrong-schema"), ""),
+                 (0, response(stopped=[], all_stopped=False), ""),
+                 (0, response(stopped=[], endpoints_retired=False), ""),
+                 (0, response(stopped=["malformed row"]), ""),
+                 (0, "[]", ""),
+                 OSError("cannot execute stop")]
+        for module in MODULES:
+            for failure in cases:
+                with self.subTest(suite=module.__name__, failure=str(failure)):
+                    suite = self.suite(module, ("424242", "424243"))
+                    suite.kin_run.side_effect = [failure, (0, response(), "")]
+                    result = suite.shutdown()
+                    self.assertEqual(result.status, module.FAIL)
+                    self.assertEqual(suite.kin_run.call_count, 2)
+                    self.kill.assert_not_called()
+
+    def test_missing_manifest_cannot_stop_an_enclosing_repository(self):
+        for module in MODULES:
+            suite = self.suite(module)
+            path = Path(next(iter(suite.fixtures.values())))
+            (path / ".kin" / "manifest.json").unlink()
+            result = suite.shutdown()
+            self.assertEqual(result.status, module.FAIL)
+            suite.kin_run.assert_not_called()
+            self.kill.assert_not_called()
+
+    def test_failed_magic_builder_stays_registered_for_cleanup(self):
+        module = MODULES[0]
+        suite = self.suite(module, ())
+        suite.workdir = str(self.root)
+        suite.run_id = "synthetic"
+        def partial(path):
+            marker = Path(path) / ".kin"
+            marker.mkdir()
+            (marker / "manifest.json").write_text("{}")
+            raise RuntimeError("partial init")
+        suite._build_partial = partial
+        with self.assertRaises(RuntimeError):
+            suite.fixture("partial")
+        self.assertIn("partial", suite.fixtures)
+        self.assertEqual(suite.shutdown().status, module.PASS)
+        suite.kin_run.assert_called_once()
+        self.kill.assert_not_called()
+
+    def test_failed_brownfield_init_stays_registered_for_cleanup(self):
+        module = MODULES[1]
+        suite = self.suite(module, ())
+        suite.workdir = str(self.root)
+        suite.run_id = "synthetic"
+        name = next(iter(module.CORPORA))
+        suite._cache_repo = mock.Mock(return_value=str(self.root / "cache"))
+        suite.git = mock.Mock(return_value=(0, module.CORPORA[name]["tree"], ""))
+        def partial(args, repo, **kwargs):
+            if args[0] == "init":
+                marker = Path(repo) / ".kin"
+                marker.mkdir()
+                (marker / "manifest.json").write_text("{}")
+                return (1, "", "partial init")
+            return (0, response(), "")
+        suite.kin_run.side_effect = partial
+        process = mock.Mock(returncode=0)
+        process.communicate.return_value = (b"", b"")
+        with mock.patch.object(module.subprocess, "Popen", return_value=process):
+            with self.assertRaises(module.ProbeError):
+                suite.fixture(name)
+        self.assertIn(name, suite.fixtures)
+        self.assertEqual(suite.shutdown().status, module.PASS)
+        self.assertEqual(suite.kin_run.call_count, 2)
+        self.kill.assert_not_called()
+
+    def test_no_running_worker_and_no_fixtures_are_successful(self):
+        for module in MODULES:
+            suite = self.suite(module)
+            suite.kin_run.return_value = (0, json.dumps({"schema": "kin.daemon-stop.v1",
+                "scope": "current-repo", "stopped": [], "all_stopped": True}), "")
+            self.assertEqual(suite.shutdown().status, module.PASS)
+            suite.fixtures = {}
+            suite.kin_run.reset_mock()
+            self.assertEqual(suite.shutdown().status, module.PASS)
+            suite.kin_run.assert_not_called()
+
+    def test_main_grades_cleanup_in_json_and_keeps_failed_fixture(self):
+        for module in MODULES:
+            for failed in (False, True, "interrupt", "empty"):
+                with self.subTest(suite=module.__name__, failed=failed):
+                    suite = self.suite(module)
+                    if failed is True:
+                        suite.kin_run.return_value = (1, response(all_stopped=False), "refused")
+                    workdir = self.root / (module.__name__ + str(failed))
+                    workdir.mkdir()
+                    output = self.root / "result.json"
+                    probe = module.Result("probe", "TEST", "synthetic probe")
+                    probe.ok("synthetic success")
+                    args = ["--kin", sys.executable, "--daemon", sys.executable,
+                            "--json", str(output)]
+                    if module.__name__ == "brownfield_repro":
+                        args += ["--corpus-cache", str(self.root / "cache")]
+                    with mock.patch.object(module, "Suite", return_value=suite), \
+                         mock.patch.object(module, "CHECKS", [] if failed == "empty" else [("probe", mock.Mock(side_effect=KeyboardInterrupt) if failed == "interrupt" else lambda _: probe)]), \
+                         mock.patch.object(module, "run", return_value=(0, "kin synthetic", "")), \
+                         mock.patch.object(module.tempfile, "mkdtemp", return_value=str(workdir)), \
+                         contextlib.redirect_stdout(io.StringIO()):
+                        if failed == "interrupt":
+                            with self.assertRaises(KeyboardInterrupt):
+                                module.main(args)
+                            suite.kin_run.assert_called_once()
+                            self.kill.assert_not_called()
+                            continue
+                        rc = module.main(args)
+                    self.assertEqual(rc, 1 if failed else 0)
+                    rows = GATE.load_report(str(output))
+                    self.assertEqual(rows["cleanup"]["status"], module.FAIL if failed is True else module.PASS)
+                    failures, _ = GATE.decide({"fixture": rows}, {})
+                    self.assertEqual(bool(failures), bool(failed))
+                    self.assertEqual(workdir.exists(), failed is True)
+                    self.kill.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Stop magic and brownfield fixture workers through `kin daemon stop --json`, scoped to each fixture. Cleanup now has a graded result in the acceptance JSON and keeps the run root when shutdown or endpoint retirement fails.

## Why

The old cleanup trusted a number in `daemon.pid` and called `os.kill(pid, 15)`. A reused or foreign PID could therefore be signaled by the acceptance harness. Cleanup errors were swallowed, and the hosted gate could still report success because it reads JSON results instead of the suite exit code alone.

## How

Use the CLI's existing identity and incarnation checks. Require a fixture-local manifest before invoking current-repo discovery. Record fixtures before init can start a worker and then fail. Run cleanup in `finally`, attempt remaining fixtures after any refusal, and validate the stop report's scope, outcomes, and endpoint retirement. A successful cleanup cannot turn an empty check selection into a passing run.

The new synthetic regression test runs in the required Fast gate lint and policy job. This draft is held for independent review and landing.

## Testing

No Rust code changed, so cargo test, clippy, and fmt were not run. No product binary, real daemon, or parity suite was run. All process creation and signaling in the focused regression tests is intercepted.

- [x] Every commit carries a `Signed-off-by` trailer.

Before product edits, `python3 scripts/acceptance/test_fixture_shutdown.py` failed on the direct safety assertion:

```text
AssertionError: Expected 'kill' to not have been called. Called 1 times.
Calls: [call(424242, 15)].
Ran 5 tests
FAILED (failures=8, errors=21)
```

Final focused run:

```text
$ python3 scripts/acceptance/test_fixture_shutdown.py
Ran 8 tests in 0.042s
OK
```

Private broken-copy falsification used `python3 .kin-coord/reports/safeacceptance-scratch/falsify.py` from the umbrella. It changed only temporary copies and asserted the intended test failed. All 20 Kin mutations were rejected. They cover numeric signaling, stop exit status, retirement, scope, manifest boundaries, missing JSON verdicts, fixture retention, partial init, interruption, and empty selection. The paired sweep also covered seven first-run mutations:

```text
magic_repro-ignore-stop-rc rc=1 FAILED (failures=1)
brownfield_repro-ignore-retirement rc=1 FAILED (failures=2)
magic-lost-partial-fixture rc=1 FAILED (failures=1)
brownfield-lost-partial-fixture rc=1 FAILED (failures=1)
All 27 broken copies failed their intended tests; worktree sources stayed intact.
```

```text
$ actionlint -shellcheck='' .github/workflows/ci.yml
rc=0
$ python3 scripts/acceptance/gate.py --self-test
acceptance gate: self-test passed
$ python3 scripts/acceptance/test_workflow_step_visibility.py --self-test
self-test: all 2 controls clean, all 24 adversarial mutants caught
$ python3 scripts/acceptance/test_workflow_step_visibility.py
workflow authority holds: 27 suite reports reach one always-running verdict in order
$ python3 scripts/verify-zero-file-search.py
Verification PASSED: Zero File-Search Invariant holds.
$ bash scripts/zero_file_search_guard.sh
Zero File-Search guard passed: 71 answer modules are graph-clean (8 with declared boundary pins deferred to verify-zero-file-search.py).
$ git diff --check
rc=0
```
