### PR TITLE
Replace retired canon lines in README with the unified packet's

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <p align="center">
-  <img src="docs/assets/kin-banner-2026.png" alt="Kin, the system of record for AI-written software" width="100%" />
+  <img src="docs/assets/kin-banner-2026.png" alt="Kin, a graph-native code repository for people and AI agents" width="100%" />
 </p>
 
 <div align="center">
 
-<h3>The diff is not the change.</h3>
+<h3>AI changed who writes code.<br />Kin changes what they build on.</h3>
 
-<p><strong>The system of record for AI-written software.</strong></p>
+<p><strong>A graph-native code repository for people and AI agents.</strong></p>
 
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE) [![Latest release](https://img.shields.io/badge/release-latest-6E56CF.svg)](https://github.com/firelock-ai/kin/releases/latest) [![kinlab.ai](https://img.shields.io/badge/hosted-kinlab.ai-111111.svg)](https://kinlab.ai)
 
@@ -906,4 +906,4 @@ live at [kinlab.ai/blog](https://kinlab.ai/blog) with a feed at
 
 [Apache-2.0](LICENSE).
 
-<p align="center"><em>Software that remembers itself.</em></p>
+<p align="center"><em>Software, beyond files.</em></p>


### PR DESCRIPTION
The README still used retired opening and closing lines. This updates its banner description, opening lockup, category line, and closing line to the current approved messaging. The change is four lines; product facts, commands, and measured admission figures are unchanged.

Validation at `0c4b0001fed9579e7017bbaa30f16479f3d6823a`: the full check-run set contains 46 concluded checks, with 25 successful and 21 skipped. `Release version gate` was skipped. The release-intent classifier treats Markdown changes as non-release. The v0.7.4 tag exists at the preceding candidate, preserving release isolation.
