### PR TITLE
Poll kin refs before asserting the relocated caller edge

### DIFF
--- a/crates/kin-cli/tests/entity_file_retirement.rs
+++ b/crates/kin-cli/tests/entity_file_retirement.rs
@@ -28,6 +28,7 @@
 use serde_json::Value;
 use std::fs;
 use std::path::Path;
+use std::time::{Duration, Instant};
 use tempfile::tempdir;
 
 mod common;
@@ -201,6 +202,53 @@ fn references_text(runtime: &common::IsolatedDaemonRuntime, repo: &Path, entity:
     String::from_utf8_lossy(&output.stdout).to_string()
 }
 
+/// Bound on how long the relocation commit's caller edge may take to reach
+/// `kin refs`, and how often to ask again while waiting.
+///
+/// The daemon's live query graph catches up to a commit asynchronously, and a
+/// read taken right after `kin commit` returns can measure that catch-up
+/// instead of the relocation. CI run 34000661616 (kin main 75ffe8933, `Check &
+/// Test ubuntu shard (1)`, panicked at entity_file_retirement.rs:277 on
+/// 2026-09-06T00:26:01Z after a 7.306s test) read `kin refs moved_target`
+/// immediately after this same relocation commit and got "No incoming Calls,
+/// Imports, References relations", qualified with "Kin cannot rule out
+/// references it did not see: this build produced no entity-level call edge
+/// for Python although the source carries call sites". That is not a
+/// permanent absence: the identical query is asserted to hold both before this
+/// commit (`references_before`, above) and on ordinary runs after it, so the
+/// qualifier was disclosing a graph still mid-catch-up rather than a real gap.
+///
+/// How long that catch-up takes is itself load-sensitive: this test passed in
+/// 4.95s run alone, and with a 30s bound it still timed out when run alongside
+/// three sibling tests in this file (each spinning up its own daemon) plus an
+/// unrelated build sharing the machine. Ninety seconds covers that kind of
+/// shared-box contention and stays well short of `COMMAND_TIMEOUT`.
+const RELOCATED_CALLER_EDGE_TIMEOUT: Duration = Duration::from_secs(90);
+const RELOCATED_CALLER_EDGE_POLL: Duration = Duration::from_millis(100);
+
+/// Poll `kin refs entity` until its text contains `needle`, bounded by
+/// [`RELOCATED_CALLER_EDGE_TIMEOUT`].
+///
+/// This retries the exact command and the exact fact the test asserts on,
+/// never a side channel, so a caller edge that is genuinely gone still fails
+/// below, just after the catch-up window instead of on whichever read the
+/// daemon's scheduler happened to win.
+fn wait_for_reference(
+    runtime: &common::IsolatedDaemonRuntime,
+    repo: &Path,
+    entity: &str,
+    needle: &str,
+) -> String {
+    let deadline = Instant::now() + RELOCATED_CALLER_EDGE_TIMEOUT;
+    loop {
+        let text = references_text(runtime, repo, entity);
+        if text.contains(needle) || Instant::now() >= deadline {
+            return text;
+        }
+        std::thread::sleep(RELOCATED_CALLER_EDGE_POLL);
+    }
+}
+
 /// Renaming a committed entity-owning file with a bare `mv`, then committing.
 ///
 /// The incoming-edge assertion is the point of this test, not decoration. A
@@ -273,11 +321,13 @@ fn renaming_a_committed_entity_owning_file_relocates_it_rather_than_stranding_it
         "the moved entity is not ranked at the path it arrived on: {after:?}"
     );
 
-    let references_after = references_text(&runtime, &repo, "moved_target");
+    let references_after = wait_for_reference(&runtime, &repo, "moved_target", "src/caller.py");
     assert!(
         references_after.contains("src/caller.py"),
         "the caller lost its edge into the moved function, which is what a removal plus an \
-         addition does and what relocating in one delta exists to prevent: {references_after}"
+         addition does and what relocating in one delta exists to prevent, even after waiting up \
+         to {RELOCATED_CALLER_EDGE_TIMEOUT:?} for the daemon's derived reference graph to catch up \
+         with the relocation commit: {references_after}"
     );
 
     // The repository still accepts work. This is the half that made the defect


### PR DESCRIPTION
## Summary

The rename test in `entity_file_retirement.rs` read `kin refs` once, immediately after the
relocation commit, and asserted the caller's edge into the moved function was still there. The
daemon's live query graph catches up to a commit asynchronously, so that single read sometimes
measured the catch-up instead of the relocation. This is a test determinism fix. No product code
changed.

## The failure

CI run 34000661616 (kin main 75ffe8933, `Check & Test ubuntu shard (1)`, attempt 1, concluded
failure at 2026-09-06T00:26:26Z). The job log:

```
2026-09-06T00:26:01.3477612Z FAIL [7.306s] kin-cli::entity_file_retirement renaming_a_committed_entity_owning_file_relocates_it_rather_than_stranding_it
2026-09-06T00:26:01.3493624Z thread '...' panicked at crates/kin-cli/tests/entity_file_retirement.rs:277:5:
2026-09-06T00:26:01.3496659Z the caller lost its edge into the moved function, ...: References to 'moved_target' -> moved_target (Function) @ src/renamed.py
2026-09-06T00:26:01.3498667Z No incoming Calls, Imports, References relations.
2026-09-06T00:26:01.3500994Z Kin cannot rule out references it did not see: this build produced no entity-level call edge for Python although the source carries call sites, so a use reaching this entity from another file could not have been found. The gap is in the linker, not in the code.
2026-09-06T00:26:01.3504073Z Kin cannot rule out references it did not see: this graph holds no cross-file import or reference edges for Python, so a use reaching this entity from another file could not have been found.
```

## The fix

`references_after` now goes through a new `wait_for_reference` helper that polls `kin refs`, the
same command and the same fact the test already asserts on, for up to 90 seconds before that read.
A caller edge that is genuinely gone still fails this test; it just fails after the catch-up
window instead of on whichever read the daemon's scheduler happened to win.

Ninety seconds sits under nextest's own slow-timeout warning line (120s in
`.config/nextest.toml`) and is negligible against the 60 minute `Check & Test ubuntu shard` job
budget (`timeout-minutes: 60`, ci.yml:1761), so it costs nothing on the runs that already pass and
gives real margin on the rare one that does not.

## Falsification

Reproduced the race on demand: started 14 CPU-stress processes (each pinned near 100%) and ran the
test with an artificially short bound, then with the real bound, under the identical load.

Short bound (200ms) under stress, fails with the same panic the CI run hit:

```
$ cargo test -p kin-cli --test entity_file_retirement renaming_a_committed_entity_owning_file -- --test-threads=1
thread '...' panicked at crates/kin-cli/tests/entity_file_retirement.rs:325:5:
the caller lost its edge into the moved function, which is what a removal plus an addition does and what relocating in one delta exists to prevent, even after waiting up to 200ms for the daemon's derived reference graph to catch up with the relocation commit: References to 'moved_target' -> moved_target (Function) @ src/renamed.py
No incoming Calls, Imports, References relations.
Kin cannot rule out references it did not see: this build produced no entity-level call edge for Python although the source carries call sites, so a use reaching this entity from another file could not have been found. The gap is in the linker, not in the code.
Kin cannot rule out references it did not see: this graph holds no cross-file import or reference edges for Python, so a use reaching this entity from another file could not have been found.

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 12 filtered out; finished in 6.17s
```

Real bound (90s) under the same stress, passes clean:

```
$ cargo test -p kin-cli --test entity_file_retirement renaming_a_committed_entity_owning_file -- --test-threads=1
test renaming_a_committed_entity_owning_file_relocates_it_rather_than_stranding_it ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 6.04s
```

Stress processes killed immediately after; confirmed none remained.

## Verification

```
$ cargo fmt --all -- --check
(exit 0, clean)
```

```
$ cargo clippy -p kin-cli --all-targets --all-features -- <the 45 allows from .github/clippy-allowed-lints.txt>
clippy debt allow-list: 45 lints
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 54.21s
(exit 0, no new warnings)
```

20 consecutive runs, single-threaded, one process per run:

```
=== run 1/20 ===  test result: ok. 1 passed; 0 failed; ...; finished in 5.07s
=== run 2/20 ===  test result: ok. 1 passed; 0 failed; ...; finished in 4.94s
=== run 3/20 ===  test result: ok. 1 passed; 0 failed; ...; finished in 4.94s
=== run 4/20 ===  test result: ok. 1 passed; 0 failed; ...; finished in 4.95s
=== run 5/20 ===  test result: ok. 1 passed; 0 failed; ...; finished in 5.14s
=== run 6/20 ===  test result: ok. 1 passed; 0 failed; ...; finished in 4.97s
=== run 7/20 ===  test result: ok. 1 passed; 0 failed; ...; finished in 5.07s
=== run 8/20 ===  test result: ok. 1 passed; 0 failed; ...; finished in 4.93s
=== run 9/20 ===  test result: ok. 1 passed; 0 failed; ...; finished in 4.91s
=== run 10/20 === test result: ok. 1 passed; 0 failed; ...; finished in 4.92s
=== run 11/20 === test result: ok. 1 passed; 0 failed; ...; finished in 5.05s
=== run 12/20 === test result: ok. 1 passed; 0 failed; ...; finished in 4.94s
=== run 13/20 === test result: ok. 1 passed; 0 failed; ...; finished in 5.13s
=== run 14/20 === test result: ok. 1 passed; 0 failed; ...; finished in 4.98s
=== run 15/20 === test result: ok. 1 passed; 0 failed; ...; finished in 5.70s
=== run 16/20 === test result: ok. 1 passed; 0 failed; ...; finished in 5.02s
=== run 17/20 === test result: ok. 1 passed; 0 failed; ...; finished in 5.11s
=== run 18/20 === test result: ok. 1 passed; 0 failed; ...; finished in 5.05s
=== run 19/20 === test result: ok. 1 passed; 0 failed; ...; finished in 4.93s
=== run 20/20 === test result: ok. 1 passed; 0 failed; ...; finished in 5.02s
ALL 20 RUNS GREEN
```

Re-verified once more after rebasing onto the current main (b1837fa59):

```
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 47.72s
```

Test-only change. No product code touched.
