### PR TITLE
Correct the store-size page's component model and ratio range

### DIFF
--- a/docs/store-size.md
+++ b/docs/store-size.md
@@ -31,7 +31,8 @@ store.
 The store is not a copy of the packfile, so it is not bounded by one, and the
 gap is much larger than the semantic layer alone accounts for.
 
-Two things inside `.kin/` account for all of it, to within rounding. Broken down on
+Two things account for almost all of the store on the repository broken down
+below, and a third can appear and rival the snapshot in size. Broken down on
 ripgrep at 2,261 commits, whose 6.1 MiB object store became a 405.4 MiB store:
 
 | Part of `.kin/` | Size | Share |
@@ -58,9 +59,22 @@ entities across 2,327 changes, and an entity's identity is derived partly from
 its starting line, so an edit that shifts a function down a file retires one
 identity and creates another for code that did not change.
 
-Both terms scale with **history depth** rather than with the size of your
-checkout, which is why a repository with a small working tree and thousands of
-commits can still produce a large store.
+**The prepared query graph.** Not present in the ripgrep breakdown above, and
+large enough elsewhere that a reader should not treat that breakdown as the
+shape of every store. Kin writes a prepared workspace query graph at
+`kindb/<repo>/prepared/<workspace>.kpqg`, with a small `.kpqg.json` binding
+beside it, to accelerate reopening a workspace. On psf/requests at `dae7ef63b`
+under v0.7.0 it measured 1163.50 MiB, 46.2% of a 2.46 GiB store, slightly
+smaller than that store's graph snapshot and roughly nine times its admitted
+bodies. It is written during `kin init` rather than by a later commit: on the
+measured store its mtime preceded the command's own return by 24 seconds. It
+appears to be tied to a workspace carrying a semantic overlay rather than
+written unconditionally, so treat it as a component that can appear and can be
+roughly half the store, not as a guaranteed third row.
+
+The first two terms scale with **history depth** rather than with the size of
+your checkout, which is why a repository with a small working tree and thousands
+of commits can still produce a large store.
 
 The ratio is not a constant and is not fully explained. It varies by more than
 3x across repositories of similar size in different languages, and why is an open
@@ -105,10 +119,24 @@ listed as corroboration rather than as rows measured the same way: anyhow 47x,
 click 109.1x, zod 163x, sinatra 75.1x, and a 27-file shell repository with zero
 entities extracted at 27.4x.
 
+Across every real repository named on this page, the table and the corroboration
+list together, the measured ratios span **27.4x to 163x**: 27.4x, 47x, 55.6x,
+66.5x, 75.1x, 109.1x and 163x. The table's other two rows are fixtures built to
+show edge behaviour rather than repositories. So the table's two repository rows
+are not the range, and reading the table alone gives a much narrower impression
+than this page's own numbers support.
+
 This is a record of what has been measured, not a bound. Kin does not currently
 cap store size, warn above a threshold, or refuse to admit a repository for
-being large. If your repository lands far outside this range, that is worth
+being large. If your repository lands far outside 27.4x to 163x, that is worth
 reporting, and the numbers `kin status` prints are what to report.
+
+One repository is deliberately absent from the table. psf/requests at
+`dae7ef63b` has been measured at 178.0x under v0.7.0, but that store carried a
+partial embedding pass and one commit, so it was not produced by `kin init`
+alone and a row from it would not mean what the other rows mean. It is named
+here rather than added above, because a table whose rows were gathered different
+ways stops being a comparison.
 
 ## Where to see it
 


### PR DESCRIPTION
## What this changes

`docs/store-size.md` describes the store as two components and records a ratio table. A store
measured on psf/requests shows the component model is missing a third piece that was 46% of that
store, and the table's two repository rows are much narrower than the ratios the same page lists
one paragraph below it.

Docs only. `classifyPath` in `scripts/release-intent.mjs` treats `docs/` as non-release, so no
version bump.

### 1. The prepared query graph was undocumented

The page said two things account for the whole store, with "everything else under 1 MiB". On
psf/requests at `dae7ef63b`, a full filesystem walk found:

| Component | MiB | Files | Share |
|---|---:|---:|---:|
| `kindb/<repo>/snapshots/*.kndb` | 1218.55 | 1 | 48.4% |
| `kindb/<repo>/prepared/*.kpqg` | 1163.50 | 2 | 46.2% |
| `kindb/<repo>/source-blobs/` | 127.77 | 26863 | 5.1% |
| everything else, all search structures included | 6.12 | 219 | 0.2% |

27,090 regular files, 2,638,230,556 logical bytes by the page's own walk method (`stat` size over
regular files, symlinks skipped), 2,659,496 KiB by `du -sk`.

The artifact is written during `kin init`, not by a later commit. Its mtime is
`2026-09-06T16:03:59Z` and that `kin init` returned at `16:04:23Z`, 24 seconds later. Its layout
is documented in kin-db at `crates/kin-db/src/storage/backend.rs:3315-3325`.

It is documented as a component that can appear and can be roughly half the store, rather than as
a guaranteed third row, because `kin graph status` on the same store reported "This workspace
carries a semantic overlay, so a durable prepared artifact may answer an open before the section
is consulted", which reads as conditional.

### 2. The ratio range the page implies is narrower than the range it records

The table's two real repositories are 55.6x and 66.5x. The paragraph directly below records
27.4x, 47x, 75.1x, 109.1x and 163x. A reader taking the table as the range gets a span the page's
own numbers do not support, and the "far outside this range" advice inherits it. This states the
27.4x to 163x span, names which table rows are fixtures rather than repositories, and points that
advice at the real numbers.

### 3. The requests store is named, not added as a row

It carried a partial embedding pass and one commit, so it was not produced by `kin init` alone and
would not mean what the other rows mean. The page says so rather than silently omitting it.

## Falsification

Prose has no red-first test, so the check is that the strings must be absent before and present
after, with a control that must not move.

Before, at `2026-09-06T16:26:47Z`, on the unmodified file:

```
grep -ic 'prepared'  = 0
grep -ic 'kpqg'      = 0
grep -ic 'snapshots' = 1     <- control
```

After:

```
grep -ic 'prepared'  = 3
grep -ic 'kpqg'      = 1
grep -ic 'snapshots' = 1     <- control, unmoved
```

Every ratio asserted in the new range sentence was checked to exist on the page, each hit at least
twice (its original site plus the new sentence): 27.4x, 47x, 55.6x, 66.5x, 75.1x, 109.1x, 163x.

Two negative checks that must stay at zero: no em dash anywhere in the file, and no string
matching `fifty to seventy|50x to 70x|50 to 70`.

## Scope

One file. No code, no behaviour change, no test change.
