### PR TITLE
Run the hosted object-store destination tests in the fast gate (FIR-3256)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1151,6 +1151,69 @@ jobs:
               -- --exact --nocapture --test-threads=1
           done
 
+      # kin-remote's hosted object-store destination is behind a non-default
+      # `gcs` feature, and until this step nothing in any workflow ran its
+      # tests. Clippy's `--all-targets --all-features` above compiles them, which
+      # is a build and not a run; nextest below runs a changed-crate scope with
+      # default features; and `Feature permutation tests` covers neither, because
+      # its pull-request leg runs no tests at all and its real leg is scoped to
+      # `-p kin-daemon`. So every test in that module was compiled by this
+      # repository and executed by nothing, on any event, on any branch.
+      #
+      # They belong in this required context rather than beside the other
+      # permutations on the push-to-main job, because they guard how a hosted
+      # publication's destination is composed: a prefix that names a different
+      # object than it appears to, an identifier a hosted record will refuse
+      # after the publication has already committed, and an emulator recorded as
+      # the real service. A class answered only after landing is rediscovered by
+      # the next person.
+      #
+      # Two assertions, and the second is the one that keeps this step honest.
+      #
+      # Per name: `cargo test <name> -- --exact` matches the whole test path, so
+      # a renamed or moved test filters everything out, runs nothing and exits 0,
+      # which reads exactly like a pass. This is the same assertion the Firestore
+      # step above makes, for the same reason.
+      #
+      # Over the set: the list below is hand maintained, so a test added to
+      # `gcs_tests` and not added here would be graded by nothing while this step
+      # stayed green, which is the same silent-allowlist shape the per-name
+      # assertion exists to stop, one level up. It drifted inside an hour on the
+      # pull request that introduced it. So the listing's total for that module
+      # must equal the number of names enumerated here, and the count comes from
+      # the array itself rather than from a second literal that could disagree
+      # with it.
+      - name: Test hosted object-store destination composition
+        shell: bash
+        run: |
+          set -euo pipefail
+          listing="$(cargo test -p kin-remote --features gcs --locked --lib -- --list | tr -d '\r')"
+          tests=(
+            first_publication_gcs::gcs_tests::a_publication_is_found_at_the_key_this_destination_names
+            first_publication_gcs::gcs_tests::a_destination_under_a_different_prefix_sees_nothing
+            first_publication_gcs::gcs_tests::an_independently_opened_destination_reads_the_same_publication
+            first_publication_gcs::gcs_tests::the_ordinary_memory_store_cannot_stand_in_for_a_bucket
+            first_publication_gcs::gcs_tests::the_endpoint_class_travels_with_the_opened_destination
+            first_publication_gcs::gcs_tests::a_destination_that_cannot_compose_an_identifier_never_yields_a_backend
+            first_publication_gcs::gcs_tests::opening_a_real_client_derives_the_class_from_the_endpoint_it_was_given
+            first_publication_gcs::gcs_tests::a_real_client_is_never_built_for_a_destination_over_budget
+          )
+          listed="$(printf '%s\n' "$listing" | awk '/^first_publication_gcs::gcs_tests::[A-Za-z0-9_]+: test$/ { count += 1 } END { print count + 0 }')"
+          if [ "$listed" -ne "${#tests[@]}" ]; then
+            echo "::error title=Ungraded object-store destination test::the module lists $listed gated test(s) and this step enumerates ${#tests[@]}; add the new one here or this step grades it by nothing"
+            exit 1
+          fi
+          for test_name in "${tests[@]}"
+          do
+            matches="$(printf '%s\n' "$listing" | awk -v expected="$test_name: test" '$0 == expected { count += 1 } END { print count + 0 }')"
+            if [ "$matches" -ne 1 ]; then
+              echo "::error title=Missing object-store destination test::$test_name listed $matches time(s)"
+              exit 1
+            fi
+            cargo test -p kin-remote --features gcs --locked --lib "$test_name" \
+              -- --exact --nocapture --test-threads=1
+          done
+
       # Nine of the window's 64 failures were release ordering and npm
       # provenance policy and eight more were this gate, so a fifth of what a
       # pull request used to learn in thirty minutes is learned here in under


### PR DESCRIPTION
Runs the eight hosted object-store destination tests in the fast gate, so a pull request refuses a
break in them instead of learning about it after landing. FIR-3256.

Stacked on the branch that adds those tests, so the step has something to run. It cannot land before
that one.

## The gap this closes, and why it was invisible

The eight tests are behind kin-remote's non-default `gcs` feature. Before this change, this
repository compiled them and ran none of them, on any event, on any branch. That is a stronger statement than
"they do not run on a pull request", and it took reading three things to be sure of it:

* `cargo clippy --all-targets --all-features` runs on both platforms (`ci.yml:1127`, `:2054`). That
  builds and lints them. It is not a run.
* nextest runs a changed-crate scope with default features (`ci.yml:1383`, `:2152`), so they are not
  in its selection.
* `Feature permutation tests` is the job whose name says it covers exactly this, and it does not. Its
  pull-request leg, `feature-tests-pr-fast-path` (`ci.yml:2565`), runs no tests at all; its own
  comment says so outright, so a green context of that name on a pull request is a check that cannot
  fail. The real `feature-tests` job carries `github.event_name != 'pull_request'`, and it would not
  have covered these anyway: every `--features gcs` invocation in every workflow here is scoped to
  `-p kin-daemon` (`ci.yml:2648`, `:2653`, `:2671`, `:2676`), and no workflow in this repository
  names `kin-remote` at all.

## Why the fast gate rather than the push-to-main permutations

The permutations job is where non-default feature work usually lives, and it grades main's push run.
That is the wrong side of the merge for these two classes, because both are refusals a pull request
has to make:

* a destination prefix that is not in normal form names a different object than it appears to, so a
  receipt would record a location that is not the key;
* an over-long destination composes an artifact identifier the hosted record refuses, and the
  existing check for that runs only after the publication has already committed.

A class answered only after landing is rediscovered by the next person. `Fast gate lint and policy`
is a required context on `main`, so a break in these eight now blocks the pull request that caused
it.

## Two assertions, and both of them can fail

**Per name.** A filter passed to `cargo test` with `--exact` matches the whole test path, so a renamed
or moved test filters everything out, runs nothing, and exits 0, which is indistinguishable from a
pass. Asserting each name appears exactly once in `-- --list` before running it is what makes the step
able to fail at all. This is copied in shape from the `Test Firestore post-status response semantics`
step directly above it.

That is not hypothetical. Building the mutation harness for the branch below, the first sweep reported
every mutant caught by nobody, because the arms named bare function names instead of full test paths
and every one of them ran zero tests and exited 0.

**Over the set.** The enumerated list is hand maintained, so a test added to `gcs_tests` and not added
here would be graded by nothing while this step stayed green. That is the same silent-allowlist shape
the per-name assertion exists to stop, one level up, and it drifted inside an hour on this very pull
request: the step shipped naming five tests, review fixes on the stacked branch took the module to
eight, and the step went on passing over five of them. So the listing's total for that module must
equal the number of names enumerated here, and the count comes from the array's own length rather than
from a second literal that could disagree with it.

Falsified by dropping one name from the list, which is exactly the drift shape:

```
green arm: extracted the step body from ci.yml: 8 test names
           ... eight blocks, one test each, all ok ...
           rc_step=0

red arm:   extracted the step body from ci.yml: 7 test names
           ::error title=Ungraded object-store destination test::the module lists 8 gated test(s) and this step enumerates 7; add the new one here or this step grades it by nothing
           rc_step=1

ci.yml restored byte-for-byte
```

## The step turns a required context red, proven on this pull request

Two shas were pushed to demonstrate it and then force-pushed off, so the evidence is quoted here
rather than left in a branch that no longer holds it.

The first attempt proved nothing, and that is worth keeping. The break left a parameter unused,
`-D warnings` turned that into a Clippy error, and Clippy runs before this step in the same job, so
the job died before reaching the step under test. `Fast gate lint and policy: failure` looked exactly
like proof:

```
$ gh api repos/firelock-ai/kin/actions/jobs/101381527887 --jq '.steps[] | select(.conclusion=="failure") | "\(.conclusion)\t\(.name)"'
failure	Clippy
```

An arm that trips an earlier gate proves nothing about a later one, and the job-level red is identical
either way. The replacement keeps the parameter used, so Clippy has nothing to say and a gated test is
the only thing between the break and a green job:

```
$ gh api repos/firelock-ai/kin/actions/jobs/101382519067 --jq '.status + " " + (.conclusion // "-")'
completed failure
$ gh api repos/firelock-ai/kin/actions/jobs/101382519067 --jq '.steps[] | select(.conclusion=="failure") | "FAILED STEP: " + .name'
FAILED STEP: Test hosted object-store destination composition
```

A required context, red, at this step, on a pull request, for a break only a gated test can catch.

## Rehearsed locally before it was pushed

The step body is run verbatim against the tree before every push, and the rehearsal EXTRACTS the body
out of `ci.yml` rather than keeping its own copy. It kept its own copy at first, and when the step was
extended the rehearsal went on grading the stale list and passing, which is the same second-source-of-
truth problem the count assertion above addresses. It now refuses if it cannot find the step, if the
extracted text does not carry `cargo test` and `--exact`, or if the names it pulls out are not
distinct.

```
extracted the step body from ci.yml: 8 test names
  first_publication_gcs::gcs_tests::a_publication_is_found_at_the_key_this_destination_names
  first_publication_gcs::gcs_tests::a_destination_under_a_different_prefix_sees_nothing
  first_publication_gcs::gcs_tests::an_independently_opened_destination_reads_the_same_publication
  first_publication_gcs::gcs_tests::the_ordinary_memory_store_cannot_stand_in_for_a_bucket
  first_publication_gcs::gcs_tests::the_endpoint_class_travels_with_the_opened_destination
  first_publication_gcs::gcs_tests::a_destination_that_cannot_compose_an_identifier_never_yields_a_backend
  first_publication_gcs::gcs_tests::opening_a_real_client_derives_the_class_from_the_endpoint_it_was_given
  first_publication_gcs::gcs_tests::a_real_client_is_never_built_for_a_destination_over_budget

running 1 test
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 126 filtered out
... eight blocks, one test each ...
rc_step=0
```

Eight blocks, one test each, which is the two assertions and the eight runs doing what they claim.
