### PR TITLE
Fix capped_brownfield_init verdict to grade init_rc and the cgroup cap

### DIFF
--- a/scripts/acceptance/capped_brownfield_init.py
+++ b/scripts/acceptance/capped_brownfield_init.py
@@ -31,6 +31,13 @@ the fact; the product's own sentence is what a partner reads. A build that
 stopped emitting the sentence while still dying would pass the second alone,
 and a build that emitted it spuriously would pass the first alone.
 
+`capped_init_no_oom_kill` also requires init to have exited 0 and the cgroup's
+memory.max, read at the start and at the end, to equal the requested --cap.
+A crashed init with zero OOM kills is not a clean run, and a cap this run
+cannot confirm, whether it drifted or was never readable, is not a capped
+run; either fails this check rather than falling through on an unrelated
+oom_kill of 0.
+
 `memory.peak` is reported but NOT graded. On the arm that produced this suite it
 read 13.56 GiB against a 16.00 GiB cap, which is 2.44 GiB below the ceiling on a
 run that was nonetheless killed by the cgroup's own OOM killer, so peak equal to
@@ -121,6 +128,22 @@ def read_cgroup(name):
     if len(numbers) >= 2:
         read["memory.max"], read["memory.peak"] = numbers[0], numbers[1]
     return read
+
+
+MEM_UNITS = {"": 1, "b": 1, "k": 1 << 10, "m": 1 << 20, "g": 1 << 30}
+
+
+def parse_mem_bytes(spec):
+    """Parse a docker --memory value ("16g", "12884901888", ...) to bytes.
+
+    Returns None when the value cannot be parsed. The caller treats that the
+    same as a cap it could not confirm: unreadable, not skipped.
+    """
+    match = re.match(r"^(\d+)([bkmg]?)$", (spec or "").strip().lower())
+    if not match:
+        return None
+    digits, unit = match.groups()
+    return int(digits) * MEM_UNITS[unit]
 
 
 def main(argv):
@@ -216,16 +239,39 @@ def main(argv):
             print("memory.peak %d (%.2f GiB) against memory.max %d (%.2f GiB), reported not graded"
                   % (peak, peak / GIB, end.get("memory.max", 0), end.get("memory.max", 0) / GIB))
 
+        # The requested cap is compared against what the cgroup actually held,
+        # at both ends of the run, rather than trusted from the flag. A value
+        # missing at either read (an unparseable --cap, or a memory.max that
+        # came back unreadable, including cgroup v2's own "max" spelling for
+        # "no limit") makes cap_matches False exactly like a numeric mismatch:
+        # a cap this suite cannot confirm is not a capped run.
+        requested_bytes = parse_mem_bytes(args.cap)
+        cap_at_end = end.get("memory.max")
+        cap_matches = (requested_bytes is not None
+                       and cap["memory.max"] == requested_bytes
+                       and cap_at_end == requested_bytes)
+        result["cap_requested_bytes"] = requested_bytes
+        result["cap_matches_request"] = cap_matches
+
         if oom_kill is None:
             emit("capped_init_no_oom_kill", "UNREADABLE",
                  "memory.events carried no oom_kill field, so no kill count was read")
-        elif oom_kill == 0:
-            emit("capped_init_no_oom_kill", "PASS",
-                 "oom_kill 0 under a %.2f GiB cap read from the cgroup" % (end.get("memory.max", 0) / GIB))
-        else:
+        elif oom_kill != 0:
             emit("capped_init_no_oom_kill", "FAIL",
                  "oom_kill %d under a %.2f GiB cap read from the cgroup; peak %.2f GiB"
                  % (oom_kill, end.get("memory.max", 0) / GIB, (peak or 0) / GIB))
+        elif init.returncode != 0:
+            emit("capped_init_no_oom_kill", "FAIL",
+                 "init exited %d (expected 0) though oom_kill read 0; a failed init is not a pass"
+                 % init.returncode)
+        elif not cap_matches:
+            emit("capped_init_no_oom_kill", "FAIL",
+                 "cgroup memory.max read %r at start and %r at end, does not match the requested "
+                 "cap %s (%r bytes)" % (cap["memory.max"], cap_at_end, args.cap, requested_bytes))
+        else:
+            emit("capped_init_no_oom_kill", "PASS",
+                 "oom_kill 0 under a %.2f GiB cap read from the cgroup, matching the requested %s, "
+                 "init rc 0" % (end.get("memory.max", 0) / GIB, args.cap))
 
         text = init.stdout or ""
         if not text.strip():

--- a/scripts/acceptance/test_capped_brownfield_init.py
+++ b/scripts/acceptance/test_capped_brownfield_init.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Regression tests for capped_brownfield_init's final-verdict logic.
+
+capped_init_no_oom_kill grades three things that must ALL hold before it
+passes: no OOM kill, a clean init exit, and a cgroup memory.max that matches
+what --cap asked for at both the start and the end of the run. Docker and the
+twelve-minute conversion are never touched here; MODULE.run and MODULE.docker
+are replaced with fakes that answer the exact sequence main() issues, so what
+is graded is the verdict arithmetic itself.
+
+Three cases are red against the pre-fix logic, which read oom_kill alone:
+
+    failed init, zero OOM      -- init_rc was recorded but never graded
+    cap differs from request   -- the cgroup cap was never compared to --cap
+    cap unreadable at the end  -- read_cgroup drops memory.max silently when
+                                   the file holds cgroup v2's literal "max"
+                                   (unlimited) instead of a byte count, which
+                                   is a real value a container can report
+
+Each is falsified in the PR body by reverting just the branch it guards and
+showing that one test go red again.
+"""
+import contextlib
+import importlib.util
+import io
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+
+def load():
+    spec = importlib.util.spec_from_file_location(
+        "capped_brownfield_init", Path(__file__).with_name("capped_brownfield_init.py"))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = load()
+
+
+def cgroup_text(memory_max="17179869184", memory_peak="1048576", oom_kill=0):
+    """Render what `cat memory.max memory.peak; cat memory.events` prints.
+
+    memory_max is a string because the real file can hold either a byte count
+    or cgroup v2's literal "max" for "no limit currently applied".
+    """
+    return ("%s\n%s\n"
+            "low 0\nhigh 0\nmax 0\noom 0\noom_kill %d\noom_group_kill 0\n"
+            % (memory_max, memory_peak, oom_kill))
+
+
+class FakeCompleted:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class CappedBrownfieldInitTests(unittest.TestCase):
+    def setUp(self):
+        self.addCleanup(mock.patch.stopall)
+        mock.patch.object(MODULE, "run", side_effect=self._fake_run).start()
+        mock.patch.object(MODULE, "docker", side_effect=self._fake_docker).start()
+        mock.patch("os.path.isfile", return_value=True).start()
+        # Popped in call order: read_cgroup runs once before install and once
+        # after init, so index 0 is the start read and index 1 is the end read.
+        self.cgroup_reads = [cgroup_text(), cgroup_text()]
+        self.init_rc = 0
+        self.init_stdout = "kin init: converted 1200 objects\n"
+
+    def _fake_run(self, argv, **kw):
+        if argv[:2] == ["docker", "info"]:
+            return FakeCompleted(0)
+        if argv[:2] == ["docker", "run"]:
+            return FakeCompleted(0, stdout="fake-container-id\n")
+        raise AssertionError("unexpected run() call: %r" % (argv,))
+
+    def _fake_docker(self, name, script):
+        if "memory.max" in script and "memory.peak" in script:
+            return FakeCompleted(0, stdout=self.cgroup_reads.pop(0))
+        if "tar xzf" in script:
+            return FakeCompleted(0, stdout="kin\nkin-daemon\n")
+        if script == "test -x /work/bin/kin-daemon":
+            return FakeCompleted(0)
+        if script == "/work/bin/kin --version":
+            return FakeCompleted(0, stdout="kin 0.7.2-test\n")
+        if "git clone -q" in script:
+            return FakeCompleted(0, stdout="%s\n" % MODULE.REVISION)
+        if "kin init" in script:
+            return FakeCompleted(self.init_rc, stdout=self.init_stdout)
+        raise AssertionError("unexpected docker() call: %r" % (script,))
+
+    def run_main(self, cap="16g", json_path=None):
+        args = ["--run", "--archive", "/fake/kin-linux-aarch64.tar.gz", "--cap", cap]
+        if json_path:
+            args += ["--json", json_path]
+        # EMITTED is a module-level accumulator that a real invocation never
+        # reuses (one process, one main() call). This test process calls
+        # main() once per test method, so it must be cleared here or later
+        # calls inherit earlier tests' CHECK lines and trip the "expected 2"
+        # tally for a reason that has nothing to do with the code under test.
+        MODULE.EMITTED.clear()
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            rc = MODULE.main(args)
+        return rc, out.getvalue()
+
+    # --- the three red-first regressions -----------------------------------
+
+    def test_failed_init_with_zero_oom_fails(self):
+        """A failed init with oom_kill 0 must not read as a pass.
+
+        Pre-fix: init_rc is stored in result["init_rc"] but no branch reads
+        it, so oom_kill == 0 alone reaches the PASS branch on both checks.
+        """
+        self.init_rc = 1
+        self.init_stdout = "kin init: fatal: could not reach registry\n"
+        rc, out = self.run_main()
+        self.assertEqual(rc, 1, out)
+        self.assertIn("CHECK capped_init_no_oom_kill FIR-2988 FAIL", out)
+        self.assertIn("init exited 1", out)
+
+    def test_cap_differing_from_request_fails(self):
+        """A cgroup cap that does not match --cap must not read as a pass.
+
+        Pre-fix: the cgroup's memory.max is captured at start and end
+        (result["memory.max_at_start"], result["memory.max"]) but neither is
+        ever compared against the requested --cap, so a container that ran
+        under the wrong limit passes exactly like one that ran under the
+        right one.
+        """
+        requested = MODULE.parse_mem_bytes("12g")
+        actual = MODULE.parse_mem_bytes("16g")
+        self.assertNotEqual(requested, actual)
+        self.cgroup_reads = [cgroup_text(memory_max=str(actual)),
+                             cgroup_text(memory_max=str(actual))]
+        with tempfile.TemporaryDirectory(prefix="capped-init-test-") as tmp:
+            json_path = str(Path(tmp) / "result.json")
+            rc, out = self.run_main(cap="12g", json_path=json_path)
+            self.assertEqual(rc, 1, out)
+            self.assertIn("CHECK capped_init_no_oom_kill FIR-2988 FAIL", out)
+            self.assertIn("does not match the requested cap 12g", out)
+            result = json.loads(Path(json_path).read_text())
+        self.assertEqual(result["cap_requested_bytes"], requested)
+        self.assertFalse(result["cap_matches_request"])
+
+    def test_unreadable_cap_fails(self):
+        """A cap that cannot be confirmed must not read as a pass.
+
+        The end-of-run memory.max reads the literal "max" (cgroup v2's
+        spelling for "no limit"), a real value a container can report.
+        read_cgroup's own number parsing drops it silently (it is not
+        `.isdigit()`), so memory.max is simply absent from the end read while
+        memory.peak and oom_kill still parse fine. Pre-fix, nothing reads
+        memory.max at the end at all, so this is invisible.
+        """
+        self.cgroup_reads = [cgroup_text(),
+                             cgroup_text(memory_max="max", memory_peak="999999")]
+        with tempfile.TemporaryDirectory(prefix="capped-init-test-") as tmp:
+            json_path = str(Path(tmp) / "result.json")
+            rc, out = self.run_main(json_path=json_path)
+            self.assertEqual(rc, 1, out)
+            self.assertIn("CHECK capped_init_no_oom_kill FIR-2988 FAIL", out)
+            self.assertIn("does not match the requested cap", out)
+            result = json.loads(Path(json_path).read_text())
+        self.assertNotIn("memory.max", result)  # read_cgroup never set it
+        self.assertFalse(result["cap_matches_request"])
+
+    # --- control: the same run, nothing wrong, must still pass --------------
+
+    def test_clean_run_still_passes(self):
+        rc, out = self.run_main()
+        self.assertEqual(rc, 0, out)
+        self.assertIn("CHECK capped_init_no_oom_kill FIR-2988 PASS", out)
+        self.assertIn("CHECK capped_init_no_kill_line FIR-2988 PASS", out)
+
+    # --- the OOM-kill positive control this suite already had --------------
+
+    def test_real_oom_kill_still_fails_first(self):
+        """oom_kill > 0 must still FAIL and must still name the kill count,
+        even with a matching cap and a zero init_rc, unchanged from before
+        this fix."""
+        self.cgroup_reads = [cgroup_text(), cgroup_text(oom_kill=1)]
+        rc, out = self.run_main()
+        self.assertEqual(rc, 1, out)
+        self.assertIn("CHECK capped_init_no_oom_kill FIR-2988 FAIL", out)
+        self.assertIn("oom_kill 1", out)
+
+
+class ParseMemBytesTests(unittest.TestCase):
+    def test_known_units(self):
+        self.assertEqual(MODULE.parse_mem_bytes("16g"), 16 * (1 << 30))
+        self.assertEqual(MODULE.parse_mem_bytes("12g"), 12 * (1 << 30))
+        self.assertEqual(MODULE.parse_mem_bytes("500m"), 500 * (1 << 20))
+        self.assertEqual(MODULE.parse_mem_bytes("2048k"), 2048 * (1 << 10))
+        self.assertEqual(MODULE.parse_mem_bytes("1024b"), 1024)
+        self.assertEqual(MODULE.parse_mem_bytes("2048"), 2048)
+
+    def test_unparseable_is_none(self):
+        for spec in ("max", "16gb", "16 g", "", None, "-16g"):
+            self.assertIsNone(MODULE.parse_mem_bytes(spec), spec)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes two bugs in `capped_brownfield_init.py`'s verdict logic, found by a coverage audit
(`.kin-coord/reports/local-memory-acceptance-coverage-20260905.md`).

Bug 1: `init.returncode` is captured into `result["init_rc"]` at line 207 but nothing in the
verdict block (the old lines 219-228) reads it. A `kin init` that fails outright, with zero OOM
kills and no kill sentence in its output, passed both checks.

Bug 2: the cgroup's `memory.max` is captured at the start (line 197) and merged into `result` again
at the end (line 212), but neither is ever compared against the cap the run actually requested
(`--cap`, default `16g`), despite `read_cgroup`'s own docstring (lines 111-113) already saying it
is: "the flag is recorded separately and compared rather than trusted." A cap that drifted, was
never applied, or could not be read back at either point was invisible to the verdict.

Both live inside the same check, `capped_init_no_oom_kill`, so the fix stays inside its existing
branches rather than adding a third CHECK line. Its PASS now additionally requires
`init.returncode == 0` and a new `cap_matches` boolean: the cgroup's `memory.max` at both the start
and the end read equals the parsed `--cap` value. A value missing at either read, including an
unparseable `--cap` or a `memory.max` that comes back unreadable, makes `cap_matches` False the
same way a numeric mismatch does. The default (`16g`) is unchanged. `capped_init_no_kill_line` is
untouched; it grades an independent signal, the product's own printed sentence.

## Tests

New file `scripts/acceptance/test_capped_brownfield_init.py`, mirroring
`test_fixture_shutdown.py`'s pattern: `unittest` plus an `importlib.util` file loader, with
`MODULE.run` and `MODULE.docker` replaced by fakes that answer the exact command sequence
`main()` issues. No Docker is touched. Three regression tests plus a clean-run control, a control
that the suite's pre-existing OOM-kill positive control still fails first, and two unit tests on
the new `parse_mem_bytes` helper. All seven pass against the fixed file:

```
test_cap_differing_from_request_fails ... ok
test_clean_run_still_passes ... ok
test_failed_init_with_zero_oom_fails ... ok
test_real_oom_kill_still_fails_first ... ok
test_unreadable_cap_fails ... ok
test_known_units ... ok
test_unparseable_is_none ... ok

Ran 7 tests in 0.006s
OK
```

## Falsification

Each of the two new guard clauses was removed on its own, the suite rerun, and put back.

Removing `elif init.returncode != 0: FAIL(...)` restores the exact bug 1 behavior (any `init_rc`
ignored once `oom_kill == 0`). Exactly one test goes red:

```
test_failed_init_with_zero_oom_fails ... FAIL
    AssertionError: 0 != 1 : ...
    CHECK capped_init_no_oom_kill FIR-2988 PASS oom_kill 0 under a 16.00 GiB cap read from the
    cgroup, matching the requested 16g, init rc 0
(every other test: ok)
FAILED (failures=1)
```

Removing `elif not cap_matches: FAIL(...)` restores the exact bug 2 behavior (the cgroup cap never
compared to `--cap`). Exactly the two cap tests go red, since both exercise that one guard from
different input shapes, a numeric mismatch and a value missing at the end read:

```
test_cap_differing_from_request_fails ... FAIL
    AssertionError: 0 != 1 : ... flag was 12g
    CHECK capped_init_no_oom_kill FIR-2988 PASS oom_kill 0 under a 16.00 GiB cap read from the
    cgroup, matching the requested 12g, init rc 0
test_unreadable_cap_fails ... FAIL
    AssertionError: 0 != 1 : ...
    CHECK capped_init_no_oom_kill FIR-2988 PASS oom_kill 0 under a 0.00 GiB cap read from the
    cgroup, matching the requested 16g, init rc 0
(every other test: ok)
FAILED (failures=2)
```

Both times, every other test stayed green, and the suite was fully green again after restoring the
branch. `git diff` was checked afterward against the intended fix, with no falsification leftovers.

## Scope

Not wired into `.github/workflows/ci.yml`: `capped_brownfield_init.py` itself is not referenced by
any workflow today (it is an opt-in `--run` tool used manually), and this correction is scoped to
the fix file plus one test file.

## Verification

`bin/kin-precheck kin --repo-dir kin=<worktree>`: 21 gates ran, 21 passed, 0 failed.
