### PR TITLE
Answer kin_graph_status from a seeded boundary reading, and stop calling a warming daemon absent (FIR-3266)

### DIFF
--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -1425,6 +1425,42 @@ impl StatusAdmission {
     }
 }
 
+/// What `kin status` says about a daemon that is up and still opening authority.
+///
+/// Split out from [`admit_before_reading`] so the sentence can be graded without
+/// a daemon on either side of it, exactly as `unreachable_daemon_sentence` is.
+///
+/// It states three things: that a daemon exists, which one, and how long this
+/// command waited before saying so. The pid and port are the pair an operator
+/// reads out of `.kin/daemon.pid` and `.kin/daemon.port`, so a reader who
+/// disbelieves the line can check it by hand.
+///
+/// The two arms are different news. `warming` true is the daemon's own flag off
+/// its readiness answer, so the state is known. `warming` false means it never
+/// answered readiness inside the budget, so all that is known is that its process
+/// is alive, and claiming it is warming would be inventing the part this command
+/// could not read.
+fn opening_authority_admission_sentence(
+    pid: u32,
+    port: u16,
+    detail: &str,
+    waited: std::time::Duration,
+    warming: bool,
+) -> String {
+    let waited_ms = waited.as_millis();
+    let state = if warming {
+        "is warming: it is listening and has not finished opening repository authority"
+    } else {
+        "is alive and did not answer a readiness check"
+    };
+    format!(
+        "this repository's daemon {state} (pid {pid}, port {port}), and it still had not after \
+         {waited_ms} ms, so nothing admitted the working copy and this reports durable authority \
+         alone; it last reported {detail}. Re-run once it is ready, or `kin admit` takes what the \
+         working copy holds"
+    )
+}
+
 /// Admit the complete exact tree, then let the caller read.
 ///
 /// Best effort by construction and never fatal: a status that refuses to print
@@ -1436,14 +1472,29 @@ impl StatusAdmission {
 /// lease keeps a daemon alive indefinitely, which is the defect this would be
 /// trading for.
 pub async fn admit_before_reading(layout: &kin_core::KinLayout) -> StatusAdmission {
-    let Some(base_url) = crate::daemon_client::resolve_daemon_url_if_running_async(layout).await
-    else {
-        return StatusAdmission::Skipped(
-            "no daemon is running for this repository, so nothing admitted the working copy \
-             and this reports durable authority alone; `kin admit` takes what the working \
-             copy holds"
-                .to_string(),
-        );
+    let base_url = match crate::daemon_client::running_daemon_reading(layout).await {
+        crate::daemon_client::RunningDaemonReading::Serving(url) => url,
+        // A daemon that is up and still opening authority is not an absent one,
+        // so it does not get the absent sentence below.
+        crate::daemon_client::RunningDaemonReading::OpeningAuthority {
+            pid,
+            port,
+            detail,
+            waited,
+            warming,
+        } => {
+            return StatusAdmission::Skipped(opening_authority_admission_sentence(
+                pid, port, &detail, waited, warming,
+            ));
+        }
+        crate::daemon_client::RunningDaemonReading::Absent => {
+            return StatusAdmission::Skipped(
+                "no daemon is running for this repository, so nothing admitted the working copy \
+                 and this reports durable authority alone; `kin admit` takes what the working \
+                 copy holds"
+                    .to_string(),
+            );
+        }
     };
     let Ok(client) = crate::daemon_client::DaemonClient::from_base_url_for_layout(base_url, layout)
     else {
@@ -1799,6 +1850,107 @@ fn build_id(sha: &str, dirty: bool) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A daemon that is up and still opening authority must never be reported as
+    /// absent.
+    ///
+    /// The fixture publishes what a warming daemon publishes: a `/readiness`
+    /// that answers 503 carrying the daemon's own `warming: true`, the shape
+    /// `kin_daemon::api::serve_warming_until` serves while authority loads.
+    /// Nothing here is inferred from the filesystem; the endpoint files say
+    /// where to ask and the answer comes from the server.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn a_daemon_still_opening_authority_is_not_reported_as_absent() {
+        let root = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(root.path()).unwrap().layout;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let warming = tokio::spawn(async move {
+            let app = axum::Router::new().route(
+                "/readiness",
+                axum::routing::get(|| async {
+                    (
+                        axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                        axum::Json(serde_json::json!({ "ready": false, "warming": true })),
+                    )
+                }),
+            );
+            let _ = axum::serve(listener, app).await;
+        });
+
+        // The pair an operator reads by hand to prove a daemon is up. This
+        // process is the live pid, so the endpoint is genuinely owned by
+        // something alive and the probe has no excuse to call it stale.
+        std::fs::write(
+            layout.root().join("daemon.pid"),
+            std::process::id().to_string(),
+        )
+        .unwrap();
+        std::fs::write(layout.root().join("daemon.port"), port.to_string()).unwrap();
+
+        let mut env = kin_core::test_env::EnvVarGuard::new();
+        // A one-second budget so the bounded wait is exercised without the test
+        // paying the operator default. The wait itself is what is under test:
+        // it must end, and it must end with a reading rather than a guess.
+        env.apply("KIN_DAEMON_EXISTING_READY_TIMEOUT_SECS", Some("1"));
+        // An inherited override would resolve before the endpoint files are ever
+        // consulted and the arm under test would never run.
+        env.apply("KIN_DAEMON_URL", None::<&str>);
+
+        let pass = admit_before_reading(&layout).await;
+        warming.abort();
+
+        let StatusAdmission::Skipped(why) = pass else {
+            panic!("a daemon that never opened authority admits nothing");
+        };
+        assert!(
+            !why.contains("no daemon is running"),
+            "a live, listening daemon must not be reported as absent: {why}"
+        );
+        assert!(
+            why.contains("warming"),
+            "the reader is told what the daemon is doing: {why}"
+        );
+        assert!(
+            why.contains(&format!("pid {}", std::process::id())),
+            "the reader is told which daemon, so the claim is checkable by hand: {why}"
+        );
+        assert!(
+            why.contains(&format!("port {port}")),
+            "the reader is told where, so the claim is checkable by hand: {why}"
+        );
+        assert!(
+            why.contains("ms"),
+            "the reader is told how long this command waited before saying so: {why}"
+        );
+    }
+
+    /// The control: with nothing recorded and nothing listening, the absent
+    /// sentence is correct and must survive.
+    ///
+    /// Without this, the arm above is satisfied by deleting the absent sentence
+    /// altogether, which would replace a false claim of absence with a false
+    /// claim of presence.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn a_repository_with_no_daemon_still_says_so() {
+        let root = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(root.path()).unwrap().layout;
+
+        let mut env = kin_core::test_env::EnvVarGuard::new();
+        env.apply("KIN_DAEMON_EXISTING_READY_TIMEOUT_SECS", Some("1"));
+        env.apply("KIN_DAEMON_URL", None::<&str>);
+
+        let StatusAdmission::Skipped(why) = admit_before_reading(&layout).await else {
+            panic!("no daemon admits nothing");
+        };
+        assert!(
+            why.contains("no daemon is running"),
+            "an absent daemon is still reported as absent: {why}"
+        );
+    }
 
     /// The coverage a bare authority read publishes. These cases exercise the
     /// durable half of the report, where no live graph was consulted, so this

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -8219,6 +8219,93 @@ pub async fn resolve_daemon_url_if_running_async(layout: &KinLayout) -> Option<S
     supervisor_route_for_repo_if_running_async(layout.root()).await
 }
 
+/// What this repository's own record says about its daemon, when supervisor
+/// resolution produced no endpoint.
+///
+/// [`resolve_daemon_url_if_running_async`] answers `Option<String>`, and its
+/// `None` collapses seven outcomes: no live supervisor, a route request that did
+/// not send, did not return 2xx or did not parse, an endpoint that failed the
+/// trust check, a `/health` probe that did the same, and a health answer that did
+/// not identify this repository as serving. None of those establishes whether a
+/// daemon process exists, so that `None` must not be rendered as a claim about
+/// one.
+///
+/// While authority loads, a daemon serves a warming surface whose `/readiness`
+/// answers 503 with `warming: true` and whose `/health` answers 200 with
+/// `status: "warming"`. [`probe_daemon_endpoint`] reads exactly that, on a
+/// deadline, and returns [`EndpointVerdict::LiveNotReady`] carrying the flag and
+/// the daemon's own detail; [`supervisor_route_for_repo`] has always used it.
+/// This asks it about the endpoint the repository itself recorded in
+/// `.kin/daemon.pid` and `.kin/daemon.port`.
+///
+/// Additive by construction: supervisor resolution is asked first and unchanged,
+/// so this can only turn a false absence into a true reading and never the
+/// reverse.
+#[derive(Debug)]
+pub enum RunningDaemonReading {
+    /// A daemon answered readiness and identified itself as serving this
+    /// repository, at this base URL.
+    Serving(String),
+    /// A daemon process is alive and has not finished opening repository
+    /// authority. `warming` is the daemon's own flag rather than this probe's
+    /// inference: true means it said so, false means it never answered readiness
+    /// at all, and those are different news for a reader.
+    OpeningAuthority {
+        pid: u32,
+        port: u16,
+        detail: String,
+        waited: Duration,
+        warming: bool,
+    },
+    /// Nothing this repository recorded is alive, so there is no daemon.
+    Absent,
+}
+
+/// Resolve this repository's daemon without ever starting one, and say which of
+/// the three states was found rather than collapsing two of them into `None`.
+///
+/// The wait is bounded by [`existing_daemon_ready_timeout_secs`], the same knob
+/// and the same default the auto-start path already waits on, and it ends early
+/// the moment readiness answers. It polls the daemon's own readiness signal and
+/// never sleeps on a guess or infers liveness from the filesystem: the endpoint
+/// files say where to ask, and the answer comes from the daemon.
+pub async fn running_daemon_reading(layout: &KinLayout) -> RunningDaemonReading {
+    if let Some(url) = resolve_daemon_url_if_running_async(layout).await {
+        return RunningDaemonReading::Serving(url);
+    }
+    let kin_root = layout.root();
+    let Some(endpoint) = live_daemon_endpoint(kin_root) else {
+        return RunningDaemonReading::Absent;
+    };
+    let started = Instant::now();
+    let verdict = probe_daemon_endpoint(
+        kin_root,
+        endpoint,
+        Duration::from_secs(existing_daemon_ready_timeout_secs()),
+    )
+    .await;
+    match verdict {
+        EndpointVerdict::Serving(base_url) => RunningDaemonReading::Serving(base_url),
+        EndpointVerdict::LiveNotReady {
+            pid,
+            port,
+            detail,
+            warming,
+        } => RunningDaemonReading::OpeningAuthority {
+            pid,
+            port,
+            detail,
+            waited: started.elapsed(),
+            warming,
+        },
+        // Positive evidence the record is wrong: the recorded process is gone,
+        // or the endpoint answered and named a different repository. Either way
+        // no daemon is serving this one, which is the sentence the caller has
+        // always printed and which is finally true here.
+        EndpointVerdict::Invalid(_) => RunningDaemonReading::Absent,
+    }
+}
+
 pub async fn resolve_daemon_url(layout: &KinLayout) -> Result<Option<String>> {
     resolve_daemon_url_inner(layout, None).await
 }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -2905,7 +2905,7 @@ impl GraphStatusSettledCache {
     /// Record a reading that completed the full live fence. O(1), taken after
     /// the fence is released, so recording can never lengthen the window an
     /// embed worker waits on.
-    fn record(
+    pub(crate) fn record(
         &self,
         scope: kin_mcp::handlers::entities::GraphStatusScope,
         graph: &Arc<kin_db::InMemoryGraph>,
@@ -2961,12 +2961,12 @@ impl GraphStatusSettledCache {
 /// Reading index metadata needs no embedder and takes no additional lock beyond
 /// the index's own.
 #[cfg(feature = "vector")]
-fn selected_graph_index_population(graph: &kin_db::InMemoryGraph) -> Option<usize> {
+pub(crate) fn selected_graph_index_population(graph: &kin_db::InMemoryGraph) -> Option<usize> {
     graph.vector_index_stats().map(|(_, population)| population)
 }
 
 #[cfg(not(feature = "vector"))]
-fn selected_graph_index_population(_graph: &kin_db::InMemoryGraph) -> Option<usize> {
+pub(crate) fn selected_graph_index_population(_graph: &kin_db::InMemoryGraph) -> Option<usize> {
     None
 }
 
@@ -42131,13 +42131,27 @@ mod tests {
     /// The one case with nothing honest to publish still must not answer with a
     /// bare retry instruction: it names what was tried, the state that blocked
     /// it, and the condition that changes the outcome.
+    ///
+    /// Asked about a graph this daemon holds no settled reading of, because the
+    /// HEAD slot no longer reaches this state: `DaemonState::open` records a
+    /// reading before any embedding worker can exist. The refusal graded here is
+    /// still reachable, for a selected graph with no slot of its own, so what
+    /// moved is which graph reaches it and not what it must say.
     #[tokio::test]
     async fn graph_status_with_no_settled_reading_names_the_blocking_state() {
         let state = test_state();
-        let graph = Arc::clone(&state.graph);
+        let unseeded: Arc<kin_db::InMemoryGraph> = Arc::new(kin_db::InMemoryGraph::new());
         let _embedding_guard = state.embedding_work.lock().unwrap();
 
-        let result = head_graph_status(&state, &graph).await;
+        let result = mcp_graph_status_with_stable_authority(
+            &state,
+            None,
+            &unseeded,
+            RequestGraphAuthority::Head,
+            kin_mcp::handlers::entities::GraphStatusScope::Head,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(result.is_error, Some(true));
         let text = mcp_result_text(&result);

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -240,6 +240,20 @@ fn run_background_embedding_batch(
         }
     };
 
+    // Record a settled status reading before this batch makes one impossible.
+    //
+    // `kin_graph_status` samples every counter under this same lock, which this
+    // batch is about to hold for its whole length, so a status call landing
+    // inside the batch answers from the settled cache. This is where that
+    // reading is taken, at an instant when no embedding work is in flight.
+    //
+    // At the top of the batch and not the bottom: `embedding_status` is memoized
+    // on the graph truth epoch and the vector index key-set token, this batch
+    // changes that token, and the worker's own batch decision just filled the
+    // memo. A call here hits it; a call after `process` always misses and
+    // rescans the retrievable key set.
+    state.seed_settled_head_graph_status();
+
     match process(state) {
         Ok(count) => BackgroundEmbeddingBatchOutcome::Completed(count),
         Err(error)

--- a/crates/kin-daemon/src/graph_status_first_contact.rs
+++ b/crates/kin-daemon/src/graph_status_first_contact.rs
@@ -1,0 +1,337 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! First contact with `kin_graph_status`, through the surface an agent calls.
+//!
+//! The status sampler takes `DaemonState::embedding_work` so it can read every
+//! counter under one fence, the background worker holds that lock across a whole
+//! batch, and the sampler's bounded budget is 75 ms. A call landing inside a
+//! batch therefore spends every attempt without sampling and must answer from
+//! the settled cache. These tests grade what it answers on a daemon that has
+//! never completed a live sample.
+//!
+//! They drive `POST /mcp/tools/call` through [`crate::api::router`], because
+//! what matters is what an MCP client receives rather than what an internal
+//! helper returns. They are a separate module from `api.rs`'s own tests on
+//! purpose: the behaviour under test is FIRST contact, so the state must never
+//! have answered a status call before the one being graded, and a fixture shared
+//! with tests that call status first would seed the cache these depend on being
+//! empty.
+//!
+//! Every reply is parsed through `GraphStatusReport`, whose `Deserialize` runs
+//! the same `validate` the production path runs, so parsing is itself an
+//! assertion that the published counters satisfy their cross-counter invariants:
+//! indexed at most total, pending at least the uncovered count, index keys at
+//! least indexed, and a staleness disclosure present exactly when the sampling
+//! says the reading was replayed.
+
+use std::path::PathBuf;
+use std::sync::{Arc, OnceLock};
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use kin_db::EntityStore;
+use tower::ServiceExt;
+
+use crate::state::DaemonState;
+
+/// Point registry authority at a scratch directory instead of the developer's
+/// real `~/.kin`, once for the whole test binary.
+///
+/// The `TempDir` handle is held in the `OnceLock` beside the path rather than
+/// dropped, because the path stays installed in the environment for the life of
+/// the process: dropping the handle would delete the registry out from under
+/// every test after the first.
+///
+/// Built through `tempfile` rather than `std::fs`, because
+/// `scripts/verify-zero-file-search.py` scans this crate's sources for
+/// filesystem reach and it is right to. It caught this file doing
+/// `std::fs::create_dir_all` and the honest fix is to stop, not to claim an
+/// exemption for test setup that does not need one.
+fn install_test_registry_override() {
+    static REGISTRY: OnceLock<(tempfile::TempDir, PathBuf)> = OnceLock::new();
+    let _guard = crate::test_env_lock();
+    let (_root, path) = REGISTRY.get_or_init(|| {
+        let root = tempfile::tempdir().expect("a scratch directory for the test registry");
+        let path = root.path().join("registry.toml");
+        kin_core::registry::KinRegistry { repos: Vec::new() }
+            .save_to(&path)
+            .unwrap();
+        (root, path)
+    });
+    kin_core::test_env::install_process_wide("KIN_REGISTRY_PATH", path);
+}
+
+/// The daemon an agent meets: opened over a real store, and never yet asked a
+/// status question.
+///
+/// The tempdir is returned rather than dropped, because dropping it deletes the
+/// store out from under the daemon still holding it open.
+fn daemon_at_first_contact() -> (tempfile::TempDir, Arc<DaemonState>) {
+    install_test_registry_override();
+    let dir = tempfile::tempdir().unwrap();
+    let layout = kin_core::init(dir.path()).unwrap().layout;
+    let state = Arc::new(DaemonState::open(layout).unwrap());
+    state
+        .is_initialized
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    (dir, state)
+}
+
+fn test_entity(name: &str, path: &str) -> kin_model::Entity {
+    kin_model::Entity {
+        id: kin_model::EntityId::new(),
+        kind: kin_model::EntityKind::Function,
+        name: name.to_string(),
+        language: kin_model::LanguageId::Python,
+        fingerprint: kin_model::SemanticFingerprint {
+            algorithm: kin_model::FingerprintAlgorithm::V1TreeSitter,
+            ast_hash: kin_model::Hash256::from_bytes([0x01; 32]),
+            signature_hash: kin_model::Hash256::from_bytes([0x02; 32]),
+            behavior_hash: kin_model::Hash256::from_bytes([0x03; 32]),
+            equivalence_hash: kin_model::Hash256::from_bytes([0; 32]),
+            stability_score: 1.0,
+        },
+        file_origin: Some(kin_model::FilePathId::new(path)),
+        span: Some(kin_model::SourceSpan {
+            file: kin_model::FilePathId::new(path),
+            start_byte: 0,
+            end_byte: 0,
+            start_line: 1,
+            start_col: 1,
+            end_line: 1,
+            end_col: 20,
+        }),
+        signature: format!("def {name}()"),
+        visibility: kin_model::Visibility::Public,
+        role: kin_model::EntityRole::Source,
+        doc_summary: None,
+        metadata: Default::default(),
+        lineage_parent: None,
+        created_in: None,
+        superseded_by: None,
+    }
+}
+
+/// Put entities into the live query graph, the way admission does.
+fn admit_two_entities(state: &Arc<DaemonState>) {
+    state
+        .graph
+        .upsert_entity(&test_entity("first_contact_alpha", "src/alpha.py"))
+        .unwrap();
+    state
+        .graph
+        .upsert_entity(&test_entity("first_contact_beta", "src/beta.py"))
+        .unwrap();
+}
+
+/// Call `kin_graph_status` the way an MCP client does.
+async fn graph_status_over_mcp(state: Arc<DaemonState>) -> kin_mcp::ToolCallResult {
+    let response = crate::api::router(state)
+        .oneshot(
+            Request::post("/mcp/tools/call")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "name": "kin_graph_status", "arguments": {} }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    serde_json::from_slice(&body).unwrap()
+}
+
+fn result_text(result: &kin_mcp::ToolCallResult) -> String {
+    match result.content.first().unwrap() {
+        kin_mcp::ContentBlock::Text { text } => text.clone(),
+    }
+}
+
+/// Parse, which also runs the production `validate`.
+fn parse_report(
+    result: &kin_mcp::ToolCallResult,
+) -> kin_mcp::handlers::entities::GraphStatusReport {
+    serde_json::from_str(&result_text(result))
+        .unwrap_or_else(|error| panic!("status is not a valid report: {error}: {result:?}"))
+}
+
+/// The defect, at the surface an agent sees.
+///
+/// A daemon that has never completed a status sample, with an embedding pass
+/// holding embedding-work serialization, must still answer. Today this returns
+/// `isError: true` with "holds no settled reading of this graph", because the
+/// settled cache's only writer is downstream of the lock this call cannot take.
+#[tokio::test]
+async fn first_contact_graph_status_answers_while_an_embedding_pass_holds_the_lock() {
+    let (_dir, state) = daemon_at_first_contact();
+    admit_two_entities(&state);
+
+    let _embedding_guard = state.embedding_work.lock().unwrap();
+    let result = graph_status_over_mcp(Arc::clone(&state)).await;
+
+    assert_ne!(
+        result.is_error,
+        Some(true),
+        "the first tool an agent calls must not fail for the length of an embedding pass: {}",
+        result_text(&result)
+    );
+}
+
+/// The answer must be a report, and it must name where it came from.
+///
+/// Parsing runs the production `validate`, so reaching the assertions below at
+/// all proves the published counters are internally consistent. The assertions
+/// then pin the three facts a caller needs to know what it is holding: which
+/// graph was read, which authority answered, and at which observation fence.
+#[tokio::test]
+async fn the_first_contact_answer_names_its_scope_authority_and_epoch() {
+    let (_dir, state) = daemon_at_first_contact();
+    admit_two_entities(&state);
+    let epoch = state
+        .stable_graph_authority_epoch()
+        .expect("a quiescent graph publishes a stable authority epoch");
+
+    let _embedding_guard = state.embedding_work.lock().unwrap();
+    let result = graph_status_over_mcp(Arc::clone(&state)).await;
+    assert_ne!(result.is_error, Some(true), "{}", result_text(&result));
+
+    let report = parse_report(&result);
+    assert_eq!(
+        report.scope,
+        kin_mcp::handlers::entities::GraphStatusScope::Head,
+        "an unscoped call reports the HEAD view"
+    );
+    assert_eq!(
+        report.authority,
+        kin_mcp::handlers::entities::GraphStatusAuthority::RepoDaemon,
+        "the answer names the authority that produced it"
+    );
+    // Nothing has moved this graph's authority since it opened, so the reading's
+    // epoch must be the one the daemon is on. A reading carrying some other
+    // epoch would be describing a fence this daemon never stood at.
+    assert_eq!(
+        report.authority_epoch, epoch,
+        "the reading carries the epoch it was taken at"
+    );
+}
+
+/// A reading taken at an earlier instant says which instant.
+///
+/// The whole point of answering rather than erroring is that a caller can act on
+/// the answer, and it can only do that if it knows how old the answer is and
+/// what stopped a live one.
+#[tokio::test]
+async fn a_replayed_first_contact_reading_states_its_age_and_what_blocked_the_live_sample() {
+    let (_dir, state) = daemon_at_first_contact();
+    admit_two_entities(&state);
+
+    let _embedding_guard = state.embedding_work.lock().unwrap();
+    let result = graph_status_over_mcp(Arc::clone(&state)).await;
+    assert_ne!(result.is_error, Some(true), "{}", result_text(&result));
+
+    let report = parse_report(&result);
+    assert_eq!(
+        report.sampling,
+        kin_mcp::handlers::entities::GraphStatusSampling::LastSettledSelectedGraph,
+        "a reading taken before this call is not a live point-in-time sample"
+    );
+    let stale = report
+        .stale
+        .as_ref()
+        .expect("a replayed reading discloses itself");
+    assert_eq!(
+        stale.reason,
+        kin_mcp::handlers::entities::GraphStatusStaleReason::EmbeddingCoverageChanging,
+        "the disclosure names the state that blocked the live sample"
+    );
+    assert!(
+        stale.note.contains("in-flight embedding pass"),
+        "the note states the blocking state in words: {}",
+        stale.note
+    );
+    assert!(
+        stale.note.contains("kin embed"),
+        "the note names what would change the outcome: {}",
+        stale.note
+    );
+}
+
+/// The boundary reading carries the graph the batch actually found.
+///
+/// `run_background_embedding_batch` calls
+/// [`DaemonState::seed_settled_head_graph_status`] at the top of every batch,
+/// from inside the guard it already holds. Driving that same production seam
+/// here is what pins the counters to a real observation: a reading recorded
+/// after an import must carry the import.
+///
+/// This is the arm that makes "no invented zeros" falsifiable. A fix that seeded
+/// only at open, when this store was still empty, satisfies every other arm in
+/// this module and fails this one, because it would publish two entities as
+/// zero.
+#[tokio::test]
+async fn a_boundary_reading_carries_the_graph_the_batch_actually_found() {
+    let (_dir, state) = daemon_at_first_contact();
+    admit_two_entities(&state);
+    let live_entities = state.graph.entity_count();
+    let live_relations = state.graph.relation_count();
+    assert!(
+        live_entities > 0,
+        "the fixture must hold entities for a published zero to be falsifiable"
+    );
+
+    // What the embedding worker does at the top of each batch.
+    state.seed_settled_head_graph_status();
+
+    let _embedding_guard = state.embedding_work.lock().unwrap();
+    let result = graph_status_over_mcp(Arc::clone(&state)).await;
+    assert_ne!(result.is_error, Some(true), "{}", result_text(&result));
+
+    let report = parse_report(&result);
+    assert_eq!(
+        report.sampling,
+        kin_mcp::handlers::entities::GraphStatusSampling::LastSettledSelectedGraph,
+        "the lock is held, so this is the boundary reading and not a live sample"
+    );
+    assert_eq!(
+        report.entity_count, live_entities,
+        "the boundary reading carries the entities the batch found, not the empty graph the open saw"
+    );
+    assert_eq!(
+        report.relation_count, live_relations,
+        "and the relations beside them"
+    );
+}
+
+/// Control, and it passes on the unmodified source.
+///
+/// An uncontended first contact already answers live. It is here so the arms
+/// above cannot be satisfied by making every answer stale, and so the shape of a
+/// healthy reading stays pinned beside the shape of a contended one.
+#[tokio::test]
+async fn an_uncontended_first_contact_is_a_live_point_in_time_sample() {
+    let (_dir, state) = daemon_at_first_contact();
+    admit_two_entities(&state);
+
+    let result = graph_status_over_mcp(Arc::clone(&state)).await;
+    assert_ne!(result.is_error, Some(true), "{}", result_text(&result));
+
+    let report = parse_report(&result);
+    assert_eq!(
+        report.sampling,
+        kin_mcp::handlers::entities::GraphStatusSampling::PointInTimeSelectedGraph,
+        "an uncontended sample is live"
+    );
+    assert!(
+        report.stale.is_none(),
+        "a live sample carries no staleness disclosure: {report:?}"
+    );
+    assert_eq!(
+        report.entity_count,
+        state.graph.entity_count(),
+        "a live sample carries this graph's own counters"
+    );
+}

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -123,6 +123,12 @@ pub mod daemon;
 pub mod error;
 pub mod gcs_endpoint;
 pub mod graph_only_members;
+/// First contact with `kin_graph_status` while an embedding pass holds
+/// embedding-work serialization. Test-only, and its own module so the fixture
+/// can guarantee no status call has run against the state before the one under
+/// test.
+#[cfg(test)]
+mod graph_status_first_contact;
 pub mod hosted_start;
 pub mod lifecycle;
 mod local_repository_authority;

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -3853,6 +3853,70 @@ impl DaemonState {
             < crate::api::GRAPH_STATUS_UNANSWERABLE_STREAK
     }
 
+    /// Record a coherent settled `kin_graph_status` reading of the HEAD graph.
+    ///
+    /// The status sampler reads every counter under `embedding_work` so the set
+    /// describes one instant, and the background worker holds that lock for the
+    /// length of a batch. A status call landing inside a batch therefore spends
+    /// its whole bounded budget without sampling and answers from the settled
+    /// cache instead. This is what puts a reading in that cache.
+    ///
+    /// Called at two points and only two: the end of the open, before any
+    /// embedding worker exists, and the start of each background batch, from
+    /// inside the guard that batch already holds.
+    ///
+    /// # The caller owns the fence
+    ///
+    /// This takes no lock. `embedding_work` is a non-reentrant `std::sync::Mutex`
+    /// and the batch-boundary caller already holds it, so acquiring it here would
+    /// self-deadlock. Call this only where no embedding work can be in flight:
+    /// holding `embedding_work`, or before the worker exists.
+    ///
+    /// # Nothing incoherent is recorded
+    ///
+    /// The authority epoch is read before the counters and revalidated after
+    /// them, as the live sampler does. An epoch that could not be read, or that
+    /// moved during the capture, records nothing. An absent settled reading is a
+    /// state the status path reports honestly; a torn one would be published as
+    /// fact and would fail `GraphStatusReport::validate` on its cross-counter
+    /// invariants.
+    ///
+    /// # Cost
+    ///
+    /// This cache may not cost work proportional to the graph. `entity_count`
+    /// and `relation_count` are map lengths and `vector_index_stats` is index
+    /// metadata, all O(1). `embedding_status` can scan, but kin-db memoizes it on
+    /// the graph truth epoch and the vector index key-set token: a batch changes
+    /// that token, so a reading taken after a batch always misses and rescans,
+    /// while one taken before it lands on the memo the worker's own batch
+    /// decision just filled. That is why the batch call site is the top of the
+    /// batch and not the bottom.
+    pub(crate) fn seed_settled_head_graph_status(&self) {
+        let Some(authority_epoch) = self.stable_graph_authority_epoch() else {
+            return;
+        };
+        let embeddings = self.graph.embedding_status();
+        let observation = kin_mcp::handlers::entities::GraphStatusObservation {
+            authority_epoch,
+            entity_count: self.graph.entity_count(),
+            relation_count: self.graph.relation_count(),
+            embeddings_indexed: embeddings.indexed,
+            embeddings_pending: embeddings.pending,
+            embeddings_total: embeddings.total,
+            embedding_index_keys: crate::api::selected_graph_index_population(&self.graph),
+            durable_entity_count: self.durable_entity_count(),
+            durable_relation_count: self.durable_relation_count(),
+        };
+        if !self.graph_authority_epoch_is_current(authority_epoch) {
+            return;
+        }
+        self.graph_status_settled.record(
+            kin_mcp::handlers::entities::GraphStatusScope::Head,
+            &self.graph,
+            observation,
+        );
+    }
+
     /// Load a persisted vector-index sidecar into a graph that was NOT built
     /// through `SnapshotManager` (the storage-backend path uses
     /// `InMemoryGraph::from_snapshot_with_text_index`, which does not load the
@@ -5495,6 +5559,12 @@ impl DaemonState {
             }
         }
         state.register_daemon_system_session();
+        // The first settled status reading, taken here because this is the last
+        // instant before the daemon can start embedding. A background pass holds
+        // `embedding_work` across whole batches and the status sampler needs that
+        // same lock, so without a reading recorded now a status call during the
+        // initial pass has nothing to answer from.
+        state.seed_settled_head_graph_status();
         phases.emit(&state.cached_repo_id, &state.layout);
         Ok(state)
     }


### PR DESCRIPTION
Two first-contact defects found by the journey run on the sealed candidate, both landing in the first
minutes a stranger wires an agent to a real repository.

## kin_graph_status returned isError for the whole of a store's first embedding pass

The status sampler takes `DaemonState::embedding_work` so it can read every counter under one fence.
The background worker holds that lock across a whole batch, and the sampler's budget is three
attempts across 75 ms, so a call landing inside a batch loses every attempt by construction rather
than by luck. The settled-reading replay built for exactly that case could not help: its only writer
was the sampler itself, downstream of the same lock, so a daemon whose first act is an embedding pass
never completed the sample that would seed it. Meanwhile `command_graph`, behind `kin graph status`,
takes no such lock and answered in full off the same graph in the same daemon at the same second.

The fix records a real coherent reading at the two instants where no embedding work can be in flight:
at the end of `DaemonState::open`, and at the top of each background batch from inside the guard that
batch already holds. The wire format, the replay contract and the staleness disclosure are unchanged.
The answer is the most recent valid boundary reading and publishes its actual age; no wall-clock
staleness ceiling is claimed, because a paused or refused worker would break one.

The batch seam is at the top of the batch and not the bottom for a reason that is not stylistic.
kin-db memoizes `embedding_status` on the graph truth epoch and the vector index key-set token, and
the batch changes that token, so a call after it always rescans the retrievable key set while a call
before it lands on the memo the worker's own batch decision just filled. That keeps the settled cache
inside the constraint FIR-2416 put on it: no work proportional to the graph.

An earlier design narrowing the serialization with a reset-only seqlock was withdrawn before it was
written. `GraphStatusReport::validate` requires indexed at most total, pending at least the uncovered
count, and index keys at least indexed, and a sample taken across an in-flight batch can violate the
second or third, so it would have traded one isError for another.

**Scope residual, not fixed here.** The seed covers the HEAD slot.
`DaemonState::graph_for_request_with_authority` returns `SessionScope` only for a session holding a
registered unexpired temporal scope and `Head` otherwise, and the MCP dispatch maps that authority
straight onto the status scope, so an agent that has not opened a temporal scope reads HEAD and is
covered. A session that opens one during an embedding pass still finds an empty session slot and
still gets the refusal.

## kin status called a live, warming daemon absent

The sentence came from an `Option<String>` whose `None` collapses seven distinct outcomes: no live
supervisor, a route request that did not send, did not return 2xx or did not parse, an endpoint that
failed the trust check, a health probe that did the same, and a health answer that did not identify
this repository as serving. None of those establishes whether a daemon process exists. Against a
daemon that was listening and still opening authority, `kin status` printed "no daemon is running for
this repository" and then paid 27.9 s of in-process open that re-verifies every persisted body.

The daemon publishes the truth on the way up: while authority loads it serves a readiness endpoint
carrying its own warming flag. `probe_daemon_endpoint` already reads exactly that, on a deadline, and
returns a three-way verdict, and `supervisor_route_for_repo` has always used it. This path now asks
it, on the same bounded budget, about the endpoint the repository itself recorded in `daemon.pid` and
`daemon.port`, which is the pair an operator reads by hand to check the same claim.

Supervisor resolution is asked first and unchanged, so this can only turn a false absence into a true
reading and never the reverse. A repository with no endpoint recorded, or one whose process is gone,
is `Absent` before any probe runs; a registered serving daemon resolves as it always did; only the
warming path spends the budget. `admit_before_reading` has two callers, so `kin diff` gains the same
correction.

## Tests

`crates/kin-daemon/src/graph_status_first_contact.rs` is new and drives `POST /mcp/tools/call`
through the public router, because the defect is about what an MCP client receives. On the unmodified
source three of its arms fail carrying the production refusal verbatim:

```
test result: FAILED. 1 passed; 3 failed; 0 ignored; 0 measured; 1451 filtered out; finished in 3.82s

assertion `left != right` failed: the first tool an agent calls must not fail for the length of an
embedding pass: kin_graph_status could not sample the selected graph: embedding-work serialization
was held by an in-flight embedding pass across 3 attempts, and this daemon holds no settled reading
of this graph to report as of an earlier instant. ...
  left: Some(true)
 right: Some(true)
```

With the fix, that suite and its neighbours in api.rs:

```
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 1445 filtered out; finished in 36.50s
```

`a_boundary_reading_carries_the_graph_the_batch_actually_found` drives the same production seam
`run_background_embedding_batch` drives, and is what pins the counters to a real observation: remove
that seed and the reading reverts to the empty graph the open saw, publishing two entities as zero.
Every reply is parsed through `GraphStatusReport`, whose `Deserialize` runs the production
`validate`, so parsing is itself the cross-counter invariant check.

Two arms in `crates/kin-cli/src/commands/status.rs` grade the warming sentence against a real
readiness surface and keep the absent control. On the pre-fix resolver:

```
a live, listening daemon must not be reported as absent: no daemon is running for this repository,
so nothing admitted the working copy and this reports durable authority alone; `kin admit` takes what
the working copy holds
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2207 filtered out; finished in 1.93s
```

With the fix, run over the ten neighbouring status tests as well:

```
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 2196 filtered out; finished in 12.03s
```

Both classes are crate tests rather than acceptance cases, because `Product Acceptance` carries
`if: ${{ github.event_name != 'pull_request' }}` and would not grade the pull request that broke them.

`graph_status_with_no_settled_reading_names_the_blocking_state` asserted the defect: it demanded a
refusal from a HEAD scope that can no longer reach that state. It is repointed at a graph with no
settled reading, with every assertion about the message intact.

## File overlap, and who rebases

This branch touches two files other lanes are working in, both cleared as disjoint hunks:

- `crates/kin-daemon/src/daemon.rs`: one seed call plus its comment at the top of
  `run_background_embedding_batch`, no control flow change. Disjoint from the concurrent
  embed-worker admission work in that file.
- `crates/kin-daemon/src/api.rs`: three hunks, none of them production behaviour. Two visibility
  words (`GraphStatusSettledCache::record` and `selected_graph_index_population` become
  `pub(crate)`) and the one test repointed above. Disjoint from the concurrent `command_commit` and
  `CommitAttempt` work in that file.

Whichever of these branches lands second rebases onto main and re-runs its gates.
