### PR TITLE
Preserve identities across retained session moves (FIR-3278)

### DIFF
--- a/crates/kin-cli/src/commands/reconcile.rs
+++ b/crates/kin-cli/src/commands/reconcile.rs
@@ -16,9 +16,9 @@ use std::io::Read as _;
 use std::path::{Component, Path, PathBuf};
 
 use anyhow::{anyhow, bail, Context, Result};
-use kin_model::{ArtifactId, Hash256, RepoPath, ResolvedTree, TreeDelta};
 #[cfg(any(unix, test))]
-use kin_model::{ResolvedArtifact, TreeEntry};
+use kin_model::TreeEntry;
+use kin_model::{ArtifactId, Hash256, RepoPath, ResolvedTree, TreeDelta};
 use serde::{Deserialize, Serialize};
 
 #[cfg(unix)]
@@ -465,18 +465,18 @@ fn build_desired_tree(base: &SessionWorkspaceBase, scan: &SessionScan) -> Result
         .copied()
         .collect::<BTreeSet<_>>();
     let scoped = base.scope.is_some();
-    let mut by_path = base
+    let mut observed = base
         .source_workspace
         .tree
         .artifacts_by_path()
         .filter(|artifact| !materialized.contains(&artifact.artifact_id))
-        .map(|artifact| (artifact.path.clone(), artifact.clone()))
+        .map(|artifact| (artifact.path.clone(), artifact.entry))
         .collect::<BTreeMap<_, _>>();
 
-    for (path, observed) in &scan.entries {
+    for (path, entry) in &scan.entries {
         let existing = base.source_workspace.tree.artifact_at_path(path);
-        let artifact_id = match existing {
-            Some(existing) if materialized.contains(&existing.artifact_id) => existing.artifact_id,
+        match existing {
+            Some(existing) if materialized.contains(&existing.artifact_id) => {}
             Some(existing) => {
                 bail!(
                     "session observation attempted to mutate unmaterialized artifact {} ({})",
@@ -487,15 +487,23 @@ fn build_desired_tree(base: &SessionWorkspaceBase, scan: &SessionScan) -> Result
             None if scoped => {
                 bail!("scoped session cannot add artifact {path} outside its retained capability")
             }
-            None => deterministic_added_artifact_id(base.reconcile_operation_id, path),
-        };
-        by_path.insert(
-            path.clone(),
-            ResolvedArtifact::new(artifact_id, path.clone(), observed.entry),
-        );
+            None => {}
+        }
+        observed.insert(path.clone(), entry.entry);
     }
 
-    ResolvedTree::from_artifacts(by_path.into_values())
+    let mut deltas = kin_core::plan_observed_tree_deltas(&base.source_workspace.tree, observed)?;
+    // The shared planner retains unique moves and refuses ambiguous identity.
+    // New members additionally need session-stable identity so observing the
+    // same retained directory twice reconstructs the same transaction.
+    for delta in &mut deltas {
+        if let TreeDelta::Added { artifact_id, new } = delta {
+            *artifact_id = deterministic_added_artifact_id(base.reconcile_operation_id, &new.path);
+        }
+    }
+    base.source_workspace
+        .tree
+        .apply(&deltas)
         .map_err(|error| anyhow!("build complete desired session tree: {error}"))
 }
 
@@ -1068,6 +1076,7 @@ fn require_directory_identity(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use kin_model::ResolvedArtifact;
 
     #[test]
     fn byte_safe_paths_never_require_lossy_utf8() {

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6304,6 +6304,7 @@ async fn reconcile_session_workspace(
         )
         .map_err(repository_commit_error)?;
         let vacated = plan.vacated.clone();
+        let module_relocations = plan.module_relocations.clone();
         let committed = crate::repository_commit::commit_session_workspace_admission(
             &state.layout,
             state.blobs.as_ref(),
@@ -6343,12 +6344,28 @@ async fn reconcile_session_workspace(
             // here was refused after authority had already moved, leaving the
             // two graphs holding different trees. Targeted reads rather than a
             // snapshot of the whole store, which this path cannot afford.
-            let (retired_entity_deltas, retired_relation_deltas) =
+            let (mut retired_entity_deltas, retired_relation_deltas) =
                 crate::repository_commit::retire_live_semantics_on_vacated(
                     state.graph.as_ref(),
                     &vacated,
                 )
                 .map_err(repository_commit_error)?;
+            let moves = crate::repository_commit::session_artifact_moves(observation.deltas());
+            for (from, to) in &moves {
+                retired_entity_deltas.extend(
+                    crate::repository_commit::plan_session_entity_relocations(
+                        state.graph.as_ref(),
+                        from,
+                        to,
+                    )
+                    .map_err(repository_commit_error)?,
+                );
+            }
+            crate::repository_commit::bind_session_module_relocations(
+                &mut retired_entity_deltas,
+                &module_relocations,
+            )
+            .map_err(repository_commit_error)?;
             state
                 .graph
                 .apply_transaction_delta(&TransactionDelta {
@@ -6358,6 +6375,24 @@ async fn reconcile_session_workspace(
                     ..TransactionDelta::default()
                 })
                 .map_err(internal_error)?;
+            // Destination facets are re-derived below from exact admitted
+            // bytes. Clear only departed keys; a swap's keys still belong to
+            // surviving artifacts and must not erase each other's records.
+            for (from, _) in &moves {
+                let old_path = RepoPath::from_utf8(from.0.clone()).map_err(internal_error)?;
+                if observation
+                    .desired_tree()
+                    .artifact_at_path(&old_path)
+                    .is_none()
+                {
+                    crate::loop_runner::clear_incompatible_facets_in(
+                        state.graph.as_ref(),
+                        from,
+                        crate::loop_runner::EnrichmentFacet::None,
+                    )
+                    .map_err(internal_error)?;
+                }
+            }
             for delta in &retired_entity_deltas {
                 let kin_model::EntityDelta::Removed { old } = delta else {
                     continue;
@@ -19231,6 +19266,8 @@ fn bind_std_listener(
 
 #[cfg(test)]
 mod tests {
+    mod session_identity;
+    mod session_move_identity;
     /// THE WIRING SPINE (FIR-2524, captain's rider). The envelope the impact
     /// route hands the CLI must carry the daemon's degraded signals.
     ///

--- a/crates/kin-daemon/src/api/tests/session_identity.rs
+++ b/crates/kin-daemon/src/api/tests/session_identity.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+#![cfg(unix)]
+
+use super::*;
+use anyhow::Result;
+use kin_cli::commands::reconcile::{observe_session_workspace, SessionReconcileObservation};
+use kin_cli::commands::session_workspace::SessionWorkspaceBase;
+use kin_model::TreeDelta;
+
+async fn retained_fixture() -> (
+    tempfile::TempDir,
+    Arc<DaemonState>,
+    PathBuf,
+    SessionWorkspaceBase,
+) {
+    let repo = tempfile::tempdir().unwrap();
+    let layout = kin_core::init(repo.path()).unwrap().layout;
+    let state = Arc::new(DaemonState::open(layout).unwrap());
+    state
+        .is_initialized
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    std::fs::write(repo.path().join("old.rs"), b"pub fn moved() {}\n").unwrap();
+    std::fs::write(repo.path().join("keep.rs"), b"pub fn keep() {}\n").unwrap();
+    let app = router(Arc::clone(&state));
+    commit_through_api(
+        &app,
+        kin_model::OperationId::new(),
+        "admit identity fixture",
+    )
+    .await;
+    let session = state.layout.runs_dir().join("session-identity");
+    materialize_session_through_api(&app, &session).await;
+    let base =
+        serde_json::from_slice(&std::fs::read(session.join(".kin-session/base.json")).unwrap())
+            .unwrap();
+    (repo, state, session, base)
+}
+
+fn observe(state: &DaemonState, session: &std::path::Path) -> Result<SessionReconcileObservation> {
+    let binding = state.local_repository_authority_binding()?;
+    observe_session_workspace(
+        &state.layout,
+        &binding,
+        session,
+        state.blobs.as_ref(),
+        false,
+    )
+}
+
+#[tokio::test]
+#[serial_test::serial(commit_phase_capture)]
+async fn session_identity_matches_unique_move_and_preserves_unchanged_path() {
+    let (_repo, layout, session, base) = retained_fixture().await;
+    std::fs::rename(session.join("old.rs"), session.join("new.rs")).unwrap();
+    let observation = observe(&layout, &session).unwrap();
+    let before = base
+        .source_workspace
+        .tree
+        .artifact_at_path(&RepoPath::from_utf8("old.rs").unwrap())
+        .unwrap();
+    let moved = observation
+        .desired_tree()
+        .artifact_at_path(&RepoPath::from_utf8("new.rs").unwrap())
+        .unwrap();
+    assert_eq!(
+        moved.artifact_id, before.artifact_id,
+        "a retained-scanner move must keep identity"
+    );
+    assert!(matches!(observation.deltas(), [TreeDelta::Updated { .. }]));
+    let keep = RepoPath::from_utf8("keep.rs").unwrap();
+    assert_eq!(
+        observation.desired_tree().artifact_at_path(&keep),
+        base.source_workspace.tree.artifact_at_path(&keep)
+    );
+    assert_eq!(
+        observe(&layout, &session).unwrap().desired_tree(),
+        observation.desired_tree()
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(commit_phase_capture)]
+async fn session_identity_refuses_ambiguous_duplicate_destinations() {
+    let (_repo, layout, session, _base) = retained_fixture().await;
+    std::fs::rename(session.join("old.rs"), session.join("new.rs")).unwrap();
+    std::fs::copy(session.join("new.rs"), session.join("duplicate.rs")).unwrap();
+    let error = observe(&layout, &session)
+        .err()
+        .expect("two identical destinations must not guess a moved identity");
+    assert!(
+        error
+            .to_string()
+            .contains("ambiguous repository identity transition"),
+        "{error:#}"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(commit_phase_capture)]
+async fn session_identity_preserves_changed_path_and_keeps_unmatched_addition_distinct() {
+    let (_repo, layout, session, base) = retained_fixture().await;
+    std::fs::write(
+        session.join("keep.rs"),
+        b"pub fn keep() { let edited = 1; }\n",
+    )
+    .unwrap();
+    std::fs::remove_file(session.join("old.rs")).unwrap();
+    std::fs::write(session.join("new.rs"), b"pub fn different() {}\n").unwrap();
+    let observation = observe(&layout, &session).unwrap();
+    let keep = RepoPath::from_utf8("keep.rs").unwrap();
+    assert_eq!(
+        observation
+            .desired_tree()
+            .artifact_at_path(&keep)
+            .unwrap()
+            .artifact_id,
+        base.source_workspace
+            .tree
+            .artifact_at_path(&keep)
+            .unwrap()
+            .artifact_id
+    );
+    let old = base
+        .source_workspace
+        .tree
+        .artifact_at_path(&RepoPath::from_utf8("old.rs").unwrap())
+        .unwrap();
+    assert!(
+        observation.desired_tree().get(&old.artifact_id).is_none(),
+        "unmatched deletion must not become a guessed move"
+    );
+    let new_path = RepoPath::from_utf8("new.rs").unwrap();
+    assert_ne!(
+        observation
+            .desired_tree()
+            .artifact_at_path(&new_path)
+            .unwrap()
+            .artifact_id,
+        old.artifact_id
+    );
+    assert_eq!(
+        observe(&layout, &session).unwrap().desired_tree(),
+        observation.desired_tree(),
+        "additions must remain retry-stable"
+    );
+}

--- a/crates/kin-daemon/src/api/tests/session_move_identity.rs
+++ b/crates/kin-daemon/src/api/tests/session_move_identity.rs
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+use super::*;
+
+fn sole_entity(state: &DaemonState, path: &str) -> Entity {
+    let entities = state
+        .graph
+        .query_entities(&kin_db::EntityFilter {
+            file_path: Some(FilePathId::new(path)),
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(
+        entities.len(),
+        1,
+        "one parsed entity at {path}: {entities:?}"
+    );
+    entities[0].clone()
+}
+
+fn assert_moved_identity(
+    state: &DaemonState,
+    entity: &Entity,
+    artifact: kin_model::ArtifactId,
+    incoming: &kin_model::Relation,
+    deleted: &Entity,
+) {
+    let moved = state
+        .graph
+        .get_entity(&entity.id)
+        .unwrap()
+        .expect("session move must preserve the original entity identity");
+    assert_eq!(moved.file_origin, Some(FilePathId::new("new.rs")));
+    assert_eq!(moved.span.as_ref().unwrap().file, FilePathId::new("new.rs"));
+    assert_eq!(sole_entity(state, "new.rs").id, entity.id);
+    assert_eq!(
+        state
+            .graph
+            .resolved_tree()
+            .artifact_at_path(&RepoPath::from_utf8("new.rs").unwrap())
+            .unwrap()
+            .artifact_id,
+        artifact,
+        "the move must preserve artifact identity"
+    );
+    assert!(state
+        .graph
+        .resolved_tree()
+        .artifact_at_path(&RepoPath::from_utf8("old.rs").unwrap())
+        .is_none());
+    assert!(
+        state.graph.get_entity(&deleted.id).unwrap().is_none(),
+        "a true deletion must still retire its entity"
+    );
+    assert!(
+        state
+            .graph
+            .resolved_tree()
+            .artifact_at_path(&RepoPath::from_utf8("earlier.rs").unwrap())
+            .is_none(),
+        "replay must not resurrect a deletion already in the retained overlay"
+    );
+    assert_eq!(
+        state
+            .graph
+            .get_all_relations_for_node(&incoming.dst)
+            .unwrap()
+            .iter()
+            .find(|edge| edge.id == incoming.id),
+        Some(incoming),
+        "the incoming edge must keep its identity and endpoints"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+#[serial_test::serial(commit_phase_capture)]
+async fn session_move_preserves_path_named_module_identity() {
+    let repo = tempfile::tempdir().unwrap();
+    let layout = kin_core::init(repo.path()).unwrap().layout;
+    let state = Arc::new(DaemonState::open(layout.clone()).unwrap());
+    state
+        .is_initialized
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    std::fs::write(repo.path().join("old.py"), "def moved():\n    return 7\n").unwrap();
+    let app = router(Arc::clone(&state));
+    commit_through_api(&app, kin_model::OperationId::new(), "publish Python module").await;
+    let before = state
+        .graph
+        .query_entities(&kin_db::EntityFilter {
+            file_path: Some(FilePathId::new("old.py")),
+            ..Default::default()
+        })
+        .unwrap();
+    assert!(
+        before
+            .iter()
+            .any(|entity| entity.kind == EntityKind::Module),
+        "the fixture must include the path-named module"
+    );
+    assert!(before
+        .iter()
+        .any(|entity| entity.kind == EntityKind::Function));
+    let session = layout.runs_dir().join("session-module-identity");
+    materialize_session_through_api(&app, &session).await;
+    std::fs::rename(session.join("old.py"), session.join("new.py")).unwrap();
+    reconcile_session_through_api(&app, &session).await;
+    for original in &before {
+        let moved = state
+            .graph
+            .get_entity(&original.id)
+            .unwrap()
+            .unwrap_or_else(|| panic!("the move lost {:?} {}", original.kind, original.name));
+        assert_eq!(moved.file_origin, Some(FilePathId::new("new.py")));
+    }
+    reconcile_session_through_api(&app, &session).await;
+    drop(app);
+    drop(state);
+    let state = Arc::new(DaemonState::open(layout.clone()).unwrap());
+    state
+        .is_initialized
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    crate::loop_runner::drain_semantic_debt(&state)
+        .await
+        .unwrap();
+    let app = router(Arc::clone(&state));
+    commit_through_api(&app, kin_model::OperationId::new(), "publish module move").await;
+    drop(app);
+    drop(state);
+    let cold = DaemonState::open(layout).unwrap();
+    for original in &before {
+        let moved = cold
+            .graph
+            .get_entity(&original.id)
+            .unwrap()
+            .expect("module identity must survive cold commit history");
+        assert_eq!(moved.file_origin, Some(FilePathId::new("new.py")));
+        assert_eq!(moved.span.as_ref().unwrap().file, FilePathId::new("new.py"));
+        if original.kind == EntityKind::Module {
+            assert_eq!(
+                moved.name, "new",
+                "the module name must follow the real parser"
+            );
+        }
+    }
+}
+
+async fn assert_session_refused_without_advancing(
+    state: &Arc<DaemonState>,
+    app: &axum::Router,
+    session: &PathBuf,
+) {
+    let roots = ActiveApiRepositoryAuthority::open(state)
+        .unwrap()
+        .manager
+        .read_authority()
+        .roots()
+        .clone();
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post("/reconcile")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({"session_dir": session, "confirm_mass_deletion": false}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), 128 * 1024)
+        .await
+        .unwrap();
+    assert!(
+        status.is_client_error(),
+        "changed or superseded session must be refused: {status} {}",
+        String::from_utf8_lossy(&body)
+    );
+    assert_eq!(
+        ActiveApiRepositoryAuthority::open(state)
+            .unwrap()
+            .manager
+            .read_authority()
+            .roots(),
+        &roots
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+#[serial_test::serial(commit_phase_capture)]
+async fn session_move_preserves_identity_through_admission_commit_and_two_cold_reopens() {
+    let repo = tempfile::tempdir().unwrap();
+    let layout = kin_core::init(repo.path()).unwrap().layout;
+    let state = Arc::new(DaemonState::open(layout.clone()).unwrap());
+    state
+        .is_initialized
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    for (path, body) in [
+        ("caller.rs", "pub fn caller() -> u32 { 1 }\n"),
+        ("old.rs", "pub fn moved() -> u32 { 2 }\n"),
+        ("deleted.rs", "pub fn deleted() -> u32 { 3 }\n"),
+        ("earlier.rs", "pub fn earlier() -> u32 { 4 }\n"),
+    ] {
+        std::fs::write(repo.path().join(path), body).unwrap();
+    }
+    let app = router(Arc::clone(&state));
+    commit_through_api(&app, kin_model::OperationId::new(), "publish source").await;
+    let original = sole_entity(&state, "old.rs");
+    let caller = sole_entity(&state, "caller.rs");
+    let deleted = sole_entity(&state, "deleted.rs");
+    let artifact = state
+        .graph
+        .resolved_tree()
+        .artifact_at_path(&RepoPath::from_utf8("old.rs").unwrap())
+        .unwrap()
+        .artifact_id;
+    let incoming = kin_model::Relation {
+        id: kin_model::RelationId::new(),
+        kind: RelationKind::Calls,
+        src: kin_model::GraphNodeId::Entity(caller.id),
+        dst: kin_model::GraphNodeId::Entity(original.id),
+        confidence: 1.0,
+        origin: kin_model::RelationOrigin::Manual,
+        created_in: None,
+        import_source: None,
+        evidence: Vec::new(),
+    };
+    state
+        .graph
+        .apply_transaction_delta(&TransactionDelta {
+            relation_deltas: vec![kin_model::RelationDelta::Added {
+                new: incoming.clone(),
+            }],
+            ..Default::default()
+        })
+        .unwrap();
+    commit_through_api(&app, kin_model::OperationId::new(), "publish incoming edge").await;
+    assert!(state
+        .graph
+        .get_all_relations_for_node(&incoming.dst)
+        .unwrap()
+        .contains(&incoming));
+
+    let earlier = layout.runs_dir().join("session-prior-deletion");
+    materialize_session_through_api(&app, &earlier).await;
+    std::fs::remove_file(earlier.join("earlier.rs")).unwrap();
+    reconcile_session_through_api(&app, &earlier).await;
+
+    let session_dir = layout.root().join("runs/session-move-identity");
+    materialize_session_through_api(&app, &session_dir).await;
+    std::fs::rename(session_dir.join("old.rs"), session_dir.join("new.rs")).unwrap();
+    std::fs::remove_file(session_dir.join("deleted.rs")).unwrap();
+    let summary = reconcile_session_through_api(&app, &session_dir).await;
+    eprintln!(
+        "real session move: added={} modified={} removed={}",
+        summary.added, summary.modified, summary.removed
+    );
+    assert_moved_identity(&state, &original, artifact, &incoming, &deleted);
+
+    let original_body = std::fs::read(session_dir.join("new.rs")).unwrap();
+    std::fs::write(session_dir.join("new.rs"), b"pub fn moved() -> u32 { 9 }\n").unwrap();
+    assert_session_refused_without_advancing(&state, &app, &session_dir).await;
+    std::fs::write(session_dir.join("new.rs"), original_body).unwrap();
+    assert_eq!(
+        (summary.added, summary.modified, summary.removed),
+        (0, 1, 1)
+    );
+    assert_eq!(sole_entity(&state, "caller.rs").id, caller.id);
+
+    let replay = reconcile_session_through_api(&app, &session_dir).await;
+    assert!(
+        replay.idempotent_replay,
+        "the identical retained move must recover its original receipt"
+    );
+    assert_eq!(replay.authority_generation, summary.authority_generation);
+    assert_moved_identity(&state, &original, artifact, &incoming, &deleted);
+
+    drop(app);
+    drop(state);
+    let reopened = Arc::new(DaemonState::open(layout.clone()).unwrap());
+    reopened
+        .is_initialized
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    assert_moved_identity(&reopened, &original, artifact, &incoming, &deleted);
+    crate::loop_runner::drain_semantic_debt(&reopened)
+        .await
+        .unwrap();
+    assert_moved_identity(&reopened, &original, artifact, &incoming, &deleted);
+    let app = router(Arc::clone(&reopened));
+    commit_through_api(&app, kin_model::OperationId::new(), "commit session move").await;
+    assert_moved_identity(&reopened, &original, artifact, &incoming, &deleted);
+    assert_session_refused_without_advancing(&reopened, &app, &session_dir).await;
+    drop(app);
+    drop(reopened);
+    let cold = Arc::new(DaemonState::open(layout).unwrap());
+    assert_moved_identity(&cold, &original, artifact, &incoming, &deleted);
+}

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -8772,14 +8772,9 @@ mod tests {
     /// a carried removal becomes reachable, so the arm it guards has something
     /// to guard.
     ///
-    /// A move is NOT a removal beside an addition, and an earlier version of
-    /// this comment said it was. `TreeDelta::Updated` carries an old and a new
-    /// state and nothing requires their paths to match, so a move is one delta
-    /// that keeps its artifact identity;
-    /// `a_pending_move_is_one_updated_delta_and_ambient_admission_refuses_it`
-    /// asserts that from the product's own tree correction. What a move shares
-    /// with a removal is only this refusal, because it vacates its old path the
-    /// same way.
+    /// A surviving artifact can move through one `TreeDelta::Updated`. Session
+    /// admission carries its entity relocations in the same transaction; the
+    /// move tests below cover that path through an MCP commit and cold reopen.
     #[test]
     fn ambient_admission_cannot_vacate_a_path_without_retiring_its_semantics() {
         let (_dir, state) = test_state();
@@ -9160,18 +9155,7 @@ mod tests {
         );
     }
 
-    /// Leave one working file moved the way a session leaves it, and hand back
-    /// whatever refused if something did.
-    ///
-    /// Same shape as the removal helper, and for the same reason: the ambient
-    /// publication path can refuse this, and which layer refuses is the answer
-    /// worth having rather than a panic.
-    /// The same tree with one artifact at a different path and the same
-    /// identity, which is what a move leaves behind.
-    ///
-    /// Built by naming the artifacts rather than by assembling the delta the
-    /// assertion is about, so the correction under test is derived from two
-    /// states rather than read back from an answer the fixture supplied.
+    /// Preserve each artifact identity while moving one path in the desired tree.
     fn moved_workspace_tree(
         tree: &kin_model::ResolvedTree,
         from: &RepoPath,
@@ -9188,224 +9172,236 @@ mod tests {
         .expect("moving one artifact keeps every identity and every path unique")
     }
 
-    fn admit_pending_working_tree_move(
-        state: &Arc<DaemonState>,
-        from: &str,
-        to: &str,
-    ) -> crate::error::Result<()> {
-        let from_path = RepoPath::from_utf8(from).unwrap();
-        let to_path = RepoPath::from_utf8(to).unwrap();
-        let working = state.layout.working_dir();
-        if let Some(parent) = working.join(to).parent() {
-            std::fs::create_dir_all(parent).unwrap();
+    fn move_incoming_edge(caller: &Entity, moved: &Entity) -> Relation {
+        Relation {
+            id: kin_model::RelationId::new(),
+            kind: kin_model::relation::RelationKind::Calls,
+            src: GraphNodeId::Entity(caller.id),
+            dst: GraphNodeId::Entity(moved.id),
+            confidence: 1.0,
+            origin: RelationOrigin::Manual,
+            created_in: None,
+            import_source: None,
+            evidence: Vec::new(),
         }
-        std::fs::rename(working.join(from), working.join(to)).unwrap();
-        let artifact = state
-            .graph
-            .resolved_tree()
-            .artifact_at_path(&from_path)
-            .cloned()
-            .expect("a move takes an already admitted artifact");
-        state.graph.apply_transaction_delta(&TransactionDelta {
-            tree_deltas: vec![TreeDelta::Updated {
-                artifact_id: artifact.artifact_id,
-                old: artifact.located_entry(),
-                new: LocatedEntry::new(to_path, artifact.entry),
-            }],
-            ..TransactionDelta::default()
-        })?;
-        try_publish_pending_workspace_tree(state)
     }
 
-    /// `TreeDelta::Updated` can carry a path change, and ambient admission
-    /// cannot publish the transition either way.
-    ///
-    /// An earlier comment in this module asserted the opposite, that a moved
-    /// path must arrive as a `Removed` beside an `Added` because `TreeDelta` has
-    /// no move variant. The variant count does not settle it: `Updated` carries
-    /// an old and a new state and nothing requires their paths to match, so the
-    /// carry code cannot assume it will see a pair, and this holds that where it
-    /// can see it.
-    ///
-    /// What follows from either shape is the same, and is the second half: the
-    /// old path ends with no artifact while its entities still stand there,
-    /// which is the transition repository authority refuses, in the same words
-    /// it refuses a pending deletion.
-    /// The scope of the first half is exactly the correction, and not the
-    /// scanner that feeds it. `exact_tree_correction` is handed two tree states
-    /// in which one artifact keeps its identity at a different path, and it
-    /// answers with a single `Updated` carrying both paths, which is what says
-    /// `TreeDelta::Updated` does not require its old and new paths to match.
-    /// Whether any particular scanner produces that input is a separate
-    /// question with a separate answer: a scanner that mints fresh identity for
-    /// the new path yields a `Removed` beside an `Added` instead. Both shapes
-    /// leave the old path with no artifact and its entities still standing,
-    /// which is the state the refusal below is about, so the second half holds
-    /// either way.
-    #[test]
-    fn a_relocated_artifact_corrects_to_one_updated_delta_ambient_admission_refuses() {
+    fn assert_carried_move_identity(
+        state: &DaemonState,
+        original: &Entity,
+        artifact: kin_model::ArtifactId,
+        incoming: &Relation,
+    ) {
+        let moved = state
+            .graph
+            .get_entity(&original.id)
+            .unwrap()
+            .expect("a carried move must preserve entity identity");
+        assert_eq!(moved.file_origin, Some(FilePathId::new("src/new.rs")));
+        assert_eq!(
+            moved.span.as_ref().unwrap().file,
+            FilePathId::new("src/new.rs")
+        );
+        assert_eq!(
+            state
+                .graph
+                .resolved_tree()
+                .artifact_at_path(&RepoPath::from_utf8("src/new.rs").unwrap())
+                .unwrap()
+                .artifact_id,
+            artifact
+        );
+        assert!(state
+            .graph
+            .resolved_tree()
+            .artifact_at_path(&RepoPath::from_utf8("src/old.rs").unwrap())
+            .is_none());
+        assert_eq!(
+            state
+                .graph
+                .get_all_relations_for_node(&incoming.dst)
+                .unwrap()
+                .iter()
+                .find(|edge| edge.id == incoming.id),
+            Some(incoming)
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial_test::serial(commit_phase_capture)]
+    async fn session_move_keeps_identity_and_incoming_edges_through_mcp_commit_and_reopen() {
+        use axum::{body::Body, http::Request};
+        use tower::ServiceExt;
+
         let (_dir, state) = test_state();
-        install_exact_source(
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let (caller, _) = install_exact_source(
             &state,
             "src/lib.rs",
             b"pub fn value() -> u8 { 1 }\n",
             "value",
         );
-        install_exact_source(
-            &state,
-            "src/old.rs",
-            b"pub fn moved() -> u8 { 1 }\n",
-            "moved",
-        );
-        let before = load_native_commit_base(&state.layout).unwrap();
-
-        // The tree transition a move actually produces, from the product's own
-        // correction rather than from a delta assembled to look like one.
-        let from_path = RepoPath::from_utf8("src/old.rs").unwrap();
-        let to_path = RepoPath::from_utf8("src/new.rs").unwrap();
-        let artifact = before
-            .tree
-            .artifact_at_path(&from_path)
-            .cloned()
-            .expect("the fixture installed this path");
-        let moved_tree = moved_workspace_tree(&before.tree, &from_path, &to_path);
-        let deltas = kin_core::exact_tree_correction(&before.tree, &moved_tree).unwrap();
-        assert_eq!(
-            deltas.len(),
-            1,
-            "an artifact that keeps its identity at a new path corrects to one delta: {deltas:#?}"
-        );
-        assert!(
-            matches!(
-                &deltas[0],
-                TreeDelta::Updated { artifact_id, old, new }
-                    if *artifact_id == artifact.artifact_id
-                        && old.path == from_path
-                        && new.path == to_path
-            ),
-            "and that delta is an Updated whose paths differ, so a path change is not necessarily \
-             a Removed beside an Added: {:#?}",
-            deltas[0]
-        );
-
-        let refusal = admit_pending_working_tree_move(&state, "src/old.rs", "src/new.rs")
-            .expect_err("authority must refuse a move whose old path's semantics still stand");
-        let message = refusal.to_string();
-        assert!(
-            message.contains("src/old.rs"),
-            "the refusal must name the path being vacated: {message}"
-        );
-        assert!(
-            message.contains("carry its exact entity removal or relocation in the same delta"),
-            "the refusal must say what a caller has to carry instead: {message}"
-        );
-        assert_eq!(
-            load_native_commit_base(&state.layout).unwrap().roots,
-            before.roots,
-            "no repository authority may move behind a refused admission"
-        );
-    }
-
-    /// The seam that CAN admit a move retires the moved path's identity before
-    /// any MCP commit could see it.
-    ///
-    /// This is the half the ambient refusal above does not settle. Session
-    /// admission carries the retirement the refusal demands, and it derives that
-    /// retirement from the vacated set rather than from a relocation: an entity
-    /// on the old path is removed outright, and so is every relation incident to
-    /// it. So a carried move reaches the MCP commit planner with the file at its
-    /// new path and no entities anywhere, which is why the derivation in this
-    /// module can make that file answerable again but cannot give it back the
-    /// identity it had. The loss happens here, in the admission, not in the
-    /// carry.
-    ///
-    /// Driven through the product's own `VacatedPaths::from_deltas` and
-    /// `retire_semantics_on_vacated`, which is what `plan_session_workspace_
-    /// admission` calls, rather than through a hand-built delta.
-    ///
-    /// **Every assertion here describes retirement, and retirement is not the
-    /// behaviour a preserved move identity would have.** The whole set inverts
-    /// under a relocating admission: the moved entity becomes an
-    /// `EntityDelta::Modified` carrying its original id at the new path, its
-    /// incident relations survive with both endpoints intact, and the assertion
-    /// that nothing relocates it becomes the failing one. Replace them together
-    /// when that is what the admission does. This test is a record of a
-    /// mechanism, not an argument that the mechanism is right.
-    #[test]
-    fn session_admission_retires_a_moved_path_identity_and_its_incoming_edges() {
-        let (_dir, state) = test_state();
-        let (caller, _) = install_exact_source(
-            &state,
-            "src/caller.rs",
-            b"pub fn caller() -> u8 { 1 }\n",
-            "caller",
-        );
         let (moved, _) = install_exact_source(
             &state,
             "src/old.rs",
-            b"pub fn moved() -> u8 { 1 }\n",
+            b"pub fn moved() -> u8 { 7 }\n",
             "moved",
         );
-        // An incoming edge, so the retirement's reach is asserted rather than
-        // assumed.
+        let artifact = state
+            .graph
+            .resolved_tree()
+            .artifact_at_path(&RepoPath::from_utf8("src/old.rs").unwrap())
+            .unwrap()
+            .artifact_id;
+        let incoming = move_incoming_edge(&caller, &moved);
         state
             .graph
             .apply_transaction_delta(&TransactionDelta {
                 relation_deltas: vec![RelationDelta::Added {
-                    new: Relation {
-                        id: kin_model::RelationId::new(),
-                        kind: kin_model::relation::RelationKind::Calls,
-                        src: GraphNodeId::Entity(caller.id),
-                        dst: GraphNodeId::Entity(moved.id),
-                        confidence: 1.0,
-                        origin: RelationOrigin::Manual,
-                        created_in: None,
-                        import_source: None,
-                        evidence: Vec::new(),
-                    },
+                    new: incoming.clone(),
                 }],
                 ..TransactionDelta::default()
             })
             .unwrap();
-        commit_live_graph(&state, "install the incoming edge", false);
+        commit_live_graph(&state, "publish incoming edge before move", true);
+        let layout = state.layout.clone();
+        let session = layout.runs_dir().join("session-mcp-carried-move");
+        let app = crate::api::router(Arc::clone(&state));
+        let response = app
+            .clone()
+            .oneshot(
+                Request::post("/commands/session-workspace")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"session_dir": session}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 128 * 1024)
+            .await
+            .unwrap();
+        assert_eq!(status, 200, "{}", String::from_utf8_lossy(&body));
+        std::fs::rename(session.join("src/old.rs"), session.join("src/new.rs")).unwrap();
+        let response = app
+            .clone()
+            .oneshot(
+                Request::post("/reconcile")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"session_dir": session, "confirm_mass_deletion": false})
+                            .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 128 * 1024)
+            .await
+            .unwrap();
+        assert_eq!(status, 200, "{}", String::from_utf8_lossy(&body));
+        assert_carried_move_identity(&state, &moved, artifact, &incoming);
+        drop(app);
+        drop(state);
 
+        let state = Arc::new(DaemonState::open(layout.clone()).unwrap());
+        assert_carried_move_identity(&state, &moved, artifact, &incoming);
+        crate::loop_runner::drain_semantic_debt(&state)
+            .await
+            .unwrap();
+        let sessions = test_sessions();
+        let (_, arguments) = stage_entity_edit(&sessions, &caller, "pub fn value() -> u8 { 2 }");
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_ne!(result.is_error, Some(true), "{}", result_text(&result));
+        let reply = commit_reply(&result);
+        assert_eq!(
+            reply["carried_pending_files"],
+            serde_json::json!(["src/new.rs"])
+        );
+        assert_carried_move_identity(&state, &moved, artifact, &incoming);
+        assert_eq!(semantic_disagreement(&state, "src/new.rs"), None);
+        assert_eq!(semantic_disagreement(&state, "src/lib.rs"), None);
+        drop(state);
+
+        let cold = Arc::new(DaemonState::open(layout).unwrap());
+        assert_carried_move_identity(&cold, &moved, artifact, &incoming);
+        assert_eq!(semantic_disagreement(&cold, "src/new.rs"), None);
+        assert_eq!(semantic_disagreement(&cold, "src/lib.rs"), None);
+    }
+
+    #[test]
+    fn session_move_plans_relocation_without_retiring_identity_or_incoming_edges() {
+        let (_dir, state) = test_state();
+        let (caller, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let (moved, _) = install_exact_source(
+            &state,
+            "src/old.rs",
+            b"pub fn moved() -> u8 { 7 }\n",
+            "moved",
+        );
+        let incoming = move_incoming_edge(&caller, &moved);
+        state
+            .graph
+            .apply_transaction_delta(&TransactionDelta {
+                relation_deltas: vec![RelationDelta::Added {
+                    new: incoming.clone(),
+                }],
+                ..TransactionDelta::default()
+            })
+            .unwrap();
+        commit_live_graph(&state, "publish incoming edge before move", false);
         let base = load_native_commit_base(&state.layout).unwrap();
         let from_path = RepoPath::from_utf8("src/old.rs").unwrap();
         let to_path = RepoPath::from_utf8("src/new.rs").unwrap();
+        let artifact = base.tree.artifact_at_path(&from_path).unwrap().artifact_id;
         let moved_tree = moved_workspace_tree(&base.tree, &from_path, &to_path);
         let deltas = kin_core::exact_tree_correction(&base.tree, &moved_tree).unwrap();
-
+        assert_eq!(deltas.len(), 1);
+        assert!(
+            matches!(&deltas[0], TreeDelta::Updated { artifact_id, old, new }
+                if *artifact_id == artifact && old.path == from_path && new.path == to_path)
+        );
         let vacated = crate::repository_commit::VacatedPaths::from_deltas(&deltas);
         assert!(
-            !vacated.is_empty(),
-            "a move's old path is vacated, because the kept set is built from new paths only"
+            vacated.is_empty(),
+            "a surviving artifact must not be retired"
         );
-
         let retirement = crate::repository_commit::retire_semantics_on_vacated(
             &base.graph.to_snapshot(),
             &vacated,
         )
         .unwrap();
-        assert!(
-            retirement.entity_deltas().iter().any(|delta| matches!(
-                delta,
-                EntityDelta::Removed { old } if old.id == moved.id
-            )),
-            "session admission removes the moved entity outright rather than relocating it: {:#?}",
-            retirement.entity_deltas()
-        );
-        assert!(
-            !retirement.relation_deltas().is_empty(),
-            "and takes every edge incident to it with it: {:#?}",
-            retirement.relation_deltas()
-        );
-        assert!(
-            retirement.entity_deltas().iter().all(|delta| !matches!(
-                delta,
-                EntityDelta::Modified { new, .. } if new.id == moved.id
-            )),
-            "nothing here relocates the entity, which is why the identity is gone by the time a \
-             carried move reaches an MCP commit"
-        );
+        assert!(retirement.entity_deltas().is_empty());
+        assert!(retirement.relation_deltas().is_empty());
+        let relocations = crate::repository_commit::plan_session_entity_relocations(
+            state.graph.as_ref(),
+            &FilePathId::new("src/old.rs"),
+            &FilePathId::new("src/new.rs"),
+        )
+        .unwrap();
+        assert!(relocations.iter().any(|delta| matches!(delta,
+                EntityDelta::Modified { old, new }
+                    if old.id == moved.id && new.id == moved.id
+                        && new.file_origin == Some(FilePathId::new("src/new.rs")))));
+        state
+            .graph
+            .apply_transaction_delta(&TransactionDelta {
+                tree_deltas: deltas,
+                entity_deltas: relocations,
+                ..TransactionDelta::default()
+            })
+            .unwrap();
+        assert_carried_move_identity(&state, &moved, artifact, &incoming);
     }
 }

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -435,8 +435,8 @@ pub(crate) fn plan_session_workspace_admission(
     source_hashes.extend(shared_policy.sources.iter().map(|source| source.body_hash));
 
     let lease = authority.read_authority();
-    let current_workspace = lease
-        .metadata()
+    let metadata = lease.metadata();
+    let current_workspace = metadata
         .workspaces
         .iter()
         .find(|workspace| workspace.workspace_id == workspace_id)
@@ -454,7 +454,7 @@ pub(crate) fn plan_session_workspace_admission(
         // operation it names: a persisted receipt stopped repeating that record
         // in kin-db 0.7.89 (FIR-3064), and `rejoined_receipt` does the pairing
         // and the validation the `validate` here used to do.
-        let receipt = kin_core::rejoined_receipt(lease.metadata(), base.reconcile_operation_id)
+        let receipt = kin_core::rejoined_receipt(metadata, base.reconcile_operation_id)
             .ok_or_else(|| {
                 invalid(
                     "repository authority moved after session materialization; exact reconcile \

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -237,6 +237,7 @@ pub struct SessionWorkspaceAdmissionPlan {
     /// retirement from the live graph with the same set, because the two can
     /// hold different payloads for the same entity and each must drop its own.
     pub vacated: VacatedPaths,
+    pub(crate) module_relocations: Vec<SessionModuleRelocation>,
     pub workspace_id: WorkspaceId,
     source_hashes: Vec<Hash256>,
     recovered_receipt: Option<RepositoryCommitReceipt>,
@@ -302,15 +303,40 @@ pub(crate) fn plan_session_workspace_admission(
     // refusal surfaced as a 500, and the file's entities kept answering
     // queries with nothing on disk behind them.
     let vacated = VacatedPaths::from_deltas(&deltas);
-    let semantic_delta = if vacated.is_empty() {
+    let moves = session_artifact_moves(&deltas);
+    let module_relocations = plan_session_module_relocations(blobs, &authority, &deltas)?;
+    let semantic_delta = if vacated.is_empty() && moves.is_empty() {
         WorkspaceSemanticDelta::default()
     } else {
         let snapshot = {
             let lease = authority.read_authority();
-            lease.workspace_graph_snapshot(&workspace_id)?
+            let mut snapshot = lease.workspace_graph_snapshot(&workspace_id)?;
+            let current = lease
+                .metadata()
+                .workspaces
+                .iter()
+                .find(|workspace| workspace.workspace_id == workspace_id)
+                .ok_or_else(|| invalid("session workspace is absent from authority"))?;
+            if current != &base.source_workspace {
+                if let Some(snapshot) = &mut snapshot {
+                    restore_retained_session_semantics(snapshot, current, &base.source_workspace)?;
+                }
+            }
+            snapshot
         };
         match snapshot {
-            Some(snapshot) => retire_semantics_on_vacated(&snapshot, &vacated)?,
+            Some(snapshot) => {
+                let retirement = retire_semantics_on_vacated(&snapshot, &vacated)?;
+                let mut entities = retirement.entity_deltas().to_vec();
+                if !moves.is_empty() {
+                    let graph = kin_db::InMemoryGraph::from_snapshot_without_text_index(snapshot)?;
+                    for (from, to) in &moves {
+                        entities.extend(plan_session_entity_relocations(&graph, from, to)?);
+                    }
+                    bind_session_module_relocations(&mut entities, &module_relocations)?;
+                }
+                WorkspaceSemanticDelta::new(entities, retirement.relation_deltas().to_vec())?
+            }
             None => WorkspaceSemanticDelta::default(),
         }
     };
@@ -450,19 +476,236 @@ pub(crate) fn plan_session_workspace_admission(
         target_tree: desired_tree.clone(),
         deltas,
         vacated,
+        module_relocations,
         workspace_id,
         source_hashes: source_hashes.into_iter().collect(),
         recovered_receipt,
     })
 }
 
+#[derive(Clone)]
+pub(crate) struct SessionModuleRelocation {
+    from: kin_model::FilePathId,
+    to: kin_model::FilePathId,
+    old_name: String,
+    old_signature: String,
+    new_name: String,
+    new_signature: String,
+}
+
+/// A file module's name can derive from its path. Parse the same immutable
+/// body at both locations and bind modules by exact kind, fingerprint and
+/// source span, never by a guessed basename. This lets the subsequent ordinary
+/// reconciliation retain their IDs even when their parser-owned names change.
+fn plan_session_module_relocations(
+    blobs: &kin_blobs::BlobStore,
+    authority: &RepositoryAuthorityManager<LocalFileBackend>,
+    deltas: &[kin_model::TreeDelta],
+) -> Result<Vec<SessionModuleRelocation>> {
+    let pipeline = kin_index::IndexPipeline::new();
+    let mut bindings = Vec::new();
+    for delta in deltas {
+        let kin_model::TreeDelta::Updated { old, new, .. } = delta else {
+            continue;
+        };
+        if old.path == new.path || old.entry != new.entry {
+            continue;
+        }
+        let kin_model::TreeEntry::Blob { hash, .. } = new.entry else {
+            continue;
+        };
+        let (Some(from), Some(to)) = (old.path.as_utf8(), new.path.as_utf8()) else {
+            continue;
+        };
+        let from = kin_model::FilePathId::new(from);
+        let to = kin_model::FilePathId::new(to);
+        let body = read_publishable_source(blobs, authority, hash)?;
+        let digest = kin_blobs::Hash256::from_bytes(*hash.as_bytes());
+        let before = pipeline
+            .index_any_content(&from, body.body(), digest)
+            .map_err(|error| invalid(format!("parse moved source {from}: {error}")))?;
+        let after = pipeline
+            .index_any_content(&to, body.body(), digest)
+            .map_err(|error| invalid(format!("parse moved source {to}: {error}")))?;
+        let (
+            kin_index::IndexedAny::EntitySource(before),
+            kin_index::IndexedAny::EntitySource(after),
+        ) = (before, after)
+        else {
+            continue;
+        };
+        let mut claimed = std::collections::HashSet::new();
+        for old_module in before
+            .entities
+            .iter()
+            .filter(|entity| entity.kind == kin_model::EntityKind::Module)
+        {
+            if before.language != after.language
+                || !matches!(before.parse_state, kin_model::ParseState::Valid)
+                || !matches!(after.parse_state, kin_model::ParseState::Valid)
+            {
+                return Err(invalid(format!(
+                    "moved module in {from} requires complete parses in the same language at {to}"
+                )));
+            }
+            let matches = after
+                .entities
+                .iter()
+                .filter(|entity| {
+                    let mut relocated_span = entity.span.clone();
+                    if let Some(span) = &mut relocated_span {
+                        span.file = from.clone();
+                    }
+                    entity.kind == old_module.kind
+                        && entity.fingerprint.algorithm == old_module.fingerprint.algorithm
+                        && entity.fingerprint.ast_hash == old_module.fingerprint.ast_hash
+                        && entity.fingerprint.behavior_hash == old_module.fingerprint.behavior_hash
+                        && relocated_span.is_some()
+                        && relocated_span == old_module.span
+                })
+                .collect::<Vec<_>>();
+            let [new_module] = matches.as_slice() else {
+                return Err(invalid(format!(
+                    "moved module in {from} has no unambiguous exact-byte identity at {to}"
+                )));
+            };
+            if !claimed.insert(new_module.id) {
+                return Err(invalid(format!(
+                    "moved modules in {from} share one exact-byte identity at {to}"
+                )));
+            }
+            bindings.push(SessionModuleRelocation {
+                from: from.clone(),
+                to: to.clone(),
+                old_name: old_module.name.clone(),
+                old_signature: old_module.signature.clone(),
+                new_name: new_module.name.clone(),
+                new_signature: new_module.signature.clone(),
+            });
+        }
+    }
+    Ok(bindings)
+}
+
+pub(crate) fn bind_session_module_relocations(
+    deltas: &mut [kin_model::EntityDelta],
+    bindings: &[SessionModuleRelocation],
+) -> Result<()> {
+    for binding in bindings {
+        let mut matched = false;
+        for delta in deltas.iter_mut() {
+            let kin_model::EntityDelta::Modified { old, new } = delta else {
+                continue;
+            };
+            if old.kind == kin_model::EntityKind::Module
+                && old.file_origin.as_ref() == Some(&binding.from)
+                && new.file_origin.as_ref() == Some(&binding.to)
+                && old.name == binding.old_name
+                && old.signature == binding.old_signature
+            {
+                if matched {
+                    return Err(invalid(
+                        "more than one graph module claims the moved parser identity",
+                    ));
+                }
+                matched = true;
+                new.name.clone_from(&binding.new_name);
+                new.signature.clone_from(&binding.new_signature);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Recover the semantic input of an exact session retry from persisted
+/// overlays over the same immutable base. Replanning against the already
+/// relocated workspace would produce an empty delta and a different hash.
+/// The caller still requires the reconstructed transaction hash to match the
+/// original durable receipt before it can return an idempotent result.
+fn restore_retained_session_semantics(
+    snapshot: &mut kin_db::GraphSnapshot,
+    current: &kin_model::WorkspaceState,
+    retained: &kin_model::WorkspaceState,
+) -> Result<()> {
+    if current.base_target != retained.base_target
+        || current.base_tree_hash != retained.base_tree_hash
+        || current.semantic_overlay.external_reference_deltas()
+            != retained.semantic_overlay.external_reference_deltas()
+    {
+        return Err(invalid(
+            "session retry no longer shares its retained semantic base",
+        ));
+    }
+    for delta in current.semantic_overlay.entity_deltas() {
+        if snapshot.entities.get(&delta.target_id()) != delta.new_state() {
+            return Err(invalid(
+                "current session entity overlay does not match authority",
+            ));
+        }
+        match delta.old_state() {
+            Some(old) => {
+                snapshot.entities.insert(old.id, old.clone());
+            }
+            None => {
+                snapshot.entities.remove(&delta.target_id());
+            }
+        }
+    }
+    for delta in current.semantic_overlay.relation_deltas() {
+        if snapshot.relations.get(&delta.target_id()) != delta.new_state() {
+            return Err(invalid(
+                "current session relation overlay does not match authority",
+            ));
+        }
+        match delta.old_state() {
+            Some(old) => {
+                snapshot.relations.insert(old.id, old.clone());
+            }
+            None => {
+                snapshot.relations.remove(&delta.target_id());
+            }
+        }
+    }
+    for delta in retained.semantic_overlay.entity_deltas() {
+        if snapshot.entities.get(&delta.target_id()) != delta.old_state() {
+            return Err(invalid(
+                "retained session entity overlay does not match its base",
+            ));
+        }
+        match delta.new_state() {
+            Some(new) => {
+                snapshot.entities.insert(new.id, new.clone());
+            }
+            None => {
+                snapshot.entities.remove(&delta.target_id());
+            }
+        }
+    }
+    for delta in retained.semantic_overlay.relation_deltas() {
+        if snapshot.relations.get(&delta.target_id()) != delta.old_state() {
+            return Err(invalid(
+                "retained session relation overlay does not match its base",
+            ));
+        }
+        match delta.new_state() {
+            Some(new) => {
+                snapshot.relations.insert(new.id, new.clone());
+            }
+            None => {
+                snapshot.relations.remove(&delta.target_id());
+            }
+        }
+    }
+    snapshot.resolved_tree = retained.tree.clone();
+    Ok(())
+}
+
 /// The paths a tree transition leaves with nothing at them, and the artifact
 /// identities that held them.
 ///
-/// A path some delta's old state held and no delta's new state holds. A
-/// modification keeps its path and a rename vacates only its old one, so a
-/// moved file retires its semantics here and the enrichment that follows the
-/// publication re-derives them at the new path. Paths are kept only in their
+/// A removed artifact whose old path no new state holds. A surviving artifact
+/// keeps its semantic identity when its path changes; its entities relocate
+/// in the same transaction as the tree. Paths are kept only in their
 /// UTF-8 rendering, because only those can own entities; artifact identities
 /// are kept for every vacated entry, because the cross-file linker binds
 /// relations to artifact nodes whatever the path is made of.
@@ -480,6 +723,9 @@ impl VacatedPaths {
             .collect::<BTreeSet<_>>();
         let mut vacated = Self::default();
         for delta in deltas {
+            if delta.new_state().is_some() {
+                continue;
+            }
             let Some(old) = delta.old_state() else {
                 continue;
             };
@@ -497,6 +743,45 @@ impl VacatedPaths {
     pub(crate) fn is_empty(&self) -> bool {
         self.artifacts.is_empty()
     }
+}
+
+/// Artifact identity, carried by the exact tree delta, binds each relocation.
+/// Entity deltas are planned from each graph's own payloads before any move is
+/// applied, so swaps cannot accidentally relocate an entity twice.
+pub(crate) fn session_artifact_moves(
+    deltas: &[kin_model::TreeDelta],
+) -> Vec<(kin_model::FilePathId, kin_model::FilePathId)> {
+    deltas
+        .iter()
+        .filter_map(|delta| {
+            let kin_model::TreeDelta::Updated { old, new, .. } = delta else {
+                return None;
+            };
+            if old.path == new.path {
+                return None;
+            }
+            Some((
+                kin_model::FilePathId::new(old.path.as_utf8()?),
+                kin_model::FilePathId::new(new.path.as_utf8()?),
+            ))
+        })
+        .collect()
+}
+
+pub(crate) fn plan_session_entity_relocations(
+    graph: &kin_db::InMemoryGraph,
+    from: &kin_model::FilePathId,
+    to: &kin_model::FilePathId,
+) -> Result<Vec<kin_model::EntityDelta>> {
+    let mut deltas = crate::mcp_commit::plan_entity_relocations(graph, from, to)?;
+    for delta in &mut deltas {
+        if let kin_model::EntityDelta::Modified { new, .. } = delta {
+            if let Some(span) = &mut new.span {
+                span.file = to.clone();
+            }
+        }
+    }
+    Ok(deltas)
 }
 
 /// The canonical semantic transition that retires everything one graph holds


### PR DESCRIPTION
An exact file move in a retained session minted a new artifact identity and retired the old path's entities and incoming relations. Preserve the original artifact and entity IDs through session admission, CLI and MCP commits, and cold reopen. Actual deletions still retire their semantics.

Reuse the existing unambiguous exact-entry matcher at the explicit ingestion boundary. Publish entity relocation with the tree transition in both authority and the live graph. Bind path-derived module names to parses of the exact moved CAS bytes at both paths. Reconstruct an identical retained session's semantic input over its immutable base so replay preserves the original receipt; changed observations and intervening commits still refuse.

The regression fixtures use real session materialization and reconcile routes, graph commits, and fresh repository opens. The incoming-edge fixture deliberately stores a manual Calls relation through repository history. It proves exact stored-edge identity and endpoint preservation; parser-produced edge behavior remains a separate candidate runtime check.

Resolves FIR-3278. This PR awaits full CI. It contains only the three move commits above landed commit barrier `41e90228a866bef37beb0991f8ce6a430b3a1bcc`; MCP carry work was already on main. No release or runtime acceptance claim is made here.

Verified focused commands at `fc9b7df80bca16c820fc23be8f312fe7c14058fd`, with `KIN_EMBED_BACKEND=cpu CARGO_BUILD_JOBS=2`, through the fleet's heavy-slot wrapper:

```text
cargo test -p kin-daemon --lib mcp_commit::tests:: -- --nocapture
test result: ok. 73 passed; 0 failed; 0 ignored; 0 measured; 1421 filtered out; finished in 33.93s

cargo test -p kin-daemon --lib api::tests::session_ -- --nocapture
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 1487 filtered out; finished in 9.33s

cargo test -p kin-cli --lib commands::reconcile -- --nocapture
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 2204 filtered out; finished in 0.95s
```

The original real-router regression failed before the fix with `added=1 modified=0 removed=2` and the original entity missing. The corrected move plus separate deletion reports `added=0 modified=1 removed=1`. Additional checks cover duplicate-body ambiguity, unchanged-path and retry identity, changed source, path-named Python modules, prior retained overlay, changed-observation refusal, exact replay, and intervening-commit refusal.

Ten production mutation arms compiled and failed on test assertions, then exact restored sources passed. Nine core arms used preserved proof revision `b14aae20949446d8e0b91d138a60d3b88ae0a589`; that core was transplanted onto the corrected barrier with the same stable patch ID. The additional MCP retirement arm exercised composed source `637acff0efeb216cc3d25776f2b356cdd80b3b68`. The final follow-up only shares metadata from one immutable lease between workspace and receipt checks; no guard exemption changed. No compile failure was counted as falsification. Core arms ran `cargo test -p kin-daemon --lib api::tests::session_identity:: -- --nocapture` or the matching `api::tests::session_move_identity::` test; the composition arm ran `cargo test -p kin-daemon --lib mcp_commit::tests::session_move_ -- --nocapture`.

| Production mutation | Actual assertion outcome |
| --- | --- |
| Restore old path-only scanner | 1 passed, 2 failed |
| Replace deterministic Added IDs with random IDs | 2 passed, 1 failed |
| Retire surviving moved artifacts | 0 passed, 2 failed |
| Omit authority relocation | 0 passed, 2 failed |
| Omit live relocation | 0 passed, 2 failed |
| Omit authority module binding | 0 passed, 1 failed after cold commit reopen |
| Omit live module binding | 0 passed, 1 failed at admission |
| Omit replay input recovery | 0 passed, 2 failed on original receipt mismatch |
| Omit durable source-span path update | 0 passed, 1 failed, old.rs instead of new.rs |
| Restore move retirement against both MCP replacement tests | 0 passed, 2 failed |

Actual restored tails:

```text
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 1468 filtered out; finished in 10.43s
PASS: 9 compiled mutants assertion-red; baseline and restored green; exact sources restored.

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 1492 filtered out; finished in 3.50s
PASS: both new MCP composition tests assertion-red under compiled retirement mutant; restored baseline green.
```

The 21-gate local precheck passed at `fc9b7df80bca16c820fc23be8f312fe7c14058fd`:

```text
kin-precheck kin --repo-dir kin=<moveidentity worktree>
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin fc9b7df80bca16c820fc23be8f312fe7c14058fd
```

The normal three-commit rebase onto landed barrier #1552 produced `f199e84c2f2ecac4019c8e3e6c99bd6bc67491ec`. The entire final Git tree remained identical (`a5d0abcedb0777b3789ec08a5aaf4bfa21ab7c9c`), and `git diff --exit-code fc9b7df80bca16c820fc23be8f312fe7c14058fd f199e84c2f2ecac4019c8e3e6c99bd6bc67491ec` returned zero. No barrier history was duplicated.

All 84 focused tests also passed after the rebase at exact `f199e84c2f2ecac4019c8e3e6c99bd6bc67491ec`:

```text
MCP module: test result: ok. 73 passed; 0 failed; 0 ignored; 0 measured; 1421 filtered out; finished in 49.65s
Session routes: test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 1487 filtered out; finished in 28.34s
CLI reconcile: test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 2204 filtered out; finished in 2.49s
PASS: all three validation commands ran at unchanged clean head f199e84c2f2ecac4019c8e3e6c99bd6bc67491ec
```
