### PR TITLE
Qualify a concept answer whose returned locate rows are all fallback

### DIFF
--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -4907,9 +4907,9 @@ mod tests {
             "a ranking that named the query's symbol needs no relevance caveat: {named}"
         );
     }
-    /// GAP-F, on the surface an agent reads: the compact page the same tool
-    /// returns when the whole-ranking flag is ABSENT because one row the caller
-    /// never saw carried the query's word.
+    /// The surface an agent reads: the compact page this tool returns when the
+    /// whole-ranking flag is ABSENT because one row the caller never saw carried
+    /// the query's word.
     ///
     /// Measured on express at 798 of 798 embedded. "attach an encoding label to
     /// a media type string" returned eight rows all `matched: text_fallback` at

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -4907,6 +4907,117 @@ mod tests {
             "a ranking that named the query's symbol needs no relevance caveat: {named}"
         );
     }
+    /// GAP-F, on the surface an agent reads: the compact page the same tool
+    /// returns when the whole-ranking flag is ABSENT because one row the caller
+    /// never saw carried the query's word.
+    ///
+    /// Measured on express at 798 of 798 embedded. "attach an encoding label to
+    /// a media type string" returned eight rows all `matched: text_fallback` at
+    /// scores 52.05 down to 52.02, `setCharset` was not in the ranking at limit
+    /// 8 or limit 40, and `_kin.verdict` read `certified` with a null limiting
+    /// factor and the note that every qualifying input agreed. The kinds over
+    /// the whole 31-row ranking were text_fallback 28, name 1, semantic 2, so
+    /// `all_fallback` was false and the gate above could not see this page at
+    /// all. An agent that reads `verdict.state` first, exactly as the server
+    /// instructions tell it to, was told the answer is the whole set.
+    #[test]
+    fn a_prose_locate_page_of_lexical_neighbours_never_certifies_on_the_compact_surface() {
+        let page = |named_first: bool| {
+            let first = if named_first {
+                json!({
+                    "id": "00000000-0000-0000-0000-0000000000ad",
+                    "name": "app.render",
+                    "kind": "function",
+                    "file": "lib/application.js",
+                    "line": 522,
+                    "score": 427.00,
+                    "matched": "name"
+                })
+            } else {
+                json!({
+                    "id": "00000000-0000-0000-0000-0000000000ae",
+                    "name": "app.use",
+                    "kind": "function",
+                    "file": "lib/application.js",
+                    "line": 190,
+                    "score": 52.05,
+                    "matched": "text_fallback"
+                })
+            };
+            let payload = json!({
+                "query": "attach an encoding label to a media type string",
+                "granularity": "entity",
+                "routing": "fused-v1",
+                "page": 0,
+                "surface": "compact",
+                "entities": [
+                    first,
+                    {
+                        "id": "00000000-0000-0000-0000-0000000000af",
+                        "name": "View.render",
+                        "kind": "method",
+                        "file": "lib/view.js",
+                        "line": 133,
+                        "score": 52.03,
+                        "matched": "text_fallback"
+                    }
+                ],
+                "files": ["lib/application.js", "lib/view.js"],
+                "total_ranked": 31,
+                "ranked_by": "vector, lexical and graph signals",
+                "semantic_coverage": {
+                    "indexed": 798,
+                    "total": 798,
+                    "pending": 0,
+                    "complete": true
+                }
+            });
+            annotated_value(&finalize(
+                ToolCallResult::text(payload.to_string()),
+                ready_daemon_envelope(),
+                "semantic_locate",
+            ))
+        };
+
+        let neighbours = page(false);
+        let verdict = &neighbours[ENVELOPE_KEY]["verdict"];
+        assert_eq!(verdict["state"], "inconclusive", "{neighbours}");
+        assert_eq!(verdict["safe_to_conclude_absent"], false, "{neighbours}");
+        let factor = verdict["limiting_factor"]
+            .as_str()
+            .expect("an inconclusive verdict names what limited it");
+        assert!(factor.contains("relevance_floor_unmeasured"), "{factor}");
+        assert_eq!(
+            neighbours[crate::negative::NEGATIVE_KEY]["kind"],
+            "relevance_unverified",
+            "{neighbours}"
+        );
+        assert!(
+            crate::verdict::disagreements(&neighbours).is_empty(),
+            "a response may not contradict its own verdict: {neighbours}"
+        );
+
+        // The control, and the positive one this repair is scoped by: the same
+        // page whose FIRST returned row carries the name the query used keeps
+        // its certified verdict and its target at rank 1. `app.render` answers
+        // "render a view template with a layout" on this store at score 427.00,
+        // and that name match rests on the ordinary word "render", so a rule
+        // that asked for a symbol-shaped token would have taken this answer's
+        // verdict away too.
+        let named = page(true);
+        assert_eq!(
+            named[ENVELOPE_KEY]["verdict"]["state"], "certified",
+            "{named}"
+        );
+        assert!(
+            named.get(crate::negative::NEGATIVE_KEY).is_none(),
+            "a page whose returned rows name what the query used needs no relevance caveat: {named}"
+        );
+        assert_eq!(
+            named["entities"][0]["name"], "app.render",
+            "the control's target must still be first: {named}"
+        );
+    }
 
     /// One shape, but not one substrate. A ranked answer depends on embeddings
     /// and never traverses an edge, so its classes name embeddings and an

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -1273,6 +1273,19 @@ fn locate_empty_window_over_nonempty_ranking(payload: &Value) -> bool {
 /// to drift into retrieval by being shared with it. Hyphens are excluded because
 /// ordinary prose hyphenates, and a rule that reads `graph-native` as a symbol
 /// name would qualify half of all English queries.
+///
+/// Capitals alone are excluded for the same reason, and that exclusion is the
+/// difference between this gate covering real questions and exempting most of
+/// them. Counting capitals alone made `JSON` a named symbol, so "send a JSON
+/// response body to the client" was routed to the symbol gate beside this one,
+/// which asks a different question and fires only on the whole-ranking
+/// `all_fallback` flag that a paged answer often does not carry. The measured
+/// consequence was that the identical page of fallback neighbours certified
+/// under that phrasing, and HTTP, API, URL, SQL, HTML, XML, UUID, DNS and TLS
+/// did it too. Mixed case is what separates a name from an abbreviation, and a
+/// token carrying an underscore, a dot or a path separator stays a symbol
+/// whatever its case, so `MAX_RETRIES`, `README.md`, `IOError` and
+/// `HTTPServer` are all still symbol lookups.
 fn query_names_a_symbol(query: &str) -> bool {
     query.split_whitespace().any(|token| {
         let core = token.trim_matches(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_'));
@@ -1280,7 +1293,8 @@ fn query_names_a_symbol(query: &str) -> bool {
             && (core.contains('_')
                 || core.contains("::")
                 || core.contains('.')
-                || core.chars().filter(|ch| ch.is_ascii_uppercase()).count() >= 2)
+                || (core.chars().filter(|ch| ch.is_ascii_uppercase()).count() >= 2
+                    && core.chars().any(|ch| ch.is_ascii_lowercase())))
     })
 }
 
@@ -1415,11 +1429,11 @@ fn locate_relevance_unverified(payload: &Value) -> bool {
 /// today stops firing.
 ///
 /// A name match is NOT discounted for resting on an ordinary English word, even
-/// though the row that silenced this gate on express was one. The tool's three
-/// best answers are that shape too: `app.render` for "render a view template
-/// with a layout" and `res.json` for "send a JSON response body to the client"
-/// are both name matches on a plain lowercase token, both first row, both right.
-/// A returned name row IS the calibrated floor a locate response publishes, and
+/// though the row that silenced this gate on express was one. Two of the tool's
+/// best answers are that shape: `app.render` for "render a view template with a
+/// layout" and `res.json` for "send a JSON response body to the client" are both
+/// name matches on a plain lowercase token, both first row, both right. A
+/// returned name row IS the calibrated floor a locate response publishes, and
 /// the defect is that a name row the caller cannot see was allowed to stand in
 /// for one. Telling `app.render` from a question's stray word is a ranking
 /// judgment and belongs where ranking is decided.
@@ -7164,8 +7178,8 @@ mod tests {
         row
     }
 
-    /// The eight rows express returned for the concept query in GAP-F, kinds and
-    /// scores as measured.
+    /// The eight rows express returned for the concept query, kinds and scores
+    /// as measured.
     fn gap_f_fallback_rows() -> Value {
         json!([
             compact_locate_row(
@@ -7206,7 +7220,7 @@ mod tests {
 
     #[test]
     fn a_prose_page_of_lexical_neighbours_is_qualified_when_the_named_row_is_off_the_page() {
-        // journey072 GAP-F, on express with the vector index complete at 798 of
+        // Measured on express with the vector index complete at 798 of
         // 798. The caller asked "attach an encoding label to a media type
         // string" and received eight lexical neighbours at scores 52.05 down to
         // 52.02, none of them `setCharset`, which was not in the ranking at any
@@ -7246,11 +7260,14 @@ mod tests {
     #[test]
     fn a_prose_page_whose_returned_rows_name_the_query_stays_unqualified() {
         // The control that pins the repair's scope, and the reason this gate
-        // must not discount a plain-word name match. All three are prose queries
-        // measured on the same express store, all three answered first row, and
-        // all three name matches rest on an ordinary English token, so a rule
-        // that demanded a symbol-shaped one would refuse to certify the tool's
-        // three best answers.
+        // must not discount a plain-word name match. All three questions are
+        // prose by this module's own rule, all three answered first row on the
+        // same store, and the first two are named by an ordinary English token,
+        // so a rule that demanded a symbol-shaped one would refuse to certify
+        // the tool's best answers. The second reaches this gate at all only
+        // because an acronym is not a symbol the caller named: while `JSON`
+        // counted as one, `query_names_a_symbol` returned true and the row
+        // classifier below was never consulted for that question.
         for (query, name, file, score) in [
             (
                 "render a view template with a layout",
@@ -7289,7 +7306,7 @@ mod tests {
 
     #[test]
     fn a_prose_page_of_vector_neighbours_stays_qualified() {
-        // The other half of GAP-F, measured in the same session: "decide which
+        // The other half of the same measurement: "decide which
         // proxy addresses may be believed" returned eight rows all
         // `matched: semantic` at 96.28 down to 94.41, with `all_fallback` set,
         // and was correctly inconclusive. Widening the gate to read the returned
@@ -7369,6 +7386,188 @@ mod tests {
             "a file answer carries no entity match kinds and must not be read as fallback: \
              {payload}"
         );
+    }
+
+    /// One page on the FULL fused surface, which serializes `LocateEntity`
+    /// verbatim: `match_kind` per row and no compact `matched` key.
+    fn full_fused_page(query: &str, entities: Value, total_ranked: u64) -> Value {
+        json!({
+            "query": query,
+            "granularity": "entity",
+            "routing": "fused-v1",
+            "page": 0,
+            "entities": entities,
+            "files": [{"path": "lib/response.js", "score": 52.05}],
+            "total_ranked": total_ranked,
+        })
+    }
+
+    fn full_fused_row(name: &str, match_kind: &str) -> Value {
+        json!({
+            "entity_id": "00000000-0000-0000-0000-0000000000ba",
+            "kind": "function",
+            "name": name,
+            "score": 52.05,
+            "definition": true,
+            "match_kind": match_kind,
+            "provenance": { "file": "lib/response.js" },
+        })
+    }
+
+    #[test]
+    fn a_prose_page_of_fallback_rows_is_qualified_on_the_full_fused_surface() {
+        // The compact projection is not the only surface this gate has to read.
+        // `fused_semantic_locate_payload` serializes the reused `LocateResult`
+        // types when the caller asks for the full shape, and there a row's kind
+        // is `match_kind` rather than `matched`. A classifier reading only the
+        // compact spelling would let every full-surface page certify, and no
+        // fixture would notice: swapping the `match_kind` read for a second
+        // `matched` read leaves the rest of this suite green.
+        let payload = full_fused_page(
+            "attach an encoding label to a media type string",
+            json!([
+                full_fused_row("res.send", "text_fallback"),
+                full_fused_row("res.sendFile", "text_fallback"),
+            ]),
+            31,
+        );
+        // A real full-fused row carries a `match_evidence` object beside its
+        // `match_kind` (`crates/kin-daemon/src/api.rs:11642`). This one omits it
+        // for the same reason the cosine fixture below omits `match_kind`: with
+        // one spelling present, the arm under test is the only thing that can
+        // classify the row, and a mutation to it cannot hide behind a sibling.
+        assert!(
+            payload["entities"][0].get("matched").is_none(),
+            "this fixture omits the compact spelling so match_kind is the only classifier: \
+             {payload}"
+        );
+        let negative = negative_for(
+            "semantic_locate",
+            &payload,
+            &semantic_authoritative_envelope(),
+        )
+        .expect("a full-surface page of fallback rows may not certify a concept answer");
+        assert_eq!(negative["kind"], json!("relevance_unverified"));
+        assert_eq!(negative["trust"], json!("inconclusive"));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(reason.contains("relevance_floor_unmeasured"), "{reason}");
+
+        // The control on the same surface: one returned row carrying the name
+        // the query used is the calibrated floor, and it is read through the
+        // same spelling.
+        let named = full_fused_page(
+            "attach an encoding label to a media type string",
+            json!([
+                full_fused_row("type", "name"),
+                full_fused_row("res.sendFile", "text_fallback"),
+            ]),
+            31,
+        );
+        assert!(
+            negative_for(
+                "semantic_locate",
+                &named,
+                &semantic_authoritative_envelope()
+            )
+            .is_none(),
+            "a full-surface page whose row names the query needs no caveat: {named}"
+        );
+    }
+
+    #[test]
+    fn a_prose_page_of_fallback_rows_is_qualified_on_the_cosine_surface() {
+        // The third spelling: `match_evidence.name_match`, the cosine arm's own
+        // word for the fact the other two surfaces spell `name`.
+        //
+        // A stock daemon's cosine entity row carries BOTH keys. It has emitted
+        // `match_kind` on every entity-granularity hit since `917bf1d3b`
+        // (2026-08-12), at `crates/kin-daemon/src/api.rs:11248`, derived from
+        // the same predicate the evidence object reports so the two cannot
+        // disagree. This fixture is therefore not a sample of what that arm
+        // sends today. It is the compatibility read, for a producer that
+        // publishes the evidence object and no `match_kind`, and it omits the
+        // sibling key on purpose so that the arm under test is the only thing
+        // that can classify the row. Without that arm every row here reports an
+        // unknown kind, the gate never fires, and a prose page of neighbours
+        // certifies.
+        let payload = json!({
+            "query": "attach an encoding label to a media type string",
+            "routing": "cosine-v0",
+            "page": 0,
+            "total_ranked": 31,
+            "results": [
+                cosine_locate_hit("res_send", "none"),
+                cosine_locate_hit("res_send_file", "partial"),
+            ],
+        });
+        assert!(
+            payload["results"][0].get("match_kind").is_none(),
+            "this fixture omits match_kind so the evidence arm is the only classifier: {payload}"
+        );
+        let negative = negative_for(
+            "semantic_locate",
+            &payload,
+            &semantic_authoritative_envelope(),
+        )
+        .expect("a cosine page of neighbours may not certify a concept answer");
+        assert_eq!(negative["kind"], json!("relevance_unverified"));
+        assert_eq!(negative["trust"], json!("inconclusive"));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(reason.contains("relevance_floor_unmeasured"), "{reason}");
+
+        // The control: `exact` is the cosine arm's own word for the fact the
+        // other two surfaces spell `name`.
+        let named = json!({
+            "query": "attach an encoding label to a media type string",
+            "routing": "cosine-v0",
+            "page": 0,
+            "total_ranked": 31,
+            "results": [
+                cosine_locate_hit("type", "exact"),
+                cosine_locate_hit("res_send_file", "partial"),
+            ],
+        });
+        assert!(
+            negative_for(
+                "semantic_locate",
+                &named,
+                &semantic_authoritative_envelope()
+            )
+            .is_none(),
+            "an exact name match is the floor on this surface too: {named}"
+        );
+    }
+
+    #[test]
+    fn an_acronym_in_a_question_does_not_exempt_it_from_the_relevance_gate() {
+        // The same eight-row all-fallback page, asked with an acronym in the
+        // sentence. `query_names_a_symbol` used to read any three-character
+        // token with two capitals as a named symbol, so `JSON` alone sent the
+        // question to the symbol gate, which needs the whole-ranking
+        // `all_fallback` flag this page does not carry, and the page certified.
+        // That exempted the most common shape of real question there is: HTTP,
+        // API, URL, SQL, HTML, XML, UUID, DNS and TLS all did it too.
+        let payload = compact_fused_page(
+            "send a JSON response body to the client",
+            gap_f_fallback_rows(),
+            31,
+        );
+        let negative = negative_for(
+            "semantic_locate",
+            &payload,
+            &semantic_authoritative_envelope(),
+        )
+        .expect("an acronym in the sentence is not a symbol the caller named");
+        assert_eq!(negative["kind"], json!("relevance_unverified"));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(reason.contains("relevance_floor_unmeasured"), "{reason}");
+
+        // The control that keeps the symbol gate's own territory: a token that
+        // mixes case IS a symbol name, and a query naming one is answered by
+        // the gate beside this one rather than by this one.
+        assert!(query_names_a_symbol("how does HTTPServer parse a header"));
+        assert!(query_names_a_symbol("IOError"));
+        assert!(query_names_a_symbol("MAX_RETRIES"));
     }
 
     #[test]
@@ -7724,6 +7923,21 @@ mod tests {
         assert!(!query_names_a_symbol("Checks That Cannot Fail"));
         assert!(!query_names_a_symbol("graph-native repo substrate"));
         assert!(!query_names_a_symbol(""));
+        // An all-capital token is an acronym English prose is full of, not a
+        // symbol the caller named. Mixed case is what separates the two, and a
+        // token carrying an underscore, a dot or a path separator stays a
+        // symbol whatever its case.
+        assert!(!query_names_a_symbol(
+            "send a JSON response body to the client"
+        ));
+        assert!(!query_names_a_symbol(
+            "which HTTP status does a redirect use"
+        ));
+        assert!(!query_names_a_symbol("parse the URL and the DNS name"));
+        assert!(query_names_a_symbol("how does HTTPServer parse a header"));
+        assert!(query_names_a_symbol("IOError"));
+        assert!(query_names_a_symbol("MAX_RETRIES"));
+        assert!(query_names_a_symbol("README.md"));
     }
 
     /// FIR-2542's second half. `edge_coverage_unreported` reached every

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -1351,11 +1351,14 @@ fn locate_ranking_names_nothing(payload: &Value) -> bool {
 
 /// True when locate returned only fallback neighbours for a prose query.
 ///
-/// `all_fallback` is computed over the full retained ranking, so this reads the
-/// producer's observation rather than guessing from one page. A prose query
-/// does not name a symbol whose absence can be checked. The relevant fact is
-/// instead that the ranking has no calibrated floor saying any returned row
-/// answers the concept the caller described.
+/// Two triggers, and neither guesses. `all_fallback` is the producer's verdict
+/// over the full retained ranking, computed before the daemon windows a page.
+/// [`locate_returned_rows_are_all_fallback`] asks the same question of the rows
+/// this response actually returned, which is the only surface the caller can
+/// check, and it is what stops one name hit ranked off the page from certifying
+/// a page of neighbours. A prose query does not name a symbol whose absence can
+/// be checked. The relevant fact is instead that the ranking has no calibrated
+/// floor saying any returned row answers the concept the caller described.
 ///
 /// This gate replaced one that deliberately said the opposite, and that
 /// argument is answered rather than dropped. It held that `all_fallback` fires
@@ -1379,8 +1382,95 @@ fn locate_relevance_unverified(payload: &Value) -> bool {
     let Some(query) = payload.get("query").and_then(Value::as_str) else {
         return false;
     };
-    !query_names_a_symbol(query)
-        && payload.get("all_fallback").and_then(Value::as_bool) == Some(true)
+    if query_names_a_symbol(query) {
+        return false;
+    }
+    payload.get("all_fallback").and_then(Value::as_bool) == Some(true)
+        || locate_returned_rows_are_all_fallback(payload)
+}
+
+/// True when every row THIS RESPONSE returned is a fallback neighbour.
+///
+/// The second trigger, and it exists because `all_fallback` answers a different
+/// question than the one this gate asks. That flag is a verdict over the WHOLE
+/// retained ranking, which is right for [`locate_ranking_names_nothing`]: an
+/// exact name sitting on page two means the ranking did carry the symbol, so
+/// claiming it names nothing would be false. This gate asks how far the rows the
+/// caller RECEIVED can be trusted, and a row the caller never saw establishes
+/// nothing about them.
+///
+/// Measured on express at 798 of 798 embedded. "attach an encoding label to a
+/// media type string" returned eight rows, every one of them a lexical fallback
+/// neighbour scoring 52.05 down to 52.02, and `setCharset`, which does exactly
+/// what the query describes, was not in the ranking at limit 8 or limit 40. The
+/// response certified with a null limiting factor, because one row of the 31 the
+/// ranking held did carry `match_kind: name` (the kinds over that ranking were
+/// text_fallback 28, name 1, semantic 2), so the producer omitted `all_fallback`
+/// and both locate gates read `None`. In the same session a concept query whose
+/// rows were all VECTOR neighbours, scoring 96.28 down to 94.41, was correctly
+/// inconclusive. The answer with the higher scores was qualified and the
+/// 52-point lexical one was certified.
+///
+/// A strict widening: it adds a trigger and removes none, so nothing that fires
+/// today stops firing.
+///
+/// A name match is NOT discounted for resting on an ordinary English word, even
+/// though the row that silenced this gate on express was one. The tool's three
+/// best answers are that shape too: `app.render` for "render a view template
+/// with a layout" and `res.json` for "send a JSON response body to the client"
+/// are both name matches on a plain lowercase token, both first row, both right.
+/// A returned name row IS the calibrated floor a locate response publishes, and
+/// the defect is that a name row the caller cannot see was allowed to stand in
+/// for one. Telling `app.render` from a question's stray word is a ranking
+/// judgment and belongs where ranking is decided.
+fn locate_returned_rows_are_all_fallback(payload: &Value) -> bool {
+    let Some(primary) = crate::budget::primary_collection_for(payload, "semantic_locate") else {
+        return false;
+    };
+    let Some(rows) = payload.get(primary).and_then(Value::as_array) else {
+        return false;
+    };
+    // An empty page is not all-fallback: nothing was returned, so there is
+    // nothing to mistake for an answer, and the empty-window and no-ranked-match
+    // gates are what speak to it. Both `all_fallback` producers state the same
+    // rule, and stating it differently here is how two readings of one question
+    // start disagreeing.
+    !rows.is_empty()
+        && rows
+            .iter()
+            .all(|row| locate_row_names_the_query(row) == Some(false))
+}
+
+/// Whether one returned row carries a name the query used: `None` when the row
+/// reports nothing that answers the question.
+///
+/// Three spellings, one fact. `match_kind` is what the full fused surface and
+/// the cosine arm write, `matched` is what the compact projection writes, and
+/// the compact surface is the one an agent actually receives, so a rule reading
+/// only the first would be absent from every response that matters. Both carry
+/// `LocateMatchKind`'s own serialization, so the two spellings cannot disagree
+/// about a word. `match_evidence.name_match` is the cosine evidence object,
+/// which reports the same fact under its own name and whose `exact` is the value
+/// [`locate_ranking_names_nothing`] already reads.
+///
+/// `None` is a third answer and not a shade of either. A record from a daemon
+/// predating these fields, and a file-granularity row, which carries no match
+/// kind at all because `files[]` is a path roll-up, both land here, and the
+/// caller treats an unanswered row as reason to qualify nothing. That is the
+/// same refusal to guess the page inference above makes, and it is what keeps a
+/// successful file answer out of a gate about entity naming.
+fn locate_row_names_the_query(row: &Value) -> Option<bool> {
+    if let Some(kind) = row
+        .get("match_kind")
+        .or_else(|| row.get("matched"))
+        .and_then(Value::as_str)
+    {
+        return Some(kind == "name");
+    }
+    row.get("match_evidence")
+        .and_then(|evidence| evidence.get("name_match"))
+        .and_then(Value::as_str)
+        .map(|name_match| name_match == "exact")
 }
 
 /// The wire word for the one embedding verdict, so the absence object and the
@@ -2574,9 +2664,9 @@ pub fn negative_for(
                    this ranking publishes no measured relevance floor";
         trustworthy = false;
         trust_reason = format!(
-            "relevance_floor_unmeasured: every ranked row was a fallback neighbour and the \
-             response publishes no calibrated threshold establishing that any row answers the \
-             concept; observed substrate state: {trust_reason}"
+            "relevance_floor_unmeasured: every row this response returned was a fallback \
+             neighbour and the response publishes no calibrated threshold establishing that any \
+             of them answers the concept; observed substrate state: {trust_reason}"
         );
     }
     if tool == "graph_neighborhood" {
@@ -7030,6 +7120,254 @@ mod tests {
             advice.contains("Inspect the returned code")
                 && advice.contains("do not conclude the concept is absent"),
             "{advice}"
+        );
+    }
+    /// One compact fused page in the shape an agent actually receives:
+    /// `project_for_mcp` writes `matched` per row, omits `results` entirely, and
+    /// omits `all_fallback` unless the producer set it.
+    fn compact_fused_page(query: &str, entities: Value, total_ranked: u64) -> Value {
+        json!({
+            "query": query,
+            "granularity": "entity",
+            "routing": "fused-v1",
+            "page": 0,
+            "surface": "compact",
+            "entities": entities,
+            "files": ["lib/application.js", "lib/view.js"],
+            "total_ranked": total_ranked,
+            "next_cursor": "eyJrZXkiOiJsb2NhdGUtcmFua2luZyJ9",
+            "ranked_by": "vector, lexical and graph signals",
+            "semantic_coverage": {
+                "indexed": 798,
+                "total": 798,
+                "pending": 0,
+                "complete": true,
+            },
+        })
+    }
+
+    /// One row of that page. `matched` is `None` for a record from a daemon
+    /// predating the field, which is a state this module must not read as either
+    /// answer.
+    fn compact_locate_row(name: &str, file: &str, score: f64, matched: Option<&str>) -> Value {
+        let mut row = json!({
+            "id": "00000000-0000-0000-0000-0000000000ac",
+            "name": name,
+            "kind": "function",
+            "file": file,
+            "line": 190,
+            "score": score,
+        });
+        if let Some(matched) = matched {
+            row["matched"] = json!(matched);
+        }
+        row
+    }
+
+    /// The eight rows express returned for the concept query in GAP-F, kinds and
+    /// scores as measured.
+    fn gap_f_fallback_rows() -> Value {
+        json!([
+            compact_locate_row(
+                "app.use",
+                "lib/application.js",
+                52.05,
+                Some("text_fallback")
+            ),
+            compact_locate_row(
+                "app.render",
+                "lib/application.js",
+                52.05,
+                Some("text_fallback")
+            ),
+            compact_locate_row(
+                "app.defaultConfiguration",
+                "lib/application.js",
+                52.05,
+                Some("text_fallback"),
+            ),
+            compact_locate_row("View.render", "lib/view.js", 52.03, Some("text_fallback")),
+            compact_locate_row("View.lookup", "lib/view.js", 52.02, Some("text_fallback")),
+            compact_locate_row("View.resolve", "lib/view.js", 52.02, Some("text_fallback")),
+            compact_locate_row(
+                "app.listen",
+                "lib/application.js",
+                52.02,
+                Some("text_fallback")
+            ),
+            compact_locate_row(
+                "app.path",
+                "lib/application.js",
+                52.02,
+                Some("text_fallback")
+            ),
+        ])
+    }
+
+    #[test]
+    fn a_prose_page_of_lexical_neighbours_is_qualified_when_the_named_row_is_off_the_page() {
+        // journey072 GAP-F, on express with the vector index complete at 798 of
+        // 798. The caller asked "attach an encoding label to a media type
+        // string" and received eight lexical neighbours at scores 52.05 down to
+        // 52.02, none of them `setCharset`, which was not in the ranking at any
+        // limit. The response carried NO `all_fallback`, because one row of the
+        // 31 the ranking held did carry `matched: name` (the kinds at limit 40
+        // were text_fallback 28, name 1, semantic 2) and the producer computes
+        // that flag over the whole ranking. So the flag reported a name hit the
+        // caller never saw, both locate gates read `None`, and the answer
+        // certified.
+        //
+        // The rows the caller DID receive publish no calibrated threshold saying
+        // any of them answers the concept, which is the same sentence the
+        // vector-neighbour case below is qualified with.
+        let payload = compact_fused_page(
+            "attach an encoding label to a media type string",
+            gap_f_fallback_rows(),
+            31,
+        );
+        assert!(
+            payload.get("all_fallback").is_none(),
+            "the measured response carried no all_fallback: {payload}"
+        );
+        let negative = negative_for(
+            "semantic_locate",
+            &payload,
+            &semantic_authoritative_envelope(),
+        )
+        .expect("a returned page of fallback neighbours may not certify a concept answer");
+        assert_eq!(negative["kind"], json!("relevance_unverified"));
+        assert_eq!(negative["interpretation"], json!("nearest_neighbors_only"));
+        assert_eq!(negative["trust"], json!("inconclusive"));
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(reason.contains("relevance_floor_unmeasured"), "{reason}");
+    }
+
+    #[test]
+    fn a_prose_page_whose_returned_rows_name_the_query_stays_unqualified() {
+        // The control that pins the repair's scope, and the reason this gate
+        // must not discount a plain-word name match. All three are prose queries
+        // measured on the same express store, all three answered first row, and
+        // all three name matches rest on an ordinary English token, so a rule
+        // that demanded a symbol-shaped one would refuse to certify the tool's
+        // three best answers.
+        for (query, name, file, score) in [
+            (
+                "render a view template with a layout",
+                "app.render",
+                "lib/application.js",
+                427.00,
+            ),
+            (
+                "send a JSON response body to the client",
+                "res.json",
+                "lib/response.js",
+                453.10,
+            ),
+            ("setCharset", "setCharset", "lib/utils.js", 480.00),
+        ] {
+            let payload = compact_fused_page(
+                query,
+                json!([
+                    compact_locate_row(name, file, score, Some("name")),
+                    compact_locate_row("View.render", "lib/view.js", 52.03, Some("text_fallback")),
+                ]),
+                31,
+            );
+            assert!(
+                negative_for(
+                    "semantic_locate",
+                    &payload,
+                    &semantic_authoritative_envelope()
+                )
+                .is_none(),
+                "a page whose first row carries the name the query used needs no relevance \
+                 caveat: {query}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_prose_page_of_vector_neighbours_stays_qualified() {
+        // The other half of GAP-F, measured in the same session: "decide which
+        // proxy addresses may be believed" returned eight rows all
+        // `matched: semantic` at 96.28 down to 94.41, with `all_fallback` set,
+        // and was correctly inconclusive. Widening the gate to read the returned
+        // page may not cost that case its qualifier.
+        let mut payload = compact_fused_page(
+            "decide which proxy addresses may be believed",
+            json!([
+                compact_locate_row("compileTrust", "lib/utils.js", 96.28, Some("semantic")),
+                compact_locate_row("proxyaddr", "lib/utils.js", 94.41, Some("semantic")),
+            ]),
+            2,
+        );
+        payload["all_fallback"] = json!(true);
+        let negative = negative_for(
+            "semantic_locate",
+            &payload,
+            &semantic_authoritative_envelope(),
+        )
+        .expect("a vector-neighbour page keeps the qualifier it already had");
+        assert_eq!(negative["kind"], json!("relevance_unverified"));
+        assert_eq!(negative["trust"], json!("inconclusive"));
+    }
+
+    #[test]
+    fn a_prose_page_whose_rows_report_no_match_kind_is_left_alone() {
+        // The refusal to guess, in the one shape that can still produce it: a
+        // daemon predating `matched` publishes rows carrying no kind at all, and
+        // its absent `all_fallback` is then the only statement the response
+        // makes about whether anything was named. Reading those rows as fallback
+        // would qualify an answer on evidence nobody produced, which is the same
+        // refusal the cosine page inference beside it already makes.
+        let payload = compact_fused_page(
+            "attach an encoding label to a media type string",
+            json!([
+                compact_locate_row("app.use", "lib/application.js", 52.05, None),
+                compact_locate_row("View.render", "lib/view.js", 52.03, None),
+            ]),
+            31,
+        );
+        assert!(
+            negative_for(
+                "semantic_locate",
+                &payload,
+                &semantic_authoritative_envelope()
+            )
+            .is_none(),
+            "rows that report no match kind answer nothing about naming: {payload}"
+        );
+    }
+
+    #[test]
+    fn a_prose_file_answer_is_not_qualified_by_the_relevance_gate() {
+        // The symmetry `fused_semantic_locate_payload` built deliberately, kept
+        // here by the refusal to guess rather than by a special case. A file
+        // answer IS the `files[]` roll-up, its rows carry no match kind at all,
+        // and labelling a successful file answer with an entity-naming caveat is
+        // exactly what clearing `all_fallback` at file granularity exists to
+        // prevent.
+        let payload = json!({
+            "query": "attach an encoding label to a media type string",
+            "granularity": "file",
+            "routing": "fused-v1",
+            "page": 0,
+            "total_ranked": 2,
+            "files": [
+                {"path": "lib/utils.js", "score": 52.05, "signals": ["lexical"]},
+                {"path": "lib/response.js", "score": 52.02, "signals": ["lexical"]},
+            ],
+        });
+        assert!(
+            negative_for(
+                "semantic_locate",
+                &payload,
+                &semantic_authoritative_envelope()
+            )
+            .is_none(),
+            "a file answer carries no entity match kinds and must not be read as fallback: \
+             {payload}"
         );
     }
 


### PR DESCRIPTION
Tracker: FIR-3281.

## What was wrong

`semantic_locate` certified a concept answer that was only lexical fallback, and whose actual answer
was not in the ranking at all.

Measured on express with the vector index complete at 798 of 798: the query "attach an encoding
label to a media type string" returned eight rows, every one `matched: text_fallback`, scoring 52.05
down to 52.02, with `setCharset` not ranked at limit 8 or at limit 40. The response came back
`verdict.state: certified`, `limiting_factor: null`, with the note "Every input that could qualify
this answer agreed, so the counts here are the whole set". An agent that reads `verdict.state` first,
exactly as the server instructions tell it to, was told the answer is the whole set when the answer
was not in it.

The same session, same store, a concept query whose rows were all vector neighbours at scores 96.28
down to 94.41 came back `inconclusive` with `relevance_floor_unmeasured`. The higher-scoring answer
was qualified and the 52-point lexical one was certified.

## Why the gate did not fire

Two reasons, and both are fixed here.

**The flag it reads answers a different question.** `all_fallback` is the producer's verdict over the
FULL retained ranking (`kin-cli/src/commands/locate.rs:18399`), true only when no entity anywhere in
it carries `match_kind: name`. That ranking held 31 rows whose kinds were `text_fallback` 28, `name`
1, `semantic` 2. One row carried a name, off the page the caller received, so the producer omitted
the flag, so both locate gates in `kin-mcp/src/negative.rs` read `None` and the page certified. The
vector-neighbour query had no name row anywhere, so its flag was set and the same gate fired.

**An acronym in the question exempted it from the gate entirely.** `locate_relevance_unverified`
returns before it reads a row when `query_names_a_symbol` is true, and that predicate counted any
three-character token with two capitals as a named symbol. So `JSON` alone routed "send a JSON
response body to the client" to the symbol gate beside it, which fires only on the whole-ranking
flag this page does not carry. The identical eight-row page certified under that phrasing, and HTTP,
API, URL, SQL, HTML, XML, UUID, DNS and TLS did it too.

## The change

`locate_relevance_unverified` keeps its `all_fallback` trigger and gains a second one: fire when the
rows THIS RESPONSE returned are non-empty, all report a match kind, and none of them is a name
match. It is a strict widening, so nothing that fires today stops firing and the vector-neighbour
case stays inconclusive by construction.

Rows are read through `budget::primary_collection_for`, the one rule for which array is the answer,
so both arms and file granularity are classified by the same function the response budget uses. One
row's kind comes from `match_kind` (the full fused surface and the cosine arm), from `matched` (the
compact surface, which is what an agent actually receives), or from `match_evidence.name_match` (the
cosine evidence object). A row that reports none of the three answers `None` and the gate does not
fire, which is the same refusal to guess the page inference beside it already makes, and it is what
keeps a file-granularity answer, whose rows carry no match kind at all, out of a gate about entity
naming.

`query_names_a_symbol` now also requires a lowercase letter before capitals make a token a symbol,
so mixed case is what separates a name from an abbreviation. Everything carrying an underscore, a
dot or a path separator stays a symbol whatever its case, so `MAX_RETRIES`, `README.md`, `IOError`
and `HTTPServer` are untouched and every assertion the pre-existing symbol-shape test made still
holds. This cannot lose a qualifier: the two gates are complementary, `locate_ranking_names_nothing`
fires on `symbol && all_fallback` and this one on `!symbol && (all_fallback || page all fallback)`,
so moving a question from the first to the second is strictly more coverage. What changes is the
wording, and for a question with an acronym in it the second gate's wording is the true one. The
residual is a bare all-capital token that really is a symbol, such as a C macro queried as `NULL`:
it is still qualified, more broadly than before, but under the concept-query sentence.

Ranking is untouched. The wire sentence for `relevance_floor_unmeasured` now says "every row this
response returned", which is what the widened trigger checks.

### One case left open on purpose

A name match is not discounted for resting on an ordinary English word, even though the row that
silenced this gate was one. The tool's best answers are that shape: `app.render` answers "render a
view template with a layout" first row at 427.00 and `res.json` answers "send a JSON response body
to the client" first row at 453.10, and both are name matches on a plain lowercase token. So the
same query at limit 40, where that collision row IS on the returned page, still certifies. Telling
`app.render` from a question's stray word is a ranking judgment, not a verdict one, and it belongs in
a separate ticket.

## Verification

Head under test: `d76c44d47259a3cdb6994a0a87c88fcd03e503b4`. Every command below ran through the fleet's builder slot, one at a
time. The green run and the gates ran against that head. The red-first tails below come from a tree
without the fix, which is what red first means, and the mutation sweep ran one commit earlier; each
of those two is said again where it appears. One substitution is noted where it appears.

Red first. The tests describing the defect were written against unmodified product code, and the two
of them failed while the controls passed:

```
$ cargo test -p kin-mcp --lib
test envelope::tests::a_prose_locate_page_of_lexical_neighbours_never_certifies_on_the_compact_surface ... FAILED
test negative::tests::a_prose_page_of_lexical_neighbours_is_qualified_when_the_named_row_is_off_the_page ... FAILED
test negative::tests::a_prose_page_of_vector_neighbours_stays_qualified ... ok
test negative::tests::a_prose_page_whose_returned_rows_name_the_query_stays_unqualified ... ok
test negative::tests::a_prose_page_whose_rows_report_no_match_kind_is_left_alone ... ok
test result: FAILED. 927 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
```

The envelope failure printed the envelope the fixture produces without the fix, which is the express
reading word for word:

```
"verdict":{... "limiting_factor":null,
 "note":"Every input that could qualify this answer agreed, so the counts here are the whole set. ...",
 "safe_to_conclude_absent":false,"state":"certified"}
  left: String("certified")
 right: "inconclusive"
```

The acronym test was red the same way before the guard was scoped:

```
$ cargo test -p kin-mcp --lib
test negative::tests::an_acronym_in_a_question_does_not_exempt_it_from_the_relevance_gate ... FAILED
test negative::tests::symbol_shape_rule_separates_identifiers_from_prose ... FAILED
test result: FAILED. 931 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 39.18s
```

Green:

```
$ cargo test -p kin-mcp --lib
test result: ok. 933 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 16.45s
```

Falsified. Eight mutations, each run against the FULL `kin-mcp` lib rather than a name filter so
collateral is visible, each restored from a pristine copy afterwards. No survivors. The block below
is the sweep driver's own output, which normalizes cargo's lines: it prints the `test result:` line
first and the failing test names under it as `FAILED <name>`, where cargo prints
`test <name> ... FAILED` above its result line. The counts and the names are verbatim.

The sweep ran one commit earlier, before a comment correction, and the diff between that tree and
this head is comments plus two `assert!` failure-message strings, nothing a mutant can interact
with. The green run above is on this head.

```
===== M1 page arm dead (|| -> &&): cargo exit 101
   test result: FAILED. 926 passed; 7 failed
   FAILED envelope::tests::a_prose_locate_page_of_lexical_neighbours_never_certifies_on_the_compact_surface
   FAILED envelope::tests::a_prose_locate_page_of_neighbours_never_certifies_on_the_compact_surface
   FAILED negative::tests::a_prose_page_of_fallback_rows_is_qualified_on_the_cosine_surface
   FAILED negative::tests::a_prose_page_of_fallback_rows_is_qualified_on_the_full_fused_surface
   FAILED negative::tests::a_prose_page_of_lexical_neighbours_is_qualified_when_the_named_row_is_off_the_page
   FAILED negative::tests::an_acronym_in_a_question_does_not_exempt_it_from_the_relevance_gate
   FAILED negative::tests::prose_query_over_fallback_hits_refuses_to_certify_relevance
===== M2 an unclassified row counts as fallback: cargo exit 101
   test result: FAILED. 929 passed; 4 failed
   FAILED envelope::tests::a_prose_locate_page_of_neighbours_never_certifies_on_the_compact_surface
   FAILED negative::tests::a_prose_file_answer_is_not_qualified_by_the_relevance_gate
   FAILED negative::tests::a_prose_page_whose_rows_report_no_match_kind_is_left_alone
   FAILED negative::tests::cosine_file_granularity_counts_its_file_primary_for_empty_and_populated_pages
===== M3 the compact `matched` arm ignored: cargo exit 101
   test result: FAILED. 930 passed; 3 failed
   FAILED envelope::tests::a_prose_locate_page_of_lexical_neighbours_never_certifies_on_the_compact_surface
   FAILED negative::tests::a_prose_page_of_lexical_neighbours_is_qualified_when_the_named_row_is_off_the_page
   FAILED negative::tests::an_acronym_in_a_question_does_not_exempt_it_from_the_relevance_gate
===== M4 one fallback row is enough (all -> any): cargo exit 101
   test result: FAILED. 929 passed; 4 failed
   FAILED envelope::tests::a_prose_locate_page_of_lexical_neighbours_never_certifies_on_the_compact_surface
   FAILED negative::tests::a_prose_page_of_fallback_rows_is_qualified_on_the_cosine_surface
   FAILED negative::tests::a_prose_page_of_fallback_rows_is_qualified_on_the_full_fused_surface
   FAILED negative::tests::a_prose_page_whose_returned_rows_name_the_query_stays_unqualified
===== M5 the whole gate deleted: cargo exit 101
   test result: FAILED. 925 passed; 8 failed
   FAILED envelope::tests::a_prose_locate_page_of_lexical_neighbours_never_certifies_on_the_compact_surface
   FAILED envelope::tests::a_prose_locate_page_of_neighbours_never_certifies_on_the_compact_surface
   FAILED negative::tests::a_prose_page_of_fallback_rows_is_qualified_on_the_cosine_surface
   FAILED negative::tests::a_prose_page_of_fallback_rows_is_qualified_on_the_full_fused_surface
   FAILED negative::tests::a_prose_page_of_lexical_neighbours_is_qualified_when_the_named_row_is_off_the_page
   FAILED negative::tests::a_prose_page_of_vector_neighbours_stays_qualified
   FAILED negative::tests::an_acronym_in_a_question_does_not_exempt_it_from_the_relevance_gate
   FAILED negative::tests::prose_query_over_fallback_hits_refuses_to_certify_relevance
===== M6 the full fused `match_kind` arm ignored: cargo exit 101
   test result: FAILED. 932 passed; 1 failed
   FAILED negative::tests::a_prose_page_of_fallback_rows_is_qualified_on_the_full_fused_surface
===== M7 the cosine `match_evidence.name_match` arm deleted: cargo exit 101
   test result: FAILED. 932 passed; 1 failed
   FAILED negative::tests::a_prose_page_of_fallback_rows_is_qualified_on_the_cosine_surface
===== M8 capitals alone make a symbol again (the acronym exemption): cargo exit 101
   test result: FAILED. 931 passed; 2 failed
   FAILED negative::tests::an_acronym_in_a_question_does_not_exempt_it_from_the_relevance_gate
   FAILED negative::tests::symbol_shape_rule_separates_identifiers_from_prose
===== RESTORED, confirming green: cargo exit 0
   test result: ok. 933 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 18.42s
===== survivors: none
```

Three of those say more than that they were caught. M1 turns the widening into an `and` and takes two
pre-existing tests down with it, which is the check that the second trigger is additive rather than a
replacement. M2 makes an unclassified row count as fallback and breaks two tests that predate this
change, so the refusal to guess is load-bearing. M6 and M7 are the two surfaces that had no fixture
until this round: each now fails exactly one test, the one written for it.

Local gates, on the same head:

```
$ bin/kin-precheck kin --repo-dir kin=<worktree>
kin-precheck: repo=kin tree=<worktree> sha=d76c44d47259a3cdb6994a0a87c88fcd03e503b4 branch=chore/lane-locatefloor-kin
kin-precheck: behind origin/main 1 commit(s); the gate list below is the one on THIS tree, not the one on main
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin d76c44d47259a3cdb6994a0a87c88fcd03e503b4
```

The worktree path is substituted as `<worktree>` in that block and nowhere else, and the tree was
one commit behind `origin/main` when it ran, which is what that second line says and why it says the
gate list is this tree's. Those gates cover
`cargo fmt -- --check`, `cargo clippy --all-targets --all-features` with the repository's own allow
list, and the guard scripts the check job names, including `scripts/zero_file_search_guard.sh`.
Hosted CI remains the gate of record for the full workspace.

One flake to know about, not from this change. `server::tests::daemon_required_tools_do_not_use_local_handlers`
(`crates/kin-mcp/src/server.rs:2383`) reads `std::env::current_dir()` to place a fixture while
`crates/kin-mcp/src/handlers/work.rs` calls `std::env::set_current_dir` at `:632`, `:675` and `:702`
in the same test binary. The current directory is process-wide and the tests run on threads, so the
two race. It failed once during review and passed on every rerun. It wants its own ticket.
