### PR TITLE
Answer what changed between two refs from the repository read view

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -24506,6 +24506,71 @@ mod tests {
         assert_eq!(refusal, None, "an answered comparison carries no refusal");
     }
 
+    /// A blank ref is refused rather than quietly becoming the default.
+    ///
+    /// `resolve_read_point` reads a blank reference as "none given" and answers
+    /// the default ref, which is right for the blob route and wrong here. This
+    /// route has no default: a blank base would become the head's own ref, and
+    /// the answer would be zero files, zero ahead and zero behind, which is the
+    /// exact shape a comparison route exists not to invent. The 200 that a
+    /// defaulted base produces is what these two arms would read without the
+    /// check, so they are written against that answer rather than against a
+    /// crash.
+    #[tokio::test]
+    async fn a_blank_compare_ref_on_either_side_is_refused_rather_than_defaulted() {
+        let repo_id = format!("hostedcompare-blank-{}", Uuid::new_v4());
+        let (state, _working, storage) = replica_state(&repo_id);
+        let repository_id = RepositoryId::new(&repo_id).unwrap();
+        publish_hosted_semantic_change(
+            storage.path(),
+            &repository_id,
+            None,
+            0x3279_0031,
+            "publish a generation to compare",
+            &[("first_symbol", "src/first.rs", "fn first_symbol() {}\n")],
+        );
+        state.evict_repo_cache_for_test(&repo_id).await;
+
+        // An empty base, and a head that is nothing but spaces. Both reach the
+        // shared resolver as a blank reference, and both would resolve to main.
+        for (query, side) in [
+            ("base=&head=main", "base"),
+            ("base=main&head=%20%20", "head"),
+        ] {
+            let (status, refusal, body) = repo_compare_route(
+                Arc::clone(&state),
+                &format!("/repos/{repo_id}/compare?{query}"),
+            )
+            .await;
+            let message = String::from_utf8_lossy(&body);
+            assert_eq!(
+                status,
+                StatusCode::BAD_REQUEST,
+                "{query} must be refused rather than defaulted: {message}"
+            );
+            assert_eq!(
+                refusal.as_deref(),
+                Some("bad-request"),
+                "{query} must be refused BY NAME: {message}"
+            );
+            assert!(
+                message.contains(side),
+                "{query}: the refusal must name the side that was blank: {message}"
+            );
+        }
+
+        // The control: the same repository answers when both sides are named,
+        // so the two above are refused for their blankness and not because this
+        // fixture refuses everything.
+        let (status, refusal, body) = repo_compare_route(
+            Arc::clone(&state),
+            &format!("/repos/{repo_id}/compare?base=main&head=main"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        assert_eq!(refusal, None, "an answered comparison carries no refusal");
+    }
+
     /// A daemon carrying the compare route says so on its health endpoint.
     ///
     /// A hosted control plane keys its fallback on this string, and the

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -1212,6 +1212,14 @@ const REPO_SCOPED_SEMANTIC_CAPABILITY: &str = "repo_scoped_semantic_tools_v1";
 /// them means "ask an older daemon a different question". Advertising it is
 /// what lets that caller keep a truthful fallback instead of a heuristic.
 const REPO_SCOPED_BLOB_CAPABILITY: &str = "repo_scoped_blob_v1";
+/// This daemon answers what changed between two refs of a repository.
+///
+/// Advertised for the same reason the blob capability is, and with a sharper
+/// edge: a caller that cannot tell a daemon without this route from one with it
+/// has to decide what an unanswered comparison means, and the tempting answer
+/// is a comparison of zero files, which is indistinguishable from two refs that
+/// really are identical. A caller reading this string never has to guess.
+const REPO_SCOPED_COMPARE_CAPABILITY: &str = "repo_scoped_compare_v1";
 /// Retained continuations per repository, not per daemon.
 ///
 /// A per-daemon cap is a shared resource across tenants, and the eviction that
@@ -2222,6 +2230,10 @@ fn api_routes() -> Router<Arc<DaemonState>> {
         .route("/repos/{repo_id}/entities", get(repo_entities))
         .route("/repos/{repo_id}/files", get(repo_files))
         .route("/repos/{repo_id}/blob", get(crate::repo_blob::repo_blob))
+        .route(
+            "/repos/{repo_id}/compare",
+            get(crate::repo_compare::repo_compare),
+        )
         .route("/repos/{repo_id}/refs", get(repo_refs))
         .route("/repos/{repo_id}/history", get(repo_history))
         .route(
@@ -15391,7 +15403,7 @@ impl RepositoryReadView {
     }
 
     /// One change out of this generation's history.
-    fn change(
+    pub(crate) fn change(
         &self,
         change_id: &kin_model::SemanticChangeId,
     ) -> Result<Option<kin_model::SemanticChange>, (StatusCode, String)> {
@@ -16428,6 +16440,7 @@ async fn repo_health(
                 vec![
                     REPO_SCOPED_SEMANTIC_CAPABILITY.to_string(),
                     REPO_SCOPED_BLOB_CAPABILITY.to_string(),
+                    REPO_SCOPED_COMPARE_CAPABILITY.to_string(),
                 ]
             })
             .unwrap_or_default(),
@@ -24225,6 +24238,309 @@ mod tests {
         );
     }
 
+    /// A compare read over the router, keeping the refusal header.
+    async fn repo_compare_route(
+        state: Arc<DaemonState>,
+        path: &str,
+    ) -> (StatusCode, Option<String>, Vec<u8>) {
+        let response = router(state)
+            .oneshot(Request::get(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let status = response.status();
+        let refusal = response
+            .headers()
+            .get(crate::repo_compare::REPO_COMPARE_REFUSAL_HEADER)
+            .map(|value| value.to_str().unwrap().to_string());
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        (status, refusal, body.to_vec())
+    }
+
+    /// Two published generations, compared in both directions over the router.
+    ///
+    /// Every arm here is one a comparison that answers without reading would
+    /// get wrong. Zero ahead, zero behind and no files is what two identical
+    /// refs look like, so the identical case is read beside the two real ones:
+    /// the zero answer has to be earned rather than assumed. The reverse
+    /// direction is here because a route that returned the same body for both
+    /// orders would still pass the forward arm.
+    #[tokio::test]
+    async fn the_compare_route_answers_a_real_difference_in_both_directions() {
+        let repo_id = format!("hostedcompare-diff-{}", Uuid::new_v4());
+        let (state, _working, storage) = replica_state(&repo_id);
+        let repository_id = RepositoryId::new(&repo_id).unwrap();
+
+        let (first_change, _entities) = publish_hosted_semantic_change(
+            storage.path(),
+            &repository_id,
+            None,
+            0x3279_0001,
+            "publish the first generation",
+            &[(
+                "only_in_first",
+                "src/only_in_first.rs",
+                "fn only_in_first() {}\n",
+            )],
+        );
+        let (second_change, _entities) = publish_hosted_semantic_change(
+            storage.path(),
+            &repository_id,
+            Some(first_change),
+            0x3279_0002,
+            "publish the second generation",
+            &[(
+                "only_in_second",
+                "src/only_in_second.rs",
+                "fn only_in_second() {}\n",
+            )],
+        );
+        add_hosted_ref(
+            storage.path(),
+            &repository_id,
+            0x3279_0003,
+            kin_model::RefName::branch(b"legacy").unwrap(),
+            first_change,
+        );
+        state.evict_repo_cache_for_test(&repo_id).await;
+
+        let (status, refusal, body) = repo_compare_route(
+            Arc::clone(&state),
+            &format!("/repos/{repo_id}/compare?base=legacy&head=main"),
+        )
+        .await;
+        let message = String::from_utf8_lossy(&body);
+        assert_eq!(status, StatusCode::OK, "{message}");
+        assert_eq!(
+            refusal, None,
+            "an answered comparison carries no refusal header: {message}"
+        );
+        let forward: crate::repo_compare::RepoCompareResponse =
+            serde_json::from_slice(&body).unwrap();
+        assert_eq!(forward.repo_id, repo_id);
+        assert_eq!(
+            forward.base_ref,
+            first_change.to_string(),
+            "each side reports the change it resolved to"
+        );
+        assert_eq!(forward.head_ref, second_change.to_string());
+        assert_eq!(
+            forward.merge_base_ref,
+            first_change.to_string(),
+            "the base is an ancestor of the head, so it is the merge base"
+        );
+        assert_eq!(
+            forward.ahead, 1,
+            "the head carries one change the base lacks"
+        );
+        assert_eq!(forward.behind, 0);
+        assert_eq!(
+            forward.files.len(),
+            1,
+            "one file was added between the two: {:?}",
+            forward.files
+        );
+        assert_eq!(forward.files[0].path, "src/only_in_second.rs");
+        assert_eq!(forward.files[0].status, "added");
+        assert!(
+            forward.conflicts.is_empty(),
+            "this route establishes no conflicts and must claim none"
+        );
+
+        // The same pair the other way round. A file added going forward is a
+        // file deleted coming back, and the distance swaps sides.
+        let (status, _refusal, body) = repo_compare_route(
+            Arc::clone(&state),
+            &format!("/repos/{repo_id}/compare?base=main&head=legacy"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let reverse: crate::repo_compare::RepoCompareResponse =
+            serde_json::from_slice(&body).unwrap();
+        assert_eq!(reverse.ahead, 0);
+        assert_eq!(reverse.behind, 1);
+        assert_eq!(reverse.merge_base_ref, first_change.to_string());
+        assert_eq!(reverse.files.len(), 1, "{:?}", reverse.files);
+        assert_eq!(reverse.files[0].path, "src/only_in_second.rs");
+        assert_eq!(reverse.files[0].status, "deleted");
+
+        // And a ref against itself, which is the only shape that earns zero.
+        let (status, _refusal, body) = repo_compare_route(
+            Arc::clone(&state),
+            &format!("/repos/{repo_id}/compare?base=main&head=main"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let identical: crate::repo_compare::RepoCompareResponse =
+            serde_json::from_slice(&body).unwrap();
+        assert_eq!(identical.ahead, 0);
+        assert_eq!(identical.behind, 0);
+        assert!(identical.files.is_empty(), "{:?}", identical.files);
+        assert_eq!(
+            identical.merge_base_ref,
+            second_change.to_string(),
+            "a change is its own merge base with itself"
+        );
+    }
+
+    /// The compare route publishes its refusal kind on every refusal.
+    ///
+    /// The header is what a hosted caller branches on, and the branch that
+    /// matters most is the one between "this daemon cannot answer" and "these
+    /// refs really are identical". An arm that forgot the header would look to
+    /// that caller like a route that had never heard of the question.
+    #[tokio::test]
+    async fn every_compare_refusal_the_router_can_produce_carries_its_kind() {
+        let repo_id = format!("hostedcompare-kinds-{}", Uuid::new_v4());
+        let (state, _working, storage) = replica_state(&repo_id);
+        let repository_id = RepositoryId::new(&repo_id).unwrap();
+
+        let (first_change, _entities) = publish_hosted_semantic_change(
+            storage.path(),
+            &repository_id,
+            None,
+            0x3279_0011,
+            "publish the first generation",
+            &[(
+                "only_in_first",
+                "src/only_in_first.rs",
+                "fn only_in_first() {}\n",
+            )],
+        );
+        let (second_change, _entities) = publish_hosted_semantic_change(
+            storage.path(),
+            &repository_id,
+            Some(first_change),
+            0x3279_0012,
+            "publish the second generation",
+            &[(
+                "only_in_second",
+                "src/only_in_second.rs",
+                "fn only_in_second() {}\n",
+            )],
+        );
+        // A branch and a tag that shorten to the same alias and point at
+        // different changes, so a comparison against `v2` cannot be answered
+        // without picking one of them.
+        add_hosted_ref(
+            storage.path(),
+            &repository_id,
+            0x3279_0013,
+            kin_model::RefName::branch(b"v2").unwrap(),
+            first_change,
+        );
+        add_hosted_ref(
+            storage.path(),
+            &repository_id,
+            0x3279_0014,
+            kin_model::RefName::tag(b"v2").unwrap(),
+            second_change,
+        );
+        state.evict_repo_cache_for_test(&repo_id).await;
+
+        let cases = [
+            (
+                "base=no-such-ref&head=main",
+                StatusCode::NOT_FOUND,
+                "unknown-ref",
+                "base",
+            ),
+            (
+                "base=main&head=no-such-ref",
+                StatusCode::NOT_FOUND,
+                "unknown-ref",
+                "head",
+            ),
+            (
+                "base=v2&head=main",
+                StatusCode::CONFLICT,
+                "ambiguous-ref",
+                "refs/tags/v2",
+            ),
+            ("base=main", StatusCode::BAD_REQUEST, "bad-request", "head"),
+            ("head=main", StatusCode::BAD_REQUEST, "bad-request", "base"),
+        ];
+        for (query, expected_status, expected_kind, expected_text) in cases {
+            let (status, refusal, body) = repo_compare_route(
+                Arc::clone(&state),
+                &format!("/repos/{repo_id}/compare?{query}"),
+            )
+            .await;
+            let message = String::from_utf8_lossy(&body);
+            assert_eq!(status, expected_status, "{query}: {message}");
+            assert_eq!(
+                refusal.as_deref(),
+                Some(expected_kind),
+                "{query} must be refused BY NAME: {message}"
+            );
+            assert!(
+                message.contains(expected_text),
+                "{query}: the refusal must say {expected_text:?}: {message}"
+            );
+        }
+
+        // A repository this daemon does not serve, which shares its status with
+        // the unknown-ref arms and is a different kind.
+        let (status, refusal, body) = repo_compare_route(
+            Arc::clone(&state),
+            "/repos/not-served-here/compare?base=main&head=main",
+        )
+        .await;
+        let message = String::from_utf8_lossy(&body);
+        assert_eq!(status, StatusCode::NOT_FOUND, "{message}");
+        assert_eq!(refusal.as_deref(), Some("unknown-repository"), "{message}");
+
+        // The control: the same repository answers a well-formed comparison, so
+        // every refusal above is refused for its own shape rather than because
+        // this fixture cannot answer anything.
+        let (status, refusal, body) = repo_compare_route(
+            Arc::clone(&state),
+            &format!(
+                "/repos/{repo_id}/compare?base={first_change}&head={}",
+                second_change
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        assert_eq!(refusal, None, "an answered comparison carries no refusal");
+    }
+
+    /// A daemon carrying the compare route says so on its health endpoint.
+    ///
+    /// A hosted control plane keys its fallback on this string, and the
+    /// fallback available without it is inventing an empty comparison, so an
+    /// image with the route that does not advertise it is the same outage as
+    /// one without the route.
+    #[tokio::test]
+    async fn a_hosted_daemon_advertises_the_repo_scoped_compare_capability() {
+        let repo_id = format!("hostedcompare-capability-{}", Uuid::new_v4());
+        let (state, _working, storage) = replica_state(&repo_id);
+        let repository_id = RepositoryId::new(&repo_id).unwrap();
+        publish_hosted_semantic_change(
+            storage.path(),
+            &repository_id,
+            None,
+            0x3279_0021,
+            "publish a generation to compare",
+            &[("first_symbol", "src/first.rs", "fn first_symbol() {}\n")],
+        );
+        state.evict_repo_cache_for_test(&repo_id).await;
+
+        let (status, body) =
+            repo_route(Arc::clone(&state), &format!("/repos/{repo_id}/health")).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let health: RepoHealthResponse = serde_json::from_slice(&body).unwrap();
+        assert!(
+            health
+                .semantic_capabilities
+                .iter()
+                .any(|capability| capability == REPO_SCOPED_COMPARE_CAPABILITY),
+            "a daemon carrying the compare route must advertise it: {:?}",
+            health.semantic_capabilities
+        );
+    }
+
     /// A publication that moves the generation is not answered from the tree
     /// resolved before it (FIR-2924).
     ///
@@ -24811,6 +25127,7 @@ mod tests {
             vec![
                 REPO_SCOPED_SEMANTIC_CAPABILITY.to_string(),
                 REPO_SCOPED_BLOB_CAPABILITY.to_string(),
+                REPO_SCOPED_COMPARE_CAPABILITY.to_string(),
             ]
         );
 

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -138,6 +138,7 @@ mod pending_commits;
 pub mod publication_lease;
 pub mod replica_adoption;
 pub mod repo_blob;
+pub mod repo_compare;
 mod repository_admit;
 mod repository_branch;
 mod repository_checkout;

--- a/crates/kin-daemon/src/repo_blob.rs
+++ b/crates/kin-daemon/src/repo_blob.rs
@@ -340,7 +340,7 @@ pub async fn repo_blob(
 /// report, because none was involved. Anything else is `unknown-ref`, which is a
 /// 404 about the read point and never about the path, since no tree was resolved
 /// and nothing was looked up in one.
-fn resolve_read_point(
+pub(crate) fn resolve_read_point(
     view: &crate::api::RepositoryReadView,
     reference: Option<&str>,
     repo_id: &str,

--- a/crates/kin-daemon/src/repo_compare.rs
+++ b/crates/kin-daemon/src/repo_compare.rs
@@ -187,14 +187,25 @@ pub async fn repo_compare(
         )
     })?;
 
+    // Both sides are required and neither may be blank, checked before anything
+    // is opened. The shared resolver reads a blank reference as no reference
+    // given and answers the repository's default ref, which is correct for a
+    // route that has a default and wrong for one that does not: a blank base
+    // would quietly become the head's own ref, and the answer would be zero
+    // files, zero ahead and zero behind, which is the shape this route exists
+    // not to invent. The refusal travels through this route's own error so it
+    // carries the refusal header like every other.
+    let base = nonblank_ref("base", &query.base)?;
+    let head = nonblank_ref("head", &query.head)?;
+
     // Three views because `resolve_tree_at` consumes one and this needs two
     // trees plus a history walk. On a hosted daemon each is a generation-cache
     // read, which is the path that exists to make repeated reads cheap.
     let walk_view = open_view(&state, &repo_id).await?;
-    let base_change = resolve_read_point(&walk_view, Some(&query.base), &repo_id)
+    let base_change = resolve_read_point(&walk_view, Some(base), &repo_id)
         .map_err(|error| RepoCompareError::from_read_point("base", error))?
         .0;
-    let head_change = resolve_read_point(&walk_view, Some(&query.head), &repo_id)
+    let head_change = resolve_read_point(&walk_view, Some(head), &repo_id)
         .map_err(|error| RepoCompareError::from_read_point("head", error))?
         .0;
 
@@ -223,6 +234,22 @@ pub async fn repo_compare(
         files: changed_files(&base_tree, &head_tree)?,
         conflicts: Vec::new(),
     }))
+}
+
+/// One side of the comparison, refused when it names nothing.
+fn nonblank_ref<'a>(side: &str, value: &'a str) -> Result<&'a str, RepoCompareError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(RepoCompareError::new(
+            StatusCode::BAD_REQUEST,
+            RepoCompareRefusal::BadRequest,
+            format!(
+                "{side} must name a ref or a change id, and this request left it blank. This \
+                 route compares two read points a caller chose and has no default for either."
+            ),
+        ));
+    }
+    Ok(trimmed)
 }
 
 async fn open_view(

--- a/crates/kin-daemon/src/repo_compare.rs
+++ b/crates/kin-daemon/src/repo_compare.rs
@@ -1,0 +1,709 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! `GET /repos/{repo_id}/compare` — what changed between two refs, from the graph.
+//!
+//! The daemon could answer for one file's bytes and for one ref's whole tree. It
+//! could not answer the question a reader asks before either: what is different
+//! between these two refs. A caller that cannot ask it has to decide what an
+//! unanswered comparison means, and the shape closest to hand is a comparison of
+//! zero files, zero ahead and zero behind, which is indistinguishable from two
+//! refs that really are identical.
+//!
+//! So this route refuses wherever it cannot compute, and the refusals are the
+//! design rather than the leftovers. A ref that does not resolve names which
+//! side. Two histories with no common ancestor refuse rather than reporting no
+//! distance. A history walk past its bound refuses and names the bound. None of
+//! them is a comparison of zero files.
+//!
+//! Identities, not bytes. The changed-file list is a set difference over the two
+//! resolved trees, and a path present in both is modified when its tree entry
+//! differs, which catches a mode change as well as a content change. Nothing
+//! here reads the content-addressed store, because a comparison needs to know
+//! which files differ and not what they say; a caller wanting the text asks
+//! `/repos/{repo_id}/blob` twice. And nothing here reads a filesystem.
+//!
+//! Renames are not reported, and that is a claim about evidence rather than a
+//! gap. A resolved tree carries a path and an entry per artifact and no rename
+//! record, so a rename could only be inferred by similarity. An addition beside
+//! a deletion is what the tree proves.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::extract::rejection::QueryRejection;
+use axum::extract::{Path, Query, State};
+use axum::http::{HeaderName, HeaderValue, StatusCode};
+use axum::response::IntoResponse;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+use crate::api::{repository_read_view, RepositoryReadView};
+use crate::repo_blob::{resolve_read_point, RepoBlobRefusal};
+use crate::state::DaemonState;
+
+/// How many changes either side's ancestor walk records before refusing.
+///
+/// A bound is needed because two histories with no common ancestor are only
+/// discovered by walking both of them to their roots, and this route answers a
+/// page. Past it the honest answer is that the distance was not established,
+/// which is why the refusal names the bound rather than reporting a distance of
+/// zero.
+pub const MAX_COMPARE_HISTORY_DEPTH: usize = 10_000;
+
+/// The header every refusal from this route carries, naming which refusal it is.
+pub const REPO_COMPARE_REFUSAL_HEADER: &str = "x-kin-compare-refusal";
+
+/// Which refusal, in a closed set a caller can branch on without reading English.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepoCompareRefusal {
+    /// The request itself could not be understood, so nothing was resolved.
+    BadRequest,
+    /// This daemon does not serve a repository by that id.
+    UnknownRepository,
+    /// It serves the id and could not read it as a repository.
+    RepositoryUnreadable,
+    /// One side named neither a ref this repository carries nor a change id.
+    UnknownRef,
+    /// One side is a short alias more than one ref answers to.
+    AmbiguousRef,
+    /// The two histories share no ancestor, so there is no distance to report.
+    NoCommonAncestor,
+    /// One side's history ran past the walk's bound before an ancestor was found.
+    HistoryTooDeep,
+    /// Several best common ancestors exist and none descends from another.
+    AmbiguousMergeBase,
+    /// A changed path's bytes are not UTF-8, so this response cannot name it.
+    PathNotRepresentable,
+}
+
+impl RepoCompareRefusal {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::BadRequest => "bad-request",
+            Self::UnknownRepository => "unknown-repository",
+            Self::RepositoryUnreadable => "repository-unreadable",
+            Self::UnknownRef => "unknown-ref",
+            Self::AmbiguousRef => "ambiguous-ref",
+            Self::NoCommonAncestor => "no-common-ancestor",
+            Self::HistoryTooDeep => "history-too-deep",
+            Self::AmbiguousMergeBase => "ambiguous-merge-base",
+            Self::PathNotRepresentable => "path-not-representable",
+        }
+    }
+}
+
+/// A refusal from this route: a status, a kind, and a sentence for a person.
+#[derive(Debug)]
+pub struct RepoCompareError {
+    pub status: StatusCode,
+    pub kind: RepoCompareRefusal,
+    pub message: String,
+}
+
+impl RepoCompareError {
+    fn new(status: StatusCode, kind: RepoCompareRefusal, message: impl Into<String>) -> Self {
+        Self {
+            status,
+            kind,
+            message: message.into(),
+        }
+    }
+
+    /// Carry a blob-route refusal across under the matching compare kind.
+    ///
+    /// Both routes resolve a read point by the same rule, so they refuse a ref
+    /// for the same reasons. Mapping the kind rather than re-deriving it is what
+    /// keeps one rule: the exact-name precedence and the ambiguous-alias refusal
+    /// that route already carries apply here without being written twice.
+    fn from_read_point(side: &str, error: crate::repo_blob::RepoBlobError) -> Self {
+        let kind = match error.kind {
+            RepoBlobRefusal::UnknownRef => RepoCompareRefusal::UnknownRef,
+            RepoBlobRefusal::AmbiguousRef => RepoCompareRefusal::AmbiguousRef,
+            RepoBlobRefusal::UnknownRepository => RepoCompareRefusal::UnknownRepository,
+            _ => RepoCompareRefusal::RepositoryUnreadable,
+        };
+        // Which side failed is the first thing a caller needs and the status
+        // cannot carry it, so it leads the sentence.
+        Self::new(error.status, kind, format!("{side}: {}", error.message))
+    }
+}
+
+impl IntoResponse for RepoCompareError {
+    fn into_response(self) -> axum::response::Response {
+        let mut response = (self.status, self.message).into_response();
+        response.headers_mut().insert(
+            HeaderName::from_static(REPO_COMPARE_REFUSAL_HEADER),
+            HeaderValue::from_static(self.kind.as_str()),
+        );
+        response
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RepoCompareQuery {
+    /// A ref name or a canonical change id. Required: this route has no default.
+    base: String,
+    head: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RepoCompareFileEntry {
+    pub path: String,
+    /// `added`, `deleted` or `modified`. Never `renamed`; see the module note.
+    pub status: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RepoCompareResponse {
+    pub repo_id: String,
+    /// The change each side resolved to, not the string the caller sent.
+    pub base_ref: String,
+    pub head_ref: String,
+    pub merge_base_ref: String,
+    pub ahead: usize,
+    pub behind: usize,
+    pub files: Vec<RepoCompareFileEntry>,
+    /// Always empty here. Conflict detection is a merge question, not a
+    /// comparison one, and an empty list is the truthful answer rather than a
+    /// placeholder: this route establishes no conflicts and claims none.
+    pub conflicts: Vec<serde_json::Value>,
+}
+
+/// GET /repos/{repo_id}/compare — the changed-file list and the distance.
+pub async fn repo_compare(
+    Path(repo_id): Path<String>,
+    State(state): State<Arc<DaemonState>>,
+    // Fallible for the same reason the blob route's is: an axum rejection
+    // carries no refusal header, and a caller branching on that header would
+    // read a malformed request as a route that forgot to name its refusal.
+    query: Result<Query<RepoCompareQuery>, QueryRejection>,
+) -> Result<impl IntoResponse, RepoCompareError> {
+    let Query(query) = query.map_err(|rejection| {
+        RepoCompareError::new(
+            rejection.status(),
+            RepoCompareRefusal::BadRequest,
+            rejection.body_text(),
+        )
+    })?;
+
+    // Three views because `resolve_tree_at` consumes one and this needs two
+    // trees plus a history walk. On a hosted daemon each is a generation-cache
+    // read, which is the path that exists to make repeated reads cheap.
+    let walk_view = open_view(&state, &repo_id).await?;
+    let base_change = resolve_read_point(&walk_view, Some(&query.base), &repo_id)
+        .map_err(|error| RepoCompareError::from_read_point("base", error))?
+        .0;
+    let head_change = resolve_read_point(&walk_view, Some(&query.head), &repo_id)
+        .map_err(|error| RepoCompareError::from_read_point("head", error))?
+        .0;
+
+    let distance = measure_distance(&walk_view, &base_change, &head_change)?;
+
+    let base_tree = open_view(&state, &repo_id)
+        .await?
+        .resolve_tree_at(&state, &base_change)
+        .map_err(|parts| {
+            RepoCompareError::new(parts.0, RepoCompareRefusal::RepositoryUnreadable, parts.1)
+        })?;
+    let head_tree = open_view(&state, &repo_id)
+        .await?
+        .resolve_tree_at(&state, &head_change)
+        .map_err(|parts| {
+            RepoCompareError::new(parts.0, RepoCompareRefusal::RepositoryUnreadable, parts.1)
+        })?;
+
+    Ok(Json(RepoCompareResponse {
+        repo_id,
+        base_ref: base_change.to_string(),
+        head_ref: head_change.to_string(),
+        merge_base_ref: distance.merge_base.to_string(),
+        ahead: distance.ahead,
+        behind: distance.behind,
+        files: changed_files(&base_tree, &head_tree)?,
+        conflicts: Vec::new(),
+    }))
+}
+
+async fn open_view(
+    state: &DaemonState,
+    repo_id: &str,
+) -> Result<RepositoryReadView, RepoCompareError> {
+    repository_read_view(state, repo_id).await.map_err(|parts| {
+        let kind = if parts.0 == StatusCode::NOT_FOUND {
+            RepoCompareRefusal::UnknownRepository
+        } else {
+            RepoCompareRefusal::RepositoryUnreadable
+        };
+        RepoCompareError::new(parts.0, kind, parts.1)
+    })
+}
+
+#[derive(Debug)]
+pub(crate) struct Distance {
+    pub(crate) merge_base: kin_model::SemanticChangeId,
+    pub(crate) ahead: usize,
+    pub(crate) behind: usize,
+}
+
+/// Every ancestor of `tip`, inclusive of it, over ALL parents.
+///
+/// First-parent only is the wrong walk here and the difference is not academic.
+/// A head that merged a side branch reaches those changes through a second
+/// parent, so a first-parent walk reports a distance that omits everything the
+/// merge brought in, and two tips whose only relationship runs through a merge
+/// can look unrelated. Distance is a question about reachability, so the walk
+/// has to follow every edge reachability follows.
+fn ancestors<P>(
+    tip: &kin_model::SemanticChangeId,
+    side: &str,
+    parents_of: &mut P,
+) -> Result<std::collections::HashSet<kin_model::SemanticChangeId>, RepoCompareError>
+where
+    P: FnMut(
+        &kin_model::SemanticChangeId,
+    ) -> Result<Vec<kin_model::SemanticChangeId>, RepoCompareError>,
+{
+    let mut seen = std::collections::HashSet::new();
+    let mut queue = vec![*tip];
+    while let Some(change_id) = queue.pop() {
+        if !seen.insert(change_id) {
+            continue;
+        }
+        if seen.len() > MAX_COMPARE_HISTORY_DEPTH {
+            return Err(too_deep(side));
+        }
+        queue.extend(parents_of(&change_id)?);
+    }
+    Ok(seen)
+}
+
+/// How far apart two changes are, by ancestor-set difference.
+///
+/// `ahead` is what the head reaches and the base does not, `behind` the reverse,
+/// which is the same shape `git rev-list --count base...head` answers and
+/// therefore counts changes a merge brought in. The merge base is the
+/// descendant-most common ancestor: a common ancestor that no other common
+/// ancestor descends from. Several incomparable ones is a real repository shape
+/// and this response can carry one, so it refuses rather than picking.
+pub(crate) fn measure_distance_with<P>(
+    base: &kin_model::SemanticChangeId,
+    head: &kin_model::SemanticChangeId,
+    parents_of: &mut P,
+) -> Result<Distance, RepoCompareError>
+where
+    P: FnMut(
+        &kin_model::SemanticChangeId,
+    ) -> Result<Vec<kin_model::SemanticChangeId>, RepoCompareError>,
+{
+    let base_ancestors = ancestors(base, "base", parents_of)?;
+    let head_ancestors = ancestors(head, "head", parents_of)?;
+    let common: std::collections::HashSet<_> = base_ancestors
+        .intersection(&head_ancestors)
+        .copied()
+        .collect();
+    if common.is_empty() {
+        return Err(RepoCompareError::new(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            RepoCompareRefusal::NoCommonAncestor,
+            format!(
+                "{base} and {head} share no ancestor, so there is no distance between them to \
+                 report"
+            ),
+        ));
+    }
+
+    // A common ancestor that another common ancestor descends from is not the
+    // best one. Striking everything reachable from a common ancestor's PARENTS
+    // leaves exactly the descendant-most, and one walk over the union of those
+    // ancestries answers it for every candidate at once: a change already
+    // walked has already been struck, so a second visit could add nothing.
+    // Starting at parents rather than at the candidates themselves is what
+    // keeps a candidate from striking itself.
+    let mut superseded = std::collections::HashSet::new();
+    let mut walked = std::collections::HashSet::new();
+    let mut queue = Vec::new();
+    for candidate in &common {
+        queue.extend(parents_of(candidate)?);
+    }
+    while let Some(change_id) = queue.pop() {
+        if !walked.insert(change_id) {
+            continue;
+        }
+        if common.contains(&change_id) {
+            superseded.insert(change_id);
+        }
+        queue.extend(parents_of(&change_id)?);
+    }
+    let mut best: Vec<_> = common.difference(&superseded).copied().collect();
+    best.sort_by_key(|change_id| change_id.to_string());
+    let merge_base = match best.as_slice() {
+        [only] => *only,
+        [] => {
+            return Err(RepoCompareError::new(
+                StatusCode::FAILED_DEPENDENCY,
+                RepoCompareRefusal::RepositoryUnreadable,
+                format!(
+                    "{base} and {head} share ancestors but none is descendant-most, which means \
+                     the history reached here contains a cycle"
+                ),
+            ));
+        }
+        several => {
+            let names: Vec<String> = several.iter().map(ToString::to_string).collect();
+            return Err(RepoCompareError::new(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                RepoCompareRefusal::AmbiguousMergeBase,
+                format!(
+                    "{base} and {head} have {} best common ancestors and none descends from \
+                     another: {}. This response carries one merge base, so it will not pick.",
+                    several.len(),
+                    names.join(", ")
+                ),
+            ));
+        }
+    };
+
+    Ok(Distance {
+        merge_base,
+        ahead: head_ancestors.difference(&base_ancestors).count(),
+        behind: base_ancestors.difference(&head_ancestors).count(),
+    })
+}
+
+fn measure_distance(
+    view: &RepositoryReadView,
+    base: &kin_model::SemanticChangeId,
+    head: &kin_model::SemanticChangeId,
+) -> Result<Distance, RepoCompareError> {
+    // Parents are read once per change and cached, because the best-common-
+    // ancestor pass walks the common set again and a repository read is not
+    // free on either arm.
+    let mut cache: HashMap<kin_model::SemanticChangeId, Vec<kin_model::SemanticChangeId>> =
+        HashMap::new();
+    let mut parents_of = |change_id: &kin_model::SemanticChangeId| {
+        if let Some(parents) = cache.get(change_id) {
+            return Ok(parents.clone());
+        }
+        let change = view
+            .change(change_id)
+            .map_err(|parts| {
+                RepoCompareError::new(parts.0, RepoCompareRefusal::RepositoryUnreadable, parts.1)
+            })?
+            .ok_or_else(|| {
+                RepoCompareError::new(
+                    StatusCode::FAILED_DEPENDENCY,
+                    RepoCompareRefusal::RepositoryUnreadable,
+                    format!("history references missing change {change_id}"),
+                )
+            })?;
+        let parents = change.parents.clone();
+        cache.insert(*change_id, parents.clone());
+        Ok(parents)
+    };
+    measure_distance_with(base, head, &mut parents_of)
+}
+
+fn too_deep(side: &str) -> RepoCompareError {
+    RepoCompareError::new(
+        StatusCode::UNPROCESSABLE_ENTITY,
+        RepoCompareRefusal::HistoryTooDeep,
+        format!(
+            "{side} history reached this route's {MAX_COMPARE_HISTORY_DEPTH}-change walk limit \
+             before the comparison could be established"
+        ),
+    )
+}
+
+/// The changed-file list, as a set difference over two resolved trees.
+///
+/// A path in both is modified when its ENTRY differs rather than when its blob
+/// digest differs, so a file that changed only its mode is still reported. A
+/// path in neither tree cannot appear, and a path in both with an identical
+/// entry is not a change and is omitted.
+pub(crate) fn changed_files(
+    base: &kin_model::ResolvedTree,
+    head: &kin_model::ResolvedTree,
+) -> Result<Vec<RepoCompareFileEntry>, RepoCompareError> {
+    let name = |path: &kin_model::RepoPath| {
+        path.as_utf8().map(ToOwned::to_owned).ok_or_else(|| {
+            RepoCompareError::new(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                RepoCompareRefusal::PathNotRepresentable,
+                format!("this comparison cannot name the changed path {path}, whose bytes are not UTF-8"),
+            )
+        })
+    };
+    let base_by_path: HashMap<_, _> = base
+        .artifacts()
+        .map(|artifact| (artifact.path.clone(), artifact))
+        .collect();
+    let mut files = Vec::new();
+    let mut seen_in_head = std::collections::HashSet::new();
+    for artifact in head.artifacts() {
+        seen_in_head.insert(artifact.path.clone());
+        match base_by_path.get(&artifact.path) {
+            None => files.push(RepoCompareFileEntry {
+                path: name(&artifact.path)?,
+                status: "added".to_string(),
+            }),
+            Some(before) if before.entry != artifact.entry => files.push(RepoCompareFileEntry {
+                path: name(&artifact.path)?,
+                status: "modified".to_string(),
+            }),
+            Some(_) => {}
+        }
+    }
+    for artifact in base.artifacts() {
+        if !seen_in_head.contains(&artifact.path) {
+            files.push(RepoCompareFileEntry {
+                path: name(&artifact.path)?,
+                status: "deleted".to_string(),
+            });
+        }
+    }
+    // Sorted so two runs over one pair of trees answer identically, which is
+    // what lets a caller cache or diff the answer itself.
+    files.sort_by(|left, right| {
+        left.path
+            .cmp(&right.path)
+            .then(left.status.cmp(&right.status))
+    });
+    Ok(files)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A change id built from one byte, so a test DAG reads like a diagram.
+    fn id(n: u8) -> kin_model::SemanticChangeId {
+        kin_model::SemanticChangeId::from_hash(kin_model::Hash256::from_bytes([n; 32]))
+    }
+
+    /// A change id minted from a counter, distinct from every `id(n)` because
+    /// its trailing bytes are zero and `id`'s are not.
+    fn minted_id(n: u32) -> kin_model::SemanticChangeId {
+        let mut bytes = [0u8; 32];
+        bytes[..4].copy_from_slice(&n.to_le_bytes());
+        kin_model::SemanticChangeId::from_hash(kin_model::Hash256::from_bytes(bytes))
+    }
+
+    /// A synthetic history: child to parents, newest first in each list.
+    ///
+    /// The distance question is about the shape of a graph, so the tests give it
+    /// a graph directly. A fixture that could only be built by publishing real
+    /// changes could not express a diamond in six lines, and the diamond is the
+    /// case a first-parent walk gets wrong.
+    fn dag(
+        edges: &[(u8, &[u8])],
+    ) -> impl FnMut(
+        &kin_model::SemanticChangeId,
+    ) -> Result<Vec<kin_model::SemanticChangeId>, RepoCompareError> {
+        let map: HashMap<kin_model::SemanticChangeId, Vec<kin_model::SemanticChangeId>> = edges
+            .iter()
+            .map(|(child, parents)| (id(*child), parents.iter().map(|p| id(*p)).collect()))
+            .collect();
+        move |change_id: &kin_model::SemanticChangeId| {
+            Ok(map.get(change_id).cloned().unwrap_or_default())
+        }
+    }
+
+    #[test]
+    fn a_merge_is_counted_over_every_parent_and_not_the_first_one_only() {
+        // 1 -> 2 and 1 -> 3, then 4 merges both with 2 as its first parent.
+        //   base = 2, head = 4.
+        // Over all parents: head reaches 4 and 3 that the base does not, so
+        // ahead is 2. A first-parent walk from 4 goes 4, 2 and never sees 3, so
+        // it would answer ahead 1 and silently omit the change the merge brought
+        // in. That difference is the whole reason this walk follows every edge.
+        let mut parents = dag(&[(4, &[2, 3]), (3, &[1]), (2, &[1]), (1, &[])]);
+        let distance = measure_distance_with(&id(2), &id(4), &mut parents).unwrap();
+        assert_eq!(distance.merge_base, id(2));
+        assert_eq!(
+            distance.ahead, 2,
+            "the merged side branch has to be counted"
+        );
+        assert_eq!(distance.behind, 0);
+    }
+
+    #[test]
+    fn two_identical_tips_are_zero_apart_and_their_own_merge_base() {
+        // Zero and zero is the truthful answer here, and only here. It is the
+        // reading a fabricated compare used to give for reads that never
+        // happened, so the case that legitimately produces it is pinned.
+        let mut parents = dag(&[(2, &[1]), (1, &[])]);
+        let distance = measure_distance_with(&id(2), &id(2), &mut parents).unwrap();
+        assert_eq!(distance.merge_base, id(2));
+        assert_eq!(distance.ahead, 0);
+        assert_eq!(distance.behind, 0);
+    }
+
+    #[test]
+    fn a_base_that_is_an_ancestor_of_the_head_is_the_merge_base() {
+        let mut parents = dag(&[(3, &[2]), (2, &[1]), (1, &[])]);
+        let distance = measure_distance_with(&id(1), &id(3), &mut parents).unwrap();
+        assert_eq!(distance.merge_base, id(1));
+        assert_eq!(distance.ahead, 2);
+        assert_eq!(distance.behind, 0);
+
+        // And the same pair the other way round, so ahead and behind cannot be
+        // swapped without a test noticing.
+        let distance = measure_distance_with(&id(3), &id(1), &mut parents).unwrap();
+        assert_eq!(distance.ahead, 0);
+        assert_eq!(distance.behind, 2);
+    }
+
+    #[test]
+    fn unrelated_histories_refuse_rather_than_reporting_no_distance() {
+        let mut parents = dag(&[(2, &[1]), (1, &[]), (4, &[3]), (3, &[])]);
+        let refusal = measure_distance_with(&id(2), &id(4), &mut parents).unwrap_err();
+        assert_eq!(refusal.kind, RepoCompareRefusal::NoCommonAncestor);
+        assert_eq!(refusal.status, StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[test]
+    fn two_incomparable_best_common_ancestors_refuse_rather_than_picking_one() {
+        // Criss-cross: 4 and 5 each merge both 2 and 3, and neither 2 nor 3
+        // descends from the other. Picking either silently would report a
+        // distance measured from a base the caller never chose.
+        let mut parents = dag(&[(5, &[2, 3]), (4, &[2, 3]), (3, &[1]), (2, &[1]), (1, &[])]);
+        let refusal = measure_distance_with(&id(4), &id(5), &mut parents).unwrap_err();
+        assert_eq!(refusal.kind, RepoCompareRefusal::AmbiguousMergeBase);
+        assert!(
+            refusal.message.contains("will not pick"),
+            "the refusal has to say it is declining rather than failing: {}",
+            refusal.message
+        );
+    }
+
+    #[test]
+    fn a_history_past_the_walk_bound_refuses_and_names_the_bound() {
+        // A history with no end: every change's parent is one nobody has seen
+        // before, so the walk runs out of budget rather than out of history.
+        // A cycle would not exercise this at all, because revisiting a change
+        // the walk already recorded terminates it correctly.
+        let mut minted: u32 = 0;
+        let mut parents = |_change_id: &kin_model::SemanticChangeId| {
+            minted += 1;
+            Ok(vec![minted_id(minted)])
+        };
+        let refusal = measure_distance_with(&id(1), &id(9), &mut parents).unwrap_err();
+        assert_eq!(refusal.kind, RepoCompareRefusal::HistoryTooDeep);
+        assert!(
+            refusal
+                .message
+                .contains(&MAX_COMPARE_HISTORY_DEPTH.to_string()),
+            "the refusal has to name the bound it hit: {}",
+            refusal.message
+        );
+    }
+
+    fn tree(entries: &[(&str, u8, bool)]) -> kin_model::ResolvedTree {
+        kin_model::ResolvedTree::from_artifacts(entries.iter().map(|(path, digest, executable)| {
+            kin_model::ResolvedArtifact::new(
+                kin_model::ArtifactId::new(),
+                kin_model::RepoPath::from_utf8(*path).unwrap(),
+                kin_model::TreeEntry::blob(
+                    kin_model::Hash256::from_bytes([*digest; 32]),
+                    *executable,
+                ),
+            )
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn the_changed_file_list_is_the_difference_between_two_trees() {
+        let base = tree(&[
+            ("src/kept.rs", 1, false),
+            ("src/gone.rs", 2, false),
+            ("src/edited.rs", 3, false),
+        ]);
+        let head = tree(&[
+            ("src/kept.rs", 1, false),
+            ("src/edited.rs", 4, false),
+            ("src/new.rs", 5, false),
+        ]);
+        let files = changed_files(&base, &head).unwrap();
+        let rendered: Vec<(String, String)> = files
+            .into_iter()
+            .map(|entry| (entry.path, entry.status))
+            .collect();
+        assert_eq!(
+            rendered,
+            vec![
+                ("src/edited.rs".to_string(), "modified".to_string()),
+                ("src/gone.rs".to_string(), "deleted".to_string()),
+                ("src/new.rs".to_string(), "added".to_string()),
+            ],
+            "an unchanged path must not appear, and the order must be stable"
+        );
+    }
+
+    #[test]
+    fn a_file_whose_only_change_is_its_mode_is_still_reported() {
+        // Comparing blob digests alone would call these identical, and a file
+        // that became executable did change.
+        let base = tree(&[("scripts/run.sh", 7, false)]);
+        let head = tree(&[("scripts/run.sh", 7, true)]);
+        let files = changed_files(&base, &head).unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].status, "modified");
+    }
+
+    /// A tree whose one path is not UTF-8, which a JSON response cannot name.
+    fn tree_with_raw_path(bytes: &[u8]) -> kin_model::ResolvedTree {
+        kin_model::ResolvedTree::from_artifacts(std::iter::once(kin_model::ResolvedArtifact::new(
+            kin_model::ArtifactId::new(),
+            kin_model::RepoPath::from_bytes(bytes.to_vec()).unwrap(),
+            kin_model::TreeEntry::blob(kin_model::Hash256::from_bytes([9; 32]), false),
+        )))
+        .unwrap()
+    }
+
+    #[test]
+    fn a_changed_path_that_is_not_utf8_is_refused_rather_than_mangled() {
+        // A repository path is bytes, and JSON strings are not. Answering the
+        // lossy rendering would name a path that is not the one that changed,
+        // and a caller asking for that path's bytes would be told it does not
+        // exist. The refusal is the honest answer.
+        let base = tree(&[("src/kept.rs", 1, false)]);
+        let head = tree_with_raw_path(b"src/\xff\xfe.rs");
+        let refusal = changed_files(&base, &head).unwrap_err();
+        assert_eq!(refusal.kind, RepoCompareRefusal::PathNotRepresentable);
+        assert_eq!(refusal.status, StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[test]
+    fn two_identical_trees_produce_no_changed_files() {
+        // The control for both tests above: a real empty list, from two trees
+        // that really are the same, which is what makes a non-empty one mean
+        // something.
+        let base = tree(&[("src/kept.rs", 1, false), ("src/also.rs", 2, true)]);
+        let head = tree(&[("src/kept.rs", 1, false), ("src/also.rs", 2, true)]);
+        assert!(changed_files(&base, &head).unwrap().is_empty());
+    }
+
+    #[test]
+    fn every_refusal_kind_has_a_distinct_stable_spelling() {
+        let kinds = [
+            RepoCompareRefusal::BadRequest,
+            RepoCompareRefusal::UnknownRepository,
+            RepoCompareRefusal::RepositoryUnreadable,
+            RepoCompareRefusal::UnknownRef,
+            RepoCompareRefusal::AmbiguousRef,
+            RepoCompareRefusal::NoCommonAncestor,
+            RepoCompareRefusal::HistoryTooDeep,
+            RepoCompareRefusal::AmbiguousMergeBase,
+            RepoCompareRefusal::PathNotRepresentable,
+        ];
+        let spellings: std::collections::BTreeSet<&str> =
+            kinds.iter().map(|kind| kind.as_str()).collect();
+        assert_eq!(spellings.len(), kinds.len(), "two kinds share a spelling");
+        assert!(
+            spellings.iter().all(|s| HeaderValue::from_str(s).is_ok()),
+            "every spelling has to survive the header it travels in"
+        );
+    }
+}

--- a/crates/kin-daemon/src/repo_compare.rs
+++ b/crates/kin-daemon/src/repo_compare.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-//! `GET /repos/{repo_id}/compare` — what changed between two refs, from the graph.
+//! `GET /repos/{repo_id}/compare`: what changed between two refs, from the graph.
 //!
 //! The daemon could answer for one file's bytes and for one ref's whole tree. It
 //! could not answer the question a reader asks before either: what is different
@@ -170,7 +170,7 @@ pub struct RepoCompareResponse {
     pub conflicts: Vec<serde_json::Value>,
 }
 
-/// GET /repos/{repo_id}/compare — the changed-file list and the distance.
+/// GET /repos/{repo_id}/compare, answering the changed-file list and the distance.
 pub async fn repo_compare(
     Path(repo_id): Path<String>,
     State(state): State<Arc<DaemonState>>,
@@ -347,6 +347,13 @@ where
     // walked has already been struck, so a second visit could add nothing.
     // Starting at parents rather than at the candidates themselves is what
     // keeps a candidate from striking itself.
+    //
+    // This walk carries no budget of its own and does not need one, but the
+    // reason lives in `ancestors` rather than here: every candidate is a member
+    // of both ancestor sets, and `ancestors` records a change before queueing
+    // its parents, so everything reachable from a candidate's parents is
+    // already inside a set the budget bounded. A change to how `ancestors`
+    // enumerates would make this loop unbounded, and nothing here would say so.
     let mut superseded = std::collections::HashSet::new();
     let mut walked = std::collections::HashSet::new();
     let mut queue = Vec::new();
@@ -556,9 +563,9 @@ mod tests {
 
     #[test]
     fn two_identical_tips_are_zero_apart_and_their_own_merge_base() {
-        // Zero and zero is the truthful answer here, and only here. It is the
-        // reading a fabricated compare used to give for reads that never
-        // happened, so the case that legitimately produces it is pinned.
+        // Zero and zero is the truthful answer here, and only here. It is also
+        // the answer a comparison that never ran would give, so the one shape
+        // a correct route and a broken one share is pinned by a test.
         let mut parents = dag(&[(2, &[1]), (1, &[])]);
         let distance = measure_distance_with(&id(2), &id(2), &mut parents).unwrap();
         assert_eq!(distance.merge_base, id(2));


### PR DESCRIPTION
Held as a draft on purpose. It is safe on today's production daemon because it adds a route
rather than changing one, and it is held because the hosted consumer for it is a separate change
that is not open yet. Ready to mark when that consumer is.

## What this adds

`GET /repos/{repo_id}/compare?base=<ref>&head=<ref>` answers what changed between two refs of one
repository, from the repository read view alone: the changed-file list, ahead and behind, and the
merge base. The daemon could already answer for one file's bytes and for one ref's whole tree. It
could not answer the question a reader asks before either.

That gap has a cost outside this repo. A caller with no compare route has to decide what an
unanswered comparison means, and the tempting answer is a comparison of zero files, zero ahead
and zero behind, which is exactly what two identical refs look like. The route is the honest
answer, and the capability string beside it, `repo_scoped_compare_v1` on
`/repos/{repo_id}/health`, is what lets a caller tell a daemon that can answer from one that
cannot, instead of guessing from a 404.

## The distance is over every parent

`ahead` and `behind` are ancestor-set differences over ALL parents, not a first-parent walk, and
the merge base is the descendant-most common ancestor. That is the same shape
`git rev-list --count base...head` answers, and it is not a detail: a head that merged a side
branch reaches those changes through a second parent, so a first-parent walk reports a distance
that omits everything the merge brought in.

The fixture proves the difference rather than asserting it. In a diamond where 4 merges 2 and 3
with 2 as its first parent, comparing 2 to 4 answers ahead 2; a first-parent walk from 4 goes 4,
2 and never sees 3, so it would answer 1.

Several incomparable best common ancestors is a real repository shape, and this response carries
one merge base, so it refuses with `ambiguous-merge-base` rather than picking. A history walk
past its bound refuses and names the bound.

## Refusals are the design

Every refusal carries `x-kin-compare-refusal` over a closed set a caller can branch on without
reading English: `bad-request`, `unknown-repository`, `repository-unreadable`, `unknown-ref`,
`ambiguous-ref`, `no-common-ancestor`, `history-too-deep`, `ambiguous-merge-base`,
`path-not-representable`. None of them is a comparison of zero files.

The `Query` extractor is fallible for the same reason the blob route's is: an axum rejection
carries no header of ours, and a caller branching on the header cannot tell an absent header from
a wrong one.

Ref resolution is not written twice. The route calls `resolve_read_point` from `repo_blob.rs`, so
the exact-full-name precedence and the ambiguous-alias refusal that route already carries apply
here without a second copy that could drift.

The two sides are named `base` and `head`, and no alias spelling is accepted. A caller can also
be found sending `left` and `right`, and that pair is deliberately left out: no live caller sends
it today, and an alias nobody uses is a second spelling to keep true. It belongs in the change
that introduces the caller needing it.

Nothing here reads the content-addressed store, because a comparison needs to know which files
differ and not what they say, and nothing here reads a filesystem. A path present in both trees
is modified when its tree ENTRY differs rather than when its blob digest differs, so a file that
changed only its mode is still reported. Renames are not reported: a resolved tree carries no
rename record, so an addition beside a deletion is what the tree proves.

The changed-file list carries no cap, deliberately. It is bounded by the union of two resolved
trees, which is what `/repos/{repo_id}/files` already answers uncapped, so a cap here would be a
new rule on one route rather than a fix. If one is wanted it belongs on both, with one refusal
kind, as its own change.

FIR-3279.

## Local verification, with the output rather than the claim

Hosted CI's Fast gate test shard, scoped to kin-daemon, ran this change's tests green on this pull request; what follows is the local evidence for the claims the PR surface does not show, each as the command and what it printed.

Fourteen new tests, and every one of them falsified. Each arm breaks one behaviour, runs the
filter, then restores the source and verifies the restore by sha256. All fourteen were killed
and the driver exits nonzero on a survivor:

```
ARM walk only the first parent: KILLED rc=101 restored=True
    red: repo_compare::tests::a_merge_is_counted_over_every_parent_and_not_the_first_one_only
    red: repo_compare::tests::two_incomparable_best_common_ancestors_refuse_rather_than_picking_one
ARM swap ahead and behind: KILLED rc=101 restored=True
ARM pick a merge base instead of refusing several: KILLED rc=101 restored=True
ARM truncate at the walk bound instead of refusing: KILLED rc=101 restored=True
ARM decide modified on the blob digest alone: KILLED rc=101 restored=True
ARM drop the no-common-ancestor refusal: KILLED rc=101 restored=True
ARM spell two refusal kinds the same: KILLED rc=101 restored=True
ARM drop the deleted side of the difference: KILLED rc=101 restored=True
ARM prefer a superseded common ancestor as the merge base: KILLED rc=101 restored=True
ARM name every path in both trees as modified: KILLED rc=101 restored=True
ARM answer a UTF-8 replacement instead of refusing the path: KILLED rc=101 restored=True
ARM publish the refusal kind under a different header: KILLED rc=101 restored=True
ARM resolve the base from the head's ref: KILLED rc=101 restored=True
ARM stop advertising the compare capability: KILLED rc=101 restored=True
all arms done
SWEEP_RC=0
```

The blank-ref check on the second commit was written red first and falsified the same way. The
test ran against the unfixed route and failed on the answer rather than on a crash, which is the
defect itself: the same change id on both sides and no files.

```
  left: 200  right: 400
  {"base_ref":"a8847f52...","head_ref":"a8847f52...","merge_base_ref":"a8847f52...",
   "ahead":0,"behind":0,"files":[],"conflicts":[]}

ARM accept a blank ref: KILLED rc=101 restored=True
    red: api::tests::a_blank_compare_ref_on_either_side_is_refused_rather_than_defaulted
```

Both tails are kept whole rather than quoted from:
`.kin-coord/reports/hostedcompare-3279-blankref-redfirst-20260905.log` and
`.kin-coord/reports/hostedcompare-3279-blankref-mutant-20260905.log`, beside the fourteen-arm
sweep at `.kin-coord/reports/hostedcompare-3279-mutants-20260905.log`.

`cargo test -p kin-daemon --lib compare`, the filter every arm above is graded through:

```
test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 1511 filtered out
```

Fifteen of those sixteen are this change's; the sixteenth is a pre-existing `auth_rotation` test
the filter also selects.

`cargo test -p kin-daemon --lib`:

```
test result: ok. 1524 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 413.11s
LIB_RC=0
```

`bin/kin-precheck kin`:

```
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 5fb70bb88bae5dcd7036d1a3a16447fe4b450f3e
```

That sha is this branch's head with a clean tree, so the gates graded exactly the committed
content rather than a working tree that resembled it. The lib suite above ran on the same sha.

Both zero-file-search halves, run separately. Read the second one for this change: the shell
guard derives its module list from `crates/kin-cli/src/commands` only, so its 71 modules do not
include anything under kin-daemon and it cannot fail on this route. `verify-zero-file-search.py`
is the half that walks every crate and grades the new module, and it is the line to read here.

```
Zero File-Search guard passed: 71 answer modules are graph-clean (8 with declared boundary pins
deferred to verify-zero-file-search.py).
GUARD_SH_RC=0
Verification PASSED: Zero File-Search Invariant holds.
GUARD_PY_RC=0
```

