### PR TITLE
Add an executable adapter for hosted first publication (FIR-3256)

### DIFF
--- a/crates/kin-cli/src/commands/hosted_publication.rs
+++ b/crates/kin-cli/src/commands/hosted_publication.rs
@@ -1024,16 +1024,22 @@ pub fn install_no_replace(path: &Path, bytes: &[u8], label: &str) -> Result<bool
     })();
     let _ = fs::remove_file(&staged);
     let installed = install?;
-    if installed {
-        #[cfg(unix)]
-        {
-            // A link the directory entry has not recorded is not durable.
-            // `File::open` on a directory is unavailable on Windows, where the
-            // guarantee is the file's own flush plus the atomic link.
-            fs::File::open(parent)
-                .and_then(|directory| directory.sync_all())
-                .with_context(|| format!("flush {label} directory {}", parent.display()))?;
-        }
+    #[cfg(unix)]
+    {
+        // Unconditional, and the declined path is the reason. A writer that
+        // finds the link already there is about to treat that record as durable
+        // and move on to the irreversible compare-and-swap, while the writer
+        // that created the link may not have flushed the directory entry yet and
+        // may never get to. Flushing here means whoever ACCEPTS the record is
+        // the one who made sure it survives, rather than trusting a peer to
+        // finish a step it can crash before reaching.
+        //
+        // A link the directory entry has not recorded is not durable.
+        // `File::open` on a directory is unavailable on Windows, where the
+        // guarantee is the file's own flush plus the atomic link.
+        fs::File::open(parent)
+            .and_then(|directory| directory.sync_all())
+            .with_context(|| format!("flush {label} directory {}", parent.display()))?;
     }
     Ok(installed)
 }

--- a/crates/kin-cli/src/commands/hosted_publication.rs
+++ b/crates/kin-cli/src/commands/hosted_publication.rs
@@ -1,0 +1,1861 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Executable adapter for the first publication of a reserved hosted repository.
+//!
+//! An orchestrator that has reserved a repository identity needs a way to turn a
+//! trusted materialized source into that repository's durable graph authority,
+//! and to be told, in checkable values, exactly what it got. The library
+//! primitive for the publication itself already exists
+//! (`kin_remote::first_publication`). What did not exist is a transport to it:
+//! no subcommand, no route, no tool. This module is that transport, and nothing
+//! more.
+//!
+//! Four rules shape everything below.
+//!
+//! Measured state and echoed input never share a field. The evidence record has
+//! a `measured` object, whose every value was read back out of destination
+//! storage through a backend handle this process did not publish through, and an
+//! `echoed` object, whose every value came from the manifest and was verified by
+//! nothing here. An orchestrator assembling a receipt needs to know which is
+//! which, and a record that blurs them is worse than one that omits them.
+//!
+//! Nothing here signs anything. The receipts a hosted control plane stores are
+//! minted by a trusted signer holding a key this process must never see. This
+//! adapter reports observations; turning an observation into an attestation is
+//! somebody else's authority, deliberately.
+//!
+//! A lost response is not permission to overwrite. The intended snapshot, roots,
+//! ref bindings and body closure are made durable before the compare-and-swap
+//! that makes the publication permanent, and the recovery path compares what is
+//! on the destination against that record. It agrees, or it is a conflict that
+//! keeps the reserved identity and changes nothing. The recovery path contains
+//! no write call at all, which is how that promise is kept rather than merely
+//! stated.
+//!
+//! A ref is its target, not its name. Two imports can carry the same ref names
+//! and the same `HEAD` while a second branch or an annotated tag points
+//! somewhere else, so the manifest states an exact binding for every ref it
+//! claims and those bindings are checked against the imported authority before
+//! publication and against the fresh readback afterwards.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{anyhow, bail, Context, Result};
+use kin_db::{
+    GraphSnapshot, LocalFileBackend, PersistedRepositoryAuthority, RepositoryAuthorityManager,
+    StorageBackend,
+};
+use kin_model::{
+    AuthorityRoot, ExternalObjectKind, GitMaterialHead, GitObjectFormat, GitObjectId, Hash256,
+    RefName, RefTarget, RepositoryId, RepositoryRef, RootBundle,
+};
+use kin_remote::first_publication::{
+    publish_first_repository_observed, read_pinned_published_authority, FirstPublicationError,
+    FirstPublicationIntent, FirstPublicationMode, SourceBodyClosure,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Exit status for a destination that holds no publication.
+///
+/// Distinct from every failure below it, because it is the one outcome a caller
+/// may safely retry: nothing was installed, the reserved identity is untouched,
+/// and a later attempt is the correct next move.
+pub const EXIT_ABSENT: i32 = 3;
+
+/// Exit status for a destination that holds a publication which is not the one
+/// this operation intended. Never retryable and never resolved here: the
+/// reserved identity is retained and a person decides.
+pub const EXIT_CONFLICT: i32 = 4;
+
+/// Exit status for a destination whose state could not be established either
+/// way. Unknown is not absent, and the difference is most of the reason this
+/// code exists, so it gets its own status rather than sharing one with either
+/// neighbour.
+pub const EXIT_INDETERMINATE: i32 = 5;
+
+const MANIFEST_SCHEMA: &str = "kin.hosted-first-publication-manifest.v1";
+const INTENT_SCHEMA: &str = "kin.hosted-first-publication-intent.v1";
+const EVIDENCE_SCHEMA: &str = "kin.hosted-first-publication-evidence.v1";
+const CLOSURE_ALGORITHM: &str = "kin.first-publication-body-closure.v1";
+const ARTIFACT_ID_PREFIX: &str = "kin.first-publication.v1";
+
+/// Domain separator for the canonical binding over a complete root bundle.
+const AUTHORITY_ROOT_DOMAIN: &[u8] = b"kin.first-publication-authority-root.v1\0";
+
+/// Ceiling on the composed artifact identifier.
+///
+/// A hosted control plane stores this as bounded text with a 256-byte limit, so
+/// a long destination prefix has to be refused here, where the reason is
+/// visible, rather than at a store that can only say the field was invalid.
+const ARTIFACT_ID_MAX_BYTES: usize = 256;
+
+/// Hops a symbolic ref may take before resolution gives up.
+///
+/// A symbolic target is resolvable state, not an error, so it is followed
+/// rather than refused. A cycle or a chain this long is neither resolvable nor
+/// worth guessing at.
+const MAX_SYMBOLIC_HOPS: usize = 8;
+
+// ---------------------------------------------------------------------------
+// Wire types
+// ---------------------------------------------------------------------------
+
+/// Which boundary the reserved repository was created from.
+///
+/// Stated by the manifest rather than inferred from the source directory. The
+/// publication primitive independently refuses a mode that disagrees with the
+/// authority's own external-Git metadata, so a lie here fails loudly instead of
+/// publishing the wrong shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PublicationMode {
+    NativeEmpty,
+    ExactGit,
+}
+
+impl PublicationMode {
+    fn parse(value: &str) -> Result<Self> {
+        match value {
+            "native-empty" => Ok(Self::NativeEmpty),
+            "exact-git" => Ok(Self::ExactGit),
+            other => Err(anyhow!(
+                "unknown publication mode {other:?}: expected native-empty or exact-git"
+            )),
+        }
+    }
+
+    fn as_primitive(self) -> FirstPublicationMode {
+        match self {
+            Self::NativeEmpty => FirstPublicationMode::Native,
+            Self::ExactGit => FirstPublicationMode::GitImported,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::NativeEmpty => "native-empty",
+            Self::ExactGit => "exact-git",
+        }
+    }
+}
+
+/// The operation this publication belongs to, carried through unchanged.
+///
+/// None of its meaning is verified here. Kin has no view of an orchestrator's
+/// operation truth, and pretending otherwise would put a second, weaker copy of
+/// that authority in this process. Its shape is another matter: every value
+/// below is copied verbatim into a receipt that a hosted store decodes, so a
+/// value this process accepts and that store refuses would fail at the far end
+/// of a publication that had already happened. The grammars are therefore
+/// checked here, where a refusal costs nothing.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OperationBinding {
+    pub org_id: String,
+    pub operation_id: String,
+    pub operation_revision: u64,
+    pub request_hash: String,
+    pub holder_id: String,
+    pub fencing_token: u64,
+}
+
+impl OperationBinding {
+    /// Whether two bindings name the same operation.
+    ///
+    /// Revision, holder and fencing token are excluded deliberately. A worker
+    /// lease is renewable and a reclaimed operation gets a new holder and a new
+    /// fence, so a resumption under a renewed lease legitimately carries a
+    /// different revision for the same operation. Treating any of the three as
+    /// part of the identity would turn every honest resumption into a conflict,
+    /// which is the opposite of what a durable intent is for. What does not move
+    /// is the org, the operation and the request digest the reservation was
+    /// created from, so those are the identity.
+    fn names_same_operation(&self, other: &Self) -> bool {
+        let Self {
+            org_id,
+            operation_id,
+            operation_revision: _,
+            request_hash,
+            holder_id: _,
+            fencing_token: _,
+        } = self;
+        org_id == &other.org_id
+            && operation_id == &other.operation_id
+            && request_hash == &other.request_hash
+    }
+
+    fn validate(&self) -> Result<()> {
+        require_segment(&self.org_id, "operation.org_id")?;
+        require_segment(&self.holder_id, "operation.holder_id")?;
+        require_uuid(&self.operation_id, "operation.operation_id")?;
+        require_digest(&self.request_hash, "operation.request_hash")?;
+        if self.operation_revision < 1 {
+            bail!("operation.operation_revision must be at least 1");
+        }
+        if self.fencing_token < 1 {
+            bail!("operation.fencing_token must be at least 1");
+        }
+        Ok(())
+    }
+}
+
+/// A portable identifier: at most 128 characters of `[A-Za-z0-9_-]`, opening on
+/// an alphanumeric.
+///
+/// Narrower than "bounded text without control characters", deliberately. A dot
+/// or a colon would pass a looser check here and be refused at the store, after
+/// the publication it describes had already landed.
+fn require_segment(value: &str, label: &str) -> Result<()> {
+    let mut characters = value.chars();
+    let opens = characters
+        .next()
+        .is_some_and(|first| first.is_ascii_alphanumeric());
+    let rest = characters.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-');
+    if !opens || !rest || value.len() > 128 {
+        bail!(
+            "{label} must open on an alphanumeric and carry only letters, digits, underscores              and hyphens, within 128 characters"
+        );
+    }
+    Ok(())
+}
+
+/// A lowercase RFC 4122 UUID.
+///
+/// Lowercase rather than either case. A hosted store lowercases what it decodes
+/// and then compares receipts to stored operations by exact string, so emitting
+/// an uppercase value would produce a receipt that decodes and then fails to
+/// bind, which is a much harder failure to read than this one.
+fn require_uuid(value: &str, label: &str) -> Result<()> {
+    let bytes = value.as_bytes();
+    let shaped = bytes.len() == 36
+        && bytes.iter().enumerate().all(|(index, byte)| match index {
+            8 | 13 | 18 | 23 => *byte == b'-',
+            _ => byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase(),
+        })
+        && matches!(bytes[14], b'1'..=b'8')
+        && matches!(bytes[19], b'8' | b'9' | b'a' | b'b');
+    if !shaped {
+        bail!("{label} must be a lowercase RFC 4122 UUID");
+    }
+    Ok(())
+}
+
+/// A canonical 256-bit digest as sixty-four lowercase hex characters.
+fn require_digest(value: &str, label: &str) -> Result<()> {
+    let shaped = value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase());
+    if !shaped {
+        bail!("{label} must be a canonical 256-bit digest in lowercase hex");
+    }
+    Ok(())
+}
+
+/// Exactly where one ref points.
+///
+/// Rendered rather than reused from `kin_model::RefTarget`, whose derived
+/// encoding writes a digest as a JSON array of thirty-two numbers. This is the
+/// same information as hex, which is what the other side of this contract reads
+/// and writes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum RefTargetRecord {
+    /// A Kin semantic change, named directly.
+    Change { change_id: String },
+    /// A raw Git object, named by kind and object id. The object id keeps its
+    /// format: a forty-character value is a SHA-1 identity and a
+    /// sixty-four-character value is a SHA-256 one, and the two never compare
+    /// equal.
+    ExternalObject {
+        object_kind: String,
+        object_format: String,
+        oid: String,
+    },
+    /// Another ref in the same repository.
+    Symbolic { target: String },
+}
+
+impl RefTargetRecord {
+    fn from_target(target: &RefTarget) -> Result<Self> {
+        Ok(match target {
+            RefTarget::Change { change_id } => Self::Change {
+                change_id: change_id.to_string(),
+            },
+            RefTarget::ExternalObject { object } => Self::ExternalObject {
+                object_kind: external_object_kind_name(object.kind).to_string(),
+                object_format: match object.oid {
+                    GitObjectId::Sha1(_) => "sha1".to_string(),
+                    GitObjectId::Sha256(_) => "sha256".to_string(),
+                },
+                oid: object.oid.to_string(),
+            },
+            RefTarget::Symbolic { target } => Self::Symbolic {
+                target: exact_ref_name(target)?,
+            },
+        })
+    }
+}
+
+fn external_object_kind_name(kind: ExternalObjectKind) -> &'static str {
+    match kind {
+        ExternalObjectKind::Commit => "commit",
+        ExternalObjectKind::Tree => "tree",
+        ExternalObjectKind::Blob => "blob",
+        ExternalObjectKind::Tag => "tag",
+    }
+}
+
+/// One ref and the exact thing it points at.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RefBinding {
+    pub name: String,
+    pub target: RefTargetRecord,
+}
+
+/// How completely a set of ref bindings describes the imported authority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RefScope {
+    /// The bindings are the whole ref set. Any extra ref is a refusal.
+    Complete,
+    /// The bindings must each be present and exact. Other refs may exist.
+    ///
+    /// This is what an import of a narrower scope than the provider's current
+    /// state records, so a partial import is never described as a full mirror.
+    NamedSubset,
+}
+
+/// The exact refs an import claims, and how completely it claims them.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExpectedRefs {
+    pub scope: RefScope,
+    pub bindings: Vec<RefBinding>,
+}
+
+/// What the source must be, as distinct from where it currently is.
+///
+/// A filesystem path is machine-local, so it is a command-line argument rather
+/// than a manifest field: a manifest recovered onto a different host would
+/// otherwise name a path that does not exist there, or one that does and holds
+/// something else.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum SourceSpec {
+    NativeEmpty {
+        default_branch: String,
+    },
+    ExactGit {
+        provider: String,
+        object_format: String,
+        source_commit_oid: String,
+        default_branch: String,
+        expected_refs: ExpectedRefs,
+    },
+}
+
+impl SourceSpec {
+    fn mode(&self) -> PublicationMode {
+        match self {
+            Self::NativeEmpty { .. } => PublicationMode::NativeEmpty,
+            Self::ExactGit { .. } => PublicationMode::ExactGit,
+        }
+    }
+
+    fn default_branch(&self) -> &str {
+        match self {
+            Self::NativeEmpty { default_branch } | Self::ExactGit { default_branch, .. } => {
+                default_branch
+            }
+        }
+    }
+}
+
+/// Where the published authority is to live.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum DestinationSpec {
+    Filesystem { root: PathBuf },
+    Gcs { bucket: String, prefix: String },
+}
+
+impl DestinationSpec {
+    /// Open a backend for this destination.
+    ///
+    /// Called more than once per run on purpose. The measurement pass builds its
+    /// own handle rather than reusing the one the publication went through, so a
+    /// backend answering from a cache it populated while writing cannot satisfy
+    /// the readback.
+    fn open(&self) -> Result<Arc<dyn StorageBackend>> {
+        match self {
+            Self::Filesystem { root } => {
+                if !root.is_absolute() {
+                    bail!(
+                        "destination root must be an absolute path, got {}",
+                        root.display()
+                    );
+                }
+                fs::create_dir_all(root)
+                    .with_context(|| format!("create destination root {}", root.display()))?;
+                Ok(Arc::new(LocalFileBackend::new(root.clone())))
+            }
+            Self::Gcs { .. } => bail!(
+                "destination_backend_unavailable: this build publishes to a filesystem \
+                 destination only, and hosted object-store publication is a separate acceptance"
+            ),
+        }
+    }
+
+    fn scope(&self) -> String {
+        match self {
+            Self::Filesystem { root } => format!("fs:{}", root.display()),
+            Self::Gcs { bucket, prefix } => format!("gcs:{bucket}/{prefix}"),
+        }
+    }
+}
+
+/// One authority root, rendered as hex rather than as a byte array.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuthorityRootRecord {
+    pub version: u32,
+    pub hash: String,
+}
+
+impl From<&AuthorityRoot> for AuthorityRootRecord {
+    fn from(root: &AuthorityRoot) -> Self {
+        Self {
+            version: root.version,
+            hash: root.hash.to_string(),
+        }
+    }
+}
+
+/// A complete root bundle, losslessly, in a shape another language can read.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RootBundleRecord {
+    pub version: u32,
+    pub generation: u64,
+    pub history: AuthorityRootRecord,
+    pub ref_state: AuthorityRootRecord,
+    pub ref_log: AuthorityRootRecord,
+    pub collaboration: AuthorityRootRecord,
+    pub replication: AuthorityRootRecord,
+    pub local_state: AuthorityRootRecord,
+}
+
+impl From<&RootBundle> for RootBundleRecord {
+    fn from(bundle: &RootBundle) -> Self {
+        // Destructured rather than read field by field on purpose. Both this
+        // record and the binding digest beneath enumerate the roots by hand, so
+        // a seventh root added upstream has to break this build. Read field by
+        // field it would be dropped silently by both, and the digest would not
+        // change to say so.
+        let RootBundle {
+            version,
+            generation,
+            history,
+            ref_state,
+            ref_log,
+            collaboration,
+            replication,
+            local_state,
+        } = bundle;
+        Self {
+            version: *version,
+            generation: *generation,
+            history: history.into(),
+            ref_state: ref_state.into(),
+            ref_log: ref_log.into(),
+            collaboration: collaboration.into(),
+            replication: replication.into(),
+            local_state: local_state.into(),
+        }
+    }
+}
+
+/// One canonical digest over a complete root bundle.
+///
+/// A hosted receipt carries a single authority-root field, and a Kin root bundle
+/// is a version, a generation and six separate roots. Sending one of the six
+/// would silently drop the other five, so this binds all of them, in the order
+/// they are declared upstream, domain-separated and length-fixed. The whole
+/// bundle also ships beside this value, so the digest stays checkable rather
+/// than merely trusted.
+fn authority_root_binding(bundle: &RootBundle) -> Hash256 {
+    let RootBundle {
+        version,
+        generation,
+        history,
+        ref_state,
+        ref_log,
+        collaboration,
+        replication,
+        local_state,
+    } = bundle;
+    let mut hasher = Sha256::new();
+    hasher.update(AUTHORITY_ROOT_DOMAIN);
+    hasher.update(version.to_le_bytes());
+    hasher.update(generation.to_le_bytes());
+    for root in [
+        history,
+        ref_state,
+        ref_log,
+        collaboration,
+        replication,
+        local_state,
+    ] {
+        hasher.update(root.version.to_le_bytes());
+        hasher.update(root.hash.as_bytes());
+    }
+    Hash256::from_bytes(hasher.finalize().into())
+}
+
+/// The referenced source-body closure, as three checkable numbers and a digest.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClosureRecord {
+    pub algorithm: String,
+    pub digest: String,
+    pub body_count: u64,
+    pub total_bytes: u64,
+}
+
+impl From<&SourceBodyClosure> for ClosureRecord {
+    fn from(closure: &SourceBodyClosure) -> Self {
+        Self {
+            algorithm: CLOSURE_ALGORITHM.to_string(),
+            digest: closure.digest().to_string(),
+            body_count: closure.body_count(),
+            total_bytes: closure.total_bytes(),
+        }
+    }
+}
+
+/// The operation-bound input.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Manifest {
+    pub schema: String,
+    pub operation: OperationBinding,
+    pub repository_id: String,
+    pub source: SourceSpec,
+    /// The orchestrator's own canonical digest over its source record.
+    ///
+    /// Carried, never recomputed. Reproducing another system's canonical JSON
+    /// encoder here would put the definition of this value in two languages, and
+    /// the day they disagree is the day a correct publication is refused for a
+    /// reason nobody can see. It lands in the echoed half of the evidence, where
+    /// it cannot be mistaken for something this process checked.
+    pub source_input_hash: String,
+    pub destination: DestinationSpec,
+    /// The exact authority this run expects to find, or `None` for a first
+    /// attempt, which expects to find nothing at all.
+    pub expected_authority: Option<IntentRecord>,
+}
+
+/// What is about to be published, made durable before it becomes permanent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IntentRecord {
+    pub schema: String,
+    pub repository_id: String,
+    pub operation: OperationBinding,
+    pub mode: PublicationMode,
+    pub intended_snapshot_sha256: String,
+    pub intended_roots: RootBundleRecord,
+    pub intended_source_closure: ClosureRecord,
+    pub intended_default_branch: String,
+    pub intended_head_change_id: Option<String>,
+    pub intended_ref_bindings: Vec<RefBinding>,
+    pub destination: DestinationSpec,
+    pub written_at: String,
+}
+
+impl IntentRecord {
+    /// Whether two intents describe the same publication.
+    ///
+    /// `written_at` is excluded deliberately. A second attempt at the same
+    /// publication writes a new timestamp and is still the same intent, and
+    /// making the clock part of the identity would turn every honest retry into
+    /// a conflict. Both sides are destructured so that a field added later has
+    /// to be classified here rather than silently ignored.
+    fn describes_same_publication(&self, other: &Self) -> bool {
+        let Self {
+            schema,
+            repository_id,
+            operation,
+            mode,
+            intended_snapshot_sha256,
+            intended_roots,
+            intended_source_closure,
+            intended_default_branch,
+            intended_head_change_id,
+            intended_ref_bindings,
+            destination,
+            written_at: _,
+        } = self;
+        let Self {
+            schema: other_schema,
+            repository_id: other_repository_id,
+            operation: other_operation,
+            mode: other_mode,
+            intended_snapshot_sha256: other_snapshot,
+            intended_roots: other_roots,
+            intended_source_closure: other_closure,
+            intended_default_branch: other_branch,
+            intended_head_change_id: other_head,
+            intended_ref_bindings: other_bindings,
+            destination: other_destination,
+            written_at: _,
+        } = other;
+        schema == other_schema
+            && repository_id == other_repository_id
+            && operation.names_same_operation(other_operation)
+            && mode == other_mode
+            && intended_snapshot_sha256 == other_snapshot
+            && intended_roots == other_roots
+            && intended_source_closure == other_closure
+            && intended_default_branch == other_branch
+            && intended_head_change_id == other_head
+            && intended_ref_bindings == other_bindings
+            && destination == other_destination
+    }
+}
+
+/// How a run ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Outcome {
+    /// This run installed the publication.
+    Published,
+    /// The publication was already there and is exactly the intended one.
+    Recovered,
+    /// The destination holds no publication.
+    Absent,
+    /// The destination holds a publication that is not the intended one.
+    Conflict,
+    /// The destination's state could not be established either way.
+    Indeterminate,
+}
+
+impl Outcome {
+    fn exit_code(self) -> i32 {
+        match self {
+            // A recovery is a success the caller proceeds from, so it shares an
+            // exit status with a fresh publication and the record's own outcome
+            // field is what tells them apart. A distinct non-zero status would
+            // abort an ordinary shell runner on a correct result.
+            Self::Published | Self::Recovered => 0,
+            Self::Absent => EXIT_ABSENT,
+            Self::Conflict => EXIT_CONFLICT,
+            Self::Indeterminate => EXIT_INDETERMINATE,
+        }
+    }
+}
+
+/// Where a reported digest came from, stated rather than assumed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SnapshotDigestSource {
+    /// The publication primitive's own digest over the bytes it installed.
+    Receipt,
+    /// The durable intent written before the compare-and-swap.
+    Intent,
+}
+
+/// Everything this process read back out of destination storage.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MeasuredAuthority {
+    pub artifact_id: String,
+    /// Digest over the bytes a fresh handle read back from the destination.
+    pub artifact_sha256: String,
+    /// The publisher's digest over the bytes it meant to install.
+    pub snapshot_sha256: String,
+    pub snapshot_sha256_source: SnapshotDigestSource,
+    pub storage_generation: String,
+    pub authority_root_binding: String,
+    pub roots: RootBundleRecord,
+    pub source_closure: ClosureRecord,
+    pub mode: PublicationMode,
+    pub git_external_authority_present: bool,
+    pub default_branch: String,
+    pub head_change_id: Option<String>,
+    pub ref_bindings: Vec<RefBinding>,
+    pub observed_at: String,
+}
+
+/// Everything carried in from the manifest and checked by nothing here.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EchoedInput {
+    pub source_input_hash: String,
+    pub requested_default_branch: String,
+    pub expected_refs: Option<ExpectedRefs>,
+}
+
+/// One field on which the destination disagreed with the intent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Difference {
+    pub field: String,
+    pub intended: String,
+    pub observed: String,
+}
+
+/// The record a trusted signer reads to build a preparation receipt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidenceRecord {
+    pub schema: String,
+    pub outcome: Outcome,
+    pub repository_id: String,
+    pub operation: OperationBinding,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub measured: Option<MeasuredAuthority>,
+    pub echoed: EchoedInput,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub differences: Vec<Difference>,
+    /// Why a run without measured authority ended the way it did, verbatim.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub detail: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Reading the authority
+// ---------------------------------------------------------------------------
+
+/// A ref name as exact UTF-8, or a refusal.
+///
+/// Kin ref names are bytes, and a hosted contract carries them as strings. A
+/// name that is not UTF-8 is refused rather than rendered lossily, because a
+/// lossy name would compare unequal to itself on the next read and would be
+/// impossible to act on.
+fn exact_ref_name(name: &RefName) -> Result<String> {
+    name.as_utf8().map(str::to_string).ok_or_else(|| {
+        anyhow!(
+            "ref name is not exact UTF-8 and cannot be carried in a hosted binding: {}",
+            hex::encode(name.as_bytes())
+        )
+    })
+}
+
+/// The short branch name behind a default ref, or a refusal.
+fn default_branch_name(name: &RefName) -> Result<String> {
+    if !name.is_branch() {
+        bail!(
+            "default ref {} is not a branch, so it names no default branch",
+            exact_ref_name(name).unwrap_or_else(|_| hex::encode(name.as_bytes()))
+        );
+    }
+    let exact = exact_ref_name(name)?;
+    exact
+        .strip_prefix("refs/heads/")
+        .map(str::to_string)
+        .ok_or_else(|| anyhow!("branch ref {exact} does not carry the refs/heads/ prefix"))
+}
+
+/// Every ref the published authority holds, with its exact target.
+fn measure_ref_bindings(metadata: &PersistedRepositoryAuthority) -> Result<Vec<RefBinding>> {
+    let mut bindings = Vec::with_capacity(metadata.ref_state.refs.len());
+    for repository_ref in &metadata.ref_state.refs {
+        bindings.push(RefBinding {
+            name: exact_ref_name(&repository_ref.name)?,
+            target: RefTargetRecord::from_target(&repository_ref.target)?,
+        });
+    }
+    bindings.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(bindings)
+}
+
+/// The semantic change the default ref resolves to, or `None` when unborn.
+///
+/// An imported Git ref points at a raw external object rather than at a change,
+/// so the graph's own external-change aliases are what resolve it. `GitObjectId`
+/// carries its object format in its own identity, so a SHA-1 object id can never
+/// match a SHA-256 alias and nothing here casts one identity into the other. A
+/// target with no alias, or one that somehow carries more than one, is refused
+/// rather than guessed at. A default ref with no entry at all is unborn, which
+/// repository ref state permits and which a native empty repository always is.
+fn resolve_head_change_id(
+    metadata: &PersistedRepositoryAuthority,
+    repository_id: &RepositoryId,
+) -> Result<Option<String>> {
+    let Some(default_ref) = metadata.ref_state.default_ref.as_ref() else {
+        return Ok(None);
+    };
+    let mut name = default_ref.clone();
+    let mut seen: BTreeSet<Vec<u8>> = BTreeSet::new();
+    for _ in 0..MAX_SYMBOLIC_HOPS {
+        if !seen.insert(name.as_bytes().to_vec()) {
+            bail!(
+                "default ref {} resolves through a symbolic cycle",
+                exact_ref_name(&name).unwrap_or_else(|_| hex::encode(name.as_bytes()))
+            );
+        }
+        let Some(found) = find_ref(&metadata.ref_state.refs, &name) else {
+            // Unborn. The ref state's own contract allows a default ref whose
+            // target does not exist yet, and a repository created empty is
+            // exactly that.
+            return Ok(None);
+        };
+        match &found.target {
+            RefTarget::Change { change_id } => return Ok(Some(change_id.to_string())),
+            RefTarget::ExternalObject { object } => {
+                let mut matches = metadata.aliases.iter().filter(|alias| {
+                    alias.oid == object.oid && &alias.repository_id == repository_id
+                });
+                let Some(alias) = matches.next() else {
+                    bail!(
+                        "default ref target {} has no semantic change alias in the published \
+                         authority, so its head cannot be named",
+                        object.oid
+                    );
+                };
+                if matches.next().is_some() {
+                    bail!(
+                        "default ref target {} carries more than one semantic change alias",
+                        object.oid
+                    );
+                }
+                return Ok(Some(alias.change_id.to_string()));
+            }
+            RefTarget::Symbolic { target } => name = target.clone(),
+        }
+    }
+    bail!(
+        "default ref {} did not resolve within {MAX_SYMBOLIC_HOPS} symbolic hops",
+        exact_ref_name(default_ref).unwrap_or_else(|_| hex::encode(default_ref.as_bytes()))
+    )
+}
+
+fn find_ref<'a>(refs: &'a [RepositoryRef], name: &RefName) -> Option<&'a RepositoryRef> {
+    refs.iter().find(|candidate| &candidate.name == name)
+}
+
+/// Check measured ref bindings against the exact set an import claimed.
+fn verify_expected_refs(expected: &ExpectedRefs, measured: &[RefBinding]) -> Result<()> {
+    let observed: BTreeMap<&str, &RefTargetRecord> = measured
+        .iter()
+        .map(|binding| (binding.name.as_str(), &binding.target))
+        .collect();
+    for binding in &expected.bindings {
+        let Some(target) = observed.get(binding.name.as_str()) else {
+            bail!(
+                "expected ref {} is not present in the imported authority",
+                binding.name
+            );
+        };
+        if *target != &binding.target {
+            bail!(
+                "expected ref {} points at {:?} rather than the claimed {:?}",
+                binding.name,
+                target,
+                binding.target
+            );
+        }
+    }
+    if expected.scope == RefScope::Complete {
+        let claimed: BTreeSet<&str> = expected
+            .bindings
+            .iter()
+            .map(|binding| binding.name.as_str())
+            .collect();
+        let extra: Vec<&str> = observed
+            .keys()
+            .copied()
+            .filter(|name| !claimed.contains(name))
+            .collect();
+        if !extra.is_empty() {
+            bail!(
+                "import claims a complete ref scope but the authority also holds {}",
+                extra.join(", ")
+            );
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Durable files
+// ---------------------------------------------------------------------------
+
+/// Read one JSON document, refusing a symlink at the path.
+///
+/// A path an orchestrator supplies is not automatically a regular file, and
+/// following a link here would let whoever can create one decide what this
+/// process reads.
+fn read_json<T: serde::de::DeserializeOwned>(path: &Path, label: &str) -> Result<T> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("read {label} at {}", path.display()))?;
+    if metadata.file_type().is_symlink() {
+        bail!("{label} path is a symlink: {}", path.display());
+    }
+    let bytes = fs::read(path).with_context(|| format!("read {label} at {}", path.display()))?;
+    serde_json::from_slice(&bytes).with_context(|| format!("parse {label} at {}", path.display()))
+}
+
+/// Install one JSON document so that a later read sees all of it or none of it.
+///
+/// Written to a private temporary beside the target, flushed, then renamed. The
+/// containing directory is flushed too on Unix, because a rename that the
+/// directory entry has not recorded is not durable; `File::open` on a directory
+/// is not available on Windows, and the guarantee this function offers there is
+/// the file's own flush plus an atomic rename.
+fn write_json_atomically(path: &Path, value: &impl Serialize, label: &str) -> Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .ok_or_else(|| anyhow!("{label} path {} has no parent directory", path.display()))?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("create {label} directory {}", parent.display()))?;
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| anyhow!("{label} path {} names no file", path.display()))?;
+    // Named by this process, because a shared scratch name is a race with every
+    // other publication running on the same box.
+    let temporary = parent.join(format!(
+        ".{}.tmp-{}",
+        file_name.to_string_lossy(),
+        std::process::id()
+    ));
+    let mut bytes = serde_json::to_vec_pretty(value)
+        .with_context(|| format!("encode {label} for {}", path.display()))?;
+    bytes.push(b'\n');
+    {
+        // `create_new` refuses anything already at the temporary path,
+        // including a symlink, so nothing this writes can be redirected.
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary)
+            .with_context(|| format!("create {label} temporary {}", temporary.display()))?;
+        file.write_all(&bytes)
+            .with_context(|| format!("write {label} temporary {}", temporary.display()))?;
+        file.sync_all()
+            .with_context(|| format!("flush {label} temporary {}", temporary.display()))?;
+    }
+    fs::rename(&temporary, path).with_context(|| {
+        format!(
+            "install {label} {} from {}",
+            path.display(),
+            temporary.display()
+        )
+    })?;
+    #[cfg(unix)]
+    {
+        fs::File::open(parent)
+            .and_then(|directory| directory.sync_all())
+            .with_context(|| format!("flush {label} directory {}", parent.display()))?;
+    }
+    Ok(())
+}
+
+/// Distinguishes one staging file from every other in this process.
+static STAGING_SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Install one JSON document only if nothing is at the path, atomically.
+///
+/// Returns whether this call is the one that installed it.
+///
+/// The install is a `link`, not a `rename`, and the difference is the whole
+/// point. A rename replaces whatever is at the destination, so checking for
+/// absence and then renaming leaves a window in which another writer's document
+/// is installed and then destroyed by this one. `link` fails when the
+/// destination exists, so the check and the install are the same operation and
+/// there is no window to lose. A symlink at the destination is a directory entry
+/// like any other, so it makes this fail too rather than being followed.
+pub fn install_no_replace(path: &Path, bytes: &[u8], label: &str) -> Result<bool> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .ok_or_else(|| anyhow!("{label} path {} has no parent directory", path.display()))?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("create {label} directory {}", parent.display()))?;
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| anyhow!("{label} path {} names no file", path.display()))?;
+    // Named by this process AND by a per-call sequence. The process id alone
+    // was not enough and the concurrent test is what said so: two callers inside
+    // one process shared a staging name, so one deleted the other's staged file
+    // and the link that followed had nothing to install. A live peer can never
+    // hold this name, because no two live processes share a pid and no two calls
+    // in this one share a sequence number, which is what makes the pre-emptive
+    // remove below safe: the only file it can ever delete is a stale one this
+    // caller's own name was left on.
+    let staged = parent.join(format!(
+        ".{}.staged-{}-{}",
+        file_name.to_string_lossy(),
+        std::process::id(),
+        STAGING_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    ));
+    let _ = fs::remove_file(&staged);
+    let install = (|| -> Result<bool> {
+        {
+            // `create_new` refuses anything already at the staged path,
+            // including a symlink, so nothing written here can be redirected.
+            let mut file = fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&staged)
+                .with_context(|| format!("create {label} staging file {}", staged.display()))?;
+            file.write_all(bytes)
+                .with_context(|| format!("write {label} staging file {}", staged.display()))?;
+            file.sync_all()
+                .with_context(|| format!("flush {label} staging file {}", staged.display()))?;
+        }
+        match fs::hard_link(&staged, path) {
+            Ok(()) => Ok(true),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
+            Err(error) => {
+                Err(error).with_context(|| format!("install {label} at {}", path.display()))
+            }
+        }
+    })();
+    let _ = fs::remove_file(&staged);
+    let installed = install?;
+    if installed {
+        #[cfg(unix)]
+        {
+            // A link the directory entry has not recorded is not durable.
+            // `File::open` on a directory is unavailable on Windows, where the
+            // guarantee is the file's own flush plus the atomic link.
+            fs::File::open(parent)
+                .and_then(|directory| directory.sync_all())
+                .with_context(|| format!("flush {label} directory {}", parent.display()))?;
+        }
+    }
+    Ok(installed)
+}
+
+/// Make the intended publication durable, never replacing a different one.
+///
+/// The install itself is what refuses: it cannot overwrite, so a document that
+/// is already there was put there by somebody, and this reads it back to decide
+/// who. This same publication means the file is already durable and there is
+/// nothing left to do. A different one means another attempt or another writer
+/// got here first, and its record is the only evidence that could ever resolve
+/// that attempt, so this run stops rather than destroying it.
+fn write_intent_durably(path: &Path, record: &IntentRecord) -> Result<()> {
+    let mut bytes = serde_json::to_vec_pretty(record).context("encode the durable intent")?;
+    bytes.push(b'\n');
+    if install_no_replace(path, &bytes, "intent")? {
+        return Ok(());
+    }
+    let existing: IntentRecord = read_json(path, "existing intent")?;
+    if existing.describes_same_publication(record) {
+        return Ok(());
+    }
+    bail!(
+        "intent path {} already records a different publication, which this run will not replace",
+        path.display()
+    )
+}
+
+fn now_utc() -> String {
+    chrono::Utc::now()
+        .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+        .to_string()
+}
+
+// ---------------------------------------------------------------------------
+// The source
+// ---------------------------------------------------------------------------
+
+/// Open the reserved repository's source authority, initializing it once.
+///
+/// A store that already exists is reused rather than rebuilt. Running init a
+/// second time after a crash can mint different workspace and initialization
+/// metadata under the same repository identity, and a recovery comparing that
+/// fresh candidate against the durable intent would call the difference a
+/// conflict when nothing was actually wrong.
+fn open_or_initialize_source(
+    source_dir: &Path,
+    repository_id: &RepositoryId,
+    spec: &SourceSpec,
+) -> Result<Arc<RepositoryAuthorityManager<dyn StorageBackend>>> {
+    let kin_dir = source_dir.join(".kin");
+    let already_initialized = match fs::symlink_metadata(&kin_dir) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            bail!("source store marker is a symlink: {}", kin_dir.display())
+        }
+        Ok(_) => true,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+        Err(error) => {
+            return Err(error).with_context(|| format!("inspect source {}", kin_dir.display()))
+        }
+    };
+    let kindb_dir = if already_initialized {
+        kin_core::KinLayout::new(kin_dir).kindb_dir()
+    } else {
+        let result = match spec {
+            SourceSpec::NativeEmpty { default_branch } => {
+                fs::create_dir_all(source_dir).with_context(|| {
+                    format!("create native source directory {}", source_dir.display())
+                })?;
+                kin_core::init_replica_adopting(source_dir, default_branch, repository_id)
+                    .with_context(|| {
+                        format!(
+                            "initialize an unborn native authority on {default_branch} adopting \
+                             {repository_id}"
+                        )
+                    })?
+            }
+            SourceSpec::ExactGit { .. } => {
+                kin_core::init_from_git_adopting(source_dir, repository_id).with_context(|| {
+                    format!("admit exact Git repository authority adopting {repository_id}")
+                })?
+            }
+        };
+        result.layout.kindb_dir()
+    };
+    let backend: Arc<dyn StorageBackend> = Arc::new(LocalFileBackend::new(kindb_dir));
+    Ok(Arc::new(
+        RepositoryAuthorityManager::open(repository_id.clone(), backend)
+            .with_context(|| format!("open the source authority for {repository_id}"))?,
+    ))
+}
+
+/// Check the source authority against everything the manifest claims about it.
+///
+/// Kin does not re-authorize the source; that boundary belongs to whoever
+/// materialized it. What this does is refuse to publish a source that is not the
+/// one the manifest describes, reading the claim off graph-owned authority
+/// rather than off the working directory.
+fn verify_source_authority(
+    metadata: &PersistedRepositoryAuthority,
+    snapshot: &GraphSnapshot,
+    repository_id: &RepositoryId,
+    spec: &SourceSpec,
+) -> Result<Vec<RefBinding>> {
+    if &metadata.repository_id != repository_id {
+        bail!(
+            "source authority owns {} rather than the reserved {repository_id}",
+            metadata.repository_id
+        );
+    }
+    // Ahead of the mode match on purpose. "This source is not unborn" is a fact
+    // about the request's own claim, and absent Git metadata is only evidence
+    // that a store was not imported, never that it is empty. An existing store
+    // is reused rather than rebuilt, so without this a committed native
+    // repository would publish under a reservation that promised an empty one.
+    if matches!(spec, SourceSpec::NativeEmpty { .. }) {
+        if !snapshot.entities.is_empty() {
+            bail!(
+                "a native-empty publication requires an unborn source, and this one already \
+                 holds {} entities",
+                snapshot.entities.len()
+            );
+        }
+        if !snapshot.changes.is_empty() {
+            bail!(
+                "a native-empty publication requires an unborn source, and this one already \
+                 holds {} semantic changes",
+                snapshot.changes.len()
+            );
+        }
+        if !metadata.ref_state.refs.is_empty() {
+            bail!(
+                "a native-empty publication requires an unborn source, and this one already \
+                 holds {} refs",
+                metadata.ref_state.refs.len()
+            );
+        }
+    }
+    let git = metadata.git_external_authority.as_ref();
+    match (spec, git) {
+        (SourceSpec::NativeEmpty { .. }, Some(_)) => {
+            bail!("a native-empty publication cannot be built from an imported Git authority")
+        }
+        (SourceSpec::ExactGit { .. }, None) => {
+            bail!("an exact-Git publication requires an imported Git authority")
+        }
+        (SourceSpec::NativeEmpty { .. }, None) => {}
+        (
+            SourceSpec::ExactGit {
+                provider,
+                object_format,
+                source_commit_oid,
+                ..
+            },
+            Some(git),
+        ) => {
+            if provider != "github" {
+                bail!("unsupported exact-Git provider {provider:?}");
+            }
+            let imported_format = match git.object_format {
+                GitObjectFormat::Sha1 => "sha1",
+                GitObjectFormat::Sha256 => "sha256",
+            };
+            if imported_format != object_format {
+                bail!(
+                    "imported Git authority uses {imported_format} object identity rather than \
+                     the claimed {object_format}"
+                );
+            }
+            match &git.material_head {
+                GitMaterialHead::Commit { commit_oid, .. } => {
+                    let observed = commit_oid.to_string();
+                    if &observed != source_commit_oid {
+                        bail!(
+                            "imported Git authority resolves HEAD to {observed} rather than the \
+                             claimed {source_commit_oid}"
+                        );
+                    }
+                }
+                GitMaterialHead::Unborn { .. } => {
+                    bail!("imported Git authority has an unborn HEAD and names no source commit")
+                }
+                GitMaterialHead::NonMaterializable { .. } => {
+                    bail!("imported Git HEAD cannot seed a workspace, so it names no source commit")
+                }
+            }
+        }
+    }
+    let Some(default_ref) = metadata.ref_state.default_ref.as_ref() else {
+        bail!("source authority carries no default ref and cannot be published");
+    };
+    let observed_branch = default_branch_name(default_ref)?;
+    if observed_branch != spec.default_branch() {
+        bail!(
+            "source authority defaults to {observed_branch} rather than the requested {}",
+            spec.default_branch()
+        );
+    }
+    let bindings = measure_ref_bindings(metadata)?;
+    if let SourceSpec::ExactGit { expected_refs, .. } = spec {
+        verify_expected_refs(expected_refs, &bindings)
+            .context("imported refs do not match the exact bindings this import claims")?;
+    }
+    Ok(bindings)
+}
+
+// ---------------------------------------------------------------------------
+// Measuring the destination
+// ---------------------------------------------------------------------------
+
+/// What a fresh look at the destination found.
+enum DestinationReading {
+    /// Nothing is published under this identity.
+    Absent,
+    /// The destination could not be read either way.
+    Indeterminate(String),
+    /// A publication is there, measured through a handle that never wrote.
+    Present(Box<MeasuredAuthority>),
+}
+
+/// Read the published authority back through a handle that never wrote to it.
+///
+/// The publication primitive already compares what it installed against what it
+/// reads back, but it does so through the handle it published through. This
+/// opens a new one from the destination specification, so a backend that would
+/// answer from state it cached while writing cannot satisfy this readback.
+fn measure_destination(
+    destination: &DestinationSpec,
+    repository_id: &RepositoryId,
+    mode: PublicationMode,
+    snapshot_sha256: String,
+    snapshot_sha256_source: SnapshotDigestSource,
+) -> Result<DestinationReading> {
+    let backend = destination.open()?;
+    match backend.load_snapshot_cursor(repository_id.as_str()) {
+        Ok(None) => return Ok(DestinationReading::Absent),
+        Ok(Some(_)) => {}
+        // An inspection failure is not an absence. Reporting it as one is the
+        // exact mistake that turns an unknown storage state into a second
+        // publication under the same reserved identity.
+        Err(error) => return Ok(DestinationReading::Indeterminate(error.to_string())),
+    }
+    // ONE read. Everything below is derived from exactly these bytes, because
+    // three separate selections are three separate authorities: the backend
+    // releases its lock on each read, and an opened manager recovers over
+    // acknowledged journal frames while a snapshot load returns only the base.
+    // A writer advancing the destination between them would otherwise produce a
+    // reading whose digest belongs to one authority and whose roots and refs
+    // belong to another, with every field of it looking measured.
+    let (bytes, generation) = match backend.load_snapshot(repository_id.as_str()) {
+        Ok(Some(found)) => found,
+        Ok(None) => {
+            return Ok(DestinationReading::Indeterminate(
+                "destination reported a publication cursor and then no snapshot".to_string(),
+            ))
+        }
+        Err(error) => return Ok(DestinationReading::Indeterminate(error.to_string())),
+    };
+    let pinned = Arc::new(bytes);
+    let artifact_sha256 = Hash256::from_bytes(Sha256::digest(pinned.as_slice()).into()).to_string();
+    let reading = read_pinned_published_authority(repository_id, backend, pinned)
+        .with_context(|| format!("read the published authority for {repository_id}"))?;
+    let metadata = &reading.authority;
+    if &metadata.repository_id != repository_id {
+        bail!(
+            "published authority owns {} rather than the reserved {repository_id}",
+            metadata.repository_id
+        );
+    }
+    let roots = reading.roots.clone();
+    let default_ref = metadata
+        .ref_state
+        .default_ref
+        .as_ref()
+        .ok_or_else(|| anyhow!("published authority carries no default ref"))?;
+    let default_branch = default_branch_name(default_ref)?;
+    let head_change_id = resolve_head_change_id(metadata, repository_id)?;
+    let ref_bindings = measure_ref_bindings(metadata)?;
+    let git_external_authority_present = metadata.git_external_authority.is_some();
+    let closure = reading.source_closure;
+    let artifact_id = compose_artifact_id(destination, repository_id, generation)?;
+    Ok(DestinationReading::Present(Box::new(MeasuredAuthority {
+        artifact_id,
+        artifact_sha256,
+        snapshot_sha256,
+        snapshot_sha256_source,
+        storage_generation: generation.to_string(),
+        authority_root_binding: authority_root_binding(&roots).to_string(),
+        roots: RootBundleRecord::from(&roots),
+        source_closure: ClosureRecord::from(&closure),
+        mode,
+        git_external_authority_present,
+        default_branch,
+        head_change_id,
+        ref_bindings,
+        observed_at: now_utc(),
+    })))
+}
+
+/// Name the exact durable object the authority landed in.
+///
+/// Composed rather than reconstructed by a reader from three other fields, and
+/// refused here when it would exceed what a hosted store accepts, so the reason
+/// is visible in this process rather than as an invalid field at the store.
+fn compose_artifact_id(
+    destination: &DestinationSpec,
+    repository_id: &RepositoryId,
+    generation: u64,
+) -> Result<String> {
+    let artifact_id = format!(
+        "{ARTIFACT_ID_PREFIX}:{}/{repository_id}@{generation}",
+        destination.scope()
+    );
+    // A hosted store trims what it stores here, so a value with surrounding
+    // whitespace would be silently normalized into something that is no longer
+    // the identifier this process reported. Control characters it refuses
+    // outright. Both are refused here instead, where the destination that
+    // produced them can be named.
+    if artifact_id != artifact_id.trim() {
+        bail!("composed artifact identifier carries surrounding whitespace: {artifact_id:?}");
+    }
+    if artifact_id.chars().any(char::is_control) {
+        bail!("composed artifact identifier carries a control character");
+    }
+    if artifact_id.len() > ARTIFACT_ID_MAX_BYTES {
+        bail!(
+            "composed artifact identifier is {} bytes, over the {ARTIFACT_ID_MAX_BYTES} a hosted \
+             record accepts; shorten the destination scope",
+            artifact_id.len()
+        );
+    }
+    Ok(artifact_id)
+}
+
+/// Every way the destination can disagree with what was intended.
+///
+/// Named field by field rather than as one equality, because a caller resolving
+/// a conflict needs to know which value moved.
+fn compare_with_intent(intent: &IntentRecord, measured: &MeasuredAuthority) -> Vec<Difference> {
+    let mut differences = Vec::new();
+    let mut note = |field: &str, intended: String, observed: String| {
+        if intended != observed {
+            differences.push(Difference {
+                field: field.to_string(),
+                intended,
+                observed,
+            });
+        }
+    };
+    note(
+        "snapshot_sha256",
+        intent.intended_snapshot_sha256.clone(),
+        measured.artifact_sha256.clone(),
+    );
+    note(
+        "mode",
+        intent.mode.as_str().to_string(),
+        measured.mode.as_str().to_string(),
+    );
+    note(
+        "default_branch",
+        intent.intended_default_branch.clone(),
+        measured.default_branch.clone(),
+    );
+    note(
+        "head_change_id",
+        format!("{:?}", intent.intended_head_change_id),
+        format!("{:?}", measured.head_change_id),
+    );
+    note(
+        "roots",
+        format!("{:?}", intent.intended_roots),
+        format!("{:?}", measured.roots),
+    );
+    note(
+        "source_closure",
+        format!("{:?}", intent.intended_source_closure),
+        format!("{:?}", measured.source_closure),
+    );
+    note(
+        "ref_bindings",
+        format!("{:?}", intent.intended_ref_bindings),
+        format!("{:?}", measured.ref_bindings),
+    );
+    differences
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+/// Where the caller says the source is now and where the evidence goes.
+pub struct PublishArgs {
+    pub manifest: PathBuf,
+    pub source: PathBuf,
+    pub intent_out: PathBuf,
+    pub evidence_out: PathBuf,
+    pub expect_repository_id: String,
+    pub expect_mode: String,
+}
+
+/// A read-only look at a destination, against a durable intent.
+pub struct VerifyArgs {
+    pub manifest: PathBuf,
+    pub intent: Option<PathBuf>,
+    pub evidence_out: PathBuf,
+    pub expect_repository_id: String,
+    pub expect_mode: String,
+}
+
+/// A manifest, checked against the identity the caller believes it holds.
+///
+/// The manifest is authoritative and the flags are a cross-check, refused on any
+/// disagreement. This is not redundancy for its own sake. A worker recovering
+/// after a crash reconstructs its own state, and the failure that costs a tenant
+/// its repository is a recovered worker picking up the previous operation's
+/// manifest file. The flags are what the recovering caller believes; the
+/// manifest is what some earlier process wrote. Making them agree turns that
+/// into a refusal.
+fn read_checked_manifest(
+    path: &Path,
+    expect_repository_id: &str,
+    expect_mode: &str,
+) -> Result<(Manifest, RepositoryId, PublicationMode)> {
+    let manifest: Manifest = read_json(path, "manifest")?;
+    if manifest.schema != MANIFEST_SCHEMA {
+        bail!(
+            "manifest declares schema {:?}, and this build reads only {MANIFEST_SCHEMA}",
+            manifest.schema
+        );
+    }
+    if manifest.repository_id != expect_repository_id {
+        bail!(
+            "manifest reserves {:?} but this invocation expects {expect_repository_id:?}",
+            manifest.repository_id
+        );
+    }
+    let expected_mode = PublicationMode::parse(expect_mode)?;
+    let manifest_mode = manifest.source.mode();
+    if manifest_mode != expected_mode {
+        bail!(
+            "manifest describes a {} source but this invocation expects {}",
+            manifest_mode.as_str(),
+            expected_mode.as_str()
+        );
+    }
+    require_uuid(&manifest.repository_id, "repository_id")?;
+    manifest.operation.validate()?;
+    require_digest(&manifest.source_input_hash, "source_input_hash")?;
+    let repository_id = RepositoryId::new(manifest.repository_id.clone())
+        .map_err(|error| anyhow!("reserved repository identity is unusable: {error}"))?;
+    Ok((manifest, repository_id, manifest_mode))
+}
+
+/// Bring the inline expected authority and the on-disk intent to one value, and
+/// refuse one that does not belong to this operation.
+///
+/// The two sources are never ranked. Two records that disagree are two accounts
+/// of the same attempt, and choosing between them would decide, silently, which
+/// crash to believe.
+///
+/// The binding check is not a formality. An intent path is supplied by the
+/// caller and an intent file outlives the run that wrote it, so a worker that
+/// reused a path, or recovered onto a machine that still held an earlier
+/// operation's file, would otherwise be handed a stranger's intent, find the
+/// destination matching it, and report a recovery for work this operation never
+/// did.
+fn reconcile_expected_intent(
+    manifest: &Manifest,
+    path: Option<&Path>,
+) -> Result<Option<IntentRecord>> {
+    let inline = manifest.expected_authority.as_ref();
+    let on_disk = match path {
+        Some(path) if path.exists() => Some(read_json::<IntentRecord>(path, "intent")?),
+        _ => None,
+    };
+    let resolved = match (inline, on_disk) {
+        (Some(inline), Some(on_disk)) => {
+            if !inline.describes_same_publication(&on_disk) {
+                bail!(
+                    "the manifest's expected authority and the intent file describe different \
+                     publications, and this run will not choose between them"
+                );
+            }
+            Some(on_disk)
+        }
+        (Some(inline), None) => Some(inline.clone()),
+        (None, on_disk) => on_disk,
+    };
+    if let Some(intent) = resolved.as_ref() {
+        if intent.schema != INTENT_SCHEMA {
+            bail!(
+                "durable intent declares schema {:?}, and this build reads only {INTENT_SCHEMA}",
+                intent.schema
+            );
+        }
+        if intent.repository_id != manifest.repository_id {
+            bail!(
+                "the durable intent records repository {:?} and this manifest reserves {:?}",
+                intent.repository_id,
+                manifest.repository_id
+            );
+        }
+        if !intent.operation.names_same_operation(&manifest.operation) {
+            bail!(
+                "the durable intent belongs to another operation, so it cannot say what this \
+                 one published"
+            );
+        }
+        // Same class as the check above. The reading this intent is compared
+        // against comes from the manifest's destination, so an intent recording
+        // a different one would have its intended values checked against
+        // somewhere it never wrote, and a coincidental match would be reported
+        // as a recovery.
+        if intent.destination != manifest.destination {
+            bail!(
+                "the durable intent records a different destination than this manifest, so it \
+                 cannot say what is published there"
+            );
+        }
+    }
+    Ok(resolved)
+}
+
+fn echoed_input(manifest: &Manifest) -> EchoedInput {
+    EchoedInput {
+        source_input_hash: manifest.source_input_hash.clone(),
+        requested_default_branch: manifest.source.default_branch().to_string(),
+        expected_refs: match &manifest.source {
+            SourceSpec::NativeEmpty { .. } => None,
+            SourceSpec::ExactGit { expected_refs, .. } => Some(expected_refs.clone()),
+        },
+    }
+}
+
+fn finish(evidence_out: &Path, record: EvidenceRecord) -> Result<i32> {
+    let rendered = serde_json::to_string_pretty(&record).context("encode the evidence record")?;
+    write_json_atomically(evidence_out, &record, "evidence")?;
+    println!("{rendered}");
+    Ok(record.outcome.exit_code())
+}
+
+/// Decide what a destination reading means against a durable intent.
+fn resolve_against_intent(
+    manifest: &Manifest,
+    intent: &IntentRecord,
+    reading: DestinationReading,
+) -> EvidenceRecord {
+    let base = EvidenceRecord {
+        schema: EVIDENCE_SCHEMA.to_string(),
+        outcome: Outcome::Absent,
+        repository_id: manifest.repository_id.clone(),
+        operation: manifest.operation.clone(),
+        measured: None,
+        echoed: echoed_input(manifest),
+        differences: Vec::new(),
+        detail: None,
+    };
+    match reading {
+        DestinationReading::Absent => EvidenceRecord {
+            detail: Some(
+                "destination holds no publication under the reserved identity".to_string(),
+            ),
+            ..base
+        },
+        DestinationReading::Indeterminate(detail) => EvidenceRecord {
+            outcome: Outcome::Indeterminate,
+            detail: Some(detail),
+            ..base
+        },
+        DestinationReading::Present(measured) => {
+            let differences = compare_with_intent(intent, &measured);
+            if differences.is_empty() {
+                EvidenceRecord {
+                    outcome: Outcome::Recovered,
+                    measured: Some(*measured),
+                    ..base
+                }
+            } else {
+                EvidenceRecord {
+                    outcome: Outcome::Conflict,
+                    measured: Some(*measured),
+                    differences,
+                    detail: Some(
+                        "destination holds a publication that is not the intended one; the \
+                         reserved identity is retained and nothing was changed"
+                            .to_string(),
+                    ),
+                    ..base
+                }
+            }
+        }
+    }
+}
+
+/// Build the reserved repository's durable graph authority.
+pub fn run_publish(args: PublishArgs) -> Result<i32> {
+    let (manifest, repository_id, mode) = read_checked_manifest(
+        &args.manifest,
+        &args.expect_repository_id,
+        &args.expect_mode,
+    )?;
+    let expected_intent = reconcile_expected_intent(&manifest, Some(args.intent_out.as_path()))?;
+    // Opened before any source work, so an unavailable destination is reported
+    // without first spending an import on it.
+    manifest.destination.open()?;
+
+    if let Some(intent) = expected_intent.as_ref() {
+        let reading = measure_destination(
+            &manifest.destination,
+            &repository_id,
+            mode,
+            intent.intended_snapshot_sha256.clone(),
+            SnapshotDigestSource::Intent,
+        )?;
+        if !matches!(reading, DestinationReading::Absent) {
+            let record = resolve_against_intent(&manifest, intent, reading);
+            return finish(&args.evidence_out, record);
+        }
+    } else if let Some(record) = refuse_a_stranger(&manifest, &repository_id)? {
+        return finish(&args.evidence_out, record);
+    }
+
+    let source = open_or_initialize_source(&args.source, &repository_id, &manifest.source)?;
+    let (intended_branch, intended_head, intended_bindings) = {
+        let lease = source.read_authority();
+        let metadata = lease.metadata();
+        let bindings =
+            verify_source_authority(metadata, lease.snapshot(), &repository_id, &manifest.source)?;
+        let branch = metadata
+            .ref_state
+            .default_ref
+            .as_ref()
+            .map(default_branch_name)
+            .transpose()?
+            .ok_or_else(|| anyhow!("source authority carries no default ref"))?;
+        let head = resolve_head_change_id(metadata, &repository_id)?;
+        (branch, head, bindings)
+    };
+
+    let destination = manifest.destination.open()?;
+    let mut written_intent: Option<IntentRecord> = None;
+    let result = publish_first_repository_observed(
+        source,
+        &repository_id,
+        mode.as_primitive(),
+        destination,
+        |intent: &FirstPublicationIntent<'_>| {
+            let record = IntentRecord {
+                schema: INTENT_SCHEMA.to_string(),
+                repository_id: manifest.repository_id.clone(),
+                operation: manifest.operation.clone(),
+                mode,
+                intended_snapshot_sha256: intent.snapshot_sha256.to_string(),
+                intended_roots: RootBundleRecord::from(intent.roots),
+                intended_source_closure: ClosureRecord::from(intent.source_closure),
+                intended_default_branch: intended_branch.clone(),
+                intended_head_change_id: intended_head.clone(),
+                intended_ref_bindings: intended_bindings.clone(),
+                destination: manifest.destination.clone(),
+                written_at: now_utc(),
+            };
+            if let Some(expected) = expected_intent.as_ref() {
+                if !expected.describes_same_publication(&record) {
+                    return Err(FirstPublicationError::Refused(
+                        "the prepared source no longer produces the publication this operation \
+                         already intended, so it will not be published under that identity"
+                            .to_string(),
+                    ));
+                }
+            }
+            write_intent_durably(&args.intent_out, &record)
+                .map_err(|error| FirstPublicationError::Refused(format!("{error:#}")))?;
+            written_intent = Some(record);
+            Ok(())
+        },
+    );
+
+    match (&result, &written_intent) {
+        (Ok(receipt), _) => {
+            let reading = measure_destination(
+                &manifest.destination,
+                &repository_id,
+                mode,
+                receipt.snapshot_sha256.to_string(),
+                SnapshotDigestSource::Receipt,
+            )?;
+            let DestinationReading::Present(measured) = reading else {
+                bail!(
+                    "the publication reported success and a fresh handle then found no authority \
+                     for {repository_id}"
+                );
+            };
+            if measured.artifact_sha256 != receipt.snapshot_sha256.to_string() {
+                bail!(
+                    "a fresh handle read back {} where the publication installed {}",
+                    measured.artifact_sha256,
+                    receipt.snapshot_sha256
+                );
+            }
+            if measured.storage_generation != receipt.cursor.backend_generation().to_string() {
+                bail!(
+                    "a fresh handle read generation {} where the publication committed {}",
+                    measured.storage_generation,
+                    receipt.cursor.backend_generation()
+                );
+            }
+            // Every field against the durable intent, on success as much as on
+            // recovery. A publication that returned cleanly and then found a
+            // later authority in front of it has not published what it intended,
+            // and saying so is the only truthful answer; a success whose fields
+            // were never compared is how a mixed reading would be reported as
+            // one.
+            let intent = written_intent
+                .as_ref()
+                .ok_or_else(|| anyhow!("a completed publication always wrote its intent"))?;
+            let differences = compare_with_intent(intent, &measured);
+            let (outcome, detail) = if differences.is_empty() {
+                (Outcome::Published, None)
+            } else {
+                (
+                    Outcome::Conflict,
+                    Some(
+                        "the publication committed and the destination then disagreed with the \
+                         intent it committed, so this is not a first-publication success"
+                            .to_string(),
+                    ),
+                )
+            };
+            finish(
+                &args.evidence_out,
+                EvidenceRecord {
+                    schema: EVIDENCE_SCHEMA.to_string(),
+                    outcome,
+                    repository_id: manifest.repository_id.clone(),
+                    operation: manifest.operation.clone(),
+                    measured: Some(*measured),
+                    echoed: echoed_input(&manifest),
+                    differences,
+                    detail,
+                },
+            )
+        }
+        // The intent was made durable, so this failure is at or after the
+        // boundary that can leave state behind. What the destination holds now
+        // decides the outcome, not the error text.
+        (Err(error), Some(intent)) => {
+            let reading = measure_destination(
+                &manifest.destination,
+                &repository_id,
+                mode,
+                intent.intended_snapshot_sha256.clone(),
+                SnapshotDigestSource::Intent,
+            )?;
+            let mut record = resolve_against_intent(&manifest, intent, reading);
+            record.detail = Some(match record.detail.take() {
+                Some(detail) => format!("{detail}; publication reported: {error}"),
+                None => format!("publication reported: {error}"),
+            });
+            finish(&args.evidence_out, record)
+        }
+        // The observer never ran, so nothing was installed and there is nothing
+        // to recover. This is a refusal, not an outcome.
+        (Err(error), None) => Err(anyhow!("{error}"))
+            .with_context(|| format!("publish the reserved repository {repository_id}")),
+    }
+}
+
+/// Report a destination that already holds something this run cannot account for.
+///
+/// A first attempt carries no intent, so a publication already under the
+/// reserved identity cannot be shown to be this operation's work. It is
+/// therefore a conflict rather than a recovery, and it is reported instead of
+/// republished.
+fn refuse_a_stranger(
+    manifest: &Manifest,
+    repository_id: &RepositoryId,
+) -> Result<Option<EvidenceRecord>> {
+    let backend = manifest.destination.open()?;
+    let (outcome, detail) = match backend.load_snapshot_cursor(repository_id.as_str()) {
+        Ok(None) => return Ok(None),
+        Ok(Some(_)) => (
+            Outcome::Conflict,
+            "destination already holds a publication and this run carries no intent to compare \
+             it against; the reserved identity is retained and nothing was changed"
+                .to_string(),
+        ),
+        Err(error) => (Outcome::Indeterminate, error.to_string()),
+    };
+    Ok(Some(EvidenceRecord {
+        schema: EVIDENCE_SCHEMA.to_string(),
+        outcome,
+        repository_id: manifest.repository_id.clone(),
+        operation: manifest.operation.clone(),
+        measured: None,
+        echoed: echoed_input(manifest),
+        differences: Vec::new(),
+        detail: Some(detail),
+    }))
+}
+
+/// Read a destination against a durable intent, and write nothing.
+pub fn run_verify(args: VerifyArgs) -> Result<i32> {
+    let (manifest, repository_id, mode) = read_checked_manifest(
+        &args.manifest,
+        &args.expect_repository_id,
+        &args.expect_mode,
+    )?;
+    let intent =
+        reconcile_expected_intent(&manifest, args.intent.as_deref())?.ok_or_else(|| {
+            anyhow!(
+                "verification needs the durable intent it is verifying against, in the manifest's \
+             expected authority or in an intent file"
+            )
+        })?;
+    let reading = measure_destination(
+        &manifest.destination,
+        &repository_id,
+        mode,
+        intent.intended_snapshot_sha256.clone(),
+        SnapshotDigestSource::Intent,
+    )?;
+    let record = resolve_against_intent(&manifest, &intent, reading);
+    finish(&args.evidence_out, record)
+}

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -40,6 +40,7 @@ pub mod graph_health;
 pub mod graph_viz;
 pub mod health;
 pub mod history;
+pub mod hosted_publication;
 pub mod impact;
 pub mod init;
 pub mod intent;

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -576,6 +576,16 @@ enum Command {
         #[command(subcommand)]
         action: Option<ReviewAction>,
     },
+    /// Publish a reserved hosted repository's first graph authority.
+    ///
+    /// Hidden because it is an operator boundary rather than a Kin verb: it is
+    /// driven by a trusted orchestrator that has already reserved an identity
+    /// and materialized a source, and it is meaningless without both.
+    #[command(hide = true)]
+    HostedPublication {
+        #[command(subcommand)]
+        action: HostedPublicationAction,
+    },
     /// Show entity history
     History {
         /// Entity name or ID
@@ -1403,6 +1413,49 @@ enum Command {
     Resources {
         #[command(subcommand)]
         action: ResourcesAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum HostedPublicationAction {
+    /// Build the reserved repository's durable authority and report what landed
+    Publish {
+        /// Operation-bound manifest naming the reservation, source and destination
+        #[arg(long, value_name = "PATH")]
+        manifest: PathBuf,
+        /// Trusted materialized source, as it exists on this machine
+        #[arg(long, value_name = "DIR")]
+        source: PathBuf,
+        /// Where the intended publication is made durable before it is permanent
+        #[arg(long, value_name = "PATH")]
+        intent_out: PathBuf,
+        /// Where the evidence record is written
+        #[arg(long, value_name = "PATH")]
+        evidence_out: PathBuf,
+        /// The reserved identity the caller believes the manifest holds
+        #[arg(long, value_name = "ID")]
+        expect_repository_id: String,
+        /// native-empty or exact-git, refused when it disagrees with the manifest
+        #[arg(long, value_name = "MODE")]
+        expect_mode: String,
+    },
+    /// Read a destination against a durable intent, writing nothing
+    Verify {
+        /// Operation-bound manifest naming the reservation and destination
+        #[arg(long, value_name = "PATH")]
+        manifest: PathBuf,
+        /// The durable intent to verify against, when it is not in the manifest
+        #[arg(long, value_name = "PATH")]
+        intent: Option<PathBuf>,
+        /// Where the evidence record is written
+        #[arg(long, value_name = "PATH")]
+        evidence_out: PathBuf,
+        /// The reserved identity the caller believes the manifest holds
+        #[arg(long, value_name = "ID")]
+        expect_repository_id: String,
+        /// native-empty or exact-git, refused when it disagrees with the manifest
+        #[arg(long, value_name = "MODE")]
+        expect_mode: String,
     },
 }
 
@@ -3409,6 +3462,52 @@ fn run() -> Result<()> {
                     reference,
                     all_revisions,
                 } => commands::history::run(entity, reference, all_revisions).await,
+                Command::HostedPublication { action } => {
+                    // The exit status carries the outcome a caller branches on,
+                    // the way `kin init` reports an unattested conversion: a
+                    // destination that holds nothing, one that holds somebody
+                    // else's publication and one that cannot be read either way
+                    // are three different answers, and the evidence record on
+                    // stdout names which one it was.
+                    let code = match action {
+                        HostedPublicationAction::Publish {
+                            manifest,
+                            source,
+                            intent_out,
+                            evidence_out,
+                            expect_repository_id,
+                            expect_mode,
+                        } => commands::hosted_publication::run_publish(
+                            commands::hosted_publication::PublishArgs {
+                                manifest,
+                                source,
+                                intent_out,
+                                evidence_out,
+                                expect_repository_id,
+                                expect_mode,
+                            },
+                        )?,
+                        HostedPublicationAction::Verify {
+                            manifest,
+                            intent,
+                            evidence_out,
+                            expect_repository_id,
+                            expect_mode,
+                        } => commands::hosted_publication::run_verify(
+                            commands::hosted_publication::VerifyArgs {
+                                manifest,
+                                intent,
+                                evidence_out,
+                                expect_repository_id,
+                                expect_mode,
+                            },
+                        )?,
+                    };
+                    if code != 0 {
+                        std::process::exit(code);
+                    }
+                    Ok(())
+                }
                 Command::DeadCode {
                     seed,
                     limit,

--- a/crates/kin-cli/tests/hosted_first_publication.rs
+++ b/crates/kin-cli/tests/hosted_first_publication.rs
@@ -1353,3 +1353,52 @@ fn a_pinned_reading_never_mixes_in_a_later_authority() {
         "the pinned closure is the pinned authority's, and this one references no bodies"
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn a_declined_install_still_flushes_the_directory_before_it_returns() {
+    // The declined path is where this matters. A writer that finds the link
+    // already there is about to treat that record as durable and move on to the
+    // irreversible compare-and-swap, while the writer that created the link may
+    // not have flushed the directory entry yet and may never get to. Whoever
+    // ACCEPTS the record has to be the one who made sure it survives.
+    //
+    // Observed by taking the flush's own ability to run away: with the parent
+    // unreadable, opening it fails, so an implementation that flushes on this
+    // path reports that failure and one that skips the flush returns a cheerful
+    // `false` having touched nothing.
+    use std::os::unix::fs::PermissionsExt;
+
+    let case = Case::new();
+    let home = case.path("declined");
+    fs::create_dir_all(&home).expect("create the install directory");
+    let target = home.join("intent.json");
+    assert!(
+        install_no_replace(&target, b"{\"first\":true}\n", "intent").expect("the first install"),
+        "the first writer installs"
+    );
+
+    let original = fs::metadata(&home)
+        .expect("read directory mode")
+        .permissions();
+    // Write and traverse, no read: the file is still reachable by name and the
+    // directory can no longer be opened.
+    fs::set_permissions(&home, fs::Permissions::from_mode(0o300))
+        .expect("make the directory unreadable");
+    let declined = install_no_replace(&target, b"{\"second\":true}\n", "intent");
+    fs::set_permissions(&home, original).expect("restore the directory mode");
+
+    let error = declined.expect_err(
+        "a declined install must flush the directory it is about to let a caller trust",
+    );
+    let rendered = format!("{error:#}");
+    assert!(
+        rendered.contains("flush intent directory"),
+        "the failure names the flush it could not perform: {rendered}"
+    );
+    assert_eq!(
+        fs::read_to_string(&target).expect("the installed record is untouched"),
+        "{\"first\":true}\n",
+        "a declined install changes nothing it found"
+    );
+}

--- a/crates/kin-cli/tests/hosted_first_publication.rs
+++ b/crates/kin-cli/tests/hosted_first_publication.rs
@@ -1,0 +1,1355 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Executable first publication of a reserved hosted repository.
+//!
+//! Every case here builds a real source through the exact adopting-init
+//! boundary, publishes through the real primitive into a real filesystem
+//! destination, and then drops every handle and reads the result back off the
+//! durable files. Nothing is stubbed, and no case asserts on a value the
+//! adapter merely echoed.
+//!
+//! The durable boundaries are reached deliberately rather than by timing a
+//! signal. A run whose intent cannot be made durable stops before the
+//! compare-and-swap with the bodies already written, which is exactly the state
+//! a process killed there would leave, and the case that follows proves a later
+//! attempt still completes from it. A signal-timed kill would reach the same
+//! states less reliably and prove no more.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use kin_cli::commands::hosted_publication::{
+    install_no_replace, run_publish, run_verify, EvidenceRecord, IntentRecord, Outcome,
+    PublishArgs, RefTargetRecord, VerifyArgs, EXIT_ABSENT, EXIT_CONFLICT,
+};
+use kin_db::{LocalFileBackend, RepositoryAuthorityManager, StorageBackend};
+use kin_model::{Hash256, RepositoryId};
+use kin_remote::first_publication::read_pinned_published_authority;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use tempfile::tempdir;
+
+const RESERVED_ID: &str = "9f1c2e04-3b7a-4d21-9c55-0ab61d7e8f30";
+const OLD_BODY: &[u8] = b"initial historical body, retained after replacement\n";
+const NEW_BODY: &[u8] = b"current imported body, checked after first publication\n";
+const SOURCE_INPUT_HASH: &str = "a71b0f5c2d9e4813a6c07f52b8d31e94a05c76fb28d13e0947ab65cf2081d3e7";
+const REQUEST_HASH: &str = "5f2c81a30bd47e6915c8f0234ab7de91c605f3821de74a90bc3f2178e045a6d1";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+fn git(root: &Path, args: &[&str]) {
+    let output = std::process::Command::new("git")
+        .args([
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            "commit.gpgsign=false",
+            "-c",
+            "tag.gpgsign=false",
+            "-c",
+            "user.name=Publication fixture",
+            "-c",
+            "user.email=fixture@example.invalid",
+        ])
+        .args(args)
+        .current_dir(root)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {args:?}: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Two commits, an annotated tag, and a body that only the first commit holds.
+fn materialize_git_source(root: &Path) -> String {
+    fs::create_dir_all(root).expect("create git source");
+    git(root, &["init", "--initial-branch=main"]);
+    fs::write(root.join("source.txt"), OLD_BODY).expect("write old body");
+    git(root, &["add", "source.txt"]);
+    git(root, &["commit", "-m", "Initial source"]);
+    fs::write(root.join("source.txt"), NEW_BODY).expect("write new body");
+    git(root, &["add", "source.txt"]);
+    git(root, &["commit", "-m", "Update source"]);
+    git(root, &["tag", "-a", "baseline", "-m", "Imported reference"]);
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(root)
+        .output()
+        .expect("read HEAD");
+    String::from_utf8(output.stdout)
+        .expect("HEAD is utf-8")
+        .trim()
+        .to_string()
+}
+
+fn operation() -> serde_json::Value {
+    json!({
+        "org_id": "org-7f3c",
+        // A UUID, because a hosted receipt decodes this field with the same
+        // decoder it uses for a repository id.
+        "operation_id": "2a91c3f0-51bd-4e77-9a06-8c4127de35b1",
+        "operation_revision": 7,
+        "request_hash": REQUEST_HASH,
+        "holder_id": "worker-3",
+        "fencing_token": 4,
+    })
+}
+
+fn native_manifest(destination: &Path, branch: &str) -> serde_json::Value {
+    json!({
+        "schema": "kin.hosted-first-publication-manifest.v1",
+        "operation": operation(),
+        "repository_id": RESERVED_ID,
+        "source": { "kind": "native-empty", "default_branch": branch },
+        "source_input_hash": SOURCE_INPUT_HASH,
+        "destination": { "kind": "filesystem", "root": destination },
+        "expected_authority": serde_json::Value::Null,
+    })
+}
+
+fn git_manifest(
+    destination: &Path,
+    commit_oid: &str,
+    bindings: serde_json::Value,
+    scope: &str,
+) -> serde_json::Value {
+    json!({
+        "schema": "kin.hosted-first-publication-manifest.v1",
+        "operation": operation(),
+        "repository_id": RESERVED_ID,
+        "source": {
+            "kind": "exact-git",
+            "provider": "github",
+            "object_format": "sha1",
+            "source_commit_oid": commit_oid,
+            "default_branch": "main",
+            "expected_refs": { "scope": scope, "bindings": bindings },
+        },
+        "source_input_hash": SOURCE_INPUT_HASH,
+        "destination": { "kind": "filesystem", "root": destination },
+        "expected_authority": serde_json::Value::Null,
+    })
+}
+
+fn write_manifest(path: &Path, value: &serde_json::Value) {
+    fs::write(
+        path,
+        serde_json::to_vec_pretty(value).expect("encode manifest"),
+    )
+    .expect("write manifest");
+}
+
+struct Case {
+    _temp: tempfile::TempDir,
+    root: PathBuf,
+}
+
+impl Case {
+    fn new() -> Self {
+        let temp = tempdir().expect("temp dir");
+        let root = temp.path().to_path_buf();
+        Self { _temp: temp, root }
+    }
+
+    fn path(&self, name: &str) -> PathBuf {
+        self.root.join(name)
+    }
+
+    fn publish_args(&self, mode: &str) -> PublishArgs {
+        PublishArgs {
+            manifest: self.path("manifest.json"),
+            source: self.path("source"),
+            intent_out: self.path("intent.json"),
+            evidence_out: self.path("evidence.json"),
+            expect_repository_id: RESERVED_ID.to_string(),
+            expect_mode: mode.to_string(),
+        }
+    }
+
+    fn verify_args(&self, mode: &str, evidence: &str) -> VerifyArgs {
+        VerifyArgs {
+            manifest: self.path("manifest.json"),
+            intent: Some(self.path("intent.json")),
+            evidence_out: self.path(evidence),
+            expect_repository_id: RESERVED_ID.to_string(),
+            expect_mode: mode.to_string(),
+        }
+    }
+
+    fn evidence(&self, name: &str) -> EvidenceRecord {
+        let bytes = fs::read(self.path(name)).expect("read evidence");
+        serde_json::from_slice(&bytes).expect("decode evidence")
+    }
+
+    fn intent(&self) -> IntentRecord {
+        let bytes = fs::read(self.path("intent.json")).expect("read intent");
+        serde_json::from_slice(&bytes).expect("decode intent")
+    }
+
+    /// Every authority handle is gone by the time this runs, so what it reads is
+    /// the durable files and nothing else.
+    fn reopen_destination(&self) -> Arc<RepositoryAuthorityManager<dyn StorageBackend>> {
+        let backend: Arc<dyn StorageBackend> =
+            Arc::new(LocalFileBackend::new(self.path("destination")));
+        Arc::new(
+            RepositoryAuthorityManager::open(
+                RepositoryId::new(RESERVED_ID).expect("reserved id"),
+                backend,
+            )
+            .expect("reopen the published authority from durable files"),
+        )
+    }
+}
+
+fn hash(bytes: &[u8]) -> Hash256 {
+    Hash256::from_bytes(Sha256::digest(bytes).into())
+}
+
+// ---------------------------------------------------------------------------
+// Compositions
+// ---------------------------------------------------------------------------
+
+#[test]
+fn native_empty_on_a_non_default_branch_publishes_and_reopens_from_durable_files() {
+    let case = Case::new();
+    write_manifest(
+        &case.path("manifest.json"),
+        &native_manifest(&case.path("destination"), "trunk"),
+    );
+
+    let code = run_publish(case.publish_args("native-empty")).expect("publish a native empty");
+    assert_eq!(code, 0, "a completed publication exits zero");
+
+    let evidence = case.evidence("evidence.json");
+    assert_eq!(evidence.outcome, Outcome::Published);
+    let measured = evidence
+        .measured
+        .as_ref()
+        .expect("published evidence measures");
+    assert_eq!(
+        measured.default_branch, "trunk",
+        "the published default branch is measured off the authority, not echoed from the request"
+    );
+    assert_eq!(
+        measured.head_change_id, None,
+        "an unborn default ref names no head change"
+    );
+    assert_eq!(
+        measured.source_closure.body_count, 0,
+        "a native empty authority references no source bodies"
+    );
+    assert_eq!(measured.source_closure.total_bytes, 0);
+    assert!(
+        !measured.git_external_authority_present,
+        "a native publication carries no imported Git authority"
+    );
+    assert_eq!(
+        measured.storage_generation, "1",
+        "a first publication lands at the backend's first generation"
+    );
+    assert_eq!(
+        measured.artifact_sha256, measured.snapshot_sha256,
+        "the fresh readback agrees with what the publication installed"
+    );
+    assert_eq!(
+        evidence.echoed.source_input_hash, SOURCE_INPUT_HASH,
+        "the orchestrator's own source digest is carried, never recomputed"
+    );
+
+    // Every handle above is dropped here; what follows reads durable files.
+    let reopened = case.reopen_destination();
+    let lease = reopened.read_authority();
+    assert_eq!(
+        lease.metadata().repository_id.as_str(),
+        RESERVED_ID,
+        "the reserved identity survives the publication"
+    );
+    let default_ref = lease
+        .metadata()
+        .ref_state
+        .default_ref
+        .as_ref()
+        .expect("published authority carries a default ref");
+    assert_eq!(
+        default_ref.as_utf8(),
+        Some("refs/heads/trunk"),
+        "the requested non-default branch is the one that landed"
+    );
+    assert_eq!(
+        measured.authority_root_binding.len(),
+        64,
+        "the root binding is a canonical 256-bit digest"
+    );
+}
+
+#[test]
+fn exact_git_with_two_commits_a_tag_and_a_historical_body_publishes_completely() {
+    let case = Case::new();
+    let commit_oid = materialize_git_source(&case.path("source"));
+    write_manifest(
+        &case.path("manifest.json"),
+        &git_manifest(
+            &case.path("destination"),
+            &commit_oid,
+            json!([]),
+            "named-subset",
+        ),
+    );
+
+    let code = run_publish(case.publish_args("exact-git")).expect("publish an exact Git import");
+    assert_eq!(code, 0);
+
+    let evidence = case.evidence("evidence.json");
+    assert_eq!(evidence.outcome, Outcome::Published);
+    let measured = evidence
+        .measured
+        .as_ref()
+        .expect("published evidence measures");
+    assert!(
+        measured.git_external_authority_present,
+        "an exact Git publication carries its imported Git authority"
+    );
+    assert_eq!(measured.default_branch, "main");
+    let head = measured
+        .head_change_id
+        .as_ref()
+        .expect("an imported HEAD resolves to a semantic change");
+    assert_eq!(
+        head.len(),
+        64,
+        "the head is a semantic change id, never a Git object id cast into one"
+    );
+    assert_ne!(
+        head, &commit_oid,
+        "the head change id is the alias target, not the Git commit it was imported from"
+    );
+    assert!(
+        measured.source_closure.body_count >= 2,
+        "the closure counts the replaced body as well as the current one, got {}",
+        measured.source_closure.body_count
+    );
+    let tag = measured
+        .ref_bindings
+        .iter()
+        .find(|binding| binding.name == "refs/tags/baseline")
+        .expect("the annotated tag is one of the published ref bindings");
+    assert!(
+        matches!(tag.target, RefTargetRecord::ExternalObject { .. }),
+        "an imported tag binds a raw Git object, {:?}",
+        tag.target
+    );
+
+    let reopened = case.reopen_destination();
+    for body in [OLD_BODY, NEW_BODY] {
+        assert_eq!(
+            reopened
+                .load_source_blob(hash(body))
+                .expect("read a published body")
+                .as_deref(),
+            Some(body),
+            "every referenced body is readable from the durable destination"
+        );
+    }
+}
+
+#[test]
+fn exact_ref_bindings_are_checked_against_the_imported_authority() {
+    let case = Case::new();
+    let commit_oid = materialize_git_source(&case.path("source"));
+    // A binding that names the right ref and the wrong target. Names alone would
+    // accept this; a binding must not.
+    write_manifest(
+        &case.path("manifest.json"),
+        &git_manifest(
+            &case.path("destination"),
+            &commit_oid,
+            json!([{
+                "name": "refs/heads/main",
+                "target": {
+                    "kind": "external-object",
+                    "object_kind": "commit",
+                    "object_format": "sha1",
+                    "oid": "0".repeat(40),
+                },
+            }]),
+            "named-subset",
+        ),
+    );
+
+    let error = run_publish(case.publish_args("exact-git"))
+        .expect_err("a ref binding that does not match the import must refuse");
+    let rendered = format!("{error:#}");
+    assert!(
+        rendered.contains("refs/heads/main"),
+        "the refusal names the ref that disagreed: {rendered}"
+    );
+    assert!(
+        !case.path("destination").join("repos").exists() || destination_is_unpublished(&case),
+        "a refused import publishes nothing"
+    );
+}
+
+fn destination_is_unpublished(case: &Case) -> bool {
+    let backend = LocalFileBackend::new(case.path("destination"));
+    backend
+        .load_snapshot_cursor(RESERVED_ID)
+        .expect("inspect the destination")
+        .is_none()
+}
+
+// ---------------------------------------------------------------------------
+// Identity and second invocations
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_manifest_that_reserves_another_identity_is_refused_before_any_work() {
+    let case = Case::new();
+    let mut manifest = native_manifest(&case.path("destination"), "trunk");
+    manifest["repository_id"] = json!("11111111-2222-4333-8444-555555555555");
+    write_manifest(&case.path("manifest.json"), &manifest);
+
+    let error = run_publish(case.publish_args("native-empty"))
+        .expect_err("a manifest naming another identity must be refused");
+    let rendered = format!("{error:#}");
+    assert!(
+        rendered.contains(RESERVED_ID),
+        "the refusal names the identity this invocation expected: {rendered}"
+    );
+    assert!(
+        !case.path("intent.json").exists(),
+        "an identity refusal writes no intent"
+    );
+    assert!(
+        !case.path("source").exists(),
+        "an identity refusal initializes no source"
+    );
+}
+
+#[test]
+fn a_mode_that_disagrees_with_the_manifest_is_refused() {
+    let case = Case::new();
+    write_manifest(
+        &case.path("manifest.json"),
+        &native_manifest(&case.path("destination"), "trunk"),
+    );
+
+    let error = run_publish(case.publish_args("exact-git"))
+        .expect_err("a mode flag that disagrees with the manifest must be refused");
+    let rendered = format!("{error:#}");
+    assert!(
+        rendered.contains("native-empty") && rendered.contains("exact-git"),
+        "the refusal names both modes: {rendered}"
+    );
+}
+
+#[test]
+fn an_identical_second_invocation_recovers_rather_than_republishing() {
+    let case = Case::new();
+    write_manifest(
+        &case.path("manifest.json"),
+        &native_manifest(&case.path("destination"), "trunk"),
+    );
+    assert_eq!(
+        run_publish(case.publish_args("native-empty")).expect("first publication"),
+        0
+    );
+    let first = case.evidence("evidence.json");
+    let first_measured = first.measured.expect("first run measures");
+
+    // The intent from the first run is still on disk, which is exactly the state
+    // a restarted worker finds.
+    let code = run_publish(case.publish_args("native-empty")).expect("second invocation");
+    assert_eq!(code, 0, "a recovery is a success the caller proceeds from");
+    let second = case.evidence("evidence.json");
+    assert_eq!(
+        second.outcome,
+        Outcome::Recovered,
+        "the second invocation recovers the publication it already made"
+    );
+    let second_measured = second.measured.expect("a recovery measures");
+    assert_eq!(
+        second_measured.storage_generation, first_measured.storage_generation,
+        "recovery does not advance the storage generation, so nothing was overwritten"
+    );
+    assert_eq!(
+        second_measured.artifact_sha256, first_measured.artifact_sha256,
+        "recovery reads back the same authority bytes"
+    );
+    assert_eq!(
+        second_measured.artifact_id, first_measured.artifact_id,
+        "one reserved identity keeps one permanent artifact identity"
+    );
+}
+
+#[test]
+fn a_publication_this_run_cannot_account_for_is_a_conflict_rather_than_a_second_publication() {
+    let case = Case::new();
+    write_manifest(
+        &case.path("manifest.json"),
+        &native_manifest(&case.path("destination"), "trunk"),
+    );
+    assert_eq!(
+        run_publish(case.publish_args("native-empty")).expect("first publication"),
+        0
+    );
+    let before = case.evidence("evidence.json").measured.expect("measured");
+    // A worker that lost its durable intent, which is the case the reserved
+    // identity must survive rather than be republished under.
+    fs::remove_file(case.path("intent.json")).expect("drop the durable intent");
+
+    let mut args = case.publish_args("native-empty");
+    args.evidence_out = case.path("stranger.json");
+    let code = run_publish(args).expect("a stranger publication reports rather than throws");
+    assert_eq!(
+        code, EXIT_CONFLICT,
+        "a publication this run cannot account for is a conflict"
+    );
+    let record = case.evidence("stranger.json");
+    assert_eq!(record.outcome, Outcome::Conflict);
+    assert!(
+        record
+            .detail
+            .as_deref()
+            .is_some_and(|detail| detail.contains("no intent")),
+        "the conflict says why it could not account for what it found: {:?}",
+        record.detail
+    );
+    let after = case.reopen_destination();
+    assert_eq!(
+        after.read_authority().roots().generation,
+        before.roots.generation,
+        "a conflict changes nothing on the destination"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Durable boundaries
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_run_that_cannot_make_its_intent_durable_stops_before_the_compare_and_swap() {
+    let case = Case::new();
+    write_manifest(
+        &case.path("manifest.json"),
+        &native_manifest(&case.path("destination"), "trunk"),
+    );
+    // A directory where the intent file belongs. The bodies are already written
+    // by the time the intent is, so this reaches the exact durable state a
+    // process killed between the body writes and the compare-and-swap leaves.
+    fs::create_dir_all(case.path("intent.json")).expect("occupy the intent path");
+
+    let error = run_publish(case.publish_args("native-empty"))
+        .expect_err("a publication whose intent cannot be made durable must not commit");
+    assert!(
+        format!("{error:#}").contains("intent"),
+        "the refusal names the intent it could not write: {error:#}"
+    );
+    assert!(
+        destination_is_unpublished(&case),
+        "no publication is installed when the intent never became durable"
+    );
+
+    // The same destination, now with bodies already written, still completes.
+    fs::remove_dir(case.path("intent.json")).expect("free the intent path");
+    assert_eq!(
+        run_publish(case.publish_args("native-empty")).expect("a later attempt completes"),
+        0
+    );
+    assert_eq!(case.evidence("evidence.json").outcome, Outcome::Published);
+}
+
+#[test]
+fn evidence_lost_after_the_compare_and_swap_is_recovered_from_the_durable_intent() {
+    let case = Case::new();
+    write_manifest(
+        &case.path("manifest.json"),
+        &native_manifest(&case.path("destination"), "trunk"),
+    );
+    assert_eq!(
+        run_publish(case.publish_args("native-empty")).expect("publish"),
+        0
+    );
+    let published = case.evidence("evidence.json").measured.expect("measured");
+    // The exact durable state of a process killed after the compare-and-swap and
+    // before it could report: the publication is there and the evidence is not.
+    fs::remove_file(case.path("evidence.json")).expect("drop the evidence");
+
+    let code = run_verify(case.verify_args("native-empty", "recovered.json"))
+        .expect("verification reads a destination against a durable intent");
+    assert_eq!(code, 0);
+    let recovered = case.evidence("recovered.json");
+    assert_eq!(recovered.outcome, Outcome::Recovered);
+    let measured = recovered.measured.expect("a recovery measures");
+    assert_eq!(measured.artifact_sha256, published.artifact_sha256);
+    assert_eq!(measured.storage_generation, published.storage_generation);
+    assert_eq!(
+        measured.roots, published.roots,
+        "the recovered roots are the published ones"
+    );
+}
+
+#[test]
+fn verification_reads_the_destination_and_never_the_source() {
+    // A publication that is not this operation's, standing where this
+    // operation's is expected. Both authorities decode cleanly and differ only
+    // in their default branch, so nothing but reading the destination can tell
+    // them apart, and a verifier that answered from the intent it was handed
+    // would call the second one a recovery of the first.
+    //
+    // The stranger is moved onto this operation's own destination rather than
+    // verified in place, because an intent is bound to the destination it names
+    // and a manifest pointed somewhere else is refused before any reading.
+    let case = Case::new();
+    write_manifest(
+        &case.path("manifest.json"),
+        &native_manifest(&case.path("destination"), "trunk"),
+    );
+    assert_eq!(
+        run_publish(case.publish_args("native-empty")).expect("publish trunk"),
+        0
+    );
+    let trunk = case
+        .evidence("evidence.json")
+        .measured
+        .expect("the first publication measures");
+
+    let stranger = Case::new();
+    write_manifest(
+        &stranger.path("manifest.json"),
+        &native_manifest(&stranger.path("destination"), "release"),
+    );
+    assert_eq!(
+        run_publish(stranger.publish_args("native-empty")).expect("publish release"),
+        0
+    );
+    let release = stranger
+        .evidence("evidence.json")
+        .measured
+        .expect("the second publication measures");
+    assert_ne!(
+        trunk.artifact_sha256, release.artifact_sha256,
+        "the fixture must publish two different authorities, or this case proves nothing"
+    );
+
+    replace_directory(&case.path("destination"), &stranger.path("destination"));
+
+    let code = run_verify(case.verify_args("native-empty", "stranger-evidence.json"))
+        .expect("verification reports rather than throws");
+    assert_eq!(
+        code, EXIT_CONFLICT,
+        "a destination holding another authority is a conflict, never a recovery"
+    );
+    let record = case.evidence("stranger-evidence.json");
+    assert_eq!(record.outcome, Outcome::Conflict);
+    let fields: Vec<&str> = record
+        .differences
+        .iter()
+        .map(|difference| difference.field.as_str())
+        .collect();
+    assert!(
+        fields.contains(&"snapshot_sha256"),
+        "the conflict names the digest that disagreed: {fields:?}"
+    );
+    assert!(
+        fields.contains(&"default_branch"),
+        "the conflict names the branch that disagreed: {fields:?}"
+    );
+    let measured = record
+        .measured
+        .expect("a conflict still measures what it found");
+    assert_eq!(
+        measured.default_branch, "release",
+        "the report carries what the destination actually holds, not what was intended"
+    );
+    assert_eq!(
+        measured.artifact_sha256, release.artifact_sha256,
+        "the digest is measured off the destination that was read"
+    );
+}
+
+/// Put `source`'s contents where `target`'s were, leaving nothing of the old.
+fn replace_directory(target: &Path, source: &Path) {
+    fs::remove_dir_all(target).expect("clear the destination");
+    copy_tree(source, target);
+}
+
+fn copy_tree(source: &Path, target: &Path) {
+    fs::create_dir_all(target).expect("create the copy root");
+    for entry in fs::read_dir(source).expect("read the source tree") {
+        let entry = entry.expect("read a source entry");
+        let to = target.join(entry.file_name());
+        if entry.file_type().expect("classify a source entry").is_dir() {
+            copy_tree(&entry.path(), &to);
+        } else {
+            fs::copy(entry.path(), &to).expect("copy a source file");
+        }
+    }
+}
+
+#[test]
+fn a_destination_whose_bytes_no_longer_decode_is_never_a_recovery() {
+    let case = Case::new();
+    write_manifest(
+        &case.path("manifest.json"),
+        &native_manifest(&case.path("destination"), "trunk"),
+    );
+    assert_eq!(
+        run_publish(case.publish_args("native-empty")).expect("publish"),
+        0
+    );
+    corrupt_published_snapshot(&case);
+
+    match run_verify(case.verify_args("native-empty", "corrupt.json")) {
+        Ok(code) => {
+            assert_ne!(code, 0, "a corrupt destination is not a success");
+            let record = case.evidence("corrupt.json");
+            assert_ne!(record.outcome, Outcome::Recovered);
+            assert_ne!(record.outcome, Outcome::Published);
+        }
+        Err(error) => assert!(
+            !format!("{error:#}").is_empty(),
+            "a corrupt destination fails with a reason"
+        ),
+    }
+}
+
+/// Replace the published snapshot bytes in place, leaving everything else.
+fn corrupt_published_snapshot(case: &Case) {
+    let mut replaced = false;
+    let mut stack = vec![case.path("destination")];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            let Ok(bytes) = fs::read(&path) else { continue };
+            if bytes.len() > 64 && path.to_string_lossy().contains("snapshot") {
+                let mut corrupted = bytes.clone();
+                let last = corrupted.len() - 1;
+                corrupted[last] ^= 0xff;
+                fs::write(&path, corrupted).expect("corrupt the published snapshot");
+                replaced = true;
+            }
+        }
+    }
+    assert!(
+        replaced,
+        "the fixture must actually change a published snapshot, or this case proves nothing"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Records
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_intent_is_durable_before_the_publication_and_names_the_same_authority() {
+    let case = Case::new();
+    write_manifest(
+        &case.path("manifest.json"),
+        &native_manifest(&case.path("destination"), "trunk"),
+    );
+    assert_eq!(
+        run_publish(case.publish_args("native-empty")).expect("publish"),
+        0
+    );
+    let intent = case.intent();
+    let measured = case.evidence("evidence.json").measured.expect("measured");
+    assert_eq!(
+        intent.intended_snapshot_sha256, measured.artifact_sha256,
+        "what was intended before the compare-and-swap is what a fresh handle read back"
+    );
+    assert_eq!(intent.intended_roots, measured.roots);
+    assert_eq!(intent.intended_source_closure, measured.source_closure);
+    assert_eq!(intent.intended_default_branch, measured.default_branch);
+    assert_eq!(intent.intended_head_change_id, measured.head_change_id);
+    assert_eq!(intent.intended_ref_bindings, measured.ref_bindings);
+}
+
+#[test]
+fn an_intent_recording_another_publication_is_never_replaced() {
+    let case = Case::new();
+    write_manifest(
+        &case.path("manifest.json"),
+        &native_manifest(&case.path("destination"), "trunk"),
+    );
+    assert_eq!(
+        run_publish(case.publish_args("native-empty")).expect("publish"),
+        0
+    );
+    let mut intent: serde_json::Value =
+        serde_json::from_slice(&fs::read(case.path("intent.json")).expect("read intent"))
+            .expect("decode intent");
+    intent["intended_snapshot_sha256"] = json!("b".repeat(64));
+    fs::write(
+        case.path("intent.json"),
+        serde_json::to_vec_pretty(&intent).expect("encode"),
+    )
+    .expect("install a foreign intent");
+
+    let mut args = case.publish_args("native-empty");
+    args.evidence_out = case.path("foreign.json");
+    let code = run_publish(args).expect("a foreign intent is reported rather than thrown");
+    assert_eq!(
+        code, EXIT_CONFLICT,
+        "a durable intent that names another publication is a conflict"
+    );
+    let record = case.evidence("foreign.json");
+    assert_eq!(record.outcome, Outcome::Conflict);
+    assert!(
+        record
+            .differences
+            .iter()
+            .any(|difference| difference.field == "snapshot_sha256"),
+        "the conflict names the field that disagreed: {:?}",
+        record.differences
+    );
+}
+
+#[test]
+fn a_gcs_destination_is_refused_by_name() {
+    let case = Case::new();
+    let mut manifest = native_manifest(&case.path("destination"), "trunk");
+    manifest["destination"] = json!({ "kind": "gcs", "bucket": "kin-graph", "prefix": "hosted" });
+    write_manifest(&case.path("manifest.json"), &manifest);
+
+    let error = run_publish(case.publish_args("native-empty"))
+        .expect_err("an object-store destination is not implemented by this build");
+    assert!(
+        format!("{error:#}").contains("destination_backend_unavailable"),
+        "the refusal names the missing capability: {error:#}"
+    );
+}
+
+#[test]
+fn the_evidence_separates_what_was_measured_from_what_was_carried() {
+    let case = Case::new();
+    write_manifest(
+        &case.path("manifest.json"),
+        &native_manifest(&case.path("destination"), "trunk"),
+    );
+    assert_eq!(
+        run_publish(case.publish_args("native-empty")).expect("publish"),
+        0
+    );
+    let rendered: serde_json::Value =
+        serde_json::from_slice(&fs::read(case.path("evidence.json")).expect("read evidence"))
+            .expect("decode evidence");
+    let measured = rendered["measured"]
+        .as_object()
+        .expect("measured is an object");
+    let echoed = rendered["echoed"].as_object().expect("echoed is an object");
+    assert!(
+        !measured.contains_key("source_input_hash"),
+        "an input the adapter never checked must not appear as a measurement"
+    );
+    assert_eq!(
+        echoed["source_input_hash"],
+        json!(SOURCE_INPUT_HASH),
+        "the carried digest is exactly what the manifest supplied"
+    );
+    // No single value fills more than one measured slot except the two snapshot
+    // digests, which are two independent measurements that must agree.
+    let mut seen: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for (key, value) in measured {
+        if let Some(text) = value.as_str() {
+            if text.len() == 64 {
+                seen.entry(text.to_string()).or_default().push(key.clone());
+            }
+        }
+    }
+    for (value, keys) in seen {
+        assert!(
+            keys.len() == 1 || keys == ["artifact_sha256", "snapshot_sha256"],
+            "digest {value} fills {keys:?}, which is more than one meaning"
+        );
+    }
+}
+
+#[test]
+fn a_resumption_under_a_renewed_lease_recovers_rather_than_conflicting() {
+    // The store bounds a worker lease to fifteen minutes and a renewal advances
+    // the operation's revision, holder and fence. A resumption therefore holds a
+    // renewed record of the same intent while the file its earlier attempt wrote
+    // still carries the old one, and both are handed to this run. Treating any
+    // of the three as part of the publication's identity would make those two
+    // accounts of one attempt look like two publications and refuse.
+    let case = Case::new();
+    write_manifest(
+        &case.path("manifest.json"),
+        &native_manifest(&case.path("destination"), "trunk"),
+    );
+    assert_eq!(
+        run_publish(case.publish_args("native-empty")).expect("first publication"),
+        0
+    );
+    let first = case
+        .evidence("evidence.json")
+        .measured
+        .expect("the first run measures");
+
+    // What the store would hand back after a renewal: the same intent, carried
+    // at the current revision, holder and fence.
+    let mut renewed_intent: serde_json::Value =
+        serde_json::from_slice(&fs::read(case.path("intent.json")).expect("read intent"))
+            .expect("decode intent");
+    renewed_intent["operation"]["operation_revision"] = json!(11);
+    renewed_intent["operation"]["holder_id"] = json!("worker-9");
+    renewed_intent["operation"]["fencing_token"] = json!(6);
+    let mut renewed = native_manifest(&case.path("destination"), "trunk");
+    renewed["operation"]["operation_revision"] = json!(11);
+    renewed["operation"]["holder_id"] = json!("worker-9");
+    renewed["operation"]["fencing_token"] = json!(6);
+    renewed["expected_authority"] = renewed_intent;
+    write_manifest(&case.path("renewed.json"), &renewed);
+    // The file on disk is still the pre-renewal one, which is the whole point.
+    let on_disk = case.intent();
+    assert_eq!(
+        on_disk.operation.operation_revision, 7,
+        "the fixture must leave the earlier revision on disk, or this case proves nothing"
+    );
+
+    let mut args = case.publish_args("native-empty");
+    args.manifest = case.path("renewed.json");
+    args.evidence_out = case.path("renewed-evidence.json");
+    let code = run_publish(args).expect("a resumption under a renewed lease");
+    assert_eq!(
+        code, 0,
+        "a renewed lease resuming its own publication is a recovery, not a conflict"
+    );
+    let record = case.evidence("renewed-evidence.json");
+    assert_eq!(record.outcome, Outcome::Recovered);
+    assert_eq!(
+        record.operation.operation_revision, 11,
+        "the evidence carries the revision this run was given, not the one the intent holds"
+    );
+    let measured = record.measured.expect("a recovery measures");
+    assert_eq!(
+        measured.storage_generation, first.storage_generation,
+        "a resumption advances no generation"
+    );
+    assert_eq!(measured.artifact_sha256, first.artifact_sha256);
+}
+
+#[test]
+fn a_resumption_that_names_another_operation_is_still_refused() {
+    // The other half of the same rule. Revision, holder and fence may move; the
+    // org, the operation and the request digest may not. An intent file outlives
+    // the run that wrote it, so without this an operation could be handed a
+    // stranger's intent, find the destination matching it, and report a recovery
+    // for work it never did.
+    let case = Case::new();
+    write_manifest(
+        &case.path("manifest.json"),
+        &native_manifest(&case.path("destination"), "trunk"),
+    );
+    assert_eq!(
+        run_publish(case.publish_args("native-empty")).expect("first publication"),
+        0
+    );
+
+    let mut foreign = native_manifest(&case.path("destination"), "trunk");
+    foreign["operation"]["operation_id"] = json!("77e10b4c-9a32-4d58-b0e1-6f2c845d19aa");
+    write_manifest(&case.path("foreign-op.json"), &foreign);
+
+    let mut args = case.publish_args("native-empty");
+    args.manifest = case.path("foreign-op.json");
+    args.evidence_out = case.path("foreign-op-evidence.json");
+    let error =
+        run_publish(args).expect_err("an intent belonging to another operation must be refused");
+    assert!(
+        format!("{error:#}").contains("belongs to another operation"),
+        "the refusal says whose intent it is: {error:#}"
+    );
+    assert!(
+        !case.path("foreign-op-evidence.json").exists(),
+        "a refusal writes no evidence record"
+    );
+}
+
+#[test]
+fn an_intent_recording_another_destination_is_refused() {
+    // The same class as the operation check. The reading an intent is compared
+    // against comes from the manifest's destination, so an intent that records a
+    // different one would have its intended values checked against somewhere it
+    // never wrote. Two destinations holding byte-identical authorities make that
+    // concrete: without the check this reads as a clean recovery.
+    let case = Case::new();
+    write_manifest(
+        &case.path("manifest.json"),
+        &native_manifest(&case.path("destination"), "trunk"),
+    );
+    assert_eq!(
+        run_publish(case.publish_args("native-empty")).expect("publish here"),
+        0
+    );
+    let here = case.intent();
+
+    let elsewhere = Case::new();
+    write_manifest(
+        &elsewhere.path("manifest.json"),
+        &native_manifest(&elsewhere.path("destination"), "trunk"),
+    );
+    assert_eq!(
+        run_publish(elsewhere.publish_args("native-empty")).expect("publish elsewhere"),
+        0
+    );
+    // Deliberately not asserted equal. Each initialization mints its own
+    // workspace identity, so two stores under one repository id do not publish
+    // identical bytes, which is exactly why an intent has to be bound to the
+    // destination it names rather than recognized by its contents. What makes
+    // this case about the destination check and not about a content mismatch is
+    // the refusal text asserted at the end: a content mismatch is reported as a
+    // conflict record, never as a refusal.
+    let there = elsewhere.intent();
+    assert_ne!(
+        here.intended_snapshot_sha256, there.intended_snapshot_sha256,
+        "two stores mint separate workspace identities, so their publications differ"
+    );
+
+    // This operation, this authority, and the other operation's destination.
+    let mut crossed = native_manifest(&elsewhere.path("destination"), "trunk");
+    crossed["expected_authority"] = serde_json::to_value(&here).expect("carry the intent");
+    write_manifest(&case.path("crossed-destination.json"), &crossed);
+
+    let error = run_verify(VerifyArgs {
+        manifest: case.path("crossed-destination.json"),
+        intent: None,
+        evidence_out: case.path("crossed-destination-evidence.json"),
+        expect_repository_id: RESERVED_ID.to_string(),
+        expect_mode: "native-empty".to_string(),
+    })
+    .expect_err("an intent recording another destination must be refused");
+    assert!(
+        format!("{error:#}").contains("different destination"),
+        "the refusal says the intent names another destination: {error:#}"
+    );
+}
+
+#[test]
+fn a_destination_holding_nothing_is_absent_and_retryable() {
+    // The one outcome a caller may safely retry, and the one that must never be
+    // confused with a conflict. Nothing was installed, the reserved identity is
+    // untouched, and a later attempt is the correct next move, so it gets its
+    // own exit status rather than sharing one with a failure.
+    let case = Case::new();
+    write_manifest(
+        &case.path("manifest.json"),
+        &native_manifest(&case.path("destination"), "trunk"),
+    );
+    assert_eq!(
+        run_publish(case.publish_args("native-empty")).expect("publish"),
+        0
+    );
+    let intent = case.intent();
+
+    // The same durable intent, pointed at a destination nothing ever published
+    // to.
+    let empty = Case::new();
+    let mut elsewhere = native_manifest(&empty.path("destination"), "trunk");
+    elsewhere["expected_authority"] = serde_json::to_value(&IntentRecord {
+        destination: serde_json::from_value(json!({
+            "kind": "filesystem",
+            "root": empty.path("destination"),
+        }))
+        .expect("destination spec"),
+        ..intent
+    })
+    .expect("carry the intent");
+    write_manifest(&case.path("empty.json"), &elsewhere);
+
+    let code = run_verify(VerifyArgs {
+        manifest: case.path("empty.json"),
+        intent: None,
+        evidence_out: case.path("empty-evidence.json"),
+        expect_repository_id: RESERVED_ID.to_string(),
+        expect_mode: "native-empty".to_string(),
+    })
+    .expect("verification reports rather than throws");
+    assert_eq!(
+        code, EXIT_ABSENT,
+        "a destination holding nothing is absent, which is retryable, not a conflict"
+    );
+    let record = case.evidence("empty-evidence.json");
+    assert_eq!(record.outcome, Outcome::Absent);
+    assert!(
+        record.measured.is_none(),
+        "an absent destination measures no authority"
+    );
+    assert!(
+        record.differences.is_empty(),
+        "an absent destination disagrees with nothing"
+    );
+}
+
+#[test]
+fn only_one_concurrent_writer_installs_the_intent_and_the_rest_leave_it_alone() {
+    // The install is what refuses, not a check before it. A check followed by a
+    // rename would let every one of these writers see an empty path and then
+    // replace whatever landed there while it was encoding, so the last one home
+    // would destroy the record its predecessors are the only evidence for. This
+    // drives that window directly rather than through a publication, because the
+    // window belongs to the install and nothing above it can widen or close it.
+    let case = Case::new();
+    let path = case.path("contended-intent.json");
+    let writers = 8;
+    let barrier = Arc::new(std::sync::Barrier::new(writers));
+    let installed = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+    let handles: Vec<_> = (0..writers)
+        .map(|writer| {
+            let path = path.clone();
+            let barrier = barrier.clone();
+            let installed = installed.clone();
+            std::thread::spawn(move || {
+                let payload = format!("{{\"writer\":{writer}}}\n");
+                barrier.wait();
+                let won = install_no_replace(&path, payload.as_bytes(), "intent")
+                    .expect("an install either wins or declines, and never fails here");
+                if won {
+                    installed.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                }
+                (won, payload)
+            })
+        })
+        .collect();
+
+    let results: Vec<(bool, String)> = handles
+        .into_iter()
+        .map(|handle| handle.join().expect("a writer thread finished"))
+        .collect();
+    assert_eq!(
+        installed.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "exactly one writer may install a contended path"
+    );
+    let winner = results
+        .iter()
+        .find(|(won, _)| *won)
+        .map(|(_, payload)| payload.clone())
+        .expect("one writer reported the install");
+    let landed = fs::read_to_string(&path).expect("read the installed intent");
+    assert_eq!(
+        landed, winner,
+        "the bytes on disk are the winner's, untouched by every writer that declined"
+    );
+    // And a late writer, arriving after the contention is over, still declines.
+    assert!(
+        !install_no_replace(&path, b"{\"writer\":\"late\"}\n", "intent")
+            .expect("a late install declines"),
+        "an install never replaces what is already there"
+    );
+    assert_eq!(
+        fs::read_to_string(&path).expect("re-read the installed intent"),
+        winner,
+        "a declined install changes nothing"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn an_intent_path_that_is_a_symlink_is_never_written_through() {
+    // A symlink is a directory entry like any other, so the install declines
+    // rather than following it. Whoever can create one at this path must not be
+    // able to choose what this process overwrites.
+    let case = Case::new();
+    let decoy = case.path("decoy.json");
+    fs::write(&decoy, b"{\"decoy\":true}\n").expect("write the decoy");
+    let link = case.path("linked-intent.json");
+    std::os::unix::fs::symlink(&decoy, &link).expect("create the symlink");
+
+    assert!(
+        !install_no_replace(&link, b"{\"written\":\"through\"}\n", "intent")
+            .expect("an install over a symlink declines"),
+        "an install must not follow a symlink at its destination"
+    );
+    assert_eq!(
+        fs::read_to_string(&decoy).expect("read the decoy"),
+        "{\"decoy\":true}\n",
+        "nothing was written through the link"
+    );
+}
+
+#[test]
+fn a_source_that_already_holds_history_cannot_be_published_as_native_empty() {
+    // Absent Git metadata says a store was not imported, not that it is empty,
+    // and a source directory that already holds a store is reused rather than
+    // rebuilt. Without a baseline check a repository with committed content
+    // would publish under a reservation that promised an empty one, and the
+    // operation would carry that label for good.
+    //
+    // The fixture is an admitted Git repository because that is the way to build
+    // real committed graph-owned content in this process. `kin commit` needs a
+    // daemon and the installed `kin-daemon` here is stale (graph snapshot
+    // version 8 against the CLI's 16), so driving it would test the environment
+    // rather than the check. What matters is that the check under test never
+    // looks at Git metadata: it reads entities, semantic changes and refs, and
+    // it runs before the mode comparison, so this source exercises exactly the
+    // condition it exists for.
+    //
+    // The store is admitted here rather than left to the publish, because the
+    // publish initializes by the mode the manifest asked for: a native-empty
+    // request inits natively and would produce an empty store no matter what
+    // else sat in the directory. Reuse is the path under test, so the store has
+    // to exist, with history, before the run begins.
+    let case = Case::new();
+    materialize_git_source(&case.path("source"));
+    let admitted = kin_core::init_from_git_adopting(
+        &case.path("source"),
+        &RepositoryId::new(RESERVED_ID).expect("reserved id"),
+    )
+    .expect("admit the Git repository under the reserved identity");
+    assert_eq!(
+        admitted.repository_id.as_str(),
+        RESERVED_ID,
+        "the fixture must adopt the reserved identity, or the publish refuses for another reason"
+    );
+    write_manifest(
+        &case.path("manifest.json"),
+        &native_manifest(&case.path("destination"), "main"),
+    );
+
+    let error = run_publish(case.publish_args("native-empty"))
+        .expect_err("a source with committed content is not a native-empty publication");
+    let rendered = format!("{error:#}");
+    assert!(
+        rendered.contains("requires an unborn source"),
+        "the refusal says the source is not unborn: {rendered}"
+    );
+    assert!(
+        rendered.contains("entities") || rendered.contains("semantic changes"),
+        "the refusal is about graph-owned content and not only about the head: {rendered}"
+    );
+    assert!(
+        !case.path("intent.json").exists(),
+        "the refusal lands before any intent is made durable"
+    );
+    assert!(
+        destination_is_unpublished(&case),
+        "the refusal lands before the compare-and-swap"
+    );
+}
+
+#[test]
+fn an_unborn_native_source_is_still_accepted() {
+    // The positive control for the case above. A native-empty publication is
+    // valid with zero entities, zero changes and no refs, and the baseline check
+    // must not have made the ordinary path unreachable.
+    let case = Case::new();
+    write_manifest(
+        &case.path("manifest.json"),
+        &native_manifest(&case.path("destination"), "trunk"),
+    );
+    assert_eq!(
+        run_publish(case.publish_args("native-empty")).expect("an unborn native source publishes"),
+        0
+    );
+    let measured = case
+        .evidence("evidence.json")
+        .measured
+        .expect("the publication measures");
+    assert_eq!(measured.source_closure.body_count, 0);
+    assert_eq!(measured.head_change_id, None);
+    assert!(measured.ref_bindings.is_empty());
+}
+
+#[test]
+fn a_pinned_reading_never_mixes_in_a_later_authority() {
+    // Three separate reads are three separate authorities. The backend releases
+    // its lock on each one, and an opened manager recovers over acknowledged
+    // journal frames while a snapshot load returns only the base, so a writer
+    // that advances the destination between them yields a reading whose digest
+    // belongs to one authority and whose roots and refs belong to another.
+    //
+    // This drives that directly: bytes are pinned from one authority, the
+    // destination is then advanced to a different one, and the reading must
+    // still describe the pinned bytes alone. The control beneath proves the
+    // destination really did advance, so a reading that agreed with it would be
+    // reading storage rather than what it was given.
+    let case = Case::new();
+    write_manifest(
+        &case.path("manifest.json"),
+        &native_manifest(&case.path("destination"), "trunk"),
+    );
+    assert_eq!(
+        run_publish(case.publish_args("native-empty")).expect("publish trunk"),
+        0
+    );
+    let identity = RepositoryId::new(RESERVED_ID).expect("reserved id");
+    let pinned_backend: Arc<dyn StorageBackend> =
+        Arc::new(LocalFileBackend::new(case.path("destination")));
+    let (pinned_bytes, _) = pinned_backend
+        .load_snapshot(RESERVED_ID)
+        .expect("read the published snapshot")
+        .expect("a publication is present");
+
+    let later = Case::new();
+    write_manifest(
+        &later.path("manifest.json"),
+        &native_manifest(&later.path("destination"), "release"),
+    );
+    assert_eq!(
+        run_publish(later.publish_args("native-empty")).expect("publish release"),
+        0
+    );
+    replace_directory(&case.path("destination"), &later.path("destination"));
+
+    let advanced: Arc<dyn StorageBackend> =
+        Arc::new(LocalFileBackend::new(case.path("destination")));
+    // The control. An ordinary open of this destination now describes the later
+    // authority, so the pinned read below is answering from its bytes and not
+    // from storage.
+    let ordinary = RepositoryAuthorityManager::open(identity.clone(), advanced.clone())
+        .expect("open the advanced destination");
+    assert_eq!(
+        ordinary
+            .read_authority()
+            .metadata()
+            .ref_state
+            .default_ref
+            .as_ref()
+            .and_then(|name| name.as_utf8())
+            .map(str::to_string),
+        Some("refs/heads/release".to_string()),
+        "the fixture must actually advance the destination, or this case proves nothing"
+    );
+    drop(ordinary);
+
+    let reading = read_pinned_published_authority(&identity, advanced, Arc::new(pinned_bytes))
+        .expect("a pinned reading of the published bytes");
+    assert_eq!(
+        reading
+            .authority
+            .ref_state
+            .default_ref
+            .as_ref()
+            .and_then(|name| name.as_utf8())
+            .map(str::to_string),
+        Some("refs/heads/trunk".to_string()),
+        "the reading describes the bytes it was pinned to, never the authority now in storage"
+    );
+    assert_eq!(
+        reading.authority.repository_id.as_str(),
+        RESERVED_ID,
+        "the pinned reading keeps the reserved identity"
+    );
+    assert_eq!(
+        reading.source_closure.body_count(),
+        0,
+        "the pinned closure is the pinned authority's, and this one references no bodies"
+    );
+}

--- a/crates/kin-remote/src/first_publication.rs
+++ b/crates/kin-remote/src/first_publication.rs
@@ -3,11 +3,12 @@
 
 //! Complete first publication into an unserved, previously absent repository.
 
-use std::sync::Arc;
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 
 use kin_db::{
-    Generation, KinDbError, RepositoryAuthorityManager, SnapshotCursor, SnapshotSaveOutcome,
-    StorageBackend,
+    Generation, KinDbError, PersistedRepositoryAuthority, RepositoryAuthorityManager,
+    SnapshotCursor, SnapshotSaveOutcome, StorageBackend,
 };
 use kin_model::{Hash256, RepositoryId, RootBundle};
 use sha2::{Digest, Sha256};
@@ -24,6 +25,72 @@ pub struct FirstPublicationReceipt {
     pub roots: RootBundle,
     pub snapshot_sha256: Hash256,
     pub cursor: SnapshotCursor,
+}
+
+/// Domain separator for the canonical source-body closure digest.
+///
+/// Version it with the encoding beneath it. A reader in another language
+/// reproduces the digest from this constant and that encoding alone.
+const BODY_CLOSURE_DOMAIN: &[u8] = b"kin.first-publication-body-closure.v1\0";
+
+/// The distinct source bodies the destination-side validator actually asked
+/// for, with each body's exact length.
+///
+/// This is measured, not declared. It comes from the validation view that reads
+/// out of the destination, so it names what the destination proved it holds
+/// rather than what the source offered. An empty closure is a real value: a
+/// native repository with no history references no bodies, and its digest is
+/// the digest of the empty set rather than an absence.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SourceBodyClosure {
+    bodies: BTreeMap<[u8; 32], u64>,
+}
+
+impl SourceBodyClosure {
+    /// Distinct referenced bodies. A digest requested twice counts once.
+    pub fn body_count(&self) -> u64 {
+        self.bodies.len() as u64
+    }
+
+    /// Summed length of every distinct referenced body.
+    pub fn total_bytes(&self) -> u64 {
+        self.bodies.values().sum()
+    }
+
+    /// Canonical digest over the closure.
+    ///
+    /// Domain-separated, count-prefixed, and ordered by the raw digest bytes,
+    /// which is the order a `BTreeMap` keyed by `[u8; 32]` already yields. Each
+    /// body contributes its digest and its little-endian length, so the value
+    /// binds sizes as well as contents and stays reproducible from this
+    /// function's text in any language.
+    pub fn digest(&self) -> Hash256 {
+        let mut hasher = Sha256::new();
+        hasher.update(BODY_CLOSURE_DOMAIN);
+        hasher.update(self.body_count().to_le_bytes());
+        for (digest, length) in &self.bodies {
+            hasher.update(digest);
+            hasher.update(length.to_le_bytes());
+        }
+        Hash256::from_bytes(hasher.finalize().into())
+    }
+}
+
+/// Exactly what is about to be published, offered before the irreversible CAS.
+///
+/// A publication whose response is lost is recoverable only against something
+/// durable that was written first. This is that something: the observer runs
+/// after the destination has proved it holds the complete body closure and
+/// before the snapshot compare-and-swap, so a caller that persists these values
+/// can tell its own completed publication from a stranger's on the next open.
+/// An observer that returns an error stops the publication before the CAS.
+#[derive(Debug)]
+pub struct FirstPublicationIntent<'a> {
+    pub repository_id: &'a RepositoryId,
+    pub mode: FirstPublicationMode,
+    pub roots: &'a RootBundle,
+    pub snapshot_sha256: Hash256,
+    pub source_closure: &'a SourceBodyClosure,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -56,6 +123,37 @@ pub fn publish_first_repository<B: StorageBackend + ?Sized + 'static>(
     mode: FirstPublicationMode,
     destination: Arc<dyn StorageBackend>,
 ) -> Result<FirstPublicationReceipt, FirstPublicationError> {
+    publish_first_repository_observed(
+        source,
+        expected_repository_id,
+        mode,
+        destination,
+        |_| Ok(()),
+    )
+}
+
+/// [`publish_first_repository`], with the intended publication offered to the
+/// caller before the CAS that makes it permanent.
+///
+/// `before_commit` runs once, after the destination has validated the complete
+/// authority and its body closure out of its own storage and before the
+/// snapshot compare-and-swap. Its error stops the publication with nothing
+/// installed. It exists so an orchestrator can make the intended snapshot,
+/// roots and closure durable first, which is the only evidence that can tell a
+/// lost response apart from a foreign publication when the destination is
+/// reopened. It is otherwise identical to [`publish_first_repository`], which
+/// passes an observer that does nothing.
+pub fn publish_first_repository_observed<B, O>(
+    source: Arc<RepositoryAuthorityManager<B>>,
+    expected_repository_id: &RepositoryId,
+    mode: FirstPublicationMode,
+    destination: Arc<dyn StorageBackend>,
+    before_commit: O,
+) -> Result<FirstPublicationReceipt, FirstPublicationError>
+where
+    B: StorageBackend + ?Sized + 'static,
+    O: FnOnce(&FirstPublicationIntent<'_>) -> Result<(), FirstPublicationError>,
+{
     use FirstPublicationError::{Indeterminate, NotCommitted, Refused};
     let lease = source.read_authority();
     let metadata = lease
@@ -109,17 +207,25 @@ pub fn publish_first_repository<B: StorageBackend + ?Sized + 'static>(
     };
     RepositoryAuthorityManager::open(repository_id.clone(), Arc::new(copy))
         .map_err(NotCommitted)?;
-    let read_destination = destination.clone();
-    let read_id = repository_id.clone();
-    let staged = SnapshotBodyReader {
-        repository_id: repository_id.clone(),
-        snapshot: snapshot.clone(),
-        read_body: Box::new(move |digest, max_bytes| {
-            read_destination.load_source_blob_bounded(read_id.as_str(), digest, max_bytes)
-        }),
-    };
+    // The closure is recorded on this view rather than on the copy view above,
+    // because this is the view that reads out of the destination. What the
+    // source was willing to hand over is not evidence; what the destination
+    // answered with is.
+    let (staged, referenced) =
+        recording_destination_view(&repository_id, snapshot.clone(), destination.clone());
     RepositoryAuthorityManager::open(repository_id.clone(), Arc::new(staged))
         .map_err(NotCommitted)?;
+    let snapshot_sha256 = Hash256::from_bytes(Sha256::digest(&*snapshot).into());
+    let source_closure = SourceBodyClosure {
+        bodies: lock_recovering(&referenced).clone(),
+    };
+    before_commit(&FirstPublicationIntent {
+        repository_id: &repository_id,
+        mode,
+        roots: &roots,
+        snapshot_sha256,
+        source_closure: &source_closure,
+    })?;
     let cursor = match destination.save_snapshot_classified(
         repository_id.as_str(),
         &snapshot,
@@ -149,9 +255,103 @@ pub fn publish_first_repository<B: StorageBackend + ?Sized + 'static>(
     Ok(FirstPublicationReceipt {
         repository_id,
         roots,
-        snapshot_sha256: Hash256::from_bytes(Sha256::digest(&*snapshot).into()),
+        snapshot_sha256,
         cursor,
     })
+}
+
+/// One authority reading, taken entirely from one set of snapshot bytes.
+#[derive(Debug)]
+pub struct PinnedAuthorityReading {
+    pub roots: RootBundle,
+    pub authority: PersistedRepositoryAuthority,
+    pub source_closure: SourceBodyClosure,
+}
+
+/// Read a published authority and its referenced body closure from exactly the
+/// snapshot bytes the caller supplies, writing nothing.
+///
+/// The pinning is the point. Loading a snapshot for its digest, opening the
+/// destination again for its roots, and opening it a third time for its closure
+/// gives three selections that no lock spans: the backend releases its lock on
+/// each read, and an opened manager performs its own recovery over acknowledged
+/// journal frames while a snapshot load returns only the base. A writer that
+/// advances the destination between those calls therefore produces a reading
+/// whose digest belongs to one authority and whose roots and refs belong to
+/// another, and every field of it looks measured.
+///
+/// So there is one read here. The caller supplies the exact bytes it hashed, and
+/// the roots, the metadata and the closure all come from those bytes through a
+/// view that reports no journal frames at all, which is what makes an
+/// acknowledged advance unable to leak into this reading. Only the bodies are
+/// read from the destination, deliberately, because a body's presence there is
+/// the thing being proved.
+///
+/// The view is read-only: every write method on it refuses. Nothing here
+/// creates, repairs or replaces destination state.
+pub fn read_pinned_published_authority(
+    repository_id: &RepositoryId,
+    destination: Arc<dyn StorageBackend>,
+    snapshot: Arc<Vec<u8>>,
+) -> Result<PinnedAuthorityReading, FirstPublicationError> {
+    use FirstPublicationError::Indeterminate;
+    let (view, referenced) = recording_destination_view(repository_id, snapshot, destination);
+    let pinned = RepositoryAuthorityManager::open(repository_id.clone(), Arc::new(view))
+        .map_err(Indeterminate)?;
+    let lease = pinned.read_authority();
+    let roots = lease.roots().clone();
+    let authority = lease.metadata().clone();
+    drop(lease);
+    let source_closure = SourceBodyClosure {
+        bodies: lock_recovering(&referenced).clone(),
+    };
+    Ok(PinnedAuthorityReading {
+        roots,
+        authority,
+        source_closure,
+    })
+}
+
+/// A validation view over `destination`, recording every body it answers with.
+///
+/// One builder for both callers on purpose. A publication records the closure
+/// it is about to commit and a recovery records the closure that is already
+/// there, and the two values are only comparable while they are produced by the
+/// same walk over the same kind of view.
+type ReferencedBodies = Arc<Mutex<BTreeMap<[u8; 32], u64>>>;
+
+fn recording_destination_view(
+    repository_id: &RepositoryId,
+    snapshot: Arc<Vec<u8>>,
+    destination: Arc<dyn StorageBackend>,
+) -> (SnapshotBodyReader, ReferencedBodies) {
+    let referenced: ReferencedBodies = Arc::new(Mutex::new(BTreeMap::new()));
+    let recorder = referenced.clone();
+    let read_id = repository_id.clone();
+    let view = SnapshotBodyReader {
+        repository_id: repository_id.clone(),
+        snapshot,
+        read_body: Box::new(move |digest, max_bytes| {
+            let body = destination.load_source_blob_bounded(read_id.as_str(), digest, max_bytes)?;
+            if let Some(body) = body.as_ref() {
+                lock_recovering(&recorder).insert(digest, body.len() as u64);
+            }
+            Ok(body)
+        }),
+    };
+    (view, referenced)
+}
+
+/// Take a lock this module fully owns, recovering rather than panicking.
+///
+/// The only holder inserts into a map, so it cannot panic while holding the
+/// lock and the poisoned arm is unreachable in practice. Recovering anyway
+/// keeps a publication from turning an impossible lock state into a panic in
+/// the middle of a body walk.
+fn lock_recovering(
+    bodies: &Mutex<BTreeMap<[u8; 32], u64>>,
+) -> MutexGuard<'_, BTreeMap<[u8; 32], u64>> {
+    bodies.lock().unwrap_or_else(PoisonError::into_inner)
 }
 
 type BodyRead = dyn Fn([u8; 32], u64) -> Result<Option<Vec<u8>>, KinDbError> + Send + Sync;

--- a/crates/kin-remote/src/first_publication.rs
+++ b/crates/kin-remote/src/first_publication.rs
@@ -300,7 +300,19 @@ pub fn read_pinned_published_authority(
         .map_err(Indeterminate)?;
     let lease = pinned.read_authority();
     let roots = lease.roots().clone();
-    let authority = lease.metadata().clone();
+    // Read out of the pinned snapshot itself rather than through the lease's
+    // metadata accessor. It is the same value by construction, since the view
+    // this manager opened reports these bytes and no journal frames, and taking
+    // it from the snapshot says where it came from.
+    let authority = lease
+        .snapshot()
+        .repository_authority
+        .clone()
+        .ok_or_else(|| {
+            Indeterminate(KinDbError::StorageError(
+                "pinned snapshot carries no repository authority".into(),
+            ))
+        })?;
     drop(lease);
     let source_closure = SourceBodyClosure {
         bodies: lock_recovering(&referenced).clone(),

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -1244,6 +1244,12 @@
       "expiration": "2027-04-23"
     },
     {
+      "file": "crates/kin-cli/src/commands/hosted_publication.rs",
+      "reason": "Operator boundary for the first publication of a reserved hosted repository, end to end. Every filesystem touch here is an explicit input or output of that boundary and none of them is a semantic answer: reading the operation-bound manifest, making the intended publication durable before the irreversible compare-and-swap and reading an earlier one back to refuse replacing it, and writing the evidence record. The reads that decide anything are graph reads: the published authority is opened through RepositoryAuthorityManager and its body closure measured through kin-remote's own validation view, never by walking destination files. The existence and symlink probes are safety checks on those same operator-supplied paths, because following a link would let whoever can create one decide what this process reads or overwrites. This module resolves no locate, search, context, trace, review or xref result, and any future answer logic belongs elsewhere and requires narrowing or removing this exemption. Whole-file rather than expression pins because the module is dedicated to the boundary; narrowing to pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
+      "owner": "kin-cli",
+      "expiration": "2027-04-23"
+    },
+    {
       "file": "crates/kin-cli/src/commands/publish.rs",
       "reason": "Release publication transport. Brought under the guard by FIR-2282 on 2026-09-04, when the command surface stopped being opt-in. This module was never scanned before, by nobody's decision: it simply was not named in QUERY_COMMANDS. The entry preserves that effective scope while making it accountable, and the expiry is when it has to be narrowed to pins or defended again.",
       "owner": "kin-cli",


### PR DESCRIPTION
## What this adds

`kin_remote::first_publication::publish_first_repository` builds a reserved repository's durable
graph authority, and until now nothing outside tests could call it: no subcommand, no route, no
tool. An orchestrator that had reserved an identity had no transport to it, so a hosted reservation
could not be completed by anything.

This adds that transport as a hidden `kin hosted-publication`, with a `publish` action and a
read-only `verify` action, plus two narrow additive entry points in `kin-remote` that it needs.

Held draft. Nothing lands without an exact-head accept.

## Stacked dependency

This branch is stacked on the held hostedfleet head
`b01a7095812a9c9651109968b05a9367784027a5`, which carries the two held commits
`f3d8b5fa2` ("Add complete first publication for hosted repositories", PR #1538) and
`b01a70958` ("Admit prepared repositories through additive hosted fleet rollouts", PR #1549).
Those two commits are the dependency, not this lane's work, and they appear in this branch's
history only because `crates/kin-remote/src/first_publication.rs` does not exist on `main` yet.
Once both land, this branch is rebased onto `main` and the stack disappears; the diff to review here
is this lane's three files plus one allowlist entry.

## Which tree each gate graded

Every command below ran from the lane worktree through the fleet's builder slots, and each printed
the tree it resolved before it graded anything.

```
kin-lane: run lane=pubdriver repo=kin worktree=/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/pubdriver-kin target=/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/cargo-target/pubdriver-kin embed=cpu
```

Branch `chore/lane-pubdriver-kin`, base `b01a7095812a9c9651109968b05a9367784027a5`, head
`b4e49309a3bcc8e48a9e7939cffdc2871490a861`.

The head carries one more correction, from a source review of `a0662d88e`. The intent install's
parent-directory flush ran only when THIS call installed the record, so a second writer arriving
with an identical intent could observe the link after the first writer's `hard_link` and before its
flush, decline, read the matching record, and walk on to the irreversible compare-and-swap trusting
a directory entry that was not yet durable and whose writer might crash before making it so. The
flush is now unconditional after any successful install result, `AlreadyExists` included, and it
happens before the declined path returns.

Its regression takes away the flush's own ability to run rather than adding a seam: with the parent
directory set to write and traverse without read, the installed file stays reachable by name and
opening the directory fails, so an implementation that flushes on this path reports that failure
while one that skips it returns a cheerful `false` having touched nothing. That is mutant M16:

```
===== BASELINE (all arms, must be green) =====
rc=0
test result: ok. 25 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.26s

===== M16 parent flush only when this call installed (declined path trusts a peer) =====
rc=101
a declined install must flush the directory it is about to let a caller trust: false

===== precheck =====
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin a0662d88ed8d65f0232de79fd23805aefed2c049 DIRTY
rc=0
```

`DIRTY` is that correction sitting uncommitted in the worktree, which is the content this head
carries. `cargo fmt -- --check` returned 0 in the same run.

The gates below graded THIS tree, and that sentence is load-bearing. An earlier head was pushed red
on `Fast gate lint and policy` because I quoted a precheck that had run before the last three edits,
so the gate I cited had graded a tree I did not push. The violation was
`scripts/verify-zero-file-search.py` matching `.metadata()` in `first_publication.rs` without knowing
the receiver is a graph-authority lease. It is fixed by reading `repository_authority` out of the
pinned snapshot instead, which is the same value by construction and says where it came from, rather
than by an allowlist exemption. Every gate and the whole composition were then re-run against the
exact content of this head:

```
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 6e71fbd67a8b76dc32e56b9cd1bd894f7fe14bbd DIRTY
```

`DIRTY` there is the fix sitting uncommitted in the worktree, which is the content this head carries.
Both halves of the zero-file-search pair are in that tally, the shell guard and the Python checker:

```
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
PASS     guard:verify-hydration-semantics.py  python3 scripts/verify-hydration-semantics.py
PASS     guard:check_private_repo_coupling.sh, guard:check_runtime_boundaries.sh,
         guard:test-release-policy-gate.sh, guard:test-windows-authority-legs.sh,
         guard:check-kin-vfs-compat.mjs, guard:check-rc-build-drift.mjs,
         guard:check-required-contexts.py, guard:test-assertion-reachability.py,
         guard:test-guard-duplicate-release-run.py, guard:test-homebrew-release-gate.py,
         guard:test-install-checksum.py, guard:test-private-repo-coupling.py,
         guard:test-release-tag-evaluate-dispatch.py, guard:test-release-workflow-authority.py,
         guard:test-select-release-candidate.py, node-test
```

### Type check

```
$ heavy-slot.sh pubdriver kin -- cargo check -p kin-remote -p kin-cli
    Checking kin-remote v0.7.2 (.../pubdriver-kin/crates/kin-remote)
    Checking kin-cli v0.7.2 (.../pubdriver-kin/crates/kin-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 18.16s
heavy-slot: pubdriver command exit rc=0 at 2026-09-05T18:47:55Z
```

### Acceptance composition

```
$ heavy-slot.sh pubdriver kin -- cargo test -p kin-cli --test hosted_first_publication
test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.92s
```

Nineteen arms, no compiler warnings. Two of them were red at baseline before any mutation was
applied, and each found a real defect rather than confirming one:

`a_resumption_that_names_another_operation_is_still_refused` failed with
`an intent belonging to another operation must be refused: 0`. The on-disk intent was read and
handed back without ever checking it belonged to this manifest's operation, so a run whose manifest
named a different operation was given the earlier operation's intent, found the destination matching
it, and reported a recovery for work it never did. An intent path is caller-supplied and an intent
file outlives the run that wrote it, so this is reachable by a worker that reused a path or
recovered onto a machine still holding an earlier file. Closed in `reconcile_expected_intent`.

`an_intent_recording_another_destination_is_refused` failed on its own fixture control, which
asserted that two native-empty publications of one branch produce identical bytes. They do not:
each initialization mints its own workspace identity, which is why an intent has to be bound to the
destination it names rather than recognized by its contents. The control is inverted rather than
deleted, and the destination is now bound alongside the operation.

### Falsification

Every arm below is a single mutation applied to this branch, the named test run against it, and the
source restored from a backup copy afterwards. Restoring from a backup rather than from git, because
these files were uncommitted at the time and `git checkout --` would have discarded them.

Three rounds, twelve mutants, every one red on a named assertion, every source file restored from a
backup and the restore verified.

| Mutant | What it breaks | Red on |
|---|---|---|
| M1 | Bodies never written to the destination | The destination-side validation refusing before the CAS |
| M2 | The closure records only the first body | `the closure counts the replaced body as well as the current one, got 1` |
| M3 | Manifest and flag identity no longer cross-checked | The identity refusal |
| M4 | The durable intent ignored on a second run | `a recovery is a success the caller proceeds from`, left 4 right 0 |
| M5 | Ref bindings checked by name, not by target | The binding refusal |
| M6 | A Git object id reported as the head change | `the head is a semantic change id, never a Git object id cast into one`, left 40 right 64 |
| M7 | The conflict comparison never disagrees | `a destination holding another authority is a conflict, never a recovery`, left 0 right 4 |
| M8 | Renewal treated as a different publication | `the manifest's expected authority and the intent file describe different publications` |
| M9 | Operation identity dropped from the intent binding | The stranger-intent refusal |
| M10 | The intent binding check removed | `an intent belonging to another operation must be refused: 0` |
| M11 | The destination binding check removed | `an intent recording another destination must be refused: 4` |

One mutant survived its first attempt and is worth stating rather than hiding. Restoring full
operation equality left the renewal case green, because `describes_same_publication` is only reached
when both an inline expected authority and an on-disk intent are present and the case supplied only
the file, so the mutated line never ran. It was answered with a new input only the target can catch,
never by weakening a guard: the case now supplies both accounts of one attempt as a real resumption
does, and asserts the file on disk really is the pre-renewal one so the fixture cannot quietly stop
setting up the case it exists for.

## What the composition drives, exactly

Stated plainly so nothing here can be read as more than it is. The arms call the CLI's own
`run_publish` and `run_verify` in this process, against real adopting-init sources, a real
filesystem destination and real durable files. They do not run the installed `kin` binary's own
journey, and nothing here is a native end-to-end CLI acceptance; that belongs to the separate
integration gate the design names, along with GCS, fleet admission and receipt signing.

The evidence record's success is exactly what was compared and no more. A `published` outcome means
every measured field agreed with the durable intent that was written before the compare-and-swap. It
asserts nothing about a journal this reading did not see and nothing about a head newer than the
bytes it was pinned to; a destination that has moved past those bytes produces a conflict naming the
fields that moved, never a first-publication success.

Four more mutants, run after a source review of this branch found three producer defects and they
were fixed. Baseline green at twenty-four arms in the same run.

```
===== BASELINE (all arms, must be green) =====
rc=0
test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.88s

===== M12 install replaces instead of refusing (rename in place of link) =====
assertion `left == right` failed: exactly one writer may install a contended path
  left: 8
 right: 1

===== M13 the same mutant against the symlink arm =====
an install must not follow a symlink at its destination

===== M14 native-empty baseline unchecked (a history-bearing source passes) =====
the refusal says the source is not unborn: a native-empty publication cannot be built from an
imported Git authority

===== M15 authority taken from a second open of live storage, not the pinned bytes =====
assertion `left == right` failed: the reading describes the bytes it was pinned to, never the
authority now in storage
  left: Some("refs/heads/release")
 right: Some("refs/heads/trunk")

===== RESTORED =====
hosted_publication.rs restored
first_publication.rs restored
```

M14 deserves its exact reading rather than a summary. With the emptiness check removed, this input is
still refused, by the mode check one step later, and what goes red is the assertion that the refusal
names the unborn requirement rather than Git metadata. That is the property under test and it is the
right red. It also means the emptiness check is not the only thing refusing THIS input; a native
store carrying history and no Git metadata would be refused by it alone, and that source cannot be
built in this process because `kin commit` needs a daemon whose installed binary here is stale.
Stated so the control is read as what it is: a boundary control on the check's reason, not proof that
the check is the sole gate for every shape it covers.

Two mutant rounds are absent from these tails on purpose. Their baselines did not compile, and
`cargo test` returns 101 for a mutation and 101 for a build error, so reading the first as
falsification would be the mistake this whole section exists to avoid. Their results were discarded
rather than quoted.

## What is NOT claimed

Two things, stated because a reviewer should not have to infer them.

The durable boundaries are reached deliberately rather than by timing a signal. A run whose intent
cannot be made durable stops before the compare-and-swap with the bodies already written, which is
the same durable state a process killed there leaves behind, and the next case proves a later attempt
completes from it. Removing the evidence file after a successful publication is the same durable
state a process killed after the compare-and-swap leaves behind, and `verify` recovers from it. These
are simulated states, honestly labelled, not real signals.

One property is structural rather than proven. The evidence is measured through a backend handle
built fresh from the destination specification, never the handle the publication went through, which
is what would catch a backend answering from a cache it populated while writing. On
`LocalFileBackend` both handles read the same files, so a mutation that reused the publishing handle
would stay green. Falsifying it needs an injectable backend that lies to the second reader, and this
CLI path has no seam for one. What is pinned is the weaker, real claim: the evidence digest is
computed from bytes read back after the publication returned, and a disagreement with the receipt's
digest or the committed generation refuses.

Hosted object-store publication is out of scope here and refused by name
(`destination_backend_unavailable`). Fleet admission, receipt signing and the control-plane join are
separate lanes; this process signs nothing and admits nothing.

## Guard allowlist

`crates/kin-cli/src/commands/hosted_publication.rs` is added to
`scripts/zero-file-search-allowlist.json` as a whole-file entry. The zero-file-search guard treats
every module under `crates/kin-cli/src/commands/` as an answer module, and this one reads a manifest,
makes an intent durable and writes an evidence record. None of that is a semantic answer: the reads
that decide anything go through `RepositoryAuthorityManager` and `kin-remote`'s own validation view,
never a filesystem walk. The entry carries an owner and an expiry, and narrowing it to expression
pins is the named follow-up.
