### PR TITLE
FIR-3256: Admit prepared repositories through additive hosted fleets

### DIFF
--- a/crates/kin-daemon/src/hosted_start.rs
+++ b/crates/kin-daemon/src/hosted_start.rs
@@ -343,7 +343,7 @@ pub const REPO_IDS: HostedStartRequirement = HostedStartRequirement {
     required: true,
     introduced_in: "0.6.2",
     consequence: "publication fencing has no fleet to fence: the daemon exits during startup. The \
-                  durable spine additionally requires exactly five canonical entries, and one \
+                  durable spine additionally requires 1 through 64 canonical entries, and one \
                   that omits the served repo id is refused by name",
     refusals: &[
         (

--- a/crates/kin-daemon/src/publication_lease.rs
+++ b/crates/kin-daemon/src/publication_lease.rs
@@ -2592,7 +2592,9 @@ fn completed_lease_matches(
     completed.kind == kind && completed.token == proof.token && completed.fence == proof.fence
 }
 
-fn canonical_repositories(repositories: &[String]) -> Result<Vec<String>, PublicationControlError> {
+pub(crate) fn canonical_repositories(
+    repositories: &[String],
+) -> Result<Vec<String>, PublicationControlError> {
     if repositories.is_empty() {
         return Err(PublicationControlError::Invalid(
             "fleet repositories must not be empty".to_string(),

--- a/crates/kin-daemon/src/publication_lease/tests/first_publication.rs
+++ b/crates/kin-daemon/src/publication_lease/tests/first_publication.rs
@@ -450,3 +450,6 @@ fn first_publication_preserves_indeterminate_outcome_and_durable_recovery_eviden
     assert_eq!(reopened.read_authority().roots(), &roots);
     assert!(publish_first_repository(source, &id, FirstPublicationMode::Native, durable).is_err());
 }
+
+#[cfg(feature = "gcs")]
+mod hosted_fleet;

--- a/crates/kin-daemon/src/publication_lease/tests/first_publication/hosted_fleet.rs
+++ b/crates/kin-daemon/src/publication_lease/tests/first_publication/hosted_fleet.rs
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+// Actual GCS generation fencing and daemon rollout over emulated object storage
+// and Firestore. Fresh backend objects prove cache-independent recovery here;
+// this fixture does not prove live cloud durability or a process restart.
+use super::*;
+use crate::state::DaemonState;
+
+fn hosted_image(
+    raw: Arc<VersionedMemoryStore>,
+    spine: Arc<kin_spine::test_support::FakeSpineStore>,
+    fleet: &[String],
+) -> (Arc<PublicationControl>, DaemonState, tempfile::TempDir) {
+    let object_store: Arc<dyn ObjectStore> = raw.clone();
+    let control = Arc::new(
+        PublicationControl::new(
+            SCOPE,
+            READER_A,
+            fleet.to_vec(),
+            Arc::new(ObjectStorePublicationControlStore::new(object_store, "v2")),
+        )
+        .unwrap(),
+    );
+    let repo = tempfile::tempdir().unwrap();
+    let layout = kin_core::init_adopting(repo.path(), &RepositoryId::new("kin").unwrap())
+        .unwrap()
+        .layout;
+    let state = DaemonState::open_with_backend_and_publication_control(
+        layout,
+        Box::new(GcsBackend::from_store(Box::new(raw), "v2")),
+        "kin",
+        Some(fleet.iter().cloned().collect()),
+        control.clone(),
+    )
+    .unwrap();
+    state.install_hosted_durable_spine_for_test(Arc::new(
+        kin_spine::FirestoreSpineBackend::with_store(spine),
+    ));
+    assert!(state.hosted_spine_readiness_required());
+    (control, state, repo)
+}
+
+fn extend_and_reopen(git_import: bool) {
+    // Keep backend ownership outside async frames, including failed assertions.
+    // GCS may own a fallback runtime created by a blocking publication worker.
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let mut environment = kin_core::test_env::EnvVarGuard::new();
+    environment.apply("GOOGLE_CLOUD_PROJECT", Some("fixture-project"));
+    environment.apply("KIN_GCS_BUCKET", Some("fixture"));
+    environment.apply("KIN_GCS_PREFIX", Some("v2"));
+    environment.apply::<_, &str>("KIN_DISABLE_SPINE", None);
+    let temp = tempfile::tempdir().unwrap();
+    let raw = Arc::new(VersionedMemoryStore::new());
+    let spine = Arc::new(kin_spine::test_support::FakeSpineStore::cold());
+    let backend: Arc<dyn StorageBackend> =
+        Arc::new(GcsBackend::from_store(Box::new(raw.clone()), "v2"));
+    let old_ids = canonical_repositories(&staging_fleet()).unwrap();
+    environment.apply("KIN_REPO_IDS", Some(&old_ids.join(",")));
+    let mut originals = BTreeMap::new();
+    for name in &old_ids {
+        let id = RepositoryId::new(name.clone()).unwrap();
+        let original = source(&temp.path().join(name), &id, false);
+        let roots = original.read_authority().roots().clone();
+        publish_first_repository(original, &id, FirstPublicationMode::Native, backend.clone())
+            .unwrap();
+        originals.insert(
+            name.clone(),
+            (roots, backend.load_snapshot(name).unwrap().unwrap().0),
+        );
+    }
+    let (old, old_state, _old_repo) = hosted_image(raw.clone(), spine.clone(), &old_ids);
+    let first = old.bootstrap_runtime_if_absent().unwrap().unwrap();
+    runtime
+        .block_on(old_state.complete_hosted_startup_rollout(
+            &old,
+            first,
+            Some(format!("sha256:{}", "d".repeat(64))),
+        ))
+        .expect("the original five-member fleet must be genuinely ready");
+    runtime
+        .block_on(old_state.hosted_readiness_spine_authority())
+        .unwrap();
+    let original_seal = spine.legacy_migration_seal.lock().unwrap().clone().unwrap();
+    let (paused_bytes, paused_generation) = backend.load_snapshot("kin").unwrap().unwrap();
+    // An identical payload is an idempotent retry. A pending write must carry
+    // different, valid snapshot bytes so the generation fence is what refuses.
+    let pending_write = kin_db::GraphSnapshot::empty().to_bytes().unwrap();
+    kin_db::GraphSnapshot::from_bytes(&pending_write).unwrap();
+    assert_ne!(pending_write, paused_bytes);
+
+    let id = RepositoryId::new("private-sixth").unwrap();
+    let mut target = old_ids.clone();
+    target.push(id.to_string());
+    let target = canonical_repositories(&target).unwrap();
+    environment.apply("KIN_REPO_IDS", Some(&target.join(",")));
+    let (candidate, candidate_state, _candidate_repo) =
+        hosted_image(raw.clone(), spine.clone(), &target);
+    assert_eq!(
+        candidate.runtime_reader_identity(),
+        old.runtime_reader_identity(),
+        "membership alone must fence the old runtime"
+    );
+    assert!(candidate.bootstrap_runtime_if_absent().unwrap().is_none());
+    assert!(candidate
+        .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
+        .is_err());
+    assert!(runtime
+        .block_on(candidate_state.hosted_readiness_spine_authority())
+        .is_err());
+    let before = candidate.status().unwrap();
+    let mut request = rollout_request_for_fleet(target.clone(), "fixture", "prepared-sixth", None);
+    request.previous_repositories = Some(old_ids.clone());
+    let mut wrong_previous = request.clone();
+    wrong_previous.previous_repositories.as_mut().unwrap().pop();
+    assert!(
+        candidate.acquire_rollout(wrong_previous).is_err(),
+        "previous membership must be exact"
+    );
+    assert_eq!(candidate.status().unwrap(), before);
+    let missing = candidate.acquire_rollout(request.clone()).unwrap_err();
+    assert!(
+        missing
+            .to_string()
+            .contains("has no graph authority object"),
+        "{missing}"
+    );
+    assert!(candidate
+        .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
+        .is_err());
+    for (name, (_, bytes)) in &originals {
+        assert_eq!(&backend.load_snapshot(name).unwrap().unwrap().0, bytes);
+    }
+    assert_eq!(
+        backend.load_snapshot("kin").unwrap().unwrap().1,
+        paused_generation,
+        "an incomplete capture must not rewrite old authority"
+    );
+
+    let prepared = source(&temp.path().join("sixth-source"), &id, git_import);
+    let expected_roots = prepared.read_authority().roots().clone();
+    let expected_refs =
+        serde_json::to_value(&prepared.read_authority().metadata().ref_state).unwrap();
+    let expected_git = prepared
+        .read_authority()
+        .metadata()
+        .git_external_authority
+        .clone();
+    let mode = if git_import {
+        FirstPublicationMode::GitImported
+    } else {
+        FirstPublicationMode::Native
+    };
+    publish_first_repository(prepared, &id, mode, backend.clone()).unwrap();
+    let lease = candidate.acquire_rollout(request.clone()).unwrap();
+    let retried = candidate.acquire_rollout(request).unwrap();
+    assert_eq!(retried.token, lease.token);
+    assert_eq!(retried.fence, lease.fence);
+    assert_eq!(lease.fence_repositories, target);
+    assert_eq!(lease.authority_fence.len(), 6);
+    let proof = proof(&lease);
+    let full_fence = candidate.spine_rollout_fence(&proof).unwrap();
+    for omitted in ["kin", "private-sixth"] {
+        let rows = full_fence
+            .repositories
+            .iter()
+            .filter(|row| row.repo_id != omitted)
+            .cloned()
+            .collect::<Vec<_>>();
+        let subset = rows
+            .iter()
+            .map(|row| row.repo_id.clone())
+            .collect::<Vec<_>>();
+        let incomplete = kin_spine::SpineRolloutFence::new_exact(
+            SCOPE.to_string(),
+            lease.fence,
+            &lease.token,
+            &subset,
+            rows,
+        )
+        .unwrap();
+        assert!(
+            runtime
+                .block_on(candidate_state.advance_hosted_spine_rollout_fence(incomplete))
+                .is_err(),
+            "a validly encoded partial fence must not advance: {omitted}"
+        );
+    }
+    assert!(runtime
+        .block_on(candidate_state.hosted_readiness_spine_authority())
+        .is_err());
+    runtime
+        .block_on(candidate_state.complete_hosted_startup_rollout(&candidate, lease, None))
+        .expect("the actual daemon must publish and admit all six members");
+    runtime
+        .block_on(candidate_state.hosted_readiness_spine_authority())
+        .unwrap();
+    let status = candidate.status().unwrap();
+    assert_eq!(status.repositories, target);
+    assert_eq!(
+        status
+            .last_authority_fence
+            .iter()
+            .map(|row| row.repo_id.clone())
+            .collect::<Vec<_>>(),
+        target
+    );
+    assert!(status.active_lease.is_none());
+    let mut heads = spine
+        .publication_state
+        .lock()
+        .unwrap()
+        .heads
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    heads.sort();
+    assert_eq!(heads, target, "the spine must commit the exact target set");
+    assert!(
+        old.assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
+            .is_err(),
+        "the same-image old fleet must be fenced"
+    );
+    assert!(runtime
+        .block_on(old_state.hosted_readiness_spine_authority())
+        .is_err());
+    let stale = backend
+        .save_snapshot("kin", &pending_write, paused_generation)
+        .expect_err("a paused writer must lose its pre-fence generation");
+    assert!(stale.to_string().contains("generation mismatch"), "{stale}");
+    assert_eq!(
+        spine
+            .legacy_migration_seal
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap(),
+        &original_seal
+    );
+    drop(candidate_state);
+    drop(candidate);
+    drop(old_state);
+    drop(old);
+    drop(backend);
+
+    // Corrupt one durable input, not the cache or proof. Fresh adoption must
+    // refuse before a missing head can masquerade as an admitted empty repo.
+    let removed = spine
+        .publication_state
+        .lock()
+        .unwrap()
+        .heads
+        .remove("private-sixth")
+        .unwrap();
+    let (damaged, damaged_state, _damaged_repo) = hosted_image(raw.clone(), spine.clone(), &target);
+    let RuntimeSpineAuthority::Completed(evidence) = damaged.runtime_spine_authority().unwrap()
+    else {
+        panic!("rollout must have completed")
+    };
+    assert!(
+        runtime
+            .block_on(damaged_state.adopt_hosted_spine_rollout_fence(evidence))
+            .is_err(),
+        "fresh adoption must prove all six committed heads"
+    );
+    drop(damaged_state);
+    drop(damaged);
+    spine
+        .publication_state
+        .lock()
+        .unwrap()
+        .heads
+        .insert("private-sixth".to_string(), removed);
+
+    let (fresh, fresh_state, _fresh_repo) = hosted_image(raw.clone(), spine, &target);
+    let RuntimeSpineAuthority::Completed(evidence) = fresh.runtime_spine_authority().unwrap()
+    else {
+        panic!("rollout must have completed")
+    };
+    runtime
+        .block_on(fresh_state.adopt_hosted_spine_rollout_fence(evidence))
+        .expect("fresh reader must prove the six-member durable fleet");
+    fresh
+        .assert_runtime_admitted(kin_db::GraphSnapshot::CURRENT_VERSION)
+        .unwrap();
+    runtime
+        .block_on(fresh_state.hosted_readiness_spine_authority())
+        .unwrap();
+    assert!(fresh_state.serves_repo_id("private-sixth"));
+    assert!(!fresh_state.serves_repo_id("unadmitted-seventh"));
+    let reopened_backend: Arc<dyn StorageBackend> =
+        Arc::new(GcsBackend::from_store(Box::new(raw), "v2"));
+    for (name, (roots, bytes)) in originals {
+        assert_eq!(
+            reopened_backend.load_snapshot(&name).unwrap().unwrap().0,
+            bytes
+        );
+        let authority = RepositoryAuthorityManager::open(
+            RepositoryId::new(name).unwrap(),
+            reopened_backend.clone(),
+        )
+        .unwrap();
+        assert_eq!(authority.read_authority().roots(), &roots);
+    }
+    let sixth = RepositoryAuthorityManager::open(id, reopened_backend).unwrap();
+    assert_eq!(sixth.read_authority().roots(), &expected_roots);
+    assert_eq!(
+        serde_json::to_value(&sixth.read_authority().metadata().ref_state).unwrap(),
+        expected_refs
+    );
+    assert_eq!(
+        sixth.read_authority().metadata().git_external_authority,
+        expected_git
+    );
+    if git_import {
+        for body in [OLD_BODY, NEW_BODY] {
+            assert_eq!(
+                sixth.load_source_blob(hash(body)).unwrap().as_deref(),
+                Some(body)
+            );
+        }
+    } else {
+        assert!(sixth.read_authority().snapshot().entities.is_empty());
+    }
+}
+
+#[test]
+#[serial_test::serial]
+fn hosted_fleet_admits_prepared_native_sixth_and_reopens() {
+    extend_and_reopen(false);
+}
+
+#[test]
+#[serial_test::serial]
+fn hosted_fleet_admits_prepared_git_sixth_and_reopens() {
+    extend_and_reopen(true);
+}

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1699,7 +1699,6 @@ const HOSTED_SPINE_AUTHORITY_REFRESH_INTERVAL: Duration = Duration::from_secs(60
 /// wakes one, so a persistent drift cannot turn the probe back into the thing
 /// that drives a continuous refresh.
 const HOSTED_SPINE_AUTHORITY_RETRY_FLOOR: Duration = Duration::from_secs(1);
-const HOSTED_SPINE_FLEET_SIZE: usize = 5;
 const HOSTED_SPINE_CURSOR_CAS_REQUIRED: &str =
     "hosted persistent spine is unavailable until its durable backend can stage rows and compare-and-swap a head bound to the exact source publication cursor";
 
@@ -5998,7 +5997,7 @@ impl DaemonState {
         {
             return Err("KIN_GCS_PREFIX must be a non-empty canonical object prefix".to_string());
         }
-        let mut fleet = self
+        let fleet = self
             .allowed_repo_ids
             .as_ref()
             .ok_or_else(|| {
@@ -6009,16 +6008,8 @@ impl DaemonState {
             .iter()
             .cloned()
             .collect::<Vec<_>>();
-        fleet.sort();
-        if fleet.len() != HOSTED_SPINE_FLEET_SIZE
-            || fleet.iter().any(|repo_id| {
-                repo_id.is_empty() || repo_id.trim() != repo_id || repo_id.contains('/')
-            })
-        {
-            return Err(format!(
-                "hosted durable spine requires exactly {HOSTED_SPINE_FLEET_SIZE} canonical KIN_REPO_IDS entries"
-            ));
-        }
+        let fleet = crate::publication_lease::canonical_repositories(&fleet)
+            .map_err(|error| format!("hosted durable spine fleet is invalid: {error}"))?;
         Ok((format!("gcs://{bucket}/{prefix}"), fleet))
     }
 
@@ -11972,6 +11963,7 @@ impl Drop for EmbedPassGuard<'_> {
 
 #[cfg(test)]
 mod tests {
+    mod hosted_fleet;
     use super::*;
     use kin_model::{
         ArtifactId, ChangeOrigin, Entity, EntityKind, EntityMetadata, FileLayout, FilePathId,
@@ -19704,7 +19696,7 @@ mod tests {
     }
     /// The complete hosted spine contract, from which one requirement at a
     /// time is removed below.
-    fn hosted_spine_fleet() -> [&'static str; HOSTED_SPINE_FLEET_SIZE] {
+    fn hosted_spine_fleet() -> [&'static str; 5] {
         ["kin", "kin-db", "kin-lsp", "kin-model", "kin-search"]
     }
 

--- a/crates/kin-daemon/src/state/tests/hosted_fleet.rs
+++ b/crates/kin-daemon/src/state/tests/hosted_fleet.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+use super::*;
+
+#[test]
+#[serial_test::serial]
+fn hosted_fleet_contract_accepts_six_prepared_repository_ids() {
+    let mut environment = kin_core::test_env::EnvVarGuard::new();
+    environment.apply("GOOGLE_CLOUD_PROJECT", Some("fixture-project"));
+    environment.apply("KIN_GCS_BUCKET", Some("fixture-bucket"));
+    environment.apply("KIN_GCS_PREFIX", Some("fixture-prefix"));
+    let (mut state, _repo) = hosted_state_for_contract(true);
+    let (_, original) = state
+        .hosted_spine_contract()
+        .expect("five-member positive control");
+    state
+        .allowed_repo_ids
+        .as_mut()
+        .unwrap()
+        .insert("private-sixth".to_string());
+    let (_, target) = state
+        .hosted_spine_contract()
+        .expect("a complete six-member configured fleet must be accepted");
+    assert_eq!(target.len(), 6);
+    assert!(original.iter().all(|id| target.contains(id)));
+    assert!(target.contains(&"private-sixth".to_string()));
+}
+
+#[test]
+#[serial_test::serial]
+fn hosted_fleet_contract_retains_canonical_bounds() {
+    let mut environment = kin_core::test_env::EnvVarGuard::new();
+    environment.apply("GOOGLE_CLOUD_PROJECT", Some("fixture-project"));
+    environment.apply("KIN_GCS_BUCKET", Some("fixture-bucket"));
+    environment.apply("KIN_GCS_PREFIX", Some("fixture-prefix"));
+    let (mut state, _repo) = hosted_state_for_contract(true);
+    for size in [1, 5, 6, 64] {
+        let fleet = (0..size)
+            .map(|i| format!("repo-{i:02}"))
+            .collect::<Vec<_>>();
+        state.allowed_repo_ids = Some(fleet.iter().cloned().collect());
+        assert_eq!(state.hosted_spine_contract().unwrap().1, fleet);
+    }
+    for size in [0, 65] {
+        state.allowed_repo_ids = Some((0..size).map(|i| format!("repo-{i}")).collect());
+        assert!(
+            state.hosted_spine_contract().is_err(),
+            "invalid fleet size {size}"
+        );
+    }
+    for invalid in ["", " bad", "bad/name", "bad\\name", "repo name"] {
+        state.allowed_repo_ids = Some([invalid.to_string()].into_iter().collect());
+        assert!(
+            state.hosted_spine_contract().is_err(),
+            "invalid repo ID {invalid:?}"
+        );
+    }
+    state.allowed_repo_ids = None;
+    assert!(state.hosted_spine_contract().is_err());
+    let duplicate = vec!["kin".to_string(), "kin".to_string()];
+    assert!(crate::publication_lease::canonical_repositories(&duplicate).is_err());
+}

--- a/crates/kin-spine/src/firestore.rs
+++ b/crates/kin-spine/src/firestore.rs
@@ -373,29 +373,12 @@ impl LegacyMigrationSeal {
                 "legacy migration seal writer-drain evidence is not self-consistent".to_string(),
             ));
         }
-        let expected_repository_ids = active
-            .fence
-            .repositories
-            .iter()
-            .map(|row| row.repo_id.clone())
-            .collect::<Vec<_>>();
-        if self.scope != active.fence.scope
-            || self.repository_ids != expected_repository_ids
-            || self.rollout_fence_evidence.rollout_fence > active.fence.rollout_fence
-        {
-            return Err(SpineError::Backend(
-                "legacy migration seal does not belong to the active rollout scope and exact fleet"
-                    .to_string(),
-            ));
-        }
-        if self.rollout_fence_evidence.rollout_fence == active.fence.rollout_fence
-            && self.rollout_fence_evidence != active.evidence()
-        {
-            return Err(SpineError::Backend(
-                "legacy migration seal carries different evidence for the active rollout fence"
-                    .to_string(),
-            ));
-        }
+        validate_legacy_seal_fleet(
+            &self.scope,
+            &self.repository_ids,
+            &self.rollout_fence_evidence,
+            active,
+        )?;
         let observed_ids = self
             .sealed_heads
             .iter()
@@ -418,6 +401,58 @@ impl LegacyMigrationSeal {
         }
         Ok(())
     }
+}
+
+// The seal attests the original legacy writer drain. A later additive rollout
+// keeps that history, while hydration and reader admission independently prove
+// every current publication against the exact active fleet and GCS evidence.
+#[cfg(any(feature = "firestore", feature = "test-support", test))]
+pub(crate) fn validate_legacy_seal_fleet(
+    sealed_scope: &str,
+    sealed_repository_ids: &[String],
+    sealed_evidence: &SpineRolloutFenceEvidence,
+    active: &LoadedSpineRolloutFence,
+) -> Result<(), SpineError> {
+    active.fence.validate()?;
+    if active.update_time.is_empty()
+        || sealed_repository_ids.is_empty()
+        || sealed_repository_ids
+            .windows(2)
+            .any(|pair| pair[0] >= pair[1])
+    {
+        return Err(SpineError::Serialization(
+            "legacy seal fleet or active fence revision is not canonical".to_string(),
+        ));
+    }
+    if sealed_scope != active.fence.scope
+        || sealed_evidence.rollout_fence > active.fence.rollout_fence
+    {
+        return Err(SpineError::Backend(
+            "legacy migration seal does not belong to the active rollout scope and fence"
+                .to_string(),
+        ));
+    }
+    let active_repository_ids = active
+        .fence
+        .repositories
+        .iter()
+        .map(|row| row.repo_id.clone())
+        .collect::<Vec<_>>();
+    if sealed_evidence.rollout_fence == active.fence.rollout_fence {
+        if sealed_repository_ids != active_repository_ids || *sealed_evidence != active.evidence() {
+            return Err(SpineError::Backend(
+                "legacy migration seal carries different membership or evidence for the active rollout fence".to_string(),
+            ));
+        }
+    } else if sealed_repository_ids
+        .iter()
+        .any(|repo_id| active.fence.repository(repo_id).is_none())
+    {
+        return Err(SpineError::Backend(
+            "a later rollout must retain every sealed legacy repository".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(feature = "firestore")]
@@ -3901,6 +3936,8 @@ impl SpineStore for FirestoreStore {
 
 #[cfg(test)]
 mod tests {
+    mod hosted_fleet;
+
     use super::*;
     use crate::publication::RepoPublicationConflict;
     use crate::test_support::*;

--- a/crates/kin-spine/src/firestore/tests/hosted_fleet.rs
+++ b/crates/kin-spine/src/firestore/tests/hosted_fleet.rs
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+use super::*;
+
+#[cfg(feature = "firestore")]
+#[test]
+fn legacy_seal_allows_a_later_additive_fleet_without_resealing() {
+    let (_, original, _, seal) = five_repository_seal_fixture();
+    seal.validate_against_active(&original).unwrap();
+    let bytes = serde_json::to_vec(&seal).unwrap();
+    let expanded = LoadedSpineRolloutFence {
+        fence: test_rollout_fence(
+            8,
+            "six-repo-rollout",
+            &[
+                "kin",
+                "kin-db",
+                "kin-lsp",
+                "kin-model",
+                "kin-search",
+                "private-sixth",
+            ],
+        ),
+        update_time: "later-revision".to_string(),
+    };
+    seal.validate_against_active(&expanded)
+        .expect("a later fenced addition must retain the historical legacy drain seal");
+    assert_eq!(serde_json::to_vec(&seal).unwrap(), bytes);
+}
+
+fn active_with(fence: u64, ids: &[&str]) -> LoadedSpineRolloutFence {
+    LoadedSpineRolloutFence {
+        fence: test_rollout_fence(fence, "fleet-transition", ids),
+        update_time: "next-revision".to_string(),
+    }
+}
+
+#[cfg(feature = "firestore")]
+#[test]
+fn legacy_seal_rejects_removing_an_original_member() {
+    let (_, _, _, seal) = five_repository_seal_fixture();
+    let removed = active_with(
+        8,
+        &["kin", "kin-db", "kin-model", "kin-search", "private-sixth"],
+    );
+    let error = seal.validate_against_active(&removed).unwrap_err();
+    assert!(error.to_string().contains("retain every sealed"), "{error}");
+}
+
+#[cfg(feature = "firestore")]
+#[test]
+fn legacy_seal_rejects_changed_same_fence_membership_and_evidence() {
+    let (_, original, _, seal) = five_repository_seal_fixture();
+    let same_fence = active_with(
+        7,
+        &[
+            "kin",
+            "kin-db",
+            "kin-lsp",
+            "kin-model",
+            "kin-search",
+            "private-sixth",
+        ],
+    );
+    assert!(
+        seal.validate_against_active(&same_fence).is_err(),
+        "same-fence addition must refuse"
+    );
+    let mut changed_revision = original.clone();
+    changed_revision.update_time = "other-revision".to_string();
+    assert!(
+        seal.validate_against_active(&changed_revision).is_err(),
+        "same-fence revision must be exact"
+    );
+    let changed_payload = active_with(7, &["kin", "kin-db", "kin-lsp", "kin-model", "kin-search"]);
+    assert!(
+        seal.validate_against_active(&changed_payload).is_err(),
+        "same-fence payload must be exact"
+    );
+}
+
+#[cfg(feature = "firestore")]
+#[test]
+fn legacy_seal_rejects_rollback_and_foreign_scope() {
+    let (_, _, _, seal) = five_repository_seal_fixture();
+    let lower = active_with(6, &["kin", "kin-db", "kin-lsp", "kin-model", "kin-search"]);
+    assert!(
+        seal.validate_against_active(&lower).is_err(),
+        "a seal cannot attest an older fence"
+    );
+    let next = active_with(
+        8,
+        &[
+            "kin",
+            "kin-db",
+            "kin-lsp",
+            "kin-model",
+            "kin-search",
+            "private-sixth",
+        ],
+    );
+    let foreign = LoadedSpineRolloutFence {
+        fence: SpineRolloutFence::new_exact(
+            "gcs://other-bucket/other-prefix".to_string(),
+            8,
+            "foreign",
+            &seal.repository_ids,
+            next.fence.repositories[..5].to_vec(),
+        )
+        .unwrap(),
+        update_time: "foreign-revision".to_string(),
+    };
+    assert!(
+        seal.validate_against_active(&foreign).is_err(),
+        "foreign scope must refuse even with valid payload"
+    );
+}
+
+#[cfg(feature = "firestore")]
+#[test]
+fn legacy_seal_rejects_invalid_active_fence_and_missing_revision() {
+    let (_, original, _, seal) = five_repository_seal_fixture();
+    let mut invalid = active_with(
+        8,
+        &[
+            "kin",
+            "kin-db",
+            "kin-lsp",
+            "kin-model",
+            "kin-search",
+            "private-sixth",
+        ],
+    );
+    invalid.fence.payload_sha256 = format!("sha256:{}", "0".repeat(64));
+    assert!(
+        seal.validate_against_active(&invalid).is_err(),
+        "the active payload must validate"
+    );
+    let mut missing = original;
+    missing.update_time.clear();
+    assert!(seal.validate_against_active(&missing).is_err());
+}
+
+#[cfg(feature = "firestore")]
+#[test]
+fn legacy_seal_keeps_original_head_and_drain_evidence_validated_after_expansion() {
+    let (_, _, _, seal) = five_repository_seal_fixture();
+    let next = active_with(
+        8,
+        &[
+            "kin",
+            "kin-db",
+            "kin-lsp",
+            "kin-model",
+            "kin-search",
+            "private-sixth",
+        ],
+    );
+    let mut malformed_digest = seal.clone();
+    malformed_digest.head_set_sha256 = format!("sha256:{}", "0".repeat(64));
+    assert!(
+        malformed_digest.validate_against_active(&next).is_err(),
+        "the original head-set digest must still validate"
+    );
+    let mut missing_head = seal.clone();
+    missing_head.sealed_heads.pop();
+    assert!(missing_head.validate_against_active(&next).is_err());
+    let mut changed_drain = seal.clone();
+    changed_drain
+        .writer_drain
+        .rollout_fence_evidence
+        .rollout_fence += 1;
+    assert!(changed_drain.validate_against_active(&next).is_err());
+    let mut duplicate = seal;
+    duplicate
+        .repository_ids
+        .insert(0, duplicate.repository_ids[0].clone());
+    assert!(duplicate.validate_against_active(&next).is_err());
+}
+
+#[test]
+fn legacy_seal_expansion_still_requires_every_new_committed_head() {
+    let store = Arc::new(FakeSpineStore::cold());
+    let backend = FirestoreSpineBackend::with_store(store.clone());
+    assert!(matches!(
+        backend
+            .advance_rollout_fence(test_rollout_fence(1, "original", &["repo"]))
+            .unwrap(),
+        SpineRolloutFenceCommit::Advanced(_)
+    ));
+    publish_success(
+        &backend,
+        metadata_publication("repo", 1, "old-root", Vec::new()),
+    );
+    backend
+        .complete_legacy_migration(test_writer_drain(&store))
+        .unwrap();
+    backend.hydrate().unwrap();
+    let original_seal = store.legacy_migration_seal.lock().unwrap().clone();
+    assert!(matches!(
+        backend
+            .advance_rollout_fence(test_rollout_fence(2, "expanded", &["repo", "sixth"]))
+            .unwrap(),
+        SpineRolloutFenceCommit::Advanced(_)
+    ));
+    assert!(
+        backend.legacy_migration_complete().unwrap(),
+        "the historical seal remains valid"
+    );
+    let cold = FirestoreSpineBackend::with_store(store.clone());
+    let missing = cold.hydrate().unwrap_err();
+    assert!(
+        missing
+            .to_string()
+            .contains("head set does not equal the active exact fleet"),
+        "{missing}"
+    );
+    publish_success(
+        &backend,
+        metadata_publication("sixth", 1, "new-root", Vec::new()),
+    );
+    cold.hydrate()
+        .expect("all current complete publications make the additive fence readable");
+    assert_eq!(*store.legacy_migration_seal.lock().unwrap(), original_seal);
+}
+
+#[test]
+fn legacy_seal_fleet_validator_preserves_additive_authority_without_features() {
+    let original = active_with(7, &["kin", "kin-db", "kin-lsp", "kin-model", "kin-search"]);
+    let ids = original
+        .fence
+        .repositories
+        .iter()
+        .map(|row| row.repo_id.clone())
+        .collect::<Vec<_>>();
+    let evidence = original.evidence();
+    let validate = |active: &LoadedSpineRolloutFence| {
+        validate_legacy_seal_fleet(&original.fence.scope, &ids, &evidence, active)
+    };
+    validate(&original).unwrap();
+    let later = active_with(
+        8,
+        &[
+            "kin",
+            "kin-db",
+            "kin-lsp",
+            "kin-model",
+            "kin-search",
+            "private-sixth",
+        ],
+    );
+    validate(&later).expect("the production validator must allow a later additive fleet");
+    let removed = active_with(
+        8,
+        &["kin", "kin-db", "kin-model", "kin-search", "private-sixth"],
+    );
+    assert!(validate(&removed).is_err(), "sealed members must remain");
+    let same = active_with(
+        7,
+        &[
+            "kin",
+            "kin-db",
+            "kin-lsp",
+            "kin-model",
+            "kin-search",
+            "private-sixth",
+        ],
+    );
+    assert!(
+        validate(&same).is_err(),
+        "same-fence membership must stay exact"
+    );
+    let mut revision = original.clone();
+    revision.update_time = "different-revision".to_string();
+    assert!(
+        validate(&revision).is_err(),
+        "same-fence revision must stay exact"
+    );
+    let lower = active_with(6, &["kin", "kin-db", "kin-lsp", "kin-model", "kin-search"]);
+    assert!(validate(&lower).is_err(), "rollback must refuse");
+    let foreign = LoadedSpineRolloutFence {
+        fence: SpineRolloutFence::new_exact(
+            "gcs://foreign/scope".to_string(),
+            8,
+            "foreign",
+            &ids,
+            original.fence.repositories.clone(),
+        )
+        .unwrap(),
+        update_time: "foreign-revision".to_string(),
+    };
+    assert!(validate(&foreign).is_err(), "scope must stay bound");
+    let mut invalid = later;
+    invalid.fence.payload_sha256 = format!("sha256:{}", "0".repeat(64));
+    assert!(
+        validate(&invalid).is_err(),
+        "active fence payload must validate"
+    );
+}

--- a/crates/kin-spine/src/test_support.rs
+++ b/crates/kin-spine/src/test_support.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 use crate::backend::SpineError;
 use crate::firestore::{
     classify_rollout_fence_reconciliation, publication_stage_is_cleanup_safe,
-    RolloutFenceReconciliation,
+    validate_legacy_seal_fleet, RolloutFenceReconciliation,
 };
 use crate::index::{CrossRepoEdge, EntityEntry};
 use crate::publication::{
@@ -437,26 +437,25 @@ impl SpineStore for FakeSpineStore {
             .fence
             .repositories
             .iter()
-            .map(|row| row.repo_id.as_str())
+            .map(|row| row.repo_id.clone())
             .collect::<Vec<_>>();
-        let current_ids = current
-            .fence
-            .repositories
-            .iter()
-            .map(|row| row.repo_id.as_str())
-            .collect::<Vec<_>>();
+        validate_legacy_seal_fleet(
+            &sealed_fence.fence.scope,
+            &sealed_ids,
+            &sealed_fence.evidence(),
+            &current,
+        )?;
         let head_ids = sealed_heads
             .iter()
-            .map(|head| head.repo_id.as_str())
+            .map(|head| head.repo_id.clone())
             .collect::<Vec<_>>();
-        if sealed_fence.fence.scope != current.fence.scope
-            || sealed_ids != current_ids
-            || head_ids != current_ids
-            || sealed_fence.fence.rollout_fence > current.fence.rollout_fence
-            || writer_drain.rollout_fence_evidence != sealed_fence.evidence()
+        for head in sealed_heads {
+            head.validate()?;
+        }
+        if head_ids != sealed_ids || writer_drain.rollout_fence_evidence != sealed_fence.evidence()
         {
             return Err(SpineError::Backend(
-                "fake legacy migration seal does not match active authority".to_string(),
+                "fake legacy migration seal does not match its original authority".to_string(),
             ));
         }
         Ok(true)


### PR DESCRIPTION
## What

Allow a prepared repository to join a canonical hosted fleet of 1 through 64 repositories. A later additive fence retains the immutable legacy migration seal and every repository that seal covered.

## Why

A sixth repository was refused by the five-entry runtime contract, then by seal validation even after all six publications completed. This is a prerequisite for FIR-3256, not the complete hosted create/import path.

## How

Reuse publication control's canonical bounded validator. Keep exact membership and complete evidence equality at the seal's original fence. A later fence must preserve scope and every sealed member; original head and writer-drain evidence still validate. Current complete-head coverage, GCS/Firestore admission, and old-reader fencing remain required.

This stacks the exact first-publication patch from held #1538 (97519ad4df2294572d3400af4427237c89c85b44). The composed fixtures prepare native-empty and exact-Git sixth repositories, drive actual daemon rollout and fresh authority reopening, and preserve old bytes/roots, Git refs and both historical/current bodies. They use the existing object-store and Firestore transport fakes. Live cloud, process-restart acceptance, hosted endpoints and orchestration remain separate work.

## Testing

- [x] Targeted crate tests below pass on macOS with CPU embedding and registry-only kin-db 0.7.104.
- [x] Normal CI precheck: all 21 gates pass, including clippy with the CI allow-list.
- [x] `cargo fmt --all -- --check` passes.
- [x] Both commits carry `Signed-off-by` trailers from normal hooks.

Commands and actual result tails from the final intact run:

```text
cargo test --locked -p kin-spine --lib --features firestore
156 passed; 0 failed
cargo test --locked -p kin-spine --lib --no-default-features
120 passed; 0 failed
cargo test --locked -p kin-daemon --lib --no-default-features hosted_fleet_contract -- --nocapture --test-threads=1
2 passed; 0 failed
cargo test --locked -p kin-daemon --lib --no-default-features --features gcs publication_lease::tests -- --test-threads=1
71 passed; 0 failed
cargo test --locked -p kin-daemon --lib --no-default-features --features gcs a_promoted_image_rolls_out_over_the_seal_an_earlier_image_wrote -- --nocapture --test-threads=1
1 passed; 0 failed
cargo test --locked -p kin-daemon --lib --no-default-features --features gcs hosted_start::tests -- --nocapture --test-threads=1
8 passed; 0 failed
cargo test --locked -p kin-daemon --lib --no-default-features --features gcs every_declared_spine_requirement_closes_the_hosted_contract -- --nocapture --test-threads=1
1 passed; 0 failed
```

The private falsifier ran through heavy-slot against a separate source copy, with unchanged assertions. Its unselected baselines passed 8 spine and 4 daemon tests. Each named control then compiled and failed at its intended assertion, rc101: five-only, unbounded, removed-sealed-member, same-fence-change, rollback, foreign-scope, invalid-active, seal-head-digest, incomplete-current-heads, partial-state-fence, old-reader-membership, previous-fleet-proof, fresh-adoption-hydration.

```text
/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/reports/hostedfleet-falsify.py
SOURCE RESTORED
ALL 13 MUTANTS ASSERTION-RED; SOURCE RESTORED
exit 0
```

The final intact tests above ran after restoration. Complete commands, source hashes and output are retained in `.kin-coord/reports/hosted-variable-fleet-20260905.md`, `hostedfleet-final-intact.log`, and `hostedfleet-falsification-results.json` in the umbrella workspace.


```text
/Users/troyfortinjr/GitHub/kin-ecosystem/bin/kin-precheck kin --repo-dir kin=/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/hostedfleet-kin
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin b01a7095812a9c9651109968b05a9367784027a5
elapsed_seconds=472.284 rc=0
```
