### PR TITLE
Bind fresh entity spans to exact source blobs

### DIFF
--- a/crates/kin-cli/tests/caller_arrival_separates_a_measured_shortfall.rs
+++ b/crates/kin-cli/tests/caller_arrival_separates_a_measured_shortfall.rs
@@ -90,7 +90,7 @@ fn parse(path: &str, source: &str) -> (FileParseData, Vec<Entity>) {
         .index_file_content_with_tests(
             &FilePathId::new(path),
             source.as_bytes(),
-            kin_blobs::Hash256::from_bytes([5; 32]),
+            kin_blobs::digest(source.as_bytes()),
         )
         .unwrap_or_else(|error| panic!("indexing {path} failed: {error}"))
         .indexed_file;

--- a/crates/kin-cli/tests/reference_call_site_lines.rs
+++ b/crates/kin-cli/tests/reference_call_site_lines.rs
@@ -112,7 +112,6 @@ struct IndexedFixtureFile {
 
 fn index_files(fixture: &Fixture) -> Vec<IndexedFixtureFile> {
     let pipeline = IndexPipeline::new();
-    let blob_hash = kin_blobs::Hash256::from_bytes([0u8; 32]);
     [
         (fixture.defs_path, fixture.defs_source),
         (fixture.caller_path, fixture.caller_source),
@@ -120,7 +119,11 @@ fn index_files(fixture: &Fixture) -> Vec<IndexedFixtureFile> {
     .into_iter()
     .map(|(path, source)| {
         let indexed = pipeline
-            .index_file_content_with_tests(&FilePathId::new(path), source.as_bytes(), blob_hash)
+            .index_file_content_with_tests(
+                &FilePathId::new(path),
+                source.as_bytes(),
+                kin_blobs::digest(source.as_bytes()),
+            )
             .unwrap_or_else(|error| panic!("{} index {path}: {error}", fixture.language))
             .indexed_file;
         IndexedFixtureFile {

--- a/crates/kin-cli/tests/repository_merge_resolution.rs
+++ b/crates/kin-cli/tests/repository_merge_resolution.rs
@@ -78,6 +78,7 @@ fn run_kin_without_enrichment(
         .env("GIT_CONFIG_NOSYSTEM", "1")
         .env("KIN_DAEMON_BIN", runtime.daemon_bin())
         .env("KIN_DAEMON_DISABLE_LSP", "1")
+        .env("KIN_EMBED_BACKEND", "cpu")
         .current_dir(repo)
         .output()
         .expect("run kin")
@@ -1685,28 +1686,11 @@ fn entity_named(state: &kin_model::graph::ResolvedGraphState, name: &str) -> kin
     found.pop().expect("checked immediately above")
 }
 
-/// An entity NEITHER branch edited still differs between the branches, and the
-/// measurement says on which field.
-///
-/// Measured rather than assumed, and the measurement corrected the guess that
-/// produced it. `beta` is untouched by both sides, so provenance looked like the
-/// likely difference; `created_in` is in fact EQUAL, because nothing re-minted
-/// the record. The one field that differs is `span`, and the reason is that the
-/// two edits to `alpha` above it are different LENGTHS, so every byte offset
-/// below shifts by a different amount on each side.
-///
-/// That is why one changed function reports three entity conflicts here and
-/// nine in the rc062j stranger run. A byte offset is a projection of whichever
-/// bytes the merge publishes, not an independent decision, so the operator is
-/// being asked a question whose answer is already determined by another answer.
-/// Removing that question is the derived-conflict design, which is FIR-2960 and
-/// not this change: this test records the premise, and the count it explains.
-///
-/// The assertion is an equality against the exact measured set rather than a
-/// subset check, so an entity that starts differing on a SEMANTIC field fails
-/// here rather than being quietly folded into the same explanation.
+/// Different-length edits to `alpha` shift the untouched `beta` span and change
+/// the complete source blob on each branch. Both digests must bind their exact
+/// admitted trees. Every other metadata and entity field must remain equal.
 #[test]
-fn an_untouched_entity_differs_between_branches_only_in_its_span() {
+fn an_untouched_entity_differs_between_branches_only_in_its_span_and_source_digest() {
     let root = tempdir().expect("temp root");
     let repo = container_settle_repository(root.path());
     let runtime = common::IsolatedDaemonRuntime::new(&repo);
@@ -1717,12 +1701,35 @@ fn an_untouched_entity_differs_between_branches_only_in_its_span() {
     let ours = graph_at(&layout, &branch_change(&layout, "main"));
     let theirs = graph_at(&layout, &branch_change(&layout, "feature"));
 
-    let untouched =
-        entity_field_differences(&entity_named(&ours, "beta"), &entity_named(&theirs, "beta"));
+    let mut ours_beta = entity_named(&ours, "beta");
+    let mut theirs_beta = entity_named(&theirs, "beta");
+    for (state, entity) in [(&ours, &ours_beta), (&theirs, &theirs_beta)] {
+        let span = entity.span.as_ref().expect("untouched function has a span");
+        let artifact = state
+            .tree
+            .artifact_at_path(&kin_model::RepoPath::from_utf8(&span.file.0).unwrap())
+            .expect("span source belongs to the exact branch tree");
+        let digest = artifact.entry.blob_identity().expect("source is a blob");
+        assert_eq!(
+            entity.metadata.extra.get("blob_hash"),
+            Some(&Value::String(digest.to_string())),
+            "untouched entity must bind the exact source blob in its branch tree"
+        );
+    }
+    assert_eq!(
+        entity_field_differences(&ours_beta, &theirs_beta),
+        vec!["span", "metadata"],
+        "different branch source bytes must change both the span and its provenance"
+    );
+    // Remove only the independently verified source digest before comparing.
+    // Every other metadata field remains part of the strict entity comparison.
+    ours_beta.metadata.extra.remove("blob_hash");
+    theirs_beta.metadata.extra.remove("blob_hash");
+    let untouched = entity_field_differences(&ours_beta, &theirs_beta);
     assert_eq!(
         untouched,
         vec!["span"],
-        "an entity neither side edited differs only in its byte offsets; it actually differed on {untouched:?}"
+        "apart from its exact source digest, an untouched entity differs only in its byte offsets; it actually differed on {untouched:?}"
     );
 
     // The control that keeps the reading honest: the entity both sides DID edit

--- a/crates/kin-index/src/error.rs
+++ b/crates/kin-index/src/error.rs
@@ -20,6 +20,13 @@ pub enum IndexError {
         source: std::io::Error,
     },
 
+    #[error("source bytes for {path} have digest {actual}, not supplied blob digest {expected}")]
+    SourceDigestMismatch {
+        path: String,
+        expected: kin_blobs::Hash256,
+        actual: kin_blobs::Hash256,
+    },
+
     #[error("unsupported file: {0}")]
     UnsupportedFile(String),
 

--- a/crates/kin-index/src/history.rs
+++ b/crates/kin-index/src/history.rs
@@ -56,7 +56,7 @@ use crate::pipeline::IndexPipeline;
 /// version keeps whatever its past was authored to contain until it is admitted
 /// again. Carrying the authoring version on the wire, automatic re-derivation,
 /// migration and refusing to answer over a gap all remain open follow-up work.
-pub const HYDRATION_SEMANTICS_VERSION: u32 = 10;
+pub const HYDRATION_SEMANTICS_VERSION: u32 = 11;
 
 /// Semantic graph delta derived for one pre-enrichment change identity.
 ///
@@ -1289,6 +1289,137 @@ mod tests {
             error.to_string().contains("was not enriched first"),
             "{error}"
         );
+    }
+
+    #[test]
+    fn span_provenance_history_tracks_exact_tree_bytes_and_reuses_unchanged_files() {
+        let root = tempdir().unwrap();
+        let repository = root.path().join("source");
+        fs::create_dir(&repository).unwrap();
+        git(&repository, &["init", "--initial-branch=main"]);
+        git(
+            &repository,
+            &["config", "user.email", "kin@example.invalid"],
+        );
+        git(&repository, &["config", "user.name", "Kin Test"]);
+        let initial = b"def merge_setting(value):\n    return value\n";
+        write(&repository, "src/sessions.py", initial);
+        write(
+            &repository,
+            "src/unchanged.py",
+            b"def unchanged():\n    return 7\n",
+        );
+        git(&repository, &["add", "--all"]);
+        git(&repository, &["commit", "-m", "initial source"]);
+        let shifted = b"# leading source comment\ndef merge_setting(value):\n    return value\n";
+        write(&repository, "src/sessions.py", shifted);
+        git(&repository, &["add", "--all"]);
+        git(
+            &repository,
+            &[
+                "commit",
+                "-m",
+                "move function without changing its behavior",
+            ],
+        );
+        write(&repository, "README.md", b"unrelated artifact change\n");
+        git(&repository, &["add", "--all"]);
+        git(&repository, &["commit", "-m", "retain source unchanged"]);
+        let blob_store = BlobStore::new(root.path().join("cas")).unwrap();
+        let snapshot = capture_lossless_git_repository(
+            &repository,
+            RepositoryId::new("span-provenance-history").unwrap(),
+            &blob_store,
+        )
+        .unwrap();
+        let plan = plan_semantic_git_import(&snapshot, &blob_store).unwrap();
+        let trees = trees_by_change(&plan);
+        // Enrichment must use the captured graph and CAS, even when a checkout differs.
+        write(
+            &repository,
+            "src/sessions.py",
+            b"def unrelated_checkout():\n    pass\n",
+        );
+        let deltas = derive_historical_semantic_deltas(&plan.changes, &trees, &blob_store).unwrap();
+        assert_eq!(deltas.len(), 3);
+        let mut entities = BTreeMap::new();
+        for delta in &deltas {
+            for change in &delta.entity_deltas {
+                if let Some(entity) = change.new_state() {
+                    entities.insert(entity.id, entity.clone());
+                }
+            }
+            assert_eq!(
+                entities
+                    .values()
+                    .filter(|entity| entity.kind == EntityKind::Function)
+                    .count(),
+                2,
+                "both fixture functions must survive replay"
+            );
+            let tree = &trees[&delta.change_id];
+            for entity in entities.values() {
+                let path = entity.file_origin.as_ref().unwrap();
+                let artifact = tree
+                    .artifact_at_path(&kin_model::RepoPath::from_utf8(&path.0).unwrap())
+                    .unwrap();
+                let digest = artifact.entry.blob_identity().unwrap();
+                assert_eq!(
+                    entity
+                        .metadata
+                        .extra
+                        .get("blob_hash")
+                        .and_then(|value| value.as_str()),
+                    Some(digest.to_string().as_str()),
+                    "{} span must bind its exact historical tree body",
+                    entity.name
+                );
+                let body = blob_store
+                    .read(&kin_blobs::Hash256::from_bytes(*digest.as_bytes()))
+                    .unwrap();
+                let span = entity.span.as_ref().unwrap();
+                let excerpt = &body[span.start_byte as usize..span.end_byte as usize];
+                if entity.kind == EntityKind::Function {
+                    assert!(String::from_utf8_lossy(excerpt).contains(&entity.name));
+                }
+            }
+        }
+        let moved = deltas[1]
+            .entity_deltas
+            .iter()
+            .find_map(|delta| match delta {
+                EntityDelta::Modified { old, new } if new.name == "merge_setting" => {
+                    Some((old, new))
+                }
+                _ => None,
+            })
+            .expect("span-only edit must persist a modified entity");
+        assert_eq!(moved.0.id, moved.1.id);
+        assert_eq!(moved.0.fingerprint, moved.1.fingerprint);
+        assert_ne!(
+            moved.0.metadata.extra["blob_hash"],
+            moved.1.metadata.extra["blob_hash"]
+        );
+        assert!(
+            deltas[2].entity_deltas.is_empty(),
+            "unchanged source needs no semantic delta"
+        );
+        let bindings = deltas
+            .iter()
+            .map(|delta| {
+                kin_git::HistoricalSemanticBinding::borrowed(
+                    delta.change_id,
+                    &delta.entity_deltas,
+                    &delta.relation_deltas,
+                )
+            })
+            .collect::<Vec<_>>();
+        let enriched = plan
+            .with_historical_semantics(&blob_store, bindings)
+            .unwrap();
+        let admitted = admit_semantic_git_import(&enriched, &blob_store).unwrap();
+        admitted.validate(&blob_store).unwrap();
+        assert_eq!(admitted.changes[1].entity_deltas, deltas[1].entity_deltas);
     }
 
     fn trees_by_change(

--- a/crates/kin-index/src/pipeline.rs
+++ b/crates/kin-index/src/pipeline.rs
@@ -125,6 +125,14 @@ impl IndexPipeline {
         source: &[u8],
         blob_hash: kin_blobs::Hash256,
     ) -> Result<IndexedFileWithTests> {
+        let actual = kin_blobs::digest(source);
+        if actual != blob_hash {
+            return Err(IndexError::SourceDigestMismatch {
+                path: file_id.0.clone(),
+                expected: blob_hash,
+                actual,
+            });
+        }
         let path = Path::new(&file_id.0);
         let ext = path
             .extension()
@@ -170,6 +178,7 @@ impl IndexPipeline {
                 ent
             })
             .collect();
+        attach_span_source_digest(&mut entities, blob_hash);
         attach_file_context_metadata(&mut entities, file_id, &imports);
         attach_file_reference_parse_counts(
             &mut entities,
@@ -330,6 +339,7 @@ impl IndexPipeline {
                 ent
             })
             .collect();
+        attach_span_source_digest(&mut entities, blob_hash);
         attach_file_context_metadata(&mut entities, file_id, &imports);
         attach_file_reference_parse_counts(
             &mut entities,
@@ -641,6 +651,17 @@ pub fn normalize_file_path_id(path: &Path, root: &Path) -> FilePathId {
     let relative = path.strip_prefix(root).unwrap_or(path);
     let normalized = relative.to_string_lossy().replace('\\', "/");
     FilePathId::new(normalized)
+}
+
+/// Bind parser-derived spans to the complete source blob, including trivia.
+fn attach_span_source_digest(entities: &mut [Entity], blob_hash: kin_blobs::Hash256) {
+    let digest = blob_hash.to_string();
+    for entity in entities {
+        entity
+            .metadata
+            .extra
+            .insert("blob_hash".into(), digest.clone().into());
+    }
 }
 
 /// Attach the behavior-equivalence class to each entity of a participating
@@ -1731,6 +1752,128 @@ mod tests {
             role_of("shipped"),
             EntityRole::Source,
             "the production function beside it keeps its role"
+        );
+    }
+
+    fn assert_span_blob_provenance(indexed: &IndexedFile, source: &[u8]) {
+        let expected = kin_blobs::digest(source).to_string();
+        assert_eq!(indexed.blob_hash.to_string(), expected);
+        assert!(
+            !indexed.entities.is_empty(),
+            "source fixture must produce entities"
+        );
+        for entity in &indexed.entities {
+            let span = entity
+                .span
+                .as_ref()
+                .expect("parsed entity must have a span");
+            assert!(source
+                .get(span.start_byte as usize..span.end_byte as usize)
+                .is_some());
+            assert_eq!(
+                entity
+                    .metadata
+                    .extra
+                    .get("blob_hash")
+                    .and_then(|value| value.as_str()),
+                Some(expected.as_str()),
+                "{} span must name the exact parsed source blob",
+                entity.name
+            );
+        }
+    }
+
+    #[test]
+    fn span_provenance_current_content_and_file_ingestion_bind_exact_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob_store = BlobStore::new(dir.path().join("blobs")).unwrap();
+        let pipeline = IndexPipeline::new();
+        for (relative, source) in [
+            (
+                "src/lib.rs",
+                &b"// exact file bytes\npub fn answer() -> u8 { 1 }\n"[..],
+            ),
+            (
+                "src/sessions.py",
+                &b"# exact file bytes\ndef merge_setting(value):\n    return value\n"[..],
+            ),
+        ] {
+            let path = write_repo_file(dir.path(), relative, source);
+            let blob_hash = blob_store.write(source).unwrap();
+            let content = pipeline
+                .index_file_content_with_tests(&FilePathId::new(relative), source, blob_hash)
+                .unwrap()
+                .indexed_file;
+            assert_span_blob_provenance(&content, source);
+            let file = pipeline
+                .index_file_relative(&path, &blob_store, dir.path())
+                .unwrap();
+            assert_span_blob_provenance(&file, source);
+            assert_eq!(file.entities, content.entities);
+        }
+    }
+
+    #[test]
+    fn span_provenance_incremental_edit_advances_digest_for_unchanged_entity() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob_store = BlobStore::new(dir.path().join("blobs")).unwrap();
+        let pipeline = IndexPipeline::new();
+        let before = b"pub fn answer() -> u8 { 1 }\n";
+        let after = b"\npub fn answer() -> u8 { 1 }\n";
+        let path = write_repo_file(dir.path(), "src/lib.rs", before);
+        let (old, tree) = pipeline
+            .index_file_relative_with_hint(&path, &blob_store, dir.path(), None, None)
+            .unwrap();
+        assert_span_blob_provenance(&old, before);
+        std::fs::write(&path, after).unwrap();
+        let hint = kin_parser::EditHint {
+            start_byte: 0,
+            old_end_byte: 0,
+            new_end_byte: 1,
+        };
+        let (new, _) = pipeline
+            .index_file_relative_with_hint(&path, &blob_store, dir.path(), Some(&tree), Some(&hint))
+            .unwrap();
+        assert_span_blob_provenance(&new, after);
+        assert_ne!(old.blob_hash, new.blob_hash);
+        let old_answer = old
+            .entities
+            .iter()
+            .find(|entity| entity.name == "answer")
+            .unwrap();
+        let new_answer = new
+            .entities
+            .iter()
+            .find(|entity| entity.name == "answer")
+            .unwrap();
+        assert_eq!(old_answer.fingerprint, new_answer.fingerprint);
+        assert_ne!(old_answer.span, new_answer.span);
+        let full = pipeline
+            .index_file_relative(&path, &blob_store, dir.path())
+            .unwrap();
+        assert_eq!(new.entities, full.entities);
+    }
+
+    #[test]
+    fn span_provenance_rejects_digest_for_different_source_bytes() {
+        let source = b"pub fn answer() -> u8 { 1 }\n";
+        let unrelated = kin_blobs::digest(b"pub fn answer() -> u8 { 2 }\n");
+        let error = IndexPipeline::new()
+            .index_file_content_with_tests(&FilePathId::new("src/lib.rs"), source, unrelated)
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("supplied blob digest"),
+            "{error}"
+        );
+        assert!(
+            error.to_string().contains(&unrelated.to_string()),
+            "{error}"
+        );
+        assert!(
+            error
+                .to_string()
+                .contains(&kin_blobs::digest(source).to_string()),
+            "{error}"
         );
     }
 }

--- a/crates/kin-index/tests/behavior_equivalence_ingest.rs
+++ b/crates/kin-index/tests/behavior_equivalence_ingest.rs
@@ -23,7 +23,11 @@ fn ingest_equivalence_hash(source: &str, entity: &str, ext: &str) -> Hash256 {
     let pipeline = IndexPipeline::new();
     let file_id = FilePathId::new(format!("pkg/mod.{ext}"));
     let indexed = pipeline
-        .index_file_content_with_tests(&file_id, source.as_bytes(), zero())
+        .index_file_content_with_tests(
+            &file_id,
+            source.as_bytes(),
+            kin_blobs::digest(source.as_bytes()),
+        )
         .expect("indexing should succeed")
         .indexed_file;
     indexed

--- a/crates/kin-index/tests/certified_answers_account_for_the_file.rs
+++ b/crates/kin-index/tests/certified_answers_account_for_the_file.rs
@@ -26,13 +26,13 @@
 use kin_index::IndexPipeline;
 use kin_model::{FilePathId, ParseCompleteness};
 
-fn blob_hash() -> kin_blobs::Hash256 {
-    kin_blobs::Hash256::from_bytes([7; 32])
-}
-
 fn index(path: &str, source: &str) -> kin_index::IndexedFile {
     IndexPipeline::new()
-        .index_file_content_with_tests(&FilePathId::new(path), source.as_bytes(), blob_hash())
+        .index_file_content_with_tests(
+            &FilePathId::new(path),
+            source.as_bytes(),
+            kin_blobs::digest(source.as_bytes()),
+        )
         .unwrap_or_else(|error| panic!("indexing {path} failed: {error}"))
         .indexed_file
 }

--- a/crates/kin-index/tests/entity_role_survives_ingest.rs
+++ b/crates/kin-index/tests/entity_role_survives_ingest.rs
@@ -29,10 +29,6 @@ use kin_model::{
     TransactionDelta, TreeDelta, TreeEntry,
 };
 
-fn zero() -> Hash256 {
-    Hash256::from_bytes([0; 32])
-}
-
 /// Admit `path` into the repository tree.
 ///
 /// `apply_to_graph` refuses semantic enrichment for a path repository authority
@@ -85,7 +81,11 @@ fn ingest_batch(graph: &InMemoryGraph, path: &str, source: &str) {
     let pipeline = IndexPipeline::new();
     let file_id = FilePathId::new(path.to_string());
     let indexed = pipeline
-        .index_file_content_with_tests(&file_id, source.as_bytes(), zero())
+        .index_file_content_with_tests(
+            &file_id,
+            source.as_bytes(),
+            kin_blobs::digest(source.as_bytes()),
+        )
         .expect("indexing succeeds")
         .indexed_file;
     admit(graph, &indexed.file_id.0);

--- a/crates/kin-index/tests/parse_side_call_counts_reach_a_converted_store.rs
+++ b/crates/kin-index/tests/parse_side_call_counts_reach_a_converted_store.rs
@@ -96,13 +96,13 @@ def summarize_measured(db, note_id):
     return note_body(db, note_id)
 "#;
 
-fn blob_hash() -> kin_blobs::Hash256 {
-    kin_blobs::Hash256::from_bytes([9; 32])
-}
-
 fn index(path: &str, source: &str) -> kin_index::IndexedFile {
     IndexPipeline::new()
-        .index_file_content_with_tests(&FilePathId::new(path), source.as_bytes(), blob_hash())
+        .index_file_content_with_tests(
+            &FilePathId::new(path),
+            source.as_bytes(),
+            kin_blobs::digest(source.as_bytes()),
+        )
         .unwrap_or_else(|error| panic!("indexing {path} failed: {error}"))
         .indexed_file
 }

--- a/crates/kin-index/tests/relation_evidence_span_coverage.rs
+++ b/crates/kin-index/tests/relation_evidence_span_coverage.rs
@@ -554,7 +554,6 @@ impl Counts {
 /// either arm counts for that edge.
 fn measure(files: &[(String, Vec<u8>)]) -> Counts {
     let pipeline = IndexPipeline::new();
-    let blob_hash = kin_blobs::Hash256::from_bytes([0u8; 32]);
 
     let mut merged: HashMap<RelationId, Relation> = HashMap::new();
     let mut parse_data = Vec::new();
@@ -563,7 +562,7 @@ fn measure(files: &[(String, Vec<u8>)]) -> Counts {
     for (path, source) in files {
         let file_id = FilePathId::new(path);
         let indexed = pipeline
-            .index_file_content_with_tests(&file_id, source, blob_hash)
+            .index_file_content_with_tests(&file_id, source, kin_blobs::digest(source))
             .unwrap_or_else(|error| panic!("index `{path}`: {error}"))
             .indexed_file;
 

--- a/scripts/hydration-semantics-manifest.json
+++ b/scripts/hydration-semantics-manifest.json
@@ -1,6 +1,6 @@
 {
   "comment": "Replay-semantics surface pinned by scripts/verify-hydration-semantics.py. These functions re-author the entity/relation deltas persisted for historical changes during Git admission, so editing one changes what a repository's past is said to contain the next time that repository is admitted. A digest mismatch is not a failure to fix by regenerating: decide first whether replay semantics changed, and if so bump HYDRATION_SEMANTICS_VERSION and hydration_semantics_version together. Bumping the version records the decision and every surface now discloses it: kin_core::hydration_semantics persists the version into a store at creation, compares the record when the store is read, and admitting a native transfer pack discards that record because the wire carries no authoring version. Bumping still does not migrate, invalidate or re-enrich a repository that was already admitted.",
-  "hydration_semantics_version": 10,
+  "hydration_semantics_version": 11,
   "guarded": [
     {
       "file": "crates/kin-index/src/history.rs",
@@ -92,6 +92,13 @@
       "digest": "sha256:fed7906995c0ecd2272309ec87d356fbb1cc29cc96cdeec44b4455dcedb3482a",
       "reason": "Assigns the stable artifact identities trees and entities are keyed by across the imported history. Reassignment here silently repoints every historical file.",
       "owner": "kin-git"
+    },
+    {
+      "file": "crates/kin-index/src/pipeline.rs",
+      "function": "attach_span_source_digest",
+      "digest": "sha256:bf7a5afa7762f4d0969222749db641216a899f06dd2e97689cf6a84ef32101cd",
+      "reason": "Writes the exact source blob digest consumed by span coherence checks in both ingestion conversions; changing this field changes freshly derived historical entity payloads.",
+      "owner": "kin-index"
     }
   ]
 }


### PR DESCRIPTION
## What

Bind freshly indexed entity spans to the exact source blob. Full content ingestion and incremental parsing now persist `metadata.extra.blob_hash`. The content API rejects a supplied digest that does not match the parsed bytes.

## Why

A fresh full-history Requests import returned the correct `merge_setting` source body and byte span with `span_coherence: unverified`. Historical ingestion verified the CAS body but omitted its digest from the entity metadata consumed by the source coherence check. Reconcile already records this provenance.

## How

Both ingestion conversions use one stamping helper. Historical semantics advances from 10 to 11 because newly derived entity payloads change, and the hydration manifest pins the helper. Existing unstamped history retains its current unverified behavior. No source-serving code changes.

Existing test fixtures now supply their actual source digests. The merge fixture independently verifies the digest in each admitted branch tree and permits only span and exact source-digest differences for an untouched function; every other metadata and entity field remains equal. Regression coverage exercises current file/content indexing, a real incremental edit, historical span movement and unchanged-file reuse, and mismatched digest rejection. Historical derivation uses captured CAS bodies even after the fixture checkout changes.

A changed file digest can produce entity modifications when semantic fingerprints are unchanged. This follows the existing exact-span provenance contract. Large-history memory impact has not been measured.

## Testing

- [x] `cargo test -p kin-index`: 546 passed, 0 failed, 3 existing ignored tests.
- [x] `cargo test --locked -p kin-cli --test reference_call_site_lines --test caller_arrival_separates_a_measured_shortfall`: 3 passed.
- [x] Implementation head `ffd1a1f` passed CI-shaped Clippy and formatting through `kin-precheck`: 21 gates ran, 21 passed, 0 failed. Its 11 verified files are unchanged in the final test-only correction.
- [x] Signed-off-by trailer present.

Cargo ran through the lane heavy-slot helper with `RUSTFLAGS=-Dwarnings`, `HF_HUB_OFFLINE=1`, and CPU embedding. The repository precheck uses its own CI warning flags and lint allow list.

The four new regressions failed on unchanged product code before the fix:

```text
assertion `left == right` failed: unchanged span must bind its exact historical tree body
  left: None
 right: Some("7afe4a3eff962c19cedbbd0bb393516a4453d463e1421dd8f2cca41d5da34da9")
test result: FAILED. 0 passed; 4 failed; 0 ignored; 0 measured; 370 filtered out
```

Each controlled mutation ran `cargo test -p kin-index --lib span_provenance -- --nocapture` against the committed tests. Test assertions were unchanged.

| Mutation | Executed result |
| --- | --- |
| Remove the stamp call in `index_file_content_with_tests` | rc101, 3 failed, 1 passed. This also breaks the incremental test's full-parse parity comparison. |
| Remove the stamp call in `index_file_hint_with_id` | rc101, 1 failed, 3 passed. |
| Change the digest check to `if false && actual != blob_hash` | rc101, 1 failed, 3 passed. |
| Restore original source | 4 passed, 0 failed, 370 filtered out. |

```text
3/3 mutations caught; source restored e8ca79771049f12b24e3c264751f4d52e83a1988bbfdba7a2a95db1101e9bfbf
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 370 filtered out; finished in 0.78s
kin-precheck: 21 gates ran, 21 passed, 0 failed
```

A separate source-copy control changed the helper's metadata key to `unstamped_blob_hash`. `python3 scripts/verify-hydration-semantics.py <poisoned-root>` exited 1 and named the changed helper digest. The intact guard passes with 14 functions at version 11.

The first hosted run exposed the old merge fixture expectation: `an_untouched_entity_differs_between_branches_only_in_its_span` expected `[span]`, while the stamped records correctly differed on `[span, metadata]`. [Failed shard output](https://github.com/firelock-ai/kin/actions/runs/33978639360/job/101339747891).

The correction is test-only. It validates both `blob_hash` values against the exact admitted branch trees before removing only those keys for the strict comparison. The test helper explicitly passes CPU embedding because the isolated runtime clears inherited Kin configuration.

Final correction checks:

```sh
cargo test --locked -p kin-cli --test repository_merge_resolution an_untouched_entity_differs_between_branches_only_in_its_span_and_source_digest -- --exact --nocapture
cargo test --locked -p kin-index --lib span_provenance -- --nocapture
cargo fmt --all -- --check
python3 scripts/verify-hydration-semantics.py
```

Three separate corruption controls changed one fixture entity loaded from the real admitted branch graph before the unchanged assertions:

| Input corruption | Executed result |
| --- | --- |
| Remove `ours_beta.metadata.extra["blob_hash"]` | rc101, 0 passed, 1 failed at the exact branch digest assertion. |
| Replace it with `theirs_beta.metadata.extra["blob_hash"]` | rc101, 0 passed, 1 failed at the exact branch digest assertion. |
| Insert `unrelated_metadata: true` in the first entity | rc101, 0 passed, 1 failed at the remaining-metadata comparison after only the validated digest was removed. |

The integration source was restored byte for byte, then the final checks passed:

```text
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 36 filtered out; finished in 3.52s
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 370 filtered out; finished in 0.75s
Hydration replay-semantics guard passed: 14 guarded function(s) match the manifest at HYDRATION_SEMANTICS_VERSION=11.
```

The integration test used its existing private temporary HOME, registry and process-group guardian. Read-only process receipts recorded fixture creation and retirement after intact and corrupted runs, with no observed fixture process remaining. This is focused integration evidence. Installed-byte, large-history memory, release and production verification remain open.

Held draft for independent review.
