### PR TITLE
Publish carried working-tree semantics with the bytes an MCP commit seals (FIR-3265)

### DIFF
--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -9229,6 +9229,15 @@ mod tests {
     /// and then shows the consequence: the old path is vacated with its entities
     /// still standing, which is the transition repository authority refuses,
     /// exactly as it refuses a pending deletion.
+    /// One half of this is durable and one half is not, and the difference
+    /// matters for FIR-3278. That a move is a single `Updated` delta keeping its
+    /// artifact identity is a fact about the model and stays true. That the old
+    /// path is left with its entities standing, which is what forces the refusal
+    /// below, is the state FIR-3278 removes by relocating those entities instead
+    /// of retiring them. The refusal itself should survive that repair, because
+    /// `publish_workspace_tree` always sends an empty semantic delta and so can
+    /// never carry a relocation either; if FIR-3278 makes this arm fail, the
+    /// refusal moved and this test is the place to record where.
     #[test]
     fn a_pending_move_is_one_updated_delta_and_ambient_admission_refuses_it() {
         let (_dir, state) = test_state();
@@ -9304,6 +9313,16 @@ mod tests {
     /// Driven through the product's own `VacatedPaths::from_deltas` and
     /// `retire_semantics_on_vacated`, which is what `plan_session_workspace_
     /// admission` calls, rather than through a hand-built delta.
+    ///
+    /// **This test asserts the CURRENT behaviour, and that behaviour is the
+    /// defect (FIR-3278).** It is here so the mechanism is pinned with output
+    /// rather than argued in prose, and so the repair has evidence to work
+    /// against. When FIR-3278 lands, every assertion below inverts: the moved
+    /// entity is expected as `EntityDelta::Modified` carrying its original id at
+    /// the new path, its incident relations are expected to survive with both
+    /// endpoints intact, and the "nothing relocates it" assertion is expected to
+    /// be the one that fails. Replace them then. Do not read this test's green
+    /// as a reason to leave the retirement alone.
     #[test]
     fn session_admission_retires_a_moved_path_identity_and_its_incoming_edges() {
         let (_dir, state) = test_state();

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -705,29 +705,58 @@ fn record_commit_provenance(
         .iter()
         .filter_map(|path| path.as_utf8().map(FilePathId::new))
         .collect::<HashSet<_>>();
+    // Where each entity this change names lives, read from the change's own
+    // payloads before the graph. A removed entity is gone from the graph by
+    // here, so a lookup alone would report it as owned by no file and wave it
+    // through; the delta still carries the payload that says which file it came
+    // from. The graph answers for the rest, which is every relation endpoint
+    // this change did not otherwise touch.
+    let mut origin_of = HashMap::new();
+    for delta in &committed.change.entity_deltas {
+        let entity = match delta {
+            EntityDelta::Added { new } | EntityDelta::Modified { new, .. } => new,
+            EntityDelta::Removed { old } => old,
+        };
+        if let Some(origin) = entity.file_origin.clone() {
+            origin_of.insert(entity.id, origin);
+        }
+    }
+    let is_carried = |entity_id: &kin_model::EntityId| -> bool {
+        if let Some(origin) = origin_of.get(entity_id) {
+            return carried_origins.contains(origin);
+        }
+        graph
+            .get_entity(entity_id)
+            .ok()
+            .flatten()
+            .and_then(|entity| entity.file_origin)
+            .is_some_and(|origin| carried_origins.contains(&origin))
+    };
     let mut entities = committed
         .change
         .entity_deltas
         .iter()
         .map(|delta| match delta {
-            EntityDelta::Added { new } | EntityDelta::Modified { new, .. } => new,
-            EntityDelta::Removed { old } => old,
+            EntityDelta::Added { new } | EntityDelta::Modified { new, .. } => new.id,
+            EntityDelta::Removed { old } => old.id,
         })
-        .filter(|entity| {
-            entity
-                .file_origin
-                .as_ref()
-                .is_none_or(|file| !carried_origins.contains(file))
-        })
-        .map(|entity| entity.id)
+        .filter(|entity_id| !is_carried(entity_id))
         .collect::<Vec<_>>();
-    // A relation-only commit changed no entity, so it has no entity delta to
-    // scope to, but it is still an agent write against the entities the relation
-    // joins. Scoping it to the change alone made it unfindable: every reader
-    // that answers "who touched this entity" selects changes by scanning entity
-    // deltas, which a relation-only change has none of, so the commit was
+    // A relation-only commit changed no entity of its own, so it has no entity
+    // delta to scope to, but it is still an agent write against the entities the
+    // relation joins. Scoping it to the change alone made it unfindable: every
+    // reader that answers "who touched this entity" selects changes by scanning
+    // entity deltas, which a relation-only change has none of, so the commit was
     // recorded and invisible. Its endpoints are the entities an operator would
     // ask about, so they are what it is attributed to.
+    //
+    // The carried filter applies to this source as well as to the one above, and
+    // that is the whole reason it is written twice rather than once. A carried
+    // file now contributes entity deltas, so a relation-only transaction beside
+    // a carried edit to one of its endpoints leaves the list above empty, opens
+    // this fallback, and would hand the carried endpoint straight back to the
+    // committing session. The trigger is "no scopes the agent authored" rather
+    // than "no entity deltas" for the same reason.
     if entities.is_empty() {
         entities.extend(
             committed
@@ -743,7 +772,8 @@ fn record_commit_provenance(
                 .filter_map(|endpoint| match endpoint {
                     GraphNodeId::Entity(id) => Some(id),
                     _ => None,
-                }),
+                })
+                .filter(|entity_id| !is_carried(entity_id)),
         );
     }
     entities.sort_unstable();
@@ -2292,12 +2322,40 @@ fn derive_carried_pending_semantics(
                 standing.len()
             ));
         };
+        // Named per variant rather than left to a wildcard, so a new entry kind
+        // cannot be handed to the parser by accident.
+        //
+        // Neither a symlink nor a gitlink carries a source body, so neither is
+        // parsed and neither is ever dereferenced: a symlink's target is not
+        // this repository's answer for this path. What they CAN carry is the
+        // previous occupant's entities, and that is not an assumption this code
+        // gets to make about the tree. kin-db revalidates an invalidated path by
+        // requiring an artifact to remain at it and does not require that
+        // artifact to be a blob (0.7.104 `src/engine/graph.rs:8705`), so a
+        // same-path source-to-symlink conversion satisfies every check while the
+        // old entities keep describing bytes the repository no longer holds.
+        // That is this function's own defect wearing a different tree entry, so
+        // it gets the same refusal the unsupported-blob arm gives.
         let hash = match &located.entry {
             TreeEntry::Blob { hash, .. } => *hash,
-            // Neither carries a source body, so neither has entities that could
-            // disagree with it. Named rather than left to a wildcard so a new
-            // entry kind cannot be handed to the parser by accident.
-            TreeEntry::Symlink { .. } | TreeEntry::Gitlink { .. } => continue,
+            TreeEntry::Symlink { .. } => {
+                refuse_carry_standing_over_unparsed_content(
+                    prospective,
+                    &file_id,
+                    path,
+                    "a symlink",
+                )?;
+                continue;
+            }
+            TreeEntry::Gitlink { .. } => {
+                refuse_carry_standing_over_unparsed_content(
+                    prospective,
+                    &file_id,
+                    path,
+                    "a submodule pointer",
+                )?;
+                continue;
+            }
         };
         let body = load_native_source_blob(authority_context, hash)
             .map_err(|error| format!("load carried source body for {path}: {error}"))?;
@@ -2309,32 +2367,15 @@ fn derive_carried_pending_semantics(
             .index_any_content(&file_id, &body, digest)
             .map_err(|error| format!("parse carried source {path}: {error}"))?;
         let kin_index::IndexedAny::EntitySource(indexed) = indexed else {
-            // Bytes that do not classify as entity source carry no entities, so
-            // a carry of one is tree-only and coherent as it stands. Unless the
-            // graph still holds entities for the path, in which case this
-            // commit would publish those entities over bytes they were never
-            // derived from, which is the whole defect. That is refused with the
-            // path named rather than sealed, because deriving nothing from
-            // unsupported bytes cannot answer it and silently retiring a
-            // human's entities on their behalf is not this commit's call.
-            let standing = prospective
-                .query_entities(&kin_model::EntityFilter {
-                    file_path: Some(file_id.clone()),
-                    ..Default::default()
-                })
-                .map_err(|error| format!("read carried entities for {path}: {error}"))?;
-            if standing.is_empty() {
-                continue;
-            }
-            return Err(format!(
-                "the workspace holds pending content for {path} that no longer classifies as \
-                 supported entity source, and committing it would publish the {} entities the \
-                 graph still derives from the bytes it replaces over content they never came \
-                 from. Stage that file in this transaction with verb 'replace' to re-derive it or \
-                 verb 'delete' to retire it, or revert the working file, then re-send this \
-                 transaction unchanged.",
-                standing.len()
-            ));
+            // The third shape of the same condition: content the parser cannot
+            // derive entities from, standing where entities already are.
+            refuse_carry_standing_over_unparsed_content(
+                prospective,
+                &file_id,
+                path,
+                "content that no longer classifies as supported entity source",
+            )?;
+            continue;
         };
         let reconcile = reconciler
             .reconcile_indexed_content(&indexed, state.blobs.as_ref(), prospective)
@@ -2364,6 +2405,44 @@ fn derive_carried_pending_semantics(
     } else {
         CarriedDerivation::AlreadyCoherent
     })
+}
+
+/// Refuse a carried path whose new tree entry cannot have derived the entities
+/// the graph still holds for it.
+///
+/// One helper for three arms, because "the content at this path cannot be what
+/// those entities describe" is one condition whether the new entry is a symlink,
+/// a submodule pointer, or a blob that stopped classifying as source. Nothing
+/// standing there is the ordinary tree-only carry, and returns quietly.
+///
+/// A refusal rather than a retirement, and rather than a skip. Publishing the
+/// entities over content they never came from is the defect this module is
+/// closing. Retiring somebody else's entities is not this commit's call to
+/// make: no operation in it named that file. So it says what it found, names
+/// the path, and gives the three ways out.
+fn refuse_carry_standing_over_unparsed_content(
+    prospective: &kin_db::InMemoryGraph,
+    file_id: &FilePathId,
+    path: &RepoPath,
+    became: &str,
+) -> Result<(), String> {
+    let standing = prospective
+        .query_entities(&kin_model::EntityFilter {
+            file_path: Some(file_id.clone()),
+            ..Default::default()
+        })
+        .map_err(|error| format!("read carried entities for {path}: {error}"))?;
+    if standing.is_empty() {
+        return Ok(());
+    }
+    Err(format!(
+        "the workspace holds pending content for {path} whose new tree entry is {became}, and \
+         committing it would publish the {} entities the graph still derives from the source it \
+         replaces over content they never came from. Stage that file in this transaction with \
+         verb 'replace' to re-derive it or verb 'delete' to retire it, or revert the working file, \
+         then re-send this transaction unchanged.",
+        standing.len()
+    ))
 }
 
 fn apply_relation_operations(
@@ -8799,6 +8878,280 @@ mod tests {
             load_native_commit_base(&state.layout).unwrap().roots,
             before.roots,
             "no repository authority may move behind a refusal"
+        );
+    }
+
+    /// Leave one source path converted to a symlink the way a working session
+    /// leaves it, and hand back whatever refused if something did.
+    ///
+    /// A real transition, not a fabricated tree: the working copy gets an actual
+    /// symlink and the admitted tree is the one the live graph resolves. Both
+    /// halves can refuse, and which one refuses is the interesting answer, so
+    /// neither is unwrapped here.
+    #[cfg(unix)]
+    fn admit_pending_working_tree_symlink(
+        state: &Arc<DaemonState>,
+        file: &str,
+        target: &str,
+    ) -> crate::error::Result<()> {
+        let path = RepoPath::from_utf8(file).unwrap();
+        let on_disk = state.layout.working_dir().join(file);
+        std::fs::remove_file(&on_disk).unwrap();
+        std::os::unix::fs::symlink(target, &on_disk).unwrap();
+        let digest = state.blobs.write(target.as_bytes()).unwrap();
+        let artifact = state
+            .graph
+            .resolved_tree()
+            .artifact_at_path(&path)
+            .cloned()
+            .expect("a conversion lands on an already admitted artifact");
+        state.graph.apply_transaction_delta(&TransactionDelta {
+            tree_deltas: vec![TreeDelta::Updated {
+                artifact_id: artifact.artifact_id,
+                old: artifact.located_entry(),
+                new: LocatedEntry::new(path, TreeEntry::symlink(Hash256::from_bytes(digest.0))),
+            }],
+            ..TransactionDelta::default()
+        })?;
+        try_publish_pending_workspace_tree(state)
+    }
+
+    /// A carried path that became a symlink is refused by name, not skipped.
+    ///
+    /// The first cut of the derivation skipped every non-blob tree entry on the
+    /// reasoning that a symlink carries no source body and therefore no entities
+    /// to disagree with it. The first half is true and the second does not
+    /// follow: the tree and the semantics are independent, and kin-db
+    /// revalidates an invalidated path by requiring an artifact to remain at it
+    /// without requiring that artifact to be a blob (0.7.104
+    /// `src/engine/graph.rs:8705`). So a same-path source-to-symlink conversion
+    /// satisfies every check while the entities the old source derived keep
+    /// standing, and the skip published them over a link. It is the same defect
+    /// as an unsupported blob, so it gets the same refusal.
+    #[cfg(unix)]
+    #[test]
+    fn a_carried_source_to_symlink_conversion_is_refused_by_name() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        install_exact_source(
+            &state,
+            "src/other.rs",
+            b"pub fn other() -> u8 { 1 }\n",
+            "other",
+        );
+        admit_pending_working_tree_symlink(&state, "src/other.rs", "lib.rs").expect(
+            "if some earlier layer refuses this conversion, that mechanism is the finding and \
+             this test must be rewritten around it rather than deleted",
+        );
+        let before = load_native_commit_base(&state.layout).unwrap();
+
+        let sessions = test_sessions();
+        let (transaction_id, arguments) =
+            stage_entity_edit(&sessions, &entity, "pub fn value() -> u8 { 2 }");
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+
+        assert_eq!(
+            result.is_error,
+            Some(true),
+            "publishing source entities over a symlink is not an option: {}",
+            result_text(&result)
+        );
+        let message = result_text(&result);
+        assert!(
+            message.contains("src/other.rs"),
+            "the refusal must name the path it cannot derive: {message}"
+        );
+        assert!(
+            message.contains("a symlink"),
+            "the refusal must say what the path became: {message}"
+        );
+        assert!(
+            message.contains("'replace'") && message.contains("'delete'"),
+            "the refusal must say what to do about it: {message}"
+        );
+        assert_eq!(
+            sessions.get_transaction(&transaction_id).unwrap().state,
+            "active",
+            "a refused commit leaves the transaction where the caller can retry it"
+        );
+        assert_eq!(
+            load_native_commit_base(&state.layout).unwrap().roots,
+            before.roots,
+            "no repository authority may move behind a refusal"
+        );
+    }
+
+    /// A newly admitted symlink with nothing standing under it stays a legal
+    /// tree-only carry, and its target is never resolved through the parser.
+    ///
+    /// The control for the refusal above. A symlink is a perfectly ordinary
+    /// thing for a workspace to carry, and refusing every one of them would
+    /// trade one broken commit for another. The refusal is about the entities
+    /// standing at the path, not about the entry kind, and this is what says so.
+    #[cfg(unix)]
+    #[test]
+    fn a_carried_symlink_with_no_standing_entities_is_a_legal_tree_only_carry() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+
+        let path = RepoPath::from_utf8("src/link.rs").unwrap();
+        let on_disk = state.layout.working_dir().join("src/link.rs");
+        std::os::unix::fs::symlink("lib.rs", &on_disk).unwrap();
+        let digest = state.blobs.write(b"lib.rs").unwrap();
+        state
+            .graph
+            .apply_transaction_delta(&TransactionDelta {
+                tree_deltas: vec![TreeDelta::Added {
+                    artifact_id: kin_model::ArtifactId::new(),
+                    new: LocatedEntry::new(path, TreeEntry::symlink(Hash256::from_bytes(digest.0))),
+                }],
+                ..TransactionDelta::default()
+            })
+            .unwrap();
+        publish_pending_workspace_tree(&state);
+
+        let sessions = test_sessions();
+        let (_, arguments) = stage_entity_edit(&sessions, &entity, "pub fn value() -> u8 { 2 }");
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "a symlink nothing derives entities from must still commit: {}",
+            result_text(&result)
+        );
+        let reply = commit_reply(&result);
+        assert_eq!(
+            reply["carried_pending_files"],
+            serde_json::json!(["src/link.rs"]),
+            "the symlink is carried and declared like any other pending path: {reply:#}"
+        );
+        assert!(
+            state
+                .graph
+                .query_entities(&EntityFilter {
+                    file_path: Some(FilePathId::new("src/link.rs")),
+                    ..EntityFilter::default()
+                })
+                .unwrap()
+                .is_empty(),
+            "the link's target must never be resolved through the parser on its behalf"
+        );
+        assert_eq!(
+            semantic_disagreement(&state, "src/lib.rs"),
+            None,
+            "the file the operation authored stays coherent beside a carried symlink"
+        );
+    }
+
+    /// A relation-only commit beside a carried edit attributes the endpoint the
+    /// agent joined and not the one it carried.
+    ///
+    /// The carried-path filter that keeps a folded-in file out of attribution
+    /// applies while entity-delta scopes are collected. A relation-only commit
+    /// has no entity deltas of its own, so it falls back to the relation's
+    /// endpoints, and once a carried file contributes entity deltas the two
+    /// interact: the carried entity is filtered out of the first list, the list
+    /// is empty, the fallback opens, and an unfiltered fallback hands the carried
+    /// endpoint straight back to the committing session. Both sources are
+    /// filtered for that reason.
+    #[test]
+    fn a_relation_only_commit_beside_a_carry_attributes_only_the_endpoint_it_joined() {
+        let (_dir, state) = test_state();
+        let (caller, _) = install_exact_source(
+            &state,
+            "src/caller.rs",
+            b"pub fn caller() -> u8 { 1 }\n",
+            "caller",
+        );
+        let (callee, _) = install_exact_source(
+            &state,
+            "src/callee.rs",
+            b"pub fn callee() -> u8 { 2 }\n",
+            "callee",
+        );
+        // The carried half, on the callee's own path, so the commit re-derives
+        // the entity the staged relation points at.
+        admit_pending_working_tree_edit(&state, "src/callee.rs", b"pub fn callee() -> u8 { 7 }\n");
+
+        let sessions = kin_mcp::SessionRegistry::new();
+        let session = start_agent_session(&sessions, "gemini-cli", "relation-writer");
+        let session_id = session.session_id.to_string();
+        let transaction = sessions
+            .begin_transaction(&session_id, "relations")
+            .unwrap();
+        sessions
+            .stage_transaction(
+                &transaction.transaction_id,
+                vec![kin_mcp::McpMutationOperation {
+                    verb: "create".to_string(),
+                    target: String::new(),
+                    payload: Some(kin_mcp::McpMutationPayload::Relation {
+                        from: caller.id,
+                        to: callee.id,
+                        kind: kin_model::relation::RelationKind::Calls,
+                    }),
+                    body: None,
+                    description: "link the call".to_string(),
+                    destination: None,
+                }],
+            )
+            .unwrap();
+
+        let result = commit_exact_transaction(
+            &state,
+            &sessions,
+            &HashMap::from([(
+                "transaction_id".to_string(),
+                serde_json::json!(transaction.transaction_id),
+            )]),
+            None,
+        );
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "a relation-only commit beside a carry must still land: {}",
+            result_text(&result)
+        );
+        let reply = commit_reply(&result);
+        assert_eq!(
+            reply["carried_pending_files"],
+            serde_json::json!(["src/callee.rs"]),
+            "the fixture must actually exercise the carry: {reply:#}"
+        );
+
+        let scoped = state
+            .graph
+            .query_audit_events(Some(&mcp_actor_id(&session_id)), 16)
+            .unwrap()
+            .into_iter()
+            .filter_map(|event| match event.target_scope {
+                Some(WorkScope::Entity(id)) => Some(id),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            scoped.contains(&caller.id),
+            "the endpoint the agent joined and did not carry is still attributed to it"
+        );
+        assert!(
+            !scoped.contains(&callee.id),
+            "an endpoint inside a carried file must not reach the committing session's \
+             attribution through the relation fallback"
+        );
+        assert_eq!(
+            semantic_disagreement(&state, "src/callee.rs"),
+            None,
+            "the carried endpoint's own entities still describe the bytes this commit published"
         );
     }
 }

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -687,22 +687,39 @@ fn record_commit_provenance(
         .create_actor(&actor.actor)
         .map_err(|error| format!("record committing agent actor: {error}"))?;
 
-    // Scoped to the entities this change actually moved, which is what keeps a
-    // folded-in pending file from being attributed to the agent. Such a file
-    // reaches the change as a tree delta and nothing else, because the prospective
-    // graph reparses only the files the staged operations spliced, so it
-    // contributes no entity delta, receives no attribution event here, and leaves
-    // every entity inside it answering `kin_provenance_query` with the authorship
-    // it already had. The fold is declared at the level it happened at, in the
-    // change message, which the `change_id` recorded below leads to.
+    // Scoped to the entities this change moved that the agent's own operations
+    // wrote, which is what keeps a folded-in pending file from being attributed
+    // to the agent.
+    //
+    // A carried file's entities DO move in this change. They have to: a change
+    // that publishes new bytes for a file must publish the semantics those bytes
+    // derive to, or it seals a tree and an entity set that describe different
+    // source (see `derive_carried_pending_semantics`). That is a content
+    // revision, and it belongs in the change. It is not an authorship claim, and
+    // that is why it is filtered out here rather than left to reach the audit
+    // trail: every entity inside a carried file keeps answering
+    // `kin_provenance_query` with the authorship it already had, and the fold is
+    // declared at the level it happened at, in the change message, which the
+    // `change_id` recorded below leads to.
+    let carried_origins = carried_pending_files
+        .iter()
+        .filter_map(|path| path.as_utf8().map(FilePathId::new))
+        .collect::<HashSet<_>>();
     let mut entities = committed
         .change
         .entity_deltas
         .iter()
         .map(|delta| match delta {
-            EntityDelta::Added { new } | EntityDelta::Modified { new, .. } => new.id,
-            EntityDelta::Removed { old } => old.id,
+            EntityDelta::Added { new } | EntityDelta::Modified { new, .. } => new,
+            EntityDelta::Removed { old } => old,
         })
+        .filter(|entity| {
+            entity
+                .file_origin
+                .as_ref()
+                .is_none_or(|file| !carried_origins.contains(file))
+        })
+        .map(|entity| entity.id)
         .collect::<Vec<_>>();
     // A relation-only commit changed no entity, so it has no entity delta to
     // scope to, but it is still an agent write against the entities the relation
@@ -1300,18 +1317,46 @@ fn plan_exact_transaction(
         );
     }
 
-    let native = plan_native_commit_from_base_declaring_carry(
+    let plan_against = |graph: &kin_db::InMemoryGraph| {
+        plan_native_commit_from_base_declaring_carry(
+            graph,
+            state.blobs.as_ref(),
+            authority_context,
+            operation_id,
+            kin_model::Timestamp::now(),
+            actor.author.clone(),
+            &authored_files,
+            &|carried| commit_message(&transaction.transaction_id, carried),
+            base,
+        )
+        .map_err(|error| format!("plan exact MCP repository commit: {error}"))
+    };
+    let native = plan_against(&prospective)?;
+    // Planned first, then read for what it carries, because the carried set is
+    // not knowable until the published tree deltas are: it is the fold
+    // `carried_pending_paths` computes from them. Taking it from the plan rather
+    // than computing it a second way is what keeps the files re-derived below
+    // and the files declared in the reply the same set by construction.
+    let native = match derive_carried_pending_semantics(
+        state,
         &prospective,
-        state.blobs.as_ref(),
+        &pipeline,
         authority_context,
-        operation_id,
-        kin_model::Timestamp::now(),
-        actor.author.clone(),
-        &authored_files,
-        &|carried| commit_message(&transaction.transaction_id, carried),
-        base,
-    )
-    .map_err(|error| format!("plan exact MCP repository commit: {error}"))?;
+        &native,
+        &mut layouts,
+    )? {
+        // The carry moved no semantics, so this plan already describes the graph
+        // it was planned from and nothing is spent on the common case.
+        CarriedDerivation::AlreadyCoherent => native,
+        // Semantics moved under the carried paths, so the plan is stale by
+        // exactly that much. Planned once more and never in a loop: the second
+        // pass publishes the same tree bytes as the first, so it carries the
+        // same set, and re-deriving that set again would find nothing.
+        CarriedDerivation::Derived => {
+            drop(native);
+            plan_against(&prospective)?
+        }
+    };
     let carried_pending_files = native.carried_pending_files.clone();
     Ok(ExactMcpPlan {
         native,
@@ -1337,9 +1382,11 @@ const CARRIED_SAMPLE: usize = 10;
 /// When something was carried, the first line says so on its own, because a
 /// subject-only view of history is where a reader is most likely to meet this
 /// change and least able to ask a follow-up question. The body then says what
-/// the fold does not do: the bytes move, the semantics of those files are not
-/// re-derived here, so the entities inside them keep the authorship they
-/// already had rather than silently becoming this agent's work.
+/// the fold does and does not do: the bytes move and the semantics move with
+/// them, because a change that published one without the other would describe
+/// two different sources, and the entities inside those files keep the
+/// authorship they already had rather than silently becoming this agent's work,
+/// because no operation here wrote them.
 fn commit_message(transaction_id: &str, carried: &[RepoPath]) -> String {
     if carried.is_empty() {
         return format!("MCP transaction {transaction_id}");
@@ -1359,8 +1406,10 @@ fn commit_message(transaction_id: &str, carried: &[RepoPath]) -> String {
         "MCP transaction {transaction_id} (also admitted {count} pending working-tree {files})\n\n\
          The workspace already held admitted working-tree content its base change did not carry, \
          so this change publishes that content beside the staged operations rather than reverting \
-         it. No operation in this transaction authored it, and its semantics are not re-derived \
-         here, so the entities inside it keep the authorship they already had.\n\
+         it, and re-derives its semantics from the exact bytes published here, because a change \
+         that moved one without the other would describe two different sources. No operation in \
+         this transaction authored that content, so the entities inside it keep the authorship \
+         they already had.\n\
          Carried: {sample}"
     )
 }
@@ -2117,6 +2166,204 @@ fn plan_replaced_source_files(
         layouts.push(layout);
     }
     Ok(())
+}
+
+/// What re-deriving the carried paths did to the prospective graph.
+enum CarriedDerivation {
+    /// Nothing semantic moved. Every carried path's entities already described
+    /// the bytes the plan publishes for it, so the plan that produced the
+    /// carried set still describes the graph it was planned from.
+    AlreadyCoherent,
+    /// Semantics moved under one or more carried paths, so the plan is stale by
+    /// exactly that much and has to be planned again.
+    Derived,
+}
+
+/// Re-derive the semantics of every file this commit carries in, so the change
+/// it seals describes the bytes it publishes.
+///
+/// The two commit surfaces plan from different graphs. The CLI route is handed
+/// the daemon's live derived graph, which the reconcile loop keeps current
+/// against the working tree, so a pending file's entities there came from the
+/// pending bytes. The MCP route is handed repository authority's own workspace
+/// graph snapshot, whose tree is the workspace tree and whose entities are
+/// whatever the last published semantic delta left, because
+/// `publish_workspace_tree` advances that tree with an empty
+/// `WorkspaceSemanticDelta`. [`plan_exact_transaction`] reparses only the files
+/// its staged operations name, so a file the workspace admitted and no
+/// operation authored arrives at publication as new bytes standing over old
+/// entity spans, and the change seals both.
+///
+/// Declaring the carry does not settle that. The declaration says who authored
+/// the file, and this is about whether one change's tree and entities agree
+/// with each other. Nothing downstream repairs it either:
+/// [`install_authority_graph`] corrects the live graph ONTO authority, so on
+/// this path it propagates the disagreement rather than closing it, and
+/// `semantic_workspace_matches` passes because both sides then hold the same
+/// wrong answer.
+///
+/// Every byte read here is graph-owned. The paths come from the plan's own
+/// carried set rather than from a second computation, so the files re-derived
+/// are exactly the files the reply and the change message declare; the blob
+/// identities come from the tree deltas that same change publishes; and the
+/// bodies come out of repository CAS through [`load_native_source_blob`], never
+/// off the working copy.
+///
+/// Republishing a carried file's semantics is not a claim on its authorship.
+/// The reconciler matches the entities the graph already holds against the
+/// declarations the new bytes parse to, so an entity that merely changed body
+/// keeps its id, its lineage and every incoming edge, and
+/// [`record_commit_provenance`] keeps the carried paths out of the attribution
+/// it writes.
+fn derive_carried_pending_semantics(
+    state: &DaemonState,
+    prospective: &kin_db::InMemoryGraph,
+    pipeline: &kin_index::IndexPipeline,
+    authority_context: &LocalRepositoryAuthorityContext,
+    planned: &crate::repository_commit::NativeCommitPlan,
+    layouts: &mut Vec<FileLayout>,
+) -> Result<CarriedDerivation, String> {
+    if planned.carried_pending_files.is_empty() {
+        return Ok(CarriedDerivation::AlreadyCoherent);
+    }
+    let carried = planned
+        .carried_pending_files
+        .iter()
+        .collect::<BTreeSet<_>>();
+    let mut reconciler = kin_reconcile::Reconciler::new(PathBuf::new());
+    reconciler.seed_cross_file_linker_from_graph(prospective);
+    let mut derived = false;
+
+    for delta in &planned.change.tree_deltas {
+        // A deletion is named through its old state, which is the only state it
+        // has, exactly as `carried_pending_paths` names it.
+        let Some(path) = delta
+            .new_state()
+            .or_else(|| delta.old_state())
+            .map(|located| &located.path)
+        else {
+            continue;
+        };
+        // Only the carried half. A path this transaction's operations wrote was
+        // reparsed when it was planned, and parsing the same bytes again would
+        // be work to conclude nothing.
+        if !carried.contains(&path) {
+            continue;
+        }
+        let file_id = path
+            .as_utf8()
+            .map(FilePathId::new)
+            .ok_or_else(|| format!("carried repository path {path} is not valid UTF-8"))?;
+
+        let Some(located) = delta.new_state() else {
+            // A carried removal, which two independent mechanisms make
+            // unreachable rather than one. Ambient admission publishes the tree
+            // and no semantics, so vacating a path that way would leave that
+            // path's entities standing over a tree that no longer carries it,
+            // and repository authority refuses the transaction outright:
+            // "transaction leaves entity <id> on repository path <path> absent
+            // from the staged tree; carry its exact entity removal or relocation
+            // in the same delta". The seam that does vacate a path,
+            // `commit_session_workspace_admission`, derives the retirement
+            // through `retire_semantics_on_vacated` and carries it in the same
+            // transaction. So a carried tree delta is an addition or an update,
+            // and the only removals that reach a plan are the ones a staged
+            // `delete` authored, which are not carried.
+            //
+            // Asserted rather than repaired. A retirement written here would be
+            // a branch nothing can reach and nothing can falsify, and if either
+            // mechanism above ever regresses, sealing a change quietly is the
+            // wrong answer and saying so is the right one.
+            let standing = prospective
+                .query_entities(&kin_model::EntityFilter {
+                    file_path: Some(file_id.clone()),
+                    ..Default::default()
+                })
+                .map_err(|error| format!("read carried entities for {path}: {error}"))?;
+            if standing.is_empty() {
+                continue;
+            }
+            return Err(format!(
+                "this commit carries a removal of {path} that no operation in it authored, and \
+                 the graph still holds {} entities derived from that path. Repository authority \
+                 does not admit a vacated path without retiring its semantics, so this state \
+                 should be unreachable; report it rather than working around it. Nothing was \
+                 published.",
+                standing.len()
+            ));
+        };
+        let hash = match &located.entry {
+            TreeEntry::Blob { hash, .. } => *hash,
+            // Neither carries a source body, so neither has entities that could
+            // disagree with it. Named rather than left to a wildcard so a new
+            // entry kind cannot be handed to the parser by accident.
+            TreeEntry::Symlink { .. } | TreeEntry::Gitlink { .. } => continue,
+        };
+        let body = load_native_source_blob(authority_context, hash)
+            .map_err(|error| format!("load carried source body for {path}: {error}"))?;
+        let digest = state
+            .blobs
+            .write(&body)
+            .map_err(|error| format!("store carried source {path}: {error}"))?;
+        let indexed = pipeline
+            .index_any_content(&file_id, &body, digest)
+            .map_err(|error| format!("parse carried source {path}: {error}"))?;
+        let kin_index::IndexedAny::EntitySource(indexed) = indexed else {
+            // Bytes that do not classify as entity source carry no entities, so
+            // a carry of one is tree-only and coherent as it stands. Unless the
+            // graph still holds entities for the path, in which case this
+            // commit would publish those entities over bytes they were never
+            // derived from, which is the whole defect. That is refused with the
+            // path named rather than sealed, because deriving nothing from
+            // unsupported bytes cannot answer it and silently retiring a
+            // human's entities on their behalf is not this commit's call.
+            let standing = prospective
+                .query_entities(&kin_model::EntityFilter {
+                    file_path: Some(file_id.clone()),
+                    ..Default::default()
+                })
+                .map_err(|error| format!("read carried entities for {path}: {error}"))?;
+            if standing.is_empty() {
+                continue;
+            }
+            return Err(format!(
+                "the workspace holds pending content for {path} that no longer classifies as \
+                 supported entity source, and committing it would publish the {} entities the \
+                 graph still derives from the bytes it replaces over content they never came \
+                 from. Stage that file in this transaction with verb 'replace' to re-derive it or \
+                 verb 'delete' to retire it, or revert the working file, then re-send this \
+                 transaction unchanged.",
+                standing.len()
+            ));
+        };
+        let reconcile = reconciler
+            .reconcile_indexed_content(&indexed, state.blobs.as_ref(), prospective)
+            .map_err(|error| format!("derive semantics for carried source {path}: {error}"))?;
+        // Entity and relation deltas are the only two that change what the
+        // sealed change carries, so they are what decides whether the plan has
+        // to be taken again. A carried file whose edit moved neither leaves the
+        // first plan correct.
+        derived |= !reconcile.delta.entity_deltas.is_empty()
+            || !reconcile.delta.relation_deltas.is_empty();
+        prospective
+            .apply_transaction_delta(&reconcile.delta)
+            .map_err(|error| format!("apply derived semantics for carried {path}: {error}"))?;
+        let layout = reconciler
+            .projection()
+            .get_layout(&file_id)
+            .cloned()
+            .ok_or_else(|| format!("parsing produced no file layout for carried source {path}"))?;
+        prospective
+            .upsert_file_layout(&layout)
+            .map_err(|error| format!("install prospective layout for carried {path}: {error}"))?;
+        layouts.push(layout);
+    }
+
+    Ok(if derived {
+        CarriedDerivation::Derived
+    } else {
+        CarriedDerivation::AlreadyCoherent
+    })
 }
 
 fn apply_relation_operations(
@@ -2974,7 +3221,29 @@ mod tests {
             })
             .unwrap();
 
-        let base = load_native_commit_base(&state.layout).unwrap();
+        publish_pending_workspace_tree(state);
+    }
+
+    /// Advance workspace authority to whatever the live graph's tree now holds,
+    /// publishing no semantic change.
+    ///
+    /// The second half of every ambient admission, shared by the helpers above
+    /// and below so a pending edit, a pending addition and a pending removal all
+    /// reach authority through the same call the reconcile loop uses. This is
+    /// where the split the MCP commit route inherits is created:
+    /// `publish_workspace_tree` moves the tree and hands it an empty
+    /// `WorkspaceSemanticDelta`.
+    fn publish_pending_workspace_tree(state: &Arc<DaemonState>) {
+        try_publish_pending_workspace_tree(state)
+            .expect("a moved working tree must advance workspace authority");
+    }
+
+    /// The same publication, handing back what repository authority said.
+    ///
+    /// Ambient admission is refused for some transitions and the refusal is the
+    /// interesting half, so one caller needs it rather than a panic.
+    fn try_publish_pending_workspace_tree(state: &Arc<DaemonState>) -> crate::error::Result<()> {
+        let base = load_native_commit_base(&state.layout)?;
         let admitted = crate::repository_commit::admitted_workspace_tree_for_test(
             state.layout.working_dir(),
             base.roots.clone(),
@@ -2987,12 +3256,85 @@ mod tests {
             &admitted,
             OperationId::new(),
             AuthorId::new("kin-session-reconcile"),
-        )
-        .unwrap()
-        .expect("an edited working tree must advance workspace authority");
+        )?
+        .expect("a moved working tree must advance workspace authority");
         state
             .record_repository_authority_commit(admission.receipt.generation)
             .unwrap();
+        Ok(())
+    }
+
+    /// Leave one brand new working file admitted the way the watcher leaves it.
+    ///
+    /// The workspace tree gains a path its base change never carried and no
+    /// semantic change is published for it, so the change that follows carries
+    /// this path as a `TreeDelta::Added` with no entities behind it.
+    fn admit_pending_working_tree_file(state: &Arc<DaemonState>, file: &str, content: &[u8]) {
+        let path = RepoPath::from_utf8(file).unwrap();
+        let target = state.layout.working_dir().join(file);
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&target, content).unwrap();
+        let digest = state.blobs.write(content).unwrap();
+        state
+            .graph
+            .apply_transaction_delta(&TransactionDelta {
+                tree_deltas: vec![TreeDelta::Added {
+                    artifact_id: kin_model::ArtifactId::new(),
+                    new: LocatedEntry::new(
+                        path,
+                        TreeEntry::blob(Hash256::from_bytes(digest.0), false),
+                    ),
+                }],
+                ..TransactionDelta::default()
+            })
+            .unwrap();
+        publish_pending_workspace_tree(state);
+    }
+
+    /// Leave one working file's removal admitted the way the watcher leaves it.
+    ///
+    /// The entities go with the artifact in the LIVE graph, because kin-db
+    /// refuses a tree transition that strands an entity on a path the staged
+    /// tree no longer carries. Workspace authority still learns only about the
+    /// tree, because that is all `publish_workspace_tree` publishes, which is
+    /// what leaves the entities standing on the authority side.
+    fn admit_pending_working_tree_removal(
+        state: &Arc<DaemonState>,
+        file: &str,
+    ) -> crate::error::Result<()> {
+        let path = RepoPath::from_utf8(file).unwrap();
+        let file_id = FilePathId::new(file);
+        std::fs::remove_file(state.layout.working_dir().join(file)).unwrap();
+        let artifact = state
+            .graph
+            .resolved_tree()
+            .artifact_at_path(&path)
+            .cloned()
+            .expect("a pending removal takes an already admitted artifact");
+        let standing = state
+            .graph
+            .query_entities(&EntityFilter {
+                file_path: Some(file_id),
+                ..EntityFilter::default()
+            })
+            .unwrap();
+        state
+            .graph
+            .apply_transaction_delta(&TransactionDelta {
+                entity_deltas: standing
+                    .into_iter()
+                    .map(|old| EntityDelta::Removed { old })
+                    .collect(),
+                tree_deltas: vec![TreeDelta::Removed {
+                    artifact_id: artifact.artifact_id,
+                    old: artifact.located_entry(),
+                }],
+                ..TransactionDelta::default()
+            })
+            .unwrap();
+        try_publish_pending_workspace_tree(state)
     }
 
     /// Whether workspace authority still holds a tree its base change does not.
@@ -7787,12 +8129,25 @@ mod tests {
 
     /// Carrying a file in never rewrites who authored what is inside it.
     ///
-    /// A carried file reaches the change as a tree delta and nothing else, so
-    /// its entities gain no revision and no attribution event. That is what
-    /// keeps a provenance reader from being told the agent wrote a human's
-    /// uncommitted work. The fold is still reachable from provenance, one level
-    /// up, because the change every attributed entity names carries the
-    /// declaration in its message.
+    /// A carried file reaches the change as a tree delta AND the semantics those
+    /// bytes derive to, because a change that published one without the other
+    /// would seal a tree and an entity set describing different source. So its
+    /// entities do gain a revision, and that revision is a statement about
+    /// content, not about authorship: the entity keeps its id and the change it
+    /// was created in, and no attribution event names it, which is what keeps a
+    /// provenance reader from being told the agent wrote a human's uncommitted
+    /// work. The fold is also reachable from provenance one level up, because
+    /// the change every attributed entity names carries the declaration in its
+    /// message.
+    ///
+    /// The assertion that the carried entity's history did NOT contain this
+    /// change was here until the incoherence it described was fixed. It could
+    /// not survive the fix and be true at the same time: `get_entity_history`
+    /// selects changes by scanning entity deltas, so the only change that
+    /// satisfies it is one that publishes bytes for a file and no semantics for
+    /// them. What that assertion was protecting is below, in the origin change
+    /// and the attribution, and it is asserted there rather than through the
+    /// absence of a revision.
     #[test]
     fn a_carried_file_keeps_the_authorship_its_entities_already_had() {
         let (_dir, state) = test_state();
@@ -7821,13 +8176,23 @@ mod tests {
         assert!(
             carried_history
                 .iter()
-                .all(|change| change.id.to_string() != change_id),
-            "the carried file's entity must not be attributed to the agent's change"
+                .any(|change| change.id.to_string() == change_id),
+            "the change that republished the carried file's bytes must carry its semantics too, \
+             or it seals a tree and an entity set describing different source"
         );
         assert_eq!(
             carried_history.first().map(|change| change.id),
             Some(installed_change),
-            "the carried file's entity keeps the change it already had"
+            "the carried file's entity keeps the change it was created in"
+        );
+        assert_eq!(
+            state
+                .graph
+                .get_entity(&carried_entity.id)
+                .unwrap()
+                .map(|entity| (entity.name, entity.kind)),
+            Some((carried_entity.name.clone(), carried_entity.kind)),
+            "the carried file's entity keeps the identity it already had"
         );
 
         let attributed = state
@@ -7869,6 +8234,571 @@ mod tests {
             declared.message.contains("src/other.rs"),
             "the change an audit event names must declare the fold: {}",
             declared.message
+        );
+    }
+
+    /// How the store's own entities disagree with the exact bytes it publishes
+    /// for one file.
+    ///
+    /// The oracle is Kin's own parser reading Kin's own CAS: the graph names a
+    /// blob for the path, the blob is read back out of repository CAS rather
+    /// than off the working copy, and the entities it parses to are compared
+    /// with the entities the graph answers with for that file. `None` is a
+    /// coherent file. Anything else is a file whose entities describe bytes the
+    /// repository no longer holds, which is what a change that seals newer tree
+    /// bytes over older semantic spans leaves behind.
+    ///
+    /// Read against the live graph on purpose. `install_authority_graph` levels
+    /// it onto repository authority inside every commit reply and
+    /// `verify_workspace_matches_authority` refuses if it did not, so after a
+    /// commit the live graph, authority and the change just sealed are the same
+    /// answer, and asking the cheapest of the three asks all of them.
+    fn semantic_disagreement(state: &Arc<DaemonState>, file: &str) -> Option<String> {
+        let file_id = FilePathId::new(file);
+        let path = RepoPath::from_utf8(file).unwrap();
+        let tree = state.graph.resolved_tree();
+        let artifact = tree
+            .artifact_at_path(&path)
+            .unwrap_or_else(|| panic!("the store must publish {file}"));
+        let TreeEntry::Blob { hash, .. } = artifact.entry else {
+            panic!("{file} must be a blob in the published tree");
+        };
+        let body = load_native_source_blob(&state.layout, hash)
+            .unwrap_or_else(|error| panic!("repository CAS must hold the body of {file}: {error}"));
+        let digest = state.blobs.write(&body).unwrap();
+        let indexed = kin_index::IndexPipeline::new()
+            .index_any_content(&file_id, &body, digest)
+            .unwrap();
+        let kin_index::IndexedAny::EntitySource(indexed) = indexed else {
+            panic!("{file} must classify as supported source");
+        };
+        for parsed in &indexed.entities {
+            let held = state
+                .graph
+                .query_entities(&EntityFilter {
+                    name_pattern: Some(parsed.name.clone()),
+                    file_path: Some(file_id.clone()),
+                    ..EntityFilter::default()
+                })
+                .unwrap()
+                .into_iter()
+                .find(|entity| entity.name == parsed.name);
+            let Some(held) = held else {
+                return Some(format!(
+                    "{file}: the published bytes declare {} and the store holds no entity by that \
+                     name",
+                    parsed.name
+                ));
+            };
+            if held.fingerprint.behavior_hash != parsed.fingerprint.behavior_hash {
+                return Some(format!(
+                    "{file}: entity {} answers with behaviour hash {} while the exact bytes the \
+                     store publishes for it parse to {}",
+                    parsed.name, held.fingerprint.behavior_hash, parsed.fingerprint.behavior_hash
+                ));
+            }
+            let held_span = held
+                .span
+                .as_ref()
+                .map(|span| (span.start_byte, span.end_byte));
+            let parsed_span = parsed
+                .span
+                .as_ref()
+                .map(|span| (span.start_byte, span.end_byte));
+            if held_span != parsed_span {
+                return Some(format!(
+                    "{file}: entity {} answers with span {held_span:?} while the exact bytes the \
+                     store publishes for it place it at {parsed_span:?}",
+                    parsed.name
+                ));
+            }
+        }
+        None
+    }
+
+    /// A commit over MCP must publish entities that describe the bytes it
+    /// published, for a carried file as much as for an authored one.
+    ///
+    /// The two commit surfaces plan from different graphs. The CLI route is
+    /// handed the daemon's live derived graph, which the reconcile loop keeps
+    /// current, so a pending file's entities there came from the pending bytes.
+    /// The MCP route is handed repository authority's own workspace graph
+    /// snapshot, whose tree is the workspace tree and whose entities are
+    /// whatever the last published semantic delta left, because
+    /// `publish_workspace_tree` advances the tree with an empty
+    /// `WorkspaceSemanticDelta`. `plan_exact_transaction` reparses only the
+    /// files its staged operations name, so a carried file reaches the sealed
+    /// change as new tree bytes over old entity spans and nothing on that path
+    /// re-derives them.
+    ///
+    /// Declaring the carry does not make that acceptable. The declaration is
+    /// about authorship, and this is about whether canonical truth agrees with
+    /// itself.
+    #[test]
+    fn a_carried_immediate_edit_commits_entities_that_describe_the_bytes_it_published() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        install_exact_source(
+            &state,
+            "src/other.rs",
+            b"pub fn other() -> u8 { 1 }\n",
+            "other",
+        );
+        admit_pending_working_tree_edit(&state, "src/other.rs", b"pub fn other() -> u8 { 100 }\n");
+
+        let sessions = test_sessions();
+        let (_, arguments) = stage_entity_edit(&sessions, &entity, "pub fn value() -> u8 { 2 }");
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_ne!(result.is_error, Some(true), "{}", result_text(&result));
+        let reply = commit_reply(&result);
+        assert_eq!(
+            reply["carried_pending_files"],
+            serde_json::json!(["src/other.rs"]),
+            "the fixture must actually exercise the carry: {reply:#}"
+        );
+
+        // The control for the check itself. The authored file is re-derived by
+        // the edit path, so a checker that could not tell a coherent file from
+        // an incoherent one would report this one too.
+        assert_eq!(
+            semantic_disagreement(&state, "src/lib.rs"),
+            None,
+            "the file the operation authored must be coherent, or the check below proves nothing"
+        );
+        assert_eq!(
+            semantic_disagreement(&state, "src/other.rs"),
+            None,
+            "the carried file's entities must describe the bytes this commit published for it"
+        );
+    }
+
+    /// The same defect where no span moves, so only a fingerprint can catch it.
+    ///
+    /// `return 1` to `return 7` leaves every byte offset in the file identical,
+    /// so a coherence check written as a span or a length comparison passes over
+    /// it while the entity's body is still wrong. `behavior_hash` is the hash of
+    /// an entity's full source text, so it is the field that moves, and this arm
+    /// exists to keep the check honest about which one it reads.
+    #[test]
+    fn a_carried_same_length_body_edit_commits_entities_that_describe_the_bytes_it_published() {
+        const BEFORE: &[u8] = b"pub fn other() -> u8 { 1 }\n";
+        const AFTER: &[u8] = b"pub fn other() -> u8 { 7 }\n";
+        assert_eq!(
+            BEFORE.len(),
+            AFTER.len(),
+            "this arm's whole point is that no span moves"
+        );
+
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let (carried_entity, _) = install_exact_source(&state, "src/other.rs", BEFORE, "other");
+        let span_before = carried_entity
+            .span
+            .as_ref()
+            .map(|span| (span.start_byte, span.end_byte))
+            .expect("an installed source entity has a span");
+        admit_pending_working_tree_edit(&state, "src/other.rs", AFTER);
+
+        let sessions = test_sessions();
+        let (_, arguments) = stage_entity_edit(&sessions, &entity, "pub fn value() -> u8 { 2 }");
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_ne!(result.is_error, Some(true), "{}", result_text(&result));
+        let reply = commit_reply(&result);
+        assert_eq!(
+            reply["carried_pending_files"],
+            serde_json::json!(["src/other.rs"]),
+            "the fixture must actually exercise the carry: {reply:#}"
+        );
+
+        assert_eq!(
+            semantic_disagreement(&state, "src/lib.rs"),
+            None,
+            "the file the operation authored must be coherent, or the check below proves nothing"
+        );
+        assert_eq!(
+            semantic_disagreement(&state, "src/other.rs"),
+            None,
+            "the carried file's entities must describe the bytes this commit published for it, \
+             including when the edit moved no byte offset"
+        );
+
+        let carried_after = state
+            .graph
+            .get_entity(&carried_entity.id)
+            .unwrap()
+            .expect("the carried entity keeps its identity across the commit");
+        assert_eq!(
+            carried_after
+                .span
+                .as_ref()
+                .map(|span| (span.start_byte, span.end_byte)),
+            Some(span_before),
+            "a same-length edit must leave the span exactly where it was, so the assertion above \
+             can only have been answered by the fingerprint"
+        );
+    }
+
+    /// The same defect on a store nothing in this process derived.
+    ///
+    /// Reopening drops every graph this process built and rebuilds the daemon's
+    /// view from what the store persisted, so the commit that follows plans
+    /// against cold repository authority and cold source. If the incoherence
+    /// were an artifact of live in-memory state carried across the admission it
+    /// would not survive here; it does, because the snapshot the MCP route plans
+    /// from is the persisted one.
+    #[test]
+    fn a_carried_edit_committed_after_a_reopen_publishes_entities_that_describe_its_tree() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        install_exact_source(
+            &state,
+            "src/other.rs",
+            b"pub fn other() -> u8 { 1 }\n",
+            "other",
+        );
+        admit_pending_working_tree_edit(&state, "src/other.rs", b"pub fn other() -> u8 { 7 }\n");
+
+        let layout = state.layout.clone();
+        drop(state);
+        let state = Arc::new(DaemonState::open(layout).unwrap());
+
+        let sessions = test_sessions();
+        let (_, arguments) = stage_entity_edit(&sessions, &entity, "pub fn value() -> u8 { 2 }");
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_ne!(result.is_error, Some(true), "{}", result_text(&result));
+        let reply = commit_reply(&result);
+        assert_eq!(
+            reply["carried_pending_files"],
+            serde_json::json!(["src/other.rs"]),
+            "the fixture must actually exercise the carry: {reply:#}"
+        );
+
+        assert_eq!(
+            semantic_disagreement(&state, "src/lib.rs"),
+            None,
+            "the file the operation authored must be coherent, or the check below proves nothing"
+        );
+        assert_eq!(
+            semantic_disagreement(&state, "src/other.rs"),
+            None,
+            "a cold graph and cold source must still publish entities that describe the bytes the \
+             commit published"
+        );
+    }
+
+    /// The success contract a carried commit already has, held to while the
+    /// semantics are repaired.
+    ///
+    /// Deriving a carried file's semantics into the commit is the fix, and the
+    /// thing it could plausibly break is everything this asserts: the commit
+    /// still lands, the reply and the change record still declare the fold, the
+    /// carried entity keeps its identity and the change it was created in, and
+    /// no attribution event names it. Republishing an entity's bytes is not the
+    /// same as claiming its authorship, and this is where the two stay separate.
+    #[test]
+    fn a_coherent_carried_pending_commit_still_succeeds_and_declares_the_carry() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let (carried_entity, installed_change) = install_exact_source(
+            &state,
+            "src/other.rs",
+            b"pub fn other() -> u8 { 1 }\n",
+            "other",
+        );
+        admit_pending_working_tree_edit(&state, "src/other.rs", b"pub fn other() -> u8 { 7 }\n");
+
+        let sessions = test_sessions();
+        let (_, arguments) = stage_entity_edit(&sessions, &entity, "pub fn value() -> u8 { 2 }");
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "a workspace holding pending content must still commit: {}",
+            result_text(&result)
+        );
+        let reply = commit_reply(&result);
+        let change_id = reply["change_id"].as_str().unwrap().to_string();
+        assert_eq!(
+            reply["staged_operation_files"],
+            serde_json::json!(["src/lib.rs"])
+        );
+        assert_eq!(
+            reply["carried_pending_files"],
+            serde_json::json!(["src/other.rs"])
+        );
+        assert_eq!(
+            reply["modified_files"],
+            serde_json::json!(["src/lib.rs", "src/other.rs"])
+        );
+
+        let declared = state
+            .graph
+            .get_entity_history(&entity.id)
+            .unwrap()
+            .into_iter()
+            .find(|change| change.id.to_string() == change_id)
+            .expect("the published change is reachable from the entity the operation wrote");
+        assert!(
+            declared
+                .message
+                .contains("also admitted 1 pending working-tree file")
+                && declared.message.contains("src/other.rs"),
+            "the change record must still state the fold and sample it: {}",
+            declared.message
+        );
+
+        let carried_after = state
+            .graph
+            .get_entity(&carried_entity.id)
+            .unwrap()
+            .expect("the carried entity keeps the identity it already had");
+        assert_eq!(carried_after.name, carried_entity.name);
+        assert_eq!(carried_after.kind, carried_entity.kind);
+        assert_eq!(
+            state
+                .graph
+                .get_entity_history(&carried_entity.id)
+                .unwrap()
+                .first()
+                .map(|change| change.id),
+            Some(installed_change),
+            "the carried entity keeps the change it was created in"
+        );
+
+        let attributed = state
+            .graph
+            .query_audit_events(None, 64)
+            .unwrap()
+            .into_iter()
+            .filter(|event| {
+                event.action == "kin_transaction_commit"
+                    && event
+                        .details
+                        .as_deref()
+                        .is_some_and(|details| details.contains(&change_id))
+            })
+            .filter_map(|event| match event.target_scope {
+                Some(WorkScope::Entity(id)) => Some(id),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            attributed.contains(&entity.id),
+            "the entity the operation wrote is attributed to the committing session"
+        );
+        assert!(
+            !attributed.contains(&carried_entity.id),
+            "republishing a carried entity's bytes must not attribute it to the committing session"
+        );
+
+        assert!(
+            !workspace_is_dirty(&state),
+            "the commit must leave the workspace level with its base"
+        );
+    }
+
+    /// A carried path the workspace ADDED reaches the change with the entities
+    /// its bytes derive to.
+    ///
+    /// The other carried arms exercise a `TreeDelta::Updated`, where the entity
+    /// deltas are modifications. This one is the admission of untracked content:
+    /// the workspace tree gains a path its base change never carried, and
+    /// because ambient admission publishes no semantic delta, the change would
+    /// otherwise publish a source file with no entities inside it at all. That
+    /// is not a subtler version of the same defect; it is a file the graph
+    /// cannot answer a single question about.
+    #[test]
+    fn a_carried_added_path_commits_the_entities_its_bytes_derive_to() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        admit_pending_working_tree_file(&state, "src/added.rs", b"pub fn added() -> u8 { 5 }\n");
+
+        let sessions = test_sessions();
+        let (_, arguments) = stage_entity_edit(&sessions, &entity, "pub fn value() -> u8 { 2 }");
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_ne!(result.is_error, Some(true), "{}", result_text(&result));
+        let reply = commit_reply(&result);
+        assert_eq!(
+            reply["carried_pending_files"],
+            serde_json::json!(["src/added.rs"]),
+            "the fixture must actually exercise the carry: {reply:#}"
+        );
+
+        assert_eq!(
+            semantic_disagreement(&state, "src/lib.rs"),
+            None,
+            "the file the operation authored must be coherent, or the check below proves nothing"
+        );
+        assert_eq!(
+            semantic_disagreement(&state, "src/added.rs"),
+            None,
+            "a carried file the workspace admitted must reach the change with its entities"
+        );
+        assert!(
+            state
+                .graph
+                .query_entities(&EntityFilter {
+                    file_path: Some(FilePathId::new("src/added.rs")),
+                    ..EntityFilter::default()
+                })
+                .unwrap()
+                .iter()
+                .any(|held| held.name == "added"),
+            "the graph must be able to answer about the file the commit published"
+        );
+    }
+
+    /// A carried path is never a removal, and this is the mechanism rather than
+    /// an assumption.
+    ///
+    /// Ambient admission publishes the tree and no semantics, so vacating a path
+    /// that way would leave the entities that file derived standing over a tree
+    /// that no longer carries it. Repository authority refuses the transaction
+    /// outright, so `publish_workspace_tree` cannot create the state at all. The
+    /// seam that does vacate a path, `commit_session_workspace_admission`,
+    /// derives the retirement through `retire_semantics_on_vacated` and carries
+    /// it in the same transaction. Two independent mechanisms, one conclusion:
+    /// every carried tree delta the MCP commit planner sees is an addition or an
+    /// update, and the only removals that reach a plan are the ones a staged
+    /// `delete` authored, which are not carried.
+    ///
+    /// That is why `derive_carried_pending_semantics` asserts the invariant
+    /// instead of implementing a retirement, and this is what makes the
+    /// assertion evidence rather than decoration: take either mechanism away and
+    /// a carried removal becomes reachable, so the arm it guards has something
+    /// to guard.
+    ///
+    /// A moved path is the same fact read twice, because `TreeDelta` has no move
+    /// variant: the half that arrives is an addition, covered above, and the half
+    /// that departs is this refusal.
+    #[test]
+    fn ambient_admission_cannot_vacate_a_path_without_retiring_its_semantics() {
+        let (_dir, state) = test_state();
+        install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        install_exact_source(
+            &state,
+            "src/other.rs",
+            b"pub fn other() -> u8 { 1 }\n",
+            "other",
+        );
+        let before = load_native_commit_base(&state.layout).unwrap();
+
+        let refusal = admit_pending_working_tree_removal(&state, "src/other.rs")
+            .expect_err("authority must refuse a vacated path whose semantics still stand");
+
+        let message = refusal.to_string();
+        assert!(
+            message.contains("src/other.rs"),
+            "the refusal must name the path it will not vacate: {message}"
+        );
+        assert!(
+            message.contains("absent from the staged tree"),
+            "the refusal must say what is wrong with the transition: {message}"
+        );
+        assert!(
+            message.contains("carry its exact entity removal or relocation in the same delta"),
+            "the refusal must say what a caller has to carry instead: {message}"
+        );
+        assert_eq!(
+            load_native_commit_base(&state.layout).unwrap().roots,
+            before.roots,
+            "no repository authority may move behind a refused admission"
+        );
+    }
+
+    /// A carried path whose new bytes stop being source is refused by name, not
+    /// published with the old entities still standing over them.
+    ///
+    /// Deriving cannot answer this one: there is nothing to parse, so there are
+    /// no entities to replace the ones the graph holds. Publishing anyway is the
+    /// defect in its worst form, entities describing source the repository is
+    /// about to stop holding. Retiring them silently is not this commit's call
+    /// either, because no operation in it named that file and a retirement is a
+    /// decision about somebody else's work. So it refuses, names the path, says
+    /// what the graph still holds, and gives the three ways out.
+    #[test]
+    fn a_carried_path_that_stops_being_source_is_refused_by_name() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        install_exact_source(
+            &state,
+            "src/other.rs",
+            b"pub fn other() -> u8 { 1 }\n",
+            "other",
+        );
+        // Not valid UTF-8, so the classifier cannot call it entity source no
+        // matter what the extension says.
+        admit_pending_working_tree_edit(&state, "src/other.rs", &[0xff, 0xfe, 0x00, 0x01]);
+        let before = load_native_commit_base(&state.layout).unwrap();
+
+        let sessions = test_sessions();
+        let (transaction_id, arguments) =
+            stage_entity_edit(&sessions, &entity, "pub fn value() -> u8 { 2 }");
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+
+        assert_eq!(
+            result.is_error,
+            Some(true),
+            "publishing stale entities under bytes they never came from is not an option: {}",
+            result_text(&result)
+        );
+        let message = result_text(&result);
+        assert!(
+            message.contains("src/other.rs"),
+            "the refusal must name the path that cannot be derived: {message}"
+        );
+        assert!(
+            message.contains("no longer classifies as supported entity source"),
+            "the refusal must say what is wrong with it: {message}"
+        );
+        assert!(
+            message.contains("'replace'") && message.contains("'delete'"),
+            "the refusal must say what to do about it: {message}"
+        );
+        assert_eq!(
+            sessions.get_transaction(&transaction_id).unwrap().state,
+            "active",
+            "a refused commit leaves the transaction where the caller can retry it"
+        );
+        assert_eq!(
+            load_native_commit_base(&state.layout).unwrap().roots,
+            before.roots,
+            "no repository authority may move behind a refusal"
         );
     }
 }

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -8772,9 +8772,14 @@ mod tests {
     /// a carried removal becomes reachable, so the arm it guards has something
     /// to guard.
     ///
-    /// A moved path is the same fact read twice, because `TreeDelta` has no move
-    /// variant: the half that arrives is an addition, covered above, and the half
-    /// that departs is this refusal.
+    /// A move is NOT a removal beside an addition, and an earlier version of
+    /// this comment said it was. `TreeDelta::Updated` carries an old and a new
+    /// state and nothing requires their paths to match, so a move is one delta
+    /// that keeps its artifact identity;
+    /// `a_pending_move_is_one_updated_delta_and_ambient_admission_refuses_it`
+    /// asserts that from the product's own tree correction. What a move shares
+    /// with a removal is only this refusal, because it vacates its old path the
+    /// same way.
     #[test]
     fn ambient_admission_cannot_vacate_a_path_without_retiring_its_semantics() {
         let (_dir, state) = test_state();
@@ -9152,6 +9157,228 @@ mod tests {
             semantic_disagreement(&state, "src/callee.rs"),
             None,
             "the carried endpoint's own entities still describe the bytes this commit published"
+        );
+    }
+
+    /// Leave one working file moved the way a session leaves it, and hand back
+    /// whatever refused if something did.
+    ///
+    /// Same shape as the removal helper, and for the same reason: the ambient
+    /// publication path can refuse this, and which layer refuses is the answer
+    /// worth having rather than a panic.
+    /// The same tree with one artifact at a different path and the same
+    /// identity, which is what a move leaves behind.
+    ///
+    /// Built by naming the artifacts rather than by assembling the delta the
+    /// assertion is about, so the correction under test is derived from two
+    /// states rather than read back from an answer the fixture supplied.
+    fn moved_workspace_tree(
+        tree: &kin_model::ResolvedTree,
+        from: &RepoPath,
+        to: &RepoPath,
+    ) -> kin_model::ResolvedTree {
+        kin_model::ResolvedTree::from_artifacts(tree.artifacts_by_path().map(|artifact| {
+            let path = if &artifact.path == from {
+                to.clone()
+            } else {
+                artifact.path.clone()
+            };
+            kin_model::ResolvedArtifact::new(artifact.artifact_id, path, artifact.entry.clone())
+        }))
+        .expect("moving one artifact keeps every identity and every path unique")
+    }
+
+    fn admit_pending_working_tree_move(
+        state: &Arc<DaemonState>,
+        from: &str,
+        to: &str,
+    ) -> crate::error::Result<()> {
+        let from_path = RepoPath::from_utf8(from).unwrap();
+        let to_path = RepoPath::from_utf8(to).unwrap();
+        let working = state.layout.working_dir();
+        if let Some(parent) = working.join(to).parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::rename(working.join(from), working.join(to)).unwrap();
+        let artifact = state
+            .graph
+            .resolved_tree()
+            .artifact_at_path(&from_path)
+            .cloned()
+            .expect("a move takes an already admitted artifact");
+        state.graph.apply_transaction_delta(&TransactionDelta {
+            tree_deltas: vec![TreeDelta::Updated {
+                artifact_id: artifact.artifact_id,
+                old: artifact.located_entry(),
+                new: LocatedEntry::new(to_path, artifact.entry),
+            }],
+            ..TransactionDelta::default()
+        })?;
+        try_publish_pending_workspace_tree(state)
+    }
+
+    /// A move is one `Updated` delta whose paths differ, not a removal beside an
+    /// addition, and ambient admission cannot publish one either.
+    ///
+    /// An earlier comment in this module claimed a move must be a `Removed` and
+    /// an `Added` pair because `TreeDelta` has no move variant. That was wrong:
+    /// `TreeDelta::Updated` carries an old and a new state and nothing requires
+    /// their paths to match, and `commit_deltas.rs` already asserts a real move
+    /// through admission produces exactly one such delta with the artifact
+    /// identity unchanged. This holds that fact where the carry code can see it,
+    /// and then shows the consequence: the old path is vacated with its entities
+    /// still standing, which is the transition repository authority refuses,
+    /// exactly as it refuses a pending deletion.
+    #[test]
+    fn a_pending_move_is_one_updated_delta_and_ambient_admission_refuses_it() {
+        let (_dir, state) = test_state();
+        install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        install_exact_source(
+            &state,
+            "src/old.rs",
+            b"pub fn moved() -> u8 { 1 }\n",
+            "moved",
+        );
+        let before = load_native_commit_base(&state.layout).unwrap();
+
+        // The tree transition a move actually produces, from the product's own
+        // correction rather than from a delta assembled to look like one.
+        let from_path = RepoPath::from_utf8("src/old.rs").unwrap();
+        let to_path = RepoPath::from_utf8("src/new.rs").unwrap();
+        let artifact = before
+            .tree
+            .artifact_at_path(&from_path)
+            .cloned()
+            .expect("the fixture installed this path");
+        let moved_tree = moved_workspace_tree(&before.tree, &from_path, &to_path);
+        let deltas = kin_core::exact_tree_correction(&before.tree, &moved_tree).unwrap();
+        assert_eq!(deltas.len(), 1, "a move is one delta: {deltas:#?}");
+        assert!(
+            matches!(
+                &deltas[0],
+                TreeDelta::Updated { artifact_id, old, new }
+                    if *artifact_id == artifact.artifact_id
+                        && old.path == from_path
+                        && new.path == to_path
+            ),
+            "a move is an Updated whose paths differ, with the artifact identity kept: {:#?}",
+            deltas[0]
+        );
+
+        let refusal = admit_pending_working_tree_move(&state, "src/old.rs", "src/new.rs")
+            .expect_err("authority must refuse a move whose old path's semantics still stand");
+        let message = refusal.to_string();
+        assert!(
+            message.contains("src/old.rs"),
+            "the refusal must name the path being vacated: {message}"
+        );
+        assert!(
+            message.contains("carry its exact entity removal or relocation in the same delta"),
+            "the refusal must say what a caller has to carry instead: {message}"
+        );
+        assert_eq!(
+            load_native_commit_base(&state.layout).unwrap().roots,
+            before.roots,
+            "no repository authority may move behind a refused admission"
+        );
+    }
+
+    /// The seam that CAN admit a move retires the moved path's identity before
+    /// any MCP commit could see it.
+    ///
+    /// This is the half the ambient refusal above does not settle. Session
+    /// admission carries the retirement the refusal demands, and it derives that
+    /// retirement from the vacated set rather than from a relocation: an entity
+    /// on the old path is removed outright, and so is every relation incident to
+    /// it. So a carried move reaches the MCP commit planner with the file at its
+    /// new path and no entities anywhere, which is why the derivation in this
+    /// module can make that file answerable again but cannot give it back the
+    /// identity it had. The loss happens here, in the admission, not in the
+    /// carry.
+    ///
+    /// Driven through the product's own `VacatedPaths::from_deltas` and
+    /// `retire_semantics_on_vacated`, which is what `plan_session_workspace_
+    /// admission` calls, rather than through a hand-built delta.
+    #[test]
+    fn session_admission_retires_a_moved_path_identity_and_its_incoming_edges() {
+        let (_dir, state) = test_state();
+        let (caller, _) = install_exact_source(
+            &state,
+            "src/caller.rs",
+            b"pub fn caller() -> u8 { 1 }\n",
+            "caller",
+        );
+        let (moved, _) = install_exact_source(
+            &state,
+            "src/old.rs",
+            b"pub fn moved() -> u8 { 1 }\n",
+            "moved",
+        );
+        // An incoming edge, so the retirement's reach is asserted rather than
+        // assumed.
+        state
+            .graph
+            .apply_transaction_delta(&TransactionDelta {
+                relation_deltas: vec![RelationDelta::Added {
+                    new: Relation {
+                        id: kin_model::RelationId::new(),
+                        kind: kin_model::relation::RelationKind::Calls,
+                        src: GraphNodeId::Entity(caller.id),
+                        dst: GraphNodeId::Entity(moved.id),
+                        confidence: 1.0,
+                        origin: RelationOrigin::Manual,
+                        created_in: None,
+                        import_source: None,
+                        evidence: Vec::new(),
+                    },
+                }],
+                ..TransactionDelta::default()
+            })
+            .unwrap();
+        commit_live_graph(&state, "install the incoming edge", false);
+
+        let base = load_native_commit_base(&state.layout).unwrap();
+        let from_path = RepoPath::from_utf8("src/old.rs").unwrap();
+        let to_path = RepoPath::from_utf8("src/new.rs").unwrap();
+        let moved_tree = moved_workspace_tree(&base.tree, &from_path, &to_path);
+        let deltas = kin_core::exact_tree_correction(&base.tree, &moved_tree).unwrap();
+
+        let vacated = crate::repository_commit::VacatedPaths::from_deltas(&deltas);
+        assert!(
+            !vacated.is_empty(),
+            "a move's old path is vacated, because the kept set is built from new paths only"
+        );
+
+        let retirement = crate::repository_commit::retire_semantics_on_vacated(
+            &base.graph.to_snapshot(),
+            &vacated,
+        )
+        .unwrap();
+        assert!(
+            retirement.entity_deltas().iter().any(|delta| matches!(
+                delta,
+                EntityDelta::Removed { old } if old.id == moved.id
+            )),
+            "session admission removes the moved entity outright rather than relocating it: {:#?}",
+            retirement.entity_deltas()
+        );
+        assert!(
+            !retirement.relation_deltas().is_empty(),
+            "and takes every edge incident to it with it: {:#?}",
+            retirement.relation_deltas()
+        );
+        assert!(
+            retirement.entity_deltas().iter().all(|delta| !matches!(
+                delta,
+                EntityDelta::Modified { new, .. } if new.id == moved.id
+            )),
+            "nothing here relocates the entity, which is why the identity is gone by the time a \
+             carried move reaches an MCP commit"
         );
     }
 }

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -9217,29 +9217,33 @@ mod tests {
         try_publish_pending_workspace_tree(state)
     }
 
-    /// A move is one `Updated` delta whose paths differ, not a removal beside an
-    /// addition, and ambient admission cannot publish one either.
+    /// `TreeDelta::Updated` can carry a path change, and ambient admission
+    /// cannot publish the transition either way.
     ///
-    /// An earlier comment in this module claimed a move must be a `Removed` and
-    /// an `Added` pair because `TreeDelta` has no move variant. That was wrong:
-    /// `TreeDelta::Updated` carries an old and a new state and nothing requires
-    /// their paths to match, and `commit_deltas.rs` already asserts a real move
-    /// through admission produces exactly one such delta with the artifact
-    /// identity unchanged. This holds that fact where the carry code can see it,
-    /// and then shows the consequence: the old path is vacated with its entities
-    /// still standing, which is the transition repository authority refuses,
-    /// exactly as it refuses a pending deletion.
-    /// One half of this is durable and one half is not, and the difference
-    /// matters for FIR-3278. That a move is a single `Updated` delta keeping its
-    /// artifact identity is a fact about the model and stays true. That the old
-    /// path is left with its entities standing, which is what forces the refusal
-    /// below, is the state FIR-3278 removes by relocating those entities instead
-    /// of retiring them. The refusal itself should survive that repair, because
-    /// `publish_workspace_tree` always sends an empty semantic delta and so can
-    /// never carry a relocation either; if FIR-3278 makes this arm fail, the
-    /// refusal moved and this test is the place to record where.
+    /// An earlier comment in this module asserted the opposite, that a moved
+    /// path must arrive as a `Removed` beside an `Added` because `TreeDelta` has
+    /// no move variant. The variant count does not settle it: `Updated` carries
+    /// an old and a new state and nothing requires their paths to match, so the
+    /// carry code cannot assume it will see a pair, and this holds that where it
+    /// can see it.
+    ///
+    /// What follows from either shape is the same, and is the second half: the
+    /// old path ends with no artifact while its entities still stand there,
+    /// which is the transition repository authority refuses, in the same words
+    /// it refuses a pending deletion.
+    /// The scope of the first half is exactly the correction, and not the
+    /// scanner that feeds it. `exact_tree_correction` is handed two tree states
+    /// in which one artifact keeps its identity at a different path, and it
+    /// answers with a single `Updated` carrying both paths, which is what says
+    /// `TreeDelta::Updated` does not require its old and new paths to match.
+    /// Whether any particular scanner produces that input is a separate
+    /// question with a separate answer: a scanner that mints fresh identity for
+    /// the new path yields a `Removed` beside an `Added` instead. Both shapes
+    /// leave the old path with no artifact and its entities still standing,
+    /// which is the state the refusal below is about, so the second half holds
+    /// either way.
     #[test]
-    fn a_pending_move_is_one_updated_delta_and_ambient_admission_refuses_it() {
+    fn a_relocated_artifact_corrects_to_one_updated_delta_ambient_admission_refuses() {
         let (_dir, state) = test_state();
         install_exact_source(
             &state,
@@ -9266,7 +9270,11 @@ mod tests {
             .expect("the fixture installed this path");
         let moved_tree = moved_workspace_tree(&before.tree, &from_path, &to_path);
         let deltas = kin_core::exact_tree_correction(&before.tree, &moved_tree).unwrap();
-        assert_eq!(deltas.len(), 1, "a move is one delta: {deltas:#?}");
+        assert_eq!(
+            deltas.len(),
+            1,
+            "an artifact that keeps its identity at a new path corrects to one delta: {deltas:#?}"
+        );
         assert!(
             matches!(
                 &deltas[0],
@@ -9275,7 +9283,8 @@ mod tests {
                         && old.path == from_path
                         && new.path == to_path
             ),
-            "a move is an Updated whose paths differ, with the artifact identity kept: {:#?}",
+            "and that delta is an Updated whose paths differ, so a path change is not necessarily \
+             a Removed beside an Added: {:#?}",
             deltas[0]
         );
 
@@ -9314,15 +9323,14 @@ mod tests {
     /// `retire_semantics_on_vacated`, which is what `plan_session_workspace_
     /// admission` calls, rather than through a hand-built delta.
     ///
-    /// **This test asserts the CURRENT behaviour, and that behaviour is the
-    /// defect (FIR-3278).** It is here so the mechanism is pinned with output
-    /// rather than argued in prose, and so the repair has evidence to work
-    /// against. When FIR-3278 lands, every assertion below inverts: the moved
-    /// entity is expected as `EntityDelta::Modified` carrying its original id at
-    /// the new path, its incident relations are expected to survive with both
-    /// endpoints intact, and the "nothing relocates it" assertion is expected to
-    /// be the one that fails. Replace them then. Do not read this test's green
-    /// as a reason to leave the retirement alone.
+    /// **Every assertion here describes retirement, and retirement is not the
+    /// behaviour a preserved move identity would have.** The whole set inverts
+    /// under a relocating admission: the moved entity becomes an
+    /// `EntityDelta::Modified` carrying its original id at the new path, its
+    /// incident relations survive with both endpoints intact, and the assertion
+    /// that nothing relocates it becomes the failing one. Replace them together
+    /// when that is what the admission does. This test is a record of a
+    /// mechanism, not an argument that the mechanism is right.
     #[test]
     fn session_admission_retires_a_moved_path_identity_and_its_incoming_edges() {
         let (_dir, state) = test_state();


### PR DESCRIPTION
## What was wrong

The CLI and MCP commit routes plan from different graphs, and only one of them keeps a carried file's semantics with its bytes.

`publish_workspace_tree` writes real `tree_deltas` beside `semantic_delta: WorkspaceSemanticDelta::default()` (`crates/kin-daemon/src/repository_commit.rs:807`), so ambient admission moves the workspace tree and no semantics. kin-db 0.7.104 then materializes the workspace graph as the base change's semantics plus `exact_tree_transition(base.resolved_tree, workspace.tree)` (`src/storage/repository.rs:6340`), asserting `materialized.resolved_tree == workspace.tree`. The workspace graph snapshot therefore holds post-edit tree bytes over pre-edit entities by construction.

`plan_exact_transaction` builds its prospective graph from exactly that snapshot (`mcp_commit.rs:933`), and reparses only the files a staged operation names: `plan_new_source_files`, `plan_replaced_source_files`, the per-edit reconcile, the rename path. A carried file is named by none of them. `plan_native_commit_inner` then diffs the prospective graph against the resolved parent (`repository_commit.rs:1146`), which for that path yields a `TreeDelta` naming the post-edit blob and no `EntityDelta` at all, and seals it at `repository_commit.rs:1223`. `install_authority_graph` corrects the live graph **onto** authority, so it propagated the disagreement rather than closing it, and `semantic_workspace_matches` passed because both sides then held the same wrong answer.

The CLI route does not have this. `plan_native_commit` is handed the daemon's live derived graph, which the reconcile loop keeps current against the working tree, so a pending file's entities there came from the pending bytes and the diff emits entity deltas for them. One surface publishes semantics for a carried file and the other did not.

Declaring the carry does not settle it. The declaration says who authored a file. This is about whether one change's tree and its entities describe the same source.

## What this does

`derive_carried_pending_semantics` re-derives them, entirely inside `crates/kin-daemon/src/mcp_commit.rs`.

It reads the carried set off the plan rather than computing it a second way, so the files re-derived are exactly the files the reply and the change message declare, off the one definition of the fold (`carried_pending_paths`). The blob identities come from the tree deltas that same change publishes and the bodies out of repository CAS through `load_native_source_blob`, never off the working copy, so nothing here reads raw filesystem content as semantic authority. Each carried file is indexed and reconciled against the prospective graph exactly as a staged `replace` is, which is why an entity that merely changed body keeps its id, its lineage and its incoming edges.

The plan is taken once more only when a reconcile moved an entity or a relation, and never in a loop: the second pass publishes the same tree bytes, so it carries the same set and re-deriving it again finds nothing. An empty carried set returns before doing anything, so a commit that carries nothing pays nothing.

`TreeEntry::Symlink` and `TreeEntry::Gitlink` are named and skipped rather than left to a wildcard. Bytes that no longer classify as supported entity source are skipped when the graph holds no entities for the path and refused with the path named when it does, because publishing entities over content they never came from and retiring somebody else's entities on their behalf are both wrong answers.

A carried removal is asserted rather than repaired, and that came out of writing the test for it. Repository authority refuses to vacate a path whose semantics are still standing, and the seam that does vacate one (`commit_session_workspace_admission`) derives its retirement through `retire_semantics_on_vacated` and carries it in the same transaction. Two independent mechanisms, one conclusion: a carried tree delta is an `Added` or an `Updated`, never a `Removed`. A retirement branch here would be code nothing can reach and nothing can falsify, so the arm asserts the invariant and refuses loudly if either mechanism ever regresses. A carried move follows: `TreeDelta` has no move variant, so a move is that refusal plus a carried addition, and both halves are covered.

`record_commit_provenance` keeps the carried paths out of the attribution it writes. Republishing a carried file's bytes is a content revision, not a claim on its authorship, and this is where the two stay separate.

## The one existing assertion that changed

In `a_carried_file_keeps_the_authorship_its_entities_already_had`, the claim that the carried entity's history did **not** contain the committing change can only be satisfied by a change that publishes bytes without their semantics, which is the defect. `get_entity_history` selects changes by scanning entity deltas, so coherence and that assertion cannot both hold.

It now asserts that the history does contain it, that the entity keeps the change it was created in, and that it keeps its name and kind. The audit-attribution assertions beside it are untouched and still green, which is where the authorship claim actually lives. The change message body said the semantics were not re-derived, which is no longer true, so it now says the bytes and the semantics move together and the authorship does not.

## Verification

Everything below is a local run whose only witness is this branch, so each is the command and its output tail. `CARGO_TARGET_DIR` pinned to the lane target, every cargo command through `heavy-slot.sh mcpcarry kin`.

**Red first, on unmodified source.** `cargo test -p kin-daemon --lib mcp_commit::tests` with the tests added and no fix:

```
test result: FAILED. 62 passed; 3 failed; 0 ignored; 0 measured; 1390 filtered out; finished in 73.70s

panicked at crates/kin-daemon/src/mcp_commit.rs:8008:9:
assertion `left == right` failed: the carried file's entities must describe the bytes this commit published for it
  left: Some("src/other.rs: entity other answers with behaviour hash 74641426f719c6f159366b2d2b6ce9743c40a9438a81f09321cb05b2695945d2 while the exact bytes the store publishes for it parse to 4fb4d9cc94ceb4ef44771d9be7b8c6f2ee2feb0b8dda478bcee7e5fa52b5f320")
 right: None

panicked at crates/kin-daemon/src/mcp_commit.rs:8063:9:
assertion `left == right` failed: the carried file's entities must describe the bytes this commit published for it, including when the edit moved no byte offset
  left: Some("src/other.rs: entity other answers with behaviour hash 74641426f719c6f159366b2d2b6ce9743c40a9438a81f09321cb05b2695945d2 while the exact bytes the store publishes for it parse to 60dbb90af66f3b3bd860ced1501fed17ae8caeba83cdda4fc7462dd3b5968a2a")
 right: None

panicked at crates/kin-daemon/src/mcp_commit.rs:8131:9:
assertion `left == right` failed: a cold graph and cold source must still publish entities that describe the bytes the commit published
  left: Some("src/other.rs: entity other answers with behaviour hash 74641426f719c6f159366b2d2b6ce9743c40a9438a81f09321cb05b2695945d2 while the exact bytes the store publishes for it parse to 60dbb90af66f3b3bd860ced1501fed17ae8caeba83cdda4fc7462dd3b5968a2a")
 right: None
```

Three arms: an immediate carried edit, a same-length body edit where no byte offset moves and only the behaviour hash does, and a cold graph and cold source after a reopen. Each asserts the file the transaction's own operation authored is coherent **first**, and that assertion passes in all three, so none of them is a checker that fires on whatever it is pointed at. `a_coherent_carried_pending_commit_still_succeeds_and_declares_the_carry` and all three FIR-3208 arms passed in that same run, so the fixture is a working carried commit rather than a broken one.

**Green with the fix**, same command:

```
test result: ok. 68 passed; 0 failed; 0 ignored; 0 measured; 1390 filtered out; finished in 152.20s
```

**Falsification, three arms**, each removing one load-bearing piece from this commit and restored afterwards with a clean `git status --porcelain`:

```
Arm A, derivation call removed:
test result: FAILED. 62 passed; 6 failed
    a_carried_added_path_commits_the_entities_its_bytes_derive_to
    a_carried_edit_committed_after_a_reopen_publishes_entities_that_describe_its_tree
    a_carried_file_keeps_the_authorship_its_entities_already_had
    a_carried_immediate_edit_commits_entities_that_describe_the_bytes_it_published
    a_carried_path_that_stops_being_source_is_refused_by_name
    a_carried_same_length_body_edit_commits_entities_that_describe_the_bytes_it_published

Arm B, derivation kept and the re-plan removed:
test result: FAILED. 63 passed; 5 failed
    a_carried_added_path_commits_the_entities_its_bytes_derive_to
    a_carried_edit_committed_after_a_reopen_publishes_entities_that_describe_its_tree
    a_carried_file_keeps_the_authorship_its_entities_already_had
    a_carried_immediate_edit_commits_entities_that_describe_the_bytes_it_published
    a_carried_same_length_body_edit_commits_entities_that_describe_the_bytes_it_published

Arm C, provenance filter removed:
test result: FAILED. 66 passed; 2 failed
    a_carried_file_keeps_the_authorship_its_entities_already_had
    a_coherent_carried_pending_commit_still_succeeds_and_declares_the_carry
```

Five under B rather than six, and the difference is the point: the source-classification refusal fires during derivation, before any re-plan, so it stays green under B and goes red under A. The re-plan is load-bearing for the coherence arms and nothing else. Arm C moves only the two attribution assertions, which is what says the filter separates content revision from authorship and does nothing else. None of the three weakens an assertion; each removes production behaviour and the assertion written for it goes red.

**The refusal the deleted case turned up.** Writing the removal fixture is what proved a carried removal unreachable, because `publish_workspace_tree` refused it:

```
called `Result::unwrap()` on an `Err` value: Graph(StorageError("transaction leaves entity
c1c65391-a6d1-5ea3-971e-437f0ed3ce3a on repository path src/other.rs absent from the staged tree;
carry its exact entity removal or relocation in the same delta"))
```

That refusal is now the test `ambient_admission_cannot_vacate_a_path_without_retiring_its_semantics`, which is what makes the invariant in the code evidence rather than decoration.

**`bin/kin-precheck kin --repo-dir kin=<this worktree>`:**

```
kin-precheck: repo=kin tree=.kin-coord/worktrees/mcpcarry-kin sha=cbba896b2cc154d588a29eed5d5b3f54a7c5f104 branch=chore/lane-mcpcarry-kin
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
...
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin cbba896b2cc154d588a29eed5d5b3f54a7c5f104
```

Both zero-file-search guards are in that set, which matters here: the derivation reads blob identities out of the change's own tree deltas and bodies out of repository CAS, and never touches the working copy.

`cargo fmt --all -- --check` is clean, and clippy exactly as `ci.yml` assembles it, `RUSTFLAGS=-D warnings` with the 45-lint debt allow-list read out of `.github/clippy-allowed-lints.txt`, is clean.

Acceptance is not restated here: it grades main, not this pull request.

## Scope

One file, `crates/kin-daemon/src/mcp_commit.rs`. No change to `repository_commit.rs`, `error.rs`, `api.rs`, `commit_deltas.rs`, `state.rs` or `loop_runner.rs`.

---

## Second round, after independent review

Independent review of the first commit found two P2 defects in it and one unproved case. All three were real; two were mine. Three commits answer them.

### The non-blob arm skipped what it should have refused

The derivation skipped a symlink or a gitlink on the reasoning that neither carries a source body and therefore neither has entities to disagree with it. The first half is true and the second does not follow, because the tree and the semantics are independent. kin-db 0.7.104 revalidates an invalidated path by requiring an artifact to remain at it, and does not require that artifact to be a blob (`src/engine/graph.rs:8705`), so a same-path source-to-symlink conversion satisfies every check while the entities the old source derived keep standing. The skip published them over a link. That is this module's own defect wearing a different tree entry.

All three arms now share one refusal, because "the content at this path cannot be what those entities describe" is one condition whether the new entry is a symlink, a submodule pointer, or a blob that stopped classifying as source. Neither link kind is parsed or dereferenced, the per-variant match stays so a new entry kind cannot reach the parser by accident, and a symlink with nothing standing under it is still an ordinary tree-only carry.

### The attribution filtered one of its two sources

Carried paths were kept out while entity-delta scopes were collected, and the relation-only fallback then appended every relation endpoint unfiltered. Those two never interacted before, because a carried file contributed no entity delta. Now that it does, a relation-only transaction beside a carried edit to one of its endpoints leaves the first list empty, opens the fallback, and hands the carried endpoint straight back to the committing session.

Both sources are filtered now, and the fallback's trigger is "no scopes the agent authored" rather than "no entity deltas" for the same reason. Endpoint ownership resolves from the change's own entity-delta payloads before the graph, so a removed endpoint cannot evade the filter by being absent from a lookup, and a commit whose every scope was carried still records its change-level event.

### What a carried move actually is

The first commit's comment claimed a move must be a removal beside an addition because `TreeDelta` has no move variant. That is wrong, and two tests now hold the correction where the carry code can see it.

`kin_core::exact_tree_correction`, handed two tree states in which one artifact keeps its identity at a different path, returns exactly one `TreeDelta::Updated` carrying both paths. That is a fact about the correction and about the variant, not about any scanner: the carry code cannot assume a path change arrives as a pair. Which shape a given scanner produces is a separate question with a separate answer, and independent measurement of the retained session scanner has it emitting a `Removed` beside an `Added` instead, so the constructed test above is not end-to-end evidence about that scanner and does not claim to be. Both shapes leave the old path with no artifact and its entities still standing, which is the transition ambient admission cannot publish: repository authority refuses it in the same words it refuses a pending deletion, with the path named and authority unmoved.

The seam that can admit a move is session admission, and the second test drives its own `VacatedPaths::from_deltas` and `retire_semantics_on_vacated` over that same real correction with an incoming edge seeded. The moved entity comes back as `EntityDelta::Removed`, its incident relations come back removed, and nothing comes back `Modified`.

### Verification, second round

```
mcp_commit::tests with both P2 fixes:
test result: ok. 71 passed; 0 failed; 0 ignored; 0 measured; 1390 filtered out; finished in 68.96s

mcp_commit::tests with the move mechanism added:
test result: ok. 73 passed; 0 failed; 0 ignored; 0 measured; 1390 filtered out; finished in 154.47s

full kin-daemon lib suite:
test result: ok. 1460 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 769.34s
```

Each P2 fix is falsified by restoring the reviewed commit's exact behaviour rather than a synthetic mutant, which makes each arm the red-first evidence for the finding it closes:

```
The non-blob skip restored:
test result: FAILED. 70 passed; 1 failed
    a_carried_source_to_symlink_conversion_is_refused_by_name

The unfiltered relation fallback restored:
test result: FAILED. 70 passed; 1 failed
    a_relation_only_commit_beside_a_carry_attributes_only_the_endpoint_it_joined
panicked at crates/kin-daemon/src/mcp_commit.rs:9145:9:
an endpoint inside a carried file must not reach the committing session's attribution through the relation fallback
```

One failure each, and what stays green under them is half the evidence. Under the first arm, `a_carried_symlink_with_no_standing_entities_is_a_legal_tree_only_carry` passes, which is what says the refusal fires on the entities standing at the path and not on the entry kind. Under the second, every other audit-scope assertion passes, including the unchanged relation-only commit that must still name both of its endpoints.

`cargo fmt --all -- --check` and clippy as `ci.yml` assembles it are both clean on the head.

### Residual, filed as FIR-3278

A carried move reaches this derivation with the file at its new path and no entities anywhere. What lands here makes that file answerable again, with correct entities under new ids, which is strictly better than the nothing it had. It cannot return an identity that was retired two seams earlier, and it does not pretend to.

The repair belongs where the retirement is. `VacatedPaths::from_deltas` treats any old path absent from the new-path set as vacated, so a move's old path is vacated and session admission then retires it, and an artifact that survives a transition with its identity intact moved rather than vacated. `plan_entity_relocations` already carries the "or relocation" half kin-db's own refusal names. That is `repository_commit.rs`, owned elsewhere and already under change, so it is FIR-3278 rather than a hunk in this branch, and it fixes the CLI route as well as this one.

The two move tests above therefore assert what the code does today, and for the retirement one that is the defect itself. Its whole assertion set inverts under a relocating admission: the moved entity becomes an `EntityDelta::Modified` carrying its original id at the new path, its incident relations survive with both endpoints intact, and the assertion that nothing relocates it becomes the failing one. Replace them together when FIR-3278 lands. The other test is narrower than its first draft and stays true either way, because it is scoped to the correction rather than to a scanner. Both say beside themselves what they describe and what would invert, without carrying the ticket id in source, so a green test that records a defect can never be the reason its own repair is blocked.
