### PR TITLE
Retire and relocate semantics when a workspace tree publication moves (FIR-3274)

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -39683,24 +39683,19 @@ mod tests {
     /// The same purge over a path a COMMIT published entities for, which is what
     /// a repository that has ever committed its source actually holds.
     ///
-    /// Red today, and named here rather than left to be rediscovered.
-    /// `repository_commit::publish_workspace_tree` carries
+    /// `repository_commit::publish_workspace_tree` used to carry
     /// `WorkspaceSemanticDelta::default()`, so the tree publication that retires
-    /// the path leaves repository authority holding entities on it and kin-db
-    /// refuses the whole transition with "transaction leaves entity ... absent
-    /// from the staged tree". The session admission in that same module already
-    /// carries `retire_semantics_on_vacated` over its vacated set; the tree
-    /// publication does not, and every caller of `publish_exact_workspace_tree`
-    /// inherits the gap, the watch loop's standalone admission included. That is
-    /// the FIR-2429 class surviving on the paths its fix did not reach, and it is
-    /// tracked as FIR-3274.
+    /// the path left repository authority holding entities on it and kin-db
+    /// refused the whole transition with "transaction leaves entity ... absent
+    /// from the staged tree". The session admission in that same module carries
+    /// `retire_semantics_on_vacated` over its vacated set; the tree publication
+    /// did not, and every caller of `publish_exact_workspace_tree` inherited the
+    /// gap, the watch loop's standalone admission included.
     ///
-    /// Ignored so the suite stays green while the class stays written down where
-    /// the fix will find it. Run it by name with
-    /// `cargo test -p kin-daemon --lib -- --ignored
-    /// purge_ignored_retires_the_entities_a_commit_published_for_a_vacated_path`.
+    /// Falsify by restoring `WorkspaceSemanticDelta::default()` in
+    /// `publish_workspace_tree`: the purge answers 409 and this fails on the
+    /// status.
     #[tokio::test]
-    #[ignore = "FIR-3274: publish_workspace_tree carries no retirement for a vacated path"]
     async fn purge_ignored_retires_the_entities_a_commit_published_for_a_vacated_path() {
         let state = test_state();
         state
@@ -39737,6 +39732,257 @@ mod tests {
             state.graph.get_entity(&private.id).unwrap().is_none(),
             "a purged path's entity still resolves, so it still ranks"
         );
+    }
+
+    /// Deleting a committed entity-owning file has to reconcile.
+    ///
+    /// The watch loop's standalone admission publishes its exact tree through
+    /// `publish_exact_workspace_tree`, the same seam the purge uses, so the same
+    /// missing retirement refused it: a removal of a path repository authority
+    /// holds entities for strands them and kin-db refuses the whole transition
+    /// rather than the one entity. `rm` of a plain file reconciled and `rm` of an
+    /// entity-owning file did not.
+    ///
+    /// The path is COMMITTED on purpose. A merely admitted file's entities live
+    /// in the live graph, which the loop evicts on its own; only a commit puts
+    /// them in repository authority, where the publication has to carry their
+    /// removal in the same delta.
+    ///
+    /// Falsify by restoring `WorkspaceSemanticDelta::default()` in
+    /// `publish_workspace_tree`: the admission answers 409 and
+    /// `admit_through_api` fails on the status.
+    #[tokio::test]
+    async fn admitting_a_deleted_entity_owning_file_retires_its_semantics() {
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        for (path, content) in [
+            ("src/kept.py", &b"def kept(): pass\n"[..]),
+            ("src/gone.py", &b"def gone(): pass\n"[..]),
+        ] {
+            install_working_copy_file(&state, path, content, false);
+            install_repository_file(&state, path, content);
+        }
+        let doomed = derived_entity(&state, "src/gone.py", "gone", EntityKind::Function);
+        let kept = derived_entity(&state, "src/kept.py", "kept", EntityKind::Function);
+        assert!(
+            state.graph.get_entity(&doomed.id).unwrap().is_some(),
+            "the deleted path has to own an entity, or this admission has nothing to retire"
+        );
+
+        std::fs::remove_file(state.layout.working_dir().join("src/gone.py")).unwrap();
+        let app = router(Arc::clone(&state));
+        admit_through_api(&app).await;
+
+        let live = tracked_paths(&state);
+        assert!(
+            !live.contains("src/gone.py"),
+            "the admission has to retire the deleted path: {live:?}"
+        );
+        assert!(
+            state.graph.get_entity(&doomed.id).unwrap().is_none(),
+            "a deleted path's entity still resolves, so it still answers queries with nothing \
+             on disk behind it"
+        );
+        assert!(state
+            .graph
+            .query_entities(&kin_db::EntityFilter {
+                file_path: Some(kin_model::FilePathId::new("src/gone.py")),
+                ..Default::default()
+            })
+            .unwrap()
+            .is_empty());
+
+        // The two-sided arm: an untouched sibling keeps both its artifact and
+        // its entity, so the admission retired one path rather than the tree.
+        assert!(live.contains("src/kept.py"));
+        assert_eq!(state.graph.get_entity(&kept.id).unwrap(), Some(kept));
+    }
+
+    /// A move across BASENAMES keeps every identity it carries, at three points.
+    ///
+    /// `kin_core::exact_tree` plans a move as ONE `TreeDelta::Updated` with the
+    /// artifact identity kept and the paths differing, never as a removal beside
+    /// an arrival, because that pair would mint new entity ids and orphan every
+    /// incoming reference. So the publication that records the move relocates
+    /// what the old path owned in the same delta.
+    ///
+    /// The module entity is the hard half and the basename is why. A file's
+    /// module takes its NAME and its SIGNATURE from the path it sits on, so
+    /// `src/old.py` moving to `lib/new.py` has to keep one id while its name
+    /// goes from `old` to `new`. A move that keeps the basename cannot exercise
+    /// that at all, which is what makes this fixture rename the file rather than
+    /// only move it.
+    ///
+    /// Graded at three points, because each one can pass while the next fails.
+    /// Live, straight after the admission. Then after an edit and a commit,
+    /// which re-parses the body at its new path: a later parse mints the id the
+    /// NEW path implies, so an id that survives here is one the relocation bound
+    /// rather than one the parse happened to agree on. Then after a cold reopen,
+    /// which rebuilds the graph from repository authority alone and is the only
+    /// one of the three that grades what was durably published.
+    ///
+    /// An incoming edge is carried through all three, because relocating an
+    /// entity while its references drop is the orphaning the single `Updated`
+    /// exists to prevent.
+    #[tokio::test]
+    async fn admitting_a_moved_entity_owning_file_keeps_its_semantics() {
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let layout = state.layout.clone();
+
+        install_working_copy_file(&state, "src/old.py", b"def moved(): pass\n", false);
+        install_repository_file(&state, "src/old.py", b"def moved(): pass\n");
+        install_working_copy_file(&state, "src/caller.py", b"def caller(): pass\n", false);
+        install_repository_file(&state, "src/caller.py", b"def caller(): pass\n");
+        let function = derived_entity(&state, "src/old.py", "moved", EntityKind::Function);
+        let module = derived_entity(&state, "src/old.py", "old", EntityKind::Module);
+        let caller = derived_entity(&state, "src/caller.py", "caller", EntityKind::Function);
+        link_every_class(&state, &caller, &function);
+        let incoming = inbound_relation_count(&state, function.id);
+        assert!(
+            incoming > 0,
+            "the fixture must hold an incoming edge, or the orphaning arm asserts nothing"
+        );
+
+        std::fs::create_dir_all(layout.working_dir().join("lib")).unwrap();
+        std::fs::rename(
+            layout.working_dir().join("src/old.py"),
+            layout.working_dir().join("lib/new.py"),
+        )
+        .unwrap();
+        let app = router(Arc::clone(&state));
+        admit_through_api(&app).await;
+
+        let live = tracked_paths(&state);
+        assert!(
+            live.contains("lib/new.py") && !live.contains("src/old.py"),
+            "the admission has to record the move: {live:?}"
+        );
+
+        // Point one: live, straight after the admission. The bytes have not
+        // changed, so the offsets may not either.
+        assert_moved_identity(&state, &module, "new", true, "live");
+        assert_moved_identity(&state, &function, "moved", true, "live");
+        assert_eq!(
+            inbound_relation_count(&state, function.id),
+            incoming,
+            "live: the move dropped an incoming edge"
+        );
+
+        // Point two: after an edit and a commit, so the body is parsed again at
+        // its new path and the ids that parse would mint are the new path's.
+        std::fs::write(
+            layout.working_dir().join("lib/new.py"),
+            b"def moved(): pass\n\n\ndef later(): pass\n",
+        )
+        .unwrap();
+        commit_through_api(
+            &app,
+            kin_model::OperationId::new(),
+            "commit an edit at the path the file moved to",
+        )
+        .await;
+        assert_moved_identity(&state, &module, "new", false, "after the edit and commit");
+        assert_moved_identity(
+            &state,
+            &function,
+            "moved",
+            false,
+            "after the edit and commit",
+        );
+        assert_eq!(
+            inbound_relation_count(&state, function.id),
+            incoming,
+            "after the edit and commit: an incoming edge was dropped"
+        );
+
+        // Point three: a cold reopen, which rebuilds from repository authority.
+        drop(app);
+        drop(state);
+        let reopened = Arc::new(DaemonState::open(layout).unwrap());
+        assert_moved_identity(&reopened, &module, "new", false, "after a cold reopen");
+        assert_moved_identity(&reopened, &function, "moved", false, "after a cold reopen");
+        assert_eq!(
+            inbound_relation_count(&reopened, function.id),
+            incoming,
+            "after a cold reopen: an incoming edge was dropped"
+        );
+    }
+
+    /// Every relation with this entity at either end, which is what a relocation
+    /// has to leave standing.
+    fn inbound_relation_count(state: &Arc<DaemonState>, entity: kin_model::EntityId) -> usize {
+        state
+            .graph
+            .get_all_relations_for_node(&kin_model::GraphNodeId::Entity(entity))
+            .unwrap()
+            .len()
+    }
+
+    /// One moved identity, graded on the fields a relocation has to preserve or
+    /// carry forward.
+    ///
+    /// The id is the identity itself and never moves. The name and the signature
+    /// follow the path, which is the module case: `src/old.py` becoming
+    /// `lib/new.py` renames its module. The span names the new path, and its byte
+    /// offsets hold only while the bytes have not changed.
+    fn assert_moved_identity(
+        state: &Arc<DaemonState>,
+        before: &Entity,
+        name: &str,
+        bytes_unchanged: bool,
+        at: &str,
+    ) {
+        let after = state
+            .graph
+            .get_entity(&before.id)
+            .unwrap()
+            .unwrap_or_else(|| {
+                panic!(
+                    "{at}: the moved file's {name} entity lost its identity {}",
+                    before.id
+                )
+            });
+        assert_eq!(
+            after.name, name,
+            "{at}: the moved entity carries the wrong name"
+        );
+        assert_eq!(
+            after.file_origin.as_ref().map(|origin| origin.0.as_str()),
+            Some("lib/new.py"),
+            "{at}: the moved entity still answers at its old path"
+        );
+        if after.kind == EntityKind::Module {
+            assert!(
+                after.signature.contains("lib/new.py"),
+                "{at}: the module's signature still names the path it moved off: {}",
+                after.signature
+            );
+        }
+        let span = after
+            .span
+            .as_ref()
+            .unwrap_or_else(|| panic!("{at}: the moved entity lost its span"));
+        assert_eq!(
+            span.file.0, "lib/new.py",
+            "{at}: the span still names the path the file moved off"
+        );
+        if bytes_unchanged {
+            let before_span = before
+                .span
+                .as_ref()
+                .expect("the fixture entity carries a span");
+            assert_eq!(
+                (span.start_byte, span.end_byte),
+                (before_span.start_byte, before_span.end_byte),
+                "{at}: the bytes did not change, so the offsets may not either"
+            );
+        }
     }
 
     fn branch_change(state: &DaemonState) -> SemanticChangeId {

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -962,15 +962,42 @@ fn exact_tree_admission(
         // the entities on the old path have to move instead. They move in THIS
         // transaction, beside the tree delta that carries them, because kin-db
         // refuses a transition that leaves an entity on a path the staged tree
-        // no longer holds, and a relocation published as a second transaction
-        // is refused exactly as a stranded entity is (FIR-2429).
+        // no longer holds, and a relocation published as a second transaction is
+        // refused exactly as a stranded entity is.
+        //
+        // Through the same planner and binder the session admission uses, not a
+        // shorter local rule. A file's module takes its name, its signature and
+        // its id from the path it sits on, so relocating only `file_origin`
+        // leaves the derived graph holding a module named for a path nothing
+        // carries, and the next parse at the new path mints a different id for
+        // it: the old identity is dropped and every reference to it with it. The
+        // binder is what keeps one id across that rename.
         let relocations = path_relocations_in(&deltas);
         let mut relocated_entities = Vec::new();
-        for (from_id, to_id) in &relocations {
-            relocated_entities.extend(
-                crate::mcp_commit::plan_entity_relocations(state.graph.as_ref(), from_id, to_id)
-                    .map_err(DaemonError::Graph)?,
-            );
+        if !relocations.is_empty() {
+            let authority_context =
+                crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(
+                    state,
+                )?;
+            let authority = authority_context.open().map_err(DaemonError::Graph)?;
+            let module_relocations = crate::repository_commit::plan_session_module_relocations(
+                state.blobs.as_ref(),
+                &authority,
+                &deltas,
+            )?;
+            for (from_id, to_id) in &relocations {
+                relocated_entities.extend(
+                    crate::repository_commit::plan_session_entity_relocations(
+                        state.graph.as_ref(),
+                        from_id,
+                        to_id,
+                    )?,
+                );
+            }
+            crate::repository_commit::bind_session_module_relocations(
+                &mut relocated_entities,
+                &module_relocations,
+            )?;
         }
         state
             .graph

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -8752,39 +8752,44 @@ mod tests {
         );
     }
 
-    /// A carried path is never a removal, and this is the mechanism rather than
-    /// an assumption.
+    /// A vacated path takes its semantics with it, and this is the mechanism
+    /// rather than an assumption.
     ///
-    /// Ambient admission publishes the tree and no semantics, so vacating a path
-    /// that way would leave the entities that file derived standing over a tree
-    /// that no longer carries it. Repository authority refuses the transaction
-    /// outright, so `publish_workspace_tree` cannot create the state at all. The
-    /// seam that does vacate a path, `commit_session_workspace_admission`,
-    /// derives the retirement through `retire_semantics_on_vacated` and carries
-    /// it in the same transaction. Two independent mechanisms, one conclusion:
-    /// every carried tree delta the MCP commit planner sees is an addition or an
-    /// update, and the only removals that reach a plan are the ones a staged
-    /// `delete` authored, which are not carried.
+    /// Ambient admission publishes the workspace tree, and a tree that stops
+    /// carrying a path has to carry the removal of everything that path owned in
+    /// the same transaction: kin-db refuses a transition that leaves an entity on
+    /// a path the staged tree no longer holds, and it refuses the whole
+    /// transition rather than the one entity. `publish_workspace_tree` derives
+    /// that retirement through `retire_semantics_on_vacated` over authority's own
+    /// workspace snapshot, which is the same rule
+    /// `commit_session_workspace_admission` applies to its own vacated set.
     ///
-    /// That is why `derive_carried_pending_semantics` asserts the invariant
-    /// instead of implementing a retirement, and this is what makes the
-    /// assertion evidence rather than decoration: take either mechanism away and
-    /// a carried removal becomes reachable, so the arm it guards has something
-    /// to guard.
+    /// So a carried removal never reaches the MCP commit planner. By the time it
+    /// plans, the admission has already published the path's departure together
+    /// with its semantics, and every carried tree delta the planner sees is an
+    /// addition or an update; the only removals that reach a plan are the ones a
+    /// staged `delete` authored, which are not carried. That is why
+    /// `derive_carried_pending_semantics` asserts the invariant instead of
+    /// implementing a retirement, and this is what makes the assertion evidence
+    /// rather than decoration.
     ///
-    /// A surviving artifact can move through one `TreeDelta::Updated`. Session
-    /// admission carries its entity relocations in the same transaction; the
-    /// move tests below cover that path through an MCP commit and cold reopen.
+    /// A surviving artifact can move through one `TreeDelta::Updated`, which is
+    /// not a vacancy and is not retired as one; the move tests below cover that
+    /// path through an MCP commit and cold reopen.
+    ///
+    /// Falsify by publishing `WorkspaceSemanticDelta::default()` from
+    /// `publish_workspace_tree`: repository authority refuses the admission and
+    /// the first assertion below fails on that refusal.
     #[test]
-    fn ambient_admission_cannot_vacate_a_path_without_retiring_its_semantics() {
+    fn ambient_admission_vacates_a_path_by_retiring_its_semantics() {
         let (_dir, state) = test_state();
-        install_exact_source(
+        let (kept, _) = install_exact_source(
             &state,
             "src/lib.rs",
             b"pub fn value() -> u8 { 1 }\n",
             "value",
         );
-        install_exact_source(
+        let (gone, _) = install_exact_source(
             &state,
             "src/other.rs",
             b"pub fn other() -> u8 { 1 }\n",
@@ -8792,26 +8797,38 @@ mod tests {
         );
         let before = load_native_commit_base(&state.layout).unwrap();
 
-        let refusal = admit_pending_working_tree_removal(&state, "src/other.rs")
-            .expect_err("authority must refuse a vacated path whose semantics still stand");
+        admit_pending_working_tree_removal(&state, "src/other.rs")
+            .expect("the admission carries the vacated path's retirement, so authority accepts it");
 
-        let message = refusal.to_string();
-        assert!(
-            message.contains("src/other.rs"),
-            "the refusal must name the path it will not vacate: {message}"
-        );
-        assert!(
-            message.contains("absent from the staged tree"),
-            "the refusal must say what is wrong with the transition: {message}"
-        );
-        assert!(
-            message.contains("carry its exact entity removal or relocation in the same delta"),
-            "the refusal must say what a caller has to carry instead: {message}"
-        );
-        assert_eq!(
+        assert_ne!(
             load_native_commit_base(&state.layout).unwrap().roots,
             before.roots,
-            "no repository authority may move behind a refused admission"
+            "the admission has to move repository authority, or it published nothing at all"
+        );
+
+        let published: Vec<Entity> = {
+            let context = authority_context(&state).unwrap();
+            let workspace_id = context.workspace_id();
+            let authority = context.open().unwrap();
+            let lease = authority.read_authority();
+            lease
+                .workspace_graph_snapshot(&workspace_id)
+                .unwrap()
+                .expect("repository authority holds a workspace graph snapshot")
+                .entities
+                .values()
+                .cloned()
+                .collect()
+        };
+        assert!(
+            !published.iter().any(|entity| entity.id == gone.id),
+            "the vacated path's entity still stands in repository authority, so it answers \
+             queries with nothing in the tree behind it"
+        );
+        assert!(
+            published.iter().any(|entity| entity.id == kept.id),
+            "an untouched sibling lost its entity, so the retirement took more than the path \
+             that vacated"
         );
     }
 

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -497,7 +497,7 @@ pub(crate) struct SessionModuleRelocation {
 /// body at both locations and bind modules by exact kind, fingerprint and
 /// source span, never by a guessed basename. This lets the subsequent ordinary
 /// reconciliation retain their IDs even when their parser-owned names change.
-fn plan_session_module_relocations(
+pub(crate) fn plan_session_module_relocations(
     blobs: &kin_blobs::BlobStore,
     authority: &RepositoryAuthorityManager<LocalFileBackend>,
     deltas: &[kin_model::TreeDelta],
@@ -1017,6 +1017,57 @@ pub(crate) fn publish_workspace_tree(
     }
 
     let tree_deltas = kin_core::exact_tree_correction(&workspace.tree, desired_tree)?;
+    // An entity may not outlive the path that owns it, and this publication is
+    // the caller that owes the removal. kin-db refuses a transition that leaves
+    // one on a path the staged tree no longer carries, and it refuses the whole
+    // transition rather than the one entity, so a publication that retires a
+    // path repository authority holds entities for carries their removal in the
+    // same delta.
+    //
+    // The set is authority's own, read from authority's own workspace snapshot.
+    // Entities no commit ever published are not here to retire: they live in the
+    // daemon's derived graph, which the watch loop and the purge evict for
+    // themselves after this returns.
+    //
+    // A move is not a vacancy. `exact_tree` plans one as a single `Updated` with
+    // the artifact identity kept and the paths differing, so the entities on the
+    // old path move in this same delta, through the relocation planner the
+    // session admission uses rather than a second copy of the rule. kin-db
+    // refuses a relocation published as a later transaction exactly as it
+    // refuses a stranded entity.
+    let vacated = VacatedPaths::from_deltas(&tree_deltas);
+    let moves = session_artifact_moves(&tree_deltas);
+    let module_relocations = plan_session_module_relocations(blobs, &authority, &tree_deltas)?;
+    let semantic_delta = if vacated.is_empty() && moves.is_empty() {
+        WorkspaceSemanticDelta::default()
+    } else {
+        match lease.workspace_graph_snapshot(&workspace_id)? {
+            Some(snapshot) => {
+                let retirement = retire_semantics_on_vacated(&snapshot, &vacated)?;
+                let mut entities = retirement.entity_deltas().to_vec();
+                if !moves.is_empty() {
+                    let graph = kin_db::InMemoryGraph::from_snapshot_without_text_index(snapshot)?;
+                    for (from, to) in &moves {
+                        entities.extend(plan_session_entity_relocations(&graph, from, to)?);
+                    }
+                    bind_session_module_relocations(&mut entities, &module_relocations)?;
+                }
+                WorkspaceSemanticDelta::new(entities, retirement.relation_deltas().to_vec())?
+            }
+            // A vacated set with no snapshot to retire from is nothing to carry.
+            // A MOVE with no snapshot is different: the identity is real, this
+            // publication cannot prove it survives, and publishing the tree
+            // anyway would strand it exactly as the missing retirement stranded
+            // a removal. Refusing leaves authority untouched.
+            None if !moves.is_empty() => {
+                return Err(invalid(
+                    "repository authority holds no workspace graph snapshot to relocate a moved \
+                     identity into, so publishing this tree would strand it",
+                ))
+            }
+            None => WorkspaceSemanticDelta::default(),
+        }
+    };
     let mut source_lengths = std::collections::BTreeMap::new();
     let (shared_policy, _) = SharedAdmissionPolicy::derive_from_tree_with_allowances(
         Some(&workspace.shared_admission_policy),
@@ -1089,7 +1140,7 @@ pub(crate) fn publish_workspace_tree(
             new_base_tree_hash: workspace.base_tree_hash,
             tree_deltas: tree_deltas.clone(),
             new_tree_hash: tree_hash,
-            semantic_delta: WorkspaceSemanticDelta::default(),
+            semantic_delta,
             new_shared_admission_policy: shared_policy.clone(),
             new_admission_policy: EffectiveAdmissionPolicyStamp {
                 shared: shared_policy.stamp(),


### PR DESCRIPTION
## The defect

An entity may not outlive the path that owns it. kin-db refuses a transition that leaves one
on a path the staged tree no longer carries, and it refuses the whole transition rather than
the one entity.

The session admission carries that removal. The standalone workspace tree publication did
not: `publish_workspace_tree` sent `WorkspaceSemanticDelta::default()`, so both of its callers
were refused over any path a commit had ever published entities for. Deleting a committed
source file could not be admitted, which is `rm` reconciling for a plain file and not for an
entity-owning one. The ignore purge could untrack build output and not a committed source
path.

## The fix

The publication carries authority's own retirement, derived through
`retire_semantics_on_vacated` over authority's own workspace snapshot. That is the same set
the session admission retires, and it is not the derived graph's set: entities no commit ever
published live in the daemon's graph, which the watch loop and the purge evict for themselves
after this returns.

A move is not a vacancy. `exact_tree` plans one as a single `TreeDelta::Updated` with the
artifact identity kept and the paths differing, never as a removal beside an arrival, because
that pair would mint new entity ids and orphan every incoming reference. So the entities on
the old path move in the same delta, through `plan_session_entity_relocations` and
`bind_session_module_relocations`, the planner and binder the session admission uses. Where
authority holds no workspace snapshot to relocate a moved identity into, the publication
refuses and authority is unchanged, because publishing the tree without the relocation would
strand the identity exactly as the missing retirement stranded a removal.

The watcher's live relocation goes through those same two helpers. Relocating `file_origin`
alone left the derived graph holding a module named for a path nothing carried, and the next
parse at the new path minted a different id for it, so a rename across basenames dropped the
module identity and every reference to it. `plan_session_module_relocations` is `pub(crate)`
for that call and its body is unchanged.

## Regressions, all active, each red before its own half of the fix

```
purge_ignored_retires_the_entities_a_commit_published_for_a_vacated_path
admitting_a_deleted_entity_owning_file_retires_its_semantics
admitting_a_moved_entity_owning_file_keeps_its_semantics
mcp_commit::tests::ambient_admission_vacates_a_path_by_retiring_its_semantics
```

The first two were red without the retirement:

```
test api::tests::admitting_a_deleted_entity_owning_file_retires_its_semantics ... FAILED
test api::tests::purge_ignored_retires_the_entities_a_commit_published_for_a_vacated_path ... FAILED
assertion `left == right` failed: Graph error: storage error: transaction leaves entity
266aa95c-... on repository path investor/deck/build_deck.py absent from the staged tree;
carry its exact entity removal or relocation in the same delta
test result: FAILED. 0 passed; 2 failed; 1488 filtered out; finished in 2.29s
```

The rename control was red without the live relocation going through the shared binder:

```
thread 'api::tests::admitting_a_moved_entity_owning_file_keeps_its_semantics' panicked at
crates/kin-daemon/src/api.rs:39295:17:
live: the moved file's new entity lost its identity bcb80335-314b-5390-a860-378bbfb75faf
test result: FAILED. 0 passed; 1 failed; 1495 filtered out; finished in 1.66s
```

It moves `src/old.py` to `lib/new.py`, crossing basenames on purpose: a file's module takes
its name, its signature and its id from the path it sits on, so a move that keeps the
basename cannot exercise the rename at all. It grades id, name, signature, `span.file`, the
byte offsets while the bytes are unchanged, and the incoming edge count, at three points.
Live. Then after an edit and a commit, so the body is parsed again at its new path and the id
that parse would mint is the new path's, which makes a surviving id one the binder bound
rather than one the parse agreed on. Then after a cold reopen, which rebuilds from repository
authority alone and is the only one of the three that grades what was durably published.

`mcp_commit::tests::ambient_admission_vacates_a_path_by_retiring_its_semantics` replaces a
test that pinned the refusal this change removes. It asserts the mechanism that replaces it:
the admission succeeds, repository authority moves, the vacated path's entity is gone from
authority's own workspace snapshot, and an untouched sibling keeps its entity. Falsify it by
publishing an empty semantic delta again and authority refuses the admission. Its invariant
paragraph, which `derive_carried_pending_semantics` depends on, is preserved rather than
deleted: a carried removal still never reaches the MCP commit planner, now because the
admission has already published the path's departure with its semantics.

## Gates

```
$ cargo test -p kin-daemon --lib   (the eight focused regressions and their neighbours)
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 1504 filtered out; finished in 6.19s

$ cargo test -p kin-daemon --lib
test result: ok. 1509 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 294.20s
FULL_RC=0

$ bin/kin-precheck kin --repo-dir kin=<worktree>
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 66b1067fcf33c41b0bffdefa2742f31c0bb639a0
PRECHECK_RC=0
```

Based on the landed move change, so the vacated-path classifier this builds on is the one
that skips any delta whose new state is present.
