### PR TITLE
Answer one file's exact bytes for a repository and ref (FIR-3277)

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -105,7 +105,7 @@ impl ActiveApiRepositoryAuthority {
     }
 }
 
-fn repository_authority_error(error: impl std::fmt::Display) -> (StatusCode, String) {
+pub(crate) fn repository_authority_error(error: impl std::fmt::Display) -> (StatusCode, String) {
     (
         StatusCode::FAILED_DEPENDENCY,
         format!("this repository's authority could not be opened: {error}"),
@@ -1203,6 +1203,15 @@ struct RepoScopedMcpToolCallRequest {
 }
 
 const REPO_SCOPED_SEMANTIC_CAPABILITY: &str = "repo_scoped_semantic_tools_v1";
+/// This daemon serves one file's bytes for a repository and ref.
+///
+/// A capability rather than a probe, because the caller that needs it is a
+/// hosted control plane talking to whatever image production currently runs,
+/// and the alternative is guessing from a 404: an unmatched axum route and a
+/// path the ref genuinely does not carry both answer 404, and only one of
+/// them means "ask an older daemon a different question". Advertising it is
+/// what lets that caller keep a truthful fallback instead of a heuristic.
+const REPO_SCOPED_BLOB_CAPABILITY: &str = "repo_scoped_blob_v1";
 /// Retained continuations per repository, not per daemon.
 ///
 /// A per-daemon cap is a shared resource across tenants, and the eviction that
@@ -2212,6 +2221,7 @@ fn api_routes() -> Router<Arc<DaemonState>> {
         .route("/repos/{repo_id}/health", get(repo_health))
         .route("/repos/{repo_id}/entities", get(repo_entities))
         .route("/repos/{repo_id}/files", get(repo_files))
+        .route("/repos/{repo_id}/blob", get(crate::repo_blob::repo_blob))
         .route("/repos/{repo_id}/refs", get(repo_refs))
         .route("/repos/{repo_id}/history", get(repo_history))
         .route(
@@ -15094,7 +15104,7 @@ async fn repository_ref_metadata(
     Ok(Arc::new(repository_metadata(&snapshot)?.clone()))
 }
 
-fn default_repository_ref(
+pub(crate) fn default_repository_ref(
     metadata: &kin_db::PersistedRepositoryAuthority,
 ) -> Result<Option<&kin_model::RepositoryRef>, (StatusCode, String)> {
     crate::state::select_repository_default_ref(metadata).map_err(repository_authority_error)
@@ -15126,7 +15136,7 @@ fn default_repository_ref(
 /// A local daemon keeps opening its own authority. Its startup cache entry
 /// carries no envelope, so there is nothing cached for the local arm to read,
 /// and a local repository has no publication cursor to bind reuse to.
-enum RepositoryReadView {
+pub(crate) enum RepositoryReadView {
     Hosted {
         generation: Arc<crate::state::HostedRepoCacheEntry>,
         metadata: Arc<kin_db::PersistedRepositoryAuthority>,
@@ -15146,7 +15156,9 @@ impl RepositoryReadView {
     /// wearing that name spends the guard's allowlist on a call that touches no
     /// filesystem, and the guard runs only in the `check` job, which pull
     /// requests skip, so the cost lands on main rather than on the PR.
-    fn authority(&self) -> Result<&kin_db::PersistedRepositoryAuthority, (StatusCode, String)> {
+    pub(crate) fn authority(
+        &self,
+    ) -> Result<&kin_db::PersistedRepositoryAuthority, (StatusCode, String)> {
         match self {
             Self::Hosted { metadata, .. } => Ok(metadata.as_ref()),
             Self::Local { snapshot } => repository_metadata(snapshot),
@@ -15154,7 +15166,7 @@ impl RepositoryReadView {
     }
 
     /// Resolve one ref target to the change it names.
-    fn resolve_target(
+    pub(crate) fn resolve_target(
         &self,
         target: &kin_model::RefTarget,
     ) -> Result<kin_model::SemanticChangeId, (StatusCode, String)> {
@@ -15182,7 +15194,7 @@ impl RepositoryReadView {
     /// its own snapshot, and a caller still holding the view would keep two
     /// copies of one repository resident for the length of the response, which
     /// is the memory shape this change exists to remove.
-    fn resolve_tree_at(
+    pub(crate) fn resolve_tree_at(
         self,
         state: &DaemonState,
         change_id: &kin_model::SemanticChangeId,
@@ -15205,7 +15217,7 @@ impl RepositoryReadView {
 /// Addressability is decided first and by the same rule
 /// [`repo_scoped_graph`] uses, so an id this daemon does not serve keeps
 /// answering the refusal that already names both identities.
-async fn repository_read_view(
+pub(crate) async fn repository_read_view(
     state: &DaemonState,
     repo_id: &str,
 ) -> Result<RepositoryReadView, (StatusCode, String)> {
@@ -15267,7 +15279,7 @@ fn repository_tree_at(
         .map_err(repository_authority_error)
 }
 
-fn short_ref_name(name: &kin_model::RefName) -> String {
+pub(crate) fn short_ref_name(name: &kin_model::RefName) -> String {
     let bytes = name.as_bytes();
     for prefix in [b"refs/heads/".as_slice(), b"refs/tags/".as_slice()] {
         if let Some(short) = bytes.strip_prefix(prefix) {
@@ -16196,7 +16208,12 @@ async fn repo_health(
         semantic_capabilities: state
             .storage_backend
             .as_ref()
-            .map(|_| vec![REPO_SCOPED_SEMANTIC_CAPABILITY.to_string()])
+            .map(|_| {
+                vec![
+                    REPO_SCOPED_SEMANTIC_CAPABILITY.to_string(),
+                    REPO_SCOPED_BLOB_CAPABILITY.to_string(),
+                ]
+            })
             .unwrap_or_default(),
         repository_read_cache: RepositoryReadCacheHealth {
             hits: state
@@ -18091,30 +18108,27 @@ impl ExactSourceEntry {
     }
 }
 
-fn parse_exact_source_change_id(
-    source_change_id: &str,
+/// Parse a canonical semantic change id out of one named request field.
+///
+/// The field name is a parameter because the refusal is the whole value here:
+/// two routes accept a change id under two different names, and a message that
+/// names the wrong one sends a caller looking at the wrong parameter.
+pub(crate) fn parse_semantic_change_id(
+    field: &str,
+    value: &str,
 ) -> Result<kin_model::SemanticChangeId, (StatusCode, String)> {
-    if source_change_id.len() != 64
-        || !source_change_id
-            .bytes()
-            .all(|byte| byte.is_ascii_hexdigit())
-    {
+    if value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
         return Err((
             StatusCode::BAD_REQUEST,
-            "source_change_id must be a canonical 64-character hexadecimal semantic change ID"
-                .to_string(),
+            format!("{field} must be a canonical 64-character hexadecimal semantic change ID"),
         ));
     }
-    let decoded = hex::decode(source_change_id).map_err(|error| {
-        (
-            StatusCode::BAD_REQUEST,
-            format!("invalid source_change_id: {error}"),
-        )
-    })?;
+    let decoded = hex::decode(value)
+        .map_err(|error| (StatusCode::BAD_REQUEST, format!("invalid {field}: {error}")))?;
     let bytes: [u8; 32] = decoded.try_into().map_err(|_| {
         (
             StatusCode::BAD_REQUEST,
-            "source_change_id must decode to 32 bytes".to_string(),
+            format!("{field} must decode to 32 bytes"),
         )
     })?;
     Ok(kin_model::SemanticChangeId::from_hash(
@@ -18333,49 +18347,86 @@ fn build_exact_source_tar_gz(
     Ok((bytes, manifest_hash))
 }
 
+/// One repository's source-CAS reader, its arm chosen once for a whole read.
+///
+/// Two callers need the same choice and neither should re-derive it: the exact
+/// source archive, which loads every artifact in a tree, and
+/// [`crate::repo_blob`], which loads one. Handing back a loader rather than a
+/// per-call function is what keeps the local arm's authority opened once. That
+/// open re-reads the whole authority out of storage and revalidates its
+/// history, so paying it per artifact is the shape [`RepositoryReadView`]
+/// exists to remove.
+pub(crate) type RepositorySourceBlobLoader = Box<
+    dyn FnMut(&RepoPath, kin_model::Hash256, u64) -> Result<Option<Vec<u8>>, (StatusCode, String)>
+        + Send,
+>;
+
+/// Open the reader for `repo_id`'s exact source bytes.
+///
+/// Capability decides which authority answers, by the same rule
+/// [`repository_read_view`] uses and for the same reason: a daemon with a
+/// storage backend reaches every repository it serves through that backend, and
+/// a daemon without one has only the local binding it opened at startup. Reading
+/// the tree from one authority and the bytes from the other is what this rule
+/// exists to stop, and it is reachable: `cached_repo_id` is the id this daemon
+/// resolved from its own manifest, so a hosted daemon serving a repository of
+/// that name would otherwise resolve the tree from its generation and then look
+/// for the bytes in a local CAS it does not have.
+///
+/// Neither arm has a filesystem fallback, and `Ok(None)` from either means the
+/// bytes were never persisted rather than that they might be found somewhere
+/// else.
+pub(crate) fn repository_source_blob_loader(
+    state: &DaemonState,
+    repo_id: &str,
+) -> Result<RepositorySourceBlobLoader, (StatusCode, String)> {
+    let Some(backend) = state.storage_backend.as_ref().map(Arc::clone) else {
+        let authority = ActiveApiRepositoryAuthority::open(state)?;
+        return Ok(Box::new(
+            move |path: &RepoPath, digest: kin_model::Hash256, _remaining_bytes: u64| {
+                authority.manager.load_source_blob(digest).map_err(|error| {
+                    (
+                        StatusCode::FAILED_DEPENDENCY,
+                        format!("repository CAS blob load failed for {path} at {digest}: {error}"),
+                    )
+                })
+            },
+        ));
+    };
+    let repo_id = repo_id.to_string();
+    Ok(Box::new(
+        move |path: &RepoPath, digest: kin_model::Hash256, remaining_bytes: u64| {
+            backend
+                .load_source_blob_bounded(&repo_id, *digest.as_bytes(), remaining_bytes)
+                .map_err(|error| {
+                    let status = if matches!(
+                        &error,
+                        kin_db::KinDbError::SourceBlobReadLimitExceeded { .. }
+                    ) {
+                        StatusCode::PAYLOAD_TOO_LARGE
+                    } else {
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    };
+                    (
+                        status,
+                        format!(
+                            "immutable source blob load failed for {} at {}: {error}",
+                            path, digest
+                        ),
+                    )
+                })
+        },
+    ))
+}
+
 fn load_exact_source_entries(
     state: &DaemonState,
     repo_id: &str,
     tree: &kin_model::ResolvedTree,
 ) -> Result<Vec<ExactSourceEntry>, (StatusCode, String)> {
-    if repo_id == state.cached_repo_id {
-        let authority = ActiveApiRepositoryAuthority::open(state)?;
-        return load_exact_source_entries_with(tree, |path, digest, _remaining_bytes| {
-            authority.manager.load_source_blob(digest).map_err(|error| {
-                (
-                    StatusCode::FAILED_DEPENDENCY,
-                    format!("repository CAS blob load failed for {path} at {digest}: {error}"),
-                )
-            })
-        });
-    }
-
-    let backend = state.storage_backend.as_ref().ok_or_else(|| {
-        (
-            StatusCode::SERVICE_UNAVAILABLE,
-            "exact source export requires immutable backend source storage".to_string(),
-        )
-    })?;
+    let mut load_blob = repository_source_blob_loader(state, repo_id)?;
     load_exact_source_entries_with(tree, |path, digest, remaining_bytes| {
-        backend
-            .load_source_blob_bounded(repo_id, *digest.as_bytes(), remaining_bytes)
-            .map_err(|error| {
-                let status = if matches!(
-                    &error,
-                    kin_db::KinDbError::SourceBlobReadLimitExceeded { .. }
-                ) {
-                    StatusCode::PAYLOAD_TOO_LARGE
-                } else {
-                    StatusCode::INTERNAL_SERVER_ERROR
-                };
-                (
-                    status,
-                    format!(
-                        "immutable source blob load failed for {} at {}: {error}",
-                        path, digest
-                    ),
-                )
-            })
+        load_blob(path, digest, remaining_bytes)
     })
 }
 
@@ -18538,7 +18589,7 @@ async fn repo_exact_source_tar_gz(
     // complete in-memory archive. Serialize this bounded path until backend
     // streaming lands so concurrent requests cannot multiply peak RSS.
     let archive_permit = try_acquire_exact_source_archive_slot(exact_source_archive_exports())?;
-    let requested_change = parse_exact_source_change_id(&source_change_id)?;
+    let requested_change = parse_semantic_change_id("source_change_id", &source_change_id)?;
     let view = repository_read_view(&state, &repo_id).await?;
     if view.change(&requested_change)?.is_none() {
         return Err((
@@ -23365,6 +23416,597 @@ mod tests {
         );
     }
 
+    /// Read one file's bytes and the digest the route verified them against.
+    ///
+    /// The paths these tests use carry no character a query string would need
+    /// escaped, and the assertion below keeps it that way rather than leaving a
+    /// silently mis-encoded path to look like an absent file.
+    async fn repo_blob_read(
+        state: Arc<DaemonState>,
+        repo_id: &str,
+        path: &str,
+    ) -> (StatusCode, Vec<u8>) {
+        assert!(
+            path.bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || b"/._-".contains(&byte)),
+            "this helper does not escape {path}"
+        );
+        repo_route(state, &format!("/repos/{repo_id}/blob?path={path}")).await
+    }
+
+    /// The blob route answers a published file with its exact bytes (FIR-3277).
+    ///
+    /// This is the whole point of the route, so it is graded end to end through
+    /// the router rather than only at the verification helper: the bytes the
+    /// publication persisted come back, and `content_sha256` is the digest they
+    /// were checked against rather than a digest recomputed for the response.
+    #[tokio::test]
+    async fn the_blob_route_serves_published_bytes_under_the_digest_it_verified() {
+        let repo_id = format!("hostedblob-{}", Uuid::new_v4());
+        let (state, _working, storage) = replica_state(&repo_id);
+        let repository_id = RepositoryId::new(&repo_id).unwrap();
+        let source = "fn first_symbol() {}\n";
+        publish_hosted_semantic_change(
+            storage.path(),
+            &repository_id,
+            None,
+            0x3277_0001,
+            "publish a file to read",
+            &[("first_symbol", "src/first.rs", source)],
+        );
+        state.evict_repo_cache_for_test(&repo_id).await;
+
+        let (status, body) = repo_blob_read(Arc::clone(&state), &repo_id, "src/first.rs").await;
+        let message = String::from_utf8_lossy(&body);
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "the blob route must answer: {message}"
+        );
+        let blob: crate::repo_blob::RepoBlobResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(blob.display_path, "src/first.rs");
+        assert_eq!(blob.content.as_deref(), Some(source));
+        assert!(blob.is_utf8);
+        assert_eq!(blob.byte_len, source.len() as u64);
+        let expected: [u8; 32] = Sha256::digest(source.as_bytes()).into();
+        assert_eq!(
+            blob.content_sha256,
+            hex::encode(expected),
+            "the response must name the digest the bytes were verified against"
+        );
+        assert_eq!(blob.resolved_ref.as_deref(), Some("main"));
+    }
+
+    /// A path the ref's tree does not carry is a refusal, never a filesystem
+    /// read that might find one (FIR-3277).
+    #[tokio::test]
+    async fn the_blob_route_refuses_a_path_the_ref_does_not_carry() {
+        let repo_id = format!("hostedblob-absent-{}", Uuid::new_v4());
+        let (state, _working, storage) = replica_state(&repo_id);
+        let repository_id = RepositoryId::new(&repo_id).unwrap();
+        publish_hosted_semantic_change(
+            storage.path(),
+            &repository_id,
+            None,
+            0x3277_0002,
+            "publish a file to read",
+            &[("first_symbol", "src/first.rs", "fn first_symbol() {}\n")],
+        );
+        state.evict_repo_cache_for_test(&repo_id).await;
+
+        let (status, body) =
+            repo_blob_read(Arc::clone(&state), &repo_id, "src/never_published.rs").await;
+        let message = String::from_utf8_lossy(&body);
+        assert_eq!(status, StatusCode::NOT_FOUND, "{message}");
+        assert!(
+            message.contains("src/never_published.rs"),
+            "the refusal must name the path asked for: {message}"
+        );
+    }
+
+    /// The blob route is addressed the way every other repo route is, so an
+    /// unpublished repository refuses here for the same named reason (FIR-3277).
+    ///
+    /// It also proves the route is registered at all: an unmatched axum route
+    /// answers 404 with an empty body, and this answers 424 with a sentence.
+    #[tokio::test]
+    async fn the_blob_route_shares_the_repo_addressing_refusal() {
+        let repo_id = format!("hostedblob-unpublished-{}", Uuid::new_v4());
+        let (state, _working, _storage) = replica_state(&repo_id);
+
+        let (status, body) = repo_blob_read(Arc::clone(&state), &repo_id, "src/first.rs").await;
+        let message = String::from_utf8_lossy(&body);
+        assert_eq!(status, StatusCode::FAILED_DEPENDENCY, "{message}");
+        assert!(
+            message.contains("authority envelope"),
+            "the refusal must name the missing envelope: {message}"
+        );
+    }
+
+    /// Drive one blob request and keep its response headers.
+    ///
+    /// `repo_route` drops them, and the refusal kind this route publishes lives
+    /// in a header precisely so a caller does not have to read English. A test
+    /// that could not see the header could not grade the contract.
+    async fn repo_blob_route(
+        state: Arc<DaemonState>,
+        path: &str,
+    ) -> (StatusCode, Option<String>, Vec<u8>) {
+        let response = router(state)
+            .oneshot(Request::get(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let status = response.status();
+        let refusal = response
+            .headers()
+            .get(crate::repo_blob::REPO_BLOB_REFUSAL_HEADER)
+            .map(|value| value.to_str().unwrap().to_string());
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        (status, refusal, body.to_vec())
+    }
+
+    /// Point a second, non-default ref at an earlier change (FIR-3277).
+    ///
+    /// `publish_hosted_semantic_change` only ever moves `main`, so a test that
+    /// wants to prove a read honours the ref it was given needs a ref that is
+    /// not `main` and does not point where `main` points. This writes one, and
+    /// nothing else: no change, no workspace mutation, no default-ref move.
+    fn add_hosted_ref(
+        storage: &FsPath,
+        repository_id: &RepositoryId,
+        operation: u128,
+        ref_name: kin_model::RefName,
+        target: SemanticChangeId,
+    ) {
+        use kin_model::{
+            RefExpectation, RefMutation, RefTarget, RefUpdatePolicy, RepositoryTransaction,
+            REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+        };
+
+        let manager = RepositoryAuthorityManager::open(
+            repository_id.clone(),
+            Arc::new(kin_db::LocalFileBackend::new(storage.to_path_buf())),
+        )
+        .unwrap();
+        let lease = manager.read_authority();
+        let transaction = RepositoryTransaction {
+            schema_version: REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+            operation_id: kin_model::OperationId::from_uuid(Uuid::from_u128(operation)),
+            repository_id: repository_id.clone(),
+            expected_generation: lease.roots().generation,
+            expected_roots: lease.roots().clone(),
+            actor: AuthorId::new("repo-scoped-blob-test"),
+            reason: format!("point {ref_name} at a change"),
+            external_objects: Vec::new(),
+            git_authority_delta: None,
+            changes: Vec::new(),
+            aliases: Vec::new(),
+            ref_mutations: vec![RefMutation {
+                name: ref_name,
+                expected: RefExpectation::MustNotExist,
+                new_target: Some(RefTarget::change(target)),
+                policy: RefUpdatePolicy::FastForwardOnly,
+            }],
+            default_ref_mutation: None,
+            workspace_mutation: None,
+            local_overlay_delta: None,
+            merge_transaction_delta: None,
+            sealed_observation: None,
+            collaboration_delta: None,
+        };
+        drop(lease);
+        manager.commit_repository_transaction(transaction).unwrap();
+    }
+
+    /// The blob route reads the ref it was given, not the default one (FIR-3277).
+    ///
+    /// Every other test here reads the default ref, so none of them can tell a
+    /// route that honours `ref` from one that ignores it: both answer the same
+    /// bytes. This publishes two generations, points `legacy` at the first, and
+    /// reads across the gap in three ways that only a ref-honouring route gets
+    /// right. Make `resolve_read_point` ignore its `reference` argument and all
+    /// three go red: the second generation's file becomes readable at a ref
+    /// whose tree never carried it, and the first generation's read comes back
+    /// labelled with `main` and the second change's id.
+    #[tokio::test]
+    async fn the_blob_route_serves_the_requested_ref_rather_than_the_default() {
+        let repo_id = format!("hostedblob-ref-{}", Uuid::new_v4());
+        let (state, _working, storage) = replica_state(&repo_id);
+        let repository_id = RepositoryId::new(&repo_id).unwrap();
+        let first_source = "fn only_in_first() {}\n";
+        let second_source = "fn only_in_second() {}\n";
+
+        let (first_change, _entities) = publish_hosted_semantic_change(
+            storage.path(),
+            &repository_id,
+            None,
+            0x3277_0011,
+            "publish the first generation",
+            &[("only_in_first", "src/only_in_first.rs", first_source)],
+        );
+        publish_hosted_semantic_change(
+            storage.path(),
+            &repository_id,
+            Some(first_change),
+            0x3277_0012,
+            "publish the second generation",
+            &[("only_in_second", "src/only_in_second.rs", second_source)],
+        );
+        add_hosted_ref(
+            storage.path(),
+            &repository_id,
+            0x3277_0013,
+            kin_model::RefName::branch(b"legacy").unwrap(),
+            first_change,
+        );
+        state.evict_repo_cache_for_test(&repo_id).await;
+
+        // The default ref carries both generations' files, so this is the arm
+        // that would still pass under a route that ignores `ref`. It is here to
+        // establish that the second file is readable at all, which is what makes
+        // the refusal below evidence rather than an absent fixture.
+        let (status, body) =
+            repo_blob_read(Arc::clone(&state), &repo_id, "src/only_in_second.rs").await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let at_default: crate::repo_blob::RepoBlobResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(at_default.content.as_deref(), Some(second_source));
+        assert_eq!(at_default.resolved_ref.as_deref(), Some("main"));
+
+        // The same path at a ref whose tree never carried it. A route that fell
+        // back to the default would answer 200 here.
+        let (status, refusal, body) = repo_blob_route(
+            Arc::clone(&state),
+            &format!("/repos/{repo_id}/blob?path=src/only_in_second.rs&ref=legacy"),
+        )
+        .await;
+        let message = String::from_utf8_lossy(&body);
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "a ref whose tree lacks the path must refuse, not serve the default ref: {message}"
+        );
+        assert_eq!(
+            refusal.as_deref(),
+            Some("path-not-found"),
+            "a ref that exists and lacks the path is the absent-side case: {message}"
+        );
+        assert!(
+            message.contains("legacy"),
+            "the refusal must name the ref it read: {message}"
+        );
+
+        // And the ref's own bytes, labelled with the ref and the change it
+        // resolved to rather than with the default's.
+        let (status, body) = repo_route(
+            Arc::clone(&state),
+            &format!("/repos/{repo_id}/blob?path=src/only_in_first.rs&ref=legacy"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let at_legacy: crate::repo_blob::RepoBlobResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(at_legacy.content.as_deref(), Some(first_source));
+        assert_eq!(at_legacy.requested_ref.as_deref(), Some("legacy"));
+        assert_eq!(at_legacy.resolved_ref.as_deref(), Some("legacy"));
+        assert_eq!(at_legacy.change_id, first_change.to_string());
+
+        // A canonical change id is the other read point the route accepts, and
+        // it names no ref because none was involved.
+        let (status, body) = repo_route(
+            Arc::clone(&state),
+            &format!(
+                "/repos/{repo_id}/blob?path=src/only_in_first.rs&ref={}",
+                first_change
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let at_change: crate::repo_blob::RepoBlobResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(at_change.content.as_deref(), Some(first_source));
+        assert_eq!(at_change.resolved_ref, None);
+        assert_eq!(at_change.change_id, first_change.to_string());
+
+        // And a ref this repository does not carry at all. It shares its status
+        // with the case above and means the opposite: nothing was resolved, no
+        // tree was read, and no path was looked up in one. A caller that read
+        // this as an absent side would assemble a comparison out of a file that
+        // was never missing.
+        let (status, refusal, body) = repo_blob_route(
+            Arc::clone(&state),
+            &format!("/repos/{repo_id}/blob?path=src/only_in_first.rs&ref=no-such-ref"),
+        )
+        .await;
+        let message = String::from_utf8_lossy(&body);
+        assert_eq!(status, StatusCode::NOT_FOUND, "{message}");
+        assert_eq!(
+            refusal.as_deref(),
+            Some("unknown-ref"),
+            "an unresolvable ref must not wear the absent-path kind: {message}"
+        );
+        assert!(
+            message.contains("no-such-ref"),
+            "the refusal must name the ref that could not be resolved: {message}"
+        );
+    }
+
+    /// A ref's full name outranks another ref's short alias (FIR-3277).
+    ///
+    /// A branch may be named so that its own short alias is another ref's full
+    /// name: `refs/heads/refs/tags/v1` shortens to `refs/tags/v1`, which is the
+    /// tag `refs/tags/v1`'s full name. A lookup that accepts either spelling in
+    /// one pass answers with whichever the ref list holds first, so an explicit
+    /// full name can serve a different ref's bytes, and nothing about the
+    /// response says so. Both refs here resolve, they point at different
+    /// changes, and only one of them is the one that was asked for.
+    #[tokio::test]
+    async fn a_full_ref_name_outranks_another_refs_short_alias() {
+        let repo_id = format!("hostedblob-alias-{}", Uuid::new_v4());
+        let (state, _working, storage) = replica_state(&repo_id);
+        let repository_id = RepositoryId::new(&repo_id).unwrap();
+        let first_source = "fn only_in_first() {}\n";
+        let second_source = "fn only_in_second() {}\n";
+
+        let (first_change, _entities) = publish_hosted_semantic_change(
+            storage.path(),
+            &repository_id,
+            None,
+            0x3277_0031,
+            "publish the first generation",
+            &[("only_in_first", "src/only_in_first.rs", first_source)],
+        );
+        let (second_change, _entities) = publish_hosted_semantic_change(
+            storage.path(),
+            &repository_id,
+            Some(first_change),
+            0x3277_0032,
+            "publish the second generation",
+            &[("only_in_second", "src/only_in_second.rs", second_source)],
+        );
+        // The branch whose SHORT name is the tag's FULL name, pointed at the
+        // first generation, and the tag itself pointed at the second.
+        add_hosted_ref(
+            storage.path(),
+            &repository_id,
+            0x3277_0033,
+            kin_model::RefName::branch(b"refs/tags/v1").unwrap(),
+            first_change,
+        );
+        add_hosted_ref(
+            storage.path(),
+            &repository_id,
+            0x3277_0034,
+            kin_model::RefName::tag(b"v1").unwrap(),
+            second_change,
+        );
+        state.evict_repo_cache_for_test(&repo_id).await;
+
+        let (status, refusal, body) = repo_blob_route(
+            Arc::clone(&state),
+            &format!("/repos/{repo_id}/blob?path=src/only_in_second.rs&ref=refs/tags/v1"),
+        )
+        .await;
+        let message = String::from_utf8_lossy(&body);
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "the tag named in full must answer, refusal={refusal:?}: {message}"
+        );
+        let blob: crate::repo_blob::RepoBlobResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            blob.change_id,
+            second_change.to_string(),
+            "the full name names the tag, not the branch that shortens to it"
+        );
+        assert_eq!(blob.resolved_ref.as_deref(), Some("v1"));
+        assert_eq!(blob.content.as_deref(), Some(second_source));
+    }
+
+    /// A short alias two refs answer to is refused, not guessed (FIR-3277).
+    #[tokio::test]
+    async fn a_short_alias_two_refs_answer_to_is_refused() {
+        let repo_id = format!("hostedblob-ambiguous-{}", Uuid::new_v4());
+        let (state, _working, storage) = replica_state(&repo_id);
+        let repository_id = RepositoryId::new(&repo_id).unwrap();
+
+        let (first_change, _entities) = publish_hosted_semantic_change(
+            storage.path(),
+            &repository_id,
+            None,
+            0x3277_0041,
+            "publish the first generation",
+            &[(
+                "only_in_first",
+                "src/only_in_first.rs",
+                "fn only_in_first() {}\n",
+            )],
+        );
+        let (second_change, _entities) = publish_hosted_semantic_change(
+            storage.path(),
+            &repository_id,
+            Some(first_change),
+            0x3277_0042,
+            "publish the second generation",
+            &[(
+                "only_in_second",
+                "src/only_in_second.rs",
+                "fn only_in_second() {}\n",
+            )],
+        );
+        // A branch and a tag that share the short alias `v2` and point at
+        // different changes, so picking either one serves the wrong bytes.
+        add_hosted_ref(
+            storage.path(),
+            &repository_id,
+            0x3277_0043,
+            kin_model::RefName::branch(b"v2").unwrap(),
+            first_change,
+        );
+        add_hosted_ref(
+            storage.path(),
+            &repository_id,
+            0x3277_0044,
+            kin_model::RefName::tag(b"v2").unwrap(),
+            second_change,
+        );
+        state.evict_repo_cache_for_test(&repo_id).await;
+
+        let (status, refusal, body) = repo_blob_route(
+            Arc::clone(&state),
+            &format!("/repos/{repo_id}/blob?path=src/only_in_first.rs&ref=v2"),
+        )
+        .await;
+        let message = String::from_utf8_lossy(&body);
+        assert_eq!(status, StatusCode::CONFLICT, "{message}");
+        assert_eq!(refusal.as_deref(), Some("ambiguous-ref"), "{message}");
+        assert!(
+            message.contains("refs/heads/v2") && message.contains("refs/tags/v2"),
+            "the refusal must name both refs so a caller can pick one: {message}"
+        );
+    }
+
+    /// The blob route publishes its refusal kind on every refusal (FIR-3277).
+    ///
+    /// The header is the contract a hosted caller branches on, so an arm that
+    /// forgot to set it would look like a missing header rather than a wrong
+    /// one, and a caller reading `undefined` would fall back to whatever its
+    /// default is. Three different refusals, three different kinds, one shape.
+    #[tokio::test]
+    async fn every_blob_refusal_carries_its_kind() {
+        let repo_id = format!("hostedblob-kinds-{}", Uuid::new_v4());
+        let (state, _working, storage) = replica_state(&repo_id);
+        let repository_id = RepositoryId::new(&repo_id).unwrap();
+        publish_hosted_semantic_change(
+            storage.path(),
+            &repository_id,
+            None,
+            0x3277_0021,
+            "publish a file to read",
+            &[("first_symbol", "src/first.rs", "fn first_symbol() {}\n")],
+        );
+        state.evict_repo_cache_for_test(&repo_id).await;
+
+        let cases = [
+            (
+                "path=src/absent.rs",
+                StatusCode::NOT_FOUND,
+                "path-not-found",
+            ),
+            (
+                "path=src/first.rs&ref=no-such-ref",
+                StatusCode::NOT_FOUND,
+                "unknown-ref",
+            ),
+        ];
+        for (query, expected_status, expected_kind) in cases {
+            let (status, refusal, body) = repo_blob_route(
+                Arc::clone(&state),
+                &format!("/repos/{repo_id}/blob?{query}"),
+            )
+            .await;
+            let message = String::from_utf8_lossy(&body);
+            assert_eq!(status, expected_status, "{query}: {message}");
+            assert_eq!(
+                refusal.as_deref(),
+                Some(expected_kind),
+                "{query}: {message}"
+            );
+        }
+
+        // A repository this daemon does not serve, which shares its status with
+        // the two above and is neither of them.
+        let (status, refusal, body) = repo_blob_route(
+            Arc::clone(&state),
+            "/repos/not-served-here/blob?path=src/first.rs",
+        )
+        .await;
+        let message = String::from_utf8_lossy(&body);
+        assert_eq!(status, StatusCode::NOT_FOUND, "{message}");
+        assert_eq!(refusal.as_deref(), Some("unknown-repository"), "{message}");
+    }
+
+    /// A malformed query is named too, not left to the extractor (FIR-3277).
+    ///
+    /// `Query<T>` refuses a missing or repeated parameter before a handler body
+    /// runs, and that refusal carries no `x-kin-blob-refusal`. To a caller
+    /// branching on the header, an absent header and a wrong one are the same
+    /// reading, so a malformed request would look like a route that forgot to
+    /// name its refusal. These are the requests the handler never gets to think
+    /// about, and they are the ones most likely to be read wrong.
+    #[tokio::test]
+    async fn a_malformed_blob_query_is_refused_by_name() {
+        let repo_id = format!("hostedblob-query-{}", Uuid::new_v4());
+        let (state, _working, storage) = replica_state(&repo_id);
+        let repository_id = RepositoryId::new(&repo_id).unwrap();
+        publish_hosted_semantic_change(
+            storage.path(),
+            &repository_id,
+            None,
+            0x3277_0051,
+            "publish a file to read",
+            &[("first_symbol", "src/first.rs", "fn first_symbol() {}\n")],
+        );
+        state.evict_repo_cache_for_test(&repo_id).await;
+
+        // No `path` at all, and the same parameter given twice. Both are refused
+        // before the handler resolves anything, and both must still say so.
+        for query in [
+            "",
+            "?ref=main",
+            "?path=src/first.rs&path=src/other.rs",
+            "?path=a&ref=b&ref=c",
+        ] {
+            let (status, refusal, body) =
+                repo_blob_route(Arc::clone(&state), &format!("/repos/{repo_id}/blob{query}")).await;
+            let message = String::from_utf8_lossy(&body);
+            assert_eq!(
+                status,
+                StatusCode::BAD_REQUEST,
+                "query {query:?} must be refused: {message}"
+            );
+            assert_eq!(
+                refusal.as_deref(),
+                Some("bad-request"),
+                "query {query:?} must be refused BY NAME: {message}"
+            );
+        }
+
+        // The control: a well-formed query on the same repository answers, so
+        // the four above are refused for their own shape and not because this
+        // fixture refuses everything.
+        let (status, refusal, body) = repo_blob_route(
+            Arc::clone(&state),
+            &format!("/repos/{repo_id}/blob?path=src/first.rs"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        assert_eq!(refusal, None, "a successful read carries no refusal header");
+    }
+
+    /// A hosted daemon says it can serve one file's bytes (FIR-3277).
+    ///
+    /// The hosted control plane keys its fallback on this string, so an image
+    /// that carries the route and does not advertise it is the same outage as
+    /// one that carries neither. Graded here rather than left implicit.
+    #[tokio::test]
+    async fn a_hosted_daemon_advertises_the_repo_scoped_blob_capability() {
+        let repo_id = format!("hostedblob-capability-{}", Uuid::new_v4());
+        let (state, _working, _storage) = replica_state(&repo_id);
+
+        let (status, body) =
+            repo_route(Arc::clone(&state), &format!("/repos/{repo_id}/health")).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let health: RepoHealthResponse = serde_json::from_slice(&body).unwrap();
+        assert!(
+            health
+                .semantic_capabilities
+                .iter()
+                .any(|capability| capability == REPO_SCOPED_BLOB_CAPABILITY),
+            "a daemon carrying the blob route must advertise it: {:?}",
+            health.semantic_capabilities
+        );
+    }
+
     /// A publication that moves the generation is not answered from the tree
     /// resolved before it (FIR-2924).
     ///
@@ -23948,7 +24590,10 @@ mod tests {
         let health: RepoHealthResponse = serde_json::from_slice(&body).unwrap();
         assert_eq!(
             health.semantic_capabilities,
-            vec![REPO_SCOPED_SEMANTIC_CAPABILITY.to_string()]
+            vec![
+                REPO_SCOPED_SEMANTIC_CAPABILITY.to_string(),
+                REPO_SCOPED_BLOB_CAPABILITY.to_string(),
+            ]
         );
 
         // Authentication must run before even the cheap repository-address

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -137,6 +137,7 @@ mod mcp_commit;
 mod pending_commits;
 pub mod publication_lease;
 pub mod replica_adoption;
+pub mod repo_blob;
 mod repository_admit;
 mod repository_branch;
 mod repository_checkout;

--- a/crates/kin-daemon/src/repo_blob.rs
+++ b/crates/kin-daemon/src/repo_blob.rs
@@ -1,0 +1,619 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! `GET /repos/{repo_id}/blob` — one file's exact bytes, for a repository and a ref.
+//!
+//! The daemon could already list a repository's files and could already export
+//! every byte of a change as one archive. It could not answer the question in
+//! between, which is the one a reader actually asks: show me this file. A
+//! hosted surface that wants to render a file therefore had nothing to call,
+//! and the honest thing it could do was say so.
+//!
+//! The answer comes from the repository read view and the content-addressed
+//! store and from nowhere else. The path is looked up in the tree the requested
+//! ref resolves to, the bytes come back under the digest that tree recorded,
+//! and the digest is checked against the bytes before they are served. A path
+//! the ref's tree does not carry is a refusal naming both, never a walk of a
+//! working copy that might happen to hold it.
+//!
+//! The digest check is not ceremony. `Ok(None)` from the store already means
+//! the bytes were never persisted, and the store verifies its own read, but
+//! this route serves those bytes to a browser under a ref and a path, and the
+//! response says which digest they were verified against. A claim that specific
+//! is worth re-establishing at the point that makes it.
+
+use std::sync::Arc;
+
+use axum::extract::rejection::QueryRejection;
+use axum::extract::{Path, Query, State};
+use axum::http::{HeaderName, HeaderValue, StatusCode};
+use axum::response::IntoResponse;
+use axum::Json;
+use kin_model::RepoPath;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::api::{
+    default_repository_ref, parse_semantic_change_id, repository_read_view,
+    repository_source_blob_loader, short_ref_name, RepositorySourceBlobLoader,
+};
+use crate::state::DaemonState;
+
+/// The largest single file this route will materialize into a JSON response.
+///
+/// A code view renders source, and the response holds the whole body in memory
+/// on both sides of the wire. The exact-source archive's own ceiling is two
+/// orders of magnitude larger because it is a download; this is a read. Over
+/// this, the route refuses and names the size rather than sending it.
+pub const MAX_REPO_BLOB_BYTES: u64 = 8 * 1024 * 1024;
+
+/// The header every refusal from this route carries, naming which refusal it is.
+pub const REPO_BLOB_REFUSAL_HEADER: &str = "x-kin-blob-refusal";
+
+/// Which refusal, in a closed set a caller can branch on without reading English.
+///
+/// The status code alone cannot carry this and the sentence must not be asked
+/// to. `path-not-found` and `unknown-ref` are both 404 and mean opposite things
+/// to a caller assembling a comparison: the first says this ref's tree does not
+/// carry that path, which is what an added or a deleted file looks like from one
+/// side; the second says nothing was read at all, and treating it as an absent
+/// side manufactures a change that never happened. So the kind travels in a
+/// header, in a fixed vocabulary, and every refusal this route emits carries one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepoBlobRefusal {
+    /// The request itself could not be understood, so nothing was resolved.
+    BadRequest,
+    /// This daemon does not serve a repository by that id.
+    UnknownRepository,
+    /// It serves the id and could not read it as a repository.
+    RepositoryUnreadable,
+    /// The read point named neither a ref this repository carries nor a
+    /// canonical change id, so no tree was resolved and no path was looked up.
+    UnknownRef,
+    /// The read point is a short alias more than one ref answers to, and this
+    /// route will not pick one of them.
+    AmbiguousRef,
+    /// The ref resolved and its tree carries no such path.
+    PathNotFound,
+    /// The path resolved and its bytes could not be served.
+    SourceUnavailable,
+}
+
+impl RepoBlobRefusal {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::BadRequest => "bad-request",
+            Self::UnknownRepository => "unknown-repository",
+            Self::RepositoryUnreadable => "repository-unreadable",
+            Self::UnknownRef => "unknown-ref",
+            Self::AmbiguousRef => "ambiguous-ref",
+            Self::PathNotFound => "path-not-found",
+            Self::SourceUnavailable => "source-unavailable",
+        }
+    }
+}
+
+/// A refusal from this route: a status, a kind, and a sentence for a person.
+#[derive(Debug)]
+pub struct RepoBlobError {
+    pub status: StatusCode,
+    pub kind: RepoBlobRefusal,
+    pub message: String,
+}
+
+impl RepoBlobError {
+    fn new(status: StatusCode, kind: RepoBlobRefusal, message: impl Into<String>) -> Self {
+        Self {
+            status,
+            kind,
+            message: message.into(),
+        }
+    }
+
+    /// Carry a helper's `(status, message)` refusal out under an explicit kind.
+    ///
+    /// The kind is named at the call site rather than guessed from the status,
+    /// because two of them share a status and the whole point of the header is
+    /// that a caller does not have to guess.
+    fn from_parts(kind: RepoBlobRefusal, parts: (StatusCode, String)) -> Self {
+        Self::new(parts.0, kind, parts.1)
+    }
+}
+
+impl IntoResponse for RepoBlobError {
+    fn into_response(self) -> axum::response::Response {
+        let mut response = (self.status, self.message).into_response();
+        response.headers_mut().insert(
+            HeaderName::from_static(REPO_BLOB_REFUSAL_HEADER),
+            HeaderValue::from_static(self.kind.as_str()),
+        );
+        response
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RepoBlobQuery {
+    /// The repository-relative path, exactly as `/repos/{repo_id}/files` spells it.
+    path: String,
+    /// A ref name or a canonical change id. Absent means the default ref.
+    #[serde(default, rename = "ref")]
+    reference: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RepoBlobResponse {
+    pub repo_id: String,
+    pub path: RepoPath,
+    pub display_path: String,
+    /// What the caller asked for, echoed so a cache can key on it.
+    pub requested_ref: Option<String>,
+    /// The ref this actually read, or `None` when a change id was named directly.
+    pub resolved_ref: Option<String>,
+    /// The change the ref resolved to.
+    pub change_id: String,
+    /// The digest the bytes below were verified against, before they were sent.
+    pub content_sha256: String,
+    pub byte_len: u64,
+    /// False for bytes that are not UTF-8, where `content` is `null`.
+    pub is_utf8: bool,
+    pub content: Option<String>,
+}
+
+/// The bytes one path resolves to, and the digest they were checked against.
+#[derive(Debug)]
+pub(crate) struct VerifiedBlob {
+    pub(crate) digest: kin_model::Hash256,
+    pub(crate) bytes: Vec<u8>,
+}
+
+/// Read one path out of a resolved tree, and verify what the store returns.
+///
+/// `describe_ref` appears in every refusal, because "this repository holds no
+/// file at that path" is not actionable and "the tree at main holds no file at
+/// that path" is.
+pub(crate) fn read_verified_blob(
+    tree: &kin_model::ResolvedTree,
+    path: &RepoPath,
+    describe_ref: &str,
+    load_blob: &mut RepositorySourceBlobLoader,
+) -> Result<VerifiedBlob, RepoBlobError> {
+    let artifact = tree.artifact_at_path(path).ok_or_else(|| {
+        RepoBlobError::new(
+            StatusCode::NOT_FOUND,
+            RepoBlobRefusal::PathNotFound,
+            format!(
+                "the repository tree at {describe_ref} holds no file at {path}; \
+                 GET /repos/{{repo_id}}/files lists what it does hold"
+            ),
+        )
+    })?;
+    let digest = artifact.entry.blob_identity().ok_or_else(|| {
+        RepoBlobError::new(
+            StatusCode::FAILED_DEPENDENCY,
+            RepoBlobRefusal::SourceUnavailable,
+            format!("{path} at {describe_ref} is a gitlink and has no source body of its own"),
+        )
+    })?;
+    let bytes = load_blob(path, digest, MAX_REPO_BLOB_BYTES)
+        .map_err(|parts| RepoBlobError::from_parts(RepoBlobRefusal::SourceUnavailable, parts))?
+        .ok_or_else(|| {
+            RepoBlobError::new(
+                StatusCode::FAILED_DEPENDENCY,
+                RepoBlobRefusal::SourceUnavailable,
+                format!(
+                    "exact source bytes are unavailable for {path} at {digest}; \
+                     no fallback was attempted"
+                ),
+            )
+        })?;
+    let byte_len = u64::try_from(bytes.len()).map_err(|_| {
+        RepoBlobError::new(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            RepoBlobRefusal::SourceUnavailable,
+            format!("source blob length for {path} does not fit the allocation limit"),
+        )
+    })?;
+    if byte_len > MAX_REPO_BLOB_BYTES {
+        return Err(RepoBlobError::new(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            RepoBlobRefusal::SourceUnavailable,
+            format!(
+                "{path} at {describe_ref} is {byte_len} bytes, over this route's \
+                 {MAX_REPO_BLOB_BYTES}-byte ceiling"
+            ),
+        ));
+    }
+    let actual: [u8; 32] = Sha256::digest(&bytes).into();
+    if actual != *digest.as_bytes() {
+        return Err(RepoBlobError::new(
+            StatusCode::FAILED_DEPENDENCY,
+            RepoBlobRefusal::SourceUnavailable,
+            format!(
+                "source blob digest mismatch for {path} at {describe_ref}: \
+                 tree records {digest}, store returned {}",
+                hex::encode(actual)
+            ),
+        ));
+    }
+    Ok(VerifiedBlob { digest, bytes })
+}
+
+/// GET /repos/{repo_id}/blob — one file's exact bytes at one ref.
+pub async fn repo_blob(
+    Path(repo_id): Path<String>,
+    State(state): State<Arc<DaemonState>>,
+    // Fallible on purpose. `Query<T>` rejects a missing or repeated parameter
+    // before a handler body runs, and an axum rejection carries no
+    // `x-kin-blob-refusal`. A caller that branches on the header would read a
+    // malformed request as a header this route forgot to set, which is the one
+    // reading the header exists to prevent. Taking the rejection means every
+    // refusal from this route, including the ones it never got to think about,
+    // is named.
+    query: Result<Query<RepoBlobQuery>, QueryRejection>,
+) -> Result<impl IntoResponse, RepoBlobError> {
+    let Query(query) = query.map_err(|rejection| {
+        RepoBlobError::new(
+            rejection.status(),
+            RepoBlobRefusal::BadRequest,
+            rejection.body_text(),
+        )
+    })?;
+    let requested_path = RepoPath::from_utf8(query.path.clone()).map_err(|error| {
+        RepoBlobError::new(
+            StatusCode::BAD_REQUEST,
+            RepoBlobRefusal::BadRequest,
+            format!(
+                "path {:?} is not a usable repository path: {error}",
+                query.path
+            ),
+        )
+    })?;
+    let view = repository_read_view(&state, &repo_id)
+        .await
+        .map_err(|parts| {
+            // Addressability and readability are different facts about the same
+            // repository, and the status the shared helper already chose is what
+            // separates them: it refuses an id this daemon does not serve with a
+            // 404 before it attempts any load.
+            let kind = if parts.0 == StatusCode::NOT_FOUND {
+                RepoBlobRefusal::UnknownRepository
+            } else {
+                RepoBlobRefusal::RepositoryUnreadable
+            };
+            RepoBlobError::from_parts(kind, parts)
+        })?;
+    let (change_id, resolved_ref) =
+        resolve_read_point(&view, query.reference.as_deref(), &repo_id)?;
+    let describe_ref = resolved_ref
+        .clone()
+        .unwrap_or_else(|| change_id.to_string());
+    let tree = view
+        .resolve_tree_at(&state, &change_id)
+        .map_err(|parts| RepoBlobError::from_parts(RepoBlobRefusal::RepositoryUnreadable, parts))?;
+
+    let repo_for_load = repo_id.clone();
+    let path_for_load = requested_path.clone();
+    let describe_for_load = describe_ref.clone();
+    let state_for_load = Arc::clone(&state);
+    // The store read is blocking and the digest check runs over the whole body,
+    // so neither belongs on the request's own thread.
+    let blob = tokio::task::spawn_blocking(move || {
+        let mut load_blob = repository_source_blob_loader(&state_for_load, &repo_for_load)
+            .map_err(|parts| {
+                RepoBlobError::from_parts(RepoBlobRefusal::SourceUnavailable, parts)
+            })?;
+        read_verified_blob(&tree, &path_for_load, &describe_for_load, &mut load_blob)
+    })
+    .await
+    .map_err(|error| {
+        RepoBlobError::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            RepoBlobRefusal::SourceUnavailable,
+            format!("repository blob worker failed: {error}"),
+        )
+    })??;
+
+    let byte_len = blob.bytes.len() as u64;
+    let content = String::from_utf8(blob.bytes).ok();
+    Ok(Json(RepoBlobResponse {
+        repo_id,
+        display_path: requested_path
+            .as_utf8()
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| query.path.clone()),
+        path: requested_path,
+        requested_ref: query.reference,
+        resolved_ref,
+        change_id: change_id.to_string(),
+        content_sha256: hex::encode(blob.digest.as_bytes()),
+        byte_len,
+        is_utf8: content.is_some(),
+        content,
+    }))
+}
+
+/// Turn the caller's `ref` into the change to read, and the ref name to say.
+///
+/// Three inputs, one answer. Nothing names a ref: the repository's own default,
+/// which is what `/repos/{repo_id}/files` already reads. A name the authority
+/// carries: that ref. A canonical change id: that change, with no ref name to
+/// report, because none was involved. Anything else is `unknown-ref`, which is a
+/// 404 about the read point and never about the path, since no tree was resolved
+/// and nothing was looked up in one.
+fn resolve_read_point(
+    view: &crate::api::RepositoryReadView,
+    reference: Option<&str>,
+    repo_id: &str,
+) -> Result<(kin_model::SemanticChangeId, Option<String>), RepoBlobError> {
+    let authority = view
+        .authority()
+        .map_err(|parts| RepoBlobError::from_parts(RepoBlobRefusal::RepositoryUnreadable, parts))?;
+    let resolve = |target: &kin_model::RefTarget| {
+        view.resolve_target(target).map_err(|parts| {
+            RepoBlobError::from_parts(RepoBlobRefusal::RepositoryUnreadable, parts)
+        })
+    };
+    let Some(reference) = reference.map(str::trim).filter(|value| !value.is_empty()) else {
+        let default_ref = default_repository_ref(authority)
+            .map_err(|parts| {
+                RepoBlobError::from_parts(RepoBlobRefusal::RepositoryUnreadable, parts)
+            })?
+            .ok_or_else(|| {
+                RepoBlobError::new(
+                    StatusCode::FAILED_DEPENDENCY,
+                    RepoBlobRefusal::UnknownRef,
+                    format!(
+                        "repository {repo_id} carries no refs, so it has no default ref to read"
+                    ),
+                )
+            })?;
+        let name = short_ref_name(&default_ref.name);
+        return Ok((resolve(&default_ref.target)?, Some(name)));
+    };
+
+    // A ref's full name wins outright, and only then its short alias, because a
+    // repository may hold a branch whose full name IS another ref's short alias:
+    // `refs/heads/refs/tags/v1` shortens to `refs/tags/v1`, which is the tag
+    // `refs/tags/v1`'s own full name. One pass matching either spelling answers
+    // whichever of the two the ref list happens to hold first, so an explicit
+    // full name could resolve to a different ref than the one it names.
+    if let Some(repository_ref) = authority
+        .ref_state
+        .refs
+        .iter()
+        .find(|repository_ref| repository_ref.name.to_string() == reference)
+    {
+        let name = short_ref_name(&repository_ref.name);
+        return Ok((resolve(&repository_ref.target)?, Some(name)));
+    }
+
+    // Then the short alias, and only when exactly one ref answers to it. Two
+    // refs sharing an alias is a question this route cannot answer, and picking
+    // either one silently serves bytes from a ref the caller did not ask for.
+    let mut by_alias = authority
+        .ref_state
+        .refs
+        .iter()
+        .filter(|repository_ref| short_ref_name(&repository_ref.name) == reference);
+    if let Some(repository_ref) = by_alias.next() {
+        if by_alias.next().is_some() {
+            let names: Vec<String> = authority
+                .ref_state
+                .refs
+                .iter()
+                .filter(|candidate| short_ref_name(&candidate.name) == reference)
+                .map(|candidate| candidate.name.to_string())
+                .collect();
+            return Err(RepoBlobError::new(
+                StatusCode::CONFLICT,
+                RepoBlobRefusal::AmbiguousRef,
+                format!(
+                    "repository {repo_id} holds more than one ref answering to {reference}: {}; \
+                     name the one you mean in full",
+                    names.join(", ")
+                ),
+            ));
+        }
+        let name = short_ref_name(&repository_ref.name);
+        return Ok((resolve(&repository_ref.target)?, Some(name)));
+    }
+
+    // Not a ref this repository carries. A canonical change id is the only
+    // other thing this route accepts, and its own refusal names the field.
+    let change_id = parse_semantic_change_id("ref", reference).map_err(|(_, message)| {
+        RepoBlobError::new(
+            StatusCode::NOT_FOUND,
+            RepoBlobRefusal::UnknownRef,
+            format!("repository {repo_id} carries no ref named {reference}, and {message}"),
+        )
+    })?;
+    Ok((change_id, None))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hash_of(bytes: &[u8]) -> kin_model::Hash256 {
+        let digest: [u8; 32] = Sha256::digest(bytes).into();
+        kin_model::Hash256::from_bytes(digest)
+    }
+
+    fn tree_with(path: &str, entry: kin_model::TreeEntry) -> kin_model::ResolvedTree {
+        kin_model::ResolvedTree::from_artifacts([kin_model::ResolvedArtifact::new(
+            kin_model::ArtifactId::new(),
+            RepoPath::from_utf8(path).unwrap(),
+            entry,
+        )])
+        .unwrap()
+    }
+
+    fn loader_returning(
+        answer: Result<Option<Vec<u8>>, (StatusCode, String)>,
+    ) -> RepositorySourceBlobLoader {
+        Box::new(move |_path, _digest, _remaining| answer.clone())
+    }
+
+    #[test]
+    fn a_verified_blob_carries_the_digest_its_bytes_were_checked_against() {
+        let bytes = b"fn main() {}\n".to_vec();
+        let hash = hash_of(&bytes);
+        let tree = tree_with("src/main.rs", kin_model::TreeEntry::blob(hash, false));
+        let path = RepoPath::from_utf8("src/main.rs").unwrap();
+        let mut load = loader_returning(Ok(Some(bytes.clone())));
+
+        let blob = read_verified_blob(&tree, &path, "main", &mut load).unwrap();
+
+        assert_eq!(blob.bytes, bytes);
+        assert_eq!(blob.digest, hash);
+    }
+
+    #[test]
+    fn every_refusal_kind_has_a_distinct_stable_spelling() {
+        // A caller branches on these strings, so a collision or a rename is a
+        // silent behaviour change on the other side of the wire.
+        let kinds = [
+            RepoBlobRefusal::BadRequest,
+            RepoBlobRefusal::UnknownRepository,
+            RepoBlobRefusal::RepositoryUnreadable,
+            RepoBlobRefusal::UnknownRef,
+            RepoBlobRefusal::AmbiguousRef,
+            RepoBlobRefusal::PathNotFound,
+            RepoBlobRefusal::SourceUnavailable,
+        ];
+        let spellings: std::collections::BTreeSet<&str> =
+            kinds.iter().map(|kind| kind.as_str()).collect();
+        assert_eq!(spellings.len(), kinds.len(), "two kinds share a spelling");
+        assert_eq!(
+            RepoBlobRefusal::PathNotFound.as_str(),
+            "path-not-found",
+            "the one kind a caller may read as an absent side is pinned by name"
+        );
+        assert_eq!(RepoBlobRefusal::UnknownRef.as_str(), "unknown-ref");
+        assert_eq!(RepoBlobRefusal::AmbiguousRef.as_str(), "ambiguous-ref");
+        assert!(
+            spellings
+                .iter()
+                .all(|spelling| HeaderValue::from_str(spelling).is_ok()),
+            "every spelling has to survive the header it travels in"
+        );
+    }
+
+    #[test]
+    fn bytes_that_do_not_match_the_tree_digest_are_refused_rather_than_served() {
+        // The falsification target. Delete the digest comparison in
+        // `read_verified_blob` and this is the assertion that goes red: the
+        // route would answer 200 with bytes the tree never recorded, under a
+        // `content_sha256` naming the digest it did record.
+        let recorded = b"fn main() {}\n".to_vec();
+        let hash = hash_of(&recorded);
+        let tree = tree_with("src/main.rs", kin_model::TreeEntry::blob(hash, false));
+        let path = RepoPath::from_utf8("src/main.rs").unwrap();
+        let mut load = loader_returning(Ok(Some(b"corrupt source bytes".to_vec())));
+
+        let refusal = read_verified_blob(&tree, &path, "main", &mut load).unwrap_err();
+        let (status, message, kind) = (refusal.status, refusal.message, refusal.kind);
+
+        assert_eq!(status, StatusCode::FAILED_DEPENDENCY);
+        assert_eq!(kind, RepoBlobRefusal::SourceUnavailable);
+        assert!(
+            message.contains("digest mismatch"),
+            "the refusal must name the mismatch: {message}"
+        );
+        assert!(
+            message.contains("src/main.rs") && message.contains("main"),
+            "the refusal must name the path and the ref: {message}"
+        );
+    }
+
+    #[test]
+    fn a_path_the_ref_does_not_carry_is_a_refusal_naming_the_ref() {
+        let bytes = b"fn main() {}\n".to_vec();
+        let tree = tree_with(
+            "src/main.rs",
+            kin_model::TreeEntry::blob(hash_of(&bytes), false),
+        );
+        let path = RepoPath::from_utf8("src/absent.rs").unwrap();
+        let mut load = loader_returning(Ok(Some(bytes)));
+
+        let refusal = read_verified_blob(&tree, &path, "main", &mut load).unwrap_err();
+        let (status, message, kind) = (refusal.status, refusal.message, refusal.kind);
+
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(
+            kind,
+            RepoBlobRefusal::PathNotFound,
+            "an absent path is the one refusal a caller may read as an absent side"
+        );
+        assert!(
+            message.contains("src/absent.rs") && message.contains("main"),
+            "the refusal must name the path and the ref it was not in: {message}"
+        );
+    }
+
+    #[test]
+    fn bytes_the_store_never_persisted_are_refused_without_a_fallback() {
+        let bytes = b"fn main() {}\n".to_vec();
+        let tree = tree_with(
+            "src/main.rs",
+            kin_model::TreeEntry::blob(hash_of(&bytes), false),
+        );
+        let path = RepoPath::from_utf8("src/main.rs").unwrap();
+        let mut load = loader_returning(Ok(None));
+
+        let refusal = read_verified_blob(&tree, &path, "main", &mut load).unwrap_err();
+        let (status, message, kind) = (refusal.status, refusal.message, refusal.kind);
+
+        assert_eq!(status, StatusCode::FAILED_DEPENDENCY);
+        assert_eq!(kind, RepoBlobRefusal::SourceUnavailable);
+        assert!(
+            message.contains("no fallback was attempted"),
+            "an absent body must say so rather than leave the reader guessing: {message}"
+        );
+    }
+
+    #[test]
+    fn the_store_refusal_is_passed_through_rather_than_reclassified() {
+        // A control for the test above. Both arms end in an error, and only
+        // this one proves the route does not flatten every store outcome into
+        // one shape.
+        let bytes = b"fn main() {}\n".to_vec();
+        let tree = tree_with(
+            "src/main.rs",
+            kin_model::TreeEntry::blob(hash_of(&bytes), false),
+        );
+        let path = RepoPath::from_utf8("src/main.rs").unwrap();
+        let mut load = loader_returning(Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "immutable backend source storage is not configured".to_string(),
+        )));
+
+        let refusal = read_verified_blob(&tree, &path, "main", &mut load).unwrap_err();
+        let (status, message, kind) = (refusal.status, refusal.message, refusal.kind);
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(kind, RepoBlobRefusal::SourceUnavailable);
+        assert!(message.contains("immutable backend source storage"));
+    }
+
+    #[test]
+    fn a_body_over_the_route_ceiling_is_refused_and_names_its_size() {
+        let bytes = vec![b'x'; (MAX_REPO_BLOB_BYTES + 1) as usize];
+        let tree = tree_with(
+            "src/huge.rs",
+            kin_model::TreeEntry::blob(hash_of(&bytes), false),
+        );
+        let path = RepoPath::from_utf8("src/huge.rs").unwrap();
+        let mut load = loader_returning(Ok(Some(bytes)));
+
+        let refusal = read_verified_blob(&tree, &path, "main", &mut load).unwrap_err();
+        let (status, message, kind) = (refusal.status, refusal.message, refusal.kind);
+
+        assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(kind, RepoBlobRefusal::SourceUnavailable);
+        assert!(
+            message.contains(&MAX_REPO_BLOB_BYTES.to_string()),
+            "the refusal must name the ceiling it hit: {message}"
+        );
+    }
+}


### PR DESCRIPTION
The daemon could list a repository's files and could export every byte of a
change as one archive. It could not answer the question in between, which is the
one a reader actually asks: show me this file. `/repos/{repo_id}/files` walks the
tree the default ref resolves to and returns paths only; `/vfs/blob/{hash}` is
not repo-scoped and always serves the daemon's own primary repository. So a
hosted surface rendering a repository had nothing to call for a file's contents,
and the honest thing it could do was say so.

`GET /repos/{repo_id}/blob?path=<path>&ref=<ref or change id>` answers it from
the graph and the content-addressed store and from nowhere else. It resolves the
read point through the same `RepositoryReadView` every other repo route uses,
looks the path up in the tree that ref resolves to, takes the digest that tree
recorded, loads the bytes from the store, and re-checks the digest against the
bytes before answering. The response names the digest they were verified
against, so a caller can say what it is showing rather than only that something
came back.

Every failure is its own refusal. A path the ref's tree does not carry is a 404
naming the path and the ref, never a walk of a working copy that might happen to
hold it. A gitlink, a body the store never persisted, and a digest that does not
match are each a 424 naming what happened, and the absent-body refusal says no
fallback was attempted. A body over the route's ceiling is a 413 naming the
ceiling. No arm of this route reads a filesystem.

Path traversal needs no separate guard and gets none. The lookup is an exact
match against the paths the resolved tree carries, so `../etc/passwd` is simply a
path that tree does not carry and takes the same 404 as any other absent path.
There is no directory to walk out of, because no directory is walked.

The digest re-check is not ceremony. The store verifies its own read, and
`Ok(None)` already means the bytes were never persisted. But this route hands
those bytes to a browser under a ref and a path, and says which digest they were
checked against. A claim that specific is worth re-establishing at the point that
makes it.

## What this changes in api.rs

One route line beside `/repos/{repo_id}/files`, and `pub(crate)` on the items the
new module reads through: `repository_read_view`, `RepositoryReadView` with its
`authority`, `resolve_target` and `resolve_tree_at`, `default_repository_ref`,
`short_ref_name` and `repository_authority_error`.

Two things were extracted rather than duplicated. `repository_source_blob_loader`
comes out of `load_exact_source_entries`, so the archive path and this route
choose the CAS arm in one place. It hands back a loader rather than a per-call
function on purpose: the local arm's authority open re-reads and revalidates the
whole authority, and paying that per artifact is the shape `RepositoryReadView`
exists to remove. `parse_exact_source_change_id` becomes
`parse_semantic_change_id(field, value)`, because two routes now accept a change
id under two different names and a refusal naming the wrong parameter sends a
caller to the wrong place.

`/repos/{repo_id}/health` also advertises `repo_scoped_blob_v1`. The caller that
needs it is a hosted control plane talking to whatever image production currently
runs, and the alternative is guessing from a 404: an unmatched route and a path a
ref genuinely does not carry both answer 404, and only one of them means "this
image cannot do it". A capability lets that caller keep a truthful fallback
instead of a heuristic.

## Evidence

Six unit tests in `crates/kin-daemon/src/repo_blob.rs` grade the verification
helper directly, over a tree built in the test: a verified read, a digest
mismatch, an absent path, a body the store never persisted, a store refusal
passed through rather than flattened, and a body over the ceiling. Four tests in
the api test module drive the real router: the route serving published bytes
under the digest it verified, a path the ref does not carry, the addressing
refusal an unpublished repository already gives on every other repo route, and
the capability advertisement.

The end-to-end test is the load-bearing one. It publishes a real semantic change
carrying `fn first_symbol() {}` at `src/first.rs`, asks the router for that path,
and asserts the bytes come back and `content_sha256` equals the SHA-256 of the
published source rather than a digest recomputed for the response.

Falsification: deleting the digest comparison in `read_verified_blob` turns
`bytes_that_do_not_match_the_tree_digest_are_refused_rather_than_served` red,
because the route then answers with bytes the tree never recorded under a
`content_sha256` naming the digest it did record.

## A wrong authority the route tests caught

The extraction started by preserving the arm selection it inherited, which chose
on `repo_id == state.cached_repo_id`. The first full run of the lib suite came
back 1467 passed and 2 failed, and both failures were the new route tests, on
`this repository's authority could not be opened: local daemon is missing its
startup workspace binding`.

`cached_repo_id` is the id this daemon resolved from its own manifest at
construction. It is not "the repository this request is about", so a hosted
daemon serving a repository of that name resolved the tree from its generation
cache and then went looking for the bytes in a local CAS it does not have. That
disagrees with `repository_read_view`, whose own doc states the rule: a daemon
with a storage backend reaches every repository it serves through that backend,
and a daemon without one has only the local binding it opened at startup.

So the loader selects on the presence of a storage backend, the same rule, which
also means the exact-source archive now reads its tree and its bytes from one
authority instead of two. A daemon with no backend is unaffected. The two tests
are the falsification: they were red under the old selection for exactly this
reason and are green under the new one, with the rest of the suite unchanged.

## The requested-ref contract, and what an independent read of it found

An independent source review made three demands of this route, and all three were
right about a real defect rather than about style.

**A ref other than the default was never actually exercised.** Every route test
here read the default ref, so none of them could tell a route that honours `ref`
from one that ignores it. The new test publishes two generations, points a
`legacy` branch at the first, and reads across the gap three ways: the second
generation's file at `legacy` must be a 404, because that ref's tree never
carried it; the first generation's file at `legacy` must come back labelled with
that ref and that change; and the same file by canonical change id must come back
labelled with no ref at all.

**Two 404s meant opposite things.** A path a ref's tree does not carry and a ref
that could not be resolved shared a status and a body, and a caller assembling a
comparison reads the first as one side of an added or a deleted file. Reading the
second the same way manufactures a change nobody made. So every refusal now
carries its kind in the `x-kin-blob-refusal` header, from a closed set:
`bad-request`, `unknown-repository`, `repository-unreadable`, `unknown-ref`,
`ambiguous-ref`, `path-not-found`, `source-unavailable`. A unit test pins
`path-not-found` by name, because it is the only one a comparison may treat as an
absent side, and asserts no two kinds share a spelling.

**A short alias could outrank an explicit full name.** The lookup matched either
spelling in one pass and took the first hit. A repository may hold a branch whose
full name is `refs/heads/refs/tags/v1`, whose short alias is therefore
`refs/tags/v1`, which is a tag's own full name. Exact full name now wins
outright, then a unique short alias, and an alias two refs answer to is a 409
carrying `ambiguous-ref` and naming both, rather than a guess. The test is
adversarial by construction: that branch and that tag, pointing at different
changes, and the explicit full name must serve the tag.

Falsified, three mutants against the nine-test tranche, each reding exactly its
own tests:

```
GREEN_RC=0            9 passed; 0 failed
RED_ref_RC=101        5 passed; 4 failed
    a_full_ref_name_outranks_another_refs_short_alias
    a_short_alias_two_refs_answer_to_is_refused
    every_blob_refusal_carries_its_kind
    the_blob_route_serves_the_requested_ref_rather_than_the_default
RED_kind_RC=101       7 passed; 2 failed
    every_blob_refusal_carries_its_kind
    the_blob_route_serves_the_requested_ref_rather_than_the_default
RED_alias_RC=101      7 passed; 2 failed
    a_full_ref_name_outranks_another_refs_short_alias
    a_short_alias_two_refs_answer_to_is_refused
GREEN_AGAIN_RC=0      9 passed; 0 failed
```

The query-rejection change came after those arms and is an adapter change with no
new logic, so it was graded by the focused tranche plus its own controls rather
than by repeating the suite: `FMT_CHECK_RC=0`, `TRANCHE_RC=0`, 10 passed and 0
failed of 1493. Hosted CI grades the rest.

`RED_ref` ignores the requested ref; `RED_kind` collapses `unknown-ref` into
`path-not-found`; `RED_alias` restores the single-pass either-spelling lookup. All
three reverted before the last green arm, which is what `GREEN_AGAIN` is for.

**A refusal the handler never got to make still has to be named.** `Query<T>`
rejects a missing or repeated parameter before a handler body runs, and an axum
rejection carries no `x-kin-blob-refusal`. To a caller branching on that header,
an absent header and a wrong one read the same, so a malformed request would look
like a route that forgot to name its refusal. The extractor is fallible now and
its rejection is mapped through `bad-request`, and four real-router controls
cover a missing `path`, a `ref` with no `path`, a repeated `path` and a repeated
`ref`, each asserting the header. A well-formed read on the same fixture is the
control beside them, and it asserts the header is absent on success.

## What this deliberately does not do

There is no `/repos/{repo_id}/compare` on this daemon and this pull request does
not add one. A hosted caller can build a real per-file patch out of two reads
through this route, one at each side's ref, which is what the control plane
already does from a base blob and a head blob. What it still cannot get is the
changed-file list and how far ahead or behind two refs are, and that needs a
compare route of its own: resolve both refs to changes, diff the two resolved
trees by path and blob identity, and walk first-parent history to a merge base.
That is its own piece of work and it is filed as its own ticket rather than
folded in here.
