### PR TITLE
Route the auth logout tests' environment writes through the sanctioned guard

### DIFF
--- a/crates/kin-cli/src/commands/auth.rs
+++ b/crates/kin-cli/src/commands/auth.rs
@@ -980,7 +980,7 @@ mod tests {
         let store = tempfile::tempdir().expect("a private credential store");
         let _root = TestCredentialRoot::set(&store.path().join("auth"));
         let base_url = "https://kinlab.example.com";
-        std::env::remove_var("KINLAB_AUTH_PASSPHRASE");
+        let _passphrase = kin_core::test_env::EnvVarGuard::unset("KINLAB_AUTH_PASSPHRASE");
 
         store_credential(base_url, &test_credential(base_url)).expect("store the plaintext tier");
         let plaintext = fallback_credential_path(base_url)
@@ -1021,7 +1021,7 @@ mod tests {
         let _root = TestCredentialRoot::set(&store.path().join("auth"));
         let mine = "https://kinlab.example.com";
         let theirs = "https://other.example.com";
-        std::env::remove_var("KINLAB_AUTH_PASSPHRASE");
+        let _passphrase = kin_core::test_env::EnvVarGuard::unset("KINLAB_AUTH_PASSPHRASE");
 
         store_credential(mine, &test_credential(mine)).expect("store mine");
         store_credential(theirs, &test_credential(theirs)).expect("store theirs");
@@ -1044,7 +1044,8 @@ mod tests {
         let store = tempfile::tempdir().expect("a private credential store");
         let _root = TestCredentialRoot::set(&store.path().join("auth"));
         let base_url = "https://kinlab.example.com";
-        std::env::set_var("KINLAB_AUTH_PASSPHRASE", "not-a-real-passphrase");
+        let _passphrase =
+            kin_core::test_env::EnvVarGuard::set("KINLAB_AUTH_PASSPHRASE", "not-a-real-passphrase");
 
         store_credential(base_url, &test_credential(base_url)).expect("store the encrypted tier");
         let encrypted = fallback_credential_path(base_url).expect("resolve the credential path");
@@ -1055,7 +1056,6 @@ mod tests {
 
         let removal = delete_credential(base_url).expect("logout removes the local credential");
 
-        std::env::remove_var("KINLAB_AUTH_PASSPHRASE");
         assert!(!encrypted.exists(), "the encrypted form has to be gone too");
         assert!(
             removal.is_clean(),
@@ -1079,9 +1079,10 @@ mod tests {
         let _root = TestCredentialRoot::set(&store.path().join("auth"));
         let base_url = "https://kinlab.example.com";
 
-        std::env::set_var("KINLAB_AUTH_PASSPHRASE", "not-a-real-passphrase");
+        let mut passphrase = kin_core::test_env::EnvVarGuard::new();
+        passphrase.apply("KINLAB_AUTH_PASSPHRASE", Some("not-a-real-passphrase"));
         store_credential(base_url, &test_credential(base_url)).expect("store encrypted");
-        std::env::remove_var("KINLAB_AUTH_PASSPHRASE");
+        passphrase.apply("KINLAB_AUTH_PASSPHRASE", None::<&str>);
         store_credential(base_url, &test_credential(base_url)).expect("store plaintext");
 
         let paths = persisted_credential_paths(base_url).expect("both forms");


### PR DESCRIPTION
Main run 33968191651 on kin's default branch went red on kin-core's workspace-wide environment guard test. This is a test-only fix, nothing else changes.

The failing test, `test_env::tests::no_source_outside_the_sanctioned_guard_writes_the_environment`, scans every source file in the workspace for a direct `std::env::set_var` or `std::env::remove_var` call outside `crates/kin-core/src/test_env.rs`. A plain `cargo test` run shares one process across every test in a binary, so a direct write leaks into every test that runs beside it and after it. PR #1534 added six such writes to `crates/kin-cli/src/commands/auth.rs`'s new logout tests, all on `KINLAB_AUTH_PASSPHRASE`.

The fix routes those six writes through `kin_core::test_env::EnvVarGuard`, the same guard already used for this variable elsewhere in this file and across the workspace. Each guard restores its variable on drop, including on panic, and serializes against other environment-mutating tests. No product code changed, and no file other than `auth.rs` was touched. The `#[serial]` attributes on the four affected tests are unchanged.

**Reproduced red first**, naming exactly the six lines PR #1534 added:
```
thread 'test_env::tests::no_source_outside_the_sanctioned_guard_writes_the_environment' panicked at crates/kin-core/src/test_env.rs:362:9:
these sources write the process environment directly. Test code must go through kin_core::test_env::EnvVarGuard ...
Offenders: [
    "crates/kin-cli/src/commands/auth.rs:1024 env::remove_var(",
    "crates/kin-cli/src/commands/auth.rs:1047 env::set_var(",
    "crates/kin-cli/src/commands/auth.rs:1058 env::remove_var(",
    "crates/kin-cli/src/commands/auth.rs:1082 env::set_var(",
    "crates/kin-cli/src/commands/auth.rs:1084 env::remove_var(",
    "crates/kin-cli/src/commands/auth.rs:983 env::remove_var(",
]
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 865 filtered out; finished in 0.18s
```

**Fixed and green**, the guard test and the full `kin-cli` auth module:
```
test test_env::tests::no_source_outside_the_sanctioned_guard_writes_the_environment ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 865 filtered out; finished in 0.18s

running 17 tests
test commands::auth::tests::an_unread_keyring_is_not_an_absent_credential ... ok
test commands::auth::tests::the_provider_wire_names_are_what_the_login_route_reads ... ok
test commands::auth::tests::a_logout_never_claims_a_revocation_the_server_did_not_confirm ... ok
test commands::auth::tests::the_logout_line_states_only_what_actually_happened ... ok
test commands::auth::tests::the_default_provider_is_the_google_login_that_shipped ... ok
test commands::auth::tests::asking_for_a_provider_replaces_one_the_server_already_named ... ok
test commands::auth::tests::asking_for_a_provider_keeps_every_parameter_the_flow_needs ... ok
test commands::auth::tests::a_logout_leaves_another_accounts_credential_alone ... ok
test commands::auth::tests::a_credential_stored_before_providers_existed_names_none ... ok
test commands::auth::tests::a_logout_with_nothing_stored_removes_nothing_and_fails_nothing ... ok
test commands::auth::tests::the_credential_root_redirect_applies_and_then_stops_applying ... ok
test commands::auth::tests::the_plaintext_tier_is_owner_only_and_announced ... ok
test commands::auth::tests::a_logout_removes_the_plaintext_credential_a_later_load_would_read ... ok
test commands::auth::tests::default_cli_actor_id_prefers_saved_credential_email ... ok
test commands::auth::tests::a_logout_removes_the_encrypted_credential ... ok
test commands::auth::tests::a_logout_removes_both_persisted_forms_when_both_exist ... ok
test commands::auth::tests::an_existing_world_readable_credential_directory_is_tightened ... ok
test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 2189 filtered out; finished in 5.30s
```

**Falsified**: put one direct `env::remove_var` back at `auth.rs:983`, confirmed the guard test names exactly that one line and nothing else, then restored the fix (re-applied the edit, never `git checkout --`):
```
thread 'test_env::tests::no_source_outside_the_sanctioned_guard_writes_the_environment' panicked at crates/kin-core/src/test_env.rs:362:9:
Offenders: [
    "crates/kin-cli/src/commands/auth.rs:983 env::remove_var(",
]
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 865 filtered out; finished in 0.22s
```

**Gates**: `bin/kin-precheck kin`, run against this worktree by absolute path:
```
kin-precheck: repo=kin tree=.../envfix-kin sha=6c61b816d4a80173e2df4ec38fea090175f724c1 branch=chore/lane-envfix-kin DIRTY
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:check_private_repo_coupling.sh bash scripts/check_private_repo_coupling.sh
PASS     guard:check_runtime_boundaries.sh    bash scripts/check_runtime_boundaries.sh
PASS     guard:test-release-policy-gate.sh    bash scripts/test-release-policy-gate.sh
PASS     guard:test-windows-authority-legs.sh bash scripts/test-windows-authority-legs.sh
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:check-kin-vfs-compat.mjs       node scripts/check-kin-vfs-compat.mjs
PASS     guard:check-rc-build-drift.mjs       node scripts/check-rc-build-drift.mjs
PASS     guard:check-required-contexts.py     python3 scripts/check-required-contexts.py
PASS     guard:test-assertion-reachability.py python3 scripts/test-assertion-reachability.py
PASS     guard:test-guard-duplicate-release-run.py python3 scripts/test-guard-duplicate-release-run.py
PASS     guard:test-homebrew-release-gate.py  python3 scripts/test-homebrew-release-gate.py
PASS     guard:test-install-checksum.py       python3 scripts/test-install-checksum.py
PASS     guard:test-private-repo-coupling.py  python3 scripts/test-private-repo-coupling.py
PASS     guard:test-release-tag-evaluate-dispatch.py python3 scripts/test-release-tag-evaluate-dispatch.py
PASS     guard:test-release-workflow-authority.py python3 scripts/test-release-workflow-authority.py
PASS     guard:test-select-release-candidate.py python3 scripts/test-select-release-candidate.py
PASS     guard:verify-hydration-semantics.py  python3 scripts/verify-hydration-semantics.py
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
PASS     node-test                            node --test <15 file(s) named by the check job>
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 6c61b816d4a80173e2df4ec38fea090175f724c1 DIRTY
```

`cargo fmt --all -- --check` also passes on its own, ahead of the precheck run above.
