### PR TITLE
Stop telling a first-run reader to delete their Kin installation

### DIFF
--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1294,13 +1294,33 @@ fn reject_existing_repository(dir: &Path) -> Result<()> {
     Ok(())
 }
 
-/// The refusal `kin init` raises over a directory that already holds a store.
+/// The refusal `kin init` raises over a directory that already holds a `.kin`.
 ///
-/// The reader who arrives here most often is the one the store wall just sent,
-/// after an older store refused to open. That wall names a rebuild, and `kin
-/// init` is half of it, so this refusal names the same rebuild instead of
-/// stopping at the fact that a store exists.
+/// Two different directories answer to that name, and naming one remedy for
+/// both is how this went wrong. A repository store is the case the store wall
+/// sends readers from, after an older store refused to open; that wall names a
+/// rebuild, and `kin init` is half of it, so the refusal names the same
+/// rebuild.
+///
+/// The managed install root is the other, and it is the one a first-run reader
+/// reaches. The installer puts `~/.kin` in the home directory a fresh terminal
+/// already opens in, so a `kin init` typed before any `cd` lands on the
+/// toolchain rather than on a project. Naming the rebuild there tells that
+/// reader to delete the binaries, the injected shim and the cross-repo registry
+/// they installed a minute earlier, which is worse than the refusal it explains.
+/// [`KinLayout::discover`](kin_core::KinLayout::discover) already declines to
+/// bind this directory as a repository, and asking the same question here keeps
+/// the two from disagreeing about what `~/.kin` is.
 fn existing_repository_refusal(dir: &Path) -> String {
+    if kin_core::layout::is_managed_kin_home(&dir.join(".kin")) {
+        return format!(
+            "the .kin in {} is your Kin installation, not a repository. `kin init` runs inside a \
+             project, so change into the repository you want Kin to admit and run it there. Leave \
+             this directory where it is: it holds the installed binaries, the injected shim and \
+             the cross-repo registry.",
+            dir.display(),
+        );
+    }
     format!(
         "Kin repository already exists at {}; `kin init` never rebuilds graph authority from the \
          working tree. If this build cannot open that store, {} again to rebuild it from the \
@@ -3319,6 +3339,74 @@ mod tests {
         assert!(
             !wall.contains("fresh checkout") && !refusal.contains("fresh checkout"),
             "neither text may send the reader to a checkout they do not have"
+        );
+    }
+
+    /// The `.kin` a first-run reader actually meets is the installation, and
+    /// the refusal over it must never name a removal.
+    ///
+    /// The installer writes `~/.kin`, a fresh terminal opens in `~`, and the
+    /// quickstart ends on `kin init`. A reader who types that before any `cd`
+    /// points `kin init` at the toolchain. Sending them to `remove .kin/` there
+    /// deletes the binaries, the injected shim and the cross-repo registry they
+    /// installed a minute earlier, so this arm names a `cd` instead and tells
+    /// them the directory is theirs to keep.
+    ///
+    /// The fixture carries the installer's own markers rather than repointing
+    /// `HOME`, so the question is decided by what the directory holds and the
+    /// test does not race another test over a process-wide variable.
+    #[test]
+    fn the_refusal_over_the_installation_never_names_a_removal() {
+        let scratch = tempfile::tempdir().unwrap();
+        let home = scratch.path();
+        let managed = home.join(".kin");
+        std::fs::create_dir_all(managed.join("bin")).unwrap();
+        std::fs::create_dir_all(managed.join("lib")).unwrap();
+        std::fs::write(managed.join("registry.toml"), "").unwrap();
+
+        let refusal = existing_repository_refusal(home);
+
+        assert!(
+            !refusal.contains(crate::commands::REBUILD_INCOMPATIBLE_STORE),
+            "the install root must not be sent to the store rebuild: {refusal}"
+        );
+        assert!(
+            !refusal.contains("remove"),
+            "the install root must not be named in a removal at all: {refusal}"
+        );
+        assert!(
+            refusal.contains("is your Kin installation, not a repository"),
+            "the refusal must say what the directory actually is: {refusal}"
+        );
+        assert!(
+            refusal.contains("change into the repository"),
+            "the refusal must name the move that works: {refusal}"
+        );
+    }
+
+    /// The store arm, so the branch above cannot be satisfied by answering the
+    /// installation text everywhere.
+    ///
+    /// A `.kin` holding a manifest and none of the installer's markers is a
+    /// reader's own repository, and the shared rebuild remedy is still the one
+    /// the store wall sent them to look for.
+    #[test]
+    fn the_refusal_over_a_real_store_still_names_the_rebuild() {
+        let scratch = tempfile::tempdir().unwrap();
+        let repo = scratch.path();
+        let store = repo.join(".kin");
+        std::fs::create_dir_all(&store).unwrap();
+        std::fs::write(store.join("manifest.json"), "{}").unwrap();
+
+        let refusal = existing_repository_refusal(repo);
+
+        assert!(
+            refusal.contains(crate::commands::REBUILD_INCOMPATIBLE_STORE),
+            "a real store must still name the shared rebuild remedy: {refusal}"
+        );
+        assert!(
+            !refusal.contains("is your Kin installation"),
+            "a real store must not be described as the installation: {refusal}"
         );
     }
 

--- a/crates/kin-core/src/layout.rs
+++ b/crates/kin-core/src/layout.rs
@@ -512,7 +512,14 @@ fn same_dir(a: &Path, b: &Path) -> bool {
 /// and it is still bound. A directory carrying the markers is the install root
 /// whatever else appears in it, so planting a `manifest.json` there does not
 /// turn it into a repository.
-fn is_managed_kin_home(candidate: &Path) -> bool {
+///
+/// Public because [`discover`](KinLayout::discover) is not the only caller that
+/// has to tell the two directories apart. `kin init` refuses a directory that
+/// already holds a `.kin`, and the remedy it should name depends on which of
+/// them this is; asking here keeps that answer in one place, so a command
+/// cannot decide the install root is a repository while discovery decides it is
+/// not.
+pub fn is_managed_kin_home(candidate: &Path) -> bool {
     if carries_managed_home_markers(candidate) {
         return true;
     }


### PR DESCRIPTION
## What this fixes

`kin init` refused any directory already holding a `.kin` with one message, and that message names `remove .kin/` as the remedy. In a home directory the `.kin` it finds is the installation, so following the advice deletes `bin`, `lib`, the injected shim and the cross-repo registry.

This is the default first-run path, not an edge case. The installer writes `~/.kin`, a fresh terminal opens in `~`, and the quickstart ends on `kin init`, so a reader who runs it before changing directory points `kin init` at the toolchain.

## The actual shape of the bug

`KinLayout::discover` has always refused to bind the install root, and it decides that with `is_managed_kin_home`, from the entries an install root carries rather than from `$HOME`. So the codebase already knew the right answer. `kin init` was the one call site still asking whether a `.kin` merely exists, and the two disagreed about what `~/.kin` is.

That is why the fix makes the existing helper public instead of adding a second predicate. A duplicated definition of this question is how the two call sites drift apart again.

## Measured, against the published v0.7.2 bytes

Installed into a scratch `HOME` from `https://get.kinlab.dev/install`, then `kin init` run in that home directory.

Before, from the shipped v0.7.2 binary:

```
Error: Kin repository already exists at <home>; `kin init` never rebuilds graph authority from the working tree. If this build cannot open that store, remove .kin/ and run `kin init` again to rebuild it from the repository's Git history.
```

After, from this branch's binary, same home, same working directory:

```
Error: the .kin in <home> is your Kin installation, not a repository. `kin init` runs inside a project, so change into the repository you want Kin to admit and run it there. Leave this directory where it is: it holds the installed binaries, the injected shim and the cross-repo registry.
```

Both exit 1. Running `kin init` a second time inside a real repository is unchanged and still names the shared rebuild remedy.

## Tests, and how they were falsified

Two crate tests in `init.rs`, so `ci.yml` grades them on this pull request. `Product Acceptance` carries `if: github.event_name != 'pull_request'`, so an acceptance rule would not have graded the PR that breaks this.

Both fixtures decide the question from what the directory holds rather than by repointing `HOME`, so neither races another test over a process-wide variable.

Falsified twice:

- Deleting the branch turns `the_refusal_over_the_installation_never_names_a_removal` red, with `remove .kin/ and run kin init` printed in the failure.
- Inverting its condition turns both new tests red.

The install-root test pins the absence of `REBUILD_INCOMPATIBLE_STORE` and the absence of the word `remove`, so removal advice cannot come back into this arm without a red test.

## Local verification

```
cargo test -p kin-cli --lib      2254 passed, 0 failed
cargo test -p kin-core --lib      872 passed, 0 failed
bin/kin-precheck kin               21 gates enumerated, 21 passed, 0 failed
```

## One sibling, reported rather than fixed here

`crates/kin-cli/src/commands/health.rs:2248` guards the same case, but by comparing the path against the resolved managed directory rather than asking what the directory holds. That is the identity-only mechanism `is_managed_kin_home` documents as the original defect, and the branch beneath it also ends in "remove the partial `.kin` directory first". It is a narrower exposure than this one and it deserves its own change with its own falsified test, so it is out of scope here.
