### PR TITLE
Say when a held rail's tag was never cut, and name the publisher that is off

### DIFF
--- a/scripts/release-hold-alarm.mjs
+++ b/scripts/release-hold-alarm.mjs
@@ -69,6 +69,30 @@ function describeFailedRelease(marker) {
   return `The Release run that owns it is ${url || `run ${id}`} (id ${id}).`;
 }
 
+// The one hold reason that means the blocking tag does not exist.
+//
+// Both exits this body used to name unconditionally assume the tag is real.
+// Recovery retries the Release run that tag produced, and abandonment records
+// the tag in `scripts/abandoned-release-tags.json`, whose entries carry a `sha`
+// and a `failed_release_run_id`. A tag nobody ever created has neither, so a
+// reader who tries either one spends the trip and arrives nowhere.
+//
+// The train already tells the two apart and this reader used to throw that away.
+// `.github/workflows/release-train.yml` fetches every tag
+// (`git fetch origin "+refs/tags/*:refs/tags/*"`) BEFORE it decides, and only
+// then writes this reason, under `if ! git rev-parse --verify --quiet
+// "${tag}^{commit}"`. So the code is a proof taken against a complete tag set
+// that the tag this alarm names was never cut. `tag_not_finalized`, the other
+// reason that reaches this body, is written when a tag does exist and is not
+// GitHub Latest, and both original exits apply there unchanged.
+//
+// This is not a cosmetic wrong. On 2026-09-07 the alarm fired truthfully and on
+// time, and a captain and a lane still spent about forty minutes establishing
+// that a workflow switch was off, because the body sent them to a Release run
+// that had never started and to a tag that had never been created. The real
+// cause was reachable in two API calls that nothing told them to make.
+export const STAGED_REASON = "tag_staged";
+
 export function buildBody(marker, consecutive, threshold) {
   const drift = marker.drift;
   const blocking = marker.blocking_tag || "an unresolved tag";
@@ -88,24 +112,76 @@ export function buildBody(marker, consecutive, threshold) {
   lines.push(`Hold reason reported by the train: ${marker.detail || marker.reason || "unreported"}.`);
   lines.push(`Most recent train run: ${marker.run_url || `run ${marker.run_id ?? "unknown"}`}.`);
   lines.push("");
-  lines.push(describeFailedRelease(marker));
-  lines.push("");
-  lines.push("There are two ways out, and both of them move the rail.");
-  lines.push("");
-  lines.push(
-    "Recover the release. If the defect that blocks the tag can still be " +
-      "reached, fix it and let Release Recovery retry the tag. A tag run " +
-      "resolves its workflows from the tag, so confirm the fix is reachable " +
-      "from the tagged tree before spending a retry on it.",
-  );
-  lines.push("");
-  lines.push(
-    "Record the abandonment. If the defect is frozen into the tag, add the " +
-      "tag to `scripts/abandoned-release-tags.json` with all five required " +
-      "fields, prove the entry with `python3 " +
-      "scripts/select-admissible-release-tag.py`, and land it. The train steps " +
-      "past a tag only on a reviewed record.",
-  );
+  if (marker.reason === STAGED_REASON) {
+    lines.push(
+      `\`${blocking}\` was never cut. The train reports it as staged on main, ` +
+        "which it writes only after fetching every tag and finding that ref " +
+        "absent. This is a tag that does not exist, not a tag whose release " +
+        "failed.",
+    );
+    lines.push("");
+    lines.push(
+      "The two usual exits do not apply, and both will waste the trip. " +
+        "Recovery retries the Release run that owns a tag, and no Release run " +
+        "has ever started for this one. Abandonment records a tag in " +
+        "`scripts/abandoned-release-tags.json`, whose entries carry a `sha` " +
+        "and a `failed_release_run_id` that an uncut tag cannot supply.",
+    );
+    lines.push("");
+    lines.push(
+      "What is stuck is candidate selection. " +
+        "`.github/workflows/release-tag.yml` tags the newest reviewed main " +
+        "commit in the staged version's range carrying " +
+        "`evidence/<sha>/preflight.json` on the `release-evidence` branch. " +
+        "With no such commit it reports having no candidate and exits 0, " +
+        "which is why every mint run reads green while the rail stands still.",
+    );
+    lines.push("");
+    lines.push(
+      "The only automated publisher of that record is `Release Cut`, " +
+        "`.github/workflows/release-cut.yml`, which this fleet operates as a " +
+        "switch rather than leaving on. Read these two before looking " +
+        "anywhere else:",
+    );
+    lines.push("");
+    lines.push("```");
+    lines.push(
+      "gh api repos/{owner}/{repo}/actions/workflows/release-cut.yml --jq .state",
+    );
+    lines.push(
+      'gh api "repos/{owner}/{repo}/git/trees/release-evidence?recursive=1" \\',
+    );
+    lines.push(
+      "  --jq '[.tree[].path | select(endswith(\"preflight.json\"))] | length'",
+    );
+    lines.push("```");
+    lines.push("");
+    lines.push(
+      "`disabled_manually` is the whole answer: no candidate can exist until " +
+        "that workflow is enabled. Enabling it opens a window in which the " +
+        "cut proves whatever is newest and green, so it is a decision to take " +
+        "deliberately rather than an automatic repair.",
+    );
+  } else {
+    lines.push(describeFailedRelease(marker));
+    lines.push("");
+    lines.push("There are two ways out, and both of them move the rail.");
+    lines.push("");
+    lines.push(
+      "Recover the release. If the defect that blocks the tag can still be " +
+        "reached, fix it and let Release Recovery retry the tag. A tag run " +
+        "resolves its workflows from the tag, so confirm the fix is reachable " +
+        "from the tagged tree before spending a retry on it.",
+    );
+    lines.push("");
+    lines.push(
+      "Record the abandonment. If the defect is frozen into the tag, add the " +
+        "tag to `scripts/abandoned-release-tags.json` with all five required " +
+        "fields, prove the entry with `python3 " +
+        "scripts/select-admissible-release-tag.py`, and land it. The train steps " +
+        "past a tag only on a reviewed record.",
+    );
+  }
   lines.push("");
   lines.push(
     `This issue closes itself on the next cycle that mints, and it stays quiet ` +

--- a/scripts/release-hold-alarm.test.mjs
+++ b/scripts/release-hold-alarm.test.mjs
@@ -37,6 +37,20 @@ function held({ drift = 9, blocking = 'v0.5.18', latest = 'v0.5.17' } = {}) {
   };
 }
 
+// A hold whose blocking tag does not exist. The train writes `tag_staged` only
+// after fetching every tag and failing to resolve this one, so the reason code
+// is the whole discriminator and no other field has to be consulted.
+function staged({ drift = 7, blocking = 'v0.7.3', latest = 'v0.7.2' } = {}) {
+  return {
+    ...held({ drift, blocking, latest }),
+    reason: 'tag_staged',
+    detail: `${blocking} is already staged on main; tag reconciliation owns the next transition`,
+    base_tag: latest,
+    failed_release_run_id: null,
+    failed_release_run_url: null,
+  };
+}
+
 function clear() {
   return {
     schema: MARKER_SCHEMA,
@@ -172,6 +186,41 @@ test('the body names both exits and never uses an em dash', () => {
   assert.match(body, /abandoned-release-tags\.json/);
   assert.match(body, /Release Recovery retry the tag/);
   assert.doesNotMatch(body, /—/);
+});
+
+test('a tag that was never cut says so, and points at the publisher rather than at two exits that need a tag', () => {
+  const markers = [staged(), staged(), staged(), staged()];
+  const { body } = decide({ markers, issue: null });
+  assert.match(body, /`v0\.7\.3` was never cut/);
+  assert.match(body, /release-cut\.yml --jq \.state/);
+  assert.match(body, /evidence\/<sha>\/preflight\.json/);
+  // The sentence that sent a reader down two dead ends. Its absence is the
+  // whole behaviour, so it is asserted rather than left to the eye.
+  assert.doesNotMatch(body, /There are two ways out/);
+  assert.doesNotMatch(body, /Release Recovery retry the tag/);
+  assert.doesNotMatch(body, /—/);
+});
+
+test('a tag that exists still gets both original exits, so the staged branch cannot swallow the body everyone reads', () => {
+  const markers = [held(), held(), held(), held()];
+  const { body } = decide({ markers, issue: null });
+  assert.match(body, /There are two ways out/);
+  assert.match(body, /Release Recovery retry the tag/);
+  assert.match(body, /abandoned-release-tags\.json/);
+  assert.doesNotMatch(body, /was never cut/);
+  assert.doesNotMatch(body, /release-cut\.yml/);
+});
+
+test('an existing tag whose failed Release run could not be found is not mistaken for a tag that was never cut', () => {
+  // The trap this guards. A `tag_not_finalized` marker can also carry a null
+  // failed run id, because the train's lookup is allowed to come back empty.
+  // Keying the branch on that null instead of on the reason code would hand
+  // this marker the staged body and tell a captain a real tag does not exist.
+  const marker = { ...held(), failed_release_run_id: null, failed_release_run_url: null };
+  const { body } = decide({ markers: [marker, marker, marker, marker], issue: null });
+  assert.match(body, /No failed Release run was found/);
+  assert.doesNotMatch(body, /was never cut/);
+  assert.doesNotMatch(body, /release-cut\.yml/);
 });
 
 test('the command line agrees with the exported decision', () => {


### PR DESCRIPTION
The held-rail alarm always closed with the same two exits, and both assume the blocking tag exists.
Recovery retries the Release run that tag produced. Abandonment records the tag in
`scripts/abandoned-release-tags.json`, whose entries carry a `sha` and a `failed_release_run_id`. A
tag nobody ever created has neither, so a reader who tries either one spends the trip and arrives
nowhere.

The train already knows the difference and this reader threw it away.
`.github/workflows/release-train.yml` fetches every tag with
`git fetch origin "+refs/tags/*:refs/tags/*"` before it decides, and only then writes the
`tag_staged` reason, under `if ! git rev-parse --verify --quiet "${tag}^{commit}"`. That one code is
a proof, taken against a complete tag set, that the tag the alarm names was never cut.
`tag_not_finalized`, the other reason that reaches this body, is written when a tag does exist and is
not GitHub Latest, and both original exits apply there unchanged.

So the body branches on it. No new marker field, no new API call, no workflow change.

## What a staged tag now reads

```
`v0.7.3` was never cut. The train reports it as staged on main, which it writes only after
fetching every tag and finding that ref absent. This is a tag that does not exist, not a tag
whose release failed.

The two usual exits do not apply, and both will waste the trip. Recovery retries the Release
run that owns a tag, and no Release run has ever started for this one. Abandonment records a
tag in `scripts/abandoned-release-tags.json`, whose entries carry a `sha` and a
`failed_release_run_id` that an uncut tag cannot supply.

What is stuck is candidate selection. `.github/workflows/release-tag.yml` tags the newest
reviewed main commit in the staged version's range carrying `evidence/<sha>/preflight.json` on
the `release-evidence` branch. With no such commit it reports having no candidate and exits 0,
which is why every mint run reads green while the rail stands still.

The only automated publisher of that record is `Release Cut`,
`.github/workflows/release-cut.yml`, which this fleet operates as a switch rather than leaving
on. Read these two before looking anywhere else:

    gh api repos/{owner}/{repo}/actions/workflows/release-cut.yml --jq .state
    gh api "repos/{owner}/{repo}/git/trees/release-evidence?recursive=1" \
      --jq '[.tree[].path | select(endswith("preflight.json"))] | length'

`disabled_manually` is the whole answer: no candidate can exist until that workflow is
enabled. ...
```

Both printed commands were run from a lane worktree before they went into the body. The first
returned `.github/workflows/release-cut.yml state=disabled_manually` and the second returned `29`.
`gh` expands `{owner}` and `{repo}` from the repository of the working directory, so the line is
correct to paste with no editing.

## Why this is worth a change

On 2026-09-07 the alarm fired truthfully and on time, four consecutive cycles with seven reviewed
commits waiting. Two sessions then spent about forty minutes establishing that a workflow switch was
off, because the body sent them to a Release run that had never started and to a tag that had never
been created. The real cause was reachable in the two API calls above and nothing told them to make
them.

## Every existing body is unchanged, byte for byte

Proven by comparing the rendered output of `buildBody` at `origin/main` against this branch across
six marker shapes, rather than by asserting it:

```
IDENTICAL  1423b vs 1423b  tag_not_finalized with a failed run
IDENTICAL  1507b vs 1507b  tag_not_finalized, failed run absent
IDENTICAL  1423b vs 1423b  no reason field at all
IDENTICAL  1423b vs 1423b  reason is empty string
IDENTICAL  1423b vs 1423b  an unknown future reason
IDENTICAL  1433b vs 1433b  blocking tag missing

--- positive control: the staged case MUST differ, or the comparison proves nothing ---
CHANGED (control hit)  1507b vs 2277b
```

A comparison where nothing differs would pass whether or not the new branch existed, so the control
is the half that makes the other six mean anything.

## Falsification

Two arms, each a mutation of the behaviour rather than a weakened assertion.

**Arm 1, make the branch unreachable** (`if (marker.reason === STAGED_REASON)` to `if (false)`):

```
not ok 17 - a tag that was never cut says so, and points at the publisher rather than at two exits that need a tag
  location: 'scripts/release-hold-alarm.test.mjs:191:1'
  error: |-
    The input did not match the regular expression /`v0\.7\.3` was never cut/. Input:
    ...
    'No failed Release run was found for that tag, so the tag may have never been cut, ...'
    'There are two ways out, and both of them move the rail.\n' +
# pass 20
# fail 1
```

Exactly one test fails, it is the new one, the message names the regex this change added, and the
input it prints is the old body handing a reader the two dead ends. No neighbouring control moved.

**Arm 2, key the branch on the absent failed run instead of the reason code**
(`if (!marker.failed_release_run_id)`):

```
not ok 14 - an absent failed Release run is reported as absent rather than invented
not ok 19 - an existing tag whose failed Release run could not be found is not mistaken for a tag that was never cut
  location: 'scripts/release-hold-alarm.test.mjs:214:1'
    The input did not match the regular expression /No failed Release run was found/. Input:
# pass 19
# fail 2
```

This is the mistake the next author would make, and it is why the discriminator is the reason code.
A `tag_not_finalized` marker can also carry a null run id, because the train's lookup is allowed to
come back empty, and keying on that null would tell a captain a real tag does not exist. The
pre-existing test 14 catches the same mutation, which is reinforcing rather than redundant.

## Gates run locally

```
node --test scripts/release-hold-alarm.test.mjs        # tests 21, pass 21, fail 0 (was 18)
node --test <the full 12-file list ci.yml:149 runs>    # tests 164, pass 164, fail 0
node --check scripts/release-hold-alarm.mjs            # OK, the check ci.yml:169 runs
python3 scripts/test-release-workflow-authority.py     # rc=0
bash scripts/zero_file_search_guard.sh                 # rc=0, 71 answer modules graph-clean
python3 scripts/check-quarantine.py                    # rc=0
```

No cargo gate was run and none can see this change: it touches two `.mjs` files and no Rust. Hosted
CI is the gate of record for the full workspace.

`scripts/release-hold-alarm.test.mjs` runs on every pull request through the `npm launcher tests`
job (`ci.yml:159`), which carries no `pull_request` restriction, so these tests grade this PR. A
rule under `scripts/acceptance/` would not, because `Product Acceptance` carries
`if: ${{ github.event_name != 'pull_request' }}`.

The `Release version gate` job does not apply here: it runs only when the head ref is
`automation/release-next` or the PR carries the `release:automated` label, so no version bump is
required despite `classifyPath` treating `scripts/release-hold-alarm.mjs` as release-affecting.

## Scope

Two files. No workflow, no mint, no cut, no selector. This changes the text of an issue body and
nothing that can create, move or block a tag.
