### PR TITLE
Say what a repo-format change does to Git state and to native state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.4] - 2026-09-07
 
+**How a repo-format change affects your work.** 0.7.3 does not change Kin's on-disk repo format. An upcoming release will, and a store created before it will not open afterward. Your working tree is never touched.
+
+If you admitted your repository from Git, the recovery path is `kin init` again, and it is tested. Delete `.kin`, re-run it, and everything Git holds comes back. Measured on 0.7.3 against a 261-commit repository: all 261 commits, all 61 refs and every tag returned, and the Git head was unchanged. Keep the `Repository:` id that `kin init` printed, though. A rebuild mints a new one and every exact-transfer surface is bound to it, so a store that has ever pushed to a Kin remote needs `kin init --adopt-repository-id <ID>` to push where the old one could.
+
+Work that only ever lived in Kin is a different question, because Git never had it. Native commits, Kin branches, reviews and specs live in `.kin` and go when it goes, and today the only way to carry any of it out is `kin git export --output <dir>`, which writes commits and refs into a plain Git repository and carries no review, no spec and no entity history. So the format change ships together with an upgrade command that carries native state forward, or it does not ship.
+
 ### Changed
 
 - Fix quickstart paste boundaries and repository selection (FIR-3348) (#1581)
@@ -16,7 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.3] - 2026-09-06
 
-**Heads up:** 0.7.3 does not change Kin's on-disk repo format, but an upcoming release will. Any store you create before that lands will not open afterward, and rebuilding one just means running `kin init` again. Nothing in your working tree is touched.
+**How a repo-format change affects your work.** 0.7.3 does not change Kin's on-disk repo format. An upcoming release will, and a store created before it will not open afterward. Your working tree is never touched.
+
+If you admitted your repository from Git, the recovery path is `kin init` again, and it is tested. Delete `.kin`, re-run it, and everything Git holds comes back. Measured on 0.7.3 against a 261-commit repository: all 261 commits, all 61 refs and every tag returned, and the Git head was unchanged. Keep the `Repository:` id that `kin init` printed, though. A rebuild mints a new one and every exact-transfer surface is bound to it, so a store that has ever pushed to a Kin remote needs `kin init --adopt-repository-id <ID>` to push where the old one could.
+
+Work that only ever lived in Kin is a different question, because Git never had it. Native commits, Kin branches, reviews and specs live in `.kin` and go when it goes, and today the only way to carry any of it out is `kin git export --output <dir>`, which writes commits and refs into a plain Git repository and carries no review, no spec and no entity history. So the format change ships together with an upgrade command that carries native state forward, or it does not ship.
 
 ### Changed
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -263,6 +263,32 @@ byte counts under `store_footprint`. Kin does not cap store size or refuse a
 repository for being large, so plan disk against your history rather than
 against your checkout.
 
+### What survives if you have to rebuild the store
+
+An upcoming release changes Kin's on-disk repo format, and a store created
+before it will not open afterward. Your working tree is never touched, so
+nothing you have on disk is at risk.
+
+What a rebuild recovers depends on where the work came from. Kin writes `.kin`
+and reads `.git`, so deleting the store cannot touch Git history: if you
+admitted this repository from Git, the recovery path is `kin init` again, and it
+is tested. Measured on 0.7.3 against a 261-commit repository, deleting `.kin`
+and re-running `kin init` returned all 261 commits, all 61 refs and every tag,
+each pointing at the same object as before. Keep the `Repository:` id that
+`kin init` printed, though. A rebuild mints a new one and every exact-transfer
+surface is bound to it, so a store that has ever pushed to a Kin remote needs
+`kin init --adopt-repository-id <ID>` to push where the old one could.
+
+Work that only ever lived in Kin is a different question, because Git never had
+it. `kin commit` records in Kin authority and not in Git, and native commits,
+Kin branches, reviews and specs all live in `.kin` and go when it goes. Today
+the only way to carry any of it out is `kin git export --output <dir>`, which
+writes every imported commit, every ref and your native commits into a fresh Git
+repository. It carries no review, no spec and no entity history, and it refuses
+a destination that already exists, so treat it as a way out rather than as a
+backup. The format change will ship together with an upgrade command that
+carries native state forward, or it will not ship.
+
 ### Profiling a slow command
 
 Every `kin` command can profile itself. No rebuild, no external profiler, and


### PR DESCRIPTION
The 0.7.3 note added by #1579 answers the file question and leaves open the one that costs a reader their evening. It says a store made before the format change will not open afterward, that rebuilding is `kin init` again, and that the working tree is untouched. All three are true for a repository admitted from Git. None of them says what happens to a commit, a branch, a review or a spec that exists only in Kin, and someone who makes native state tonight has no way to tell that `kin init` again does not bring it back.

So I measured both recovery paths before rewriting anything.

## What I measured, and against which bytes

The published v0.7.3 macOS release asset, not a local build:

```
$ shasum -a 256 kin-macos-aarch64.tar.gz
d6b808b6680a9075bd2a593ab575d63d9c523be7d3bf84b818cee69b6d834765
$ cat kin-macos-aarch64.tar.gz.sha256
d6b808b6680a9075bd2a593ab575d63d9c523be7d3bf84b818cee69b6d834765  kin-macos-aarch64.tar.gz
$ kin --version
kin 0.7.3 (72f1cfba717b5fde8a7d6de261526a6c99a422e9 detached 2026-09-07T13:51:48Z)
```

Isolated `HOME` and `KIN_HOME`, `KIN_EMBED_BACKEND=cpu`, no gpu lock, no daemon lock, no cargo. Subject repository: `BurntSushi/byteorder` cloned `--single-branch`, 261 commits, 61 refs, 58 of them annotated tags.

## Path one: delete `.kin`, run `kin init` again

Everything Git holds comes back, and the reason is stronger than "Kin restores it". Kin writes `.kin` and reads `.git`, so deleting the store cannot damage Git history. Across the full cycle, clone to `kin init` to native work to export to `rm -rf .kin` to `kin init` again, every one of the 61 ref oids is byte-identical:

```
refs before: 61  refs after: 61
diff rc=0  (0 = every ref oid identical across the whole cycle)
with a planted ref, diff rc=1 (nonzero proves the check can fail)
$ git fsck --no-progress
fsck rc=0
```

Nothing native came back. Every negative is paired with a positive control that hit:

```
--- native commit subject present after re-init? ---
0
--- positive control: a Git commit subject that MUST be present after re-init ---
control subject: github: add FUNDING
1

--- branches after ---
* refs/heads/master -> Commit 5a82625fae462e8ba64cec8146b24a372b4d75c6 [default]

--- reviews after ---
No reviews found.

--- specs after ---
No specs found.
```

The working tree kept the edited file and lost the record of it:

```
$ grep -c 'MPATH-NATIVE-EDIT-1' src/lib.rs
1
$ git status --porcelain
 M src/lib.rs
```

That is the founder's distinction, measured. The content is on disk as an uncommitted modification; the message, author, timestamp, change id, parentage and entity deltas are gone.

One loss nobody had named. `kin init` remints the repository identity, `6ca7e4c8-0544-4f65-9d96-aaea7c3b11b4` became `ac9a495c-d587-4190-9e1e-36a80df413e1`. `kin init --help` says every exact-transfer surface is identity-exact and cannot be retargeted after the fact, so a rebuilt store can never push where the old one could unless the reader kept the old id and passed it back with `--adopt-repository-id`. Today's note gives them no reason to keep it. The new text does.

## Path two: what can leave a store

`kin git export --output` is the only verb, and there is no `kin git import` or `kin git sync` (asserted by a parse test at `crates/kin-cli/src/main.rs:5709`).

```
$ kin git export --output <fresh dir>
Exported repository 6ca7e4c8-... authority generation 3 to <fresh dir>
261 imported commits reused, 1 native commits written, 62 refs written
```

Native commits do come out, as real fast-forward Git commits carrying a `kin-change-id` header, authored `<kin@localhost>`. The review and the spec appear in no reachable object, scanned over everything `git rev-list --objects --all` reaches:

```
raw object scan for review/spec markers (expect 0):
0
raw object scan positive control (native commit marker):
1
```

By construction it also carries no entity history, no relation graph, no risk summary, no approval and no audit trail, because the output is a Git repository. It refuses a destination that already exists, so it is a one-shot way out rather than a backup. `kin backup` is not the answer either: it writes under `.kin/backups/` so it dies with the store, and on this store `kin backup create` failed outright with `no graph snapshot found at .kin/kindb/graph.kndb`.

## What changed here

The note now says the two things separately, in the founder register, with no date and no version because neither is set. It replaces the #1579 note under `## [0.7.3]` and goes byte-identically under `## [0.7.4]`, because `extractSection` (`scripts/extract-release-notes.mjs:35-48`) takes one version's section only, v0.7.4 has no GitHub release yet, and once it is cut its body would otherwise carry no warning at all.

`docs/quickstart.md` gains the same facts as a subsection in section 3, right after "How much disk the store takes". That is where a first-time reader decides whether to trust the store with work, and a changelog is not somewhere they will look.

Both render cleanly through the extractor:

```
$ node ./scripts/extract-release-notes.mjs --version 0.7.3 --input ./CHANGELOG.md --output /tmp/n.md
$ node ./scripts/extract-release-notes.mjs --version 0.7.4 --input ./CHANGELOG.md --output /tmp/n.md
```

The v0.7.3 GitHub release body was edited by hand in the same pass, because `release.yml` renders a body once at publish (`push: tags`, `extract-release-notes.mjs --input ./CHANGELOG.md`) and nothing regenerates it. The only later body writes anywhere in the workflow set are `release-promote.yml:136` and `:174`, and both pipe the body through `read-promotion-plan.mjs strip-notice`, which removes only the `kin-first-contact-proof` marker block and whose own comment says the cut is "bounded by the block this release chain writes, so a body a human edited underneath keeps its text." Verified after the edit, with a negative control:

```
live body vs what I sent:      rc=0   (identical)
live body vs the ORIGINAL:     rc=1   (the edit really landed)
first-contact marker present:  1
"What's Changed" present:      1
"Full Changelog" present:      1
latest tag: v0.7.3    isPrerelease: false
```

## Local gates

`bin/kin-precheck kin`, run through `heavy-slot.sh` against this exact tree and sha, clean rather
than dirty:

```
kin-precheck: repo=kin tree=.../worktrees/migrationpath-kin sha=676afeb43a5bbc5b4d4a922ce08629b981b19b08 branch=chore/lane-migrationpath-kin
kin-precheck: behind origin/main 0 commit(s)
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 676afeb43a5bbc5b4d4a922ce08629b981b19b08
```

The `Release version gate` needs no bump here: `classifyPath` treats markdown as non-release, and
both changed files are markdown.

## No new tests, and why

This is a documentation change with no runtime behaviour to guard. The behaviour it describes is the class that needs a scripted check, and that check belongs to the `kin upgrade` command that does not exist yet. The report carries the acceptance test for it, with a falsification arm per record kind, so it lands with the command rather than as prose here.

No em dashes added: `git diff -U0 | grep '^+'` matches zero dash lookalikes, and a planted en dash matches 1 as the control. The 25 em dashes already in `CHANGELOG.md` are from 0.2.x-era release sections and are left alone; rewriting published release notes for punctuation is a bigger decision than this change.

Full measurement report, including the `kin upgrade` requirement written as a fileable ticket and three findings for separate tickets (annotated tags flattened by export, `kin backup create` refusing a healthy store, and export refusing an existing destination): `.kin-coord/reports/migrationpath-20260907.md`.
