### PR TITLE
Fix Windows compilation of session move fixtures

### DIFF
--- a/crates/kin-daemon/src/api/tests/session_move_identity.rs
+++ b/crates/kin-daemon/src/api/tests/session_move_identity.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
+#![cfg(unix)]
+
 use super::*;
 
 fn sole_entity(state: &DaemonState, path: &str) -> Entity {


### PR DESCRIPTION
Native Windows authority CI could not compile the daemon library tests because three session-move helpers remained enabled while their only callers were Unix-only tests. Apply the same Unix condition to the test module, matching its sibling fixture. Both tests and all assertions remain unchanged; production compilation already excludes the enclosing `cfg(test)` module.

Validation with `RUSTFLAGS='-D warnings'`:

- `cargo check --locked --target x86_64-pc-windows-gnu -p kin-daemon --no-default-features --tests` passed. Native Windows failure evidence is [CI run33988184912, Windows authority tests](https://github.com/firelock-ai/kin/actions/runs/33988184912/job/101365505276).
- `cargo test --locked -p kin-daemon --lib api::tests::session_move_identity:: -- --test-threads=1` passed both identity tests.
- Formatting and all21 enumerated `kin-precheck` gates passed, including all-target/all-feature clippy and repository guards.
- Removing only the new module condition reproduced the same three Windows unused-helper compiler errors. Restoring the exact fixed source made the identical Windows command pass again.

Actual output tails:

```text
Checking kin-daemon v0.7.2
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 36s

test api::tests::session_move_identity::session_move_preserves_identity_through_admission_commit_and_two_cold_reopens ... ok
test api::tests::session_move_identity::session_move_preserves_path_named_module_identity ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 1510 filtered out; finished in 5.28s

kin-precheck: 21 gates ran, 21 passed, 0 failed

error: function `sole_entity` is never used
error: function `assert_moved_identity` is never used
error: function `assert_session_refused_without_advancing` is never used
error: could not compile `kin-daemon` (lib test) due to 3 previous errors

Finished `dev` profile [unoptimized + debuginfo] target(s) in 28.17s
PASS: exact original three Windows compiler errors reproduced; exact fixed source restored and compiled
```

The local cross-target check proves Windows test compilation. Native MSVC authority execution remains the main CI gate.
