### PR TITLE
Refuse to seal a commit over bytes whose semantics have not caught up (FIR-3264)

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -38677,6 +38677,16 @@ mod tests {
     /// Untracking is not enough. Entities are what rank, so a purge that left
     /// them behind produced the worst reading of all: the artifact listing no
     /// longer names the file while search and locate still return it.
+    ///
+    /// The purged path reaches the graph the way an ambient admission leaves
+    /// one: its bytes in repository authority, its entities derived into the
+    /// live graph, and no commit publishing a semantic delta for them. That is
+    /// the state this eviction is about, and admitting through the daemon's own
+    /// `/commands/admit` is what produces it rather than a hand-placed entity
+    /// standing in for a parse. The committed shape, whose entities repository
+    /// authority holds too, is covered by
+    /// `purge_ignored_retires_the_entities_a_commit_published_for_a_vacated_path`
+    /// and is red for a reason of its own.
     #[tokio::test]
     async fn purge_ignored_evicts_the_entities_that_made_a_path_rank() {
         let state = test_state();
@@ -38684,27 +38694,40 @@ mod tests {
             .is_initialized
             .store(true, std::sync::atomic::Ordering::Relaxed);
 
-        // The rule lands after the admission, which is the whole scenario: a
-        // repository that already carries a path is told to stop carrying it.
         for (path, content) in [
             (
                 "investor/deck/build_deck.py",
                 &b"def valuation(): pass\n"[..],
             ),
             ("src/lib.py", &b"def kept(): pass\n"[..]),
-            (".kinignore", &b"investor\n"[..]),
         ] {
             install_working_copy_file(&state, path, content, false);
-            install_repository_file(&state, path, content);
         }
+        let app = router(Arc::clone(&state));
+        admit_through_api(&app).await;
 
-        let private = test_entity("valuation", "investor/deck/build_deck.py");
-        let kept = test_entity("kept", "src/lib.py");
-        state.graph.upsert_entity(&private).unwrap();
-        state.graph.upsert_entity(&kept).unwrap();
+        // The rule lands after the admission, which is the whole scenario: a
+        // repository that already carries a path is told to stop carrying it.
+        // It stays untracked on purpose, because admitting it would retract the
+        // covered path on its own and leave this purge nothing to do.
+        install_working_copy_file(&state, ".kinignore", b"investor\n", false);
+
+        let derived = |path: &str, name: &str| {
+            state
+                .graph
+                .query_entities(&kin_db::EntityFilter {
+                    file_path: Some(kin_model::FilePathId::new(path)),
+                    ..Default::default()
+                })
+                .unwrap()
+                .into_iter()
+                .find(|candidate| candidate.name == name)
+                .unwrap_or_else(|| panic!("the admission must derive {name} for {path}"))
+        };
+        let private = derived("investor/deck/build_deck.py", "valuation");
+        let kept = derived("src/lib.py", "kept");
         assert!(state.graph.get_entity(&private.id).unwrap().is_some());
 
-        let app = router(Arc::clone(&state));
         let (_, applied) = purge_ignored_through_api(&app, true).await;
         assert_eq!(applied["report"]["purge_count"], json!(1));
 
@@ -38727,6 +38750,69 @@ mod tests {
         // entity, so the purge removed one path rather than clearing the graph.
         assert!(live.contains("src/lib.py"));
         assert_eq!(state.graph.get_entity(&kept.id).unwrap(), Some(kept));
+    }
+
+    /// The same purge over a path a COMMIT published entities for, which is what
+    /// a repository that has ever committed its source actually holds.
+    ///
+    /// Red today, and named here rather than left to be rediscovered.
+    /// `repository_commit::publish_workspace_tree` carries
+    /// `WorkspaceSemanticDelta::default()`, so the tree publication that retires
+    /// the path leaves repository authority holding entities on it and kin-db
+    /// refuses the whole transition with "transaction leaves entity ... absent
+    /// from the staged tree". The session admission in that same module already
+    /// carries `retire_semantics_on_vacated` over its vacated set; the tree
+    /// publication does not, and every caller of `publish_exact_workspace_tree`
+    /// inherits the gap, the watch loop's standalone admission included. That is
+    /// the FIR-2429 class surviving on the paths its fix did not reach, and it is
+    /// tracked as FIR-3274.
+    ///
+    /// Ignored so the suite stays green while the class stays written down where
+    /// the fix will find it. Run it by name with
+    /// `cargo test -p kin-daemon --lib -- --ignored
+    /// purge_ignored_retires_the_entities_a_commit_published_for_a_vacated_path`.
+    #[tokio::test]
+    #[ignore = "FIR-3274: publish_workspace_tree carries no retirement for a vacated path"]
+    async fn purge_ignored_retires_the_entities_a_commit_published_for_a_vacated_path() {
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        // Committed, not merely admitted: the install plans and commits a native
+        // change, so its entity deltas reach repository authority exactly as a
+        // person's `kin commit` would put them there.
+        for (path, content) in [
+            (
+                "investor/deck/build_deck.py",
+                &b"def valuation(): pass\n"[..],
+            ),
+            ("src/lib.py", &b"def kept(): pass\n"[..]),
+        ] {
+            install_working_copy_file(&state, path, content, false);
+            install_repository_file(&state, path, content);
+        }
+        install_working_copy_file(&state, ".kinignore", b"investor\n", false);
+        let app = router(Arc::clone(&state));
+
+        let private = state
+            .graph
+            .query_entities(&kin_db::EntityFilter {
+                file_path: Some(kin_model::FilePathId::new("investor/deck/build_deck.py")),
+                ..Default::default()
+            })
+            .unwrap()
+            .into_iter()
+            .find(|candidate| candidate.name == "valuation")
+            .expect("the install must derive the entity the purge has to retire");
+
+        let (_, applied) = purge_ignored_through_api(&app, true).await;
+        assert_eq!(applied["report"]["purge_count"], json!(1));
+        assert!(!tracked_paths(&state).contains("investor/deck/build_deck.py"));
+        assert!(
+            state.graph.get_entity(&private.id).unwrap().is_none(),
+            "a purged path's entity still resolves, so it still ranks"
+        );
     }
 
     fn branch_change(state: &DaemonState) -> SemanticChangeId {
@@ -41472,10 +41558,10 @@ mod tests {
             "def handler():\n    return 'checkout drift'\n",
         )
         .unwrap();
-        let mut entity = test_entity("handler", "src/lib.py");
-        entity.span.as_mut().unwrap().end_byte = source.len();
-        entity.span.as_mut().unwrap().end_line = 2;
-        state.graph.upsert_entity(&entity).unwrap();
+        // The entity under test is the one installing the file derived, which
+        // is what the daemon's admission leaves behind. A hand-made duplicate
+        // on the same path made this query name two entities and the endpoint
+        // return three records for a fixture that holds one definition.
         state
             .is_initialized
             .store(true, std::sync::atomic::Ordering::Relaxed);
@@ -41504,16 +41590,39 @@ mod tests {
             .unwrap();
         let result: kin_cli::commands::search::DaemonSearchResponse =
             serde_json::from_slice(&body).unwrap();
-        assert_eq!(result.records.len(), 1);
-        match result.records.first().unwrap() {
-            kin_cli::commands::search::DaemonSearchRecord::Entity(entity) => {
-                assert_eq!(entity.name, "handler");
-                assert_eq!(entity.file.as_deref(), Some("src/lib.py"));
-                assert_eq!(entity.body.as_deref(), Some("def handler():"));
-                assert_eq!(entity.body_omitted_line_count, 1);
-            }
-            other => panic!("expected entity record, got {other:?}"),
-        }
+        // Installing a real source file derives the file's own module beside its
+        // function, and a text search for the function's name matches the
+        // module's body as well, so the graph answers with two records where a
+        // single hand-made entity answered with one. Both are named here rather
+        // than counted, because the count on its own says nothing about which
+        // record the body assertions below are about.
+        let mut named: Vec<(&str, &str)> = result
+            .records
+            .iter()
+            .map(|record| match record {
+                kin_cli::commands::search::DaemonSearchRecord::Entity(entity) => {
+                    (entity.name.as_str(), entity.kind.as_str())
+                }
+                other => panic!("expected entity records, got {other:?}"),
+            })
+            .collect();
+        named.sort_unstable();
+        assert_eq!(named, [("handler", "Function"), ("lib", "Module")]);
+        let entity = result
+            .records
+            .iter()
+            .find_map(|record| match record {
+                kin_cli::commands::search::DaemonSearchRecord::Entity(entity)
+                    if entity.name == "handler" =>
+                {
+                    Some(entity)
+                }
+                _ => None,
+            })
+            .expect("the search must return the function the query names");
+        assert_eq!(entity.file.as_deref(), Some("src/lib.py"));
+        assert_eq!(entity.body.as_deref(), Some("def handler():"));
+        assert_eq!(entity.body_omitted_line_count, 1);
     }
 
     #[tokio::test]
@@ -44390,13 +44499,12 @@ mod tests {
         let state = test_state();
         // Coverage healthy on purpose, so the degradation is the only reason
         // left to refuse and the assertion cannot pass for the wrong cause.
-        let mut caller = test_entity("caller", "src/a.py");
-        let mut callee = test_entity("callee", "src/b.py");
-        let mut orphan = test_entity("orphan", "src/orphan.py");
-        for entity in [&mut caller, &mut callee, &mut orphan] {
-            install_trace_fixture_file(&state, entity);
-            state.graph.upsert_entity(entity).unwrap();
-        }
+        let caller = install_trace_fixture_file(&state, "caller", "src/a.py");
+        let callee = install_trace_fixture_file(&state, "callee", "src/b.py");
+        // The focal has to reach nothing AND hold no same-file neighbour, so it
+        // is the module of a file that declares nothing rather than a function
+        // sitting beside its own module.
+        install_lone_module_fixture_file(&state, "orphan");
         link_every_class(&state, &caller, &callee);
         state
             .is_initialized
@@ -44441,12 +44549,8 @@ mod tests {
     #[tokio::test]
     async fn a_trace_that_finds_dependencies_stays_unqualified_even_when_degraded() {
         let state = test_state();
-        let mut caller = test_entity("caller", "src/a.py");
-        let mut callee = test_entity("callee", "src/b.py");
-        for entity in [&mut caller, &mut callee] {
-            install_trace_fixture_file(&state, entity);
-            state.graph.upsert_entity(entity).unwrap();
-        }
+        let caller = install_trace_fixture_file(&state, "caller", "src/a.py");
+        let callee = install_trace_fixture_file(&state, "callee", "src/b.py");
         link_every_class(&state, &caller, &callee);
         state
             .is_initialized
@@ -44471,31 +44575,64 @@ mod tests {
         );
     }
 
-    /// Put an entity's file into repository authority and the working copy.
+    /// Install a source file that declares nothing, and hand back the module
+    /// entity that is then the file's ONLY entity.
     ///
-    /// `/trace` resolves a repository authority binding before it renders, so a
-    /// graph-only fixture answers 500 and the assertions below never run.
-    fn install_trace_fixture_file(state: &Arc<DaemonState>, entity: &mut Entity) {
-        let path = entity
-            .file_origin
-            .as_ref()
-            .expect("trace fixture entities carry a file")
-            .0
-            .clone();
-        let source = format!("def {}():\n    return 1\n", entity.name);
+    /// A trace focal that must reach nothing needs a file with no same-file
+    /// neighbour either. `kin_context::build_context_pack` fills an empty
+    /// dependency walk with same-file neighbours and the trace's absence
+    /// qualifier prints only while `dependency_signatures` is empty, so a focal
+    /// sitting in a file that also holds its own module never reaches that
+    /// branch. A Python file holding a function derives both, so the file here
+    /// declares nothing and its module is the focal.
+    fn install_lone_module_fixture_file(state: &Arc<DaemonState>, name: &str) -> Entity {
+        let path = format!("src/{name}.py");
+        let source =
+            format!("# {name} declares nothing, so its module is this file's one entity\n");
         install_repository_file(state, &path, source.as_bytes());
         let working = state.layout.working_dir().join(&path);
         std::fs::create_dir_all(working.parent().unwrap()).unwrap();
         std::fs::write(&working, source.as_bytes()).unwrap();
-        // `test_entity` spans 0..0, which the route rejects against a file that
-        // has bytes. Left unfixed the route answers 500 and every assertion
-        // below never runs.
-        let span = entity
-            .span
-            .as_mut()
-            .expect("trace fixture entities carry a span");
-        span.end_byte = source.len();
-        span.end_line = 2;
+        state
+            .graph
+            .query_entities(&kin_db::EntityFilter {
+                file_path: Some(kin_model::FilePathId::new(&path)),
+                ..Default::default()
+            })
+            .unwrap()
+            .into_iter()
+            .find(|candidate| candidate.name == name && candidate.kind == EntityKind::Module)
+            .unwrap_or_else(|| panic!("installing {path} must derive the module {name}"))
+    }
+
+    /// Put a fixture's file into repository authority and the working copy, and
+    /// hand back the entity the install derived from its bytes.
+    ///
+    /// `/trace` resolves a repository authority binding before it renders, so a
+    /// graph-only fixture answers 500 and the assertions below never run.
+    ///
+    /// The entity comes from the install rather than from `test_entity` because
+    /// installing a source file derives one already, exactly as the daemon's
+    /// admission does. Upserting a second hand-made entity on the same path
+    /// builds a graph the daemon never produces: `orphan` named three entities
+    /// and `caller` two, and the trace then resolved an ambiguity these tests
+    /// never meant to exercise.
+    fn install_trace_fixture_file(state: &Arc<DaemonState>, name: &str, path: &str) -> Entity {
+        let source = format!("def {name}():\n    return 1\n");
+        install_repository_file(state, path, source.as_bytes());
+        let working = state.layout.working_dir().join(path);
+        std::fs::create_dir_all(working.parent().unwrap()).unwrap();
+        std::fs::write(&working, source.as_bytes()).unwrap();
+        state
+            .graph
+            .query_entities(&kin_db::EntityFilter {
+                file_path: Some(kin_model::FilePathId::new(path)),
+                ..Default::default()
+            })
+            .unwrap()
+            .into_iter()
+            .find(|candidate| candidate.name == name && candidate.kind == EntityKind::Function)
+            .unwrap_or_else(|| panic!("installing {path} must derive the function {name}"))
     }
 
     /// Drive `/trace` in its DEFAULT rendering and return the lines it printed.
@@ -49816,12 +49953,8 @@ mod tests {
     /// behavior.
     fn reference_fixture() -> (Arc<DaemonState>, Entity) {
         let state = test_state();
-        let mut target = test_entity("sweep_target", "src/target.py");
-        let mut caller = test_entity("sweep_caller", "src/caller.py");
-        for entity in [&mut target, &mut caller] {
-            install_trace_fixture_file(&state, entity);
-            state.graph.upsert_entity(entity).unwrap();
-        }
+        let target = install_trace_fixture_file(&state, "sweep_target", "src/target.py");
+        let caller = install_trace_fixture_file(&state, "sweep_caller", "src/caller.py");
         link_every_class(&state, &caller, &target);
         (state, target)
     }
@@ -53448,28 +53581,32 @@ mod tests {
         let second =
             "\ndef parse_config_list(paths):\n    return [parse_config(p) for p in paths]\n";
         let source = format!("{first}{second}");
-        install_repository_file(&state, "src/config.py", source.as_bytes());
-        install_working_copy_file(&state, "src/config.py", source.as_bytes(), false);
+        // The module entity an install derives takes the file stem, so a path of
+        // `src/config.py` would put an entity named `config` in this graph and
+        // the descriptive query below would name it by name. Keeping the stem
+        // outside the query is what leaves `all_fallback` a statement about the
+        // query rather than about the fixture's file name.
+        install_repository_file(&state, "src/loader.py", source.as_bytes());
+        install_working_copy_file(&state, "src/loader.py", source.as_bytes(), false);
 
-        for (name, start_byte, end_byte, preview) in [
-            ("parse_config", 0, first.len(), "def parse_config(path):"),
-            (
-                "parse_config_list",
-                first.len(),
-                source.len(),
-                "def parse_config_list(paths):",
-            ),
+        // The two definitions are the ones the install derived from those bytes,
+        // carrying their real spans. Upserting hand-made entities beside them
+        // would leave the graph holding each definition twice, which is a shape
+        // the daemon never produces.
+        for (name, preview) in [
+            ("parse_config", "def parse_config(path):"),
+            ("parse_config_list", "def parse_config_list(paths):"),
         ] {
-            let mut entity = test_entity(name, "src/config.py");
-            entity.span = Some(SourceSpan {
-                file: kin_model::FilePathId::new("src/config.py"),
-                start_byte,
-                end_byte,
-                start_line: 0,
-                start_col: 0,
-                end_line: 1,
-                end_col: 24,
-            });
+            let mut entity = state
+                .graph
+                .query_entities(&kin_db::EntityFilter {
+                    file_path: Some(kin_model::FilePathId::new("src/loader.py")),
+                    ..Default::default()
+                })
+                .unwrap()
+                .into_iter()
+                .find(|candidate| candidate.name == name && candidate.kind == EntityKind::Function)
+                .unwrap_or_else(|| panic!("installing src/loader.py must derive {name}"));
             // The fused ranker reads this to call an entity a definition rather
             // than a bare reference, and only definitions are ranked.
             entity

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6555,7 +6555,7 @@ fn session_reconcile_error(error: impl std::fmt::Display) -> (StatusCode, String
 /// how the placeholder author this endpoint used to stamp reached permanent
 /// history. A request that names nobody is refused by deserialization rather
 /// than completed by the daemon.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct CommandCommitRequest {
     operation_id: kin_model::OperationId,
@@ -6569,6 +6569,26 @@ struct CommandCommitRequest {
     author: kin_model::AuthorId,
     #[serde(default)]
     session_id: Option<String>,
+}
+
+/// Why one attempt at publishing a commit did not produce a change.
+///
+/// Two answers rather than one, because they ask for different next steps. A
+/// refusal is already worded for the caller and travels out as it is. Semantics
+/// that have not caught up with their bytes is not a refusal yet: the parse that
+/// settles it is one bounded pass away, and this route takes that pass before it
+/// decides. Recovering the difference from the worded refusal afterwards would
+/// mean matching on message text, and a classification inferred from a failure
+/// string stops holding the first time the wording moves.
+enum CommitAttempt {
+    Refused((StatusCode, String)),
+    SemanticsBehindTree(Vec<RepoPath>),
+}
+
+impl From<(StatusCode, String)> for CommitAttempt {
+    fn from(refusal: (StatusCode, String)) -> Self {
+        Self::Refused(refusal)
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -6671,7 +6691,50 @@ async fn command_commit(
     .await
     .map_err(commit_admission_error)?;
 
-    match command_commit_after_admission(&state, request, deferred_tree.as_ref()) {
+    // A commit plans its tree half and its entity half out of one live graph,
+    // and that graph is allowed to be behind itself: an exact-tree admission
+    // moves a path's bytes into authority on its own, and the parse that moves
+    // that path's spans onto them runs afterwards and does not survive the daemon
+    // that ran it. The drain above repairs the paths a writer recorded as owed.
+    // For anything it missed the planner refuses by name, and the answer is one
+    // bounded re-derivation of exactly those paths through the seam the drain
+    // uses, under the gate this commit already holds, before asking again.
+    //
+    // Once, not in a loop. The re-derivation is best effort and the planner is
+    // the guarantee: a second refusal is the store saying the parse will not
+    // settle from here, and asking again until it does would hold the gate for
+    // as long as the caller waits.
+    let attempt =
+        match command_commit_after_admission(&state, request.clone(), deferred_tree.as_ref()) {
+            Err(CommitAttempt::SemanticsBehindTree(paths)) => {
+                let owed: std::collections::BTreeSet<RepoPath> = paths.into_iter().collect();
+                let named = owed
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let waiting_since = Instant::now();
+                // Its own commit phase, so what the wait cost is attributed on the
+                // phase table beside the planning it precedes rather than hiding
+                // inside it.
+                let readmitted = crate::mcp_commit::timed_commit_phase_async(
+                    "await_pending_reconcile",
+                    crate::loop_runner::readmit_semantics_for_paths(&state, &owed),
+                )
+                .await;
+                info!(
+                    paths = %named,
+                    enriched = readmitted.enriched,
+                    unresolved = readmitted.failed.len(),
+                    waited_ms = waiting_since.elapsed().as_millis(),
+                    "these paths held entities their own admitted bytes do not reproduce, so this \
+                     commit re-derived them before planning the change that seals those bytes"
+                );
+                command_commit_after_admission(&state, request, deferred_tree.as_ref())
+            }
+            attempted => attempted,
+        };
+    match attempt {
         Ok(response) => {
             // A transaction that reached authority carried the tree the graph
             // holds with it, which is the divergence an earlier unclosed
@@ -6718,11 +6781,21 @@ async fn command_commit(
             crate::semantic_debt::settle_all(&state);
             Ok(response)
         }
-        Err(error) => {
-            if let Some(admitted) = deferred_tree {
-                crate::loop_runner::publish_deferred_tree_after_failure(&state, &admitted);
+        Err(CommitAttempt::SemanticsBehindTree(paths)) => {
+            if let Some(admitted) = deferred_tree.as_ref() {
+                crate::loop_runner::publish_deferred_tree_after_failure(&state, admitted);
             }
-            Err(error)
+            Err(repository_commit_error(
+                crate::error::DaemonError::SemanticsBehindTree {
+                    paths: paths.iter().map(ToString::to_string).collect(),
+                },
+            ))
+        }
+        Err(CommitAttempt::Refused(refusal)) => {
+            if let Some(admitted) = deferred_tree.as_ref() {
+                crate::loop_runner::publish_deferred_tree_after_failure(&state, admitted);
+            }
+            Err(refusal)
         }
     }
 }
@@ -6738,12 +6811,12 @@ fn command_commit_after_admission(
     state: &Arc<DaemonState>,
     request: CommandCommitRequest,
     observed: Option<&crate::repository_commit::AdmittedWorkspaceTree>,
-) -> Result<Json<CommandCommitResponse>, (StatusCode, String)> {
+) -> Result<Json<CommandCommitResponse>, CommitAttempt> {
     let graph = &*state.graph;
     let authority_context =
         crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(state)
             .map_err(repository_commit_error)?;
-    let plan = crate::mcp_commit::timed_commit_phase("plan_transaction", || {
+    let planned = crate::mcp_commit::timed_commit_phase("plan_transaction", || {
         if let Some(expected_head) = request.expected_head {
             crate::repository_commit::plan_native_amend(
                 graph,
@@ -6772,11 +6845,24 @@ fn command_commit_after_admission(
                 })?,
             )
         }
-    })
-    .map_err(repository_commit_error)?;
+    });
+    let plan = match planned {
+        Ok(plan) => plan,
+        // The one planning outcome this route can still do something about, so
+        // it keeps its paths instead of being flattened into a worded refusal.
+        Err(crate::error::DaemonError::SemanticsBehindTree { paths }) => {
+            return Err(CommitAttempt::SemanticsBehindTree(
+                paths
+                    .into_iter()
+                    .filter_map(|path| RepoPath::from_utf8(path).ok())
+                    .collect(),
+            ))
+        }
+        Err(error) => return Err(repository_commit_error(error).into()),
+    };
     if !request.amend {
         if let Some(refusal) = refuse_a_successor_that_records_nothing(&plan) {
-            return Err(refusal);
+            return Err(refusal.into());
         }
     }
     let change_id = plan.change.id;
@@ -6832,7 +6918,10 @@ fn command_commit_after_admission(
                             foreign_blocks.len()
                         ),
                     });
-                    return Err((StatusCode::CONFLICT, body.to_string()));
+                    return Err(CommitAttempt::Refused((
+                        StatusCode::CONFLICT,
+                        body.to_string(),
+                    )));
                 }
             }
         }
@@ -6986,6 +7075,18 @@ fn projection_blocked_refusal(error: &crate::error::DaemonError) -> Option<(Stat
 fn repository_commit_error(error: crate::error::DaemonError) -> (StatusCode, String) {
     if let Some(refusal) = projection_blocked_refusal(&error) {
         return refusal;
+    }
+    // Semantics that have not caught up with their bytes is a state of the store
+    // a caller can act on, not a fault in it: the files are intact, the bytes are
+    // authority, and one re-derivation settles it. Answering it as an internal
+    // error would send a reader to the daemon for files they can see.
+    if let crate::error::DaemonError::SemanticsBehindTree { paths } = &error {
+        let body = serde_json::json!({
+            "error": "semantics_behind_tree",
+            "message": error.to_string(),
+            "paths": paths,
+        });
+        return (StatusCode::CONFLICT, body.to_string());
     }
     let status = match &error {
         crate::error::DaemonError::Graph(kin_db::KinDbError::Model(
@@ -29780,6 +29881,28 @@ mod tests {
                 external_reference_deltas: Vec::new(),
             })
             .unwrap();
+        // The admission that puts a source file's bytes in the tree derives its
+        // entities in the same pass. Seeding the bytes alone leaves the graph
+        // holding no semantics for a path it is about to seal, which is the
+        // defect the commit planner refuses, so a fixture that skips it is
+        // building that state rather than an ordinary installed file.
+        let file_id = kin_model::FilePathId::new(rel_path);
+        if let Ok(kin_index::IndexedAny::EntitySource(indexed)) =
+            kin_index::IndexPipeline::new().index_any_content(&file_id, content, blob_hash)
+        {
+            state
+                .graph
+                .apply_transaction_delta(&kin_model::TransactionDelta {
+                    entity_deltas: indexed
+                        .entities
+                        .iter()
+                        .cloned()
+                        .map(|new| kin_model::EntityDelta::Added { new })
+                        .collect(),
+                    ..kin_model::TransactionDelta::default()
+                })
+                .unwrap();
+        }
         let plan = crate::repository_commit::plan_native_commit(
             &state.graph,
             &state.blobs,
@@ -35668,6 +35791,7 @@ mod tests {
             "a refused commit must record no change at all"
         );
     }
+
     /// FIR-3200. Read the published start line of the sole entity a path holds.
     #[cfg(unix)]
     fn published_start_line(state: &Arc<DaemonState>, path: &str) -> u32 {
@@ -36081,6 +36205,91 @@ mod tests {
             published_start_line(&reopened, "shifted.rs"),
             before,
             "an unparseable file keeps its last readable version's spans"
+        );
+    }
+
+    /// FIR-3208, the half a record cannot cover. A commit re-derives a stale
+    /// path no debt row ever named, then seals the bytes with the spans they
+    /// produce.
+    ///
+    /// The record the drain works from is written by the writers that know they
+    /// owe a parse. A path can reach the same state with no row at all: the
+    /// startup layout backfill finds the staleness by comparing the graph's
+    /// spans against a fresh parse of the tree's own bytes, publishes the layout
+    /// as partial, and enqueues an ordinary host event for the ambient loop,
+    /// recording nothing. A commit landing before that event is serviced plans
+    /// its tree half and its entity half out of a graph that does not agree with
+    /// itself, and seals the new bytes against the old spans. Removing the
+    /// record here is what leaves the planner's own check standing alone.
+    ///
+    /// Falsifies both halves of that check. Remove the barrier from
+    /// `plan_native_commit_inner` and the commit succeeds with the span still
+    /// where the pre-edit parse left it, so the assertion below fails. Remove
+    /// the one re-derivation from `command_commit` and the commit answers 409
+    /// `semantics_behind_tree`, so `commit_through_api` fails on the status.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial_test::serial(commit_phase_capture)]
+    async fn a_commit_re_derives_a_stale_path_no_debt_row_ever_named() {
+        const PREPENDED_LINES: u32 = 17;
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let layout = initialized.layout.clone();
+        let state = Arc::new(DaemonState::open(initialized.layout).unwrap());
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        std::fs::write(
+            repo.path().join("shifted.rs"),
+            b"pub fn shifted() -> u32 { 7 }\n",
+        )
+        .unwrap();
+
+        let app = router(Arc::clone(&state));
+        commit_through_api(&app, kin_model::OperationId::new(), "publish the fixture").await;
+        let before = published_start_line(&state, "shifted.rs");
+
+        let session_dir = layout.root().join("runs/session-unrecorded-stale-path");
+        materialize_session_through_api(&app, &session_dir).await;
+        prepend_session_lines(&session_dir.join("shifted.rs"), PREPENDED_LINES);
+        reconcile_session_through_api(&app, &session_dir).await;
+
+        // The restart is what makes the graph stale: the publication's own
+        // re-derivation lives in the derived graph, and the next daemon rebuilds
+        // that from a history this publication deliberately did not write.
+        drop(app);
+        drop(state);
+        // And this is what makes it a path nothing recorded. The `expect` is the
+        // fixture's own guard: if the reconcile stopped writing the record, the
+        // removal proves nothing and this test has to say so rather than pass.
+        std::fs::remove_file(layout.root().join("semantic-debt.json")).expect(
+            "the session reconcile must have recorded what it owed, or removing the record \
+             proves nothing",
+        );
+
+        let reopened = Arc::new(DaemonState::open(layout).unwrap());
+        reopened
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            published_start_line(&reopened, "shifted.rs"),
+            before,
+            "the reopened graph has to answer at the pre-edit position, or there is nothing for \
+             the commit to re-derive"
+        );
+
+        let reopened_app = router(Arc::clone(&reopened));
+        commit_through_api(
+            &reopened_app,
+            kin_model::OperationId::new(),
+            "commit the session's edit",
+        )
+        .await;
+        assert_eq!(
+            published_start_line(&reopened, "shifted.rs"),
+            before + PREPENDED_LINES,
+            "the commit had to re-derive a stale path nothing had recorded before it could seal \
+             the bytes that moved those spans"
         );
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -29771,6 +29771,31 @@ mod tests {
         );
     }
 
+    /// The entity an install derived for `path`, named and of the kind asked for.
+    ///
+    /// Fixtures take the entity the install produced rather than upserting a
+    /// hand-made one beside it. Installing a source file derives its entities the
+    /// way the daemon's admission does, so a second entity with the same name on
+    /// the same path is a graph the daemon never produces, and a query that then
+    /// names two entities resolves an ambiguity the fixture never meant to build.
+    fn derived_entity(
+        state: &Arc<DaemonState>,
+        path: &str,
+        name: &str,
+        kind: EntityKind,
+    ) -> Entity {
+        state
+            .graph
+            .query_entities(&kin_db::EntityFilter {
+                file_path: Some(kin_model::FilePathId::new(path)),
+                ..Default::default()
+            })
+            .unwrap()
+            .into_iter()
+            .find(|candidate| candidate.name == name && candidate.kind == kind)
+            .unwrap_or_else(|| panic!("installing {path} must derive {kind:?} {name}"))
+    }
+
     fn test_entity(name: &str, path: &str) -> Entity {
         Entity {
             id: EntityId::new(),
@@ -38712,20 +38737,13 @@ mod tests {
         // covered path on its own and leave this purge nothing to do.
         install_working_copy_file(&state, ".kinignore", b"investor\n", false);
 
-        let derived = |path: &str, name: &str| {
-            state
-                .graph
-                .query_entities(&kin_db::EntityFilter {
-                    file_path: Some(kin_model::FilePathId::new(path)),
-                    ..Default::default()
-                })
-                .unwrap()
-                .into_iter()
-                .find(|candidate| candidate.name == name)
-                .unwrap_or_else(|| panic!("the admission must derive {name} for {path}"))
-        };
-        let private = derived("investor/deck/build_deck.py", "valuation");
-        let kept = derived("src/lib.py", "kept");
+        let private = derived_entity(
+            &state,
+            "investor/deck/build_deck.py",
+            "valuation",
+            EntityKind::Function,
+        );
+        let kept = derived_entity(&state, "src/lib.py", "kept", EntityKind::Function);
         assert!(state.graph.get_entity(&private.id).unwrap().is_some());
 
         let (_, applied) = purge_ignored_through_api(&app, true).await;
@@ -38795,16 +38813,12 @@ mod tests {
         install_working_copy_file(&state, ".kinignore", b"investor\n", false);
         let app = router(Arc::clone(&state));
 
-        let private = state
-            .graph
-            .query_entities(&kin_db::EntityFilter {
-                file_path: Some(kin_model::FilePathId::new("investor/deck/build_deck.py")),
-                ..Default::default()
-            })
-            .unwrap()
-            .into_iter()
-            .find(|candidate| candidate.name == "valuation")
-            .expect("the install must derive the entity the purge has to retire");
+        let private = derived_entity(
+            &state,
+            "investor/deck/build_deck.py",
+            "valuation",
+            EntityKind::Function,
+        );
 
         let (_, applied) = purge_ignored_through_api(&app, true).await;
         assert_eq!(applied["report"]["purge_count"], json!(1));
@@ -44593,16 +44607,7 @@ mod tests {
         let working = state.layout.working_dir().join(&path);
         std::fs::create_dir_all(working.parent().unwrap()).unwrap();
         std::fs::write(&working, source.as_bytes()).unwrap();
-        state
-            .graph
-            .query_entities(&kin_db::EntityFilter {
-                file_path: Some(kin_model::FilePathId::new(&path)),
-                ..Default::default()
-            })
-            .unwrap()
-            .into_iter()
-            .find(|candidate| candidate.name == name && candidate.kind == EntityKind::Module)
-            .unwrap_or_else(|| panic!("installing {path} must derive the module {name}"))
+        derived_entity(state, &path, name, EntityKind::Module)
     }
 
     /// Put a fixture's file into repository authority and the working copy, and
@@ -44623,16 +44628,7 @@ mod tests {
         let working = state.layout.working_dir().join(path);
         std::fs::create_dir_all(working.parent().unwrap()).unwrap();
         std::fs::write(&working, source.as_bytes()).unwrap();
-        state
-            .graph
-            .query_entities(&kin_db::EntityFilter {
-                file_path: Some(kin_model::FilePathId::new(path)),
-                ..Default::default()
-            })
-            .unwrap()
-            .into_iter()
-            .find(|candidate| candidate.name == name && candidate.kind == EntityKind::Function)
-            .unwrap_or_else(|| panic!("installing {path} must derive the function {name}"))
+        derived_entity(state, path, name, EntityKind::Function)
     }
 
     /// Drive `/trace` in its DEFAULT rendering and return the lines it printed.
@@ -53597,16 +53593,7 @@ mod tests {
             ("parse_config", "def parse_config(path):"),
             ("parse_config_list", "def parse_config_list(paths):"),
         ] {
-            let mut entity = state
-                .graph
-                .query_entities(&kin_db::EntityFilter {
-                    file_path: Some(kin_model::FilePathId::new("src/loader.py")),
-                    ..Default::default()
-                })
-                .unwrap()
-                .into_iter()
-                .find(|candidate| candidate.name == name && candidate.kind == EntityKind::Function)
-                .unwrap_or_else(|| panic!("installing src/loader.py must derive {name}"));
+            let mut entity = derived_entity(&state, "src/loader.py", name, EntityKind::Function);
             // The fused ranker reads this to call an entity a definition rather
             // than a bare reference, and only definitions are ranked.
             entity
@@ -54589,27 +54576,23 @@ mod tests {
         let valid_source = "def valid_func():\n    return 42\n";
         install_repository_file(&state, "src/good.py", valid_source.as_bytes());
         install_working_copy_file(&state, "src/good.py", valid_source.as_bytes(), false);
-        let mut valid_entity = test_entity("valid_func", "src/good.py");
-        valid_entity.span = Some(SourceSpan {
-            file: kin_model::FilePathId::new("src/good.py"),
-            start_byte: 0,
-            end_byte: valid_source.len(),
-            start_line: 0,
-            start_col: 0,
-            end_line: 1,
-            end_col: 15,
-        });
+        let mut valid_entity =
+            derived_entity(&state, "src/good.py", "valid_func", EntityKind::Function);
         valid_entity.metadata.extra.insert(
             "embedding_body_preview".to_string(),
             json!("def valid_func():"),
         );
         state.graph.upsert_entity(&valid_entity).unwrap();
 
-        // bad.py has valid source text but bad_entity has an out-of-bounds span (100..200 > 25)
+        // bad.py has valid source text; the entity the install derived for it is
+        // given an out-of-bounds span (100..200 > 25), which is the unreadable
+        // source under test. The derived entity is corrupted rather than joined
+        // by a hand-made twin, because a readable second `bad_func` outranks the
+        // unreadable one and the page then reports no degradation at all.
         let bad_source = "def bad_func():\n    pass\n";
         install_repository_file(&state, "src/bad.py", bad_source.as_bytes());
         install_working_copy_file(&state, "src/bad.py", bad_source.as_bytes(), false);
-        let mut bad_entity = test_entity("bad_func", "src/bad.py");
+        let mut bad_entity = derived_entity(&state, "src/bad.py", "bad_func", EntityKind::Function);
         bad_entity.span = Some(SourceSpan {
             file: kin_model::FilePathId::new("src/bad.py"),
             start_byte: 100,
@@ -54655,16 +54638,8 @@ mod tests {
         let valid_source = "def valid_func():\n    return 42\n";
         install_repository_file(&state, "src/good.py", valid_source.as_bytes());
         install_working_copy_file(&state, "src/good.py", valid_source.as_bytes(), false);
-        let mut valid_entity = test_entity("valid_func", "src/good.py");
-        valid_entity.span = Some(SourceSpan {
-            file: kin_model::FilePathId::new("src/good.py"),
-            start_byte: 0,
-            end_byte: valid_source.len(),
-            start_line: 0,
-            start_col: 0,
-            end_line: 1,
-            end_col: 15,
-        });
+        let mut valid_entity =
+            derived_entity(&state, "src/good.py", "valid_func", EntityKind::Function);
         valid_entity.metadata.extra.insert(
             "embedding_body_preview".to_string(),
             json!("def valid_func():"),

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6602,6 +6602,79 @@ struct CommandCommitResponse {
     file_count: usize,
 }
 
+/// Copy the bodies a bounded re-derivation is about to read back into ingestion
+/// staging, from the store that durably holds them.
+///
+/// The detector that names these paths reads each one's tree-named body through
+/// `source_cas::read_publishable_source`, which answers from ingestion staging
+/// first and from repository CAS second. `readmit_semantics_for_paths` reads
+/// staging alone. Staging is disposable and repository CAS is not, so a store
+/// that reopened after its staged copies were pruned reaches this with the
+/// detector able to read every body and the re-derivation able to read none: the
+/// readmission fails its read, the second plan refuses exactly as the first did,
+/// and every later commit repeats it. Nothing is lost and nothing repairs it.
+///
+/// So the exact bodies the refused paths name are re-ingested first. This is
+/// explicit ingestion of bytes the repository already published, bounded to the
+/// paths the planner refused, and it changes no identity: the body is written
+/// back under the content address the tree already names.
+///
+/// A path whose body neither store holds is left alone. That absence is the
+/// publication's own refusal to make by name, and the re-derivation reports it
+/// as unresolved exactly as it did before.
+fn stage_refused_bodies_from_repository_cas(
+    state: &DaemonState,
+    owed: &std::collections::BTreeSet<RepoPath>,
+) -> usize {
+    let Ok(context) =
+        crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(state)
+    else {
+        return 0;
+    };
+    let Ok(authority) = context.open() else {
+        return 0;
+    };
+    let tree = state.graph.resolved_tree();
+    let mut refilled = 0;
+    for path in owed {
+        let Some(artifact) = tree.artifact_at_path(path) else {
+            continue;
+        };
+        let kin_model::TreeEntry::Blob { hash, .. } = artifact.entry else {
+            continue;
+        };
+        let staged_hash = kin_blobs::Hash256::from_bytes(*hash.as_bytes());
+        if state.blobs.read(&staged_hash).is_ok() {
+            continue;
+        }
+        match crate::source_cas::read_publishable_source(&state.blobs, &authority, hash) {
+            Ok(source) => match state.blobs.write(source.body()) {
+                Ok(written) if written == staged_hash => refilled += 1,
+                Ok(written) => warn!(
+                    path = %path,
+                    expected = %staged_hash,
+                    written = %written,
+                    "re-ingesting a published body produced a different content address, so it \
+                     was not the body this path's tree entry names"
+                ),
+                Err(error) => warn!(
+                    path = %path,
+                    error = %error,
+                    "the body repository CAS holds for this path could not be re-ingested, so \
+                     its semantics cannot be re-derived"
+                ),
+            },
+            Err(error) => warn!(
+                path = %path,
+                error = %error,
+                "neither store holds the body this path's tree entry names, so its semantics \
+                 cannot be re-derived"
+            ),
+        }
+    }
+    refilled
+}
+
 async fn command_commit(
     State(state): State<Arc<DaemonState>>,
     Json(request): Json<CommandCommitRequest>,
@@ -6714,6 +6787,12 @@ async fn command_commit(
                     .collect::<Vec<_>>()
                     .join(", ");
                 let waiting_since = Instant::now();
+                // The re-derivation reads ingestion staging and the detector
+                // reads staging plus repository CAS, so the bodies it is about
+                // to read are put back within reach first. On a store whose
+                // staged copies are gone this is the difference between one
+                // repair and a permanent refusal.
+                let refilled = stage_refused_bodies_from_repository_cas(&state, &owed);
                 // Its own commit phase, so what the wait cost is attributed on the
                 // phase table beside the planning it precedes rather than hiding
                 // inside it.
@@ -6724,6 +6803,7 @@ async fn command_commit(
                 .await;
                 info!(
                     paths = %named,
+                    refilled,
                     enriched = readmitted.enriched,
                     unresolved = readmitted.failed.len(),
                     waited_ms = waiting_since.elapsed().as_millis(),
@@ -36315,6 +36395,154 @@ mod tests {
             before + PREPENDED_LINES,
             "the commit had to re-derive a stale path nothing had recorded before it could seal \
              the bytes that moved those spans"
+        );
+    }
+
+    /// The bounded repair has to reach a body only repository CAS still holds.
+    ///
+    /// The detector reads each refused path's tree-named body through
+    /// `source_cas::read_publishable_source`, which answers from ingestion
+    /// staging first and repository CAS second. `readmit_semantics_for_paths`
+    /// reads staging alone, and staging is disposable: a store that reopened
+    /// after its staged copies were pruned reaches the repair with every body
+    /// durable and none of them staged. The re-derivation then fails its read,
+    /// the second plan refuses exactly as the first did, and every later commit
+    /// repeats it, with no body lost and nothing that repairs it.
+    ///
+    /// The fixture removes ONLY the staged copy and asserts repository CAS still
+    /// holds the same body, so this is a missing staged copy rather than a
+    /// missing body. It then reopens a second time, cold, and asserts the
+    /// persisted entities reproduce a parse of the body the tree names, because a
+    /// repair that only moved the live graph would pass a check of that graph.
+    ///
+    /// Falsify by removing the refill from `command_commit`: the commit answers
+    /// 409 `semantics_behind_tree` and `commit_through_api` fails on the status.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial_test::serial(commit_phase_capture)]
+    async fn a_commit_re_derives_a_stale_path_whose_body_only_repository_cas_holds() {
+        const PREPENDED_LINES: u32 = 17;
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let layout = initialized.layout.clone();
+        let state = Arc::new(DaemonState::open(initialized.layout).unwrap());
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        std::fs::write(
+            repo.path().join("shifted.rs"),
+            b"pub fn shifted() -> u32 { 7 }\n",
+        )
+        .unwrap();
+
+        let app = router(Arc::clone(&state));
+        commit_through_api(&app, kin_model::OperationId::new(), "publish the fixture").await;
+        let before = published_start_line(&state, "shifted.rs");
+
+        let session_dir = layout.root().join("runs/session-staging-pruned");
+        materialize_session_through_api(&app, &session_dir).await;
+        prepend_session_lines(&session_dir.join("shifted.rs"), PREPENDED_LINES);
+        reconcile_session_through_api(&app, &session_dir).await;
+
+        drop(app);
+        drop(state);
+        std::fs::remove_file(layout.root().join("semantic-debt.json")).expect(
+            "the session reconcile must have recorded what it owed, or removing the record \
+             proves nothing",
+        );
+
+        let reopened = Arc::new(DaemonState::open(layout.clone()).unwrap());
+        reopened
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            published_start_line(&reopened, "shifted.rs"),
+            before,
+            "the reopened graph has to answer at the pre-edit position, or there is nothing for \
+             the commit to re-derive"
+        );
+
+        // Prune the staged copy the way a reopen on a pruned ingestion CAS does,
+        // and prove the durable body is still there, or this fixture is about an
+        // absent body rather than an absent staged copy.
+        let repo_path = RepoPath::from_utf8("shifted.rs".to_string()).unwrap();
+        let tree = reopened.graph.resolved_tree();
+        let kin_model::TreeEntry::Blob { hash, .. } =
+            tree.artifact_at_path(&repo_path).unwrap().entry
+        else {
+            panic!("the fixture is a regular file");
+        };
+        drop(tree);
+        let staged_hash = kin_blobs::Hash256::from_bytes(*hash.as_bytes());
+        reopened.blobs.delete(&staged_hash).unwrap();
+        assert!(
+            reopened.blobs.read(&staged_hash).is_err(),
+            "the staged copy has to be gone, or the refill under test is never exercised"
+        );
+        let sealed_body = {
+            let context =
+                crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(
+                    &reopened,
+                )
+                .unwrap();
+            let authority = context.open().unwrap();
+            crate::source_cas::read_publishable_source(&reopened.blobs, &authority, hash)
+                .expect("repository CAS still holds the published body")
+                .body()
+                .to_vec()
+        };
+
+        let reopened_app = router(Arc::clone(&reopened));
+        commit_through_api(
+            &reopened_app,
+            kin_model::OperationId::new(),
+            "commit the session's edit with staging pruned",
+        )
+        .await;
+        assert_eq!(
+            published_start_line(&reopened, "shifted.rs"),
+            before + PREPENDED_LINES,
+            "the commit had to re-derive from the body repository CAS holds before it could seal \
+             the bytes that moved those spans"
+        );
+
+        // A second cold reopen. The repair has to be in durable authority rather
+        // than only in the graph the committing process happened to hold.
+        drop(reopened_app);
+        drop(reopened);
+        let cold = Arc::new(DaemonState::open(layout).unwrap());
+        cold.is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            published_start_line(&cold, "shifted.rs"),
+            before + PREPENDED_LINES,
+            "the re-derived spans have to survive a cold reopen, or the commit sealed a repair \
+             nothing persisted"
+        );
+        let persisted = cold
+            .graph
+            .query_entities(&kin_model::EntityFilter {
+                file_path: Some(kin_model::FilePathId::new("shifted.rs")),
+                ..Default::default()
+            })
+            .unwrap();
+        let fresh = kin_index::IndexPipeline::new()
+            .index_file_content_with_tests(
+                &kin_model::FilePathId::new("shifted.rs"),
+                &sealed_body,
+                staged_hash,
+            )
+            .unwrap()
+            .indexed_file
+            .entities;
+        assert!(
+            !persisted.is_empty() && !fresh.is_empty(),
+            "both sides of the comparison have to hold something, or it proves nothing"
+        );
+        assert!(
+            crate::repository_commit::semantics_follow_the_bytes(&persisted, &fresh),
+            "after a cold reopen the persisted entities have to reproduce a parse of the body \
+             the tree names, bodies and all, not merely sit at the right line"
         );
     }
 

--- a/crates/kin-daemon/src/error.rs
+++ b/crates/kin-daemon/src/error.rs
@@ -157,6 +157,27 @@ pub enum DaemonError {
     #[error("{0}")]
     SemanticReadmissionFailed(String),
 
+    /// Paths a commit would seal whose graph entities a parse of the bytes it
+    /// is sealing does not reproduce.
+    ///
+    /// Separate from
+    /// [`SemanticReadmissionFailed`](Self::SemanticReadmissionFailed), which is
+    /// a re-derivation this daemon attempted and could not complete. This is one
+    /// that has not happened yet: the bytes are durable authority, the parse that
+    /// would move the spans onto them is still owed, and a commit planned inside
+    /// that window records the new bytes against the old spans. Nothing is broken
+    /// and nothing needs repairing, so the answer is to re-derive and ask again
+    /// rather than to report a fault, and the paths travel with the refusal
+    /// because a caller cannot do either without them.
+    #[error(
+        "these paths hold entities that a parse of the bytes this commit would seal does not \
+         reproduce, so their semantics have not caught up with their bytes and the change would \
+         record the new bytes against spans derived from the old ones; nothing was written, and \
+         the commit records them correctly once they are re-derived: {}",
+        paths.join(", ")
+    )]
+    SemanticsBehindTree { paths: Vec<String> },
+
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 }

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -907,6 +907,7 @@ pub(crate) fn plan_native_amend(
         &|_| String::new(),
         None,
         Some(amend),
+        SemanticCurrency::DaemonMaintained,
     )
 }
 
@@ -933,6 +934,7 @@ pub(crate) fn plan_native_commit(
         &|_| message.clone(),
         None,
         None,
+        SemanticCurrency::DaemonMaintained,
     )
 }
 
@@ -965,6 +967,7 @@ pub(crate) fn plan_native_commit_from_base(
         &|_| message.clone(),
         Some(&base.roots),
         None,
+        SemanticCurrency::AuthoritySnapshot,
     )
 }
 
@@ -1008,6 +1011,7 @@ pub(crate) fn plan_native_commit_from_base_declaring_carry(
         message,
         Some(&base.roots),
         None,
+        SemanticCurrency::AuthoritySnapshot,
     )
 }
 
@@ -1038,6 +1042,211 @@ pub(crate) fn carried_pending_paths(
 }
 
 #[allow(clippy::too_many_arguments)]
+/// One entity as a parse of the file's own bytes reproduces it: what it is,
+/// what it is called, exactly which bytes it spans, and what those bytes are.
+///
+/// Every field is derived from the source and recorded by the graph, and none is
+/// a generated id. Ids are deliberately absent: the reconciler keeps an entity's
+/// id stable across an edit that moves it (`stable_entity_ids` in kin-reconcile),
+/// so ids agree on a store that is stale, which is backwards for this question.
+///
+/// The span and the behaviour hash answer different edits, and both are needed.
+/// An insertion moves every span after it and leaves the bodies alone. A
+/// same-length body edit, `return 1` becoming `return 2`, leaves every span
+/// exactly where it was and changes the token stream, so `behavior_hash`, the
+/// hash of the entity's own source text, is the only field that moves. A
+/// comparison on spans alone would seal the second one.
+fn semantic_keys(entities: &[kin_model::Entity]) -> Vec<String> {
+    let mut keys = entities
+        .iter()
+        .filter(|entity| entity.role == kin_model::EntityRole::Source)
+        .filter_map(|entity| {
+            let span = entity.span.as_ref()?;
+            Some(format!(
+                "{:?}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}",
+                entity.kind,
+                entity.name,
+                span.start_byte,
+                span.end_byte,
+                entity.fingerprint.behavior_hash,
+            ))
+        })
+        .collect::<Vec<_>>();
+    keys.sort();
+    keys
+}
+
+/// Whether the entities the graph holds for one path and the entities a parse of
+/// that path's own bytes produces are the same set.
+///
+/// Compared in both directions, as sorted multisets. One direction is not
+/// enough: a declaration appended to the end of a file leaves every entity the
+/// graph already held exactly where it was, with the same bytes, so a
+/// held-to-fresh scan finds all of them and reports nothing while the graph is
+/// missing an entity the change is about to seal bytes for.
+fn semantics_follow_the_bytes(held: &[kin_model::Entity], fresh: &[kin_model::Entity]) -> bool {
+    semantic_keys(held) == semantic_keys(fresh)
+}
+
+/// Which of a change's tree deltas the check covers.
+///
+/// A path the change UPDATES can hold entities derived from the bytes it is
+/// replacing. A path it ADDS cannot hold stale entities, but that is not the same
+/// as holding a complete parse: a source file whose bytes reached the tree and
+/// whose enrichment was lost holds no entities at all, and a change that seals it
+/// leaves every declaration in it unanswerable. Both are the same defect seen
+/// from different sides, so both are checked.
+///
+/// The exception is the ROOT change, which has no parent. Its delta is the whole
+/// tree, every path in it is added, and checking them would parse the entire
+/// repository at the one moment nothing has had a chance to go stale: the
+/// admission that derived those entities ran inside the same command. So an
+/// import pays no parse at all, and every commit after it stays bounded to its
+/// own changed paths rather than to the repository.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SealedPathScope {
+    /// Every path this change seals bytes for.
+    AddedAndUpdated,
+    /// Only the paths it updates, which for a root change is none of them.
+    UpdatedOnly,
+}
+
+/// Whether the graph a plan is being built from is one the daemon keeps level
+/// with its own tree.
+///
+/// The CLI route plans from the daemon's live derived graph. The reconcile keeps
+/// that graph's entities level with the tree it holds, a path whose parse has
+/// not landed there is the window this check exists to close, and the route can
+/// re-derive it and ask again.
+///
+/// The MCP route plans from repository authority's own workspace graph snapshot
+/// ([`load_native_commit_base`]), applies only the staged operations to it, and
+/// deliberately carries pending working-tree content in as bytes. A working-tree
+/// admission advances the workspace tree with no semantic delta, so authority's
+/// snapshot holds the pre-edit entities for a carried path by design and there is
+/// nothing on that path to re-derive from. Checking there would refuse the
+/// carried-pending flow rather than catch a race. That surface seals new bytes
+/// against older spans for a carried file for the same underlying reason and
+/// needs its own answer; this check does not pretend to give it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SemanticCurrency {
+    /// The daemon's live derived graph, which the reconcile keeps current.
+    DaemonMaintained,
+    /// A repository-authority workspace snapshot, which nothing re-derives.
+    AuthoritySnapshot,
+}
+
+/// Paths this commit is about to seal whose graph entities a parse of the bytes
+/// it is sealing does not reproduce.
+///
+/// A change's tree half and entity half are both read from one live graph, and
+/// that graph is allowed to be behind itself for a window. An exact-tree
+/// admission moves a path's bytes into repository authority on its own, and the
+/// enrichment that re-derives that path's entities runs after it, can be lost
+/// with the daemon that ran it, and does not survive a restart, because entities
+/// reach durable authority only inside a semantic change. A commit planned
+/// inside that window seals the new bytes against entities derived from the old
+/// ones, and reports no entity delta at all, because the graph's entities still
+/// equal the parent change's. `loop_runner` already names the class in the
+/// comment above its own semantic-debt drain: an empty transition means the
+/// working copy and the graph agree about bytes, not that the graph agrees with
+/// itself. That drain repairs the paths some writer recorded; this refuses the
+/// ones nobody did.
+///
+/// Answered from graph-owned truth alone. The resolved tree names a body, the
+/// body is read from the content-addressed stores this commit already publishes
+/// from, and the parse of it is compared against the entities the graph holds.
+/// Nothing here reads the working copy.
+///
+/// Bounded to the tree delta, and inside it to the paths the change updates. A
+/// path this change adds carries no earlier parse to be stale against, so an
+/// import commit, whose delta is the whole tree, pays no parse at all; a path it
+/// removes seals no bytes.
+pub(crate) fn paths_whose_semantics_the_sealed_bytes_do_not_reproduce(
+    graph: &kin_db::InMemoryGraph,
+    blobs: &kin_blobs::BlobStore,
+    authority: &RepositoryAuthorityManager<LocalFileBackend>,
+    tree_deltas: &[kin_model::TreeDelta],
+    scope: SealedPathScope,
+) -> Result<Vec<RepoPath>> {
+    use kin_model::EntityStore;
+
+    let mut behind = Vec::new();
+    let pipeline = kin_index::IndexPipeline::new();
+    for delta in tree_deltas {
+        // A removal seals no bytes, so it is never in scope.
+        let new = match (scope, delta) {
+            (_, kin_model::TreeDelta::Updated { new, .. }) => new,
+            (SealedPathScope::AddedAndUpdated, kin_model::TreeDelta::Added { new, .. }) => new,
+            _ => continue,
+        };
+        // Symlinks and gitlinks are never parsed as source owned by the link
+        // path, which is the rule the layout backfill and the readmission both
+        // apply.
+        let kin_model::TreeEntry::Blob { hash, .. } = new.entry else {
+            continue;
+        };
+        let Some(path) = new.path.as_utf8() else {
+            continue;
+        };
+        if !matches!(
+            kin_index::FileClassifier::classify(std::path::Path::new(path)),
+            kin_index::FileClassification::EntitySource
+        ) {
+            continue;
+        }
+        // A body neither store holds is a different refusal, and the publication
+        // this plan feeds makes it by name. Staying quiet here leaves that one
+        // intact instead of replacing it with a staleness verdict this cannot
+        // reach.
+        let Ok(source) = read_publishable_source(blobs, authority, hash) else {
+            continue;
+        };
+        let content = source.body();
+        // Content decides the facet exactly as admission decides it: a path
+        // whose extension says source but whose bytes are opaque belongs to
+        // another facet and holds no source spans of its own.
+        if !matches!(
+            kin_index::FileClassifier::classify_with_content(std::path::Path::new(path), content),
+            kin_index::FileClassification::EntitySource
+        ) {
+            continue;
+        }
+        let file_id = kin_model::FilePathId::new(path);
+        let Ok(indexed) = pipeline.index_file_content_with_tests(
+            &file_id,
+            content,
+            kin_blobs::Hash256::from_bytes(*hash.as_bytes()),
+        ) else {
+            continue;
+        };
+        let indexed = indexed.indexed_file;
+        // Only a clean parse can say the graph's entities are wrong. A file the
+        // parser could not read whole keeps the entities its last readable
+        // version produced, deliberately: the daemon reconciles under
+        // `ReconcilePolicy::FallbackToLkg`, an author mid-edit produces this
+        // constantly, and a fresh parse of a half-written file disagrees with
+        // the graph for a reason that has nothing to do with the window this
+        // check exists to close. Refusing on it would leave a caller holding one
+        // broken file unable to record anything at all, which is the outcome
+        // `drain_semantic_debt` already declines to produce for the same reason.
+        if !matches!(indexed.parse_state, kin_model::ParseState::Valid) {
+            continue;
+        }
+        let held = graph.query_entities(&kin_model::EntityFilter {
+            file_path: Some(file_id.clone()),
+            ..Default::default()
+        })?;
+        // No skip for a path the graph holds nothing at: a clean parse that
+        // produces entities where the graph has none is the same defect one step
+        // further along, and the comparison below already says so.
+        if !semantics_follow_the_bytes(&held, &indexed.entities) {
+            behind.push(new.path.clone());
+        }
+    }
+    Ok(behind)
+}
+
 fn plan_native_commit_inner(
     graph: &kin_db::InMemoryGraph,
     blobs: &kin_blobs::BlobStore,
@@ -1049,6 +1258,7 @@ fn plan_native_commit_inner(
     message: &dyn Fn(&[RepoPath]) -> String,
     expected_roots: Option<&RootBundle>,
     amend: Option<&NativeAmend>,
+    currency: SemanticCurrency,
 ) -> Result<NativeCommitPlan> {
     let repository_id = authority_context.repository_id().clone();
     let workspace_id = authority_context.workspace_id();
@@ -1145,6 +1355,35 @@ fn plan_native_commit_inner(
     let deltas = crate::mcp_commit::timed_commit_phase("plan_compute_deltas", || {
         compute_deltas_vs_repository_authority(graph, lease.snapshot(), parent.as_ref())
     })?;
+    // A graph the daemon keeps current has to agree with itself before either
+    // half of it is sealed. Its own phase, so what this costs is attributed
+    // rather than folded into the planning around it.
+    let semantics_behind_tree = match currency {
+        SemanticCurrency::AuthoritySnapshot => Vec::new(),
+        SemanticCurrency::DaemonMaintained => {
+            crate::mcp_commit::timed_commit_phase("plan_verify_semantics_follow_bytes", || {
+                paths_whose_semantics_the_sealed_bytes_do_not_reproduce(
+                    graph,
+                    blobs,
+                    &authority,
+                    &deltas.tree_deltas,
+                    if parent.is_some() {
+                        SealedPathScope::AddedAndUpdated
+                    } else {
+                        SealedPathScope::UpdatedOnly
+                    },
+                )
+            })?
+        }
+    };
+    if !semantics_behind_tree.is_empty() {
+        return Err(DaemonError::SemanticsBehindTree {
+            paths: semantics_behind_tree
+                .iter()
+                .map(ToString::to_string)
+                .collect(),
+        });
+    }
     let mut source_lengths = std::collections::BTreeMap::new();
     let (shared_policy, admission_policy_delta) =
         crate::mcp_commit::timed_commit_phase("plan_derive_admission_policy", || {
@@ -2483,6 +2722,8 @@ mod tests {
             b"pub fn second() {}\n",
             |hash| TreeEntry::blob(hash, false),
         );
+        // Its semantics land with its bytes, as an admission derives them.
+        derive_entities_into_graph(&graph, &blobs, "second.rs", b"pub fn second() {}\n");
         let plan = plan_native_commit(
             &init.layout,
             &graph,
@@ -3852,5 +4093,391 @@ mod tests {
             "the admitted workspace policy must carry the tree's one approval: {carried:?}"
         );
         assert_eq!(carried[0].content_hash, blob_hash(&secret));
+    }
+
+    /// Source a parse can place, and the same file with an import prepended so
+    /// every span after it moves.
+    const SESSIONS_BEFORE: &[u8] = b"def alpha():\n    return 1\n\n\ndef beta():\n    return 2\n";
+    const SESSIONS_AFTER: &[u8] =
+        b"import os\n\n\ndef alpha():\n    return 1\n\n\ndef beta():\n    return 2\n";
+    /// The same file with one literal swapped for another of the same width, so
+    /// every entity keeps exactly the bytes it held and only the token stream
+    /// under it moves.
+    const SESSIONS_SAME_LENGTH: &[u8] =
+        b"def alpha():\n    return 9\n\n\ndef beta():\n    return 2\n";
+    /// The same file with a declaration appended, so every entity the graph
+    /// holds survives byte-identical and the parse produces one it does not.
+    const SESSIONS_APPENDED: &[u8] = b"def alpha():\n    return 1\n\n\ndef beta():\n                                           return 2\n\n\ndef gamma():\n    return 3\n";
+
+    /// Put the entities a parse of `bytes` produces into the graph, the way the
+    /// reconcile that follows an admission does.
+    fn derive_entities_into_graph(
+        graph: &kin_db::InMemoryGraph,
+        blobs: &kin_blobs::BlobStore,
+        path: &str,
+        bytes: &[u8],
+    ) -> Vec<kin_model::Entity> {
+        let file_id = kin_model::FilePathId::new(path);
+        let digest = blobs.write(bytes).unwrap();
+        let entities = kin_index::IndexPipeline::new()
+            .index_file_content_with_tests(&file_id, bytes, digest)
+            .unwrap()
+            .indexed_file
+            .entities;
+        assert!(
+            !entities.is_empty(),
+            "the fixture must parse to at least one entity, or nothing below can go stale"
+        );
+        graph
+            .apply_transaction_delta(&TransactionDelta {
+                entity_deltas: entities
+                    .iter()
+                    .cloned()
+                    .map(|new| kin_model::EntityDelta::Added { new })
+                    .collect(),
+                ..TransactionDelta::default()
+            })
+            .unwrap();
+        entities
+    }
+
+    /// Move one artifact's bytes in the tree and touch nothing else, which is
+    /// what an exact-tree admission whose enrichment half never ran leaves
+    /// behind.
+    fn update_artifact_bytes(
+        graph: &kin_db::InMemoryGraph,
+        blobs: &kin_blobs::BlobStore,
+        artifact: &ResolvedArtifact,
+        bytes: &[u8],
+    ) -> ResolvedArtifact {
+        let digest = blobs.write(bytes).unwrap();
+        let entry = TreeEntry::blob(Hash256::from_bytes(digest.0), false);
+        graph
+            .apply_transaction_delta(&TransactionDelta {
+                tree_deltas: vec![TreeDelta::Updated {
+                    artifact_id: artifact.artifact_id,
+                    old: LocatedEntry::new(artifact.path.clone(), artifact.entry),
+                    new: LocatedEntry::new(artifact.path.clone(), entry),
+                }],
+                ..TransactionDelta::default()
+            })
+            .unwrap();
+        ResolvedArtifact::new(artifact.artifact_id, artifact.path.clone(), entry)
+    }
+
+    /// Retire the entities one parse produced and install the ones the current
+    /// bytes produce, which is what the reconcile lands when it finally runs.
+    fn replace_entities_in_graph(
+        graph: &kin_db::InMemoryGraph,
+        blobs: &kin_blobs::BlobStore,
+        path: &str,
+        held: &[kin_model::Entity],
+        bytes: &[u8],
+    ) {
+        graph
+            .apply_transaction_delta(&TransactionDelta {
+                entity_deltas: held
+                    .iter()
+                    .cloned()
+                    .map(|old| kin_model::EntityDelta::Removed { old })
+                    .collect(),
+                ..TransactionDelta::default()
+            })
+            .unwrap();
+        derive_entities_into_graph(graph, blobs, path, bytes);
+    }
+
+    /// Publish one file, then move its bytes in the tree without re-deriving its
+    /// semantics, and ask for a commit.
+    fn commit_then_move_bytes_without_reparsing(
+        init: &kin_core::InitResult,
+        graph: &kin_db::InMemoryGraph,
+        blobs: &kin_blobs::BlobStore,
+        after: &[u8],
+    ) -> Vec<kin_model::Entity> {
+        let artifact = add_artifact(graph, blobs, b"sessions.py", SESSIONS_BEFORE, |hash| {
+            TreeEntry::blob(hash, false)
+        });
+        let held = derive_entities_into_graph(graph, blobs, "sessions.py", SESSIONS_BEFORE);
+        let plan = plan_native_commit(
+            &init.layout,
+            graph,
+            blobs,
+            OperationId::new(),
+            fixed_timestamp(),
+            AuthorId::new("commitrace"),
+            "publish the pre-edit file".to_string(),
+        )
+        .expect("the pre-edit commit plans, so the barrier below is not refusing everything");
+        commit_native_plan_with_projection(&init.layout, blobs, plan).unwrap();
+        update_artifact_bytes(graph, blobs, &artifact, after);
+        held
+    }
+
+    /// A commit must not seal a tree delta over a path whose graph entities a
+    /// parse of the bytes it is sealing does not reproduce.
+    ///
+    /// This is the FIR-3201 restart window seen from the commit side. An exact
+    /// tree reaches authority, the enrichment half that would re-derive its
+    /// entities does not run or does not survive, and the planner reads the tree
+    /// half and the entity half out of one graph that no longer agrees with
+    /// itself. The change it seals then records the new bytes against spans
+    /// derived from the old ones, and reports the entity delta as empty because
+    /// the graph's entities still equal the parent change's.
+    ///
+    /// Falsify by removing the barrier from `plan_native_commit_inner`: the plan
+    /// comes back `Ok` and this assertion fails.
+    #[test]
+    fn a_commit_refuses_a_path_whose_semantics_the_sealed_bytes_do_not_reproduce() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+
+        commit_then_move_bytes_without_reparsing(&init, &graph, &blobs, SESSIONS_AFTER);
+
+        let refusal = plan_native_commit(
+            &init.layout,
+            &graph,
+            &blobs,
+            OperationId::new(),
+            fixed_timestamp(),
+            AuthorId::new("commitrace"),
+            "publish the edit".to_string(),
+        );
+        let Some(error) = refusal.err() else {
+            panic!(
+                "the commit sealed a tree delta for sessions.py against entities derived from the \
+                 pre-edit bytes; the change records the new bytes and reports no entity delta at \
+                 all, which is the psf/requests entities=0 result"
+            );
+        };
+        let message = error.to_string();
+        assert!(
+            message.contains("sessions.py"),
+            "the refusal has to name the path whose reconcile has not landed, or a caller cannot \
+             act on it: {message}"
+        );
+    }
+
+    /// A path this change ADDS whose semantics never landed is caught too.
+    ///
+    /// "No earlier parse to be stale against" is not the same as "a complete
+    /// current parse". A source file admitted into the tree whose enrichment was
+    /// lost carries no entities at all, and a change that seals its bytes leaves
+    /// every declaration in it unanswerable, which is the FIR-2606 shape rather
+    /// than the FIR-3201 one. The comparison already says so; the question is
+    /// only whether the check looks at added paths.
+    ///
+    /// Falsify by scoping the check to `TreeDelta::Updated` alone: the plan comes
+    /// back `Ok` and this assertion fails.
+    #[test]
+    fn a_commit_refuses_a_new_source_path_the_graph_holds_no_semantics_for() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+
+        // One published file, so the change under test has a parent and is not
+        // the root change whose delta is the whole tree.
+        add_artifact(&graph, &blobs, b"sessions.py", SESSIONS_BEFORE, |hash| {
+            TreeEntry::blob(hash, false)
+        });
+        derive_entities_into_graph(&graph, &blobs, "sessions.py", SESSIONS_BEFORE);
+        let plan = plan_native_commit(
+            &init.layout,
+            &graph,
+            &blobs,
+            OperationId::new(),
+            fixed_timestamp(),
+            AuthorId::new("commitrace"),
+            "publish the first file".to_string(),
+        )
+        .expect("the root commit plans, so the refusal below is about the added path");
+        commit_native_plan_with_projection(&init.layout, &blobs, plan).unwrap();
+
+        // A second source file reaches the tree and nothing parses it.
+        add_artifact(&graph, &blobs, b"helpers.py", SESSIONS_BEFORE, |hash| {
+            TreeEntry::blob(hash, false)
+        });
+
+        let refusal = plan_native_commit(
+            &init.layout,
+            &graph,
+            &blobs,
+            OperationId::new(),
+            fixed_timestamp(),
+            AuthorId::new("commitrace"),
+            "publish the new file".to_string(),
+        );
+        let Some(error) = refusal.err() else {
+            panic!(
+                "the commit sealed a new source file the graph holds no entity for, so every \
+                 declaration in it answers as though it is not there"
+            );
+        };
+        assert!(
+            error.to_string().contains("helpers.py"),
+            "the refusal has to name the path: {error}"
+        );
+    }
+
+    /// A declaration the graph is missing does not follow the bytes.
+    ///
+    /// The direction claim, tested where it can be stated exactly rather than
+    /// through a fixture. Every entity the graph holds is reproduced by the
+    /// parse, so a scan from held into fresh finds all of them and reports
+    /// nothing, while the parse produces one the graph does not hold and the
+    /// change is about to seal bytes for it.
+    ///
+    /// Falsify by comparing one direction only, the held keys against the fresh
+    /// ones: the second assertion fails.
+    #[test]
+    fn a_declaration_the_graph_is_missing_does_not_follow_the_bytes() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let file_id = kin_model::FilePathId::new("sessions.py");
+        let digest = blobs.write(SESSIONS_BEFORE).unwrap();
+        let parsed = kin_index::IndexPipeline::new()
+            .index_file_content_with_tests(&file_id, SESSIONS_BEFORE, digest)
+            .unwrap()
+            .indexed_file
+            .entities;
+        assert!(
+            parsed.len() >= 2,
+            "the fixture must parse to at least two entities, or one cannot go missing: {parsed:?}"
+        );
+        let held = &parsed[..parsed.len() - 1];
+
+        assert!(
+            super::semantics_follow_the_bytes(&parsed, &parsed),
+            "one set has to agree with itself, or this test proves nothing"
+        );
+        assert!(
+            !super::semantics_follow_the_bytes(held, &parsed),
+            "a declaration the bytes produce and the graph does not hold has to be reported; a \
+             scan from held into fresh finds every held key and says the graph is current"
+        );
+    }
+
+    /// A same-length body edit is caught, which a comparison on spans cannot do.
+    ///
+    /// `return 1` becoming `return 9` leaves every entity at exactly the bytes it
+    /// held, so kind, name and both span offsets match and the only field that
+    /// moves is `behavior_hash`, the hash of the entity's own source text. The
+    /// change would seal the new bytes against semantics that describe the old
+    /// ones, and every span in it would be correct, which is what makes this
+    /// shape the one a span check waves through.
+    ///
+    /// Falsify by dropping `behavior_hash` from `semantic_keys`: the plan comes
+    /// back `Ok` and this assertion fails.
+    #[test]
+    fn a_commit_refuses_a_same_length_body_edit_its_semantics_did_not_follow() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+
+        commit_then_move_bytes_without_reparsing(&init, &graph, &blobs, SESSIONS_SAME_LENGTH);
+
+        let refusal = plan_native_commit(
+            &init.layout,
+            &graph,
+            &blobs,
+            OperationId::new(),
+            fixed_timestamp(),
+            AuthorId::new("commitrace"),
+            "publish the same-length edit".to_string(),
+        );
+        let Some(error) = refusal.err() else {
+            panic!(
+                "the commit sealed bytes whose entity bodies the graph does not hold; every span \
+                 in the change is correct and every body under it describes the previous bytes"
+            );
+        };
+        assert!(
+            error.to_string().contains("sessions.py"),
+            "the refusal has to name the path: {error}"
+        );
+    }
+
+    /// A declaration the sealed bytes add and the graph does not hold is caught,
+    /// which a one-way comparison cannot do.
+    ///
+    /// Appending `gamma` leaves `alpha` and `beta` byte-identical, so a scan from
+    /// the graph's entities into a fresh parse finds every one of them and
+    /// reports nothing, while the change seals bytes for a declaration no query
+    /// can answer about.
+    ///
+    /// Falsify by removing the barrier: the plan comes back `Ok` and this
+    /// assertion fails. The direction of the comparison has its own test below,
+    /// because appending to this fixture moves the preceding declaration's own
+    /// key too, so a one-way scan already reports it and this case cannot tell
+    /// the two comparisons apart.
+    #[test]
+    fn a_commit_refuses_a_declaration_the_sealed_bytes_add_that_the_graph_lacks() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+
+        commit_then_move_bytes_without_reparsing(&init, &graph, &blobs, SESSIONS_APPENDED);
+
+        let refusal = plan_native_commit(
+            &init.layout,
+            &graph,
+            &blobs,
+            OperationId::new(),
+            fixed_timestamp(),
+            AuthorId::new("commitrace"),
+            "publish the appended declaration".to_string(),
+        );
+        let Some(error) = refusal.err() else {
+            panic!(
+                "the commit sealed bytes carrying a declaration the graph holds no entity for, so \
+                 the file answers as though that declaration is not there"
+            );
+        };
+        assert!(
+            error.to_string().contains("sessions.py"),
+            "the refusal has to name the path: {error}"
+        );
+    }
+
+    /// The same commit plans once the re-derivation has landed.
+    ///
+    /// The positive control for the test above. Without it a barrier that
+    /// refused every commit would pass, and the refusal has to clear itself the
+    /// moment the graph agrees with its own tree.
+    #[test]
+    fn a_commit_plans_the_edit_once_its_semantics_have_been_re_derived() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+
+        let held = commit_then_move_bytes_without_reparsing(&init, &graph, &blobs, SESSIONS_AFTER);
+        replace_entities_in_graph(&graph, &blobs, "sessions.py", &held, SESSIONS_AFTER);
+
+        let plan = plan_native_commit(
+            &init.layout,
+            &graph,
+            &blobs,
+            OperationId::new(),
+            fixed_timestamp(),
+            AuthorId::new("commitrace"),
+            "publish the edit".to_string(),
+        )
+        .expect("a path whose semantics were re-derived from its own bytes must commit");
+        assert_eq!(
+            plan.file_count, 1,
+            "the change still carries the one file whose bytes moved"
+        );
+        assert!(
+            plan.entity_count > 0,
+            "the re-derived spans must reach the change as entity deltas, or the commit is still \
+             recording bytes with no semantics"
+        );
     }
 }

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -1158,10 +1158,10 @@ pub(crate) enum SemanticCurrency {
 /// from, and the parse of it is compared against the entities the graph holds.
 /// Nothing here reads the working copy.
 ///
-/// Bounded to the tree delta, and inside it to the paths the change updates. A
-/// path this change adds carries no earlier parse to be stale against, so an
-/// import commit, whose delta is the whole tree, pays no parse at all; a path it
-/// removes seals no bytes.
+/// Bounded to the tree delta, and inside it to the paths [`SealedPathScope`]
+/// admits: a path the change removes seals no bytes and is never in scope, and a
+/// root change checks nothing at all, so an import commit whose delta is the
+/// whole tree pays no parse.
 pub(crate) fn paths_whose_semantics_the_sealed_bytes_do_not_reproduce(
     graph: &kin_db::InMemoryGraph,
     blobs: &kin_blobs::BlobStore,

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -1056,14 +1056,24 @@ pub(crate) fn carried_pending_paths(
 /// exactly where it was and changes the token stream, so `behavior_hash`, the
 /// hash of the entity's own source text, is the only field that moves. A
 /// comparison on spans alone would seal the second one.
+///
+/// Every entity carrying a span is keyed, whatever role it holds, because the
+/// role is the parser's verdict about the PATH rather than about whether the
+/// repository owns the entity: `kin_index::classify_file_role` stamps `Test` on
+/// everything parsed out of a test path, and `Vendored`, `Generated`, `Docs` and
+/// `External` on their own trees. Keeping only `EntityRole::Source` compared an
+/// empty key set against an empty key set for every one of those paths, so a
+/// stale test file passed whatever its bytes did. The role is part of the key
+/// too, so a file that moves into a test tree and re-parses under a new role
+/// does not read as unchanged.
 fn semantic_keys(entities: &[kin_model::Entity]) -> Vec<String> {
     let mut keys = entities
         .iter()
-        .filter(|entity| entity.role == kin_model::EntityRole::Source)
         .filter_map(|entity| {
             let span = entity.span.as_ref()?;
             Some(format!(
-                "{:?}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}",
+                "{:?}\u{1f}{:?}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}",
+                entity.role,
                 entity.kind,
                 entity.name,
                 span.start_byte,
@@ -1084,7 +1094,10 @@ fn semantic_keys(entities: &[kin_model::Entity]) -> Vec<String> {
 /// graph already held exactly where it was, with the same bytes, so a
 /// held-to-fresh scan finds all of them and reports nothing while the graph is
 /// missing an entity the change is about to seal bytes for.
-fn semantics_follow_the_bytes(held: &[kin_model::Entity], fresh: &[kin_model::Entity]) -> bool {
+pub(crate) fn semantics_follow_the_bytes(
+    held: &[kin_model::Entity],
+    fresh: &[kin_model::Entity],
+) -> bool {
     semantic_keys(held) == semantic_keys(fresh)
 }
 
@@ -1097,12 +1110,13 @@ fn semantics_follow_the_bytes(held: &[kin_model::Entity], fresh: &[kin_model::En
 /// leaves every declaration in it unanswerable. Both are the same defect seen
 /// from different sides, so both are checked.
 ///
-/// The exception is the ROOT change, which has no parent. Its delta is the whole
-/// tree, every path in it is added, and checking them would parse the entire
-/// repository at the one moment nothing has had a chance to go stale: the
-/// admission that derived those entities ran inside the same command. So an
-/// import pays no parse at all, and every commit after it stays bounded to its
-/// own changed paths rather than to the repository.
+/// The exception is the FIRST admission into a repository with no head at all.
+/// Its delta is the whole tree, every path in it is added, and checking them
+/// would parse the entire repository at the one moment nothing has had a chance
+/// to go stale: the admission that derived those entities ran inside the same
+/// command. So an import pays no parse at all, and every commit after it stays
+/// bounded to its own changed paths rather than to the repository. An amend of
+/// the root is not that case, however few parents it carries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SealedPathScope {
     /// Every path this change seals bytes for.
@@ -1367,7 +1381,13 @@ fn plan_native_commit_inner(
                     blobs,
                     &authority,
                     &deltas.tree_deltas,
-                    if parent.is_some() {
+                    // The EXISTING head, not this change's parentage. An
+                    // amend keeps its target's parents, so amending the root
+                    // produces a change with none while the repository has a
+                    // head, a published tree and every chance to have gone
+                    // stale. Reading parentage as proof of first admission let
+                    // a root amend seal whatever the graph held.
+                    if head.is_some() {
                         SealedPathScope::AddedAndUpdated
                     } else {
                         SealedPathScope::UpdatedOnly
@@ -4195,10 +4215,22 @@ mod tests {
         blobs: &kin_blobs::BlobStore,
         after: &[u8],
     ) -> Vec<kin_model::Entity> {
-        let artifact = add_artifact(graph, blobs, b"sessions.py", SESSIONS_BEFORE, |hash| {
+        commit_then_move_bytes_without_reparsing_at(init, graph, blobs, "sessions.py", after)
+    }
+
+    /// The same fixture at a path the caller names, so a test tree can be
+    /// exercised beside a production one.
+    fn commit_then_move_bytes_without_reparsing_at(
+        init: &kin_core::InitResult,
+        graph: &kin_db::InMemoryGraph,
+        blobs: &kin_blobs::BlobStore,
+        path: &str,
+        after: &[u8],
+    ) -> Vec<kin_model::Entity> {
+        let artifact = add_artifact(graph, blobs, path.as_bytes(), SESSIONS_BEFORE, |hash| {
             TreeEntry::blob(hash, false)
         });
-        let held = derive_entities_into_graph(graph, blobs, "sessions.py", SESSIONS_BEFORE);
+        let held = derive_entities_into_graph(graph, blobs, path, SESSIONS_BEFORE);
         let plan = plan_native_commit(
             &init.layout,
             graph,
@@ -4450,6 +4482,210 @@ mod tests {
     /// The positive control for the test above. Without it a barrier that
     /// refused every commit would pass, and the refusal has to clear itself the
     /// moment the graph agrees with its own tree.
+    /// A path the repository classifies as TEST is checked like any other.
+    ///
+    /// `kin_index::classify_file_role` gives every entity parsed out of a test
+    /// path the `Test` role, and a comparison that kept only `EntityRole::Source`
+    /// compared an empty key set against an empty key set for all of them, so a
+    /// test file passed the barrier whatever its bytes did. Those entities are
+    /// the repository's own, derived by the same parse from the same tree-named
+    /// body, and a test file sealed against semantics that describe older bytes
+    /// answers questions about declarations that are not there exactly as a
+    /// production file does.
+    ///
+    /// Falsify by restoring the `EntityRole::Source` filter in `semantic_keys`:
+    /// the plan comes back `Ok` and this assertion fails.
+    #[test]
+    fn a_commit_refuses_a_test_path_whose_semantics_the_sealed_bytes_do_not_reproduce() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+
+        let held = commit_then_move_bytes_without_reparsing_at(
+            &init,
+            &graph,
+            &blobs,
+            "tests/test_sessions.py",
+            SESSIONS_SAME_LENGTH,
+        );
+        // The premise, asserted rather than assumed: this path really does parse
+        // to Test-role entities, so the arm below exercises the roles the old
+        // filter dropped rather than passing for the ordinary reason.
+        assert!(
+            !held.is_empty()
+                && held
+                    .iter()
+                    .all(|entity| entity.role == kin_model::EntityRole::Test),
+            "the fixture must parse to Test-role entities: {:?}",
+            held.iter().map(|entity| entity.role).collect::<Vec<_>>()
+        );
+
+        let refusal = plan_native_commit(
+            &init.layout,
+            &graph,
+            &blobs,
+            OperationId::new(),
+            fixed_timestamp(),
+            AuthorId::new("commitrace"),
+            "publish the test file's edit".to_string(),
+        );
+        let Some(error) = refusal.err() else {
+            panic!(
+                "the commit sealed a test path's new bytes against entities derived from the old \
+                 ones; every declaration in it now answers from spans and bodies that describe \
+                 the previous version"
+            );
+        };
+        assert!(
+            error.to_string().contains("tests/test_sessions.py"),
+            "the refusal has to name the path: {error}"
+        );
+
+        // The positive control on the same path: once the re-derivation lands,
+        // the same commit plans, so the roles are not simply refused.
+        replace_entities_in_graph(
+            &graph,
+            &blobs,
+            "tests/test_sessions.py",
+            &held,
+            SESSIONS_SAME_LENGTH,
+        );
+        let plan = plan_native_commit(
+            &init.layout,
+            &graph,
+            &blobs,
+            OperationId::new(),
+            fixed_timestamp(),
+            AuthorId::new("commitrace"),
+            "publish the test file's edit".to_string(),
+        )
+        .expect("the same commit plans once the test path's semantics have caught up");
+        assert!(
+            !plan.change.entity_deltas.is_empty(),
+            "the re-derived commit has to carry the entity delta the refused one was missing"
+        );
+    }
+
+    /// A test path this change ADDS with no semantics at all is caught too.
+    ///
+    /// The Source-only filter dropped the fresh Test entities as well as the held
+    /// ones, so an added test file whose enrichment never landed compared empty
+    /// against empty and was sealed with nothing answering for it.
+    ///
+    /// Falsify by restoring the `EntityRole::Source` filter in `semantic_keys`:
+    /// the plan comes back `Ok` and this assertion fails.
+    #[test]
+    fn a_commit_refuses_a_new_test_path_the_graph_holds_no_semantics_for() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+
+        // One published file, so the change under test has a parent and is not
+        // the first admission, whose delta is the whole tree.
+        add_artifact(&graph, &blobs, b"sessions.py", SESSIONS_BEFORE, |hash| {
+            TreeEntry::blob(hash, false)
+        });
+        derive_entities_into_graph(&graph, &blobs, "sessions.py", SESSIONS_BEFORE);
+        let plan = plan_native_commit(
+            &init.layout,
+            &graph,
+            &blobs,
+            OperationId::new(),
+            fixed_timestamp(),
+            AuthorId::new("commitrace"),
+            "publish the first file".to_string(),
+        )
+        .expect("the first commit plans, so the refusal below is about the added path");
+        commit_native_plan_with_projection(&init.layout, &blobs, plan).unwrap();
+
+        // The bytes reach the tree and the enrichment does not, which is the
+        // state a lost derived-graph pass leaves behind.
+        add_artifact(
+            &graph,
+            &blobs,
+            b"tests/test_sessions.py",
+            SESSIONS_BEFORE,
+            |hash| TreeEntry::blob(hash, false),
+        );
+
+        let refusal = plan_native_commit(
+            &init.layout,
+            &graph,
+            &blobs,
+            OperationId::new(),
+            fixed_timestamp(),
+            AuthorId::new("commitrace"),
+            "publish the new test file".to_string(),
+        );
+        let Some(error) = refusal.err() else {
+            panic!(
+                "the commit sealed a new test file the graph holds no entity for, so every \
+                 declaration in it answers as though it is not there"
+            );
+        };
+        assert!(
+            error.to_string().contains("tests/test_sessions.py"),
+            "the refusal has to name the path: {error}"
+        );
+    }
+
+    /// Amending the ROOT change is not a first admission.
+    ///
+    /// An amend keeps its target's parents, so amending the root produces a
+    /// change with none while the repository has a head, a published tree and
+    /// every chance to have gone stale since. A scope keyed on the change's own
+    /// parentage read that as the import case and checked nothing, so this exact
+    /// one-commit repository could seal the replacement root over stale spans.
+    ///
+    /// Falsify by restoring the `parent.is_some()` discriminator in
+    /// `plan_native_commit_inner`: the plan comes back `Ok` and this assertion
+    /// fails.
+    #[test]
+    fn an_amend_of_the_root_refuses_a_path_whose_semantics_the_sealed_bytes_do_not_reproduce() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+
+        let artifact = add_artifact(&graph, &blobs, b"sessions.py", SESSIONS_BEFORE, |hash| {
+            TreeEntry::blob(hash, false)
+        });
+        derive_entities_into_graph(&graph, &blobs, "sessions.py", SESSIONS_BEFORE);
+        let plan = plan_native_commit(
+            &init.layout,
+            &graph,
+            &blobs,
+            OperationId::new(),
+            fixed_timestamp(),
+            AuthorId::new("commitrace"),
+            "publish the root".to_string(),
+        )
+        .expect("the root commit plans, so the refusal below is about the amend");
+        let root_change = commit_native_plan_with_projection(&init.layout, &blobs, plan)
+            .unwrap()
+            .change
+            .id;
+
+        // The same lost-enrichment window as the ordinary commit case: the bytes
+        // move in the tree and no parse follows them.
+        update_artifact_bytes(&graph, &blobs, &artifact, SESSIONS_AFTER);
+
+        let refusal = plan_amend_for_test(&init, &blobs, &graph, root_change, None);
+        let Some(error) = refusal.err() else {
+            panic!(
+                "the amend sealed the replacement root over entities derived from the pre-edit \
+                 bytes, because its own parentage is empty by design and that was read as proof \
+                 nothing had gone stale yet"
+            );
+        };
+        assert!(
+            error.to_string().contains("sessions.py"),
+            "the refusal has to name the path: {error}"
+        );
+    }
+
     #[test]
     fn a_commit_plans_the_edit_once_its_semantics_have_been_re_derived() {
         let root = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## The defect

A commit plans its tree half and its entity half out of one live graph, and that graph is
allowed to be behind itself. An exact-tree admission moves a path's bytes into repository
authority on its own; the parse that re-derives that path's entities runs afterwards, is a
derived-graph mutation no change carries, and does not survive the daemon that ran it. A
commit planned inside that window seals the new bytes against spans derived from the old
ones and reports no entity delta at all.

`loop_runner` already names the class in the comment above its own semantic-debt drain: an
empty transition means the working copy and the graph agree about bytes, not that the graph
agrees with itself. That drain repairs the paths some writer recorded. This refuses the ones
nobody did, and one observed run reached it with no debt row at all: a daemon was killed, the
next one's startup layout backfill found the staleness by comparing spans against a fresh
parse of the tree's own bytes, published a partial layout and enqueued an ordinary host
event, recording nothing. The commit that ran 34 seconds later sealed the tree delta against
the pre-edit spans, and the pending re-derivation landed 70 seconds after planning finished.

## The check

`plan_native_commit_inner` verifies, before it seals anything, that a parse of the bytes it
is about to seal reproduces the entities the graph holds for those paths. It reads the
resolved tree and the content-addressed body that tree names, through the same
`read_publishable_source` the publication itself uses, and never the working copy.

The comparison is a sorted multiset of role, kind, name, start_byte, end_byte and
`behavior_hash`, compared for equality, which is both directions at once. Spans alone would
pass a same-length body edit, `return 1` becoming `return 9`, where every span is correct and
only the token stream under it moves. One direction alone would pass a declaration the parse
adds and the graph lacks. Ids are absent because the reconciler keeps them stable across an
edit that moves an entity, so ids agree exactly when the store is stale.

Every entity carrying a span is keyed whatever role it holds, because `classify_file_role`
stamps the role of the PATH on everything the parser produces: a test tree, a vendored tree
or a generated one. Keeping only `EntityRole::Source` compared an empty key set against an
empty key set for all of them.

Bounded three ways. Only paths in this change's tree delta, only the ones it seals bytes for,
and only when the graph it plans from is one the daemon keeps current. The FIRST admission
into a repository with no head checks nothing at all, so an import whose delta is the whole
tree pays no parse; an amend of the root is not that case however few parents it carries,
which is why the discriminator is the existing head rather than the change's parentage.

Three cases are deliberately not refusals. A body neither store holds, which the publication
already refuses by name. A path whose bytes are opaque, which owns no source spans. And
source the parser could not read whole, which keeps the spans its last readable version
produced: the daemon reconciles under `ReconcilePolicy::FallbackToLkg`, an author mid-edit
produces that constantly, and refusing on it would leave a caller holding one broken file
unable to record anything, which is the outcome the semantic-debt drain already declines to
produce.

`SemanticCurrency` scopes the check to the daemon's live derived graph, which is the CLI
commit route. The MCP from-base planners pass `AuthoritySnapshot` and are not checked: they
plan from repository authority's own workspace snapshot, where a carried pending file holds
its pre-edit entities by design and nothing on that path re-derives them. This covers the CLI
commit route, the surface the observed failure exercised and the only one that can repair
itself.

## The repair, and what guarantees the outcome

`/commands/commit` takes one bounded re-derivation of exactly the refused paths through
`readmit_semantics_for_paths`, the seam the debt drain uses, under the coordination gate the
commit already holds, then plans again. Once, not in a loop: a second refusal is the store
saying the parse will not settle from here, and asking again until it does would hold the
gate for as long as the caller waits. It leaves as a 409 `semantics_behind_tree` naming the
paths, and nothing is written.

The re-derivation is best effort and the planner is the guarantee.

That re-derivation reads ingestion staging and the detector reads staging plus repository
CAS, so the exact tree-named bodies of the refused paths are re-ingested from the durable
store first. Staging is disposable: without the refill, a store reopened after its staged
copies were pruned reached the repair with every body durable and none staged, the
re-derivation failed its read, the second plan refused identically, and no later commit could
change that.

## Falsification

Eight arms. Each mutates the check and never an assertion, runs only the test that mutation
must redden, then restores both files from a byte copy taken before the run and proves byte
identity with `cmp`. Three of them, F, G and H, are also the red-first evidence for the
regressions added in this PR, because each restores exactly the behaviour its finding
described.

```
CONTROL   no mutation                                       13 passed; 0 failed   RC=0
ARM A     remove the refusal from plan_native_commit_inner  1 failed              RC=101
ARM B     drop behavior_hash from the comparison key        1 failed              RC=101
ARM C     compare one direction only, held into fresh       1 failed              RC=101
ARM D     re-derive nothing in command_commit               1 failed              RC=101
ARM E     drop added paths from the sealed-path scope       1 failed              RC=101
ARM F     restore the EntityRole::Source filter             2 failed              RC=101
ARM G     restore the parent.is_some() discriminator        1 failed              RC=101
ARM H     remove the repository-CAS refill                  1 failed              RC=101
RESTORED  no mutation                                       13 passed; 0 failed   RC=0
repository_commit.rs identical / api.rs identical   after every arm
```

Script and full log, byte-identical copies kept beside the report at
`.kin-coord/reports/commitrace2-evidence-50fa8e07e/commitrace2-arms.sh` and
`.kin-coord/reports/commitrace2-evidence-50fa8e07e/commitrace2-arms.log`.

Tails, one per arm:

```
ARM A  a_commit_refuses_a_path_whose_semantics_the_sealed_bytes_do_not_reproduce
       panicked at crates/kin-daemon/src/repository_commit.rs:4281:13
       test result: FAILED. 0 passed; 1 failed; 1470 filtered out; finished in 1.19s

ARM B  a_commit_refuses_a_same_length_body_edit_its_semantics_did_not_follow
       panicked at crates/kin-daemon/src/repository_commit.rs:4426:13
       test result: FAILED. 0 passed; 1 failed; 1470 filtered out; finished in 1.32s

ARM C  a_declaration_the_graph_is_missing_does_not_follow_the_bytes
       panicked at crates/kin-daemon/src/repository_commit.rs:4390:9
       test result: FAILED. 0 passed; 1 failed; 1470 filtered out; finished in 0.99s

ARM D  a_commit_re_derives_a_stale_path_no_debt_row_ever_named
       assertion `left == right` failed: {"error":"semantics_behind_tree", ... "paths":["shifted.rs"]}
       test result: FAILED. 0 passed; 1 failed; 1470 filtered out; finished in 1.96s

ARM E  a_commit_refuses_a_new_source_path_the_graph_holds_no_semantics_for
       panicked at crates/kin-daemon/src/repository_commit.rs:4342:13
       test result: FAILED. 0 passed; 1 failed; 1470 filtered out; finished in 1.25s

ARM F  a_commit_refuses_a_new_test_path_the_graph_holds_no_semantics_for
       a_commit_refuses_a_test_path_whose_semantics_the_sealed_bytes_do_not_reproduce
       test result: FAILED. 0 passed; 2 failed; 1469 filtered out; finished in 2.03s

ARM G  an_amend_of_the_root_refuses_a_path_whose_semantics_the_sealed_bytes_do_not_reproduce
       panicked at crates/kin-daemon/src/repository_commit.rs:4677:13
       test result: FAILED. 0 passed; 1 failed; 1470 filtered out; finished in 2.69s

ARM H  a_commit_re_derives_a_stale_path_whose_body_only_repository_cas_holds
       assertion `left == right` failed: {"error":"semantics_behind_tree", ... "paths":["shifted.rs"]}
       test result: FAILED. 0 passed; 1 failed; 1470 filtered out; finished in 1.50s
```

One earlier arm did NOT go red and is recorded because of it. Appending a declaration to the
fixture moves the preceding declaration's own key, so a one-way scan already reports the
difference and the appended-declaration commit test passes either way. The direction claim
therefore has its own test at the level where it can be stated exactly, entities parsed from
the fixture compared against the same set minus its last member, and that is the test ARM C
reddens.

## The touched fixtures, so they are not read as weakened

The barrier reddened 25 existing tests, all from two helpers that seeded a path's bytes with
no semantics at all, which is the defect state hand-built rather than an ordinary installed
file. `install_repository_entry` now derives what it installs through `kin_index` when the
content classifies as entity source, leaving every non-source path untouched, and the
staging-loss pair derives its second file through the shared helper.

That left five, and then two more, from a different cause: a fixture that ALSO upserted a
hand-made entity for the same name on the same path now held each definition twice, which is
a graph the daemon never produces. Measured rather than argued, a real Python file derives
its own module beside its functions, so `orphan` named three entities and a descriptive
query naming `config` matched the module of `src/config.py` by name. Each fixture takes the
entity its install derived, through one shared reader. No expectation was moved to fit the
barrier and no assertion was weakened.

Two of those are worth naming. The semantic-locate degradation pair builds an unreadable
entity out of a corrupted span; a readable second entity of the same name outranked it and
the page reported no degradation at all, so the derived entity is corrupted now rather than
joined by a twin. And a trace focal that must reach nothing is the module of a file that
declares nothing, because the context builder fills an empty dependency walk with same-file
neighbours and the trace's absence qualifier prints only while that group is empty.

## A defect this surfaced and does not fix

`purge_ignored_evicts_the_entities_that_made_a_path_rank` was the one failure that was not a
duplicate, and the cause is not the barrier. `publish_workspace_tree` carries
`WorkspaceSemanticDelta::default()`, so a workspace tree publication that retires a path
whose authority graph holds entities strands them and kin-db refuses the whole transition.
The session-admission path in the same module already carries `retire_semantics_on_vacated`
over its vacated set; the tree publication does not, and every caller of
`publish_exact_workspace_tree` inherits the gap, including the watch loop's standalone
admission. That is FIR-3274 and it has its own PR.

Until it lands, `purge-ignored` over a committed entity-owning path still refuses. The class
is carried here rather than concealed, as
`purge_ignored_retires_the_entities_a_commit_published_for_a_vacated_path`, ignored with that
ticket in its reason so the suite stays green, and the fixture under test admits its path
through the daemon's own `/commands/admit`, which is the state a purge actually runs against:
bytes in repository authority, entities in the live graph, no commit publishing a semantic
delta for them.

## Overlap

`api.rs` also carries hunks from kin #1546 and the branch is rebased onto main at d3a1032a6,
which includes #1546, #1548 and #1550. The gates below ran on the rebased tree.

## Gates, all on the rebased tree at 50fa8e07e

```
$ bin/kin-precheck kin --repo-dir kin=<worktree>
kin-precheck: repo=kin tree=<worktree> sha=50fa8e07ed7da484e4710e8e83d46f10a386cf5e branch=<branch>
kin-precheck: behind origin/main 0 commit(s)
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
...
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 50fa8e07ed7da484e4710e8e83d46f10a386cf5e
PRECHECK_RC=0
```

```
$ cargo test -p kin-daemon --lib
test result: ok. 1485 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 297.46s
FULL_RC=0
```

One full run before the rebase reported a single failure,
`commit_liveness::tests::an_open_transaction_reads_as_open_for_its_own_pid_and_absent_for_another`,
reading `materialize_graph_section` where it wanted `plan_transaction`. Three isolation runs
on this tree pass:

```
$ cargo test -p kin-daemon --lib -- --exact commit_liveness::tests::an_open_transaction_reads_as_open_for_its_own_pid_and_absent_for_another
test result: ok. 1 passed; 0 failed   (x3, LIVENESS_1_RC=0 LIVENESS_2_RC=0 LIVENESS_3_RC=0)
```

The mechanism is in that test's own comment: the open transaction lives in one process-wide
slot, and any concurrent commit's phase timer writes into it. It is a property of the
single-process `cargo test` binary and cannot occur under nextest, which CI runs and which
gives every test its own process.
