### PR TITLE
Fix quickstart paste boundaries and repository selection (FIR-3348)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,13 +141,24 @@ can open later.
 
 ## Shortest graph-backed path
 
-Five commands, and the last one is the answer:
+Run the installer on its own and finish any setup prompts:
 
 ```sh
 curl -fsSL https://get.kinlab.dev/install | sh
+```
+
+Once it finishes, reload your shell with this separate command:
+
+```sh
 exec "$SHELL" -l
-cd /path/to/your/repository
-kin init .
+```
+
+At the new prompt, replace the path below with your repository's location and
+run this block:
+
+```sh
+cd /path/to/your/repository &&
+kin init . &&
 kin locate "where are webhook retries handled"
 ```
 
@@ -174,11 +185,21 @@ same path with the detail behind each step.
 
 ### 1. Install and configure Kin
 
-On macOS or Linux:
+On macOS or Linux, run the installer on its own and finish any setup prompts:
 
 ```sh
 curl -fsSL https://get.kinlab.dev/install | sh
+```
+
+Once it finishes, reload your shell with this separate command:
+
+```sh
 exec "$SHELL" -l
+```
+
+At the new prompt, configure your client:
+
+```sh
 kin setup --intent agent
 ```
 
@@ -259,9 +280,10 @@ Windows install path.
 
 ### 2. Admit an existing repository as graph truth
 
+Replace the path below with your repository's location:
+
 ```sh
-cd /path/to/your/repository
-kin init .
+cd /path/to/your/repository && kin init .
 ```
 
 In a detected Git repository, `kin init` atomically admits complete reachable


### PR DESCRIPTION
Separate the installer, shell reload, and repository commands into independently copied blocks. A multiline paste into zsh previously discarded commands after `exec`, including repository initialization or the selected agent setup intent. Keeping the installer alone also prevents interactive setup prompts from consuming subsequent pasted commands.

Chain the repository `cd` and initialization with `&&`, so an unchanged placeholder cannot initialize the directory where the terminal happened to start.

Addresses FIR-3348. README only; no runtime or release-version change.

Validation used the exact README blocks in real interactive PTYs with isolated installer and Kin command fixtures. All six cases passed: zsh bracketed paste, zsh raw paste, stock macOS bash raw paste, explicit agent setup, failed-directory protection, and a control reproducing the original zsh command discard. This verifies shell and paste behavior, not released-binary acceptance. The existing main candidate separately passed its CI and Acceptance push runs on attempt one.

Command:

```text
python3 /Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/reports/verify-launchpaste-cx.py --repo-dir /Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/launchpaste-cx-kin --lab /Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/reports/launchpaste-cx-pty
```

Actual output tail:

```text
PASS: 6 PTY cases; original zsh defect reproduced; failed cd cannot initialize another directory.
```

`git diff --check` exited 0.
