### PR TITLE
Draw the Kin mark on first contact and lead help with the orientation

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -696,7 +696,7 @@ async fn check_daemon_running() -> HealthCheck {
                 "daemon_running",
                 "kin-daemon running",
                 HealthStatus::Unsupported,
-                "n/a — not in a Kin repository (the daemon is repo-scoped)",
+                "not in a Kin repository, and the daemon is repo-scoped",
             )
             .with_manual_fix(
                 "cd into a Kin repository, then run any `kin` command to start its daemon",
@@ -745,7 +745,7 @@ fn daemon_not_running_check_for(repo: &str, endpoint_record: &Path) -> HealthChe
             "daemon_running",
             "kin-daemon running",
             HealthStatus::Unsupported,
-            format!("no daemon started for {repo} yet — one starts on first use"),
+            format!("no daemon started for {repo} yet; one starts on first use"),
         )
         .fixable()
         .with_manual_fix("run any `kin` command in the repo to auto-start the daemon")
@@ -1217,7 +1217,7 @@ fn vfs_projection_check_for(
             "VFS projection",
             HealthStatus::Misconfigured,
             format!(
-                "shim is 0 bytes ({}) — a 0-byte injected library crashes processes",
+                "shim is 0 bytes ({}), and a 0-byte injected library crashes processes",
                 lib_path.display()
             ),
         )
@@ -1228,7 +1228,7 @@ fn vfs_projection_check_for(
             "VFS projection",
             HealthStatus::Misconfigured,
             format!(
-                "shim at {} is not a valid {} — it is truncated or corrupt",
+                "shim at {} is not a valid {}, so it is truncated or corrupt",
                 lib_path.display(),
                 shim_object_kind()
             ),
@@ -2298,7 +2298,7 @@ fn session_runtime_check_for(layout: Option<&kin_core::KinLayout>) -> HealthChec
             "session_runtime",
             "Session runtime",
             HealthStatus::Unsupported,
-            "not inside a Kin repository — from a Kin repo, run project tools with `kin exec -- <cmd>`",
+            "not inside a Kin repository; from one, run project tools with `kin exec -- <cmd>`",
         );
     };
 
@@ -3037,7 +3037,7 @@ fn mcp_client_check_from(
             &label,
             HealthStatus::Unsupported,
             format!(
-                "kin is not registered in this client — {} is a config Kin has not written to",
+                "kin is not registered in this client, and {} is a config Kin has not written to",
                 path.display()
             ),
         )
@@ -3178,7 +3178,7 @@ fn check_setup_ledger() -> HealthCheck {
             "setup_ledger",
             "Install ledger",
             HealthStatus::Unsupported,
-            "no install ledger yet — run `kin setup` to record what gets installed",
+            "no install ledger yet; run `kin setup` to record what gets installed",
         );
     }
 
@@ -3457,7 +3457,7 @@ async fn check_background_work() -> HealthCheck {
             "background_work",
             "Background work",
             HealthStatus::Unsupported,
-            "n/a — not in a Kin repository",
+            "not in a Kin repository",
         );
     };
     let Some(daemon_url) = crate::daemon_client::resolve_daemon_url_if_running_async(&layout).await
@@ -3466,7 +3466,7 @@ async fn check_background_work() -> HealthCheck {
             "background_work",
             "Background work",
             HealthStatus::Unsupported,
-            "n/a — no daemon running for this repository, so there is no background work to \
+            "no daemon running for this repository, so there is no background work to \
              account for; a daemon starts on first use",
         );
     };
@@ -3562,7 +3562,7 @@ fn coverage_row_for_unread_graph<'a>(
             ID,
             LABEL,
             HealthStatus::Unsupported,
-            "n/a — not in a Kin repository",
+            "not in a Kin repository",
         )),
         GraphStatusForRun::NoDaemon => Err(coverage_unreadable(
             HealthStatus::Unsupported,
@@ -3735,13 +3735,13 @@ fn relation_census_row_for_unread_graph(
             ID,
             LABEL,
             HealthStatus::Unsupported,
-            "n/a — not in a Kin repository",
+            "not in a Kin repository",
         )),
         GraphStatusForRun::NoDaemon => Err(HealthCheck::new(
             ID,
             LABEL,
             HealthStatus::Unsupported,
-            "n/a — no daemon running for this repository, so the relation census cannot be \
+            "no daemon running for this repository, so the relation census cannot be \
              read; a daemon starts on first use",
         )
         .with_manual_fix("run any `kin` command in the repo to auto-start the daemon")),
@@ -3823,8 +3823,10 @@ fn coverage_unreadable(
 
     let detail = detail.into();
     if missing_servers.is_empty() {
-        return HealthCheck::new(ID, LABEL, status, format!("n/a — {detail}"))
-            .with_manual_fix(manual_fix);
+        // The report's status column already prints "n/a", so the "n/a - "
+        // this detail used to be prefixed with said it twice and spent an em
+        // dash doing it.
+        return HealthCheck::new(ID, LABEL, status, detail).with_manual_fix(manual_fix);
     }
     // A missing server is a measured host fact even when the graph is not
     // readable, so it decides the status rather than deferring to the unread
@@ -3939,7 +3941,7 @@ fn semantic_query_readiness_without_a_daemon() -> HealthCheck {
         "semantic_query_readiness",
         "Semantic query readiness",
         HealthStatus::Unsupported,
-        "n/a — no daemon running for this repository, so graph embedding coverage cannot \
+        "no daemon running for this repository, so graph embedding coverage cannot \
          be read; a daemon starts on first use",
     )
     .with_manual_fix("run any `kin` command in the repo to auto-start the daemon")
@@ -4092,7 +4094,7 @@ async fn check_semantic_query_readiness() -> SemanticQueryReadinessSample {
                 "semantic_query_readiness",
                 "Semantic query readiness",
                 HealthStatus::Unsupported,
-                "n/a — not in a Kin repository",
+                "not in a Kin repository",
             )
             .into();
         }
@@ -5509,7 +5511,7 @@ fn check_retrieval_profile() -> HealthCheck {
     .collect();
     let detail =
         format!(
-        "{}profile {} — semantic_locate routing: {}; entity fusion: {}; lexical parity floor: {}; \
+        "{}profile {}. semantic_locate routing: {}; entity fusion: {}; lexical parity floor: {}; \
          cross-encoder rerank: {} (model {} {})",
         if levers_off.is_empty() {
             ""
@@ -5570,6 +5572,47 @@ mod tests {
     use super::*;
     use kin_core::test_env::EnvVarGuard;
     use serial_test::serial;
+
+    /// No em dash reaches a reader through this file.
+    ///
+    /// `kin doctor` shipped eight of them in v0.7.2, in rows like
+    /// `n/a - not in a Kin repository`. The brand book says it twice, under
+    /// Voice and again under Claim discipline: hyphens, not em dashes, and the
+    /// kinlab web build fails public copy carrying one with no carve-out. The
+    /// CLI is public copy and has no such build gate, so this is it.
+    ///
+    /// Comment lines are exempt: a doc comment is not copy, and this file's
+    /// comments carry em dashes in quoted prose that documents the defects
+    /// above them. The scan is scoped to the lines a string can be printed
+    /// from, which is where the ones a reader met actually lived.
+    ///
+    /// A scan that read nothing would pass, so the reading is checked first
+    /// against a needle this file certainly contains.
+    #[test]
+    fn no_em_dash_reaches_a_reader_from_this_file() {
+        let source = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/commands/health.rs"
+        ))
+        .expect("this file is readable from its own test");
+
+        assert!(
+            source.contains("Embedding model"),
+            "the scan did not read this file, so its result says nothing"
+        );
+
+        let offenders: Vec<(usize, &str)> = source
+            .lines()
+            .enumerate()
+            .filter(|(_, line)| line.contains('\u{2014}'))
+            .filter(|(_, line)| !line.trim_start().starts_with("//"))
+            .map(|(index, line)| (index + 1, line.trim()))
+            .collect();
+        assert!(
+            offenders.is_empty(),
+            "these lines put an em dash in front of a reader: {offenders:#?}"
+        );
+    }
 
     fn write_editor_manifest(
         extensions_dir: &Path,

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -5601,10 +5601,29 @@ mod tests {
             "the scan did not read this file, so its result says nothing"
         );
 
+        // Both forms. The character is the obvious one. The escape is what a
+        // mutation sweep put in this file to test this guard, and the guard
+        // stayed green: `\u{2014}` is seven ASCII bytes in the source and an em
+        // dash on the reader's terminal, so a scan of source bytes alone misses
+        // exactly the case someone would write to get around it.
+        // Built from the code point rather than written as an escape. Spelled
+        // out, this line would carry the very sequence the scan below looks
+        // for, and the guard would report itself: a self-matching guard passes
+        // only while it is the one offender, then fails forever for the wrong
+        // reason and gets deleted.
+        const EM_DASH_CODE: u32 = 0x2014;
+        let em_dash = char::from_u32(EM_DASH_CODE).expect("2014 is a character");
+        // No case folding. Folding the line was the first attempt and it made
+        // this guard unable to fire at all: `to_uppercase` turns the `u` of
+        // `\u{...}` into `U`, so the needle never matched a line that carried
+        // it. The mutation sweep is what caught that, because the escape form
+        // went in and the test stayed green. The hex here is four digits and no
+        // letters, so there is no case to fold in the first place.
+        let escape = format!("\\u{{{EM_DASH_CODE:04x}}}");
         let offenders: Vec<(usize, &str)> = source
             .lines()
             .enumerate()
-            .filter(|(_, line)| line.contains('\u{2014}'))
+            .filter(|(_, line)| line.contains(em_dash) || line.contains(&escape))
             .filter(|(_, line)| !line.trim_start().starts_with("//"))
             .map(|(index, line)| (index + 1, line.trim()))
             .collect();

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1641,15 +1641,20 @@ fn render_human_result(
     // parsed: the acceptance suites read this block, and every one of them
     // captures stdout, so off a terminal this is the headline alone and every
     // reader of it sees what it always saw.
-    let header = crate::mark::beside_for_stdout(&[
-        "",
-        &format!(
-            "Initialized Kin repository authority at {}",
-            result.layout.root().display()
+    let root = result.layout.root().display().to_string();
+    let header = match crate::mark::MarkStyle::for_stdout() {
+        // On a terminal the path takes its own row beside the mark. On one
+        // line with the mark's seven columns in front of it, an ordinary path
+        // made this ninety-two columns and it wrapped, and the mark is not
+        // what a reader should pay for.
+        Some(style) => crate::mark::beside(
+            style,
+            &["", "Initialized Kin repository authority", &root, ""],
         ),
-        "",
-        "",
-    ]);
+        // Off a terminal, the one line every reader of this block already
+        // parses, unchanged.
+        None => vec![format!("Initialized Kin repository authority at {root}")],
+    };
     // More than the headline means the mark drew, and its lower rows would
     // otherwise sit directly on top of the detail lines below, which are
     // indented two rather than seven. The blank line is part of the mark, so it
@@ -1772,12 +1777,25 @@ fn workspace_head_line(head: &kin_model::WorkspaceHead) -> String {
 /// Two commands, not a menu. `locate` is the one the README leads with, and
 /// `status` is the one that answers what just happened to this repository.
 fn next_step_lines() -> Vec<String> {
-    vec![
-        String::new(),
-        "Next:".to_string(),
-        "  kin locate \"<what you are looking for>\"  ask the graph".to_string(),
-        "  kin status                                what this repository holds now".to_string(),
-    ]
+    // Padded from the commands themselves rather than by hand. Written out, the
+    // two descriptions landed a column apart, and the kind of drift nobody
+    // notices in a diff is exactly the kind a reader sees straight away.
+    let steps = [
+        ("kin locate \"<what you are looking for>\"", "ask the graph"),
+        ("kin status", "what this repository holds now"),
+    ];
+    let widest = steps
+        .iter()
+        .map(|(command, _)| command.chars().count())
+        .max()
+        .unwrap_or(0);
+    let mut lines = vec![String::new(), "Next:".to_string()];
+    lines.extend(
+        steps
+            .iter()
+            .map(|(command, description)| format!("  {command:<widest$}  {description}")),
+    );
+    lines
 }
 
 /// Keep language-server and cross-file guidance before the embedding notice.
@@ -2174,6 +2192,26 @@ mod tests {
                 "the next step must not put an em dash in front of a reader: {line}"
             );
         }
+
+        // Every description starts in the same column. Written out by hand the
+        // two landed a column apart, which a diff hides and a reader sees.
+        let columns: Vec<usize> = lines[2..]
+            .iter()
+            .map(|line| {
+                let gap = line
+                    .find("  ")
+                    .and_then(|_| line[2..].find("  ").map(|at| at + 2))
+                    .expect("each step separates its command from its description");
+                line[gap..]
+                    .find(|c: char| !c.is_whitespace())
+                    .expect("each step carries a description")
+                    + gap
+            })
+            .collect();
+        assert!(
+            columns.windows(2).all(|pair| pair[0] == pair[1]),
+            "the descriptions start at columns {columns:?}, so the block is ragged"
+        );
     }
 
     /// A queue nobody is draining is not work in flight.

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1637,11 +1637,30 @@ fn render_human_result(
 ) -> Result<String> {
     let default_ref = initialized_default_ref(result);
     let mut out = String::new();
-    writeln!(
-        out,
-        "Initialized Kin repository authority at {}",
-        result.layout.root().display()
-    )?;
+    // The mark goes beside the headline, and only on a terminal. `kin init` is
+    // parsed: the acceptance suites read this block, and every one of them
+    // captures stdout, so off a terminal this is the headline alone and every
+    // reader of it sees what it always saw.
+    let header = crate::mark::beside_for_stdout(&[
+        "",
+        &format!(
+            "Initialized Kin repository authority at {}",
+            result.layout.root().display()
+        ),
+        "",
+        "",
+    ]);
+    // More than the headline means the mark drew, and its lower rows would
+    // otherwise sit directly on top of the detail lines below, which are
+    // indented two rather than seven. The blank line is part of the mark, so it
+    // appears exactly when the mark does and a capture keeps its shape.
+    let marked = header.len() > 1;
+    for line in header {
+        writeln!(out, "{line}")?;
+    }
+    if marked {
+        writeln!(out)?;
+    }
     writeln!(out, "  Authority: repository-v6 (graph-owned)")?;
     writeln!(out, "  Repository: {}", result.repository_id)?;
     writeln!(out, "  Workspace: {}", result.workspace_id)?;
@@ -1661,8 +1680,8 @@ fn render_human_result(
     )?;
     writeln!(
         out,
-        "  Workspace head: {}",
-        serde_json::to_string(&result.authority.workspace.workspace_head)?
+        "{}",
+        workspace_head_line(&result.authority.workspace.workspace_head)
     )?;
     writeln!(
         out,
@@ -1718,7 +1737,47 @@ fn render_human_result(
     for line in uncommitted_worktree_disclosure(&result.workspace_divergence) {
         writeln!(out, "{line}")?;
     }
+    for line in next_step_lines() {
+        writeln!(out, "{line}")?;
+    }
     Ok(out)
+}
+
+/// The workspace head, rendered rather than serialized.
+///
+/// This line used to be
+/// `{"type":"symbolic","target":{"bytes_hex":"726566732f68656164732f6d6173746572"}}`,
+/// and that hex decodes to `refs/heads/master`, which is the ref name printed
+/// four lines above it. So the one machine-shaped line in a first-time reader's
+/// result carried nothing the block had not already said in words, and said it
+/// as a byte array.
+///
+/// `kin status` has rendered the same value as `symbolic refs/heads/master` all
+/// along. This is that renderer, and pulling the line into its own function is
+/// what lets a test hold it to a ref name.
+fn workspace_head_line(head: &kin_model::WorkspaceHead) -> String {
+    format!("  Workspace head: {}", super::status::render_head(head))
+}
+
+/// What to do with the graph this command just spent its time building.
+///
+/// `kin init` is the slow step and the one that earns the rest: the README's
+/// five-command path spends four of them getting here and the fifth is the
+/// answer. The result block ended on store size and a pointer to a document
+/// about store size, so the command that had just run for ninety-three seconds
+/// on a small repository said nothing about what the graph is now for. Every
+/// other first-run surface already ends this way; `kin setup` prints a Next
+/// steps block and `kin doctor` puts a fix on every row that needs one.
+///
+/// Two commands, not a menu. `locate` is the one the README leads with, and
+/// `status` is the one that answers what just happened to this repository.
+fn next_step_lines() -> Vec<String> {
+    vec![
+        String::new(),
+        "Next:".to_string(),
+        "  kin locate \"<what you are looking for>\"  ask the graph".to_string(),
+        "  kin status                                what this repository holds now".to_string(),
+    ]
 }
 
 /// Keep language-server and cross-file guidance before the embedding notice.
@@ -2064,6 +2123,58 @@ fn initialized_raw_git_head(result: &kin_core::InitResult) -> Option<&kin_model:
 mod tests {
     use super::*;
     use crate::commands::status::SemanticEnrichmentView;
+
+    /// The workspace head reaches a reader as a ref name, not as a byte array.
+    ///
+    /// v0.7.2 serialized the model here, so the line read
+    /// `{"type":"symbolic","target":{"bytes_hex":"726566732f68656164732f6d6173746572"}}`
+    /// and the hex was the ref name spelled out four lines above it. The
+    /// assertions are on what a reader can and cannot see: the ref name has to
+    /// be there, and none of the shapes a serialized model brings with it may
+    /// be.
+    #[test]
+    fn the_workspace_head_line_names_the_ref_rather_than_serializing_it() {
+        let head = kin_model::WorkspaceHead::Symbolic {
+            target: kin_model::RefName::from_bytes(b"refs/heads/master".to_vec())
+                .expect("a valid ref name"),
+        };
+        let line = workspace_head_line(&head);
+        assert_eq!(line, "  Workspace head: symbolic refs/heads/master");
+        for shape in ["bytes_hex", "{", "\"type\"", "726566732f"] {
+            assert!(
+                !line.contains(shape),
+                "the head line carries {shape:?}, so it is a serialized model: {line}"
+            );
+        }
+    }
+
+    /// `kin init` ends by saying what the graph it just built is for.
+    ///
+    /// It used to end on store size and a pointer to a document about store
+    /// size, after ninety-three seconds of work on a small repository. The
+    /// README's five-command path spends four commands getting here and the
+    /// fifth is the answer, so the command that earns the graph names it.
+    #[test]
+    fn the_result_ends_by_naming_the_next_command() {
+        let lines = next_step_lines();
+        assert_eq!(lines[0], "", "a blank line separates it from the detail");
+        assert_eq!(lines[1], "Next:");
+        let body = lines[2..].join("\n");
+        assert!(
+            body.contains("kin locate"),
+            "the next step must name the command the README leads with: {body}"
+        );
+        assert!(
+            body.contains("kin status"),
+            "the next step must name what answers what just happened: {body}"
+        );
+        for line in &lines {
+            assert!(
+                !line.contains('\u{2014}'),
+                "the next step must not put an em dash in front of a reader: {line}"
+            );
+        }
+    }
 
     /// A queue nobody is draining is not work in flight.
     ///

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -13200,9 +13200,10 @@ fn labelled_lines(label: &str, text: &str, width: Option<usize>) -> Vec<String> 
 /// into captured output and every piped `kin doctor` gained a first line it
 /// never had, while the mark correctly did not.
 ///
-/// `None` for the title means the report has already announced itself:
-/// `--fix` prints the table twice, once before the repairs and once after, and
-/// the mark belongs to the first of them.
+/// `None` for the title is for a caller that has already announced itself.
+/// `kin doctor --fix` is not one: the un-fixed path prints its table and
+/// returns, so `--fix` reaches only the table after the repairs, and passing
+/// `None` there left that command with no mark at all.
 fn report_header(
     title: Option<&str>,
     platform: &str,
@@ -14379,7 +14380,7 @@ pub async fn doctor(fix: bool, install_language_servers: bool, json: bool) -> Re
     }
     println!("Re-running checks...");
     println!();
-    print_human_report(&after, None);
+    print_human_report(&after, Some("Kin doctor"));
 
     let still_manual = manual_attention_checks(&after);
     if !still_manual.is_empty() {
@@ -15952,6 +15953,42 @@ mod tests {
                 drawn[1].ends_with(name),
                 "the header must carry {name:?}, got {:?}",
                 drawn[1]
+            );
+        }
+    }
+
+    /// Every command that prints this report names itself in it.
+    ///
+    /// Read from the source rather than asserted from memory, because the
+    /// mistake this catches was made by reading two call sites and missing the
+    /// `if !fix { ... return }` between them: `kin doctor --fix` reaches only
+    /// the table printed after its repairs, so passing no title there left that
+    /// one command with no mark at all.
+    ///
+    /// The scan checks its own reading first, since one that found no call
+    /// sites would pass.
+    #[test]
+    fn no_call_site_prints_this_report_without_naming_its_command() {
+        let source = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/commands/setup.rs"
+        ))
+        .expect("this file is readable from its own test");
+
+        let calls: Vec<&str> = source
+            .lines()
+            .map(str::trim)
+            .filter(|line| line.starts_with("print_human_report(&"))
+            .collect();
+        assert!(
+            calls.len() >= 4,
+            "the scan found {} call sites, too few to be reading this file",
+            calls.len()
+        );
+        for call in &calls {
+            assert!(
+                call.contains("Some(\""),
+                "this call prints the report without naming its command: {call}"
             );
         }
     }

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -13082,11 +13082,103 @@ fn status_label(status: &crate::commands::health::HealthStatus) -> &'static str 
     }
 }
 
+/// Where the detail column starts, from the row format below.
+///
+/// Two leading spaces, the status glyph, a space, a twenty-six column label, a
+/// space, a fourteen column status word, and a space.
+const DETAIL_COLUMN: usize = 46;
+
+/// Indent for a detail that moved off its row.
+///
+/// Six rather than forty-six. A detail wrapped into the thirty-four columns
+/// left of an eighty-column terminal would be twenty-three lines of ribbon; the
+/// same text at this indent is six lines that read like a paragraph, and it
+/// lines up with the `fix:` and `note:` lines already printed under a row.
+const DETAIL_CONTINUATION_INDENT: usize = 6;
+
+/// A detail short enough to sit on its row, or the lines it becomes.
+enum DetailLayout {
+    Beside,
+    Below(Vec<String>),
+}
+
+/// Decide how one row's detail is laid out at a known width.
+///
+/// `None` is "nothing is watching": no terminal, or a width that could not be
+/// read. That arm prints exactly what this report has always printed, which is
+/// what keeps every capture of it, and every acceptance suite reading one,
+/// seeing the same bytes.
+///
+/// The measured case is `kin doctor` on an eighty-column terminal, where
+/// thirty-three of forty-seven lines ran past the margin and the longest was
+/// seven hundred and seventy-eight characters inside a row whose columns are
+/// aligned for a short value. A terminal reflows that to the left margin with
+/// no hanging indent, so the table's alignment is destroyed by its own content.
+fn detail_layout(detail: &str, width: Option<usize>) -> DetailLayout {
+    let Some(width) = width else {
+        return DetailLayout::Beside;
+    };
+    if DETAIL_COLUMN + console::measure_text_width(detail) <= width {
+        return DetailLayout::Beside;
+    }
+    DetailLayout::Below(wrap_words(
+        detail,
+        width.saturating_sub(DETAIL_CONTINUATION_INDENT).max(20),
+    ))
+}
+
+/// Greedy word wrap. A word longer than the width gets its own line rather than
+/// being broken, because the long words here are paths and hashes and half of
+/// one is worse than an overhanging one.
+fn wrap_words(text: &str, width: usize) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    for word in text.split_whitespace() {
+        if current.is_empty() {
+            current.push_str(word);
+        } else if console::measure_text_width(&current) + 1 + console::measure_text_width(word)
+            <= width
+        {
+            current.push(' ');
+            current.push_str(word);
+        } else {
+            lines.push(std::mem::take(&mut current));
+            current.push_str(word);
+        }
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    lines
+}
+
+/// The width to lay a report out at, or `None` when nothing is watching.
+fn report_width() -> Option<usize> {
+    if !io::stdout().is_terminal() {
+        return None;
+    }
+    console::Term::stdout()
+        .size_checked()
+        .map(|(_, columns)| usize::from(columns))
+}
+
 /// Render a [`HealthReport`] as the human-readable table used by
 /// `kin setup status` and `kin doctor`.
 fn print_human_report(report: &crate::commands::health::HealthReport) {
     use crate::commands::health::HealthStatus;
-    println!("Platform: {}", report.platform);
+    let width = report_width();
+    // `kin doctor` is the command the archive's own INSTALL.md tells a reader
+    // to run before anything else, so it is one of the three surfaces that
+    // carry the mark. Off a terminal this is the `Platform:` line alone, which
+    // is what every capture of this report has always started with.
+    for line in crate::mark::beside_for_stdout(&[
+        "",
+        "Kin doctor",
+        &format!("Platform: {}", report.platform),
+        "",
+    ]) {
+        println!("{line}");
+    }
     println!();
     for check in &report.checks {
         let mark = match check.status {
@@ -13098,12 +13190,24 @@ fn print_human_report(report: &crate::commands::health::HealthReport) {
             HealthStatus::Pending => style("…").yellow(),
             HealthStatus::Unsupported => style("→").cyan(),
         };
-        println!(
-            "  {mark} {:<26} {:<14} {}",
-            check.label,
-            status_label(&check.status),
-            check.detail
-        );
+        match detail_layout(&check.detail, width) {
+            DetailLayout::Beside => println!(
+                "  {mark} {:<26} {:<14} {}",
+                check.label,
+                status_label(&check.status),
+                check.detail
+            ),
+            DetailLayout::Below(lines) => {
+                println!(
+                    "  {mark} {:<26} {}",
+                    check.label,
+                    status_label(&check.status)
+                );
+                for line in lines {
+                    println!("{}{line}", " ".repeat(DETAIL_CONTINUATION_INDENT));
+                }
+            }
+        }
         if let Some(note) = &check.platform_note {
             println!("      note: {note}");
         }
@@ -15674,6 +15778,80 @@ mod tests {
     use super::{fix_verdict, readiness_line, UnfinishedRepair};
     use crate::commands::health::{HealthCheck, HealthReport, HealthStatus, HealthVerdict};
     use kin_model::LanguageId;
+
+    /// A row's detail stays on its row while it fits, and moves under it when
+    /// it does not.
+    ///
+    /// The measurement this is written from: on the released v0.7.2 bytes at
+    /// eighty columns, thirty-three of `kin doctor`'s forty-seven lines ran
+    /// past the margin, and the `Memory floor` row's detail was seven hundred
+    /// and seventy-eight characters on one line.
+    #[test]
+    fn a_detail_that_does_not_fit_its_row_moves_under_it() {
+        use super::{detail_layout, DetailLayout, DETAIL_COLUMN};
+
+        let short = "ok";
+        assert!(
+            matches!(detail_layout(short, Some(80)), DetailLayout::Beside),
+            "a short detail must stay on its row"
+        );
+
+        let long = "x ".repeat(400);
+        let DetailLayout::Below(lines) = detail_layout(&long, Some(80)) else {
+            panic!("a {}-character detail must not stay on a row that starts at column {DETAIL_COLUMN} of 80", long.len());
+        };
+        assert!(lines.len() > 1, "the detail must actually be wrapped");
+        for line in &lines {
+            let width = console::measure_text_width(line) + super::DETAIL_CONTINUATION_INDENT;
+            assert!(
+                width <= 80,
+                "the wrapped line {line:?} is {width} columns wide once indented"
+            );
+        }
+    }
+
+    /// Off a terminal the report is byte-identical to what it always printed.
+    ///
+    /// The acceptance suites capture this report and read substrings out of it,
+    /// and a substring that spans a wrap point is a substring that stops
+    /// matching. Nothing is watching a captured stream, so nothing is wrapped
+    /// in one.
+    #[test]
+    fn a_captured_report_is_never_rewrapped() {
+        use super::{detail_layout, DetailLayout};
+
+        let long = "x ".repeat(400);
+        assert!(
+            matches!(detail_layout(&long, None), DetailLayout::Beside),
+            "with no width to lay out at, the detail must be printed as it always was"
+        );
+    }
+
+    /// Wrapping never loses or reorders a word, and never splits one.
+    ///
+    /// The long details here are paths, hashes and daemon ids. Half of a hash
+    /// is worse than an overhanging one, so a word past the width takes its own
+    /// line whole.
+    #[test]
+    fn wrapping_preserves_every_word_and_splits_none() {
+        use super::wrap_words;
+
+        let text = "128.0 GiB of memory here (this host's RAM); one repository daemon is allowed \
+                    8.0 GiB of that";
+        let wrapped = wrap_words(text, 30);
+        assert_eq!(
+            wrapped.join(" ").split_whitespace().collect::<Vec<_>>(),
+            text.split_whitespace().collect::<Vec<_>>(),
+            "wrapping changed the words"
+        );
+
+        let hash = "a".repeat(64);
+        let wrapped = wrap_words(&format!("seal {hash} sealed"), 20);
+        assert!(
+            wrapped.iter().any(|line| line == &hash),
+            "a word past the width must survive whole; got {wrapped:?}"
+        );
+    }
 
     #[tokio::test]
     async fn post_install_refresh_requires_an_available_enrichment_channel() {

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -13152,6 +13152,41 @@ fn wrap_words(text: &str, width: usize) -> Vec<String> {
     lines
 }
 
+/// Print a `note:` or `fix:` line under a row, wrapped when it does not fit.
+///
+/// These carry the remedy, so they are the lines a reader most needs to be able
+/// to read. Wrapped, the continuation lines align under the text rather than
+/// under the label, so the label keeps marking where one remedy starts. Off a
+/// terminal, `width` is `None` and the line is printed exactly as it always was.
+fn print_labelled_line(label: &str, text: &str, width: Option<usize>) {
+    for line in labelled_lines(label, text, width) {
+        println!("{line}");
+    }
+}
+
+/// The lines [`print_labelled_line`] would print.
+///
+/// Split from the printing so the decision can be tested. Written as one
+/// function that printed as it went, the only test that could reach it was a
+/// test of `wrap_words` beside it, and a mutation that made this always take
+/// the fits arm left that test green: it never called this code at all.
+fn labelled_lines(label: &str, text: &str, width: Option<usize>) -> Vec<String> {
+    let indent = DETAIL_CONTINUATION_INDENT;
+    let hanging = indent + label.chars().count();
+    let fits = width.is_none_or(|width| hanging + console::measure_text_width(text) <= width);
+    if fits {
+        return vec![format!("{}{label}{text}", " ".repeat(indent))];
+    }
+    let width = width.unwrap_or_default();
+    let mut wrapped = wrap_words(text, width.saturating_sub(hanging).max(20)).into_iter();
+    let Some(first) = wrapped.next() else {
+        return Vec::new();
+    };
+    let mut lines = vec![format!("{}{label}{first}", " ".repeat(indent))];
+    lines.extend(wrapped.map(|line| format!("{}{line}", " ".repeat(hanging))));
+    lines
+}
+
 /// The width to lay a report out at, or `None` when nothing is watching.
 fn report_width() -> Option<usize> {
     if !io::stdout().is_terminal() {
@@ -13209,11 +13244,11 @@ fn print_human_report(report: &crate::commands::health::HealthReport) {
             }
         }
         if let Some(note) = &check.platform_note {
-            println!("      note: {note}");
+            print_labelled_line("note: ", note, width);
         }
         if !matches!(check.status, HealthStatus::Healthy) {
             if let Some(fix) = &check.manual_fix {
-                println!("      fix:  {fix}");
+                print_labelled_line("fix:  ", fix, width);
             }
         }
     }
@@ -15825,6 +15860,52 @@ mod tests {
             matches!(detail_layout(&long, None), DetailLayout::Beside),
             "with no width to lay out at, the detail must be printed as it always was"
         );
+    }
+
+    /// A `fix:` line that does not fit is wrapped under its own label.
+    ///
+    /// These carry the remedy, so they are the lines a reader most needs whole.
+    /// After the row wrap landed, seven of `kin doctor`'s lines were still past
+    /// an eighty-column margin at 80 and four at 120, and every one of them was
+    /// a `fix:`. The continuation lines align under the text rather than under
+    /// the label, so the label keeps marking where one remedy starts.
+    #[test]
+    fn a_fix_line_that_does_not_fit_wraps_under_its_label() {
+        use super::{labelled_lines, DETAIL_CONTINUATION_INDENT};
+
+        let fix = "run `kin vfs on` to engage a projection and record it, or `kin vfs status` \
+                   for what each mode would need here";
+        let hanging = DETAIL_CONTINUATION_INDENT + "fix:  ".len();
+        assert!(
+            hanging + console::measure_text_width(fix) > 80,
+            "this fixture must be a line that does not fit, or the test proves nothing"
+        );
+
+        let lines = labelled_lines("fix:  ", fix, Some(80));
+        assert!(
+            lines.len() > 1,
+            "a line this long must be wrapped: {lines:?}"
+        );
+        assert!(
+            lines[0].starts_with(&format!("{}fix:  ", " ".repeat(DETAIL_CONTINUATION_INDENT))),
+            "the label stays on the first line: {:?}",
+            lines[0]
+        );
+        for line in &lines {
+            let width = console::measure_text_width(line);
+            assert!(width <= 80, "the wrapped line {line:?} is {width} columns");
+        }
+        for line in &lines[1..] {
+            assert!(
+                line.starts_with(&" ".repeat(hanging)),
+                "continuation lines align under the text, not under the label: {line:?}"
+            );
+        }
+
+        // Off a terminal it is one line, exactly as this report always printed.
+        let plain = labelled_lines("fix:  ", fix, None);
+        assert_eq!(plain.len(), 1);
+        assert_eq!(plain[0], format!("      fix:  {fix}"));
     }
 
     /// Wrapping never loses or reorders a word, and never splits one.

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -12256,7 +12256,7 @@ pub async fn run_wizard(opts: WizardOptions) -> Result<()> {
     println!("=== Health checklist ===");
     println!();
     let report = crate::commands::health::run_health_checks().await;
-    print_human_report(&report);
+    print_human_report(&report, Some("Kin setup"));
 
     print_next_steps(intent, plan.install_shell_hook, &configured_assistants);
 
@@ -13064,7 +13064,7 @@ pub async fn status(json: bool) -> Result<()> {
         return Ok(());
     }
 
-    print_human_report(&report);
+    print_human_report(&report, Some("Kin setup status"));
     Ok(())
 }
 
@@ -13187,6 +13187,34 @@ fn labelled_lines(label: &str, text: &str, width: Option<usize>) -> Vec<String> 
     lines
 }
 
+/// The lines this report opens with.
+///
+/// Pure, and separate from the printing, because the gating is the whole point
+/// and a function that prints as it goes cannot be reached by a test. Written
+/// inline the first time, a mutation that ungated the title left every test
+/// green: the only test that could reach it asserted on `beside_or_plain`
+/// beside it, which is not where the decision lives. That is the second time
+/// in this change that a test named a helper rather than the code under test.
+///
+/// The title and the mark are one unit. Gated separately, the title survived
+/// into captured output and every piped `kin doctor` gained a first line it
+/// never had, while the mark correctly did not.
+///
+/// `None` for the title means the report has already announced itself:
+/// `--fix` prints the table twice, once before the repairs and once after, and
+/// the mark belongs to the first of them.
+fn report_header(
+    title: Option<&str>,
+    platform: &str,
+    style: Option<crate::mark::MarkStyle>,
+) -> Vec<String> {
+    let platform = format!("Platform: {platform}");
+    match (title, style) {
+        (Some(title), Some(style)) => crate::mark::beside(style, &["", title, &platform, ""]),
+        _ => vec![platform],
+    }
+}
+
 /// The width to lay a report out at, or `None` when nothing is watching.
 fn report_width() -> Option<usize> {
     if !io::stdout().is_terminal() {
@@ -13199,19 +13227,23 @@ fn report_width() -> Option<usize> {
 
 /// Render a [`HealthReport`] as the human-readable table used by
 /// `kin setup status` and `kin doctor`.
-fn print_human_report(report: &crate::commands::health::HealthReport) {
+fn print_human_report(report: &crate::commands::health::HealthReport, title: Option<&str>) {
     use crate::commands::health::HealthStatus;
     let width = report_width();
-    // `kin doctor` is the command the archive's own INSTALL.md tells a reader
-    // to run before anything else, so it is one of the three surfaces that
-    // carry the mark. Off a terminal this is the `Platform:` line alone, which
-    // is what every capture of this report has always started with.
-    for line in crate::mark::beside_for_stdout(&[
-        "",
-        "Kin doctor",
-        &format!("Platform: {}", report.platform),
-        "",
-    ]) {
+    // The title and the mark are one unit, and both are terminal-only. Written
+    // through `beside_for_stdout`, whose no-style arm keeps every non-empty
+    // line, the title survived into captured output and every piped
+    // `kin doctor` gained a first line it never had. The mark was gated and the
+    // title beside it was not, which is the whole of that defect.
+    //
+    // The title is a parameter because this renderer serves four commands.
+    // Hardcoded, `kin setup` and `kin setup status` announced themselves as
+    // Kin doctor.
+    for line in report_header(
+        title,
+        &report.platform,
+        crate::mark::MarkStyle::for_stdout(),
+    ) {
         println!("{line}");
     }
     println!();
@@ -14065,7 +14097,7 @@ pub async fn doctor(fix: bool, install_language_servers: bool, json: bool) -> Re
         if json {
             println!("{}", serde_json::to_string_pretty(&report)?);
         } else {
-            print_human_report(&report);
+            print_human_report(&report, Some("Kin doctor"));
         }
         // Printed last, so a human reads it under the report rather than above
         // it. Before this, the flag was dead on this path: bound at the
@@ -14347,7 +14379,7 @@ pub async fn doctor(fix: bool, install_language_servers: bool, json: bool) -> Re
     }
     println!("Re-running checks...");
     println!();
-    print_human_report(&after);
+    print_human_report(&after, None);
 
     let still_manual = manual_attention_checks(&after);
     if !still_manual.is_empty() {
@@ -15860,6 +15892,68 @@ mod tests {
             matches!(detail_layout(&long, None), DetailLayout::Beside),
             "with no width to lay out at, the detail must be printed as it always was"
         );
+    }
+
+    /// A captured report gains nothing, not even a title.
+    ///
+    /// The mark was gated on a terminal and the title beside it was not, so
+    /// every piped `kin doctor` gained a first line reading `Kin doctor` that
+    /// it never had, while the pull request claimed nothing new could reach a
+    /// script.
+    ///
+    /// This calls `report_header`, which is where the gating decision lives.
+    /// The first version of this test called `beside_or_plain` beside it, and
+    /// a mutation that ungated the title left it green, because it never
+    /// reached the code the claim was about.
+    #[test]
+    fn a_captured_report_gains_no_title_and_no_mark() {
+        use super::report_header;
+        use crate::mark::{Glyphs, MarkStyle, Paint};
+
+        // No terminal: the platform line alone, whatever title is passed.
+        assert_eq!(
+            report_header(Some("Kin doctor"), "macos", None),
+            vec!["Platform: macos".to_string()],
+            "a captured report must gain nothing, and a title is something"
+        );
+        assert_eq!(
+            report_header(None, "macos", None),
+            vec!["Platform: macos".to_string()]
+        );
+
+        // A terminal, but no title: the report already announced itself, so the
+        // mark is not drawn a second time.
+        let style = MarkStyle::new(Glyphs::Unicode, Paint::None);
+        assert_eq!(
+            report_header(None, "macos", Some(style)),
+            vec!["Platform: macos".to_string()],
+            "`--fix` prints this table twice and the mark belongs to the first"
+        );
+
+        // A terminal and a title: both.
+        let drawn = report_header(Some("Kin doctor"), "macos", Some(style));
+        assert_eq!(drawn.len(), 4);
+        assert!(drawn[1].ends_with("Kin doctor"));
+        assert!(drawn[2].ends_with("Platform: macos"));
+    }
+
+    /// Each command announces itself by its own name.
+    ///
+    /// One hardcoded title on a renderer four commands share had `kin setup`
+    /// and `kin setup status` calling themselves Kin doctor.
+    #[test]
+    fn each_command_names_itself_in_the_header() {
+        use super::report_header;
+        use crate::mark::{Glyphs, MarkStyle, Paint};
+        let style = MarkStyle::new(Glyphs::Unicode, Paint::None);
+        for name in ["Kin setup", "Kin setup status", "Kin doctor"] {
+            let drawn = report_header(Some(name), "macos", Some(style));
+            assert!(
+                drawn[1].ends_with(name),
+                "the header must carry {name:?}, got {:?}",
+                drawn[1]
+            );
+        }
     }
 
     /// A `fix:` line that does not fit is wrapped under its own label.

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -13200,10 +13200,11 @@ fn labelled_lines(label: &str, text: &str, width: Option<usize>) -> Vec<String> 
 /// into captured output and every piped `kin doctor` gained a first line it
 /// never had, while the mark correctly did not.
 ///
-/// `None` for the title is for a caller that has already announced itself.
-/// `kin doctor --fix` is not one: the un-fixed path prints its table and
-/// returns, so `--fix` reaches only the table after the repairs, and passing
-/// `None` there left that command with no mark at all.
+/// `None` for the title is for a caller that has already announced itself. No
+/// shipping caller is one. `kin doctor --fix` was given `None` on the belief
+/// that it prints two tables; the un-fixed path prints its table and returns,
+/// so `--fix` reaches only the table after the repairs and that left the
+/// command with no mark at all.
 fn report_header(
     title: Option<&str>,
     platform: &str,
@@ -13232,7 +13233,7 @@ fn print_human_report(report: &crate::commands::health::HealthReport, title: Opt
     use crate::commands::health::HealthStatus;
     let width = report_width();
     // The title and the mark are one unit, and both are terminal-only. Written
-    // through `beside_for_stdout`, whose no-style arm keeps every non-empty
+    // through `beside_or_plain`, whose no-style arm keeps every non-empty
     // line, the title survived into captured output and every piped
     // `kin doctor` gained a first line it never had. The mark was gated and the
     // title beside it was not, which is the whole of that defect.
@@ -15922,13 +15923,17 @@ mod tests {
             vec!["Platform: macos".to_string()]
         );
 
-        // A terminal, but no title: the report already announced itself, so the
-        // mark is not drawn a second time.
+        // A terminal but no title: the platform line alone. No shipping caller
+        // passes None today. It is kept because the two arguments are
+        // independent and a caller that has already announced itself is a
+        // reasonable thing to have; the message says that rather than naming
+        // `--fix`, which prints one table and not two, and believing otherwise
+        // is what left that command with no mark at all.
         let style = MarkStyle::new(Glyphs::Unicode, Paint::None);
         assert_eq!(
             report_header(None, "macos", Some(style)),
             vec!["Platform: macos".to_string()],
-            "`--fix` prints this table twice and the mark belongs to the first"
+            "with no title there is nothing for the mark to sit beside"
         );
 
         // A terminal and a title: both.

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -1822,7 +1822,12 @@ fn render_embedding_coverage(coverage: &EmbeddingCoverage) -> String {
     }
 }
 
-fn render_head(head: &WorkspaceHead) -> String {
+/// A workspace head in a reader's terms.
+///
+/// `pub(crate)` because `kin init` needs the same rendering. It used to
+/// serialize the model instead, so the last line of a first-time reader's
+/// `kin init` was a hex-encoded byte array whose payload was `refs/heads/main`.
+pub(crate) fn render_head(head: &WorkspaceHead) -> String {
     match head {
         WorkspaceHead::Symbolic { target } => format!("symbolic {target}"),
         WorkspaceHead::Detached { target } => format!("detached {}", render_target(target)),

--- a/crates/kin-cli/src/lib.rs
+++ b/crates/kin-cli/src/lib.rs
@@ -16,6 +16,7 @@ pub mod daemon_error;
 pub mod embed_model;
 pub mod entity_identity;
 pub mod entity_ref;
+pub mod mark;
 pub mod model_residency;
 pub mod open_files;
 pub mod output_style;

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -4626,9 +4626,17 @@ where
                 .with_ansi(ansi)
                 .with_filter(EnvFilter::new(directives).and(
                     tracing_subscriber::filter::filter_fn(move |metadata| {
+                        // Two separate reasons a record does not belong on the
+                        // fmt layer, named, then one negation over them. The
+                        // reasons are what a reader of this filter needs, and
+                        // `!a && !b` spelled out inline is the same expression
+                        // clippy's nonminimal_bool refuses either way, so the
+                        // names carry the meaning and the shape stays minimal.
                         let target = metadata.target();
-                        !is_periodic_admission_progress(target)
-                            && !(quiet_admission_records && is_terminal_admission_record(target))
+                        let scribbles_on_the_ladder = is_periodic_admission_progress(target);
+                        let restated_by_the_command =
+                            quiet_admission_records && is_terminal_admission_record(target);
+                        !(scribbles_on_the_ladder || restated_by_the_command)
                     }),
                 )),
         )

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -2785,12 +2785,9 @@ fn version_lines(version: &str) -> Vec<String> {
     ];
     // The commit sha gets its own line, and the branch and build time the next.
     // Together they are seventy columns on a release build, whose branch reads
-    // `detached`, and ninety on a working branch whose name is long: the first
-    // build of this change printed
-    // `5372dc8c2299f86d7cfaedfd0b0108a9a177f8b8 chore/lane-clilook-kin
-    // 2026-09-06T16:52:11Z`, which wraps at eighty. Splitting them is what makes
-    // the bound hold for every branch name rather than for the ones a release
-    // happens to have.
+    // `detached`, and ninety when the branch name is long, which wraps at
+    // eighty. Splitting them is what makes the bound hold for every branch
+    // name rather than for the ones a release happens to have.
     match build.split_once(' ') {
         Some((commit, rest)) => {
             lines.push(commit.to_string());
@@ -5352,12 +5349,12 @@ mod tests {
         assert_eq!(lines[4], "detached 2026-09-06T08:24:29Z");
 
         // Both a release build, whose branch reads `detached`, and a working
-        // branch with a long name. The second is not hypothetical: the first
-        // build of this change reported `chore/lane-clilook-kin` and its
-        // version line was ninety columns, which the release-shaped input alone
-        // could never have caught.
-        let working = "0.7.3 (5372dc8c2299f86d7cfaedfd0b0108a9a177f8b8 \
-                       chore/lane-clilook-kin 2026-09-06T16:52:11Z)";
+        // branch with a long name. The second is not hypothetical: a build off
+        // a branch named like this one reported a version line of ninety
+        // columns, which the release-shaped input alone could never have
+        // caught.
+        let working = "0.7.3 (0123456789abcdef0123456789abcdef01234567 \
+                       a-working-branch-with-a-long-name 2026-01-02T03:04:05Z)";
         for version in [composed, working] {
             for paint in [
                 kin_cli::mark::Paint::Truecolor,

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -2778,12 +2778,27 @@ fn version_lines(version: &str) -> Vec<String> {
         Some((number, rest)) => (number, rest.trim_end_matches(')')),
         None => (version, ""),
     };
-    vec![
+    let mut lines = vec![
         String::new(),
         format!("kin {number}"),
         CATEGORY_LINE.to_string(),
-        build.to_string(),
-    ]
+    ];
+    // The commit sha gets its own line, and the branch and build time the next.
+    // Together they are seventy columns on a release build, whose branch reads
+    // `detached`, and ninety on a working branch whose name is long: the first
+    // build of this change printed
+    // `5372dc8c2299f86d7cfaedfd0b0108a9a177f8b8 chore/lane-clilook-kin
+    // 2026-09-06T16:52:11Z`, which wraps at eighty. Splitting them is what makes
+    // the bound hold for every branch name rather than for the ones a release
+    // happens to have.
+    match build.split_once(' ') {
+        Some((commit, rest)) => {
+            lines.push(commit.to_string());
+            lines.push(rest.to_string());
+        }
+        None => lines.push(build.to_string()),
+    }
+    lines
 }
 
 /// The canon Category line, shared by `--help` and `--version`.
@@ -5230,23 +5245,30 @@ mod tests {
         // is an assertion that cannot fail, and it would sit here looking like
         // one that could.
         assert_eq!(lines[2], "The system of record for AI-written software.");
-        assert_eq!(
-            lines[3],
-            "dca8e950e99f6a1cb9afe4359611e2da288004f2 detached 2026-09-06T08:24:29Z"
-        );
+        assert_eq!(lines[3], "dca8e950e99f6a1cb9afe4359611e2da288004f2");
+        assert_eq!(lines[4], "detached 2026-09-06T08:24:29Z");
 
-        for paint in [
-            kin_cli::mark::Paint::Truecolor,
-            kin_cli::mark::Paint::Indexed,
-            kin_cli::mark::Paint::None,
-        ] {
-            let style = kin_cli::mark::MarkStyle::new(kin_cli::mark::Glyphs::Unicode, paint);
-            for line in rendered_version(composed, Some(style)).lines() {
-                let width = console::measure_text_width(line);
-                assert!(
-                    width <= 80,
-                    "the version line {line:?} is {width} columns wide, so it wraps at 80"
-                );
+        // Both a release build, whose branch reads `detached`, and a working
+        // branch with a long name. The second is not hypothetical: the first
+        // build of this change reported `chore/lane-clilook-kin` and its
+        // version line was ninety columns, which the release-shaped input alone
+        // could never have caught.
+        let working = "0.7.3 (5372dc8c2299f86d7cfaedfd0b0108a9a177f8b8 \
+                       chore/lane-clilook-kin 2026-09-06T16:52:11Z)";
+        for version in [composed, working] {
+            for paint in [
+                kin_cli::mark::Paint::Truecolor,
+                kin_cli::mark::Paint::Indexed,
+                kin_cli::mark::Paint::None,
+            ] {
+                let style = kin_cli::mark::MarkStyle::new(kin_cli::mark::Glyphs::Unicode, paint);
+                for line in rendered_version(version, Some(style)).lines() {
+                    let width = console::measure_text_width(line);
+                    assert!(
+                        width <= 80,
+                        "the version line {line:?} is {width} columns wide, so it wraps at 80"
+                    );
+                }
             }
         }
     }
@@ -5280,6 +5302,7 @@ mod tests {
         let lines = version_lines("0.7.2");
         assert_eq!(lines[1], "kin 0.7.2");
         assert_eq!(lines[3], "");
+        assert_eq!(lines.len(), 4, "an absent build detail adds no second line");
     }
 
     /// With no terminal, `--version` is the exact line it has always been.

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -4453,8 +4453,31 @@ fn is_periodic_admission_progress(target: &str) -> bool {
 /// place.
 const ADMISSION_TERMINAL_TARGETS: [&str; 2] = ["kin_core::init", "kin_core::git_init"];
 
-fn is_terminal_admission_record(target: &str) -> bool {
-    ADMISSION_TERMINAL_TARGETS.contains(&target)
+/// Whether one event is an admission record the command restates itself.
+///
+/// Keyed on the event, never on its target. Those two targets carry five
+/// callsites between them, not two: the two admission records, an
+/// `initialized`/`recovered`/`reclaimed` trio about staging, and a `warn` about
+/// a stage whose owner lock could not be attempted. One of the trio is the
+/// notice telling a reader that `kin init` kept earlier staging directories and
+/// that they cost disk, and it has no other sink at all. A target-keyed
+/// suppression takes every one of them, so the reader loses a warning and a
+/// disk notice to make a log line quieter.
+///
+/// The two records are the only events on these targets that carry both a
+/// `repository` and a `workspace` field at `INFO`, which is what identifies
+/// them: the staging trio carries `count` and `parent`, and the refusal is a
+/// `warn` with `path` and `error`. The level is part of the test so a future
+/// `warn` carrying the same fields is not swallowed by this.
+fn is_terminal_admission_record(metadata: &tracing::Metadata<'_>) -> bool {
+    if !ADMISSION_TERMINAL_TARGETS.contains(&metadata.target()) {
+        return false;
+    }
+    if *metadata.level() != tracing::Level::INFO {
+        return false;
+    }
+    let fields = metadata.fields();
+    fields.field("repository").is_some() && fields.field("workspace").is_some()
 }
 
 /// Render an admission progress event onto the live phase line.
@@ -4632,10 +4655,10 @@ where
                         // `!a && !b` spelled out inline is the same expression
                         // clippy's nonminimal_bool refuses either way, so the
                         // names carry the meaning and the shape stays minimal.
-                        let target = metadata.target();
-                        let scribbles_on_the_ladder = is_periodic_admission_progress(target);
+                        let scribbles_on_the_ladder =
+                            is_periodic_admission_progress(metadata.target());
                         let restated_by_the_command =
-                            quiet_admission_records && is_terminal_admission_record(target);
+                            quiet_admission_records && is_terminal_admission_record(metadata);
                         !(scribbles_on_the_ladder || restated_by_the_command)
                     }),
                 )),
@@ -5191,6 +5214,49 @@ mod tests {
         );
     }
 
+    /// Only the two admission records are quietened, and nothing else on
+    /// those targets.
+    ///
+    /// The first shape of this keyed on the target, and those two targets carry
+    /// five callsites, not two. It swallowed a `warn` about a stage whose owner
+    /// lock could not be attempted, and the notice telling a reader that
+    /// `kin init` kept earlier staging directories and that they cost disk,
+    /// which has no other sink at all. A reader lost a warning and a disk
+    /// notice so that a log line could be quieter.
+    ///
+    /// Every one of the five shapes is exercised here, because the ones that
+    /// must survive are the point.
+    #[test]
+    fn the_suppression_takes_the_records_and_leaves_the_notices() {
+        let quiet = captured_with_quiet_admission(true);
+
+        assert!(
+            !quiet.contains("admitted exact Git repository"),
+            "the git admission record must be quiet by default: {quiet:?}"
+        );
+        assert!(
+            !quiet.contains("initialized unborn kin repository authority"),
+            "the native admission record must be quiet by default: {quiet:?}"
+        );
+        assert!(
+            quiet.contains("could not prove"),
+            "the retained-staging disk notice has no other sink and must still print: {quiet:?}"
+        );
+        assert!(
+            quiet.contains("owner lock could not be attempted"),
+            "a warn on these targets must never be swallowed: {quiet:?}"
+        );
+        assert!(
+            quiet.contains("reclaimed stranded repository initialization stages"),
+            "the staging trio must still print: {quiet:?}"
+        );
+        assert!(
+            quiet.contains("a warning that happens to name a repository"),
+            "only INFO records are quietened, so a warn carrying the same fields must still \
+             print: {quiet:?}"
+        );
+    }
+
     /// The phase ladder's own progress is untouched by the suppression.
     ///
     /// The two live on the same directives, so a fix that quietened the record
@@ -5200,7 +5266,7 @@ mod tests {
     #[test]
     fn quieting_the_admission_record_leaves_the_periodic_progress_alone() {
         assert!(
-            !is_terminal_admission_record("kin_db::storage::history_replay"),
+            !ADMISSION_TERMINAL_TARGETS.contains(&"kin_db::storage::history_replay"),
             "the periodic progress target must not be swept up in the suppression"
         );
         assert!(
@@ -5227,10 +5293,39 @@ mod tests {
             quiet,
         );
         tracing::subscriber::with_default(subscriber, || {
+            // The five shapes these two targets actually carry. The two
+            // records name a repository and a workspace at info; the staging
+            // trio names a count; the refusal is a warn.
             tracing::info!(
                 target: "kin_core::git_init",
-                seal = "cca6fdfb",
+                repository = "r", workspace = "w", seal = "cca6fdfb",
                 "admitted exact Git repository as graph-owned Kin authority"
+            );
+            tracing::info!(
+                target: "kin_core::init",
+                repository = "r", workspace = "w", head = "h",
+                "initialized unborn kin repository authority"
+            );
+            tracing::info!(
+                target: "kin_core::init", count = 2, parent = "/tmp",
+                "kin init kept 2 earlier stages because it could not prove them unused"
+            );
+            tracing::warn!(
+                target: "kin_core::init", path = "/tmp/x", error = "denied",
+                "retaining repository stage whose owner lock could not be attempted"
+            );
+            // A warn carrying the record's own fields. This is what the level
+            // test is for, and without this case removing that check changed
+            // nothing observable: the mutation survived, and the check read as
+            // guarded when it was not.
+            tracing::warn!(
+                target: "kin_core::init",
+                repository = "r", workspace = "w",
+                "a warning that happens to name a repository and a workspace"
+            );
+            tracing::info!(
+                target: "kin_core::init", count = 1, bytes = 10, parent = "/tmp",
+                "reclaimed stranded repository initialization stages"
             );
         });
         let captured = buffer.lock().expect("log buffer poisoned").clone();

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -22,12 +22,30 @@ kin_buildinfo::embed_update_build_identity!(
     kin_db::GraphSnapshot::CURRENT_VERSION
 );
 
-/// Orientation for the flat subcommand list. The command surface is wide
-/// because it spans version control, semantic query, sessions, and operations,
-/// and clap renders subcommands as one undifferentiated block with no grouping
-/// primitive. Naming the everyday path here is what separates it from the
-/// benchmarking, hosted-release, and diagnostic commands beside it.
-const AFTER_HELP: &str = "\
+/// What `kin` says about itself, and the everyday path, above the command list.
+///
+/// The command surface is wide because it spans version control, semantic
+/// query, sessions, and operations, and clap renders subcommands as one
+/// undifferentiated block with no grouping primitive. Naming the everyday path
+/// is what separates it from the benchmarking, hosted-release, and diagnostic
+/// commands beside it.
+///
+/// This is `before_help` rather than `after_help`, which is where it used to
+/// be, because position was hiding it. The subcommand list runs to eighty
+/// entries, so on an eighty-column, fifty-row terminal a reader who typed
+/// `kin` saw commands from the fifth line to the ninety-second and never
+/// reached the orientation below them without scrolling back. The lines a
+/// first-time reader needs now come first, and the wide list follows.
+///
+/// The first line is the brand canon's Category line, taken verbatim. The line
+/// it replaces, "Kin semantic VCS", is the "semantic version control"
+/// construction the canon lists under "Retired - do not ship", and it was the
+/// first thing `kin --help` printed. A surface needing a headline takes a
+/// locked line rather than getting a new one, so this is that line and not a
+/// rewrite of it.
+const ORIENTATION: &str = "\
+The system of record for AI-written software.
+
 Start here:
   kin init            admit an existing or new repository
   kin clone <source>  admit a repository from elsewhere
@@ -36,8 +54,10 @@ Start here:
   kin log / kin diff  read the immutable change log and exact changes
 
 Ask the graph:
-  kin locate / search / trace / impact / refs / context
+  kin locate / search / trace / impact / refs / context";
 
+/// What follows the command list: where to read the rest.
+const AFTER_HELP: &str = "\
 `kin capabilities` prints the full readiness matrix, `--json` for machines.";
 
 /// The `[OPEN GATE]` legend, which is only true while something carries the
@@ -75,7 +95,7 @@ fn after_help() -> String {
 #[command(
     name = "kin",
     version = kin_buildinfo::version(),
-    about = "Kin semantic VCS",
+    before_help = ORIENTATION,
     after_help = after_help(),
 )]
 struct Cli {
@@ -2744,10 +2764,71 @@ fn retired_command_signpost(args: &[String]) -> Option<(String, &'static str)> {
 /// Anything clap reports that is not a retired path, including `--help` and
 /// `--version`, is handed back to clap so its exit codes and rendering stay
 /// exactly as they were.
+/// The version text, split into the lines the mark is set beside.
+///
+/// `kin_buildinfo::version()` composes `0.7.2 (<sha> <branch> <time>)`, one
+/// line and eighty-two columns wide, so on an eighty-column terminal the one
+/// thing `kin --version` has to say wrapped. Split, it reads at both widths the
+/// walk measured, and every fact the single line carried is still here.
+///
+/// The empty first element leaves the mark's top row to the mark, which is what
+/// sets the version number against the arm rather than above it.
+fn version_lines(version: &str) -> Vec<String> {
+    let (number, build) = match version.split_once(" (") {
+        Some((number, rest)) => (number, rest.trim_end_matches(')')),
+        None => (version, ""),
+    };
+    vec![
+        String::new(),
+        format!("kin {number}"),
+        CATEGORY_LINE.to_string(),
+        build.to_string(),
+    ]
+}
+
+/// The canon Category line, shared by `--help` and `--version`.
+const CATEGORY_LINE: &str = "The system of record for AI-written software.";
+
+/// What `kin --version` prints.
+///
+/// A terminal gets the mark and the split lines. Anything else gets the exact
+/// single line it got before, because a redirected `kin --version` is being
+/// read by something: the README tells a reader to confirm an install with it
+/// on every install path, and the Homebrew tap, the npm launcher, and every
+/// install script parse it. Four rows of art in that stream would break them
+/// all, so the decision is made once, here, by whether stdout is a terminal.
+fn rendered_version(version: &str, style: Option<kin_cli::mark::MarkStyle>) -> String {
+    match style {
+        Some(style) => kin_cli::mark::beside(
+            style,
+            &version_lines(version)
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+        )
+        .join("\n"),
+        None => format!("kin {version}"),
+    }
+}
+
 fn parse_cli_or_report_retired_command() -> Cli {
     match Cli::try_parse() {
         Ok(cli) => cli,
         Err(err) => {
+            // clap reports `--version` as an error of its own kind and would
+            // print the bare line itself. Taken here so the mark reaches the
+            // one surface a reader hits before anything else, while clap keeps
+            // deciding what counts as asking for the version.
+            if err.kind() == clap::error::ErrorKind::DisplayVersion {
+                println!(
+                    "{}",
+                    rendered_version(
+                        kin_buildinfo::version(),
+                        kin_cli::mark::MarkStyle::for_stdout()
+                    )
+                );
+                std::process::exit(0);
+            }
             if err.kind() == clap::error::ErrorKind::InvalidSubcommand {
                 let args: Vec<String> = std::env::args().skip(1).collect();
                 if let Some((path, guidance)) = retired_command_signpost(&args) {
@@ -2842,6 +2923,8 @@ fn run() -> Result<()> {
         // The fmt layer does not sniff for a terminal, so without this it
         // writes colour escapes into a redirected log or a captured transcript.
         std::io::stderr().is_terminal(),
+        // An operator who set RUST_LOG asked for the records; nobody else did.
+        std::env::var_os("RUST_LOG").is_none(),
     )
     .init();
 
@@ -4329,6 +4412,36 @@ fn is_periodic_admission_progress(target: &str) -> bool {
     target == "kin_db::storage::history_replay"
 }
 
+/// The admission targets whose one event a command's own result restates.
+///
+/// Both carry terminal records: an admission that finished, and a recovered
+/// stale staging. They are raised to `info` for `init` and `clone` because
+/// [`AdmissionProgressLayer`] reads them, and until now the fmt layer rendered
+/// them too. On `kin init` that put a line like
+///
+/// ```text
+/// 2026-09-06T15:58:17Z  INFO kin_core::git_init: admitted exact Git repository as
+/// graph-owned Kin authority path=... repository=... workspace=... generation=1
+/// observed_trees=932 observed_entries=35028 sealed_bodies=1195 ...
+/// seal=cca6fdfb47522ce9...
+/// ```
+///
+/// between the phase ladder and the human result, eight machine fields and a
+/// sixty-four-character seal, on the first command a new reader ever runs. Both
+/// commands already print the path, the repository id, the workspace id and the
+/// generation in their own result blocks, in that reader's own terms, so the
+/// record restates what the next twelve lines say properly.
+///
+/// Only the fmt layer drops them. The progress layer still sees them, `RUST_LOG`
+/// still brings them back in full, and nothing changes for any other command,
+/// because no other command raises these targets above `warn` in the first
+/// place.
+const ADMISSION_TERMINAL_TARGETS: [&str; 2] = ["kin_core::init", "kin_core::git_init"];
+
+fn is_terminal_admission_record(target: &str) -> bool {
+    ADMISSION_TERMINAL_TARGETS.contains(&target)
+}
+
 /// Render an admission progress event onto the live phase line.
 ///
 /// The event's own message is not reused. `history_replay` reports elapsed
@@ -4484,6 +4597,7 @@ fn tracing_stack<W>(
     profile_session: Option<kin_cli::profile::ProfileSession>,
     writer: W,
     ansi: bool,
+    quiet_admission_records: bool,
 ) -> impl tracing::Subscriber + Send + Sync + 'static
 where
     W: for<'writer> tracing_subscriber::fmt::MakeWriter<'writer> + Send + Sync + 'static,
@@ -4496,8 +4610,10 @@ where
                 .with_writer(writer)
                 .with_ansi(ansi)
                 .with_filter(EnvFilter::new(directives).and(
-                    tracing_subscriber::filter::filter_fn(|metadata| {
-                        !is_periodic_admission_progress(metadata.target())
+                    tracing_subscriber::filter::filter_fn(move |metadata| {
+                        let target = metadata.target();
+                        !is_periodic_admission_progress(target)
+                            && !(quiet_admission_records && is_terminal_admission_record(target))
                     }),
                 )),
         )
@@ -4987,6 +5103,10 @@ mod tests {
             Some(session.clone()),
             CapturedLog(buffer.clone()),
             false,
+            // Composition is what is under test here, so the admission record
+            // this asserts on is left reaching the fmt layer. The suppression
+            // has its own test beside this one.
+            false,
         );
 
         tracing::subscriber::with_default(subscriber, || {
@@ -5020,6 +5140,165 @@ mod tests {
                 .map(|span| span.name.as_str())
                 .collect::<Vec<_>>()
         );
+    }
+
+    /// `kin init` no longer prints its own admission record at the reader.
+    ///
+    /// The record is a terminal one, so it landed between the phase ladder and
+    /// the human result with eight machine fields and a sixty-four-character
+    /// seal on it. The result block that follows already names the path, the
+    /// repository, the workspace and the generation, so the record restated
+    /// them in a shape nobody reading a first `kin init` can use.
+    ///
+    /// Both arms, because dropping the record everywhere would take it from the
+    /// operator who asked for it, and that failure is invisible until someone
+    /// needs the log.
+    #[test]
+    fn the_admission_record_is_quiet_by_default_and_returns_under_rust_log() {
+        let quiet = captured_with_quiet_admission(true);
+        assert!(
+            !quiet.contains("admitted exact Git repository"),
+            "the default `kin init` still prints its own admission record; captured {quiet:?}"
+        );
+
+        let asked_for = captured_with_quiet_admission(false);
+        assert!(
+            asked_for.contains("admitted exact Git repository"),
+            "RUST_LOG must still deliver the record; captured {asked_for:?}"
+        );
+    }
+
+    /// The phase ladder's own progress is untouched by the suppression.
+    ///
+    /// The two live on the same directives, so a fix that quietened the record
+    /// by lowering `kin_core::git_init` out of the filter would take the
+    /// ladder's input with it, and the symptom would be a `kin init` that shows
+    /// no phases at all.
+    #[test]
+    fn quieting_the_admission_record_leaves_the_periodic_progress_alone() {
+        assert!(
+            !is_terminal_admission_record("kin_db::storage::history_replay"),
+            "the periodic progress target must not be swept up in the suppression"
+        );
+        assert!(
+            is_periodic_admission_progress("kin_db::storage::history_replay"),
+            "the periodic target must still be the one the ladder reads"
+        );
+        for target in ADMISSION_TERMINAL_TARGETS {
+            assert!(
+                ADMISSION_PROGRESS_TARGETS.contains(&target),
+                "{target} is suppressed on the fmt layer but never raised to info, so the \
+                 suppression is describing a record that was never emitted"
+            );
+        }
+    }
+
+    /// Run one admission record through the stack and return what was written.
+    fn captured_with_quiet_admission(quiet: bool) -> String {
+        let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = tracing_stack(
+            &default_filter_directives("init"),
+            None,
+            CapturedLog(buffer.clone()),
+            false,
+            quiet,
+        );
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!(
+                target: "kin_core::git_init",
+                seal = "cca6fdfb",
+                "admitted exact Git repository as graph-owned Kin authority"
+            );
+        });
+        let captured = buffer.lock().expect("log buffer poisoned").clone();
+        String::from_utf8(captured).expect("captured log is utf-8")
+    }
+
+    /// `kin --version` splits into lines that fit the terminal it is read on.
+    ///
+    /// The composed single line is eighty-two columns, so the one thing this
+    /// command has to say wrapped on an eighty-column terminal. Every fact it
+    /// carried is still here, on lines that fit.
+    #[test]
+    fn the_version_block_keeps_every_fact_and_fits_eighty_columns() {
+        let composed = "0.7.2 (dca8e950e99f6a1cb9afe4359611e2da288004f2 detached \
+                        2026-09-06T08:24:29Z)";
+        let lines = version_lines(composed);
+        assert_eq!(lines[0], "", "the mark keeps its top row");
+        assert_eq!(lines[1], "kin 0.7.2");
+        // The literal, not the constant. Comparing the constant against itself
+        // is an assertion that cannot fail, and it would sit here looking like
+        // one that could.
+        assert_eq!(lines[2], "The system of record for AI-written software.");
+        assert_eq!(
+            lines[3],
+            "dca8e950e99f6a1cb9afe4359611e2da288004f2 detached 2026-09-06T08:24:29Z"
+        );
+
+        for paint in [
+            kin_cli::mark::Paint::Truecolor,
+            kin_cli::mark::Paint::Indexed,
+            kin_cli::mark::Paint::None,
+        ] {
+            let style = kin_cli::mark::MarkStyle::new(kin_cli::mark::Glyphs::Unicode, paint);
+            for line in rendered_version(composed, Some(style)).lines() {
+                let width = console::measure_text_width(line);
+                assert!(
+                    width <= 80,
+                    "the version line {line:?} is {width} columns wide, so it wraps at 80"
+                );
+            }
+        }
+    }
+
+    /// `--help` and `--version` lead with the same line.
+    ///
+    /// The canon line is written twice, once inside [`ORIENTATION`] where a
+    /// clap attribute needs a `const`, and once as [`CATEGORY_LINE`] where
+    /// `--version` needs it. `concat!` takes literals rather than constants, so
+    /// the two cannot be built from one another without a dependency this crate
+    /// does not carry. This is what keeps them from drifting apart, which is
+    /// the failure a reader would meet as two different taglines on two
+    /// commands.
+    #[test]
+    fn the_help_and_the_version_lead_with_the_same_line() {
+        assert!(
+            ORIENTATION.starts_with(CATEGORY_LINE),
+            "help opens with {:?} and --version with {CATEGORY_LINE:?}",
+            ORIENTATION.lines().next().unwrap_or_default()
+        );
+    }
+
+    /// A version string with no build detail still renders.
+    ///
+    /// `kin_buildinfo::version()` composes the parenthesised half from build
+    /// environment variables, and a build that set none of them hands back a
+    /// bare number. Splitting on a separator that is not there must not panic
+    /// on the one command an install script runs to check the install.
+    #[test]
+    fn a_version_with_no_build_detail_still_splits() {
+        let lines = version_lines("0.7.2");
+        assert_eq!(lines[1], "kin 0.7.2");
+        assert_eq!(lines[3], "");
+    }
+
+    /// With no terminal, `--version` is the exact line it has always been.
+    ///
+    /// The README tells a reader to confirm every install path with this
+    /// command, and the Homebrew tap, the npm launcher and every install script
+    /// parse what it prints. `MarkStyle::for_stdout` answers `None` off a
+    /// terminal; this pins what that answer produces, byte for byte, without
+    /// depending on whether the harness running it happens to hold one.
+    #[test]
+    fn a_redirected_version_stays_the_single_line_callers_parse() {
+        let composed = "0.7.2 (dca8e950 detached 2026-09-06T08:24:29Z)";
+        let rendered = rendered_version(composed, None);
+        assert_eq!(
+            rendered, "kin 0.7.2 (dca8e950 detached 2026-09-06T08:24:29Z)",
+            "a redirected --version must be the line every install path already parses"
+        );
+        assert_eq!(rendered.lines().count(), 1);
+        assert!(!rendered.contains('\u{1b}'), "no escapes reach a pipe");
     }
 
     /// With no admission ladder open, a progress event is printed rather than
@@ -5644,6 +5923,60 @@ mod tests {
         });
     }
 
+    /// The orientation has to come before the command list, not merely exist.
+    ///
+    /// It existed for as long as the list did, at the bottom, under eighty
+    /// subcommand lines. On the eighty-column terminal the walk was measured
+    /// on, `kin` printed commands from line five to line ninety-two and the
+    /// orientation at line ninety-four, so the only lines that tell a reader
+    /// what to type first were the ones a fifty-row terminal had already
+    /// scrolled away. Containment alone passes on both layouts, which is why
+    /// this asserts the order.
+    #[test]
+    fn the_orientation_precedes_the_command_list() {
+        on_cli_test_stack(|| {
+            let mut command = Cli::command();
+            let help = command.render_long_help().to_string();
+            let orientation = help
+                .find("Start here:")
+                .expect("help carries the orientation");
+            let commands = help
+                .find("Commands:")
+                .expect("help carries the command list");
+            assert!(
+                orientation < commands,
+                "the orientation is at byte {orientation} and the command list at {commands}, so \
+                 a reader meets eighty subcommands before the five lines that orient them"
+            );
+        });
+    }
+
+    /// Help leads with a locked line, not with a retired construction.
+    ///
+    /// `about = "Kin semantic VCS"` was the first line `kin --help` printed.
+    /// The brand book's canon page lists "semantic version control" under
+    /// "Retired - do not ship", and carries the Category line asserted here for
+    /// exactly this job. A surface needing a headline takes a locked line; it
+    /// does not get a new one.
+    #[test]
+    fn help_leads_with_the_canon_category_line() {
+        on_cli_test_stack(|| {
+            let mut command = Cli::command();
+            let help = command.render_long_help().to_string();
+            assert!(
+                help.starts_with("The system of record for AI-written software."),
+                "help opens with {:?}",
+                help.lines().next().unwrap_or_default()
+            );
+            for retired in ["semantic VCS", "semantic version control"] {
+                assert!(
+                    !help.contains(retired),
+                    "help carries the retired construction {retired:?}"
+                );
+            }
+        });
+    }
+
     /// The legend teaches a marker, so it may only appear while a marker does.
     ///
     /// Asserting the bare string was what let it outlive the thing it
@@ -5668,7 +6001,7 @@ mod tests {
 
             // The conditional is what is under test, so exercise both arms
             // rather than only the one this inventory happens to select.
-            assert!(after_help().contains("Start here:"));
+            assert!(after_help().contains("kin capabilities"));
             assert!(!AFTER_HELP.contains(OPEN_GATE_MARKER));
             assert!(OPEN_GATE_LEGEND.contains(OPEN_GATE_MARKER));
             assert!(

--- a/crates/kin-cli/src/mark.rs
+++ b/crates/kin-cli/src/mark.rs
@@ -389,11 +389,13 @@ mod tests {
                 .find(|(_, character)| character.is_ascii_alphabetic())
                 .map(|(index, _)| line[..index].chars().count())
                 .expect("each line carries its text");
-            assert_eq!(
-                at,
-                MARK_COLUMNS + GUTTER_COLUMNS,
-                "text starts at column {at} on line {line:?}"
-            );
+            // The literal, not `MARK_COLUMNS + GUTTER_COLUMNS`. Written
+            // against the constants, this assertion recomputed its own
+            // expectation whenever either moved, so it held for every value
+            // they could take and guarded nothing. The mutation sweep found it:
+            // dropping the gutter to one column left this test green while its
+            // sibling, written against the literal, went red.
+            assert_eq!(at, 7, "text starts at column {at} on line {line:?}");
         }
     }
 

--- a/crates/kin-cli/src/mark.rs
+++ b/crates/kin-cli/src/mark.rs
@@ -189,21 +189,18 @@ pub fn beside(style: MarkStyle, text: &[&str]) -> Vec<String> {
     out
 }
 
-/// The mark beside `text` when this stdout takes one, and `text` alone when it
-/// does not.
-///
-/// This is what a command calls. It is the only place the decision and the
-/// drawing meet, so a caller cannot draw the mark into a pipe by forgetting to
-/// ask whether it should.
-pub fn beside_for_stdout(text: &[&str]) -> Vec<String> {
-    beside_or_plain(MarkStyle::for_stdout(), text)
-}
-
 /// [`beside`] under a style, and the text alone under none.
 ///
-/// Split from [`beside_for_stdout`] so both arms can be exercised without a
+/// Split from the terminal check so both arms can be exercised without a
 /// terminal. A test that asks for the no-style arm by reimplementing the filter
 /// inline is a test that passes whatever this function does.
+///
+/// This deliberately keeps every non-empty line, which is right for a version
+/// block whose lines are all content and wrong for a header whose title is
+/// decoration. A caller with something that should vanish along with the mark
+/// has to decide that before calling here; `report_header` in `commands/setup`
+/// is what that looks like, and getting it wrong is what put a title into every
+/// piped `kin doctor`.
 ///
 /// The empty lines a caller used to place text against the mark's rows are
 /// dropped here rather than printed as blanks: without the mark there is

--- a/crates/kin-cli/src/mark.rs
+++ b/crates/kin-cli/src/mark.rs
@@ -1,0 +1,559 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! The Kin mark, drawn for a terminal.
+//!
+//! One implementation, three call sites: `kin --version`, the `kin init`
+//! result, and the `kin doctor` header. Nothing else prints it. A mark on every
+//! command is a mark nobody sees, and it would break every caller that reads a
+//! command's first line.
+//!
+//! The shape comes from the brand kit's mark, `docs/brand/assets/svg/
+//! kin-mark-gradient.svg` at v1.2. That file is two filled paths and no
+//! vertical spine: an arm running from the upper right down to the left, and a
+//! leg running from there down to the lower right, separated by a hairline
+//! split. At terminal resolution the split is narrower than a cell, so the rows
+//! below carry it as a one-column notch between the arm's last row and the
+//! leg's first, which is the only way the two strokes stay legible as two.
+//!
+//! The colours are the kit's own `gradient/kin-arm` and `gradient/kin-leg`
+//! stops. A terminal that advertises truecolor gets those hexes exactly; every
+//! other coloured terminal gets four 256-colour indices chosen to hold the same
+//! magenta-to-blue ramp, because a nearest-cube mapping of the four stops
+//! collapses two of them onto one index and the ramp goes flat.
+//!
+//! Four ways out, in the order they are checked. Not a terminal: nothing is
+//! drawn and the caller's text is returned untouched, so a redirected or piped
+//! `kin --version` stays the single line every script already parses. Too
+//! narrow: nothing is drawn, because seven columns of mark on a forty-column
+//! terminal costs more than it gives. A locale that is not UTF-8: the ASCII
+//! rows. Colour off, meaning `NO_COLOR`, `TERM=dumb`, or a pipe: the glyphs
+//! without escapes. `NO_COLOR` is about colour and not about glyphs, so a
+//! terminal under it still gets the mark, in plain text.
+
+use std::io::IsTerminal;
+
+/// The mark's four rows in box-drawing half blocks.
+///
+/// Rows 0 and 1 are the arm, rows 2 and 3 the leg. The leg is indented one
+/// column past where the arm ends, and that offset is the split: without it the
+/// arm's lower half-block and the leg's upper half-block share a column edge,
+/// join into a solid bar, and the mark reads as a plain chevron.
+const UNICODE_ROWS: [&str; 4] = [
+    "  \u{2584}\u{2580}",
+    "\u{2584}\u{2580}",
+    " \u{2580}\u{2584}",
+    "   \u{2580}\u{2584}",
+];
+
+/// The same shape where the locale cannot carry the block characters.
+const ASCII_ROWS: [&str; 4] = ["  /", "/", " \\", "   \\"];
+
+/// Columns reserved for the mark itself, wide enough for the longest row.
+const MARK_COLUMNS: usize = 5;
+
+/// Blank columns between the mark and the text beside it.
+const GUTTER_COLUMNS: usize = 2;
+
+/// Below this terminal width the mark is not drawn at all.
+///
+/// The mark plus its gutter takes [`MARK_COLUMNS`] + [`GUTTER_COLUMNS`] columns
+/// away from every line beside it. On a terminal this narrow the text needs
+/// them more than the mark does.
+const MIN_TERMINAL_COLUMNS: usize = 40;
+
+/// The brand kit's gradient stops, arm first then leg.
+const TRUECOLOR_STOPS: [(u8, u8, u8); 4] = [
+    (0xAE, 0x5A, 0xFF),
+    (0x6C, 0x48, 0xFA),
+    (0x5B, 0x55, 0xFD),
+    (0x3B, 0x74, 0xFB),
+];
+
+/// The same ramp in the 256-colour cube.
+///
+/// Chosen rather than derived. Mapping the four stops to their nearest cube
+/// entries yields 135, 63, 63 and 75: the arm's second stop and the leg's first
+/// land on the same index, so the middle of the mark goes flat exactly where
+/// the split is. These four hold the ramp and keep the four rows distinct.
+const INDEXED_STOPS: [u8; 4] = [141, 99, 63, 69];
+
+/// Which glyphs this terminal can carry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Glyphs {
+    /// Box-drawing half blocks.
+    Unicode,
+    /// Slashes, for a locale that is not UTF-8.
+    Ascii,
+}
+
+/// How much colour this terminal takes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Paint {
+    /// 24-bit escapes carrying the kit's hexes exactly.
+    Truecolor,
+    /// 256-colour indices holding the same ramp.
+    Indexed,
+    /// No escapes at all.
+    None,
+}
+
+/// A decided way to draw the mark here.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MarkStyle {
+    glyphs: Glyphs,
+    paint: Paint,
+}
+
+impl MarkStyle {
+    /// A style named outright, for tests and for a caller that already knows.
+    pub fn new(glyphs: Glyphs, paint: Paint) -> Self {
+        Self { glyphs, paint }
+    }
+
+    /// How the mark should be drawn on this process's stdout, or `None` when it
+    /// should not be drawn at all.
+    ///
+    /// The two `None` cases are the ones that would do harm. A stdout that is
+    /// not a terminal is being read by something, and four rows of art would
+    /// break it. A terminal under [`MIN_TERMINAL_COLUMNS`] cannot spare the
+    /// columns.
+    pub fn for_stdout() -> Option<Self> {
+        if !std::io::stdout().is_terminal() {
+            return None;
+        }
+        if terminal_columns().is_some_and(|columns| columns < MIN_TERMINAL_COLUMNS) {
+            return None;
+        }
+        Some(Self {
+            glyphs: detect_glyphs(),
+            paint: detect_paint(),
+        })
+    }
+
+    fn rows(&self) -> [&'static str; 4] {
+        match self.glyphs {
+            Glyphs::Unicode => UNICODE_ROWS,
+            Glyphs::Ascii => ASCII_ROWS,
+        }
+    }
+
+    /// One row of the mark, painted if this style paints.
+    fn paint_row(&self, index: usize, row: &str) -> String {
+        if row.is_empty() {
+            return String::new();
+        }
+        match self.paint {
+            Paint::None => row.to_string(),
+            Paint::Truecolor => {
+                let (r, g, b) = TRUECOLOR_STOPS[index.min(TRUECOLOR_STOPS.len() - 1)];
+                format!("\u{1b}[38;2;{r};{g};{b}m{row}\u{1b}[0m")
+            }
+            Paint::Indexed => {
+                let code = INDEXED_STOPS[index.min(INDEXED_STOPS.len() - 1)];
+                format!("\u{1b}[38;5;{code}m{row}\u{1b}[0m")
+            }
+        }
+    }
+}
+
+/// The mark with `text` set beside it, one text line per mark row.
+///
+/// Index-aligned on purpose: the caller decides which row a line sits on by
+/// where it puts the line, and an empty string leaves that row to the mark
+/// alone. More text lines than mark rows is fine; they continue under the mark,
+/// indented to the same column so the block stays one shape.
+///
+/// A row with no text ends at the last glyph. Trailing spaces on a mark row
+/// would be invisible on screen and would show up in every captured transcript,
+/// every snapshot, and every terminal that highlights them.
+pub fn beside(style: MarkStyle, text: &[&str]) -> Vec<String> {
+    let rows = style.rows();
+    let indent = MARK_COLUMNS + GUTTER_COLUMNS;
+    let height = rows.len().max(text.len());
+    let mut out = Vec::with_capacity(height);
+    for index in 0..height {
+        let glyph = rows.get(index).copied().unwrap_or("");
+        let line = text.get(index).copied().unwrap_or("");
+        if line.is_empty() {
+            out.push(style.paint_row(index, glyph));
+            continue;
+        }
+        let pad = indent.saturating_sub(glyph.chars().count());
+        out.push(format!(
+            "{}{}{line}",
+            style.paint_row(index, glyph),
+            " ".repeat(pad)
+        ));
+    }
+    out
+}
+
+/// The mark beside `text` when this stdout takes one, and `text` alone when it
+/// does not.
+///
+/// This is what a command calls. It is the only place the decision and the
+/// drawing meet, so a caller cannot draw the mark into a pipe by forgetting to
+/// ask whether it should.
+pub fn beside_for_stdout(text: &[&str]) -> Vec<String> {
+    beside_or_plain(MarkStyle::for_stdout(), text)
+}
+
+/// [`beside`] under a style, and the text alone under none.
+///
+/// Split from [`beside_for_stdout`] so both arms can be exercised without a
+/// terminal. A test that asks for the no-style arm by reimplementing the filter
+/// inline is a test that passes whatever this function does.
+///
+/// The empty lines a caller used to place text against the mark's rows are
+/// dropped here rather than printed as blanks: without the mark there is
+/// nothing for them to align to, and a leading blank line would still change
+/// what a reader of the output sees.
+pub fn beside_or_plain(style: Option<MarkStyle>, text: &[&str]) -> Vec<String> {
+    match style {
+        Some(style) => beside(style, text),
+        None => text
+            .iter()
+            .filter(|line| !line.is_empty())
+            .map(|line| (*line).to_string())
+            .collect(),
+    }
+}
+
+/// This terminal's width, when it can be read.
+fn terminal_columns() -> Option<usize> {
+    let (_, columns) = console::Term::stdout().size_checked()?;
+    Some(usize::from(columns))
+}
+
+/// The glyphs this locale can carry.
+///
+/// The first of the three locale variables that is set and non-empty decides
+/// it, which is the order POSIX gives them. None set at all means Unicode:
+/// Windows sets none of them and its console reads UTF-8, and the CLI already
+/// prints check marks and arrows on every platform, so ASCII here would be a
+/// fallback for a case that does not arise while making the common case worse.
+fn detect_glyphs() -> Glyphs {
+    let values: Vec<Option<String>> = ["LC_ALL", "LC_CTYPE", "LANG"]
+        .into_iter()
+        .map(|name| std::env::var_os(name).map(|value| value.to_string_lossy().into_owned()))
+        .collect();
+    glyphs_for_locale(&values)
+}
+
+/// The glyph choice for a given set of locale values, in POSIX precedence.
+///
+/// Split from the environment read so both arms are testable: no test in this
+/// binary can set an environment variable without racing every other test in
+/// it, and a test that asserts on a locale string it wrote itself proves
+/// nothing about the function that reads one.
+fn glyphs_for_locale(values: &[Option<String>]) -> Glyphs {
+    for value in values {
+        let Some(value) = value else { continue };
+        if value.is_empty() {
+            continue;
+        }
+        return if value.to_ascii_lowercase().contains("utf") {
+            Glyphs::Unicode
+        } else {
+            Glyphs::Ascii
+        };
+    }
+    Glyphs::Unicode
+}
+
+/// How much colour to use, deferring to the CLI's one colour decision.
+fn detect_paint() -> Paint {
+    if !crate::output_style::enabled() {
+        return Paint::None;
+    }
+    match std::env::var("COLORTERM") {
+        Ok(value)
+            if value.eq_ignore_ascii_case("truecolor") || value.eq_ignore_ascii_case("24bit") =>
+        {
+            Paint::Truecolor
+        }
+        _ => Paint::Indexed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The plain mark, which every other rendering is a variation of.
+    ///
+    /// Written out rather than built from the constants: a snapshot that
+    /// composes itself from the same source it is checking passes whatever that
+    /// source becomes, and this one exists to notice the shape changing.
+    #[test]
+    fn the_unicode_mark_is_the_split_k() {
+        let drawn = beside(MarkStyle::new(Glyphs::Unicode, Paint::None), &[]);
+        assert_eq!(
+            drawn,
+            vec![
+                "  \u{2584}\u{2580}".to_string(),
+                "\u{2584}\u{2580}".to_string(),
+                " \u{2580}\u{2584}".to_string(),
+                "   \u{2580}\u{2584}".to_string(),
+            ]
+        );
+    }
+
+    /// The split is what separates the mark from a plain chevron.
+    ///
+    /// The arm's last row ends at column 1 and the leg's first row starts at
+    /// column 1 with a half block on the opposite side, so the two strokes meet
+    /// diagonally rather than sharing a column edge. Delete the leading space
+    /// on row 2 and the mark becomes a solid `<`, which is the failure this
+    /// pins.
+    #[test]
+    fn the_arm_and_the_leg_do_not_share_a_column() {
+        let arm_last = UNICODE_ROWS[1];
+        let leg_first = UNICODE_ROWS[2];
+        let arm_end = arm_last.chars().count();
+        let leg_start = leg_first
+            .chars()
+            .position(|character| character != ' ')
+            .expect("the leg's first row draws something");
+        assert!(
+            leg_start >= arm_end - 1,
+            "the leg starts at column {leg_start} and the arm ends at column {arm_end}, so the \
+             two strokes share a column and the split is gone"
+        );
+    }
+
+    /// The ASCII rows carry the same shape at the same columns.
+    #[test]
+    fn the_ascii_mark_holds_the_shape() {
+        let drawn = beside(MarkStyle::new(Glyphs::Ascii, Paint::None), &[]);
+        assert_eq!(
+            drawn,
+            vec![
+                "  /".to_string(),
+                "/".to_string(),
+                " \\".to_string(),
+                "   \\".to_string(),
+            ]
+        );
+    }
+
+    /// Truecolor paints the kit's own hexes, one stop per row.
+    #[test]
+    fn truecolor_paints_the_brand_stops() {
+        let drawn = beside(MarkStyle::new(Glyphs::Unicode, Paint::Truecolor), &[]);
+        assert_eq!(
+            drawn,
+            vec![
+                "\u{1b}[38;2;174;90;255m  \u{2584}\u{2580}\u{1b}[0m".to_string(),
+                "\u{1b}[38;2;108;72;250m\u{2584}\u{2580}\u{1b}[0m".to_string(),
+                "\u{1b}[38;2;91;85;253m \u{2580}\u{2584}\u{1b}[0m".to_string(),
+                "\u{1b}[38;2;59;116;251m   \u{2580}\u{2584}\u{1b}[0m".to_string(),
+            ]
+        );
+    }
+
+    /// The 256-colour ramp keeps four distinct indices.
+    #[test]
+    fn the_indexed_ramp_has_four_distinct_stops() {
+        let drawn = beside(MarkStyle::new(Glyphs::Unicode, Paint::Indexed), &[]);
+        assert_eq!(
+            drawn,
+            vec![
+                "\u{1b}[38;5;141m  \u{2584}\u{2580}\u{1b}[0m".to_string(),
+                "\u{1b}[38;5;99m\u{2584}\u{2580}\u{1b}[0m".to_string(),
+                "\u{1b}[38;5;63m \u{2580}\u{2584}\u{1b}[0m".to_string(),
+                "\u{1b}[38;5;69m   \u{2580}\u{2584}\u{1b}[0m".to_string(),
+            ]
+        );
+        let mut seen: Vec<u8> = INDEXED_STOPS.to_vec();
+        seen.sort_unstable();
+        seen.dedup();
+        assert_eq!(
+            seen.len(),
+            INDEXED_STOPS.len(),
+            "two rows of the mark share a 256-colour index, so the ramp is flat where they meet"
+        );
+    }
+
+    /// Every text line starts at the same column, whatever its row draws.
+    #[test]
+    fn text_beside_the_mark_is_left_aligned() {
+        let drawn = beside(
+            MarkStyle::new(Glyphs::Unicode, Paint::None),
+            &["one", "two", "three", "four"],
+        );
+        for line in &drawn {
+            let at = line
+                .char_indices()
+                .find(|(_, character)| character.is_ascii_alphabetic())
+                .map(|(index, _)| line[..index].chars().count())
+                .expect("each line carries its text");
+            assert_eq!(
+                at,
+                MARK_COLUMNS + GUTTER_COLUMNS,
+                "text starts at column {at} on line {line:?}"
+            );
+        }
+    }
+
+    /// Text longer than the mark keeps the same indent under it.
+    #[test]
+    fn text_past_the_last_row_stays_indented() {
+        let drawn = beside(
+            MarkStyle::new(Glyphs::Unicode, Paint::None),
+            &["", "", "", "", "fifth"],
+        );
+        assert_eq!(drawn.len(), 5);
+        assert_eq!(drawn[4], format!("{}fifth", " ".repeat(7)));
+    }
+
+    /// A row the caller left to the mark carries no trailing spaces.
+    #[test]
+    fn a_mark_only_row_ends_at_its_last_glyph() {
+        for style in [
+            MarkStyle::new(Glyphs::Unicode, Paint::None),
+            MarkStyle::new(Glyphs::Unicode, Paint::Truecolor),
+            MarkStyle::new(Glyphs::Ascii, Paint::None),
+        ] {
+            for line in beside(style, &["", "", "", ""]) {
+                assert!(
+                    !line.ends_with(' '),
+                    "the row {line:?} pads past its last glyph"
+                );
+            }
+        }
+    }
+
+    /// The whole block fits the terminals the walk was measured at.
+    ///
+    /// Both widths, and the width the mark itself costs is checked separately
+    /// so a regression says which of the two moved.
+    #[test]
+    fn the_block_fits_eighty_and_one_hundred_and_twenty_columns() {
+        let text = [
+            "",
+            "kin 0.7.2",
+            "The system of record for AI-written software.",
+            "",
+        ];
+        for style in [
+            MarkStyle::new(Glyphs::Unicode, Paint::None),
+            MarkStyle::new(Glyphs::Unicode, Paint::Truecolor),
+            MarkStyle::new(Glyphs::Unicode, Paint::Indexed),
+            MarkStyle::new(Glyphs::Ascii, Paint::None),
+        ] {
+            for line in beside(style, &text) {
+                let width = console::measure_text_width(&line);
+                assert!(
+                    width <= 80,
+                    "the line {line:?} is {width} columns wide, so it wraps at 80"
+                );
+            }
+        }
+    }
+
+    /// The mark never costs more than the columns it reserved.
+    #[test]
+    fn the_mark_stays_inside_its_own_columns() {
+        for rows in [UNICODE_ROWS, ASCII_ROWS] {
+            for row in rows {
+                let width = console::measure_text_width(row);
+                assert!(
+                    width <= MARK_COLUMNS,
+                    "the row {row:?} is {width} columns wide, past the {MARK_COLUMNS} reserved"
+                );
+            }
+        }
+    }
+
+    /// Colour is escapes and nothing else.
+    ///
+    /// Stripping them from a painted block yields the unpainted block exactly,
+    /// which is what lets a caller reason about width without knowing whether
+    /// colour is on.
+    #[test]
+    fn stripping_the_escapes_yields_the_plain_block() {
+        let text = ["", "kin 0.7.2", "", ""];
+        let plain = beside(MarkStyle::new(Glyphs::Unicode, Paint::None), &text);
+        for paint in [Paint::Truecolor, Paint::Indexed] {
+            let painted = beside(MarkStyle::new(Glyphs::Unicode, paint), &text);
+            let stripped: Vec<String> = painted
+                .iter()
+                .map(|line| console::strip_ansi_codes(line).into_owned())
+                .collect();
+            assert_eq!(stripped, plain, "painting changed more than the colour");
+        }
+    }
+
+    /// With no style, the caller's text is all that is printed.
+    ///
+    /// This is the shape a pipe gets, and it is why `kin --version | cat` is
+    /// still one line that a script can read. The empty rows a caller placed
+    /// text against go with the mark, so no leading blank line survives either.
+    #[test]
+    fn without_a_style_only_the_text_survives() {
+        assert_eq!(
+            beside_or_plain(None, &["", "kin 0.7.2", "", ""]),
+            vec!["kin 0.7.2".to_string()]
+        );
+        assert_eq!(
+            beside_or_plain(None, &["", "one", "two", ""]),
+            vec!["one".to_string(), "two".to_string()]
+        );
+    }
+
+    /// A locale that names a non-UTF-8 charset takes the ASCII rows.
+    #[test]
+    fn a_non_utf8_locale_name_selects_ascii() {
+        let set = |value: &str| vec![None, None, Some(value.to_string())];
+        for name in ["en_US.ISO8859-1", "C", "POSIX", "ru_RU.KOI8-R"] {
+            assert_eq!(
+                glyphs_for_locale(&set(name)),
+                Glyphs::Ascii,
+                "{name} must not be read as UTF-8"
+            );
+        }
+        for name in ["en_US.UTF-8", "C.utf8", "en_GB.UTF8"] {
+            assert_eq!(
+                glyphs_for_locale(&set(name)),
+                Glyphs::Unicode,
+                "{name} must be read as UTF-8"
+            );
+        }
+    }
+
+    /// The first locale value that is set decides, and an empty one does not.
+    ///
+    /// POSIX gives `LC_ALL` precedence over `LC_CTYPE` over `LANG`, and an
+    /// empty value is unset rather than a charset name. A loop that returned on
+    /// the first Some rather than the first non-empty Some would read an
+    /// exported-but-empty `LC_ALL`, which is common, as a non-UTF-8 locale and
+    /// hand every such terminal the ASCII rows.
+    #[test]
+    fn locale_precedence_skips_empty_values() {
+        assert_eq!(
+            glyphs_for_locale(&[
+                Some("en_US.UTF-8".to_string()),
+                Some("C".to_string()),
+                Some("C".to_string())
+            ]),
+            Glyphs::Unicode,
+            "LC_ALL must win"
+        );
+        assert_eq!(
+            glyphs_for_locale(&[
+                Some(String::new()),
+                Some(String::new()),
+                Some("en_US.UTF-8".to_string())
+            ]),
+            Glyphs::Unicode,
+            "an empty value must be skipped rather than read as a charset"
+        );
+        assert_eq!(
+            glyphs_for_locale(&[None, None, None]),
+            Glyphs::Unicode,
+            "no locale set at all is the Windows case, and its console reads UTF-8"
+        );
+    }
+}


### PR DESCRIPTION
## What a Show HN reader meets today

Walked the released v0.7.2 macOS archive, sha-verified against the published
`checksums-sha256.txt` (`51587ec352ec29d081d139fc569ccf0431669c52dc870b7a475bee312e0422ea`),
installed into a scratch prefix per its own INSTALL.md, called by absolute path, under a pty at
80 and 120 columns with `env -i` and no `KIN_*` set at all.

    kin --version   one line, 82 columns, so it wraps at 80. No mark anywhere in the CLI:
                    `grep -ni "banner\|ascii_art\|logo" crates/kin-cli/src` finds no rendering
                    code, only unrelated prose in doc comments.

    kin --help      110 lines. Lines 5 to 92 are 80 subcommands. The `Start here:` block that
                    names the five commands a new user wants is at line 94, below all of them.

    kin init        after 93 seconds on a 931-commit repository, the result carries
                    `Workspace head: {"type":"symbolic","target":{"bytes_hex":"726566732f…"}}`
                    (that hex is `refs/heads/master`), a raw `INFO kin_core::git_init` record
                    with eight machine fields and a 64-hex seal, and no next step.

    kin doctor      47 lines, 33 over 80 columns and 27 over 120. The longest is 778 characters
                    inside a table row whose columns are aligned for a short value, so a terminal
                    reflows it to the left margin and the table's alignment is destroyed by its
                    own content. Sixteen strings carried an em dash, eight of them visible in this one screen.

And the first line of `kin --help` was `Kin semantic VCS`. The brand book's canon page lists
"semantic version control" under **Retired - do not ship**, and carries the Category line for
exactly this job.

## What this changes

**A Kin mark, one implementation, on the first-run and health surfaces.**
`crates/kin-cli/src/mark.rs`, drawn on `kin --version`, the `kin init` result, and the report
header that `kin doctor`, `kin setup` and `kin setup status` share. Five commands, not three: an
earlier draft of this body said three and no others, which was false, and the measurement offered
for it counted glyphs in `kin --help`, bare `kin` and `kin --version`, none of which were ever in
question. The measurement above now samples every command the claim is about, including the two
that made the earlier one wrong.

It is drawn on no query command and on neither help surface. The shape
comes from `docs/brand/assets/svg/kin-mark-gradient.svg` at brand kit v1.2: two filled paths, no
vertical spine, an arm and a leg split by a hairline. At terminal resolution that split is
narrower than a cell, so the rows carry it as a one-column notch. Without the notch the two half
blocks share a column edge, join into a bar, and the mark reads as a plain chevron; a test pins
it. Colour is the kit's own `gradient/kin-arm` and `gradient/kin-leg` stops in truecolor, and
four hand-chosen 256-colour indices elsewhere, because the nearest-cube mapping of those stops
collapses two rows onto one index and flattens the ramp exactly where the split is.

**Help leads with the orientation and the canon line.** The `Start here:` block moved from
`after_help` to `before_help`, and the tagline is now `The system of record for AI-written
software.`, taken verbatim from the canon rather than rewritten.

**`kin init` says what it did and what to do next.** The workspace head is rendered through
`status::render_head` instead of serialised, the raw admission record no longer reaches the fmt
layer on the default filter, and the block ends by naming `kin locate` and `kin status`.

**`kin doctor` fits its terminal and drops its em dashes.** A detail too long for its row prints
under it, wrapped, at indent six. Sixteen strings carried one, measured against `origin/main`, not the eight
visible in a single captured screen. Seven of those were an `n/a - ` prefix whose status column
already said `n/a`, so those lines lost a duplicated status word too; the rest were restated
rather than punctuation-swapped.

## Nothing here can reach a script or an acceptance suite

Every change to what is *drawn* is gated on stdout being a terminal. `kin --version` off a
terminal is byte-identical to what it has always printed, which matters because the README tells
a reader to confirm every install path with it and the Homebrew tap, the npm launcher and every
install script parse it.

This claim was false when this pull request first opened, and the correction is the reason to
read it carefully now. The `kin doctor` title was drawn beside the mark but gated separately from
it, so every piped `kin doctor` gained a first line reading `Kin doctor`. The measurement that
would have caught it was in this body: `piped 48 lines after, 47 before`. The title and the mark
are now one unit in one `match`, and a test pins the shape of the defect rather than the shape of
the fix.

No script under `scripts/acceptance/` allocates a pty, so none of them ever sees a mark or a
wrapped row:

```
$ grep -rln "import pty\|openpty\|pexpect\|winpty" scripts/acceptance/
$ grep -rln "subprocess" scripts/acceptance/ | wc -l
      32
```

The second command is the positive control: a search that could not read that directory would
return nothing for both, and the first result alone would look like proof.

The changes that were wrong on every path (the hex head, the raw record, the em dashes, the
retired tagline, the orientation's position) are not gated, on purpose.

## Falsification

Every new test broken on purpose, one mutation at a time, each restored by rewriting the file
from a copy rather than by `git checkout`. Red tails below.

Twenty-two mutations, each applied alone, tests run, then the file restored by rewriting it
from a copy rather than by `git checkout`. Every one turns the test it targets red:

    f01-split            red      the_arm_and_the_leg_do_not_share_a_column, the_unicode_mark_is_the_split_k
    f02-ascii            red      the_ascii_mark_holds_the_shape
    f03-ramp             red      the_indexed_ramp_has_four_distinct_stops
    f04-stop             red      truecolor_paints_the_brand_stops
    f05-gutter           red      text_past_the_last_row_stays_indented, text_beside_the_mark_is_left_aligned
    f06-pad              red      a_mark_only_row_ends_at_its_last_glyph
    f07-rowwidth         red      the_mark_stays_inside_its_own_columns
    f08-blockwidth       red      the_block_fits_eighty_and_one_hundred_and_twenty_columns
    f09-escapes          red      stripping_the_escapes_yields_the_plain_block
    f10-plainarm         red      without_a_style_only_the_text_survives
    f11-emptylocale      red      locale_precedence_skips_empty_values
    f12-utf              red      a_non_utf8_locale_name_selects_ascii
    f13-headjson         red      the_workspace_head_line_names_the_ref_rather_than_serializing_it
    f14-nextstep         red      the_result_ends_by_naming_the_next_command
    f15-wrap             red      a_detail_that_does_not_fit_its_row_moves_under_it
    f16-capture          red      a_captured_report_is_never_rewrapped
    f17-wordloss         red      wrapping_preserves_every_word_and_splits_none
    f18-emdash           red      no_em_dash_reaches_a_reader_from_this_file
    f19-versionsplit     red      the_version_block_keeps_every_fact_and_fits_eighty_columns
    f20-stepalign        red      the_result_ends_by_naming_the_next_command
    f21-fixwrap          red      a_fix_line_that_does_not_fit_wraps_under_its_label
    f22-emdash-escape    red      no_em_dash_reaches_a_reader_from_this_file

Read by a classifier rather than by exit code, because a build break and a failing test both exit
101. Each log has to show the named test `FAILED` with zero `error[E...]` or `could not compile`
lines; anything else was re-run. That classifier caught four defects in these tests that a green
build would never have shown:

- `f04` returned 101 from a compile error I caused by editing a file mid-sweep, and read as proof.
- `f05` showed `text_beside_the_mark_is_left_aligned` computing its expectation from
  `MARK_COLUMNS + GUTTER_COLUMNS`, the same constants the mutation changes, so it could not fail.
- `f21` named a test that called `wrap_words` directly and never reached the function the mutation
  changed. The function printed as it went and had no seam; it is now split into `labelled_lines`
  and a printer.
- `f22` showed the em-dash guard could not fire: `to_uppercase`, added to make the hex
  case-insensitive, turns the `u` of `\u{...}` into `U`, so the needle matched nothing. The hex is
  four digits with no letters, so the fold is gone.

One red tail in full, `f13-headjson`, which serializes the workspace head again:

```
ead: {\"type\":\"symbolic\",\"target\":{\"bytes_hex\":\"726566732f68656164732f6d6173746572\"}}"
 right: "  Workspace head: symbolic refs/heads/master"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
failures:
    commands::init::tests::the_workspace_head_line_names_the_ref_rather_than_serializing_it
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2238 filtered out; finished in 0.02s
   Compiling kin-buildinfo v0.7.3 (/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/clilook-kin/crates/kin-buildinfo)
   Compiling kin-cli v0.7.3 (/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/clilook-kin/crates/kin-cli)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 35.37s
warning: the following packages contain code that will be rejected by a future version of Rust: block v0.1.6
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
     Running unittests src/lib.rs (/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/cargo-target/clilook-kin/debug/deps/kin_cli-a8cae6ae3b50d890)
error: test failed, to rerun pass `-p kin-cli --lib`
```


## Verification

Everything through `.kin-coord/bin/heavy-slot.sh clilook kin`, never a bare cargo.

    cargo test -p kin-cli --lib --bin kin    2239 lib + 44 bin, 0 failed
    cargo fmt --all                          applied
    cargo build --release                    kin and kin-daemon
    bash scripts/zero_file_search_guard.sh   rc 0, 71 answer modules graph-clean
    python3 scripts/check-quarantine.py      rc 0, 1 ticketed row, pre-existing

Measured on the release build of the head this pull request carries, under a pty, `env -i`, no `KIN_*` set. Each number with the command that produced it and the output behind it:

### kin doctor at 80 columns

    $ kin doctor   # under a pty of 80 columns, ANSI stripped before measuring
    released v0.7.2   47 lines, 33 over the margin, longest 778
    this branch      116 lines,  1 over the margin, longest 101

### kin doctor at 120 columns

    $ kin doctor   # under a pty of 120 columns, ANSI stripped before measuring
    released v0.7.2   46 lines, 18 over the margin, longest 778
    this branch       85 lines,  0 over the margin, longest 120

### kin --version at 80 columns

    $ kin --version   # under a pty of 80 columns
    released v0.7.2  longest 82, 1 over the margin
    this branch      longest 53, 0 over the margin

### kin init, what left the human path (released v0.7.2)

    $ kin init .   # full clone of dtolnay/anyhow, 931 commits
    lines carrying kin_core::git_init : 1
    lines carrying bytes_hex          : 1
    Workspace head: {"type":"symbolic","target":{"bytes_hex":"726566732f68656164732f6d6173746572"}}

### kin init, what left the human path (this branch)

    $ kin init .   # full clone of dtolnay/anyhow, 931 commits
    lines carrying kin_core::git_init : 0
    lines carrying bytes_hex          : 0
    Workspace head: symbolic refs/heads/master

### which commands draw the mark

    $ count lines carrying a mark glyph in each capture
    draws it, on a terminal
      kin --version      4 lines carry a mark glyph
      kin init           4 lines carry a mark glyph
      kin doctor         4 lines carry a mark glyph
      kin setup status   4 lines carry a mark glyph
    must not draw it
      kin --help         0 lines carry a mark glyph
      kin                0 lines carry a mark glyph
    piped, where nothing may draw it
      kin doctor         0 lines carry a mark glyph
      kin setup status   0 lines carry a mark glyph


## Known limits, named rather than left for a reader to find

**The wrapper can split a backticked command.** `wrap_words` breaks on whitespace and knows
nothing about quoting, so a long backticked run can straddle a line. Reproduced rather than
assumed: `run \`kin vfs on --mode nfs\` to engage it` splits at 20 and 24 columns and does not at
28 or 34, so it needs a narrow terminal and a long command together. Teaching the wrapper about
quoting is a real improvement and a different change from this one.

**The root command has no `about`.** The identity line moved into `before_help`, where it can sit
above the orientation, and nothing was put back in the `about` slot. Nothing reads it: every
`get_about` caller in the tree is scoped to subcommands. Still worth closing if anything ever
generates documentation from the clap tree.

**The mark is drawn at one size.** Four rows, five columns, whatever the terminal. Below forty
columns it is not drawn at all rather than drawn smaller, which is the right call for this change
and not obviously the right call forever.

**The 256-colour ramp is hand-picked, not derived.** Four indices chosen to hold the brand's
magenta-to-blue gradient, because mapping the four stops to their nearest cube entries collapses
two onto one index. That means a future change to the brand stops will not flow through to the
indexed path on its own.

## Follow-ups this change does not take

Named rather than left for the next reader to rediscover.

**The guard test's floor equals the call-site count.** `no_call_site_prints_this_report_without_
naming_its_command` requires at least four call sites and there are exactly four, so the floor
catches a scan that read nothing and not a call site that was deleted. A floor that tracks the
real count would need updating on every change; this one is honest about being a
did-the-scan-run check.

**A wrong title is not caught.** The guard requires every call site to pass `Some("...")`, not
that the string names the right command. `kin setup` passing `Some("Kin doctor")` would satisfy
it. Catching that means the call site and the command name meeting in one place, which the four
call sites do not currently share.

**`report_header`'s `None` arm has no shipping caller.** It is kept because the two arguments are
independent and a caller that has already announced itself is a reasonable thing to have, but
nothing exercises it outside its test.

**No capture of `kin doctor --fix` is in the walk.** The mark on that path was verified by running
the shipping binary and counting glyphs, not by a captured screen beside the others.

**The `kin init` capture carries a scratch worktree path.** Every screenshot shows
`/private/tmp/clilook-walk/...`, which is where the walk ran. It is honest and it is noise.

**The mark lands mid-output on two paths.** `kin init` and `kin doctor` both print progress before
the header, so the mark appears partway down rather than at the top of what the reader sees. That
is inherent to those commands announcing themselves after they have done work, and moving it
means deciding what "the top" is for a command that streams.
