### PR TITLE
Resolve a commit's baseline without building a graph it drops (FIR-3263)

### DIFF
--- a/crates/kin-daemon/src/commit_deltas.rs
+++ b/crates/kin-daemon/src/commit_deltas.rs
@@ -57,6 +57,95 @@ pub fn compute_deltas_vs_last_commit(
     compute_deltas_from_resolved_state(graph, committed)
 }
 
+/// Resolve the graph at one change out of persisted authority, without
+/// building a graph to throw away.
+///
+/// The commit planner needs the parent's entities, relations and tree so it can
+/// diff the live graph against them. It used to get them by cloning the
+/// authority snapshot, constructing a whole `InMemoryGraph` from it, calling
+/// `resolve_graph_at` once, and dropping the graph. Constructing it was not
+/// free. `from_snapshot` rebuilds a lexical index over every entity, which
+/// nothing here searches, and an authority snapshot always arrives with
+/// `entity_revisions` cleared (kin-db clears them on purpose, because a
+/// repository with multiple refs has no single revision view), which selects
+/// the branch that derives entity revisions across the entire history. Neither
+/// result reaches the delta this returns.
+///
+/// Measured on one repository at two history depths, six files and twenty-five
+/// entities either way: at 5 changes the commit took 0.43 s and 52.2 MiB of
+/// daemon resident set, and at 2000 changes the same edit produced the same 6
+/// entities and 143 relations while taking 7.57 s and 166.2 MiB. The 1995 extra
+/// changes changed no output.
+///
+/// Two arms, in cost order, and the second is not a degraded mode. The
+/// materialized section is authority's own memo of this exact resolution and is
+/// refreshed at the change that becomes the next commit's parent, by
+/// `refresh_workspace_base_graph_section` after every native commit and by
+/// `kin init`. When it answers, nothing decodes the change map at all. When it
+/// does not, folding the history is always available beside it and is always
+/// correct; a refusal can only ever cost time. Amend is the recurring miss and
+/// misses correctly, because it resolves at the amended change's own parent
+/// rather than at the workspace base the section names.
+///
+/// Public so the heap-ceiling guard can measure both arms against the
+/// graph-building path in the same process, which is the only way its ceiling is
+/// evidence rather than an arbitrary constant.
+pub fn resolve_authority_baseline(
+    authority_snapshot: &GraphSnapshot,
+    parent: &SemanticChangeId,
+) -> Result<ResolvedGraphState> {
+    match baseline_from_materialized_section(authority_snapshot, parent) {
+        Ok(state) => Ok(state),
+        Err(refusal) => {
+            tracing::debug!(
+                %parent,
+                %refusal,
+                "the materialized graph section did not answer for this commit's parent, so the \
+                 baseline folds from history instead"
+            );
+            baseline_from_history(authority_snapshot, parent)
+        }
+    }
+}
+
+/// Authority's own memo of `resolve_graph_at` at exactly this change.
+///
+/// Deliberately no re-derivation to check the memo. Recomputing the resolution
+/// to decide whether to trust a memo of the resolution would pay the whole cost
+/// this avoids and conclude what the change id already proves: a change id
+/// hashes every immutable field including `parents`, so naming the change names
+/// its complete ancestry and therefore the graph. This mirrors kin-db's own
+/// provider for the same section rather than inventing a second policy.
+fn baseline_from_materialized_section(
+    authority_snapshot: &GraphSnapshot,
+    parent: &SemanticChangeId,
+) -> std::result::Result<ResolvedGraphState, kin_db::MaterializedGraphRefusal> {
+    let section = authority_snapshot
+        .materialized_graph
+        .as_ref()
+        .ok_or(kin_db::MaterializedGraphRefusal::Absent)?;
+    section.validate_for(parent)?;
+    Ok(section.state.clone())
+}
+
+/// Fold the parent out of persisted history, borrowing the change map.
+///
+/// `resolve_graph_at` reaches its store through `get_change` and nothing else
+/// (`kin_model::graph::collect_changes_first_parent`), so the graph this used to
+/// construct served one lookup loop. Borrowing does still decode the change map,
+/// because `ChangeMap` derefs through `force()`; what it drops is the throwaway
+/// graph, its lexical index, and the whole-history entity-revision derivation.
+fn baseline_from_history(
+    authority_snapshot: &GraphSnapshot,
+    parent: &SemanticChangeId,
+) -> Result<ResolvedGraphState> {
+    crate::state::HostedAuthorityHistory {
+        changes: &authority_snapshot.changes,
+    }
+    .resolve_graph_at(parent)
+    .map_err(DaemonError::Graph)
+}
+
 /// Diff the live admitted graph against one repository-v6 authority lease.
 ///
 /// The baseline comes exclusively from the persisted semantic history. The
@@ -69,14 +158,7 @@ pub fn compute_deltas_vs_repository_authority(
     parent: Option<&SemanticChangeId>,
 ) -> Result<CommitDeltas> {
     let committed = match parent {
-        Some(parent) => {
-            let mut snapshot = authority_snapshot.clone();
-            snapshot.repository_authority = None;
-            InMemoryGraph::from_snapshot(snapshot)
-                .map_err(DaemonError::Graph)?
-                .resolve_graph_at(parent)
-                .map_err(DaemonError::Graph)?
-        }
+        Some(parent) => resolve_authority_baseline(authority_snapshot, parent)?,
         None => ResolvedGraphState {
             entities: Default::default(),
             relations: Default::default(),
@@ -2404,6 +2486,188 @@ mod tests {
                 new: reprovenanced,
             }],
             "a moved payload must reach the published change, not the workspace overlay"
+        );
+    }
+
+    // ── The commit baseline: which arm answered, and do they agree ──
+    //
+    // `resolve_authority_baseline` has two arms and they must return the same
+    // graph. These fixtures make WHICH arm answered observable, because an
+    // equality assertion alone cannot tell a section hit from a fallback that
+    // happened to agree. The section here is given a state history cannot
+    // reproduce, purely so the test can read the answer's provenance off its
+    // content; a real section is authority's own memo of the same fold.
+
+    fn baseline_entity(name: &str) -> Entity {
+        Entity {
+            id: kin_model::EntityId::new(),
+            kind: EntityKind::Function,
+            name: name.to_string(),
+            language: LanguageId::Rust,
+            fingerprint: SemanticFingerprint {
+                algorithm: FingerprintAlgorithm::V1TreeSitter,
+                ast_hash: Hash256::from_bytes([1; 32]),
+                signature_hash: Hash256::from_bytes([2; 32]),
+                behavior_hash: Hash256::from_bytes([3; 32]),
+                equivalence_hash: Hash256::from_bytes([0; 32]),
+                stability_score: 1.0,
+            },
+            file_origin: Some(FilePathId::new("src/lib.rs")),
+            span: None,
+            signature: format!("fn {name}()"),
+            visibility: Visibility::Public,
+            role: kin_model::EntityRole::Source,
+            doc_summary: None,
+            metadata: EntityMetadata::default(),
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        }
+    }
+
+    fn baseline_change(
+        parent: Option<SemanticChangeId>,
+        entity_deltas: Vec<EntityDelta>,
+    ) -> kin_model::SemanticChange {
+        let mut change = kin_model::SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([0; 32])),
+            origin: kin_model::ChangeOrigin::Native,
+            parents: parent.into_iter().collect(),
+            timestamp: Timestamp::from(
+                chrono::DateTime::parse_from_rfc3339("2026-09-05T12:00:00Z")
+                    .unwrap()
+                    .with_timezone(&chrono::Utc),
+            ),
+            author: AuthorId::new("relchurn"),
+            message: "baseline fixture".to_string(),
+            entity_deltas,
+            relation_deltas: Vec::new(),
+            tree_deltas: Vec::new(),
+            admission_policy_delta: None,
+            projected_files: Vec::new(),
+            spec_link: None,
+            evidence: Vec::new(),
+            risk_summary: None,
+            external_reference_deltas: Vec::new(),
+        };
+        change.id = kin_model::compute_semantic_change_id(&change).unwrap();
+        change
+    }
+
+    /// A snapshot shaped like the one a commit holds: several linear changes
+    /// carrying entity deltas, and `entity_revisions` cleared, which is what
+    /// repository authority always does to them.
+    fn authority_like_snapshot(depth: usize) -> (GraphSnapshot, SemanticChangeId) {
+        let graph = InMemoryGraph::new();
+        let mut head = None;
+        let mut carried: Option<Entity> = None;
+        for index in 0..depth {
+            let deltas = match carried.take() {
+                None => {
+                    let entity = baseline_entity(&format!("seed_{index}"));
+                    carried = Some(entity.clone());
+                    vec![EntityDelta::Added { new: entity }]
+                }
+                Some(previous) => {
+                    let mut next = previous.clone();
+                    next.signature = format!("fn seed_{index}()");
+                    carried = Some(next.clone());
+                    vec![EntityDelta::Modified {
+                        old: previous,
+                        new: next,
+                    }]
+                }
+            };
+            let change = baseline_change(head, deltas);
+            graph.create_change(&change).unwrap();
+            head = Some(change.id);
+        }
+        if let Some(entity) = carried {
+            graph.upsert_entity(&entity).unwrap();
+        }
+        let mut snapshot = graph.to_snapshot();
+        snapshot.repository_authority = None;
+        snapshot.entity_revisions.clear();
+        (snapshot, head.expect("depth is at least one change"))
+    }
+
+    /// The pre-change baseline path, kept here as the reference the two arms
+    /// are measured against rather than as production code.
+    fn baseline_by_building_a_graph(
+        snapshot: &GraphSnapshot,
+        head: &SemanticChangeId,
+    ) -> ResolvedGraphState {
+        let mut owned = snapshot.clone();
+        owned.repository_authority = None;
+        InMemoryGraph::from_snapshot(owned)
+            .unwrap()
+            .resolve_graph_at(head)
+            .unwrap()
+    }
+
+    fn marked_section(
+        resolved_at: SemanticChangeId,
+        mut state: ResolvedGraphState,
+    ) -> kin_db::MaterializedGraphSection {
+        let marker = baseline_entity("only_a_section_can_answer_with_this");
+        state.entities.insert(marker.id, marker);
+        kin_db::MaterializedGraphSection {
+            schema_version: kin_db::MATERIALIZED_GRAPH_SCHEMA_VERSION,
+            resolved_at,
+            state,
+        }
+    }
+
+    #[test]
+    fn folding_history_returns_what_building_a_graph_returned() {
+        let (snapshot, head) = authority_like_snapshot(6);
+        let expected = baseline_by_building_a_graph(&snapshot, &head);
+
+        let folded = baseline_from_history(&snapshot, &head).unwrap();
+
+        assert_eq!(folded.entities, expected.entities);
+        assert_eq!(folded.relations, expected.relations);
+        assert_eq!(folded.tree, expected.tree);
+        // The reference is not vacuous: this fixture resolves real entities.
+        assert!(
+            !expected.entities.is_empty(),
+            "a fixture that resolves to nothing would let any implementation pass"
+        );
+    }
+
+    #[test]
+    fn a_section_at_the_parent_answers_without_folding_history() {
+        let (mut snapshot, head) = authority_like_snapshot(6);
+        let folded = baseline_from_history(&snapshot, &head).unwrap();
+        snapshot.materialized_graph = Some(Arc::new(marked_section(head, folded.clone())));
+
+        let resolved = resolve_authority_baseline(&snapshot, &head).unwrap();
+
+        assert_eq!(
+            resolved.entities.len(),
+            folded.entities.len() + 1,
+            "the section arm must have answered; a fallback would have dropped its marker"
+        );
+    }
+
+    #[test]
+    fn a_section_at_another_change_falls_back_and_still_answers() {
+        let (mut snapshot, head) = authority_like_snapshot(6);
+        let folded = baseline_from_history(&snapshot, &head).unwrap();
+        let stale = SemanticChangeId::from_hash(Hash256::from_bytes([0x5a; 32]));
+        assert_ne!(stale, head, "the stale target must not be the parent");
+        snapshot.materialized_graph = Some(Arc::new(marked_section(stale, folded.clone())));
+
+        let resolved = resolve_authority_baseline(&snapshot, &head).unwrap();
+
+        assert_eq!(
+            resolved.entities, folded.entities,
+            "a section naming another change must be refused, not trusted"
+        );
+        assert_eq!(
+            resolved.entities.len(),
+            folded.entities.len(),
+            "the marker proves the refused section did not answer"
         );
     }
 }

--- a/crates/kin-daemon/src/commit_deltas.rs
+++ b/crates/kin-daemon/src/commit_deltas.rs
@@ -20,6 +20,7 @@
 //! already reflects the current working state — diffing against the DAG
 //! baseline captures exactly what changed since the last commit.
 
+use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use kin_db::{GraphSnapshot, InMemoryGraph};
@@ -54,7 +55,7 @@ pub fn compute_deltas_vs_last_commit(
     let committed = graph
         .resolve_graph_at(branch_head)
         .map_err(DaemonError::Graph)?;
-    compute_deltas_from_resolved_state(graph, committed)
+    compute_deltas_from_resolved_state(graph, &committed)
 }
 
 /// Resolve the graph at one change out of persisted authority, without
@@ -90,12 +91,12 @@ pub fn compute_deltas_vs_last_commit(
 /// Public so the heap-ceiling guard can measure both arms against the
 /// graph-building path in the same process, which is the only way its ceiling is
 /// evidence rather than an arbitrary constant.
-pub fn resolve_authority_baseline(
-    authority_snapshot: &GraphSnapshot,
+pub fn resolve_authority_baseline<'a>(
+    authority_snapshot: &'a GraphSnapshot,
     parent: &SemanticChangeId,
-) -> Result<ResolvedGraphState> {
+) -> Result<Cow<'a, ResolvedGraphState>> {
     match baseline_from_materialized_section(authority_snapshot, parent) {
-        Ok(state) => Ok(state),
+        Ok(state) => Ok(Cow::Borrowed(state)),
         Err(refusal) => {
             tracing::debug!(
                 %parent,
@@ -103,7 +104,7 @@ pub fn resolve_authority_baseline(
                 "the materialized graph section did not answer for this commit's parent, so the \
                  baseline folds from history instead"
             );
-            baseline_from_history(authority_snapshot, parent)
+            baseline_from_history(authority_snapshot, parent).map(Cow::Owned)
         }
     }
 }
@@ -116,16 +117,16 @@ pub fn resolve_authority_baseline(
 /// hashes every immutable field including `parents`, so naming the change names
 /// its complete ancestry and therefore the graph. This mirrors kin-db's own
 /// provider for the same section rather than inventing a second policy.
-fn baseline_from_materialized_section(
-    authority_snapshot: &GraphSnapshot,
+fn baseline_from_materialized_section<'a>(
+    authority_snapshot: &'a GraphSnapshot,
     parent: &SemanticChangeId,
-) -> std::result::Result<ResolvedGraphState, kin_db::MaterializedGraphRefusal> {
+) -> std::result::Result<&'a ResolvedGraphState, kin_db::MaterializedGraphRefusal> {
     let section = authority_snapshot
         .materialized_graph
         .as_ref()
         .ok_or(kin_db::MaterializedGraphRefusal::Absent)?;
     section.validate_for(parent)?;
-    Ok(section.state.clone())
+    Ok(&section.state)
 }
 
 /// Fold the parent out of persisted history, borrowing the change map.
@@ -159,7 +160,7 @@ pub fn compute_deltas_vs_repository_authority(
 ) -> Result<CommitDeltas> {
     let committed = match parent {
         Some(parent) => resolve_authority_baseline(authority_snapshot, parent)?,
-        None => ResolvedGraphState {
+        None => Cow::Owned(ResolvedGraphState {
             entities: Default::default(),
             relations: Default::default(),
             entity_revisions: Default::default(),
@@ -167,9 +168,9 @@ pub fn compute_deltas_vs_repository_authority(
             entity_tombstones: Default::default(),
             relation_tombstones: Default::default(),
             external_references: HashMap::new(),
-        },
+        }),
     };
-    compute_deltas_from_resolved_state(graph, committed)
+    compute_deltas_from_resolved_state(graph, &committed)
 }
 
 /// Build the complete derived-graph transition for one selected-path checkout.
@@ -516,7 +517,7 @@ fn checkout_path_contains(selected: &RepoPath, path: &RepoPath) -> bool {
 
 fn compute_deltas_from_resolved_state(
     graph: &InMemoryGraph,
-    committed: ResolvedGraphState,
+    committed: &ResolvedGraphState,
 ) -> Result<CommitDeltas> {
     // One coherent live snapshot keeps entity, relation, and exact-tree deltas
     // on the same graph generation.

--- a/crates/kin-daemon/src/commit_deltas.rs
+++ b/crates/kin-daemon/src/commit_deltas.rs
@@ -2649,6 +2649,24 @@ mod tests {
             folded.entities.len() + 1,
             "the section arm must have answered; a fallback would have dropped its marker"
         );
+        // Equality is not enough here, and this is the assertion that matters.
+        // A section arm that went back to handing out `section.state.clone()`
+        // would return a value equal to this one in every field, so every
+        // assertion above would still pass while the copy this change exists to
+        // remove was back. Only the borrow itself distinguishes them.
+        assert!(
+            matches!(resolved, Cow::Borrowed(_)),
+            "the section arm must borrow its answer; an owned value means the clone came back"
+        );
+        let section_state: *const ResolvedGraphState = &snapshot
+            .materialized_graph
+            .as_ref()
+            .expect("the fixture installed a section")
+            .state;
+        assert!(
+            std::ptr::eq(&*resolved, section_state),
+            "the borrow must point at the section's own state, not at a copy of it"
+        );
     }
 
     #[test]

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -38,14 +38,19 @@ use crate::error::{DaemonError, Result};
 use crate::hosted_start;
 use crate::session_registry::SessionCoordinator;
 
-/// Borrowed immutable history used to materialize a hosted repository ref.
+/// Borrowed immutable history for resolving a change out of persisted
+/// authority without building a graph to throw away.
 ///
 /// Repository-v6 snapshots intentionally leave their top-level graph domains
 /// empty. `ChangeStore::resolve_graph_at` needs only `get_change`, so borrowing
 /// the admitted change map avoids cloning the payload-heavy history into a
 /// throwaway graph before every hosted load.
-struct HostedAuthorityHistory<'a> {
-    changes: &'a HashMap<SemanticChangeId, SemanticChange>,
+///
+/// `pub(crate)` for the second caller with that same shape: the native commit
+/// planner resolves its baseline at the parent change and reads nothing else
+/// from the graph it was building for it (`commit_deltas.rs`).
+pub(crate) struct HostedAuthorityHistory<'a> {
+    pub(crate) changes: &'a HashMap<SemanticChangeId, SemanticChange>,
 }
 
 impl HostedAuthorityHistory<'_> {

--- a/crates/kin-daemon/tests/commit_baseline_heap_ceiling.rs
+++ b/crates/kin-daemon/tests/commit_baseline_heap_ceiling.rs
@@ -37,9 +37,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use kin_daemon::commit_deltas::resolve_authority_baseline;
 use kin_db::{GraphSnapshot, InMemoryGraph};
 use kin_model::{
-    ChangeStore, Entity, EntityDelta, EntityKind, EntityMetadata, EntityStore,
-    FingerprintAlgorithm, FilePathId, Hash256, LanguageId, SemanticChangeId, SemanticFingerprint,
-    Timestamp, Visibility,
+    ChangeStore, Entity, EntityDelta, EntityKind, EntityMetadata, EntityStore, FilePathId,
+    FingerprintAlgorithm, Hash256, LanguageId, SemanticChangeId, SemanticFingerprint, Timestamp,
+    Visibility,
 };
 
 static LIVE: AtomicUsize = AtomicUsize::new(0);
@@ -187,7 +187,9 @@ fn change(
 /// selects the expensive branch in `InMemoryGraph::from_snapshot`.
 fn authority_like_snapshot() -> (GraphSnapshot, SemanticChangeId) {
     let graph = InMemoryGraph::new();
-    let mut live: Vec<Entity> = (0..ENTITIES).map(|i| entity(&format!("seed_{i}"))).collect();
+    let mut live: Vec<Entity> = (0..ENTITIES)
+        .map(|i| entity(&format!("seed_{i}")))
+        .collect();
 
     let seeded = change(
         None,

--- a/crates/kin-daemon/tests/commit_baseline_heap_ceiling.rs
+++ b/crates/kin-daemon/tests/commit_baseline_heap_ceiling.rs
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Live-heap ceiling for resolving a commit's baseline out of authority.
+//!
+//! Planning a native commit needs the parent change's entities, relations and
+//! tree. It used to get them by cloning the authority snapshot, constructing a
+//! whole `InMemoryGraph` from it, calling `resolve_graph_at` once, and dropping
+//! the graph. That construction is not free and none of its cost reaches the
+//! delta: it rebuilds a lexical index over every entity that nothing here
+//! searches, and because an authority snapshot always arrives with
+//! `entity_revisions` cleared, it also derives entity revisions across the
+//! entire history, which kin-db's own comment calls the largest thing a
+//! conversion's workspace lap does.
+//!
+//! The guard measures live heap rather than resident set, following
+//! `kin-core/tests/init_peak_heap_ceiling.rs`: RSS keeps counting pages the
+//! allocator has not returned to the OS, so it is reproducible only within one
+//! allocator and one platform, while live heap moves when and only when the
+//! code allocates differently.
+//!
+//! The ceiling is evidence only because the same binary measures the path it
+//! replaced. A bare "stays under N bytes" assertion would pass for reasons
+//! unrelated to this change and would keep passing if the throwaway graph came
+//! back. So the graph-building path runs here too, on the same fixture, and
+//! must exceed the ceiling. If that control ever stops exceeding it, the
+//! ceiling has stopped meaning anything and this test says so rather than
+//! reporting a pass.
+//!
+//! This binary installs a counting global allocator, so it holds exactly one
+//! test on purpose: the counters are process-wide and a second test running
+//! beside it would charge its allocations here.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use kin_daemon::commit_deltas::resolve_authority_baseline;
+use kin_db::{GraphSnapshot, InMemoryGraph};
+use kin_model::{
+    ChangeStore, Entity, EntityDelta, EntityKind, EntityMetadata, EntityStore,
+    FingerprintAlgorithm, FilePathId, Hash256, LanguageId, SemanticChangeId, SemanticFingerprint,
+    Timestamp, Visibility,
+};
+
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+
+fn live() -> usize {
+    LIVE.load(Ordering::SeqCst)
+}
+
+fn peak() -> usize {
+    PEAK.load(Ordering::SeqCst)
+}
+
+/// Drop the high-water mark to what is live now, so the fixture's own
+/// allocation is not charged to the path under measurement.
+fn reset_peak() {
+    PEAK.store(LIVE.load(Ordering::SeqCst), Ordering::SeqCst);
+}
+
+struct Counting;
+
+fn charge(bytes: usize) {
+    let live = LIVE.fetch_add(bytes, Ordering::Relaxed) + bytes;
+    PEAK.fetch_max(live, Ordering::Relaxed);
+}
+
+// SAFETY: every branch forwards to the system allocator with the same pointer
+// and layout it was given, and only adjusts counters around that call.
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() {
+            charge(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc_zeroed(layout) };
+        if !ptr.is_null() {
+            charge(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
+        unsafe { System.dealloc(ptr, layout) };
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let fresh = unsafe { System.realloc(ptr, layout, new_size) };
+        if !fresh.is_null() {
+            if new_size >= layout.size() {
+                charge(new_size - layout.size());
+            } else {
+                LIVE.fetch_sub(layout.size() - new_size, Ordering::Relaxed);
+            }
+        }
+        fresh
+    }
+}
+
+#[global_allocator]
+static ALLOC: Counting = Counting;
+
+/// Changes in the fixture history.
+///
+/// The cost this guards is changes multiplied by entity deltas per change, so
+/// the fixture buys both: every change here carries an entity delta, which is
+/// the shape a real repository has and the shape a churn-only history does not.
+/// Measured on four local fixtures, a history whose changes carry no entity
+/// deltas costs materially less than one of a fifth the depth whose changes do.
+const CHANGES: usize = 400;
+
+/// Distinct entities the history advances, rotating.
+///
+/// 224 and 400 are not round numbers picked for size. They are the shape of the
+/// local fixture that convicted this cost in the first place, whose commit ran
+/// 4.79 s at 178.4 MiB of daemon resident set while a fixture of the same graph
+/// at five changes ran 0.43 s at 52.2 MiB. Matching that shape keeps the guard
+/// measuring the case that was actually observed rather than one tuned to make
+/// the gap look wide.
+const ENTITIES: usize = 224;
+
+fn entity(name: &str) -> Entity {
+    Entity {
+        id: kin_model::EntityId::new(),
+        kind: EntityKind::Function,
+        name: name.to_string(),
+        language: LanguageId::Rust,
+        fingerprint: SemanticFingerprint {
+            algorithm: FingerprintAlgorithm::V1TreeSitter,
+            ast_hash: Hash256::from_bytes([1; 32]),
+            signature_hash: Hash256::from_bytes([2; 32]),
+            behavior_hash: Hash256::from_bytes([3; 32]),
+            equivalence_hash: Hash256::from_bytes([0; 32]),
+            stability_score: 1.0,
+        },
+        file_origin: Some(FilePathId::new("src/lib.rs")),
+        span: None,
+        signature: format!("fn {name}()"),
+        visibility: Visibility::Public,
+        role: kin_model::EntityRole::Source,
+        doc_summary: None,
+        metadata: EntityMetadata::default(),
+        lineage_parent: None,
+        created_in: None,
+        superseded_by: None,
+    }
+}
+
+fn change(
+    parent: Option<SemanticChangeId>,
+    entity_deltas: Vec<EntityDelta>,
+) -> kin_model::SemanticChange {
+    let mut change = kin_model::SemanticChange {
+        id: SemanticChangeId::from_hash(Hash256::from_bytes([0; 32])),
+        origin: kin_model::ChangeOrigin::Native,
+        parents: parent.into_iter().collect(),
+        timestamp: Timestamp::from(
+            chrono::DateTime::parse_from_rfc3339("2026-09-05T12:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+        ),
+        author: kin_model::AuthorId::new("relchurn"),
+        message: "heap fixture".to_string(),
+        entity_deltas,
+        relation_deltas: Vec::new(),
+        tree_deltas: Vec::new(),
+        admission_policy_delta: None,
+        projected_files: Vec::new(),
+        spec_link: None,
+        evidence: Vec::new(),
+        risk_summary: None,
+        external_reference_deltas: Vec::new(),
+    };
+    change.id = kin_model::compute_semantic_change_id(&change).expect("fixture change id");
+    change
+}
+
+/// A snapshot shaped like the one a commit holds: a linear history whose every
+/// change carries an entity delta, with `entity_revisions` cleared, which is
+/// what repository authority always does to them and is the condition that
+/// selects the expensive branch in `InMemoryGraph::from_snapshot`.
+fn authority_like_snapshot() -> (GraphSnapshot, SemanticChangeId) {
+    let graph = InMemoryGraph::new();
+    let mut live: Vec<Entity> = (0..ENTITIES).map(|i| entity(&format!("seed_{i}"))).collect();
+
+    let seeded = change(
+        None,
+        live.iter()
+            .cloned()
+            .map(|new| EntityDelta::Added { new })
+            .collect(),
+    );
+    graph.create_change(&seeded).expect("seed change");
+    let mut head = Some(seeded.id);
+
+    for step in 1..CHANGES {
+        let slot = step % ENTITIES;
+        let old = live[slot].clone();
+        let mut new = old.clone();
+        new.signature = format!("fn seed_{slot}_r{step}()");
+        live[slot] = new.clone();
+        let advanced = change(head, vec![EntityDelta::Modified { old, new }]);
+        graph.create_change(&advanced).expect("advancing change");
+        head = Some(advanced.id);
+    }
+
+    for entity in &live {
+        graph.upsert_entity(entity).expect("live entity");
+    }
+    let mut snapshot = graph.to_snapshot();
+    snapshot.repository_authority = None;
+    snapshot.entity_revisions.clear();
+    (snapshot, head.expect("the fixture has a head"))
+}
+
+/// The path this change replaced, kept as the control the ceiling is read
+/// against.
+fn baseline_by_building_a_graph(snapshot: &GraphSnapshot, head: &SemanticChangeId) -> usize {
+    let mut owned = snapshot.clone();
+    owned.repository_authority = None;
+    let resolved = InMemoryGraph::from_snapshot(owned)
+        .expect("control graph")
+        .resolve_graph_at(head)
+        .expect("control resolution");
+    resolved.entities.len()
+}
+
+#[test]
+fn resolving_a_commit_baseline_does_not_pay_for_a_graph_it_drops() {
+    let (snapshot, head) = authority_like_snapshot();
+
+    reset_peak();
+    let before = live();
+    let folded = resolve_authority_baseline(&snapshot, &head).expect("baseline");
+    let borrowed_peak = peak() - before;
+    assert_eq!(
+        folded.entities.len(),
+        ENTITIES,
+        "the fixture must resolve every live entity, or the measurement is of nothing"
+    );
+    drop(folded);
+
+    reset_peak();
+    let before = live();
+    let control_entities = baseline_by_building_a_graph(&snapshot, &head);
+    let graph_peak = peak() - before;
+    assert_eq!(
+        control_entities, ENTITIES,
+        "the control must resolve the same graph, or it is not a control"
+    );
+
+    eprintln!("borrowed_peak_bytes={borrowed_peak} graph_peak_bytes={graph_peak}");
+
+    assert!(
+        borrowed_peak < PEAK_HEAP_CEILING,
+        "resolving the baseline allocated {borrowed_peak} bytes, over the {PEAK_HEAP_CEILING} \
+         ceiling; the throwaway graph, its lexical index or the whole-history revision \
+         derivation is being paid for again"
+    );
+    assert!(
+        graph_peak > PEAK_HEAP_CEILING,
+        "the control allocated {graph_peak} bytes, which does not exceed the {PEAK_HEAP_CEILING} \
+         ceiling, so this ceiling no longer separates the two paths and is not evidence; \
+         re-measure both and reset it rather than trusting the pass above"
+    );
+}
+
+/// Ceiling on live heap for resolving one commit's baseline.
+///
+/// Measured on this fixture, both arms in the same process on the same host:
+/// resolving the baseline peaked at 1_610_386 bytes and the graph-building path
+/// it replaced peaked at 2_808_080. The ceiling sits between them with roughly
+/// symmetric margin, about 30 percent of headroom under it and about 34 percent
+/// of overshoot above it, so neither side is one allocation away from flipping.
+///
+/// Be precise about what this catches and what it does not. It is a floor under
+/// gross regressions, not proof that no copy came back. The gap it reads is
+/// 1.2 MB on a 400-change, 224-entity fixture, so a change that reintroduced a
+/// copy materially smaller than the whole graph build would pass it, and any
+/// change to this path still needs its own measurement rather than a green tick
+/// here. The number is also from one host and one allocator; it is set this wide
+/// partly because that determinism has only been observed on macOS while this
+/// suite also runs on Linux and Windows.
+const PEAK_HEAP_CEILING: usize = 2_100_000;


### PR DESCRIPTION
Planning a native commit resolved its baseline by cloning the authority snapshot, building a whole
`InMemoryGraph` from it, calling `resolve_graph_at` once, and dropping the graph. None of that
construction reaches the delta. It rebuilds a lexical index over every entity that nothing on this
path searches, and because an authority snapshot always arrives with `entity_revisions` cleared, it
also derives entity revisions across the entire history, which kin-db's own comment calls the
largest thing a conversion's workspace lap does.

`resolve_authority_baseline` now has two arms in cost order. The first takes authority's own memo of
this exact resolution, `materialized_graph`, validates it with kin-db's public
`MaterializedGraphSection::validate_for`, and touches the change map not at all. The second folds the
parent out of history through a borrowed change-map view, which is what `resolve_graph_at` actually
needs, since it reaches its store through `get_change` and nothing else. The fallback is not a
degraded mode: the history the section memoizes sits in the same file, so a refusal can only ever
cost time. Amend is the recurring miss and misses correctly, because it resolves at the amended
change's own parent rather than at the workspace base the section names.

A second commit stops the section arm copying what it hands back. `section.state.clone()` was
copying the whole `ResolvedGraphState`, including the `entity_revisions` the delta never reads and
which kin-db measured at 173.8 MiB on a converted store. Doing that properly takes three edits
rather than one, because a function that sometimes borrows and sometimes owns has to say so in its
type: the section arm returns a reference, `resolve_authority_baseline` returns
`Cow<'_, ResolvedGraphState>`, and `compute_deltas_from_resolved_state` takes its baseline by
reference. Changing only the parameter would have left the clone exactly where it was.

`HostedAuthorityHistory` in `state.rs` becomes `pub(crate)`; it already existed for the hosted load
path with a doc comment naming this exact problem. Its name no longer fits both callers and renaming
it would touch a use site outside this change, so that is left as a follow-up.

## Why, measured

Four local fixtures, one repository shape varied along two axes, built from this checkout's own
binaries.

| Arm | Entities | Changes | Changes carry entity deltas | Commit output | Wall | Peak RSS |
|---|---|---|---|---|---|---|
| control | 25 | 5 | n/a | 6 entities, 143 relations | 0.43 s | 52.2 MiB |
| bigraph | 844 | 5 | n/a | 3 entities, 3330 relations | 0.64 s | 168.8 MiB |
| bigdag | 25 | 2000 | no | 6 entities, 143 relations | 7.57 s | 166.2 MiB |
| dagsrc | 224 | 400 | yes | 3 entities, 813 relations | 4.79 s | 178.4 MiB |

`bigdag` is `control` with a deeper history and nothing else changed: same files, same 25 entities,
same 190 relations, same edit, and a byte-identical commit output. It costs 3.2x the memory and
17.6x the wall time. Those 1995 extra changes change no output.

`dagsrc` carries the highest peak of the four with 3.8x fewer entities than `bigraph` and 5x fewer
changes than `bigdag`. Neither axis alone explains it; what it has is the product, 400 changes that
each carry entity deltas, which is exactly the cost model of
`derive_entity_revisions_across_history`.

These are resident-set numbers and therefore shape evidence, not an allocation delta. The citable
before-and-after is live heap, below.

## Context: what the relation counts on these commits actually are

FIR-3203 recorded a 27-line docstring edit producing 3375 relation deltas on an imported
psf/requests store and read that as churn caused by the edit. It is not. Those deltas are the
language-server enrichment backlog the workspace had accumulated and never written to history, and
the first commit after a sweep publishes all of it whatever the edit is. This change does not fix
that; it fixes why such a commit is expensive. The counts are here so the numbers in this PR are not
misread as churn.

The enrichment publish and the commit report the same figure, from the same daemon log, in the same
unit. `published` is `semantic_delta.relation_deltas().len()`
(`crates/kin-daemon/src/state.rs:10534`):

```
$ grep "published language-server enrichment" requests/.kin/daemon.log
2026-09-05T13:27:00.912734Z  INFO kin_daemon::state: published language-server enrichment into
  workspace authority repo_id="0142a934-..." published=3375 generation=2

$ kin log
Deltas: entities=0 relations=3375 tree=1 policy=false
    Document the redirect flow in the sessions module docstring
```

The express arm separates the two terms, because its reconcile landed before its commit:

```
$ grep "published language-server enrichment" express/.kin/daemon.log
2026-09-05T13:45:14.333386Z  INFO kin_daemon::state: ... published=1255 generation=2

$ kin commit -m "Document app.handle as the express-to-router boundary"
Created semantic change c8b8f330... on branch 'refs/heads/master'
  (21 entities, 1277 relations, 1 artifacts)
```

1277 minus 1255 is 22. **On express, 22 of 1277 relation deltas came from the edit and 1255 were
backlog. On requests, 0 of 3375 came from the edit**, because that commit planned before its file
was reconciled.

## The citable figure: live heap

Resident set is a high-water mark of pages the allocator has not returned, so it is reproducible
only within one allocator and one platform. The before-and-after therefore comes from a counting
global allocator, both arms in the same process on the same fixture, following the shape
`kin-core/tests/init_peak_heap_ceiling.rs` already uses.

```
$ cargo test -p kin-daemon --test commit_baseline_heap_ceiling -- --nocapture
borrowed_peak_bytes=1610386 graph_peak_bytes=2808080
```

1,610,386 bytes resolving the baseline, against 2,808,080 for the graph-building path it replaced.
A 1.20 MB reduction, 1.74x, on a fixture of 224 entities and 400 changes each carrying an entity
delta, which is the shape of the local arm that convicted the cost.

That figure is the fallback arm, folding history through the borrowed view, against the old graph
build. It is not the section arm, which the fixture does not exercise and which does strictly less
work again. Guarding the worst case is deliberate: the guard has to hold when the section refuses,
not only when it hits.

## Guards

Three crate tests in `commit_deltas.rs`, which `ci.yml` grades on this pull request, plus one
heap-ceiling binary.

- `folding_history_returns_what_building_a_graph_returned`: the borrowed view returns what the
  replaced path returned. It also asserts the fixture resolves a non-empty graph, since a fixture
  resolving to nothing would let any implementation pass.
- `a_section_at_the_parent_answers_without_folding_history`: the section arm actually answered. Its
  fixture section carries an entity history cannot produce, so the test reads the answer's
  provenance off its content rather than assuming equality implies a hit.
- `a_section_at_another_change_falls_back_and_still_answers`: a section naming another change is
  refused and the fold answers instead, with that marker's absence as the proof.
- `crates/kin-daemon/tests/commit_baseline_heap_ceiling.rs`: one test in its own binary, because the
  counting allocator is process-wide. Its ceiling is evidence only because the same binary runs the
  replaced path on the same fixture and asserts that path exceeds the ceiling. If the control ever
  stops exceeding it, the test fails saying the ceiling has stopped separating the two paths, rather
  than reporting a pass.

The ceiling is a floor under gross regressions, not proof no copy came back. The gap it reads is
1.2 MB, so a change reintroducing a copy materially smaller than the whole graph build would pass
it, and any change to this path still needs its own measurement.

No automated check here proves the absence of a change-map decode on the section arm. That would
need a snapshot whose `ChangeMap` is still encoded, which means a store on disk and a reopen; an
in-memory fixture has a decoded map from the start, so `is_decoded()` would be true in both arms and
prove nothing. The marker test above is the evidence that the fold did not run, and the fold is the
only thing on this path that touches the change map.

## Follow-up, not in this change

`HostedAuthorityHistory` is no longer hosted-specific. Renaming it would touch a use site outside
this change, so it keeps its name here.

## Falsification

Each guard was made to fail, one mutation at a time, each reverted before the next, with a final
byte-comparison that the tree came back.

Restoring the throwaway graph inside the fold arm:

```
borrowed_peak_bytes=2807528 graph_peak_bytes=2807416
panicked at crates/kin-daemon/tests/commit_baseline_heap_ceiling.rs:260:5:
  resolving the baseline allocated 2807528 bytes, over the 2100000 ceiling
test result: FAILED. 0 passed; 1 failed; 0 ignored
exit 101
```

Under that mutation the measured arm and the control are the same code, and they read 2,807,528 and
2,807,416, 112 bytes apart. That is the stronger half of the result: it says the 1.2 MB the
unmutated test reports is the graph construction and nothing else.

Dropping `section.validate_for(parent)?`, so any section is trusted:

```
assertion `left == right` failed: a section naming another change must be refused, not trusted
test result: FAILED. 0 passed; 1 failed; 0 ignored; 1445 filtered out
exit 101
```

Never consulting the section, always folding:

```
assertion `left == right` failed: the section arm must have answered; a fallback would have
  dropped its marker
test result: FAILED. 0 passed; 1 failed; 0 ignored; 1445 filtered out
exit 101
```

Every arm failed on its own assertion rather than on a compile error, which is the distinction that
matters. The tree was byte-compared against the copy taken before the first mutation and came back
identical.

Review found one more gap, and it was the one that mattered. Every assertion above would still have
passed if `section.state.clone()` came back: the section arm's value equals the fold's in every
field, and the heap ceiling cannot see it because its fixture carries no section. So the copy this
change exists to remove had no guard. The provenance test now asserts `Cow::Borrowed` and, with
`std::ptr::eq`, that the borrow points at the section's own state. Falsified with the regression a
refactor would actually write:

```
the section arm must borrow its answer; an owned value means the clone came back
test result: FAILED. 29 passed; 1 failed; 0 ignored; 1416 filtered out
exit 101
```

**Twenty-nine of the thirty passed under that mutant.** One assertion sees it.

Restored and rerun on the same tree: `30 passed; 0 failed`, exit 0.

## Local gates

```
cargo test -p kin-daemon
  ten test-result lines, all ok; 1494 passed, 0 failed
  exit 0
```

## What was not verified here

Local gates and this measurement are the author's own; hosted CI is the gate of record for the full
workspace, and on this repository acceptance grades main's push run rather than a pull request. The
commands above are pasted with their actual output tails rather than described, because a claim CI
does not itself check has no other witness.
