### PR TITLE
Refresh the workspace base graph section on every transition that moves it

### DIFF
--- a/crates/kin-cli/src/commands/clone.rs
+++ b/crates/kin-cli/src/commands/clone.rs
@@ -186,6 +186,7 @@ async fn clone_native(source: NativeCloneSource, target: &Path) -> Result<()> {
         true,
     )
     .context("persist native clone origin")?;
+    materialize_cloned_base(&layout).await;
     let request = CommandTransferRequest {
         remote_base_url: source.endpoint.base_url.clone(),
         remote_token: source.endpoint.auth_token,
@@ -253,6 +254,47 @@ async fn clone_native(source: NativeCloneSource, target: &Path) -> Result<()> {
         println!("  Head: {head}");
     }
     Ok(())
+}
+
+/// Persist the cloned replica's workspace base graph section, before this
+/// command starts a daemon on it.
+///
+/// A clone's history does NOT arrive through the transfer receiver. It arrives
+/// inside `kin_core::init::replica::initialize`, as one bootstrap transaction
+/// committed into a staged layout, so every refresh that hangs off a receive or
+/// a workspace transition is on a path this replica never took, and a fresh
+/// clone read `Graph section: absent, so every open of this store folds this
+/// workspace's base out of history` while naming `kin graph materialize` as the
+/// fix. Journey GAP-4. A stranger's first act on a peer's repository should not
+/// leave them a store that pays a full history fold at every open.
+///
+/// Here rather than inside `initialize`, and here rather than after the
+/// transfer below, because this is the one moment nothing holds the store:
+/// `materialize_workspace_base_offline` takes repository runtime authority
+/// first, and the transfer below connects a daemon that holds it. A clone whose
+/// own pull then admits more history moves the base again, and the daemon's own
+/// follow of that moved ref refreshes the section for it.
+///
+/// Never fatal, exactly as `kin init` treats the same phase: the replica is
+/// durable, complete and verified, and a memoization that did not persist is a
+/// slower next open rather than a failed clone. The warning names the retry, and
+/// `kin graph status` and `kin doctor` keep reading the state from the store, so
+/// a failure here is disclosed rather than papered over.
+async fn materialize_cloned_base(layout: &kin_core::KinLayout) {
+    let layout = layout.clone();
+    let outcome = tokio::task::spawn_blocking(move || {
+        crate::commands::repository_authority::materialize_workspace_base_offline(&layout)
+    })
+    .await;
+    let error = match outcome {
+        Ok(Ok(_)) => return,
+        Ok(Err(error)) => error,
+        Err(error) => anyhow::anyhow!("graph-section materialization did not complete: {error}"),
+    };
+    eprintln!(
+        "warning: the clone completed, but preparing its first graph reopen did not; run \
+         `kin graph materialize` in the clone to retry: {error:#}"
+    );
 }
 
 fn require_available_target(target: &Path) -> Result<bool> {

--- a/crates/kin-cli/src/commands/remote.rs
+++ b/crates/kin-cli/src/commands/remote.rs
@@ -598,7 +598,8 @@ pub async fn lease(
     if native_remote_bearer_token(&target.base_url).is_none() {
         anyhow::bail!(
             "no auth token available for {}; {}",
-            kin_remote::repository_transfer::redacted_remote_address(&target.base_url),
+            kin_remote::repository_transfer::redacted_remote_address(&target.base_url)
+                .unwrap_or_else(|| "that remote".to_string()),
             kin_remote::repository_transfer::bearer_token_next_step(&target.base_url)
         );
     }
@@ -976,7 +977,8 @@ pub async fn sessions(remote: Option<String>, json: bool) -> Result<()> {
     if native_remote_bearer_token(&target.base_url).is_none() {
         anyhow::bail!(
             "no auth token available for {}; {}",
-            kin_remote::repository_transfer::redacted_remote_address(&target.base_url),
+            kin_remote::repository_transfer::redacted_remote_address(&target.base_url)
+                .unwrap_or_else(|| "that remote".to_string()),
             kin_remote::repository_transfer::bearer_token_next_step(&target.base_url)
         );
     }

--- a/crates/kin-cli/src/commands/remote.rs
+++ b/crates/kin-cli/src/commands/remote.rs
@@ -134,6 +134,25 @@ pub(crate) fn native_remote_bearer_token(base_url: &str) -> Option<String> {
         .or_else(|| auth::load_saved_bearer_token(base_url))
 }
 
+/// The refusal both `kin remote` session pre-flights print when no bearer token
+/// is configured for a remote.
+///
+/// A function rather than two `format!` calls, because the address half has a
+/// `None` arm and inlining it put that arm where no test could reach it.
+/// `redacted_remote_address` withholds a URL it cannot parse, and the obvious
+/// way to spend that `Option` at a call site is
+/// `unwrap_or_else(|| base_url.to_string())`, which hands the whole
+/// credential-bearing URL back and restores exactly the leak the redaction
+/// exists to close. Here one test grades that arm directly.
+pub(crate) fn missing_bearer_token_message(base_url: &str) -> String {
+    let address = kin_remote::repository_transfer::redacted_remote_address(base_url)
+        .unwrap_or_else(|| "that remote".to_string());
+    format!(
+        "no auth token available for {address}; {}",
+        kin_remote::repository_transfer::bearer_token_next_step(base_url)
+    )
+}
+
 pub(crate) fn attach_native_remote_auth(
     builder: reqwest::RequestBuilder,
     base_url: &str,
@@ -596,12 +615,7 @@ pub async fn lease(
         &plan.repo_id,
     )?;
     if native_remote_bearer_token(&target.base_url).is_none() {
-        anyhow::bail!(
-            "no auth token available for {}; {}",
-            kin_remote::repository_transfer::redacted_remote_address(&target.base_url)
-                .unwrap_or_else(|| "that remote".to_string()),
-            kin_remote::repository_transfer::bearer_token_next_step(&target.base_url)
-        );
+        anyhow::bail!("{}", missing_bearer_token_message(&target.base_url));
     }
 
     let actor_id = actor_id.unwrap_or_else(|| default_cli_actor_id(&target.base_url));
@@ -975,12 +989,7 @@ pub async fn sessions(remote: Option<String>, json: bool) -> Result<()> {
         &plan.repo_id,
     )?;
     if native_remote_bearer_token(&target.base_url).is_none() {
-        anyhow::bail!(
-            "no auth token available for {}; {}",
-            kin_remote::repository_transfer::redacted_remote_address(&target.base_url)
-                .unwrap_or_else(|| "that remote".to_string()),
-            kin_remote::repository_transfer::bearer_token_next_step(&target.base_url)
-        );
+        anyhow::bail!("{}", missing_bearer_token_message(&target.base_url));
     }
 
     let response = attach_native_remote_auth(
@@ -1022,9 +1031,9 @@ mod tests {
     use super::upsert_remote_config;
     use super::{
         ensure_git_remote, evaluate_push_plan, explicit_native_remote_target, format_push_decision,
-        map_to_remote_ref, native_remote_endpoint, resolve_native_remote_bearer_token_with,
-        resolve_native_remote_target, resolve_remote, workspace_branch_short_name,
-        NativeRemoteTarget, PushPlanContext,
+        map_to_remote_ref, missing_bearer_token_message, native_remote_endpoint,
+        resolve_native_remote_bearer_token_with, resolve_native_remote_target, resolve_remote,
+        workspace_branch_short_name, NativeRemoteTarget, PushPlanContext,
     };
     use kin_core::{
         GitBranchTrackingConfig, GitRemoteTransportConfig, KinConfig, RemoteHostKind,
@@ -1560,6 +1569,55 @@ mod tests {
         assert_eq!(
             target.repo_locator(),
             "https://kinlab.ai/api/orgs/demo/repos/kin"
+        );
+    }
+
+    /// The `None` arm of the redaction, graded where the two `kin remote`
+    /// pre-flights actually spend it.
+    ///
+    /// `redacted_remote_address` withholds a URL whose `@` sits outside the
+    /// authority, because it cannot tell a smuggled userinfo from an ordinary
+    /// path character. What this refusal does with that withholding is a CLI
+    /// decision, and it has exactly one wrong answer: printing the URL back.
+    #[test]
+    fn a_url_the_redaction_withholds_is_never_named_in_the_refusal() {
+        // The unencoded `/` ends the authority before the `@`, so this is the
+        // shape no redactor can parse and every one of these is a credential.
+        let message = missing_bearer_token_message("https://alice:s3cr3t/pw@kinlab.ai/org");
+        for (named, carried) in [
+            ("the password", "s3cr3t"),
+            ("the username", "alice"),
+            ("a host it could not vouch for", "kinlab.ai"),
+        ] {
+            assert!(
+                !message.contains(carried),
+                "the pre-flight refusal named {named} out of a URL the redaction withheld: \
+                 {message}"
+            );
+        }
+        assert!(
+            message.contains("no auth token available for that remote"),
+            "it must still say a remote refused, without naming one: {message}"
+        );
+    }
+
+    /// The positive control for the assertions above, in both directions: a
+    /// refusal that named nothing would pass every one of them, and a remote
+    /// whose URL parses must still be named in full.
+    #[test]
+    fn a_remote_the_redaction_can_parse_is_named_without_its_credentials() {
+        let message = missing_bearer_token_message("https://alice:s3cr3t@kinlab.ai/org?t=v#f");
+        assert!(
+            message.contains("no auth token available for https://kinlab.ai/org;"),
+            "a parseable remote must be named, path included: {message}"
+        );
+        assert!(
+            !message.contains("s3cr3t") && !message.contains("alice") && !message.contains("t=v"),
+            "and named without the credentials it carried: {message}"
+        );
+        assert!(
+            message.contains("KIN_REMOTE_BEARER_TOKEN=$(cat <peer>/.kin/daemon.token)"),
+            "the refusal must still carry the recipe that fixes it: {message}"
         );
     }
 

--- a/crates/kin-cli/src/commands/remote.rs
+++ b/crates/kin-cli/src/commands/remote.rs
@@ -598,7 +598,7 @@ pub async fn lease(
     if native_remote_bearer_token(&target.base_url).is_none() {
         anyhow::bail!(
             "no auth token available for {}; {}",
-            target.base_url,
+            kin_remote::repository_transfer::redacted_remote_address(&target.base_url),
             kin_remote::repository_transfer::bearer_token_next_step(&target.base_url)
         );
     }
@@ -976,7 +976,7 @@ pub async fn sessions(remote: Option<String>, json: bool) -> Result<()> {
     if native_remote_bearer_token(&target.base_url).is_none() {
         anyhow::bail!(
             "no auth token available for {}; {}",
-            target.base_url,
+            kin_remote::repository_transfer::redacted_remote_address(&target.base_url),
             kin_remote::repository_transfer::bearer_token_next_step(&target.base_url)
         );
     }

--- a/crates/kin-cli/tests/graph_section_after_transfer.rs
+++ b/crates/kin-cli/tests/graph_section_after_transfer.rs
@@ -1,0 +1,504 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! What the graph section reads after history arrives, or a base moves, any way
+//! other than a commit.
+//!
+//! A commit refreshes this replica's workspace base graph section, so a store
+//! that has only ever committed opens without folding its base out of history.
+//! Nothing else did. A fresh `kin clone` read `Graph section: absent`, and a
+//! store whose base a branch switch or a merge had moved read `present but
+//! refused (resolved_at)`, both naming `kin graph materialize` as the fix, so a
+//! stranger who did nothing unusual paid a full history fold at every open of a
+//! store they had just created. That is journey GAP-4's surviving half.
+//!
+//! The journey read the `resolved_at` refusal on an origin right after it
+//! received a push, and that attribution is wrong: kin-remote's
+//! `transfer_transaction` builds every received pack with
+//! `workspace_mutation: None`, so a receive moves a ref and never the receiver's
+//! own base. Measured here on `0b67c5048` at 2026-09-05T21:43Z, an origin that
+//! received a push still served its own base from its own section; what folded
+//! was the store whose base a branch switch had moved, which is what journey
+//! step 6 did before step 7 read it, and which is also what the product's own
+//! remedy for a workspace behind its ref asks a user to run.
+//!
+//! Every case here drives two real repository daemons through the product CLI
+//! and reads the product's own `kin graph status` line, because the state under
+//! test is a property of the store on disk rather than of any one process. The
+//! positive control that keeps the rest honest is
+//! [`a_committed_store_serves_its_workspace_base_from_a_section`]: the same
+//! assertion, on the one path that already refreshed.
+
+use std::fs;
+use std::path::Path;
+use std::process::Output;
+
+use serde_json::Value;
+use tempfile::tempdir;
+
+mod common;
+
+/// The prefix of the one `kin graph status` line this file is about.
+const SECTION_PREFIX: &str = "Graph section:";
+
+/// What the line says when an open serves the base from a persisted section.
+const SERVING: &str = "present and current at";
+
+fn require_success(output: Output) -> Output {
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn run(runtime: &common::IsolatedDaemonRuntime, repo: &Path, args: &[&str]) -> Output {
+    runtime
+        .kin_command()
+        .env("KIN_DAEMON_BIN", runtime.daemon_bin())
+        .env("KIN_DAEMON_DISABLE_LSP", "1")
+        .env("KIN_EMBED_BACKEND", "cpu")
+        .current_dir(repo)
+        .args(args)
+        .output()
+        .expect("run isolated Kin command")
+}
+
+/// The product's own `Graph section:` line, read from `kin graph status`.
+///
+/// Read off stdout rather than asserted on a successful exit, because
+/// `kin graph status` exits non-zero when it finds a critical graph health
+/// issue and the section line is printed either way. A missing line is the one
+/// thing that panics, and it panics with both streams, because a surface that
+/// fell silent about the state is the defect this whole module exists to catch.
+fn graph_section_line(runtime: &common::IsolatedDaemonRuntime, repo: &Path) -> String {
+    let output = run(runtime, repo, &["graph", "status"]);
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    stdout
+        .lines()
+        .find(|line| line.starts_with(SECTION_PREFIX))
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            panic!(
+                "kin graph status printed no `{SECTION_PREFIX}` line in {}\nstdout={stdout}\nstderr={}",
+                repo.display(),
+                String::from_utf8_lossy(&output.stderr)
+            )
+        })
+}
+
+fn assert_serving(line: &str, what: &str) {
+    assert!(
+        line.contains(SERVING),
+        "{what} must serve its workspace base from a persisted section, so no open of it folds \
+         history: {line}"
+    );
+}
+
+fn history(runtime: &common::IsolatedDaemonRuntime, repo: &Path) -> Value {
+    serde_json::from_slice(
+        &require_success(run(runtime, repo, &["log", "--json", "--count", "1"])).stdout,
+    )
+    .expect("history JSON")
+}
+
+/// The change this workspace's base resolves to, as the hex the section line
+/// prints.
+///
+/// `SemanticChangeId` wraps `Hash256`, which wraps `[u8; 32]`, and serde's
+/// newtype passthrough serializes all three as an array of 32 numbers rather
+/// than as a string. Its `Display` is `hex::encode`, so the hex has to be built
+/// here to compare against the line the product prints; reading the field with
+/// `as_str` reports every head as absent.
+fn base_change(runtime: &common::IsolatedDaemonRuntime, repo: &Path) -> String {
+    let report = history(runtime, repo);
+    let bytes = report["start_change"].as_array().unwrap_or_else(|| {
+        panic!(
+            "{} reports no workspace base change: {}",
+            repo.display(),
+            report["start_change"]
+        )
+    });
+    bytes
+        .iter()
+        .map(|byte| {
+            format!(
+                "{:02x}",
+                byte.as_u64().expect("a change id byte is a number")
+            )
+        })
+        .collect()
+}
+
+fn configure_author(repo: &Path) {
+    let path = repo.join(".kin/config.toml");
+    let mut config = kin_core::KinConfig::load_or_default(&path).unwrap();
+    config.default_author =
+        Some("Graph Section Transfer Test <graph-section@example.invalid>".to_string());
+    config.save(&path).unwrap();
+}
+
+fn initialize_source(runtime: &common::IsolatedDaemonRuntime, source: &Path) -> (String, String) {
+    fs::create_dir(source).unwrap();
+    let initialized = kin_core::init_replica(source, "trunk").unwrap();
+    let repository = initialized.repository_id.to_string();
+    drop(initialized);
+    configure_author(source);
+    fs::create_dir(source.join("src")).unwrap();
+    fs::write(source.join("src/lib.rs"), b"pub fn answer() -> u8 { 42 }\n").unwrap();
+    require_success(run(
+        runtime,
+        source,
+        &["commit", "-m", "Add a native source body"],
+    ));
+    let port = fs::read_to_string(source.join(".kin/daemon.port")).unwrap();
+    (repository, format!("http://127.0.0.1:{}", port.trim()))
+}
+
+fn clone_from(
+    runtime: &common::IsolatedDaemonRuntime,
+    parent: &Path,
+    destination: &Path,
+    source: &Path,
+    endpoint: &str,
+    repository: &str,
+) -> Output {
+    let token = fs::read_to_string(source.join(".kin/daemon.token")).unwrap();
+    runtime
+        .kin_command()
+        .env("KIN_DAEMON_BIN", runtime.daemon_bin())
+        .env("KIN_DAEMON_DISABLE_LSP", "1")
+        .env("KIN_EMBED_BACKEND", "cpu")
+        .fixture_remote_bearer_token(token.trim())
+        .current_dir(parent)
+        .args(["clone", endpoint, "--repository", repository])
+        .arg(destination)
+        .output()
+        .expect("clone native repository")
+}
+
+fn transfer(
+    runtime: &common::IsolatedDaemonRuntime,
+    destination: &Path,
+    source: &Path,
+    verb: &str,
+) {
+    let token = fs::read_to_string(source.join(".kin/daemon.token")).unwrap();
+    require_success(
+        runtime
+            .kin_command()
+            .env("KIN_DAEMON_BIN", runtime.daemon_bin())
+            .env("KIN_DAEMON_DISABLE_LSP", "1")
+            .env("KIN_EMBED_BACKEND", "cpu")
+            .fixture_remote_bearer_token(token.trim())
+            .current_dir(destination)
+            .arg(verb)
+            .output()
+            .expect("transfer native repository"),
+    );
+}
+
+/// One commit in a replica, so it has a head of its own to push.
+fn commit_in_clone(runtime: &common::IsolatedDaemonRuntime, destination: &Path) {
+    configure_author(destination);
+    fs::write(
+        destination.join("src/added.rs"),
+        b"pub fn introduced() -> bool { true }\n",
+    )
+    .unwrap();
+    require_success(run(
+        runtime,
+        destination,
+        &["commit", "-m", "Publish a native artifact from the clone"],
+    ));
+}
+
+/// The control that keeps every case below honest.
+///
+/// A store that has only committed already reads `present and current`, because
+/// the commit path refreshes the section. If this ever goes red the assertion
+/// itself is broken, not the transfer paths, and every other case in this file
+/// is measuring nothing.
+#[test]
+fn a_committed_store_serves_its_workspace_base_from_a_section() {
+    let scratch = tempdir().unwrap();
+    let source = scratch.path().join("source");
+    let source_runtime = common::IsolatedDaemonRuntime::new(&source);
+    initialize_source(&source_runtime, &source);
+    assert_serving(
+        &graph_section_line(&source_runtime, &source),
+        "a store whose own commit refreshed its section",
+    );
+}
+
+/// A stranger's first act on a peer's repository must not leave a store that
+/// folds its whole base out of history at every open.
+#[test]
+fn a_fresh_clone_serves_its_workspace_base_from_a_section() {
+    let scratch = tempdir().unwrap();
+    let source = scratch.path().join("source");
+    let destination = scratch.path().join("replica");
+    let source_runtime = common::IsolatedDaemonRuntime::new(&source);
+    let clone_runtime = common::IsolatedDaemonRuntime::new(&destination);
+    let (repository, endpoint) = initialize_source(&source_runtime, &source);
+    require_success(clone_from(
+        &clone_runtime,
+        scratch.path(),
+        &destination,
+        &source,
+        &endpoint,
+        &repository,
+    ));
+    assert_serving(
+        &graph_section_line(&clone_runtime, &destination),
+        "a fresh native clone",
+    );
+}
+
+/// The section a clone leaves has to be on disk, not in the process that wrote
+/// it. A daemon restart is the ordinary case: it happens more often than a
+/// person commits, and a store whose acceleration does not survive one pays the
+/// fold at every open exactly as if nothing had been written.
+#[test]
+fn a_cold_reopen_of_a_fresh_clone_still_serves_from_its_section() {
+    let scratch = tempdir().unwrap();
+    let source = scratch.path().join("source");
+    let destination = scratch.path().join("replica");
+    let source_runtime = common::IsolatedDaemonRuntime::new(&source);
+    let clone_runtime = common::IsolatedDaemonRuntime::new(&destination);
+    let (repository, endpoint) = initialize_source(&source_runtime, &source);
+    require_success(clone_from(
+        &clone_runtime,
+        scratch.path(),
+        &destination,
+        &source,
+        &endpoint,
+        &repository,
+    ));
+    require_success(run(&clone_runtime, &destination, &["daemon", "stop"]));
+    assert_serving(
+        &graph_section_line(&clone_runtime, &destination),
+        "a fresh native clone reopened by a new daemon",
+    );
+}
+
+/// A pull is the other way history reaches a replica that did not author it,
+/// and it lands through the daemon's receive path rather than through the
+/// bootstrap a clone takes, so it is its own case.
+#[test]
+fn a_replica_that_pulled_serves_its_workspace_base_from_a_section() {
+    let scratch = tempdir().unwrap();
+    let source = scratch.path().join("source");
+    let destination = scratch.path().join("replica");
+    let source_runtime = common::IsolatedDaemonRuntime::new(&source);
+    let clone_runtime = common::IsolatedDaemonRuntime::new(&destination);
+    let (repository, endpoint) = initialize_source(&source_runtime, &source);
+    require_success(clone_from(
+        &clone_runtime,
+        scratch.path(),
+        &destination,
+        &source,
+        &endpoint,
+        &repository,
+    ));
+    fs::write(source.join("src/lib.rs"), b"pub fn answer() -> u8 { 43 }\n").unwrap();
+    require_success(run(
+        &source_runtime,
+        &source,
+        &["commit", "-m", "Advance the origin past the clone"],
+    ));
+    let pulled = base_change(&source_runtime, &source);
+    transfer(&clone_runtime, &destination, &source, "pull");
+    let line = graph_section_line(&clone_runtime, &destination);
+    assert_serving(&line, "a replica that pulled new history");
+    assert!(
+        line.contains(&pulled),
+        "the section must describe the head the pull admitted ({pulled}): {line}"
+    );
+}
+
+/// An origin that received a push must not be the one store in the round trip
+/// that folds, and after this the section it serves must still be its OWN base.
+///
+/// A received transfer moves a ref and nothing else: kin-remote's
+/// `transfer_transaction` builds every pack's transaction with
+/// `workspace_mutation: None`, so the receiver's workspace stays where it was
+/// and the section its last commit wrote still answers for it. Measured on
+/// `0b67c5048` at 2026-09-05T21:43Z, this case was already green, which is why
+/// it is stated as the regression guard it is rather than as a defect: a
+/// post-receive refresh that wrote a section at the RECEIVED head would be
+/// writing one kin-db then refuses for this workspace, turning a store that
+/// serves into a store that folds.
+#[test]
+fn an_origin_that_received_a_push_still_serves_its_own_workspace_base() {
+    let scratch = tempdir().unwrap();
+    let source = scratch.path().join("source");
+    let destination = scratch.path().join("replica");
+    let source_runtime = common::IsolatedDaemonRuntime::new(&source);
+    let clone_runtime = common::IsolatedDaemonRuntime::new(&destination);
+    let (repository, endpoint) = initialize_source(&source_runtime, &source);
+    let origins_own_base = base_change(&source_runtime, &source);
+    require_success(clone_from(
+        &clone_runtime,
+        scratch.path(),
+        &destination,
+        &source,
+        &endpoint,
+        &repository,
+    ));
+    commit_in_clone(&clone_runtime, &destination);
+    transfer(&clone_runtime, &destination, &source, "push");
+    let line = graph_section_line(&source_runtime, &source);
+    assert_serving(&line, "an origin that received a push");
+    assert!(
+        line.contains(&origins_own_base),
+        "and the section must still answer for the origin's own base \
+         ({origins_own_base}), which the push did not move: {line}"
+    );
+}
+
+/// The received-head test, taken at the point the head actually reaches this
+/// workspace.
+///
+/// A push leaves the origin's working tree behind its own ref, and `kin status`
+/// says so and prints `kin branch switch <ref>` as the remedy. That switch is
+/// what moves this workspace onto the delivered head, and until now nothing
+/// refreshed the section afterwards, so following the product's own advice
+/// turned a store that served into one that folds. A section that names the
+/// wrong change is refused by kin-db exactly as an absent one is, so this
+/// asserts the change by name rather than only the word `present`.
+#[test]
+fn the_section_an_origin_serves_names_the_head_the_push_delivered() {
+    let scratch = tempdir().unwrap();
+    let source = scratch.path().join("source");
+    let destination = scratch.path().join("replica");
+    let source_runtime = common::IsolatedDaemonRuntime::new(&source);
+    let clone_runtime = common::IsolatedDaemonRuntime::new(&destination);
+    let (repository, endpoint) = initialize_source(&source_runtime, &source);
+    let before_push = base_change(&source_runtime, &source);
+    require_success(clone_from(
+        &clone_runtime,
+        scratch.path(),
+        &destination,
+        &source,
+        &endpoint,
+        &repository,
+    ));
+    commit_in_clone(&clone_runtime, &destination);
+    let delivered = base_change(&clone_runtime, &destination);
+    assert_ne!(
+        delivered, before_push,
+        "the push must deliver a head the origin did not already hold"
+    );
+    transfer(&clone_runtime, &destination, &source, "push");
+    require_success(run(
+        &source_runtime,
+        &source,
+        &["branch", "switch", "trunk"],
+    ));
+    let line = graph_section_line(&source_runtime, &source);
+    assert_serving(&line, "an origin that followed the ref a push moved");
+    assert!(
+        line.contains(&delivered),
+        "the section must describe the head the push delivered ({delivered}): {line}"
+    );
+    assert!(
+        !line.contains(&before_push),
+        "and not the head the origin held before it ({before_push}): {line}"
+    );
+}
+
+/// Truthfulness, which is the other half of never being fatal.
+///
+/// A clone of a repository with no history has no base to memoize, so there is
+/// nothing for any refresh to write. The surface must say that, in kin-db's own
+/// vocabulary, rather than report the `present and current` that a refresh
+/// which reported its own intention rather than reading the store would print.
+#[test]
+fn a_clone_with_no_base_reports_the_state_it_is_in_rather_than_a_section() {
+    let scratch = tempdir().unwrap();
+    let source = scratch.path().join("source");
+    let destination = scratch.path().join("replica");
+    fs::create_dir(&source).unwrap();
+    let initialized = kin_core::init_replica(&source, "trunk").unwrap();
+    let repository = initialized.repository_id.to_string();
+    drop(initialized);
+    configure_author(&source);
+    let source_runtime = common::IsolatedDaemonRuntime::new(&source);
+    let clone_runtime = common::IsolatedDaemonRuntime::new(&destination);
+    require_success(run(&source_runtime, &source, &["admit"]));
+    let port = fs::read_to_string(source.join(".kin/daemon.port")).unwrap();
+    let endpoint = format!("http://127.0.0.1:{}", port.trim());
+    require_success(clone_from(
+        &clone_runtime,
+        scratch.path(),
+        &destination,
+        &source,
+        &endpoint,
+        &repository,
+    ));
+    let line = graph_section_line(&clone_runtime, &destination);
+    assert!(
+        line.contains("names no base target"),
+        "a replica with no history must report that it has no base rather than claim a section: \
+         {line}"
+    );
+    assert!(
+        !line.contains(SERVING),
+        "and must never claim to serve a base it does not have: {line}"
+    );
+}
+
+/// The journey read the origin's `resolved_at` refusal after a received push,
+/// but a received transfer carries `workspace_mutation: None`, so it moves a ref
+/// and never the receiver's own base. What moves a base without committing is a
+/// workspace transition, and this walks the ones journey step 6 walked: a branch
+/// created, switched onto, committed on, switched away from, and merged back.
+///
+/// Each step names itself, so a red run says which transition left the section
+/// behind rather than only that one did.
+#[test]
+fn every_workspace_transition_leaves_a_section_serving_the_base_it_moved_to() {
+    let scratch = tempdir().unwrap();
+    let source = scratch.path().join("source");
+    let runtime = common::IsolatedDaemonRuntime::new(&source);
+    initialize_source(&runtime, &source);
+    assert_serving(&graph_section_line(&runtime, &source), "after the commit");
+
+    require_success(run(&runtime, &source, &["branch", "create", "feature"]));
+    assert_serving(
+        &graph_section_line(&runtime, &source),
+        "after `kin branch create`",
+    );
+
+    require_success(run(&runtime, &source, &["branch", "switch", "feature"]));
+    assert_serving(
+        &graph_section_line(&runtime, &source),
+        "after `kin branch switch feature`",
+    );
+
+    fs::write(source.join("src/lib.rs"), b"pub fn answer() -> u8 { 41 }\n").unwrap();
+    require_success(run(
+        &runtime,
+        &source,
+        &["commit", "-m", "Edit the answer on a branch"],
+    ));
+    assert_serving(
+        &graph_section_line(&runtime, &source),
+        "after committing on the branch",
+    );
+
+    require_success(run(&runtime, &source, &["branch", "switch", "trunk"]));
+    assert_serving(
+        &graph_section_line(&runtime, &source),
+        "after switching back to the default branch",
+    );
+
+    require_success(run(&runtime, &source, &["merge", "feature"]));
+    assert_serving(
+        &graph_section_line(&runtime, &source),
+        "after merging the branch back",
+    );
+}

--- a/crates/kin-cli/tests/graph_section_after_transfer.rs
+++ b/crates/kin-cli/tests/graph_section_after_transfer.rs
@@ -16,8 +16,8 @@
 //! received a push, and that attribution is wrong: kin-remote's
 //! `transfer_transaction` builds every received pack with
 //! `workspace_mutation: None`, so a receive moves a ref and never the receiver's
-//! own base. Measured here on `0b67c5048` at 2026-09-05T21:43Z, an origin that
-//! received a push still served its own base from its own section; what folded
+//! own base. An origin that received a push was measured serving its own base
+//! from its own section before this change landed; what folded
 //! was the store whose base a branch switch had moved, which is what journey
 //! step 6 did before step 7 read it, and which is also what the product's own
 //! remedy for a workspace behind its ref asks a user to run.
@@ -325,9 +325,9 @@ fn a_replica_that_pulled_serves_its_workspace_base_from_a_section() {
 /// A received transfer moves a ref and nothing else: kin-remote's
 /// `transfer_transaction` builds every pack's transaction with
 /// `workspace_mutation: None`, so the receiver's workspace stays where it was
-/// and the section its last commit wrote still answers for it. Measured on
-/// `0b67c5048` at 2026-09-05T21:43Z, this case was already green, which is why
-/// it is stated as the regression guard it is rather than as a defect: a
+/// and the section its last commit wrote still answers for it. This case was
+/// measured already green before the change this file guards, which is why it
+/// is stated as the regression guard it is rather than as a defect: a
 /// post-receive refresh that wrote a section at the RECEIVED head would be
 /// writing one kin-db then refuses for this workspace, turning a store that
 /// serves into a store that folds.

--- a/crates/kin-daemon/src/repository_branch.rs
+++ b/crates/kin-daemon/src/repository_branch.rs
@@ -451,6 +451,41 @@ where
         state.invalidate_projection();
     }
 
+    // The freeze this transition committed under is an EXCLUSIVE cross-process
+    // lease over the repository's storage lock, held until it is dropped, and
+    // the graph-section writer takes that same lock. Refreshing while it is
+    // alive is a command waiting on itself: measured, `kin branch switch` and a
+    // pull's workspace follow both hung for the harness's full 180 second
+    // budget. Everything above has already read what it needs from the freeze,
+    // so it is released here rather than at the end of the function.
+    drop(execution.authority_freeze);
+
+    // A switch and a follow both move this workspace's base, and until now
+    // nothing refreshed the graph section afterwards, so every later open of the
+    // store folded the new base out of history until somebody ran
+    // `kin graph materialize`. That is where journey GAP-4's surviving
+    // `resolved_at` refusal actually came from: a pull's follow of a moved ref
+    // reaches here, and so does the branch switch the product itself prints as
+    // the remedy for a workspace behind its ref.
+    //
+    // Runs for a create and a delete too. Neither moves a base, so the writer
+    // finds the section already valid and returns `AlreadyCurrent` without a
+    // durable write; a rule per request kind would cost a reader more than it
+    // saves. Still under the persistence and graph-authority gates the
+    // transition ran under, so nothing moves the base between the two.
+    //
+    // Never fatal, for the reason the commit path gives: the transition is
+    // durable and receipted, and a memoization that did not persist is a slower
+    // next open rather than a failed command. What the surface reports is read
+    // from the store by `kin_core::graph_section::read`, never from this call,
+    // so a refresh that failed is disclosed as the refusal it left behind.
+    crate::repository_commit::refresh_workspace_base_graph_section(
+        &authority.manager,
+        &authority.repository_id,
+        authority.workspace_id,
+        "workspace transition",
+    );
+
     drop(persistence);
     drop(graph_mutation);
     Ok(execution.response)

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -2139,10 +2139,21 @@ pub(crate) fn commit_native_plan(
 /// transaction above is durable and the change is committed; a memoization that
 /// did not persist is a slower next open, not a failed commit, and turning one
 /// into the other would be a strictly worse product than the row this fixes.
-fn refresh_workspace_base_graph_section(
+/// `transition` names the local repository operation that moved the base, so a
+/// log line says which one paid for the refresh. A commit is not the only such
+/// operation: a branch switch, a pull's follow of a moved ref and a merge all
+/// move the workspace base without committing through this module, and every
+/// one of them left a section behind that kin-db then refuses. Journey GAP-4
+/// read that refusal on an origin right after it received a push, which is the
+/// one transfer that does NOT move a base: a received pack carries
+/// `workspace_mutation: None` (`kin-remote`'s `transfer_transaction`), so the
+/// staleness the journey saw came from the branch switches and the merge that
+/// preceded it.
+pub(crate) fn refresh_workspace_base_graph_section(
     authority: &RepositoryAuthorityManager<LocalFileBackend>,
     repository_id: &kin_model::RepositoryId,
     workspace_id: WorkspaceId,
+    transition: &'static str,
 ) {
     let changes_in_store = authority.read_authority().snapshot().changes.len();
     let started = std::time::Instant::now();
@@ -2154,22 +2165,25 @@ fn refresh_workspace_base_graph_section(
         Ok(Some(outcome)) => tracing::info!(
             repository = %repository_id,
             workspace = %workspace_id,
+            transition,
             changes_in_store,
             elapsed_ms,
             outcome = ?outcome,
-            "refreshed the workspace base graph section after a native commit"
+            "refreshed the workspace base graph section after a local repository transition"
         ),
         Ok(None) => tracing::info!(
             repository = %repository_id,
             workspace = %workspace_id,
+            transition,
             "no workspace to refresh a graph section for"
         ),
         Err(error) => tracing::warn!(
             repository = %repository_id,
             workspace = %workspace_id,
+            transition,
             elapsed_ms,
             %error,
-            "the workspace base graph section did not persist after this commit, so the next \
+            "the workspace base graph section did not persist after this transition, so the next \
              open folds this base out of history; `kin graph materialize` writes one"
         ),
     }
@@ -2375,6 +2389,7 @@ fn commit_native_plan_with_working_copy_proof(
         &authority,
         &repository_id,
         authority_context.workspace_id(),
+        "native commit",
     );
     Ok(NativeCommitResult {
         change: plan.change,

--- a/crates/kin-daemon/src/repository_merge.rs
+++ b/crates/kin-daemon/src/repository_merge.rs
@@ -359,6 +359,30 @@ pub(crate) fn execute(
         execution.response.lines.extend(settle_merged_graph(state));
     }
 
+    // The freeze this merge committed under is an EXCLUSIVE cross-process lease
+    // over the repository's storage lock, and the graph-section writer takes
+    // that same lock, so it is released before the refresh rather than at the
+    // end of the function. Holding it across the refresh is a command waiting on
+    // itself.
+    drop(execution.authority_freeze);
+
+    // A merge moves this workspace's base exactly as a commit does, and it
+    // publishes through this module rather than through the commit path that
+    // refreshes the section, so before this a fast-forward or a settled merge
+    // left every later open folding the new base out of history. Same rule as
+    // the commit and the workspace transition: idempotent, run under the gates
+    // the merge already holds, and never fatal, because the merge is durable and
+    // a memoization that did not persist is a slower next open.
+    //
+    // A parked merge reaches here too and moves no base, so the writer finds the
+    // section valid and returns `AlreadyCurrent` with no durable write.
+    crate::repository_commit::refresh_workspace_base_graph_section(
+        &authority.manager,
+        &authority.repository_id,
+        authority.workspace_id,
+        "merge",
+    );
+
     drop(persistence);
     drop(graph_mutation);
     Ok(execution.response)

--- a/crates/kin-remote/src/repository_transfer.rs
+++ b/crates/kin-remote/src/repository_transfer.rs
@@ -259,7 +259,16 @@ pub fn bearer_token_next_step(base_url: &str) -> String {
 /// character. A redactor cannot tell them apart, so it must not guess. An `@`
 /// at or after the authority's end means this is not a well-formed URL, and
 /// this returns `None` rather than vouch for a host that may be a password
-/// fragment. Callers say so instead of printing an address.
+/// fragment. Callers say so instead of printing an address. An authority that
+/// ends up empty, which is every degenerate string down to `""`, is withheld by
+/// the same rule: an empty host is not an address, and rendering one would put
+/// nothing where the remote's name belongs.
+///
+/// That cost is wider than a path. `https://kinlab.ai/org?redirect=a@b` and the
+/// same `@` in a fragment are withheld too, because the rule reads the whole
+/// string past the authority and cannot tell those from a userinfo either.
+/// Three URL parts rather than one, and still the right trade, because none of
+/// them is part of the endpoint a remote base URL actually is.
 ///
 /// Hand-written rather than parsed, and that is not a shortcut: a lenient
 /// parser resolves `https://alice:pa/ss@kinlab.ai/org` to host `pa`, which is
@@ -286,6 +295,12 @@ pub fn redacted_remote_address(base_url: &str) -> Option<String> {
         Some(at) => authority_start + at + 1,
         None => authority_start,
     };
+    // Nothing left to name. `""`, `"@"`, `"://"` and `"://@"` all land here and
+    // would otherwise render as `Some("")` or `Some("://")`, which reads in a
+    // refusal as "the remote at  accepts".
+    if trimmed[host_start..authority_end].is_empty() {
+        return None;
+    }
     let kept = format!("{}{}", &trimmed[..authority_start], &trimmed[host_start..]);
     // Query and fragment last, over a string that no longer carries a userinfo.
     Some(match kept.find(['?', '#']) {
@@ -5151,8 +5166,8 @@ mod bearer_token_next_step_tests {
     fn the_next_step_keeps_the_address_a_reader_has_to_act_on() {
         let message = bearer_token_next_step(CREDENTIAL_BEARING);
         assert!(
-            message.contains("https://kinlab.example"),
-            "the remedy must still name which remote refused: {message}"
+            message.contains("https://kinlab.example/base"),
+            "the remedy must still name which remote refused, path included: {message}"
         );
     }
 
@@ -5252,6 +5267,30 @@ mod redacted_remote_address_tests {
         );
     }
 
+    /// A string with nothing where a host belongs takes the `None` arm too.
+    ///
+    /// These reached the end of the function and rendered as `Some("")` and
+    /// `Some("://")`, so a refusal built from one read "the remote at  accepts"
+    /// or "the remote at :// accepts". Neither is an address, and this
+    /// function's own rule is that what it cannot vouch for is withheld rather
+    /// than rendered.
+    #[test]
+    fn a_string_with_no_host_is_withheld_rather_than_rendered_as_an_empty_address() {
+        for input in ["", "   ", "@", "://", "://@", "https://", "https://@/org"] {
+            assert_eq!(
+                redacted_remote_address(input),
+                None,
+                "{input:?} names no host, so it must be withheld"
+            );
+        }
+        // The positive control: the shortest real address still resolves, so
+        // the rule above cannot be satisfied by withholding everything.
+        assert_eq!(
+            redacted_remote_address("https://a").as_deref(),
+            Some("https://a")
+        );
+    }
+
     /// The property, stated once over every shape above: nothing a caller could
     /// have put a secret in survives.
     #[test]
@@ -5269,6 +5308,14 @@ mod redacted_remote_address_tests {
                 "userinfo and a fragment with no scheme",
                 "alice:s3cr3t@kinlab.ai#t0ken",
             ),
+            (
+                "a userinfo carrying an unencoded slash",
+                "https://alice:s3cr3t/pw@kinlab.ai/org",
+            ),
+            (
+                "a userinfo carrying an unencoded question mark",
+                "https://alice:s3cr3t?pw@kinlab.ai/org",
+            ),
         ] {
             // Withholding is a pass here and the reason is the point: for the
             // two unencoded-delimiter shapes there is no host this can name
@@ -5280,7 +5327,6 @@ mod redacted_remote_address_tests {
             assert!(
                 !redacted.contains("s3cr3t")
                     && !redacted.contains("t0ken")
-                    && !redacted.contains("pa/ss")
                     && !redacted.contains("alice"),
                 "{case}: a credential survived redaction"
             );

--- a/crates/kin-remote/src/repository_transfer.rs
+++ b/crates/kin-remote/src/repository_transfer.rs
@@ -5068,22 +5068,36 @@ mod bearer_token_next_step_tests {
     const CREDENTIAL_BEARING: &str =
         "https://alice:s3cr3tpassw0rd@kinlab.example/base?access_token=t0kenvalue#frag";
 
+    /// Every credential that URL carries, each paired with the name the failure
+    /// text uses for it.
+    ///
+    /// The failure text names the credential and never interpolates its value,
+    /// and that is the point rather than a style choice: a test proving the
+    /// product does not echo a credential must not echo one itself, and a
+    /// format string carrying this value is a logging sink to any reader and to
+    /// CodeQL's `rust/cleartext-logging` alike, panic message or not. Which
+    /// credential leaked plus the function's name is the whole diagnosis; the
+    /// value adds nothing a maintainer does not already have in this table.
+    const CARRIED_CREDENTIALS: [(&str, &str); 4] = [
+        ("the password", "s3cr3tpassw0rd"),
+        ("the query token", "t0kenvalue"),
+        ("the username", "alice:"),
+        ("the query that carried a token", "access_token"),
+    ];
+
     /// The refusal is the one place a stranger reads a whole URL back, so it is
     /// the one place a credential typed into a remote config gets copied into a
     /// terminal, a bug report and a shell history.
     #[test]
     fn the_next_step_never_echoes_a_credential_from_the_url_it_names() {
         let message = bearer_token_next_step(CREDENTIAL_BEARING);
-        for secret in ["s3cr3tpassw0rd", "t0kenvalue", "alice:"] {
+        for (named, carried) in CARRIED_CREDENTIALS {
             assert!(
-                !message.contains(secret),
-                "the remedy echoed {secret} out of the remote URL: {message}"
+                !message.contains(carried),
+                "bearer_token_next_step echoed {named} out of the remote URL it named; it must \
+                 strip userinfo, query and fragment"
             );
         }
-        assert!(
-            !message.contains("access_token"),
-            "and must not echo the query that carried one: {message}"
-        );
     }
 
     /// The positive control for the assertions above: a message that redacted
@@ -5167,23 +5181,32 @@ mod redacted_remote_address_tests {
     /// have put a secret in survives.
     #[test]
     fn no_userinfo_query_or_fragment_survives_redaction() {
-        for input in [
-            "https://alice:s3cr3t@kinlab.ai/org?access_token=t0ken#frag",
-            "http://s3cr3t@127.0.0.1:53848?t0ken=1",
-            "alice:s3cr3t@kinlab.ai#t0ken",
+        for (case, input) in [
+            (
+                "userinfo, query and fragment together",
+                "https://alice:s3cr3t@kinlab.ai/org?access_token=t0ken#frag",
+            ),
+            (
+                "userinfo and a query on a loopback peer",
+                "http://s3cr3t@127.0.0.1:53848?t0ken=1",
+            ),
+            (
+                "userinfo and a fragment with no scheme",
+                "alice:s3cr3t@kinlab.ai#t0ken",
+            ),
         ] {
             let redacted = redacted_remote_address(input);
             assert!(
                 !redacted.contains("s3cr3t") && !redacted.contains("t0ken"),
-                "{input} redacted to {redacted}"
+                "{case}: a credential survived redaction"
             );
             assert!(
                 !redacted.contains('?') && !redacted.contains('#'),
-                "{input} redacted to {redacted}"
+                "{case}: a query or fragment survived redaction"
             );
             assert!(
                 redacted.contains("kinlab.ai") || redacted.contains("127.0.0.1"),
-                "the host a reader acts on must survive: {input} redacted to {redacted}"
+                "{case}: the host a reader acts on must survive redaction"
             );
         }
     }

--- a/crates/kin-remote/src/repository_transfer.rs
+++ b/crates/kin-remote/src/repository_transfer.rs
@@ -205,12 +205,66 @@ pub enum RepositoryTransferError {
 /// times with no next step; the token that peer accepts was in its
 /// repository's `.kin/daemon.token` the whole time, and this names it.
 pub fn bearer_token_next_step(base_url: &str) -> String {
+    let address = redacted_remote_address(base_url);
+    let carried = if address == base_url.trim() {
+        ""
+    } else {
+        ". The address above is that remote without the credentials its URL carried, because Kin \
+         sends the token from the environment rather than from the URL"
+    };
     format!(
-        "send a bearer token the remote at {base_url} accepts: for a peer daemon on this \
+        "send a bearer token the remote at {address} accepts: for a peer daemon on this \
          machine, set KIN_REMOTE_BEARER_TOKEN=$(cat <peer>/.kin/daemon.token) where <peer> is \
          that repository's working directory; for KinLab, run `kin auth login --base-url \
-         {base_url}` or set KIN_REMOTE_BEARER_TOKEN to a KinLab token"
+         {address}` or set KIN_REMOTE_BEARER_TOKEN to a KinLab token{carried}"
     )
+}
+
+/// One remote's address with everything secret-bearing removed: the scheme,
+/// host, port and path a reader has to act on, and nothing else.
+///
+/// A refusal is the one place a stranger reads a whole remote URL back, so it
+/// is the one place a credential typed into a remote config is copied into a
+/// terminal, a bug report and a shell history. Three URL parts can carry one:
+/// the userinfo before `@`, the query, and the fragment. None of them is part
+/// of the address a caller needs, and Kin never authenticates from any of them,
+/// so all three go.
+///
+/// The address itself stays. A message that named no remote at all would leak
+/// nothing and help nobody: a stranger with two accounts could not tell which
+/// peer refused them.
+///
+/// Hand-written rather than parsed, because this must answer for a string that
+/// is not a valid URL as safely as for one that is. A parser would have to
+/// choose between returning the input unchanged, which is the leak, and
+/// returning nothing, which is the useless message above. Cutting on the
+/// delimiters does neither: an unparseable string still loses its query, its
+/// fragment and its userinfo.
+pub fn redacted_remote_address(base_url: &str) -> String {
+    let trimmed = base_url.trim();
+    // Query and fragment first, so a userinfo scan can never run over one. A
+    // raw `?` or `#` cannot appear inside userinfo or a host; both are
+    // percent-encoded there.
+    let addressed = trimmed
+        .find(['?', '#'])
+        .map_or(trimmed, |cut| &trimmed[..cut]);
+    // The authority is what lies between the scheme and the path. A string with
+    // no scheme is treated as bare authority rather than skipped, so a
+    // malformed remote loses its userinfo too.
+    let authority_start = addressed.find("://").map_or(0, |scheme_end| scheme_end + 3);
+    let authority_end = addressed[authority_start..]
+        .find('/')
+        .map_or(addressed.len(), |offset| authority_start + offset);
+    // The LAST `@`, because a password may itself contain an encoded one and the
+    // authority ends at the final separator.
+    match addressed[authority_start..authority_end].rfind('@') {
+        Some(at) => format!(
+            "{}{}",
+            &addressed[..authority_start],
+            &addressed[authority_start + at + 1..]
+        ),
+        None => addressed.to_string(),
+    }
 }
 
 pub type Result<T> = std::result::Result<T, RepositoryTransferError>;
@@ -4996,6 +5050,141 @@ mod tests {
                 RepositoryTransferApplyOutcome::IdempotentReplay
             );
             assert_eq!(calls.get(), 1, "the replay re-ran the policy");
+        }
+    }
+}
+
+#[cfg(test)]
+mod bearer_token_next_step_tests {
+    use super::bearer_token_next_step;
+
+    /// A remote whose locator carries every credential shape a URL can hold.
+    ///
+    /// `kin clone` refuses one of these at its own boundary, but this function
+    /// is not reached only from clone: the 401 arm of the HTTP transport and
+    /// two `kin remote` pre-flights build the same sentence from a configured
+    /// remote's URL, and nothing between a config file and this format string
+    /// strips anything.
+    const CREDENTIAL_BEARING: &str =
+        "https://alice:s3cr3tpassw0rd@kinlab.example/base?access_token=t0kenvalue#frag";
+
+    /// The refusal is the one place a stranger reads a whole URL back, so it is
+    /// the one place a credential typed into a remote config gets copied into a
+    /// terminal, a bug report and a shell history.
+    #[test]
+    fn the_next_step_never_echoes_a_credential_from_the_url_it_names() {
+        let message = bearer_token_next_step(CREDENTIAL_BEARING);
+        for secret in ["s3cr3tpassw0rd", "t0kenvalue", "alice:"] {
+            assert!(
+                !message.contains(secret),
+                "the remedy echoed {secret} out of the remote URL: {message}"
+            );
+        }
+        assert!(
+            !message.contains("access_token"),
+            "and must not echo the query that carried one: {message}"
+        );
+    }
+
+    /// The positive control for the assertions above: a message that redacted
+    /// everything, including the recipe, would pass all of them and help nobody.
+    #[test]
+    fn the_next_step_still_names_the_environment_variable_and_its_recipe() {
+        let message = bearer_token_next_step(CREDENTIAL_BEARING);
+        assert!(
+            message.contains("KIN_REMOTE_BEARER_TOKEN=$(cat <peer>/.kin/daemon.token)"),
+            "the remedy must still name the token a same-machine peer accepts: {message}"
+        );
+        assert!(
+            message.contains("kin auth login --base-url"),
+            "and still name the hosted alternative: {message}"
+        );
+    }
+
+    /// The redaction may not cost a reader the address they have to act on.
+    ///
+    /// A message that named no remote at all would pass the negative above and
+    /// leave a stranger with two accounts and no way to tell which peer refused
+    /// them, so the scheme, host and port survive and only the credentials go.
+    #[test]
+    fn the_next_step_keeps_the_address_a_reader_has_to_act_on() {
+        let message = bearer_token_next_step(CREDENTIAL_BEARING);
+        assert!(
+            message.contains("https://kinlab.example/"),
+            "the remedy must still name which remote refused: {message}"
+        );
+    }
+
+    /// An ordinary loopback peer, which is the shape the journey met, must read
+    /// exactly as it did before. Redaction that rewrote a clean URL would break
+    /// the one command a stranger copies.
+    #[test]
+    fn a_peer_url_with_no_credentials_is_named_unchanged() {
+        let message = bearer_token_next_step("http://127.0.0.1:53848");
+        assert!(
+            message.contains("the remote at http://127.0.0.1:53848 accepts"),
+            "a clean peer endpoint must be named verbatim: {message}"
+        );
+        assert!(
+            message.contains("kin auth login --base-url http://127.0.0.1:53848"),
+            "including in the hosted alternative: {message}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod redacted_remote_address_tests {
+    use super::redacted_remote_address;
+
+    /// The address a caller acts on survives every part that can carry a
+    /// secret, and only those parts go.
+    #[test]
+    fn only_the_secret_bearing_parts_of_a_url_are_removed() {
+        for (input, expected) in [
+            ("http://127.0.0.1:53848", "http://127.0.0.1:53848"),
+            ("https://kinlab.ai/org/repo", "https://kinlab.ai/org/repo"),
+            ("https://user:pw@kinlab.ai/org", "https://kinlab.ai/org"),
+            ("https://token@kinlab.ai", "https://kinlab.ai"),
+            (
+                "https://kinlab.ai/org?access_token=v",
+                "https://kinlab.ai/org",
+            ),
+            ("https://kinlab.ai/org#tok", "https://kinlab.ai/org"),
+            ("https://u:p@kinlab.ai/org?t=v#f", "https://kinlab.ai/org"),
+            // A path that carries an `@` is a path, not userinfo, and a reader
+            // needs it: the authority ends at the first `/`.
+            ("https://kinlab.ai/a@b", "https://kinlab.ai/a@b"),
+            // Not a URL at all. A parser would hand this back untouched, which
+            // is the leak; the delimiters still say where the secret was.
+            ("u:p@kinlab.ai/org?t=v", "kinlab.ai/org"),
+            ("  https://kinlab.ai  ", "https://kinlab.ai"),
+        ] {
+            assert_eq!(redacted_remote_address(input), expected, "for {input}");
+        }
+    }
+
+    /// The property, stated once over every shape above: nothing a caller could
+    /// have put a secret in survives.
+    #[test]
+    fn no_userinfo_query_or_fragment_survives_redaction() {
+        for input in [
+            "https://alice:s3cr3t@kinlab.ai/org?access_token=t0ken#frag",
+            "http://s3cr3t@127.0.0.1:53848?t0ken=1",
+            "alice:s3cr3t@kinlab.ai#t0ken",
+        ] {
+            let redacted = redacted_remote_address(input);
+            assert!(
+                !redacted.contains("s3cr3t") && !redacted.contains("t0ken"),
+                "{input} redacted to {redacted}"
+            );
+            assert!(
+                !redacted.contains('?') && !redacted.contains('#'),
+                "{input} redacted to {redacted}"
+            );
+            assert!(
+                redacted.contains("kinlab.ai") || redacted.contains("127.0.0.1"),
+                "the host a reader acts on must survive: {input} redacted to {redacted}"
+            );
         }
     }
 }

--- a/crates/kin-remote/src/repository_transfer.rs
+++ b/crates/kin-remote/src/repository_transfer.rs
@@ -205,7 +205,22 @@ pub enum RepositoryTransferError {
 /// times with no next step; the token that peer accepts was in its
 /// repository's `.kin/daemon.token` the whole time, and this names it.
 pub fn bearer_token_next_step(base_url: &str) -> String {
-    let address = redacted_remote_address(base_url);
+    let recipe = "for a peer daemon on this machine, set \
+                  KIN_REMOTE_BEARER_TOKEN=$(cat <peer>/.kin/daemon.token) where <peer> is that \
+                  repository's working directory; for KinLab, set KIN_REMOTE_BEARER_TOKEN to a \
+                  KinLab token";
+    let Some(address) = redacted_remote_address(base_url) else {
+        // Naming no remote is worse than naming one, and naming a WRONG one is
+        // worse than both: a string this helper cannot parse may be a host or
+        // may be half a password, and it has no way to tell. So it says which
+        // it is, and the recipe below still works without an address.
+        return format!(
+            "send a bearer token that remote accepts. Its configured URL is not a well-formed \
+             URL, so this refusal does not repeat it: an `@` outside a URL's authority may be \
+             part of a host or part of a password, and nothing here can tell them apart. Fix the \
+             remote's URL, then {recipe}, or run `kin auth login --base-url <that remote>`"
+        );
+    };
     let carried = if address == base_url.trim() {
         ""
     } else {
@@ -213,58 +228,70 @@ pub fn bearer_token_next_step(base_url: &str) -> String {
          sends the token from the environment rather than from the URL"
     };
     format!(
-        "send a bearer token the remote at {address} accepts: for a peer daemon on this \
-         machine, set KIN_REMOTE_BEARER_TOKEN=$(cat <peer>/.kin/daemon.token) where <peer> is \
-         that repository's working directory; for KinLab, run `kin auth login --base-url \
-         {address}` or set KIN_REMOTE_BEARER_TOKEN to a KinLab token{carried}"
+        "send a bearer token the remote at {address} accepts: {recipe}, or run `kin auth login \
+         --base-url {address}`{carried}"
     )
 }
 
-/// One remote's address with everything secret-bearing removed: the scheme,
-/// host, port and path a reader has to act on, and nothing else.
+/// One remote's address with everything secret-bearing removed, or `None` when
+/// this cannot parse the string well enough to vouch for any part of it.
 ///
 /// A refusal is the one place a stranger reads a whole remote URL back, so it
 /// is the one place a credential typed into a remote config is copied into a
 /// terminal, a bug report and a shell history. Three URL parts can carry one:
-/// the userinfo before `@`, the query, and the fragment. None of them is part
-/// of the address a caller needs, and Kin never authenticates from any of them,
-/// so all three go.
+/// the userinfo before `@`, the query, and the fragment. None is part of the
+/// address a caller needs and Kin authenticates from none of them, so all three
+/// go, and the scheme, host, port and path stay.
 ///
-/// The address itself stays. A message that named no remote at all would leak
-/// nothing and help nobody: a stranger with two accounts could not tell which
-/// peer refused them.
+/// **The `None` arm is the whole correctness of this function.** A URL's
+/// authority ends at the first `/`, `?` or `#`, and its userinfo lives before
+/// the last `@` inside that authority. An earlier version scanned for `@` only
+/// inside the authority and returned its input untouched when it found none,
+/// which made `https://alice:pa/ss@kinlab.ai/org` a complete no-op: the
+/// unencoded `/` ends the authority before the `@` that marks the userinfo, so
+/// the refusal printed that password verbatim. `https://alice:p?w@kinlab.ai/org`
+/// was worse, redacting to `https://alice:p`, which leaks half a credential and
+/// names a host that is not the remote.
 ///
-/// Hand-written rather than parsed, because this must answer for a string that
-/// is not a valid URL as safely as for one that is. A parser would have to
-/// choose between returning the input unchanged, which is the leak, and
-/// returning nothing, which is the useless message above. Cutting on the
-/// delimiters does neither: an unparseable string still loses its query, its
-/// fragment and its userinfo.
-pub fn redacted_remote_address(base_url: &str) -> String {
+/// No textual rule recovers from that, because the information is not there: in
+/// `https://alice:pa/ss@kinlab.ai/org` the `@` marks a userinfo, and in
+/// `https://kinlab.ai/a@b` an identical-looking `@` is an ordinary path
+/// character. A redactor cannot tell them apart, so it must not guess. An `@`
+/// at or after the authority's end means this is not a well-formed URL, and
+/// this returns `None` rather than vouch for a host that may be a password
+/// fragment. Callers say so instead of printing an address.
+///
+/// Hand-written rather than parsed, and that is not a shortcut: a lenient
+/// parser resolves `https://alice:pa/ss@kinlab.ai/org` to host `pa`, which is
+/// part of the password, so parsing would have produced a confident wrong
+/// answer where this produces an honest refusal.
+pub fn redacted_remote_address(base_url: &str) -> Option<String> {
     let trimmed = base_url.trim();
-    // Query and fragment first, so a userinfo scan can never run over one. A
-    // raw `?` or `#` cannot appear inside userinfo or a host; both are
-    // percent-encoded there.
-    let addressed = trimmed
-        .find(['?', '#'])
-        .map_or(trimmed, |cut| &trimmed[..cut]);
     // The authority is what lies between the scheme and the path. A string with
     // no scheme is treated as bare authority rather than skipped, so a
     // malformed remote loses its userinfo too.
-    let authority_start = addressed.find("://").map_or(0, |scheme_end| scheme_end + 3);
-    let authority_end = addressed[authority_start..]
-        .find('/')
-        .map_or(addressed.len(), |offset| authority_start + offset);
-    // The LAST `@`, because a password may itself contain an encoded one and the
-    // authority ends at the final separator.
-    match addressed[authority_start..authority_end].rfind('@') {
-        Some(at) => format!(
-            "{}{}",
-            &addressed[..authority_start],
-            &addressed[authority_start + at + 1..]
-        ),
-        None => addressed.to_string(),
+    let authority_start = trimmed.find("://").map_or(0, |scheme_end| scheme_end + 3);
+    let authority_end = trimmed[authority_start..]
+        .find(['/', '?', '#'])
+        .map_or(trimmed.len(), |offset| authority_start + offset);
+    // An `@` out here is the unparseable case above. Checked against the
+    // ORIGINAL string rather than one already shortened, because cutting the
+    // query first is exactly what hid the `?w@` shape.
+    if trimmed[authority_end..].contains('@') {
+        return None;
     }
+    // The LAST `@`, because a password may itself contain an encoded one and
+    // the userinfo ends at the final separator.
+    let host_start = match trimmed[authority_start..authority_end].rfind('@') {
+        Some(at) => authority_start + at + 1,
+        None => authority_start,
+    };
+    let kept = format!("{}{}", &trimmed[..authority_start], &trimmed[host_start..]);
+    // Query and fragment last, over a string that no longer carries a userinfo.
+    Some(match kept.find(['?', '#']) {
+        Some(cut) => kept[..cut].to_string(),
+        None => kept,
+    })
 }
 
 pub type Result<T> = std::result::Result<T, RepositoryTransferError>;
@@ -5124,7 +5151,7 @@ mod bearer_token_next_step_tests {
     fn the_next_step_keeps_the_address_a_reader_has_to_act_on() {
         let message = bearer_token_next_step(CREDENTIAL_BEARING);
         assert!(
-            message.contains("https://kinlab.example/"),
+            message.contains("https://kinlab.example"),
             "the remedy must still name which remote refused: {message}"
         );
     }
@@ -5165,16 +5192,64 @@ mod redacted_remote_address_tests {
             ),
             ("https://kinlab.ai/org#tok", "https://kinlab.ai/org"),
             ("https://u:p@kinlab.ai/org?t=v#f", "https://kinlab.ai/org"),
-            // A path that carries an `@` is a path, not userinfo, and a reader
-            // needs it: the authority ends at the first `/`.
-            ("https://kinlab.ai/a@b", "https://kinlab.ai/a@b"),
             // Not a URL at all. A parser would hand this back untouched, which
             // is the leak; the delimiters still say where the secret was.
             ("u:p@kinlab.ai/org?t=v", "kinlab.ai/org"),
             ("  https://kinlab.ai  ", "https://kinlab.ai"),
         ] {
-            assert_eq!(redacted_remote_address(input), expected, "for {input}");
+            assert_eq!(
+                redacted_remote_address(input).as_deref(),
+                Some(expected),
+                "for {input}"
+            );
         }
+    }
+
+    /// The `continue` in the property below is only honest if something else
+    /// pins which shapes take it. These are those shapes, and each one is a
+    /// measured leak from the review of this change: the authority-bounded scan
+    /// could not see either `@`, so before the `None` arm the first returned its
+    /// input untouched and the second returned `https://alice:p`, half a
+    /// password wearing a host's place in the sentence.
+    #[test]
+    fn a_userinfo_carrying_an_unencoded_delimiter_is_withheld_rather_than_guessed() {
+        for (case, input) in [
+            ("an unencoded slash", "https://alice:pa/ss@kinlab.ai/org"),
+            (
+                "an unencoded question mark",
+                "https://alice:p?w@kinlab.ai/org",
+            ),
+            ("an unencoded hash", "https://alice:p#w@kinlab.ai/org"),
+        ] {
+            assert_eq!(
+                redacted_remote_address(input),
+                None,
+                "{case}: a URL this cannot parse must be withheld, not guessed at"
+            );
+        }
+        // The same rule withholds an ordinary path that happens to carry an
+        // `@`. That is the cost of not guessing, taken deliberately: this
+        // cannot tell `/a@b` from a smuggled userinfo, and over-redacting an
+        // address is recoverable where printing a password is not.
+        assert_eq!(redacted_remote_address("https://kinlab.ai/a@b"), None);
+    }
+
+    /// A withheld address must not leave the refusal naming a remote it cannot
+    /// vouch for, and must still carry the recipe.
+    #[test]
+    fn the_next_step_names_no_address_when_it_cannot_parse_one() {
+        let message = super::bearer_token_next_step("https://alice:pa/ss@kinlab.ai/org");
+        for carried in ["pa/ss", "alice", "kinlab.ai"] {
+            assert!(
+                !message.contains(carried),
+                "the refusal named part of a URL it could not parse"
+            );
+        }
+        assert!(
+            message.contains("not a well-formed URL")
+                && message.contains("KIN_REMOTE_BEARER_TOKEN=$(cat <peer>/.kin/daemon.token)"),
+            "it must say why it named no remote and still give the recipe: {message}"
+        );
     }
 
     /// The property, stated once over every shape above: nothing a caller could
@@ -5195,14 +5270,23 @@ mod redacted_remote_address_tests {
                 "alice:s3cr3t@kinlab.ai#t0ken",
             ),
         ] {
-            let redacted = redacted_remote_address(input);
+            // Withholding is a pass here and the reason is the point: for the
+            // two unencoded-delimiter shapes there is no host this can name
+            // without risking naming a password fragment, so `None` IS the
+            // correct redaction rather than a gap in it.
+            let Some(redacted) = redacted_remote_address(input) else {
+                continue;
+            };
             assert!(
-                !redacted.contains("s3cr3t") && !redacted.contains("t0ken"),
+                !redacted.contains("s3cr3t")
+                    && !redacted.contains("t0ken")
+                    && !redacted.contains("pa/ss")
+                    && !redacted.contains("alice"),
                 "{case}: a credential survived redaction"
             );
             assert!(
-                !redacted.contains('?') && !redacted.contains('#'),
-                "{case}: a query or fragment survived redaction"
+                !redacted.contains('?') && !redacted.contains('#') && !redacted.contains('@'),
+                "{case}: a query, fragment or userinfo survived redaction"
             );
             assert!(
                 redacted.contains("kinlab.ai") || redacted.contains("127.0.0.1"),


### PR DESCRIPTION
## What

Refresh this workspace's base graph section after every local repository transition that can move
that base, and stop the bearer-token refusal from echoing a credential out of a remote URL.

Journey GAP-4's surviving half and journey GAP-B.

## Why

A native commit refreshed the section and nothing else did. Every other way a base moves left a
store folding that base out of history at every open until somebody ran `kin graph materialize`.
A fresh `kin clone` read `Graph section: absent`, and a store whose base a branch switch or a merge
had moved read `present but refused (resolved_at)`.

The journey attributed the second state to a received `kin push`. That attribution is wrong, and
the red run says so. `transfer_transaction` builds every received pack with
`workspace_mutation: None`, and `validate_head_base` refuses a symbolic base target, so a receive
moves a ref and never the receiver's own base. An origin that committed and then received a push
read `present and current`. What the journey saw was the branch switches and the merge that
preceded it, which is also the transition the product's own remedy for a workspace behind its ref
asks a user to run: following that advice turned a store that served into one that folds.

## How

One rule, four sites.

`refresh_workspace_base_graph_section` becomes shared and takes a label naming the transition that
paid for it. No behaviour change on the commit path.

`repository_branch::run_workspace_mutation` refreshes after finalization, under the persistence and
graph-authority gates the transition already holds. That covers `kin branch switch` and a pull's
follow of a moved ref. Create and delete move no base, so kin-db's writer finds the section valid
and returns `AlreadyCurrent` with no durable write; a rule per request kind would cost a reader more
than it saves.

`repository_merge::execute` refreshes the same way, because a merge publishes off the commit path
and moves the base exactly as a commit does.

`clone_native` materializes offline between the replica bootstrap and the daemon it then starts. A
clone's history arrives inside `kin_core::init::replica::initialize` as one bootstrap transaction
and never through the receiver, so no daemon-side refresh can see it, and that is the one moment
nothing holds repository runtime authority. A clone whose own pull then admits more history moves
the base again, and the branch seam covers that.

Nothing is added to the receive path, and that is a decision. A refresh there finds the section
already valid and writes nothing, while one that targeted the received head instead would write a
section kin-db then refuses for that workspace, turning a store that serves into one that folds.

Every call is idempotent and never fatal: the transition is durable and receipted, and a
memoization that did not persist is a slower next open rather than a failed command. What
`kin graph status` and `kin doctor` report is still read from the store through
`kin_core::graph_section::read`, so a refresh that failed is disclosed as the refusal it left
behind, and a failed clone materialization prints the retry the same way `kin init` does.

Separately, `bearer_token_next_step` interpolated its `base_url` verbatim twice, and two
`kin remote` pre-flights printed the same URL beside it, so a remote configured with userinfo or a
query token printed that credential into a terminal, a bug report and a shell history. One exported
`redacted_remote_address` now answers for all three printers, and it answers with an `Option`. When
the URL parses, it keeps the scheme, host, port and path a reader has to act on and drops the
userinfo, the query and the fragment. When it does not parse, it returns nothing and the callers
say a remote refused without naming one.

That `None` arm is where the correctness lives. A URL's authority ends at the first `/`, `?` or `#`,
so a userinfo carrying one of those unencoded puts its `@` outside the authority:
`https://alice:pa/ss@kinlab.ai/org` and `https://alice:p?w@kinlab.ai/org` are not URLs any textual
rule can read, and no rule can tell either from `https://kinlab.ai/a@b`, where an identical `@` is
an ordinary path character. Parsing is worse than useless here, because a lenient parser resolves
the first to host `pa`, which is part of the password. So the function withholds rather than
guesses. The cost is that a legitimate `@` in a path, a query or a fragment is withheld too, three
shapes rather than the one the first draft named, and the trade is deliberate: over-redacting an
address is recoverable, printing a password is not. A string with nothing where a host belongs is
withheld by the same rule.

On the CLI side both pre-flights build that refusal through one `missing_bearer_token_message`
instead of inlining the `Option`'s fallback twice, because the fallback is the one place this can
go wrong and a call site inside a long async command is not somewhere a test can reach. The refusal
still names `KIN_REMOTE_BEARER_TOKEN` and the `$(cat <peer>/.kin/daemon.token)` recipe, and nothing
auto-discovers another repository's credentials.

## Review follow-ups

Two review rounds, in order.

At `22687f2e9`, `redacted_remote_address` missed a userinfo carrying an unencoded `/`, `?` or `#`,
because the authority ends at the first of those and the `@` then fell outside the scanned slice:
`https://alice:pa/ss@kinlab.ai/org` was a complete no-op and `https://alice:p?w@kinlab.ai/org`
returned `https://alice:p`, half a credential where the host belongs. It now returns
`Option<String>` and withholds, for the reasons in How. Two source comments citing a base sha and a
wall-clock time are gone.

The round after that found the fix's CLI half unguarded: reverting both `None` arms in
`crates/kin-cli/src/commands/remote.rs` to `unwrap_or_else(|| target.base_url.clone())`, the exact
shape the fix replaced, left the whole kin-cli library suite green. `missing_bearer_token_message`
and its two tests close that, measured as arm A2 below. Five smaller findings are taken with it:
a property comment describing shapes its own table did not contain, a clause in that property that
could never fire, an address assertion relaxed for nothing, a stated cost of withholding narrower
than the real one, and four degenerate inputs that rendered as an empty address instead of taking
the `None` arm.

## Testing

All commands run through the fleet's builder slots on macOS with `KIN_EMBED_BACKEND=cpu` and
registry-only `kin-db 0.7.104`. `kin-daemon` is built explicitly in front of every `kin-cli`
integration run, because `cargo test -p kin-cli --test <name>` builds no daemon binary and the
harness's own compat probe did not force a rebuild for a same-version source change; a whole green
pass read three false reds before that was caught.

Full commands, output tails and every mutation's log live in the lane report at
`.kin-coord/reports/showhn-gapclone-20260905.md` in the umbrella workspace, with the sweep scripts
and their raw logs beside it as `gapclone-*.{sh,log}`.

- [x] Every new test was red first against the unchanged tree, then green, then falsified. All
      three tests this commit adds have their own arm: A2, C and D below.
- [x] `bin/kin-precheck kin`, on a CLEAN committed head, not a dirty base: `21 gates ran, 21 passed, 0 failed, on kin
      e3bbd016d9c2d828e800209cffe3de8b8045fa57`, with no `DIRTY` suffix.
- [x] `cargo fmt --all -- --check` passes (it is one of those 21).
- [x] The commit carries a `Signed-off-by` trailer.

Red first, GAP-4, `2026-09-05T21:43:27Z`, against `0b67c5048` with no product change:

```text
cargo test -p kin-cli --test graph_section_after_transfer -- --test-threads=2
test result: FAILED. 12 passed; 5 failed

a_fresh_clone_serves_its_workspace_base_from_a_section ... FAILED
  Graph section: absent, so every open of this store folds this workspace's base out of
  history, 1 change. `kin graph materialize` writes one
every_workspace_transition_leaves_a_section_serving_the_base_it_moved_to ... FAILED
  after switching back to the default branch:
  Graph section: present but refused (resolved_at), so every open of this store folds this
  workspace's base out of history ... A section was written and is not being used
an_origin_that_received_a_push... ... ok      <- a push breaks nothing
a_committed_store_serves_its_workspace_base_from_a_section ... ok      <- positive control
```

Red first, GAP-B, `2026-09-05T21:38:17Z`:

```text
cargo test -p kin-remote --lib bearer_token_next_step_tests
test result: FAILED. 2 passed; 2 failed

the remedy echoed s3cr3tpassw0rd out of the remote URL: send a bearer token the remote at
https://alice:s3cr3tpassw0rd@kinlab.example/base?access_token=t0kenvalue#frag accepts: ...
```

Red first, the two review-round tests, each against the tree that lacked its fix. The withholding
test ran against the pre-fix body wrapped in `Some`, since the signature itself changed:

```text
the helper's None arm hands the URL back, which is what that revert does:
cargo test -p kin-cli --lib
test result: FAILED. 2208 passed; 1 failed

commands::remote::tests::a_url_the_redaction_withholds_is_never_named_in_the_refusal
  the pre-flight refusal named the password out of a URL the redaction withheld:
  no auth token available for https://alice:s3cr3t/pw@kinlab.ai/org; send a bearer
  token that remote accepts. Its configured URL is not a well-formed URL, so ...

the empty-host guard removed, which is the behaviour before this round:
cargo test -p kin-remote --lib
test result: FAILED. 112 passed; 1 failed

repository_transfer::redacted_remote_address_tests::
a_string_with_no_host_is_withheld_rather_than_rendered_as_an_empty_address
  assertion `left == right` failed: "" names no host, so it must be withheld
    left: Some("")
   right: None
```

Green at this head:

```text
cargo test -p kin-remote --lib
test result: ok. 113 passed; 0 failed; finished in 15.81s

cargo test -p kin-cli --lib
test result: ok. 2209 passed; 0 failed; 1 ignored; finished in 157.13s

cargo build -p kin-daemon --bin kin-daemon && \
cargo test -p kin-cli --test graph_section_after_transfer -- --test-threads=3
test result: ok. 17 passed; 0 failed; finished in 15.14s

cargo test -p kin-daemon --lib
test result: ok. 1518 passed; 0 failed; 3 ignored; finished in 397.83s
```

Falsification. Each mutation leaves the property it targets in place and changes only the thing the
assertion is written about; every file is restored by plain copy plus `touch`, never `cp -p` and
never `git checkout --`, and each sweep ends by printing `git status --porcelain` empty.

Eight mutations for the original change, `22:20Z` to `22:37Z`:

```text
M5  redaction removed entirely                106 passed; 4 failed   both positive controls green
M6  query and fragment go, userinfo survives  106 passed; 4 failed   the userinfo arm is separately live
M7  the address is redacted away              106 passed; 4 failed   address preservation is live
M1  run_workspace_mutation stops refreshing     2 passed; 3 failed   pull + received-head + walk red, BOTH clone cases green
M2  merge execute stops refreshing              2 passed; 1 failed   only the walk, at its merge step
M3  clone_native stops materializing            1 passed; 2 failed   both clone cases red, pull green
M4  serving sentence stops naming its base      2 passed; 2 failed   assert_serving stays green, only the by-name head assertions catch it
M5b the unborn arm claims to serve              2 passed; 1 failed   the truthfulness case is live
```

Three more from the re-grade sweep, `2026-09-06T00:23:35Z` to `2026-09-06T00:40:45Z`:

```text
A1  both pre-flights back to the inline unwrap_or_else, helper and tests kept
      cargo test -p kin-cli --lib     2209 passed; 0 failed   GREEN, and that is the finding
      RUSTFLAGS='-D warnings' cargo clippy -p kin-cli --lib -- $allows
        error: function `missing_bearer_token_message` is never used
           --> crates/kin-cli/src/commands/remote.rs:147:15
            = note: `-D dead-code` implied by `-D warnings`
        error: could not compile `kin-cli` (lib) due to 1 previous error     exit 101
      same command on the clean tree                                        exit 0
A2  the helper's None arm hands the URL back, which is that revert's behaviour
      cargo test -p kin-cli --lib     2208 passed; 1 failed
      a_url_the_redaction_withholds_is_never_named_in_the_refusal
C   the empty-host guard removed from redacted_remote_address
      cargo test -p kin-remote --lib  112 passed; 1 failed
      a_string_with_no_host_is_withheld_rather_than_rendered_as_an_empty_address
    green again after every restore: kin-remote 113 passed, kin-cli 2209 passed
```

And the fourth, `2026-09-06T01:20:55Z` to `2026-09-06T01:28:21Z`. Arms A2 and C leave the
withholding test's own control green by construction, since A2's input parses so the fallback never
runs and C makes more inputs resolve rather than fewer. The mutation that can kill it is the
opposite one:

```text
D   redacted_remote_address withholds everything
      cargo test -p kin-cli --lib     2208 passed; 1 failed
      a_remote_the_redaction_can_parse_is_named_without_its_credentials
      a parseable remote must be named, path included: no auth token available for that
      remote; send a bearer token that remote accepts. Its configured URL is not a
      well-formed URL ...
    green again after restore: kin-cli 2209 passed
```

Read A1 and A2 together. The suite does not catch the literal call-site revert, because the test
module keeps the helper alive and `dead_code` cannot fire under `cfg(test)`. What catches that
revert is the lint. `ci.yml` sets `RUSTFLAGS: "-D warnings"` workspace-wide at line 40, and the
`Fast gate lint and policy` job, a required context on main, runs
`cargo clippy --all-targets --all-features -- $allows` over that same non-test lib target;
`.github/clippy-allowed-lints.txt` carries 45 allows and `dead_code` is not among them.

The first version of this section pasted a clippy run that printed the warning and exited 0,
because it carried neither `-D warnings` nor the allow list, over a lib that emits warnings anyway.
The conclusion was right and that tail did not carry it. The exit codes above were measured in
review under CI's own flags, in both the `--lib` and the `--all-targets --all-features` form, each
against a clean-tree control at exit 0, so the failure belongs to the mutation. A2 is the behaviour
guard and it is red on its own. Neither claim leans on the other.

Two numbers above are not from this head and should be read that way. `1518 passed` for
`cargo test -p kin-daemon --lib` is from `2026-09-05T22:19Z`; this commit changes no file in
kin-daemon, so it was not re-run. Everything else was measured on
`e3bbd016d9c2d828e800209cffe3de8b8045fa57` after the sweep restored the tree.

The bug the tests caught in my own first draft is worth naming: refreshing while the transition's
`LocalRepositoryAuthorityFreeze` was still alive made `kin branch switch` and a pull's workspace
follow hang for the harness's full 180 second budget, because that freeze is an exclusive
cross-process lease over the same storage lock the section writer takes. It would have shipped as
an intermittent hang.

Not run here, by design: acceptance grades main rather than pull requests on this repo, and the
full workspace suite is hosted CI's job.
