### PR TITLE
Give the authority tests a retry budget on every must-succeed acquisition

### DIFF
--- a/crates/kin-cli/src/commands/repository_authority.rs
+++ b/crates/kin-cli/src/commands/repository_authority.rs
@@ -666,9 +666,13 @@ mod tests {
     fn offline_materialization_refuses_runtime_contention_before_authority_open() {
         let directory = tempfile::tempdir().unwrap();
         let initialized = kin_core::init(directory.path()).unwrap();
+        // Setting up the holder is not a timing property either. This call
+        // creates `.kin/daemon.lifecycle`, since nothing before it does, and
+        // then claims it, so a zero budget would decide the whole test on one
+        // non-blocking claim against a freshly created inode.
         let held = crate::daemon_client::acquire_repository_runtime_authority_within(
             initialized.layout.root(),
-            std::time::Duration::ZERO,
+            kin_daemon_spawn::REPOSITORY_RUNTIME_AUTHORITY_RETRY_BUDGET,
         )
         .unwrap()
         .expect("test owns repository runtime authority");
@@ -688,9 +692,17 @@ mod tests {
         );
 
         drop(held);
+        // The refusal above is the property under test and takes the zero
+        // budget so it decides without waiting. The recovery below is not a
+        // timing property, so it takes the budget the shipped command uses.
+        // Acquisition claims the coordination inode before the authority
+        // inode, and a single non-blocking claim on either can report
+        // contention that no holder explains, so a zero budget here would
+        // assert that acquisition wins on its first syscall, which is not
+        // something acquisition promises.
         let outcome = materialize_workspace_base_offline_within(
             &initialized.layout,
-            std::time::Duration::ZERO,
+            kin_daemon_spawn::REPOSITORY_RUNTIME_AUTHORITY_RETRY_BUDGET,
         )
         .unwrap();
         assert_eq!(
@@ -701,6 +713,82 @@ mod tests {
             repository_authority_opens_on_this_thread(),
             opens_before + 1,
             "the successful maintenance arm opens authority exactly once"
+        );
+    }
+
+    /// A hold on the coordination inode is not authority contention.
+    ///
+    /// `.kin/daemon.lifecycle` serializes runtime acquisition against endpoint
+    /// publication, so a brief section owns it while nothing owns runtime
+    /// authority at all. Offline maintenance must wait that window out within
+    /// its budget. Answering it as contention would tell an operator to stop a
+    /// daemon that is not running, and would leave the graph section
+    /// unmaterialized for a lock that was already free.
+    ///
+    /// The hold is shorter than the retry budget by two orders of magnitude, so
+    /// this asserts the retry exists rather than racing it. Give the call the
+    /// zero budget instead and it fails on the first attempt.
+    #[test]
+    fn offline_materialization_waits_out_a_coordination_hold_that_is_not_authority() {
+        use fs2::FileExt;
+
+        /// Long enough to outlast the acquire's first claim and its first
+        /// retry interval, and far shorter than the budget it is measured
+        /// against.
+        const HOLD: std::time::Duration = std::time::Duration::from_millis(150);
+
+        let directory = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(directory.path()).unwrap();
+        let kin_root = initialized.layout.root().canonicalize().unwrap();
+
+        let coordination = std::fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(kin_root.join("daemon.lifecycle"))
+            .unwrap();
+        coordination.try_lock_exclusive().unwrap();
+        assert!(
+            crate::daemon_client::acquire_repository_runtime_authority_within(
+                initialized.layout.root(),
+                std::time::Duration::ZERO,
+            )
+            .unwrap()
+            .is_none(),
+            "the coordination hold must really block a zero-budget acquisition"
+        );
+
+        let opens_before = repository_authority_opens_on_this_thread();
+        let releasing = std::thread::spawn(move || {
+            std::thread::sleep(HOLD);
+            fs2::FileExt::unlock(&coordination).unwrap();
+        });
+
+        let started = std::time::Instant::now();
+        let outcome = materialize_workspace_base_offline_within(
+            &initialized.layout,
+            kin_daemon_spawn::REPOSITORY_RUNTIME_AUTHORITY_RETRY_BUDGET,
+        )
+        .expect("a coordination hold nobody holds authority behind must not refuse");
+        let waited = started.elapsed();
+        releasing.join().unwrap();
+
+        assert_eq!(
+            outcome.state,
+            GraphSectionMaterializationState::NoBaseTarget
+        );
+        // The hold outlives the call's first claim by construction, so this
+        // cannot be met by a run that never retried. Without it the assertion
+        // above passes just as well when the hold was already gone.
+        assert!(
+            waited >= HOLD,
+            "acquisition returned in {waited:?}, before the {HOLD:?} hold could have been released"
+        );
+        assert_eq!(
+            repository_authority_opens_on_this_thread(),
+            opens_before + 1,
+            "waiting out the hold still opens authority exactly once"
         );
     }
 }

--- a/crates/kin-daemon-spawn/src/runtime_authority.rs
+++ b/crates/kin-daemon-spawn/src/runtime_authority.rs
@@ -179,6 +179,19 @@ fn without_blocking_runtime_worker<T>(work: impl FnOnce() -> T) -> T {
 mod tests {
     use super::*;
 
+    /// Budget for an acquisition a test asserts MUST succeed.
+    ///
+    /// Not zero, because one non-blocking claim can report contention that no
+    /// holder explains, and this path takes two inodes before it answers; a
+    /// zero budget would rest a must-succeed assertion on both claims winning
+    /// on their first syscall. Not the shipped
+    /// [`REPOSITORY_RUNTIME_AUTHORITY_RETRY_BUDGET`] either, because that is
+    /// long enough to absorb a real regression: this arm is what fails when
+    /// release stops being visible to the next acquisition, and it can only do
+    /// that while its tolerance stays far below the interval a defect would
+    /// hold for. Several retry intervals is the width that answers both.
+    const REACQUIRE_BUDGET: Duration = Duration::from_millis(1_000);
+
     #[test]
     fn authority_is_canonical_exclusive_and_never_unlinks_its_inode() {
         let directory = tempfile::tempdir().unwrap();
@@ -206,7 +219,7 @@ mod tests {
             ""
         );
         assert!(
-            acquire_repository_runtime_authority_within(&root, Duration::ZERO, "owner-b")
+            acquire_repository_runtime_authority_within(&root, REACQUIRE_BUDGET, "owner-b")
                 .unwrap()
                 .is_some()
         );


### PR DESCRIPTION
**Test-only. No shipped byte changes.** Every hunk is inside a `#[cfg(test)]` module, and the
commands have always passed the 5 s `REPOSITORY_RUNTIME_AUTHORITY_RETRY_BUDGET`. The product
already waits these holds out; the tests did not.

`offline_materialization_refuses_runtime_contention_before_authority_open` is graded by
`Feature permutation tests (ubuntu-latest)` and `(macos-latest)`, both in `REQUIRED_CHECKS` at
`release-tag.yml:961-962`, so a flake there makes a green sha unmintable. It has gone red twice.

**Draft on purpose**, held until the v0.7.2 cut clears.

## Measurement

Two red jobs, both running `cargo test -p kin-cli --no-default-features --lib --tests --locked`
in the step `Test featureless kin-cli` (`ci.yml:2762`).

| Date | Run | Leg | Head sha | Panic site | Result |
|---|---|---|---|---|---|
| 2026-09-06 | 34004028113 | macos-latest | b1837fa59 | `repository_authority.rs:695:10` | `2176 passed; 1 failed` in 177.79s |
| 2026-09-02 | 33683158138 | ubuntu-latest | 8f3988c31 | `repository_authority.rs:633:10` | `2058 passed; 1 failed` in 328.17s |

```
thread '...offline_materialization_refuses_runtime_contention_before_authority_open' (130334)
panicked at crates/kin-cli/src/commands/repository_authority.rs:695:10:
called `Result::unwrap()` on an `Err` value: another Kin process holds repository runtime authority
for /private/var/folders/df/.../.tmpa9CXnB/.kin; run `kin daemon stop`, then retry `kin graph materialize`
```

```
thread '...offline_materialization_refuses_runtime_contention_before_authority_open' (33588)
panicked at crates/kin-cli/src/commands/repository_authority.rs:633:10:
called `Result::unwrap()` on an `Err` value: another Kin process holds repository runtime authority
for /tmp/.tmpK1euMp/.kin; run `kin daemon stop`, then retry `kin graph materialize`
```

Read at each sha, `695:10` and `633:10` are the same statement: the `.unwrap()` after
`drop(held)`. The refusal assertion the test is named for passed on both red runs, and so did the
assertion that contention is decided before an authority open. One red is macOS and one is Linux,
which rules out anything OS specific.

## Mechanism

`acquire_repository_runtime_authority_within` computes `deadline = Instant::now() + budget` once
(`runtime_authority.rs:77`), so `Duration::ZERO` is one non-blocking attempt with no retry. The
attempt claims `.kin/daemon.lifecycle` through `acquire_lifecycle_coordination` (line 108) before
it claims `.kin/daemon.lock` (line 109), and a `WouldBlock` on either with the deadline expired
becomes the same `Ok(None)` the caller renders as "another Kin process holds repository runtime
authority".

So a zero budget on an acquisition a test asserts **must succeed** rests that assertion on both
claims winning on their first syscall. `daemon_client.rs:3608-3626` records why that is not safe:

> One non-blocking `flock` is not evidence that anybody holds this lock. It was observed failing
> with `EWOULDBLOCK` on a freshly created file that nothing else had ever opened, with `lsof`
> naming only the caller's own descriptor and an immediate retry on that same descriptor
> succeeding.

kin-cli answers that with a 250 ms floor; kin-daemon-spawn answers it with a 5 s budget and a
100 ms interval. These tests defeated both by passing zero. Refusal arms are not exposed, because
a spurious contention cannot make a refusal wrong; only must-succeed arms are.

## The change

Three must-succeed acquisitions, all in test code.

1. `repository_authority.rs`, the recovery arm after `drop(held)`: takes
   `REPOSITORY_RUNTIME_AUTHORITY_RETRY_BUDGET`.
2. `repository_authority.rs`, the setup acquisition three lines above it: same. This one creates
   `daemon.lifecycle`, since nothing under `crates/kin-core` references it, so it was taking one
   non-blocking claim on a freshly created inode, which is precisely the case quoted above.
3. `runtime_authority.rs:208-212`, the same shape in kin-daemon-spawn, which rolls up into
   `Check & Test (ubuntu-latest)` and `(macos-latest)`, also in `REQUIRED_CHECKS`.

Number 3 takes a bounded `REACQUIRE_BUDGET` of 1 s rather than the shipped 5 s, and that
difference is deliberate. That arm is the only remaining guard for the class "release stops being
visible to the next acquisition for a bounded interval". Giving it 5 s would remove the last
witness for that class silently. Arms D and E below measure the difference rather than assert it.

Refusal arms keep `Duration::ZERO`. The refusal assertion and both
`repository_authority_opens_on_this_thread()` counts are unchanged.

Plus a scripted check for the class, `offline_materialization_waits_out_a_coordination_hold_that_is_not_authority`,
since the permutations do not grade pull requests. The coordination inode serializes acquisition
against endpoint publication, so a brief section owns it while nothing owns authority, and
answering that as contention would tell an operator to stop a daemon that is not running. It
asserts an elapsed floor and the authority-open count as well as the outcome, so it cannot pass on
a hold that was already gone.

## Reproduction

**Natural, under load: not reproduced. 960 of 960 passed.** 24 concurrent workers, 40 iterations
each, on the base bytes for that test, on an 18-core box also running cargo builds. Twenty
isolated runs also passed. The spurious contention did not appear locally, and an idle developer
box is the wrong place to hunt a rare environmental event.

**Deterministic, by injection: reproduced.** Hold only the coordination inode, so nothing holds
runtime authority, then call with the zero budget:

```
PROBE-ZERO error: another Kin process holds repository runtime authority for
/private/var/folders/pg/.../.tmp15Qbjc/.kin; run `kin daemon stop`, then retry `kin graph materialize`

PROBE-BUDGET outcome: NoBaseTarget
```

Same message as CI apart from the temp path, and the shipped budget survives the identical hold.
That reproduces the failure mode, not the kernel event that triggered it in CI.

## Falsification

Six arms, each reverted and the file hash checked against the pre-mutation blob before the next.

**A. Remove the contention refusal** in `materialize_workspace_base_offline_within`:

```
panicked at crates/kin-cli/src/commands/repository_authority.rs:676:10:
called `Result::unwrap_err()` on an `Ok` value: GraphSectionMaterialization { ... state: NoBaseTarget, ... }
test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 2179 filtered out
```

**B. Give the new test the zero budget.** Red with the exact CI message, which is what ties this
test to the two red jobs:

```
a coordination hold nobody holds authority behind must not refuse: another Kin process holds
repository runtime authority for /private/var/folders/pg/.../.tmpPDeeVt/.kin;
run `kin daemon stop`, then retry `kin graph materialize`
test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 2179 filtered out
```

**C. Hold the coordination inode across the setup acquisition.** On the previous head this
panicked at `expect("test owns repository runtime authority")`. On this head:

```
test ...offline_materialization_refuses_runtime_contention_before_authority_open ... ok
test ...offline_materialization_waits_out_a_coordination_hold_that_is_not_authority ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2179 filtered out; finished in 2.49s
```

**D. Make release invisible to the next acquisition for a bounded 2 s** (`try_clone` in `Drop`
shares the open file description, so the advisory lock outlives the guard). The kin-daemon-spawn
arm must still catch it:

```
panicked at crates/kin-daemon-spawn/src/runtime_authority.rs:230:9:
assertion failed: acquire_repository_runtime_authority_within(&root, REACQUIRE_BUDGET,
            "owner-b").unwrap().is_some()
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 127 filtered out; finished in 1.01s
```

**E. The same mutation with the shipped 5 s budget instead**, which is why that arm is bounded:

```
test runtime_authority::tests::authority_is_canonical_exclusive_and_never_unlinks_its_inode ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 127 filtered out; finished in 2.07s
```

The regression passes. A 5 s budget there would have dropped the guard while looking like a fix.

**F. Release the hold before the call rather than during it**, so only the new elapsed floor can
notice:

```
panicked at crates/kin-cli/src/commands/repository_authority.rs:785:9:
acquisition returned in 7.4685ms, before the 150ms hold could have been released
```

## Local verification

Nothing below is checked by hosted CI, so the commands and their output are here rather than
prose. The green formatting and lint contexts on this PR already speak for themselves.

Twenty runs each way, both crates' tests in every run:

```
threads1: pass=20 fail=0
default:  pass=20 fail=0
```

```
$ cargo fmt --all -- --check
FMT CLEAN
$ cargo test -p kin-cli -p kin-daemon-spawn --no-default-features --lib --tests --locked --no-run
rc=0
```

`bin/kin-precheck kin --repo-dir`, run on the committed head with a clean tree so the tally is
bound to these exact bytes:

```
kin-precheck: repo=kin sha=eceb5a9074790a437b8f261c30cf4eab4be3081f
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin eceb5a9074790a437b8f261c30cf4eab4be3081f
```

The enumerated line reads 21 and 21 ran. It names three check-job steps it deliberately does not
run, the language-server provisioner, the event-routed release policy gate and the poisoned-copy
hydration falsifier, so this says nothing about those three.

## How to read this PR's own green

`Feature permutation tests (ubuntu-latest)` and `(macos-latest)` are green here and prove nothing
about the fix. On a pull request they come from `feature-tests-pr-fast-path` (`ci.yml:2627`),
which runs no tests and exists only to publish the names. `Check & Test (ubuntu-latest)` and
`(macos-latest)` are the same shape from `check-pr-fast-path` (`ci.yml:1712-1723`). Both sets are
graded on main's push run after landing.

What does grade the change here is `Fast gate build and tests`, whose shards ran both kin-cli
tests on the previous head:

```
PASS [0.254s] (436/1919) kin-cli ...offline_materialization_waits_out_a_coordination_hold_that_is_not_authority
PASS [0.067s] (424/1851) kin-cli ...offline_materialization_refuses_runtime_contention_before_authority_open
```

## Not fixed here

`acquire_repository_runtime_authority_within` returns the same `Ok(None)` for "the coordination
lock stayed held to the deadline" and "another process holds runtime authority", and the CLI turns
both into "run `kin daemon stop`". Only the second justifies that advice. It needs a coordination
hold longer than the budget to surface, which is why it has not. It changes an operator-facing
error path in lock code, and this PR's value is that it changes no shipped bytes, so folding it in
would cost exactly the property that makes it safe to land mid-cut. It is going to a ticket, along
with the bounded-budget question above.
