### PR TITLE
Stop certifying a reference site count that is only a floor (FIR-3267)

### DIFF
--- a/crates/kin-cli/tests/reference_call_site_lines.rs
+++ b/crates/kin-cli/tests/reference_call_site_lines.rs
@@ -108,17 +108,25 @@ struct IndexedFixtureFile {
     entities: Vec<Entity>,
     same_file_relations: Vec<Relation>,
     artifact_id: ArtifactId,
+    /// This file's real content digest, carried so the tree entry admitting the
+    /// artifact names the same bytes the index was given. `kin_model::Hash256`
+    /// is a re-export of `kin_blobs::Hash256`, so one value serves both.
+    blob_hash: Hash256,
 }
 
 fn index_files(fixture: &Fixture) -> Vec<IndexedFixtureFile> {
     let pipeline = IndexPipeline::new();
-    let blob_hash = kin_blobs::Hash256::from_bytes([0u8; 32]);
     [
         (fixture.defs_path, fixture.defs_source),
         (fixture.caller_path, fixture.caller_source),
     ]
     .into_iter()
     .map(|(path, source)| {
+        // The file's real content digest, per file, not a shared zero hash. The
+        // daemon checks that the digest matches the bytes it indexed, so a
+        // placeholder is a fixture that stops resembling the product the moment
+        // that check tightens. The same value goes into the tree entry below.
+        let blob_hash = kin_blobs::digest(source.as_bytes());
         let indexed = pipeline
             .index_file_content_with_tests(&FilePathId::new(path), source.as_bytes(), blob_hash)
             .unwrap_or_else(|error| panic!("{} index {path}: {error}", fixture.language))
@@ -133,6 +141,7 @@ fn index_files(fixture: &Fixture) -> Vec<IndexedFixtureFile> {
             entities: indexed.entities,
             same_file_relations: indexed.relations,
             artifact_id: ArtifactId::new(),
+            blob_hash,
         }
     })
     .collect()
@@ -195,17 +204,16 @@ fn graph_with(files: &[IndexedFixtureFile], linked: &[Relation]) -> InMemoryGrap
     // refuses them at the write. A transaction carrying a `TreeDelta::Added`
     // is the product's own admission path.
     for file in files {
-        let mut seed = [0u8; 32];
-        for (slot, byte) in seed.iter_mut().zip(file.parse.file_path.as_bytes()) {
-            *slot = *byte;
-        }
         graph
             .apply_transaction_delta(&TransactionDelta {
                 tree_deltas: vec![TreeDelta::Added {
                     artifact_id: file.artifact_id,
                     new: LocatedEntry::new(
                         RepoPath::from_utf8(&file.parse.file_path).expect("fixture path is utf-8"),
-                        TreeEntry::blob(Hash256::from_bytes(seed), false),
+                        // The file's own content digest, the same one the index
+                        // was given. It was the path bytes padded with zeros,
+                        // which is a value no blob store would ever hold.
+                        TreeEntry::blob(file.blob_hash, false),
                     ),
                 }],
                 ..TransactionDelta::default()

--- a/crates/kin-cli/tests/reference_site_completeness.rs
+++ b/crates/kin-cli/tests/reference_site_completeness.rs
@@ -32,8 +32,11 @@
 use std::collections::HashMap;
 
 use kin_db::InMemoryGraph;
-use kin_index::linker::ArtifactIdentityMap;
-use kin_index::{FileParseData, IndexPipeline};
+use kin_index::linker::{ArtifactIdentityMap, IncrementalLinker};
+use kin_index::{
+    link_cross_file_incremental_with_completeness, FileParseCompletenessMap, FileParseData,
+    IndexPipeline,
+};
 use kin_model::{
     ArtifactId, Entity, EntityStore, FilePathId, GraphNodeId, Hash256, LocatedEntry, Relation,
     RelationEvidence, RelationId, RelationKind, RelationOrigin, RepoPath, SourceSpan,
@@ -349,5 +352,92 @@ async fn a_function_level_caller_lists_every_site_and_certifies_them() {
         body["counts"]["reference_sites_complete"],
         serde_json::json!(true),
         "a complete site set must still be able to say complete: {body:#}"
+    );
+}
+
+/// The linker's own incompleteness marker floors the row, and the sites it did
+/// record all survive.
+///
+/// Producer-backed rather than hand-stamped: the completeness map is the
+/// linker's input, so passing `ParseCompleteness::Partial` for the caller file
+/// makes `call_shape_evidence` emit `call_shape_incomplete_parse_v1` and
+/// `relation_evidence` write each call site's span ONTO that marker record.
+/// Every byte of the evidence under test is what the real linker produced.
+///
+/// The shape is the one an origin check cannot see: five real, correct lines
+/// beside the producer's own statement that the parse it read them from was not
+/// exhaustive. Listing all five and still refusing to certify is the honest
+/// answer, and it is what this asserts.
+#[tokio::test]
+async fn a_recovered_parse_floors_the_row_while_keeping_every_site_it_recorded() {
+    let sites = call_site_lines(FUNCTION_LEVEL_CALLER);
+    assert_eq!(sites.len(), 5, "the fixture must write five calls");
+
+    let files = index_files(FUNCTION_LEVEL_CALLER);
+    let mut linker = IncrementalLinker::new();
+    for file in &files {
+        linker.add_file(&file.parse.file_path, file.artifact_id, &file.entities);
+    }
+    // The one input that changes: this file's parse was recovered, not full.
+    let completeness: FileParseCompletenessMap = files
+        .iter()
+        .map(|file| {
+            let state = if file.parse.file_path == CALLER_PATH {
+                kin_model::ParseCompleteness::Partial("fixture: recovered parse".to_string())
+            } else {
+                kin_model::ParseCompleteness::Full
+            };
+            (file.parse.file_path.clone(), state)
+        })
+        .collect();
+    let batch: Vec<FileParseData> = files.iter().map(|file| file.parse.clone()).collect();
+    let linked = link_cross_file_incremental_with_completeness(&batch, &linker, &completeness)
+        .expect("incremental cross-file linking");
+    let graph = graph_with(&files, &linked);
+
+    let target = entity_in(&files, DEFS_PATH, "setCharset").clone();
+    let body = find_references(&graph, &target).await;
+    let rows = body["references"]
+        .as_array()
+        .unwrap_or_else(|| panic!("references array: {body:#}"));
+    let row = rows
+        .iter()
+        .find(|row| row["name"] == "run")
+        .unwrap_or_else(|| panic!("no row for caller `run`: {body:#}"));
+
+    // Non-vacuity for the fixture itself: if the marker never reached the graph
+    // this asserts nothing, so the evidence is read back from the linker's own
+    // output rather than assumed.
+    let marked = linked.iter().any(|relation| {
+        relation.evidence.iter().any(|evidence| {
+            evidence.parser_rule.as_deref()
+                == Some(kin_index::linker::CALL_SHAPE_EVIDENCE_INCOMPLETE_PARSE_V1)
+                && evidence.source_span.is_some()
+        })
+    });
+    assert!(
+        marked,
+        "the linker must have stamped the incomplete-parse marker onto a spanned record, or \
+         this fixture proves nothing"
+    );
+
+    assert_eq!(
+        row["reference_lines"],
+        serde_json::json!(sites),
+        "every site the recovered parse did record must still be reported: {row:#}"
+    );
+    assert_eq!(
+        row["reference_lines_partial_reason"], "incomplete_call_evidence",
+        "the linker said the parse was short, so the answer must not certify: {row:#}"
+    );
+    assert_eq!(
+        body["counts"]["reference_sites"],
+        serde_json::Value::Null,
+        "a site total over incomplete evidence is not a number: {body:#}"
+    );
+    assert_eq!(
+        body["counts"]["reference_sites_complete"],
+        serde_json::json!(false),
+        "{body:#}"
     );
 }

--- a/crates/kin-cli/tests/reference_site_completeness.rs
+++ b/crates/kin-cli/tests/reference_site_completeness.rs
@@ -1,0 +1,353 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! A reference answer that claims its site list is complete must actually hold
+//! every site.
+//!
+//! `find_references` answered express's `setCharset` with three referencing
+//! entities, `reference_sites: 3`, `known_reference_sites: 3`,
+//! `reference_sites_complete: true` and verdict `certified`, while
+//! `test/utils.js` alone calls it on lines 50, 54, 58, 62 and 66. That file
+//! holds exactly one entity, so it was not a per-entity split. Two things
+//! produced it, and only the second is fixed here:
+//!
+//! 1. The site list really was short. The JavaScript adapter reaches
+//!    `extract_calls_from_context` only from named-declaration arms of
+//!    `extract_js_node` (`kin-parser/src/languages/javascript.rs:1489`), so a
+//!    module-level statement records no call edge, and express's tests are
+//!    `describe`/`it` at module level. The row that did come back came from
+//!    language-server enrichment, which keeps
+//!    `CallHierarchyOutgoingCall.from_ranges.first()` and drops the rest
+//!    (kin-lsp `src/enrichment.rs:292`). Both are scoped follow-ups.
+//! 2. The answer CERTIFIED that short list. `reference_sites_complete` asked
+//!    only whether every returned row carried at least one line, which a row
+//!    holding one of five satisfies, so a reader could not tell an undercount
+//!    from a small repository.
+//!
+//! So this asserts the invariant rather than either number: an answer either
+//! lists every site, or does not claim its site set is complete. It goes red on
+//! the flag this fixes and stays green when the two producers above are fixed,
+//! because then the five lines are all there.
+
+use std::collections::HashMap;
+
+use kin_db::InMemoryGraph;
+use kin_index::linker::ArtifactIdentityMap;
+use kin_index::{FileParseData, IndexPipeline};
+use kin_model::{
+    ArtifactId, Entity, EntityStore, FilePathId, GraphNodeId, Hash256, LocatedEntry, Relation,
+    RelationEvidence, RelationId, RelationKind, RelationOrigin, RepoPath, SourceSpan,
+    TransactionDelta, TreeDelta, TreeEntry,
+};
+
+/// The definition every fixture calls. Written as a plain declaration so the
+/// adapter yields a `setCharset` function entity to point `find_references` at.
+const DEFS: &str = "function setCharset(type, charset) {\n\
+                    \x20 return charset ? type : type;\n\
+                    }\n\
+                    \n\
+                    module.exports = { setCharset };\n";
+
+/// express's `test/utils.js` in miniature: one module entity, five calls at
+/// module level, each inside an `it(...)` callback, each on its own line.
+const MODULE_LEVEL_CALLER: &str = "var utils = require('../lib/utils');\n\
+                                   \n\
+                                   describe('the charset helper', function () {\n\
+                                   \x20 it('a', function () {\n\
+                                   \x20   utils.setCharset();\n\
+                                   \x20 });\n\
+                                   \n\
+                                   \x20 it('b', function () {\n\
+                                   \x20   utils.setCharset('text/html');\n\
+                                   \x20 });\n\
+                                   \n\
+                                   \x20 it('c', function () {\n\
+                                   \x20   utils.setCharset('text/plain');\n\
+                                   \x20 });\n\
+                                   \n\
+                                   \x20 it('d', function () {\n\
+                                   \x20   utils.setCharset('text/xml');\n\
+                                   \x20 });\n\
+                                   \n\
+                                   \x20 it('e', function () {\n\
+                                   \x20   utils.setCharset('text/css');\n\
+                                   \x20 });\n\
+                                   });\n";
+
+/// The same five calls inside a named function, which is the shape the adapter
+/// does extract. The positive control: here the graph holds every site, so the
+/// answer must both list all five and certify them.
+const FUNCTION_LEVEL_CALLER: &str = "var utils = require('../lib/utils');\n\
+                                     \n\
+                                     function run() {\n\
+                                     \x20 utils.setCharset();\n\
+                                     \x20 utils.setCharset('text/html');\n\
+                                     \x20 utils.setCharset('text/plain');\n\
+                                     \x20 utils.setCharset('text/xml');\n\
+                                     \x20 utils.setCharset('text/css');\n\
+                                     }\n";
+
+const DEFS_PATH: &str = "lib/utils.js";
+const CALLER_PATH: &str = "test/utils.js";
+
+/// The 1-based lines the calls are written on, read off the fixture source so
+/// editing the fixture cannot leave the expectation behind.
+fn call_site_lines(source: &str) -> Vec<u32> {
+    source
+        .lines()
+        .enumerate()
+        .filter(|(_, line)| line.contains("utils.setCharset("))
+        .map(|(index, _)| index as u32 + 1)
+        .collect()
+}
+
+struct IndexedFile {
+    parse: FileParseData,
+    entities: Vec<Entity>,
+    same_file_relations: Vec<Relation>,
+    artifact_id: ArtifactId,
+}
+
+fn index_files(caller_source: &str) -> Vec<IndexedFile> {
+    let pipeline = IndexPipeline::new();
+    let blob_hash = kin_blobs::Hash256::from_bytes([0u8; 32]);
+    [(DEFS_PATH, DEFS), (CALLER_PATH, caller_source)]
+        .into_iter()
+        .map(|(path, source)| {
+            let indexed = pipeline
+                .index_file_content_with_tests(&FilePathId::new(path), source.as_bytes(), blob_hash)
+                .unwrap_or_else(|error| panic!("index {path}: {error}"))
+                .indexed_file;
+            IndexedFile {
+                parse: FileParseData {
+                    file_path: path.to_string(),
+                    entities: indexed.entities.clone(),
+                    relations: indexed.extracted_relations,
+                    imports: indexed.imports,
+                },
+                entities: indexed.entities,
+                same_file_relations: indexed.relations,
+                artifact_id: ArtifactId::new(),
+            }
+        })
+        .collect()
+}
+
+fn link(files: &[IndexedFile]) -> Vec<Relation> {
+    let pipeline = IndexPipeline::new();
+    let mut artifact_ids = ArtifactIdentityMap::new();
+    for file in files {
+        artifact_ids.insert(file.parse.file_path.clone(), file.artifact_id);
+    }
+    let parses: Vec<FileParseData> = files.iter().map(|file| file.parse.clone()).collect();
+    pipeline
+        .resolve_cross_file(&parses, &artifact_ids)
+        .expect("cross-file linking")
+}
+
+/// The graph both fixtures are asked, with every entity span removed.
+///
+/// The non-vacuity control: with no definition line in the graph, any line a
+/// reference row reports can only have come from a relation's own evidence.
+fn graph_with(files: &[IndexedFile], linked: &[Relation]) -> InMemoryGraph {
+    let graph = InMemoryGraph::new();
+    for file in files {
+        let mut seed = [0u8; 32];
+        for (slot, byte) in seed.iter_mut().zip(file.parse.file_path.as_bytes()) {
+            *slot = *byte;
+        }
+        graph
+            .apply_transaction_delta(&TransactionDelta {
+                tree_deltas: vec![TreeDelta::Added {
+                    artifact_id: file.artifact_id,
+                    new: LocatedEntry::new(
+                        RepoPath::from_utf8(&file.parse.file_path).expect("fixture path is utf-8"),
+                        TreeEntry::blob(Hash256::from_bytes(seed), false),
+                    ),
+                }],
+                ..TransactionDelta::default()
+            })
+            .expect("admit fixture artifact");
+    }
+    for file in files {
+        for entity in &file.entities {
+            let mut entity = entity.clone();
+            entity.span = None;
+            graph.upsert_entity(&entity).unwrap();
+        }
+        for relation in &file.same_file_relations {
+            graph.upsert_relation(relation).unwrap();
+        }
+    }
+    for relation in linked {
+        graph.upsert_relation(relation).unwrap();
+    }
+    graph
+}
+
+fn entity_in<'a>(files: &'a [IndexedFile], path: &str, name: &str) -> &'a Entity {
+    files
+        .iter()
+        .find(|file| file.parse.file_path == path)
+        .unwrap_or_else(|| panic!("indexed file {path}"))
+        .entities
+        .iter()
+        .find(|entity| entity.name == name)
+        .unwrap_or_else(|| panic!("entity `{name}` in {path}"))
+}
+
+async fn find_references(graph: &InMemoryGraph, target: &Entity) -> serde_json::Value {
+    let args = HashMap::from([(
+        "entity_id".to_string(),
+        serde_json::json!(target.id.to_string()),
+    )]);
+    let response = kin_mcp::handlers::entities::handle_find_references(&args, graph, None)
+        .await
+        .expect("find_references");
+    let kin_mcp::types::ContentBlock::Text { text } = response.content.first().unwrap();
+    serde_json::from_str(text).expect("find_references body is json")
+}
+
+/// The edge language-server enrichment writes for this caller: one relation for
+/// the whole (caller, callee, kind) pair, carrying exactly one site whatever the
+/// file holds.
+///
+/// Built here rather than by running a language server, because the collapse is
+/// in what kin-lsp stores, not in what the server answered: `enrich_entity_calls`
+/// keeps `call.from_ranges.first()` (kin-lsp `src/enrichment.rs:292`), so this is
+/// the shape the graph receives.
+fn language_server_call_edge(caller: &Entity, target: &Entity, first_site_line: u32) -> Relation {
+    Relation {
+        id: RelationId::new(),
+        kind: RelationKind::Calls,
+        src: GraphNodeId::Entity(caller.id),
+        dst: GraphNodeId::Entity(target.id),
+        confidence: 0.95,
+        origin: RelationOrigin::Lsp,
+        created_in: None,
+        import_source: None,
+        evidence: vec![RelationEvidence {
+            source_span: Some(SourceSpan {
+                file: FilePathId::new(CALLER_PATH),
+                start_byte: 0,
+                end_byte: 1,
+                // The graph convention is 0-based; the surface adds one.
+                start_line: first_site_line - 1,
+                start_col: 0,
+                end_line: first_site_line - 1,
+                end_col: 1,
+            }),
+            parser_rule: Some("lsp_call_hierarchy".to_string()),
+            ..RelationEvidence::default()
+        }],
+    }
+}
+
+/// The express shape: five call sites in one file with one entity, reachable
+/// only through the enrichment edge. The answer must not certify its site set.
+#[tokio::test]
+async fn a_module_level_caller_reached_only_by_enrichment_does_not_certify_its_sites() {
+    let sites = call_site_lines(MODULE_LEVEL_CALLER);
+    assert_eq!(
+        sites.len(),
+        5,
+        "the fixture must write five calls on five lines or it does not reproduce GAP-A"
+    );
+
+    let files = index_files(MODULE_LEVEL_CALLER);
+    let linked = link(&files);
+    let graph = graph_with(&files, &linked);
+
+    let target = entity_in(&files, DEFS_PATH, "setCharset").clone();
+    let caller = entity_in(&files, CALLER_PATH, "utils").clone();
+    graph
+        .upsert_relation(&language_server_call_edge(&caller, &target, sites[0]))
+        .unwrap();
+
+    let body = find_references(&graph, &target).await;
+    let rows = body["references"]
+        .as_array()
+        .unwrap_or_else(|| panic!("references array: {body:#}"));
+    let row = rows
+        .iter()
+        .find(|row| row["file_path"] == CALLER_PATH)
+        .unwrap_or_else(|| panic!("no row for {CALLER_PATH}: {body:#}"));
+
+    let reported: Vec<u32> = row["reference_lines"]
+        .as_array()
+        .unwrap_or_else(|| panic!("reference_lines array: {row:#}"))
+        .iter()
+        .map(|line| line.as_u64().expect("a site line is a number") as u32)
+        .collect();
+
+    // The invariant, stated once: every site, or no claim of completeness.
+    if reported != sites {
+        assert_eq!(
+            body["counts"]["reference_sites_complete"],
+            serde_json::json!(false),
+            "the row reports {reported:?} of the five sites at {sites:?}, so the answer must \
+             not claim its site set is complete: {body:#}"
+        );
+        assert_eq!(
+            body["counts"]["reference_sites"],
+            serde_json::Value::Null,
+            "a site total that is only a floor is not emitted as a number: {body:#}"
+        );
+        assert_eq!(
+            row["reference_lines_partial_reason"], "language_server_edge",
+            "a row whose sites are a floor must name why: {row:#}"
+        );
+    }
+
+    // Non-vacuity: the fixture removes entity spans, so any line above came from
+    // relation evidence rather than from a definition line.
+    assert_eq!(
+        row["start_line"],
+        serde_json::Value::Null,
+        "the fixture removes entity spans on purpose: {row:#}"
+    );
+    assert!(
+        !reported.is_empty(),
+        "the enrichment edge carries one site, so the row must not be empty: {row:#}"
+    );
+}
+
+/// The positive control, and the reason this is not a fix that marks every
+/// answer uncertain: the same five calls inside a named function are all
+/// recorded by the adapter, and that answer both lists them and certifies them.
+#[tokio::test]
+async fn a_function_level_caller_lists_every_site_and_certifies_them() {
+    let sites = call_site_lines(FUNCTION_LEVEL_CALLER);
+    assert_eq!(sites.len(), 5, "the control must also write five calls");
+
+    let files = index_files(FUNCTION_LEVEL_CALLER);
+    let linked = link(&files);
+    let graph = graph_with(&files, &linked);
+
+    let target = entity_in(&files, DEFS_PATH, "setCharset").clone();
+    let body = find_references(&graph, &target).await;
+    let rows = body["references"]
+        .as_array()
+        .unwrap_or_else(|| panic!("references array: {body:#}"));
+    let row = rows
+        .iter()
+        .find(|row| row["name"] == "run")
+        .unwrap_or_else(|| panic!("no row for caller `run`: {body:#}"));
+
+    assert_eq!(
+        row["reference_lines"],
+        serde_json::json!(sites),
+        "the adapter records each call site, so every one must be reported: {row:#}"
+    );
+    assert_eq!(row["reference_line_count"], 5);
+    assert_eq!(
+        row["reference_lines_partial_reason"],
+        serde_json::Value::Null,
+        "a parsed row holds every site the parse saw: {row:#}"
+    );
+    assert_eq!(
+        body["counts"]["reference_sites_complete"],
+        serde_json::json!(true),
+        "a complete site set must still be able to say complete: {body:#}"
+    );
+}

--- a/crates/kin-cli/tests/reference_site_completeness.rs
+++ b/crates/kin-cli/tests/reference_site_completeness.rs
@@ -113,10 +113,14 @@ struct IndexedFile {
 
 fn index_files(caller_source: &str) -> Vec<IndexedFile> {
     let pipeline = IndexPipeline::new();
-    let blob_hash = kin_blobs::Hash256::from_bytes([0u8; 32]);
     [(DEFS_PATH, DEFS), (CALLER_PATH, caller_source)]
         .into_iter()
         .map(|(path, source)| {
+            // The file's real content digest, per file, not a shared zero hash.
+            // The daemon checks that the digest matches the bytes it indexed, so
+            // a placeholder here is a fixture that stops resembling the product
+            // the moment that check tightens.
+            let blob_hash = kin_blobs::digest(source.as_bytes());
             let indexed = pipeline
                 .index_file_content_with_tests(&FilePathId::new(path), source.as_bytes(), blob_hash)
                 .unwrap_or_else(|error| panic!("index {path}: {error}"))

--- a/crates/kin-cli/tests/reference_site_completeness.rs
+++ b/crates/kin-cli/tests/reference_site_completeness.rs
@@ -109,6 +109,10 @@ struct IndexedFile {
     entities: Vec<Entity>,
     same_file_relations: Vec<Relation>,
     artifact_id: ArtifactId,
+    /// This file's real content digest, carried so the tree entry admitting the
+    /// artifact names the same bytes the index was given. `kin_model::Hash256`
+    /// is a re-export of `kin_blobs::Hash256`, so one value serves both.
+    blob_hash: Hash256,
 }
 
 fn index_files(caller_source: &str) -> Vec<IndexedFile> {
@@ -119,7 +123,9 @@ fn index_files(caller_source: &str) -> Vec<IndexedFile> {
             // The file's real content digest, per file, not a shared zero hash.
             // The daemon checks that the digest matches the bytes it indexed, so
             // a placeholder here is a fixture that stops resembling the product
-            // the moment that check tightens.
+            // the moment that check tightens. The same value goes into the tree
+            // entry below, so the fixture names one digest for one file's bytes
+            // rather than two unrelated stand-ins.
             let blob_hash = kin_blobs::digest(source.as_bytes());
             let indexed = pipeline
                 .index_file_content_with_tests(&FilePathId::new(path), source.as_bytes(), blob_hash)
@@ -135,6 +141,7 @@ fn index_files(caller_source: &str) -> Vec<IndexedFile> {
                 entities: indexed.entities,
                 same_file_relations: indexed.relations,
                 artifact_id: ArtifactId::new(),
+                blob_hash,
             }
         })
         .collect()
@@ -159,17 +166,16 @@ fn link(files: &[IndexedFile]) -> Vec<Relation> {
 fn graph_with(files: &[IndexedFile], linked: &[Relation]) -> InMemoryGraph {
     let graph = InMemoryGraph::new();
     for file in files {
-        let mut seed = [0u8; 32];
-        for (slot, byte) in seed.iter_mut().zip(file.parse.file_path.as_bytes()) {
-            *slot = *byte;
-        }
         graph
             .apply_transaction_delta(&TransactionDelta {
                 tree_deltas: vec![TreeDelta::Added {
                     artifact_id: file.artifact_id,
                     new: LocatedEntry::new(
                         RepoPath::from_utf8(&file.parse.file_path).expect("fixture path is utf-8"),
-                        TreeEntry::blob(Hash256::from_bytes(seed), false),
+                        // The file's own content digest, the same one the index
+                        // was given. It was the path bytes padded with zeros,
+                        // which is a value no blob store would ever hold.
+                        TreeEntry::blob(file.blob_hash, false),
                     ),
                 }],
                 ..TransactionDelta::default()

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -1752,8 +1752,8 @@ fn counted_for(tool: &str, payload: &Value) -> Option<Value> {
         counted["floor_reason"] = json!("receiver_name_candidates_withheld");
     }
     // The site numbers FIR-2398 added answer a narrower question than this
-    // object does: whether every RETURNED row could be located at a line, not
-    // whether the row set is whole. They are carried verbatim rather than folded
+    // object does: whether every RETURNED row's sites are whole, not whether the
+    // row set is whole. They are carried verbatim rather than folded
     // into `exact`, because collapsing the two is how a complete row set with one
     // unlocatable site would come to read as an incomplete answer.
     if let Some(sites) = payload.get("counts").and_then(|counts| {

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -1190,6 +1190,18 @@ pub enum ReferenceLinesPartial {
     /// others, so it cannot license a site total. An unrecognized origin lands
     /// here too, because a producer nobody has checked has made no promise.
     ProducerWithoutSiteContract,
+    /// An edge behind this row carries the linker's own marker saying the parse
+    /// or the call extraction that produced it was not exhaustive.
+    ///
+    /// `call_shape_incomplete_parse_v1` is stamped on evidence recovered from a
+    /// parse that was not fully valid, and `call_shape_incomplete_extraction_v1`
+    /// on a syntax-valid file whose adapter could not represent every call
+    /// expression. Both say sibling occurrences may have been omitted, in the
+    /// producer's own words. `relation_evidence` then writes the site span ONTO
+    /// that marker record rather than beside it, so such an edge arrives with a
+    /// real line and an explicit statement that the line is not the whole set:
+    /// the one shape a check reading only [`RelationOrigin`] cannot see.
+    IncompleteCallEvidence,
 }
 
 impl ReferenceLinesPartial {
@@ -1197,8 +1209,37 @@ impl ReferenceLinesPartial {
         match self {
             Self::LanguageServerEdge => "language_server_edge",
             Self::ProducerWithoutSiteContract => "producer_without_site_contract",
+            Self::IncompleteCallEvidence => "incomplete_call_evidence",
         }
     }
+
+    /// Which gap is the more useful one to report when a row has several.
+    ///
+    /// They all mean the same thing to a caller, that the lines are a floor, so
+    /// the only question is which names the most specific cause. An edge whose
+    /// own evidence declares the parse incomplete has said so outright, which
+    /// beats anything inferred from its producer; a measured one-site-per-edge
+    /// producer beats the general case of a producer nobody has checked.
+    fn specificity(self) -> u8 {
+        match self {
+            Self::IncompleteCallEvidence => 2,
+            Self::LanguageServerEdge => 1,
+            Self::ProducerWithoutSiteContract => 0,
+        }
+    }
+}
+
+/// Whether one evidence record declares its own call coverage incomplete.
+///
+/// Read against the linker's exported constants rather than against copies of
+/// their strings, so a producer that renames a marker cannot leave this quietly
+/// matching nothing.
+fn evidence_declares_incomplete_calls(evidence: &kin_model::RelationEvidence) -> bool {
+    let Some(rule) = evidence.parser_rule.as_deref() else {
+        return false;
+    };
+    rule == kin_index::linker::CALL_SHAPE_EVIDENCE_INCOMPLETE_PARSE_V1
+        || rule == kin_index::linker::CALL_SHAPE_EVIDENCE_INCOMPLETE_EXTRACTION_V1
 }
 
 /// Why this edge cannot license a site total, and `None` when it can.
@@ -1222,9 +1263,22 @@ impl ReferenceLinesPartial {
 /// Treating `Inferred` as contract-less would floor a correct answer: the Python
 /// batch arm of `kin-cli`'s `reference_call_site_lines` reports both of its real
 /// parsed sites on a `type_resolved` row, and it went red under that reading.
+/// The origin is read only after the evidence, because the evidence can refuse
+/// on the linker's behalf. `relation_evidence` stamps an incomplete parse or an
+/// incomplete extraction onto the record it then writes the site span onto, so a
+/// `Parsed` or `Inferred` edge can carry a real line beside its producer's own
+/// statement that it did not see every call. An origin check alone reads that
+/// edge as complete.
 fn edge_site_contract_gap(
     relation: &kin_model::relation::Relation,
 ) -> Option<ReferenceLinesPartial> {
+    if relation
+        .evidence
+        .iter()
+        .any(evidence_declares_incomplete_calls)
+    {
+        return Some(ReferenceLinesPartial::IncompleteCallEvidence);
+    }
     match relation.origin {
         kin_model::RelationOrigin::Parsed | kin_model::RelationOrigin::Inferred => None,
         kin_model::RelationOrigin::Lsp => Some(ReferenceLinesPartial::LanguageServerEdge),
@@ -1232,20 +1286,17 @@ fn edge_site_contract_gap(
     }
 }
 
-/// Keep the most specific gap a row has seen.
-///
-/// Both values mean the same thing to a caller, that the lines are a floor, so
-/// the only question is which is more useful to read. `LanguageServerEdge` names
-/// a measured one-site-per-edge producer and points at a specific fix, so it
-/// wins over the general case.
+/// Keep the most specific gap a row has seen, by
+/// [`ReferenceLinesPartial::specificity`].
 fn merge_site_contract_gap(
     current: &mut Option<ReferenceLinesPartial>,
     incoming: Option<ReferenceLinesPartial>,
 ) {
-    match (*current, incoming) {
-        (_, None) => {}
-        (Some(ReferenceLinesPartial::LanguageServerEdge), _) => {}
-        (_, Some(gap)) => *current = Some(gap),
+    let Some(gap) = incoming else {
+        return;
+    };
+    if current.is_none_or(|held| gap.specificity() > held.specificity()) {
+        *current = Some(gap);
     }
 }
 

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -1171,37 +1171,82 @@ impl ReferenceLinesAbsent {
 ///
 /// The distinction is the producer's own contract, which is a graph fact rather
 /// than a guess: [`RelationOrigin`](kin_model::RelationOrigin) says which
-/// producer recorded an edge, and only some of them record every site.
+/// producer recorded an edge, and exactly one of the four records every site.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReferenceLinesPartial {
-    /// At least one relation kind behind this row was recorded only by
-    /// language-server enrichment, which records at most one site per edge.
+    /// An edge behind this row came from language-server enrichment, which
+    /// records at most one site per edge.
     ///
     /// kin-lsp takes `CallHierarchyOutgoingCall.from_ranges.first()` for a call
     /// edge, keeps the first location per target for a `UsesType` edge, and
-    /// carries no span at all on its `References` edges. Every one of those is a
-    /// single site standing in for however many the file holds, so a row that
-    /// depends on one for a kind knows its lines are a lower bound.
+    /// carries no span at all on its `References` edges. Each is one site
+    /// standing in for however many the file holds.
     LanguageServerEdge,
+    /// An edge behind this row came from a producer with no every-site
+    /// contract: `Manual`, or an origin added after this was written.
+    ///
+    /// A hand-authored edge asserts that the reference exists. A span on it is
+    /// one position somebody recorded, never a statement that the file holds no
+    /// others, so it cannot license a site total. An unrecognized origin lands
+    /// here too, because a producer nobody has checked has made no promise.
+    ProducerWithoutSiteContract,
 }
 
 impl ReferenceLinesPartial {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::LanguageServerEdge => "language_server_edge",
+            Self::ProducerWithoutSiteContract => "producer_without_site_contract",
         }
     }
 }
 
-/// Whether the producer that recorded this edge records EVERY site for it.
+/// Why this edge cannot license a site total, and `None` when it can.
 ///
-/// The parser emits one edge per syntax occurrence, each with its own span, and
-/// [`accumulate_relation`](kin_index::linker) merges them into one relation
-/// keyed on the span, so a parsed edge's evidence holds every site the parse
-/// saw. Language-server enrichment reports one site per edge by construction.
-/// A relation carries which of the two produced it, so this needs no heuristic.
-fn edge_records_every_site(relation: &kin_model::relation::Relation) -> bool {
-    relation.origin != kin_model::RelationOrigin::Lsp
+/// The claim is made from positive proof, by naming the origins that carry an
+/// every-site contract, rather than from the absence of one known bad producer.
+/// Reading it the other way round, as `origin != Lsp`, certified `Manual` by
+/// default and would certify any origin added later the same way.
+///
+/// `Parsed` and `Inferred` both carry the contract, and the enum is misleading
+/// about why. Both are the linker's own output over one adapter extraction:
+/// `make_relation` (`kin-index/src/linker.rs`) picks between them purely on
+/// confidence, `origin = if confidence >= 1.0 { Parsed } else { Inferred }`, and
+/// builds the evidence for both from the same `ExtractedRelation::site`. So
+/// `Inferred` here describes how firmly the DESTINATION was resolved, never how
+/// many sites were recorded: an import-pinned cross-file call resolves at 0.9
+/// and is `Inferred` while carrying every call site the parse saw. The linker's
+/// two other `Inferred` producers, the external-import reference and the include
+/// marker, record no `source_span` at all, so they contribute no line to floor.
+///
+/// Treating `Inferred` as contract-less would floor a correct answer: the Python
+/// batch arm of `kin-cli`'s `reference_call_site_lines` reports both of its real
+/// parsed sites on a `type_resolved` row, and it went red under that reading.
+fn edge_site_contract_gap(
+    relation: &kin_model::relation::Relation,
+) -> Option<ReferenceLinesPartial> {
+    match relation.origin {
+        kin_model::RelationOrigin::Parsed | kin_model::RelationOrigin::Inferred => None,
+        kin_model::RelationOrigin::Lsp => Some(ReferenceLinesPartial::LanguageServerEdge),
+        _ => Some(ReferenceLinesPartial::ProducerWithoutSiteContract),
+    }
+}
+
+/// Keep the most specific gap a row has seen.
+///
+/// Both values mean the same thing to a caller, that the lines are a floor, so
+/// the only question is which is more useful to read. `LanguageServerEdge` names
+/// a measured one-site-per-edge producer and points at a specific fix, so it
+/// wins over the general case.
+fn merge_site_contract_gap(
+    current: &mut Option<ReferenceLinesPartial>,
+    incoming: Option<ReferenceLinesPartial>,
+) {
+    match (*current, incoming) {
+        (_, None) => {}
+        (Some(ReferenceLinesPartial::LanguageServerEdge), _) => {}
+        (_, Some(gap)) => *current = Some(gap),
+    }
 }
 
 /// One row per REFERENCING ENTITY that reaches `entity_id` over an allowed
@@ -1227,15 +1272,6 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
     // "the parser recorded nothing" and "what it recorded was unusable here"
     // into one silent empty list.
     let mut spans_outside_caller_file: HashMap<EntityId, usize> = HashMap::new();
-    // Which relation kinds behind each row an exhaustive producer recorded, and
-    // which a one-site-per-edge producer recorded. Kept per kind rather than per
-    // row because a language server routinely re-derives an edge the parser
-    // already enumerated in full: marking that row a floor because a second
-    // producer also saw it would report almost every row on an enriched
-    // repository as incomplete, which is as useless as the over-claim it
-    // replaces. A kind only a language server recorded is the real floor.
-    let mut exhaustive_kinds: HashMap<EntityId, Vec<RelationKind>> = HashMap::new();
-    let mut partial_kinds: HashMap<EntityId, Vec<RelationKind>> = HashMap::new();
 
     // One held authority for the whole reference set. This projects a body per
     // REFERENCING entity, so it is the same multi-entity shape the retrieval
@@ -1326,13 +1362,13 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
             .entry(source_entity_id)
             .or_default() += tally.outside_caller_file;
         push_reference_kind(&mut entry.relation_kinds, rel.kind);
-        push_reference_kind(
-            if edge_records_every_site(&rel) {
-                exhaustive_kinds.entry(source_entity_id).or_default()
-            } else {
-                partial_kinds.entry(source_entity_id).or_default()
-            },
-            rel.kind,
+        // Any contribution without an every-site contract keeps the row a floor.
+        // A parsed edge holds every site the PARSE saw, which is not evidence
+        // about the occurrences some other edge stands for, and no coverage
+        // witness in the graph joins the two.
+        merge_site_contract_gap(
+            &mut entry.reference_lines_partial,
+            edge_site_contract_gap(&rel),
         );
         let resolution = RelationResolution::of(&rel);
         entry.resolution = Some(match entry.resolution {
@@ -1425,13 +1461,9 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
                 .entry(source_entity_id)
                 .or_default() += tally.outside_caller_file;
             push_reference_kind(&mut entry.relation_kinds, rel.kind);
-            push_reference_kind(
-                if edge_records_every_site(&rel) {
-                    exhaustive_kinds.entry(source_entity_id).or_default()
-                } else {
-                    partial_kinds.entry(source_entity_id).or_default()
-                },
-                rel.kind,
+            merge_site_contract_gap(
+                &mut entry.reference_lines_partial,
+                edge_site_contract_gap(&rel),
             );
             let resolution = RelationResolution::of(&rel);
             entry.resolution = Some(match entry.resolution {
@@ -1453,17 +1485,12 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
         row.relation_kinds.sort_by_key(relation_kind_rank);
         row.reference_lines.sort_unstable();
         row.reference_lines.dedup();
-        // A kind no exhaustive producer recorded rests on an edge that reports
-        // one site whatever the file holds, so this row's lines are a floor.
-        let exhaustive = exhaustive_kinds
-            .remove(&source_entity_id)
-            .unwrap_or_default();
-        row.reference_lines_partial = partial_kinds
-            .remove(&source_entity_id)
-            .unwrap_or_default()
-            .iter()
-            .any(|kind| !exhaustive.contains(kind))
-            .then_some(ReferenceLinesPartial::LanguageServerEdge);
+        // A row with no lines has nothing to call a floor: `reference_lines_absent`
+        // below is the whole story, and carrying both would state one absence
+        // twice under two names.
+        if row.reference_lines.is_empty() {
+            row.reference_lines_partial = None;
+        }
         row.reference_lines_absent = if !row.reference_lines.is_empty() {
             None
         } else if spans_outside_caller_file

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -1056,6 +1056,15 @@ pub struct ReferenceRow {
     /// than a derived guess -- and `reference_lines_absent` then names which
     /// absence it is.
     pub reference_lines: Vec<u32>,
+    /// Why this row's `reference_lines` are a lower bound rather than the whole
+    /// set, and `None` when every kind behind the row came from a producer that
+    /// records each site.
+    ///
+    /// Separate from `reference_lines_absent` because a partial list and an
+    /// empty one are different follow-ups: an empty list sends a reader to
+    /// another surface, a partial one tells them the sites they have are real
+    /// and there may be more.
+    pub reference_lines_partial: Option<ReferenceLinesPartial>,
     /// Why this row carries no `reference_lines`, and `None` when it carries
     /// some.
     ///
@@ -1151,6 +1160,50 @@ impl ReferenceLinesAbsent {
     }
 }
 
+/// Why a reference row's site lines are a FLOOR rather than the whole set.
+///
+/// A row can carry lines and still be incomplete, and until this existed nothing
+/// in the response said so: `reference_sites_complete` asked only whether every
+/// row had at least one line, which a row holding one of five sites satisfies.
+/// express's `test/utils.js` calls `setCharset` on lines 50, 54, 58, 62 and 66,
+/// and `find_references` reported `reference_lines: [50]` under a `certified`
+/// verdict with both site flags reading complete.
+///
+/// The distinction is the producer's own contract, which is a graph fact rather
+/// than a guess: [`RelationOrigin`](kin_model::RelationOrigin) says which
+/// producer recorded an edge, and only some of them record every site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReferenceLinesPartial {
+    /// At least one relation kind behind this row was recorded only by
+    /// language-server enrichment, which records at most one site per edge.
+    ///
+    /// kin-lsp takes `CallHierarchyOutgoingCall.from_ranges.first()` for a call
+    /// edge, keeps the first location per target for a `UsesType` edge, and
+    /// carries no span at all on its `References` edges. Every one of those is a
+    /// single site standing in for however many the file holds, so a row that
+    /// depends on one for a kind knows its lines are a lower bound.
+    LanguageServerEdge,
+}
+
+impl ReferenceLinesPartial {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::LanguageServerEdge => "language_server_edge",
+        }
+    }
+}
+
+/// Whether the producer that recorded this edge records EVERY site for it.
+///
+/// The parser emits one edge per syntax occurrence, each with its own span, and
+/// [`accumulate_relation`](kin_index::linker) merges them into one relation
+/// keyed on the span, so a parsed edge's evidence holds every site the parse
+/// saw. Language-server enrichment reports one site per edge by construction.
+/// A relation carries which of the two produced it, so this needs no heuristic.
+fn edge_records_every_site(relation: &kin_model::relation::Relation) -> bool {
+    relation.origin != kin_model::RelationOrigin::Lsp
+}
+
 /// One row per REFERENCING ENTITY that reaches `entity_id` over an allowed
 /// relation kind.
 ///
@@ -1174,6 +1227,15 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
     // "the parser recorded nothing" and "what it recorded was unusable here"
     // into one silent empty list.
     let mut spans_outside_caller_file: HashMap<EntityId, usize> = HashMap::new();
+    // Which relation kinds behind each row an exhaustive producer recorded, and
+    // which a one-site-per-edge producer recorded. Kept per kind rather than per
+    // row because a language server routinely re-derives an edge the parser
+    // already enumerated in full: marking that row a floor because a second
+    // producer also saw it would report almost every row on an enriched
+    // repository as incomplete, which is as useless as the over-claim it
+    // replaces. A kind only a language server recorded is the real floor.
+    let mut exhaustive_kinds: HashMap<EntityId, Vec<RelationKind>> = HashMap::new();
+    let mut partial_kinds: HashMap<EntityId, Vec<RelationKind>> = HashMap::new();
 
     // One held authority for the whole reference set. This projects a body per
     // REFERENCING entity, so it is the same multi-entity shape the retrieval
@@ -1229,6 +1291,7 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
                 file_path: file_path.clone(),
                 start_line: entity_presentation_start_line(&entity),
                 reference_lines: Vec::new(),
+                reference_lines_partial: None,
                 reference_lines_absent: None,
                 signature: Some(entity.signature.clone()),
                 // Project the caller's bounded body once, where the entity is in
@@ -1263,6 +1326,14 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
             .entry(source_entity_id)
             .or_default() += tally.outside_caller_file;
         push_reference_kind(&mut entry.relation_kinds, rel.kind);
+        push_reference_kind(
+            if edge_records_every_site(&rel) {
+                exhaustive_kinds.entry(source_entity_id).or_default()
+            } else {
+                partial_kinds.entry(source_entity_id).or_default()
+            },
+            rel.kind,
+        );
         let resolution = RelationResolution::of(&rel);
         entry.resolution = Some(match entry.resolution {
             Some(current) => current.max(resolution),
@@ -1335,6 +1406,7 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
                     file_path,
                     start_line: entity_presentation_start_line(&entity),
                     reference_lines: Vec::new(),
+                    reference_lines_partial: None,
                     reference_lines_absent: None,
                     signature: Some(entity.signature.clone()),
                     snippet,
@@ -1353,6 +1425,14 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
                 .entry(source_entity_id)
                 .or_default() += tally.outside_caller_file;
             push_reference_kind(&mut entry.relation_kinds, rel.kind);
+            push_reference_kind(
+                if edge_records_every_site(&rel) {
+                    exhaustive_kinds.entry(source_entity_id).or_default()
+                } else {
+                    partial_kinds.entry(source_entity_id).or_default()
+                },
+                rel.kind,
+            );
             let resolution = RelationResolution::of(&rel);
             entry.resolution = Some(match entry.resolution {
                 Some(current) => current.max(resolution),
@@ -1373,6 +1453,17 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
         row.relation_kinds.sort_by_key(relation_kind_rank);
         row.reference_lines.sort_unstable();
         row.reference_lines.dedup();
+        // A kind no exhaustive producer recorded rests on an edge that reports
+        // one site whatever the file holds, so this row's lines are a floor.
+        let exhaustive = exhaustive_kinds
+            .remove(&source_entity_id)
+            .unwrap_or_default();
+        row.reference_lines_partial = partial_kinds
+            .remove(&source_entity_id)
+            .unwrap_or_default()
+            .iter()
+            .any(|kind| !exhaustive.contains(kind))
+            .then_some(ReferenceLinesPartial::LanguageServerEdge);
         row.reference_lines_absent = if !row.reference_lines.is_empty() {
             None
         } else if spans_outside_caller_file

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -1576,10 +1576,11 @@ sites could not be located OR are only a floor, with `known_reference_sites` the
 bound and each such row naming why under `reference_lines_absent_reason` (no lines at \
 all) or `reference_lines_partial_reason` (lines came back but there may be more). That \
 second reason is `language_server_edge` when an edge came from language-server \
-enrichment, which reports one site per edge, and `producer_without_site_contract` when \
-one was hand-authored, which proves a reference rather than an occurrence count. Only a \
-row built entirely from edges the parse produced lists every site it has, and only that \
-row sets neither reason. Rows omit the caller's body by \
+enrichment, which reports one site per edge, `producer_without_site_contract` when one \
+was hand-authored, which proves a reference rather than an occurrence count, and \
+`incomplete_call_evidence` when one carries the linker's marker for a recovered parse or \
+a call extraction that was not exhaustive. Only a row built entirely from edges a \
+complete parse produced lists every site it has, and only that row sets neither reason. Rows omit the caller's body by \
 default to keep the response small; pass include_snippets=true for the signature and a \
 bounded body excerpt, or drill to any row's entity_id with get_entity_source. \
 Use it to answer \"who calls / imports / uses this?\" before you \
@@ -1954,11 +1955,13 @@ fn reference_row_json(row: ReferenceRow, include_snippets: bool) -> serde_json::
             .map(ReferenceLinesAbsent::as_str),
         // Why the lines that DID come back are a floor: `language_server_edge`
         // (an edge behind this row came from language-server enrichment, which
-        // reports one site per edge) or `producer_without_site_contract` (one
-        // was hand-authored, or came from an origin with no checked contract,
-        // so it proves a reference rather than an occurrence count). Null when
-        // every edge behind the row came from the parse, and then
-        // `reference_line_count` is the whole count for this caller.
+        // reports one site per edge), `producer_without_site_contract` (one was
+        // hand-authored, or came from an origin with no checked contract, so it
+        // proves a reference rather than an occurrence count), or
+        // `incomplete_call_evidence` (one carries the linker's own marker saying
+        // the parse was recovered or the call extraction was not exhaustive).
+        // Null when every edge behind the row came from a complete parse, and
+        // then `reference_line_count` is the whole count for this caller.
         "reference_lines_partial_reason": row
             .reference_lines_partial
             .map(ReferenceLinesPartial::as_str),
@@ -8179,6 +8182,92 @@ mod tests {
         assert_eq!(body["counts"]["reference_sites"], serde_json::Value::Null);
         assert_eq!(body["counts"]["known_reference_sites"], 2);
         assert_eq!(body["counts"]["reference_sites_complete"], false);
+    }
+
+    /// An edge whose own evidence declares the parse or the extraction
+    /// incomplete does not certify its site set, at either confidence.
+    ///
+    /// This is the shape an origin check cannot see. `relation_evidence`
+    /// (`kin-index/src/linker.rs`) builds the shape record first, stamping
+    /// `call_shape_incomplete_parse_v1` when the parse was recovered or
+    /// `call_shape_incomplete_extraction_v1` when the adapter could not
+    /// represent every call expression, and then writes the site span ONTO that
+    /// record rather than beside it. So a `Parsed` or `Inferred` edge arrives
+    /// carrying a real line next to the linker's own statement that sibling
+    /// occurrences may have been omitted. Both markers are read from the
+    /// linker's exported constants, so renaming one there breaks this rather
+    /// than silently matching nothing.
+    #[tokio::test]
+    async fn find_references_will_not_certify_evidence_marked_incomplete() {
+        for (marker, origin, confidence, label) in [
+            (
+                kin_index::linker::CALL_SHAPE_EVIDENCE_INCOMPLETE_PARSE_V1,
+                RelationOrigin::Parsed,
+                1.0_f32,
+                "recovered parse at full confidence",
+            ),
+            (
+                kin_index::linker::CALL_SHAPE_EVIDENCE_INCOMPLETE_PARSE_V1,
+                RelationOrigin::Inferred,
+                0.9_f32,
+                "recovered parse at import-pinned confidence",
+            ),
+            (
+                kin_index::linker::CALL_SHAPE_EVIDENCE_INCOMPLETE_EXTRACTION_V1,
+                RelationOrigin::Parsed,
+                1.0_f32,
+                "incomplete extraction at full confidence",
+            ),
+            (
+                kin_index::linker::CALL_SHAPE_EVIDENCE_INCOMPLETE_EXTRACTION_V1,
+                RelationOrigin::Inferred,
+                0.9_f32,
+                "incomplete extraction at import-pinned confidence",
+            ),
+        ] {
+            let store = InMemoryGraph::new();
+            let caller = make_entity("caller", "src/a.rs");
+            let target = make_entity("target", "src/b.rs");
+            store.upsert_entity(&caller).unwrap();
+            store.upsert_entity(&target).unwrap();
+
+            // The site the linker writes onto the marker record, exactly as
+            // `relation_evidence` does: one record, both fields set.
+            let mut relation =
+                make_relation_with_site(caller.id, target.id, RelationKind::Calls, "src/a.rs", 11);
+            relation.origin = origin;
+            relation.confidence = confidence;
+            relation.evidence[0].parser_rule = Some(marker.to_string());
+            store.upsert_relation(&relation).unwrap();
+
+            let args = HashMap::from([(
+                "entity_id".to_string(),
+                serde_json::json!(target.id.to_string()),
+            )]);
+            let body = parsed_response(&handle_find_references(&args, &store, None).await.unwrap());
+            let row = &body["references"].as_array().unwrap()[0];
+
+            // The line it does have is still served. A floor is not a refusal.
+            assert_eq!(
+                row["reference_lines"],
+                serde_json::json!([12]),
+                "{label}: the known site must survive: {row:#}"
+            );
+            assert_eq!(
+                row["reference_lines_partial_reason"], "incomplete_call_evidence",
+                "{label}: the edge's own evidence says the parse was short: {body:#}"
+            );
+            assert_eq!(
+                body["counts"]["reference_sites"],
+                serde_json::Value::Null,
+                "{label}: a site total over incomplete evidence is not a number: {body:#}"
+            );
+            assert_eq!(body["counts"]["known_reference_sites"], 1);
+            assert_eq!(
+                body["counts"]["reference_sites_complete"], false,
+                "{label}: {body:#}"
+            );
+        }
     }
 
     /// A kind ONLY the language server recorded makes the row a floor even when

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -1574,10 +1574,12 @@ The `counts` object states the unit outright and adds `files` and `reference_sit
 a count is never read against the wrong unit. `reference_sites` is null when some row's \
 sites could not be located OR are only a floor, with `known_reference_sites` the lower \
 bound and each such row naming why under `reference_lines_absent_reason` (no lines at \
-all) or `reference_lines_partial_reason` (lines came back but there may be more, \
-because a relation kind behind that row was recorded only by language-server \
-enrichment, which reports one site per edge). A row with neither reason set lists every \
-site it has. Rows omit the caller's body by \
+all) or `reference_lines_partial_reason` (lines came back but there may be more). That \
+second reason is `language_server_edge` when an edge came from language-server \
+enrichment, which reports one site per edge, and `producer_without_site_contract` when \
+one was hand-authored, which proves a reference rather than an occurrence count. Only a \
+row built entirely from edges the parse produced lists every site it has, and only that \
+row sets neither reason. Rows omit the caller's body by \
 default to keep the response small; pass include_snippets=true for the signature and a \
 bounded body excerpt, or drill to any row's entity_id with get_entity_source. \
 Use it to answer \"who calls / imports / uses this?\" before you \
@@ -1837,10 +1839,10 @@ fn answer_witnessed_classes<G: GraphStore>(
 /// call sites satisfied it, so express's `setCharset` came back as three sites,
 /// `reference_sites_complete: true`, under a `certified` verdict, while
 /// `test/utils.js` alone holds five. A reader could not tell the undercount from
-/// a small repository. The floor is now stated as a floor: a row whose producer
-/// records one site per edge sets `reference_lines_partial`, and one such row
-/// makes `reference_sites` null with `known_reference_sites` the bound, the same
-/// rule an unlocatable row already followed.
+/// a small repository. The floor is now stated as a floor: a row carrying any
+/// edge without an every-site contract sets `reference_lines_partial`, and one
+/// such row makes `reference_sites` null with `known_reference_sites` the bound,
+/// the same rule an unlocatable row already followed.
 fn reference_counts(rows: &[ReferenceRow], receiver_name_candidates: usize) -> serde_json::Value {
     let known_reference_sites: usize = rows.iter().map(|row| row.reference_lines.len()).sum();
     let reference_sites_complete = rows
@@ -1951,9 +1953,11 @@ fn reference_row_json(row: ReferenceRow, include_snippets: bool) -> serde_json::
             .reference_lines_absent
             .map(ReferenceLinesAbsent::as_str),
         // Why the lines that DID come back are a floor: `language_server_edge`
-        // (a relation kind behind this row was recorded only by language-server
-        // enrichment, which reports one site per edge). Null when every kind
-        // came from a producer that records each site, and then
+        // (an edge behind this row came from language-server enrichment, which
+        // reports one site per edge) or `producer_without_site_contract` (one
+        // was hand-authored, or came from an origin with no checked contract,
+        // so it proves a reference rather than an occurrence count). Null when
+        // every edge behind the row came from the parse, and then
         // `reference_line_count` is the whole count for this caller.
         "reference_lines_partial_reason": row
             .reference_lines_partial
@@ -8080,17 +8084,54 @@ mod tests {
         );
     }
 
-    /// A language server re-deriving an edge the parser already enumerated does
-    /// NOT make the row a floor.
+    /// A manually authored edge does not certify its site set.
     ///
-    /// The rule is per relation kind, not per row, and this is why. On any
-    /// enriched repository the call-hierarchy pass rebuilds edges the adapter
-    /// already recorded site by site, so "any language-server edge makes the row
-    /// partial" would report almost every row as incomplete and the flag would
-    /// carry no information at all. FIR-2357 item 4 in a new place: a fix that
-    /// marks every answer uncertain is not a fix.
+    /// [`RelationOrigin`](kin_model::RelationOrigin) has four values, and the
+    /// two the linker emits over a parse, `Parsed` and `Inferred`, are the ones
+    /// that carry an every-site contract. `Manual` is an edge somebody asserted:
+    /// a single span on it is one position that happened to be recorded, not
+    /// proof that the file holds no others. Certifying by `origin != Lsp`
+    /// certified it by default, and would certify any origin added later.
     #[tokio::test]
-    async fn find_references_still_certifies_a_kind_the_parser_enumerated() {
+    async fn find_references_will_not_certify_sites_from_a_manually_authored_edge() {
+        let store = InMemoryGraph::new();
+        let caller = make_entity("caller", "src/a.rs");
+        let target = make_entity("target", "src/b.rs");
+        store.upsert_entity(&caller).unwrap();
+        store.upsert_entity(&target).unwrap();
+
+        let mut relation =
+            make_relation_with_site(caller.id, target.id, RelationKind::Calls, "src/a.rs", 11);
+        relation.origin = RelationOrigin::Manual;
+        store.upsert_relation(&relation).unwrap();
+
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+        let body = parsed_response(&handle_find_references(&args, &store, None).await.unwrap());
+        let row = &body["references"].as_array().unwrap()[0];
+
+        assert_eq!(row["reference_lines"], serde_json::json!([12]));
+        assert_eq!(
+            row["reference_lines_partial_reason"], "producer_without_site_contract",
+            "a hand-authored edge proves one site, not every site: {body:#}"
+        );
+        assert_eq!(body["counts"]["reference_sites"], serde_json::Value::Null);
+        assert_eq!(body["counts"]["known_reference_sites"], 1);
+        assert_eq!(body["counts"]["reference_sites_complete"], false);
+    }
+
+    /// A parsed edge beside a language-server edge does not certify the row.
+    ///
+    /// The parsed edge holds every site the PARSE saw. That is not the same
+    /// claim as every site the enrichment edge stands for, and nothing in the
+    /// graph witnesses that the two cover the same occurrences. A rule that let
+    /// one kind's parsed edge vouch for a language-server edge of that kind was
+    /// asserting a coverage fact it had no evidence for, so any contribution
+    /// without an every-site contract now keeps the row a floor.
+    #[tokio::test]
+    async fn find_references_floors_a_row_mixing_a_parsed_and_a_language_server_edge() {
         let store = InMemoryGraph::new();
         let caller_file = FilePathId::new("src/a.rs");
         let caller = make_entity("caller", "src/a.rs");
@@ -8117,8 +8158,6 @@ mod tests {
             .collect();
         store.upsert_relation(&parsed).unwrap();
 
-        // The enrichment edge for the SAME kind, carrying the first of those two
-        // sites. It adds no line the parser did not already have.
         let mut enriched =
             make_relation_with_site(caller.id, target.id, RelationKind::Calls, "src/a.rs", 11);
         enriched.origin = RelationOrigin::Lsp;
@@ -8131,14 +8170,15 @@ mod tests {
         let body = parsed_response(&handle_find_references(&args, &store, None).await.unwrap());
         let row = &body["references"].as_array().unwrap()[0];
 
+        // Both sites are still served; only the claim about them is withheld.
         assert_eq!(row["reference_lines"], serde_json::json!([12, 42]));
         assert_eq!(
-            row["reference_lines_partial_reason"],
-            serde_json::Value::Null,
-            "the parser enumerated this kind, so the sites are whole: {body:#}"
+            row["reference_lines_partial_reason"], "language_server_edge",
+            "the enrichment edge's own site set was never enumerated: {body:#}"
         );
-        assert_eq!(body["counts"]["reference_sites"], 2);
-        assert_eq!(body["counts"]["reference_sites_complete"], true);
+        assert_eq!(body["counts"]["reference_sites"], serde_json::Value::Null);
+        assert_eq!(body["counts"]["known_reference_sites"], 2);
+        assert_eq!(body["counts"]["reference_sites_complete"], false);
     }
 
     /// A kind ONLY the language server recorded makes the row a floor even when

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -1572,8 +1572,12 @@ that references the focal (reference_lines). Two callers in one file are two row
 `total_upstream` is the number of referencing entities, the same unit `kin refs` prints. \
 The `counts` object states the unit outright and adds `files` and `reference_sites`, so \
 a count is never read against the wrong unit. `reference_sites` is null when some row's \
-sites could not be located, with `known_reference_sites` the lower bound and each such \
-row naming why under `reference_lines_absent_reason`. Rows omit the caller's body by \
+sites could not be located OR are only a floor, with `known_reference_sites` the lower \
+bound and each such row naming why under `reference_lines_absent_reason` (no lines at \
+all) or `reference_lines_partial_reason` (lines came back but there may be more, \
+because a relation kind behind that row was recorded only by language-server \
+enrichment, which reports one site per edge). A row with neither reason set lists every \
+site it has. Rows omit the caller's body by \
 default to keep the response small; pass include_snippets=true for the signature and a \
 bounded body excerpt, or drill to any row's entity_id with get_entity_source. \
 Use it to answer \"who calls / imports / uses this?\" before you \
@@ -1716,6 +1720,10 @@ fn spine_reference_rows(
             // A federated xref carries no site span from the other repo's graph,
             // and says so rather than leaving an unexplained empty list.
             reference_lines: Vec::new(),
+            // Absent rather than partial: the row reports no site at all, which
+            // `reference_lines_absent` already names. A floor is a claim about
+            // lines that came back, and none did.
+            reference_lines_partial: None,
             reference_lines_absent: Some(ReferenceLinesAbsent::FederatedXref),
             signature: source.map(|entity| entity.signature.clone()),
             snippet: None,
@@ -1819,13 +1827,25 @@ fn answer_witnessed_classes<G: GraphStore>(
 /// site total a floor, never a fact.
 ///
 /// `reference_sites_complete` is about the rows that came back: it says every
-/// returned reference could be located at a line. Whether the row SET itself is
-/// complete is the `negative` object's question for an empty answer and
-/// `edge_coverage`'s for the classes the query read; this field does not restate
-/// either, and on an empty answer it describes an empty set.
+/// returned reference could be located at EVERY line it occupies. Whether the
+/// row SET itself is complete is the `negative` object's question for an empty
+/// answer and `edge_coverage`'s for the classes the query read; this field does
+/// not restate either, and on an empty answer it describes an empty set.
+///
+/// It asked only whether each row had at least one line, which is a much weaker
+/// thing and was published under a much stronger name. A row holding one of five
+/// call sites satisfied it, so express's `setCharset` came back as three sites,
+/// `reference_sites_complete: true`, under a `certified` verdict, while
+/// `test/utils.js` alone holds five. A reader could not tell the undercount from
+/// a small repository. The floor is now stated as a floor: a row whose producer
+/// records one site per edge sets `reference_lines_partial`, and one such row
+/// makes `reference_sites` null with `known_reference_sites` the bound, the same
+/// rule an unlocatable row already followed.
 fn reference_counts(rows: &[ReferenceRow], receiver_name_candidates: usize) -> serde_json::Value {
     let known_reference_sites: usize = rows.iter().map(|row| row.reference_lines.len()).sum();
-    let reference_sites_complete = rows.iter().all(|row| !row.reference_lines.is_empty());
+    let reference_sites_complete = rows
+        .iter()
+        .all(|row| !row.reference_lines.is_empty() && row.reference_lines_partial.is_none());
     let files = rows
         .iter()
         .filter_map(|row| row.file_path.as_deref())
@@ -1930,6 +1950,14 @@ fn reference_row_json(row: ReferenceRow, include_snippets: bool) -> serde_json::
         "reference_lines_absent_reason": row
             .reference_lines_absent
             .map(ReferenceLinesAbsent::as_str),
+        // Why the lines that DID come back are a floor: `language_server_edge`
+        // (a relation kind behind this row was recorded only by language-server
+        // enrichment, which reports one site per edge). Null when every kind
+        // came from a producer that records each site, and then
+        // `reference_line_count` is the whole count for this caller.
+        "reference_lines_partial_reason": row
+            .reference_lines_partial
+            .map(ReferenceLinesPartial::as_str),
         "relation_kinds": row
             .relation_kinds
             .into_iter()
@@ -6271,6 +6299,7 @@ mod tests {
                 file_path: Some("tests/test_requests.py".to_string()),
                 start_line: Some(4),
                 reference_lines: vec![7],
+                reference_lines_partial: None,
                 reference_lines_absent: None,
                 signature: None,
                 snippet: None,
@@ -6292,6 +6321,7 @@ mod tests {
                 file_path: Some("[other] src/app.py".to_string()),
                 start_line: None,
                 reference_lines: Vec::new(),
+                reference_lines_partial: None,
                 reference_lines_absent: Some(ReferenceLinesAbsent::FederatedXref),
                 signature: None,
                 snippet: None,
@@ -7984,6 +8014,176 @@ mod tests {
         assert_eq!(body["counts"]["reference_sites"], 2);
         assert_eq!(body["counts"]["known_reference_sites"], 2);
         assert_eq!(body["counts"]["reference_sites_complete"], true);
+        assert_eq!(
+            row["reference_lines_partial_reason"],
+            serde_json::Value::Null,
+            "a parsed edge carries every site it saw, so nothing is a floor: {body:#}"
+        );
+    }
+
+    /// One site from a producer that records one site per edge is a FLOOR, and
+    /// the answer says so instead of certifying it.
+    ///
+    /// This is journey071's GAP-A. express's `test/utils.js` calls `setCharset`
+    /// on lines 50, 54, 58, 62 and 66; `find_references` reported
+    /// `reference_lines: [50]`, `reference_sites: 3`,
+    /// `reference_sites_complete: true` under a `certified` verdict. The file
+    /// holds one entity, so it was not a per-entity split: the row's only edge
+    /// came from language-server enrichment, which records
+    /// `CallHierarchyOutgoingCall.from_ranges.first()` and drops the rest. The
+    /// old flag asked only whether each row had a line, which one of five
+    /// satisfies, so a reader could not tell an undercount from a small
+    /// repository.
+    #[tokio::test]
+    async fn find_references_will_not_certify_sites_from_a_one_site_per_edge_producer() {
+        let store = InMemoryGraph::new();
+        let caller = make_entity("caller", "src/a.rs");
+        let target = make_entity("target", "src/b.rs");
+        store.upsert_entity(&caller).unwrap();
+        store.upsert_entity(&target).unwrap();
+
+        // The edge the daemon's enrichment writes: one span, whatever the file
+        // holds. Graph row 49, reported 1-based as 50, express's first site.
+        let mut relation =
+            make_relation_with_site(caller.id, target.id, RelationKind::Calls, "src/a.rs", 49);
+        relation.origin = RelationOrigin::Lsp;
+        store.upsert_relation(&relation).unwrap();
+
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+        let body = parsed_response(&handle_find_references(&args, &store, None).await.unwrap());
+        let row = &body["references"].as_array().unwrap()[0];
+
+        // The site it does have is still served. A floor is not a refusal.
+        assert_eq!(row["reference_lines"], serde_json::json!([50]));
+        assert_eq!(row["reference_line_count"], 1);
+        assert_eq!(
+            row["reference_lines_absent_reason"],
+            serde_json::Value::Null,
+            "lines came back, so there is no absence to explain: {body:#}"
+        );
+        assert_eq!(
+            row["reference_lines_partial_reason"], "language_server_edge",
+            "a row whose sites are a floor must name why: {body:#}"
+        );
+        assert_eq!(
+            body["counts"]["reference_sites"],
+            serde_json::Value::Null,
+            "a site total that is only a floor is not emitted as a number: {body:#}"
+        );
+        assert_eq!(body["counts"]["known_reference_sites"], 1);
+        assert_eq!(
+            body["counts"]["reference_sites_complete"], false,
+            "one of five sites is not a complete site set: {body:#}"
+        );
+    }
+
+    /// A language server re-deriving an edge the parser already enumerated does
+    /// NOT make the row a floor.
+    ///
+    /// The rule is per relation kind, not per row, and this is why. On any
+    /// enriched repository the call-hierarchy pass rebuilds edges the adapter
+    /// already recorded site by site, so "any language-server edge makes the row
+    /// partial" would report almost every row as incomplete and the flag would
+    /// carry no information at all. FIR-2357 item 4 in a new place: a fix that
+    /// marks every answer uncertain is not a fix.
+    #[tokio::test]
+    async fn find_references_still_certifies_a_kind_the_parser_enumerated() {
+        let store = InMemoryGraph::new();
+        let caller_file = FilePathId::new("src/a.rs");
+        let caller = make_entity("caller", "src/a.rs");
+        let target = make_entity("target", "src/b.rs");
+        store.upsert_entity(&caller).unwrap();
+        store.upsert_entity(&target).unwrap();
+
+        let site_span = |row: u32| kin_model::entity::SourceSpan {
+            file: caller_file.clone(),
+            start_byte: 0,
+            end_byte: 1,
+            start_line: row,
+            start_col: 0,
+            end_line: row,
+            end_col: 1,
+        };
+        let mut parsed = make_relation(caller.id, target.id, RelationKind::Calls);
+        parsed.evidence = vec![11, 41]
+            .into_iter()
+            .map(|row| RelationEvidence {
+                source_span: Some(site_span(row)),
+                ..RelationEvidence::default()
+            })
+            .collect();
+        store.upsert_relation(&parsed).unwrap();
+
+        // The enrichment edge for the SAME kind, carrying the first of those two
+        // sites. It adds no line the parser did not already have.
+        let mut enriched =
+            make_relation_with_site(caller.id, target.id, RelationKind::Calls, "src/a.rs", 11);
+        enriched.origin = RelationOrigin::Lsp;
+        store.upsert_relation(&enriched).unwrap();
+
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+        let body = parsed_response(&handle_find_references(&args, &store, None).await.unwrap());
+        let row = &body["references"].as_array().unwrap()[0];
+
+        assert_eq!(row["reference_lines"], serde_json::json!([12, 42]));
+        assert_eq!(
+            row["reference_lines_partial_reason"],
+            serde_json::Value::Null,
+            "the parser enumerated this kind, so the sites are whole: {body:#}"
+        );
+        assert_eq!(body["counts"]["reference_sites"], 2);
+        assert_eq!(body["counts"]["reference_sites_complete"], true);
+    }
+
+    /// A kind ONLY the language server recorded makes the row a floor even when
+    /// another kind on the same row was fully enumerated.
+    ///
+    /// kin-lsp's `References` enrichment dedupes by referencing entity and
+    /// builds the relation with no evidence at all, so it proves references
+    /// exist at sites nothing recorded. Its lines cannot be added to the parsed
+    /// call sites and called a total.
+    #[tokio::test]
+    async fn find_references_floors_a_row_whose_extra_kind_only_enrichment_saw() {
+        let store = InMemoryGraph::new();
+        let caller = make_entity("caller", "src/a.rs");
+        let target = make_entity("target", "src/b.rs");
+        store.upsert_entity(&caller).unwrap();
+        store.upsert_entity(&target).unwrap();
+
+        store
+            .upsert_relation(&make_relation_with_site(
+                caller.id,
+                target.id,
+                RelationKind::Calls,
+                "src/a.rs",
+                11,
+            ))
+            .unwrap();
+        let mut enriched = make_relation(caller.id, target.id, RelationKind::References);
+        enriched.origin = RelationOrigin::Lsp;
+        store.upsert_relation(&enriched).unwrap();
+
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+        let body = parsed_response(&handle_find_references(&args, &store, None).await.unwrap());
+        let row = &body["references"].as_array().unwrap()[0];
+
+        assert_eq!(row["reference_lines"], serde_json::json!([12]));
+        assert_eq!(
+            row["reference_lines_partial_reason"], "language_server_edge",
+            "the References edge's own sites were never recorded: {body:#}"
+        );
+        assert_eq!(body["counts"]["reference_sites"], serde_json::Value::Null);
+        assert_eq!(body["counts"]["known_reference_sites"], 1);
+        assert_eq!(body["counts"]["reference_sites_complete"], false);
     }
 
     /// A span the parser recorded against some other file is dropped, and the


### PR DESCRIPTION
FIR-3267. `find_references` answered express's `setCharset` with `reference_sites: 3`,
`known_reference_sites: 3`, `reference_sites_complete: true` and verdict `certified`, while
`test/utils.js` alone calls it on lines 50, 54, 58, 62 and 66. That file holds exactly one entity,
so it was not a per-entity split. A caller could not tell an undercount from a small repository,
which is what makes it worth fixing before launch.

## What the fields actually meant

`reference_sites_complete` was `rows.iter().all(|row| !row.reference_lines.is_empty())`
(`crates/kin-mcp/src/handlers/entities.rs:1828` before this change). It said every returned row
carried at least one line, which a row holding one of five satisfies, and `reference_counts` then
published the per-row sum as a complete site total. The row assembly below it was already correct:
`collect_graph_reference_rows` extends from every contributing edge's evidence spans and dedupes,
and a parsed multi-site edge does report all of its sites.

## Where the missing sites go

Two producers, both left alone here and both listed under limitations below.

The JavaScript adapter records no call at module level. `extract_js_node`
(`crates/kin-parser/src/languages/javascript.rs:1489`) reaches `extract_calls_from_context` only
from its named-declaration arms (1485, 1513, 1614, 1941, 1994, 2012, 2046, 2132, 2238), and
express's tests are `describe`/`it` at module level. Measured with a throwaway `kin-parser` probe
on the express shape and on the same five calls moved inside a named function:

```
== express-shape (module level, inside it() callbacks) ==
entities:
  Module utils span=Some((0, 24))
relations touching setCharset:
total relations=0 calls=0
== function-shape (five calls inside one function) ==
relations touching setCharset:
  kind=Calls src=run dst=setCharset recv=Some("utils") site_line=Some(3)
  kind=Calls src=run dst=setCharset recv=Some("utils") site_line=Some(4)
  kind=Calls src=run dst=setCharset recv=Some("utils") site_line=Some(5)
  kind=Calls src=run dst=setCharset recv=Some("utils") site_line=Some(6)
  kind=Calls src=run dst=setCharset recv=Some("utils") site_line=Some(7)
total relations=5 calls=5
```

The per-site path works; that file never enters it. The row that did come back came from
language-server enrichment, and kin-lsp 0.7.16 `src/enrichment.rs:292-299` stores
`call.from_ranges.first()`. `fromRanges` is one range per call site, so that is the literal five to
one.

## The change

The claim is fixed, not the count. A row now carries `reference_lines_partial` when any edge behind
it came from a producer with no every-site contract. Such a row makes `reference_sites` null with
`known_reference_sites` as the bound, the rule an unlocatable row already followed, and names why
under a new `reference_lines_partial_reason`, in the same vocabulary as
`reference_lines_absent_reason`. `FIND_REFERENCES_DESC` discloses both reasons.

The contract is proved rather than assumed. `edge_site_contract_gap` names the origins that carry
one and floors everything else, including any origin added later. Reading it the other way round,
as `origin != Lsp`, certified a hand-authored `Manual` edge by default, and a single span on an edge
somebody asserted is one position that happened to be recorded rather than proof the file holds no
others.

`Parsed` and `Inferred` both carry the contract, and the enum is misleading about why. Both are the
linker's own output over one adapter extraction: `make_relation` in `kin-index/src/linker.rs` picks
between them purely on confidence, `origin = if confidence >= 1.0 { Parsed } else { Inferred }`, and
builds the evidence for both from the same `ExtractedRelation::site`. `Inferred` there describes how
firmly the DESTINATION was resolved, never how many sites were recorded: an import-pinned cross-file
call resolves at 0.9 and is `Inferred` while carrying every call site the parse saw. Reading it as
contract-less turned the Python batch arm of the shipped `reference_call_site_lines` red on a
`type_resolved` row reporting both of its real sites. The linker's other two `Inferred` producers,
the external-import reference and the include marker, record no `source_span` at all, so they
contribute no line to floor.

There is no per-kind exception. One parsed edge holds every site the PARSE saw, which is not
evidence about the occurrences a separate language-server edge stands for, and no coverage witness
in the graph joins the two.

The origin is read only after the evidence, because the evidence can refuse on the linker's behalf.
`relation_evidence` builds a call edge's shape record first, stamping
`call_shape_incomplete_parse_v1` on a recovered parse or `call_shape_incomplete_extraction_v1` on a
syntax-valid file whose adapter could not represent every call expression, and then writes the site
span ONTO that record rather than beside it. So a `Parsed` or `Inferred` edge can arrive carrying a
real line next to the linker's own statement that sibling occurrences may have been omitted, which
is the one shape an origin check cannot see. Both markers now floor the row under
`incomplete_call_evidence`, ahead of the producer-derived reasons because an edge that declares its
own coverage short has said so outright. They are read from the linker's exported constants rather
than from copies of their strings, so renaming one there breaks this instead of leaving it quietly
matching nothing.

On express this turns a certified `reference_sites: 3` into `null` beside `known_reference_sites: 3`
with each affected row saying `language_server_edge`.

## Tests, and the falsification

Five unit tests in `kin-mcp` and a three-test end-to-end repro in
`crates/kin-cli/tests/reference_site_completeness.rs`, which builds a five-call module-level fixture
through the real ingest path and adds the one-site enrichment edge the daemon writes. It asserts the
invariant rather than either number: every site, or no claim of completeness. It stays green when
the two producers above are fixed, because then the five lines are all there.

Two of the four were written red-first against the shipped behaviour, a `Manual` one-span edge and a
parsed edge mixed with a language-server edge of the same kind:

```
test handlers::entities::tests::find_references_floors_a_row_mixing_a_parsed_and_a_language_server_edge ... FAILED
test handlers::entities::tests::find_references_will_not_certify_sites_from_a_manually_authored_edge ... FAILED
assertion `left == right` failed: the enrichment edge's own site set was never enumerated
  left: Null
 right: "language_server_edge"
assertion `left == right` failed: a hand-authored edge proves one site, not every site
  left: Null
 right: "producer_without_site_contract"
test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 922 filtered out
```

Both falsification arms are red on exactly the right side. Arm A makes every producer certify:

```
test handlers::entities::tests::find_references_will_not_certify_sites_from_a_manually_authored_edge ... FAILED
test handlers::entities::tests::find_references_floors_a_row_whose_extra_kind_only_enrichment_saw ... FAILED
test handlers::entities::tests::find_references_will_not_certify_sites_from_a_one_site_per_edge_producer ... FAILED
test handlers::entities::tests::find_references_floors_a_row_mixing_a_parsed_and_a_language_server_edge ... FAILED
test result: FAILED. 0 passed; 4 failed; 0 ignored; 0 measured; 919 filtered out

test a_function_level_caller_lists_every_site_and_certifies_them ... ok
test a_module_level_caller_reached_only_by_enrichment_does_not_certify_its_sites ... FAILED
assertion `left == right` failed: the row reports [5] of the five sites at [5, 9, 13, 17, 21], so
the answer must not claim its site set is complete
```

The marker check has its own compiled mutant. Dropping it turns both new marker tests red while the
two producer-complete positives stay green:

```
test handlers::entities::tests::find_references_will_not_certify_evidence_marked_incomplete ... FAILED
assertion `left == right` failed: recovered parse at full confidence: the edge's own evidence says
the parse was short
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 923 filtered out

test a_module_level_caller_reached_only_by_enrichment_does_not_certify_its_sites ... ok
test a_function_level_caller_lists_every_site_and_certifies_them ... ok
test a_recovered_parse_floors_the_row_while_keeping_every_site_it_recorded ... FAILED
assertion `left == right` failed: the linker said the parse was short, so the answer must not certify
test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```

The integration fixture is producer-backed twice over. Each file's own `kin_blobs::digest` is
computed once and carried through both places that name its bytes, the index call and the tree entry
admitting the artifact, because the daemon checks that a blob's digest matches the bytes it indexed
and a fixture with a stand-in stops resembling the product the moment that check tightens. The index
call took one shared all-zero hash for every file and the tree entry took the file path padded with
zeros, which is a value no blob store would ever hold; `reference_call_site_lines.rs` carried the
same pair and is corrected with it. And the fixture passes `ParseCompleteness::Partial`
for the caller file, which is the linker's own input, so `call_shape_evidence` emits the marker and
`relation_evidence` attaches each of the five call-site spans to it. It reads the marker back off
the linker's output before asserting anything, so it cannot pass vacuously. The answer lists all
five real sites and still refuses to certify them, which is the honest shape.

Arm B makes nothing certify, and the positive controls go red, including the shipped one:

```
test handlers::entities::tests::find_references_reports_complete_sites_when_the_graph_carries_spans ... FAILED
test python_and_javascript_reference_rows_carry_call_site_lines_on_both_ingest_arms ... FAILED
assertion `left == right` failed: Python batch: every returned row has sites, so the answer must say so
```

Local runs at head `0e2d0f2b4`, each through `.kin-coord/bin/heavy-slot.sh` with a lane-pinned
`CARGO_TARGET_DIR`:

```
test result: ok. 924 passed; 0 failed; 0 ignored     # cargo test -p kin-mcp --lib
test result: ok. 1448 passed; 0 failed; 3 ignored    # cargo test -p kin-daemon --lib, at 52c52c325
test result: ok. 1 passed                            # kin-cli reference_call_site_lines, unchanged
test result: ok. 3 passed                            # kin-cli reference_site_completeness, new
cargo fmt --all                                      rc=0
cargo clippy --all-targets --all-features -- <the ci.yml allow list>   rc=0, RUSTFLAGS=-D warnings
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 21 gates ran, 21 passed, 0 failed
```

`kin-precheck` is local-only and hosted CI is the gate of record for the workspace suite. Its first
run reported `fmt` and `clippy` at exit 127 and `guard:test-windows-authority-legs.sh` at exit 1
with empty output; `bash -x scripts/test-windows-authority-legs.sh` ends at `++ command -v cargo` /
`+ CARGO_BIN=` and exits under `set -e`, so all three were cargo missing from its PATH, a
could-not-run rather than a red gate. With `~/.cargo/bin` on PATH all 21 pass.

## Limitations

References are NOT complete after this change. It makes the incompleteness visible; it does not
remove it. Two scoped follow-ups carry the actual undercount:

1. `crates/kin-parser/src/languages/javascript.rs:1489`. `extract_js_node` reaches
   `extract_calls_from_context` only from named-declaration arms, so module-level JavaScript and
   TypeScript statements record no call edge at all. Fixing it makes express's five sites
   graph-native. Wide blast radius: every JS and TS file gains module-level call edges.
2. kin-lsp `src/enrichment.rs:292`. `call.from_ranges.first()` should retain every range.
   `enrich_entity_uses_type` (enrichment.rs:915) keeps the first location per target, and
   `enrich_entity_references` (enrichment.rs:1007, 1019) dedupes by referencing entity and stores no
   span at all, so it contributes no line. Another repo, so it needs a version bump and a registry
   publish.

A third, reported and deliberately not taken here: `_kin.verdict` does not read the site flag, so a
floored site set still comes back `certified`. `Verdict::compute`
(`crates/kin-mcp/src/verdict.rs:248-257`) has seven readings and none of them is
`counts.reference_sites_complete`. The separation is deliberate, with its reason written at
`crates/kin-mcp/src/envelope.rs:1754-1758`, and row-set certification may coexist with a null site
total carried explicitly in `counts` and `_kin.completeness.counted.sites`.

Until the first two land, a `find_references` answer should be read as a floor wherever a row sets
`reference_lines_partial_reason`, which is now what the response says.
