### PR TITLE
Answer hosted spine reads from the cached authority proof (FIR-3269)

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -45445,6 +45445,13 @@ mod tests {
     /// The hosted fixture publishes this many repositories, which is also how
     /// many source cursor probes one bundle observation issues at once.
     const HOSTED_FIXTURE_FLEET_SIZE: usize = 5;
+    /// The one published cross-repo relationship this fixture's fleet carries.
+    /// The importing repo's graph references the imported repo's symbol, so the
+    /// rollout's edge phase resolves it and a read of `/spine/edges` over this
+    /// fixture has something to be non-empty about.
+    const HOSTED_FIXTURE_IMPORTING_REPO: &str = "kin-db";
+    const HOSTED_FIXTURE_IMPORTED_REPO: &str = "kin";
+    const HOSTED_FIXTURE_IMPORTED_SYMBOL: &str = "kin_entity";
 
     fn hosted_test_state_over(
         spine_store: Arc<dyn kin_spine::SpineStore>,
@@ -45479,12 +45486,49 @@ mod tests {
         let backend_root = tempfile::tempdir().unwrap();
         for repo_id in &fleet {
             let graph = kin_db::InMemoryGraph::new();
-            graph
-                .upsert_entity(&test_entity(
-                    &format!("{}_entity", repo_id.replace('-', "_")),
-                    "src/lib.rs",
-                ))
-                .unwrap();
+            let owned = test_entity(
+                &format!("{}_entity", repo_id.replace('-', "_")),
+                "src/lib.rs",
+            );
+            graph.upsert_entity(&owned).unwrap();
+            // One real cross-repo import, so this fleet publishes a non-empty
+            // edge set. Without it every fixture repo is an island, and a test
+            // reading `/spine/edges` cannot tell a served snapshot from an
+            // empty one: `complete` and the repo list read identically either
+            // way. The importing repo references the imported repo's symbol by
+            // name, carrying the `import_source` and the evidence token the
+            // resolver binds on, which is the shape admission enrichment writes.
+            if repo_id == HOSTED_FIXTURE_IMPORTING_REPO {
+                // The endpoint the relation names has to exist, because
+                // serializing a snapshot refuses a relation whose destination is
+                // unadmitted. It is an EXTERNAL entity with no file of its own,
+                // which is what admission enrichment writes for a symbol another
+                // repository owns, and what makes the import read as unresolved
+                // here rather than as a local definition.
+                let mut imported = test_entity(HOSTED_FIXTURE_IMPORTED_SYMBOL, "src/lib.rs");
+                imported.role = kin_model::EntityRole::External;
+                imported.file_origin = None;
+                imported.span = None;
+                graph.upsert_entity(&imported).unwrap();
+                graph
+                    .upsert_relation(&kin_model::Relation {
+                        id: kin_model::RelationId::new(),
+                        kind: kin_model::RelationKind::Calls,
+                        src: kin_model::GraphNodeId::Entity(owned.id),
+                        dst: kin_model::GraphNodeId::Entity(imported.id),
+                        confidence: 1.0,
+                        origin: kin_model::RelationOrigin::Parsed,
+                        created_in: None,
+                        import_source: Some(HOSTED_FIXTURE_IMPORTED_REPO.to_string()),
+                        evidence: vec![kin_model::RelationEvidence {
+                            token: Some(format!(
+                                "{HOSTED_FIXTURE_IMPORTED_REPO}::{HOSTED_FIXTURE_IMPORTED_SYMBOL}"
+                            )),
+                            ..Default::default()
+                        }],
+                    })
+                    .unwrap();
+            }
             kin_db::StorageBackend::save_snapshot(
                 &kin_db::LocalFileBackend::new(backend_root.path()),
                 repo_id,
@@ -45582,6 +45626,10 @@ mod tests {
         hydration_charge_ms: std::sync::atomic::AtomicU64,
         point_charge_ms: std::sync::atomic::AtomicU64,
         fail_next_hydration: std::sync::atomic::AtomicBool,
+        /// Fails the next active-fence read once. That read is the third thing
+        /// the cached-authority check makes and it maps to a BLOCKED refusal,
+        /// which is the one verdict a reader must not answer by re-proving.
+        fail_next_rollout_fence_load: std::sync::atomic::AtomicBool,
         /// Runs on every committed-head read, so a test can move durable state
         /// while a probe is between its two bundle observations.
         on_head_read: std::sync::Mutex<Option<Box<dyn Fn() + Send + Sync>>>,
@@ -45596,6 +45644,7 @@ mod tests {
                 hydration_charge_ms: std::sync::atomic::AtomicU64::new(0),
                 point_charge_ms: std::sync::atomic::AtomicU64::new(0),
                 fail_next_hydration: std::sync::atomic::AtomicBool::new(false),
+                fail_next_rollout_fence_load: std::sync::atomic::AtomicBool::new(false),
                 on_head_read: std::sync::Mutex::new(None),
             }
         }
@@ -45619,6 +45668,15 @@ mod tests {
         /// this fleet publishes exactly where it is.
         fn fail_next_hydration(&self) {
             self.fail_next_hydration
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+
+        /// Fail the next active Firestore fence read once, leaving every durable
+        /// identity this fleet publishes exactly where it is. The cached
+        /// authority check reads that fence before it reads anything else, so
+        /// this is how a test reaches its blocked verdict without moving a head.
+        fn fail_next_rollout_fence_load(&self) {
+            self.fail_next_rollout_fence_load
                 .store(true, std::sync::atomic::Ordering::SeqCst);
         }
 
@@ -45695,6 +45753,14 @@ mod tests {
         ) -> std::result::Result<Option<kin_spine::LoadedSpineRolloutFence>, kin_spine::SpineError>
         {
             self.charge_point_read();
+            if self
+                .fail_next_rollout_fence_load
+                .swap(false, std::sync::atomic::Ordering::SeqCst)
+            {
+                return Err(kin_spine::SpineError::Backend(
+                    "injected active rollout fence read failure".to_string(),
+                ));
+            }
             self.inner.load_rollout_fence()
         }
 
@@ -46535,6 +46601,198 @@ mod tests {
         assert!(
             !proved,
             "the pass itself must fail, or the window under test never existed"
+        );
+    }
+
+    // -- A query answers from the proof rather than re-establishing it ------
+    //
+    // FIR-3269. Every `/spine/*` query took the full authority pass on every
+    // request: one durable cache hydration plus a whole-fleet double-collect
+    // that loads every repository graph and recomputes every root. On the
+    // five-repo hosted fleet on 2026-09-05 the hydration half alone measured a
+    // 7.92 s median over 48 passes and a 10.15 s p90, and the whole pass the
+    // 10.46 s median recorded above. The control plane gives its org-graph read
+    // 6 s, so every read aborted and the org graph rendered seventeen
+    // repositories with no links between them while the daemon held 1489 of
+    // them and had published them four minutes after start.
+    //
+    // These three are a set. The first fails if a query re-establishes the
+    // proof. The second fails if the cheap answer stopped being an honest one.
+    // The third fails if a refusal re-proving cannot fix starts paying for a
+    // pass anyway.
+
+    /// Read `/spine/edges` through the hosted router, exactly as the control
+    /// plane does: authenticated, over a state that carries publication
+    /// control, so the reader-admission middleware runs ahead of the handler.
+    async fn read_spine_edges(state: Arc<DaemonState>) -> (StatusCode, Option<serde_json::Value>) {
+        let response = router_with_publication_control_auth(
+            state,
+            Some("daemon-test-token".to_string()),
+            Some("publication-test-token".to_string()),
+        )
+        .oneshot(
+            Request::get("/spine/edges")
+                .header("authorization", "Bearer daemon-test-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 1 << 20)
+            .await
+            .unwrap();
+        (status, serde_json::from_slice(&body).ok())
+    }
+
+    /// A hosted query must answer from the proof this process already holds.
+    #[tokio::test]
+    async fn spine_edges_answers_from_the_cached_authority_proof_without_rehydrating() {
+        let (state, store, _backend_root, _meters, _environment) =
+            admitted_hosted_test_state().await;
+        // A hydration is charged what a real one costs, so a pass returning to
+        // the query path shows up as wall clock as well as a count.
+        store.charge_each_hydration(Duration::from_secs(10));
+        let hydrations_before = store.hydration_reads();
+
+        let started = Instant::now();
+        let (status, body) = read_spine_edges(Arc::clone(&state)).await;
+        let elapsed = started.elapsed();
+        let hydrations = store.hydration_reads() - hydrations_before;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "an admitted hosted reader holding a current authority proof must serve its \
+             cross-repo snapshot"
+        );
+        assert_eq!(
+            hydrations, 0,
+            "the query hydrated the durable spine cache. Establishing authority is what the \
+             publication, rollout and background passes do; a query reads what they left."
+        );
+        let body = body.expect("the snapshot must be JSON");
+        assert_eq!(
+            body["complete"], true,
+            "an incomplete edge snapshot is a proof gap, and serving one from the cached \
+             path would hide exactly what this route exists to report"
+        );
+        let repos = body["repos"]
+            .as_array()
+            .expect("the snapshot names the fleet it was read from")
+            .len();
+        assert_eq!(
+            repos, HOSTED_FIXTURE_FLEET_SIZE,
+            "the snapshot covered {repos} repositories, not the fleet's \
+             {HOSTED_FIXTURE_FLEET_SIZE}"
+        );
+        // Everything above reads the same whether the cached path served the
+        // fleet's real edge set or an empty one, which is the exact shape of the
+        // production failure: seventeen repositories rendered with no links
+        // between them, under an answer that called itself complete. So the
+        // payload is asserted on its content, not only on its counters.
+        let edges = body["edges"]
+            .as_array()
+            .expect("the snapshot carries its edge set");
+        assert!(
+            !edges.is_empty(),
+            "the cached path served an empty edge set over a fleet that publishes one"
+        );
+        assert!(
+            edges.iter().any(|edge| {
+                edge["src_repo"] == HOSTED_FIXTURE_IMPORTING_REPO
+                    && edge["dst_repo"] == HOSTED_FIXTURE_IMPORTED_REPO
+            }),
+            "the fleet's published cross-repo edge, {HOSTED_FIXTURE_IMPORTING_REPO} to \
+             {HOSTED_FIXTURE_IMPORTED_REPO}, is not in the served snapshot: {edges:?}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(3),
+            "the query took {elapsed:?}. A durable cache hydration is charged 10 s here, so \
+             this bound is what catches one coming back onto the query path."
+        );
+    }
+
+    /// A source publication that moves past the proof must re-prove once, and
+    /// answer from what that pass finds rather than from the proof it had.
+    #[tokio::test]
+    async fn spine_edges_reproves_when_a_repository_source_advanced_under_the_proof() {
+        let (state, store, backend_root, _meters, _environment) =
+            admitted_hosted_test_state().await;
+        let (status, _) = read_spine_edges(Arc::clone(&state)).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "the fixture must serve first, or the refusal below proves nothing"
+        );
+
+        // Everything the cached path checks stays exactly where it is except
+        // one repository's source publication. An ordinary publication does not
+        // move the rollout fence, so nothing but durable identity catches this.
+        advance_repo_source_publication(&backend_root, "kin-db");
+        let hydrations_before = store.hydration_reads();
+
+        let (status, _) = read_spine_edges(Arc::clone(&state)).await;
+        let hydrations = store.hydration_reads() - hydrations_before;
+
+        assert_eq!(
+            status,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "a proof built against a superseded generation must not certify a query. \
+             Answering from it is the one thing the cheap path may never do."
+        );
+        assert_eq!(
+            hydrations, 1,
+            "a superseded proof must fall through to exactly one full pass, so the query \
+             answers from what is durably there now instead of refusing on a stale reading"
+        );
+        assert!(
+            state.ensure_spine().is_none(),
+            "and the full pass must agree: a repository whose source cursor is ahead of its \
+             committed spine head cannot be proved, so the refusal above is the cheap path \
+             reaching the verdict the expensive one reaches"
+        );
+    }
+
+    /// A refusal that re-proving cannot fix must not pay for a pass.
+    ///
+    /// A lost admission, an active rollout and an unreadable active fence are
+    /// blocked rather than superseded: the condition is in the control plane
+    /// this reader binds to, not in a head that moved, so a full pass reaches
+    /// the same refusal one process-wide hydration later. Readiness has carried
+    /// that distinction since FIR-3255, in
+    /// `a_hosted_readiness_probe_refuses_while_a_rollout_holds_the_fleet`; this
+    /// is the query route's half of the same contract.
+    #[tokio::test]
+    async fn spine_edges_refuses_without_reproving_when_the_cached_authority_is_blocked() {
+        let (state, store, _backend_root, _meters, _environment) =
+            admitted_hosted_test_state().await;
+        let (status, _) = read_spine_edges(Arc::clone(&state)).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "the fixture must serve first, or the refusal below proves nothing"
+        );
+
+        // The active Firestore fence is the third read the cached check makes
+        // and the first that can fail while every durable identity stays put.
+        store.fail_next_rollout_fence_load();
+        let hydrations_before = store.hydration_reads();
+
+        let (status, _) = read_spine_edges(Arc::clone(&state)).await;
+        let hydrations = store.hydration_reads() - hydrations_before;
+
+        assert_eq!(
+            status,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "a reader that cannot read the authority its cached proof is bound to must \
+             refuse rather than serve"
+        );
+        assert_eq!(
+            hydrations, 0,
+            "the blocked refusal hydrated the durable cache. Re-proving cannot fix a control \
+             plane the reader cannot read, so the pass refuses a second time having taken \
+             the process-wide hydration lock to do it."
         );
     }
 

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1820,6 +1820,22 @@ impl CachedAuthorityRefusal {
     }
 }
 
+/// What the authority proof this process already holds says about serving one
+/// read, before any durable refresh is considered.
+enum CachedReadAuthority<'a> {
+    /// The proof still binds to durable identity. Serve from it, with no
+    /// hydration and no graph load.
+    Proved(&'a dyn kin_spine::SpineBackend),
+    /// Refuse now. A lost admission, an active rollout or evidence this reader
+    /// cannot read are conditions in the control plane rather than heads that
+    /// moved, so a full pass reaches the same refusal one process-wide
+    /// hydration later.
+    Refuse,
+    /// Nothing usable is cached, or durable identity moved under what was. Take
+    /// the full pass once and answer from what it establishes.
+    Reprove,
+}
+
 fn hosted_spine_authority_vector_is_stable(
     first: &BTreeMap<String, HostedSpineRepoAuthorityProof>,
     second: &BTreeMap<String, HostedSpineRepoAuthorityProof>,
@@ -6803,6 +6819,74 @@ impl DaemonState {
         Some(spine)
     }
 
+    /// Whether this read can be answered from the authority proof this process
+    /// already holds, without re-establishing it.
+    ///
+    /// Establishing authority costs one full durable cache hydration plus a
+    /// whole-fleet double-collect that loads every repository graph and
+    /// recomputes every root. Every `/spine/*` query took that pass on every
+    /// request. On the five-repo hosted fleet the hydration half alone measured
+    /// a 7.92 s median over 48 passes and a 10.15 s p90, and the whole pass the
+    /// 10.46 s median recorded on
+    /// [`Self::hosted_readiness_spine_authority`]. A control plane that gives
+    /// its org-graph read 6 s therefore never saw an answer: it aborted every
+    /// time and rendered the fleet with no links between its repositories while
+    /// this daemon held 1489 of them.
+    ///
+    /// So a query answers the way a readiness probe does, from the proof the
+    /// publication, rollout and background passes establish. The reuse is
+    /// conditional on identity and never on age:
+    /// [`Self::assert_cached_hosted_spine_authority`] re-proves every
+    /// repository's committed head and source cursor on every call, so a
+    /// superseded generation is refused here rather than served.
+    fn cached_spine_read_authority(&self) -> CachedReadAuthority<'_> {
+        #[cfg(test)]
+        if self.hosted_in_memory_spine_allowed.load(Ordering::SeqCst) {
+            return CachedReadAuthority::Reprove;
+        }
+        // Hosted, and only with publication control. A local daemon
+        // re-registers its primary against the live root instead, and
+        // `assert_cached_hosted_spine_authority` answers `Ok` when there is no
+        // control to read, which means "nothing to check against" rather than
+        // "checked". Reading that `Ok` as a proof is how a process holding no
+        // control record would begin certifying its own cache.
+        if self.storage_backend.is_none() || self.publication_control.is_none() {
+            return CachedReadAuthority::Reprove;
+        }
+        // An installed proof is required for the same reason. Without one the
+        // check has nothing to bind durable identity to, and its verdict says
+        // nothing about whether this cache may answer.
+        //
+        // Read under its own statement so the guard is dropped before the check
+        // below takes the same lock.
+        let proved = self
+            .hosted_spine_authority_proof
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .is_some();
+        if !proved {
+            return CachedReadAuthority::Reprove;
+        }
+        let Ok(backend) = self.initialized_spine_backend() else {
+            return CachedReadAuthority::Reprove;
+        };
+        match self.assert_cached_hosted_spine_authority(backend) {
+            Ok(()) => CachedReadAuthority::Proved(backend),
+            Err(refusal) if refusal.superseded => CachedReadAuthority::Reprove,
+            Err(refusal) => {
+                // Record it for the same reason the admission branch below
+                // does: the caller renders `spine_unavailable_reason` into the
+                // 503, and a refusal with no reason names nothing.
+                *self
+                    .spine_initialization_failure
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) =
+                    Some(refusal.into_reason());
+                CachedReadAuthority::Refuse
+            }
+        }
+    }
+
     /// Acquire one query authority that remains stable through the caller's
     /// read. Hosted and local writers use the same gate, so the proof cannot be
     /// invalidated in the gap between readiness and response construction.
@@ -6826,7 +6910,13 @@ impl DaemonState {
                 return None;
             }
         }
-        let backend = self.ensure_spine()?;
+        // The gate and the admission assert above are unchanged and still run
+        // first, so nothing below can answer for a reader that is not admitted.
+        let backend = match self.cached_spine_read_authority() {
+            CachedReadAuthority::Proved(backend) => backend,
+            CachedReadAuthority::Refuse => return None,
+            CachedReadAuthority::Reprove => self.ensure_spine()?,
+        };
         Some(SpineAuthorityReadGuard {
             backend,
             _publication_gate: publication_gate,


### PR DESCRIPTION
Every `/spine/*` query established authority on every request: one durable Firestore cache
hydration plus a whole-fleet double-collect that loads each repository graph and recomputes every
root, twice. The hosted control plane gives its org-graph read 6 s, so it never saw an answer. It
aborted every time and rendered the fleet with no links between its repositories, while the daemon
held 1489 cross-repo edges and had published them four minutes after start.

## The measurement

48 refresh passes on the live hosted pod between 16:01:21Z and 16:27:46Z on 2026-09-05:

```
durations n=48 min=5.76 p50=7.92 p90=10.15 max=11.71 mean=8.02   (seconds)
```

That is the hydration half alone. The whole pass is the 10.46 s median already recorded on
`hosted_readiness_spine_authority`. One read, correlated exactly:

```
request left           ~16:22:30.4Z
daemon refresh start    16:22:30.806Z
daemon refresh done     16:22:36.762Z   (5.956 s)
caller returned        ~16:22:36.6Z     at 6.206 s, having already aborted
```

The caller's own evidence block reports `spineConnected:false, crossRepoEdges:0, proofGap:true`,
which is a reachability verdict from its deadline rather than a claim by this daemon that the
graph is empty.

## The change

`acquire_spine_read_authority` asks the cached authority proof first, through the same
`assert_cached_hosted_spine_authority` that FIR-3255 built for the readiness probe. Its read gate
and its runtime admission assert are unchanged and still run ahead of the shortcut, so nothing
below them can answer for a reader that is not admitted.

The shortcut is gated on hosted operation with publication control and an installed proof.
`assert_cached_hosted_spine_authority` answers `Ok` when there is no control to read, and that `Ok`
means nothing was checked rather than that the cache may answer; reading it as a proof is how a
process holding no control record would begin certifying its own cache.

`Ok` serves. A `superseded` refusal falls through to today's full `ensure_spine` exactly once, so a
generation that moved is answered from what is durably there rather than served stale. A `blocked`
refusal records its reason and fails closed, because re-proving cannot fix a control plane the
reader cannot read.

The reuse is conditional on identity and never on age: every repository's committed head and
source cursor is re-bound on every call. Nothing here relaxes what a read is allowed to answer
from; it removes a hydration and a whole-fleet graph load from the path that answers it.

## No cadence start, deliberately

`start_hosted_spine_authority_refresh_cadence` takes `self: &Arc<Self>` while
`acquire_spine_read_authority` takes `&self`, and two of its three non-route callers hold
`&DaemonState` rather than `&Arc<DaemonState>` (`command_xref_with_stable_authority`,
`mcp_bulk_check_references_with_stable_authority`), so changing the receiver would ripple well
past these two files.

It is also not needed. `/readiness` already starts the cadence on every hosted pod, under a 5 s
probe period, and correctness does not depend on it at all: the proof is re-bound to durable
identity on every call, so an old proof that still binds is still exactly right, and one that does
not returns superseded and re-proves inline.

## Tests

Three, in `mod tests` in `api.rs`, over the hosted fixture whose fleet is the production fleet.
The existing `/spine/edges` cases build on a LOCAL daemon, where `ensure_spine` never touches the
hosted authority path, so they would pass under the bug and under the fix; these are hosted.

The fixture now publishes a real cross-repo edge. Edges cannot be injected, because
`FirestoreSpineBackend::add_cross_repo_edge` refuses outright and a durable edge has to arrive
through a complete cursor-bound publication, so the importing repo carries a genuine unresolved
import and the rollout's own edge phase resolves it. Without that, a positive test reads the same
whether the path served the fleet's edges or an empty set, which is the exact shape of the failure
above.

Red first, before the `state.rs` change:

```
test api::tests::spine_edges_answers_from_the_cached_authority_proof_without_rehydrating ... FAILED
assertion `left == right` failed: the query hydrated the durable spine cache. Establishing
authority is what the publication, rollout and background passes do; a query reads what they left.
  left: 1
 right: 0
test result: FAILED. 4 passed; 1 failed; 0 ignored; 0 measured; 1449 filtered out
```

Green on the head this PR carries:

```
test api::tests::spine_edges_answers_from_the_cached_authority_proof_without_rehydrating ... ok
test api::tests::spine_edges_reproves_when_a_repository_source_advanced_under_the_proof ... ok
test api::tests::spine_edges_refuses_without_reproving_when_the_cached_authority_is_blocked ... ok
test api::tests::spine_edges_snapshot_is_stable_deduped_and_never_reads_source_files ... ok
test api::tests::spine_edges_snapshot_is_authenticated_and_read_only ... ok
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 1460 filtered out; finished in 31.99s
```

## Falsification

Four mutants, each run alone, the tree restored from a copy rather than from git afterwards.

Revert the change:

```
assertion `left == right` failed: the query hydrated the durable spine cache...
  left: 1
 right: 0
```

Serve a superseded proof, which is the cached path with no fallback:

```
assertion `left == right` failed: a proof built against a superseded generation must not certify
a query. Answering from it is the one thing the cheap path may never do.
  left: 200
 right: 503
```

Drop the blocked branch:

```
assertion `left == right` failed: a reader that cannot read the authority its cached proof is
bound to must refuse rather than serve
  left: 200
 right: 503
```

Both of those turn a refusal into a served answer, so each guard catches its mutation on what the
route hands a caller rather than on a counter.

Point the fixture's importing repo at a name not in the fleet, so nothing publishes an edge, which
is what proves the non-empty edge assertion is live:

```
the cached path served an empty edge set over a fleet that publishes one
test result: FAILED. 0 passed; 1 failed
```

## Gates

```
cargo test -p kin-daemon --lib
test result: ok. 1462 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 369.14s
```

```
bin/kin-precheck kin --repo-dir kin=<worktree>
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:check_private_repo_coupling.sh bash scripts/check_private_repo_coupling.sh
PASS     guard:check_runtime_boundaries.sh    bash scripts/check_runtime_boundaries.sh
PASS     guard:test-release-policy-gate.sh    bash scripts/test-release-policy-gate.sh
PASS     guard:test-windows-authority-legs.sh bash scripts/test-windows-authority-legs.sh
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:check-kin-vfs-compat.mjs       node scripts/check-kin-vfs-compat.mjs
PASS     guard:check-rc-build-drift.mjs       node scripts/check-rc-build-drift.mjs
PASS     guard:check-required-contexts.py     python3 scripts/check-required-contexts.py
PASS     guard:test-assertion-reachability.py python3 scripts/test-assertion-reachability.py
PASS     guard:test-guard-duplicate-release-run.py python3 scripts/test-guard-duplicate-release-run.py
PASS     guard:test-homebrew-release-gate.py  python3 scripts/test-homebrew-release-gate.py
PASS     guard:test-install-checksum.py       python3 scripts/test-install-checksum.py
PASS     guard:test-private-repo-coupling.py  python3 scripts/test-private-repo-coupling.py
PASS     guard:test-release-tag-evaluate-dispatch.py python3 scripts/test-release-tag-evaluate-dispatch.py
PASS     guard:test-release-workflow-authority.py python3 scripts/test-release-workflow-authority.py
PASS     guard:test-select-release-candidate.py python3 scripts/test-select-release-candidate.py
PASS     guard:verify-hydration-semantics.py  python3 scripts/verify-hydration-semantics.py
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
PASS     node-test                            node --test <15 file(s) named by the check job>
```

The fixture change is shared by eight tests. All seven `hosted_readiness` siblings pass, and the
lib suite above is the backstop.

Acceptance grades main rather than this pull request, so the production reading, one org-graph read
inside its 6 s budget with a non-empty edge set, is verified after the hop rather than here.

Refs FIR-3269.
