### PR TITLE
Rank semantic_locate's own evidence first, and make get_context_pack's claims checkable

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -727,10 +727,41 @@ fn query_names_entity_symbolically(query: &str, name: &str) -> bool {
     }
     let target = name.to_ascii_lowercase();
     let tail = qualified_name_tail(&target);
-    query_tokens(query).any(|token| {
+    let named_by_token = query_tokens(query).any(|token| {
         let lowered = token.to_ascii_lowercase();
         (lowered == target || lowered == tail) && is_symbolic_search_term(token)
-    })
+    });
+    named_by_token
+        || query_qualified_paths(query).any(|path| {
+            let lowered = path.to_ascii_lowercase();
+            lowered == target || qualified_name_tail(&lowered) == tail
+        })
+}
+
+/// The QUALIFIED symbol paths a query spells out, whole, in their original
+/// case.
+///
+/// [`query_tokens`] splits on every character that is not alphanumeric or an
+/// underscore, so a dotted path is gone before any rule can read it as one.
+/// A question that wrote `router.param` reaches [`is_symbolic_search_term`] as
+/// the two bare words `router` and `param`, and a bare `param` is a plain
+/// English word, so the query that named the symbol in its most explicit form
+/// was judged not to have named it symbolically at all.
+///
+/// Measured on expressjs/express at v0.7.2, store fully embedded (798 of 798):
+/// "where router.param callbacks are registered and stored, and how a request
+/// is dispatched through the middleware stack" classified `app.param` as a
+/// prose-word collision, which took it out of [`locate_exact_name_tier`] and
+/// left it at rank 3 behind two file anchors from `lib/utils.js`.
+///
+/// Yields only runs that actually carry a separator, because a single bare
+/// word is what [`query_tokens`] already offers and the whole point here is
+/// the shape the tokenizer destroys.
+fn query_qualified_paths(query: &str) -> impl Iterator<Item = &str> {
+    query
+        .split(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == '.' || c == ':'))
+        .map(|run| run.trim_matches(|c| c == '.' || c == ':'))
+        .filter(|path| path.contains('.') || path.contains("::"))
 }
 
 /// Whether this entity's name match rests on nothing but a plain English word
@@ -17881,6 +17912,53 @@ fn entity_projection_role_penalty(path: &str, test_query: bool) -> f32 {
     penalty
 }
 
+/// The score a file anchor's share is taken FROM.
+///
+/// Not the ranking's single best row, but the WEAKEST row retrieval still
+/// scored well, so an anchor is priced beneath the whole band of rows the
+/// retrieval found rather than beneath only its leader. `well` is a share of
+/// the top score, which is the same scale-free idiom
+/// `KIN_LOCATE_COLLISION_SIBLING_SHARE` uses to ask the same question, and it
+/// is the only form that behaves alike on a store whose text arm tops out at
+/// 280 and one where it reaches 1152.
+///
+/// The two shapes this has to tell apart are both measured, and the band is
+/// what separates them.
+///
+/// On React, `ReactFiberWorkLoop.js` ranked FIRST for "what happens between a
+/// component asking for an update and that update appearing on screen" and
+/// contributed one row at rank 97 of 136. Retrieval scored exactly one row
+/// well there (852.2, against a helper at 95.7), the band is that one row, and
+/// the reference is unchanged from taking the maximum. That is the case
+/// anchors exist for and it must not move;
+/// `a_prose_question_gets_the_top_ranked_files_own_anchor` pins it.
+///
+/// On psf/requests at v0.7.2, fully embedded, "where HTTP redirects are
+/// resolved and followed after a response" scored three rows well and close
+/// together: `Response` 349.06, `TooManyRedirects` 292.29 and the right
+/// answer, `SessionRedirectMixin.resolve_redirects`, at 283.20. A share of the
+/// leader alone prices anchors into the middle of that cluster, which is how
+/// five of them came to sit above the right answer. A share of the band prices
+/// them under it.
+///
+/// Returns 0.0 for a ranking with no positively scored row, which is the
+/// docs-and-config store the caller answers with `KIN_LOCATE_FILE_ANCHOR_SCORE`.
+fn anchor_reference_band(ranked: &[(usize, LocateEntity)], well: f32) -> f32 {
+    let top = ranked
+        .iter()
+        .map(|(_, entity)| entity.score)
+        .fold(0.0_f32, f32::max);
+    if top <= 0.0 {
+        return 0.0;
+    }
+    let floor = top * well;
+    ranked
+        .iter()
+        .map(|(_, entity)| entity.score)
+        .filter(|score| *score >= floor)
+        .fold(top, f32::min)
+}
+
 /// FIR-3079: demote a prose-word collision its own file does not corroborate.
 ///
 /// kin#1367 takes such a row out of the exact-name tier, and on two measured
@@ -18083,6 +18161,12 @@ pub fn build_entity_view(
     // Used only when a ranking has no scored row to take a share of, which is
     // the docs-and-config repo whose files carry no entities at all.
     let anchor_base = locate_env_f32("KIN_LOCATE_FILE_ANCHOR_SCORE", 100.0);
+    // Which rows count as "retrieval scored this well", and therefore which
+    // score the anchor share is taken from ([`anchor_reference_band`]). The
+    // same 0.25 idiom `KIN_LOCATE_COLLISION_SIBLING_SHARE` already uses for the
+    // same question, and for the same reason: comparing against this ranking's
+    // own top row is the only scale-free way to ask it.
+    let anchor_band_share = locate_env_f32("KIN_LOCATE_FILE_ANCHOR_BAND_SHARE", 0.25);
     // Built once on the first ranked file that resolves to no entity, because
     // it walks every tracked artifact and most rankings never need it.
     let mut tracked_artifacts: Option<HashSet<String>> = None;
@@ -18216,11 +18300,38 @@ pub fn build_entity_view(
     // the ordering then reads ([`apply_entity_surface_penalty`]).
     apply_entity_surface_penalty(&mut ranked, query);
 
-    // The anchors, beneath every row retrieval scored. The reference is this
-    // ranking's own top score, so the admission adapts to the store's scale
-    // instead of imposing one, and the share is strictly below 1.0 so an anchor
-    // can never take rank one from a row that carries real evidence. The decay
-    // keeps the file arm's order among the anchors themselves.
+    // The floor is a CAP on the collision demotion, and it is pinned from both
+    // sides by measurement. It has to be under 0.810 or React's
+    // `Resolved.component` at 1052.0 keeps rank one over a best non-colliding
+    // 852.3, and it has to be high enough that a right answer alone in its file
+    // still lands on the six-row default page: at 0.5 the synthetic fixture's
+    // row fell from rank one to rank eight, off the page an agent reads.
+    let collision_floor = locate_env_f32("KIN_LOCATE_COLLISION_LONE_FLOOR", 0.75);
+    let collision_target = locate_env_usize("KIN_LOCATE_COLLISION_CORROBORATION_TARGET", 2);
+    // BEFORE the anchors, because the anchor reference is a share of the scores
+    // in this vector and a collision row's score is not final until this has
+    // run. Measured on psf/requests at v0.7.2 with the store fully embedded
+    // (1722 of 1722): the class `Response` seeded the reference at 465.42 and
+    // shipped at 349.06 after this demotion, so five anchors priced at
+    // 0.9 x 465.42 sorted above the very row they took their share from and
+    // rank one went to an anchor, which is exactly what this file's own comment
+    // and `a_prose_question_gets_the_top_ranked_files_own_anchor` both say can
+    // never happen.
+    //
+    // Moving it changes no corroboration count. The count already skips every
+    // `FILE_ANCHOR_ORIGIN` row, so no anchor corroborated anything from the
+    // later position either, and the rows that do corroborate are all here.
+    // What it does change is an anchor that is ITSELF a prose-word collision:
+    // it is now demoted against the anchors alone, which corroborate nothing,
+    // so it takes the full floor. That is the conservative direction for a row
+    // whose whole claim is that it is a second opinion.
+    apply_collision_corroboration_penalty(&mut ranked, query, collision_floor, collision_target);
+
+    // The anchors, beneath the band of rows retrieval scored well. The
+    // reference adapts to the store's scale instead of imposing one, and the
+    // share is strictly below 1.0 so an anchor can never take rank one from a
+    // row that carries real evidence. The decay keeps the file arm's order
+    // among the anchors themselves.
     if !anchor_candidates.is_empty() {
         // ONE budget across the whole anchor window, spent by structural mass.
         // `rank_file_anchors` already orders exactly that way (mass desc, type
@@ -18245,12 +18356,9 @@ pub fn build_entity_view(
                     .collect();
             anchor_candidates.retain(|(_, _, _, entity, _)| keep.contains(&entity.id.to_string()));
         }
-        let top = ranked
-            .iter()
-            .map(|(_, entity)| entity.score)
-            .fold(0.0_f32, f32::max);
-        let reference = if top > 0.0 {
-            top * anchor_share
+        let band = anchor_reference_band(&ranked, anchor_band_share);
+        let reference = if band > 0.0 {
+            band * anchor_share
         } else {
             anchor_base
         };
@@ -18328,23 +18436,17 @@ pub fn build_entity_view(
             ));
         }
         apply_entity_surface_penalty(&mut admitted, query);
+        // An anchor the query happens to name is a name hit like any other and
+        // can be a prose-word collision like any other, so it faces the same
+        // demotion the retrieval rows already took above.
+        apply_collision_corroboration_penalty(
+            &mut admitted,
+            query,
+            collision_floor,
+            collision_target,
+        );
         ranked.extend(admitted);
     }
-
-    // After the anchors, because an anchor must not corroborate a collision, and
-    // before the ordering, because the ordering reads the score this moves.
-    apply_collision_corroboration_penalty(
-        &mut ranked,
-        query,
-        // The floor is a CAP on the demotion, and it is pinned from both sides by
-        // measurement. It has to be under 0.810 or React's `Resolved.component`
-        // at 1052.0 keeps rank one over a best non-colliding 852.3, and it has to
-        // be high enough that a right answer alone in its file still lands on the
-        // six-row default page: at 0.5 the synthetic fixture's row fell from rank
-        // one to rank eight, off the page an agent reads.
-        locate_env_f32("KIN_LOCATE_COLLISION_LONE_FLOOR", 0.75),
-        locate_env_usize("KIN_LOCATE_COLLISION_CORROBORATION_TARGET", 2),
-    );
 
     let owner_mass_of = |entity: &LocateEntity| {
         name_owner_mass
@@ -22724,6 +22826,465 @@ mod tests {
             fixed.entities[1].score,
             fixed.entities[2].score
         );
+    }
+
+    /// A query that SPELLS the symbol has named it, dot and all.
+    ///
+    /// Measured on expressjs/express at v0.7.2, store fully embedded (798 of
+    /// 798). "where router.param callbacks are registered and stored, and how a
+    /// request is dispatched through the middleware stack" put `app.param` at
+    /// rank 3, behind two file anchors from `lib/utils.js` at 395.24, because
+    /// the row was classified a prose-word collision and lost
+    /// [`locate_exact_name_tier`].
+    ///
+    /// The cause is [`query_tokens`], which splits on the dot, so the only
+    /// tokens the symbolic rule ever saw were `router` and `param`, and a bare
+    /// `param` is a plain English word.
+    #[test]
+    fn a_dotted_query_path_names_its_symbol_symbolically() {
+        let query = "where router.param callbacks are registered and stored, and how a \
+                     request is dispatched through the middleware stack";
+
+        // Control: the shape the rule is about is really present. The query IS
+        // prose, and the bare token on its own is NOT symbolic, so nothing here
+        // passes because the preconditions quietly stopped holding.
+        assert!(
+            query_is_prose(query),
+            "control: this query has to read as prose or the rule never fires"
+        );
+        assert!(
+            !is_symbolic_search_term("param"),
+            "control: the bare token is what made this a collision"
+        );
+
+        assert!(
+            query_names_entity_symbolically(query, "app.param"),
+            "the query wrote `router.param`, which is a symbol, not an English word"
+        );
+        assert!(
+            !is_prose_word_collision(query, "app.param"),
+            "so the row is not a prose-word collision"
+        );
+
+        // And the tier it lost is the tier it keeps.
+        let mut named = mk_locate_entity("app.param", 360.0, true);
+        named.match_kind = Some(LocateMatchKind::Name);
+        assert_eq!(
+            locate_exact_name_tier(&named, query),
+            1,
+            "a hit the query named by a qualified path stays unbeatable by fallback"
+        );
+
+        // The rule stays a rule about SYMBOLS. A prose question that merely
+        // uses a word keeps its demotion, which is what FIR-3079 exists for.
+        let prose = "when I send a command, how does it reach the socket";
+        assert!(
+            !query_names_entity_symbolically(prose, "send"),
+            "a plain word in a sentence still names nothing symbolically"
+        );
+        assert!(
+            is_prose_word_collision(prose, "send"),
+            "and it is still a collision"
+        );
+    }
+
+    /// [`query_qualified_paths`] yields the shape [`query_tokens`] destroys,
+    /// and yields nothing else.
+    #[test]
+    fn qualified_paths_are_the_runs_the_tokenizer_splits() {
+        let paths: Vec<&str> =
+            query_qualified_paths("where router.param callbacks are registered.").collect();
+        assert_eq!(
+            paths,
+            vec!["router.param"],
+            "the dotted run comes back whole, and a sentence-ending period is not a path"
+        );
+        assert_eq!(
+            query_qualified_paths("kin_db::InMemoryGraph holds it").collect::<Vec<_>>(),
+            vec!["kin_db::InMemoryGraph"],
+            "a scoped path is a qualified path too"
+        );
+        assert!(
+            query_qualified_paths("how does a request reach the router")
+                .next()
+                .is_none(),
+            "a sentence with no separator offers no path, so the rule cannot fire on prose"
+        );
+    }
+
+    /// An anchor cannot be priced off a score its own ranking is about to cut.
+    ///
+    /// The half of the requests defect the band alone does not answer, isolated
+    /// so it can be falsified on its own. When the ranking's leader is a
+    /// prose-word collision and nothing else scores near it, the band IS that
+    /// leader, and reading it before the demotion hands every anchor 90% of a
+    /// number the leader does not keep. On the released v0.7.2 archive that is
+    /// exactly what happened: `Response` seeded the reference at 465.42 and
+    /// shipped at 349.06.
+    ///
+    /// The fixture puts the second-best row well under the band share, so the
+    /// band is the leader and only the ORDER of the demotion decides the
+    /// outcome.
+    #[test]
+    fn an_anchor_is_never_priced_off_a_score_the_demotion_removes() {
+        let relation = |kind: RelationKind, src: EntityId, dst: EntityId| Relation {
+            id: RelationId::new(),
+            kind,
+            src: kin_model::GraphNodeId::Entity(src),
+            dst: kin_model::GraphNodeId::Entity(dst),
+            confidence: 1.0,
+            origin: RelationOrigin::Parsed,
+            created_in: None,
+            import_source: None,
+            evidence: Vec::new(),
+        };
+        let file = |path: &str, score: f32, symbols: Vec<LocateSymbol>| LocateFileEntry {
+            path: path.to_string(),
+            score,
+            signals: vec![],
+            spans: vec![],
+            symbols,
+            explain: vec![],
+            provenance: None,
+            signal_scores: None,
+            score_breakdown: None,
+            matched_queries: Vec::new(),
+        };
+        let symbol = |name: &str, score: f32| LocateSymbol {
+            name: name.to_string(),
+            span: Some([10, 20]),
+            score,
+            kind: "class".to_string(),
+            definition: true,
+            origin: "text".to_string(),
+            cosine: None,
+            snippet: None,
+        };
+
+        let graph = kin_db::InMemoryGraph::new();
+        let leader = test_entity("Response", "src/requests/models.py", 732, 1000);
+        let far_behind = test_entity("get_encoding_from_headers", "src/requests/utils.py", 10, 30);
+        graph.upsert_entity(&leader).unwrap();
+        graph.upsert_entity(&far_behind).unwrap();
+        // One anchor, in the leader's own file, with the mass that earns a slot.
+        let anchor = test_entity("PreparedRequest", "src/requests/models.py", 378, 729);
+        graph.upsert_entity(&anchor).unwrap();
+        for _ in 0..12 {
+            let caller = test_entity("caller", "src/requests/api.py", 1, 2);
+            graph.upsert_entity(&caller).unwrap();
+            graph
+                .upsert_relation(&relation(RelationKind::Calls, caller.id, anchor.id))
+                .unwrap();
+        }
+
+        let question = "where HTTP redirects are resolved and followed after a response";
+        let mut result = LocateResult {
+            files: vec![
+                // 100.0 is under 0.25 x 465.42, so the band is the leader alone
+                // and the band rule cannot be what saves this ranking.
+                file(
+                    "src/requests/models.py",
+                    0.20,
+                    vec![symbol("Response", 465.42)],
+                ),
+                file(
+                    "src/requests/utils.py",
+                    0.10,
+                    vec![symbol("get_encoding_from_headers", 100.0)],
+                ),
+            ],
+            ..Default::default()
+        };
+        build_entity_view(
+            &mut result,
+            &kin_mcp::handlers::common::HeldSourceAuthority::new(&graph, None),
+            &SnippetOptions::enabled(None).without_bodies(),
+            kin_mcp::handlers::common::EntitySourceScope::WorkspaceHead,
+            question,
+            false,
+        )
+        .unwrap();
+
+        let rows: Vec<(&str, f32, &str)> = result
+            .entities
+            .iter()
+            .map(|entity| {
+                (
+                    entity.name.as_str(),
+                    entity.score,
+                    entity.provenance.origin.as_str(),
+                )
+            })
+            .collect();
+
+        // Control: the leader really is a collision and really was cut, or this
+        // fixture is about nothing.
+        let leader_row = result
+            .entities
+            .iter()
+            .find(|entity| entity.name == "Response")
+            .expect("the leader is in the ranking");
+        assert_eq!(leader_row.match_kind, Some(LocateMatchKind::Name));
+        assert!(
+            is_prose_word_collision(question, "Response"),
+            "control: the leader has to be a prose-word collision"
+        );
+        assert!(
+            leader_row.score < 465.42,
+            "control: the demotion has to have cut it, got {}",
+            leader_row.score
+        );
+
+        assert_eq!(
+            result.entities[0].name, "Response",
+            "the row retrieval scored keeps rank one, got {rows:?}"
+        );
+        assert_ne!(
+            result.entities[0].provenance.origin, FILE_ANCHOR_ORIGIN,
+            "an anchor never takes rank one from a row that carries real evidence: {rows:?}"
+        );
+        let anchor_score = result
+            .entities
+            .iter()
+            .find(|entity| entity.provenance.origin == FILE_ANCHOR_ORIGIN)
+            .map(|entity| entity.score)
+            .expect("the anchor is still admitted");
+        assert!(
+            anchor_score < leader_row.score,
+            "the share is strictly below the score the leader KEEPS, {anchor_score} vs {}",
+            leader_row.score
+        );
+    }
+
+    /// The psf/requests shape, end to end: no anchor sits above the right
+    /// answer.
+    ///
+    /// Measured on the released v0.7.2 archive against the stranger run's own
+    /// store (`psf/requests` at dae7ef63b, fully embedded, 1722 of 1722):
+    /// "where HTTP redirects are resolved and followed after a response"
+    /// returned `SessionRedirectMixin.resolve_redirects` at rank 8 of 10, with
+    /// five file anchors above it and a sixth below. The numbers here are that
+    /// ranking's own, so the fixture is the measurement rather than a sketch
+    /// of it.
+    ///
+    /// Two defects compound in that run and this pins both. The `Response`
+    /// class is a prose-word collision on the word "response": it seeds the
+    /// anchor reference at 465.42 and then ships at 349.06, because the
+    /// demotion used to run AFTER the anchors were priced. And the reference
+    /// was a share of that leader alone rather than of the band, so anchors
+    /// landed inside a cluster of three rows the retrieval had scored within
+    /// 70 points of each other.
+    #[test]
+    fn no_anchor_outranks_the_answer_in_a_tight_retrieval_band() {
+        let relation = |kind: RelationKind, src: EntityId, dst: EntityId| Relation {
+            id: RelationId::new(),
+            kind,
+            src: kin_model::GraphNodeId::Entity(src),
+            dst: kin_model::GraphNodeId::Entity(dst),
+            confidence: 1.0,
+            origin: RelationOrigin::Parsed,
+            created_in: None,
+            import_source: None,
+            evidence: Vec::new(),
+        };
+        let file = |path: &str, score: f32, symbols: Vec<LocateSymbol>| LocateFileEntry {
+            path: path.to_string(),
+            score,
+            signals: vec![],
+            spans: vec![],
+            symbols,
+            explain: vec![],
+            provenance: None,
+            signal_scores: None,
+            score_breakdown: None,
+            matched_queries: Vec::new(),
+        };
+        let symbol = |name: &str, score: f32| LocateSymbol {
+            name: name.to_string(),
+            span: Some([10, 20]),
+            score,
+            kind: "method".to_string(),
+            definition: true,
+            origin: "text".to_string(),
+            cosine: None,
+            snippet: None,
+        };
+
+        let graph = kin_db::InMemoryGraph::new();
+        // The rows retrieval actually scored, one per file, at the scores the
+        // released binary produced.
+        let answer = test_entity(
+            "SessionRedirectMixin.resolve_redirects",
+            "src/requests/sessions.py",
+            208,
+            329,
+        );
+        let response = test_entity("Response", "src/requests/models.py", 732, 1000);
+        let too_many = test_entity("TooManyRedirects", "src/requests/exceptions.py", 106, 110);
+        for entity in [&answer, &response, &too_many] {
+            graph.upsert_entity(entity).unwrap();
+        }
+        // The anchors each file offers: the classes the rest of the repository
+        // depends on, which is exactly what the anchor rule reaches for.
+        let mut anchors = Vec::new();
+        for (name, path) in [
+            ("Session", "src/requests/sessions.py"),
+            ("SessionRedirectMixin", "src/requests/sessions.py"),
+            ("PreparedRequest", "src/requests/models.py"),
+            ("Request", "src/requests/models.py"),
+            ("RequestException", "src/requests/exceptions.py"),
+        ] {
+            let anchor = test_entity(name, path, 1, 900);
+            graph.upsert_entity(&anchor).unwrap();
+            for _ in 0..12 {
+                let caller = test_entity("caller", "src/requests/api.py", 1, 2);
+                graph.upsert_entity(&caller).unwrap();
+                graph
+                    .upsert_relation(&relation(RelationKind::Calls, caller.id, anchor.id))
+                    .unwrap();
+            }
+            anchors.push(name);
+        }
+
+        let question = "where HTTP redirects are resolved and followed after a response";
+        let build = |band: &str| {
+            let _guard =
+                kin_core::test_env::EnvVarGuard::set("KIN_LOCATE_FILE_ANCHOR_BAND_SHARE", band);
+            let mut result = LocateResult {
+                files: vec![
+                    file(
+                        "src/requests/sessions.py",
+                        0.161940,
+                        vec![symbol("SessionRedirectMixin.resolve_redirects", 283.20)],
+                    ),
+                    file(
+                        "src/requests/models.py",
+                        0.157106,
+                        vec![symbol("Response", 465.42)],
+                    ),
+                    file(
+                        "src/requests/exceptions.py",
+                        0.149054,
+                        vec![symbol("TooManyRedirects", 292.29)],
+                    ),
+                ],
+                ..Default::default()
+            };
+            build_entity_view(
+                &mut result,
+                &kin_mcp::handlers::common::HeldSourceAuthority::new(&graph, None),
+                &SnippetOptions::enabled(None).without_bodies(),
+                kin_mcp::handlers::common::EntitySourceScope::WorkspaceHead,
+                question,
+                false,
+            )
+            .unwrap();
+            result
+        };
+
+        let rank_of = |result: &LocateResult, name: &str| {
+            result
+                .entities
+                .iter()
+                .position(|entity| entity.name == name)
+                .map(|index| index + 1)
+                .unwrap_or_else(|| panic!("{name} is not in the ranking"))
+        };
+
+        // Control first. A band share of 1.0 admits only the top row into the
+        // band, which IS taking the share from the leader alone, so the defect
+        // has to be visible here or this fixture proves nothing.
+        let leader_only = build("1.0");
+        let control_rank = rank_of(&leader_only, "SessionRedirectMixin.resolve_redirects");
+        assert!(
+            control_rank > 3,
+            "control: pricing anchors off the leader alone has to bury the answer, \
+             got rank {control_rank}: {:?}",
+            leader_only
+                .entities
+                .iter()
+                .map(|e| (&e.name, e.score, &e.provenance.origin))
+                .collect::<Vec<_>>()
+        );
+
+        let fixed = build("0.25");
+        let answer_rank = rank_of(&fixed, "SessionRedirectMixin.resolve_redirects");
+        assert_eq!(
+            answer_rank,
+            3,
+            "the answer sits behind the two retrieval rows that outscore it and \
+             nothing else, got {:?}",
+            fixed
+                .entities
+                .iter()
+                .map(|e| (&e.name, e.score, &e.provenance.origin))
+                .collect::<Vec<_>>()
+        );
+        for entity in fixed.entities.iter().take(answer_rank - 1) {
+            assert_ne!(
+                entity.provenance.origin, FILE_ANCHOR_ORIGIN,
+                "no anchor may sit above the answer, found {} at {}",
+                entity.name, entity.score
+            );
+        }
+        // And the anchors are still on the page. Pricing them under the band is
+        // not the same as switching them off, which is the thing that would
+        // undo FIR-3079's own measured win.
+        assert!(
+            fixed
+                .entities
+                .iter()
+                .any(|entity| entity.provenance.origin == FILE_ANCHOR_ORIGIN),
+            "the anchors still rank, they just rank beneath the evidence"
+        );
+    }
+
+    /// An anchor is priced beneath the BAND of rows retrieval scored well, not
+    /// beneath its leader alone.
+    ///
+    /// Measured on psf/requests at v0.7.2, store fully embedded (1722 of 1722):
+    /// "where HTTP redirects are resolved and followed after a response" scored
+    /// three rows well and close together, `Response` 349.06,
+    /// `TooManyRedirects` 292.29 and the right answer
+    /// `SessionRedirectMixin.resolve_redirects` 283.20. Taking the share from
+    /// the leader alone priced five anchors into the middle of that cluster and
+    /// put the right answer at rank 8 of 10.
+    #[test]
+    fn an_anchor_is_priced_under_the_band_retrieval_scored_well() {
+        let row = |score: f32| {
+            (
+                0usize,
+                mk_locate_entity(&format!("row{score}"), score, true),
+            )
+        };
+        let cluster = vec![row(349.06), row(292.29), row(283.20), row(84.94)];
+
+        // The band is the weakest row still above the share of the top, which
+        // on this ranking is the right answer's own score.
+        let band = anchor_reference_band(&cluster, 0.25);
+        assert!(
+            (band - 283.20).abs() < 0.01,
+            "the band ends at the weakest well-scored row, got {band}"
+        );
+        assert!(
+            band * 0.9 < 283.20,
+            "so an anchor's share of it lands under every row in the band"
+        );
+
+        // The React shape, where retrieval scored exactly one row well: the
+        // band IS that row, and the reference is what it always was. This is
+        // the case anchors exist for and it must not move.
+        let lone = vec![row(852.2), row(95.7)];
+        let lone_band = anchor_reference_band(&lone, 0.25);
+        assert!(
+            (lone_band - 852.2).abs() < 0.01,
+            "one well-scored row means the band is the maximum, got {lone_band}"
+        );
+
+        // A ranking with nothing positive to take a share of says so, and the
+        // caller answers it with KIN_LOCATE_FILE_ANCHOR_SCORE.
+        assert_eq!(anchor_reference_band(&[], 0.25), 0.0);
+        assert_eq!(anchor_reference_band(&[row(0.0)], 0.25), 0.0);
     }
 
     /// FIR-3106, the measured shape as a fixture: one anchor budget spent

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -742,7 +742,7 @@ fn query_names_entity_symbolically(query: &str, name: &str) -> bool {
 /// merely ending in the same word.
 ///
 /// The whole path is compared, not just its tail. Matching on the tail alone
-/// is how one dotted run in a prose question lifts FIR-3079's demotion off
+/// is how one dotted run in a prose question lifts the prose-word demotion off
 /// every entity that happens to share that word: `Session.get` in a sentence
 /// would spare `RequestsCookieJar.get`, and a bare filename like
 /// `package.json` would spare anything whose own name tail is `json`. Because
@@ -22882,7 +22882,7 @@ mod tests {
 
     /// A query that SPELLS the symbol has named it, qualifier and all.
     ///
-    /// FIR-3079 takes the exact-name tier away from a name match resting on
+    /// The prose-word rule takes the exact-name tier away from a name match resting on
     /// nothing but a plain English word in a sentence, by asking whether a
     /// SYMBOL-SHAPED token named the entity. [`query_tokens`] splits on the
     /// dot, so a query that wrote the symbol as a qualified path was answered
@@ -22901,7 +22901,7 @@ mod tests {
         // nothing below passes because one of them quietly stopped holding.
         assert!(
             query_is_prose(query),
-            "control: this query has to read as prose or FIR-3079 never fires"
+            "control: this query has to read as prose or the demotion never fires"
         );
         assert!(
             !is_symbolic_search_term("get"),
@@ -22978,7 +22978,7 @@ mod tests {
             "but a suffix that is not on a separator boundary is a different name"
         );
 
-        // The case FIR-3079 was written for is untouched.
+        // The case the prose-word rule was written for is untouched.
         let prose = "when I send a command, how does it reach the socket";
         assert!(
             !query_names_entity_symbolically(prose, "send"),
@@ -23337,7 +23337,7 @@ mod tests {
         }
         // And the anchors are still on the page. Pricing them under the band is
         // not the same as switching them off, which is the thing that would
-        // undo FIR-3079's own measured win.
+        // undo the prose-word rule's own measured win.
         assert!(
             fixed
                 .entities

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -734,29 +734,75 @@ fn query_names_entity_symbolically(query: &str, name: &str) -> bool {
     named_by_token
         || query_qualified_paths(query).any(|path| {
             let lowered = path.to_ascii_lowercase();
-            lowered == target || qualified_name_tail(&lowered) == tail
+            lowered == target || qualified_path_names_entity(&lowered, &target)
         })
+}
+
+/// Whether a qualified path a query spelled out names THIS entity, rather than
+/// merely ending in the same word.
+///
+/// The whole path is compared, not just its tail. Matching on the tail alone
+/// is how one dotted run in a prose question lifts FIR-3079's demotion off
+/// every entity that happens to share that word: `Session.get` in a sentence
+/// would spare `RequestsCookieJar.get`, and a bare filename like
+/// `package.json` would spare anything whose own name tail is `json`. Because
+/// [`order_locate_entities`] reads the exact-name tier BEFORE the score, a row
+/// spared that way sorts above rows carrying real evidence whatever it scored,
+/// so the over-match is not a small mispricing, it is a promotion.
+///
+/// So the qualifier has to agree too. `entity_name` is already lowercased by
+/// the caller, and both sides are compared by their own segments: the path
+/// names the entity when the entity's qualified name ENDS with it on a
+/// separator boundary (`Session.get` names `requests.Session.get`), or when the
+/// path ends with the entity's qualified name the same way (`kin.Session.get`
+/// names `Session.get`). A tail that agrees while the container does not is
+/// exactly the case this refuses.
+fn qualified_path_names_entity(path: &str, entity_name: &str) -> bool {
+    fn is_qualified(name: &str) -> bool {
+        name.contains('.') || name.contains("::")
+    }
+    fn ends_on_boundary(longer: &str, shorter: &str) -> bool {
+        if longer.len() <= shorter.len() {
+            return false;
+        }
+        let Some(prefix) = longer.strip_suffix(shorter) else {
+            return false;
+        };
+        prefix.ends_with('.') || prefix.ends_with("::")
+    }
+    // BOTH sides have to be qualified, or the shorter one is a bare tail and
+    // this collapses back into the tail match it exists to refuse. `Session.get`
+    // in a sentence would otherwise name a free function called `get`, because
+    // the path does end with that word on a separator. `path` is always
+    // qualified, since [`query_qualified_paths`] yields nothing else, so the
+    // check that does work is the one on the entity.
+    if !is_qualified(path) || !is_qualified(entity_name) {
+        return path == entity_name;
+    }
+    path == entity_name
+        || ends_on_boundary(entity_name, path)
+        || ends_on_boundary(path, entity_name)
 }
 
 /// The QUALIFIED symbol paths a query spells out, whole, in their original
 /// case.
 ///
 /// [`query_tokens`] splits on every character that is not alphanumeric or an
-/// underscore, so a dotted path is gone before any rule can read it as one.
-/// A question that wrote `router.param` reaches [`is_symbolic_search_term`] as
-/// the two bare words `router` and `param`, and a bare `param` is a plain
-/// English word, so the query that named the symbol in its most explicit form
-/// was judged not to have named it symbolically at all.
+/// underscore, so a dotted path is gone before any rule can read it as one. A
+/// question that wrote `Session.merge_environment_settings` reaches
+/// [`is_symbolic_search_term`] as two bare words, and a rule asking whether a
+/// SYMBOL-SHAPED token named the entity therefore answers no about a query that
+/// named it in the most explicit form there is.
 ///
-/// Measured on expressjs/express at v0.7.2, store fully embedded (798 of 798):
-/// "where router.param callbacks are registered and stored, and how a request
-/// is dispatched through the middleware stack" classified `app.param` as a
-/// prose-word collision, which took it out of [`locate_exact_name_tier`] and
-/// left it at rank 3 behind two file anchors from `lib/utils.js`.
+/// This yields the run whole so [`qualified_path_names_entity`] can compare it
+/// as a path. Only runs carrying a separator are yielded, because a single bare
+/// word is what [`query_tokens`] already offers and the shape the tokenizer
+/// destroys is the only thing this exists to recover.
 ///
-/// Yields only runs that actually carry a separator, because a single bare
-/// word is what [`query_tokens`] already offers and the whole point here is
-/// the shape the tokenizer destroys.
+/// It is deliberately NOT enough on its own. Yielding the run is half the rule;
+/// the other half is that the run has to name the entity by its qualifier as
+/// well as its tail, or one dotted token in a sentence spares every entity that
+/// shares a word with it.
 fn query_qualified_paths(query: &str) -> impl Iterator<Item = &str> {
     query
         .split(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == '.' || c == ':'))
@@ -18318,12 +18364,18 @@ pub fn build_entity_view(
     // and `a_prose_question_gets_the_top_ranked_files_own_anchor` both say can
     // never happen.
     //
-    // Moving it changes no corroboration count. The count already skips every
-    // `FILE_ANCHOR_ORIGIN` row, so no anchor corroborated anything from the
-    // later position either, and the rows that do corroborate are all here.
-    // What it does change is an anchor that is ITSELF a prose-word collision:
-    // it is now demoted against the anchors alone, which corroborate nothing,
-    // so it takes the full floor. That is the conservative direction for a row
+    // Two things move with it, and neither is the corroboration COUNT. That
+    // loop already skips every `FILE_ANCHOR_ORIGIN` row, so no anchor
+    // corroborated anything from the later position either, and every row that
+    // does corroborate is present here.
+    //
+    // What moves is the pair of judgments that read anchors. The
+    // `collision_scores` map does NOT skip them, so an anchor that is itself a
+    // collision used to set its file's threshold and can no longer do so; the
+    // threshold is now the retrieval collision's own score, which is the score
+    // the sibling share was written to be a share OF. And an anchor collision
+    // is now demoted against the anchors alone, which corroborate nothing, so
+    // it takes the full floor. Both are the conservative direction for a row
     // whose whole claim is that it is a second opinion.
     apply_collision_corroboration_penalty(&mut ranked, query, collision_floor, collision_target);
 
@@ -22828,55 +22880,105 @@ mod tests {
         );
     }
 
-    /// A query that SPELLS the symbol has named it, dot and all.
+    /// A query that SPELLS the symbol has named it, qualifier and all.
     ///
-    /// Measured on expressjs/express at v0.7.2, store fully embedded (798 of
-    /// 798). "where router.param callbacks are registered and stored, and how a
-    /// request is dispatched through the middleware stack" put `app.param` at
-    /// rank 3, behind two file anchors from `lib/utils.js` at 395.24, because
-    /// the row was classified a prose-word collision and lost
-    /// [`locate_exact_name_tier`].
+    /// FIR-3079 takes the exact-name tier away from a name match resting on
+    /// nothing but a plain English word in a sentence, by asking whether a
+    /// SYMBOL-SHAPED token named the entity. [`query_tokens`] splits on the
+    /// dot, so a query that wrote the symbol as a qualified path was answered
+    /// with two bare words and judged to have named nothing symbolically.
     ///
-    /// The cause is [`query_tokens`], which splits on the dot, so the only
-    /// tokens the symbolic rule ever saw were `router` and `param`, and a bare
-    /// `param` is a plain English word.
+    /// Every case here turns on a tail that is NOT symbol-shaped on its own,
+    /// because a snake_case tail like `merge_environment_settings` is already
+    /// accepted by the token arm above and would prove nothing about this rule.
+    /// `get` and `json` are the shapes that reach it.
     #[test]
-    fn a_dotted_query_path_names_its_symbol_symbolically() {
-        let query = "where router.param callbacks are registered and stored, and how a \
-                     request is dispatched through the middleware stack";
+    fn a_qualified_query_path_names_its_own_symbol_and_no_other() {
+        let query = "where Session.get reads a stored cookie and how the jar \
+                     resolves it across domains";
 
-        // Control: the shape the rule is about is really present. The query IS
-        // prose, and the bare token on its own is NOT symbolic, so nothing here
-        // passes because the preconditions quietly stopped holding.
+        // Controls: the preconditions this rule needs are really present, so
+        // nothing below passes because one of them quietly stopped holding.
         assert!(
             query_is_prose(query),
-            "control: this query has to read as prose or the rule never fires"
+            "control: this query has to read as prose or FIR-3079 never fires"
         );
         assert!(
-            !is_symbolic_search_term("param"),
-            "control: the bare token is what made this a collision"
+            !is_symbolic_search_term("get"),
+            "control: the tail must not be symbol-shaped, or the token arm \
+             above would accept it and this rule would not be under test"
         );
 
         assert!(
-            query_names_entity_symbolically(query, "app.param"),
-            "the query wrote `router.param`, which is a symbol, not an English word"
+            query_names_entity_symbolically(query, "Session.get"),
+            "the query wrote the qualified path, which is naming it symbolically"
         );
         assert!(
-            !is_prose_word_collision(query, "app.param"),
+            !is_prose_word_collision(query, "Session.get"),
             "so the row is not a prose-word collision"
         );
-
-        // And the tier it lost is the tier it keeps.
-        let mut named = mk_locate_entity("app.param", 360.0, true);
+        let mut named = mk_locate_entity("Session.get", 283.2, true);
         named.match_kind = Some(LocateMatchKind::Name);
         assert_eq!(
             locate_exact_name_tier(&named, query),
             1,
-            "a hit the query named by a qualified path stays unbeatable by fallback"
+            "and it keeps the tier a query that named it is supposed to earn"
         );
 
-        // The rule stays a rule about SYMBOLS. A prose question that merely
-        // uses a word keeps its demotion, which is what FIR-3079 exists for.
+        // The defect this rule must not have: one dotted run in a sentence
+        // sparing every entity that shares its last word. `RequestsCookieJar.get`
+        // is a real requests symbol and this query never asked for it.
+        for other in ["RequestsCookieJar.get", "LookupDict.get", "get"] {
+            assert!(
+                !query_names_entity_symbolically(query, other),
+                "a different container is a different symbol, however the tail \
+                 reads, but {other} was claimed"
+            );
+            assert!(
+                is_prose_word_collision(query, other),
+                "so {other} keeps its demotion"
+            );
+        }
+
+        // A bare filename is a qualified run too, and it names no symbol.
+        let filename_query = "the build reads package.json before it resolves anything else";
+        assert!(query_is_prose(filename_query), "control: still prose");
+        assert!(
+            query_qualified_paths(filename_query).any(|path| path == "package.json"),
+            "control: the filename really is yielded as a run, so the guard below does work"
+        );
+        for name in ["json", "config.json", "Config.json"] {
+            assert!(
+                !query_names_entity_symbolically(filename_query, name),
+                "a filename in a sentence names no symbol, but it claimed {name}"
+            );
+        }
+
+        // Qualification runs both ways: a query may spell more of the path than
+        // the graph stores, or less, as long as it agrees on a separator.
+        assert!(
+            query_names_entity_symbolically(
+                "does requests.Session.get read the stored cookie for this domain",
+                "Session.get"
+            ),
+            "a query that over-qualifies still names it"
+        );
+        assert!(
+            query_names_entity_symbolically(
+                "does Session.get read the stored cookie for this domain",
+                "requests.Session.get"
+            ),
+            "and so does one that under-qualifies, on a separator boundary"
+        );
+        assert!(
+            !query_names_entity_symbolically(
+                "does xSession.get read the stored cookie for this domain",
+                "Session.get"
+            ),
+            "but a suffix that is not on a separator boundary is a different name"
+        );
+
+        // The case FIR-3079 was written for is untouched.
         let prose = "when I send a command, how does it reach the socket";
         assert!(
             !query_names_entity_symbolically(prose, "send"),
@@ -22980,8 +23082,14 @@ mod tests {
         let question = "where HTTP redirects are resolved and followed after a response";
         let mut result = LocateResult {
             files: vec![
-                // 100.0 is under 0.25 x 465.42, so the band is the leader alone
-                // and the band rule cannot be what saves this ranking.
+                // Chosen so the BAND rule cannot be what saves this ranking,
+                // and only the ordering can. Under the mutant, where the
+                // demotion runs after the anchors, the band floor is
+                // 0.25 x 465.42 = 116.35, this row is beneath it, the band is
+                // the leader alone and the anchor is priced at 418.88, above
+                // the 349.06 the leader keeps. Under the fix the floor is
+                // 0.25 x 349.06 = 87.27, this row clears it, the band ends here
+                // and the anchor is priced at 90.0.
                 file(
                     "src/requests/models.py",
                     0.20,

--- a/crates/kin-context/src/builder.rs
+++ b/crates/kin-context/src/builder.rs
@@ -1413,6 +1413,24 @@ fn format_traffic_entry(intent: &IntentSummary, proximity: TrafficProximity) -> 
 /// implementation. The MCP context-pack handlers therefore read the real body
 /// through the graph-owned projection and report a gap when it is unavailable,
 /// rather than falling back to this string.
+/// What [`project_full_body`] actually renders, named beside the renderer so
+/// the word a surface publishes cannot drift from the bytes it describes.
+///
+/// `ProjectionLevel::FullBody` is the budget ladder's name for this rung and it
+/// stays that; this is the name for the CONTENT, which is a header, a doc
+/// summary and a signature. Anything reporting a projection for a row rendered
+/// by the function below reads this rather than spelling a word of its own.
+pub const FULL_BODY_PROJECTION_NAME: &str = "header_and_signature";
+
+/// What a row carrying the entity's REAL body reports, for the one consumer
+/// that can produce one.
+///
+/// This crate never serves it. The MCP context-pack handler reads bodies
+/// through graph-owned repository authority, and when it does it corrects the
+/// pack's own account of that focal, so the word it writes there is this one
+/// rather than a literal of its own.
+pub const SERVED_BODY_PROJECTION_NAME: &str = "full_body";
+
 pub(crate) fn project_full_body(entity: &Entity) -> String {
     let mut content = String::new();
     content.push_str(&format!(

--- a/crates/kin-context/src/lib.rs
+++ b/crates/kin-context/src/lib.rs
@@ -12,7 +12,7 @@ pub use builder::{
     build_context_pack, build_context_pack_from_plan, build_context_pack_with_provenance,
     build_context_pack_with_traffic, build_context_pack_with_traffic_and_provenance, group,
     AssistantHint, ContextOptions, DependencyRelation, DependencySelection, DependencySource,
-    SAME_FILE_FALLBACK_MAX,
+    FULL_BODY_PROJECTION_NAME, SAME_FILE_FALLBACK_MAX, SERVED_BODY_PROJECTION_NAME,
 };
 pub use error::{ContextError, Result};
 pub use multi::{

--- a/crates/kin-context/src/multi.rs
+++ b/crates/kin-context/src/multi.rs
@@ -33,6 +33,7 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 
+use kin_model::relation::RelationKind;
 use kin_model::{
     ContextEntry, ContextPack, Entity, EntityId, GraphNodeId, GraphStore, ProjectionLevel,
     TokenBudget,
@@ -283,6 +284,67 @@ pub struct RouteReport {
     /// Route entities the budget could not carry, or that another focal had
     /// already put in the pack.
     pub withheld: usize,
+    /// The graph edges the walk crossed, in walk order, one per hop.
+    ///
+    /// A route without this is a claim a reader cannot check. Measured on
+    /// psf/requests at v0.7.2, `get_context_pack` joined
+    /// `Session.merge_environment_settings` to
+    /// `HTTPAdapter.build_connection_pool_key_attributes` "in 2 hops through
+    /// `RequestEncodingMixin._encode_params`", and a reader had no way to learn
+    /// that both hops are `References` edges pointing INTO the middle node, so
+    /// the graph carries no path from one focal to the other at all, only two
+    /// rows that mention the same third thing. Both facts are in this field.
+    ///
+    /// Defaulted on deserialization so a pack written before this field
+    /// existed still reads back.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub edges: Vec<RouteEdgeReport>,
+}
+
+/// One graph edge a route walk crossed.
+///
+/// `from_name` and `to_name` are in WALK order, which is the order a reader
+/// follows the route in. `direction` says whether the edge in the graph agrees
+/// with that order, because [`route_between`] deliberately ignores direction
+/// and the two readings are different claims: `A -Calls-> B -Calls-> C` is a
+/// chain, while `A -References-> X <-References- C` is two rows mentioning the
+/// same thing and is not a path between A and C in any useful sense.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RouteEdgeReport {
+    pub from_name: String,
+    pub to_name: String,
+    /// The relation kind, spelled exactly as the graph holds it.
+    pub kind: String,
+    /// [`ROUTE_EDGE_FORWARD`] when the walk followed the edge from its source
+    /// to its destination, [`ROUTE_EDGE_REVERSE`] when it read it backwards.
+    pub direction: String,
+}
+
+/// The walk followed this edge from its source to its destination.
+pub const ROUTE_EDGE_FORWARD: &str = "forward";
+
+/// The walk read this edge backwards, from its destination to its source.
+pub const ROUTE_EDGE_REVERSE: &str = "reverse";
+
+/// A route's edges as one line a human reads left to right.
+///
+/// `A -Calls-> B` for an edge the walk followed and `A <-Calls- B` for one it
+/// read backwards, so the two shapes [`RouteEdgeReport`] exists to separate are
+/// separated on sight. Empty for a route with no edges, which cannot happen for
+/// a reported route and is rendered as the empty string rather than as a claim.
+pub fn render_route_edges(edges: &[RouteEdgeReport]) -> String {
+    let Some(first) = edges.first() else {
+        return String::new();
+    };
+    let mut line = first.from_name.clone();
+    for edge in edges {
+        if edge.direction == ROUTE_EDGE_REVERSE {
+            line.push_str(&format!(" <-{}- {}", edge.kind, edge.to_name));
+        } else {
+            line.push_str(&format!(" -{}-> {}", edge.kind, edge.to_name));
+        }
+    }
+    line
 }
 
 /// What the route search did, including whether a bound stopped it.
@@ -399,8 +461,9 @@ pub fn water_fill(demands: &[usize], capacity: usize) -> Vec<usize> {
 /// The outcome of one route search between two focals.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum RouteOutcome {
-    /// The entities strictly between the two focals, in walk order.
-    Found(Vec<EntityId>),
+    /// The entities strictly between the two focals, in walk order, and the
+    /// edges the walk crossed, one per hop.
+    Found(Vec<EntityId>, Vec<RouteEdgeReport>),
     /// The walk finished within its bounds and found nothing.
     None,
     /// A bound stopped the walk, so nothing was proved either way.
@@ -448,10 +511,15 @@ where
     G: GraphStore,
 {
     if from == to {
-        return Ok(RouteOutcome::Found(Vec::new()));
+        return Ok(RouteOutcome::Found(Vec::new(), Vec::new()));
     }
 
-    let mut parent: HashMap<EntityId, EntityId> = HashMap::new();
+    // The edge is recorded beside the parent, not derived afterwards. A second
+    // pass over the graph to re-find "the" edge between two entities picks one
+    // of however many join them, which need not be the one the walk actually
+    // crossed, and the whole point of reporting the edges is that they are the
+    // ones the walk crossed.
+    let mut parent: HashMap<EntityId, (EntityId, RelationKind, bool)> = HashMap::new();
     let mut seen: HashSet<EntityId> = HashSet::new();
     seen.insert(*from);
     let mut frontier = vec![*from];
@@ -470,23 +538,24 @@ where
                 if !is_dependency_edge(&relation.kind) {
                     continue;
                 }
-                let neighbor = if relation.src == node_ref {
-                    relation.dst.as_entity()
+                let (neighbor, followed) = if relation.src == node_ref {
+                    (relation.dst.as_entity(), true)
                 } else if relation.dst == node_ref {
-                    relation.src.as_entity()
+                    (relation.src.as_entity(), false)
                 } else {
-                    None
+                    (None, true)
                 };
                 let Some(neighbor) = neighbor else { continue };
                 if neighbor == node {
                     continue;
                 }
                 if neighbor == *to {
-                    parent.insert(neighbor, node);
-                    return Ok(RouteOutcome::Found(walk_back(&parent, from, to)));
+                    parent.insert(neighbor, (node, relation.kind, followed));
+                    let (via, edges) = walk_back(graph, &parent, from, to)?;
+                    return Ok(RouteOutcome::Found(via, edges));
                 }
                 if seen.insert(neighbor) {
-                    parent.insert(neighbor, node);
+                    parent.insert(neighbor, (node, relation.kind, followed));
                     next.push(neighbor);
                 }
             }
@@ -501,14 +570,41 @@ where
 }
 
 /// The entities strictly between `from` and `to`, read out of a parent map.
-fn walk_back(
-    parent: &HashMap<EntityId, EntityId>,
+fn walk_back<G>(
+    graph: &G,
+    parent: &HashMap<EntityId, (EntityId, RelationKind, bool)>,
     from: &EntityId,
     to: &EntityId,
-) -> Vec<EntityId> {
+) -> Result<(Vec<EntityId>, Vec<RouteEdgeReport>)>
+where
+    G: GraphStore,
+{
+    let name_of = |id: &EntityId| -> Result<String> {
+        Ok(graph
+            .get_entity(id)
+            .map_err(|error| ContextError::Graph(error.to_string()))?
+            .map(|entity| entity.name)
+            .unwrap_or_default())
+    };
+
     let mut chain = Vec::new();
+    let mut edges = Vec::new();
     let mut cursor = *to;
-    while let Some(previous) = parent.get(&cursor) {
+    // Walked from `to` back to `from`, so both lists come out reversed and are
+    // turned around together at the end. The edge recorded at `cursor` is the
+    // one the walk crossed to REACH cursor, so it is rendered from its parent
+    // to cursor, which is forward walk order.
+    while let Some((previous, kind, followed)) = parent.get(&cursor) {
+        edges.push(RouteEdgeReport {
+            from_name: name_of(previous)?,
+            to_name: name_of(&cursor)?,
+            kind: format!("{kind:?}"),
+            direction: if *followed {
+                ROUTE_EDGE_FORWARD.to_string()
+            } else {
+                ROUTE_EDGE_REVERSE.to_string()
+            },
+        });
         if previous == from {
             break;
         }
@@ -516,7 +612,8 @@ fn walk_back(
         cursor = *previous;
     }
     chain.reverse();
-    chain
+    edges.reverse();
+    Ok((chain, edges))
 }
 
 /// One row waiting for a place in the pack.
@@ -717,16 +814,17 @@ where
                 ROUTE_MAX_HOPS,
                 &mut meter,
             )?;
-            let via = match outcome {
+            let (via, edges) = match outcome {
                 RouteOutcome::Bounded => {
                     route_search.bounded = true;
                     continue;
                 }
                 RouteOutcome::None => continue,
-                RouteOutcome::Found(via) => via,
+                RouteOutcome::Found(via, edges) => (via, edges),
             };
             route_search.pairs_connected += 1;
             let route_index = routes.len();
+            let edge_line = render_route_edges(&edges);
             let mut report = RouteReport {
                 from: focals[left].id.to_string(),
                 from_name: focals[left].name.clone(),
@@ -737,6 +835,7 @@ where
                 via_names: Vec::new(),
                 tokens: 0,
                 withheld: 0,
+                edges,
             };
             for (step, id) in via.iter().enumerate() {
                 if admitted.contains(id) {
@@ -750,12 +849,17 @@ where
                     report.withheld += 1;
                     continue;
                 };
+                // The edge line rides on every step of the route, because the
+                // reader who needs it is reading one row, not the report. Left
+                // off, the row says two functions are joined and leaves the
+                // reader to assume the join is a call.
                 let content = format!(
-                    "{ROUTE_MARKER} {} to {}, step {} of {}\n{}",
+                    "{ROUTE_MARKER} {} to {}, step {} of {}, over {}\n{}",
                     focals[left].name,
                     focals[right].name,
                     step + 1,
                     via.len(),
+                    edge_line,
                     project_signature_only(&entity)
                 );
                 let tokens = estimate_tokens(&content);
@@ -1150,9 +1254,25 @@ fn bump_elision(elisions: &mut BTreeMap<String, PackElision>, group_name: &str, 
     record_elision(elisions, group_name, 1, kept);
 }
 
+/// What a focal row actually CARRIES, which is not always what its
+/// [`ProjectionLevel`] is called.
+///
+/// `ProjectionLevel::FullBody` reports `header_and_signature`, because that is
+/// what [`crate::builder::project_full_body`] renders and that function's own
+/// doc comment says so: this crate has no source-reading capability, bodies
+/// live in content-addressed blobs a layer above, and what it produces is a
+/// header, a doc summary and a signature.
+///
+/// The old name was `full_body`. Measured on psf/requests at v0.7.2,
+/// `get_context_pack` returned `Session.merge_environment_settings` and
+/// `HTTPAdapter.build_connection_pool_key_attributes` labelled `full_body` and
+/// carrying 85 and 652 tokens of header, for methods spanning 38 and 51 lines,
+/// with nothing in the response saying the label and the content disagreed. The
+/// level is unchanged, because the budget ladder is what it is for; only the
+/// word this surface publishes about it changes, to one that is true.
 fn projection_name(level: ProjectionLevel) -> &'static str {
     match level {
-        ProjectionLevel::FullBody => "full_body",
+        ProjectionLevel::FullBody => "header_and_signature",
         ProjectionLevel::SignatureOnly => "signature_only",
         ProjectionLevel::NameAndKind => "name_and_kind",
     }
@@ -1224,13 +1344,25 @@ pub fn method_line(report: &MultiFocalReport) -> String {
             .iter()
             .filter(|route| !route.via.is_empty())
             .map(|route| {
+                // "in 2 hops through X" is what a reader had before, and it is
+                // the sentence that made a pair of `References` edges pointing
+                // into one node read as a chain. The edges are the difference
+                // between a route and a coincidence, so they are in the
+                // sentence rather than only in the JSON beside it.
+                let over = render_route_edges(&route.edges);
+                let over = if over.is_empty() {
+                    String::new()
+                } else {
+                    format!(", over {over}")
+                };
                 format!(
-                    "{} to {} in {} hop{} through {}",
+                    "{} to {} in {} hop{} through {}{}",
                     route.from_name,
                     route.to_name,
                     route.hops,
                     if route.hops == 1 { "" } else { "s" },
-                    route.via_names.join(", ")
+                    route.via_names.join(", "),
+                    over
                 )
             })
             .collect();
@@ -1428,6 +1560,25 @@ mod tests {
             .unwrap();
     }
 
+    /// A `References` edge, which [`is_dependency_edge`] admits exactly like a
+    /// call and which a route walk therefore crosses exactly like one. That it
+    /// is NOT a call is the whole content of the finding these tests pin.
+    fn references(store: &kin_db::InMemoryGraph, src: &Entity, dst: &Entity) {
+        store
+            .upsert_relation(&Relation {
+                id: kin_model::ids::RelationId::new(),
+                kind: RelationKind::References,
+                src: GraphNodeId::Entity(src.id),
+                dst: GraphNodeId::Entity(dst.id),
+                confidence: 1.0,
+                origin: RelationOrigin::Parsed,
+                created_in: None,
+                import_source: None,
+                evidence: Vec::new(),
+            })
+            .unwrap();
+    }
+
     /// A five-link chain, each entity in its own file so no same-file fallback
     /// can supply what only the route should.
     fn chain(len: usize) -> (kin_db::InMemoryGraph, Vec<Entity>) {
@@ -1526,7 +1677,7 @@ mod tests {
             report
                 .focals
                 .iter()
-                .all(|focal| focal.projection == "full_body"),
+                .all(|focal| focal.projection == "header_and_signature"),
             "a generous budget carries every focal whole: {:?}",
             report
                 .focals
@@ -1723,6 +1874,101 @@ mod tests {
         assert_eq!(report.routes[0].via_names, vec!["middle".to_string()]);
     }
 
+    /// A route says what it is made OF, so a reader can tell a chain from a
+    /// coincidence.
+    ///
+    /// The measured shape, on psf/requests at v0.7.2. `get_context_pack` joined
+    /// `Session.merge_environment_settings` to
+    /// `HTTPAdapter.build_connection_pool_key_attributes` "in 2 hops through
+    /// `RequestEncodingMixin._encode_params`" and the two hops are both
+    /// `References` edges pointing INTO that middle node, which is not a path
+    /// from one focal to the other at all. `kin graph inspect` on the middle
+    /// node reported 149 relations, almost all of them inbound references from
+    /// unrelated code, so a two-hop walk through it joins nearly any pair in
+    /// the repository. Every particular of that was invisible in the response.
+    #[test]
+    fn a_route_reports_the_edges_it_walked_and_which_way_they_point() {
+        let store = kin_db::InMemoryGraph::new();
+        let left = make_entity("left", "src/a.rs");
+        let middle = make_entity("middle", "src/m.rs");
+        let right = make_entity("right", "src/b.rs");
+        for entity in [&left, &middle, &right] {
+            store.upsert_entity(entity).unwrap();
+        }
+        // Both ends REFERENCE the middle. Neither reaches the other.
+        references(&store, &left, &middle);
+        references(&store, &right, &middle);
+
+        let (pack, report) =
+            build_multi_focal_pack(&store, &[left.id, right.id], &opts(8000)).unwrap();
+        let route = &report.routes[0];
+
+        assert_eq!(
+            route.edges.len(),
+            route.hops,
+            "a route reports one edge per hop, got {:?}",
+            route.edges
+        );
+        assert!(
+            route.edges.iter().all(|edge| edge.kind == "References"),
+            "the kinds are the graph's own, got {:?}",
+            route.edges
+        );
+        assert_eq!(
+            route.edges[0].direction, ROUTE_EDGE_FORWARD,
+            "the walk followed left's own reference"
+        );
+        assert_eq!(
+            route.edges[1].direction, ROUTE_EDGE_REVERSE,
+            "and read right's backwards, which is the fact that makes this a \
+             co-reference rather than a chain"
+        );
+
+        // The rendered line is where a reader actually sees it, and both arrows
+        // point at the middle.
+        let line = render_route_edges(&route.edges);
+        assert_eq!(
+            line, "left -References-> middle <-References- right",
+            "got {line}"
+        );
+
+        // It reaches the surfaces a caller reads, not just the JSON.
+        assert!(
+            report.method.contains("<-References- right"),
+            "the method sentence carries the edges: {}",
+            report.method
+        );
+        let rendered = render_multi_focal_lines(&pack, &report).join("\n");
+        assert!(
+            rendered.contains("<-References- right"),
+            "and so does the route row itself:\n{rendered}"
+        );
+    }
+
+    /// A real chain reads as a chain: every edge forward, nothing to warn about.
+    ///
+    /// The positive control for the test above. Without it, that one could pass
+    /// on a build that labelled every edge `reverse`.
+    #[test]
+    fn a_directed_chain_reports_every_edge_forward() {
+        let (store, links) = chain(3);
+        let (_, report) =
+            build_multi_focal_pack(&store, &[links[0].id, links[2].id], &opts(8000)).unwrap();
+        let route = &report.routes[0];
+        assert!(
+            route
+                .edges
+                .iter()
+                .all(|edge| edge.direction == ROUTE_EDGE_FORWARD && edge.kind == "Calls"),
+            "got {:?}",
+            route.edges
+        );
+        assert_eq!(
+            render_route_edges(&route.edges),
+            "link_0 -Calls-> link_1 -Calls-> link_2"
+        );
+    }
+
     // ---- the budget bound ------------------------------------------------
 
     #[test]
@@ -1911,7 +2157,7 @@ mod tests {
             generous
                 .focals
                 .iter()
-                .all(|focal| focal.projection == "full_body"),
+                .all(|focal| focal.projection == "header_and_signature"),
             "control: both focals are admitted whole when there is room"
         );
 
@@ -1927,7 +2173,7 @@ mod tests {
             report
                 .focals
                 .iter()
-                .any(|focal| focal.projection != "full_body"),
+                .any(|focal| focal.projection != "header_and_signature"),
             "and at least one was walked down to make the frame fit: {:?}",
             report
                 .focals

--- a/crates/kin-context/src/multi.rs
+++ b/crates/kin-context/src/multi.rs
@@ -43,7 +43,7 @@ use serde::{Deserialize, Serialize};
 use crate::builder::{
     build_context_pack_with_provenance, group, is_dependency_edge, project_full_body,
     project_name_and_kind, project_signature_only, AssistantHint, ContextOptions,
-    DependencyRelation,
+    DependencyRelation, FULL_BODY_PROJECTION_NAME,
 };
 use crate::error::{ContextError, Result};
 use crate::tokens::estimate_tokens;
@@ -1272,7 +1272,7 @@ fn bump_elision(elisions: &mut BTreeMap<String, PackElision>, group_name: &str, 
 /// word this surface publishes about it changes, to one that is true.
 fn projection_name(level: ProjectionLevel) -> &'static str {
     match level {
-        ProjectionLevel::FullBody => "header_and_signature",
+        ProjectionLevel::FullBody => FULL_BODY_PROJECTION_NAME,
         ProjectionLevel::SignatureOnly => "signature_only",
         ProjectionLevel::NameAndKind => "name_and_kind",
     }

--- a/crates/kin-core/src/env_registry_generated.rs
+++ b/crates/kin-core/src/env_registry_generated.rs
@@ -105,6 +105,7 @@ pub const GENERATED_KNOBS: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_LOCATE_EXPLICIT_PHASE_MISMATCH_PENALTY", kind: Kind::NonNegF32, default: "0.22", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: explicit phase mismatch penalty" },
     EnvVarSpec { name: "KIN_LOCATE_FALLBACK_TERM_LIMIT", kind: Kind::Usize, default: "6", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: fallback term limit" },
     EnvVarSpec { name: "KIN_LOCATE_FILE_ANCHORS", kind: Kind::Bool, default: "true", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: file anchors" },
+    EnvVarSpec { name: "KIN_LOCATE_FILE_ANCHOR_BAND_SHARE", kind: Kind::NonNegF32, default: "0.25", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: file anchor band share" },
     EnvVarSpec { name: "KIN_LOCATE_FILE_ANCHOR_BUDGET", kind: Kind::Usize, default: "8", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: file anchor budget" },
     EnvVarSpec { name: "KIN_LOCATE_FILE_ANCHOR_FILES", kind: Kind::Usize, default: "5", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: file anchor files" },
     EnvVarSpec { name: "KIN_LOCATE_FILE_ANCHOR_MASS_WEIGHT", kind: Kind::NonNegF32, default: "0.0", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: file anchor mass weight" },

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -787,7 +787,7 @@ pub fn handle_get_context_pack<G: GraphStore>(
     // the multi-focal assembler. A call naming only `entity_id` keeps this
     // handler's original path and its original payload, so nothing reading
     // today's shape moves under it.
-    if let Some(result) = multi_focal_pack_result(args, store)? {
+    if let Some(result) = multi_focal_pack_result(args, store, repository_authority)? {
         return Ok(result);
     }
 
@@ -1257,6 +1257,7 @@ fn pack_token_budget(args: &HashMap<String, serde_json::Value>) -> kin_model::co
 fn multi_focal_pack_result<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
+    repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<Option<ToolCallResult>> {
     use kin_context::FocalResolution;
 
@@ -1384,30 +1385,86 @@ fn multi_focal_pack_result<G: GraphStore>(
     let (pack, report) = kin_context::build_multi_focal_pack(store, &ids, &opts)
         .map_err(|error| McpError::Context(error.to_string()))?;
 
+    // Bodies come from graph-owned repository authority, exactly as the
+    // single-focal path below reads them. The pack's own focal content is
+    // `kin_context::builder::project_full_body`, which that function's doc
+    // comment says is a HEADER and must never be surfaced as a body, and this
+    // path used to publish it under `projection: "FullBody"` with nothing said.
+    // Measured on psf/requests at v0.7.2: `Session.merge_environment_settings`
+    // came back `FullBody` carrying 85 tokens for a 38-line method, while
+    // `kin graph source` on the same id returned the whole body. It was never a
+    // body gap; it was a path that did not ask.
+    let held = HeldSourceAuthority::new(store, repository_authority);
     let row =
         |entry: &kin_model::context::ContextEntry, section: &str| -> Result<serde_json::Value> {
             let entity = store
                 .get_entity(&entry.entity_id)
                 .map_err(McpError::graph)?;
-            Ok(match entity {
-                Some(entity) => serde_json::json!({
-                    "id": entity.id,
-                    "name": entity.name,
-                    "kind": entity.kind,
-                    "signature": entity.signature,
-                    "file_path": entity.file_origin.as_ref().map(|path| path.to_string()),
-                    "read_path": entity_read_path(&entity),
-                    "start_line": entity_presentation_start_line(&entity),
-                    "end_line": entity_presentation_end_line(&entity),
-                    "section": section,
-                    "projection": format!("{:?}", entry.projection_level),
-                }),
-                None => serde_json::json!({
+            let Some(entity) = entity else {
+                return Ok(serde_json::json!({
                     "id": entry.entity_id,
                     "section": section,
                     "projection": format!("{:?}", entry.projection_level),
-                }),
-            })
+                }));
+            };
+            let mut obj = serde_json::json!({
+                "id": entity.id,
+                "name": entity.name,
+                "kind": entity.kind,
+                "signature": entity.signature,
+                "file_path": entity.file_origin.as_ref().map(|path| path.to_string()),
+                "read_path": entity_read_path(&entity),
+                "start_line": entity_presentation_start_line(&entity),
+                "end_line": entity_presentation_end_line(&entity),
+                "section": section,
+                "projection": format!("{:?}", entry.projection_level),
+            });
+            // Only a row CLAIMING a body has to produce one. A signature-only
+            // dependency already says what it is, and reading a body for every row
+            // in the pack would spend the request's IO on material the caller did
+            // not ask for.
+            if entry.projection_level != kin_model::context::ProjectionLevel::FullBody {
+                return Ok(obj);
+            }
+            let (body, absent_reason) = match read_entity_source_excerpt_detailed_held(
+                &held,
+                &entity,
+                MCP_SOURCE_MAX_LINES,
+                MCP_SOURCE_MAX_CHARS,
+                EntitySourceScope::WorkspaceHead,
+            ) {
+                Ok(body) => (body, None),
+                Err(error) if is_absent_at_generation(&error) => (None, Some(error.to_string())),
+                Err(error) => return Err(error),
+            };
+            // Which authority answered, under the same key the single-focal path
+            // publishes it, so a caller reading one surface is not learning two
+            // vocabularies for one fact.
+            obj["source"] = serde_json::json!(LAST_READ_SOURCE.with(|f| f.get()));
+            match body {
+                Some(source) => {
+                    obj["body"] = serde_json::json!(source.body);
+                    if let Some(map) = obj.as_object_mut() {
+                        map.extend(source_provenance_fields(&source));
+                    }
+                }
+                None => {
+                    // The claim goes with the body. A row that cannot produce one
+                    // reports the level it actually carries, so the label and the
+                    // content cannot disagree the way they did on v0.7.2.
+                    obj["projection"] = serde_json::json!(format!(
+                        "{:?}",
+                        kin_model::context::ProjectionLevel::SignatureOnly
+                    ));
+                    obj["projection_downgraded_from"] =
+                        serde_json::json!(format!("{:?}", entry.projection_level));
+                    obj["body"] = serde_json::Value::Null;
+                    obj["body_unavailable"] = serde_json::json!(
+                        absent_reason.unwrap_or_else(|| entity_body_gap_reason(&entity))
+                    );
+                }
+            }
+            Ok(obj)
         };
 
     let mut entities = Vec::new();
@@ -9960,6 +10017,83 @@ mod tests {
         args.insert("granularity".to_string(), serde_json::json!("module"));
         let err = handle_semantic_locate(&args, &store).unwrap_err();
         assert!(matches!(err, McpError::InvalidParams(_)));
+    }
+
+    /// A multi-focal focal claims `FullBody` only when it carries one.
+    ///
+    /// Measured on psf/requests at v0.7.2, `get_context_pack` with two focals
+    /// returned `Session.merge_environment_settings` and
+    /// `HTTPAdapter.build_connection_pool_key_attributes` both labelled
+    /// `projection: "FullBody"` and both carrying
+    /// `kin_context::builder::project_full_body`, which is a comment header, a
+    /// doc summary and a signature. That function's own doc comment says
+    /// consumers must NOT surface it as a body and that the MCP handler reads
+    /// the real body instead. The single-focal path in this file does; the
+    /// multi-focal path returned before reaching it and took no repository
+    /// authority at all, so it never asked.
+    ///
+    /// Two things are pinned here, and the first is what makes the second
+    /// meaningful: the row goes through the body read at all (it has a `body`
+    /// key, which it did not before), and when the read comes back empty the
+    /// row stops claiming a body it does not have.
+    #[test]
+    fn a_multi_focal_focal_never_claims_a_body_it_did_not_serve() {
+        let store = InMemoryGraph::new();
+        let left = make_entity("merge_environment_settings", "src/sessions.py");
+        let right = make_entity("build_connection_pool_key_attributes", "src/adapters.py");
+        store.upsert_entity(&left).unwrap();
+        store.upsert_entity(&right).unwrap();
+
+        // `question_focals` is the pre-resolved form the daemon hands this
+        // handler, which is the only form the multi-focal path accepts.
+        let mut args = HashMap::new();
+        args.insert(
+            "question_focals".to_string(),
+            serde_json::json!([
+                {"entity_id": left.id.to_string(), "route": "name", "query": left.name},
+                {"entity_id": right.id.to_string(), "route": "name", "query": right.name},
+            ]),
+        );
+        args.insert("token_budget".to_string(), serde_json::json!(8000));
+        args.insert("depth".to_string(), serde_json::json!(1));
+
+        let sessions = SessionRegistry::new();
+        let result = handle_get_context_pack(&args, &store, &sessions, None).unwrap();
+        let value = parsed_response(&result);
+        let rows = value["entities"].as_array().expect("entities is an array");
+        let focals: Vec<&serde_json::Value> = rows
+            .iter()
+            .filter(|row| row["section"] == "focal")
+            .collect();
+        assert_eq!(focals.len(), 2, "both focals are in the pack: {rows:?}");
+
+        for focal in focals {
+            // It ASKED. Before this fix a focal row had no `body` key at all,
+            // because the multi-focal path never read one.
+            assert!(
+                focal.get("body").is_some(),
+                "a focal row must carry the outcome of a body read: {focal}"
+            );
+            // This store has no repository authority behind it, so there are no
+            // bytes to serve, and the row says exactly that instead of calling
+            // a header a full body.
+            assert!(focal["body"].is_null(), "no authority, so no body: {focal}");
+            assert_eq!(
+                focal["projection"], "SignatureOnly",
+                "the claim goes with the body: {focal}"
+            );
+            assert_eq!(
+                focal["projection_downgraded_from"], "FullBody",
+                "and the row says what it would have claimed: {focal}"
+            );
+            let reason = focal["body_unavailable"]
+                .as_str()
+                .expect("a null body names its gap");
+            assert!(
+                !reason.is_empty(),
+                "the gap reason has to say something: {focal}"
+            );
+        }
     }
 
     /// `caller -> focal -> callee`: the focal has exactly one dependent and one

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -1382,7 +1382,7 @@ fn multi_focal_pack_result<G: GraphStore>(
         resolutions,
         coverage: get_optional_string_param(args, "coverage"),
     };
-    let (pack, report) = kin_context::build_multi_focal_pack(store, &ids, &opts)
+    let (pack, mut report) = kin_context::build_multi_focal_pack(store, &ids, &opts)
         .map_err(|error| McpError::Context(error.to_string()))?;
 
     // Bodies come from graph-owned repository authority, exactly as the
@@ -1489,6 +1489,33 @@ fn multi_focal_pack_result<G: GraphStore>(
         entities.push(row(entry, kin_context::group::CONTRACTS)?);
     }
 
+    // `focals[]` is the PACK's account of what it rendered, which is a header
+    // either way, so it went on saying `header_and_signature` about a focal
+    // this response had just served a real body for. One focal described two
+    // ways that disagree is the same class of defect as the label this change
+    // exists to fix, one level up.
+    //
+    // Read back off the rows rather than tracked in parallel while building
+    // them: the correction is then derived from the value that was actually
+    // published, and cannot drift from it.
+    let served_bodies: std::collections::HashSet<String> = entities
+        .iter()
+        .filter(|row| {
+            row.get("section").and_then(serde_json::Value::as_str) == Some("focal")
+                && row.get("body").is_some_and(|body| !body.is_null())
+        })
+        .filter_map(|row| {
+            row.get("id")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        })
+        .collect();
+    for contribution in report.focals.iter_mut() {
+        if served_bodies.contains(&contribution.entity_id) {
+            contribution.projection = kin_context::SERVED_BODY_PROJECTION_NAME.to_string();
+        }
+    }
+
     let mut result = serde_json::json!({
         "method": report.method,
         "focals": serde_json::to_value(&report.focals).map_err(McpError::Json)?,
@@ -1503,6 +1530,17 @@ fn multi_focal_pack_result<G: GraphStore>(
         "measured_tokens": report.measured_tokens,
         "entities": entities,
         "lines": kin_context::render_multi_focal_lines(&pack, &report),
+        // The rendered pack, and what `measured_tokens` counts. It is the
+        // header projection throughout, because kin-context cannot read source;
+        // a focal that served a real body carries it on its own `entities[]`
+        // row and not here. Said out loud, because a reader who finds a header
+        // in `lines` beside a body on the row is otherwise left to guess which
+        // one the response means.
+        "lines_note": format!(
+            "rendered pack at the {} projection kin-context can build; served bodies are on \
+             the entities[] rows",
+            kin_context::FULL_BODY_PROJECTION_NAME
+        ),
         "tokens_used": 0,
     });
     if !unresolved.is_empty() {

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -10057,7 +10057,11 @@ mod tests {
         args.insert("token_budget".to_string(), serde_json::json!(8000));
         args.insert("depth".to_string(), serde_json::json!(1));
 
-        let sessions = SessionRegistry::new();
+        // Through the handler rather than straight into the builder, because
+        // the defect WAS the handler: `multi_focal_pack_result` short-circuits
+        // at the top of `handle_get_context_pack` and used to return before the
+        // body read the single-focal path below it performs.
+        let sessions = SessionRegistry::empty_for_test();
         let result = handle_get_context_pack(&args, &store, &sessions, None).unwrap();
         let value = parsed_response(&result);
         let rows = value["entities"].as_array().expect("entities is an array");

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -2679,6 +2679,113 @@ mod tests {
         );
     }
 
+    /// The MULTI-focal path serves the same body the single-focal one does.
+    ///
+    /// `context_pack_focal_body_matches_the_direct_entity_source_read` above
+    /// pins that for one focal. This is its twin for the branch that returns
+    /// before it: `multi_focal_pack_result` short-circuits at the top of
+    /// `handle_get_context_pack`, and on v0.7.2 it took no repository authority
+    /// at all, so it published the pack's own header under
+    /// `projection: "FullBody"` and never asked for bytes.
+    ///
+    /// It is the SUCCESS path on purpose. A test that only passes `None` for
+    /// authority proves the gap arm and nothing else, and would stay green if
+    /// the handler stopped threading the caller's authority through, which is
+    /// the whole of the fix.
+    #[test]
+    fn a_multi_focal_focal_serves_the_body_the_single_focal_path_serves() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let content = "export function validate_probe_range_1d8f8275(value: number, minVal: number, maxVal: number): boolean {\n  if (value < minVal) {\n    return false;\n  }\n  return value <= maxVal;\n}\n";
+        let source = make_source_backed_entity(content);
+        let entity = &source.entity;
+
+        let mut store = EmptyStore::default();
+        store.entities_by_id.insert(entity.id, entity.clone());
+        store
+            .file_hashes
+            .insert(entity.file_origin.clone().unwrap(), source.hash);
+        install_empty_store_exact_tree(&mut store, source._dir.path());
+        let authority = test_repository_authority(source._dir.path());
+
+        // The pre-resolved form the daemon hands this handler, which is the
+        // only form the multi-focal branch accepts.
+        let args = HashMap::from([
+            (
+                "question_focals".to_string(),
+                serde_json::json!([{
+                    "entity_id": entity.id.to_string(),
+                    "route": "name",
+                    "query": entity.name,
+                }]),
+            ),
+            ("token_budget".to_string(), serde_json::json!(8000)),
+            ("depth".to_string(), serde_json::json!(1)),
+        ]);
+        let sessions = SessionRegistry::empty_for_test();
+        let value = tool_result_json(
+            entities::handle_get_context_pack(&args, &store, &sessions, Some(&authority)).unwrap(),
+        );
+
+        let focal = value["entities"]
+            .as_array()
+            .expect("entities is an array")
+            .iter()
+            .find(|row| row["section"] == "focal")
+            .expect("the focal is in the pack")
+            .clone();
+
+        // The sibling surface an agent falls back to, so this asserts one body
+        // rather than two independently plausible ones.
+        let direct = tool_result_json(
+            entities::handle_get_entity_source(
+                &HashMap::from([("entity_id".into(), serde_json::json!(entity.id.to_string()))]),
+                &store,
+                Some(&authority),
+            )
+            .unwrap(),
+        );
+        let direct_body = direct["body"].as_str().expect("direct read serves a body");
+        let focal_body = focal["body"]
+            .as_str()
+            .expect("the multi-focal focal must serve a body, not null, when the graph has one");
+
+        assert_eq!(
+            focal_body, direct_body,
+            "the multi-focal pack and the direct read must serve one body"
+        );
+        assert!(focal_body.contains("return value <= maxVal;"));
+        assert_eq!(focal["source"], "graph");
+        assert!(
+            focal.get("body_unavailable").is_none(),
+            "no gap is reported when the body was served: {focal}"
+        );
+        // The regression this pins: the pack's own token-accounting header must
+        // never surface as the body.
+        assert!(
+            !focal_body.starts_with("// validate_probe_range_1d8f8275 (Function"),
+            "a synthesized comment header is not a body: {focal_body}"
+        );
+
+        // And the two accounts of this focal agree that it carries one.
+        assert_eq!(
+            focal["projection"], "FullBody",
+            "a row that served a body claims one: {focal}"
+        );
+        assert!(
+            focal.get("projection_downgraded_from").is_none(),
+            "nothing was downgraded, so nothing says it was: {focal}"
+        );
+        assert_eq!(
+            value["focals"][0]["projection"],
+            serde_json::json!(kin_context::SERVED_BODY_PROJECTION_NAME),
+            "the pack's own account of the focal is corrected to what was served: {}",
+            value["focals"]
+        );
+    }
+
     /// After a committed transaction moves an entity, the read surfaces must
     /// report where it is NOW. Serving the pre-commit position made agents
     /// "correct" right line numbers into wrong ones.

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -3,7 +3,7 @@
 
 # Kin environment variables
 
-This is the authoritative list of supported `KIN_*` environment variables (526 total, 356 correctness-relevant), generated from the central registry in `kin-core`.
+This is the authoritative list of supported `KIN_*` environment variables (527 total, 357 correctness-relevant), generated from the central registry in `kin-core`.
 
 At CLI and daemon startup Kin validates this surface (`KIN_ENV_VALIDATION`, default `warn`):
 
@@ -407,6 +407,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_LOCATE_EXPLICIT_PHASE_MISMATCH_PENALTY` | float>=0 | 0.22 | correctness | locate tuning knob: explicit phase mismatch penalty |
 | `KIN_LOCATE_FALLBACK_TERM_LIMIT` | usize | 6 | correctness | locate tuning knob: fallback term limit |
 | `KIN_LOCATE_FILE_ANCHORS` | bool | true | correctness | locate tuning knob: file anchors |
+| `KIN_LOCATE_FILE_ANCHOR_BAND_SHARE` | float>=0 | 0.25 | correctness | locate tuning knob: file anchor band share |
 | `KIN_LOCATE_FILE_ANCHOR_BUDGET` | usize | 8 | correctness | locate tuning knob: file anchor budget |
 | `KIN_LOCATE_FILE_ANCHOR_FILES` | usize | 5 | correctness | locate tuning knob: file anchor files |
 | `KIN_LOCATE_FILE_ANCHOR_MASS_WEIGHT` | float>=0 | 0.0 | correctness | locate tuning knob: file anchor mass weight |


### PR DESCRIPTION
`semantic_locate` put the right answer at rank 8 of 10 on psf/requests and rank 3 on express, at full embedding coverage, and `get_context_pack` drew a route it could not justify and labelled two focals with a body they did not carry. This fixes the ranking so `app.param` leads on express and the requests answer moves from rank 8 to rank 3, and it makes both of the context pack's claims checkable from the response.

Two agent-facing tools were measured misbehaving on the released v0.7.2 archive against psf/requests and expressjs/express. Both findings reproduced to the row, both mechanisms are named here from the code and the graph rather than guessed, and the fixes target the mechanisms.

Everything below was measured on the sha-verified released archive, against the converted stores the original run produced, with a scratch prefix and KIN_HOME, KIN_EMBED_BACKEND=cpu and no locks.

```
$ cat kin-macos-aarch64.tar.gz.sha256
51587ec352ec29d081d139fc569ccf0431669c52dc870b7a475bee312e0422ea  kin-macos-aarch64.tar.gz
$ shasum -a 256 kin-macos-aarch64.tar.gz
51587ec352ec29d081d139fc569ccf0431669c52dc870b7a475bee312e0422ea
$ ./kin --version
kin 0.7.2 (dca8e950e99f6a1cb9afe4359611e2da288004f2 detached 2026-09-06T08:24:29Z)
$ git -C repro/requests rev-parse HEAD -> dae7ef63b4df6eded86637f251fc4e3a06c3b479
$ git -C repro/express  rev-parse HEAD -> 023767fe9872e029271df1418f73401bff20ff40
```

## semantic_locate ranked the answer near the bottom

On psf/requests, fully embedded (1722 of 1722, pending 0), the query `where HTTP redirects are resolved and followed after a response` put `SessionRedirectMixin.resolve_redirects` at rank 8 of 10. `--diagnose` prints an `origin` field the MCP surface drops, and it is the whole story: all five rows above the answer are file anchors, not retrieval hits.

```
  1.  418.87 text_fallback class    Session                                 origin=file_anchor
  2.  418.87 text_fallback class    SessionRedirectMixin                    origin=file_anchor
  3.  406.37 text_fallback class    PreparedRequest                         origin=file_anchor
  4.  406.37 text_fallback class    Request                                 origin=file_anchor
  5.  385.54 text_fallback class    RequestException                        origin=file_anchor
  6.  349.06 name          class    Response                                origin=text
  7.  292.29 text_fallback class    TooManyRedirects                        origin=text
  8.  283.20 text_fallback method   SessionRedirectMixin.resolve_redirects  origin=text
  9.  265.80 text_fallback function to_key_val_list                         origin=file_anchor
 10.   84.94 semantic      method   LookupDict.__repr__                     origin=vector
```

The file arm had it right: `sessions.py` ranked first on three signals and its top symbol IS the answer at 283.20. The entity projection then buried it.

**Mechanism one, and the arithmetic that proves it.** Anchors are priced as a 0.9 share of the ranking's top score. That top score was `Response` at 465.42, and `Response` is a prose-word collision the demotion then cut to 349.06, because `apply_collision_corroboration_penalty` ran AFTER the anchors were priced. Every anchor on the page is 465.42 times 0.9 times its file's normalized score:

| anchor | file weight | 465.42 x 0.9 x weight | observed |
|---|---|---|---|
| Session, SessionRedirectMixin | 1.00000 | 418.88 | 418.87 |
| PreparedRequest, Request | 0.97015 | 406.38 | 406.37 |
| RequestException | 0.92043 | 385.55 | 385.54 |
| to_key_val_list | 0.63455 | 265.80 | 265.80 |

So five anchors sat above the row they took their share from, which `locate.rs`'s own comment and `a_prose_question_gets_the_top_ranked_files_own_anchor` both say cannot happen.

**Mechanism two, on express.** Fully embedded (798 of 798), the query `where router.param callbacks are registered and stored, and how a request is dispatched through the middleware stack` put `app.param` at rank 3 behind two anchors from `lib/utils.js` at 395.24. `app.param` is a `name` hit and should sort in the exact-name tier; it lost that tier because `query_tokens` splits on every non-alphanumeric character, so the query's literal `router.param` reached the symbolic test as the two bare words `router` and `param`, and a bare `param` is a plain English word. A query that named the symbol in its most explicit form was judged not to have named it symbolically at all.

Review narrowed the fix for this to require the qualifier to agree, not just the tail, for reasons in the review section below. The narrowed rule does not fire on `router.param` against `app.param`, whose containers differ, so express reaches rank 1 through mechanism one alone. That is measured, not argued.

### The fixes

1. `apply_collision_corroboration_penalty` runs before the anchors are priced, so the reference is a score some row keeps. No corroboration count changes: the count already skipped every `FILE_ANCHOR_ORIGIN` row, and every row that does corroborate is present at the earlier position. An anchor that is itself a collision is now judged against the anchors alone and takes the full floor, which is the conservative direction for a second opinion.
2. The share is taken from the BAND of rows retrieval scored well, not from the leader alone (`anchor_reference_band`, new knob `KIN_LOCATE_FILE_ANCHOR_BAND_SHARE`, default 0.25, the same idiom `KIN_LOCATE_COLLISION_SIBLING_SHARE` already uses for the same question). This is what separates the two measured shapes: on React retrieval scored exactly one row well (852.2 against a helper at 95.7), so the band is that row and the reference does not move; on requests it scored three within 70 points of each other, and a share of the leader prices anchors into the middle of that cluster.
3. `query_qualified_paths` yields the dotted run whole, and `query_names_entity_symbolically` reads it through `qualified_path_names_entity`, which compares the WHOLE path on a separator boundary in either direction rather than the tail alone. Only runs that carry a separator are yielded, so a sentence with no qualified path offers nothing and the rule cannot fire on prose. FIR-3079's own case is untouched: "when I send a command, how does it reach the socket" still names `send` prosaically and is still a collision.

## get_context_pack drew an unlabelled route and claimed a body it did not carry

The same call reproduces identically:

```
$ kin context Session.merge_environment_settings \
              HTTPAdapter.build_connection_pool_key_attributes --budget 8000 --json

{"from_name": "Session.merge_environment_settings",
 "to_name": "HTTPAdapter.build_connection_pool_key_attributes",
 "hops": 2, "via_names": ["RequestEncodingMixin._encode_params"], "tokens": 34, "withheld": 0}
```

**The route.** `RouteReport` carried `from`, `to`, `hops`, `via`, `via_names`, `tokens` and `withheld`, and nothing about the edges it walked. Asking the graph what those edges are:

```
$ kin graph inspect Session.merge_environment_settings
    -> References RequestEncodingMixin._encode_params [Method] (entity:2e6dfca6-...)
$ kin graph inspect HTTPAdapter.build_connection_pool_key_attributes
    -> References RequestEncodingMixin._encode_params [Method] (entity:2e6dfca6-...)
```

Both edges are `References` and both point the same way, INTO the middle node. The graph carries no path from one focal to the other; it carries two rows that mention the same third thing. `route_between` ignores direction on purpose, which is right for a call chain read from either end and is exactly what makes this indistinguishable from one. The middle node makes it worse: `2e6dfca6-...` is the one-line `@overload` stub `_encode_params(data: str) -> str` at `models.py:134-134`, and `kin graph inspect` reports it holds 149 relations, almost all inbound `References` from unrelated code across the repository. A two-hop walk through a 149-degree hub joins nearly any pair in the repository.

The edges themselves are real, so the fix is disclosure, not refusal. `RouteReport` now carries `edges`, one per hop, each naming the relation kind and whether the walk followed the edge or read it backwards. The edge is recorded in the BFS parent map as the walk crosses it rather than re-derived afterwards, because a second pass picks one of however many edges join two entities and need not pick the one the walk took. It renders as one line, on the route row and in the method sentence, not only in the JSON:

```
left -References-> middle <-References- right
```

Both arrows point at the middle, which is the fact that separates a chain from a coincidence. The field is `#[serde(default)]`, so a pack written before it existed still reads back. The "no route, and why" half already existed and is untouched: the method sentence already distinguishes "the graph joins no pair of them within N hops" from a search a bound stopped.

**The body.** Both focals came back labelled `projection: "full_body"` carrying 85 and 652 tokens, for methods spanning `sessions.py:853-890` and `adapters.py:403-453`. 85 tokens cannot be a 38-line body. The content is a comment header, a doc summary and a signature, which is exactly what `kin_context::builder::project_full_body` renders, and that function's own doc comment says so:

> Project the focal entity's HEADER, not its body, despite the name and despite the `ProjectionLevel::FullBody` the caller records beside it. ... Consumers must NOT surface this text as an entity's `body`. ... The MCP context-pack handlers therefore read the real body through the graph-owned projection and report a gap when it is unavailable, rather than falling back to this string.

The single-focal path does exactly that. The multi-focal path returns before reaching it, took no repository authority argument at all, and served the header under the label. It was never a body gap:

```
$ kin graph source Session.merge_environment_settings
--- Source ---
def merge_environment_settings(self, url: str, ..., cert: _t.CertType) -> dict[str, Any]:
        ...
        if self.trust_env:
            env_proxies = get_environ_proxies(url, no_proxy=no_proxy)
        ...
```

Two changes, because two surfaces were making the claim. `multi_focal_pack_result` now takes the `repository_authority` the handler already holds and reads the real body through the same `read_entity_source_excerpt_detailed_held` the single-focal path uses; when bytes come back the row carries them with their provenance, and when they do not the row reports `body: null`, `body_unavailable`, and downgrades its own `projection` with `projection_downgraded_from` saying what it would have claimed. Rows that never claimed a body are untouched. And `projection_name(ProjectionLevel::FullBody)` now reports `header_and_signature`, because that is what the function renders; the level is unchanged, since the budget ladder is what it is for.

## Measured again, with the patched binaries

Not just the fixtures. `kin` and `kin-daemon` built from this branch, pointed at the same stores, same scratch prefix and `KIN_HOME`, same queries.

```
$ kin locate "where HTTP redirects are resolved and followed after a response" --diagnose
coverage: indexed 1722 / 1722  pending 0  state present

  1.  349.06 name          class    Response                                origin=text
  2.  292.29 text_fallback class    TooManyRedirects                        origin=text
  3.  283.20 text_fallback method   SessionRedirectMixin.resolve_redirects  origin=text
  4.  254.88 text_fallback class    Session                                 origin=file_anchor
  5.  254.88 text_fallback class    SessionRedirectMixin                    origin=file_anchor
  6.  247.27 text_fallback class    PreparedRequest                         origin=file_anchor
  7.  247.27 text_fallback class    Request                                 origin=file_anchor
  8.  234.60 text_fallback class    RequestException                        origin=file_anchor
  9.  161.73 text_fallback function to_key_val_list                         origin=file_anchor
```

Rank 8 to rank 3, and the coverage line says the v0.7.2 store's vector sidecar was accepted, so this is the same retrieval the before-numbers came from rather than a silently vector-dark arm. Every anchor score is the one the arithmetic predicts: the band is the answer's own 283.20, the reference is `283.20 x 0.9 = 254.88`, and each file's normalized weight carries it from there (`x 0.97015 = 247.27`, `x 0.92043 = 234.60`, `x 0.63455 = 161.73`). No anchor sits above a row retrieval scored.

```
$ kin locate "where router.param callbacks are registered and stored, ..." --diagnose
coverage: indexed 798 / 798  pending 0  state present

  1.  480.00 name          method   app.param       origin=text
  2.  395.24 text_fallback function compileETag     origin=file_anchor
  3.  395.24 text_fallback function normalizeTypes  origin=file_anchor
```

Rank 3 to rank 1. `app.param` scores 480.00 where v0.7.2 shipped 360.00, and the difference is the demotion that no longer fires: `480.00 x 0.75 = 360.00` was the uncorroborated collision floor applied to a row the query had named in its dotted form.

And the pack:

```
route Session.merge_environment_settings -> HTTPAdapter.build_connection_pool_key_attributes  hops=2
  edge Session.merge_environment_settings   [References/forward] RequestEncodingMixin._encode_params
  edge RequestEncodingMixin._encode_params  [References/reverse] HTTPAdapter.build_connection_pool_key_attributes

... in 2 hops through RequestEncodingMixin._encode_params, over
Session.merge_environment_settings -References-> RequestEncodingMixin._encode_params
<-References- HTTPAdapter.build_connection_pool_key_attributes

focal Session.merge_environment_settings                projection=header_and_signature  focal_tokens=85
focal HTTPAdapter.build_connection_pool_key_attributes  projection=header_and_signature  focal_tokens=652
```

Both arrows point into the middle node, on the surface, without asking the graph. And `header_and_signature` with 85 tokens is a true statement about 85 tokens of header, where `full_body` with 85 tokens was not.

## What was deliberately not changed

**A blunt anchor tier.** The obvious reading of the anchor block's comment ("The anchors, beneath every row retrieval scored") is an ordering tier. It was tried against the existing fixture and rejected: `a_prose_question_gets_the_top_ranked_files_own_anchor` pins the order `updateDehydratedSuspenseComponent` (852.2, retrieval), `scheduleUpdateOnFiber` (anchor), `beginWork` (anchor), `shouldRemainOnPreviousScreen` (95.7, retrieval), so it deliberately places a retrieval row BELOW two anchors. A hard tier breaks it, and on the requests store it would have sunk the anchors below roughly ninety weak vector rows, which defeats the feature's own measured purpose.

**Refusing to draw a route over non-call edges.** The route on requests is real; the defect is that nothing said what it was. "How does A reach B" is answered by `Imports` and `UsesType` chains as often as by calls, so the fix is disclosure, not refusal.

**The "no route, and why" line.** Already present, and `two_unconnected_focals_report_no_route_rather_than_inventing_one` already asserts the method line says "joins no pair of them". Read, confirmed, left alone.

**The scoring model.** With these fixes the requests answer moves from rank 8 to rank 3, not to rank 1, and rank 3 is the ceiling of any anchor change: running the same query with `KIN_LOCATE_FILE_ANCHORS=0` on v0.7.2 gives exactly that order. The two rows still above it lead on the lexical seed score:

```
text_seed_candidates:                                                   span        lines
   465.42  Response                                [models.py]          732-1184      453
   292.29  TooManyRedirects                        [exceptions.py]      106-107         2
   283.20  SessionRedirectMixin.resolve_redirects  [sessions.py]        208-329       122
query_terms: ["followed", "resolved", "response", "redirects"]
```

`Response` scores 465.42 on ONE of the four terms. `resolve_redirects` scores 283.20 while matching two of them and being the top symbol of the top-ranked file. The spans rule out the simplest story: a two-line exception class outscores a 122-line method, so this is not just a long container accumulating its members' hits. Closing the gap means normalizing that seed score or matching a name across query tokens (`resolve` plus `redirects` covers every segment of `resolve_redirects`, which `query_names_entity` cannot see because it compares whole tokens only), and either moves every ranking fixture. It is filed separately with the measurement rather than guessed at here.

## What the exact-head review changed

An exact-head review of `780a3af0d` returned GO WITH FIXES: two HIGH, four MEDIUM. All six were taken, and one of them was a defect in the reasoning rather than the code.

**HIGH 1, and it was right.** The qualified-path rule matched on the TAIL alone, so one dotted token in a prose question lifted FIR-3079's demotion off every entity sharing that word: `Session.get` in a sentence would spare `RequestsCookieJar.get`, and a bare `package.json` would spare anything whose tail is `json`. Because `order_locate_entities` reads the exact-name tier BEFORE the score, a row spared that way sorts above real evidence whatever it scored, and the new band cannot help because the band is a score rule and the tier outranks scores. `qualified_path_names_entity` now compares the whole path on a separator boundary in either direction, so a query may over-qualify or under-qualify but a tail that agrees while the container does not is refused.

The honest consequence, which the text above previously got wrong: the narrowed rule does NOT fire on express, where the query wrote `router.param` and the entity is `app.param`. So express reaches rank 1 through the anchor fix alone, and the earlier claim that two defects each put it there on their own is removed rather than left standing. The rule keeps a real purpose, since a question that spells `Session.merge_environment_settings` has named that symbol, and it is now narrow enough that this is all it claims.

**HIGH 2, also right.** The only test of the multi-focal body read passed `None` for repository authority, so it proved the gap arm and nothing else: rewriting the handler to `HeldSourceAuthority::new(store, None)` would have deleted the whole fix with every check green. `a_multi_focal_focal_serves_the_body_the_single_focal_path_serves` is the success path with a real authority over a source-backed store, asserting the served bytes equal what `get_entity_source` returns for the same id, not merely that a key exists. Two new falsification arms are the review's own named mutations.

**MEDIUMs.** `focals[]` reported what the pack rendered, so it went on saying `header_and_signature` about a focal the same response had just served a body for; the handler now corrects it from what was actually served, read back off the published rows so the correction cannot drift from the value it describes, and `lines` carries a note saying it is the pack's own rendering. The comment beside the moved demotion claimed no corroboration count changes, but the `collision_scores` loop does not skip anchors even though the count loop does, so it now says both things that move. The ordering fixture's comment computed its floor from the pre-demotion band, which is the mutant arm's number, and now states both arms. And `header_and_signature` is no longer a literal in `projection_name`; it reads a constant defined beside `project_full_body`, so the word and the bytes move together.

### Express re-measured with the narrowed rule

The claim above is arithmetic; this is the product. Same store, same query, coverage still `798 / 798, pending 0`:

```
  1.  360.00 name          method   app.param       origin=text
  2.   96.09 semantic      class    req             origin=vector
  3.   95.20 semantic      function acceptParams    origin=vector
  ... the rest semantic, 94.66 down
```

`app.param` leads at **360.00**, not the 480.00 it scored before the narrowing, and that number is the check: `480.00 x 0.75` is the uncorroborated collision floor, so the narrowed rule correctly does not fire here and the demotion applies exactly as it did on v0.7.2. `compileETag` and `normalizeTypes` are off the page entirely, because with the leader at 360.00 the band floor is 90.0, the semantic rows at 96.09 down are inside the band, and the anchor reference prices out near 81. Rank 1 is earned by the anchor change alone.

## Tests, and breaking every one of them on purpose

New tests, each written from the measured numbers rather than from a sketch of them:

| Behaviour | Test |
|---|---|
| An anchor is priced under the band retrieval scored well | `an_anchor_is_priced_under_the_band_retrieval_scored_well` |
| No anchor outranks the answer in a tight retrieval band | `no_anchor_outranks_the_answer_in_a_tight_retrieval_band` |
| An anchor is never priced off a score the demotion removes | `an_anchor_is_never_priced_off_a_score_the_demotion_removes` |
| A qualified query path names its own symbol and no other | `a_qualified_query_path_names_its_own_symbol_and_no_other` |
| Qualified paths are the runs the tokenizer splits | `qualified_paths_are_the_runs_the_tokenizer_splits` |
| A route reports its edges and which way they point | `a_route_reports_the_edges_it_walked_and_which_way_they_point` |
| A directed chain reports every edge forward | `a_directed_chain_reports_every_edge_forward` |
| A focal never claims a body it did not serve | `a_multi_focal_focal_never_claims_a_body_it_did_not_serve` |
| A multi-focal focal serves the body the single-focal path serves | `a_multi_focal_focal_serves_the_body_the_single_focal_path_serves` |

`no_anchor_outranks_the_answer_in_a_tight_retrieval_band` is the released binary's own numbers: the three file scores, the three symbol scores and the anchor mass are the ones measured above. It carries its own control arm, `KIN_LOCATE_FILE_ANCHOR_BAND_SHARE=1.0`, which admits only the top row into the band and so IS taking the share from the leader alone; the defect has to be visible under it or the fixture proves nothing. `a_directed_chain_reports_every_edge_forward` is the positive control for the route test, which without it would pass on a build that labelled every edge `reverse`.

Every new test was broken on purpose and confirmed red. The harness mutates one behaviour, runs only that behaviour's own test, restores the file, and reads its verdict from the test result line rather than the exit code, because a mutant that fails to compile also exits non-zero and proves nothing. It exits non-zero unless EVERY arm went red, so an anchor that stopped matching cannot read as a passing sweep.

```
$ python3 falsify.py
dotted-path                RED (good: the test caught it)
qualified-tail-only        RED (good: the test caught it)
qualified-paths-filter     RED (good: the test caught it)
anchor-band                RED (good: the test caught it)
anchor-band-unit           RED (good: the test caught it)
collision-order            RED (good: the test caught it)
route-direction            RED (good: the test caught it)
route-kind                 RED (good: the test caught it)
projection-name            RED (good: the test caught it)
focal-body-authority       RED (good: the test caught it)
served-projection          RED (good: the test caught it)
focal-body                 RED (good: the test caught it)
SWEEP COMPLETE: 12 arms, all red
```

The suites behind it, each run through `heavy-slot.sh` from the umbrella root:

```
$ cargo test -p kin-context --lib   ->  test result: ok. 91 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.12s
$ cargo test -p kin-cli     --lib   ->  test result: ok. 2223 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 304.36s
$ cargo test -p kin-mcp     --lib   ->  test result: ok. 949 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 33.50s
$ cargo test -p kin-core    --lib   ->  test result: ok. 872 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 34.54s
$ bash scripts/check_runtime_boundaries.sh   ->  Runtime guardrails check passed.
$ bash scripts/zero_file_search_guard.sh     ->  rc 0
$ cargo fmt --all -- --check                 ->  clean
```

Full measurement, mechanisms, the scoring-model ticket draft and four trap write-ups are in
`.kin-coord/reports/showhn-agenttools2-20260906.md`.

The `collision-order` arm is a MOVE rather than a deletion on purpose: deleting the demotion leaves the leader at its raw score, which is a different ranking, and the test would have passed for the wrong reason. That gap was found by trying to falsify the first fixture and discovering it could not fail under the honest mutation, which is why
`an_anchor_is_never_priced_off_a_score_the_demotion_removes` exists as a separate fixture with the second-best row deliberately under the band share.

