### PR TITLE
Verify watcher and health readiness with bounded trace witnesses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1039,6 +1039,9 @@ jobs:
       - name: Test acceptance fixture cleanup safety
         run: python3 scripts/acceptance/test_fixture_shutdown.py
 
+      - name: Test bounded brownfield trace witnesses
+        run: python3 scripts/acceptance/test_brownfield_trace_witness.py
+
       # Here rather than in `check`, for the reason the step above records: a
       # script step in `check` is a gate `bin/kin-precheck` enumerates and must
       # classify by name, and one wired there without the matching umbrella

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -4119,8 +4119,47 @@ mod tests {
 
     #[cfg(unix)]
     async fn check_reconcile_dirty_work(edit: bool, repair_layout: u8, already_dirty: bool) {
+        use tracing_subscriber::layer::SubscriberExt;
+
+        struct Outcomes(Arc<std::sync::atomic::AtomicU64>);
+        impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for Outcomes {
+            fn on_event(
+                &self,
+                event: &tracing::Event<'_>,
+                _ctx: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                struct Outcome(bool);
+                impl tracing::field::Visit for Outcome {
+                    fn record_debug(
+                        &mut self,
+                        field: &tracing::field::Field,
+                        value: &dyn std::fmt::Debug,
+                    ) {
+                        if field.name() == "outcome" {
+                            self.0 = format!("{value:?}").contains("FilePathId(\"stable.rs\")");
+                        }
+                    }
+                }
+                let mut outcome = Outcome(false);
+                event.record(&mut outcome);
+                if outcome.0 {
+                    self.0.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }
+        let controlled_outcomes = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let _capture = crate::capture_events_on_this_thread(
+            tracing_subscriber::registry().with(Outcomes(Arc::clone(&controlled_outcomes))),
+        );
         let repo = tempfile::tempdir().unwrap();
         let state = open_test_state(&repo);
+        let canonical = repo.path().canonicalize().unwrap();
+        eprintln!(
+            "watch fixture root={} canonical={}",
+            repo.path().display(),
+            canonical.display()
+        );
+        admit_and_derive(&state, "watch-ready.rs", "pub fn waiting() {}\n");
         let original = "pub fn stable() -> u32 { 7 }\n";
         admit_and_derive(&state, "stable.rs", original);
         let file_id = FilePathId::new("stable.rs");
@@ -4182,6 +4221,45 @@ mod tests {
             RECON_IDLE,
             "the bounded startup wait must reach idle before the controlled observation"
         );
+        // Construction is not delivery. A separate file must reach graph truth
+        // before resetting the fixture; its events cannot count as stable.rs work.
+        let ready_host = repo.path().join("watch-ready.rs");
+        let ready_id = FilePathId::new("watch-ready.rs");
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let mut acknowledged = false;
+        while Instant::now() < deadline && !runner.is_finished() {
+            std::fs::write(&ready_host, "pub fn watcher_ready() {}\n").unwrap();
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            acknowledged = state
+                .graph
+                .query_entities(&EntityFilter {
+                    file_path: Some(ready_id.clone()),
+                    ..Default::default()
+                })
+                .unwrap()
+                .iter()
+                .any(|entity| entity.name == "watcher_ready");
+            if acknowledged && state.reconciliation_status.load(Ordering::Relaxed) == RECON_IDLE {
+                break;
+            }
+        }
+        if !acknowledged
+            || runner.is_finished()
+            || state.reconciliation_status.load(Ordering::Relaxed) != RECON_IDLE
+        {
+            cancel_tx.send(true).ok();
+            let terminated = runner.await;
+            panic!(
+                "watch readiness not acknowledged: root={}, status={}, runner={terminated:?}",
+                canonical.display(),
+                state.reconciliation_status.load(Ordering::Relaxed)
+            );
+        }
+        eprintln!(
+            "watch readiness acknowledged: root={}, status={}",
+            canonical.display(),
+            state.reconciliation_status.load(Ordering::Relaxed)
+        );
         // Settle fixture work through the normal persistence boundary before
         // attributing anything to the controlled notification.
         state.save_snapshot().unwrap();
@@ -4209,6 +4287,7 @@ mod tests {
             .registered(crate::background_work::PASS_RECONCILE)
             .unwrap();
         let before = pass.progress();
+        let before_controlled = controlled_outcomes.load(Ordering::Relaxed);
         let content = if edit {
             "pub fn changed() -> u32 { 8 }\n"
         } else {
@@ -4216,14 +4295,24 @@ mod tests {
         };
         std::fs::write(&host, content).unwrap();
         let deadline = Instant::now() + Duration::from_secs(10);
-        while pass.progress() <= before && Instant::now() < deadline {
+        while (pass.progress() <= before
+            || controlled_outcomes.load(Ordering::Relaxed) <= before_controlled)
+            && Instant::now() < deadline
+            && !runner.is_finished()
+        {
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
-        cancel_tx.send(true).unwrap();
-        runner.await.unwrap().unwrap();
+        let finished_before_cancel = runner.is_finished();
+        cancel_tx.send(true).ok();
+        let terminated = runner.await;
+        eprintln!("watch controlled observation: root={}, progress={before}->{}, outcomes={before_controlled}->{}, status={}, early_exit={finished_before_cancel}, runner={terminated:?}",
+            canonical.display(), pass.progress(), controlled_outcomes.load(Ordering::Relaxed),
+            state.reconciliation_status.load(Ordering::Relaxed));
+        terminated.unwrap().unwrap();
         assert!(
-            pass.progress() > before,
-            "the real watcher must process the controlled write"
+            pass.progress() > before
+                && controlled_outcomes.load(Ordering::Relaxed) > before_controlled,
+            "the real watcher must reconcile stable.rs after the controlled write"
         );
         assert_eq!(state.is_dirty(), edit || repair_layout != 0 || already_dirty,
             "an identical settled notification must not create dirty work; edits, layout repairs and existing dirty work must remain dirty");

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -4225,7 +4225,7 @@ mod tests {
         // before resetting the fixture; its events cannot count as stable.rs work.
         let ready_host = repo.path().join("watch-ready.rs");
         let ready_id = FilePathId::new("watch-ready.rs");
-        let deadline = Instant::now() + Duration::from_secs(10);
+        let deadline = Instant::now() + Duration::from_secs(30);
         let mut acknowledged = false;
         while Instant::now() < deadline && !runner.is_finished() {
             std::fs::write(&ready_host, "pub fn watcher_ready() {}\n").unwrap();

--- a/crates/kin-daemon/tests/chaos_recovery.rs
+++ b/crates/kin-daemon/tests/chaos_recovery.rs
@@ -128,6 +128,38 @@ fn spawn_daemon_with_env(repo_root: &Path, port: u16, envs: &[(&str, &str)]) -> 
         .expect("failed to spawn contained kin-daemon")
 }
 
+fn decode_ready_health(body: &[u8]) -> Result<Option<HealthResponse>, serde_json::Error> {
+    let payload: serde_json::Value = serde_json::from_slice(body)?;
+    if payload.get("status").and_then(serde_json::Value::as_str) == Some("warming") {
+        return Ok(None);
+    }
+    let health: HealthResponse = serde_json::from_value(payload)?;
+    Ok((health.status == "ok").then_some(health))
+}
+
+#[test]
+fn health_decoder_waits_for_warming_then_strict_ready() {
+    let warming = br#"{"status":"warming","process_alive":true,"reader_admitted":false,"ready":false,"warming":true}"#;
+    assert!(decode_ready_health(warming).unwrap().is_none());
+    let ready = br#"{"status":"ok","version":"test","uptime_seconds":0,"graph_loaded":true,"reconciliation_status":"idle","repo_id":"fixture","repo_root":"fixture","pid":1,"build":{"sha":"fixture","dirty":false,"built_at":"fixture"}}"#;
+    let health = decode_ready_health(ready).unwrap().expect("ready response");
+    assert_eq!(health.version, "test");
+}
+
+#[test]
+fn health_decoder_rejects_malformed_and_incomplete_ready() {
+    for body in [
+        b"not json".as_slice(),
+        br#"{"status":"ok"}"#,
+        br#"{"status":"unknown"}"#,
+    ] {
+        assert!(
+            decode_ready_health(body).is_err(),
+            "invalid response accepted"
+        );
+    }
+}
+
 async fn wait_for_health(child: &mut DaemonChild, port: u16) -> HealthResponse {
     let client = reqwest::Client::new();
     let url = format!("http://127.0.0.1:{port}/health");
@@ -137,8 +169,8 @@ async fn wait_for_health(child: &mut DaemonChild, port: u16) -> HealthResponse {
     loop {
         if let Ok(response) = client.get(&url).send().await {
             if response.status().is_success() {
-                let health = response.json::<HealthResponse>().await.unwrap();
-                if health.status == "ok" {
+                let body = response.bytes().await.expect("health response body");
+                if let Some(health) = decode_ready_health(&body).expect("valid health response") {
                     return health;
                 }
             }

--- a/crates/kin-index/src/watcher.rs
+++ b/crates/kin-index/src/watcher.rs
@@ -165,10 +165,12 @@ impl FileWatcher {
             })
             .map_err(|e| IndexError::Watcher(e.to_string()))?;
 
-        // Registered on the root as it was given. The backend resolves it or
-        // does not, and either way both forms are already held.
+        // FSEvents does not reliably deliver events when its registration path
+        // is a symlink. Register the resolved directory while retaining both
+        // spellings above for backends that report either form.
+        let watch_root = root.canonicalize().unwrap_or_else(|_| root.clone());
         watcher
-            .watch(&root, RecursiveMode::Recursive)
+            .watch(&watch_root, RecursiveMode::Recursive)
             .map_err(|e| IndexError::Watcher(e.to_string()))?;
 
         info!(root = %root.display(), "started file watcher");
@@ -434,8 +436,7 @@ mod tests {
         );
     }
 
-    /// FIR-2442, end to end through a real backend. A repository reached through
-    /// a symlink must report the writes made through it.
+    /// A repository reached through a symlink must report writes through it.
     #[cfg(unix)]
     #[test]
     fn a_watcher_bound_through_a_symlinked_root_reports_writes_through_it() {
@@ -446,27 +447,39 @@ mod tests {
         std::os::unix::fs::symlink(&real, &link).unwrap();
 
         let watcher = FileWatcher::new(&link).unwrap();
-        // The backend registers its watch asynchronously, so a write racing
-        // registration would prove nothing either way.
-        std::thread::sleep(std::time::Duration::from_millis(500));
+        let ready_path = link.join("watch-ready.rs");
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        let mut ready = false;
+        while std::time::Instant::now() < deadline {
+            std::fs::write(&ready_path, "// readiness probe\n").unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            while let Some(event) = watcher.try_recv() {
+                if matches!(event, FileEvent::Changed(ref path) if path.file_name() == ready_path.file_name())
+                {
+                    ready = true;
+                }
+            }
+            if ready {
+                break;
+            }
+        }
+        assert!(ready, "watch backend never acknowledged a readiness probe");
         std::fs::write(link.join("added.rs"), "pub fn added() {}").unwrap();
 
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
-        let mut seen = Vec::new();
-        while std::time::Instant::now() < deadline && seen.is_empty() {
-            if let Some(event) = watcher.try_recv() {
-                seen.push(event);
+        let mut seen = false;
+        while std::time::Instant::now() < deadline && !seen {
+            // Drain each batch so delayed readiness events cannot keep the
+            // target write behind a fixed one-event-per-sleep backlog.
+            while let Some(event) = watcher.try_recv() {
+                seen |= matches!(event, FileEvent::Changed(ref path) if path == &link.join("added.rs") || path == &real.canonicalize().unwrap().join("added.rs"));
             }
             std::thread::sleep(std::time::Duration::from_millis(50));
         }
 
         assert!(
-            !seen.is_empty(),
-            "a write through the symlinked root {} produced no event in 30s; the watcher \
-             placed {} event(s) outside the root it is bound to (most recent {:?})",
-            link.display(),
-            watcher.events_outside_root().count,
-            watcher.events_outside_root().last_path,
+            seen,
+            "the ready backend did not report the exact added.rs write"
         );
         assert_eq!(
             watcher.events_outside_root().count,

--- a/scripts/acceptance/brownfield_repro.py
+++ b/scripts/acceptance/brownfield_repro.py
@@ -1217,6 +1217,96 @@ def check_3(suite):
     return res
 
 
+def complete_trace_clips(suite, repo, payload, steps):
+    """Bound only depth-one fanout gaps with complete graph-owned witnesses.
+
+    The original trace remains the assertion surface. A neighborhood can prove
+    its omitted candidates harmless, but a forbidden raw edge needs a focused
+    trace before it can establish a counted-flow failure.
+    """
+    if (budget_cut(payload) or (payload.get("_kin") or {}).get("response", {}).get("bounded")
+            or payload.get("steps_omitted")
+            or payload.get("fanout_narrowed") or len(steps) >= 200):
+        raise ProbeError("trace output or total-step budget lost rows")
+    clips = payload.get("clipped_steps") or []
+    if not payload.get("truncated") and not clips:
+        return [], []
+    if not clips:
+        raise ProbeError("truncated trace has no bounded fanout disclosure")
+    confirmations, receipts = [], []
+    for clip in clips:
+        index = clip.get("step")
+        if (not isinstance(index, int) or index <= 0 or index > len(steps)
+                or steps[index - 1].get("depth") != 1
+                or clip.get("limit_per_step") != 25
+                or clip.get("dropped_callers") != 0
+                or not isinstance(clip.get("dropped_callees"), int)
+                or clip["dropped_callees"] <= 0):
+            raise ProbeError("unsupported trace clip: %r" % clip)
+        focal = clip.get("entity_id")
+        if not focal or steps[index - 1].get("entity_id") != focal:
+            raise ProbeError("clip does not identify its original trace step")
+        hood = suite.cached(repo, "graph_neighborhood",
+                            {"entity_id": focal, "depth": 1,
+                             "direction": "out", "limit": 50, "max_chars": 60000})
+        entities, relations = hood.get("entities"), hood.get("relations")
+        if (hood.get("focal_id") != focal or hood.get("depth") != 1
+                or hood.get("direction") != "out" or hood.get("truncated")
+                or budget_cut(hood) or (hood.get("_kin") or {}).get("response", {}).get("bounded")
+                or not isinstance(entities, list)
+                or not isinstance(relations, list)
+                or len(entities) != hood.get("entity_count")
+                or len(relations) != hood.get("relation_count")):
+            raise ProbeError("incomplete or mismatched neighborhood for %s" % focal)
+        by_id = {e.get("id"): e for e in entities if isinstance(e, dict)}
+        if (len(by_id) != len(entities) or focal not in by_id
+                or any(not e.get("id") or not e.get("name") for e in entities)):
+            raise ProbeError("unresolved neighborhood entity metadata")
+        eligible = set()
+        for relation in relations:
+            if not isinstance(relation, dict):
+                raise ProbeError("malformed neighborhood relation")
+            source, destination = relation.get("src"), relation.get("dst")
+            if not isinstance(source, dict) or not isinstance(destination, dict):
+                raise ProbeError("malformed neighborhood endpoint")
+            src, dst = source.get("Entity"), destination.get("Entity")
+            if (src != focal or dst not in by_id or relation.get("direction") != "outgoing"
+                    or relation.get("from") != focal
+                    or relation.get("resolution") not in ("type_resolved", "import_scoped", "name_only")):
+                raise ProbeError("unresolved neighborhood endpoint or resolution")
+            if relation.get("kind") not in ("Calls", "Imports", "References", "UsesType"):
+                continue
+            eligible.add(dst)
+            if relation["resolution"] == "name_only":
+                continue
+            name = by_id[dst]["name"]
+            if not any(name_matches(name, bad) for bad in APP_HANDLE_FABRICATED):
+                continue
+            focused = suite.cached(repo, "trace_data_flow",
+                                   {"focal": focal, "target": dst, "direction": "calls",
+                                    "depth": 1, "include_body": False,
+                                    "limit_per_step": 25, "max_chars": 200000})
+            focused_steps = trace_steps(focused)
+            if (budget_cut(focused) or focused_steps is None
+                    or focused.get("focal_id") != focal
+                    or focused.get("depth") != 1 or focused.get("direction") != "calls"
+                    or (focused.get("_kin") or {}).get("response", {}).get("bounded")):
+                raise ProbeError("focused forbidden-candidate trace unreadable")
+            matched = [row for row in focused_steps if row.get("entity_id") == dst]
+            if not matched:
+                raise ProbeError("forbidden raw candidate absent from focused confirmation")
+            confirmations.extend(row for row in matched
+                                 if row.get("resolution") != "name_only"
+                                 and row.get("proven") is not False
+                                 and row.get("unproven") is not True)
+        if len(eligible) < 25 + clip["dropped_callees"]:
+            raise ProbeError("neighborhood does not cover disclosed trace fanout")
+        receipts.append("%s: complete depth=1/out/limit=50/max_chars=60000 witness, %d entities, "
+                        "%d relations, %d trace-eligible destinations"
+                        % (focal, len(entities), len(relations), len(eligible)))
+    return confirmations, receipts
+
+
 def check_4(suite):
     """FIR-2464: express cross-file edges are real, and the one that matters is there.
 
@@ -1256,11 +1346,15 @@ def check_4(suite):
         res.unknown("trace_data_flow on %s returned zero steps, so neither the real "
                     "edges nor the fabricated ones can be judged" % APP_HANDLE)
         return res
-    if payload.get("truncated") or payload.get("clipped_steps"):
-        res.unknown("the walk came back truncated (truncated=%r, clipped_steps=%r), "
-                    "so an absent edge cannot be told from a dropped one"
-                    % (payload.get("truncated"), payload.get("clipped_steps")))
-        return res
+    complete = True
+    confirmed = []
+    try:
+        confirmed, receipts = complete_trace_clips(suite, repo, payload, steps)
+        for receipt in receipts:
+            res.ok(receipt)
+    except ProbeError as exc:
+        complete = False
+        res.unknown(str(exc))
 
     def step_name(step):
         if not isinstance(step, dict):
@@ -1318,6 +1412,8 @@ def check_4(suite):
     fabricated_counted = sorted({"%s (%s)" % (n, descent(s)) for n, s in counted
                                  if any(name_matches(n, f)
                                         for f in APP_HANDLE_FABRICATED)})
+    fabricated_counted.extend("%s (focused trace confirmation)" % step_name(row)
+                              for row in confirmed)
     if fabricated_counted:
         res.bad("counted steps include fabricated callees %s; %d of %d steps counted, "
                 "unproven_steps=%r"
@@ -1329,16 +1425,15 @@ def check_4(suite):
     missing_real = [want for want in APP_HANDLE_REAL_CALLEES
                     if not any(name_matches(n, want) for n in all_names)]
     if missing_real:
-        res.bad("the real callees %s are absent from the walk; steps are %s"
+        (res.bad if complete else res.unknown)("the real callees %s are absent from the walk; steps are %s"
                 % (", ".join(missing_real), all_names[:12]))
     else:
         res.ok("both real callees %s are present"
                % ", ".join(APP_HANDLE_REAL_CALLEES))
-    if any(name_matches(n, APP_HANDLE_MISSING_CALLEE)
-           or basename_of(n) == "handle" for n in all_names):
+    if any(name_matches(n, APP_HANDLE_MISSING_CALLEE) for n in all_names):
         res.ok("the hand-off %s is in the walk" % APP_HANDLE_MISSING_CALLEE)
     else:
-        res.bad("the hand-off this.router.handle at %s:177, the last line of "
+        (res.bad if complete else res.unknown)("the hand-off this.router.handle at %s:177, the last line of "
                 "app.handle and the edge the question is about, is absent from the "
                 "walk; steps are %s" % (APP_HANDLE_FILE, all_names[:12]))
     return res

--- a/scripts/acceptance/test_brownfield_trace_witness.py
+++ b/scripts/acceptance/test_brownfield_trace_witness.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Grade bounded trace witnesses without opening a repository or process."""
+import importlib.util
+from pathlib import Path
+import unittest
+
+spec = importlib.util.spec_from_file_location(
+    "brownfield_repro", Path(__file__).with_name("brownfield_repro.py"))
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+
+
+class Fixture:
+    def __init__(self):
+        self.trace = {"truncated": True, "chain": [
+            {"entity_id": "enabled", "entity_name": "app.enabled", "depth": 1},
+            {"entity_id": "final", "entity_name": "finalhandler", "depth": 1},
+            {"entity_id": "router", "entity_name": "router.handle", "depth": 1},
+            {"entity_id": "application", "entity_name": "application", "depth": 1}],
+            "clipped_steps": [{"step": 4, "entity_id": "application",
+                               "limit_per_step": 25, "dropped_callees": 2,
+                               "dropped_callers": 0}]}
+        self.hood = {"focal_id": "application", "depth": 1, "direction": "out",
+                     "truncated": False, "entities": [{"id": "application", "name": "application"}],
+                     "relations": []}
+        for i in range(27):
+            self.hood["entities"].append({"id": str(i), "name": "safe" + str(i)})
+            self.hood["relations"].append({"src": {"Entity": "application"},
+                "dst": {"Entity": str(i)}, "from": "application", "direction": "outgoing",
+                "kind": "Calls", "resolution": "type_resolved"})
+        self.hood.update(entity_count=28, relation_count=27)
+        self.focused = {"focal_id": "application", "depth": 1, "direction": "calls", "chain": [{"entity_id": "26", "entity_name": "req.get",
+                                   "resolution": "type_resolved", "depth": 1}]}
+        self.calls = []
+
+    def fixture(self, name):
+        assert name == "express"
+        return "fixture"
+
+    def sweep_gate(self, name):
+        assert name == "express"
+
+    def cached(self, repo, tool, args):
+        self.calls.append((tool, args))
+        if tool == "graph_neighborhood":
+            assert args == {"entity_id": "application", "depth": 1, "direction": "out", "limit": 50, "max_chars": 60000}
+            return self.hood
+        if "target" in args:
+            assert args == {"focal": "application", "target": "26", "direction": "calls",
+                            "depth": 1, "include_body": False, "limit_per_step": 25, "max_chars": 200000}
+            return self.focused
+        assert args == {"focal": m.APP_HANDLE, "direction": "calls", "depth": 2,
+                        "include_body": False, "limit_per_step": 25, "max_chars": 200000}
+        return self.trace
+
+
+class WitnessTests(unittest.TestCase):
+    def setUp(self):
+        self.s = Fixture()
+
+    def grade(self, expected):
+        result = m.check_4(self.s)
+        self.assertEqual(result.status, expected, result.asserts)
+        return result
+
+    def test_complete_27_destination_witness(self):
+        result = self.grade(m.PASS)
+        self.assertIn("27 trace-eligible", str(result.asserts))
+        self.assertEqual(len(self.s.calls), 2)
+
+    def test_returned_forbidden_survives_unreadable_clip(self):
+        self.s.trace["chain"].append({"entity_name": "req.get"})
+        self.s.hood["truncated"] = True
+        self.grade(m.FAIL)
+
+    def test_missing_positive_still_fails(self):
+        self.s.trace["chain"][0]["entity_name"] = "something_else"
+        self.grade(m.FAIL)
+
+    def test_missing_router_handoff_still_fails(self):
+        self.s.trace["chain"][2]["entity_name"] = "something_else"
+        self.grade(m.FAIL)
+
+    def test_omitted_forbidden_requires_trace_confirmation(self):
+        self.s.hood["entities"][-1]["name"] = "req.get"
+        self.grade(m.FAIL)
+        self.assertEqual(len(self.s.calls), 3)
+
+    def test_raw_forbidden_without_confirmation_is_unreadable(self):
+        self.s.hood["entities"][-1]["name"] = "req.get"
+        self.s.focused["chain"] = []
+        self.grade(m.UNREADABLE)
+
+    def test_name_only_candidate_is_not_counted(self):
+        self.s.hood["entities"][-1]["name"] = "req.get"
+        self.s.hood["relations"][-1]["resolution"] = "name_only"
+        self.grade(m.PASS)
+        self.assertEqual(len(self.s.calls), 2)
+
+    def test_focused_name_only_is_not_counted(self):
+        self.s.hood["entities"][-1]["name"] = "req.get"
+        self.s.focused["chain"][0]["resolution"] = "name_only"
+        self.grade(m.PASS)
+
+    def test_non_trace_relation_does_not_count(self):
+        self.s.hood["entities"][-1]["name"] = "req.get"
+        self.s.hood["relations"].append(dict(self.s.hood["relations"][-1], kind="Contains"))
+        self.s.hood["relations"][-2]["resolution"] = "name_only"
+        self.s.hood["relation_count"] += 1
+        self.grade(m.PASS)
+
+    def test_contradictory_small_witness_is_unreadable(self):
+        self.s.hood["entities"] = self.s.hood["entities"][:1]
+        self.s.hood["relations"] = []
+        self.s.hood.update(entity_count=1, relation_count=0)
+        self.grade(m.UNREADABLE)
+
+    def test_malformed_endpoint_is_unreadable(self):
+        self.s.hood["relations"][-1]["src"] = "bad"
+        self.grade(m.UNREADABLE)
+
+    def test_unrelated_handle_is_not_router(self):
+        self.s.trace["chain"][2]["entity_name"] = "unrelated.handle"
+        self.grade(m.FAIL)
+
+    def test_relation_clip_is_unreadable_even_without_flag(self):
+        self.s.hood["relation_count"] += 1
+        self.grade(m.UNREADABLE)
+
+    def test_wrong_focal_is_unreadable(self):
+        self.s.hood["focal_id"] = "other"
+        self.grade(m.UNREADABLE)
+
+    def test_root_clip_is_unreadable(self):
+        self.s.trace["clipped_steps"][0]["step"] = 0
+        self.grade(m.UNREADABLE)
+        self.assertEqual(len(self.s.calls), 1)
+
+    def test_unresolved_endpoint_is_unreadable(self):
+        self.s.hood["relations"][-1]["dst"] = {"Entity": "missing"}
+        self.grade(m.UNREADABLE)
+
+    def test_output_budget_loss_is_unreadable(self):
+        for target in (self.s.trace, self.s.hood):
+            target["degradations"] = [{"component": "response_budget"}]
+            self.grade(m.UNREADABLE)
+            del target["degradations"]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Watcher construction and a successful health response can both precede readiness. This registers
resolved watcher roots, recognizes explicit warming health responses before strict ready decoding,
and requires a separate graph-acknowledged readiness probe before dirty-work observations. The
controlled-write assertion now counts reconciliation of its own file, so readiness events cannot
satisfy it.

Brownfield check 4 keeps its original depth-2 trace and per-step cap of 25. A clipped depth-1 node
can receive an additional exact-ID outgoing neighborhood witness at limit 50 and max_chars 60000.
The witness must carry all reported entities and relations, resolved endpoint metadata, and no
truncation or output-budget loss. Forbidden raw candidates require focused trace confirmation. Root
clips and incomplete witnesses remain unreadable. The original positive and forbidden-callee
assertions remain active.

## What this fixes in another PR's report

The rewrite of `check_reconcile_dirty_work` in `crates/kin-daemon/src/loop_runner.rs` is the fix for
the two failures firelock-ai/kin#1599's body raised as an open question:
`loop_runner::tests::reconcile_empty_delta_real_edit_control` and
`loop_runner::tests::reconcile_empty_delta_still_repairs_a_missing_or_stale_layout`. Both panic at
`loop_runner.rs:4224` on `main` with "the real watcher must process the controlled write", and both
run through that one shared helper. #1599 does not touch this file: `loop_runner.rs` resolves to the
same blob at #1599's base and at `origin/main` while 17 other files differ between them. Those two
tests are this PR's subject, not that one's.

The old bare `pass.progress() > before` was a check that could pass without the controlled write ever
being reconciled, because unrelated background reconcile work advances the same counter. The new
conjunctive assertion also requires a `stable.rs` reconcile outcome to have been observed through the
real production `debug!(?outcome, "reconcile outcome")` event, so it cannot be satisfied that way.

## Landing

The author lane is dead: its last report write was 07:03Z, every registered working pid is gone by
an explicit per-pid check, and the only surviving process under its name is an `agent-sock` presence
listener. Lane `kintail` picked this PR up, re-verified it on its own head, and lands it under the
ledger name that owns the branch, because `merge land` resolves the lane's branch from the live
checkout and requires the PR's head ref to match it. Tracked as FIR-3401.

## The class this fixes, measured

The `loop_runner` watcher tests are load-sensitive, not deterministic. Lane kintail measured it on
firelock-ai/kin#1599's branch, which does **not** carry this PR's watcher-root change, running the
same daemon library suite twice eleven minutes apart:

```
11:50Z, box load average about 12
$ cargo test --locked -p kin-daemon --lib
test result: ok. 1563 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 389.34s

12:01Z, box load average 15 to 23
$ cargo test --locked -p kin-daemon --lib
test loop_runner::tests::a_file_rewritten_in_a_tight_loop_still_reaches_graph_truth ... FAILED
test loop_runner::tests::reconcile_empty_delta_real_edit_control ... FAILED
test loop_runner::tests::reconcile_empty_delta_does_not_dirty_a_settled_graph ... FAILED
test loop_runner::tests::reconcile_empty_delta_preserves_pending_dirty_work ... FAILED
test loop_runner::tests::reconcile_empty_delta_still_repairs_a_missing_or_stale_layout ... FAILED
test result: FAILED. 1558 passed; 5 failed; 4 ignored; 0 measured; 0 filtered out; finished in 434.14s
```

Between those two commits are one env-registry row and one generated documentation row, and nothing
`loop_runner.rs` or `kin-index` can see. For these tests it is the same code. The load was real host
noise: a worktree reap and a cargo-target collection running beside another lane's builds.

Four of the five run through `check_reconcile_dirty_work`, the helper this PR rewrites. The fifth is
`a_file_rewritten_in_a_tight_loop_still_reaches_graph_truth`, the retained-red test this PR was held
over, and it failed there **without** this PR's watcher-root change present.

## The isolation experiment the hold was for

The question was whether the retained-red
`loop_runner::tests::a_file_rewritten_in_a_tight_loop_still_reaches_graph_truth` fails because of
this PR's one production change, the watcher-root canonicalize hunk at
`crates/kin-index/src/watcher.rs:171`. It runs through `run_loop`, which builds its watcher through
the exact function that hunk changes, so the question was real and nobody had answered it.

Six runs, interleaved rather than blocked, each through
`.kin-coord/bin/heavy-slot.sh kintail kin -- ...` on this PR's exact head:

```
$ cargo test --locked -p kin-daemon --lib \
    loop_runner::tests::a_file_rewritten_in_a_tight_loop_still_reaches_graph_truth \
    -- --exact loop_runner::tests::a_file_rewritten_in_a_tight_loop_still_reaches_graph_truth --nocapture

run  arm      hunk      .watch(&_)   load start  load end  wall   rc   result
-----------------------------------------------------------------------------
1    with     present   watch_root   9.62        11.53     83s    0    ok
2    without  reverted  root         11.53       12.60     80s    0    ok
3    with     present   watch_root   12.60       16.40     76s    0    ok
4    without  reverted  root         16.40       13.32     67s    0    ok
5    with     present   watch_root   13.32       13.24     70s    0    ok
6    without  reverted  root         13.24       12.41     77s    0    ok

with the hunk:    3 pass, 0 fail of 3
without the hunk: 3 pass, 0 fail of 3
```

Interleaved, because on this box the arms would otherwise be confounded with time: the load moved
between 9.6 and 16.4 during these six runs alone, and the measurement above shows this test family
flipping on load with the code held still.

The `.watch(&_)` column is the mislabelling control. Every run printed the actual `.watch(&...)`
argument out of the tree it was about to compile, so an arm that silently failed to flip would show
the wrong token rather than pass unnoticed. The `with` rows read `watch_root` and the `without` rows
read `root`.

**The failure does not follow the hunk.** It follows load. The hunk stays.

## On quarantining, and why there is no new row

The alternative disposition was a ticket-referenced entry in `.config/nextest.toml`. There is none
here, deliberately. That table's own entry criteria are same-job, same-sha re-run evidence, and no
such evidence exists: hosted CI runs nextest one process per test and this test passes there, while
the local red appears only under `cargo test`'s shared-process model at high load. A quarantine row
would record a flake the gate of record has never seen. The local load sensitivity stays with
FIR-3391, which owns that class.

## Verification

Every command ran through `.kin-coord/bin/heavy-slot.sh kintail kin -- ...` against this PR's exact
pushed head with an empty `git status --porcelain`.

The four dirty-work wrappers this PR rewrites:

```
$ cargo test --locked -p kin-daemon --lib loop_runner::tests::reconcile_empty_delta -- --nocapture
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 1562 filtered out; finished in 10.66s
```

The watcher symlink test this PR rewrites:

```
$ cargo test --locked -p kin-index --lib a_watcher_bound_through_a_symlinked_root_reports_writes_through_it -- --nocapture
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 373 filtered out; finished in 1.81s
```

The health decoder tests this PR adds:

```
$ cargo test --locked -p kin-daemon --test chaos_recovery health_decoder -- --nocapture
running 2 tests
test health_decoder_rejects_malformed_and_incomplete_ready ... ok
test health_decoder_waits_for_warming_then_strict_ready ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 10 filtered out; finished in 0.00s
```

The acceptance witness controls this PR adds, which the new `fast-gate-lint` step also runs:

```
$ python3 scripts/acceptance/test_brownfield_trace_witness.py
Ran 17 tests in 0.002s
OK
```

Local gate run, against this PR's exact pushed head:

```
$ bin/kin-precheck kin --repo-dir kin=<lane worktree>
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
...
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:verify-hydration-semantics.py  python3 scripts/verify-hydration-semantics.py
PASS     node-test                            node --test <15 file(s) named by the check job>
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 8b62f69ecbd234dc153e431e042e78036eb46530
=== precheck exit rc=0 at 2026-09-08T12:20:20Z ===
```

Still 21 enumerated, not 22, which confirms the new `Test bounded brownfield trace witnesses` step
is wired into `fast-gate-lint` rather than `check`. That is deliberate and the comment beside it in
`ci.yml` says why: a script step in `check` is a gate precheck enumerates and must classify by name,
and one added there without the matching umbrella entry makes precheck refuse with no tally.

## The retained-red test passes on hosted CI at this head

Read out of the shard's own log rather than off a green rollup, with a positive control (the log
contains its `Summary` line) and a negative control (a string that cannot be there returns nothing),
so the grep is proven to be reading a real log:

```
Fast gate test shard (2), job 102054992125
PASS [   0.476s] (1709/3100) kin-daemon loop_runner::tests::a_file_rewritten_in_a_tight_loop_still_reaches_graph_truth
PASS [   0.360s] (1739/3100) kin-daemon loop_runner::tests::reconcile_empty_delta_preserves_pending_dirty_work

Fast gate test shard (1), job 102054992090
PASS [   0.632s] (1775/3173) kin-daemon loop_runner::tests::reconcile_empty_delta_still_repairs_a_missing_or_stale_layout

Fast gate test shard (3), job 102054992004
PASS [   0.341s] (1713/3062) kin-daemon loop_runner::tests::reconcile_empty_delta_does_not_dirty_a_settled_graph
PASS [   0.414s] (1716/3062) kin-daemon loop_runner::tests::reconcile_empty_delta_real_edit_control
```

All four rewritten wrappers and the retained-red tight-loop test, each named and each passing, under
the gate of record.

Kin-Release-Intent: patch
