### PR TITLE
Refresh the graph section after a resolved merge, and redact the org-scope refusal

### DIFF
--- a/crates/kin-cli/src/commands/transfer.rs
+++ b/crates/kin-cli/src/commands/transfer.rs
@@ -266,14 +266,7 @@ pub(crate) fn resolve_peer(
                         .map(|value| value.trim().to_string())
                         .filter(|value| !value.is_empty())
                 })
-                .with_context(|| {
-                    format!(
-                        "native-kin remote {} is hosted on KinLab, whose transfer seam is scoped \
-                         to an organization, and {base_url} names none. Re-add it with a full \
-                         locator like `--url kinlab://<org>/<repo>`, or set KIN_ORG_ID.",
-                        selected.name
-                    )
-                })?,
+                .with_context(|| missing_organization_message(&selected.name, &base_url))?,
         ),
         _ => None,
     };
@@ -283,6 +276,34 @@ pub(crate) fn resolve_peer(
         base_url,
         organization_id,
     })
+}
+
+/// The refusal a hosted remote's transfer pre-flight prints when nothing names
+/// an organization.
+///
+/// The address is redacted rather than interpolated. This site printed the
+/// configured URL back verbatim, so a remote added as
+/// `--url https://user:password@kinlab.ai` answered a missing `KIN_ORG_ID` by
+/// echoing the password onto the terminal and into whatever captured it. The
+/// three sites kin#1561 fixed already call
+/// `kin_remote::repository_transfer::redacted_remote_address`; this is the
+/// fourth, and it was the only remaining verbatim base URL in this module.
+///
+/// A function rather than an inline `format!`, for the reason
+/// `remote::missing_bearer_token_message` is one: the address half has a `None`
+/// arm, `redacted_remote_address` withholds any URL whose `@` sits outside the
+/// authority, and the obvious way to spend that `Option` at a call site is
+/// `unwrap_or_else(|| base_url.to_string())`, which hands the whole
+/// credential-bearing URL back and restores exactly the leak the redaction
+/// closes. Inlined, that arm sits where no test can reach it.
+fn missing_organization_message(remote_name: &str, base_url: &str) -> String {
+    let address = kin_remote::repository_transfer::redacted_remote_address(base_url)
+        .unwrap_or_else(|| "that remote".to_string());
+    format!(
+        "native-kin remote {remote_name} is hosted on KinLab, whose transfer seam is scoped to an \
+         organization, and {address} names none. Re-add it with a full locator like `--url \
+         kinlab://<org>/<repo>`, or set KIN_ORG_ID."
+    )
 }
 
 fn parse_ref(value: Option<&str>) -> Result<Option<RefName>> {
@@ -565,6 +586,61 @@ mod tests {
         assert!(
             !base.contains("/api/orgs/"),
             "base carries an org path: {base}"
+        );
+    }
+
+    /// The `None` arm of the redaction, graded where this pre-flight spends it.
+    ///
+    /// Same shape as `remote::a_url_the_redaction_withholds_is_never_named_in_the_refusal`:
+    /// `redacted_remote_address` withholds a URL whose `@` sits outside the
+    /// authority, because it cannot tell a smuggled userinfo from an ordinary
+    /// path character, and what a refusal does with that withholding has exactly
+    /// one wrong answer, which is printing the URL back. This refusal printed it
+    /// back unconditionally until now.
+    #[test]
+    fn a_url_the_redaction_withholds_is_never_named_in_the_org_scope_refusal() {
+        // The unencoded `/` ends the authority before the `@`, so this is the
+        // shape no redactor can parse and every part of it is a credential.
+        let message = missing_organization_message("origin", "https://alice:s3cr3t/pw@kinlab.ai");
+        for (named, carried) in [
+            ("the password", "s3cr3t"),
+            ("the username", "alice"),
+            ("a host it could not vouch for", "kinlab.ai"),
+        ] {
+            assert!(
+                !message.contains(carried),
+                "the org-scope refusal named {named} out of a URL the redaction withheld: \
+                 {message}"
+            );
+        }
+        assert!(
+            message.contains("that remote names none"),
+            "it must still say a remote named no organization, without naming one: {message}"
+        );
+        assert!(
+            message.contains("KIN_ORG_ID"),
+            "and must still carry the remedy that fixes it: {message}"
+        );
+    }
+
+    /// The positive control for the assertions above, in both directions: a
+    /// refusal that named nothing at all would pass every one of them, and a
+    /// remote whose URL parses must still be named in full.
+    #[test]
+    fn a_parseable_remote_is_named_in_the_org_scope_refusal_without_its_credentials() {
+        let message =
+            missing_organization_message("origin", "https://alice:s3cr3t@kinlab.ai/team?t=v#f");
+        assert!(
+            message.contains("https://kinlab.ai/team names none"),
+            "a parseable remote must be named, path included: {message}"
+        );
+        assert!(
+            !message.contains("s3cr3t") && !message.contains("alice") && !message.contains("t=v"),
+            "and named without the credentials it carried: {message}"
+        );
+        assert!(
+            message.contains("native-kin remote origin is hosted on KinLab"),
+            "and the refusal must still say which remote it is about: {message}"
         );
     }
 

--- a/crates/kin-cli/src/commands/transfer.rs
+++ b/crates/kin-cli/src/commands/transfer.rs
@@ -287,7 +287,11 @@ pub(crate) fn resolve_peer(
 /// echoing the password onto the terminal and into whatever captured it. The
 /// three sites kin#1561 fixed already call
 /// `kin_remote::repository_transfer::redacted_remote_address`; this is the
-/// fourth, and it was the only remaining verbatim base URL in this module.
+/// fourth, and the last of this module's REFUSALS to name the base URL
+/// verbatim. It is not the last verbatim base URL here: `kin remote plan-push`
+/// still prints the configured address unredacted, both in its `--json` dump of
+/// the plan and in its `Remote:` line. Those are a reporting surface rather than
+/// a refusal, they leak the same credential, and they are their own change.
 ///
 /// A function rather than an inline `format!`, for the reason
 /// `remote::missing_bearer_token_message` is one: the address half has a `None`

--- a/crates/kin-cli/tests/graph_section_after_resolved_merge.rs
+++ b/crates/kin-cli/tests/graph_section_after_resolved_merge.rs
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! What the graph section reads after a merge that PARKED and was then
+//! published through `kin resolve --continue`.
+//!
+//! kin#1561 refreshes this workspace's base graph section after every
+//! transition that moves the base, and installed the call at four sites. One of
+//! them is `repository_merge::execute`, the plain-merge publication. That
+//! module holds two publications: `execute` publishes a clean merge, and
+//! `publish_resolved_merge` publishes one whose conflicts were settled, which
+//! `kin resolve --continue` reaches through
+//! `repository_merge_state::execute_resolve`. The second carried no refresh.
+//!
+//! Measured on b1837fa59 by a journey walking this repository the way a
+//! stranger would: after the first commit, after each branch switch, after a
+//! fast-forward merge and after a merge that parked with conflicts, the section
+//! read present and current; after `kin resolve --all-ours` and
+//! `kin resolve --continue` it read present but refused (`resolved_at`) until
+//! `kin graph materialize` was run by hand. So the one way a merge can end that
+//! needs a person's attention is also the one way that left the store folding
+//! its merged base out of history at every open.
+//!
+//! This drives the product CLI end to end rather than the daemon's own routes,
+//! for the reason [`graph_section_after_transfer`] gives: the state under test
+//! is a property of the store on disk rather than of any one process, and
+//! kin's `Product Acceptance` job carries
+//! `if: ${{ github.event_name != 'pull_request' }}`, so a rule under
+//! `scripts/acceptance/` would not grade the pull request that breaks it. The
+//! matching daemon-level arm lives beside kin#1287's in `kin-daemon`'s
+//! `api.rs`.
+//!
+//! [`graph_section_after_transfer`]: ../graph_section_after_transfer.rs
+
+use std::fs;
+use std::path::Path;
+use std::process::Output;
+
+use serde_json::Value;
+use tempfile::tempdir;
+
+mod common;
+
+/// The prefix of the one `kin graph status` line this file is about.
+const SECTION_PREFIX: &str = "Graph section:";
+
+/// What the line says when an open serves the base from a persisted section.
+const SERVING: &str = "present and current at";
+
+fn require_success(output: Output) -> Output {
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn run(runtime: &common::IsolatedDaemonRuntime, repo: &Path, args: &[&str]) -> Output {
+    runtime
+        .kin_command()
+        .env("KIN_DAEMON_BIN", runtime.daemon_bin())
+        .env("KIN_DAEMON_DISABLE_LSP", "1")
+        .env("KIN_EMBED_BACKEND", "cpu")
+        .current_dir(repo)
+        .args(args)
+        .output()
+        .expect("run isolated Kin command")
+}
+
+/// The product's own `Graph section:` line, read from `kin graph status`.
+///
+/// Read off stdout rather than asserted on a successful exit, because
+/// `kin graph status` exits non-zero when it finds a critical graph health
+/// issue, and the line is printed either way. A missing line is the one thing
+/// that panics, because a surface that fell silent about the state is the
+/// defect this whole class is about.
+fn graph_section_line(runtime: &common::IsolatedDaemonRuntime, repo: &Path) -> String {
+    let output = run(runtime, repo, &["graph", "status"]);
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    stdout
+        .lines()
+        .find(|line| line.starts_with(SECTION_PREFIX))
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            panic!(
+                "kin graph status printed no `{SECTION_PREFIX}` line in {}\nstdout={stdout}\nstderr={}",
+                repo.display(),
+                String::from_utf8_lossy(&output.stderr)
+            )
+        })
+}
+
+fn assert_serving(line: &str, what: &str) {
+    assert!(
+        line.contains(SERVING),
+        "{what} must serve its workspace base from a persisted section, so no open of it folds \
+         history: {line}"
+    );
+}
+
+/// The change this workspace's base resolves to, as the hex the section line
+/// prints.
+///
+/// `SemanticChangeId` wraps `Hash256`, which wraps `[u8; 32]`, and serde's
+/// newtype passthrough serializes all three as an array of 32 numbers rather
+/// than as a string, so the hex is built here to compare against the line the
+/// product prints.
+fn base_change(runtime: &common::IsolatedDaemonRuntime, repo: &Path) -> String {
+    let report: Value = serde_json::from_slice(
+        &require_success(run(runtime, repo, &["log", "--json", "--count", "1"])).stdout,
+    )
+    .expect("history JSON");
+    let bytes = report["start_change"].as_array().unwrap_or_else(|| {
+        panic!(
+            "{} reports no workspace base change: {}",
+            repo.display(),
+            report["start_change"]
+        )
+    });
+    bytes
+        .iter()
+        .map(|byte| {
+            format!(
+                "{:02x}",
+                byte.as_u64().expect("a change id byte is a number")
+            )
+        })
+        .collect()
+}
+
+fn configure_author(repo: &Path) {
+    let path = repo.join(".kin/config.toml");
+    let mut config = kin_core::KinConfig::load_or_default(&path).unwrap();
+    config.default_author =
+        Some("Graph Section Resolved Merge Test <graph-section@example.invalid>".to_string());
+    config.save(&path).unwrap();
+}
+
+fn commit(runtime: &common::IsolatedDaemonRuntime, repo: &Path, message: &str) {
+    require_success(run(runtime, repo, &["commit", "-m", message]));
+}
+
+/// The journey's own repro, one step at a time, each step naming itself.
+///
+/// A conflicted merge is the reason this file exists, so the fixture has to
+/// produce one rather than hope for one: both branches rewrite the SAME
+/// function body after the split, which is what makes `kin merge` park instead
+/// of fast-forwarding. `feature` also adds a file `trunk` does not have, so
+/// settling every conflict with `--all-ours` still leaves the merge with
+/// something to publish rather than composing back to the first parent.
+///
+/// The steps before the resolution are CONTROLS, not decoration. The commit
+/// path and the plain-merge path already refresh the section, and a run where
+/// those read as folding is an assertion that broke rather than a defect in the
+/// resolve path. The base-moved check is the other control: a section nobody
+/// touched, at a base nothing moved, still reads `present and current`, so
+/// without it this passes on a tree carrying no fix.
+///
+/// The refresh is synchronous inside the command that publishes the merge, so
+/// the section is read straight after `kin resolve --continue` returns rather
+/// than polled. Nothing here waits on a daemon catching up in the background;
+/// if the line is wrong at this point it stays wrong until `kin graph
+/// materialize` is run by hand, which is exactly the journey's reading.
+#[test]
+fn a_merge_published_through_resolve_continue_leaves_a_section_serving_its_merged_base() {
+    let scratch = tempdir().unwrap();
+    let source = scratch.path().join("source");
+    let runtime = common::IsolatedDaemonRuntime::new(&source);
+
+    fs::create_dir(&source).unwrap();
+    let initialized = kin_core::init_replica(&source, "trunk").unwrap();
+    drop(initialized);
+    configure_author(&source);
+    fs::create_dir(source.join("src")).unwrap();
+    fs::write(source.join("src/lib.rs"), b"pub fn answer() -> u8 { 42 }\n").unwrap();
+    commit(&runtime, &source, "Add a native source body");
+    assert_serving(
+        &graph_section_line(&runtime, &source),
+        "a store whose own commit refreshed its section",
+    );
+
+    require_success(run(&runtime, &source, &["branch", "create", "feature"]));
+    require_success(run(&runtime, &source, &["branch", "switch", "feature"]));
+    fs::write(source.join("src/lib.rs"), b"pub fn answer() -> u8 { 41 }\n").unwrap();
+    fs::write(
+        source.join("src/only_on_feature.rs"),
+        b"pub fn introduced() -> bool { true }\n",
+    )
+    .unwrap();
+    commit(
+        &runtime,
+        &source,
+        "Edit the answer and add a file on the branch",
+    );
+    assert_serving(
+        &graph_section_line(&runtime, &source),
+        "after committing on the branch",
+    );
+
+    require_success(run(&runtime, &source, &["branch", "switch", "trunk"]));
+    fs::write(source.join("src/lib.rs"), b"pub fn answer() -> u8 { 40 }\n").unwrap();
+    commit(
+        &runtime,
+        &source,
+        "Edit the same answer on the default branch",
+    );
+    let before_merge = base_change(&runtime, &source);
+    assert_serving(
+        &graph_section_line(&runtime, &source),
+        "after diverging the default branch",
+    );
+
+    // PRECONDITION, proved rather than assumed: this merge must PARK. A clean
+    // merge publishes through `repository_merge::execute`, which the plain
+    // merge case in `graph_section_after_transfer` already covers, and would
+    // grade nothing here.
+    let merge = run(&runtime, &source, &["merge", "feature"]);
+    assert_eq!(
+        merge.status.code(),
+        Some(kin_cli::commands::merge::EXIT_MERGE_CONFLICTED),
+        "NOT RUN, precondition unmet rather than property refuted: `kin merge feature` must park \
+         with conflicts for this test to reach `publish_resolved_merge`\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&merge.stdout),
+        String::from_utf8_lossy(&merge.stderr)
+    );
+
+    // A parked merge composed nothing and moved no base, so the section its
+    // last commit wrote must still answer. This separates the parking from the
+    // publication, so a red reading below names the publication.
+    assert_serving(
+        &graph_section_line(&runtime, &source),
+        "after a merge parked with conflicts",
+    );
+
+    require_success(run(&runtime, &source, &["resolve", "--all-ours"]));
+    require_success(run(&runtime, &source, &["resolve", "--continue"]));
+
+    let after_merge = base_change(&runtime, &source);
+    // CONTROL: the resolution actually moved this workspace's base. Without
+    // this the assertion below passes on an untouched section.
+    assert_ne!(
+        after_merge, before_merge,
+        "NOT RUN, precondition unmet: `kin resolve --continue` did not move this workspace's \
+         base off {before_merge}, so a section nobody refreshed would still read as serving"
+    );
+
+    // THE PROPERTY.
+    let line = graph_section_line(&runtime, &source);
+    assert_serving(
+        &line,
+        "a store whose merge was published through `kin resolve --continue`",
+    );
+    assert!(
+        line.contains(&after_merge),
+        "the section must describe the merged base the resolution published ({after_merge}): \
+         {line}"
+    );
+    assert!(
+        !line.contains(&before_merge),
+        "and not the base the workspace held before the merge ({before_merge}): {line}"
+    );
+}
+
+/// The section a resolved merge leaves has to be on disk, not in the process
+/// that wrote it.
+///
+/// A daemon restart is the ordinary case, and a store whose acceleration does
+/// not survive one pays the fold at every open exactly as if nothing had been
+/// written. Same reasoning as
+/// `a_cold_reopen_of_a_fresh_clone_still_serves_from_its_section`.
+#[test]
+fn a_cold_reopen_after_a_resolved_merge_still_serves_from_its_section() {
+    let scratch = tempdir().unwrap();
+    let source = scratch.path().join("source");
+    let runtime = common::IsolatedDaemonRuntime::new(&source);
+
+    fs::create_dir(&source).unwrap();
+    let initialized = kin_core::init_replica(&source, "trunk").unwrap();
+    drop(initialized);
+    configure_author(&source);
+    fs::create_dir(source.join("src")).unwrap();
+    fs::write(source.join("src/lib.rs"), b"pub fn answer() -> u8 { 42 }\n").unwrap();
+    commit(&runtime, &source, "Add a native source body");
+
+    require_success(run(&runtime, &source, &["branch", "create", "feature"]));
+    require_success(run(&runtime, &source, &["branch", "switch", "feature"]));
+    fs::write(source.join("src/lib.rs"), b"pub fn answer() -> u8 { 41 }\n").unwrap();
+    fs::write(
+        source.join("src/only_on_feature.rs"),
+        b"pub fn introduced() -> bool { true }\n",
+    )
+    .unwrap();
+    commit(
+        &runtime,
+        &source,
+        "Edit the answer and add a file on the branch",
+    );
+
+    require_success(run(&runtime, &source, &["branch", "switch", "trunk"]));
+    fs::write(source.join("src/lib.rs"), b"pub fn answer() -> u8 { 40 }\n").unwrap();
+    commit(
+        &runtime,
+        &source,
+        "Edit the same answer on the default branch",
+    );
+
+    let merge = run(&runtime, &source, &["merge", "feature"]);
+    assert_eq!(
+        merge.status.code(),
+        Some(kin_cli::commands::merge::EXIT_MERGE_CONFLICTED),
+        "NOT RUN, precondition unmet: this merge must park with conflicts\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&merge.stdout),
+        String::from_utf8_lossy(&merge.stderr)
+    );
+    require_success(run(&runtime, &source, &["resolve", "--all-ours"]));
+    require_success(run(&runtime, &source, &["resolve", "--continue"]));
+
+    require_success(run(&runtime, &source, &["daemon", "stop"]));
+    assert_serving(
+        &graph_section_line(&runtime, &source),
+        "a resolved merge reopened by a new daemon",
+    );
+}

--- a/crates/kin-cli/tests/graph_section_after_resolved_merge.rs
+++ b/crates/kin-cli/tests/graph_section_after_resolved_merge.rs
@@ -12,10 +12,10 @@
 //! `kin resolve --continue` reaches through
 //! `repository_merge_state::execute_resolve`. The second carried no refresh.
 //!
-//! Measured on b1837fa59 by a journey walking this repository the way a
-//! stranger would: after the first commit, after each branch switch, after a
-//! fast-forward merge and after a merge that parked with conflicts, the section
-//! read present and current; after `kin resolve --all-ours` and
+//! Measured by a journey walking this repository the way a stranger would:
+//! after the first commit, after each branch switch, after a fast-forward merge
+//! and after a merge that parked with conflicts, the section read present and
+//! current; after `kin resolve --all-ours` and
 //! `kin resolve --continue` it read present but refused (`resolved_at`) until
 //! `kin graph materialize` was run by hand. So the one way a merge can end that
 //! needs a person's attention is also the one way that left the store folding

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -38088,16 +38088,26 @@ mod tests {
         assert!(change.admission_policy_delta.is_none());
     }
 
+    /// Read this store's graph-section state the way every reporting surface
+    /// does, off a fresh authority open.
+    ///
+    /// The whole record rather than only the standing, because a caller that
+    /// goes red wants kin-db's own refusal word in the message; `absent` and
+    /// `resolved_at` are different defects wearing the same standing.
+    fn graph_section_state(state: &Arc<DaemonState>) -> kin_core::graph_section::GraphSectionState {
+        let authority =
+            crate::local_repository_authority::ActiveLocalRepositoryAuthority::open(state)
+                .expect("open the pinned local repository authority");
+        let lease = authority.manager.read_authority();
+        kin_core::graph_section::read(&lease, &authority.workspace_id)
+    }
+
     /// Read this store's graph-section standing the way every reporting surface
     /// does, off a fresh authority open.
     fn graph_section_standing(
         state: &Arc<DaemonState>,
     ) -> kin_core::graph_section::GraphSectionStanding {
-        let authority =
-            crate::local_repository_authority::ActiveLocalRepositoryAuthority::open(state)
-                .expect("open the pinned local repository authority");
-        let lease = authority.manager.read_authority();
-        kin_core::graph_section::read(&lease, &authority.workspace_id).standing
+        graph_section_state(state).standing
     }
 
     /// A commit leaves this workspace's base graph section written, so the
@@ -40829,6 +40839,189 @@ mod tests {
         assert!(
             identity_before != identity_after,
             "the publication identity did not move across a resolved-merge publication"
+        );
+    }
+
+    /// A merge published through `resolve --continue` must leave this
+    /// workspace's base graph section written, and the plain-merge arm cannot
+    /// cover it.
+    ///
+    /// kin#1561 refreshes the section after every transition that moves the
+    /// base, and installed that call at four sites. One of them is
+    /// `repository_merge::execute`, the PLAIN-merge publication. That module
+    /// holds two publications: `execute` publishes a clean merge, and
+    /// `publish_resolved_merge` publishes one whose conflicts were settled,
+    /// which `kin resolve --continue` reaches through
+    /// `repository_merge_state::execute_resolve`. The second carried no
+    /// refresh, so a merge that parked and was then resolved left a section
+    /// kin-db refuses with `resolved_at`, and every later open of that store
+    /// folded the merged base out of history until `kin graph materialize` ran.
+    ///
+    /// Its own arm rather than a second assertion inside
+    /// `a_merge_published_through_resolve_reaches_the_live_graph_without_a_restart`
+    /// above, for the same reason that arm is separate from the plain-merge
+    /// one: its live-graph assertions run first, so a regression in kin#1287's
+    /// install would stop it before this property was reached and this class
+    /// would go back to being invisible.
+    ///
+    /// The fixture is deliberately the same one that arm drives, settled from
+    /// the same side, so a red run here cannot be blamed on a fixture that
+    /// never reached `publish_resolved_merge`. Both sides must edit the SAME
+    /// artifact or the merge is clean, `publish` runs, and this grades a path
+    /// the plain-merge arm already covers.
+    ///
+    /// Two controls rather than one assertion. The section must already be
+    /// serving before the resolution, because the commit path refreshes it, or
+    /// a red run below says nothing about the resolve path. And the base must
+    /// actually MOVE across the resolution, or a section left untouched at an
+    /// unmoved base still reads `Serving` and this passes on a tree with no fix
+    /// in it.
+    ///
+    /// The refresh is synchronous inside the command, so the section is read
+    /// straight after the response rather than polled: it is on disk by the
+    /// time `resolve --continue` answers or it never will be.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial_test::serial(repository_commit)]
+    async fn a_merge_published_through_resolve_leaves_the_graph_section_written() {
+        let (state, _layout, repository, _base_change, _feature_change) =
+            universal_branch_test_state("resolve-graph-section");
+        let app = router(Arc::clone(&state));
+
+        // Conflict on purpose: the feature branch rewrote this same file.
+        std::fs::write(
+            repository.join("selected/compose.yaml"),
+            b"services:\n  api:\n    image: active-branch-after-the-split\n",
+        )
+        .unwrap();
+        commit_through_api(
+            &app,
+            kin_model::OperationId::new(),
+            "edit the file the other side also changed",
+        )
+        .await;
+
+        // CONTROL: the commit path already refreshes, so the section serves
+        // before the merge. A failure here is this assertion breaking rather
+        // than the resolve path regressing.
+        let before = graph_section_state(&state);
+        assert_eq!(
+            before.standing,
+            kin_core::graph_section::GraphSectionStanding::Serving,
+            "NOT RUN, precondition unmet rather than property refuted: the section does not serve \
+             this workspace's base before the merge, so nothing below is evidence about the \
+             resolve path: {before:?}"
+        );
+
+        let post = |path: &'static str, body: Vec<u8>| {
+            let app = router(Arc::clone(&state));
+            async move {
+                let response = app
+                    .oneshot(
+                        Request::post(path)
+                            .header("content-type", "application/json")
+                            .body(Body::from(body))
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap();
+                let status = response.status();
+                let bytes = axum::body::to_bytes(response.into_body(), 512 * 1024)
+                    .await
+                    .unwrap();
+                (status, bytes.to_vec())
+            }
+        };
+
+        let merge = kin_cli::commands::merge::MergeRequest {
+            source: kin_model::RefName::branch(b"feature").unwrap(),
+            operation_id: kin_model::OperationId::new(),
+            actor: AuthorId::new("resolve-graph-section-test"),
+        };
+        let (_merge_status, merge_body) =
+            post("/commands/merge", serde_json::to_vec(&merge).unwrap()).await;
+        let merge_response: kin_cli::commands::merge::MergeResponse =
+            serde_json::from_slice(&merge_body).unwrap();
+        // The merge must have CONFLICTED, or this arm drove `publish` and
+        // grades the path the plain-merge arm already covers.
+        let outcome = merge_response
+            .report
+            .as_ref()
+            .map(|report| report.outcome)
+            .expect("the merge response must carry a report to read its outcome from");
+        assert!(
+            matches!(outcome, kin_cli::commands::merge::MergeOutcome::Conflicted),
+            "NOT RUN, precondition unmet: the merge reported {outcome:?} rather than Conflicted, \
+             so this arm drove `publish` rather than `publish_resolved_merge`: {}",
+            String::from_utf8_lossy(&merge_body)
+        );
+
+        // A parked merge moves no base, so the section must still serve here.
+        // This is where the four sites kin#1561 installed already hold, and
+        // saying so keeps the reading below attributable to the publication
+        // rather than to the parking.
+        let parked = graph_section_state(&state);
+        assert_eq!(
+            parked.standing,
+            kin_core::graph_section::GraphSectionStanding::Serving,
+            "a parked merge moves no base, so the section it found valid must still serve: \
+             {parked:?}"
+        );
+
+        let settle = kin_cli::commands::resolve::ResolveRequest {
+            operation_id: kin_model::OperationId::new(),
+            actor: AuthorId::new("resolve-graph-section-test"),
+            action: kin_cli::commands::resolve::ResolveAction::Settle {
+                directives: Vec::new(),
+                all: Some(kin_model::MergeSide::Theirs),
+            },
+            expected_record: None,
+        };
+        let (settle_status, settle_body) =
+            post("/commands/resolve", serde_json::to_vec(&settle).unwrap()).await;
+        assert_eq!(
+            settle_status,
+            StatusCode::OK,
+            "settling every conflict from one side must succeed: {}",
+            String::from_utf8_lossy(&settle_body)
+        );
+
+        let continue_request = kin_cli::commands::resolve::ResolveRequest {
+            operation_id: kin_model::OperationId::new(),
+            actor: AuthorId::new("resolve-graph-section-test"),
+            action: kin_cli::commands::resolve::ResolveAction::Continue,
+            expected_record: None,
+        };
+        let (continue_status, continue_body) = post(
+            "/commands/resolve",
+            serde_json::to_vec(&continue_request).unwrap(),
+        )
+        .await;
+        assert_eq!(
+            continue_status,
+            StatusCode::OK,
+            "the resolved merge must publish for this arm to grade anything: {}",
+            String::from_utf8_lossy(&continue_body)
+        );
+
+        let after = graph_section_state(&state);
+        // CONTROL: the publication moved this workspace's base. Without this a
+        // section nobody touched still reads `Serving`, and the property below
+        // passes on a tree carrying no refresh at all.
+        assert_ne!(
+            after.base_target, before.base_target,
+            "NOT RUN, precondition unmet: `resolve --continue` did not move this workspace's \
+             base, so a section left untouched would read as serving and prove nothing: \
+             before={before:?} after={after:?}"
+        );
+
+        // THE PROPERTY.
+        assert_eq!(
+            after.standing,
+            kin_core::graph_section::GraphSectionStanding::Serving,
+            "`resolve --continue` moved this workspace's base and left the section behind, so \
+             every open of this store folds that base out of history until `kin graph \
+             materialize` runs: {after:?}"
         );
     }
 

--- a/crates/kin-daemon/src/repository_merge_state.rs
+++ b/crates/kin-daemon/src/repository_merge_state.rs
@@ -470,6 +470,37 @@ pub(crate) fn execute_resolve(
             .extend(crate::repository_merge::settle_merged_graph(state));
     }
 
+    // The freeze this resolution committed under is an EXCLUSIVE cross-process
+    // lease over the repository's storage lock, and the graph-section writer
+    // takes that same lock, so it is released before the refresh rather than at
+    // the end of the function. Holding it across the refresh is a command
+    // waiting on itself.
+    //
+    // This is also why `publish_resolved_merge` cannot make the call itself the
+    // way `repository_merge::execute` does: it hands the freeze back inside its
+    // `MergeExecution` for the finalization above, so at every point inside it
+    // the lease is still alive.
+    drop(execution.authority_freeze);
+
+    // A merge published through `resolve --continue` moves this workspace's
+    // base exactly as a plain merge does, and it publishes through
+    // `publish_resolved_merge` rather than through the `execute` path that
+    // refreshes the section, so before this a resolved merge left every later
+    // open folding the merged base out of history. Same rule as the commit, the
+    // workspace transition and the plain merge: idempotent, run under the gates
+    // this resolution already holds, and never fatal, because the merge is
+    // durable and a memoization that did not persist is a slower next open.
+    //
+    // A settlement and an abort reach here too. Neither moves this workspace's
+    // base, so the writer finds the section valid and returns `AlreadyCurrent`
+    // with no durable write.
+    crate::repository_commit::refresh_workspace_base_graph_section(
+        &authority.manager,
+        &authority.repository_id,
+        authority.workspace_id,
+        "resolved merge",
+    );
+
     drop(persistence);
     drop(graph_mutation);
     Ok(execution.resolve_response)


### PR DESCRIPTION
## What

Two independent defects, two commits.

**Refresh the workspace base graph section after a merge published through `kin resolve --continue`.**
kin #1561 installed that refresh at four sites, one of which is `repository_merge::execute`. That
module holds TWO publications, and the second, `publish_resolved_merge`, carried none.

**Redact the credential in the org-scope transfer refusal.** `crates/kin-cli/src/commands/transfer.rs`
interpolated the configured base URL verbatim, so a remote added as
`--url https://user:password@kinlab.ai` answered a missing `KIN_ORG_ID` by printing the password.

## Why this was missed, and where the call has to go

`repository_merge.rs` holds two publications: `execute` (the plain merge) and
`publish_resolved_merge`, which `kin resolve --continue` reaches through
`repository_merge_state.rs:534`. The repository had already written this split down once, in the
comment beside the resolved-merge test arm at `api.rs`: the two merge publications are different
code, kin #1287 installs on both, and the plain-merge arm cannot stand in for the resolved-merge
one. #1561 installed on one.

The refresh is NOT in `publish_resolved_merge`, and that is deliberate. That function never drops
the authority freeze; it RETURNS it, from
`transition_repository_workspace_tree_and_commit_authored_transaction` into the `MergeExecution` its
caller needs for `finalize_local_repository_commit`. kin-db's own doc on
`LocalRepositoryAuthorityFreeze` says "the existing per-repository storage lock remains held until
this value is dropped", and `materialize_workspace_base_graph_section` persists through
`AuthorityPublication::rewrite_equivalent`, which takes that lock. kin #1561 measured what happens
when this is got wrong: refreshing while the freeze was still alive made `kin branch switch` and a
pull's workspace follow hang for the harness's full 180 second budget.

So the call sits in `repository_merge_state::execute_resolve`, after the finalization and the
settle, behind an explicit `drop(execution.authority_freeze)`, mirroring `repository_merge.rs:372-385`.

## The arms

**Arm 1**, `crates/kin-daemon/src/api.rs`: a sibling to kin #1287's resolved-merge arm rather than an
extension of it. That arm's live-graph assertions run first, so a regression in kin #1287's install
would stop it before this property was reached and the class would go back to being invisible. It
reuses that arm's proven conflicted-merge fixture, settled from the same side, so a red run cannot be
blamed on a fixture that never reached `publish_resolved_merge`. Three controls: the section serves
before the merge, it still serves after the merge parks, and the base actually moves across the
publication.

**Arm 2**, `crates/kin-cli/tests/graph_section_after_resolved_merge.rs`: the same journey through the
product CLI, reading `kin graph status`'s own `Graph section:` line, plus a cold-reopen case so the
section has to be on disk rather than in the process that wrote it. A crate test rather than an
acceptance rule, because `Product Acceptance` carries
`if: ${{ github.event_name != 'pull_request' }}` and so would not grade the pull request that breaks
this.

Neither arm polls. The refresh is synchronous inside the command that publishes the merge, so the
section is on disk by the time the command answers or it never will be.

**The redaction arms** sit beside `remote.rs`'s pair, on a small `missing_organization_message`
helper rather than an inline `format!`. That shape is that module's own recorded lesson: "A function
rather than two `format!` calls, because the address half has a `None` arm and inlining it put that
arm where no test could reach it." One arm grades the withheld case, the other is the positive
control in both directions.

## Mutation grid

Both mutants applied together. They are disjoint by leg, so the reading is unambiguous.

**(a) The resolved-merge refresh call removed from `execute_resolve`:**

```
$ cargo test -p kin-daemon --lib -- <the four arms>
test api::tests::a_commit_leaves_the_workspace_base_graph_section_written ... ok
test api::tests::a_merge_published_through_resolve_reaches_the_live_graph_without_a_restart ... ok
test api::tests::a_merge_published_through_resolve_leaves_the_graph_section_written ... FAILED
test api::tests::a_published_merge_reaches_the_live_graph_without_a_restart ... ok
test result: FAILED. 3 passed; 1 failed; 0 ignored; 0 measured; 1533 filtered out; in 16.83s

$ cargo test -p kin-cli --test graph_section_after_resolved_merge
test a_cold_reopen_after_a_resolved_merge_still_serves_from_its_section ... FAILED
test a_merge_published_through_resolve_continue_leaves_a_section_serving_its_merged_base ... FAILED
test result: FAILED. 9 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; in 11.69s

$ cargo test -p kin-cli --test graph_section_after_transfer
test every_workspace_transition_leaves_a_section_serving_the_base_it_moved_to ... ok
test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; in 15.75s
```

Only the new arms go red. kin #1287's resolved-merge live-graph arm, the plain-merge live-graph arm,
the commit-path section control and the plain-merge integration case all stay green, exactly as that
`api.rs` comment predicts. The plain-merge integration file is run in its own invocation on purpose:
`cargo test --test a --test b` stops after the first binary fails, so run together it would not have
executed at all.

The unfixed tree gives the same reading through the product surface, and names the refusal:

```
$ cargo test -p kin-daemon --lib a_merge_published_through_resolve_leaves_the_graph_section_written
GraphSectionState { standing: Folding, section_present: true, refusal: Some("resolved_at"),
base_target: Some("dd1736f7872de55b79a78a61928318be25de48f901ebd23c914c81f64c27bcee"),
section_resolved_at: Some("387908851d3f33bad2c55d4776e224deeb00b1104e35624c9b960e1661447c42"),
changes_in_store: 4, fold: AtMost(4), prepared_may_preempt: false }
  left: Folding
 right: Serving

$ cargo test -p kin-cli --test graph_section_after_resolved_merge
Graph section: present but refused (resolved_at), so every open of this store folds this
workspace's base out of history, 3 changes. A section was written and is not being used ...
test result: FAILED. 9 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; in 125.58s
```

**(b) The redaction removed from `missing_organization_message`:**

```
$ cargo test -p kin-cli --lib -- commands::transfer::tests commands::remote::tests::a_url_the_redaction... 
failures:
    commands::transfer::tests::a_parseable_remote_is_named_in_the_org_scope_refusal_without_its_credentials
    commands::transfer::tests::a_url_the_redaction_withholds_is_never_named_in_the_org_scope_refusal
test result: FAILED. 13 passed; 2 failed; 0 ignored; 0 measured; 2203 filtered out; in 0.03s
```

Both new arms red, with `remote.rs`'s two redaction arms among the 13 that stayed green, because
they grade `missing_bearer_token_message`, which this change does not touch. The positive control
goes red too, correctly: with the URL verbatim the refusal reads
`https://alice:s3cr3t@kinlab.ai/team?t=v#f names none` rather than `https://kinlab.ai/team names none`.

**(c) Restored, and proven rather than asserted.** `git hash-object` on both files before mutating
and after restoring gives the same pair, `77945ce44dd785022729ee10bc98f15f8c789098` and
`17542daddffd30124dac46b98666a83df046b140`, so the tree that went green below is byte-identical to
the tree that was mutated.

## Green

```
--- LEG 0: build the kin-daemon and kin binaries the integration arms drive ---
LEG0_RC=0
2026-09-06T02:41:21Z .../debug/kin-daemon
2026-09-06T02:41:01Z .../debug/kin
--- LEG 1: kin-daemon arms and controls ---
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 1533 filtered out; in 15.10s
--- LEG 2: kin-cli graph-section integration arms ---
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; in 11.39s
test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; in 13.89s
--- LEG 3: kin-cli redaction unit arms ---
test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 2203 filtered out; in 0.01s
```

Leg 0 is explicit and not optional. An earlier green run reported leg 2 red against a `kin-daemon`
binary whose mtime was `02:34:32Z`, before the fix, and finished in 10.00s rather than 125s because
nothing rebuilt it. A stale daemon binary reports a working fix as broken wearing the same red as a
real regression, so the leg now builds both binaries and prints their mtimes.

## Local gates

```
--- cargo fmt --all -- --check ---
FMT_RC=0
clippy debt allow-list: 45 lints
--- cargo clippy --all-targets --all-features -- <45 allows> ---
CLIPPY_RC=0
```

```
$ bin/kin-precheck kin --repo-dir kin=<worktree>
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:check_private_repo_coupling.sh bash scripts/check_private_repo_coupling.sh
PASS     guard:check_runtime_boundaries.sh    bash scripts/check_runtime_boundaries.sh
PASS     guard:test-release-policy-gate.sh    bash scripts/test-release-policy-gate.sh
PASS     guard:test-windows-authority-legs.sh bash scripts/test-windows-authority-legs.sh
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:check-kin-vfs-compat.mjs       node scripts/check-kin-vfs-compat.mjs
PASS     guard:check-rc-build-drift.mjs       node scripts/check-rc-build-drift.mjs
PASS     guard:check-required-contexts.py     python3 scripts/check-required-contexts.py
PASS     guard:test-assertion-reachability.py python3 scripts/test-assertion-reachability.py
PASS     guard:test-guard-duplicate-release-run.py python3 scripts/test-guard-duplicate-release-run.py
PASS     guard:test-homebrew-release-gate.py  python3 scripts/test-homebrew-release-gate.py
PASS     guard:test-install-checksum.py       python3 scripts/test-install-checksum.py
PASS     guard:test-private-repo-coupling.py  python3 scripts/test-private-repo-coupling.py
PASS     guard:test-release-tag-evaluate-dispatch.py python3 scripts/test-release-tag-evaluate-dispatch.py
PASS     guard:test-release-workflow-authority.py python3 scripts/test-release-workflow-authority.py
PASS     guard:test-select-release-candidate.py python3 scripts/test-select-release-candidate.py
PASS     guard:verify-hydration-semantics.py  python3 scripts/verify-hydration-semantics.py
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
PASS     node-test                            node --test <15 file(s) named by the check job>
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 61868a38b6a0c1655d8c43474885c1daab39e248
rc=0
```

That tally is from a run made AFTER the commits, so the sha it prints is this pull request's head and
it carries no `DIRTY` flag. An earlier run reported `fmt`, `clippy` and
`test-windows-authority-legs.sh` as FAIL; all three were one cause and none was a gate verdict, since
`cargo` was not on that shell's PATH, so the first two exited 127 and the third, which drives real
cargo through a PATH shim under `set -euo pipefail`, died on its first command and printed zero bytes.

Not run here, by design: acceptance grades main rather than pull requests on this repo, and the full
workspace suite is hosted CI's job.

## Known and deliberately not fixed here

**`kin remote plan-push` still prints the configured base URL unredacted**, in its `--json` dump of
the plan and in its `Remote:` line, so a remote added with credentials in its URL leaks the same
password this change closes in the refusal. It is the same class and a different surface: a
reporting path rather than a refusal, and the plan object is built by the daemon, so redacting it is
its own change with its own arms. Ticket to be filed beside GAP-G. The redaction helper's doc
comment names both sites so the next reader is not told the module is clean.

**The new call is reachable only through `execute_resolve`**, and nothing but a test asserts that
wiring, so a future edit removing the call site is caught by the arms here rather than by a type.
That is the same shape the four sites kin #1561 installed already have.

**The two graph-section integration files duplicate their harness helpers**
(`graph_section_line`, `assert_serving`, `base_change`, `configure_author`). Deliberate for now:
Rust integration tests share code only through the `common` module, and moving these there widens
that module for every other test binary that includes it. Worth doing when a third file wants them.

**The daemon compatibility probe does not notice a dirty tree.** It kept a `kin-daemon` built before
this fix and reported the fix as broken, which is written up in the Green section above. The probe
reads a version that a source-only change does not move. Fixing it belongs in the test harness, not
here.

Tracker: FIR-3282 follow-up (GAP-G, ticket to be filed)
