### PR TITLE
Keep a move's arrival half when a bounded observation drops it

### DIFF
--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -688,12 +688,17 @@ fn observation_covers_path(observed: &BTreeSet<RepoPath>, path: &RepoPath) -> bo
 /// [`kin_core::plan_observed_tree_deltas`] itself applies, and admitting the
 /// arrival is what lets the transition plan as one move.
 ///
-/// Anything short of that evidence yields nothing, so a copy, a
-/// move-plus-replacement and a plain deletion keep the behaviour they have.
+/// Anything short of that evidence yields nothing. A copy and a
+/// move-plus-replacement both keep the vacated path observed, so nothing
+/// departs and neither is touched. A departure with exactly one untracked
+/// byte-identical arrival is read as a move, which is the planner's own rule
+/// and what the unbounded commit seam would plan for the same tree; the
+/// retired graph-only member guard below is the one place that rule is
+/// refused.
 ///
 /// Counted through maps rather than a scan per departure, because this runs on
-/// every bounded pass and a branch switch or a large deletion departs thousands
-/// of paths at once.
+/// every bounded pass and a branch switch or a large deletion departs many
+/// paths at once.
 fn unobserved_move_destinations(
     base: &kin_model::ResolvedTree,
     observed: &crate::commit_deltas::CompleteWorkspaceObservation,
@@ -710,6 +715,8 @@ fn unobserved_move_destinations(
             departing.push(artifact.entry);
         }
     }
+    // The quiet case still pays the base pass above, one traversal and one map
+    // build; what it skips is the pass over the observation.
     if departing.is_empty() {
         return BTreeSet::new();
     }
@@ -750,7 +757,9 @@ fn unobserved_move_destinations(
 /// in and a single `touch` never costs a complete import. Within that bound an
 /// observed path moves whether or not the workspace already tracks it: a file
 /// becomes queryable because someone wrote it, not because someone remembered
-/// to run a command afterwards.
+/// to run a command afterwards. The one content-addressed exception is the
+/// arrival half of a move, which [`unobserved_move_destinations`] keeps when
+/// an observed departure has exactly one untracked byte-identical destination.
 ///
 /// What this enlarges is the workspace tree, and only the workspace tree. The
 /// publication underneath advances the workspace generation while leaving its
@@ -4724,6 +4733,88 @@ mod tests {
             tree.artifact_at_path(&test_repo_path("submodule/src/twin.py"))
                 .is_none(),
             "a removed member must not hand its host subtree to the workspace through a move"
+        );
+    }
+
+    /// Two untracked paths carry the departing entry, so nothing names one
+    /// destination and the departure stays a deletion.
+    #[cfg(unix)]
+    #[test]
+    fn a_departure_with_two_equally_good_destinations_is_not_a_move() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        state.is_initialized.store(true, Ordering::Relaxed);
+        admit_and_derive(&state, MOVED_PATH, MOVED_TARGET);
+        let target = sole_entity_named(&state, MOVED_PATH, "moved_target");
+
+        let working = state.layout.working_dir();
+        std::fs::write(working.join("src/aaa_twin.py"), MOVED_TARGET).unwrap();
+        std::fs::write(working.join("src/bbb_twin.py"), MOVED_TARGET).unwrap();
+
+        std::fs::remove_file(working.join(MOVED_PATH)).unwrap();
+        let observation = BTreeSet::from([RepoPath::from_utf8(MOVED_PATH).unwrap()]);
+        assert!(!ambient_admission_for_test(&state, &observation).unwrap());
+
+        assert!(
+            state.graph.get_entity(&target.id).unwrap().is_none(),
+            "two equally good destinations name none, so this must stay a deletion"
+        );
+        let tree = state.graph.resolved_tree();
+        assert!(
+            tree.artifact_at_path(&test_repo_path("src/aaa_twin.py"))
+                .is_none(),
+            "an ambiguous arrival must not be admitted by a pass that never observed it"
+        );
+        assert!(
+            tree.artifact_at_path(&test_repo_path("src/bbb_twin.py"))
+                .is_none(),
+            "an ambiguous arrival must not be admitted by a pass that never observed it"
+        );
+    }
+
+    /// A second tracked path carries the departing entry, so no single base
+    /// artifact owns it and the departure stays a deletion.
+    #[cfg(unix)]
+    #[test]
+    fn a_departure_whose_entry_a_second_tracked_path_shares_is_not_a_move() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        state.is_initialized.store(true, Ordering::Relaxed);
+
+        // Both in ONE observation. Admitting the twin in a second pass refuses,
+        // because a path-stable entry plus an identical observed entry is the
+        // planner's identity-underdetermined case.
+        let working = state.layout.working_dir();
+        std::fs::create_dir_all(working.join("src")).unwrap();
+        std::fs::write(working.join(MOVED_PATH), MOVED_TARGET).unwrap();
+        std::fs::write(working.join("src/duplicate.py"), MOVED_TARGET).unwrap();
+        let admission = BTreeSet::from([
+            RepoPath::from_utf8(MOVED_PATH).unwrap(),
+            test_repo_path("src/duplicate.py"),
+        ]);
+        assert!(!ambient_admission_for_test(&state, &admission).unwrap());
+        derive_semantics(&state, MOVED_PATH);
+        derive_semantics(&state, "src/duplicate.py");
+        let target = sole_entity_named(&state, MOVED_PATH, "moved_target");
+
+        std::fs::rename(working.join(MOVED_PATH), working.join(RELOCATED_PATH)).unwrap();
+        let observation = BTreeSet::from([RepoPath::from_utf8(MOVED_PATH).unwrap()]);
+        assert!(!ambient_admission_for_test(&state, &observation).unwrap());
+
+        assert!(
+            state.graph.get_entity(&target.id).unwrap().is_none(),
+            "an entry two tracked paths share names no single origin, so this must stay a deletion"
+        );
+        let tree = state.graph.resolved_tree();
+        assert!(
+            tree.artifact_at_path(&RepoPath::from_utf8(RELOCATED_PATH).unwrap())
+                .is_none(),
+            "an arrival whose origin is undetermined must not be admitted"
+        );
+        assert!(
+            tree.artifact_at_path(&test_repo_path("src/duplicate.py"))
+                .is_some(),
+            "the untouched duplicate must stay in the tree"
         );
     }
 

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -676,6 +676,68 @@ fn observation_covers_path(observed: &BTreeSet<RepoPath>, path: &RepoPath) -> bo
     })
 }
 
+/// The arrival paths a bounded observation would drop although the complete scan
+/// behind it holds them, for the tracked artifacts that observation is about to
+/// leave with no destination.
+///
+/// `observed` at the call site holds the complete scan plus every tracked path
+/// the observation did not cover, so an artifact of `base` whose path it no
+/// longer carries is one this pass is about to remove. When exactly one such
+/// artifact carries an entry, and exactly one observed path that `base` does not
+/// track carries the same entry, the pair is a move by the rule
+/// [`kin_core::plan_observed_tree_deltas`] itself applies, and admitting the
+/// arrival is what lets the transition plan as one move.
+///
+/// Anything short of that evidence yields nothing, so a copy, a
+/// move-plus-replacement and a plain deletion keep the behaviour they have.
+///
+/// Counted through maps rather than a scan per departure, because this runs on
+/// every bounded pass and a branch switch or a large deletion departs thousands
+/// of paths at once.
+fn unobserved_move_destinations(
+    base: &kin_model::ResolvedTree,
+    observed: &crate::commit_deltas::CompleteWorkspaceObservation,
+    retired: &BTreeSet<RepoPath>,
+) -> BTreeSet<RepoPath> {
+    // One pass over the base: how many artifacts carry each entry, and which
+    // entries are departing. An entry two base artifacts share names no single
+    // origin, so it is dropped below rather than guessed at.
+    let mut base_entry_counts: HashMap<TreeEntry, usize> = HashMap::new();
+    let mut departing: Vec<TreeEntry> = Vec::new();
+    for artifact in base.artifacts_by_path() {
+        *base_entry_counts.entry(artifact.entry).or_default() += 1;
+        if !observed.entries().contains_key(&artifact.path) {
+            departing.push(artifact.entry);
+        }
+    }
+    if departing.is_empty() {
+        return BTreeSet::new();
+    }
+    // One pass over the observation: the arrival each entry reached, or `None`
+    // when it reached more than one, which names no single destination. A path
+    // under a retired graph-only member is not a candidate at all, because it
+    // was written while the member still stood and was never an observation of
+    // this projection, which is the same reason `admissible` refuses it.
+    let mut arrivals: HashMap<TreeEntry, Option<&RepoPath>> = HashMap::new();
+    for (path, entry) in observed.entries() {
+        if base.artifact_id_at_path(path).is_some()
+            || crate::graph_only_members::covered_by(retired, path)
+        {
+            continue;
+        }
+        arrivals
+            .entry(*entry)
+            .and_modify(|arrival| *arrival = None)
+            .or_insert(Some(path));
+    }
+    departing
+        .into_iter()
+        .filter(|entry| base_entry_counts.get(entry) == Some(&1))
+        .filter_map(|entry| arrivals.get(&entry).copied().flatten())
+        .cloned()
+        .collect()
+}
+
 /// Derive one complete exact-tree transition from the working copy.
 ///
 /// `observation` bounds what may be admitted. `None` is an explicit admission
@@ -824,16 +886,38 @@ fn exact_tree_admission(
             observation_covers_path(observation, path)
                 && !crate::graph_only_members::covered_by(&retired, path)
         };
+        // One exception to the drop above, and it is the half of a move. A bare
+        // `mv` reaches the watcher as two events and nothing makes them one
+        // batch, so an observation can carry the path a file left without the
+        // path it arrived on. Dropping the arrival leaves the departure to plan
+        // as a whole deletion, and a deletion retires the artifact node with
+        // every relation bound to it and the entities that path carried. The
+        // arrival is then admitted by a later pass as a fresh artifact with
+        // fresh entity ids, so the file is at its new path, ranked, queryable,
+        // and every reference into the code inside it is gone. Nothing later
+        // rebuilds those edges, because nothing re-derives the files that held
+        // them.
+        //
+        // The scan behind this pass is complete, so the arrival is already in
+        // hand and keeping it costs no extra read. It is kept only on the
+        // evidence a move needs, which is why the bound is otherwise unchanged.
+        let move_destinations = unobserved_move_destinations(&planning_base, &observed, &retired);
         state
             .background_work
             .reconcile()
             .record_untracked_observation(
                 observed.entries().keys().filter(|path| {
-                    previous.artifact_id_at_path(path).is_none() && !admissible(path)
+                    previous.artifact_id_at_path(path).is_none()
+                        && !admissible(path)
+                        && !move_destinations.contains(*path)
                 }),
                 excluded_host_content(&scan),
             );
-        observed.retain(|path, _| previous.artifact_id_at_path(path).is_some() || admissible(path));
+        observed.retain(|path, _| {
+            previous.artifact_id_at_path(path).is_some()
+                || admissible(path)
+                || move_destinations.contains(path)
+        });
     }
     // A bounded tick re-inserts every tracked path its observation did not
     // cover, which would restore the paths the rules just retracted. Editing
@@ -4421,6 +4505,265 @@ mod tests {
         assert_eq!(coverage["parsed"], serde_json::json!("full"), "{coverage}");
         assert_eq!(coverage["certifies_enumeration"], serde_json::json!(true));
         assert!(census_counts_file(&state, stale_path));
+    }
+
+    #[cfg(unix)]
+    const MOVED_PATH: &str = "src/moved.py";
+    #[cfg(unix)]
+    const RELOCATED_PATH: &str = "src/renamed.py";
+    #[cfg(unix)]
+    const CALLER_PATH: &str = "src/caller.py";
+    #[cfg(unix)]
+    const MOVED_TARGET: &str = "def moved_target():\n    return 1\n";
+    #[cfg(unix)]
+    const MOVED_CALLER: &str =
+        "from moved import moved_target\n\ndef moved_caller():\n    return moved_target()\n";
+
+    /// The entity of one name on one path, which the fixtures below hold exactly
+    /// one of.
+    #[cfg(unix)]
+    fn sole_entity_named(
+        state: &Arc<DaemonState>,
+        rel_path: &str,
+        name: &str,
+    ) -> kin_model::Entity {
+        let matching = state
+            .graph
+            .query_entities(&EntityFilter {
+                file_path: Some(FilePathId::new(rel_path)),
+                ..Default::default()
+            })
+            .unwrap()
+            .into_iter()
+            .filter(|entity| entity.name == name)
+            .collect::<Vec<_>>();
+        let [entity] = matching.as_slice() else {
+            panic!("one entity named {name} at {rel_path}: {matching:?}");
+        };
+        entity.clone()
+    }
+
+    /// [`derive_semantics`] with the cross-file linker seeded from the graph,
+    /// the way `DaemonState::open` and every commit seam seed it.
+    ///
+    /// The plain helper builds a bare `Reconciler`, whose linker knows only the
+    /// file in front of it, so a fixture built with it carries no cross-file
+    /// edge at all and an assertion about losing one would pass over an empty
+    /// set. Seeding is what makes the caller's edge exist to be lost.
+    #[cfg(unix)]
+    fn derive_semantics_linked(state: &Arc<DaemonState>, rel_path: &str) {
+        let host_path = state.layout.working_dir().join(rel_path);
+        let mut reconciler =
+            kin_reconcile::Reconciler::new(state.layout.working_dir().to_path_buf());
+        reconciler.seed_cross_file_linker_from_graph(state.graph.as_ref());
+        let result = reconciler
+            .reconcile_file_change(
+                &FileEvent::Changed(host_path),
+                &state.blobs,
+                state.graph.as_ref(),
+            )
+            .expect("the reconciler derives the file");
+        let (outcome, delta) = result.into_parts();
+        assert!(
+            matches!(outcome, kin_reconcile::ReconcileOutcome::Updated { .. }),
+            "the fixture file must reconcile cleanly: {outcome:?}"
+        );
+        state.graph.apply_transaction_delta(&delta).unwrap();
+        state
+            .persist_projection_truth_from_reconcile(&reconciler, &outcome)
+            .unwrap();
+    }
+
+    /// The relation ids that point AT `entity`, sorted, which is what a caller
+    /// keeps or loses across a move.
+    #[cfg(unix)]
+    fn incoming_relations(
+        state: &Arc<DaemonState>,
+        entity: kin_model::EntityId,
+    ) -> Vec<kin_model::RelationId> {
+        let node = kin_model::GraphNodeId::Entity(entity);
+        let mut incoming = state
+            .graph
+            .get_all_relations_for_node(&node)
+            .unwrap()
+            .into_iter()
+            .filter(|relation| relation.dst == node)
+            .map(|relation| relation.id)
+            .collect::<Vec<_>>();
+        incoming.sort();
+        incoming
+    }
+
+    /// A move whose arrival half the observation did not carry.
+    ///
+    /// A bare `mv` reaches the watcher as two events and nothing makes them one
+    /// batch. When the vacated path arrives first, the bounded observation names
+    /// it alone: the complete scan behind the pass holds the file at its new
+    /// path, the bound drops that entry as an unrelated untracked addition, and
+    /// what is left to plan is one whole deletion. That retires the artifact
+    /// node with every relation bound to it and removes the entities the path
+    /// carried, so the arrival lands afterwards as a fresh artifact with fresh
+    /// entity ids and every reference into the moved code is gone.
+    ///
+    /// The observation here is the vacated path alone, which composes that order
+    /// instead of waiting for the watcher to produce it. Falsify by restoring
+    /// the plain `previous.artifact_id_at_path(path).is_some() ||
+    /// admissible(path)` retain in `exact_tree_admission`, which drops the
+    /// arrival again.
+    #[cfg(unix)]
+    #[test]
+    fn a_bounded_observation_of_a_moves_vacated_half_relocates_rather_than_orphaning_it() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        state.is_initialized.store(true, Ordering::Relaxed);
+        admit_and_derive(&state, MOVED_PATH, MOVED_TARGET);
+        admit_and_derive(&state, CALLER_PATH, MOVED_CALLER);
+        derive_semantics_linked(&state, CALLER_PATH);
+
+        let target = sole_entity_named(&state, MOVED_PATH, "moved_target");
+        let incoming = incoming_relations(&state, target.id);
+        // The module's `Imports` and the function's `Calls`, which is what
+        // `kin refs moved_target` renders as two referencing entities.
+        assert_eq!(
+            incoming.len(),
+            2,
+            "the fixture never produced the incoming edges this test is about: {incoming:?}"
+        );
+        let artifact = state
+            .graph
+            .resolved_tree()
+            .artifact_at_path(&RepoPath::from_utf8(MOVED_PATH).unwrap())
+            .expect("the fixture admitted the moved path")
+            .artifact_id;
+
+        let working = state.layout.working_dir();
+        std::fs::rename(working.join(MOVED_PATH), working.join(RELOCATED_PATH)).unwrap();
+        // The losing order: the watcher delivered the vacated path and not the
+        // arrival, so this pass is bounded by the half that is gone.
+        let observation = BTreeSet::from([RepoPath::from_utf8(MOVED_PATH).unwrap()]);
+        assert!(!ambient_admission_for_test(&state, &observation).unwrap());
+
+        let moved = state
+            .graph
+            .get_entity(&target.id)
+            .unwrap()
+            .expect("a move must keep the entity it moved rather than mint a new one");
+        assert_eq!(
+            moved.file_origin,
+            Some(FilePathId::new(RELOCATED_PATH)),
+            "the moved entity must sit at the path it arrived on"
+        );
+        assert_eq!(
+            incoming_relations(&state, target.id),
+            incoming,
+            "the caller lost its edge into the moved function, which is what a removal plus an \
+             addition does and what relocating in one delta exists to prevent"
+        );
+        let tree = state.graph.resolved_tree();
+        assert!(
+            tree.artifact_at_path(&RepoPath::from_utf8(MOVED_PATH).unwrap())
+                .is_none(),
+            "the tree must not still carry the path the file left"
+        );
+        assert_eq!(
+            tree.artifact_at_path(&RepoPath::from_utf8(RELOCATED_PATH).unwrap())
+                .expect("the tree carries the arrival path")
+                .artifact_id,
+            artifact,
+            "the move must preserve artifact identity"
+        );
+    }
+
+    /// A twin under a retired graph-only member is not a destination.
+    ///
+    /// Host content beneath a removed Gitlink was written while the member
+    /// still stood, so it was never an observation of this projection and
+    /// `admissible` refuses it. Reading it as the arrival half of a move would
+    /// walk straight around that refusal: a deleted file whose bytes happen to
+    /// match something in the retired subtree would relocate into it, put the
+    /// workspace ahead of the base a switch just made it level with, and hand
+    /// the subtree to the tree the retirement exists to keep it out of.
+    ///
+    /// Falsify by dropping the `covered_by` clause from the arrival scan in
+    /// `unobserved_move_destinations`: the deletion then plans as a move and
+    /// the entity survives at the retired path.
+    #[cfg(unix)]
+    #[test]
+    fn a_twin_under_a_retired_graph_only_member_is_not_a_move_destination() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        state.is_initialized.store(true, Ordering::Relaxed);
+        admit_and_derive(&state, MOVED_PATH, MOVED_TARGET);
+        let target = sole_entity_named(&state, MOVED_PATH, "moved_target");
+
+        // Byte-identical content beneath a member the workspace has retired,
+        // which is the only thing the scan will still hold once the tracked
+        // file is gone.
+        let working = state.layout.working_dir();
+        std::fs::create_dir_all(working.join("submodule/src")).unwrap();
+        std::fs::write(working.join("submodule/src/twin.py"), MOVED_TARGET).unwrap();
+        state
+            .retired_graph_only_members
+            .retire([&test_repo_path("submodule")]);
+
+        std::fs::remove_file(working.join(MOVED_PATH)).unwrap();
+        let observation = BTreeSet::from([RepoPath::from_utf8(MOVED_PATH).unwrap()]);
+        assert!(!ambient_admission_for_test(&state, &observation).unwrap());
+
+        assert!(
+            state.graph.get_entity(&target.id).unwrap().is_none(),
+            "a deletion beside a retired-subtree twin must still be a deletion"
+        );
+        let tree = state.graph.resolved_tree();
+        assert!(
+            tree.artifact_at_path(&RepoPath::from_utf8(MOVED_PATH).unwrap())
+                .is_none(),
+            "the deleted path must leave the tree"
+        );
+        assert!(
+            tree.artifact_at_path(&test_repo_path("submodule/src/twin.py"))
+                .is_none(),
+            "a removed member must not hand its host subtree to the workspace through a move"
+        );
+    }
+
+    /// The control the arm above needs. An ordinary deletion still retires the
+    /// entities its path carried and the edges into them, so a retain that
+    /// simply kept every scanned path would fail here rather than pass both.
+    #[cfg(unix)]
+    #[test]
+    fn a_bounded_observation_of_a_real_deletion_still_retires_its_entities() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        state.is_initialized.store(true, Ordering::Relaxed);
+        admit_and_derive(&state, MOVED_PATH, MOVED_TARGET);
+        admit_and_derive(&state, CALLER_PATH, MOVED_CALLER);
+        derive_semantics_linked(&state, CALLER_PATH);
+
+        let target = sole_entity_named(&state, MOVED_PATH, "moved_target");
+        assert_eq!(
+            incoming_relations(&state, target.id).len(),
+            2,
+            "the fixture never produced the edges whose retirement this control checks"
+        );
+
+        let working = state.layout.working_dir();
+        std::fs::remove_file(working.join(MOVED_PATH)).unwrap();
+        let observation = BTreeSet::from([RepoPath::from_utf8(MOVED_PATH).unwrap()]);
+        assert!(!ambient_admission_for_test(&state, &observation).unwrap());
+
+        assert!(
+            state.graph.get_entity(&target.id).unwrap().is_none(),
+            "a real deletion must still retire the entities its path carried"
+        );
+        assert!(
+            state
+                .graph
+                .resolved_tree()
+                .artifact_at_path(&RepoPath::from_utf8(MOVED_PATH).unwrap())
+                .is_none(),
+            "a real deletion must still leave the tree"
+        );
     }
 
     /// FIR-2442. A dropped host event is disclosed through the reconcile health


### PR DESCRIPTION
Tracker: FIR-3209 follow-up (ticket to be filed)

## What was wrong

A bare `mv` of a committed source file intermittently orphaned every incoming
reference into the code it carried. The file ended up at its new path, ranked and
queryable, with the edges into it gone.

`crates/kin-cli/tests/entity_file_retirement.rs::renaming_a_committed_entity_owning_file_relocates_it_rather_than_stranding_it`
is the test that sees it, and it has been red intermittently on `Fast gate test
shard`, most recently CI run 34000661616 on 75ffe8933. The failure text is:

```
References to 'moved_target' -> moved_target (Function) @ src/renamed.py
No incoming Calls, Imports, References relations.
Kin cannot rule out references it did not see: this build produced no entity-level call edge for Python although the source carries call sites, so a use reaching this entity from another file could not have been found. The gap is in the linker, not in the code.
```

That is the defect the test's own doc comment says it exists to catch, happening
intermittently, not a flake: "A relocation implemented as a removal plus an addition
would satisfy every path assertion here and still mint new entity ids, orphaning
every reference into the moved function."

## The mechanism, measured before anything was written

A `rename(2)` reaches the watcher as two events and nothing makes them one batch.
When the vacated path arrives first, `exact_tree_admission` runs bounded by the half
that is gone. The complete scan behind that pass already holds the file at its new
path; the bound drops that entry as an unrelated untracked addition, and what reaches
`kin_core::plan_observed_tree_deltas` is a removal with no destination, which since
FIR-3097 plans as a bare `TreeDelta::Removed`. `evict_enrichment_for_removed_paths`
then retires the artifact node with every relation bound to it and removes the
entities the path carried. The arrival is admitted by a later pass as a fresh
artifact with fresh entity ids, and nothing rebuilds the edges, because nothing
re-derives the files that held them.

Reproduced through the real `kin` and `kin-daemon` binaries, one fresh `KIN_HOME` and
one fresh repository per trial, 30 trials, 1 red. The red trial's daemon log at
`RUST_LOG=info,kin_daemon=debug,kin_core=debug,kin_index=debug`, with the rename
stamped by the harness at `02:49:35.335572Z`:

```
02:49:35.359751 DEBUG kin_daemon::loop_runner: processing file events (after dedup) count=2
02:49:35.403720 DEBUG kin_index::watcher: file changed path=.../repo/src/renamed.py
02:49:35.694793  INFO kin_daemon::loop_runner: admitted exact workspace tree into repository authority generation=3
02:49:35.702635 DEBUG kin_daemon::loop_runner: retired the relations bound to a departing artifact node artifact_id=ArtifactId(3e2d004f-1463-4c5d-a1d1-ec1afb74bce7) retired=1
02:49:35.804838 DEBUG kin_daemon::loop_runner: removed exact repository-tree entry file=src/moved.py
02:49:35.882889  INFO kin_daemon::loop_runner: admitted one complete exact-tree transition on daemon tick/startup count=1 artifacts=1
```

The ambient tick started 24 ms after the rename. The arrival path's watcher event
landed 44 ms after that, too late to be in the observation. 367 ms after the rename
the relations were retired. `kin locate --json` shows the moved function's entity id
changing across the commit while the caller's own id does not:

```
ID_TARGET_BEFORE=6413db4d-b2cb-5bc8-b329-e59acc8976f6
ID_TARGET_AFTER=a8f758b2-3bde-5da8-9b51-8c3bbae5f984
ID_CALLER_BEFORE=89b93e49-f717-5f49-aca8-ea921d6b06a4
ID_CALLER_AFTER=89b93e49-f717-5f49-aca8-ea921d6b06a4
```

Green trials carry no `retired the relations bound to a departing artifact node` line
at all: the tick stands down for the announced commit, or the commit's own unbounded
admission runs first with both halves (`count=2`).

So the edge is destroyed, not late. A bounded poll on the read cannot reach it: an
independent measurement held the identical read open for 600 s across 2771 polls with
the daemon still answering in 131 ms, and it never returned `src/caller.py`.

## The change

One file, `crates/kin-daemon/src/loop_runner.rs`. No kin-db change, no kin-core
change, no new behaviour on any surface.

`exact_tree_admission` already documents the property that was broken: "The scan
itself stays complete either way, so a rename keeps one stable artifact identity even
when its two halves arrive in different notification batches. Only the planned
transition is bounded." The scan is complete. The retain discarded the arrival before
the planner could see it.

`unobserved_move_destinations` names the arrival paths a bounded observation would
drop although the complete scan holds them, for the tracked artifacts that
observation is about to leave with no destination, and keeps one only on the evidence
`plan_observed_tree_deltas` itself reads to call something a move: exactly one
departing tracked artifact carrying that entry, and exactly one observed path the
planning base does not track carrying the same entry. Anything short of that yields
nothing. A copy and a move-plus-replacement keep the vacated path observed, so nothing
departs and neither is touched. A departure with exactly one untracked byte-identical
arrival is read as a move, which is the planner's own rule and what the unbounded commit
seam would plan for the same tree; the retired graph-only member guard is the one place
that rule is refused. The helper counts through two hash maps, so it is linear in the
tree plus the observation rather than quadratic in departures.

## Tests

Five, driving the existing `ambient_admission_for_test` seam so the losing order is
composed rather than waited for. All three are crate tests rather than acceptance
cases, so a PR that breaks the class goes red on this repo's own `Fast gate test
shard` rather than a release later.

- `a_bounded_observation_of_a_moves_vacated_half_relocates_rather_than_orphaning_it`
  renames on disk and runs one ambient pass observing the vacated path alone, then
  requires the entity id, the incoming relation ids, the artifact id and the arrival
  path.
- `a_bounded_observation_of_a_real_deletion_still_retires_its_entities` is the
  control: the same fixture with a real `remove_file`, which must still retire.
- `a_departure_with_two_equally_good_destinations_is_not_a_move` and
  `a_departure_whose_entry_a_second_tracked_path_shares_is_not_a_move` pin the two
  uniqueness clauses of the keep, one each: two byte-identical untracked twins name no
  destination, and an entry a second tracked path shares names no single origin, so
  both stay deletions. With either clause made permissive the rest of the module was
  green, which is why these exist.
- `a_twin_under_a_retired_graph_only_member_is_not_a_move_destination` deletes the
  tracked file beside a byte-identical twin under a retired member. The `admissible`
  closure refuses such content because it was written while the member still stood;
  reading it as the arrival half of a move would walk around that refusal and hand
  the retired subtree to the workspace. The deletion must stay a deletion.

A note on the fixture, because it is the part that could have made the arm hollow.
The test module's existing `derive_semantics` builds a bare `Reconciler`, whose
cross-file linker knows only the file in front of it, so the first version of these
tests carried no cross-file edge at all and the incoming-edge assertion would have
run over an empty set. That surfaced as `left: 0, right: 1` on the fixture assertion
rather than as a pass. `derive_semantics_linked` seeds the linker from the graph the
way `DaemonState::open` does, and the fixture then produces the same two edges the
product does, the module's `Imports` and the function's `Calls`.

## Falsification, on the final bytes

`crates/kin-daemon/src/loop_runner.rs` at this head is sha256
`ec09b25403e7f8d00db31550cc63ada6494a1be312ca818c87051eba773bca4e`. Each arm was
applied to that file by script, built, run over the whole `loop_runner::tests`
module, then restored from a byte copy taken first, with the restore proved by
sha256 rather than by `git checkout`.

**A. The fix's own clause reverted.** The retain put back to
`previous.artifact_id_at_path(path).is_some() || admissible(path)`:

Command, through the builder-slot wrapper with cargo by absolute path:

```
cargo test -p kin-daemon --lib loop_runner::tests
```

Output tail:

```
ARM_A_SHA=ec5bbfea0be9c11121b74eab4506feca162b59844dde81c463c237e0b1ecc57d
test loop_runner::tests::a_bounded_observation_of_a_real_deletion_still_retires_its_entities ... ok
test loop_runner::tests::a_bounded_observation_of_a_moves_vacated_half_relocates_rather_than_orphaning_it ... FAILED
test loop_runner::tests::a_twin_under_a_retired_graph_only_member_is_not_a_move_destination ... ok
panicked at crates/kin-daemon/src/loop_runner.rs:4642:14:
a move must keep the entity it moved rather than mint a new one
test result: FAILED. 116 passed; 1 failed; 0 ignored; 0 measured; 1422 filtered out; finished in 27.75s
ARM_A_RESTORED_SHA=ec09b25403e7f8d00db31550cc63ada6494a1be312ca818c87051eba773bca4e
```

**B. Inert, reported as a non-result rather than counted.** An earlier attempt at
falsifying the control added `destinations.insert(departing.path.clone())` to the
helper. Both tests stayed green. That is not evidence the control is weak:
`move_destinations` only feeds a `retain`, which filters what `observed` already
holds, and a departing path is by definition absent from it. The mutation left the
property in place, so it proves nothing and was replaced by B2.

**B2. The control's own property broken.** Every departing tracked path put back into
`observed`, so no bounded pass can ever plan a removal:

Command, through the builder-slot wrapper with cargo by absolute path:

```
cargo test -p kin-daemon --lib loop_runner::tests
```

Output tail:

```
ARM_B2_SHA=de4778a2ef4a8625fab2eae27821cca658c20328b70ab70e8a5225e2e904d813
test loop_runner::tests::a_bounded_observation_of_a_real_deletion_still_retires_its_entities ... FAILED
test loop_runner::tests::a_bounded_observation_of_a_moves_vacated_half_relocates_rather_than_orphaning_it ... FAILED
test loop_runner::tests::a_twin_under_a_retired_graph_only_member_is_not_a_move_destination ... FAILED
panicked at crates/kin-daemon/src/loop_runner.rs:4755:9:
a real deletion must still retire the entities its path carried
test result: FAILED. 113 passed; 4 failed; 0 ignored; 0 measured; 1422 filtered out; finished in 29.15s
ARM_B2_RESTORED_SHA=ec09b25403e7f8d00db31550cc63ada6494a1be312ca818c87051eba773bca4e
```

The fourth red is the pre-existing
`a_removal_takes_the_relations_bound_to_the_departing_artifact`, which the same
mutation breaks for the same reason. The control fails on its own assertion, so it
is load-bearing.

**C. The retired-member guard dropped.** The `covered_by` clause removed from the
arrival scan in `unobserved_move_destinations`:

Command, through the builder-slot wrapper with cargo by absolute path:

```
cargo test -p kin-daemon --lib loop_runner::tests
```

Output tail:

```
ARM_C_SHA=6f0abe7f74fe1e943f4d1489f872557465d64aa3daec9af4fddda6e1b19f6e91
test loop_runner::tests::a_bounded_observation_of_a_moves_vacated_half_relocates_rather_than_orphaning_it ... ok
test loop_runner::tests::a_bounded_observation_of_a_real_deletion_still_retires_its_entities ... ok
test loop_runner::tests::a_twin_under_a_retired_graph_only_member_is_not_a_move_destination ... FAILED
panicked at crates/kin-daemon/src/loop_runner.rs:4706:9:
test result: FAILED. 116 passed; 1 failed; 0 ignored; 0 measured; 1422 filtered out; finished in 28.01s
ARM_C_RESTORED_SHA=ec09b25403e7f8d00db31550cc63ada6494a1be312ca818c87051eba773bca4e
```

Each arm reds exactly the test written for it and nothing else it should not, and
the file is byte-identical to the head after every restore
(`FINAL_SHA=ec09b25403e7f8d00db31550cc63ada6494a1be312ca818c87051eba773bca4e`).

### The two uniqueness clauses, pinned in the follow-up commit

The review measured that with either uniqueness clause of
`unobserved_move_destinations` made permissive, the whole module stayed green. Two
tests now pin them, one each, lifted from the review verbatim. `loop_runner.rs` at
the corrected head is sha256
`150617d3813b3ea14c50be316a2e900bdca21bcf802b980e491c6a2e0d83f80f`, and the follow-up
commit is tests and comments only; every changed line outside `mod tests` is a
comment, checked by script.

**C1. Base-side count made permissive**,
`.filter(|entry| base_entry_counts.get(entry) == Some(&1))` replaced by
`.filter(|entry| base_entry_counts.get(entry).is_some())`. Command, through the
builder-slot wrapper with cargo by absolute path:

```
cargo test -p kin-daemon --lib loop_runner::tests
```

Output tail:

```
ARM_C1_SHA=fd421f1db77cd0d83f1767b58605fb0a04daf8035518e0a160a25d38983b865c
test loop_runner::tests::a_departure_whose_entry_a_second_tracked_path_shares_is_not_a_move ... FAILED
test loop_runner::tests::a_departure_with_two_equally_good_destinations_is_not_a_move ... ok
panicked at crates/kin-daemon/src/loop_runner.rs:4802:67:
called `Result::unwrap()` on an `Err` value: Core(Other("identity-underdetermined repository transition for artifact ArtifactId(bdd7071c-8e25-4d8b-a3c7-7402162d1206) at src/duplicate.py: the same exact entry also appears at src/renamed.py, ..."))
test result: FAILED. 118 passed; 1 failed; 0 ignored; 0 measured; 1423 filtered out; finished in 26.74s
ARM_C1_RESTORED_SHA=150617d3813b3ea14c50be316a2e900bdca21bcf802b980e491c6a2e0d83f80f
```

**C2. Arrival-side count made permissive**, the `and_modify(|arrival| *arrival = None)`
dropped so the first arrival wins instead of an ambiguous one being refused. Same
command. Output tail:

```
ARM_C2_SHA=24702e6a992c34cfbb32db99cd90c6cf928f308dbf682bf5ba2c5a293bacab7a
test loop_runner::tests::a_departure_whose_entry_a_second_tracked_path_shares_is_not_a_move ... ok
test loop_runner::tests::a_departure_with_two_equally_good_destinations_is_not_a_move ... FAILED
panicked at crates/kin-daemon/src/loop_runner.rs:4755:9:
two equally good destinations name none, so this must stay a deletion
test result: FAILED. 118 passed; 1 failed; 0 ignored; 0 measured; 1423 filtered out; finished in 25.69s
ARM_C2_RESTORED_SHA=150617d3813b3ea14c50be316a2e900bdca21bcf802b980e491c6a2e0d83f80f
```

Each probe reds under its own arm and stays green under the other, the three
earlier tests stay green under both, and after each restore the file matches the
committed bytes with `git status --porcelain` empty. On the unmutated head the module
is `119 passed; 0 failed`.

## Gates, on this head

Rebased onto `c99615f93` before opening. Every cargo command ran through the
umbrella's builder-slot wrapper against this worktree, with cargo by absolute path.

```
cargo test -p kin-daemon --lib
test result: ok. 1537 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 349.35s
```

`bin/kin-precheck kin --repo-dir kin=<worktree>`, named by absolute path from the
umbrella root, on the clean rebased tree:

```
kin-precheck: repo=kin sha=635b1f781bfcd277ccfdf613c12331518437b121
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
...
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 635b1f781bfcd277ccfdf613c12331518437b121
```

## The loop arm

Before the fix, the same fixture through the real binaries went red 1 in 30, and
the whole `entity_file_retirement` binary was measured elsewhere at 2 red in 9.
After the fix, on binaries rebuilt from this exact head (`kin` 05:40:15Z,
`kin-daemon` 05:40:05Z, `entity_file_retirement` 05:40:12Z, `TZ=UTC stat`), the
whole binary 20 times at `--test-threads=1` in fresh processes and the shell repro
60 times, run one after the other so each trial's daemon accounting stays exact:

```
binrun=1 rc=0 GREEN wall=19s daemons_left=0
binrun=2 rc=0 GREEN wall=18s daemons_left=0
binrun=3 rc=0 GREEN wall=17s daemons_left=0
...
binrun=19 rc=0 GREEN wall=18s daemons_left=0
binrun=20 rc=0 GREEN wall=18s daemons_left=0
BINTOTAL red=0 green=20 of 20
```

Per-run wall 17 to 21 s, `daemons_left=0` on every one of the 20 runs.

```
run=1 rc=0 VERDICT=GREEN wall=6s
run=2 rc=0 VERDICT=GREEN wall=6s
...
run=59 rc=0 VERDICT=GREEN wall=6s
run=60 rc=0 VERDICT=GREEN wall=7s
TOTAL red=0 green=60 of 60
```

Per-trial wall 4 to 14 s. Daemon census for this lane's build, by exact
executable path, before the binary loop, between the loops and after the shell loop:

```
PRE_MINE=0 PRE_ALL=2
MID_MINE=0 MID_ALL=2
POST_MINE=0 POST_ALL=4
```


## Follow-ups worth a ticket, not changed here

- The mirror-image order. When the watcher delivers the arrival half alone, the
  bounded loop re-inserts the vacated tracked path, so the planner sees the old path
  unchanged beside a new path with the same entry and refuses the whole pass as
  identity-underdetermined. Self-healing rather than destructive, since the next pass
  carries both halves and the tree is untouched, but it is the other half of this
  same rename race.
- The helper runs before the retracted-path retain and tests membership against the
  planning base, so a tracked path an ignore rule just retracted can count as a
  candidate arrival. Nothing is admitted, because the later retain drops it, but such
  a path sharing an entry with a real arrival makes that arrival ambiguous and quietly
  costs the move its keep. Passing the retracted set in, or running the helper after
  that retain, would close it.
- `kin daemon stop --all` stops the worker and leaves its supervisor running, argv
  `kin-daemon --supervisor --port 0`. The measurement loop found this the hard way:
  one supervisor plus one worker per trial, 175 processes and about 12 GiB resident
  on the box before the loop learned to stop what it started by pid.
