### PR TITLE
Replace the installers' pinned-version example with a placeholder

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -7,7 +7,7 @@
 #   irm https://get.kinlab.dev/install.ps1 | iex
 #
 # Options (via env vars):
-#   $env:KIN_VERSION = "0.5.25"  Pin a specific version (default: latest)
+#   $env:KIN_VERSION = "X.Y.Z"   Pin a specific version (default: latest)
 #   $env:KIN_HOME = "$HOME\.kin" Install directory (preferred; default: ~/.kin)
 #   $env:KIN_DIR = "$HOME\.kin"  Install directory compatibility alias
 #   $env:KIN_NO_SETUP = "1"     CI compatibility; native repository setup is always skipped

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,7 +8,7 @@
 #   curl -fsSL https://get.kinlab.dev/install | sh
 #
 # Options (via env vars):
-#   KIN_VERSION=0.5.25    Pin a specific version (default: latest)
+#   KIN_VERSION=X.Y.Z     Pin a specific version (default: latest)
 #   KIN_HOME=~/.kin       Install directory (preferred; default: ~/.kin)
 #   KIN_DIR=~/.kin        Install directory compatibility alias
 #   KIN_NO_SETUP=1        Skip interactive setup after install


### PR DESCRIPTION
## Summary

`scripts/install.sh`'s usage comment documented `KIN_VERSION=0.5.25` as the
pin-a-version example. The shipped release is v0.7.2, eleven minor versions
ahead, and this file is the first Kin source a Show HN reader opens right
after the one-line install command (`curl -fsSL https://get.kinlab.dev/install | sh`).
`scripts/install.ps1` carried the identical stale example for its PowerShell
env var.

Both now show a version-free `X.Y.Z` placeholder instead of a hardcoded
number.

## Why a placeholder instead of a fresher hardcoded version

A hardcoded example has no gate keeping it current, so it goes stale again
at the next release the same way this one did. This branch's own
`Cargo.toml` already reads `0.7.3`, one patch ahead of the `v0.7.2` tag that
actually shipped, proof that a literal number would be wrong again before
this PR even lands. `X.Y.Z` is not a new convention either: `install.sh`'s
own comment two lines below the one this PR touches already reads
`.../releases/tag/vX.Y.Z`, so the fix matches an existing in-file idiom.

## Sweep of both installers, falsified

Positive control, must hit and does (proves the grep isn't silently
vacuous):

    $ grep -n 'KIN_VERSION' scripts/install.sh scripts/install.ps1
    scripts/install.sh:11:#   KIN_VERSION=X.Y.Z     Pin a specific version (default: latest)
    scripts/install.sh:114:if [ -n "${KIN_VERSION:-}" ]; then
    scripts/install.sh:115:    VERSION="$KIN_VERSION"
    scripts/install.sh:135:        err "Could not determine latest version. Set KIN_VERSION manually."
    scripts/install.ps1:10:#   $env:KIN_VERSION = "X.Y.Z"   Pin a specific version (default: latest)
    scripts/install.ps1:270:if ($env:KIN_VERSION) {
    scripts/install.ps1:271:    $Version = $env:KIN_VERSION

Negative sweep, no other hardcoded X.Y.Z-shaped version string remains:

    $ grep -nE '[0-9]+\.[0-9]+\.[0-9]+' scripts/install.sh scripts/install.ps1
    (no output, rc=1)

    (the one X.Y.Z-shaped survivor, `.../releases/tag/vX.Y.Z` in a code
    comment describing a URL redirect pattern, is the placeholder convention
    itself, not a version literal)

Also checked and found current, not stale: every URL in both scripts
(`get.kinlab.dev`, `github.com/firelock-ai/kin`, `api.github.com`,
`docs/windows-wsl2.md`) against `kin/docs/ecosystem-manifest.json` (which
lists `get.kinlab.dev` as the canonical install domain) and the actual
`origin` remote (`firelock-ai/kin`); both match. Grepped for deprecated
product names (`kin-code`, `kin-pilot`) in both files: no hits, paired with
a positive control that the word `kin` itself hits 49 times in install.sh
and 28 times in install.ps1, so the search mechanism works on these files.

## Gates run locally

- `bash -n scripts/install.sh` — rc=0, clean.
- `shellcheck scripts/install.sh` (0.11.0) — one pre-existing SC2016 warning
  on line 97 (single-quoted string with literal backticks), predates this
  diff (git blame: 2026-08-06), untouched by it, and not part of what this
  diff changes.
- `python3 scripts/test_installer_parity.py` — 7 tests, OK, rc=0.
- `python3 scripts/test-install-checksum.py` — 8/8 PASS, rc=0.
- `python3 scripts/verify_installer_parity.py` — skipped. It requires a
  `tag` positional argument and diffs both installers against one
  *published* GitHub release tag; that's a live check against release
  history, not a hermetic local test, and it needs no build so much as a
  real network fetch of a tag this branch predates.

No cargo command was run, of any kind. A concurrent lane holds the gpu and
daemon locks running a `kin init` timing sweep until roughly 11:30Z, and a
build changes the load that measurement runs under. This diff is a
comment/usage-text change in two shell/PowerShell scripts; nothing a Rust
build or test checks applies to it. Hosted CI is the gate of record for the
full workspace.

Also checked: whether this diff would trip the Release version gate, which
treats any non-doc, non-test path (this one included) as release-affecting
and normally wants the workspace version bumped alongside it. Read that
job's own `if:` condition in `ci.yml`: it only runs when the PR's head
branch is `automation/release-next` or the PR carries the
`release:automated` label, neither of which applies here, so it will not
fire on this PR and no version bump is included.