### PR TITLE
Walk a default-exported expression for calls and bind default imports to the declaration (FIR-3357)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ If you admitted your repository from Git, the recovery path is `kin init` again,
 
 Work that only ever lived in Kin is a different question, because Git never had it. Native commits, Kin branches, reviews and specs live in `.kin` and go when it goes, and today the only way to carry any of it out is `kin git export --output <dir>`, which writes commits and refs into a plain Git repository and carries no review, no spec and no entity history. So the format change ships together with an upgrade command that carries native state forward, or it does not ship.
 
+**JavaScript and TypeScript callers you were not being shown.** Two defects were dropping call edges, so `kin refs --kind calls`, `kin impact` and `find_references` answered some questions with fewer callers than the code has. A module whose default export is an expression rather than a declaration, `export default isSupported && function (config) {...}` for instance, contributed no call edges at all from inside it, and a call to a default-imported callee could bind to the callee's file rather than to the callee. Both are fixed. Measured on axios at b8d67bbb, three functions went from 2 of their 15 real call sites to 15 of 15.
+
+A store admitted before this release keeps the edges it already has, because those edges are written during admission. Kin has no re-index command, so refreshing one means deleting its `.kin` and running `kin init` again, which rebuilds it from the repository's Git history. `kin init` on its own refuses on an existing store and says so. Your working tree is never touched.
+
 ### Changed
 
 - Fix quickstart paste boundaries and repository selection (FIR-3348) (#1581)

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -5589,15 +5589,52 @@ fn package_dir_candidates(pkg_name: &str) -> Vec<String> {
     }
 }
 
-/// Resolve a default export from a target file.
+/// Resolve a default export from a target file, or decline to guess.
 ///
 /// When `import Foo from './bar'` maps original_name to `"default"`, the target
-/// file may not have an entity literally named `"default"`. In JS/TS, the
-/// default export is typically the file's primary declaration. We find it by
-/// looking for the first entity in the target file that is Public (exported).
-/// If none are Public, fall back to the first entity in the file.
+/// file may hold no entity literally named `"default"`, because
+/// `export default function bar() {}` mints an entity called `bar`. This is the
+/// fallback for that case, and it answers ONLY when the file leaves it no
+/// choice: exactly one exported entity that is not the file's own module. With
+/// two or more it returns `None` and the pinned-import tier below resolves the
+/// call by the name the caller actually wrote, which is evidence rather than a
+/// guess.
+///
+/// Both halves of that rule were bought on axios at b8d67bbb.
+///
+/// The Module skip: a Module entity is the file, and no `export default` names
+/// it. The caller iterates `sorted_universe`, `entity_link_order` sorts by span,
+/// and a Module spans the whole file, so it starts at the lowest line and column
+/// of anything in that file and sorts first. Every JS and TS file carries one,
+/// so every call to a default-imported callee bound to the callee's module
+/// rather than to the callee: `settle` is `export default function settle` in
+/// `lib/core/settle.js`, and `kin refs settle --kind calls` answered "No
+/// incoming Calls relations" while `kin impact settle` found the same callers
+/// on the module identity beside it.
+///
+/// The uniqueness rule: "the first exported entity" is not the default export
+/// whenever a file exports anything ahead of it, which is ordinary. Skipping
+/// only the Module left `lib/helpers/buildURL.js` answering `encode`, because
+/// `export function encode` is declared at line 14 and
+/// `export default function buildURL` at line 31, and all three of buildURL's
+/// call sites then landed on `encode`: the wrong function in the right file,
+/// which reads as a real answer in a way the module never did. Declining sends
+/// those calls to `resolve_import_pinned_target`, which looks `buildURL` up
+/// inside the pinned file and gets it right.
+///
+/// A file with no exported entity at all also returns `None` now, where this
+/// used to answer with the file's first entity whatever it was. Same reasoning:
+/// there is no evidence in that file for which entity a default import means.
+///
+/// Keying the rule on kind and count rather than on order is also what keeps the
+/// two linkers agreeing. The batch path iterates in span order and reached the
+/// Module first, while [`resolve_default_export_incremental`] iterates in the
+/// parser's emission order, where the JS adapter pushes the module last and the
+/// declaration therefore won by luck. `entity_link_order` exists so that
+/// cross-file linking is order-independent, and a rule that reads order is what
+/// let the two drift apart.
 fn resolve_default_export(target_file: &str, universe_entities: &[&Entity]) -> Option<EntityId> {
-    let mut first_in_file: Option<EntityId> = None;
+    let mut only: Option<EntityId> = None;
     for entity in universe_entities {
         let Some(ref file_path) = entity.file_origin else {
             continue;
@@ -5605,14 +5642,15 @@ fn resolve_default_export(target_file: &str, universe_entities: &[&Entity]) -> O
         if file_path.0.as_str() != target_file {
             continue;
         }
-        if first_in_file.is_none() {
-            first_in_file = Some(entity.id);
+        if entity.kind == EntityKind::Module || entity.visibility != Visibility::Public {
+            continue;
         }
-        if entity.visibility == Visibility::Public {
-            return Some(entity.id);
+        if only.is_some() {
+            return None;
         }
+        only = Some(entity.id);
     }
-    first_in_file
+    only
 }
 
 /// Incremental cross-file relation linker state.
@@ -6093,18 +6131,22 @@ impl IncrementalLinker {
 fn resolve_default_export_incremental(
     target_file: &str,
     entities_by_file: &HashMap<String, Vec<(EntityId, Visibility)>>,
+    entity_kind_by_id: &HashMap<EntityId, EntityKind>,
 ) -> Option<EntityId> {
     let entities = entities_by_file.get(target_file)?;
-    let mut first_in_file: Option<EntityId> = None;
+    let mut only: Option<EntityId> = None;
     for &(id, visibility) in entities {
-        if first_in_file.is_none() {
-            first_in_file = Some(id);
+        if entity_kind_by_id.get(&id) == Some(&EntityKind::Module)
+            || visibility != Visibility::Public
+        {
+            continue;
         }
-        if visibility == Visibility::Public {
-            return Some(id);
+        if only.is_some() {
+            return None;
         }
+        only = Some(id);
     }
-    first_in_file
+    only
 }
 
 /// Files below which the cross-file linker prints no progress bar.
@@ -6619,7 +6661,11 @@ fn resolve_one_file_incremental(
                     let dst_id = if direct.is_some() {
                         direct
                     } else if original_name == "default" {
-                        resolve_default_export_incremental(&target_file, &linker.entities_by_file)
+                        resolve_default_export_incremental(
+                            &target_file,
+                            &linker.entities_by_file,
+                            &linker.entity_kind_by_id,
+                        )
                     } else {
                         None
                     };

--- a/crates/kin-index/tests/javascript_module_resolution.rs
+++ b/crates/kin-index/tests/javascript_module_resolution.rs
@@ -13,8 +13,11 @@
 //! (a directory whose entry is `lib/router/index.js`), and an example nested
 //! two directories deep requires `../..`, the repository root.
 
-use kin_index::{link_cross_file as link_cross_file_with_identities, FileParseData};
-use kin_model::{ArtifactId, Entity, FilePathId, GraphNodeId, Relation, RelationKind};
+use kin_index::{
+    link_cross_file as link_cross_file_with_identities, link_cross_file_incremental, FileParseData,
+    IncrementalLinker,
+};
+use kin_model::{ArtifactId, Entity, EntityKind, FilePathId, GraphNodeId, Relation, RelationKind};
 use kin_parser::{JavaScriptAdapter, LanguageAdapter, TypeScriptAdapter};
 use std::collections::HashMap;
 
@@ -337,5 +340,266 @@ fn a_specifier_that_resolves_to_the_importing_file_produces_no_edge() {
         linked.import_edge_count(),
         0,
         "a self-loop is not a resolved import"
+    );
+}
+
+// ---- Default exports: which entity in the target file a default import means ----
+
+/// `core/lib.js` names its module `lib` and its default export `defaultCallee`,
+/// so the two identities are distinguishable by name. A file whose default
+/// export is named for the file, which is the common JS idiom and is what
+/// axios's `lib/core/settle.js` does, puts both under one name and makes the
+/// mistake invisible from the outside.
+const CALLEE_LIB: &str = r#"export default function defaultCallee(response) {
+  return response;
+}
+
+export function namedCallee(response) {
+  return response;
+}
+"#;
+
+const TOP_CALLER: &str = r#"import defaultCallee from '../core/lib.js';
+import { namedCallee } from '../core/lib.js';
+
+export function topAdapter(config) {
+  return new Promise(function dispatch(resolve, reject) {
+    request.on('done', function onDone(response) {
+      defaultCallee(response);
+      namedCallee(response);
+    });
+  });
+}
+"#;
+
+/// The positive control, kept as its own test rather than as the first
+/// assertion of the one below it.
+///
+/// A control that shares a test with its subject cannot be OBSERVED to hold
+/// while the subject fails: the run reports one verdict for both, and reading
+/// it as "the control held" is reading the panic message rather than the
+/// result. Split out, it prints its own `ok` line in every falsification arm.
+///
+/// `namedCallee` is called on the line below the `defaultCallee` call the next
+/// test is about, in the same body at the same depth. It resolved before this
+/// change and it must go on resolving.
+#[test]
+fn a_named_imported_callee_resolves_from_the_same_nested_call_site() {
+    let linked = link(vec![
+        js("core/lib.js", CALLEE_LIB),
+        js("adapters/top.js", TOP_CALLER),
+    ]);
+    assert!(
+        linked.has_call(
+            linked.entity_id("adapters/top.js", "topAdapter"),
+            linked.entity_id("core/lib.js", "namedCallee")
+        ),
+        "a named-imported callee three function levels down inside a promise \
+         executor inside an event callback resolves, which is what says nesting \
+         depth is not the mechanism in the two tests below"
+    );
+}
+
+/// The default import is the subject: it landed on `lib`, the Module entity for
+/// the callee's own file, because the resolver returned the first Public entity
+/// in that file and a Module spans the whole file, so it sorts first.
+#[test]
+fn a_default_imported_callee_binds_to_the_declaration_not_the_files_module() {
+    let linked = link(vec![
+        js("core/lib.js", CALLEE_LIB),
+        js("adapters/top.js", TOP_CALLER),
+    ]);
+
+    let caller = linked.entity_id("adapters/top.js", "topAdapter");
+    let default_callee = linked.entity_id("core/lib.js", "defaultCallee");
+    let callee_module = linked.entity_id("core/lib.js", "lib");
+
+    assert!(
+        linked.has_call(caller, default_callee),
+        "a default-imported callee must reach the function it names"
+    );
+    assert!(
+        !linked.has_call(caller, callee_module),
+        "the callee file's Module entity is not its default export"
+    );
+}
+
+/// Both halves of FIR-3357 in one assertion, from the shape axios is written
+/// in: the call sits inside `export default <expression>`, which the parser
+/// walked past, and its callee is default-imported, which the linker bound to
+/// the wrong node. Either defect alone makes this red.
+#[test]
+fn a_default_export_expressions_body_reaches_a_default_imported_callee() {
+    let nested = r#"import defaultCallee from '../core/lib.js';
+
+const isSupported = true;
+
+export default isSupported &&
+  function nestedAdapter(config) {
+    return new Promise(function dispatch(resolve, reject) {
+      request.on('done', function onDone(response) {
+        defaultCallee(response);
+      });
+    });
+  };
+"#;
+    let linked = link(vec![
+        js("core/lib.js", CALLEE_LIB),
+        js("adapters/nested.js", nested),
+    ]);
+
+    let caller = linked.entity_id("adapters/nested.js", "default");
+    let default_callee = linked.entity_id("core/lib.js", "defaultCallee");
+    assert!(
+        linked.has_call(caller, default_callee),
+        "the adapter body under `export default <expression>` calls \
+         `defaultCallee`, and the graph must hold that edge"
+    );
+}
+
+/// axios's `lib/helpers/buildURL.js` shape: the file exports a helper BEFORE
+/// its default export.
+///
+/// This is the case that says the fallback must decline rather than guess.
+/// Skipping only the file's Module still left "the first exported entity",
+/// which here is `encode` at the top of the file rather than `buildUrl` below
+/// it, and on the real repository all three of `buildURL`'s call sites landed
+/// on `encode`: the wrong function in the right file. Declining hands the call
+/// to the pinned-import tier, which looks the caller's own binding name up
+/// inside the pinned file.
+#[test]
+fn a_default_export_below_a_named_one_is_not_confused_with_it() {
+    let linked = link(vec![
+        js(
+            "helpers/url.js",
+            r#"export function encode(val) {
+  return val;
+}
+
+export default function buildUrl(url, params) {
+  return encode(url) + params;
+}
+"#,
+        ),
+        js(
+            "core/axios.js",
+            r#"import buildUrl from '../helpers/url.js';
+
+export function getUri(config) {
+  return buildUrl(config.url, config.params);
+}
+"#,
+        ),
+    ]);
+
+    let caller = linked.entity_id("core/axios.js", "getUri");
+    assert!(
+        linked.has_call(caller, linked.entity_id("helpers/url.js", "buildUrl")),
+        "the default-imported callee is `buildUrl`, the file's default export"
+    );
+    assert!(
+        !linked.has_call(caller, linked.entity_id("helpers/url.js", "encode")),
+        "`encode` is exported first and is not the default export; binding to it \
+         is worse than binding to nothing, because it reads as a real answer"
+    );
+}
+
+/// The file that leaves the fallback no choice: one exported declaration and
+/// nothing else, which is axios's `lib/core/settle.js` and the common shape.
+/// Here the fallback does answer, and it must answer with the declaration
+/// rather than with the file's own module.
+#[test]
+fn a_lone_default_export_still_resolves_through_the_fallback() {
+    // The file is `settler.js` and the declaration is `settle`, so the module
+    // and the function carry different names and the assertion below can tell
+    // which of the two the call reached. axios's own file is `settle.js`, where
+    // they collide and the mistake is invisible from outside.
+    let linked = link(vec![
+        js(
+            "core/settler.js",
+            r#"export default function settle(response) {
+  return response;
+}
+"#,
+        ),
+        js(
+            "adapters/only.js",
+            r#"import settle from '../core/settler.js';
+
+export function send(response) {
+  return settle(response);
+}
+"#,
+        ),
+    ]);
+
+    let caller = linked.entity_id("adapters/only.js", "send");
+    assert!(
+        linked.has_call(caller, linked.entity_id("core/settler.js", "settle")),
+        "one exported declaration leaves no ambiguity, so the fallback answers"
+    );
+    assert!(
+        !linked.has_call(caller, linked.entity_id("core/settler.js", "settler")),
+        "and it answers with the declaration, not with the file's own module"
+    );
+}
+
+/// The incremental linker reads the entity list in the order its caller hands
+/// it over, and the batch linker sorts by span. Both must answer this the same
+/// way, so the rule is keyed on the entity's KIND rather than on where it
+/// happens to sit in a list.
+///
+/// The module is moved to the front here on purpose. In the order the JavaScript
+/// adapter emits today it sits last, so an order-reading resolver gets the right
+/// answer by luck and a test that used the emission order could not fail.
+#[test]
+fn the_incremental_linker_skips_the_module_whatever_order_it_was_given() {
+    let mut callee = js("core/lib.js", CALLEE_LIB);
+    callee
+        .entities
+        .sort_by_key(|entity| entity.kind != EntityKind::Module);
+    assert_eq!(
+        callee.entities.first().map(|entity| entity.kind),
+        Some(EntityKind::Module),
+        "the fixture must hand the module over first, or this test proves nothing"
+    );
+    let caller = js("adapters/top.js", TOP_CALLER);
+
+    let mut linker = IncrementalLinker::new();
+    let files = vec![callee, caller];
+    for file in &files {
+        linker.add_file(&file.file_path, ArtifactId::new(), &file.entities);
+    }
+    let relations = link_cross_file_incremental(&files, &linker).expect("incremental link");
+
+    let id = |file: &str, name: &str| {
+        files
+            .iter()
+            .flat_map(|f| f.entities.iter())
+            .find(|e| e.name == name && e.file_origin.as_ref().map(|p| p.0.as_str()) == Some(file))
+            .unwrap_or_else(|| panic!("entity `{name}` in `{file}` not found"))
+            .id
+    };
+    let has_call = |src, dst| {
+        relations.iter().any(|r| {
+            r.kind == RelationKind::Calls
+                && r.src == GraphNodeId::Entity(src)
+                && r.dst == GraphNodeId::Entity(dst)
+        })
+    };
+
+    assert!(
+        has_call(
+            id("adapters/top.js", "topAdapter"),
+            id("core/lib.js", "defaultCallee")
+        ),
+        "the incremental linker must reach the declaration too"
+    );
+    assert!(
+        !has_call(
+            id("adapters/top.js", "topAdapter"),
+            id("core/lib.js", "lib")
+        ),
+        "and must not park the call on the callee file's module"
     );
 }

--- a/crates/kin-parser/src/languages/javascript.rs
+++ b/crates/kin-parser/src/languages/javascript.rs
@@ -1666,6 +1666,33 @@ fn extract_js_node(
                         fingerprint: compute_fingerprint(node, source),
                         span: span_from_node(node, file_id),
                     });
+                    // The exported value's body, which nothing else walks.
+                    //
+                    // Every other arm above pairs its entity with a call walk
+                    // over the subtree that entity owns. This one minted the
+                    // entity and stopped, so a module whose default export is
+                    // an expression rather than a declaration contributed no
+                    // Calls edge at all, however the expression was written.
+                    // Measured on axios at b8d67bbb: `lib/adapters/xhr.js` is
+                    // `export default isXHRAdapterSupported && function (config)
+                    // {...}` and yielded 0 call edges for the whole file, and
+                    // `lib/adapters/http.js` is the same shape and yielded none
+                    // of the 7 sites inside its adapter body while still
+                    // yielding 95 from the declarations above it.
+                    //
+                    // Depth is not what decides this and a fix keyed on depth
+                    // would be aimed at the wrong thing: the walk below already
+                    // recurses without limit, and axios's own
+                    // `lib/adapters/fetch.js` resolves a call three function
+                    // levels down inside a promise executor because its
+                    // enclosing declaration is a `lexical_declaration` this
+                    // match has an arm for.
+                    //
+                    // `default` as the context name because that is the entity
+                    // just pushed; a relation naming the inner function would
+                    // name something the entity set does not hold, and the
+                    // linker resolves a relation's source by (file, name).
+                    extract_calls_from_context(&val, source, "default", None, relations);
                 }
             }
         }

--- a/crates/kin-parser/src/languages/typescript.rs
+++ b/crates/kin-parser/src/languages/typescript.rs
@@ -455,6 +455,12 @@ fn extract_ts_node(
                         fingerprint: compute_fingerprint(node, source),
                         span: span_from_node(node, file_id),
                     });
+                    // The exported value's body, which nothing else walks. The
+                    // JavaScript adapter carries the same line beside the same
+                    // fallback and the reasoning is written out there; a Flow
+                    // `.js` file reaches THIS extractor, so leaving it out here
+                    // would keep the defect for every Flow-annotated module.
+                    extract_calls_from_context(&val, source, "default", None, relations);
                 }
             }
         }

--- a/crates/kin-parser/tests/js_ts_call_resolution.rs
+++ b/crates/kin-parser/tests/js_ts_call_resolution.rs
@@ -44,6 +44,30 @@ fn parse_fixture(adapter: &dyn LanguageAdapter, lang: &str, file: &str) -> Parse
         .expect("extract")
 }
 
+fn parse_source(adapter: &dyn LanguageAdapter, path: &str, src: &str) -> ParseOutput {
+    let bytes = src.as_bytes();
+    let tree = adapter.parse(bytes).expect("parse");
+    adapter
+        .extract(&tree, bytes, &FilePathId::new(path))
+        .expect("extract")
+}
+
+/// Every `Calls` edge to `callee`, as `(source entity, 1-based site line)`.
+fn call_sites<'a>(output: &'a ParseOutput, callee: &str) -> Vec<(&'a str, u32)> {
+    let mut sites: Vec<(&str, u32)> = calls(output)
+        .into_iter()
+        .filter(|r| r.dst_name == callee)
+        .map(|r| {
+            (
+                r.src_name.as_str(),
+                r.site.as_ref().map(|s| s.start_line + 1).unwrap_or(0),
+            )
+        })
+        .collect();
+    sites.sort_unstable();
+    sites
+}
+
 fn calls(output: &ParseOutput) -> Vec<&ExtractedRelation> {
     output
         .relations
@@ -368,5 +392,116 @@ fn ts_member_calls_record_receivers_through_the_same_constructor() {
         receiver_for(&output, "c"),
         None,
         "`a.b().c()` is written on a call, which names no binding"
+    );
+}
+
+// ---- `export default <expression>` ----
+
+/// A module whose default export is an expression rather than a declaration.
+///
+/// The control and the subject are byte-identical bodies at the same nesting
+/// depth, three function levels down through a promise executor and an event
+/// callback, and they differ only in what encloses them at the top level. That
+/// is the whole finding: `export default <expression>` reached no arm of the
+/// adapter's walk, so the fallback that mints the file's `default` entity was
+/// the only thing that ran and the body was never read for calls.
+///
+/// Depth is explicitly NOT the variable, and the control is what proves it. On
+/// axios at b8d67bbb the missed sites sit two to four function levels deep and
+/// the found ones sit one to three deep, so a test that only asserted the
+/// nested case would pass under a fix aimed at the wrong mechanism.
+const DEFAULT_EXPORT_SOURCE: &str = r#"import settle from '../core/settle.js';
+
+const isSupported = true;
+
+export function topAdapter(config) {
+  return new Promise(function dispatch(resolve, reject) {
+    request.on('done', function onDone(response) {
+      settle(response);
+    });
+  });
+}
+
+export default isSupported &&
+  function nestedAdapter(config) {
+    return new Promise(function dispatch(resolve, reject) {
+      request.on('done', function onDone(response) {
+        settle(response);
+      });
+    });
+  };
+"#;
+
+#[test]
+fn js_default_export_expression_yields_the_calls_in_its_body() {
+    let output = parse_source(
+        &JavaScriptAdapter,
+        "adapters/both.js",
+        DEFAULT_EXPORT_SOURCE,
+    );
+    assert_eq!(
+        call_sites(&output, "settle"),
+        vec![("default", 17), ("topAdapter", 8)],
+        "both bodies call `settle` once, at the same depth; the `export default \
+         <expression>` one is recorded against the `default` entity the same \
+         fallback mints"
+    );
+}
+
+#[test]
+fn js_default_export_arrow_yields_the_calls_in_its_body() {
+    // `export default (config) => {...}` is an `arrow_function`, which the walk
+    // has no arm for either, so it took the same fallback and lost the same way.
+    let output = parse_source(
+        &JavaScriptAdapter,
+        "adapters/arrow.js",
+        "import settle from './settle.js';
+export default (config) => {
+  settle(config);
+};
+",
+    );
+    assert_eq!(
+        call_sites(&output, "settle"),
+        vec![("default", 3)],
+        "an arrow default export is an expression too"
+    );
+}
+
+#[test]
+fn ts_default_export_expression_yields_the_calls_in_its_body() {
+    // TypeScript keeps its own copy of this fallback, and a Flow-annotated
+    // `.js` file is extracted through it, so the two must not drift.
+    let output = parse_source(
+        &TypeScriptAdapter,
+        "adapters/both.ts",
+        DEFAULT_EXPORT_SOURCE,
+    );
+    assert_eq!(
+        call_sites(&output, "settle"),
+        vec![("default", 17), ("topAdapter", 8)],
+        "the TypeScript extractor must record the same two edges"
+    );
+}
+
+/// The fallback fires only when the recursion produced no entity, so a named
+/// declaration must keep exactly one edge rather than gaining a second one
+/// attributed to `default`.
+#[test]
+fn js_named_default_export_is_not_walked_twice() {
+    let output = parse_source(
+        &JavaScriptAdapter,
+        "core/settle.js",
+        "import check from './check.js';
+export default function settle(response) {
+  check(response);
+}
+",
+    );
+    assert_eq!(
+        call_sites(&output, "check"),
+        vec![("settle", 3)],
+        "`export default function settle` is walked by the function arm; the \
+         default-export fallback must not walk it again"
     );
 }


### PR DESCRIPTION
## What this does

`kin refs --kind calls` was missing callers in JavaScript and TypeScript repositories, and two
separate defects were doing it. On axios at `b8d67bbb`, the three names FIR-3357 names reached 2 of
their 15 real call sites. This PR takes that to 15 of 15.

Neither defect is nesting depth, which is what the ticket started out believing. A call three
function levels down inside a promise executor inside an event callback resolves correctly today.
The measurement below is what refuted that.

**Defect A, the parser.** `crates/kin-parser/src/languages/javascript.rs`, the `export_statement`
arm of `extract_js_node`. When the default-exported value is not a declaration the walk has a case
for, a fallback mints a synthetic `default` entity for it and stops. Every other arm in that match
pairs its entity with `extract_calls_from_context` over the subtree the entity owns; this one did
not, so the exported value's whole body was never read for calls. `extract_calls_from_context` has
no depth limit, which is why depth was never the variable.

The arm catches more shapes than it looks like. `export default X && function f() {}` is a
`binary_expression`. `export default function () {}` is a `function_expression`, which the walk's
`"function_declaration" | "function"` case does not name in tree-sitter-javascript 0.25.
`export default (c) => {}` is an `arrow_function`, also unnamed there. axios's `lib/adapters/http.js`
and `lib/adapters/xhr.js` are both the first shape, so `http.js` produced 95 call edges from the
declarations above its export and none of the 7 sites below it, and `xhr.js` produced **zero call
edges for the whole file**. `typescript.rs` carries a byte-identical copy of the same fallback, and
a Flow-annotated `.js` file is extracted through it, so both are fixed here.

**Defect B, the linker.** `crates/kin-index/src/linker.rs`, `resolve_default_export`. A call to a
default-imported callee resolves through tier (b1), which for `original_name == "default"` falls
back to "the first Public entity in the target file". That list is `sorted_universe`, which
`entity_link_order` sorts by span, and every JS and TS file now carries a Module entity spanning the
whole file, so the Module always sorts first. The edge was created at confidence 0.95 and parked on
the callee file's module, and `continue` skipped the pinned tier that would have got it right.
`kin refs settle --kind calls` therefore answered "No incoming Calls relations" while `kin impact
settle` found the same callers on the module identity sitting beside it.

Fix: `resolve_default_export` and `resolve_default_export_incremental` skip `EntityKind::Module`. A
module is a file; no `export default` names it.

## The measurement that isolated it

Every call site of `settle`, `buildURL` and `progressEventReducer` on axios at `b8d67bbb`, run
through `JavaScriptAdapter::extract` directly so no daemon, store or language server is in the way,
and classified by the chain of enclosing nodes above it. `fn_depth` counts function-like ancestors.

| file:line | callee | parsed | enclosing chain |
|---|---|---|---|
| http.js:748 | settle | no | program > export_statement > function_expression(httpAdapter) > function_expression(dispatchHttpRequest), depth 2 |
| http.js:774 | settle | no | same, depth 2 |
| http.js:899 | progressEventReducer | no | same, depth 2 |
| http.js:925 | buildURL | no | same, depth 2 |
| http.js:1160 | progressEventReducer | no | ... > function_expression(handleResponse), depth 3 |
| http.js:1258 | settle | no | ... > function_expression(handleResponse), depth 3 |
| http.js:1318 | settle | no | ... > function_expression(handleStreamEnd), depth 4 |
| xhr.js:109 | settle | no | program > export_statement > function_expression(anonymous) > function_expression(dispatchXhrRequest) > function_declaration(onloadend), depth 3 |
| xhr.js:223 | progressEventReducer | no | program > export_statement > function_expression(anonymous) > function_expression(dispatchXhrRequest), depth 2 |
| xhr.js:232 | progressEventReducer | no | same, depth 2 |
| fetch.js:385 | progressEventReducer | yes | program > lexical_declaration > arrow_function > arrow_function > lexical_declaration, depth 2 |
| fetch.js:528 | progressEventReducer | yes | same, depth 2 |
| fetch.js:594 | settle | yes | program > lexical_declaration > arrow_function > arrow_function > arrow_function, depth 3 |
| Axios.js:261 | buildURL | yes | program > class_declaration > method_definition, depth 2 |
| resolveConfig.js:44 | buildURL | yes | program > function_declaration(resolveConfig), depth 1 |

The missed sites sit at depths 2, 3 and 4 and the parsed ones at depths 1, 2 and 3, so depth
separates nothing. What separates the two lists is the top-level ancestor and only that: every
missed chain begins `program > export_statement`, and every parsed chain begins
`program > lexical_declaration`, `program > class_declaration` or `program > function_declaration`.

A four-file fixture then separated the two defects from each other, converted with the published
v0.7.3 bytes under a scratch `HOME` and `KIN_HOME` with cross-file enrichment complete on all four
files, so the language server is not the variable either. `core/lib.js` exports `defaultCallee` by
default and `namedCallee` by name; two callers hold byte-identical bodies at the same depth, one
under `export function topAdapter` and one under `export default isSupported && function
nestedAdapter(config) {...}`.

| caller | callee | import | before |
|---|---|---|---|
| topAdapter, depth 3 | namedCallee | named | resolves: `topAdapter @ adapters/top.js:5 [Calls] sites 10` |
| topAdapter, depth 3 | defaultCallee | default | missing from `defaultCallee`, and found on the module instead: `kin refs lib --kind calls` returns `topAdapter @ adapters/top.js:5 [Calls] sites 9` |
| nestedAdapter, depth 3 | namedCallee | named | missing |
| nestedAdapter, depth 3 | defaultCallee | default | missing |

Row one is the positive control that must hit, and it does. Row two isolates Defect B alone, with
the misrouted edge found rather than merely absent. Rows three and four are Defect A hiding B
underneath it.

## What `kin refs` prints for an anonymous default export

`lib/adapters/xhr.js` is `export default isXHRAdapterSupported && function (config) {...}`, so the
function has no name of its own and the entity the adapter mints for it is called `default`. A
reader asking for callers of `settle` now gets a row that names the file rather than the function:

```
$ kin refs settle --kind calls
referenced by 3 entities:
  factory @ lib/adapters/fetch.js:80 [Calls] (type_resolved) sites 594
  default @ lib/adapters/http.js:566 [Calls] (type_resolved) sites 748,774,1258,1318
  default @ lib/adapters/xhr.js:16 [Calls] (type_resolved) sites 109
```

That is the same display `References` edges on those entities already used before this change, so
nothing about how a default export reads is new; it is only that `Calls` edges now reach it too.

## Falsification

Each fix reverted alone with the other left in place, so each arm goes red for its own reason. The
positive control is its own test rather than the first assertion of the subject's, because a control
sharing a test with its subject cannot be observed to hold while the subject fails.

Arm 1, Fix A reverted, Fix B in place:

```
kin-parser  js_ts_call_resolution:        FAILED. 17 passed; 3 failed
  js_default_export_expression_yields_the_calls_in_its_body               FAILED
  js_default_export_arrow_yields_the_calls_in_its_body                    FAILED
  ts_default_export_expression_yields_the_calls_in_its_body               FAILED
kin-index   javascript_module_resolution: FAILED. 12 passed; 1 failed
  a_default_export_expressions_body_reaches_a_default_imported_callee     FAILED
  a_named_imported_callee_resolves_from_the_same_nested_call_site         ok    <- control
  a_default_imported_callee_binds_to_the_declaration_not_the_files_module ok
  the_incremental_linker_skips_the_module_whatever_order_it_was_given     ok
```

Arm 2, Fix B reverted, Fix A in place:

```
kin-parser  js_ts_call_resolution:        ok. 20 passed; 0 failed
kin-index   javascript_module_resolution: FAILED. 10 passed; 3 failed
  a_default_imported_callee_binds_to_the_declaration_not_the_files_module FAILED
  the_incremental_linker_skips_the_module_whatever_order_it_was_given     FAILED
  a_default_export_expressions_body_reaches_a_default_imported_callee     FAILED
  a_named_imported_callee_resolves_from_the_same_nested_call_site         ok    <- control
```

The first run of that harness restored the reverted files with `shutil.copy2`, which preserves the
backup's mtime, so restoring moved each timestamp backward, cargo read the crate as fresh, and arm 2
silently re-ran arm 1's parser binary. The harness now restores with `shutil.copy` and calls
`os.utime` after every write. Noting it because the shape is general: a falsification harness that
restores with `copy2` is grading the previous arm.

Both classes are expressible as crate tests, and crate tests are what `ci.yml` grades on a pull
request, so that is where they live rather than under `scripts/acceptance/`.

## Before and after on axios

axios at `b8d67bbb`, 2,180 commits over 466 tracked files, converted twice into separate stores from
identical checkouts under a scratch `HOME` and `KIN_HOME`, with `KIN_EMBED_BACKEND=cpu` and
`KIN_DAEMON_DISABLE_LSP=1` on both sides so the only variable is the binary. Before is the published
v0.7.3 bytes, whose parser and linker are byte-identical to this branch's base (`git log
72f1cfba..HEAD` over the three files returns nothing). After is this branch, built by
`bin/kin-parity`.

Three columns, because the first version of Fix B was wrong and the record should say so. It skipped
only the callee file's Module and kept "the first Public entity in the file", which on
`lib/helpers/buildURL.js` is `encode`, declared at line 14 above `export default function buildURL`
at line 31. All three of `buildURL`'s call sites moved onto `encode`: the wrong function in the right
file. That is worse than the module, because it reads as a real answer. Only a run against real bytes
showed it, since every fixture written by hand had put the default export first.

| | v0.7.3 bytes | Fix B v1 (module skip only) | this PR |
|---|---|---|---|
| `settle` | 0 of 6 | 6 of 6 | **6 of 6** |
| `buildURL` | 0 of 3 | 0 of 3, all three on `encode` | **3 of 3** |
| `progressEventReducer` | 2 of 6 | 6 of 6 | **6 of 6** |
| total | 2 of 15 | 12 of 15 plus 3 wrong edges | **15 of 15** |
| `kin refs encode --kind calls` | none | 3 rows, all wrong | **none** |

Every one of the 15 matches the ground truth read from axios's source, line for line, with nothing
spurious. `buildURL`'s three rows resolve `import_scoped` rather than `type_resolved`, which is the
pinned-import tier answering rather than the fallback, and that is the fix working as designed.

```
$ kin refs buildURL --kind calls
referenced by 3 entities:
  default @ lib/adapters/http.js:566 [Calls] (import_scoped) sites 925
  Axios.getUri @ lib/core/Axios.js:258 [Calls] (import_scoped) sites 261
  resolveConfig @ lib/helpers/resolveConfig.js:25 [Calls] (import_scoped) sites 44
```

### The coverage ratio goes down, and that is the honest result

| | before | after |
|---|---|---|
| javascript calls | 501/1852 (27%) | 578/2213 (26%) |
| Calls edges | 505 | 583 |
| cross-file entity relations | 586 | 650 |

The numerator rose by 77. The denominator rose by 361, because Fix A is what makes the parser see
those call sites at all: before, `xhr.js` contributed zero sites to BOTH halves of the ratio, so its
whole adapter body was invisible to the measurement rather than counted as missing. 27% was measured
over a denominator that omitted the sites being lost. 26% covers strictly more of the repository and
is the better-informed number. Quote the pair, not the percentage.

### What this trades

A default import whose binding name differs from the declaration name is now a reported miss rather
than a wrong edge. `import bu from './buildURL.js'` finds no entity called `bu` in that file, the
fallback declines because the file exports two things, and no edge is emitted. Before, it would have
bound to whichever declaration came first. That is the only behaviour knowingly given up, and it
trades a wrong answer for no answer.

The clean way to remove even that is a marker: have the parser record WHICH entity a file's
`export default` names, and bind the resolver to it instead of to any heuristic. No such marker
exists today. `ExtractedEntity` carries kind, name, signature, visibility, doc_summary, fingerprint
and span, so the `export_statement` arm cannot record what it already knows, and `Entity`'s
`metadata` field is unreachable from the parser. The signature is not a stand-in either:
`declaration_signature` runs on the `function_declaration` node while `export` lives in the parent,
so `export default function settle` yields a signature starting at `function settle`. Adding the
marker touches kin-parser and kin-model, and kin-model is a published crate whose release gate wants
a version bump for any `src/` change, so it is a follow-up rather than a line in this PR.

## Notes

The two adapters carry byte-identical copies of this fallback and of several helpers around it, and
they have drifted before: the TypeScript index predicate never matched `index.d.ts` while the
JavaScript one did. Deduplicating them is a real follow-up and is deliberately not in this PR.

Existing stores keep the edges they already have, because those edges are written during admission.
The CHANGELOG entry says so and names the refresh: remove the store's `.kin/` and run `kin init`
again. `kin init` on its own refuses on an existing store, which was checked rather than assumed.
