### PR TITLE
Let a settled over-budget daemon finish its embedding backlog (FIR-3268)

### DIFF
--- a/crates/kin-core/src/memory_pressure.rs
+++ b/crates/kin-core/src/memory_pressure.rs
@@ -765,6 +765,180 @@ impl Verdict {
     }
 }
 
+/// The observed retained growth at which an anchored refusal stops admitting.
+///
+/// Read this as an ADMISSION threshold and not as a bound on memory. The rule
+/// samples the tree, admits a batch, and then awaits that whole batch before it
+/// consults again, so a batch admitted just under the threshold can overshoot it
+/// and only the NEXT consultation latches. Nothing here proves a peak fits the
+/// cgroup, which is exactly why [`host_leaves_room`] gates the exception and is
+/// not optional.
+///
+/// What it does bound is drift that is observed and carried forward: the anchor
+/// never moves, so a tree that creeps upward is latched off the moment a sample
+/// lands above it, and it cannot ratchet by re-anchoring.
+///
+/// The number is chosen from both sides. It has to clear sampling jitter, or the
+/// rule latches on its own noise and changes nothing: a daemon's proportional
+/// footprint is resampled per wake while language servers and a reconcile loop
+/// are live under it, and a few tens of mebibytes of drift between two samples
+/// is ordinary. And it has to stay small against the smallest budget the
+/// derivation can produce: 64 MiB is 6% of [`DERIVED_BUDGET_FLOOR_BYTES`] and
+/// about 1% of the 6 GiB budget a twelve-gigabyte container derives.
+pub const REFUSED_EMBED_GROWTH_TOLERANCE_BYTES: u64 = 64 * 1024 * 1024;
+
+/// What one pressure consultation established about this daemon's OWN tree.
+///
+/// Three states, not a boolean, and that is the whole point. A boolean makes
+/// `false` mean both "measured, and it recovered" and "could not be measured",
+/// and the second must never be read as the first: a transient
+/// `sample_tree_footprint` failure would then clear an anchor with no evidence
+/// of recovery, and the next successful sample would anchor HIGHER. Repeat that
+/// and the fixed ceiling ratchets, which is the guarantee this type exists to
+/// keep.
+///
+/// This is the BUDGET arm on its own. The combined verdict folds in the host,
+/// so it cannot say whether a refusal came from this tree or from the machine,
+/// and only a budget refusal may ever be relaxed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BudgetObservation {
+    /// Measured, and below the rung that refuses. The tree recovered.
+    Recovered { held_bytes: u64 },
+    /// Measured, and at or past the rung that refuses.
+    Refused { held_bytes: u64 },
+    /// Not measured. Evidence of neither recovery nor growth.
+    Unobserved,
+}
+
+/// What a worker carries between wakes while its embed batches are refused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RefusedEmbedState {
+    /// Not refused, or a MEASURED recovery has been seen since the last refusal.
+    #[default]
+    Clear,
+    /// Refused, holding the tree footprint the FIRST refusal measured.
+    ///
+    /// The anchor never moves while the state stays here. A mark that advanced
+    /// with each admitted batch would licence one batch of growth per wake for
+    /// ever, which is the runaway this module exists to stop.
+    Anchored(u64),
+    /// Refused, and the tree has grown past its anchor. Nothing is admitted
+    /// until a measured recovery clears it.
+    Latched,
+}
+
+/// Whether one refused embed wake may still run a batch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefusedEmbedAdmission {
+    /// Run nothing this wake.
+    Hold,
+    /// Run a floor-size batch: the tree has not grown since it was anchored.
+    AdmitFloorBatch,
+}
+
+/// Whether the machine itself has room to spare, as opposed to this daemon.
+///
+/// `Unknown` is deliberately not room. Everywhere else in this module an
+/// unreadable host is the lowest rung so it can never make a decision worse,
+/// which is right when the question is whether to STOP. Here the question is
+/// whether to relax a stop already in force, and the answers are not symmetric:
+/// an absent measurement must not buy an exception.
+pub fn host_leaves_room(level: PressureLevel) -> bool {
+    match level {
+        PressureLevel::Nominal | PressureLevel::Elevated => true,
+        PressureLevel::Unknown | PressureLevel::Critical => false,
+    }
+}
+
+/// Whether a daemon already refused for memory may still finish work it started.
+///
+/// A refusal is the right answer to a tree that is GROWING and the wrong answer
+/// to one that has simply settled above its budget, and the two are
+/// indistinguishable from a single sample. That gap is a measured defect, not a
+/// hypothetical: a daemon in a twelve-gigabyte container derives a 6.0 GiB
+/// budget, idles at 4.8 GiB (elevated, so its batch shrinks), and comes out of
+/// its FIRST completed batch holding 6.7 GiB, because an embedding pass leaves
+/// the model and index it loaded resident for the next one. From there every
+/// later batch is refused, on a five-second wake, for the life of the process,
+/// and the store stops converging one batch into a backlog of thousands. The
+/// refusal cannot end, either: what put the tree over its budget is the very
+/// state the next batch would reuse, so waiting reclaims nothing.
+///
+/// So this asks the question a single sample cannot: has the tree grown SINCE
+/// the refusal began. The first refusal after real progress anchors what was
+/// held and still holds that wake, which is the cautious reading of a level
+/// that has just changed. Later wakes at or below that anchor plus
+/// [`REFUSED_EMBED_GROWTH_TOLERANCE_BYTES`] run a floor-size batch, because a
+/// tree that is not growing is not the tree a refusal was written for. The
+/// first sample above it latches.
+///
+/// Two things gate the exception, and neither is optional.
+///
+/// `host_level` is the machine's own rung, before this daemon's budget was
+/// folded in. An anchored tree says this PROCESS is not growing; it says nothing
+/// about what the machine has left, because the budget is per daemon and derived
+/// from a ceiling every daemon shares. Both repo daemons in the measured
+/// container derived 6.0 GiB from the same 12 GiB cgroup, which is the entire
+/// cgroup between the two of them with nothing left for the three language
+/// servers each one starts. So a critical machine, or one that could not be
+/// read, keeps its refusal whatever the anchor says.
+///
+/// [`BudgetObservation`] is the other. Only a MEASURED recovery clears the
+/// state. An unobserved wake carries Anchored or Latched forward untouched, so a
+/// gap in sampling can neither grant an exception nor move the ceiling.
+///
+/// `completed_a_batch` keeps this pointed at the measured case. A worker that
+/// has never finished a batch in this process has not established that its
+/// footprint is a settled cost rather than a rising one, so it keeps today's
+/// behaviour and refuses.
+///
+/// Pure, so every arm is testable without a daemon, an embedder or a loaded
+/// machine.
+pub fn admit_refused_embed(
+    state: RefusedEmbedState,
+    observation: BudgetObservation,
+    host_level: PressureLevel,
+    completed_a_batch: bool,
+    tolerance_bytes: u64,
+) -> (RefusedEmbedState, RefusedEmbedAdmission) {
+    // Asked before anything is read, and before any state moves: a machine that
+    // is full, or one that could not be read, neither admits work nor supplies
+    // the evidence that would retire an anchor.
+    if !host_leaves_room(host_level) {
+        return (state, RefusedEmbedAdmission::Hold);
+    }
+    let held = match observation {
+        BudgetObservation::Unobserved => return (state, RefusedEmbedAdmission::Hold),
+        BudgetObservation::Recovered { .. } => {
+            return (RefusedEmbedState::Clear, RefusedEmbedAdmission::Hold)
+        }
+        BudgetObservation::Refused { held_bytes } => held_bytes,
+    };
+    match state {
+        RefusedEmbedState::Latched => (RefusedEmbedState::Latched, RefusedEmbedAdmission::Hold),
+        RefusedEmbedState::Clear => {
+            if completed_a_batch {
+                (
+                    RefusedEmbedState::Anchored(held),
+                    RefusedEmbedAdmission::Hold,
+                )
+            } else {
+                (RefusedEmbedState::Clear, RefusedEmbedAdmission::Hold)
+            }
+        }
+        RefusedEmbedState::Anchored(anchor) => {
+            if held <= anchor.saturating_add(tolerance_bytes) {
+                (
+                    RefusedEmbedState::Anchored(anchor),
+                    RefusedEmbedAdmission::AdmitFloorBatch,
+                )
+            } else {
+                (RefusedEmbedState::Latched, RefusedEmbedAdmission::Hold)
+            }
+        }
+    }
+}
+
 /// The disclosure sentence, in the register the commit post-kill diagnosis
 /// established: what was measured, against what ceiling, what Kin did about it,
 /// and what that costs.
@@ -3520,5 +3694,289 @@ mod tests {
                 panic!("nothing forces a level in this test, yet the probe returned {level:?}")
             }
         }
+    }
+
+    const IDLE: u64 = 5_153_960_755; // 4.8 GiB, elevated against a 6.0 GiB budget
+    const AFTER_FIRST_BATCH: u64 = 7_194_070_384; // 6.7 GiB, critical
+
+    fn refused_at(held_bytes: u64) -> BudgetObservation {
+        BudgetObservation::Refused { held_bytes }
+    }
+
+    fn recovered_at(held_bytes: u64) -> BudgetObservation {
+        BudgetObservation::Recovered { held_bytes }
+    }
+
+    /// The measured stranger sequence, in the bytes the daemon actually held.
+    ///
+    /// A twelve-gigabyte container derives a 6.0 GiB budget, the daemon idles at
+    /// 4.8 GiB (elevated), completes one batch, and comes out of it holding
+    /// 6.7 GiB (critical). Before this rule the drain stopped there for the life
+    /// of the process, on a five-second wake, 128 vectors into 1722.
+    #[test]
+    fn a_tree_that_settled_above_its_budget_keeps_draining() {
+        // Idle and below the refusing rung: nothing is anchored.
+        let (state, admission) = admit_refused_embed(
+            RefusedEmbedState::Clear,
+            recovered_at(IDLE),
+            PressureLevel::Elevated,
+            false,
+            REFUSED_EMBED_GROWTH_TOLERANCE_BYTES,
+        );
+        assert_eq!(state, RefusedEmbedState::Clear);
+        assert_eq!(admission, RefusedEmbedAdmission::Hold);
+
+        // The first refusal after the first completed batch anchors and holds.
+        let (state, admission) = admit_refused_embed(
+            state,
+            refused_at(AFTER_FIRST_BATCH),
+            PressureLevel::Elevated,
+            true,
+            REFUSED_EMBED_GROWTH_TOLERANCE_BYTES,
+        );
+        assert_eq!(
+            state,
+            RefusedEmbedState::Anchored(AFTER_FIRST_BATCH),
+            "the first refusal records what the tree was holding"
+        );
+        assert_eq!(
+            admission,
+            RefusedEmbedAdmission::Hold,
+            "a level that has just changed is read cautiously for one wake"
+        );
+
+        // Every later wake at a settled footprint runs a floor-size batch. This
+        // is the arm the measured defect never reached.
+        for wake in 0..64 {
+            let jitter = AFTER_FIRST_BATCH + (wake % 8) * 1_048_576;
+            let (next, admission) = admit_refused_embed(
+                state,
+                refused_at(jitter),
+                PressureLevel::Elevated,
+                true,
+                REFUSED_EMBED_GROWTH_TOLERANCE_BYTES,
+            );
+            assert_eq!(
+                admission,
+                RefusedEmbedAdmission::AdmitFloorBatch,
+                "wake {wake}: a tree that is not growing must keep converging"
+            );
+            assert_eq!(
+                next,
+                RefusedEmbedState::Anchored(AFTER_FIRST_BATCH),
+                "wake {wake}: the anchor must not move, or admission licences \
+                 one batch of growth per wake for ever"
+            );
+        }
+    }
+
+    #[test]
+    fn a_tree_that_is_still_growing_stays_refused() {
+        let state = RefusedEmbedState::Anchored(AFTER_FIRST_BATCH);
+        let (state, admission) = admit_refused_embed(
+            state,
+            refused_at(AFTER_FIRST_BATCH + REFUSED_EMBED_GROWTH_TOLERANCE_BYTES + 1),
+            PressureLevel::Elevated,
+            true,
+            REFUSED_EMBED_GROWTH_TOLERANCE_BYTES,
+        );
+        assert_eq!(
+            admission,
+            RefusedEmbedAdmission::Hold,
+            "one byte past the tolerance is growth, and growth is what a refusal is for"
+        );
+        assert_eq!(state, RefusedEmbedState::Latched);
+
+        // The latch outlives a footprint that comes back down while still
+        // refused, so a tree sawtoothing across the tolerance cannot ride it up.
+        let (state, admission) = admit_refused_embed(
+            state,
+            refused_at(AFTER_FIRST_BATCH),
+            PressureLevel::Elevated,
+            true,
+            REFUSED_EMBED_GROWTH_TOLERANCE_BYTES,
+        );
+        assert_eq!(admission, RefusedEmbedAdmission::Hold);
+        assert_eq!(state, RefusedEmbedState::Latched);
+
+        // A MEASURED recovery is the one thing that clears it.
+        let (state, _) = admit_refused_embed(
+            state,
+            recovered_at(IDLE),
+            PressureLevel::Elevated,
+            true,
+            REFUSED_EMBED_GROWTH_TOLERANCE_BYTES,
+        );
+        assert_eq!(state, RefusedEmbedState::Clear);
+    }
+
+    /// A settled tree is not evidence of room when the machine itself is full.
+    ///
+    /// The budget is per daemon and derived from a ceiling every daemon shares.
+    /// Both repo daemons in the measured container derived 6.0 GiB from the same
+    /// 12 GiB cgroup, so an anchor proves only that THIS process stopped growing
+    /// while a sibling eats the headroom it cannot see.
+    #[test]
+    fn a_settled_tree_on_a_critical_machine_stays_refused() {
+        let anchored = RefusedEmbedState::Anchored(AFTER_FIRST_BATCH);
+
+        // Host critical, budget critical.
+        let (state, admission) = admit_refused_embed(
+            anchored,
+            refused_at(AFTER_FIRST_BATCH),
+            PressureLevel::Critical,
+            true,
+            REFUSED_EMBED_GROWTH_TOLERANCE_BYTES,
+        );
+        assert_eq!(
+            admission,
+            RefusedEmbedAdmission::Hold,
+            "a critical machine keeps its refusal whatever this tree has settled at"
+        );
+        assert_eq!(
+            state, anchored,
+            "and the anchor is held rather than latched, because the machine can recover"
+        );
+
+        // Host critical, budget NOMINAL. A recovery seen while the machine is
+        // full is not a recovery this rule may act on, so the anchor survives.
+        let (state, admission) = admit_refused_embed(
+            anchored,
+            recovered_at(IDLE),
+            PressureLevel::Critical,
+            true,
+            REFUSED_EMBED_GROWTH_TOLERANCE_BYTES,
+        );
+        assert_eq!(admission, RefusedEmbedAdmission::Hold);
+        assert_eq!(
+            state, anchored,
+            "a critical host supplies no evidence, in either direction"
+        );
+
+        // Positive control, or this test would pass for the wrong reason.
+        let (_, admission) = admit_refused_embed(
+            anchored,
+            refused_at(AFTER_FIRST_BATCH),
+            PressureLevel::Elevated,
+            true,
+            REFUSED_EMBED_GROWTH_TOLERANCE_BYTES,
+        );
+        assert_eq!(
+            admission,
+            RefusedEmbedAdmission::AdmitFloorBatch,
+            "positive control: the gate must be the host level and nothing else"
+        );
+    }
+
+    /// An absent measurement must not buy an exception, in either direction.
+    #[test]
+    fn a_settled_tree_with_unreadable_headroom_stays_refused() {
+        let anchored = RefusedEmbedState::Anchored(AFTER_FIRST_BATCH);
+        let (state, admission) = admit_refused_embed(
+            anchored,
+            refused_at(AFTER_FIRST_BATCH),
+            PressureLevel::Unknown,
+            true,
+            REFUSED_EMBED_GROWTH_TOLERANCE_BYTES,
+        );
+        assert_eq!(
+            admission,
+            RefusedEmbedAdmission::Hold,
+            "a host that could not be read is not a host with room"
+        );
+        assert_eq!(state, anchored);
+
+        assert!(!host_leaves_room(PressureLevel::Unknown));
+        assert!(!host_leaves_room(PressureLevel::Critical));
+        assert!(host_leaves_room(PressureLevel::Nominal));
+        assert!(host_leaves_room(PressureLevel::Elevated));
+    }
+
+    /// The ratchet. An unmeasured tree must not clear an anchor.
+    ///
+    /// `sample_tree_footprint` can fail transiently. When it does, the combined
+    /// verdict on a nominal host reads Proceed, and a rule that took that for
+    /// recovery would clear the anchor and re-anchor at the next, HIGHER sample.
+    /// Repeat that across wakes and the fixed ceiling walks upward, which is the
+    /// whole guarantee gone.
+    #[test]
+    fn an_unobserved_wake_cannot_move_the_anchor() {
+        let anchored = RefusedEmbedState::Anchored(AFTER_FIRST_BATCH);
+        let (state, admission) = admit_refused_embed(
+            anchored,
+            BudgetObservation::Unobserved,
+            PressureLevel::Nominal,
+            true,
+            REFUSED_EMBED_GROWTH_TOLERANCE_BYTES,
+        );
+        assert_eq!(
+            state, anchored,
+            "a wake that measured nothing carries the anchor forward untouched"
+        );
+        assert_eq!(admission, RefusedEmbedAdmission::Hold);
+
+        // Carried forward: the next critical sample above the ORIGINAL anchor
+        // plus tolerance must latch, not anchor higher.
+        let grown = AFTER_FIRST_BATCH + REFUSED_EMBED_GROWTH_TOLERANCE_BYTES + 1;
+        let (state, admission) = admit_refused_embed(
+            state,
+            refused_at(grown),
+            PressureLevel::Nominal,
+            true,
+            REFUSED_EMBED_GROWTH_TOLERANCE_BYTES,
+        );
+        assert_eq!(
+            state,
+            RefusedEmbedState::Latched,
+            "growth measured against the original anchor latches; re-anchoring here is the ratchet"
+        );
+        assert_eq!(admission, RefusedEmbedAdmission::Hold);
+    }
+
+    #[test]
+    fn an_unobserved_wake_cannot_clear_a_latch() {
+        let (state, admission) = admit_refused_embed(
+            RefusedEmbedState::Latched,
+            BudgetObservation::Unobserved,
+            PressureLevel::Nominal,
+            true,
+            REFUSED_EMBED_GROWTH_TOLERANCE_BYTES,
+        );
+        assert_eq!(
+            state,
+            RefusedEmbedState::Latched,
+            "a latched runaway is not released by a gap in sampling"
+        );
+        assert_eq!(admission, RefusedEmbedAdmission::Hold);
+
+        // And a repeated gap cannot wear it down.
+        let mut state = state;
+        for _ in 0..16 {
+            let (next, admission) = admit_refused_embed(
+                state,
+                BudgetObservation::Unobserved,
+                PressureLevel::Nominal,
+                true,
+                REFUSED_EMBED_GROWTH_TOLERANCE_BYTES,
+            );
+            assert_eq!(next, RefusedEmbedState::Latched);
+            assert_eq!(admission, RefusedEmbedAdmission::Hold);
+            state = next;
+        }
+    }
+
+    #[test]
+    fn a_worker_that_never_finished_a_batch_is_refused_as_before() {
+        // Without a completed batch there is no evidence the footprint is a
+        // settled cost rather than a rising one, so the old behaviour stands.
+        let (state, admission) = admit_refused_embed(
+            RefusedEmbedState::Clear,
+            refused_at(AFTER_FIRST_BATCH),
+            PressureLevel::Elevated,
+            false,
+            REFUSED_EMBED_GROWTH_TOLERANCE_BYTES,
+        );
+        assert_eq!(state, RefusedEmbedState::Clear, "nothing is anchored");
+        assert_eq!(admission, RefusedEmbedAdmission::Hold);
     }
 }

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -2188,6 +2188,86 @@ fn embed_batch_under_pressure(
     }
 }
 
+/// The batch size a REFUSED pass may use once its tree has been anchored.
+///
+/// A quarter of the elevated shrink, so a sixteenth of the configured size. The
+/// pass that reaches here is already past its budget, and the only thing it is
+/// asked to do is converge, so the step is picked to be the smallest one that
+/// still finishes rather than the largest one that still fits. On the measured
+/// container that is 32 entities against a configured 512, which drains a
+/// 1722-entity backlog in tens of minutes instead of never.
+///
+/// The floor of one is the same floor `embed_batch_under_pressure` keeps and
+/// for the same reason: a size knob allowed to reach zero is a silent refusal
+/// wearing an admission's name.
+fn refused_embed_batch(configured: usize) -> usize {
+    (configured / 16).max(1)
+}
+
+/// What one embed wake does, once the rule and the disclosure have answered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EmbedWakeDecision {
+    /// End the drain for this wake.
+    Hold,
+    /// Run a batch of this size.
+    Run(usize),
+}
+
+/// Compose the memory rule, the disclosure and the batch size into one answer.
+///
+/// Extracted from the worker because the composition is where the interesting
+/// mistake lives, and the worker is an async block inside a daemon that a test
+/// cannot drive. The pure rule can be right while the caller throws its answer
+/// away, which is exactly what happened here: a `Hold` was only honoured when
+/// the COMBINED verdict refused, so an anchored tree whose footprint sample
+/// failed on a nominal host produced `Proceed`, skipped the break, and ran a
+/// full-size batch. That is a daemon known to be over its budget spending the
+/// machine on the strength of a reading it did not get.
+///
+/// So the state after the rule is what governs, not the combined verdict.
+/// `refusal_state` reaches `Clear` only through a MEASURED recovery, so
+/// anything else means "known over budget, and this wake produced no licence".
+/// `Clear` keeps the behaviour it has always had, deliberately: it means no
+/// known over-budget condition, the ordinary verdict governs, and widening this
+/// change to touch that path would be new budget policy rather than a fix.
+fn embed_wake_decision(
+    refused_now: bool,
+    admission: kin_core::memory_pressure::RefusedEmbedAdmission,
+    state_after: kin_core::memory_pressure::RefusedEmbedState,
+    verdict: &kin_core::memory_pressure::Verdict,
+    configured: usize,
+) -> EmbedWakeDecision {
+    if admission == kin_core::memory_pressure::RefusedEmbedAdmission::AdmitFloorBatch {
+        return EmbedWakeDecision::Run(refused_embed_batch(configured));
+    }
+    if refused_now || state_after != kin_core::memory_pressure::RefusedEmbedState::Clear {
+        return EmbedWakeDecision::Hold;
+    }
+    EmbedWakeDecision::Run(embed_batch_under_pressure(configured, verdict))
+}
+
+/// What one consultation established about this daemon's own tree.
+///
+/// The BUDGET arm alone, never the combined rung, because only a refusal this
+/// daemon's own budget produced may be relaxed and the combined rung cannot say
+/// which arm produced it. A tree that could not be measured is `Unobserved`
+/// rather than recovered: reading a sampling gap as recovery is what lets an
+/// anchor be cleared without evidence and re-anchored higher on the next
+/// successful sample.
+fn budget_observation(call: &PressureCall) -> kin_core::memory_pressure::BudgetObservation {
+    match (call.budget_level, call.standing.as_ref()) {
+        (Some(level), Some(standing)) => {
+            let held_bytes = standing.footprint.total_bytes();
+            if level == kin_core::memory_pressure::PressureLevel::Critical {
+                kin_core::memory_pressure::BudgetObservation::Refused { held_bytes }
+            } else {
+                kin_core::memory_pressure::BudgetObservation::Recovered { held_bytes }
+            }
+        }
+        _ => kin_core::memory_pressure::BudgetObservation::Unobserved,
+    }
+}
+
 /// One row of the host's process table, in the four fields a footprint needs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ProcessRow {
@@ -2459,6 +2539,10 @@ pub(crate) fn pressure_verdict(work: kin_core::memory_pressure::HeavyWork) -> Pr
     });
     PressureCall {
         level,
+        host_level,
+        budget_level: standing
+            .as_ref()
+            .map(|standing| standing.level_under(&thresholds)),
         verdict: kin_core::memory_pressure::Verdict::decide(
             work,
             &pressure,
@@ -2472,6 +2556,25 @@ pub(crate) fn pressure_verdict(work: kin_core::memory_pressure::HeavyWork) -> Pr
 /// One consultation: what was measured, and what that means for this work.
 pub(crate) struct PressureCall {
     pub(crate) level: kin_core::memory_pressure::PressureLevel,
+    /// The HOST or cgroup rung on its own, before this daemon's own budget was
+    /// folded in.
+    ///
+    /// Carried because the two axes answer different questions and one caller
+    /// needs them apart. `level` is the worse of the two, so it cannot say
+    /// whether a critical verdict came from this tree's budget or from the
+    /// machine, and `admit_refused_embed` may only relax a refusal that came
+    /// from the budget. Two repo daemons in one container each derive half the
+    /// same cgroup, so a settled tree is no evidence at all about what the
+    /// machine has left.
+    pub(crate) host_level: kin_core::memory_pressure::PressureLevel,
+    /// This daemon's own budget rung, when its tree could be measured at all.
+    ///
+    /// `None` is an unreadable tree, which is evidence of nothing and must never
+    /// be read as recovery. Carried apart from `level` for the same reason
+    /// `host_level` is: only a refusal that this daemon's OWN budget produced
+    /// may ever be relaxed, and the combined rung cannot say which arm produced
+    /// it.
+    pub(crate) budget_level: Option<kin_core::memory_pressure::PressureLevel>,
     pub(crate) verdict: kin_core::memory_pressure::Verdict,
     /// What this daemon's own tree was holding when the call was made, when it
     /// could be measured. Carried so a caller can publish the standing without
@@ -4686,6 +4789,13 @@ pub async fn run_with_authority_on(
         // wake: the record is a statement of the current state, and rewriting
         // it every few seconds would turn a disclosure into a log.
         let mut announced_pressure: Option<kin_core::memory_pressure::PressureLevel> = None;
+        // What a refusal for memory has measured so far, and whether this worker
+        // has ever finished a batch in this process. Together they are what lets
+        // a tree that has SETTLED above its budget keep converging while a tree
+        // that is still growing stays refused. See
+        // `kin_core::memory_pressure::admit_refused_embed`.
+        let mut refusal_state = kin_core::memory_pressure::RefusedEmbedState::default();
+        let mut completed_a_batch = false;
         'wake: loop {
             // Between wakes this worker is genuinely doing nothing, so the
             // working stretch ends here. A wedged drain never reaches this
@@ -4844,13 +4954,40 @@ pub async fn run_with_authority_on(
                 let call = pressure_verdict(kin_core::memory_pressure::HeavyWork::EmbedBatch);
                 publish_footprint_standing(&embed_state, &call);
                 let pressure_changed = announced_pressure != Some(call.level);
-                if disclose_embed_pressure_refusal_if_needed(
+                // A refusal is still disclosed exactly as before; what it no
+                // longer always does is stop the drain. A tree that has not
+                // grown since its refusal was anchored runs a floor-size batch,
+                // because refusing it for ever cannot reclaim the memory that
+                // put it over: that memory is the model the next batch reuses.
+                let observation = budget_observation(&call);
+                let (next_refusal_state, admission) =
+                    kin_core::memory_pressure::admit_refused_embed(
+                        refusal_state,
+                        observation,
+                        call.host_level,
+                        completed_a_batch,
+                        kin_core::memory_pressure::REFUSED_EMBED_GROWTH_TOLERANCE_BYTES,
+                    );
+                refusal_state = next_refusal_state;
+                // Called for its record-publishing side effect before anything
+                // decides to stop, so a refusal is disclosed on the wake that
+                // produced it whatever this worker then does about it.
+                let refused_now = disclose_embed_pressure_refusal_if_needed(
                     &embed_state,
                     &mut announced_pressure,
                     &call,
-                ) {
-                    break;
-                }
+                );
+                let decision = embed_wake_decision(
+                    refused_now,
+                    admission,
+                    refusal_state,
+                    &call.verdict,
+                    embed_batch_size,
+                );
+                let batch = match decision {
+                    EmbedWakeDecision::Hold => break,
+                    EmbedWakeDecision::Run(batch) => batch,
+                };
                 if pressure_changed {
                     match &call.verdict {
                         kin_core::memory_pressure::Verdict::Shrink { reason } => {
@@ -4870,7 +5007,6 @@ pub async fn run_with_authority_on(
                 // machine. Latched, so a drain that never finishes keeps one
                 // stretch rather than restarting it every batch.
                 embed_pass.working(Instant::now());
-                let batch = embed_batch_under_pressure(embed_batch_size, &call.verdict);
                 let state_for_embed = Arc::clone(&embed_state);
                 let is_artifact = pending == 0;
                 let reset_on_index_error = !index_reset_triggered;
@@ -4910,6 +5046,10 @@ pub async fn run_with_authority_on(
                         // Progress makes the next coverage gap a new question,
                         // so a gap that once looked unclosable gets asked again.
                         backfilled_gap = None;
+                        // This worker has now established a settled footprint to
+                        // anchor against, which is what a later refusal for
+                        // memory needs before it may admit anything.
+                        completed_a_batch = true;
                         embed_pass.reset_retries();
                         info!(count, remaining = remaining.saturating_sub(count), label);
                         // Serialize successive flushes: the previous batch's
@@ -8271,10 +8411,12 @@ fn budget_no_test_can_fill() -> kin_core::test_env::EnvVarGuard {
 mod memory_pressure_tests {
     use super::{
         clear_pressure_refusal_for_work, decide_sweep_on_start, embed_batch_under_pressure,
-        embedding_coverage_is_complete, pressure_announcement_after_retirement,
-        pressure_refusal_matches_work, pressure_refusal_needs_disclosure, pressure_verdict,
-        queue_embedding_backfill_under_pressure, retire_embed_pressure_for_unavailable_persistence,
-        sample_tree_footprint, start_or_defer_background_embed, tree_footprint_from, ProcessRow,
+        embed_wake_decision, embedding_coverage_is_complete,
+        pressure_announcement_after_retirement, pressure_refusal_matches_work,
+        pressure_refusal_needs_disclosure, pressure_verdict,
+        queue_embedding_backfill_under_pressure, refused_embed_batch,
+        retire_embed_pressure_for_unavailable_persistence, sample_tree_footprint,
+        start_or_defer_background_embed, tree_footprint_from, EmbedWakeDecision, ProcessRow,
         SweepStartDecision,
     };
     // Gated exactly like its only caller, the walk test that spawns a real
@@ -8284,7 +8426,10 @@ mod memory_pressure_tests {
     #[cfg(unix)]
     use super::walk_process_table;
     use crate::state::DaemonState;
-    use kin_core::memory_pressure::{HeavyWork, PressureLevel, PressureRefusal, Verdict};
+    use kin_core::memory_pressure::{
+        admit_refused_embed, BudgetObservation, HeavyWork, PressureLevel, PressureRefusal,
+        RefusedEmbedAdmission, RefusedEmbedState, Verdict, REFUSED_EMBED_GROWTH_TOLERANCE_BYTES,
+    };
     use kin_core::test_env::EnvVarGuard;
     use kin_model::EntityStore;
 
@@ -9424,6 +9569,185 @@ mod memory_pressure_tests {
              machine"
         );
         assert_eq!(embed_batch_under_pressure(512, &call.verdict), 128);
+    }
+
+    /// The wake sequence the pure rule cannot grade, driven through the caller.
+    ///
+    /// The rule returning `Hold` is worth nothing if the composition around it
+    /// runs a batch anyway, and that is the defect this pins: an anchored tree
+    /// whose footprint sample fails on a nominal host produces a combined
+    /// `Proceed`, so a break guarded on the disclosure alone never fires and the
+    /// worker spends a FULL batch with no measured recovery behind it.
+    ///
+    /// This drives the extracted composition, not a live daemon. It grades the
+    /// decision the worker makes from the rule's answer; it does not prove the
+    /// worker is wired to this function.
+    #[test]
+    fn an_anchored_worker_does_not_resume_full_batches_on_a_reading_it_did_not_get() {
+        const CONFIGURED: usize = 512;
+        const ANCHOR: u64 = 7_194_070_384;
+        let refuse = Verdict::Refuse {
+            reason: String::new(),
+        };
+
+        // Wake 1: the first refusal after a completed batch. Anchor and hold.
+        let (state, admission) = admit_refused_embed(
+            RefusedEmbedState::Clear,
+            BudgetObservation::Refused { held_bytes: ANCHOR },
+            PressureLevel::Elevated,
+            true,
+            REFUSED_EMBED_GROWTH_TOLERANCE_BYTES,
+        );
+        assert_eq!(state, RefusedEmbedState::Anchored(ANCHOR));
+        assert_eq!(
+            embed_wake_decision(true, admission, state, &refuse, CONFIGURED),
+            EmbedWakeDecision::Hold,
+            "the anchoring wake runs nothing"
+        );
+
+        // Wake 2: the reading fails. The combined verdict on a nominal host is
+        // Proceed, so nothing refuses and nothing is disclosed. The worker must
+        // still hold, because it is over its budget and just learned nothing.
+        let (state, admission) = admit_refused_embed(
+            state,
+            BudgetObservation::Unobserved,
+            PressureLevel::Nominal,
+            true,
+            REFUSED_EMBED_GROWTH_TOLERANCE_BYTES,
+        );
+        assert_eq!(
+            state,
+            RefusedEmbedState::Anchored(ANCHOR),
+            "an unobserved wake carries the anchor forward"
+        );
+        assert_eq!(
+            embed_wake_decision(false, admission, state, &Verdict::Proceed, CONFIGURED),
+            EmbedWakeDecision::Hold,
+            "a daemon known to be over its budget must not run a full batch because \
+             its own footprint sample failed"
+        );
+
+        // Wake 3: a sample lands above the ORIGINAL anchor. Latch, still hold.
+        let (state, admission) = admit_refused_embed(
+            state,
+            BudgetObservation::Refused {
+                held_bytes: ANCHOR + REFUSED_EMBED_GROWTH_TOLERANCE_BYTES + 1,
+            },
+            PressureLevel::Elevated,
+            true,
+            REFUSED_EMBED_GROWTH_TOLERANCE_BYTES,
+        );
+        assert_eq!(
+            state,
+            RefusedEmbedState::Latched,
+            "growth is measured against the original anchor, not a moved one"
+        );
+        assert_eq!(
+            embed_wake_decision(true, admission, state, &refuse, CONFIGURED),
+            EmbedWakeDecision::Hold
+        );
+
+        // Wake 4: latched, and the reading fails again on a nominal host. Still
+        // no batch.
+        let (state, admission) = admit_refused_embed(
+            state,
+            BudgetObservation::Unobserved,
+            PressureLevel::Nominal,
+            true,
+            REFUSED_EMBED_GROWTH_TOLERANCE_BYTES,
+        );
+        assert_eq!(state, RefusedEmbedState::Latched);
+        assert_eq!(
+            embed_wake_decision(false, admission, state, &Verdict::Proceed, CONFIGURED),
+            EmbedWakeDecision::Hold,
+            "a latched runaway is not released by a gap in sampling"
+        );
+    }
+
+    /// The two arms that must still run, or the test above passes by breaking
+    /// embedding outright.
+    #[test]
+    fn a_settled_tree_runs_a_floor_batch_and_an_unrefused_one_runs_a_full_batch() {
+        const CONFIGURED: usize = 512;
+        const ANCHOR: u64 = 7_194_070_384;
+        let refuse = Verdict::Refuse {
+            reason: String::new(),
+        };
+
+        // Settled and anchored on a machine with room: a floor batch.
+        let (state, admission) = admit_refused_embed(
+            RefusedEmbedState::Anchored(ANCHOR),
+            BudgetObservation::Refused { held_bytes: ANCHOR },
+            PressureLevel::Elevated,
+            true,
+            REFUSED_EMBED_GROWTH_TOLERANCE_BYTES,
+        );
+        assert_eq!(admission, RefusedEmbedAdmission::AdmitFloorBatch);
+        assert_eq!(
+            embed_wake_decision(true, admission, state, &refuse, CONFIGURED),
+            EmbedWakeDecision::Run(32),
+            "the whole point of the change: a settled tree keeps converging"
+        );
+
+        // Never refused, nothing anchored: the ordinary verdict governs and the
+        // batch is the configured size, exactly as before this change.
+        let (state, admission) = admit_refused_embed(
+            RefusedEmbedState::Clear,
+            BudgetObservation::Recovered {
+                held_bytes: 5_153_960_755,
+            },
+            PressureLevel::Nominal,
+            true,
+            REFUSED_EMBED_GROWTH_TOLERANCE_BYTES,
+        );
+        assert_eq!(state, RefusedEmbedState::Clear);
+        assert_eq!(
+            embed_wake_decision(false, admission, state, &Verdict::Proceed, CONFIGURED),
+            EmbedWakeDecision::Run(CONFIGURED),
+            "an unrefused worker is untouched by any of this"
+        );
+    }
+
+    /// The step an anchored refusal is allowed, and why it is not the shrink.
+    ///
+    /// A pass that reaches this path is already past its budget, so it is asked
+    /// to converge rather than to go fast: a quarter of the elevated shrink, 32
+    /// against the configured 512 the measured container ran. The floor of one
+    /// is the same floor the shrink keeps, because a size knob that reaches zero
+    /// is a silent refusal wearing an admission's name.
+    #[test]
+    fn an_anchored_refusal_runs_a_smaller_batch_than_a_shrink() {
+        let refuse = Verdict::Refuse {
+            reason: String::new(),
+        };
+        // The trap this pins. `embed_batch_under_pressure` hands a refusal its
+        // configured size back unchanged, because before this path existed a
+        // refusal never reached a batch at all. An admitted refusal that took
+        // that number would run a FULL batch on a tree already past its budget,
+        // which is worse than the stall it replaces.
+        assert_eq!(embed_batch_under_pressure(512, &refuse), 512);
+        assert!(
+            refused_embed_batch(512) < embed_batch_under_pressure(512, &refuse),
+            "an admitted refusal must never take the unshrunk configured size"
+        );
+        assert_eq!(refused_embed_batch(512), 32);
+        assert!(
+            refused_embed_batch(512)
+                < embed_batch_under_pressure(
+                    512,
+                    &Verdict::Shrink {
+                        reason: String::new()
+                    }
+                ),
+            "and it must be smaller than the elevated shrink, which is 128 here"
+        );
+        assert_eq!(refused_embed_batch(8), 1);
+        assert_eq!(refused_embed_batch(1), 1);
+        assert_eq!(
+            refused_embed_batch(0),
+            1,
+            "a batch of zero embeds nothing for ever"
+        );
     }
 
     #[test]


### PR DESCRIPTION
FIR-3268.

## What this fixes

A repo daemon in a 12 GiB container derives a 6.0 GiB footprint budget, idles at 4.8 GiB, and
comes out of its **first** completed embedding batch holding 6.7 GiB, because an embedding pass
leaves the model and index it loaded resident for the next one. 6.7 against 6.0 is critical, and
critical for `EmbedBatch` is `Verdict::Refuse`. So every later batch in that process is refused, on
a five-second wake, for the life of the daemon. The refusal cannot end on its own either: what put
the tree over its budget is the state the next batch would reuse, so waiting reclaims nothing.

Measured on a stranger run of the shipped v0.7.1 npm bytes, importing `psf/requests` into a
12 GiB / 5 CPU container. From that container's own daemon log:

```
13:29:25  hold 4.8 GiB of the 6.0 GiB it is allowed   pressure="elevated" batch=128 configured=512
13:57:24  hold 4.9 GiB of the 6.0 GiB it is allowed   pressure="elevated" batch=128 configured=512
14:00:25  hold 4.8 GiB of the 6.0 GiB it is allowed   pressure="elevated" batch=128 configured=512
14:03:01  count=128 remaining=1594 label="embedded entities"
14:03:46  hold 6.7 GiB of the 6.0 GiB it is allowed; that is 706 MiB past the allowance,
          so background embedding did not start   work="embed-batch" pressure="critical"
```

4.8 / 6.0 = 0.80, which is the elevated bar, which shrinks the batch from 512 to 128. 6.7 / 6.0 =
1.12, which is the critical bar. The 14:03:46 sample is 45 seconds after the batch's own completion
line, so it is the post-batch steady state and not a peak sampled mid-pass. The store stopped 128
vectors into a 1722-entity backlog and nothing on any surface said it would not resume: the second
and every later refusal is suppressed by the disclosure latch, so the log holds one line and then
ten minutes of silence, and the sentence it holds ends "Kin resumes this work on its own once there
is room."

## The rule

`admit_refused_embed` asks the question one sample cannot: has the tree grown **since** the refusal
began.

- The first refusal after a completed batch anchors what was held, and still holds that wake.
- Later wakes at or below anchor + `REFUSED_EMBED_GROWTH_TOLERANCE_BYTES` run a floor-size batch.
- The first sample above it latches, and only the level leaving critical clears the latch.

The anchor never moves while it stands, so total growth under refusal is bounded by the tolerance
however many wakes pass, and the guard stays pointed at the runaway growth it was written for.

`REFUSED_EMBED_GROWTH_TOLERANCE_BYTES` is 64 MiB and it is the whole cost of the rule. It has to
clear per-wake sampling jitter on a daemon with language servers and a reconcile loop live under it,
or the rule latches on its own noise and changes nothing. It has to stay small against the smallest
budget the derivation can produce, or a rule meant to let a stuck store converge becomes a licence
to grow. 64 MiB is 6% of `DERIVED_BUDGET_FLOOR_BYTES` and about 1% of the 6.0 GiB budget this
container derived.

Two conservative guards beyond that. A worker that has never completed a batch in this process
keeps today's behaviour and refuses, because it has not established that its footprint is a settled
cost rather than a rising one. And an unmeasurable footprint admits nothing, because a rule that
cannot see growth must not licence any.

`refused_embed_batch` is `configured / 16` with a floor of one, so 32 against the 512 this container
ran, a quarter of the elevated shrink. A pass on this path is already past its budget and is asked
to converge rather than to go fast.

## Verification

Local, on this branch. Commands and their actual output tails, because none of this is checked by
anything on the PR surface.

`cargo test -p kin-core -p kin-daemon --lib -- memory_pressure`, through
`.kin-coord/bin/heavy-slot.sh`:

```
test result: ok. 62 passed; 0 failed; 0 ignored; 0 measured; 811 filtered out    (kin-core)
test result: ok. 33 passed; 0 failed; 0 ignored; 0 measured; 1421 filtered out   (kin-daemon)
heavy-slot: embedplateau command exit rc=0 at 2026-09-05T16:07:17Z
```

`bin/kin-precheck kin --repo-dir kin=<this worktree>`:

```
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 21 gates ran, 21 passed, 0 failed
```

### Falsification

Every rule here was broken on purpose and the test written for it had to fail. Five mutations, each
changing an implementation, never an assertion.

Disabling the admission arm:

```
test memory_pressure::tests::a_tree_that_settled_above_its_budget_keeps_draining ... FAILED
assertion `left == right` failed: wake 0: a tree that is not growing must keep converging
rc=101
```

Letting an admitted refusal take the unshrunk configured size failed
`an_anchored_refusal_runs_a_smaller_batch_than_a_shrink`, `rc=101`.

Turning `host_leaves_room` to always-true and reading `Unobserved` as recovery, together:

```
test memory_pressure::tests::a_settled_tree_with_unreadable_headroom_stays_refused ... FAILED
test memory_pressure::tests::a_settled_tree_on_a_critical_machine_stays_refused ... FAILED
test memory_pressure::tests::an_unobserved_wake_cannot_clear_a_latch ... FAILED
test memory_pressure::tests::an_unobserved_wake_cannot_move_the_anchor ... FAILED
test result: FAILED. 58 passed; 4 failed
```

58 untouched is what makes those four evidence rather than noise.

Reverting `embed_wake_decision` to honour only the disclosure, which is what the caller did before
this change:

```
test daemon::memory_pressure_tests::an_anchored_worker_does_not_resume_full_batches_on_a_reading_it_did_not_get ... FAILED
assertion `left == right` failed: a daemon known to be over its budget must not run a full batch
because its own footprint sample failed
test result: FAILED. 32 passed; 1 failed
rc=101
```

### What the tests do not cover

`embed_wake_decision` is graded as a composition, driven as a wake sequence. It is not a live-daemon
test and it does not prove the worker is wired to that function; the worker is an async block inside
`run_with_authority_on` that a test cannot drive. The end-to-end behaviour is what a rerun of the
stranger container would show.

Acceptance does not grade this PR. `Product Acceptance` carries
`if: ${{ github.event_name != 'pull_request' }}`, so these are crate tests by design, per AGENTS.md.

### Post-mutant rerun, on this exact head

Every rule above was deliberately broken and restored during review. A green taken before that
sequence says nothing about the tree that ships, so this is the restored tree at
`19714f9250aa8f803241c7c056ee7356ecaef0df`, `git status --porcelain` empty, re-verified to carry no
mutant residue (each real predicate present, each mutated form absent, counted rather than eyeballed).

`cargo test -p kin-core -p kin-daemon --lib -- memory_pressure`, through
`.kin-coord/bin/heavy-slot.sh` with `CARGO_TARGET_DIR` pinned to this lane's own directory:

```
test result: ok. 62 passed; 0 failed; 0 ignored; 0 measured; 811 filtered out    (kin-core)
test result: ok. 33 passed; 0 failed; 0 ignored; 0 measured; 1421 filtered out   (kin-daemon)
heavy-slot: embedplateau command exit rc=0 at 2026-09-05T16:25:16Z
```

All ten tests added here were confirmed present in that run by name, not inferred from the totals.
