### PR TITLE
Answer one repository's entity graph in a single read

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -2228,6 +2228,7 @@ fn api_routes() -> Router<Arc<DaemonState>> {
         .route("/repos", get(list_repos))
         .route("/repos/{repo_id}/health", get(repo_health))
         .route("/repos/{repo_id}/entities", get(repo_entities))
+        .route("/repos/{repo_id}/graph/export", get(repo_graph_export))
         .route("/repos/{repo_id}/files", get(repo_files))
         .route("/repos/{repo_id}/blob", get(crate::repo_blob::repo_blob))
         .route(
@@ -7698,7 +7699,8 @@ async fn graph_bootstrap(
     Ok(([(header::CONTENT_TYPE, "application/octet-stream")], bytes))
 }
 
-/// Query parameters for `GET /graph/export`.
+/// Query parameters for `GET /graph/export` and
+/// `GET /repos/{repo_id}/graph/export`, which take the same ones.
 #[derive(Debug, Deserialize)]
 struct GraphExportParams {
     /// Node cap. `0` asks for the whole graph; absent uses the default cap.
@@ -7730,10 +7732,45 @@ async fn graph_export(
     Query(params): Query<GraphExportParams>,
     State(state): State<Arc<DaemonState>>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    use kin_cli::commands::graph_export as export;
-
     let session_id = extract_session_id_from_headers(&headers)?;
     let graph = resolve_session_graph(&state, session_id.as_ref()).await;
+    export_graph_projection(&state, graph, params).await
+}
+
+/// GET /repos/{repo_id}/graph/export: the same drawable projection, addressed
+/// by repository rather than by session.
+///
+/// A daemon serving many repositories cannot answer from the session route. A
+/// control plane asking for one repository's graph holds a repo id and no
+/// session, and `/graph/export` resolves whatever graph the request's session
+/// names, which is not the repository being asked about. This resolves the
+/// graph the id names and then runs the same projection, so a consumer picks
+/// the route by what it is holding and types one response shape for both.
+///
+/// No session scope is read here, deliberately. A repository-addressed read is
+/// answered from the graph that id names, the same rule every other
+/// `/repos/{repo_id}` route follows.
+async fn repo_graph_export(
+    Path(repo_id): Path<String>,
+    Query(params): Query<GraphExportParams>,
+    State(state): State<Arc<DaemonState>>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let graph = repo_scoped_graph(&state, &repo_id).await?;
+    export_graph_projection(&state, graph, params).await
+}
+
+/// Project one already-resolved graph into the export payload.
+///
+/// Both export routes come through here rather than each assembling a payload
+/// of its own. The response shape is a contract a consumer types once, and a
+/// copied handler is exactly how a second route ends up serving a shape that is
+/// nearly the same.
+async fn export_graph_projection(
+    state: &DaemonState,
+    graph: Arc<kin_db::InMemoryGraph>,
+    params: GraphExportParams,
+) -> Result<Json<kin_cli::commands::graph_export::GraphExportPayload>, (StatusCode, String)> {
+    use kin_cli::commands::graph_export as export;
 
     let options = export::ExportOptions {
         limit: match params.limit {
@@ -34725,6 +34762,7 @@ mod tests {
 
         for path in [
             format!("/repos/{repo_id}/entities"),
+            format!("/repos/{repo_id}/graph/export"),
             format!("/repos/{repo_id}/refs"),
             format!("/repos/{repo_id}/files"),
             format!("/repos/{repo_id}/history"),
@@ -34771,6 +34809,7 @@ mod tests {
         for path in [
             format!("/repos/{unserved}/health"),
             format!("/repos/{unserved}/entities"),
+            format!("/repos/{unserved}/graph/export"),
             format!("/repos/{unserved}/provenance/verify"),
             format!("/repos/{unserved}/files"),
             format!("/repos/{unserved}/refs"),
@@ -41915,6 +41954,141 @@ mod tests {
         assert!(
             second.seq >= emitted.seq,
             "an export taken after the event must include it in its cut"
+        );
+    }
+
+    /// Ask a repository-addressed `/graph/export` and read its payload back.
+    async fn repo_export_payload(
+        state: Arc<DaemonState>,
+        repo_id: &str,
+        query: &str,
+    ) -> kin_cli::commands::graph_export::GraphExportPayload {
+        let uri = if query.is_empty() {
+            format!("/repos/{repo_id}/graph/export")
+        } else {
+            format!("/repos/{repo_id}/graph/export?{query}")
+        };
+        let (status, body) = repo_route(state, &uri).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "GET {uri}: {}",
+            String::from_utf8_lossy(&body)
+        );
+        serde_json::from_slice(&body).unwrap()
+    }
+
+    /// The read the session route cannot serve: one named repository's own
+    /// entity-to-entity relations, in one request.
+    ///
+    /// A control plane drawing a repository holds a repo id and no session, and
+    /// `/graph/export` answers from whatever graph the request's session
+    /// resolves to. Without this route the only repository-addressed graph read
+    /// is `/repos/{repo_id}/entities`, which carries no relations at all, so a
+    /// renderer has nothing to draw an edge from except the file each entity
+    /// happens to sit in.
+    #[tokio::test]
+    async fn a_repo_scoped_export_draws_the_named_repositorys_relations() {
+        let state = test_state();
+        let repo_id = advertised_repo_id(Arc::clone(&state)).await;
+        let caller = test_entity("caller", "src/a.py");
+        let callee = test_entity("callee", "src/b.py");
+        state.graph.upsert_entity(&caller).unwrap();
+        state.graph.upsert_entity(&callee).unwrap();
+        link(&state, &caller, &callee, RelationKind::Calls);
+
+        let payload = repo_export_payload(Arc::clone(&state), &repo_id, "").await;
+
+        assert_eq!(payload.nodes.len(), 2);
+        assert_eq!(payload.entity_count, 2);
+        assert_eq!(payload.relation_count, 1);
+        assert!(!payload.sampled);
+        assert!(
+            !payload.root_hash.is_empty(),
+            "without a root hash a client cannot pair this with the event stream"
+        );
+        assert_eq!(
+            payload.links.len(),
+            1,
+            "the entity-to-entity edge is the whole point of this route"
+        );
+        assert_eq!(payload.links[0].kind, "Calls");
+        let caller_id = caller.id.to_string();
+        let callee_id = callee.id.to_string();
+        let endpoints = [
+            payload.links[0].source.as_str(),
+            payload.links[0].target.as_str(),
+        ];
+        assert!(
+            endpoints.contains(&caller_id.as_str()) && endpoints.contains(&callee_id.as_str()),
+            "the edge must join the two entities that were linked: {endpoints:?}"
+        );
+        for node in &payload.nodes {
+            assert_eq!(
+                node.degree, 1,
+                "both endpoints of the one edge have degree 1"
+            );
+        }
+    }
+
+    /// The cap is the same cap, applied server side, and the counts still
+    /// describe the population rather than the drawing.
+    #[tokio::test]
+    async fn a_repo_scoped_export_caps_and_reports_what_it_sampled_from() {
+        let state = test_state();
+        let repo_id = advertised_repo_id(Arc::clone(&state)).await;
+        for index in 0..6 {
+            let entity = test_entity(&format!("fn{index}"), &format!("src/m{index}.py"));
+            state.graph.upsert_entity(&entity).unwrap();
+        }
+
+        let capped = repo_export_payload(Arc::clone(&state), &repo_id, "limit=2").await;
+        assert_eq!(capped.nodes.len(), 2);
+        assert!(capped.sampled);
+        assert_eq!(capped.limit, Some(2));
+        assert_eq!(
+            capped.entity_count, 6,
+            "the count is the population, not the drawing"
+        );
+
+        let uncapped = repo_export_payload(Arc::clone(&state), &repo_id, "limit=0").await;
+        assert_eq!(uncapped.nodes.len(), 6);
+        assert!(!uncapped.sampled);
+        assert_eq!(uncapped.limit, None);
+    }
+
+    /// One shape for both routes, so a consumer types the response once.
+    ///
+    /// Over the same graph the two exports differ in nothing but `seq`, which
+    /// is a cut position in the event stream and moves on its own. A copied
+    /// handler would pass every assertion above and still drift here.
+    #[tokio::test]
+    async fn both_export_routes_answer_one_shape() {
+        let state = test_state();
+        let repo_id = advertised_repo_id(Arc::clone(&state)).await;
+        let caller = test_entity("caller", "src/a.py");
+        let callee = test_entity("callee", "src/b.py");
+        state.graph.upsert_entity(&caller).unwrap();
+        state.graph.upsert_entity(&callee).unwrap();
+        link(&state, &caller, &callee, RelationKind::Calls);
+
+        // Uncapped, so both payloads sort their nodes by id and this compares
+        // values rather than two draws of a sample.
+        let query = "limit=0&include=line,signature";
+        let session = export_payload(Arc::clone(&state), query).await;
+        let scoped = repo_export_payload(Arc::clone(&state), &repo_id, query).await;
+
+        let mut session_json = serde_json::to_value(&session).unwrap();
+        let mut scoped_json = serde_json::to_value(&scoped).unwrap();
+        assert!(
+            session_json.get("seq").is_some() && scoped_json.get("seq").is_some(),
+            "both payloads carry the cut position a client resyncs on"
+        );
+        session_json["seq"] = serde_json::Value::Null;
+        scoped_json["seq"] = serde_json::Value::Null;
+        assert_eq!(
+            session_json, scoped_json,
+            "the repo-scoped export must be the session export's shape and values"
         );
     }
 

--- a/docs/graph-feed.md
+++ b/docs/graph-feed.md
@@ -55,6 +55,27 @@ its endpoints is counted once.
 A session holding a temporal scope exports the graph that scope names, the same
 resolution `/graph/bootstrap` uses.
 
+### Addressing one repository
+
+`GET /repos/{repo_id}/graph/export` is the same export over the graph a repo id
+names. Same parameters, same caps, same response, so a consumer types one shape
+and picks the route by what it is holding.
+
+```
+curl "$KIN_DAEMON_URL/repos/$REPO_ID/graph/export?limit=1400"
+```
+
+Reach for it when you hold a repository id and no session. A daemon serving
+many repositories cannot answer `/graph/export` for one of them, because that
+route resolves whichever graph the request's session names, and a control plane
+drawing a repository has no session to name it with. The id is the one
+`GET /health` advertises, and it is the same id every other `/repos/{repo_id}`
+route takes. An id this daemon does not serve answers 404 naming both the served
+and the requested id, which is an addressing mismatch rather than a failure.
+
+No session scope is read on this route. A repository-addressed read is answered
+from the graph that id names.
+
 ## The sampling rule
 
 A repository graph is bigger than any renderer wants. The cap is applied server

--- a/packages/boundary-contracts/schemas/graph-export.schema.json
+++ b/packages/boundary-contracts/schemas/graph-export.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "kin://contracts/graph-export",
-  "description": "The drawable projection of a Kin repository graph, as served by GET /graph/export on the daemon and by `kin graph export`. Nodes and links are what a renderer draws; the counts describe the population the sample was drawn from, so a consumer can say how much of the graph it is showing.",
+  "description": "The drawable projection of a Kin repository graph, as served by GET /graph/export and GET /repos/{repo_id}/graph/export on the daemon, and by `kin graph export`. Nodes and links are what a renderer draws; the counts describe the population the sample was drawn from, so a consumer can say how much of the graph it is showing.",
   "type": "object",
   "required": [
     "root_hash",

--- a/packages/boundary-contracts/src/index.d.ts
+++ b/packages/boundary-contracts/src/index.d.ts
@@ -994,9 +994,10 @@ export interface RepoImportedWorkSummary {
 /**
  * The drawable projection of a Kin repository graph.
  *
- * Served by `GET /graph/export` on the daemon and by `kin graph export`. The
- * counts describe the population the sample was drawn from, not what was
- * drawn, so a consumer can say how much of the graph it is showing.
+ * Served by `GET /graph/export` and `GET /repos/{repo_id}/graph/export` on the
+ * daemon, and by `kin graph export`. The counts describe the population the
+ * sample was drawn from, not what was drawn, so a consumer can say how much of
+ * the graph it is showing.
  */
 export interface GraphExportNode {
   /** Entity UUID. */


### PR DESCRIPTION
## What this does

Adds `GET /repos/{repo_id}/graph/export`, so a caller holding a repository id can read that
repository's entity-to-entity relations in one request.

kinlab.ai/demo draws a repository's entity graph. The only repository-addressed graph read this
daemon had was `GET /repos/{repo_id}/entities`, which carries no relations at all, so the drawing
fell back to file attribution instead of call and reference edges.

`GET /graph/export` already does the real work: it projects the graph to nodes and links, caps and
samples server side, and reports `unresolved_links`, `filtered_links` and `sampled`. One line made
it unusable here. It resolves the graph from the request's session (`api.rs:7736`), and a control
plane asking about a repository holds a repo id and no session.

So the new route registers beside the other repo-scoped routes and resolves through
`repo_scoped_graph` (`api.rs:15287`), which already 404s an id this daemon does not serve, naming
both the served and the requested identity. Same query parameters, same caps, same payload.

## The part worth arguing about

The two routes share one projection rather than one being a copy of the other. `graph_export` keeps
its own doc comment and its session resolution; its body moved to `export_graph_projection`, which
takes an already-resolved graph, and both routes call it.

The response shape is a contract a consumer types once, and a copied handler is how a second route
ends up serving a shape that is nearly the same. `both_export_routes_answer_one_shape` holds that
line: over one graph the two payloads are equal field for field apart from `seq`, which is a cut
position in the event stream and moves on its own.

`packages/boundary-contracts` needed no schema change, which is the point. Both descriptions there
now name the second route, since they already enumerated where this payload is served.

## Verification

Every claim below is a command and its actual output, because a claim hosted CI does not itself
check is worth nothing as prose. The falsification sweep and its per-test logs live at
`.kin-coord/logs/graphexport073-falsify*.log`, and the lane report is
`.kin-coord/reports/graphexport073-20260907.md`.

### The tests, and proof they can fail

`.kin-coord/bin/heavy-slot.sh graphexport073 kin -- bash .kin-coord/logs/graphexport073-falsify.sh`

```
=== baseline ===
    PASS a_repo_scoped_export_draws_the_named_repositorys_relations
    PASS a_repo_scoped_export_caps_and_reports_what_it_sampled_from
    PASS both_export_routes_answer_one_shape
    PASS health_repo_id_addresses_every_repo_scoped_route
    PASS an_unserved_repo_id_is_an_identity_mismatch_rather_than_a_storage_failure
baseline: all five ran and passed
ARM route-gone: KILLED, 5 test(s) went red
ARM repo-id-ignored: KILLED, 1 test(s) went red
ARM cap-ignored: KILLED, 1 test(s) went red
ARM links-dropped: KILLED, 1 test(s) went red
=== sweep done, fail=0 ===
```

Which test goes red per arm is the part that matters. `route-gone` (delete the registration) takes
all five, because axum answers an unmatched path with a bodiless 404 and the unserved sweep asserts
the body names both ids. `repo-id-ignored` (resolve `state.graph` instead of `repo_scoped_graph`)
takes only the unserved-id test, which is exactly right: on a local daemon the served id's graph IS
`state.graph`, so no positive test can tell the two apart and only an unserved id can.
`cap-ignored` takes only the cap test, `links-dropped` only the relations test.

Each run asserts libtest printed `running 1 test` before believing its exit code, because an
`--exact` path matching nothing exits 0 having graded nothing.

### kin-precheck

`.kin-coord/bin/heavy-slot.sh graphexport073 kin -- bin/kin-precheck kin --repo-dir kin=<worktree>`

```
kin-precheck: repo=kin tree=.kin-coord/worktrees/graphexport073-kin sha=247cac147 branch=chore/lane-graphexport073-kin DIRTY
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
PASS     node-test                            node --test <15 file(s) named by the check job>
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 247cac14788e9b154d63a48feb14615e969ad00b DIRTY
```

Fifteen more guard gates passed and are elided; the tally line is the verdict. The `DIRTY` tree it
graded is byte-identical to the commit this PR carries: the run started before the commit and
`git status --porcelain` was empty immediately after, with nothing edited in between.

### The touched crate's own suite

`cargo test -p kin-daemon` through the same heavy slot, after precheck:

```
test result: ok. 1547 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 456.53s
test result: ok. 6 passed; 0 failed; ...
test result: ok. 10 passed; 0 failed; ...
test result: ok. 1 passed; 0 failed; ...
test result: ok. 6 passed; 0 failed; ...
test result: ok. 5 passed; 0 failed; ...
test result: ok. 12 passed; 0 failed; ...
test result: ok. 3 passed; 0 failed; ...
test result: ok. 4 passed; 0 failed; ...
test result: ok. 4 passed; 0 failed; ...
cargo test -p kin-daemon rc=0
```

Ten targets, 1598 tests, 0 failed.

### The shared payload package

`npm test --prefix ./packages/boundary-contracts`: 19 tests, 19 pass, 0 fail, including the four
that grade this payload. No schema change was needed, so those four are unchanged and still green.
