### PR TITLE
Add complete first publication for hosted repositories

### DIFF
--- a/crates/kin-daemon/src/publication_lease.rs
+++ b/crates/kin-daemon/src/publication_lease.rs
@@ -4543,6 +4543,7 @@ pub(crate) mod test_clock {
 
 #[cfg(test)]
 mod tests {
+    mod first_publication;
     #[cfg(feature = "gcs")]
     use std::collections::HashMap;
     #[cfg(feature = "gcs")]

--- a/crates/kin-daemon/src/publication_lease/tests/first_publication.rs
+++ b/crates/kin-daemon/src/publication_lease/tests/first_publication.rs
@@ -1,0 +1,452 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+// Real init and filesystem persistence; GCS generation CAS uses the existing
+// versioned object-store fixture. Firestore checkpointing is simulated here.
+// This test does not establish live cloud or hosted route acceptance.
+use super::*;
+#[cfg(feature = "gcs")]
+use kin_db::GcsBackend;
+use kin_db::{LocalFileBackend, RepositoryAuthorityManager, StorageBackend};
+use kin_model::{Hash256, RepositoryId};
+use kin_remote::first_publication::{publish_first_repository, FirstPublicationMode};
+use sha2::{Digest, Sha256};
+
+const OLD_BODY: &[u8] = b"initial historical body, retained after replacement\n";
+const NEW_BODY: &[u8] = b"current imported body, checked after first publication\n";
+
+fn source(
+    root: &std::path::Path,
+    id: &RepositoryId,
+    git_import: bool,
+) -> Arc<RepositoryAuthorityManager<dyn StorageBackend>> {
+    std::fs::create_dir_all(root).unwrap();
+    let init = if git_import {
+        git(root, &["init", "--initial-branch=main"]);
+        std::fs::write(root.join("source.txt"), OLD_BODY).unwrap();
+        git(root, &["add", "source.txt"]);
+        git(root, &["commit", "-m", "Initial source"]);
+        std::fs::write(root.join("source.txt"), NEW_BODY).unwrap();
+        git(root, &["add", "source.txt"]);
+        git(root, &["commit", "-m", "Update source"]);
+        git(root, &["tag", "-a", "baseline", "-m", "Imported reference"]);
+        kin_core::init_from_git_adopting(root, id).unwrap()
+    } else {
+        kin_core::init_adopting(root, id).unwrap()
+    };
+    let backend: Arc<dyn StorageBackend> = Arc::new(LocalFileBackend::new(init.layout.kindb_dir()));
+    Arc::new(RepositoryAuthorityManager::open(id.clone(), backend).unwrap())
+}
+
+fn git(root: &std::path::Path, args: &[&str]) {
+    let output = std::process::Command::new("git")
+        .args([
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            "commit.gpgsign=false",
+            "-c",
+            "tag.gpgsign=false",
+            "-c",
+            "user.name=Publication fixture",
+            "-c",
+            "user.email=fixture@example.invalid",
+        ])
+        .args(args)
+        .current_dir(root)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {args:?}: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn local_backend(path: &std::path::Path) -> Arc<dyn StorageBackend> {
+    std::fs::create_dir_all(path).unwrap();
+    Arc::new(LocalFileBackend::new(path))
+}
+
+fn hash(bytes: &[u8]) -> Hash256 {
+    Hash256::from_bytes(Sha256::digest(bytes).into())
+}
+
+#[test]
+fn initialized_native_first_publication_reopens_from_durable_files() {
+    let temp = tempfile::tempdir().unwrap();
+    let id = RepositoryId::new("private-empty").unwrap();
+    let source = source(&temp.path().join("source"), &id, false);
+    let expected = source.read_authority().roots().clone();
+    let target = temp.path().join("published");
+    let backend: Arc<dyn StorageBackend> = local_backend(&target);
+    let receipt = publish_first_repository(source, &id, FirstPublicationMode::Native, backend)
+        .expect("initialized native authority must publish completely");
+    assert_eq!(receipt.repository_id, id);
+    assert_eq!(receipt.roots, expected);
+    let stored = local_backend(&target)
+        .load_snapshot(id.as_str())
+        .unwrap()
+        .unwrap();
+    assert_eq!(receipt.snapshot_sha256, hash(&stored.0));
+    assert_eq!(receipt.cursor.backend_generation(), stored.1);
+    let reopened = RepositoryAuthorityManager::open(id.clone(), local_backend(&target)).unwrap();
+    let lease = reopened.read_authority();
+    assert_eq!(lease.roots(), &expected);
+    assert_eq!(lease.metadata().repository_id, id);
+    assert!(lease.metadata().ref_state.default_ref.is_some());
+    assert!(lease.metadata().git_external_authority.is_none());
+    assert!(lease.snapshot().entities.is_empty());
+}
+
+#[cfg(feature = "gcs")]
+#[tokio::test(flavor = "multi_thread")]
+async fn imported_first_publication_extends_five_to_six_without_changing_old_authority() {
+    let temp = tempfile::tempdir().unwrap();
+    let raw = Arc::new(VersionedMemoryStore::new());
+    let backend: Arc<dyn StorageBackend> =
+        Arc::new(GcsBackend::from_store(Box::new(raw.clone()), "fixture"));
+    let old_ids = staging_fleet();
+    let mut before = BTreeMap::new();
+    for name in &old_ids {
+        let id = RepositoryId::new(name.clone()).unwrap();
+        let source = source(&temp.path().join(name), &id, false);
+        let roots = source.read_authority().roots().clone();
+        publish_first_repository(source, &id, FirstPublicationMode::Native, backend.clone())
+            .unwrap();
+        let bytes = backend.load_snapshot(name).unwrap().unwrap().0;
+        before.insert(name.clone(), (roots, bytes));
+    }
+    let object_store: Arc<dyn ObjectStore> = raw.clone();
+    let store: Arc<dyn PublicationControlStore> = Arc::new(
+        ObjectStorePublicationControlStore::new(object_store, "fixture"),
+    );
+    let old = PublicationControl::new(SCOPE, READER_A, old_ids.clone(), store.clone()).unwrap();
+    let bootstrap = old.bootstrap_runtime_if_absent().unwrap().unwrap();
+    release(&old, &bootstrap);
+
+    let id = RepositoryId::new("private-import").unwrap();
+    let imported = source(&temp.path().join("import"), &id, true);
+    let imported_roots = imported.read_authority().roots().clone();
+    let imported_git = imported
+        .read_authority()
+        .metadata()
+        .git_external_authority
+        .clone();
+    let imported_refs =
+        serde_json::to_value(&imported.read_authority().metadata().ref_state).unwrap();
+    for body in [OLD_BODY, NEW_BODY] {
+        assert_eq!(
+            imported.load_source_blob(hash(body)).unwrap().as_deref(),
+            Some(body)
+        );
+    }
+    let mut target = old_ids.clone();
+    target.push(id.to_string());
+    let candidate = PublicationControl::new(SCOPE, READER_B, target.clone(), store).unwrap();
+    let mut request = rollout_request_for_fleet(target.clone(), "fixture", "admit-private", None);
+    request.previous_repositories = Some(old_ids.clone());
+    let missing = candidate.acquire_rollout(request.clone()).unwrap_err();
+    assert!(
+        missing
+            .to_string()
+            .contains("has no graph authority object"),
+        "{missing}"
+    );
+    for (name, (_, bytes)) in &before {
+        assert_eq!(&backend.load_snapshot(name).unwrap().unwrap().0, bytes);
+    }
+    publish_first_repository(
+        imported,
+        &id,
+        FirstPublicationMode::GitImported,
+        backend.clone(),
+    )
+    .expect("complete imported authority and source bodies must publish");
+    let lease = candidate.acquire_rollout(request).unwrap();
+    assert_eq!(lease.authority_fence.len(), 6);
+    assert_eq!(lease.fence_repositories.len(), 6);
+    let lease = checkpoint_rollout_for_test(&candidate, &lease);
+    candidate
+        .admit_reader(AdmitReaderRequest {
+            lease: proof(&lease),
+            repositories: target,
+            reader: ReaderAdmissionInput {
+                identity: READER_B.into(),
+                min_snapshot_schema: kin_db::GraphSnapshot::MIN_SUPPORTED_VERSION,
+                max_snapshot_schema: kin_db::GraphSnapshot::MAX_SUPPORTED_VERSION,
+                valid_for_seconds: 300,
+            },
+            legacy_writer_drain_proof_sha256: None,
+        })
+        .unwrap();
+    release(&candidate, &lease);
+    assert!(old
+        .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
+        .is_err());
+    candidate
+        .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
+        .unwrap();
+    drop(backend);
+    let fresh: Arc<dyn StorageBackend> = Arc::new(GcsBackend::from_store(Box::new(raw), "fixture"));
+    for (name, (roots, bytes)) in before {
+        assert_eq!(fresh.load_snapshot(&name).unwrap().unwrap().0, bytes);
+        let reopened =
+            RepositoryAuthorityManager::open(RepositoryId::new(name).unwrap(), fresh.clone())
+                .unwrap();
+        assert_eq!(reopened.read_authority().roots(), &roots);
+    }
+    let reopened = RepositoryAuthorityManager::open(id.clone(), fresh).unwrap();
+    let view = reopened.read_authority();
+    assert_eq!(view.metadata().repository_id, id);
+    assert_eq!(view.roots(), &imported_roots);
+    assert_eq!(view.metadata().git_external_authority, imported_git);
+    assert_eq!(
+        serde_json::to_value(&view.metadata().ref_state).unwrap(),
+        imported_refs
+    );
+    for body in [OLD_BODY, NEW_BODY] {
+        assert_eq!(
+            reopened.load_source_blob(hash(body)).unwrap().as_deref(),
+            Some(body)
+        );
+    }
+}
+
+use crate::storage_delegate::{DelegatingBackend, StorageBackendDelegate};
+use kin_db::{KinDbError, SnapshotCursor, SnapshotSaveOutcome};
+use kin_remote::first_publication::FirstPublicationError;
+use std::sync::atomic::AtomicBool;
+
+#[test]
+fn first_publication_refuses_identity_mode_and_uninitialized_authority() {
+    let temp = tempfile::tempdir().unwrap();
+    let id = RepositoryId::new("reserved-native").unwrap();
+    let source = source(&temp.path().join("source"), &id, false);
+    let destination: Arc<dyn StorageBackend> = local_backend(&temp.path().join("destination"));
+    let other = RepositoryId::new("another-tenant").unwrap();
+    assert!(publish_first_repository(
+        source.clone(),
+        &other,
+        FirstPublicationMode::Native,
+        destination.clone()
+    )
+    .is_err());
+    assert!(publish_first_repository(
+        source,
+        &id,
+        FirstPublicationMode::GitImported,
+        destination.clone()
+    )
+    .is_err());
+    let unborn = Arc::new(
+        RepositoryAuthorityManager::open(id.clone(), local_backend(&temp.path().join("unborn")))
+            .unwrap(),
+    );
+    assert!(publish_first_repository(
+        unborn,
+        &id,
+        FirstPublicationMode::Native,
+        destination.clone()
+    )
+    .is_err());
+    assert!(destination.load_snapshot(id.as_str()).unwrap().is_none());
+    assert!(destination.load_snapshot(other.as_str()).unwrap().is_none());
+}
+
+#[test]
+fn first_publication_refuses_identical_retry_and_independent_existing_authority() {
+    let temp = tempfile::tempdir().unwrap();
+    let id = RepositoryId::new("reserved-existing").unwrap();
+    let original = source(&temp.path().join("source"), &id, false);
+    let destination: Arc<dyn StorageBackend> = local_backend(&temp.path().join("destination"));
+    publish_first_repository(
+        original.clone(),
+        &id,
+        FirstPublicationMode::Native,
+        destination.clone(),
+    )
+    .unwrap();
+    let before = destination.load_snapshot(id.as_str()).unwrap().unwrap();
+    assert!(publish_first_repository(
+        original,
+        &id,
+        FirstPublicationMode::Native,
+        destination.clone()
+    )
+    .is_err());
+    let replacement = source(&temp.path().join("replacement"), &id, true);
+    assert!(publish_first_repository(
+        replacement,
+        &id,
+        FirstPublicationMode::GitImported,
+        destination.clone()
+    )
+    .is_err());
+    assert_eq!(
+        destination.load_snapshot(id.as_str()).unwrap().unwrap(),
+        before
+    );
+}
+
+struct DropBodies(Arc<dyn StorageBackend>);
+impl StorageBackendDelegate for DropBodies {
+    fn delegate(&self) -> &dyn StorageBackend {
+        self.0.as_ref()
+    }
+    fn save_source_blob(&self, _: &str, _: [u8; 32], _: &[u8]) -> Result<(), KinDbError> {
+        Ok(())
+    }
+}
+
+#[test]
+fn first_publication_requires_destination_body_readback_before_snapshot_cas() {
+    let temp = tempfile::tempdir().unwrap();
+    let id = RepositoryId::new("missing-destination-bodies").unwrap();
+    let source = source(&temp.path().join("source"), &id, true);
+    let durable: Arc<dyn StorageBackend> = local_backend(&temp.path().join("destination"));
+    let destination: Arc<dyn StorageBackend> =
+        Arc::new(DelegatingBackend::new(DropBodies(durable.clone())));
+    let error =
+        publish_first_repository(source, &id, FirstPublicationMode::GitImported, destination)
+            .unwrap_err();
+    assert!(
+        matches!(error, FirstPublicationError::NotCommitted(_)),
+        "{error}"
+    );
+    assert!(
+        durable.load_snapshot(id.as_str()).unwrap().is_none(),
+        "missing source bodies must not leave published authority"
+    );
+}
+
+struct InspectionFailure(Arc<dyn StorageBackend>);
+impl StorageBackendDelegate for InspectionFailure {
+    fn delegate(&self) -> &dyn StorageBackend {
+        self.0.as_ref()
+    }
+    fn load_snapshot_cursor(&self, _: &str) -> Result<Option<SnapshotCursor>, KinDbError> {
+        Err(KinDbError::StorageError(
+            "injected unknown inspection error".into(),
+        ))
+    }
+}
+
+#[test]
+fn first_publication_does_not_treat_an_inspection_error_as_absence() {
+    let temp = tempfile::tempdir().unwrap();
+    let id = RepositoryId::new("unknown-destination").unwrap();
+    let source = source(&temp.path().join("source"), &id, false);
+    let durable: Arc<dyn StorageBackend> = local_backend(&temp.path().join("destination"));
+    let destination: Arc<dyn StorageBackend> =
+        Arc::new(DelegatingBackend::new(InspectionFailure(durable.clone())));
+    let error = publish_first_repository(source, &id, FirstPublicationMode::Native, destination)
+        .unwrap_err();
+    assert!(
+        matches!(error, FirstPublicationError::NotCommitted(_)),
+        "{error}"
+    );
+    assert!(error.to_string().contains("injected unknown inspection"));
+    assert!(durable.load_snapshot(id.as_str()).unwrap().is_none());
+}
+
+struct RacingPublication {
+    inner: Arc<dyn StorageBackend>,
+    winner: Vec<u8>,
+    installed: AtomicBool,
+}
+impl StorageBackendDelegate for RacingPublication {
+    fn delegate(&self) -> &dyn StorageBackend {
+        self.inner.as_ref()
+    }
+    fn load_source_blob_bounded(
+        &self,
+        repo_id: &str,
+        digest: [u8; 32],
+        max_bytes: u64,
+    ) -> Result<Option<Vec<u8>>, KinDbError> {
+        if !self.installed.swap(true, Ordering::SeqCst) {
+            self.inner.save_snapshot(repo_id, &self.winner, 0)?;
+        }
+        self.inner
+            .load_source_blob_bounded(repo_id, digest, max_bytes)
+    }
+}
+
+#[test]
+fn first_publication_initial_cas_preserves_a_winner_after_absence_inspection() {
+    let temp = tempfile::tempdir().unwrap();
+    let id = RepositoryId::new("racing-destination").unwrap();
+    let candidate = source(&temp.path().join("source"), &id, true);
+    let winner = source(&temp.path().join("winner"), &id, false);
+    let winner_roots = winner.read_authority().roots().clone();
+    let winner_bytes = winner.read_authority().snapshot().to_bytes().unwrap();
+    let durable: Arc<dyn StorageBackend> = local_backend(&temp.path().join("destination"));
+    let destination: Arc<dyn StorageBackend> =
+        Arc::new(DelegatingBackend::new(RacingPublication {
+            inner: durable.clone(),
+            winner: winner_bytes.clone(),
+            installed: AtomicBool::new(false),
+        }));
+    assert!(durable.load_snapshot(id.as_str()).unwrap().is_none());
+    assert!(publish_first_repository(
+        candidate,
+        &id,
+        FirstPublicationMode::GitImported,
+        destination
+    )
+    .is_err());
+    assert_eq!(
+        durable.load_snapshot(id.as_str()).unwrap().unwrap().0,
+        winner_bytes
+    );
+    let reopened = RepositoryAuthorityManager::open(id, durable).unwrap();
+    assert_eq!(reopened.read_authority().roots(), &winner_roots);
+}
+
+struct LostReply(Arc<dyn StorageBackend>);
+impl StorageBackendDelegate for LostReply {
+    fn delegate(&self) -> &dyn StorageBackend {
+        self.0.as_ref()
+    }
+    fn save_snapshot_classified(
+        &self,
+        repo_id: &str,
+        data: &[u8],
+        expected: SnapshotCursor,
+    ) -> SnapshotSaveOutcome {
+        match self.0.save_snapshot_classified(repo_id, data, expected) {
+            SnapshotSaveOutcome::Committed { .. } => SnapshotSaveOutcome::Indeterminate(
+                KinDbError::StorageError("injected lost committed response".into()),
+            ),
+            other => other,
+        }
+    }
+}
+
+#[test]
+fn first_publication_preserves_indeterminate_outcome_and_durable_recovery_evidence() {
+    let temp = tempfile::tempdir().unwrap();
+    let id = RepositoryId::new("lost-publication-response").unwrap();
+    let source = source(&temp.path().join("source"), &id, false);
+    let roots = source.read_authority().roots().clone();
+    let durable: Arc<dyn StorageBackend> = local_backend(&temp.path().join("destination"));
+    let destination: Arc<dyn StorageBackend> =
+        Arc::new(DelegatingBackend::new(LostReply(durable.clone())));
+    let error = publish_first_repository(
+        source.clone(),
+        &id,
+        FirstPublicationMode::Native,
+        destination,
+    )
+    .unwrap_err();
+    assert!(
+        matches!(error, FirstPublicationError::Indeterminate(_)),
+        "{error}"
+    );
+    let reopened = RepositoryAuthorityManager::open(id.clone(), durable.clone()).unwrap();
+    assert_eq!(reopened.read_authority().roots(), &roots);
+    assert!(publish_first_repository(source, &id, FirstPublicationMode::Native, durable).is_err());
+}

--- a/crates/kin-remote/src/first_publication.rs
+++ b/crates/kin-remote/src/first_publication.rs
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Complete first publication into an unserved, previously absent repository.
+
+use std::sync::Arc;
+
+use kin_db::{
+    Generation, KinDbError, RepositoryAuthorityManager, SnapshotCursor, SnapshotSaveOutcome,
+    StorageBackend,
+};
+use kin_model::{Hash256, RepositoryId, RootBundle};
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FirstPublicationMode {
+    Native,
+    GitImported,
+}
+
+#[derive(Debug)]
+pub struct FirstPublicationReceipt {
+    pub repository_id: RepositoryId,
+    pub roots: RootBundle,
+    pub snapshot_sha256: Hash256,
+    pub cursor: SnapshotCursor,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum FirstPublicationError {
+    #[error("first publication refused: {0}")]
+    Refused(String),
+    #[error("first publication did not commit: {0}")]
+    NotCommitted(#[source] KinDbError),
+    #[error("first publication requires durable readback: {0}")]
+    Indeterminate(#[source] KinDbError),
+}
+
+/// Copy one initialized authority without changing its identity or history.
+///
+/// The caller must own a reserved, unserved destination ID. This primitive
+/// grants no tenant access or fleet admission. Bodies become durable before
+/// the complete authority's create-if-absent CAS. A fresh authority open and
+/// exact snapshot/cursor readback precede the receipt. A retry against an
+/// existing publication is refused, including an identical prior attempt;
+/// the orchestrator must resolve a lost receipt through durable readback.
+///
+/// Source-body requirements come from kin-db's full authority validator. A
+/// private validation view copies each requested immutable body, then another
+/// view validates those bodies from destination storage before publication.
+/// Neither view is evidence of durability; only the destination CAS and reopen
+/// can establish that. No checkout, Git directory or derived index is read.
+pub fn publish_first_repository<B: StorageBackend + ?Sized + 'static>(
+    source: Arc<RepositoryAuthorityManager<B>>,
+    expected_repository_id: &RepositoryId,
+    mode: FirstPublicationMode,
+    destination: Arc<dyn StorageBackend>,
+) -> Result<FirstPublicationReceipt, FirstPublicationError> {
+    use FirstPublicationError::{Indeterminate, NotCommitted, Refused};
+    let lease = source.read_authority();
+    let metadata = lease
+        .snapshot()
+        .repository_authority
+        .as_ref()
+        .ok_or_else(|| Refused("source has no repository authority".into()))?;
+    if &metadata.repository_id != expected_repository_id {
+        return Err(Refused(
+            "source does not own the reserved repository identity".into(),
+        ));
+    }
+    if lease.roots().generation == 0 || metadata.ref_state.default_ref.is_none() {
+        return Err(Refused(
+            "source must be initialized with a default ref".into(),
+        ));
+    }
+    if metadata.git_external_authority.is_some() != (mode == FirstPublicationMode::GitImported) {
+        return Err(Refused(
+            "source does not match the declared native or Git-import mode".into(),
+        ));
+    }
+    let roots = lease.roots().clone();
+    let snapshot = Arc::new(lease.snapshot().to_bytes().map_err(NotCommitted)?);
+    drop(lease);
+    if destination
+        .load_snapshot_cursor(expected_repository_id.as_str())
+        .map_err(NotCommitted)?
+        .is_some()
+    {
+        return Err(Refused("destination already holds a publication".into()));
+    }
+    let repository_id = expected_repository_id.clone();
+    let copy_destination = destination.clone();
+    let copy_id = repository_id.clone();
+    let copy = SnapshotBodyReader {
+        repository_id: repository_id.clone(),
+        snapshot: snapshot.clone(),
+        read_body: Box::new(move |digest, max_bytes| {
+            let Some(body) = source.load_source_blob(Hash256::from_bytes(digest))? else {
+                return Ok(None);
+            };
+            if body.len() as u64 > max_bytes {
+                return Err(KinDbError::StorageError(
+                    "publication source body exceeds validator bound".into(),
+                ));
+            }
+            copy_destination.save_source_blob(copy_id.as_str(), digest, &body)?;
+            Ok(Some(body))
+        }),
+    };
+    RepositoryAuthorityManager::open(repository_id.clone(), Arc::new(copy))
+        .map_err(NotCommitted)?;
+    let read_destination = destination.clone();
+    let read_id = repository_id.clone();
+    let staged = SnapshotBodyReader {
+        repository_id: repository_id.clone(),
+        snapshot: snapshot.clone(),
+        read_body: Box::new(move |digest, max_bytes| {
+            read_destination.load_source_blob_bounded(read_id.as_str(), digest, max_bytes)
+        }),
+    };
+    RepositoryAuthorityManager::open(repository_id.clone(), Arc::new(staged))
+        .map_err(NotCommitted)?;
+    let cursor = match destination.save_snapshot_classified(
+        repository_id.as_str(),
+        &snapshot,
+        SnapshotCursor::INITIAL,
+    ) {
+        SnapshotSaveOutcome::Committed { cursor } => cursor,
+        SnapshotSaveOutcome::NotCommitted(error) => return Err(NotCommitted(error)),
+        SnapshotSaveOutcome::Indeterminate(error) => return Err(Indeterminate(error)),
+    };
+    let reopened = RepositoryAuthorityManager::open(repository_id.clone(), destination.clone())
+        .map_err(Indeterminate)?;
+    if reopened.read_authority().roots() != &roots {
+        return Err(Indeterminate(KinDbError::StorageError(
+            "published authority roots changed before verification".into(),
+        )));
+    }
+    let observed = destination
+        .load_snapshot(repository_id.as_str())
+        .map_err(Indeterminate)?;
+    if !observed.is_some_and(|(bytes, generation)| {
+        bytes == *snapshot && generation == cursor.backend_generation()
+    }) {
+        return Err(Indeterminate(KinDbError::StorageError(
+            "published snapshot or cursor changed before verification".into(),
+        )));
+    }
+    Ok(FirstPublicationReceipt {
+        repository_id,
+        roots,
+        snapshot_sha256: Hash256::from_bytes(Sha256::digest(&*snapshot).into()),
+        cursor,
+    })
+}
+
+type BodyRead = dyn Fn([u8; 32], u64) -> Result<Option<Vec<u8>>, KinDbError> + Send + Sync;
+
+// A read-only validation view, never a destination or a durable publication.
+// There is no journal or cached history proof, so open validates the full
+// supplied authority and asks the body reader for its complete closure.
+struct SnapshotBodyReader {
+    repository_id: RepositoryId,
+    snapshot: Arc<Vec<u8>>,
+    read_body: Box<BodyRead>,
+}
+
+impl SnapshotBodyReader {
+    fn check_id(&self, id: &str) -> Result<(), KinDbError> {
+        if id != self.repository_id.as_str() {
+            return Err(KinDbError::StorageError(
+                "publication validation namespace mismatch".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn read_only<T>() -> Result<T, KinDbError> {
+    Err(KinDbError::StorageError(
+        "publication validation view is read-only".into(),
+    ))
+}
+
+impl StorageBackend for SnapshotBodyReader {
+    fn list_repos(&self) -> Result<Vec<String>, KinDbError> {
+        Ok(vec![self.repository_id.to_string()])
+    }
+    fn load_snapshot(&self, repo_id: &str) -> Result<Option<(Vec<u8>, Generation)>, KinDbError> {
+        self.check_id(repo_id)?;
+        Ok(Some((self.snapshot.as_ref().clone(), 1)))
+    }
+    fn load_source_blob_bounded(
+        &self,
+        repo_id: &str,
+        digest: [u8; 32],
+        max_bytes: u64,
+    ) -> Result<Option<Vec<u8>>, KinDbError> {
+        self.check_id(repo_id)?;
+        (self.read_body)(digest, max_bytes)
+    }
+    fn load_deltas_since(
+        &self,
+        repo_id: &str,
+        _: Generation,
+    ) -> Result<Vec<(Vec<u8>, Generation)>, KinDbError> {
+        self.check_id(repo_id)?;
+        Ok(Vec::new())
+    }
+    fn load_overlay(&self, repo_id: &str, _: &str) -> Result<Option<Vec<u8>>, KinDbError> {
+        self.check_id(repo_id)?;
+        Ok(None)
+    }
+    fn save_snapshot(&self, _: &str, _: &[u8], _: Generation) -> Result<Generation, KinDbError> {
+        read_only()
+    }
+    fn save_delta(&self, _: &str, _: &[u8], _: Generation) -> Result<Generation, KinDbError> {
+        read_only()
+    }
+    fn clear_deltas(&self, _: &str) -> Result<(), KinDbError> {
+        read_only()
+    }
+    fn save_overlay(&self, _: &str, _: &str, _: &[u8]) -> Result<(), KinDbError> {
+        read_only()
+    }
+    fn delete_overlay(&self, _: &str, _: &str) -> Result<(), KinDbError> {
+        read_only()
+    }
+}

--- a/crates/kin-remote/src/lib.rs
+++ b/crates/kin-remote/src/lib.rs
@@ -5,6 +5,7 @@ pub mod connection;
 pub mod delta_bridge;
 pub mod delta_pull;
 pub mod federated;
+pub mod first_publication;
 #[cfg(feature = "http")]
 pub mod http_transport;
 pub mod invalidation;


### PR DESCRIPTION
Adds a reusable first-publication operation for a reserved, unserved repository. It retains the source repository ID and complete authority, copies every body required by kin-db's authority validator, verifies those bodies from destination storage, and publishes through the backend's initial compare-and-swap. A fresh authority open and exact snapshot/cursor readback precede the returned receipt. Existing destinations and mismatched native/Git import modes are refused, and ambiguous writes require recovery rather than reporting success.

This is a prerequisite for FIR-3256. It adds no hosted create/import route, tenant registry, fleet cardinality change, deployment orchestration or cloud resources. The draft remains held for review and the later hosted integration.

Local verification graded an isolated copy of base `7638562cbd2e40e90aaeaa8b7fc42402cdd2d626` plus this patch. All four committed files compare byte-for-byte with that tested copy. Cargo used an isolated registry config/home/target with CPU embedding. The kin-db 0.7.104 archive checksum and VCS identity were verified, and all 73 extracted source files matched its archive. The filesystem cases use durable local storage. The five-to-six case runs the real GCS and publication-control adapters against the existing versioned object-store fixture, with simulated Firestore checkpoint evidence. Live object-store/Firestore and hosted restart/authorization acceptance remain pending.

Actual commands and output tails:

```text
cargo test --locked -p kin-daemon --lib --no-default-features first_publication -- --nocapture
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 1408 filtered out; finished in 4.82s
rc=0

cargo test --locked -p kin-remote --all-features
test result: ok. 131 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 17.33s
rc=0

cargo test --locked -p kin-daemon --lib --no-default-features --features gcs publication_lease::tests -- --test-threads=1
test result: ok. 69 passed; 0 failed; 0 ignored; 0 measured; 1354 filtered out; finished in 7.14s
rc=0

/Users/troyfortinjr/GitHub/kin-ecosystem/bin/kin-precheck kin --repo-dir kin=/private/tmp/kin-hostedbootstrap-iw8zm_ew/kin
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 7638562cbd2e40e90aaeaa8b7fc42402cdd2d626 DIRTY
rc=0
```

The first fixture compiled before implementation and failed both cases at the explicit unimplemented refusal, 0 passed/2 failed, rc=101. The mutation driver then restored the scratch source after each deliberate production change and required the named assertion to fail after compilation. Each arm ran this command:

```text
cargo test --locked -p kin-daemon --lib --no-default-features --features gcs first_publication -- --nocapture --test-threads=1
```

| Production mutation | Actual result tail | Exit |
|---|---|---:|
| omit body copy | `test result: FAILED. 7 passed; 1 failed; 0 ignored; 0 measured; 1415 filtered out; finished in 7.42s` | 101 |
| omit destination body validation | `test result: FAILED. 6 passed; 2 failed; 0 ignored; 0 measured; 1415 filtered out; finished in 6.50s` | 101 |
| replace create with upsert | `test result: FAILED. 5 passed; 3 failed; 0 ignored; 0 measured; 1415 filtered out; finished in 5.39s` | 101 |
| ignore inspection error | `test result: FAILED. 7 passed; 1 failed; 0 ignored; 0 measured; 1415 filtered out; finished in 5.97s` | 101 |
| misclassify lost response | `test result: FAILED. 7 passed; 1 failed; 0 ignored; 0 measured; 1415 filtered out; finished in 6.35s` | 101 |
| ignore declared mode | `test result: FAILED. 7 passed; 1 failed; 0 ignored; 0 measured; 1415 filtered out; finished in 7.50s` | 101 |
| publish uninitialized authority | `test result: FAILED. 7 passed; 1 failed; 0 ignored; 0 measured; 1415 filtered out; finished in 7.47s` | 101 |
| ignore requested identity | `test result: FAILED. 7 passed; 1 failed; 0 ignored; 0 measured; 1415 filtered out; finished in 9.17s` | 101 |
| fence reads another repository | `test result: FAILED. 7 passed; 1 failed; 0 ignored; 0 measured; 1415 filtered out; finished in 17.46s` | 101 |
| skip snapshot cas | `test result: FAILED. 4 passed; 4 failed; 0 ignored; 0 measured; 1415 filtered out; finished in 7.04s` | 101 |

Restored source: `test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 1415 filtered out; finished in 12.35s`, rc=0. The fixture covers both initialized empty-native publication and exact Git import with historical/current bodies and an annotated ref, destination readback before CAS, identity/mode refusal, existing publications, a competing writer after absence inspection, lost committed responses, and five-to-six fleet fencing that preserves old authority bytes and roots.

The seven filesystem/refusal tests run in default PR shards. The GCS adapter case remains behind the existing `gcs` feature; the current feature-permutation execution runs on main. The results above are local evidence, not a claim of hosted CI or live cloud acceptance.
