### PR TITLE
Fail closed at credential transport and daemon startup boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3685,6 +3685,7 @@ dependencies = [
  "tokio",
  "tracing",
  "ureq",
+ "url",
  "uuid",
 ]
 

--- a/crates/kin-cli/src/commands/auth.rs
+++ b/crates/kin-cli/src/commands/auth.rs
@@ -609,6 +609,7 @@ fn prompt_for_code() -> Result<String> {
 }
 
 pub(crate) fn load_saved_bearer_token(base_url: &str) -> Option<String> {
+    kin_remote::http_transport::validate_credential_url(base_url).ok()?;
     load_credential(base_url, true)
         .ok()
         .flatten()
@@ -654,13 +655,20 @@ pub(crate) fn default_cli_actor_id(base_url: &str) -> String {
     )
 }
 
+fn credential_http_client() -> Result<reqwest::Client> {
+    Ok(reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()?)
+}
+
 pub async fn login(
     base_url: Option<String>,
     no_browser: bool,
     provider: AuthProvider,
 ) -> Result<()> {
     let base_url = normalized_base_url(base_url);
-    let client = reqwest::Client::new();
+    kin_remote::http_transport::validate_credential_url(&base_url).map_err(anyhow::Error::msg)?;
+    let client = credential_http_client()?;
     let code_verifier = random_token(32);
     let code_challenge = pkce_challenge(&code_verifier);
 
@@ -837,9 +845,10 @@ pub async fn status(base_url: Option<String>) -> Result<()> {
 
 pub async fn whoami(base_url: Option<String>) -> Result<()> {
     let base_url = normalized_base_url(base_url);
+    kin_remote::http_transport::validate_credential_url(&base_url).map_err(anyhow::Error::msg)?;
     let credential = load_credential(&base_url, true)?
         .ok_or_else(|| anyhow::anyhow!("no KinLab auth credential stored for {}", base_url))?;
-    let response = reqwest::Client::new()
+    let response = credential_http_client()?
         .get(format!("{}/api/session", base_url))
         .bearer_auth(&credential.token)
         .send()
@@ -930,10 +939,11 @@ fn logout_lines(
 
 pub async fn logout(base_url: Option<String>) -> Result<()> {
     let base_url = normalized_base_url(base_url);
+    kin_remote::http_transport::validate_credential_url(&base_url).map_err(anyhow::Error::msg)?;
     let revocation = match load_credential(&base_url, true)? {
         None => None,
         Some(credential) => Some(
-            match reqwest::Client::new()
+            match credential_http_client()?
                 .post(format!("{}/api/cli/auth/logout", base_url))
                 .bearer_auth(&credential.token)
                 .send()
@@ -963,6 +973,66 @@ pub async fn logout(base_url: Option<String>) -> Result<()> {
 mod tests {
     use super::*;
     use serial_test::serial;
+
+    #[tokio::test]
+    async fn credential_commands_refuse_insecure_urls_before_store_access() {
+        let scratch = tempfile::tempdir().unwrap();
+        let root = scratch.path().join("credentials");
+        let _root = TestCredentialRoot::set(&root);
+        for base in [
+            "http://localhost:1",
+            "http://example.com",
+            "http://127.0.0.1.example.com",
+            "ftp://127.0.0.1",
+        ] {
+            let login_error = login(Some(base.into()), true, AuthProvider::default())
+                .await
+                .unwrap_err();
+            let whoami_error = whoami(Some(base.into())).await.unwrap_err();
+            let logout_error = logout(Some(base.into())).await.unwrap_err();
+            for error in [login_error, whoami_error, logout_error] {
+                assert!(error.to_string().contains("requires HTTPS"), "{error}");
+            }
+            assert!(load_saved_bearer_token(base).is_none());
+        }
+        assert!(
+            !root.exists(),
+            "refusal must precede credential store access"
+        );
+    }
+
+    #[tokio::test]
+    async fn credential_http_client_does_not_follow_body_preserving_redirects() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let server = std::thread::spawn(move || {
+            let (mut connection, _) = listener.accept().unwrap();
+            connection
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .unwrap();
+            let mut buffer = [0; 4096];
+            let n = connection.read(&mut buffer).unwrap();
+            assert!(n > 0);
+            connection.write_all(b"HTTP/1.1 307 Temporary Redirect\r\nLocation: http://127.0.0.1:1/forwarded\r\nContent-Length: 0\r\nConnection: close\r\n\r\n").unwrap();
+        });
+        kin_remote::http_transport::validate_credential_url(&base).unwrap();
+        let response = credential_http_client()
+            .unwrap()
+            .post(&base)
+            .bearer_auth("fixture-token")
+            .json(&serde_json::json!({"codeVerifier": "fixture"}))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::TEMPORARY_REDIRECT);
+        server.join().unwrap();
+        let exact = "https://EXAMPLE.com:443/prefix";
+        assert_eq!(normalized_base_url(Some(exact.into())), exact);
+        assert_ne!(
+            account_key(exact),
+            account_key("https://example.com/prefix")
+        );
+    }
 
     /// FIR-3257. A logout removes every persisted form of the credential it
     /// just logged out of.

--- a/crates/kin-cli/src/commands/auth.rs
+++ b/crates/kin-cli/src/commands/auth.rs
@@ -937,10 +937,13 @@ fn logout_lines(
     lines
 }
 
-pub async fn logout(base_url: Option<String>) -> Result<()> {
-    let base_url = normalized_base_url(base_url);
-    kin_remote::http_transport::validate_credential_url(&base_url).map_err(anyhow::Error::msg)?;
-    let revocation = match load_credential(&base_url, true)? {
+async fn revoke_saved_session(base_url: &str) -> Result<RevocationOutcome> {
+    if let Err(reason) = kin_remote::http_transport::validate_credential_url(base_url) {
+        return Ok(RevocationOutcome::NotRevoked(format!(
+            "network revocation skipped: {reason}"
+        )));
+    }
+    let revocation = match load_credential(base_url, true)? {
         None => None,
         Some(credential) => Some(
             match credential_http_client()?
@@ -954,7 +957,12 @@ pub async fn logout(base_url: Option<String>) -> Result<()> {
             },
         ),
     };
-    let outcome = revocation_outcome(revocation);
+    Ok(revocation_outcome(revocation))
+}
+
+pub async fn logout(base_url: Option<String>) -> Result<()> {
+    let base_url = normalized_base_url(base_url);
+    let outcome = revoke_saved_session(&base_url).await?;
 
     // Local removal runs whatever the server said. A session this machine
     // cannot revoke is still a session this machine should not keep the key to.
@@ -989,8 +997,7 @@ mod tests {
                 .await
                 .unwrap_err();
             let whoami_error = whoami(Some(base.into())).await.unwrap_err();
-            let logout_error = logout(Some(base.into())).await.unwrap_err();
-            for error in [login_error, whoami_error, logout_error] {
+            for error in [login_error, whoami_error] {
                 assert!(error.to_string().contains("requires HTTPS"), "{error}");
             }
             assert!(load_saved_bearer_token(base).is_none());
@@ -999,6 +1006,79 @@ mod tests {
             !root.exists(),
             "refusal must precede credential store access"
         );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn logout_removes_legacy_insecure_credentials_without_network_revocation() {
+        let scratch = tempfile::tempdir().unwrap();
+        let _root = TestCredentialRoot::set(&scratch.path().join("auth"));
+        let _env = kin_core::test_env::EnvVarGuard::unset("KINLAB_AUTH_PASSPHRASE");
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let base = format!("http://localhost:{}", listener.local_addr().unwrap().port());
+        let other = "https://other.example.com";
+        store_credential(&base, &test_credential(&base)).unwrap();
+        store_credential(other, &test_credential(other)).unwrap();
+        let legacy = fallback_credential_path(&base)
+            .unwrap()
+            .with_extension("json");
+        assert!(legacy.exists());
+        tokio::time::timeout(Duration::from_secs(1), logout(Some(base.clone())))
+            .await
+            .expect("local logout must not wait on an unsafe endpoint")
+            .unwrap();
+        assert!(!legacy.exists());
+        assert!(load_credential(other, false).unwrap().is_some());
+        assert_eq!(
+            listener.accept().unwrap_err().kind(),
+            std::io::ErrorKind::WouldBlock
+        );
+        let outcome = revoke_saved_session(&base).await.unwrap();
+        assert!(
+            matches!(outcome, RevocationOutcome::NotRevoked(reason) if reason.contains("network revocation skipped"))
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn logout_revokes_on_allowed_transport_and_removes_local_credentials() {
+        let scratch = tempfile::tempdir().unwrap();
+        let _root = TestCredentialRoot::set(&scratch.path().join("auth"));
+        let _env = kin_core::test_env::EnvVarGuard::unset("KINLAB_AUTH_PASSPHRASE");
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        store_credential(&base, &test_credential(&base)).unwrap();
+        let server = std::thread::spawn(move || {
+            listener.set_nonblocking(true).unwrap();
+            let deadline = std::time::Instant::now() + Duration::from_secs(2);
+            let (mut connection, _) = loop {
+                match listener.accept() {
+                    Ok(connection) => break connection,
+                    Err(error)
+                        if error.kind() == std::io::ErrorKind::WouldBlock
+                            && std::time::Instant::now() < deadline =>
+                    {
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(error) => panic!("expected revocation request: {error}"),
+                }
+            };
+            connection
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .unwrap();
+            let mut buffer = [0; 4096];
+            let n = connection.read(&mut buffer).unwrap();
+            let request = String::from_utf8_lossy(&buffer[..n]).to_ascii_lowercase();
+            assert!(request.starts_with("post /api/cli/auth/logout "));
+            assert!(request.contains("authorization: bearer not-a-real-token"));
+            connection
+                .write_all(b"HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n")
+                .unwrap();
+        });
+        logout(Some(base.clone())).await.unwrap();
+        server.join().unwrap();
+        assert!(load_credential(&base, false).unwrap().is_none());
     }
 
     #[tokio::test]

--- a/crates/kin-cli/src/commands/remote.rs
+++ b/crates/kin-cli/src/commands/remote.rs
@@ -1667,7 +1667,7 @@ mod tests {
     fn credential_endpoint_refusal_prevents_bearer_attachment() {
         let _env = kin_core::test_env::EnvVarGuard::set("KIN_REMOTE_BEARER_TOKEN", "fixture-token");
         let client = reqwest::Client::new();
-        for base in ["http://example.com", "http://127.0.0.1.example.com"] {
+        for base in ["http://localhost", "http://localhost:4219"] {
             let request = super::attach_native_remote_auth(client.get(base), base)
                 .build()
                 .unwrap();

--- a/crates/kin-cli/src/commands/remote.rs
+++ b/crates/kin-cli/src/commands/remote.rs
@@ -130,8 +130,18 @@ where
 }
 
 pub(crate) fn native_remote_bearer_token(base_url: &str) -> Option<String> {
-    resolve_native_remote_bearer_token_with(|key| std::env::var(key).ok())
-        .or_else(|| auth::load_saved_bearer_token(base_url))
+    credential_for_endpoint(base_url, || {
+        resolve_native_remote_bearer_token_with(|key| std::env::var(key).ok())
+            .or_else(|| auth::load_saved_bearer_token(base_url))
+    })
+}
+
+fn credential_for_endpoint(
+    base_url: &str,
+    load: impl FnOnce() -> Option<String>,
+) -> Option<String> {
+    kin_remote::http_transport::validate_credential_url(base_url).ok()?;
+    load()
 }
 
 /// The refusal both `kin remote` session pre-flights print when no bearer token
@@ -1619,6 +1629,65 @@ mod tests {
             message.contains("KIN_REMOTE_BEARER_TOKEN=$(cat <peer>/.kin/daemon.token)"),
             "the refusal must still carry the recipe that fixes it: {message}"
         );
+    }
+
+    #[test]
+    fn credential_endpoint_refusal_precedes_token_lookup() {
+        for base in [
+            "http://example.com",
+            "http://127.0.0.1.example.com",
+            "http://localhost",
+            "ftp://127.0.0.1",
+        ] {
+            let mut lookups = 0;
+            let token = super::credential_for_endpoint(base, || {
+                lookups += 1;
+                Some("fixture-token".into())
+            });
+            assert!(token.is_none(), "{base}");
+            assert_eq!(lookups, 0, "{base}");
+        }
+        for base in [
+            "https://example.com",
+            "http://127.0.0.1:4219",
+            "http://[::1]:4219",
+        ] {
+            let mut lookups = 0;
+            let token = super::credential_for_endpoint(base, || {
+                lookups += 1;
+                Some("fixture-token".into())
+            });
+            assert_eq!(token.as_deref(), Some("fixture-token"));
+            assert_eq!(lookups, 1);
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn credential_endpoint_refusal_prevents_bearer_attachment() {
+        let _env = kin_core::test_env::EnvVarGuard::set("KIN_REMOTE_BEARER_TOKEN", "fixture-token");
+        let client = reqwest::Client::new();
+        for base in ["http://example.com", "http://127.0.0.1.example.com"] {
+            let request = super::attach_native_remote_auth(client.get(base), base)
+                .build()
+                .unwrap();
+            assert!(!request
+                .headers()
+                .contains_key(reqwest::header::AUTHORIZATION));
+        }
+        for base in [
+            "https://example.com",
+            "http://127.0.0.1:4219",
+            "http://[::1]:4219",
+        ] {
+            let request = super::attach_native_remote_auth(client.get(base), base)
+                .build()
+                .unwrap();
+            assert_eq!(
+                request.headers()[reqwest::header::AUTHORIZATION],
+                "Bearer fixture-token"
+            );
+        }
     }
 
     #[test]

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -19093,7 +19093,7 @@ pub fn bind_api_listener(
     port: u16,
 ) -> std::io::Result<(tokio::net::TcpListener, u16)> {
     let bind_host = bind_host_from_env();
-    let auth_present = resolve_serve_auth_token(layout).is_some();
+    let auth_present = resolve_serve_auth_token(layout)?.is_some();
     let listener = bind_listener(&bind_host, port, auth_present)?;
     let bound_port = listener.local_addr()?.port();
     Ok((listener, bound_port))
@@ -19114,7 +19114,7 @@ pub fn bind_api_listener_pair(
     port: u16,
 ) -> std::io::Result<(tokio::net::TcpListener, tokio::net::TcpListener, u16)> {
     let bind_host = bind_host_from_env();
-    let auth_present = resolve_serve_auth_token(layout).is_some();
+    let auth_present = resolve_serve_auth_token(layout)?.is_some();
     let bound = bind_std_listener(&bind_host, port, auth_present)?;
     // Both handles share one bound socket and one listen queue, but only on
     // Unix does the dup share status flags. On Windows, WSA socket duplication
@@ -19221,13 +19221,7 @@ pub async fn serve_bound_with_shutdown(
     mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
 ) -> std::io::Result<()> {
     let publication_control_auth_token = publication_control_auth_token_from_env();
-    let tokens = resolve_serve_rotation_tokens(&state.layout).map_err(|error| {
-        // A refusal here stops the daemon starting, which is deliberate: the two
-        // refused configurations both mean the operator believes a rotation
-        // window is open when it is not, and serving anyway would make that
-        // belief look correct until the moment traffic is dropped.
-        std::io::Error::new(std::io::ErrorKind::InvalidInput, error.to_string())
-    })?;
+    let tokens = resolve_serve_rotation_tokens(&state.layout)?;
     let app =
         router_with_rotation_tokens(state, tokens, publication_control_auth_token, shutdown_tx);
     let port = listener
@@ -19366,21 +19360,18 @@ fn loopback_token_enforced() -> bool {
 /// `KIN_DAEMON_AUTH_TOKEN` override always wins. Otherwise the per-install
 /// loopback token is auto-provisioned under `.kin/` (so local clients can adopt
 /// it) and returned for enforcement unless `KIN_DAEMON_REQUIRE_TOKEN` is set to
-/// a falsy value (the opt-out escape hatch). If provisioning fails the daemon
-/// still starts (loopback Host/Origin validation remains active) but logs a
-/// warning.
-fn resolve_serve_auth_token(layout: &kin_core::KinLayout) -> Option<String> {
+/// a falsy value (the opt-out escape hatch). Provisioning failure refuses
+/// startup when enforcement is enabled.
+fn resolve_serve_auth_token(layout: &kin_core::KinLayout) -> std::io::Result<Option<String>> {
     if let Some(env_token) = auth_token_from_env() {
-        return Some(env_token);
+        return Ok(Some(env_token));
     }
     match ensure_loopback_token(layout) {
-        Ok(token) => loopback_token_enforced().then_some(token),
+        Ok(token) => Ok(loopback_token_enforced().then_some(token)),
+        Err(error) if loopback_token_enforced() => Err(error),
         Err(error) => {
-            tracing::warn!(
-                %error,
-                "failed to provision loopback auth token; daemon will run without bearer auth"
-            );
-            None
+            tracing::warn!(%error, "failed to provision token while bearer authentication is explicitly disabled");
+            Ok(None)
         }
     }
 }
@@ -19393,9 +19384,9 @@ fn resolve_serve_auth_token(layout: &kin_core::KinLayout) -> Option<String> {
 /// quietly reappeared would hold one open past its own policy.
 fn resolve_serve_rotation_tokens(
     layout: &kin_core::KinLayout,
-) -> Result<crate::auth_rotation::RotationTokens, crate::auth_rotation::RotationConfigError> {
+) -> std::io::Result<crate::auth_rotation::RotationTokens> {
     crate::auth_rotation::RotationTokens::new(
-        resolve_serve_auth_token(layout),
+        resolve_serve_auth_token(layout)?,
         previous_auth_token_from_env(),
         DAEMON_AUTH_TOKEN_ENV,
         DAEMON_AUTH_TOKEN_PREVIOUS_ENV,
@@ -19403,8 +19394,12 @@ fn resolve_serve_rotation_tokens(
         crate::auth_rotation::RotationBounds::from_env(
             DAEMON_AUTH_ROTATION_WINDOW_SECS_ENV,
             DAEMON_AUTH_ROTATION_MAX_ACCEPTS_ENV,
-        )?,
+        )
+        .map_err(|error| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, error.to_string())
+        })?,
     )
+    .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error.to_string()))
 }
 
 fn parse_bind_host(bind_host: &str) -> std::io::Result<IpAddr> {
@@ -54321,6 +54316,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn token_provisioning_failure_refuses_bind_and_serve() {
+        let _env = env_test_lock();
+        let mut env = kin_core::test_env::EnvVarGuard::unset("KIN_DAEMON_AUTH_TOKEN")
+            .without("KIN_DAEMON_REQUIRE_TOKEN")
+            .with("KIN_DAEMON_BIND_HOST", "127.0.0.1");
+        let scratch = tempfile::tempdir().unwrap();
+        let invalid_parent = scratch.path().join("not-a-directory");
+        std::fs::write(&invalid_parent, "fixture").unwrap();
+        let layout = kin_core::KinLayout::new(invalid_parent);
+        assert!(resolve_serve_auth_token(&layout).is_err());
+        assert!(bind_api_listener(&layout, 0).is_err());
+        assert!(bind_api_listener_pair(&layout, 0).is_err());
+
+        let state = test_state();
+        let (listener, _) = bind_api_listener(&state.layout, 0).unwrap();
+        let token_path = loopback_token_path(&state.layout);
+        std::fs::remove_file(&token_path).unwrap();
+        std::fs::create_dir(&token_path).unwrap();
+        let (_tx, rx) = tokio::sync::watch::channel(false);
+        let result = tokio::time::timeout(
+            Duration::from_secs(2),
+            serve_bound_with_shutdown(state, listener, None, rx),
+        )
+        .await
+        .expect("serving must refuse before accepting requests");
+        assert!(result.is_err());
+
+        env.apply("KIN_DAEMON_REQUIRE_TOKEN", Some("off"));
+        assert_eq!(resolve_serve_auth_token(&layout).unwrap(), None);
+        assert!(bind_api_listener(&layout, 0).is_ok());
+        env.apply("KIN_DAEMON_AUTH_TOKEN", Some("explicit-test-token"));
+        assert_eq!(
+            resolve_serve_auth_token(&layout).unwrap().as_deref(),
+            Some("explicit-test-token")
+        );
+    }
+
+    #[tokio::test]
     async fn resolve_serve_auth_token_gates_enforcement() {
         let _env = env_test_lock();
         let mut tokens = kin_core::test_env::EnvVarGuard::unset("KIN_DAEMON_AUTH_TOKEN")
@@ -54333,6 +54366,7 @@ mod tests {
         // Default (no env configured at all): enforcement is ON, so a fresh
         // install requires the auto-provisioned token out of the box.
         let provisioned_default = resolve_serve_auth_token(&layout)
+            .unwrap()
             .expect("fresh install must enforce the auto-provisioned token by default");
         let provisioned = std::fs::read_to_string(loopback_token_path(&layout)).unwrap();
         assert!(!provisioned.trim().is_empty());
@@ -54342,14 +54376,14 @@ mod tests {
         // for a local client that cannot yet send the header — while the file
         // stays provisioned.
         tokens.apply("KIN_DAEMON_REQUIRE_TOKEN", Some("0"));
-        assert!(resolve_serve_auth_token(&layout).is_none());
+        assert!(resolve_serve_auth_token(&layout).unwrap().is_none());
         tokens.apply("KIN_DAEMON_REQUIRE_TOKEN", Some("false"));
-        assert!(resolve_serve_auth_token(&layout).is_none());
+        assert!(resolve_serve_auth_token(&layout).unwrap().is_none());
 
         // Explicit truthy values are equivalent to the default.
         tokens.apply("KIN_DAEMON_REQUIRE_TOKEN", Some("1"));
         assert_eq!(
-            resolve_serve_auth_token(&layout).as_deref(),
+            resolve_serve_auth_token(&layout).unwrap().as_deref(),
             Some(provisioned.trim())
         );
         tokens.apply::<_, &str>("KIN_DAEMON_REQUIRE_TOKEN", None);
@@ -54359,7 +54393,7 @@ mod tests {
         tokens.apply("KIN_DAEMON_REQUIRE_TOKEN", Some("0"));
         tokens.apply("KIN_DAEMON_AUTH_TOKEN", Some("explicit-override"));
         assert_eq!(
-            resolve_serve_auth_token(&layout).as_deref(),
+            resolve_serve_auth_token(&layout).unwrap().as_deref(),
             Some("explicit-override")
         );
     }

--- a/crates/kin-daemon/src/supervisor.rs
+++ b/crates/kin-daemon/src/supervisor.rs
@@ -1111,9 +1111,9 @@ fn previous_auth_token_from_env() -> Option<String> {
 /// token is environment-only with no on-disk fallback.
 fn resolve_serve_rotation_tokens(
     dir: &Path,
-) -> Result<crate::auth_rotation::RotationTokens, crate::auth_rotation::RotationConfigError> {
+) -> std::io::Result<crate::auth_rotation::RotationTokens> {
     crate::auth_rotation::RotationTokens::new(
-        resolve_serve_auth_token(dir),
+        resolve_serve_auth_token(dir)?,
         previous_auth_token_from_env(),
         SUPERVISOR_AUTH_TOKEN_ENV,
         SUPERVISOR_AUTH_TOKEN_PREVIOUS_ENV,
@@ -1121,8 +1121,12 @@ fn resolve_serve_rotation_tokens(
         crate::auth_rotation::RotationBounds::from_env(
             SUPERVISOR_AUTH_ROTATION_WINDOW_SECS_ENV,
             SUPERVISOR_AUTH_ROTATION_MAX_ACCEPTS_ENV,
-        )?,
+        )
+        .map_err(|error| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, error.to_string())
+        })?,
     )
+    .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error.to_string()))
 }
 
 /// Load the per-install supervisor loopback token, generating and persisting one
@@ -1206,20 +1210,18 @@ fn with_supervisor_auth(request: reqwest::RequestBuilder) -> reqwest::RequestBui
 /// Resolve the auth token the serving supervisor enforces: an explicit
 /// `KIN_SUPERVISOR_AUTH_TOKEN` override always wins. Otherwise the per-install
 /// loopback token is auto-provisioned under `.kin/` (so local clients can adopt
-/// it) but only returned for enforcement when `KIN_SUPERVISOR_REQUIRE_TOKEN`
-/// is set. Mirrors `api::resolve_serve_auth_token`.
-fn resolve_serve_auth_token(dir: &Path) -> Option<String> {
+/// it) and enforced unless `KIN_SUPERVISOR_REQUIRE_TOKEN` explicitly opts out.
+/// Provisioning failure refuses startup when enforcement is enabled. Mirrors `api::resolve_serve_auth_token`.
+fn resolve_serve_auth_token(dir: &Path) -> std::io::Result<Option<String>> {
     if let Some(env_token) = auth_token_from_env() {
-        return Some(env_token);
+        return Ok(Some(env_token));
     }
     match ensure_loopback_token(dir) {
-        Ok(token) => loopback_token_enforced().then_some(token),
+        Ok(token) => Ok(loopback_token_enforced().then_some(token)),
+        Err(error) if loopback_token_enforced() => Err(error),
         Err(error) => {
-            warn!(
-                %error,
-                "failed to provision supervisor loopback auth token; supervisor will run without bearer auth"
-            );
-            None
+            tracing::warn!(%error, "failed to provision token while bearer authentication is explicitly disabled");
+            Ok(None)
         }
     }
 }
@@ -1478,6 +1480,25 @@ async fn deregister_daemon(
     }))
 }
 
+async fn bind_supervisor_listener(
+    dir: &Path,
+    addr: SocketAddr,
+) -> std::io::Result<(
+    tokio::net::TcpListener,
+    crate::auth_rotation::RotationTokens,
+)> {
+    let tokens = resolve_serve_rotation_tokens(dir)?;
+    if !addr.ip().is_loopback() && !tokens.is_enforced() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "KIN_SUPERVISOR_AUTH_TOKEN (or KIN_SUPERVISOR_REQUIRE_TOKEN) is required when binding the supervisor to a non-loopback host",
+        ));
+    }
+
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    Ok((listener, tokens))
+}
+
 pub async fn run_supervisor(port: u16, idle_timeout: Option<Duration>) -> std::io::Result<()> {
     let state_dir = supervisor_dir();
     let startup = kin_cli::daemon_client::validate_supervisor_runtime_startup(&state_dir)?;
@@ -1499,17 +1520,7 @@ pub async fn run_supervisor(port: u16, idle_timeout: Option<Duration>) -> std::i
     // which rejects a non-loopback daemon bind that has no auth token. The
     // Host/Origin guard is always active; the token is the second layer for
     // non-browser local/LAN callers.
-    let tokens = resolve_serve_rotation_tokens(&supervisor_dir()).map_err(|error| {
-        std::io::Error::new(std::io::ErrorKind::InvalidInput, error.to_string())
-    })?;
-    if !addr.ip().is_loopback() && !tokens.is_enforced() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::PermissionDenied,
-            "KIN_SUPERVISOR_AUTH_TOKEN (or KIN_SUPERVISOR_REQUIRE_TOKEN) is required when binding the supervisor to a non-loopback host",
-        ));
-    }
-
-    let listener = tokio::net::TcpListener::bind(addr).await?;
+    let (listener, tokens) = bind_supervisor_listener(&state_dir, addr).await?;
     let bound_port = listener.local_addr()?.port();
     write_supervisor_endpoint_files(&state_dir, &supervisor_lock, bound_port)?;
     if let Err(error) = startup.acknowledge() {
@@ -3616,6 +3627,35 @@ mod tests {
     use axum::http::Request;
     use tower::ServiceExt;
 
+    #[tokio::test]
+    async fn token_provisioning_failure_refuses_supervisor_auth_resolution() {
+        let _env = env_test_lock();
+        let mut env = kin_core::test_env::EnvVarGuard::unset("KIN_SUPERVISOR_AUTH_TOKEN")
+            .without("KIN_SUPERVISOR_REQUIRE_TOKEN")
+            .without("KIN_SUPERVISOR_AUTH_TOKEN_PREVIOUS");
+        let scratch = tempfile::tempdir().unwrap();
+        let invalid_parent = scratch.path().join("not-a-directory");
+        std::fs::write(&invalid_parent, "fixture").unwrap();
+        assert!(resolve_serve_auth_token(&invalid_parent).is_err());
+        assert!(resolve_serve_rotation_tokens(&invalid_parent).is_err());
+        let addr = "127.0.0.1:0".parse().unwrap();
+        assert!(bind_supervisor_listener(&invalid_parent, addr)
+            .await
+            .is_err());
+        env.apply("KIN_SUPERVISOR_REQUIRE_TOKEN", Some("off"));
+        assert_eq!(resolve_serve_auth_token(&invalid_parent).unwrap(), None);
+        assert!(bind_supervisor_listener(&invalid_parent, addr)
+            .await
+            .is_ok());
+        env.apply("KIN_SUPERVISOR_AUTH_TOKEN", Some("explicit-test-token"));
+        assert_eq!(
+            resolve_serve_auth_token(&invalid_parent)
+                .unwrap()
+                .as_deref(),
+            Some("explicit-test-token")
+        );
+    }
+
     /// Serialize tests that mutate process-global `KIN_SUPERVISOR_*` env so they
     /// cannot race. Shares one lock with every other env-mutating test in this
     /// binary (see `crate::test_env_lock`).
@@ -4159,7 +4199,7 @@ mod tests {
         // provisioned token is returned and required, so the machine-wide
         // control plane is not readable by every local process.
         assert_eq!(
-            resolve_serve_auth_token(&dir).as_deref(),
+            resolve_serve_auth_token(&dir).unwrap().as_deref(),
             Some(token.as_str()),
             "the supervisor must enforce its loopback token by default"
         );
@@ -4167,7 +4207,7 @@ mod tests {
         // A truthy KIN_SUPERVISOR_REQUIRE_TOKEN is the same as the default.
         tokens.apply("KIN_SUPERVISOR_REQUIRE_TOKEN", Some("1"));
         assert_eq!(
-            resolve_serve_auth_token(&dir).as_deref(),
+            resolve_serve_auth_token(&dir).unwrap().as_deref(),
             Some(token.as_str())
         );
 
@@ -4176,7 +4216,7 @@ mod tests {
         for opted_out in ["0", "false", "no", "off", " OFF "] {
             tokens.apply("KIN_SUPERVISOR_REQUIRE_TOKEN", Some(opted_out));
             assert!(
-                resolve_serve_auth_token(&dir).is_none(),
+                resolve_serve_auth_token(&dir).unwrap().is_none(),
                 "{opted_out:?} must opt out of supervisor bearer auth"
             );
         }
@@ -4185,7 +4225,7 @@ mod tests {
         // An explicit KIN_SUPERVISOR_AUTH_TOKEN override always wins.
         tokens.apply("KIN_SUPERVISOR_AUTH_TOKEN", Some("explicit-override"));
         assert_eq!(
-            resolve_serve_auth_token(&dir).as_deref(),
+            resolve_serve_auth_token(&dir).unwrap().as_deref(),
             Some("explicit-override")
         );
     }

--- a/crates/kin-remote/Cargo.toml
+++ b/crates/kin-remote/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 
 [features]
 default = []
-http = ["ureq"]
+http = ["ureq", "dep:url"]
 # `object_store` is kin-db's own object-store client crate, pulled in here at the
 # same version so `GcsBackend::from_store` accepts a store this crate built. That
 # is what lets a caller point the destination at an emulator without a kin-db
@@ -34,6 +34,7 @@ kin-model = { workspace = true }
 kin-db = { workspace = true }
 sha2 = { workspace = true }
 base64 = "0.23"
+url = { version = "2", optional = true }
 ureq = { version = "3", optional = true, features = ["json"] }
 object_store = { version = "0.14", optional = true }
 

--- a/crates/kin-remote/src/http_transport.rs
+++ b/crates/kin-remote/src/http_transport.rs
@@ -113,6 +113,7 @@ impl HttpConfig {
     fn build_agent(&self) -> Agent {
         Agent::config_builder()
             .timeout_global(Some(Duration::from_secs(self.timeout_secs)))
+            .max_redirects(0)
             .build()
             .into()
     }
@@ -177,6 +178,8 @@ fn map_ureq_error_to_push(err: ureq::Error) -> MutationPushError {
 
 impl DeltaPuller for HttpDeltaPuller {
     fn pull_delta(&self, entity_id: &str) -> Result<SemanticDelta, PullError> {
+        validate_credential_url(&self.config.base_url)
+            .map_err(|message| PullError::Protocol(message.to_string()))?;
         let url = format!(
             "{}/api/sync/delta?entity_id={}",
             self.config.base_url,
@@ -202,6 +205,8 @@ impl DeltaPuller for HttpDeltaPuller {
     }
 
     fn pull_deltas_since(&self, since: DateTime<Utc>) -> Result<Vec<SemanticDelta>, PullError> {
+        validate_credential_url(&self.config.base_url)
+            .map_err(|message| PullError::Protocol(message.to_string()))?;
         let url = format!(
             "{}/api/sync/delta?since={}",
             self.config.base_url,
@@ -254,6 +259,8 @@ impl std::fmt::Debug for HttpMutationPusher {
 
 impl MutationPusher for HttpMutationPusher {
     fn push_mutations(&self, mutations: &[LocalMutation]) -> Result<PushResult, MutationPushError> {
+        validate_credential_url(&self.config.base_url)
+            .map_err(|message| MutationPushError::Protocol(message.to_string()))?;
         let url = format!("{}/api/sync/push", self.config.base_url);
         debug!(count = mutations.len(), url = %url, "pushing mutations");
 
@@ -326,8 +333,112 @@ const HEX_UPPER: [u8; 16] = *b"0123456789ABCDEF";
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
+
+    pub(crate) fn serve_once(response: String) -> (String, std::thread::JoinHandle<String>) {
+        use std::io::{Read, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let thread = std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + Duration::from_secs(3);
+            let mut stream = loop {
+                match listener.accept() {
+                    Ok((stream, _)) => break stream,
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        assert!(std::time::Instant::now() < deadline, "no fixture request");
+                        std::thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(error) => panic!("{error}"),
+                }
+            };
+            stream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .unwrap();
+            let mut request = Vec::new();
+            let mut byte = [0];
+            while !request.ends_with(b"\r\n\r\n") {
+                stream.read_exact(&mut byte).unwrap();
+                request.push(byte[0]);
+            }
+            stream.write_all(response.as_bytes()).unwrap();
+            String::from_utf8(request).unwrap()
+        });
+        (url, thread)
+    }
+
+    #[test]
+    fn sync_credentials_refuse_insecure_endpoints_before_network() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let url = format!("http://localhost:{}", listener.local_addr().unwrap().port());
+        let config = HttpConfig::new(url)
+            .with_auth("fixture-token")
+            .with_timeout(1);
+        let puller = HttpDeltaPuller::new(config.clone());
+        assert!(
+            matches!(puller.pull_delta("entity:1"), Err(PullError::Protocol(message)) if message.contains("requires HTTPS"))
+        );
+        assert!(
+            matches!(puller.pull_deltas_since(Utc::now()), Err(PullError::Protocol(message)) if message.contains("requires HTTPS"))
+        );
+        let pusher = HttpMutationPusher::new(config);
+        assert!(
+            matches!(pusher.push_mutations(&[]), Err(MutationPushError::Protocol(message)) if message.contains("requires HTTPS"))
+        );
+        assert_eq!(
+            listener.accept().unwrap_err().kind(),
+            std::io::ErrorKind::WouldBlock
+        );
+    }
+
+    #[test]
+    fn sync_credentials_allow_literal_loopback_and_refuse_redirects() {
+        let delta = serde_json::json!({"entity_id":"entity:1","before_hash":null,"after_hash":"hash","change_set":[],"timestamp":"2026-09-08T00:00:00Z","actor_id":"fixture"});
+        let bodies = [
+            delta.to_string(),
+            format!("[{delta}]"),
+            r#"{"Accepted":{"accepted_count":0,"new_remote_head":"hash"}}"#.to_owned(),
+        ];
+        for (operation, body) in bodies.into_iter().enumerate() {
+            for redirect in [false, true] {
+                let target = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+                target.set_nonblocking(true).unwrap();
+                let response = if redirect {
+                    format!("HTTP/1.1 302 Found\r\nLocation: http://{}/redirect\r\nContent-Length: 0\r\nConnection: close\r\n\r\n", target.local_addr().unwrap())
+                } else {
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                        body.len()
+                    )
+                };
+                let (url, server) = serve_once(response);
+                let config = HttpConfig::new(url)
+                    .with_auth("fixture-token")
+                    .with_timeout(1);
+                let success = match operation {
+                    0 => HttpDeltaPuller::new(config).pull_delta("entity:1").is_ok(),
+                    1 => HttpDeltaPuller::new(config)
+                        .pull_deltas_since(Utc::now())
+                        .is_ok(),
+                    _ => HttpMutationPusher::new(config).push_mutations(&[]).is_ok(),
+                };
+                let request = server.join().unwrap();
+                assert!(request
+                    .to_lowercase()
+                    .contains("authorization: bearer fixture-token"));
+                assert_eq!(
+                    success, !redirect,
+                    "operation={operation} redirect={redirect}"
+                );
+                assert_eq!(
+                    target.accept().unwrap_err().kind(),
+                    std::io::ErrorKind::WouldBlock
+                );
+            }
+        }
+    }
 
     #[test]
     fn http_config_builder() {

--- a/crates/kin-remote/src/http_transport.rs
+++ b/crates/kin-remote/src/http_transport.rs
@@ -18,6 +18,64 @@ use std::time::Duration;
 use tracing::{debug, warn};
 use ureq::Agent;
 
+/// Require TLS for credentials except on literal loopback development endpoints.
+/// Validation does not rewrite the URL used to key saved credentials.
+pub fn validate_credential_url(raw: &str) -> Result<(), &'static str> {
+    let url = url::Url::parse(raw).map_err(|_| "invalid credential endpoint URL")?;
+    if !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || url.host().is_none()
+    {
+        return Err("credential endpoint must not contain userinfo, a query, or a fragment");
+    }
+    match url.scheme() {
+        "https" => Ok(()),
+        "http"
+            if matches!(url.host(), Some(url::Host::Ipv4(ip)) if ip.is_loopback())
+                || matches!(url.host(), Some(url::Host::Ipv6(ip)) if ip.is_loopback()) =>
+        {
+            Ok(())
+        }
+        _ => Err("credential endpoint requires HTTPS or a literal loopback HTTP address"),
+    }
+}
+
+#[cfg(test)]
+mod credential_url_tests {
+    use super::validate_credential_url;
+
+    #[test]
+    fn credential_urls_require_tls_except_loopback() {
+        for raw in [
+            "https://example.com",
+            "https://example.com/prefix/",
+            "http://127.0.0.1:4219",
+            "http://127.42.0.2",
+            "http://[::1]:4219",
+        ] {
+            assert!(validate_credential_url(raw).is_ok(), "{raw}");
+        }
+        for raw in [
+            "http://example.com",
+            "http://localhost",
+            "http://127.0.0.1.example.com",
+            "http://[::ffff:127.0.0.1]",
+            "http://0.0.0.0",
+            "http://192.168.1.1",
+            "ftp://127.0.0.1",
+            "file:///tmp/a",
+            "https://user:password@example.com",
+            "https://example.com?x=y",
+            "https://example.com#fragment",
+            "not a URL",
+        ] {
+            assert!(validate_credential_url(raw).is_err(), "{raw}");
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Configuration
 // ---------------------------------------------------------------------------

--- a/crates/kin-remote/src/repository_transfer_http.rs
+++ b/crates/kin-remote/src/repository_transfer_http.rs
@@ -157,6 +157,7 @@ impl HttpRepositoryTransferTransport {
     pub fn new(endpoint: RepositoryTransferEndpoint) -> Self {
         let agent: Agent = Agent::config_builder()
             .timeout_global(Some(Duration::from_secs(endpoint.timeout_secs)))
+            .max_redirects(0)
             // A repository-v6 refusal carries the violated invariant in its
             // response body. Keep the response available so this layer can
             // preserve that reason while mapping the status to the right
@@ -487,6 +488,42 @@ mod tests {
             listener.accept().unwrap_err().kind(),
             std::io::ErrorKind::WouldBlock
         );
+    }
+
+    #[test]
+    fn transfer_credentials_allow_loopback_and_refuse_redirects() {
+        for post in [false, true] {
+            for redirect in [false, true] {
+                let target = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+                target.set_nonblocking(true).unwrap();
+                let response = if redirect {
+                    format!("HTTP/1.1 302 Found\r\nLocation: http://{}/redirect\r\nContent-Length: 0\r\nConnection: close\r\n\r\n", target.local_addr().unwrap())
+                } else {
+                    "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}".to_owned()
+                };
+                let (url, server) = crate::http_transport::tests::serve_once(response);
+                let transport = HttpRepositoryTransferTransport::new(
+                    RepositoryTransferEndpoint::new(&url)
+                        .with_auth("fixture-token")
+                        .with_timeout(1),
+                );
+                let id = RepositoryId::new("kin").unwrap();
+                let result: Result<serde_json::Value> = if post {
+                    transport.post_json(&id, &url, &serde_json::json!({}), "fixture")
+                } else {
+                    transport.get_json(&id, &url, "fixture")
+                };
+                assert_eq!(result.is_ok(), !redirect, "post={post} redirect={redirect}");
+                let request = server.join().unwrap();
+                assert!(request
+                    .to_lowercase()
+                    .contains("authorization: bearer fixture-token"));
+                assert_eq!(
+                    target.accept().unwrap_err().kind(),
+                    std::io::ErrorKind::WouldBlock
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/kin-remote/src/repository_transfer_http.rs
+++ b/crates/kin-remote/src/repository_transfer_http.rs
@@ -210,6 +210,8 @@ impl HttpRepositoryTransferTransport {
         url: &str,
         what: &str,
     ) -> Result<R> {
+        crate::http_transport::validate_credential_url(&self.endpoint.base_url)
+            .map_err(|message| RepositoryTransferError::Invalid(message.to_string()))?;
         let mut request = self.agent.get(url);
         if let Some(token) = &self.endpoint.auth_token {
             request = request.header("Authorization", &format!("Bearer {token}"));
@@ -227,6 +229,8 @@ impl HttpRepositoryTransferTransport {
         body: &T,
         what: &str,
     ) -> Result<R> {
+        crate::http_transport::validate_credential_url(&self.endpoint.base_url)
+            .map_err(|message| RepositoryTransferError::Invalid(message.to_string()))?;
         let mut request = self.agent.post(url);
         if let Some(token) = &self.endpoint.auth_token {
             request = request.header("Authorization", &format!("Bearer {token}"));
@@ -461,6 +465,28 @@ mod tests {
 
     fn json_response(payload: String) -> ureq::http::Response<ureq::Body> {
         response(200, payload)
+    }
+
+    #[test]
+    fn credential_transport_refuses_insecure_get_and_post_before_network() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let transport = HttpRepositoryTransferTransport::new(
+            RepositoryTransferEndpoint::new("http://untrusted.example")
+                .with_auth("fixture-token")
+                .with_timeout(1),
+        );
+        let id = RepositoryId::new("kin").unwrap();
+        let get: Result<serde_json::Value> = transport.get_json(&id, &url, "test");
+        assert!(matches!(get, Err(RepositoryTransferError::Invalid(_))));
+        let post: Result<serde_json::Value> =
+            transport.post_json(&id, &url, &serde_json::json!({}), "test");
+        assert!(matches!(post, Err(RepositoryTransferError::Invalid(_))));
+        assert_eq!(
+            listener.accept().unwrap_err().kind(),
+            std::io::ErrorKind::WouldBlock
+        );
     }
 
     #[test]


### PR DESCRIPTION
Credential-bearing auth, repository-transfer and exported sync requests now require HTTPS, with literal IPv4/IPv6 loopback HTTP retained for local development. Validation runs before login, whoami, remote credential lookup and transport requests. Logout still removes credentials saved for legacy insecure endpoints while skipping network revocation. Saved credential keys retain their exact URL spelling. Auth and both HTTP transport clients refuse redirects; public transport constructor signatures remain unchanged.

Daemon and supervisor startup now return provisioning errors when bearer enforcement is enabled. Both daemon bind paths and the final serve phase enforce this. Explicit opt-out, environment-token precedence, public routes, Host/Origin controls and publication-control authentication retain their behavior.

Local validation:

- `cargo test -p kin-remote --features http --lib`: `160 passed; 0 failed`, including accepted loopback bearer requests and denied redirect controls across sync and repository transfer.
- `cargo test -p kin-cli --lib commands::auth::tests`: `21 passed; 0 failed`, including legacy local logout without network traffic and accepted revocation.
- `cargo test -p kin-cli --lib commands::remote::tests`: `32 passed; 0 failed`.
- `cargo test -p kin-daemon --lib token`: `37 passed; 0 failed`.
- `cargo test -p kin-daemon --lib host_and_origin`: `2 passed; 0 failed`.
- Seventeen temporary implementation mutations produced assertion failures across URL/request guards, redirect policies, credential lookup, local logout and daemon provisioning/bind/serve controls. Sources were restored and relevant suites passed. Formatting passed.

The reviewed precheck passed all 21 gates on final head `b30202636c8d5cda5a70b7d189bd9976e226ff7f`. Final-head fresh-build first-run parity returned `PASS-WITH-ALLOWANCES` in 166.5 seconds, with existing allowances for checks 3 and 9. Earlier full parity at `d82cf852b` also carried the existing brownfield check 4 allowance. These results do not establish clean release acceptance.

No production exposure or deployment verification is claimed. Default redirect policies in sibling secret/pipeline/session clients remain a separate follow-up; this change does not claim every credential-bearing client has a unified redirect policy.
