### PR TITLE
Add a forward-looking repo-format warning to 0.7.3's release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.3] - 2026-09-06
 
+**Heads up:** 0.7.3 does not change Kin's on-disk repo format, but an upcoming release will. Any store you create before that lands will not open afterward, and rebuilding one just means running `kin init` again. Nothing in your working tree is touched.
+
 ### Changed
 
 - Give the authority tests a retry budget on every must-succeed acquisition (#1567)


### PR DESCRIPTION
v0.7.3 does not change Kin's on-disk repo format. Its only changelog entry, PR #1567, is test-only ("No shipped byte changes," every hunk inside a `#[cfg(test)]` module), and the release commit (#1568) only touches version metadata. So this adds a forward-looking note rather than the breaking-release warning: it tells a reader the format is going to be rewritten in an upcoming release, that stores made before then will not survive it, and that rebuilding is just `kin init` again. No version or date is promised, since neither is set.

It sits at the top of the `[0.7.3]` section, above the change list, and says outright that 0.7.3 itself is inert, so it reads as a courtesy heads-up rather than an alarm attached to a one-line test-only release. A Show HN reader who installs tomorrow learns the rebuild is coming before it happens, in the place they would look.

Verified `scripts/extract-release-notes.mjs --version 0.7.3` renders it cleanly, byte for byte:

```
## [0.7.3] - 2026-09-06

**Heads up:** 0.7.3 does not change Kin's on-disk repo format, but an upcoming release will. Any store you create before that lands will not open afterward, and rebuilding one just means running `kin init` again. Nothing in your working tree is touched.

### Changed

- Give the authority tests a retry budget on every must-succeed acquisition (#1567)
```

Local gates, `bin/kin-precheck kin`:

```
kin-precheck: repo=kin tree=.../breaknote-kin sha=2c545ef1c branch=chore/lane-breaknote-kin DIRTY
kin-precheck: behind origin/main 0 commit(s)
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 2c545ef1c DIRTY
```