### PR TITLE
Always test kin-core's workspace-scanning guards in the fast gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1337,6 +1337,20 @@ jobs:
             echo "cargo cannot tell you which. Refusing rather than guessing." >&2
             exit 1
           fi
+          # kin-core hosts guards whose subject is every source file in the
+          # workspace, not just kin-core's own: test_env.rs's environment-write
+          # scan and env_registry.rs's environment-read completeness scan both
+          # walk the whole tree. The closure above only follows what depends ON
+          # a changed crate, so a change to a crate kin-core does not depend on
+          # never re-selects kin-core, and a guard whose subject is the whole
+          # tree goes unchecked on exactly the pull requests that could break
+          # it. kin#1534 is the case: its new test code broke the environment
+          # guard, its own pull request stayed scoped to kin-cli and read
+          # green, and main's next push, unscoped, read red. Append kin-core
+          # unconditionally so every pull request carries every
+          # workspace-scanning guard, present or future; repeating a package
+          # or combining `-p kin-core` with `--workspace` is a harmless no-op.
+          printf '%s\n' -p kin-core >> "$RUNNER_TEMP/scope.args"
           echo "scope: $(tr '\n' ' ' < "$RUNNER_TEMP/scope.args")"
 
       # A filter that matches nothing grades nothing and exits 0, printing the


### PR DESCRIPTION
kin's pull-request fast gate scopes `cargo nextest run` to the packages a diff can have broken, plus their reverse-dependency closure (`.github/workflows/ci.yml`, the `fast-gate-tests` job, the "Choose the packages this diff can have broken" step, backed by `scripts/changed-crate-scope.py`). That closure only follows what depends ON a changed package. `kin-core` hosts two guards whose subject is every source file in the workspace, not just its own: `test_env.rs`'s environment-write scan and `env_registry.rs`'s environment-read completeness scan. Neither one runs unless `kin-core` itself is in scope, and a change to a crate `kin-core` does not depend on never puts it there. This is a blind spot for any downstream-only change, not just the one that found it.

**The class, from the two real runs.** PR #1534 changed only `crates/kin-cli/src/commands/auth.rs`. Its own fast gate (run 33967675656, job "Fast gate test shard (1)") computed:
```
changed-crate-scope: changed ['kin-cli']; with reverse dependents that is 3 of 24 packages
changed-crate-scope: rule=narrowed
scope: -p kin-cli -p kin-daemon -p kin-integration-tests
```
No `kin-core`, so neither guard ran, and the run succeeded. Main's next push (run 33968191651, the same shard) carries no diff to scope from, so the same step widens instead:
```
changed-crate-scope: no changed paths, which is a push, a merge group, or a failed diff
changed-crate-scope: rule=no-paths
scope: --workspace
```
`--workspace` includes `kin-core`, and that run failed:
```
FAIL [   0.115s] (1354/3038) kin-core test_env::tests::no_source_outside_the_sanctioned_guard_writes_the_environment
thread 'test_env::tests::no_source_outside_the_sanctioned_guard_writes_the_environment' panicked at crates/kin-core/src/test_env.rs:362:9:
these sources write the process environment directly. Test code must go through kin_core::test_env::EnvVarGuard ...
```
Same commit, same test, green on the pull request and red on main, purely because of which packages were in scope.

**The fix.** Append `kin-core` to the computed scope unconditionally, in the same step, right after it is written. This is one `printf` line plus a comment; nothing about the existing narrowing logic, its controls, or the per-shard partitioning changes. Confirmed locally that combining or repeating `-p kin-core` alongside `--workspace` is a harmless no-op (`cargo nextest list --workspace -p kin-core` behaves exactly like `--workspace` alone; `-p kin-core -p kin-core` behaves exactly like one).

**Proof that this closes the specific class**, replaying PR #1534's actual diff through the real, unmodified `scripts/changed-crate-scope.py` and a real `cargo nextest list`:
```
--- cargo nextest list with the BEFORE scope: does it carry any kin-core test? ---
0
kin-core test lines above (expect 0)

--- scope AFTER the fix ---
-p kin-cli -p kin-daemon -p kin-integration-tests -p kin-core

--- cargo nextest list with the AFTER scope: the two workspace-scanning guards ---
kin-core env_registry::tests::every_kin_env_read_in_workspace_is_registered
kin-core test_env::tests::no_source_outside_the_sanctioned_guard_writes_the_environment
```

**Gates.** `cargo fmt --all -- --check` passes. `bin/kin-precheck kin`, run against this worktree by absolute path:
```
kin-precheck: repo=kin tree=.../envfix2-kin sha=45cd4401f1936a6cf10f39e3395bdf0a83668f5f branch=chore/lane-envfix2-kin DIRTY
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:check_private_repo_coupling.sh bash scripts/check_private_repo_coupling.sh
PASS     guard:check_runtime_boundaries.sh    bash scripts/check_runtime_boundaries.sh
PASS     guard:test-release-policy-gate.sh    bash scripts/test-release-policy-gate.sh
PASS     guard:test-windows-authority-legs.sh bash scripts/test-windows-authority-legs.sh
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:check-kin-vfs-compat.mjs       node scripts/check-kin-vfs-compat.mjs
PASS     guard:check-rc-build-drift.mjs       node scripts/check-rc-build-drift.mjs
PASS     guard:check-required-contexts.py     python3 scripts/check-required-contexts.py
PASS     guard:test-assertion-reachability.py python3 scripts/test-assertion-reachability.py
PASS     guard:test-guard-duplicate-release-run.py python3 scripts/test-guard-duplicate-release-run.py
PASS     guard:test-homebrew-release-gate.py  python3 scripts/test-homebrew-release-gate.py
PASS     guard:test-install-checksum.py       python3 scripts/test-install-checksum.py
PASS     guard:test-private-repo-coupling.py  python3 scripts/test-private-repo-coupling.py
PASS     guard:test-release-tag-evaluate-dispatch.py python3 scripts/test-release-tag-evaluate-dispatch.py
PASS     guard:test-release-workflow-authority.py python3 scripts/test-release-workflow-authority.py
PASS     guard:test-select-release-candidate.py python3 scripts/test-select-release-candidate.py
PASS     guard:verify-hydration-semantics.py  python3 scripts/verify-hydration-semantics.py
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
PASS     node-test                            node --test <15 file(s) named by the check job>
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 45cd4401f1936a6cf10f39e3395bdf0a83668f5f DIRTY
```

Only `.github/workflows/ci.yml` changed. No product code, no other workflow file.
