### PR TITLE
Answer a JSON log from the running daemon, and name the plan's own cost

### DIFF
--- a/crates/kin-cli/src/commands/log.rs
+++ b/crates/kin-cli/src/commands/log.rs
@@ -342,6 +342,14 @@ fn daemon_report_this_build_may_print(response: &LogResponse) -> Option<&LogRepo
 /// whole of an 11.04 second `kin log --json --count 2`: one whole-store open in
 /// the CLI process, 3,491,976 KiB of peak resident set, to print two entries the
 /// daemon already had decoded.
+///
+/// One arm is slower than before and it is the right trade. A daemon whose
+/// report this build may not print costs the round trip AND the local open,
+/// where the old command paid only the open. That is the price of asking before
+/// deciding, and asking before deciding is what keeps the `json` condition out
+/// of `run`'s call to the daemon, so the decision lives here in one place that a
+/// test can drive. Against a whole-store open the round trip is not close, and
+/// the arm it costs is the mixed-build one rather than the ordinary one.
 fn json_log(
     layout: &kin_core::KinLayout,
     count: usize,
@@ -349,6 +357,26 @@ fn json_log(
 ) -> Result<String> {
     if let Some(report) = answered.and_then(daemon_report_this_build_may_print) {
         return Ok(serde_json::to_string_pretty(report)?);
+    }
+    if let Some(response) = answered {
+        // A daemon answered and this build declined its report, so this command
+        // is about to pay a whole-store open that a matching pair would not have
+        // paid. Said on stderr rather than in the report, because the report is
+        // the machine contract and must stay byte-identical on both branches.
+        //
+        // At `info`, the same level as the authority-open attribution line that
+        // follows it, deliberately: those two lines together are the whole
+        // reading, and it was the open line at exactly this level that attributed
+        // the 11.04 second log in the first place. A level nobody turns on is a
+        // line nobody reads, and a slow `--json` with no signal at all is what
+        // this route otherwise leaves behind.
+        tracing::info!(
+            daemon_report_revision = response.report_revision,
+            this_build_report_revision = LOG_REPORT_REVISION,
+            daemon_carried_a_report = response.report.is_some(),
+            "a daemon answered this log and this build may not print its report, so this command \
+             opens the whole store itself"
+        );
     }
     let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(layout)?;
     let (report, _tip) = local_log(&binding, count)?;
@@ -663,23 +691,54 @@ mod tests {
         );
     }
 
+    /// The same answer as it would arrive from a daemon built before
+    /// `report_revision` existed: serialized, the key removed, deserialized.
+    ///
+    /// Built by REMOVING the key rather than by setting the field to 0, because
+    /// those are different fixtures. Setting the field asserts what this build
+    /// thinks an absent key deserializes to; removing it asks. And the removal
+    /// is checked, so a rename of the field turns this into a failure rather
+    /// than into a case that quietly stops building the peer it names.
+    fn older_peer_answer(response: &LogResponse) -> LogResponse {
+        let mut value = serde_json::to_value(response).expect("a response serializes");
+        let object = value
+            .as_object_mut()
+            .expect("a response serializes as an object");
+        assert!(
+            object.remove("report_revision").is_some(),
+            "this fixture is the wire shape MINUS the revision key, so the key has to be there to \
+             remove; if it is gone or renamed, this case no longer builds an older peer"
+        );
+        serde_json::from_value(value).expect("an older peer's envelope still deserializes")
+    }
+
     /// A peer too old to name a revision reads as "cannot say", not as agreement.
     ///
     /// `report_revision` is `#[serde(default)]`, so an older daemon's silence
     /// arrives as 0. Treating 0 as a match would print that peer's report with
-    /// every field this build added since silently defaulted in.
+    /// every field this build has added since silently defaulted in.
+    ///
+    /// The fixture carries a COMPLETE report, which is what makes this a guard
+    /// rather than a restatement. `build_log_response_at` has always filled
+    /// `report`, so a genuinely old peer sends a filled report and no revision
+    /// key; and a fixture whose report is absent is refused by the
+    /// `report.as_ref()` at the end of the gate whichever way the revision
+    /// comparison goes, so it would stay green with that comparison deleted.
+    /// This arm is the one that goes red for it.
     #[test]
     fn a_json_log_answered_by_a_peer_that_names_no_revision_opens_locally() {
         let _daemon = kin_core::test_env::EnvVarGuard::unset("KIN_DAEMON_URL");
         let (_root, layout, binding, expected) = fixture_store();
-        let older_peer: LogResponse =
-            serde_json::from_value(serde_json::json!({ "lines": ["change ..."], "report": null }))
-                .expect("an older peer's envelope still deserializes");
+        let older_peer = older_peer_answer(&daemon_answer(&binding, 5));
         assert_eq!(
             older_peer.report_revision, 0,
             "silence must read as revision 0, or this case proves nothing"
         );
-        let _ = binding;
+        assert!(
+            older_peer.report.is_some(),
+            "the peer must carry a report, or the gate refuses it on the report alone and the \
+             revision comparison this case exists for is never reached"
+        );
 
         let before = kin_core::authority_opens();
         let printed = json_log(&layout, 5, Some(&older_peer)).expect("the local open prints");
@@ -688,7 +747,35 @@ mod tests {
         assert_eq!(printed, expected, "falling back answers exactly as it did");
         assert_eq!(
             opens, 1,
-            "an older peer's answer must not be printed as ours"
+            "an older peer names no revision, so its report must not be printed as ours"
+        );
+    }
+
+    /// A peer that carries no report at all is refused on the report itself.
+    ///
+    /// The other half of the refusal, kept separate from the revision arm above
+    /// so that neither can stand in for the other: a daemon that answered
+    /// without a report, and a daemon whose report this build may not print, are
+    /// different facts and each needs its own case.
+    #[test]
+    fn a_json_log_answered_by_a_peer_that_carries_no_report_opens_locally() {
+        let _daemon = kin_core::test_env::EnvVarGuard::unset("KIN_DAEMON_URL");
+        let (_root, layout, _binding, expected) = fixture_store();
+        let no_report: LogResponse = serde_json::from_value(serde_json::json!({
+            "lines": ["change ..."],
+            "report": null,
+            "report_revision": LOG_REPORT_REVISION,
+        }))
+        .expect("an envelope with no report still deserializes");
+
+        let before = kin_core::authority_opens();
+        let printed = json_log(&layout, 5, Some(&no_report)).expect("the local open prints");
+        let opens = kin_core::authority_opens() - before;
+
+        assert_eq!(printed, expected, "falling back answers exactly as it did");
+        assert_eq!(
+            opens, 1,
+            "an answer carrying no report must be answered by one local open"
         );
     }
 

--- a/crates/kin-cli/src/commands/log.rs
+++ b/crates/kin-cli/src/commands/log.rs
@@ -20,6 +20,21 @@ use super::repository_authority::ActiveRepositoryAuthority;
 
 pub const LOG_SCHEMA: &str = "kin.log.v1";
 
+/// Which fields of the report the answering build knew how to fill.
+///
+/// A different question from the schema, and it needs its own answer. The schema
+/// names what the fields MEAN, and it must not move for a shape change, because
+/// it is what a machine reader pins. This names which fields a build fills.
+///
+/// The distinction is not hypothetical: `LogEntry::entity_deltas_unchanged` was
+/// added under `#[serde(default)]` and `kin.log.v1` deliberately stayed put, so
+/// a caller trusting schema equality alone would print a peer's report with a
+/// real unchanged-entity count silently replaced by zero. Nothing would say so.
+///
+/// Bump it whenever a field is added to [`LogReport`] or [`LogEntry`].
+/// `adding_a_report_field_must_move_the_report_revision` goes red if you forget.
+pub const LOG_REPORT_REVISION: u32 = 1;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LogRequest {
     pub count: usize,
@@ -39,6 +54,14 @@ pub struct LogResponse {
     /// changes, because it has already decoded the change DAG to answer at all.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_tip: Option<crate::commands::workspace_tip::WorkspaceTip>,
+    /// The report revision the answering build filled, or 0 from a peer too old
+    /// to name one.
+    ///
+    /// `#[serde(default)]` makes an older peer's silence read as "cannot say",
+    /// and a caller that cannot say falls back to its own authority open and
+    /// answers exactly as it did before this field existed.
+    #[serde(default)]
+    pub report_revision: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -285,59 +308,107 @@ fn local_log(
     Ok((report, tip))
 }
 
+/// The daemon's own report, when this build may print it as its own.
+///
+/// `kin log --json` is a contract with a machine reader: what it prints must be
+/// what THIS build serializes, never whatever bytes a peer happened to send.
+/// Two things hold that here. The value is deserialized into this build's own
+/// [`LogReport`] and serialized by this build's own serde, so the bytes printed
+/// are this build's. And the peer must name the same [`LOG_REPORT_REVISION`], so
+/// no field this build knows about was quietly filled in by `#[serde(default)]`
+/// on behalf of a peer that never had it.
+///
+/// A peer at a different revision, or one too old to name one, is not refused
+/// and is not an error. The caller falls back to its own authority open, which
+/// is exactly what every `--json` did before this route existed.
+fn daemon_report_this_build_may_print(response: &LogResponse) -> Option<&LogReport> {
+    if response.report_revision != LOG_REPORT_REVISION {
+        return None;
+    }
+    response.report.as_ref()
+}
+
+/// The JSON `kin log --json` prints: the daemon's report when this build may
+/// print it, and one local authority open otherwise.
+///
+/// The whole decision lives here, fallback included, so what it costs is
+/// assertable without a daemon and without a process. The honest bound is the
+/// OPEN COUNT rather than the wall clock, for the reason [`local_log`] gives: an
+/// open re-verifies every persisted body, so it costs whatever the store is
+/// worth, and a fixture small enough to run in CI answers in milliseconds
+/// whether it opens or not.
+///
+/// Measured on the converted psf/requests store of 2026-09-05, that open was the
+/// whole of an 11.04 second `kin log --json --count 2`: one whole-store open in
+/// the CLI process, 3,491,976 KiB of peak resident set, to print two entries the
+/// daemon already had decoded.
+fn json_log(
+    layout: &kin_core::KinLayout,
+    count: usize,
+    answered: Option<&LogResponse>,
+) -> Result<String> {
+    if let Some(report) = answered.and_then(daemon_report_this_build_may_print) {
+        return Ok(serde_json::to_string_pretty(report)?);
+    }
+    let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(layout)?;
+    let (report, _tip) = local_log(&binding, count)?;
+    Ok(serde_json::to_string_pretty(&report)?)
+}
+
 pub async fn run(count: usize, json: bool) -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
-    // The daemon first, and only for the text path. `--json` is a contract with
-    // a machine reader and must publish the exact report this build serializes,
-    // so it stays on the local read rather than re-serializing a peer's payload.
+    // Asked once, ahead of either rendering, and deliberately not under a `json`
+    // condition. Both renderings answer from the same durable authority and only
+    // the daemon can answer from one it already holds open. What `--json` may not
+    // do is print a peer's bytes as its own, and that is decided in `json_log`
+    // rather than by declining to ask.
     //
-    // A daemon too old to carry the tip reading costs this command a named gap
+    // A daemon too old to carry the tip reading costs the text path a named gap
     // and nothing else, so it does not fall back the way `kin status` does. The
     // difference is what silence would mean: a status with no merge reading
     // prints a clean tree over a workspace holding a merge open, and this prints
     // a line saying the reading was not taken.
-    if !json {
-        if let Some(response) = daemon_log(&layout, count).await {
-            for line in response.lines {
-                println!("{line}");
-            }
-            println!(
-                "{}",
-                crate::commands::workspace_tip::line(
-                    &response.workspace_tip.unwrap_or(
-                        crate::commands::workspace_tip::WorkspaceTip::Unknown {
-                            reason: "the daemon that answered this log does not report it; \
-                                 `kin daemon stop` and re-run picks it up on this build"
-                                .to_string(),
-                        }
-                    )
-                )
-            );
-            println!(
-                "{}",
-                crate::commands::repository_authority::answered_by_line(
-                    crate::commands::repository_authority::AuthoritySource::RunningDaemon
-                )
-            );
-            return Ok(());
-        }
-    }
-    let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout)?;
-    let (report, tip) = local_log(&binding, count)?;
+    let answered = daemon_log(&layout, count).await;
     if json {
-        println!("{}", serde_json::to_string_pretty(&report)?);
-    } else {
-        for line in render_lines(&report) {
+        println!("{}", json_log(&layout, count, answered.as_ref())?);
+        return Ok(());
+    }
+    if let Some(response) = answered {
+        for line in response.lines {
             println!("{line}");
         }
-        println!("{}", crate::commands::workspace_tip::line(&tip));
+        println!(
+            "{}",
+            crate::commands::workspace_tip::line(
+                &response.workspace_tip.unwrap_or(
+                    crate::commands::workspace_tip::WorkspaceTip::Unknown {
+                        reason: "the daemon that answered this log does not report it; \
+                                 `kin daemon stop` and re-run picks it up on this build"
+                            .to_string(),
+                    }
+                )
+            )
+        );
         println!(
             "{}",
             crate::commands::repository_authority::answered_by_line(
-                crate::commands::repository_authority::AuthoritySource::OwnAuthorityOpen
+                crate::commands::repository_authority::AuthoritySource::RunningDaemon
             )
         );
+        return Ok(());
     }
+    let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout)?;
+    let (report, tip) = local_log(&binding, count)?;
+    for line in render_lines(&report) {
+        println!("{line}");
+    }
+    println!("{}", crate::commands::workspace_tip::line(&tip));
+    println!(
+        "{}",
+        crate::commands::repository_authority::answered_by_line(
+            crate::commands::repository_authority::AuthoritySource::OwnAuthorityOpen
+        )
+    );
     Ok(())
 }
 
@@ -360,6 +431,7 @@ pub fn build_log_response_at(
         lines: render_lines(&report),
         report: Some(report),
         workspace_tip: Some(workspace_tip_at(authority)),
+        report_revision: LOG_REPORT_REVISION,
     })
 }
 
@@ -493,6 +565,237 @@ mod tests {
             opens, 1,
             "one `kin log` must open repository authority once and ask that open for both the \
              history and the workspace-tip reading; opening per reading is GAP-6"
+        );
+    }
+
+    /// A fixture store, its binding, and the JSON one local open prints from it.
+    ///
+    /// The reference every `--json` case below compares against: it is what this
+    /// command printed before a daemon could answer it, and the only thing it is
+    /// allowed to print now.
+    fn fixture_store() -> (
+        tempfile::TempDir,
+        kin_core::KinLayout,
+        kin_core::LocalRepositoryAuthorityBinding,
+        String,
+    ) {
+        let root = tempfile::tempdir().expect("a temporary directory for the fixture store");
+        let init = kin_core::init(root.path()).expect("kin_core::init builds a real store");
+        let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&init.layout)
+            .expect("the fixture store binds");
+        let (report, _tip) = local_log(&binding, 5).expect("a fresh store answers a log");
+        assert_eq!(
+            report.schema, LOG_SCHEMA,
+            "the reference report must be a real one, or every comparison below is vacuous"
+        );
+        let expected = serde_json::to_string_pretty(&report).expect("a report serializes");
+        (root, init.layout, binding, expected)
+    }
+
+    /// What a daemon on THIS build answers, built through the daemon's own
+    /// helper rather than by hand, so the fixture cannot drift from the wire.
+    fn daemon_answer(
+        binding: &kin_core::LocalRepositoryAuthorityBinding,
+        count: usize,
+    ) -> LogResponse {
+        let authority =
+            ActiveRepositoryAuthority::open(binding).expect("the fixture store opens once more");
+        build_log_response_at(&authority, &LogRequest { count })
+            .expect("the daemon route builds a response")
+    }
+
+    /// `kin log --json` answered by a daemon at this revision must open nothing.
+    ///
+    /// The cost this command was paying: on the converted psf/requests store of
+    /// 2026-09-05 the CLI's own open was the whole of an 11.04 second two-entry
+    /// log, while the daemon that could have answered held one open per
+    /// publication. The count is the bound rather than the clock, because a
+    /// CI-sized fixture answers in milliseconds either way.
+    ///
+    /// Breaking it: make `json_log` ignore what the daemon answered, which is
+    /// what the shipped code did by gating the daemon route on `!json`. The
+    /// count goes to 1.
+    #[test]
+    fn a_json_log_answered_at_this_report_revision_opens_no_authority() {
+        let _daemon = kin_core::test_env::EnvVarGuard::unset("KIN_DAEMON_URL");
+        let (_root, layout, binding, expected) = fixture_store();
+        let answered = daemon_answer(&binding, 5);
+
+        let before = kin_core::authority_opens();
+        let printed = json_log(&layout, 5, Some(&answered)).expect("the daemon answer prints");
+        let opens = kin_core::authority_opens() - before;
+
+        assert_eq!(
+            printed, expected,
+            "a `--json` log routed through the daemon must print exactly what this build prints \
+             from its own open"
+        );
+        assert_eq!(
+            opens, 0,
+            "a `--json` log the daemon already answered must not open the whole store again"
+        );
+    }
+
+    /// The control for the count above, and the refusal it names.
+    ///
+    /// A peer at another report revision may hold a report whose fields this
+    /// build would fill differently, so its bytes are not this build's answer.
+    /// This is also what proves the assertion above is looking at something: the
+    /// same measurement, on the same fixture, must read 1 here.
+    #[test]
+    fn a_json_log_answered_at_another_report_revision_opens_and_answers_the_same() {
+        let _daemon = kin_core::test_env::EnvVarGuard::unset("KIN_DAEMON_URL");
+        let (_root, layout, binding, expected) = fixture_store();
+        let mut answered = daemon_answer(&binding, 5);
+        answered.report_revision = LOG_REPORT_REVISION + 1;
+
+        let before = kin_core::authority_opens();
+        let printed = json_log(&layout, 5, Some(&answered)).expect("the local open prints");
+        let opens = kin_core::authority_opens() - before;
+
+        assert_eq!(
+            printed, expected,
+            "falling back must answer exactly as it always did"
+        );
+        assert_eq!(
+            opens, 1,
+            "a report from another revision must be refused and answered by one local open"
+        );
+    }
+
+    /// A peer too old to name a revision reads as "cannot say", not as agreement.
+    ///
+    /// `report_revision` is `#[serde(default)]`, so an older daemon's silence
+    /// arrives as 0. Treating 0 as a match would print that peer's report with
+    /// every field this build added since silently defaulted in.
+    #[test]
+    fn a_json_log_answered_by_a_peer_that_names_no_revision_opens_locally() {
+        let _daemon = kin_core::test_env::EnvVarGuard::unset("KIN_DAEMON_URL");
+        let (_root, layout, binding, expected) = fixture_store();
+        let older_peer: LogResponse =
+            serde_json::from_value(serde_json::json!({ "lines": ["change ..."], "report": null }))
+                .expect("an older peer's envelope still deserializes");
+        assert_eq!(
+            older_peer.report_revision, 0,
+            "silence must read as revision 0, or this case proves nothing"
+        );
+        let _ = binding;
+
+        let before = kin_core::authority_opens();
+        let printed = json_log(&layout, 5, Some(&older_peer)).expect("the local open prints");
+        let opens = kin_core::authority_opens() - before;
+
+        assert_eq!(printed, expected, "falling back answers exactly as it did");
+        assert_eq!(
+            opens, 1,
+            "an older peer's answer must not be printed as ours"
+        );
+    }
+
+    /// Every field of the report, populated, so the shape pin below sees all of
+    /// them.
+    ///
+    /// `start_target` and `start_change` carry `skip_serializing_if`, and a fresh
+    /// store has no entries, so a report taken straight off the fixture would pin
+    /// a shape smaller than the real one and the guard would miss exactly the
+    /// fields most likely to move.
+    fn fully_populated_report(mut report: LogReport) -> LogReport {
+        let change_id = SemanticChangeId::from_hash(Hash256::from_bytes([7; 32]));
+        report.start_target = Some(RefTarget::Change { change_id });
+        report.start_change = Some(change_id);
+        report.entries = vec![LogEntry {
+            change_id,
+            depth: 0,
+            origin: ChangeOrigin::Native,
+            parents: vec![SemanticChangeId::from_hash(Hash256::from_bytes([8; 32]))],
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("ada"),
+            message: "Right-align report amounts".to_string(),
+            entity_delta_count: 2,
+            entity_deltas_unchanged: 10,
+            relation_delta_count: 3,
+            tree_delta_count: 1,
+            admission_policy_changed: false,
+        }];
+        report
+    }
+
+    fn sorted_field_names(value: &serde_json::Value) -> String {
+        let mut names: Vec<&str> = value
+            .as_object()
+            .expect("a report and its entries serialize as objects")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        names.sort_unstable();
+        names.join(",")
+    }
+
+    /// A field added to the report must move [`LOG_REPORT_REVISION`] with it.
+    ///
+    /// The revision is what lets `kin log --json` print a peer's report as its
+    /// own, and it is only true while it tracks the shape. A field added under
+    /// `#[serde(default)]` without moving it would let a peer that never had
+    /// that field supply a default this build then prints as a measurement.
+    /// Nothing else in the suite can see that, because both sides deserialize
+    /// happily and the number is simply wrong.
+    #[test]
+    fn adding_a_report_field_must_move_the_report_revision() {
+        let _daemon = kin_core::test_env::EnvVarGuard::unset("KIN_DAEMON_URL");
+        let root = tempfile::tempdir().expect("a temporary directory for the fixture store");
+        let init = kin_core::init(root.path()).expect("kin_core::init builds a real store");
+        let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&init.layout)
+            .expect("the fixture store binds");
+        let (report, _tip) = local_log(&binding, 5).expect("a fresh store answers a log");
+        let report = fully_populated_report(report);
+        let value = serde_json::to_value(&report).expect("a report serializes");
+
+        assert_eq!(
+            (
+                LOG_REPORT_REVISION,
+                sorted_field_names(&value).as_str(),
+                sorted_field_names(&value["entries"][0]).as_str(),
+            ),
+            (
+                1,
+                "authority,authority_generation,entries,repository_id,requested_count,roots,\
+                 schema,start_change,start_target,truncated,workspace_generation,workspace_head,\
+                 workspace_id",
+                "admission_policy_changed,author,change_id,depth,entity_delta_count,\
+                 entity_deltas_unchanged,message,origin,parents,relation_delta_count,timestamp,\
+                 tree_delta_count",
+            ),
+            "the log report or its entries changed shape. A peer at an older revision cannot fill \
+             a field it never had, so `LOG_REPORT_REVISION` must move in the same change as the \
+             field, and this pin must move with it"
+        );
+    }
+
+    /// A report that crosses the wire and comes back serializes to the same
+    /// bytes.
+    ///
+    /// `kin log --json` prints a value it deserialized from a peer, so every
+    /// type in the report has to round-trip. One that does not would change the
+    /// contract silently for exactly the readers that pin it.
+    #[test]
+    fn a_report_that_crosses_the_wire_serializes_to_the_same_bytes() {
+        let _daemon = kin_core::test_env::EnvVarGuard::unset("KIN_DAEMON_URL");
+        let root = tempfile::tempdir().expect("a temporary directory for the fixture store");
+        let init = kin_core::init(root.path()).expect("kin_core::init builds a real store");
+        let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&init.layout)
+            .expect("the fixture store binds");
+        let (report, _tip) = local_log(&binding, 5).expect("a fresh store answers a log");
+        let report = fully_populated_report(report);
+
+        let sent = serde_json::to_string(&report).expect("a report serializes onto the wire");
+        let received: LogReport =
+            serde_json::from_str(&sent).expect("a report deserializes off the wire");
+
+        assert_eq!(
+            serde_json::to_string_pretty(&received).expect("the received report serializes"),
+            serde_json::to_string_pretty(&report).expect("the local report serializes"),
+            "a report must survive the wire byte for byte, or `--json` prints something this \
+             build would not have printed"
         );
     }
 

--- a/crates/kin-cli/tests/log_json_answers_from_the_daemon.rs
+++ b/crates/kin-cli/tests/log_json_answers_from_the_daemon.rs
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! `kin log --json` answers from a running daemon, and answers identically.
+//!
+//! The cost it was paying, measured on a converted psf/requests store on
+//! 2026-09-05: `kin log --json --count 2` took 11.04 seconds and 3,491,976 KiB
+//! of peak resident set for two entries, because the `--json` arm was gated out
+//! of the daemon route and opened the whole store in the CLI process. An open
+//! re-verifies every persisted body against its content address, so it costs
+//! whatever the store is worth, while the daemon that could have answered holds
+//! one open per publication.
+//!
+//! What `--json` may not do is print a peer's bytes as its own, so the two arms
+//! here are one test rather than two: the daemon-served answer must be byte for
+//! byte what this build prints from its own open. The no-daemon arm is also the
+//! control for the log reading. Both arms search the same stderr for the same
+//! phrase, and it MUST be found in the arm that opens, or the arm that must not
+//! open is searching stderr that carries no authority lines at all and proves
+//! nothing.
+
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+mod common;
+
+use common::Command;
+
+/// The phrase every whole-store authority open logs about itself.
+///
+/// `kin_core::open_persisted_local_repository_authority` is the funnel every
+/// path into kin-db's recovery reaches, and it logs this at info with the caller
+/// that asked. Matched on the sentence rather than on a file and line, which
+/// move, and which a Windows `Location::file()` spells with backslashes.
+const AUTHORITY_OPEN: &str = "re-verifies every persisted body";
+
+fn run_git(repo: &Path, args: &[&str]) -> std::process::Output {
+    Command::new("git")
+        .args(args)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
+        .current_dir(repo)
+        .output()
+        .expect("run git")
+}
+
+fn require_git(repo: &Path, args: &[&str]) {
+    let output = run_git(repo, args);
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// One `kin` run with authority attribution turned on.
+///
+/// `RUST_LOG` wins over the per-command defaults this binary installs, so the
+/// open lines are here whether or not a plain `kin log` would print them. That
+/// is what makes the absence in the served arm a reading rather than a silence.
+fn run_kin(
+    runtime: &common::IsolatedDaemonRuntime,
+    repo: &Path,
+    args: &[&str],
+    daemon: Daemon,
+) -> std::process::Output {
+    let mut command = runtime.kin_command();
+    command
+        .args(args)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
+        .env("KIN_DAEMON_BIN", runtime.daemon_bin())
+        .env("KIN_DAEMON_DISABLE_LSP", "1")
+        .env("RUST_LOG", "kin_cli=info,kin_core=info")
+        .current_dir(repo);
+    match daemon {
+        Daemon::Resolved => command.env_remove("KIN_DAEMON_URL"),
+        // An empty endpoint is this CLI's own way of saying "no daemon", and it
+        // is why this arm needs no `daemon stop`: stopping one leaves a race
+        // with whatever restarts it, and this cannot be raced.
+        //
+        // Through `fixture_daemon_url` rather than `env`, because the harness
+        // scrubs inherited Kin authority from every fixture command and
+        // `KIN_DAEMON_URL` set the ordinary way does not survive it. Set that
+        // way, this arm quietly resolved the runtime's own daemon and answered
+        // from it, which is a control that cannot fail.
+        Daemon::None => command.fixture_daemon_url(""),
+    };
+    command.output().expect("run kin")
+}
+
+#[derive(Clone, Copy)]
+enum Daemon {
+    Resolved,
+    None,
+}
+
+fn require_kin(
+    runtime: &common::IsolatedDaemonRuntime,
+    repo: &Path,
+    args: &[&str],
+    daemon: Daemon,
+) -> std::process::Output {
+    let output = run_kin(runtime, repo, args, daemon);
+    assert!(
+        output.status.success(),
+        "kin {args:?} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn initialize(runtime: &common::IsolatedDaemonRuntime, repo: &Path) {
+    fs::create_dir_all(repo).expect("create repo");
+    require_git(repo, &["init", "--initial-branch=main"]);
+    require_git(repo, &["config", "commit.gpgsign", "false"]);
+    require_git(repo, &["config", "user.name", "Ada Lovelace"]);
+    require_git(repo, &["config", "user.email", "ada@example.com"]);
+    fs::create_dir_all(repo.join("src")).expect("create source directory");
+    fs::write(repo.join("src/lib.rs"), b"pub fn shipped() -> u8 { 1 }\n").expect("write source");
+    require_git(repo, &["add", "--all"]);
+    require_git(repo, &["commit", "-m", "first commit"]);
+    require_kin(runtime, repo, &["init", ".", "--json"], Daemon::Resolved);
+}
+
+/// Falsify by gating the daemon route on `!json` in `kin_cli::commands::log`,
+/// which is what the shipped command did: the served arm then opens the whole
+/// store too, and its stderr carries the same line the control arm's does.
+#[test]
+fn a_json_log_answers_from_the_daemon_without_opening_the_store_itself() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    initialize(&runtime, &repo);
+
+    // A change of its own, so the log has an entry to report and the two arms
+    // are comparing a real answer rather than an empty one.
+    fs::write(repo.join("src/added.rs"), b"pub fn added() -> u8 { 3 }\n").expect("add source");
+    require_kin(
+        &runtime,
+        &repo,
+        &["commit", "-m", "publish added source"],
+        Daemon::Resolved,
+    );
+
+    let served = require_kin(
+        &runtime,
+        &repo,
+        &["log", "--json", "--count", "2"],
+        Daemon::Resolved,
+    );
+    let opened = require_kin(
+        &runtime,
+        &repo,
+        &["log", "--json", "--count", "2"],
+        Daemon::None,
+    );
+
+    let served_log = String::from_utf8_lossy(&served.stderr).into_owned();
+    let opened_log = String::from_utf8_lossy(&opened.stderr).into_owned();
+
+    // Non-vacuity first. Without this the absence below would pass on a run that
+    // logged nothing at all.
+    assert!(
+        opened_log.contains(AUTHORITY_OPEN),
+        "a `--json` log with no daemon must open the store and say so, or this test cannot see \
+         an open at all: {opened_log}"
+    );
+    assert!(
+        !served_log.contains(AUTHORITY_OPEN),
+        "a `--json` log a running daemon answered must not open the whole store in the CLI: \
+         {served_log}"
+    );
+
+    // The report is a contract with a machine reader, so routing it through the
+    // daemon may change what it costs and nothing else.
+    assert_eq!(
+        String::from_utf8_lossy(&served.stdout),
+        String::from_utf8_lossy(&opened.stdout),
+        "a daemon-answered `--json` log must print exactly what this build prints from its own \
+         open"
+    );
+    let report: serde_json::Value =
+        serde_json::from_slice(&served.stdout).expect("a `--json` log emits JSON");
+    assert_eq!(
+        report["schema"], "kin.log.v1",
+        "the answer compared above must be a real report: {report}"
+    );
+    assert!(
+        report["entries"]
+            .as_array()
+            .is_some_and(|entries| !entries.is_empty()),
+        "the answer compared above must carry the change this test committed: {report}"
+    );
+}

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -38974,9 +38974,21 @@ mod tests {
             "scan_working_copy",
             "observe_tree_and_stage_blobs",
             "plan_transaction",
+            // The three that used to be unnamed. `plan_transaction` was the
+            // largest phase of a 77 second commit on a converted psf/requests
+            // store and every sub-phase already timed inside it stayed under the
+            // 500 ms reporting threshold, so 26.5 seconds of it had no name.
+            // These are the O(store) operations that were in that gap.
+            "plan_open_authority",
+            "plan_resolve_base",
+            "plan_authority_workspace_graph",
             "plan_snapshot_clone",
             "plan_diff_semantics",
             "plan_compute_deltas",
+            // Spent by this path and captured by this test, but never asserted
+            // until now. A phase nothing asserts is a phase that can quietly
+            // stop being named.
+            "plan_verify_semantics_follow_bytes",
             "plan_derive_admission_policy",
             "install_live_graph",
         ] {

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -1623,6 +1623,15 @@ fn plan_native_commit_inner(
     // in repository CAS against its content address. Naming them costs nothing
     // and is what makes the next measurement an attribution rather than another
     // hypothesis.
+    //
+    // What a name buys is the LOGGED `elapsed_ms`, which each closure bounds
+    // exactly. The live phase label is looser and always has been: `enter_phase`
+    // overwrites a single slot and nothing restores the enclosing phase on exit,
+    // so the roots check and the workspace lookup below are reported by the
+    // liveness ticker as still inside this phase until the next one is entered.
+    // That shape is shared with every phase already named in this function and
+    // is not changed here; it is written down so a reader of a live trace does
+    // not read the label as tightly as the durations.
     let authority = crate::mcp_commit::timed_commit_phase("plan_open_authority", || {
         authority_context.open().map_err(DaemonError::Graph)
     })?;

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -1612,7 +1612,20 @@ fn plan_native_commit_inner(
 ) -> Result<NativeCommitPlan> {
     let repository_id = authority_context.repository_id().clone();
     let workspace_id = authority_context.workspace_id();
-    let authority = authority_context.open().map_err(DaemonError::Graph)?;
+    // Named, because the phase around it is the largest of the commit and almost
+    // none of it is measured. On the converted psf/requests store of 2026-09-05
+    // `plan_transaction` took 29,081 ms while every sub-phase this function
+    // already times stayed under the 500 ms `timed_commit_phase` reports at, so
+    // not one of them appears in the daemon log and at least 26.5 seconds of a
+    // 77 second commit carries no name at all. This open and the workspace-graph
+    // materialization below are the two O(store) operations inside that gap: an
+    // open decodes the whole persisted authority and then re-verifies every body
+    // in repository CAS against its content address. Naming them costs nothing
+    // and is what makes the next measurement an attribution rather than another
+    // hypothesis.
+    let authority = crate::mcp_commit::timed_commit_phase("plan_open_authority", || {
+        authority_context.open().map_err(DaemonError::Graph)
+    })?;
     let lease = authority.read_authority();
     if expected_roots.is_some_and(|expected| expected != lease.roots()) {
         return Err(invalid(
@@ -1638,7 +1651,9 @@ fn plan_native_commit_inner(
     }
 
     let (commit_target, current_ref_target, head) =
-        resolve_commit_base(metadata, &workspace.head, workspace.base_target.as_ref())?;
+        crate::mcp_commit::timed_commit_phase("plan_resolve_base", || {
+            resolve_commit_base(metadata, &workspace.head, workspace.base_target.as_ref())
+        })?;
     let previous_change = if let Some(amend) = amend {
         require_amend_head(head, amend.expected_head)?;
         Some(
@@ -1683,14 +1698,21 @@ fn plan_native_commit_inner(
     // whole authority publication after it. It has nothing to contribute to
     // either.
     let workspace_semantic_delta = {
+        // The authority half of the diff, and the other O(store) operation in
+        // this function. It reads the workspace's graph out of authority, and on
+        // a store whose materialized base section does not resolve at the change
+        // being asked about, kin-db folds that base out of history instead. It
+        // sat untimed between two timed phases, so whatever it costs was
+        // invisible in every commit profile taken so far.
         let authority_workspace_graph =
-            lease
-                .workspace_graph_snapshot(&workspace_id)?
-                .ok_or_else(|| {
-                    invalid(format!(
-                        "repository authority has no graph snapshot for workspace {workspace_id}"
-                    ))
-                })?;
+            crate::mcp_commit::timed_commit_phase("plan_authority_workspace_graph", || {
+                lease.workspace_graph_snapshot(&workspace_id)
+            })?
+            .ok_or_else(|| {
+                invalid(format!(
+                    "repository authority has no graph snapshot for workspace {workspace_id}"
+                ))
+            })?;
         let desired_workspace_graph =
             crate::mcp_commit::timed_commit_phase("plan_snapshot_clone", || graph.to_snapshot());
         crate::mcp_commit::timed_commit_phase("plan_diff_semantics", || {


### PR DESCRIPTION
Tracker: FIR-3260.

## What this is

`kin log --json` opened the whole store in the CLI process, because the daemon route was gated
on the text path. On a converted psf/requests store (6734 changes, measured 2026-09-05) that open
was the whole of an 11.04 second two-entry log and 3,491,976 KiB of peak resident set, while the
daemon that could have answered holds one open per publication and had the change map decoded
already. An 11 second two-entry log is a product defect, not a measurement note.

`--json` now takes the daemon's structured report when this build may print it. Two things make
that honest rather than a shortcut:

The value is deserialized into this build's own `LogReport` and serialized by this build's own
serde, so the bytes printed are this build's, not a peer's.

And the peer must name the same report revision. That is a new field and a different question
from the schema. The schema names what the fields MEAN and must not move for a shape change,
because it is what a machine reader pins; the revision names which fields a build FILLS.
`entity_deltas_unchanged` was added to `LogEntry` under `#[serde(default)]` with `kin.log.v1`
deliberately left in place, so schema equality alone would let a caller print a peer's report
with a real unchanged-entity count silently replaced by zero, and nothing would say so. A peer
too old to name a revision reads as 0 and the caller falls back to its own open, answering
exactly as it did. That is the same idiom `CommandStatusResponse::authority_readings_taken` uses.

When it does fall back, it now says so on stderr with both revisions named. The report itself is
unchanged on both branches, because that is the machine contract; the disclosure rides beside it
at the same `info` level as the authority-open attribution line that follows it, which is the
line that attributed the 11.04 seconds in the first place.

## The second half: naming what the commit does not measure

The same run's commit took 77.224 s. `plan_transaction` was 29,081 ms of it, and every sub-phase
already timed inside that function stayed under the 500 ms threshold `timed_commit_phase` reports
at, so not one of them appears in the daemon log. The reading is sound because the log carries
zero `DEBUG` lines and five `INFO` lines from `kin_daemon::mcp_commit`, which is the same module
and the same macro: an `INFO` line from it is the positive control that the filter passes it, and
a missing phase name means under 500 ms. So at least 26.5 seconds of the largest phase of the
commit carried no name at all.

`plan_open_authority` and `plan_authority_workspace_graph` cover the two O(store) operations in
that gap, and `plan_resolve_base` the work between them. This removes no time. It makes the next
measurement an attribution instead of another hypothesis.

What a name buys is the logged `elapsed_ms`, which each closure bounds exactly. The live phase
label is looser: `enter_phase` overwrites one slot and nothing restores the enclosing phase on
exit, so the work between two named phases is reported by the ticker as still inside the earlier
one. That shape is pre-existing and shared with every phase already in the function; it is
written into the source comment so a reader of a live trace does not read the label as tightly as
the durations.

`plan_verify_semantics_follow_bytes` joins the asserted phase list while there. The path spends
it and the test captures it; nothing asserted it, and a phase nothing asserts can quietly stop
being named.

## Guards, red before green

Bounded on the open COUNT rather than the wall clock, because a fixture small enough to run in CI
answers in milliseconds whether it opens or not. Every tail below is from
`cargo test -p kin-cli --lib -- commands::log` unless another command is named.

The reroute, falsified by making `json_log` ignore what the daemon answered, which is what the
shipped code did:

```
$ cargo test -p kin-cli --lib -- commands::log
thread '...a_json_log_answered_at_this_report_revision_opens_no_authority' panicked at
crates/kin-cli/src/commands/log.rs:633:9:
assertion `left == right` failed: a `--json` log the daemon already answered must not open the
whole store again
  left: 1
 right: 0
test result: FAILED. 7 passed; 1 failed; 0 ignored; 0 measured; 2205 filtered out
```

The revision-0 refusal, which is the arm that occurs against a real older daemon, falsified with
a gate that trusts revision 0. Its fixture is built by taking a real daemon answer and REMOVING
the `report_revision` key, so the report stays present and the revision arrives as 0 through the
same `#[serde(default)]` a real peer would use, and the removal is itself asserted so a rename of
the field fails the case rather than quietly emptying it:

```
$ cargo test -p kin-cli --lib -- commands::log
thread '...a_json_log_answered_by_a_peer_that_names_no_revision_opens_locally' panicked at
crates/kin-cli/src/commands/log.rs:748:9:
assertion `left == right` failed: an older peer names no revision, so its report must not be
printed as ours
  left: 0
 right: 1
test result: FAILED. 8 passed; 1 failed; 0 ignored; 0 measured; 2205 filtered out; finished in 4.79s
```

`adding_a_report_field_must_move_the_report_revision` was written red on purpose with its pin left
as a placeholder, so the field list it pins came out of the code rather than out of a hand-written
list.

The end-to-end half, through the real binaries, falsified by restoring
`if json { None } else { daemon_log(...) }`:

```
$ cargo test -p kin-cli --test log_json_answers_from_the_daemon
a `--json` log a running daemon answered must not open the whole store in the CLI:
... INFO kin_core::repository_authority: opening persisted repository authority, which re-verifies
every persisted body repository=8b79dbab-... caller=crates/kin-cli/src/commands/log.rs:305
test result: FAILED. 0 passed; 1 failed
```

Its no-daemon arm is a control that must hit, and it earned that: the arm first set
`KIN_DAEMON_URL` through `Command::env`, the harness scrubs inherited Kin authority from every
fixture command, and the arm silently resolved the runtime's own daemon and answered from it. The
control caught the false green. It goes through `fixture_daemon_url` now.

The commit phase names, falsified by removing one wrapper, and the failure names which one:

```
$ cargo test -p kin-daemon --lib -- the_cli_commit_path_names_every_phase_it_spends
the commit path must name the plan_authority_workspace_graph phase; captured
["coordination_gate_wait", "scan_working_copy", "observe_tree_and_stage_blobs",
"forced_filesystem_admission", "plan_open_authority", "plan_resolve_base", "plan_snapshot_clone",
"plan_diff_semantics", "plan_compute_deltas", "plan_verify_semantics_follow_bytes",
"plan_derive_admission_policy", "plan_transaction", "open_repository_authority", ...]
test result: FAILED. 0 passed; 1 failed
```

That captured list settles something the retained logs left open: `open_repository_authority` in
the commit path is `|| plan.authority`, so the publication reuses the manager the plan opened and
a commit pays exactly one whole-store open.

## Local gates

`bin/kin-precheck kin --repo-dir kin=<worktree>`, which enumerates its gate list out of this
repo's own `ci.yml` rather than a remembered copy:

```
kin-precheck: repo=kin tree=/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/perftriage-kin sha=77411ff44bb0a378591d956567ea572c42bda5ec branch=chore/lane-perftriage-kin
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:check_private_repo_coupling.sh bash scripts/check_private_repo_coupling.sh
PASS     guard:check_runtime_boundaries.sh    bash scripts/check_runtime_boundaries.sh
PASS     guard:test-release-policy-gate.sh    bash scripts/test-release-policy-gate.sh
PASS     guard:test-windows-authority-legs.sh bash scripts/test-windows-authority-legs.sh
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:check-kin-vfs-compat.mjs       node scripts/check-kin-vfs-compat.mjs
PASS     guard:check-rc-build-drift.mjs       node scripts/check-rc-build-drift.mjs
PASS     guard:check-required-contexts.py     python3 scripts/check-required-contexts.py
PASS     guard:test-assertion-reachability.py python3 scripts/test-assertion-reachability.py
PASS     guard:test-guard-duplicate-release-run.py python3 scripts/test-guard-duplicate-release-run.py
PASS     guard:test-homebrew-release-gate.py  python3 scripts/test-homebrew-release-gate.py
PASS     guard:test-install-checksum.py       python3 scripts/test-install-checksum.py
PASS     guard:test-private-repo-coupling.py  python3 scripts/test-private-repo-coupling.py
PASS     guard:test-release-tag-evaluate-dispatch.py python3 scripts/test-release-tag-evaluate-dispatch.py
PASS     guard:test-release-workflow-authority.py python3 scripts/test-release-workflow-authority.py
PASS     guard:test-select-release-candidate.py python3 scripts/test-select-release-candidate.py
PASS     guard:verify-hydration-semantics.py  python3 scripts/verify-hydration-semantics.py
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
PASS     node-test                            node --test <15 file(s) named by the check job>
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 77411ff44bb0a378591d956567ea572c42bda5ec
```

```
$ cargo fmt --all -- --check
rc=0
```

```
$ cargo test -p kin-cli -p kin-daemon
88 test-result lines: 4719 passed, 0 failed, 6 ignored
error lines: 0
EXIT=0

kin_daemon-9917df80cb77eb9f      test result: ok. 1533 passed; 0 failed; 3 ignored; ... 333.16s
kin_daemon-7329accf8fc578dd      test result: ok. 6 passed; 0 failed; 0 ignored; ... 0.00s
log_json_answers_from_the_daemon test result: ok. 10 passed; 0 failed; 0 ignored; ... 3.12s
```

One reading trap that run produced, so nobody re-derives it. Grepping the log for
`the_cli_commit_path_names_every_phase_it_spends ... ok` returns 0 matches, and that is NOT the
test failing. Under default parallelism another test's progress output landed inside the line:

```
test api::tests::the_cli_commit_path_names_every_phase_it_spends ...   [ 6/17] apply admission policyok
```

A per-test grep over a parallel run's stdout can miss a passing test for a reason that has
nothing to do with the test. The per-binary `test result:` line is the reading that holds.

## Answering the review

`review-kin-1562-20260905.md` at `2350ebc1e`: 0 P1, 2 P2, 5 P3, and no conflict with #1561 (one
shared file, hunks 434 lines apart in different functions, `git merge-tree --write-tree` returns a
tree carrying both changes).

**P2-1 was a real hole and is fixed.** The older-peer case built its fixture as
`{"lines": [...], "report": null}`, so the gate refused it on `report.as_ref()` before the revision
comparison was reached, and its open-count assertion was satisfied by the absent report alone. The
reviewer's mutation, a gate that trusts revision 0, left every test in the module green. The
fixture is now what such a peer actually sends and the mutation now goes red; the tail is above.
The absent-report case keeps an arm of its own.

**P3-1 fixed**, the fallback now discloses itself on stderr with both revisions named.
**P3-2 accepted as a fact and declined as a code change**, with the reason in `json_log`'s doc
comment and in the non-claims below: fixing it puts the `json` condition back on the ask and lets
the decision drift out of the one function a test can drive. **P3-3 accepted**, the live ticker
label is looser than the logged durations and the precise statement is now in the source.
**P3-4 fixed**, and it disappeared on its own because the rebuilt fixture needs the binding.
**P3-5 fixed** here: the tracker line, the precheck output rather than an elided summary, and the
command above every tail. **P2-2, the draft flag, is the landing step.**

One item the reviewer could not witness, which the author did: its unverified item 1, removing a
timed phase, was executed and its tail is the `plan_authority_workspace_graph` failure above. Its
items 2, 3 and 4 are covered by the precheck run and by hosted CI on the head, by name.

## What this does not claim

No psf/requests re-measurement ran for this branch. The 11.04 s figure is the retained measurement
of the command this change reroutes, and the guards prove the reroute performs zero whole-store
opens; neither is a new timing on that store. The phase naming removes no time and says so. Which
share of the 29,081 ms belongs to the open rather than to the workspace graph is exactly what the
new phases exist to find out, and is not asserted here.

One arm is slower than before. A daemon whose report this build may not print now costs the round
trip AND the local open, where the old command paid only the open. That is the price of asking
before deciding, and asking before deciding is what keeps the `json` condition out of `run`'s call
to the daemon so the decision lives in one place a test can drive. The arm it costs is the
mixed-build one rather than the ordinary one.
