### PR TITLE
Refuse a store-size figure with no version stamp or declared method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1055,6 +1055,39 @@ jobs:
       - name: Falsify kin-actions pin visibility guard
         run: python3 scripts/falsify-kin-actions-pin-visibility.py
 
+      # docs/store-size.md published a ripgrep store size that was wrong by
+      # 1.74x for about a month, and the launch post carried it outward. Two
+      # defects made it and neither was arithmetic: the figures were measured
+      # at workspace version 0.5.6 and nothing on the page said so, and the
+      # breakdown was measured with `du` while the total came from Kin's own
+      # logical-byte walk, so the two halves could never add up. A reader who
+      # "verified" that page was adding numbers that were never comparable.
+      #
+      # It belongs in THIS job rather than under scripts/acceptance/, and the
+      # distinction is the whole value of the guard. `Product Acceptance`
+      # carries `if: github.event_name != 'pull_request'`, so a rule added
+      # there would not run on the pull request that breaks the page; it would
+      # report a release later, which is exactly the delay that let the wrong
+      # number ship. This job has no `if:` and no `needs:`, so it runs on every
+      # event including a docs-only pull request, and it carries the required
+      # `Fast gate lint and policy` context. It is a pure scanner over one
+      # markdown file with no toolchain and no network, so it costs under a
+      # second beside the guards above.
+      #
+      # The falsifier runs first on purpose: it plants sixteen mutants in the
+      # real page and requires the guard to refuse each one BY RULE NAME, plus
+      # two controls, one of which requires the guard to stay green when the
+      # du-side total moves further from the walk-side total. That control is
+      # the design property under test. The guard never reconciles across
+      # methods, because no tolerance can: pick 2% and the correct page goes
+      # red on a real 7.1% method gap, pick 10% and the original 10.3% defect
+      # walks through. Learn the guard still works before trusting its verdict.
+      - name: Falsify store-size figure guard
+        run: python3 scripts/falsify-store-size-figures.py
+
+      - name: Check store-size figures carry a version and a method
+        run: python3 scripts/check-store-size-figures.py
+
       # ADDED here rather than moved out of `check`, for the reason the kin-vfs
       # step below records. `check` carries `github.event_name != 'pull_request'`,
       # so for as long as these two guards ran only there, a pull request could

--- a/docs/store-size.md
+++ b/docs/store-size.md
@@ -41,13 +41,14 @@ whose 5.7 MiB object store became a 703.9 MiB store:
 | `kindb/<repo>/snapshots` (the graph snapshot) | 592.9 MiB | 78.6% |
 | `kindb/<repo>/source-blobs` (admitted bodies) | 154.0 MiB | 20.4% |
 | everything else | about 7 MiB | 1.0% |
+| total (by `du`) | 754.2 MiB | 100% |
 
 This breakdown is measured by `du`, which counts allocated disk blocks rather
 than the logical file bytes this page's own walk sums, so it totals 754.2 MiB
-here, above the 703.9 MiB `kin init` itself prints. The two methods measure
-different things and are not meant to be added across columns; a table like
-this one, left unlabeled, is what put a wrong number on this page the first
-time.
+here (v0.7.2, 2026-09-07), above the 703.9 MiB `kin init` itself prints. The
+two methods measure different things and are not meant to be added across
+columns; a table like this one, left unlabeled, is what put a wrong number on
+this page the first time.
 
 **Source blobs.** Git keeps history as zlib-compressed objects packed with
 deltas, so one packfile holds every revision of a file as a base plus a chain of

--- a/scripts/check-store-size-figures.py
+++ b/scripts/check-store-size-figures.py
@@ -1,0 +1,563 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+"""Refuse a store-size figure that does not say which Kin produced it, or how.
+
+docs/store-size.md published a ripgrep store size that was wrong by 1.74x for
+about a month, and the launch post carried the wrong number outward. Two
+independent defects made it, and neither was an arithmetic slip:
+
+  Version vintage. The figures were measured at workspace version 0.5.6, at
+  least a dozen releases before v0.7.2, and the graph snapshot alone roughly
+  doubled across that span. Nothing on the page said which version produced
+  any number, so a stale figure was indistinguishable from a current one.
+
+  Mixed methods. The breakdown was measured with `du`, which counts allocated
+  disk blocks, while the total came from Kin's own logical-byte walk. The two
+  halves therefore could not add up, and no amount of re-checking the
+  arithmetic would ever have found it, because the arithmetic was not the
+  error. A reader who "verified" that page was adding numbers that were never
+  comparable.
+
+## The design choice this guard makes
+
+It never reconciles across methods, and it refuses an undeclared one.
+
+Reconciling is exactly what a human wrongly did for a month, and no tolerance
+can do it correctly: there is no fixed conversion between allocated blocks and
+logical bytes, because the gap depends on block size, file count and the size
+distribution of the files. Pick 2% and the correct page goes red on a real
+7.1% method gap. Pick 10% and the original 10.3% defect walks through. The two
+cases are not separable by magnitude, which is the whole reason a careful
+reader could not tell them apart either.
+
+So every size figure must name its method, the arithmetic is checked only
+WITHIN one declared method, and a page that publishes two methods must have a
+paragraph where both are named together. An undeclared method is a failure,
+not something this guard tries to resolve.
+
+## What it refuses
+
+  P1  the page is missing one of the two tables this guard knows about, or
+      carries a third table with size figures in it. A new table is a decision
+      about provenance, so it stops here until somebody makes it.
+  V1  the Measured table has no version column. Its rows are independent
+      measurements of different repositories, so one stamp per table would
+      let a stale row hide behind a fresh one.
+  V2  a Measured row whose stamp is neither `vX.Y.Z` plus an ISO date nor the
+      exact literal `synthetic fixture`.
+  V3  the breakdown table's introducing paragraph carries no version and date.
+      That table is one measurement split into parts, so one stamp covers it.
+  V4  a paragraph outside any table that states a KiB, MiB or GiB size without
+      a version and a date beside it.
+  M1  a table whose size columns declare no measurement method, or more than
+      one. The method is read from the size column headers and the table's
+      introducing paragraph, and the vocabulary is closed on purpose: a third
+      method has to be taught to this guard before it can be published.
+  M2  a breakdown table with no total row, a size cell this guard cannot read
+      as a value, or part rows that do not sum to the total row. This is
+      within-method arithmetic, which is the only arithmetic that means
+      anything here.
+  M3  a breakdown share that does not reconcile against that table's OWN
+      total. The original page's shares reconciled against a sum it never
+      printed, which is how the reader could tell nobody had checked them.
+  M4  the page declares more than one method and no paragraph names them all
+      together. That paragraph is where the reader is told not to add across
+      them, and its absence is what made the first mistake invisible.
+  C1  a size figure this guard did not account for. A parser that quietly
+      stops finding figures reports the same green a clean page reports, so
+      every figure in the file must land in something that was graded.
+
+Usage: check-store-size-figures.py [--page <path>]
+Exit 0 when the page is clean, 1 when any rule above fires.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_PAGE = REPO_ROOT / "docs" / "store-size.md"
+
+# A Kin release, and the day a figure was read. Both, or the figure is not
+# safe to read as current.
+VERSION_RE = re.compile(r"\bv\d+\.\d+\.\d+\b")
+DATE_RE = re.compile(r"\b\d{4}-\d{2}-\d{2}\b")
+
+# The units Kin's own walk prints. KB and MB are deliberately not here: on this
+# page they describe Git-side and fixture-side facts rather than a Kin store.
+SIZE_RE = re.compile(r"(?<![\d.])(\d+(?:\.\d+)?)\s+(KiB|MiB|GiB)\b")
+
+# A size cell this guard will sum. Anything else is refused rather than
+# guessed at, because a bound ("under 1 MiB") cannot be added to anything.
+EXACT_CELL_RE = re.compile(r"^(\d+(?:\.\d+)?)\s+(KiB|MiB|GiB)$")
+APPROX_CELL_RE = re.compile(r"^(?:about|roughly|~)\s*(\d+(?:\.\d+)?)\s+(KiB|MiB|GiB)$")
+
+SHARE_CELL_RE = re.compile(r"^(\d+(?:\.\d+)?)\s*%$")
+
+# The closed method vocabulary. `du` counts allocated disk blocks; the walk
+# sums logical file bytes. Teaching this guard a third one is a deliberate
+# edit, which is the point.
+METHODS = {
+    "du": re.compile(r"\bdu\b"),
+    "walk": re.compile(r"\bwalks?\b"),
+}
+
+UNIT_BYTES = {"KiB": 1024.0, "MiB": 1024.0**2, "GiB": 1024.0**3}
+
+# The only stamp a row may carry instead of a version and a date. It is a
+# closed literal rather than free text, and every use is printed, so the
+# exemption can never be invisible in a CI log.
+FIXTURE_STAMP = "synthetic fixture"
+
+# The two tables this page publishes, keyed by the first cell of the header
+# row. BREAKDOWN is one store split into parts, so it carries one stamp and a
+# total row; MEASURED is many independent measurements, so it carries a stamp
+# column.
+BREAKDOWN_KEY = "Part of"
+MEASURED_KEY = "Repository"
+
+
+@dataclass
+class Table:
+    kind: str
+    header: list[str]
+    rows: list[list[str]]
+    start_line: int
+    intro: str
+
+
+@dataclass
+class Block:
+    lines: list[str]
+    start_line: int
+
+    @property
+    def text(self) -> str:
+        return "\n".join(self.lines)
+
+    @property
+    def is_table(self) -> bool:
+        return bool(self.lines) and all(ln.lstrip().startswith("|") for ln in self.lines)
+
+
+def split_blocks(text: str) -> list[Block]:
+    """Split the page into blank-line separated blocks, keeping line numbers."""
+    blocks: list[Block] = []
+    current: list[str] = []
+    start = 1
+    for number, line in enumerate(text.splitlines(), start=1):
+        if line.strip():
+            if not current:
+                start = number
+            current.append(line)
+        elif current:
+            blocks.append(Block(current, start))
+            current = []
+    if current:
+        blocks.append(Block(current, start))
+    return blocks
+
+
+def split_row(line: str) -> list[str]:
+    stripped = line.strip()
+    if stripped.startswith("|"):
+        stripped = stripped[1:]
+    if stripped.endswith("|"):
+        stripped = stripped[:-1]
+    return [cell.strip() for cell in stripped.split("|")]
+
+
+def plain(cell: str) -> str:
+    """Strip the markdown a cell may wear, so a value can be read out of it."""
+    return cell.replace("`", "").replace("**", "").replace("*", "").strip()
+
+
+def to_bytes(value: float, unit: str) -> float:
+    return value * UNIT_BYTES[unit]
+
+
+class Report:
+    def __init__(self) -> None:
+        self.failures: list[tuple[str, str]] = []
+        self.notes: list[str] = []
+
+    def fail(self, rule: str, message: str) -> None:
+        self.failures.append((rule, message))
+
+    def note(self, message: str) -> None:
+        self.notes.append(message)
+
+
+def collect_tables(blocks: list[Block], report: Report) -> dict[str, Table]:
+    """Find the two known tables, and refuse any third one carrying sizes."""
+    tables: dict[str, Table] = {}
+    for index, block in enumerate(blocks):
+        if not block.is_table:
+            continue
+        rows = [split_row(line) for line in block.lines]
+        if len(rows) < 3:
+            continue
+        header = rows[0]
+        body = [row for row in rows[2:] if row]
+        first = plain(header[0])
+        intro = ""
+        for previous in reversed(blocks[:index]):
+            if not previous.is_table:
+                intro = previous.text
+                break
+        if first.startswith(BREAKDOWN_KEY):
+            kind = "breakdown"
+        elif first.startswith(MEASURED_KEY):
+            kind = "measured"
+        elif any(SIZE_RE.search(cell) for row in rows for cell in row):
+            report.fail(
+                "P1",
+                f"line {block.start_line}: a table headed {first!r} publishes size "
+                "figures and this guard knows nothing about its provenance rules; "
+                f"teach it, or head the table {BREAKDOWN_KEY!r} or {MEASURED_KEY!r}",
+            )
+            continue
+        else:
+            continue
+        if kind in tables:
+            report.fail(
+                "P1",
+                f"line {block.start_line}: a second {kind} table; this guard grades "
+                "one of each and would silently leave the other ungraded",
+            )
+            continue
+        tables[kind] = Table(kind, header, body, block.start_line, intro)
+    for kind in ("breakdown", "measured"):
+        if kind not in tables:
+            report.fail(
+                "P1",
+                f"the {kind} table is missing; a page this guard cannot find its "
+                "tables in must not report the same green a clean page reports",
+            )
+    return tables
+
+
+def size_columns(table: Table) -> list[int]:
+    """Header cells that carry a size, which are the ones needing a method."""
+    columns = []
+    for index, cell in enumerate(table.header):
+        text = plain(cell).lower()
+        if "size" in text or "store" in text:
+            columns.append(index)
+    return columns
+
+
+def check_methods(tables: dict[str, Table], report: Report) -> set[str]:
+    """Rule M1: exactly one declared method per table, from a closed set."""
+    declared: set[str] = set()
+    for kind, table in tables.items():
+        columns = size_columns(table)
+        if not columns:
+            report.fail(
+                "M1",
+                f"line {table.start_line}: the {kind} table has no size column this "
+                "guard can identify, so nothing about it is being graded",
+            )
+            continue
+        haystack = " ".join(table.header[i] for i in columns) + "\n" + table.intro
+        found = {name for name, pattern in METHODS.items() if pattern.search(haystack)}
+        if not found:
+            report.fail(
+                "M1",
+                f"line {table.start_line}: the {kind} table's size columns declare no "
+                f"measurement method; name one of {sorted(METHODS)} in the size column "
+                "header or in the paragraph introducing the table",
+            )
+        elif len(found) > 1:
+            report.fail(
+                "M1",
+                f"line {table.start_line}: the {kind} table's size columns declare "
+                f"{sorted(found)} at once; one table measures one way, or its rows "
+                "cannot be compared with each other",
+            )
+        else:
+            declared |= found
+    return declared
+
+
+def check_version_stamps(tables: dict[str, Table], report: Report) -> None:
+    """Rules V1 to V3: every published figure says which Kin produced it."""
+    measured = tables.get("measured")
+    if measured is not None:
+        stamp_column = None
+        for index, cell in enumerate(measured.header):
+            if "version" in plain(cell).lower():
+                stamp_column = index
+                break
+        if stamp_column is None:
+            report.fail(
+                "V1",
+                f"line {measured.start_line}: the Measured table has no version "
+                "column; its rows are independent measurements, so one stamp for the "
+                "table would let a stale row hide behind a fresh one",
+            )
+        else:
+            for offset, row in enumerate(measured.rows, start=measured.start_line + 2):
+                subject = plain(row[0]) if row else "?"
+                cell = plain(row[stamp_column]) if stamp_column < len(row) else ""
+                if cell == FIXTURE_STAMP:
+                    report.note(
+                        f"line {offset}: {subject!r} is stamped {FIXTURE_STAMP!r} "
+                        "rather than with a version and a date, so nothing here can "
+                        "tell you whether it is current"
+                    )
+                    continue
+                if not (VERSION_RE.search(cell) and DATE_RE.search(cell)):
+                    report.fail(
+                        "V2",
+                        f"line {offset}: {subject!r} carries the stamp {cell!r}, which "
+                        "is neither a vX.Y.Z with an ISO date nor the literal "
+                        f"{FIXTURE_STAMP!r}",
+                    )
+
+    breakdown = tables.get("breakdown")
+    if breakdown is not None:
+        intro = breakdown.intro
+        if not (VERSION_RE.search(intro) and DATE_RE.search(intro)):
+            report.fail(
+                "V3",
+                f"line {breakdown.start_line}: the paragraph introducing the breakdown "
+                "table carries no version and date, and it is the only stamp that "
+                "table has",
+            )
+
+
+def check_prose_stamps(blocks: list[Block], report: Report) -> int:
+    """Rule V4: a size in prose is a published figure and carries its stamp."""
+    graded = 0
+    for block in blocks:
+        if block.is_table or not SIZE_RE.search(block.text):
+            continue
+        graded += 1
+        if VERSION_RE.search(block.text) and DATE_RE.search(block.text):
+            continue
+        figures = ", ".join(
+            f"{value} {unit}" for value, unit in SIZE_RE.findall(block.text)
+        )
+        report.fail(
+            "V4",
+            f"line {block.start_line}: this paragraph states {figures} with no version "
+            "and date beside it; an unstamped figure is indistinguishable from a "
+            "stale one, which is how the ripgrep number survived a dozen releases",
+        )
+    return graded
+
+
+def read_size_cell(cell: str) -> tuple[float, str, bool] | None:
+    text = plain(cell)
+    match = EXACT_CELL_RE.match(text)
+    if match:
+        return float(match.group(1)), match.group(2), False
+    match = APPROX_CELL_RE.match(text)
+    if match:
+        return float(match.group(1)), match.group(2), True
+    return None
+
+
+def check_breakdown_arithmetic(tables: dict[str, Table], report: Report) -> int:
+    """Rules M2 and M3: within-method arithmetic, and only within-method."""
+    table = tables.get("breakdown")
+    if table is None:
+        return 0
+    columns = size_columns(table)
+    if not columns:
+        return 0
+    size_column = columns[0]
+    share_column = None
+    for index, cell in enumerate(table.header):
+        if "share" in plain(cell).lower():
+            share_column = index
+            break
+
+    total_row = None
+    parts: list[tuple[int, str, float, str, bool]] = []
+    for offset, row in enumerate(table.rows, start=table.start_line + 2):
+        if size_column >= len(row):
+            report.fail("M2", f"line {offset}: this row has no size cell")
+            continue
+        subject = plain(row[0])
+        parsed = read_size_cell(row[size_column])
+        if parsed is None:
+            report.fail(
+                "M2",
+                f"line {offset}: the size cell {plain(row[size_column])!r} for "
+                f"{subject!r} is not a value this guard will sum; write it as "
+                "'N MiB' or 'about N MiB', because a bound cannot be added to "
+                "anything",
+            )
+            continue
+        value, unit, approximate = parsed
+        if subject.lower().startswith("total"):
+            if total_row is not None:
+                report.fail("M2", f"line {offset}: a second total row")
+                continue
+            total_row = (offset, subject, value, unit, approximate)
+        else:
+            parts.append((offset, subject, value, unit, approximate))
+
+    if total_row is None:
+        report.fail(
+            "M2",
+            f"line {table.start_line}: the breakdown table states no total of its own. "
+            "That is the defect this guard exists for: the parts were measured one way "
+            "and the only total on the page was measured another, so they could never "
+            "add up and nobody could see why",
+        )
+        return len(parts)
+    if not parts:
+        report.fail("M2", f"line {table.start_line}: the breakdown table has no parts")
+        return 0
+
+    total_bytes = to_bytes(total_row[2], total_row[3])
+    summed = sum(to_bytes(value, unit) for _, _, value, unit, _ in parts)
+    # A one-decimal figure rounds within half of the last place; a row written
+    # as "about N" is fuzzy by its own admission and gets the wider of half a
+    # unit or a tenth of itself.
+    tolerance = to_bytes(0.05, total_row[3])
+    for _, _, value, unit, approximate in parts:
+        slack = max(0.5, 0.1 * value) if approximate else 0.05
+        tolerance += to_bytes(slack, unit)
+    if abs(summed - total_bytes) > tolerance:
+        listed = " + ".join(f"{value} {unit}" for _, _, value, unit, _ in parts)
+        report.fail(
+            "M2",
+            f"line {total_row[0]}: the parts sum to {summed / UNIT_BYTES[total_row[3]]:.1f} "
+            f"{total_row[3]} ({listed}) against a stated total of {total_row[2]} "
+            f"{total_row[3]}, past the {tolerance / UNIT_BYTES[total_row[3]]:.2f} "
+            f"{total_row[3]} these rows' own rounding allows",
+        )
+
+    if share_column is None:
+        report.fail(
+            "M3",
+            f"line {table.start_line}: the breakdown table has no share column, so its "
+            "shares cannot be reconciled against its own total",
+        )
+        return len(parts)
+    for offset, subject, value, unit, approximate in parts + [total_row]:
+        if share_column >= len(table.rows[offset - table.start_line - 2]):
+            report.fail("M3", f"line {offset}: {subject!r} has no share cell")
+            continue
+        cell = plain(table.rows[offset - table.start_line - 2][share_column])
+        match = SHARE_CELL_RE.match(cell)
+        if match is None:
+            report.fail(
+                "M3",
+                f"line {offset}: the share cell {cell!r} for {subject!r} is not a "
+                "percentage, so nothing about it can be checked",
+            )
+            continue
+        stated = float(match.group(1))
+        actual = to_bytes(value, unit) / total_bytes * 100.0
+        slack = 0.35 if approximate else 0.15
+        if abs(stated - actual) > slack:
+            report.fail(
+                "M3",
+                f"line {offset}: {subject!r} states {stated}% but is {actual:.2f}% of "
+                f"this table's own {total_row[2]} {total_row[3]} total",
+            )
+    return len(parts)
+
+
+def check_method_declaration(
+    blocks: list[Block], declared: set[str], report: Report
+) -> None:
+    """Rule M4: two methods on one page need a paragraph naming both."""
+    if len(declared) < 2:
+        return
+    for block in blocks:
+        if block.is_table:
+            continue
+        if all(METHODS[name].search(block.text) for name in declared):
+            return
+    report.fail(
+        "M4",
+        f"this page publishes figures under {sorted(declared)} and no paragraph names "
+        "them together. That paragraph is where a reader is told the two are not "
+        "comparable, and its absence is what let a du-measured breakdown sit under a "
+        "walk-measured total for a month",
+    )
+
+
+def check_coverage(
+    text: str, tables: dict[str, Table], prose_blocks: int, report: Report
+) -> None:
+    """Rule C1: every size figure in the file landed in something graded."""
+    total = len(SIZE_RE.findall(text))
+    accounted = prose_blocks_figures(text)
+    for table in tables.values():
+        for row in table.rows:
+            accounted += sum(len(SIZE_RE.findall(cell)) for cell in row)
+        accounted += sum(len(SIZE_RE.findall(cell)) for cell in table.header)
+    if accounted != total:
+        report.fail(
+            "C1",
+            f"the page holds {total} size figure(s) and this guard accounted for "
+            f"{accounted}; a figure nothing grades is exactly the shape that put a "
+            "wrong number on this page",
+        )
+    else:
+        report.note(
+            f"graded {total} size figure(s) across {len(tables)} table(s) and "
+            f"{prose_blocks} prose paragraph(s)"
+        )
+
+
+def prose_blocks_figures(text: str) -> int:
+    return sum(
+        len(SIZE_RE.findall(block.text))
+        for block in split_blocks(text)
+        if not block.is_table
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--page", type=Path, default=DEFAULT_PAGE)
+    args = parser.parse_args()
+
+    if not args.page.is_file():
+        print(f"::error title=Store-size page missing::{args.page} is not a file")
+        return 1
+    text = args.page.read_text(encoding="utf-8")
+    blocks = split_blocks(text)
+    report = Report()
+
+    tables = collect_tables(blocks, report)
+    declared = check_methods(tables, report)
+    check_version_stamps(tables, report)
+    prose_graded = check_prose_stamps(blocks, report)
+    check_breakdown_arithmetic(tables, report)
+    check_method_declaration(blocks, declared, report)
+    check_coverage(text, tables, prose_graded, report)
+
+    for note in report.notes:
+        print(f"store-size: {note}")
+    if not report.failures:
+        print(f"store-size: {args.page} is clean")
+        return 0
+    annotate = bool(os.environ.get("GITHUB_ACTIONS"))
+    for rule, message in report.failures:
+        print(f"store-size: [{rule}] {message}")
+        if annotate:
+            print(f"::error title=Store-size figure guard {rule}::{message}")
+    print(
+        f"store-size: {len(report.failures)} rule(s) fired on {args.page}",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/falsify-store-size-figures.py
+++ b/scripts/falsify-store-size-figures.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+"""Falsify check-store-size-figures.py against mutants of the real page.
+
+Every probe below breaks docs/store-size.md one way and requires the guard to
+fail NAMING THE RIGHT RULE. A probe that goes red for some other reason is
+recorded as a failure here, because a guard that refuses everything is not a
+guard, it is a wish, and it looks identical to a working one from the outside.
+
+Two controls run first and must PASS, and they are the reason this file exists
+rather than a comment claiming the guard works:
+
+  [control 1] the real page, unmutated, must be clean. A guard that rejects the
+              page it ships beside would be reverted within a day, and every
+              probe below would still "pass".
+
+  [control 2] the du-side total is moved further from the walk-side total, with
+              the parts and shares kept self-consistent. The guard must stay
+              GREEN. This is the design property under test: it never reconciles
+              a du figure against a walk figure, because there is no conversion
+              between allocated blocks and logical bytes, and a human trying to
+              reconcile them by eye is what put a wrong number on that page for
+              a month. A guard that went red here would be doing the very thing
+              this one refuses to do.
+
+Usage: falsify-store-size-figures.py
+Exit 0 when every control passed and every probe was refused by name.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GUARD = REPO_ROOT / "scripts" / "check-store-size-figures.py"
+PAGE = REPO_ROOT / "docs" / "store-size.md"
+
+
+def run_guard(page: Path) -> tuple[int, str]:
+    result = subprocess.run(
+        [sys.executable, str(GUARD), "--page", str(page)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode, result.stdout + result.stderr
+
+
+def rules_fired(output: str) -> set[str]:
+    fired = set()
+    for line in output.splitlines():
+        marker = "store-size: ["
+        if line.startswith(marker):
+            fired.add(line[len(marker) : line.index("]")])
+    return fired
+
+
+def mutate(text: str, old: str, new: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(
+            f"falsify: the anchor {old!r} appears {count} time(s) in the page, so this "
+            "probe would plant something other than what it describes. Re-anchor it "
+            "against the current page rather than loosening the count."
+        )
+    return text.replace(old, new)
+
+
+# Each probe is (label, old, new, the rule that must fire).
+#
+# The stamp anchors are written out in full rather than pattern-matched: a probe
+# whose anchor has drifted must stop this script, not silently plant nothing and
+# report that the guard let it through.
+PROBES: list[tuple[str, str, str, str]] = [
+    (
+        "the ripgrep row loses its version and date",
+        "| 122.7x | v0.7.2, 2026-09-07 |",
+        "| 122.7x |  |",
+        "V2",
+    ),
+    (
+        "the ripgrep row is stamped with a version but no date",
+        "| 122.7x | v0.7.2, 2026-09-07 |",
+        "| 122.7x | v0.7.2 |",
+        "V2",
+    ),
+    (
+        "the ripgrep row is stamped with a date but no version",
+        "| 122.7x | v0.7.2, 2026-09-07 |",
+        "| 122.7x | 2026-09-07 |",
+        "V2",
+    ),
+    (
+        "a row invents its own excuse instead of a stamp",
+        "| 122.7x | v0.7.2, 2026-09-07 |",
+        "| 122.7x | current |",
+        "V2",
+    ),
+    (
+        "the Measured table loses its stamp column",
+        "| Ratio | Version, date |",
+        "| Ratio |",
+        "V1",
+    ),
+    (
+        "the breakdown table's introducing paragraph loses its stamp",
+        "ripgrep at 2,261 commits under v0.7.2 (measured 2026-09-07 at `e89fff89`),",
+        "ripgrep at 2,261 commits,",
+        "V3",
+    ),
+    (
+        "a prose paragraph states a size with no stamp",
+        "here (v0.7.2, 2026-09-07), above the 703.9 MiB",
+        "here, above the 703.9 MiB",
+        "V4",
+    ),
+    (
+        "the breakdown table stops declaring how it was measured",
+        "| Part of `.kin/` | Size (by `du`) | Share |",
+        "| Part of `.kin/` | Size | Share |",
+        "M1",
+    ),
+    (
+        "the Measured table stops declaring how it was measured",
+        "Measured with the walk described above,",
+        "Measured on stores as they stand,",
+        "M1",
+    ),
+    (
+        "the breakdown loses the total that makes its parts checkable",
+        "| total (by `du`) | 754.2 MiB | 100% |\n",
+        "",
+        "M2",
+    ),
+    (
+        "a breakdown part no longer sums to the table's own total",
+        "| `kindb/<repo>/snapshots` (the graph snapshot) | 592.9 MiB | 78.6% |",
+        "| `kindb/<repo>/snapshots` (the graph snapshot) | 492.9 MiB | 78.6% |",
+        "M2",
+    ),
+    (
+        "a breakdown size becomes a bound nothing can add",
+        "| everything else | about 7 MiB | 1.0% |",
+        "| everything else | under 8 MiB | 1.0% |",
+        "M2",
+    ),
+    (
+        "a breakdown share stops reconciling against that table's own total",
+        "| `kindb/<repo>/source-blobs` (admitted bodies) | 154.0 MiB | 20.4% |",
+        "| `kindb/<repo>/source-blobs` (admitted bodies) | 154.0 MiB | 30.4% |",
+        "M3",
+    ),
+    (
+        "a share becomes a word instead of a percentage",
+        "| everything else | about 7 MiB | 1.0% |",
+        "| everything else | about 7 MiB | rounding |",
+        "M3",
+    ),
+    (
+        "the paragraph naming both methods together is deleted",
+        "This breakdown is measured by `du`, which counts allocated disk blocks rather\n"
+        "than the logical file bytes this page's own walk sums, so it totals 754.2 MiB\n"
+        "here (v0.7.2, 2026-09-07), above the 703.9 MiB `kin init` itself prints. The\n"
+        "two methods measure different things and are not meant to be added across\n"
+        "columns; a table like this one, left unlabeled, is what put a wrong number on\n"
+        "this page the first time.\n\n",
+        "",
+        "M4",
+    ),
+    (
+        "a third table publishes sizes under rules nobody declared",
+        "## Where to see it\n",
+        "## Another store\n\n"
+        "| Thing | Size |\n"
+        "| --- | --- |\n"
+        "| some other store | 12.5 MiB |\n\n"
+        "## Where to see it\n",
+        "P1",
+    ),
+]
+
+# The parts and shares move together so the du side stays self-consistent while
+# its total moves 6 MiB further from the walk-side 703.9 MiB the page also
+# prints. Nothing here is a claim about any real store; it exists to prove the
+# guard does not compare across methods.
+CONTROL_CROSS_METHOD: list[tuple[str, str]] = [
+    (
+        "| `kindb/<repo>/snapshots` (the graph snapshot) | 592.9 MiB | 78.6% |",
+        "| `kindb/<repo>/snapshots` (the graph snapshot) | 592.9 MiB | 78.0% |",
+    ),
+    (
+        "| `kindb/<repo>/source-blobs` (admitted bodies) | 154.0 MiB | 20.4% |",
+        "| `kindb/<repo>/source-blobs` (admitted bodies) | 154.0 MiB | 20.3% |",
+    ),
+    (
+        "| everything else | about 7 MiB | 1.0% |",
+        "| everything else | about 13 MiB | 1.7% |",
+    ),
+    (
+        "| total (by `du`) | 754.2 MiB | 100% |",
+        "| total (by `du`) | 760.2 MiB | 100% |",
+    ),
+]
+
+
+def main() -> int:
+    if not PAGE.is_file():
+        print(f"falsify: {PAGE} is not a file", file=sys.stderr)
+        return 1
+    original = PAGE.read_text(encoding="utf-8")
+    failures: list[str] = []
+
+    with tempfile.TemporaryDirectory(prefix="store-size-falsify-") as directory:
+        scratch = Path(directory) / "store-size.md"
+
+        scratch.write_text(original, encoding="utf-8")
+        code, output = run_guard(scratch)
+        if code == 0:
+            print("falsify: [control 1/2] the real page is clean: PASS")
+        else:
+            failures.append("control 1: the real page does not pass its own guard")
+            print("falsify: [control 1/2] the real page is clean: FAIL")
+            print(output)
+
+        moved = original
+        for old, new in CONTROL_CROSS_METHOD:
+            moved = mutate(moved, old, new)
+        scratch.write_text(moved, encoding="utf-8")
+        code, output = run_guard(scratch)
+        if code == 0:
+            print(
+                "falsify: [control 2/2] a self-consistent du total 6 MiB further from "
+                "the walk total stays clean: PASS"
+            )
+        else:
+            failures.append(
+                "control 2: the guard went red comparing a du figure against a walk "
+                f"figure, which is the mistake it exists to refuse. Rules: "
+                f"{sorted(rules_fired(output))}"
+            )
+            print("falsify: [control 2/2] cross-method refusal: FAIL")
+            print(output)
+
+        for index, (label, old, new, expected) in enumerate(PROBES, start=1):
+            scratch.write_text(mutate(original, old, new), encoding="utf-8")
+            code, output = run_guard(scratch)
+            fired = rules_fired(output)
+            if code == 0:
+                failures.append(f"probe {index} ({label}) was let through")
+                print(f"falsify: [{index}/{len(PROBES)}] {label}: LET THROUGH")
+            elif expected not in fired:
+                failures.append(
+                    f"probe {index} ({label}) went red on {sorted(fired)} rather than "
+                    f"{expected}, so the guard refused it for the wrong reason"
+                )
+                print(
+                    f"falsify: [{index}/{len(PROBES)}] {label}: WRONG RULE "
+                    f"{sorted(fired)}"
+                )
+            else:
+                print(
+                    f"falsify: [{index}/{len(PROBES)}] {label}: refused by {expected}"
+                )
+
+    if failures:
+        print("", file=sys.stderr)
+        for failure in failures:
+            print(f"falsify: {failure}", file=sys.stderr)
+        print(
+            f"falsify: {len(failures)} of {len(PROBES) + 2} case(s) did not hold",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"falsify: 2 controls held and {len(PROBES)} probes were refused by name")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What this does

`docs/store-size.md` carried a ripgrep store size that was wrong by 1.74x for about a month, and the
launch post carried it outward. Two defects made it and neither was arithmetic: the figures were
measured at workspace version 0.5.6 and nothing on the page said so, and the breakdown was measured
with `du` while the total came from Kin's own logical-byte walk, so the two halves could never add
up. #1578 corrected the page. This PR is the scripted check the lane contract requires for every
finding class, so the class is never rediscovered a release later.

## Where it runs, and why that is the point

Both steps are in `fast-gate-lint`, the required `Fast gate lint and policy` context. That job has
no `if:` and no `needs:`, so it runs on every pull request, including a docs-only one, which is the
kind of pull request that will break this page. A rule under `scripts/acceptance/` would run only on
main's push run (`Product Acceptance` carries `if: github.event_name != 'pull_request'`), which is
exactly the delay that let the wrong number ship.

`bin/kin-precheck` enumerates the `check` job alone, so nothing here changes any lane's local gate.

## The design call

The guard never reconciles across methods, and an undeclared method is a failure. No tolerance can
do the reconciling correctly: the correct page today has a legitimate 7.1% gap between its `du` total
and its walk total, and the original defect was a 10.3% arithmetic gap. Set 2% and the correct page
goes red; set 10% and the defect walks through. The two are not separable by magnitude, which is why
a careful reader could not tell them apart for a month either. So every size table names its method
from a closed vocabulary, arithmetic is checked only within one declared method, and a page carrying
two methods must have a paragraph naming both.

## Page change

Two lines, no new figure. A total row in the breakdown table restates the 754.2 MiB already in the
prose below it, and the paragraph naming both methods gains the version and date the same
measurement already carries three lines above.

## Verification hosted CI does not itself check

The guard against the page as it stood before #1578 (`git show 2c545ef1c:docs/store-size.md`):

```
$ python3 scripts/check-store-size-figures.py --page /tmp/sizeguard-prefix-page.md
store-size: graded 14 size figure(s) across 2 table(s) and 2 prose paragraph(s)
store-size: [M1] line 38: the breakdown table's size columns declare no measurement method; name one of ['du', 'walk'] in the size column header or in the paragraph introducing the table
store-size: [V1] line 110: the Measured table has no version column; its rows are independent measurements, so one stamp for the table would let a stale row hide behind a fresh one
store-size: [V3] line 38: the paragraph introducing the breakdown table carries no version and date, and it is the only stamp that table has
store-size: [V4] line 34: this paragraph states 6.1 MiB, 405.4 MiB with no version and date beside it; an unstamped figure is indistinguishable from a stale one, which is how the ripgrep number survived a dozen releases
store-size: [V4] line 62: this paragraph states 1163.50 MiB, 2.46 GiB with no version and date beside it; an unstamped figure is indistinguishable from a stale one, which is how the ripgrep number survived a dozen releases
store-size: [M2] line 42: the size cell 'under 1 MiB' for 'everything else' is not a value this guard will sum; write it as 'N MiB' or 'about N MiB', because a bound cannot be added to anything
store-size: [M2] line 38: the breakdown table states no total of its own. That is the defect this guard exists for: the parts were measured one way and the only total on the page was measured another, so they could never add up and nobody could see why
rc=1
```

The falsifier on this branch's page, after rebasing onto `origin/main` at the head this PR carries:

```
$ python3 scripts/falsify-store-size-figures.py
falsify: [control 1/2] the real page is clean: PASS
falsify: [control 2/2] a self-consistent du total 6 MiB further from the walk total stays clean: PASS
falsify: [1/16] the ripgrep row loses its version and date: refused by V2
falsify: [2/16] the ripgrep row is stamped with a version but no date: refused by V2
falsify: [3/16] the ripgrep row is stamped with a date but no version: refused by V2
falsify: [4/16] a row invents its own excuse instead of a stamp: refused by V2
falsify: [5/16] the Measured table loses its stamp column: refused by V1
falsify: [6/16] the breakdown table's introducing paragraph loses its stamp: refused by V3
falsify: [7/16] a prose paragraph states a size with no stamp: refused by V4
falsify: [8/16] the breakdown table stops declaring how it was measured: refused by M1
falsify: [9/16] the Measured table stops declaring how it was measured: refused by M1
falsify: [10/16] the breakdown loses the total that makes its parts checkable: refused by M2
falsify: [11/16] a breakdown part no longer sums to the table's own total: refused by M2
falsify: [12/16] a breakdown size becomes a bound nothing can add: refused by M2
falsify: [13/16] a breakdown share stops reconciling against that table's own total: refused by M3
falsify: [14/16] a share becomes a word instead of a percentage: refused by M3
falsify: [15/16] the paragraph naming both methods together is deleted: refused by M4
falsify: [16/16] a third table publishes sizes under rules nobody declared: refused by P1
falsify: 2 controls held and 16 probes were refused by name
rc=0
```

The falsifier itself was falsified: with the guard mutated to always exit 0 it reports all sixteen
probes `LET THROUGH` and exits 1; mutated to always exit 1, both controls fail and it exits 1. Four
arms were also run by hand on the real file (stamp removed, breakdown broken, method declaration
removed, both-methods paragraph deleted), each going red on the named rule alone and each restored
byte-for-byte, verified with `cmp`.

`bin/kin-precheck kin` through `heavy-slot.sh` with `--repo-dir`:

```
$ .kin-coord/bin/heavy-slot.sh sizeguard kin -- bin/kin-precheck kin --repo-dir kin=<worktree>
kin-precheck: repo=kin tree=/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/sizeguard-kin sha=b76c73dd6047ffb22f0939746995f5722dd84d97 branch=chore/lane-sizeguard-kin
kin-precheck: behind origin/main 0 commit(s)
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin b76c73dd6047ffb22f0939746995f5722dd84d97
heavy-slot: sizeguard command exit rc=0 at 2026-09-07T17:46:32Z
```

## Not closed here

Two Measured rows are stamped `synthetic fixture` rather than with a version and a date. Nothing in
the tree asserts those figures, so the word "fixture" is not backed by a test. The guard accepts that
literal only, refuses any other excuse, and prints a line naming each such row on every run so the
exemption is never invisible. Closing it is one `kin init` per fixture on the shipped binary, which is
a measurement lane's job rather than this one's.

Full report: `.kin-coord/reports/showhn-sizeguard-20260907.md` in the umbrella.
