### PR TITLE
Answer a search query phrased as a sentence (FIR-3351)

### DIFF
--- a/.github/workflows/kin-registry-release.yml
+++ b/.github/workflows/kin-registry-release.yml
@@ -207,6 +207,7 @@ jobs:
             --crate kin-model
             --crate kin-db
             --crate kin-lsp
+            --crate kin-search
             --crate kin-vfs-core
           )
           title="refresh Kin registry dependency pins"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3470,6 +3470,7 @@ dependencies = [
  "kin-ranking",
  "kin-review",
  "kin-runtime",
+ "kin-search",
  "kin-spine",
  "libc",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,11 @@ kin-lsp = { version = "=0.7.16", registry = "kin" }
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
 kin-db = { version = "=0.7.104", registry = "kin", default-features = false }
+# Pinned to the exact version kin-db builds its name-token index with. A
+# per-token name query hits that index only when the token came out of the same
+# tokenizer, so a version skew here would be a silent recall loss rather than a
+# build failure.
+kin-search = { version = "=0.1.9", registry = "kin" }
 kin-vfs-core = { version = "=0.4.24", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-mcp/Cargo.toml
+++ b/crates/kin-mcp/Cargo.toml
@@ -22,6 +22,10 @@ kin-context = { workspace = true }
 kin-review = { workspace = true }
 kin-runtime = { workspace = true }
 kin-ranking = { workspace = true }
+# The tokenizer the store's name-token index is built with. A per-token name
+# query is only guaranteed to hit that index when the token came out of the same
+# splitter, so this is a correctness dependency rather than a convenience one.
+kin-search = { workspace = true }
 kin-spine = { workspace = true }
 base64 = "0.23"
 hex = { workspace = true }

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -12617,6 +12617,15 @@ mod tests {
             ("change_log", "crates/kin-daemon/src/provenance.rs"),
             // The two-word shape the hosted route was measured on.
             ("reconcile_report", "crates/kin-daemon/src/loop_runner.rs"),
+            // "where are the projections and entities stored". Both plural words
+            // have to reduce before either reaches this declaration, and neither
+            // reaches the distractor, so the question is unanswerable without
+            // the reduction and answered wrongly with only the distractor.
+            (
+                "projection_entity_store",
+                "crates/kin-projection/src/store.rs",
+            ),
+            ("stored_blob_count", "crates/kin-blobs/src/metrics.rs"),
         ] {
             store
                 .upsert_entity(&make_entity_in(LanguageId::Rust, name, file))
@@ -12776,6 +12785,44 @@ mod tests {
             payload[crate::query_tokens::LEXICAL_FALLBACK_KEY]["retrieved_by"],
             serde_json::json!("one declaration-name query per token"),
             "the answer has to say so, or the empty slot above is silent"
+        );
+    }
+
+    /// A question's plural words have to reach the singular tokens the index
+    /// holds, and this is the input that proves the reduction is load-bearing.
+    ///
+    /// Written after a falsification arm that disabled the reduction left every
+    /// other test in this file green. The reason was a second defence rather than
+    /// a weak assertion: on "where are projections written to disk" the token
+    /// `disk` retrieves the intended declaration on its own, so the plural word
+    /// never had to work for that answer to be right.
+    ///
+    /// Here it has to. Both content words of the question are plural, the
+    /// declaration that answers it is named for one projection and one entity,
+    /// and the distractor is named for the only word that needs no reduction. So
+    /// with the reduction the answer covers two of the question's words and wins;
+    /// without it the answer is not retrieved at all and the distractor is the
+    /// whole page.
+    #[test]
+    fn a_question_in_the_plural_reaches_a_declaration_named_in_the_singular() {
+        let store = phrase_store();
+        let payload = parsed_response(
+            &handle_semantic_search(
+                &search_args("where are the projections and entities stored", None),
+                &store,
+            )
+            .unwrap(),
+        );
+        let names = search_names(&payload);
+        assert_eq!(
+            names.first().map(String::as_str),
+            Some("projection_entity_store"),
+            "the plural question must reach the singular declaration: {names:?}"
+        );
+        assert!(
+            names.contains(&"stored_blob_count".to_string()),
+            "the distractor must still be retrieved, or this test could pass \
+             because the store returned nothing at all: {names:?}"
         );
     }
 

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -54,6 +54,34 @@ pub fn handle_semantic_search<G: GraphStore>(
     let compact = get_optional_bool(args, "compact", true);
 
     let entities = store.query_entities(&filter).map_err(McpError::graph)?;
+
+    // A question phrased as a sentence cannot survive the store's name filter:
+    // its index tokenizes the pattern and its predicate substring-matches the
+    // whole pattern, so anything the index does return is thrown away by the
+    // predicate, and a pattern carrying a space is what no declaration name can
+    // contain. Re-ask it as one query per token and rank the union here.
+    //
+    // Gated on the empty answer, so no query that answers today changes at all,
+    // and gated on whitespace inside `crate::query_tokens::plan`, so a bare
+    // identifier that is genuinely absent keeps reporting a clean miss rather
+    // than a page of entities that merely share a word with it.
+    let (entities, fallback) = if entities.is_empty() {
+        match crate::query_tokens::plan(&query) {
+            Some(planned) => {
+                let hits = retrieve_query_tokens(store, &filter, &planned)?;
+                let ranked = crate::query_tokens::rank(&planned, &hits);
+                let disclosure =
+                    crate::query_tokens::disclosure(&planned, &hits, ranked.len());
+                (
+                    ranked.into_iter().map(|hit| hit.entity).collect::<Vec<_>>(),
+                    Some(disclosure),
+                )
+            }
+            None => (entities, None),
+        }
+    } else {
+        (entities, None)
+    };
     let total_matches = entities.len();
 
     let mut payload = if compact {
@@ -143,8 +171,70 @@ pub fn handle_semantic_search<G: GraphStore>(
         payload[crate::edge_coverage::EDGE_COVERAGE_KEY] = observation;
     }
 
+    // Additive, and attached whether or not the fan-out found anything, because
+    // an empty answer to a sentence is exactly the answer a reader is most
+    // likely to read as "the repository does not do this".
+    if let Some(disclosure) = fallback {
+        payload[crate::query_tokens::LEXICAL_FALLBACK_KEY] = disclosure;
+    }
+
     let json = serde_json::to_string_pretty(&payload).map_err(McpError::Json)?;
     Ok(ToolCallResult::text(json))
+}
+
+/// Ask the store for each planned token in turn, under the same narrowing
+/// filters the caller asked for.
+///
+/// Sequential and bounded on purpose. One phrase becomes at most
+/// `MAX_QUERY_TOKENS` store queries, each truncated to
+/// `max_candidates_per_token`, so a long sentence cannot multiply the work a
+/// single search asks of a daemon. The narrowing filters ride along unchanged:
+/// a caller that asked for `kind: "class"` asked about classes, and a fallback
+/// that quietly widened the question would answer one nobody put.
+///
+/// A token that matches nothing is asked once more in its singular spelling,
+/// since a question says "projections" where the declaration is named for one
+/// projection, and the index holds only the tokens the names produced.
+fn retrieve_query_tokens<G: GraphStore>(
+    store: &G,
+    filter: &EntityFilter,
+    planned: &crate::query_tokens::TokenPlan,
+) -> Result<Vec<crate::query_tokens::TokenHits>> {
+    let cap = crate::query_tokens::max_candidates_per_token();
+    let mut hits = Vec::with_capacity(planned.tokens.len());
+    for token in &planned.tokens {
+        let mut pattern = token.clone();
+        let mut entities = store
+            .query_entities(&EntityFilter {
+                name_pattern: Some(pattern.clone()),
+                ..filter.clone()
+            })
+            .map_err(McpError::graph)?;
+        if entities.is_empty() {
+            if let Some(reduced) = crate::query_tokens::singular(token) {
+                entities = store
+                    .query_entities(&EntityFilter {
+                        name_pattern: Some(reduced.clone()),
+                        ..filter.clone()
+                    })
+                    .map_err(McpError::graph)?;
+                if !entities.is_empty() {
+                    pattern = reduced;
+                }
+            }
+        }
+        let total_matching = entities.len();
+        let truncated = total_matching > cap;
+        entities.truncate(cap);
+        hits.push(crate::query_tokens::TokenHits {
+            token: token.clone(),
+            pattern,
+            entities,
+            total_matching,
+            truncated,
+        });
+    }
+    Ok(hits)
 }
 
 /// The narrowing filters a search request applied beside its name pattern, named
@@ -12486,6 +12576,322 @@ mod tests {
         assert_eq!(
             value["_kin"]["degraded"]["offline_fallback"],
             serde_json::json!(true)
+        );
+    }
+
+    // ── A question phrased as a sentence ────────────────────────────────────
+
+    /// A store shaped like a slice of this repository, with a distractor beside
+    /// every answer that shares one of the question's words.
+    ///
+    /// Built on the real `InMemoryGraph` rather than a double on purpose: the
+    /// defect under test is the storage engine's own two-stage name filter, and
+    /// a hand-written matcher would be a restatement of what this code believes
+    /// that filter does rather than a run against it.
+    fn phrase_store() -> InMemoryGraph {
+        let store = InMemoryGraph::new();
+        for (name, file) in [
+            // "where does kin init stage the store"
+            ("stage_store_root", "crates/kin-cli/src/commands/init.rs"),
+            ("store_open", "crates/kin-core/src/store.rs"),
+            // "how does reconcile detect a stale graph"
+            (
+                "detect_stale_graph",
+                "crates/kin-reconcile/src/staleness.rs",
+            ),
+            ("graph_status", "crates/kin-daemon/src/status.rs"),
+            // "where does the MCP server register its tools"
+            ("register_tools", "crates/kin-mcp/src/server.rs"),
+            ("tool_budget", "crates/kin-mcp/src/budget.rs"),
+            // "where are projections written to disk"
+            (
+                "projection_disk_writer",
+                "crates/kin-projection/src/writer.rs",
+            ),
+            ("flush_pages", "crates/kin-projection/src/disk.rs"),
+            // "how is provenance recorded for a change"
+            (
+                "record_provenance_for_change",
+                "crates/kin-daemon/src/provenance.rs",
+            ),
+            ("change_log", "crates/kin-daemon/src/provenance.rs"),
+            // The two-word shape the hosted route was measured on.
+            ("reconcile_report", "crates/kin-daemon/src/loop_runner.rs"),
+        ] {
+            store
+                .upsert_entity(&make_entity_in(LanguageId::Rust, name, file))
+                .unwrap();
+        }
+        store
+    }
+
+    fn search_names(payload: &serde_json::Value) -> Vec<String> {
+        payload["results"]
+            .as_array()
+            .expect("results array")
+            .iter()
+            .map(|row| row["name"].as_str().unwrap_or_default().to_string())
+            .collect()
+    }
+
+    /// The defect, on the store the fix is then measured against.
+    ///
+    /// Asked directly of the graph, the way the handler asks it, so this is the
+    /// engine's answer and not a claim about it. Every one of these phrases
+    /// names a declaration the store holds, and the whole-query filter returns
+    /// none of them. `reconcile report` is the sharpest of the set: the same two
+    /// tokens joined by an underscore return the row, and the store's own name
+    /// index produces that row for both spellings. It is the predicate behind
+    /// the index, substring-matching the entire pattern, that throws it away
+    /// when the pattern carries a space.
+    #[test]
+    fn the_stores_whole_query_name_filter_answers_no_phrase_at_all() {
+        let store = phrase_store();
+        for phrase in [
+            "where does kin init stage the store",
+            "how does reconcile detect a stale graph",
+            "where does the MCP server register its tools",
+            "where are projections written to disk",
+            "how is provenance recorded for a change",
+            "reconcile report",
+        ] {
+            let matched = store
+                .query_entities(&EntityFilter {
+                    name_pattern: Some(phrase.to_string()),
+                    ..Default::default()
+                })
+                .unwrap();
+            assert!(
+                matched.is_empty(),
+                "the whole-query filter answered {phrase:?} with {} rows, so this store no \
+                 longer reproduces the defect the fallback exists for",
+                matched.len()
+            );
+        }
+
+        // The positive control the negatives above are worthless without: the
+        // same filter, one token, on the same store, returns the row.
+        let single = store
+            .query_entities(&EntityFilter {
+                name_pattern: Some("reconcile_report".to_string()),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(
+            single.len(),
+            1,
+            "the single-token control must hit, or every assertion above passes for the wrong \
+             reason"
+        );
+    }
+
+    /// Five questions, each phrased as a sentence, each with one declaration in
+    /// the store that answers it and one distractor that shares a word.
+    ///
+    /// Rank one rather than top three, because the store is small enough that
+    /// anything less would be evidence the ranking is not doing the work: the
+    /// question's own words are the only signal here, and the intended answer
+    /// carries more of them, or carries them on its name where the distractor
+    /// carries them on its path.
+    ///
+    /// Two of the distractors are the ones that matter. `store_open` and
+    /// `graph_status` are outranked on coverage, and `change_log` is outranked
+    /// on the field score alone: it and `record_provenance_for_change` each
+    /// carry two of that question's words, and the answer wins because it
+    /// carries "provenance" in its own name where the distractor only sits in a
+    /// file named for it. `flush_pages` is the case the response's
+    /// `retrieved_by` line describes: it shares two words with its question but
+    /// carries neither in its name, so no token query returns it and it is not
+    /// in the union to be ranked at all.
+    #[test]
+    fn a_multi_word_question_ranks_the_declaration_that_covers_it_first() {
+        let store = phrase_store();
+        for (question, expected) in [
+            ("where does kin init stage the store", "stage_store_root"),
+            (
+                "how does reconcile detect a stale graph",
+                "detect_stale_graph",
+            ),
+            (
+                "where does the MCP server register its tools",
+                "register_tools",
+            ),
+            (
+                "where are projections written to disk",
+                "projection_disk_writer",
+            ),
+            (
+                "how is provenance recorded for a change",
+                "record_provenance_for_change",
+            ),
+        ] {
+            let payload =
+                parsed_response(&handle_semantic_search(&search_args(question, None), &store).unwrap());
+            let names = search_names(&payload);
+            assert_eq!(
+                names.first().map(String::as_str),
+                Some(expected),
+                "{question:?} ranked {names:?}"
+            );
+            assert_eq!(
+                payload[crate::query_tokens::LEXICAL_FALLBACK_KEY]["answered_by"],
+                serde_json::json!("name_token_coverage"),
+                "{question:?} answered without saying which path answered"
+            );
+            assert_eq!(
+                payload[crate::query_tokens::LEXICAL_FALLBACK_KEY]["reason"],
+                serde_json::json!("no_vector_coverage")
+            );
+            assert_eq!(
+                payload[crate::query_tokens::LEXICAL_FALLBACK_KEY]["vector_ranked"],
+                serde_json::json!(false)
+            );
+        }
+    }
+
+    /// The retrieval boundary the response states, pinned rather than described.
+    ///
+    /// `flush_pages` sits in `crates/kin-projection/src/disk.rs`, so it carries
+    /// two of this question's words in its path and neither in its name. The
+    /// answer says candidates are retrieved by declaration name, and this is the
+    /// entity that makes that sentence load-bearing: a reader who assumed path
+    /// matching would read this empty slot as "no such code" rather than as "not
+    /// reachable by this path".
+    #[test]
+    fn a_declaration_no_query_token_names_is_not_in_the_union() {
+        let store = phrase_store();
+        let payload = parsed_response(
+            &handle_semantic_search(
+                &search_args("where are projections written to disk", None),
+                &store,
+            )
+            .unwrap(),
+        );
+        assert!(
+            !search_names(&payload).contains(&"flush_pages".to_string()),
+            "retrieval is by declaration name, so a path-only sharer must not appear: {:?}",
+            search_names(&payload)
+        );
+        assert_eq!(
+            payload[crate::query_tokens::LEXICAL_FALLBACK_KEY]["retrieved_by"],
+            serde_json::json!("one declaration-name query per token"),
+            "the answer has to say so, or the empty slot above is silent"
+        );
+    }
+
+    /// The two-word case, which fails one stage earlier than a sentence does and
+    /// is the shape the hosted route was measured on.
+    #[test]
+    fn two_words_and_an_underscore_now_answer_the_same_row() {
+        let store = phrase_store();
+        let underscored =
+            parsed_response(&handle_semantic_search(&search_args("reconcile_report", None), &store).unwrap());
+        assert_eq!(search_names(&underscored), vec!["reconcile_report"]);
+        assert!(
+            underscored
+                .get(crate::query_tokens::LEXICAL_FALLBACK_KEY)
+                .is_none(),
+            "a query the name filter answered must not claim a fallback ran"
+        );
+
+        let spaced =
+            parsed_response(&handle_semantic_search(&search_args("reconcile report", None), &store).unwrap());
+        assert_eq!(search_names(&spaced), vec!["reconcile_report"]);
+        assert_eq!(
+            spaced[crate::query_tokens::LEXICAL_FALLBACK_KEY]["matched"],
+            serde_json::json!(1)
+        );
+    }
+
+    /// The guarantee that keeps a certified miss certified.
+    ///
+    /// A bare identifier the graph does not hold is the one query whose empty
+    /// answer is the true answer, and the measured store had exactly that case:
+    /// a type defined in another repository and absent from this index. Answering
+    /// it with declarations that merely share a word would turn the one honest
+    /// miss in the set into a page that looks like a find, so the fallback is
+    /// gated on whitespace and this query never reaches it.
+    #[test]
+    fn a_single_identifier_that_is_absent_stays_absent_and_claims_no_fallback() {
+        let store = phrase_store();
+        let payload =
+            parsed_response(&handle_semantic_search(&search_args("SnapshotManager", None), &store).unwrap());
+        assert_eq!(payload["total_matches"], serde_json::json!(0));
+        assert!(search_names(&payload).is_empty());
+        assert!(
+            payload
+                .get(crate::query_tokens::LEXICAL_FALLBACK_KEY)
+                .is_none(),
+            "a single-token miss must keep the answer it has always given"
+        );
+    }
+
+    /// An empty answer to a sentence is the answer most likely to be misread, so
+    /// it is the one that must name the path that produced it.
+    #[test]
+    fn a_phrase_that_matches_nothing_still_says_which_path_looked() {
+        let store = phrase_store();
+        let payload = parsed_response(
+            &handle_semantic_search(&search_args("zqx not a real symbol qqzz", None), &store)
+                .unwrap(),
+        );
+        assert_eq!(payload["total_matches"], serde_json::json!(0));
+        let block = &payload[crate::query_tokens::LEXICAL_FALLBACK_KEY];
+        assert_eq!(block["matched"], serde_json::json!(0));
+        assert_eq!(block["answered_by"], serde_json::json!("name_token_coverage"));
+        assert!(block["query_tokens"]
+            .as_array()
+            .is_some_and(|tokens| tokens.iter().any(|t| t == "qqzz")));
+
+        // And the absence must not come back certified. The sentence this tool
+        // otherwise prints says no declaration in the index carries this name,
+        // which is true of every question ever typed and tells a reader nothing
+        // about whether the repository does the thing they asked about.
+        let negative = crate::negative::negative_for(
+            "semantic_search",
+            &payload,
+            &ready_daemon_envelope(11),
+            &[],
+        )
+        .expect("an empty search carries a negative");
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            serde_json::json!(false),
+            "a phrase that no declaration shares a word with is a miss about vocabulary, not a \
+             certifiable absence"
+        );
+        assert!(
+            negative["trust_reason"]
+                .as_str()
+                .is_some_and(|reason| reason.contains("lexical_fallback_matched_nothing")),
+            "the verdict must name the path that could not answer: {}",
+            negative["trust_reason"]
+        );
+    }
+
+    /// The narrowing filters a caller asked for still apply on this path.
+    ///
+    /// A fallback that quietly widened `kind` would answer a question nobody put,
+    /// and would do it on exactly the requests whose whole-query filter came back
+    /// empty because the narrowing removed everything.
+    #[test]
+    fn the_fallback_keeps_the_kind_filter_the_caller_asked_for() {
+        let store = phrase_store();
+        let payload = parsed_response(
+            &handle_semantic_search(
+                &search_args("how does reconcile detect a stale graph", Some("class")),
+                &store,
+            )
+            .unwrap(),
+        );
+        assert_eq!(
+            payload["total_matches"],
+            serde_json::json!(0),
+            "every entity in this store is a function, so a class-only question has no answer"
+        );
+        assert_eq!(
+            payload[crate::query_tokens::LEXICAL_FALLBACK_KEY]["matched"],
+            serde_json::json!(0)
         );
     }
 }

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -70,8 +70,7 @@ pub fn handle_semantic_search<G: GraphStore>(
             Some(planned) => {
                 let hits = retrieve_query_tokens(store, &filter, &planned)?;
                 let ranked = crate::query_tokens::rank(&planned, &hits);
-                let disclosure =
-                    crate::query_tokens::disclosure(&planned, &hits, ranked.len());
+                let disclosure = crate::query_tokens::disclosure(&planned, &hits, ranked.len());
                 (
                     ranked.into_iter().map(|hit| hit.entity).collect::<Vec<_>>(),
                     Some(disclosure),
@@ -12734,8 +12733,9 @@ mod tests {
                 "record_provenance_for_change",
             ),
         ] {
-            let payload =
-                parsed_response(&handle_semantic_search(&search_args(question, None), &store).unwrap());
+            let payload = parsed_response(
+                &handle_semantic_search(&search_args(question, None), &store).unwrap(),
+            );
             let names = search_names(&payload);
             assert_eq!(
                 names.first().map(String::as_str),
@@ -12831,8 +12831,9 @@ mod tests {
     #[test]
     fn two_words_and_an_underscore_now_answer_the_same_row() {
         let store = phrase_store();
-        let underscored =
-            parsed_response(&handle_semantic_search(&search_args("reconcile_report", None), &store).unwrap());
+        let underscored = parsed_response(
+            &handle_semantic_search(&search_args("reconcile_report", None), &store).unwrap(),
+        );
         assert_eq!(search_names(&underscored), vec!["reconcile_report"]);
         assert!(
             underscored
@@ -12841,8 +12842,9 @@ mod tests {
             "a query the name filter answered must not claim a fallback ran"
         );
 
-        let spaced =
-            parsed_response(&handle_semantic_search(&search_args("reconcile report", None), &store).unwrap());
+        let spaced = parsed_response(
+            &handle_semantic_search(&search_args("reconcile report", None), &store).unwrap(),
+        );
         assert_eq!(search_names(&spaced), vec!["reconcile_report"]);
         assert_eq!(
             spaced[crate::query_tokens::LEXICAL_FALLBACK_KEY]["matched"],
@@ -12861,8 +12863,9 @@ mod tests {
     #[test]
     fn a_single_identifier_that_is_absent_stays_absent_and_claims_no_fallback() {
         let store = phrase_store();
-        let payload =
-            parsed_response(&handle_semantic_search(&search_args("SnapshotManager", None), &store).unwrap());
+        let payload = parsed_response(
+            &handle_semantic_search(&search_args("SnapshotManager", None), &store).unwrap(),
+        );
         assert_eq!(payload["total_matches"], serde_json::json!(0));
         assert!(search_names(&payload).is_empty());
         assert!(
@@ -12885,7 +12888,10 @@ mod tests {
         assert_eq!(payload["total_matches"], serde_json::json!(0));
         let block = &payload[crate::query_tokens::LEXICAL_FALLBACK_KEY];
         assert_eq!(block["matched"], serde_json::json!(0));
-        assert_eq!(block["answered_by"], serde_json::json!("name_token_coverage"));
+        assert_eq!(
+            block["answered_by"],
+            serde_json::json!("name_token_coverage")
+        );
         assert!(block["query_tokens"]
             .as_array()
             .is_some_and(|tokens| tokens.iter().any(|t| t == "qqzz")));

--- a/crates/kin-mcp/src/lib.rs
+++ b/crates/kin-mcp/src/lib.rs
@@ -11,6 +11,7 @@ pub mod error;
 pub mod handlers;
 pub mod negative;
 pub mod outside_graph;
+pub mod query_tokens;
 pub mod remediation;
 pub mod server;
 pub mod session;

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -2519,6 +2519,17 @@ pub fn negative_for(
         if let Some(gap) = unadmitted_host_content_gap(envelope) {
             push_gap(&mut trustworthy, &mut trust_reason, gap);
         }
+        // A search whose whole-query name filter matched nothing and whose
+        // per-token fallback also matched nothing is a miss about vocabulary. The
+        // certified sentence for this tool says no declaration in the index
+        // carries this name, which is true and useless for a question phrased as
+        // a sentence: no declaration is named "how does reconcile detect a stale
+        // graph", and a reader who takes that as an authoritative absence reads it
+        // as proof the repository does not reconcile. Certify the name lookup,
+        // never the question.
+        if let Some(gap) = crate::query_tokens::absence_gap(payload) {
+            push_gap(&mut trustworthy, &mut trust_reason, gap);
+        }
     }
 
     // Gaps the response carries that this function cannot observe from the

--- a/crates/kin-mcp/src/query_tokens.rs
+++ b/crates/kin-mcp/src/query_tokens.rs
@@ -479,8 +479,8 @@ mod tests {
 
     #[test]
     fn the_fan_out_is_capped_and_says_so() {
-        let planned = plan("alpha beta gamma delta epsilon zeta eta theta iota kappa")
-            .expect("phrase plans");
+        let planned =
+            plan("alpha beta gamma delta epsilon zeta eta theta iota kappa").expect("phrase plans");
         assert_eq!(planned.tokens.len(), MAX_QUERY_TOKENS);
         assert!(planned.capped);
         assert!(planned.dropped.contains(&"iota".to_string()));

--- a/crates/kin-mcp/src/query_tokens.rs
+++ b/crates/kin-mcp/src/query_tokens.rs
@@ -1,0 +1,508 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Multi-token name retrieval for a question phrased as a sentence.
+//!
+//! `semantic_search` hands its whole query string to the store as one name
+//! pattern. The store answers that in two stages and the stages disagree about
+//! what a query is. Its name index tokenizes: it tries the exact-name map, then
+//! intersects the name-token index across every token of the pattern. Its
+//! predicate does not: every candidate the index produced is re-checked with a
+//! substring test against the ENTIRE lowercased pattern. So a pattern carrying a
+//! space cannot survive, twice over. A long question intersects to nothing and
+//! falls through to a substring test no declaration name can pass. A two-word
+//! question intersects to real candidates and then loses every one of them to
+//! the predicate, because no declaration name contains a space. `reconcile_report`
+//! and `reconcile report` tokenize identically and answer differently for that
+//! reason alone.
+//!
+//! Neither stage can be changed from here; they live in the storage engine, a
+//! separate repository. What kin can do is stop asking a question its own store
+//! cannot answer. This module turns one phrase into a bounded set of
+//! single-token name queries, each of which passes both stages by construction
+//! because a single token carries no separator, then ranks the union by how much
+//! of the question each entity covers.
+//!
+//! Retrieval and ranking read different things, and the response says so.
+//! Candidates come back by declaration NAME, because that is the only index the
+//! store offers a token query against; a declaration whose path mentions a query
+//! word but whose name mentions none is not in the union at all. Ranking then
+//! reads the name, signature, path and doc summary of the candidates that are.
+//!
+//! Three properties keep this from changing an answer anyone relies on today.
+//! It runs only when the whole-query filter returned nothing, so every query
+//! that answers today answers identically. It runs only for a query containing
+//! whitespace, so a single-identifier lookup that finds nothing still reports a
+//! clean miss rather than a page of plausible neighbours. And it says in the
+//! response that it ran, because a ranked list assembled this way is a weaker
+//! claim than a name match and a reader has to be able to tell.
+
+use std::collections::{HashMap, HashSet};
+
+use kin_model::entity::Entity;
+use serde_json::{json, Value};
+
+/// The response key carrying this path's disclosure.
+pub const LEXICAL_FALLBACK_KEY: &str = "lexical_fallback";
+
+/// The most query tokens that may fan out into store queries.
+///
+/// The fan-out is one store query per token, so this is the bound on how much
+/// work one sentence can ask for. Eight covers every question shape measured
+/// against the hosted route once function words are dropped; past that, the
+/// extra tokens are almost always restatements that add no ranking signal.
+pub const MAX_QUERY_TOKENS: usize = 8;
+
+/// Tokens shorter than this are dropped before the fan-out.
+///
+/// A one-character token matches a large fraction of any index and carries
+/// almost no evidence about what the reader meant.
+const MIN_TOKEN_CHARS: usize = 2;
+
+/// The most entities one token's query may contribute to the union.
+///
+/// The store returns name matches in relevance order, exact name first, then
+/// token hits, then substring hits, so the head of a token's list is its best
+/// part and a cap keeps a common word from dominating the scoring pass.
+const MAX_CANDIDATES_PER_TOKEN: usize = 400;
+
+/// The most entities the union may hold before further tokens stop adding to it.
+const MAX_UNION_CANDIDATES: usize = 2_000;
+
+/// How much of a doc summary is read for token evidence.
+const MAX_DOC_CHARS: usize = 400;
+
+/// Field weights. A question token found in a declaration's own name is much
+/// stronger evidence than the same token found in the path it happens to sit in.
+const WEIGHT_NAME: f64 = 3.0;
+const WEIGHT_SIGNATURE: f64 = 1.5;
+const WEIGHT_PATH: f64 = 1.0;
+const WEIGHT_DOC: f64 = 1.0;
+
+/// Added on top of the name weight when a question token IS the whole
+/// declaration name, so an exact identifier inside a sentence outranks a
+/// declaration that merely contains it.
+const BONUS_EXACT_NAME: f64 = 2.0;
+
+/// English function words, dropped before the fan-out.
+///
+/// Deliberately short and deliberately free of anything that reads as code. A
+/// word like `type`, `new`, `get` or `self` is a real declaration name in most
+/// repositories, so dropping it would cost a match; a word like `does` or `the`
+/// cannot be, and keeping it costs ranking precision on every question.
+const STOP_WORDS: &[&str] = &[
+    "a", "an", "and", "any", "are", "as", "at", "be", "been", "but", "by", "can", "could", "did",
+    "do", "does", "for", "from", "had", "has", "have", "how", "i", "if", "in", "into", "is", "it",
+    "its", "me", "my", "of", "on", "or", "our", "should", "so", "than", "that", "the", "their",
+    "them", "then", "there", "these", "they", "this", "to", "was", "we", "were", "what", "when",
+    "where", "which", "while", "who", "why", "will", "with", "would", "you", "your",
+];
+
+/// The tokens one phrase fans out into, plus what was left behind.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TokenPlan {
+    /// Tokens that will each become their own store query, in the order they
+    /// appeared in the question.
+    pub tokens: Vec<String>,
+    /// Tokens the plan dropped, so the disclosure can say what was ignored
+    /// rather than leaving a reader to infer it from a shorter list.
+    pub dropped: Vec<String>,
+    /// Whether [`MAX_QUERY_TOKENS`] removed tokens that were otherwise usable.
+    pub capped: bool,
+}
+
+/// Plan the fan-out for `query`, or `None` when this path must not run.
+///
+/// `None` for a query with no whitespace. A bare identifier is a name lookup and
+/// its empty answer is the true answer; replacing that with a ranked page of
+/// entities that merely share a word turns a certified miss into something that
+/// looks like a find. The measured store has exactly that case in it, an
+/// identifier defined in another repository and absent from this index, and it
+/// must keep reading as absent.
+///
+/// `None` also when fewer than two usable tokens survive, since a one-token
+/// fan-out is the query the store already ran.
+pub fn plan(query: &str) -> Option<TokenPlan> {
+    if !query.chars().any(char::is_whitespace) {
+        return None;
+    }
+
+    let mut tokens: Vec<String> = Vec::new();
+    let mut dropped: Vec<String> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+
+    // The store's name-token index is built with this tokenizer, so a token it
+    // produces is a token that index can be asked for. Splitting the query any
+    // other way would be a guess about the index's vocabulary.
+    for token in kin_search::tokenize(query) {
+        if !seen.insert(token.clone()) {
+            continue;
+        }
+        if token.chars().count() < MIN_TOKEN_CHARS || STOP_WORDS.contains(&token.as_str()) {
+            dropped.push(token);
+            continue;
+        }
+        tokens.push(token);
+    }
+
+    if tokens.len() < 2 {
+        return None;
+    }
+
+    let capped = tokens.len() > MAX_QUERY_TOKENS;
+    if capped {
+        dropped.extend(tokens.drain(MAX_QUERY_TOKENS..));
+    }
+
+    Some(TokenPlan {
+        tokens,
+        dropped,
+        capped,
+    })
+}
+
+/// One token's retrieval outcome, as the caller's store answered it.
+#[derive(Debug, Clone)]
+pub struct TokenHits {
+    /// The token this query was issued for.
+    pub token: String,
+    /// The pattern that produced these entities: the token, or its singular form
+    /// when the token itself matched nothing.
+    pub pattern: String,
+    /// The entities the store returned, already truncated by the caller.
+    pub entities: Vec<Entity>,
+    /// How many the store matched BEFORE the caller's truncation.
+    ///
+    /// Kept separately because this is the number the rarity weight reads, and
+    /// the truncated length cannot carry it: a word matching four hundred
+    /// declarations and a word matching forty thousand both arrive as four
+    /// hundred, so a very common word would weigh exactly as much as a
+    /// moderately common one on precisely the store sizes where the difference
+    /// decides the ranking.
+    pub total_matching: usize,
+    /// Whether [`MAX_CANDIDATES_PER_TOKEN`] truncated the store's answer.
+    pub truncated: bool,
+}
+
+/// The bound a caller must apply to one token's store answer before handing it
+/// here, exported so the retrieval loop and the disclosure cannot drift apart.
+pub const fn max_candidates_per_token() -> usize {
+    MAX_CANDIDATES_PER_TOKEN
+}
+
+/// The singular form of a token that reads as an English plural, or `None`.
+///
+/// A question says "where are projections written" while the declaration is
+/// named `ProjectionWriter`, and the index holds the singular token only. This
+/// is a spelling reduction, not a stemmer: it changes only the word ending, so
+/// it cannot collapse two unrelated identifiers into one token the way an
+/// aggressive stem can.
+pub fn singular(token: &str) -> Option<String> {
+    let len = token.chars().count();
+    if token.ends_with("ies") && len > 4 {
+        return Some(format!("{}y", &token[..token.len() - 3]));
+    }
+    for suffix in ["sses", "shes", "ches", "xes", "zes"] {
+        if token.ends_with(suffix) && len > suffix.chars().count() + 1 {
+            return Some(token[..token.len() - 2].to_string());
+        }
+    }
+    if len > 3
+        && token.ends_with('s')
+        && !token.ends_with("ss")
+        && !token.ends_with("us")
+        && !token.ends_with("is")
+    {
+        return Some(token[..token.len() - 1].to_string());
+    }
+    None
+}
+
+/// The comparison form of a token: its singular spelling when it has one.
+fn normalized(token: &str) -> String {
+    singular(token).unwrap_or_else(|| token.to_string())
+}
+
+/// Where a question token was found on an entity, best field first.
+fn field_weight(
+    normal: &str,
+    name_tokens: &HashSet<String>,
+    signature_tokens: &HashSet<String>,
+    path_tokens: &HashSet<String>,
+    doc_tokens: &HashSet<String>,
+) -> Option<f64> {
+    if name_tokens.contains(normal) {
+        Some(WEIGHT_NAME)
+    } else if signature_tokens.contains(normal) {
+        Some(WEIGHT_SIGNATURE)
+    } else if path_tokens.contains(normal) {
+        Some(WEIGHT_PATH)
+    } else if doc_tokens.contains(normal) {
+        Some(WEIGHT_DOC)
+    } else {
+        None
+    }
+}
+
+/// The tokens of one text, reduced to their comparison form.
+fn normalized_tokens(text: &str) -> HashSet<String> {
+    kin_search::tokenize(text)
+        .into_iter()
+        .map(|token| normalized(&token))
+        .collect()
+}
+
+/// How much a token's presence is worth, given how many entities it retrieved.
+///
+/// A token that names a handful of declarations says far more about what the
+/// reader meant than one that names a thousand, and the store's own answer size
+/// is the only breadth signal available on this path without a second pass over
+/// the index.
+fn rarity(document_frequency: usize) -> f64 {
+    1.0 / (1.0 + (1.0 + document_frequency as f64).ln())
+}
+
+/// One ranked entity and the evidence behind its position.
+#[derive(Debug, Clone)]
+pub struct RankedEntity {
+    pub entity: Entity,
+    /// How many distinct question tokens this entity carries anywhere.
+    pub coverage: usize,
+    /// The weighted sum over those tokens.
+    pub score: f64,
+}
+
+/// The ranked union of every token's hits, best first.
+///
+/// Ordered by coverage before score on purpose: an entity carrying four of the
+/// question's words is a better answer to the question than one carrying two
+/// with a higher weight on each, and coverage is the property a reader can check
+/// against the words they typed. Score breaks coverage ties, then the shorter
+/// name, then the name itself, then the id, so the order is total and does not
+/// depend on the union's assembly order.
+pub fn rank(plan: &TokenPlan, hits: &[TokenHits]) -> Vec<RankedEntity> {
+    let weights: HashMap<&str, f64> = hits
+        .iter()
+        .map(|hit| (hit.token.as_str(), rarity(hit.total_matching)))
+        .collect();
+    let normals: Vec<(String, String)> = plan
+        .tokens
+        .iter()
+        .map(|token| (token.clone(), normalized(token)))
+        .collect();
+
+    let mut union: Vec<Entity> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for hit in hits {
+        for entity in &hit.entities {
+            if union.len() >= MAX_UNION_CANDIDATES {
+                break;
+            }
+            if seen.insert(entity.id.to_string()) {
+                union.push(entity.clone());
+            }
+        }
+    }
+
+    let mut ranked: Vec<RankedEntity> = union
+        .into_iter()
+        .filter_map(|entity| {
+            let name_tokens = normalized_tokens(&entity.name);
+            let signature_tokens = normalized_tokens(&entity.signature);
+            let path_tokens = entity
+                .file_origin
+                .as_ref()
+                .map(|path| normalized_tokens(&path.to_string()))
+                .unwrap_or_default();
+            let doc_tokens = entity
+                .doc_summary
+                .as_deref()
+                .map(|doc| {
+                    let end = doc
+                        .char_indices()
+                        .nth(MAX_DOC_CHARS)
+                        .map_or(doc.len(), |(index, _)| index);
+                    normalized_tokens(&doc[..end])
+                })
+                .unwrap_or_default();
+            let lower_name = entity.name.to_lowercase();
+
+            let mut coverage = 0usize;
+            let mut score = 0.0f64;
+            for (token, normal) in &normals {
+                let Some(weight) = field_weight(
+                    normal,
+                    &name_tokens,
+                    &signature_tokens,
+                    &path_tokens,
+                    &doc_tokens,
+                ) else {
+                    continue;
+                };
+                coverage += 1;
+                let exact = if lower_name == *token || lower_name == *normal {
+                    BONUS_EXACT_NAME
+                } else {
+                    0.0
+                };
+                score += weights.get(token.as_str()).copied().unwrap_or(1.0) * (weight + exact);
+            }
+
+            // An entity retrieved by one token's substring match that carries no
+            // whole token of the question is noise, not a weak answer.
+            (coverage > 0).then_some(RankedEntity {
+                entity,
+                coverage,
+                score,
+            })
+        })
+        .collect();
+
+    ranked.sort_by(|a, b| {
+        b.coverage
+            .cmp(&a.coverage)
+            .then_with(|| b.score.total_cmp(&a.score))
+            .then_with(|| a.entity.name.len().cmp(&b.entity.name.len()))
+            .then_with(|| a.entity.name.cmp(&b.entity.name))
+            .then_with(|| a.entity.id.to_string().cmp(&b.entity.id.to_string()))
+    });
+    ranked
+}
+
+/// The response block saying this path answered, and what it can and cannot claim.
+///
+/// Attached whenever the fan-out ran, including when it also came back empty. An
+/// empty answer to a sentence is the case a reader is most likely to misread, so
+/// it is the case that most needs the path named.
+pub fn disclosure(plan: &TokenPlan, hits: &[TokenHits], matched: usize) -> Value {
+    let unmatched: Vec<&str> = hits
+        .iter()
+        .filter(|hit| hit.total_matching == 0)
+        .map(|hit| hit.token.as_str())
+        .collect();
+    let truncated: Vec<&str> = hits
+        .iter()
+        .filter(|hit| hit.truncated)
+        .map(|hit| hit.token.as_str())
+        .collect();
+    let substituted: Vec<Value> = hits
+        .iter()
+        .filter(|hit| hit.pattern != hit.token)
+        .map(|hit| json!({ "token": hit.token, "queried_as": hit.pattern }))
+        .collect();
+
+    json!({
+        "answered_by": "name_token_coverage",
+        "reason": "no_vector_coverage",
+        "detail": format!(
+            "The whole-query name filter matched nothing, so this answer was assembled by a \
+             lexical fallback across {} query tokens. Candidates are retrieved by DECLARATION \
+             NAME, one name query per token, so a declaration no query token names is not here \
+             even if its path or doc mentions one. Those candidates are then ranked by how many \
+             of the question's tokens each carries across its name, signature, path and doc \
+             summary. It reads the entity index and never the vector index, so it ranks by word \
+             overlap and not by meaning, and a store with no vector coverage has no other path to \
+             an answer for a question phrased as a sentence.",
+            plan.tokens.len()
+        ),
+        "query_tokens": plan.tokens,
+        "dropped_tokens": plan.dropped,
+        "token_cap_applied": plan.capped,
+        "tokens_with_no_declaration": unmatched,
+        "tokens_truncated_at_cap": truncated,
+        "tokens_queried_as_singular": substituted,
+        "matched": matched,
+        "retrieved_by": "one declaration-name query per token",
+        "ranked_by": "token coverage first, then a rarity-weighted field score: name, then \
+                      signature, then path, then doc summary",
+        "vector_ranked": false,
+        "caution": if matched == 0 {
+            "This fallback ran and still matched nothing. The absence is a statement about word \
+             overlap with declaration names, paths and signatures, not about whether the \
+             repository implements the behaviour the question describes."
+        } else {
+            "These results share words with the question. Word overlap is not a claim that any of \
+             them implements what the question asked about; confirm by reading the source."
+        },
+    })
+}
+
+/// The trust gap an empty fallback answer carries, for the absence verdict.
+///
+/// Returned only when this path ran AND matched nothing. A sentence that no
+/// declaration shares a word with is a miss about vocabulary, and certifying it
+/// as an authoritative absence is how a question about behaviour comes back
+/// reading like proof the behaviour is not there.
+pub fn absence_gap(payload: &Value) -> Option<String> {
+    let block = payload.get(LEXICAL_FALLBACK_KEY)?.as_object()?;
+    if block.get("matched").and_then(Value::as_u64) != Some(0) {
+        return None;
+    }
+    Some(
+        "lexical_fallback_matched_nothing: the query is a phrase, the whole-query name filter \
+         matched nothing, and the per-token fallback that ran instead ranks by word overlap with \
+         declaration names, paths and signatures rather than by meaning, so this absence cannot \
+         separate a behaviour the repository lacks from one whose declarations are worded \
+         differently than the question"
+            .to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_query_with_no_whitespace_never_plans_a_fan_out() {
+        assert_eq!(plan("SnapshotManager"), None);
+        assert_eq!(plan("reconcile_report"), None);
+        assert_eq!(plan("kin::db::open"), None);
+    }
+
+    #[test]
+    fn a_phrase_plans_its_content_words_and_drops_function_words() {
+        let planned = plan("how does reconcile detect a stale graph").expect("phrase plans");
+        assert_eq!(
+            planned.tokens,
+            vec!["reconcile", "detect", "stale", "graph"]
+        );
+        assert!(planned.dropped.contains(&"how".to_string()));
+        assert!(planned.dropped.contains(&"does".to_string()));
+        assert!(planned.dropped.contains(&"a".to_string()));
+        assert!(!planned.capped);
+    }
+
+    #[test]
+    fn a_phrase_of_only_function_words_plans_nothing() {
+        assert_eq!(plan("how does it do that"), None);
+    }
+
+    #[test]
+    fn the_fan_out_is_capped_and_says_so() {
+        let planned = plan("alpha beta gamma delta epsilon zeta eta theta iota kappa")
+            .expect("phrase plans");
+        assert_eq!(planned.tokens.len(), MAX_QUERY_TOKENS);
+        assert!(planned.capped);
+        assert!(planned.dropped.contains(&"iota".to_string()));
+        assert!(planned.dropped.contains(&"kappa".to_string()));
+    }
+
+    #[test]
+    fn plural_query_words_reduce_to_the_form_an_index_holds() {
+        assert_eq!(singular("projections").as_deref(), Some("projection"));
+        assert_eq!(singular("entities").as_deref(), Some("entity"));
+        assert_eq!(singular("branches").as_deref(), Some("branch"));
+        assert_eq!(singular("tools").as_deref(), Some("tool"));
+        assert_eq!(singular("class"), None);
+        assert_eq!(singular("status"), None);
+        assert_eq!(singular("analysis"), None);
+        assert_eq!(singular("is"), None);
+    }
+
+    #[test]
+    fn rarity_falls_as_a_token_retrieves_more() {
+        assert!(rarity(1) > rarity(10));
+        assert!(rarity(10) > rarity(1000));
+        assert!(rarity(0) > 0.0);
+    }
+}

--- a/scripts/validate-kin-registry-release.py
+++ b/scripts/validate-kin-registry-release.py
@@ -22,6 +22,7 @@ ALLOWED_SOURCES = {
     "kin-db": "firelock-ai/kin-db",
     "kin-lsp": "firelock-ai/kin-lsp",
     "kin-model": "firelock-ai/kin-model",
+    "kin-search": "firelock-ai/kin-search",
     "kin-vfs-core": "firelock-ai/kin-vfs",
 }
 PAYLOAD_KEYS = frozenset(


### PR DESCRIPTION
## What this does

`semantic_search` returns nothing for any query containing a space. Ten
natural-language questions asked of the hosted org search route returned an
empty list each, while nine of ten single-identifier lookups came back right at
rank one. `reconcile_report` returns rows; `reconcile report`, the same two
tokens with a different separator, returns none. This makes a phrase answerable.

## Where the space actually kills the match

Not in kinlab and not in kin's handler. kin builds one name pattern out of the
whole query and hands it to the store, and the store answers that in two stages
that disagree about what a query is.

Its name index tokenizes. `IndexSet::by_name_pattern` tries the exact-name map,
then intersects the name-token index across every token of the pattern. Its
predicate does not. `matches_filter` re-checks every candidate the index produced
with a substring test against the entire lowercased pattern. So a pattern
carrying a space cannot survive, and it fails at a different stage depending on
its length. A sentence intersects to nothing, because no declaration name carries
all seven of its tokens, and falls through to a substring test no name can pass.
Two words intersect to real candidates and then lose every one of them to the
predicate, because no declaration name contains a space. That is exactly why
`reconcile_report` and `reconcile report` answer differently: `kin_search::tokenize`
splits on every non-alphanumeric character, whitespace included, so the index
hands back the same candidate set for both spellings and only the predicate can
tell them apart.

Both stages are in kin-db, another repository, so this PR does not change them.
It stops kin asking a question its own store cannot answer.

## The fix

When the whole-query name filter comes back empty AND the query contains
whitespace, kin re-asks it as one name query per token and ranks the union itself.
A single token survives both of the store's stages by construction, because a
token carries no separator, so this is not routing around the index; it is asking
the index the question it is shaped to answer. The tokenizer is `kin_search::tokenize`,
the same one kin-db builds its name-token index with, which is why a per-token
query hits that index by construction rather than by coincidence.

Three gates keep this from changing an answer anyone relies on. It runs only on
the empty path, so every query that answers today answers identically. It runs
only for a query containing whitespace, so a bare identifier that is genuinely
absent still reports a clean miss instead of a page of plausible neighbours. And
it never widens the caller's `kind`, `language` or `role` filter.

Ranking is token coverage first, then a rarity-weighted field score. Coverage
first because an entity carrying four of the question's words answers it better
than one carrying two, and because coverage is the one property a reader can
check against the words they typed. The field score breaks ties: a word in a
declaration's own name counts three times the same word in its path, and each
word is weighted down by how many declarations its own query returned. Query
words reduce to a singular spelling before matching, since a question says
"projections" where the declaration is named for one projection.

Bounded: at most eight tokens after dropping function words and anything under
two characters, at most four hundred entities per token, at most two thousand in
the union, and the per-token calls run in sequence. One sentence costs at most
eight bounded store queries.

Every response the fan-out produced carries a `lexical_fallback` block naming the
path, the tokens it used and dropped, the tokens no declaration carried, and the
caution that word overlap is not a claim about behaviour. It is attached when the
fan-out found nothing too, because that is the answer a reader is most likely to
misread. On that empty case the absence verdict is downgraded: the certified
sentence this tool otherwise prints says no declaration in the index carries this
name, which is true of every question ever typed and tells a reader nothing about
whether the repository does what they asked about.

## Harness

demoask073's twenty questions, unchanged, asked of a store this machine indexed
rather than of the hosted route, through both tools. The store is kin's own
tracked tree at 247cac147 as a single commit: 35,822 entities over 1,033 files,
built with `KIN_EMBED_BACKEND=cpu`, and its `kin init` output reports
`embedding_model.present: false`, so it carries zero vector coverage. That is the
hosted condition rather than an approximation of it.

Grading was pre-registered at 19:18:28Z, before the sweep ran, in the lane report's
data directory. An identifier question is right when one of the top three hits sits
in a file containing the queried symbol, which is demoask073's rule unchanged. A
concept question is right when one of the top three hits has a file path matching
one of that question's registered patterns, written by reading kin's source before
any local result existed.

**semantic_search 16 of 20. semantic_locate 14 of 20. The bar was 14.**

| tool | identifiers | concepts | total |
|---|---|---|---|
| `semantic_search` (fixed here) | 9/10 | 7/10 | **16/20** |
| `semantic_locate` (untouched) | 10/10 | 4/10 | **14/20** |

On the hosted route those same ten concept questions scored zero, every one an
empty list.


### semantic_locate

| # | kind | query | n | top 3 | right at rank<=3? |
|---|---|---|---|---|---|
| 1 | identifier | `repo_scoped_graph` | 10 | repo_scoped_graph (crates/kin-daemon/src/api.rs); plan_and_commit (crates/kin-daemon/src/repository_checkout.rs); DaemonState::open_with_repo_id (crat | right |
| 2 | identifier | `SnapshotManager` | 6 | DaemonState::save_snapshot_impl (crates/kin-daemon/src/state.rs); DaemonState::load_validated_vector_index (crates/kin-daemon/src/state.rs); DaemonSta | right |
| 3 | identifier | `InMemoryGraph` | 5 | build_graph_status_response_for_store (crates/kin-cli/src/commands/graph.rs); build_graph_validate_response_with_census (crates/kin-cli/src/commands/g | right |
| 4 | identifier | `ranked_impact` | 3 | ranked_impact (crates/kin-review/src/lib.rs); RankedImpactCandidate (crates/kin-review/src/ranked_impact.rs); RankedImpactReport (crates/kin-review/sr | right |
| 5 | identifier | `semantic_locate` | 10 | generate_assistant_prompt (crates/kin-core/src/assistant.rs); check_retrieval_profile (crates/kin-cli/src/commands/health.rs); generate_bootstrap_docs | right |
| 6 | identifier | `build_context_response` | 10 | build_context_response (crates/kin-cli/src/commands/context.rs); context (crates/kin-daemon/src/api.rs); build_semantic_locate_result (crates/kin-daem | right |
| 7 | identifier | `reconcile_repo` | 6 | health (crates/kin-daemon/src/api.rs); run_pass (crates/kin-daemon/src/repository_admit.rs); command_graph (crates/kin-daemon/src/api.rs) | right |
| 8 | identifier | `entity_source` | 10 | build_entity_source_outcome (crates/kin-cli/src/commands/graph.rs); entity_source_not_found_message (crates/kin-cli/src/commands/graph.rs); render_ent | right |
| 9 | identifier | `trace_data_flow` | 10 | DaemonClient::trace_data_flow (crates/kin-cli/src/daemon_client.rs); trace_data_flow (crates/kin-cli/src/commands/mod.rs); build_trace_data_flow_respo | right |
| 10 | identifier | `impact_analysis` | 5 | handle_impact_analysis (crates/kin-mcp/src/handlers/review.rs); run_ladder (crates/kin-mcp/src/budget.rs); shape_for (crates/kin-mcp/src/budget.rs) | right |
| 11 | concept | `where does kin init stage the store` | 10 | ProjectionTransaction::stage (crates/kin-projection/src/tree.rs); Grader.__init__ (scripts/test-select-release-candidate.py); stranded_init_stage_chec | WRONG |
| 12 | concept | `how does reconcile detect a stale graph` | 10 | HostedRepoCacheEntry::graph (crates/kin-daemon/src/state.rs); StatusAdmission::reconcile (crates/kin-cli/src/commands/status.rs); sync_filesystem_with | right |
| 13 | concept | `how does the daemon answer a semantic search request` | 10 | DaemonClient::search (crates/kin-cli/src/daemon_client.rs); LocateRequest (crates/kin-cli/src/daemon_client.rs); DaemonClient::post_non_idempotent_jso | WRONG |
| 14 | concept | `how does review decide to block a change` | 10 | decide (scripts/acceptance/gate.py); decide (scripts/release-hold-alarm.mjs); Verdict::decide (crates/kin-core/src/memory_pressure.rs) | WRONG |
| 15 | concept | `where does the MCP server register its tools` | 10 | register (crates/kin-cli/src/commands/intent.rs); mcp (crates/kin-cli/src/commands/mod.rs); CliSpawnRegistrar::register (crates/kin-cli/src/daemon_cli | WRONG |
| 16 | concept | `how is provenance recorded for a change` | 10 | change (crates/kin-mcp/src/handlers/provenance.rs); RepositoryReadView::change (crates/kin-daemon/src/api.rs); handle_provenance_query (crates/kin-mcp | right |
| 17 | concept | `what happens when an entity is missing from the graph` | 10 | HostedRepoCacheEntry::graph (crates/kin-daemon/src/state.rs); build_entity_view (crates/kin-cli/src/commands/locate.rs); repo_provenance_entity (crate | WRONG |
| 18 | concept | `how does kin rank search results` | 10 | rank (crates/kin-mcp/src/handlers/tool_search.rs); search (crates/kin-daemon/src/api.rs); render_daemon_search_response (crates/kin-cli/src/commands/s | right |
| 19 | concept | `where are projections written to disk` | 10 | run_upload_disk (crates/kin-registry/src/oci.rs); remove_upload_session_disk (crates/kin-registry/src/oci.rs); FullDisk (crates/kin-cli/src/broken_pip | WRONG |
| 20 | concept | `how does the daemon handle a repository that is not indexed` | 10 | Envelope::daemon (crates/kin-mcp/src/envelope.rs); repository_with_policy_excluding_claude (crates/kin-daemon/src/loop_runner.rs); Envelope::with_reco | right |

### semantic_search

| # | kind | query | n | top 3 | right at rank<=3? |
|---|---|---|---|---|---|
| 1 | identifier | `repo_scoped_graph` | 1 | repo_scoped_graph (crates/kin-daemon/src/api.rs) | right |
| 2 | identifier | `SnapshotManager` | 0 | (none) | WRONG |
| 3 | identifier | `InMemoryGraph` | 4 | kin_db::InMemoryGraph::persist_primary_snapshot (crates/kin-mcp/src/server.rs); kin_db::InMemoryGraph::entity (crates/kin-cli/src/commands/impact.rs); | right |
| 4 | identifier | `ranked_impact` | 2 | ranked_impact (crates/kin-review/src/lib.rs); RANKED_IMPACT_SCHEMA_VERSION (crates/kin-review/src/ranked_impact.rs) | right |
| 5 | identifier | `semantic_locate` | 2 | handle_semantic_locate (crates/kin-mcp/src/handlers/entities.rs); mcp_semantic_locate_routes_fused_by_default_on_every_profile (crates/kin-daemon/src/ | right |
| 6 | identifier | `build_context_response` | 1 | build_context_response (crates/kin-cli/src/commands/context.rs) | right |
| 7 | identifier | `reconcile_repo` | 2 | reconcile_report (crates/kin-daemon/src/loop_runner.rs); BackgroundWorkSupervisor::reconcile_report (crates/kin-daemon/src/background_work.rs) | right |
| 8 | identifier | `entity_source` | 10 | GET_ENTITY_SOURCES_DESC (crates/kin-mcp/src/handlers/entities.rs); expand_entity_source_excerpt (crates/kin-mcp/src/handlers/common.rs); entity_source | right |
| 9 | identifier | `trace_data_flow` | 1 | trace_data_flow (crates/kin-cli/src/commands/mod.rs) | right |
| 10 | identifier | `impact_analysis` | 8 | impact_analysis_handler_emits_one_based_lines_for_affected_callers (crates/kin-mcp/src/handlers/mod.rs); impact_analysis_files_mode_names_a_resolution | right |
| 11 | concept | `where does kin init stage the store` | 10 | Stage (crates/kin-daemon/src/hosted_start.rs); stage (crates/kin-cli/src/commands/contextbench_locate.rs); store (crates/kin-spine/src/lib.rs) | WRONG |
| 12 | concept | `how does reconcile detect a stale graph` | 10 | Reconciler::detect_conflict (crates/kin-reconcile/src/reconciler.rs); stale_writer_race_falsification_detects_missing_head_precondition (crates/kin-sp | right |
| 13 | concept | `how does the daemon answer a semantic search request` | 1 | SEMANTIC_LOCATE_DESC (crates/kin-mcp/src/handlers/entities.rs) | right |
| 14 | concept | `how does review decide to block a change` | 10 | decide (crates/kin-daemon/src/repository_tag.rs); change (crates/kin-review/src/ref_graph.rs); change (crates/kin-review/src/release_gate.rs) | right |
| 15 | concept | `where does the MCP server register its tools` | 8 | tools (crates/kin-mcp/src/lib.rs); server (crates/kin-mcp/src/lib.rs); register (crates/kin-cli/src/commands/intent.rs) | WRONG |
| 16 | concept | `how is provenance recorded for a change` | 10 | change (crates/kin-mcp/src/handlers/provenance.rs); no_recorded_changes_refuses (crates/kin-cli/src/commands/rollback.rs); WorkItemRollbackRefusal::No | right |
| 17 | concept | `what happens when an entity is missing from the graph` | 10 | missing (crates/kin-cli/src/commands/verify.rs); an_ordinary_word_that_happens_to_name_a_package_does_not_refuse (crates/kin-mcp/src/outside_graph.rs) | right |
| 18 | concept | `how does kin rank search results` | 10 | search (crates/kin-daemon/src/api.rs); rank (crates/kin-mcp/src/handlers/tool_search.rs); collect_search_results (crates/kin-cli/src/commands/search.r | right |
| 19 | concept | `where are projections written to disk` | 10 | KinLayout::projections_dir (crates/kin-core/src/layout.rs); the_two_projections_carry_opposite_coverage_keys (crates/kin-cli/src/commands/locate_compa | WRONG |
| 20 | concept | `how does the daemon handle a repository that is not indexed` | 5 | daemon_not_running_check_for (crates/kin-cli/src/commands/health.rs); Reconciler::reconcile_indexed_content (crates/kin-reconcile/src/reconciler.rs);  | right |

semantic_locate: identifiers 10/10, concepts 4/10, total 14/20
semantic_search: identifiers 9/10, concepts 7/10, total 16/20

controls:
  control:negative         semantic_search   n=0   no-fallback  'zqx_not_a_real_symbol_qqzz'
  control:negative         semantic_locate   n=5   no-fallback  'zqx_not_a_real_symbol_qqzz'
  control:negative_phrase  semantic_search   n=7   fallback  'zqx not a real symbol qqzz'
  control:negative_phrase  semantic_locate   n=10  no-fallback  'zqx not a real symbol qqzz'
  control:positive         semantic_search   n=1   no-fallback  'repo_scoped_graph'
  control:positive         semantic_locate   n=10  no-fallback  'repo_scoped_graph'
  control:shape_underscore semantic_search   n=2   no-fallback  'reconcile_report'
  control:shape_underscore semantic_locate   n=10  no-fallback  'reconcile_report'
  control:shape_space      semantic_search   n=8   fallback  'reconcile report'
  control:shape_space      semantic_locate   n=10  no-fallback  'reconcile report'


Controls:

| control | tool | n | fallback ran? | what it proves |
|---|---|---|---|---|
| `zqx_not_a_real_symbol_qqzz` | `semantic_search` | 0 | no | a bare identifier that is absent still reports a clean miss |
| `repo_scoped_graph` | `semantic_search` | 1 | no | the positive control still hits, so the zero above is real |
| `reconcile_report` | `semantic_search` | 2 | no | the working query is byte-identical to before |
| `reconcile report` | `semantic_search` | 8 | yes | the measured hosted failure, answered |
| `zqx not a real symbol qqzz` | `semantic_search` | 7 | yes | the honest cost of the fallback |

That last row is the price. A nonsense phrase that used to return nothing now
returns seven rows, because five of its words are ordinary English that real
declarations are named with. That is why every fallback response says so in its
`lexical_fallback` block and why an empty phrase answer no longer certifies an
absence.

One grading note I am not banking: on "where are projections written to disk"
`semantic_search`'s rank-one hit is `KinLayout::projections_dir` in
`crates/kin-core/src/layout.rs`, which looks correct, but kin-core was not among
the patterns registered for that question before the run. It grades WRONG and
stays WRONG. The real score is probably 17.

## Falsification

Eight new tests, and every one of them was green on its first run, which is when
a test is least trustworthy. So each mechanism was broken in turn and the crate
re-run.

**Tokenizer.** `plan()` made to always return `None`, so the fan-out never runs.

    test result: FAILED. 118 passed; 5 failed

Red: `a_multi_word_question_ranks_the_declaration_that_covers_it_first`,
`two_words_and_an_underscore_now_answer_the_same_row`,
`a_phrase_that_matches_nothing_still_says_which_path_looked`,
`a_declaration_no_query_token_names_is_not_in_the_union`,
`the_fallback_keeps_the_kind_filter_the_caller_asked_for`.

Two tests stay green under this arm and that is the correct signature, not a gap.
`the_stores_whole_query_name_filter_answers_no_phrase_at_all` asserts what the
store does, which disabling the fan-out cannot change, and
`a_single_identifier_that_is_absent_stays_absent_and_claims_no_fallback` asserts
that nothing happens, which stays true when nothing happens anywhere.

**Singular reduction, first attempt: it survived.** All 123 tests in scope stayed
green with `singular()` returning `None`. Two causes, neither a weak assertion. A
second defence caught the input a step earlier: on "where are projections written
to disk" the token `disk` retrieves the intended declaration on its own, so the
plural word never had to work. And the runner scoped its filter to one test
module, so it never ran the module holding the direct assertion. Both fixed
rather than argued away, in the second commit here: the runner runs the whole
crate, and a new test uses an input only the reduction can answer, where both
content words are plural and the distractor is named for the only word needing
none.

**Singular reduction, re-run: it bites.**

    test result: FAILED. 975 passed; 2 failed

Red: `a_question_in_the_plural_reaches_a_declaration_named_in_the_singular` and
`query_tokens::tests::plural_query_words_reduce_to_the_form_an_index_holds`.

**Field weights.** All four flattened to 1.0 and the exact-name bonus zeroed.

    test result: FAILED. 976 passed; 1 failed

Red: `a_multi_word_question_ranks_the_declaration_that_covers_it_first`. That is
the `change_log` case inside it, where the distractor and the intended answer each
carry two of the question's words and only the field weighting separates them.

Green baseline for comparison: `test result: ok. 977 passed; 0 failed`. Every arm
restored the file it edited and the tree was clean after each.

The tests run against a real `kin_db::InMemoryGraph` rather than a hand-written
double, because the defect under test is the storage engine's own two-stage name
filter and a double would restate what this code believes that filter does. One
of them, `the_stores_whole_query_name_filter_answers_no_phrase_at_all`, is the
defect itself pinned as a test: it asks the store directly and asserts every
phrase still returns nothing, with a single-token positive control beside it so
the negatives cannot pass by accident.

## What this does not do

It does not touch `semantic_locate`, for the reason measured above.

It does not fix the store. Both stages that kill a spaced pattern are in kin-db,
and the right repair there is a name filter carrying a token SET rather than a
pattern string, with disjunctive matching and a per-entity count of how many
tokens the name carried. That makes the disagreement unreachable, because there is
no whole-pattern string left for a predicate to substring-match, and it would let
this fan-out collapse into one call. Until it exists, kin pays up to eight index
lookups where one would do.

It does not retrieve by path. Candidates come back by declaration name, because
that is the only index the store offers a token query against, so a declaration
whose path mentions a query word but whose name mentions none is not in the union
at all. Ranking reads name, signature, path and doc summary of the candidates that
are. The response says this under `retrieved_by`, and a test pins it.

It does not make word overlap into meaning, and it says so. A nonsense phrase now
returns rows where it used to return none. That is the cost of answering sentences
on a store with no vectors, and the `lexical_fallback` block exists so a reader can
tell that page apart from a name match.

It keeps a second stopword list. kin-cli's locate has its own, tuned for demoting
terms inside a fused ranker; this one gates which tokens become store queries, and
the two lists genuinely differ. Consolidating them would move locate's ranking, so
it is named as a follow-up rather than done here without a measurement.

## Notes for the reviewer

The two tools do not build their name pattern in the same place. `semantic_search`
builds one from the whole query in `build_semantic_search_request` and hands it to
the store, and both the offline dispatcher and the daemon reach that code, because
the daemon's `mcp_tools_call` falls through to `kin_mcp::handlers::handle_tool_call`
for this tool. `semantic_locate` never reaches it: the daemon special-cases that
tool before the generic dispatcher and answers from the fused pipeline, which
delegates ranking to kin-cli's locate. That path already tokenizes, with its own
splitter, its own stopword list, a prose-shape rule that tells a sentence from a
symbol lookup, and per-term name queries weighted by unique file count.

Measured, `semantic_locate` does not have this defect. It never returned zero for
a phrase, on any of the twenty questions, so there was nothing here to fix in it.
What it has is a ranking-quality problem on concept questions, which is FIR-3311's
subject rather than this one, and changing a ranking path with no failing number
for it would be a change nobody measured. So this PR fixes one place, not two, and
the table above reports both columns so the difference is visible rather than
asserted.

The hosted consequence is being handled separately. Hosted org search answers from
one shared store today, so it cannot see each repository's own store whatever the
tool; the repository-scoped MCP route is the only path to those, and it serves
`semantic_locate`, `get_context_pack` and `trace_data_flow` and not
`semantic_search`. Serving `semantic_search` on that route, so hosted search can
ride this fix, is a follow-up rather than part of this change.
