### PR TITLE
Preserve native state with complete recovery carriers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3295,9 +3295,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.104"
+version = "0.7.106"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "cddb9f8689824e1884b1cbc234e105865571a1a266ec2c702983f6f61412e818"
+checksum = "940d6fbde39c4b0cdb1b539c183e7ee4b1ea756cb86b4893507c90150aef5c24"
 dependencies = [
  "bincode",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ kin-lsp = { version = "=0.7.16", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.104", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.106", registry = "kin", default-features = false }
 # Pinned to the exact version kin-db builds its name-token index with. A
 # per-token name query hits that index only when the token came out of the same
 # tokenizer, so a version skew here would be a silent recall loss rather than a

--- a/crates/kin-cli/src/commands/backup.rs
+++ b/crates/kin-cli/src/commands/backup.rs
@@ -11,55 +11,90 @@ use sha2::{Digest, Sha256};
 /// Schema token stamped on every `kin backup list --json` answer.
 pub const BACKUP_LIST_SCHEMA: &str = "kin.backup.list.v1";
 
-/// `kin backup create` — Create a timestamped backup of the graph snapshot.
-pub async fn create(tag: Option<String>) -> Result<()> {
-    let layout = discover_layout()?;
-    let snapshot_path = layout.kindb_snapshot_path();
-
-    if !snapshot_path.exists() {
-        anyhow::bail!("no graph snapshot found at {}", snapshot_path.display());
+/// Restore complete native authority without replacing an existing repository.
+pub async fn restore_carrier(carrier: PathBuf, destination: PathBuf) -> Result<()> {
+    super::recovery_carrier::ensure_platform()?;
+    let destination = std::path::absolute(destination)?;
+    if destination.file_name() != Some(std::ffi::OsStr::new(".kin")) {
+        anyhow::bail!("restore --target must name an absent .kin directory in the destination working directory");
     }
-
-    let backups_dir = layout.backups_dir();
-    fs::create_dir_all(&backups_dir).with_context(|| {
-        format!(
-            "failed to create backups directory {}",
-            backups_dir.display()
-        )
-    })?;
-
-    let timestamp = chrono::Utc::now().format("%Y%m%d-%H%M%S").to_string();
-    let backup_name = match &tag {
-        Some(t) => format!("graph-{}-{}.kndb", timestamp, sanitize_tag(t)),
-        None => format!("graph-{}.kndb", timestamp),
-    };
-    let backup_path = backups_dir.join(&backup_name);
-
-    let data = fs::read(&snapshot_path)
-        .with_context(|| format!("failed to read snapshot {}", snapshot_path.display()))?;
-
-    let checksum = Sha256::digest(&data);
-    let size = data.len();
-
-    fs::write(&backup_path, &data)
-        .with_context(|| format!("failed to write backup {}", backup_path.display()))?;
-
-    println!("Backup created: {}", backup_name);
-    println!("  Size: {} bytes", size);
-    println!("  SHA-256: {}", hex::encode(checksum));
-    println!("  Path: {}", backup_path.display());
-
+    let carrier = carrier.canonicalize().context("resolve recovery carrier")?;
+    let destination = destination
+        .parent()
+        .context("restore target needs a working directory")?
+        .canonicalize()
+        .context("resolve destination working directory")?
+        .join(".kin");
+    super::recovery_carrier::restore(&carrier, &destination, |_, _| Ok(()))?;
+    println!("Restored native repository: {}", destination.display());
     Ok(())
+}
+
+/// Create a complete carrier beside, never inside, the repository state.
+pub async fn create(tag: Option<String>, output: Option<PathBuf>) -> Result<()> {
+    super::recovery_carrier::ensure_platform()?;
+    let layout = discover_layout()?;
+    let destination = match output {
+        Some(path) => path,
+        None => {
+            let backups = backups_directory(&layout)?;
+            fs::create_dir_all(&backups)?;
+            let timestamp = chrono::Utc::now().format("%Y%m%d-%H%M%S-%f");
+            let suffix = tag
+                .as_deref()
+                .map(sanitize_tag)
+                .unwrap_or_else(|| "native".into());
+            backups.join(format!("{timestamp}-{suffix}"))
+        }
+    };
+    create_carrier_at(&layout, &destination)?;
+    println!("Native recovery backup created: {}", destination.display());
+    Ok(())
+}
+
+pub(super) fn create_carrier_at(
+    layout: &kin_core::KinLayout,
+    destination: &std::path::Path,
+) -> Result<()> {
+    super::recovery_carrier::ensure_platform()?;
+    let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(layout)?;
+    let backend = kin_db::LocalFileBackend::new(layout.kindb_dir());
+    let frozen = kin_db::LocalRepositoryAuthorityFreeze::open_existing_read_only(
+        binding.repository_id().clone(),
+        &backend,
+    )?;
+    if !frozen
+        .authority()
+        .metadata()
+        .workspaces
+        .iter()
+        .any(|workspace| workspace.workspace_id == binding.workspace_id())
+    {
+        anyhow::bail!("repository authority does not contain its manifest workspace");
+    }
+    let manifest = super::recovery_carrier::Manifest {
+        schema: String::new(),
+        source_root: layout.root().to_path_buf(),
+        repository_id: binding.repository_id().to_string(),
+        workspace_id: binding.workspace_id().to_string(),
+        layout_version: layout.read_version()?,
+        roots: frozen.roots().clone(),
+        files: Default::default(),
+    };
+    super::recovery_carrier::publish(layout.root(), destination, manifest)
 }
 
 /// One backup on disk, as both the table and the JSON surface describe it.
 #[derive(Debug, Serialize)]
 pub struct BackupEntry {
-    /// Backup filename, the token `kin backup restore` matches against.
+    /// Exact carrier directory name.
     pub name: String,
-    /// Absolute path to the backup file.
+    /// Path to the complete carrier directory.
     pub path: String,
     pub size_bytes: u64,
+    pub valid: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -69,32 +104,59 @@ pub struct BackupListJson {
     pub backups: Vec<BackupEntry>,
 }
 
-/// The backups directory's contents, projected for display.
-///
-/// Reads the same `list_backup_entries` walk the text path has always used, so
-/// the two surfaces cannot report different sets.
+fn backups_directory(layout: &kin_core::KinLayout) -> Result<PathBuf> {
+    let identity = kin_core::KinManifest::load(&layout.manifest_path())?;
+    let directory = layout
+        .root()
+        .parent()
+        .and_then(|working| working.parent())
+        .context("default backups need a parent outside the working directory; use --output")?
+        .join(format!(
+            ".kin-backups-{}",
+            hex::encode(Sha256::digest(identity.repo_id.as_bytes()))
+        ));
+    match fs::symlink_metadata(&directory) {
+        Ok(metadata) if !metadata.is_dir() || metadata.file_type().is_symlink() => {
+            anyhow::bail!("default recovery backup directory must be a real directory, not a link")
+        }
+        Err(error) if error.kind() != std::io::ErrorKind::NotFound => return Err(error.into()),
+        _ => {}
+    }
+    Ok(directory)
+}
+
 fn collect_backups(backups_dir: &PathBuf) -> Result<Vec<BackupEntry>> {
+    if !backups_dir.exists() {
+        return Ok(Vec::new());
+    }
     let mut backups = Vec::new();
-    for path in list_backup_entries(backups_dir)? {
-        let meta = fs::metadata(&path)
-            .with_context(|| format!("failed to read metadata for {}", path.display()))?;
+    for entry in fs::read_dir(backups_dir)? {
+        let entry = entry?;
+        if entry.file_name().to_string_lossy().starts_with('.') {
+            continue;
+        }
+        let path = entry.path();
+        let result = super::recovery_carrier::inspect(&path).and_then(|manifest| {
+            manifest.files.values().try_fold(0u64, |size, file| {
+                size.checked_add(file.size).context("backup size overflow")
+            })
+        });
+        let (size_bytes, error) = match result {
+            Ok(size) => (size, None),
+            Err(error) => (0, Some(format!("{error:#}"))),
+        };
         backups.push(BackupEntry {
-            name: path
-                .file_name()
-                .map(|n| n.to_string_lossy().to_string())
-                .unwrap_or_default(),
+            name: entry.file_name().to_string_lossy().into_owned(),
             path: path.display().to_string(),
-            size_bytes: meta.len(),
+            size_bytes,
+            valid: error.is_none(),
+            error,
         });
     }
+    backups.sort_by(|a, b| a.name.cmp(&b.name));
     Ok(backups)
 }
 
-/// The envelope `--json` prints, built in one place so a test can gate it.
-///
-/// The runtime must not assemble this inline: a test that built its own copy
-/// would keep passing while the printed document drifted, which is the shape of
-/// a check that cannot fail.
 fn backup_list_payload(backups: Vec<BackupEntry>) -> BackupListJson {
     BackupListJson {
         schema: BACKUP_LIST_SCHEMA,
@@ -103,232 +165,71 @@ fn backup_list_payload(backups: Vec<BackupEntry>) -> BackupListJson {
     }
 }
 
-/// `kin backup list` — List available backups.
-pub async fn list(json: bool) -> Result<()> {
-    let layout = discover_layout()?;
-    let backups_dir = layout.backups_dir();
-
-    let backups = collect_backups(&backups_dir)?;
-
-    // An empty set is an ANSWER, not an absence, so `--json` emits the same
-    // stamped envelope with a zero count rather than the prose the table shows.
-    // A caller parsing this must never have to distinguish "no backups" from
-    // "not JSON".
+/// List complete carriers in the default directory outside repository state.
+pub async fn list(json: bool, directory: Option<PathBuf>) -> Result<()> {
+    let directory = match directory {
+        Some(path) => path.canonicalize().context("resolve backup directory")?,
+        None => backups_directory(&discover_layout()?)?,
+    };
+    let backups = collect_backups(&directory)?;
     if json {
         println!(
             "{}",
             serde_json::to_string_pretty(&backup_list_payload(backups))?
         );
-        return Ok(());
-    }
-
-    if backups.is_empty() {
-        println!("No backups found.");
-        return Ok(());
-    }
-
-    println!("{} backup(s):", backups.len());
-    for entry in &backups {
-        println!("  {} ({} bytes)", entry.name, entry.size_bytes);
-    }
-
-    Ok(())
-}
-
-/// `kin backup restore` — Restore a graph snapshot from a backup.
-pub async fn restore(name: Option<String>, latest: bool) -> Result<()> {
-    let layout = discover_layout()?;
-    require_explicit_offline_restore(&layout)?;
-    let backups_dir = layout.backups_dir();
-    let snapshot_path = layout.kindb_snapshot_path();
-
-    let entries = list_backup_entries(&backups_dir)?;
-
-    if entries.is_empty() {
-        anyhow::bail!("no backups found in {}", backups_dir.display());
-    }
-
-    let backup_path = if latest {
-        // Entries are sorted ascending by name (timestamp-based), so last is most recent.
-        entries.last().unwrap().clone()
-    } else if let Some(ref name) = name {
-        // Allow specifying a partial or full backup filename.
-        let matched: Vec<_> = entries
-            .iter()
-            .filter(|p| {
-                p.file_name()
-                    .map(|n| n.to_string_lossy().contains(name.as_str()))
-                    .unwrap_or(false)
-            })
-            .collect();
-
-        match matched.len() {
-            0 => anyhow::bail!("no backup matching '{}'", name),
-            1 => matched[0].clone(),
-            _ => {
-                println!("Multiple backups match '{}':", name);
-                for m in &matched {
-                    println!("  {}", m.file_name().unwrap_or_default().to_string_lossy());
-                }
-                anyhow::bail!("specify a more precise name to disambiguate");
-            }
-        }
+    } else if backups.is_empty() {
+        println!("No recovery backups found.");
     } else {
-        anyhow::bail!("specify --latest or provide a backup name");
-    };
-
-    let backup_name = backup_path
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_default();
-
-    // Validate the backup file before restoring.
-    let data = fs::read(&backup_path)
-        .with_context(|| format!("failed to read backup {}", backup_path.display()))?;
-
-    kin_db::GraphSnapshot::from_bytes(&data)
-        .map_err(|e| anyhow::anyhow!("backup is corrupt or invalid: {e}"))?;
-
-    // Back up the current snapshot before overwriting (safety net).
-    if snapshot_path.exists() {
-        let safety_name = format!(
-            "graph-pre-restore-{}.kndb",
-            chrono::Utc::now().format("%Y%m%d-%H%M%S")
-        );
-        let safety_path = backups_dir.join(&safety_name);
-        fs::copy(&snapshot_path, &safety_path).with_context(|| {
-            format!(
-                "failed to safety-copy current snapshot to {}",
-                safety_path.display()
-            )
-        })?;
-        println!("Current snapshot saved as: {}", safety_name);
+        for backup in backups {
+            if let Some(error) = backup.error {
+                println!("{} INVALID: {}", backup.path, error);
+                continue;
+            }
+            println!(
+                "{} ({} payload bytes) {}",
+                backup.name, backup.size_bytes, backup.path
+            );
+        }
     }
-
-    // Atomic restore: write to tmp, fsync, rename.
-    let tmp_path = snapshot_path.with_extension("kndb.restore-tmp");
-    {
-        use std::io::Write;
-        let mut file = fs::File::create(&tmp_path)
-            .with_context(|| format!("failed to create tmp file {}", tmp_path.display()))?;
-        file.write_all(&data)?;
-        file.sync_all()?;
-    }
-    fs::rename(&tmp_path, &snapshot_path).with_context(|| {
-        format!(
-            "failed to rename {} → {}",
-            tmp_path.display(),
-            snapshot_path.display()
-        )
-    })?;
-
-    println!("Restored from: {}", backup_name);
-    println!("  Size: {} bytes", data.len());
-
     Ok(())
 }
 
-/// `kin backup delete` — Delete a specific backup.
+/// Legacy graph-only files cannot replace complete native authority safely.
+pub async fn restore(_name: Option<String>, _latest: bool) -> Result<()> {
+    anyhow::bail!("graph-only in-place restore is unsupported; preserve the repository and legacy backup intact. Restore a complete carrier with --from <carrier> --target <fresh-working-directory>/.kin. A Git export or graph snapshot does not retain all native state")
+}
+
+/// Delete one explicitly named, validated carrier from the default directory.
 pub async fn delete(name: String) -> Result<()> {
     let layout = discover_layout()?;
-    let backups_dir = layout.backups_dir();
-
-    let entries = list_backup_entries(&backups_dir)?;
-    let matched: Vec<_> = entries
-        .iter()
-        .filter(|p| {
-            p.file_name()
-                .map(|n| n.to_string_lossy().contains(name.as_str()))
-                .unwrap_or(false)
-        })
-        .collect();
-
-    match matched.len() {
-        0 => anyhow::bail!("no backup matching '{}'", name),
-        1 => {
-            let path = matched[0];
-            let file_name = path
-                .file_name()
-                .map(|n| n.to_string_lossy().to_string())
-                .unwrap_or_default();
-            fs::remove_file(path)
-                .with_context(|| format!("failed to delete {}", path.display()))?;
-            println!("Deleted backup: {}", file_name);
-        }
-        _ => {
-            println!("Multiple backups match '{}':", name);
-            for m in &matched {
-                println!("  {}", m.file_name().unwrap_or_default().to_string_lossy());
-            }
-            anyhow::bail!("specify a more precise name to disambiguate");
-        }
+    let directory = backups_directory(&layout)?;
+    let mut components = std::path::Path::new(&name).components();
+    if !matches!(components.next(), Some(std::path::Component::Normal(_)))
+        || components.next().is_some()
+    {
+        anyhow::bail!("backup delete requires one exact carrier directory name");
     }
-
+    super::recovery_carrier::validate(&directory.join(&name))?;
+    let parent = cap_std::fs::Dir::open_ambient_dir(&directory, cap_std::ambient_authority())?;
+    parent.remove_dir_all(&name)?;
+    println!("Permanently deleted recovery backup: {}", name);
     Ok(())
 }
-
-// -- Helpers --
 
 fn discover_layout() -> Result<kin_core::KinLayout> {
     crate::commands::require_repository_layout()
 }
 
-fn require_explicit_offline_restore(layout: &kin_core::KinLayout) -> Result<()> {
-    if let Some(url) = crate::daemon_client::resolve_daemon_url_if_running(layout) {
-        anyhow::bail!(
-            "refusing to restore a graph snapshot while the Kin daemon is running at {url}; \
-             stop the daemon first so restore cannot race daemon-owned graph state"
-        );
-    }
-
-    let allowed = std::env::var("KIN_ALLOW_OFFLINE_RESTORE")
-        .ok()
-        .map(|value| offline_restore_env_allowed(&value))
-        .unwrap_or(false);
-    if !allowed {
-        anyhow::bail!(
-            "offline backup restore is an emergency repair path; set \
-             KIN_ALLOW_OFFLINE_RESTORE=1 after confirming no Kin daemon is running"
-        );
-    }
-
-    Ok(())
-}
-
-fn offline_restore_env_allowed(value: &str) -> bool {
-    matches!(value, "1" | "true" | "TRUE" | "yes" | "YES")
-}
-
-fn list_backup_entries(backups_dir: &PathBuf) -> Result<Vec<PathBuf>> {
-    if !backups_dir.exists() {
-        return Ok(vec![]);
-    }
-
-    let mut entries: Vec<PathBuf> = fs::read_dir(backups_dir)?
-        .filter_map(|e| e.ok())
-        .map(|e| e.path())
-        .filter(|p| {
-            p.extension().is_some_and(|ext| ext == "kndb")
-                && p.file_name()
-                    .is_some_and(|n| n.to_string_lossy().starts_with("graph-"))
-        })
-        .collect();
-
-    entries.sort();
-    Ok(entries)
-}
-
-/// Sanitize a user-provided tag for use in filenames.
 fn sanitize_tag(tag: &str) -> String {
     tag.chars()
+        .take(64)
         .map(|c| {
-            if c.is_alphanumeric() || c == '-' || c == '_' {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
                 c
             } else {
                 '_'
             }
         })
-        .take(64)
         .collect()
 }
 
@@ -336,179 +237,87 @@ fn sanitize_tag(tag: &str) -> String {
 mod tests {
     use super::*;
 
-    #[tokio::test]
-    async fn create_and_list_backup() {
-        let dir = tempfile::tempdir().unwrap();
-        kin_core::init(dir.path()).unwrap();
-        let layout = kin_core::KinLayout::discover(dir.path()).unwrap();
-
-        // Create a valid snapshot file.
-        let snapshot = kin_db::GraphSnapshot::empty();
-        let bytes = snapshot.to_bytes().unwrap();
-        fs::create_dir_all(layout.kindb_dir()).unwrap();
-        fs::write(layout.kindb_snapshot_path(), &bytes).unwrap();
-
-        // Run backup create (uses cwd, so we need to change the discover).
-        let backups_dir = layout.backups_dir();
-        fs::create_dir_all(&backups_dir).unwrap();
-
-        let timestamp = chrono::Utc::now().format("%Y%m%d-%H%M%S").to_string();
-        let backup_name = format!("graph-{}.kndb", timestamp);
-        let backup_path = backups_dir.join(&backup_name);
-        fs::write(&backup_path, &bytes).unwrap();
-
-        let entries = list_backup_entries(&backups_dir).unwrap();
-        assert_eq!(entries.len(), 1);
-        assert!(entries[0]
-            .file_name()
-            .unwrap()
-            .to_string_lossy()
-            .starts_with("graph-"));
-    }
-
-    /// An empty backups directory is an answer, so the envelope still goes out
-    /// stamped with a zero count.
-    ///
-    /// This is the property the whole flag exists for: a caller must never have
-    /// to tell "no backups" apart from "not JSON", which is exactly what the
-    /// text path's `No backups found.` forces it to do.
     #[test]
     fn the_json_surface_answers_an_empty_directory_with_a_stamped_zero() {
-        let dir = tempfile::tempdir().unwrap();
-        let backups = collect_backups(&dir.path().to_path_buf()).unwrap();
-        assert!(backups.is_empty());
-
-        let value = serde_json::to_value(backup_list_payload(backups)).unwrap();
+        let scratch = tempfile::tempdir().unwrap();
+        let value = serde_json::to_value(backup_list_payload(
+            collect_backups(&scratch.path().to_path_buf()).unwrap(),
+        ))
+        .unwrap();
         assert_eq!(value["schema"], BACKUP_LIST_SCHEMA);
-        assert_eq!(value["count"].as_u64().unwrap(), 0);
-        assert!(
-            value["backups"].is_array(),
-            "the list must be present and empty, never absent"
-        );
-    }
-
-    /// Sizes and names are read off the files rather than restated, and the
-    /// count matches the list it describes.
-    #[test]
-    fn the_json_surface_reports_the_backups_on_disk_with_their_real_sizes() {
-        let dir = tempfile::tempdir().unwrap();
-        let backups_dir = dir.path().to_path_buf();
-        fs::write(backups_dir.join("graph-20260101-000000.kndb"), b"abcde").unwrap();
-        fs::write(backups_dir.join("graph-20260102-000000.kndb"), b"xy").unwrap();
-        // Neither the extension nor the prefix matches, so neither may appear.
-        fs::write(backups_dir.join("graph-notes.txt"), b"ignored").unwrap();
-        fs::write(backups_dir.join("other-20260103-000000.kndb"), b"ignored").unwrap();
-
-        let backups = collect_backups(&backups_dir).unwrap();
-        let names: Vec<&str> = backups.iter().map(|b| b.name.as_str()).collect();
-        assert_eq!(
-            names,
-            vec!["graph-20260101-000000.kndb", "graph-20260102-000000.kndb"]
-        );
-        assert_eq!(backups[0].size_bytes, 5);
-        assert_eq!(backups[1].size_bytes, 2);
-        assert!(backups[0].path.ends_with("graph-20260101-000000.kndb"));
-
-        let value = serde_json::to_value(backup_list_payload(backups)).unwrap();
-        assert_eq!(
-            value["count"].as_u64().unwrap() as usize,
-            value["backups"].as_array().unwrap().len()
-        );
+        assert_eq!(value["count"], 0);
+        assert_eq!(value["backups"], serde_json::json!([]));
     }
 
     #[test]
-    fn sanitize_tag_strips_special_chars() {
-        assert_eq!(sanitize_tag("v1.0-beta"), "v1_0-beta");
-        assert_eq!(sanitize_tag("pre release!"), "pre_release_");
-        assert_eq!(sanitize_tag("normal_tag"), "normal_tag");
-    }
-
-    #[test]
-    fn sanitize_tag_truncates_long_input() {
-        let long = "a".repeat(100);
-        assert_eq!(sanitize_tag(&long).len(), 64);
-    }
-
-    #[tokio::test]
-    async fn restore_validates_backup() {
-        let dir = tempfile::tempdir().unwrap();
-        kin_core::init(dir.path()).unwrap();
-        let layout = kin_core::KinLayout::discover(dir.path()).unwrap();
-
-        let backups_dir = layout.backups_dir();
-        fs::create_dir_all(&backups_dir).unwrap();
-
-        // Write an invalid backup file.
-        let bad_path = backups_dir.join("graph-20260101-000000.kndb");
-        fs::write(&bad_path, b"not a valid snapshot").unwrap();
-
-        // Attempting to restore should fail validation.
-        let entries = list_backup_entries(&backups_dir).unwrap();
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_vendor = "apple",
+        target_os = "redox"
+    ))]
+    fn the_json_surface_lists_actual_current_format_carriers() {
+        let scratch = tempfile::tempdir_in(std::env::temp_dir().canonicalize().unwrap()).unwrap();
+        let source = scratch.path().join("source");
+        fs::create_dir(&source).unwrap();
+        let initialized = kin_core::init(&source).unwrap();
+        let backups = backups_directory(&initialized.layout).unwrap();
+        fs::create_dir(&backups).unwrap();
+        create_carrier_at(&initialized.layout, &backups.join("first")).unwrap();
+        let entries = collect_backups(&backups).unwrap();
         assert_eq!(entries.len(), 1);
-
-        let data = fs::read(&entries[0]).unwrap();
-        let result = kin_db::GraphSnapshot::from_bytes(&data);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn offline_restore_requires_explicit_env_value() {
-        assert!(offline_restore_env_allowed("1"));
-        assert!(offline_restore_env_allowed("true"));
-        assert!(offline_restore_env_allowed("YES"));
-        assert!(!offline_restore_env_allowed(""));
-        assert!(!offline_restore_env_allowed("0"));
-        assert!(!offline_restore_env_allowed("false"));
+        assert_eq!(entries[0].name, "first");
+        assert!(entries[0].size_bytes > 0);
+        assert!(entries[0].path.ends_with("/first"));
+        assert!(!backups.starts_with(&source));
+        let value = serde_json::to_value(backup_list_payload(entries)).unwrap();
+        assert_eq!(value["count"], value["backups"].as_array().unwrap().len());
+        fs::write(backups.join("first/COMPLETE"), b"invalid").unwrap();
+        create_carrier_at(&initialized.layout, &backups.join("second")).unwrap();
+        let entries = collect_backups(&backups).unwrap();
+        assert_eq!(entries.len(), 2);
+        assert!(!entries[0].valid);
+        assert!(entries[0].error.is_some());
+        assert!(entries[1].valid);
     }
 
     #[tokio::test]
-    async fn restore_roundtrip() {
-        let dir = tempfile::tempdir().unwrap();
-        kin_core::init(dir.path()).unwrap();
-        let layout = kin_core::KinLayout::discover(dir.path()).unwrap();
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_vendor = "apple",
+        target_os = "redox"
+    ))]
+    async fn explicit_listing_survives_loss_of_the_original_kin_directory() {
+        let scratch = tempfile::tempdir_in(std::env::temp_dir().canonicalize().unwrap()).unwrap();
+        let source = scratch.path().join("source");
+        fs::create_dir(&source).unwrap();
+        let initialized = kin_core::init(&source).unwrap();
+        let backups = backups_directory(&initialized.layout).unwrap();
+        fs::create_dir(&backups).unwrap();
+        create_carrier_at(&initialized.layout, &backups.join("saved")).unwrap();
+        fs::rename(
+            initialized.layout.root(),
+            scratch.path().join("original-state-preserved"),
+        )
+        .unwrap();
+        list(true, Some(backups.clone())).await.unwrap();
+        assert!(collect_backups(&backups).unwrap()[0].valid);
+    }
 
-        // Create a valid snapshot with some data.
-        let mut snapshot = kin_db::GraphSnapshot::empty();
-        let artifact_id = kin_model::ArtifactId::new();
-        let artifact_path = kin_model::RepoPath::from_utf8("main.rs").unwrap();
-        snapshot.resolved_tree =
-            kin_model::ResolvedTree::from_artifacts([kin_model::ResolvedArtifact::new(
-                artifact_id,
-                artifact_path.clone(),
-                kin_model::TreeEntry::blob(kin_model::Hash256::from_bytes([42; 32]), false),
-            )])
-            .unwrap();
-        let bytes = snapshot.to_bytes().unwrap();
-        fs::create_dir_all(layout.kindb_dir()).unwrap();
-        fs::write(layout.kindb_snapshot_path(), &bytes).unwrap();
+    #[tokio::test]
+    async fn legacy_restore_refuses_without_discovering_or_mutating_a_repository() {
+        let error = restore(Some("old-snapshot".into()), false)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("preserve"));
+        assert!(error.to_string().contains("--from"));
+    }
 
-        // Create a backup.
-        let backups_dir = layout.backups_dir();
-        fs::create_dir_all(&backups_dir).unwrap();
-        let backup_path = backups_dir.join("graph-20260325-120000.kndb");
-        fs::write(&backup_path, &bytes).unwrap();
-
-        // Overwrite snapshot with an empty one.
-        let empty = kin_db::GraphSnapshot::empty().to_bytes().unwrap();
-        fs::write(layout.kindb_snapshot_path(), &empty).unwrap();
-
-        // Verify it's empty now.
-        let current = fs::read(layout.kindb_snapshot_path()).unwrap();
-        let loaded = kin_db::GraphSnapshot::from_bytes(&current).unwrap();
-        assert!(loaded.resolved_tree.is_empty());
-
-        // Restore from backup (simulate the restore logic).
-        let backup_data = fs::read(&backup_path).unwrap();
-        kin_db::GraphSnapshot::from_bytes(&backup_data).unwrap(); // validation
-        fs::write(layout.kindb_snapshot_path(), &backup_data).unwrap();
-
-        // Verify restoration.
-        let restored_data = fs::read(layout.kindb_snapshot_path()).unwrap();
-        let restored = kin_db::GraphSnapshot::from_bytes(&restored_data).unwrap();
-        assert_eq!(restored.resolved_tree.len(), 1);
-        assert_eq!(
-            restored.resolved_tree.artifact_id_at_path(&artifact_path),
-            Some(artifact_id)
-        );
+    #[test]
+    fn tags_are_bounded_filename_components() {
+        assert_eq!(sanitize_tag("../pre release!"), "___pre_release_");
+        assert_eq!(sanitize_tag("a-b_c"), "a-b_c");
+        assert_eq!(sanitize_tag(&"a".repeat(100)).len(), 64);
     }
 }

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -2246,8 +2246,8 @@ fn repo_init_check_for(
     }
 
     let local_kin = cwd.join(".kin");
-    let is_managed_toolchain =
-        managed_kin_dir.is_some_and(|managed| same_path(managed, &local_kin));
+    let is_managed_toolchain = kin_core::layout::is_managed_kin_home(&local_kin)
+        || managed_kin_dir.is_some_and(|managed| same_path(managed, &local_kin));
     if local_kin.exists() && !is_managed_toolchain {
         return HealthCheck::new(
             "repo_init",
@@ -2259,7 +2259,8 @@ fn repo_init_check_for(
             ),
         )
         .with_manual_fix(
-            "re-run `kin init .`; if it keeps refusing, remove the partial `.kin` directory first",
+            "keep this .kin directory intact; inspect it with the Kin version that created it \
+             and preserve a complete backup outside .kin before attempting recovery",
         );
     }
 
@@ -9426,6 +9427,25 @@ mod tests {
             "~/.kin is the toolchain dir, not a failed repository, got {:?}",
             toolchain_home.status
         );
+    }
+
+    #[test]
+    fn doctor_recognizes_another_homes_managed_installation() {
+        let scratch = tempfile::tempdir().unwrap();
+        let owner = scratch.path().join("owner");
+        let managed = owner.join(".kin");
+        std::fs::create_dir_all(managed.join("bin")).unwrap();
+        std::fs::create_dir_all(managed.join("lib")).unwrap();
+        let other_home = scratch.path().join("other/.kin");
+        let check = repo_init_check_for(&owner, None, Some(&other_home));
+        assert!(matches!(check.status, HealthStatus::Unsupported));
+        assert!(!check.manual_fix.unwrap_or_default().contains("remove"));
+
+        let partial = scratch.path().join("partial");
+        std::fs::create_dir_all(partial.join(".kin")).unwrap();
+        let check = repo_init_check_for(&partial, None, Some(&other_home));
+        assert!(matches!(check.status, HealthStatus::Missing));
+        assert!(!check.manual_fix.unwrap_or_default().contains("remove"));
     }
 
     /// Kin owns one key inside an AI client's config, never the file. A config

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1323,8 +1323,9 @@ fn existing_repository_refusal(dir: &Path) -> String {
     }
     format!(
         "Kin repository already exists at {}; `kin init` never rebuilds graph authority from the \
-         working tree. If this build cannot open that store, {} again to rebuild it from the \
-         repository's Git history.",
+         working tree. If this build cannot open that store, {}. Preserve a complete backup \
+         outside .kin/ before attempting recovery. Git history cannot recover native Kin \
+         changes, reviews, specs, workspace identity or remote configuration.",
         dir.display(),
         super::REBUILD_INCOMPATIBLE_STORE
     )

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -68,6 +68,7 @@ pub mod projection;
 pub mod publish;
 pub mod purge_ignored;
 pub mod reconcile;
+mod recovery_carrier;
 pub mod ref_grammar;
 pub mod ref_lookup;
 pub mod refs;
@@ -170,27 +171,24 @@ pub(crate) fn not_a_kin_repository() -> anyhow::Error {
 
 /// The one remedy for a `.kin/` store this build cannot open.
 ///
-/// Two messages have to agree on it. The store wall sends the reader to
-/// `kin init`, and `kin init` refuses over an existing store, so a refusal that
-/// named a different path would send the reader in a circle. The consistency
-/// test in `commands::init` holds both texts against this token.
-pub(crate) const REBUILD_INCOMPATIBLE_STORE: &str = "remove .kin/ and run `kin init`";
+/// Store compatibility and initialization refusals share this preservation
+/// instruction, including repositories that contain both Git and native work.
+pub(crate) const REBUILD_INCOMPATIBLE_STORE: &str =
+    "keep .kin/ intact and open it with the Kin version that wrote it";
 
-/// The wall a store written by an older kin is refused with.
-///
-/// The version gap leads, because it is the whole reason nothing else will
-/// work. There is no in-place upgrade and no migration command, so the remedy
-/// is the rebuild the reader can actually perform, and the case where that
-/// rebuild has no source to draw on is named rather than left to be discovered.
+/// Explain an unsupported store version without suggesting destructive recovery.
 pub(crate) fn incompatible_store_refusal(
     kin_root: &std::path::Path,
     error: &kin_core::KinError,
 ) -> String {
     format!(
-        "{error} ({})\nAn older kin wrote this store and there is no in-place upgrade. Kin \
-         re-derives the store from the repository's Git history, so {REBUILD_INCOMPATIBLE_STORE} \
-         here to rebuild it. If the repository has no Git history to re-admit, keep a copy of \
-         .kin/ and open it with the kin that wrote it.",
+        "{error} ({})\nThis build cannot serve this store. {REBUILD_INCOMPATIBLE_STORE}. \
+         Preserve a complete backup outside .kin/ before attempting recovery. Git history \
+         does not preserve native Kin changes, branches, reviews, specs, audit records, \
+         workspace identity or remote configuration, even in a Git-admitted repository. \
+         Re-initialization cannot recover that state. Save the repository identity too: \
+         `kin init --adopt-repository-id <ID>` can retain that identity for a separately \
+         admitted replica, but does not restore native history.",
         kin_root.display()
     )
 }
@@ -198,6 +196,25 @@ pub(crate) fn incompatible_store_refusal(
 #[cfg(test)]
 mod repository_refusal_tests {
     use super::{require_repository_layout_at, NOT_A_KIN_REPOSITORY};
+
+    #[test]
+    fn incompatible_stores_preserve_native_work_even_with_git_history() {
+        for found in [1, 3] {
+            let message = super::incompatible_store_refusal(
+                std::path::Path::new("/repo/.kin"),
+                &kin_core::KinError::IncompatibleVersion {
+                    found,
+                    supported: 2,
+                },
+            );
+            assert!(message.contains(&format!("found v{found}")));
+            assert!(message.contains("keep .kin/ intact"));
+            assert!(message.contains("even in a Git-admitted repository"));
+            assert!(message.contains("does not restore native history"));
+            assert!(!message.contains("remove .kin"));
+            assert!(!message.contains("An older kin"));
+        }
+    }
 
     #[test]
     fn refusing_outside_a_repository_names_the_command_that_creates_one() {

--- a/crates/kin-cli/src/commands/recovery_carrier.rs
+++ b/crates/kin-cli/src/commands/recovery_carrier.rs
@@ -1,0 +1,1270 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Checked filesystem carrier for a frozen local repository generation.
+
+use std::collections::BTreeMap;
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Component, Path};
+
+use anyhow::{bail, Context, Result};
+use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt};
+use cap_std::fs::Dir;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+const SCHEMA: &str = "kin.recovery.v1";
+const MAX_MANIFEST_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_ENTRIES: usize = 100_000;
+
+pub(super) fn ensure_platform() -> Result<()> {
+    if !cfg!(any(
+        target_os = "linux",
+        target_os = "android",
+        target_vendor = "apple",
+        target_os = "redox"
+    )) {
+        bail!("atomic native recovery is not supported on this platform; preserve the source and use a supported Linux or macOS system");
+    }
+    Ok(())
+}
+
+fn ensure_directory_identity(expected: &File, path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let actual = open_directory(path)?.into_std_file().metadata()?;
+        let expected = expected.metadata()?;
+        if (actual.dev(), actual.ino()) != (expected.dev(), expected.ino()) {
+            bail!(
+                "recovery directory moved or was replaced: {}",
+                path.display()
+            );
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = (expected, path);
+    Ok(())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(super) struct Entry {
+    pub size: u64,
+    sha256: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct Manifest {
+    pub schema: String,
+    pub source_root: std::path::PathBuf,
+    pub repository_id: String,
+    pub workspace_id: String,
+    pub layout_version: u32,
+    pub roots: kin_model::RootBundle,
+    pub files: BTreeMap<String, Entry>,
+}
+
+fn open_directory(path: &Path) -> Result<Dir> {
+    let absolute = std::path::absolute(path)?;
+    let mut directory = Dir::open_ambient_dir("/", cap_std::ambient_authority())?;
+    for component in absolute.components() {
+        match component {
+            Component::RootDir => {}
+            Component::Normal(name) => directory = directory.open_dir_nofollow(name)?,
+            _ => bail!("unsupported recovery directory path"),
+        }
+    }
+    Ok(directory)
+}
+
+fn open_regular(path: &Path) -> Result<File> {
+    let parent = open_directory(path.parent().context("file parent missing")?)?;
+    open_regular_at(
+        &parent,
+        Path::new(path.file_name().context("file name missing")?),
+    )
+}
+
+fn open_regular_at(parent: &Dir, name: &Path) -> Result<File> {
+    let mut options = cap_std::fs::OpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    #[cfg(unix)]
+    {
+        use cap_std::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NONBLOCK);
+    }
+    let file = parent.open_with(name, &options)?;
+    if !file.metadata()?.is_file() {
+        bail!("recovery requires a regular file: {}", name.display());
+    }
+    Ok(file.into_std())
+}
+
+fn read_bounded(path: &Path, limit: u64) -> Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    open_regular(path)?
+        .take(limit + 1)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > limit {
+        bail!("recovery input exceeds size limit: {}", path.display());
+    }
+    Ok(bytes)
+}
+
+fn digest_file(path: &Path) -> Result<Entry> {
+    digest_open_file(open_regular(path)?)
+}
+
+fn digest_open_file(mut input: File) -> Result<Entry> {
+    let metadata = input.metadata()?;
+    if !metadata.is_file() || metadata.file_type().is_symlink() {
+        bail!("recovery requires a regular file");
+    }
+    let mut hash = Sha256::new();
+    let mut size = 0u64;
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let count = input.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        hash.update(&buffer[..count]);
+        size = size
+            .checked_add(count as u64)
+            .context("recovery size overflow")?;
+    }
+    if size != metadata.len() {
+        bail!("file changed while reading recovery input");
+    }
+    Ok(Entry {
+        size,
+        sha256: hex::encode(hash.finalize()),
+    })
+}
+
+fn safe_relative(name: &str) -> Result<&Path> {
+    let path = Path::new(name);
+    if name.is_empty()
+        || name.contains('\\')
+        || path
+            .components()
+            .any(|c| !matches!(c, Component::Normal(_)))
+    {
+        bail!("unsafe recovery payload path {name:?}");
+    }
+    Ok(path)
+}
+
+fn inventory(root: &Path) -> Result<BTreeMap<String, Entry>> {
+    let mut result = BTreeMap::new();
+    let mut pending = vec![(open_directory(root)?, std::path::PathBuf::new())];
+    while let Some((dir, prefix)) = pending.pop() {
+        for entry in dir.entries()? {
+            let entry = entry?;
+            let filename = entry.file_name();
+            let path = prefix.join(&filename);
+            let kind = entry.file_type()?;
+            if kind.is_symlink() || (!kind.is_file() && !kind.is_dir()) {
+                bail!("unsupported recovery input: {}", path.display());
+            }
+            if kind.is_dir() {
+                pending.push((dir.open_dir_nofollow(&filename)?, path));
+                continue;
+            }
+            if result.len() >= MAX_ENTRIES {
+                bail!("recovery carrier exceeds {MAX_ENTRIES} files");
+            }
+            let name = path
+                .to_str()
+                .context("non-UTF-8 recovery path")?
+                .replace(std::path::MAIN_SEPARATOR, "/");
+            safe_relative(&name)?;
+            result.insert(
+                name,
+                digest_open_file(open_regular_at(&dir, Path::new(&filename))?)?,
+            );
+        }
+    }
+    Ok(result)
+}
+
+fn write_new(path: &Path, bytes: &[u8]) -> Result<()> {
+    let mut output = OpenOptions::new().write(true).create_new(true).open(path)?;
+    output.write_all(bytes)?;
+    output.sync_all()?;
+    Ok(())
+}
+
+fn sync_directory(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    File::open(path)?.sync_all()?;
+    #[cfg(not(unix))]
+    let _ = path;
+    Ok(())
+}
+
+fn publish_absent(
+    source: &Path,
+    destination: &Path,
+    source_parent: &File,
+    destination_parent: &File,
+) -> Result<()> {
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_vendor = "apple",
+        target_os = "redox"
+    ))]
+    {
+        rustix::fs::renameat_with(
+            source_parent,
+            source.file_name().context("source name missing")?,
+            destination_parent,
+            destination
+                .file_name()
+                .context("destination name missing")?,
+            rustix::fs::RenameFlags::NOREPLACE,
+        )?;
+        Ok(())
+    }
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "android",
+        target_vendor = "apple",
+        target_os = "redox"
+    )))]
+    {
+        let _ = (source, destination, source_parent, destination_parent);
+        bail!("atomic recovery publication is unsupported on this platform");
+    }
+}
+
+fn copy_checked(source: &Path, target: &Path, files: &BTreeMap<String, Entry>) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        fs::DirBuilder::new().mode(0o700).create(target)?;
+    }
+    #[cfg(not(unix))]
+    fs::create_dir(target)?;
+    for (name, expected) in files {
+        let relative = safe_relative(name)?;
+        let from = source.join(relative);
+        let to = target.join(relative);
+        let parent = to.parent().context("payload parent missing")?;
+        fs::create_dir_all(parent)?;
+        let mut input = open_regular(&from)?;
+        let mut output = OpenOptions::new().write(true).create_new(true).open(&to)?;
+        std::io::copy(&mut input, &mut output)?;
+        output.sync_all()?;
+        if &digest_file(&to)? != expected {
+            bail!("recovery input changed: {name}");
+        }
+    }
+    let mut directories = vec![target.to_path_buf()];
+    for name in files.keys() {
+        let mut parent = target
+            .join(safe_relative(name)?)
+            .parent()
+            .unwrap()
+            .to_path_buf();
+        while parent != target {
+            directories.push(parent.clone());
+            parent.pop();
+        }
+    }
+    directories.sort();
+    directories.dedup();
+    for directory in directories.into_iter().rev() {
+        sync_directory(&directory)?;
+    }
+    Ok(())
+}
+
+/// The caller retains its authority freeze throughout this operation.
+pub(super) fn publish(source: &Path, target: &Path, mut manifest: Manifest) -> Result<()> {
+    ensure_platform()?;
+    refuse_path_bound_recovery(source)?;
+    let absolute_target = std::path::absolute(target)?;
+    let target = absolute_target.as_path();
+    if fs::symlink_metadata(target).is_ok() {
+        bail!("backup destination already exists: {}", target.display());
+    }
+    let parent = target
+        .parent()
+        .context("backup destination needs a parent")?
+        .canonicalize()?;
+    if parent.starts_with(source.canonicalize()?) {
+        bail!("backup must be outside the source .kin directory");
+    }
+    let parent_handle = open_directory(&parent)?.into_std_file();
+    let staging = tempfile::Builder::new()
+        .prefix(".kin-backup-incomplete-")
+        .tempdir_in(&parent)?;
+    ensure_directory_identity(&parent_handle, &parent)?;
+    let staging_handle = open_directory(staging.path())?.into_std_file();
+    manifest.schema = SCHEMA.into();
+    manifest.source_root = source.canonicalize()?;
+    manifest.files = inventory(source)?;
+    copy_checked(source, &staging.path().join("payload"), &manifest.files)?;
+    refuse_path_bound_recovery(source)?;
+    refuse_path_bound_recovery(&staging.path().join("payload"))?;
+    if inventory(source)? != manifest.files {
+        bail!("source changed during backup; retry after stopping writers");
+    }
+    let _staged_freeze = verify_staged_authority(&staging.path().join("payload"), &manifest)
+        .context("validate copied native authority before completing backup")?;
+    let bytes = serde_json::to_vec_pretty(&manifest)?;
+    if bytes.len() as u64 > MAX_MANIFEST_BYTES {
+        bail!("recovery manifest exceeds size limit");
+    }
+    write_new(&staging.path().join("manifest.json"), &bytes)?;
+    write_new(
+        &staging.path().join("COMPLETE"),
+        hex::encode(Sha256::digest(&bytes)).as_bytes(),
+    )?;
+    validate(staging.path())?;
+    sync_directory(staging.path())?;
+    ensure_directory_identity(&parent_handle, &parent)?;
+    ensure_directory_identity(&staging_handle, staging.path())?;
+    publish_absent(staging.path(), target, &parent_handle, &parent_handle)
+        .context("publish completed backup")?;
+    parent_handle.sync_all().context("backup was published, but parent durability is unconfirmed; preserve and inspect the destination")?;
+    Ok(())
+}
+
+pub(super) fn validate(carrier: &Path) -> Result<Manifest> {
+    ensure_platform()?;
+    let path = carrier.join("manifest.json");
+    let bytes = read_bounded(&path, MAX_MANIFEST_BYTES)?;
+    let complete = carrier.join("COMPLETE");
+    let marker = read_bounded(&complete, 64)?;
+    if marker.len() != 64 {
+        bail!("backup completion marker is invalid");
+    }
+    if marker != hex::encode(Sha256::digest(&bytes)).as_bytes() {
+        bail!("backup manifest checksum mismatch");
+    }
+    let manifest: Manifest = serde_json::from_slice(&bytes)?;
+    if manifest.schema != SCHEMA {
+        bail!("unsupported recovery carrier schema {}", manifest.schema);
+    }
+    if !manifest.source_root.is_absolute() {
+        bail!("recovery carrier source location must be absolute");
+    }
+    if manifest.files.len() > MAX_ENTRIES {
+        bail!("recovery carrier exceeds file limit");
+    }
+    for name in manifest.files.keys() {
+        safe_relative(name)?;
+    }
+    if inventory(&carrier.join("payload"))? != manifest.files {
+        bail!("backup payload is incomplete or corrupt");
+    }
+    let layout = kin_core::KinLayout::new(carrier.join("payload"));
+    let identity = kin_core::KinManifest::load(&layout.manifest_path())?;
+    if identity.repo_id != manifest.repository_id || identity.workspace_id != manifest.workspace_id
+    {
+        bail!("backup repository or workspace identity mismatch");
+    }
+    if layout.read_version()? != manifest.layout_version {
+        bail!("backup layout version mismatch");
+    }
+    Ok(manifest)
+}
+
+pub(super) fn inspect(carrier: &Path) -> Result<Manifest> {
+    let manifest = validate(carrier)?;
+    refuse_path_bound_recovery(&carrier.join("payload"))?;
+    let _freeze = verify_staged_authority(&carrier.join("payload"), &manifest)?;
+    Ok(manifest)
+}
+
+/// Retain the validated native generation until its staged files are published.
+fn verify_staged_authority(
+    path: &Path,
+    manifest: &Manifest,
+) -> Result<kin_db::LocalRepositoryAuthorityFreeze> {
+    let layout = kin_core::KinLayout::new(path.to_path_buf());
+    let identity = kin_core::KinManifest::load(&layout.manifest_path())?;
+    if identity.repo_id != manifest.repository_id || identity.workspace_id != manifest.workspace_id
+    {
+        bail!("staged repository or workspace identity mismatch");
+    }
+    let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout)?;
+    let backend = kin_db::LocalFileBackend::new(layout.kindb_dir());
+    let frozen = kin_db::LocalRepositoryAuthorityFreeze::open_existing_read_only(
+        binding.repository_id().clone(),
+        &backend,
+    )?;
+    if frozen.roots() != &manifest.roots {
+        bail!("staged native authority roots do not match the carrier");
+    }
+    if !frozen
+        .authority()
+        .metadata()
+        .workspaces
+        .iter()
+        .any(|workspace| workspace.workspace_id == binding.workspace_id())
+    {
+        bail!("staged authority does not contain its manifest workspace");
+    }
+    Ok(frozen)
+}
+
+const RUNTIME_FILES: &[&str] = &[
+    "daemon.pid",
+    "daemon.port",
+    "daemon.owner",
+    "daemon.pid.tmp",
+    "daemon.port.tmp",
+    "daemon.owner.tmp",
+    "daemon.token",
+    "daemon.lock",
+    "daemon.lifecycle",
+    "daemon.start.lock",
+];
+
+fn refuse_path_bound_recovery(root: &Path) -> Result<()> {
+    let directory = open_directory(root)?;
+    match directory.symlink_metadata("reconciliation") {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+        Ok(_) => {}
+    }
+    let control = open_directory(&root.join("reconciliation"))?;
+    for entry in control.entries()? {
+        let name = entry?.file_name();
+        if name.to_string_lossy().starts_with("tx-")
+            || name
+                .to_string_lossy()
+                .eq_ignore_ascii_case("exact-eject-journal.json")
+        {
+            bail!("path-bound reconciliation recovery remains; preserve the original repository and recover it with its matching Kin binary before creating or restoring a carrier");
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn restore(
+    carrier: &Path,
+    destination: &Path,
+    verify: impl FnOnce(&Path, &Manifest) -> Result<()>,
+) -> Result<()> {
+    ensure_platform()?;
+    let absolute_destination = std::path::absolute(destination)?;
+    let destination = absolute_destination.as_path();
+    let manifest = validate(carrier)?;
+    refuse_path_bound_recovery(&carrier.join("payload"))?;
+    let restore_files: BTreeMap<_, _> = manifest
+        .files
+        .iter()
+        .filter(|(name, _)| {
+            !RUNTIME_FILES
+                .iter()
+                .any(|runtime| name.eq_ignore_ascii_case(runtime))
+        })
+        .map(|(name, entry)| (name.clone(), entry.clone()))
+        .collect();
+    if fs::symlink_metadata(destination).is_ok() {
+        bail!(
+            "restore destination already exists: {}",
+            destination.display()
+        );
+    }
+    let parent = destination
+        .parent()
+        .context("restore destination needs a parent")?
+        .canonicalize()?;
+    if parent.starts_with(carrier.canonicalize()?) {
+        bail!("restore destination must be outside the carrier");
+    }
+    let resolved_destination = parent.join(
+        destination
+            .file_name()
+            .context("restore target needs a name")?,
+    );
+    let same_source = resolved_destination == manifest.source_root;
+    #[cfg(target_vendor = "apple")]
+    let same_source = same_source
+        || resolved_destination
+            .to_string_lossy()
+            .eq_ignore_ascii_case(&manifest.source_root.to_string_lossy());
+    if same_source {
+        bail!("restore requires a different working-directory path from the original repository; preserve the carrier and choose a fresh location");
+    }
+    let parent_handle = open_directory(&parent)?.into_std_file();
+    let staging = tempfile::Builder::new()
+        .prefix(".kin-restore-incomplete-")
+        .tempdir_in(&parent)?;
+    ensure_directory_identity(&parent_handle, &parent)?;
+    let staging_handle = open_directory(staging.path())?.into_std_file();
+    let payload = staging.path().join("payload");
+    copy_checked(&carrier.join("payload"), &payload, &restore_files)?;
+    let payload_handle = open_directory(&payload)?.into_std_file();
+    verify(&payload, &manifest)?;
+    refuse_path_bound_recovery(&payload)?;
+    let _staged_freeze = verify_staged_authority(&payload, &manifest)
+        .context("validate restored native authority")?;
+    if inventory(&payload)? != restore_files {
+        bail!("staged recovery payload changed before publication");
+    }
+    sync_directory(&payload)?;
+    ensure_directory_identity(&parent_handle, &parent)?;
+    ensure_directory_identity(&staging_handle, staging.path())?;
+    ensure_directory_identity(&payload_handle, &payload)?;
+    refuse_path_bound_recovery(&payload)?;
+    publish_absent(&payload, destination, &staging_handle, &parent_handle)
+        .context("publish restored repository")?;
+    parent_handle.sync_all().context("restore was published, but parent durability is unconfirmed; preserve and inspect the destination")?;
+    Ok(())
+}
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_vendor = "apple",
+    target_os = "redox"
+))]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch() -> tempfile::TempDir {
+        tempfile::tempdir_in(std::env::temp_dir().canonicalize().unwrap()).unwrap()
+    }
+
+    fn retain_installed_authority_marker(source: &Path) -> std::path::PathBuf {
+        let identity = kin_core::KinManifest::load(&source.join("manifest.json")).unwrap();
+        let namespace = source.join("kindb").join(identity.repo_id);
+        let bytes = fs::read(namespace.join("authority.json")).unwrap();
+        let sha256: [u8; 32] = Sha256::digest(&bytes).into();
+        let marker = namespace.join("authority.json.tmp.meta");
+        write_new(
+            &marker,
+            &serde_json::to_vec(&serde_json::json!({
+                "version": 1,
+                "byte_len": bytes.len(),
+                "sha256": sha256,
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        marker
+    }
+
+    fn fixture(root: &Path) -> (std::path::PathBuf, Manifest) {
+        let source = root.join("source");
+        fs::create_dir(&source).unwrap();
+        let initialized = kin_core::init(&source).unwrap();
+        let mut config =
+            kin_core::config::KinConfig::load(&initialized.layout.config_path()).unwrap();
+        config.remote.default = Some("origin".into());
+        config.remote.refs.push(kin_core::config::RemoteRefConfig {
+            name: "origin".into(),
+            host: kin_core::config::RemoteHostKind::Peer,
+            transport: kin_core::config::RemoteTransportKind::NativeKin,
+            url: Some("https://recovery.example.invalid/native".into()),
+            publish_review_state: true,
+            publish_proofs: false,
+        });
+        config.save(&initialized.layout.config_path()).unwrap();
+        let identity = kin_core::KinManifest::load(&initialized.layout.manifest_path()).unwrap();
+        let binding =
+            kin_core::LocalRepositoryAuthorityBinding::from_layout(&initialized.layout).unwrap();
+        let manager = binding.open_manager().unwrap();
+        let manifest = Manifest {
+            schema: SCHEMA.into(),
+            source_root: source.clone(),
+            repository_id: identity.repo_id,
+            workspace_id: identity.workspace_id,
+            layout_version: 2,
+            roots: manager.read_authority().roots().clone(),
+            files: BTreeMap::new(),
+        };
+        fs::create_dir_all(initialized.layout.root().join("specs")).unwrap();
+        fs::write(
+            initialized.layout.root().join("specs/intent.json"),
+            serde_json::to_vec(&kin_model::Spec {
+                id: kin_model::SpecId(uuid::Uuid::new_v4()),
+                intent: "preserve native intent".into(),
+                scope: vec![],
+                constraints: vec![],
+                acceptance_criteria: vec!["identity and history survive".into()],
+                affected_systems: vec![],
+                validation_requirements: vec![],
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        (initialized.layout.root().to_path_buf(), manifest)
+    }
+
+    #[test]
+    fn carrier_round_trip_preserves_every_file_and_identity() {
+        let scratch = scratch();
+        let (source, manifest) = fixture(scratch.path());
+        let expected = inventory(&source).unwrap();
+        let backup = scratch.path().join("backup");
+        publish(&source, &backup, manifest).unwrap();
+        assert_eq!(inventory(&source).unwrap(), expected);
+        let destination = scratch.path().join("restored");
+        restore(&backup, &destination, |path, manifest| {
+            let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(
+                &kin_core::KinLayout::new(path.to_path_buf()),
+            )?;
+            let manager = binding.open_manager()?;
+            let frozen = manager.freeze_current_authority(&manifest.roots)?;
+            assert_eq!(frozen.roots(), &manifest.roots);
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(inventory(&destination).unwrap(), expected);
+        assert_eq!(validate(&backup).unwrap().files, expected);
+    }
+
+    #[test]
+    fn restore_discards_runtime_endpoints_but_preserves_recovery_keys() {
+        let scratch = scratch();
+        let (source, manifest) = fixture(scratch.path());
+        for name in RUNTIME_FILES {
+            fs::write(source.join(name), b"original process").unwrap();
+        }
+        fs::rename(source.join("daemon.pid"), source.join("DAEMON.PID")).unwrap();
+        fs::create_dir_all(source.join("reconciliation")).unwrap();
+        fs::write(
+            source.join("reconciliation/authority.key"),
+            b"native authority key",
+        )
+        .unwrap();
+        let carrier = scratch.path().join("carrier");
+        publish(&source, &carrier, manifest).unwrap();
+        let restored = scratch.path().join("restored");
+        restore(&carrier, &restored, |_, _| Ok(())).unwrap();
+        for name in RUNTIME_FILES {
+            if *name != "daemon.pid" {
+                assert!(carrier.join("payload").join(name).is_file());
+            }
+            assert!(!restored.join(name).exists());
+        }
+        assert!(carrier.join("payload/DAEMON.PID").is_file());
+        assert!(!restored.join("DAEMON.PID").exists());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&restored).unwrap().permissions().mode() & 0o077,
+                0
+            );
+        }
+        assert_eq!(
+            fs::read(restored.join("reconciliation/authority.key")).unwrap(),
+            b"native authority key"
+        );
+    }
+
+    #[test]
+    fn pending_path_bound_recovery_is_preserved_and_refused() {
+        for name in [
+            "tx-empty",
+            "exact-eject-journal.json",
+            "EXACT-EJECT-JOURNAL.JSON",
+        ] {
+            let scratch = scratch();
+            let (source, manifest) = fixture(scratch.path());
+            fs::create_dir_all(source.join("reconciliation")).unwrap();
+            let pending = source.join("reconciliation").join(name);
+            if name.starts_with("tx-") {
+                fs::create_dir(&pending).unwrap();
+            } else {
+                fs::write(&pending, b"pending journal").unwrap();
+            }
+            let before = inventory(&source).unwrap();
+            let carrier = scratch.path().join("carrier");
+            assert!(publish(&source, &carrier, manifest)
+                .unwrap_err()
+                .to_string()
+                .contains("path-bound"));
+            assert!(pending.exists());
+            assert_eq!(inventory(&source).unwrap(), before);
+            assert!(!carrier.exists());
+        }
+    }
+
+    #[test]
+    fn late_empty_reconciliation_transaction_cannot_publish() {
+        let scratch = scratch();
+        let (source, manifest) = fixture(scratch.path());
+        let carrier = scratch.path().join("carrier");
+        publish(&source, &carrier, manifest).unwrap();
+        let restored = scratch.path().join("restored");
+        let error = restore(&carrier, &restored, |payload, _| {
+            fs::create_dir_all(payload.join("reconciliation/tx-late"))?;
+            Ok(())
+        })
+        .unwrap_err();
+        assert!(error.to_string().contains("path-bound"));
+        assert!(!restored.exists());
+        inspect(&carrier).unwrap();
+        fs::create_dir_all(carrier.join("payload/reconciliation/tx-pending")).unwrap();
+        assert!(inspect(&carrier)
+            .unwrap_err()
+            .to_string()
+            .contains("path-bound"));
+        assert!(restore(&carrier, &restored, |_, _| Ok(()))
+            .unwrap_err()
+            .to_string()
+            .contains("path-bound"));
+        assert!(!restored.exists());
+    }
+
+    #[test]
+    fn lost_original_path_cannot_reuse_an_existing_supervisor_route() {
+        let scratch = scratch();
+        let (source, manifest) = fixture(scratch.path());
+        let carrier = scratch.path().join("carrier");
+        publish(&source, &carrier, manifest).unwrap();
+        fs::rename(&source, scratch.path().join("preserved-original")).unwrap();
+        let error = restore(&carrier, &source, |_, _| Ok(())).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("different working-directory path"));
+        assert!(!source.exists());
+        inspect(&carrier).unwrap();
+    }
+
+    #[test]
+    fn supported_v13_authority_survives_current_carrier_restore() {
+        use kin_db::StorageBackend;
+        let scratch = scratch();
+        let (source, _) = fixture(scratch.path());
+        let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(
+            &kin_core::KinLayout::new(source.clone()),
+        )
+        .unwrap();
+        let manager = binding.open_manager().unwrap();
+        let mut snapshot = manager.read_authority().snapshot().clone();
+        drop(manager);
+        let metadata = snapshot.repository_authority.as_mut().unwrap();
+        let operations: BTreeMap<_, _> = metadata
+            .operation_log
+            .iter()
+            .map(|operation| (operation.operation_id, operation.clone()))
+            .collect();
+        assert!(metadata
+            .receipts
+            .iter()
+            .all(|receipt| receipt.operation.is_none()));
+        for receipt in &mut metadata.receipts {
+            receipt.operation = Some(operations[&receipt.operation_id].clone());
+        }
+        metadata.schema_version =
+            kin_db::storage::repository::MIN_REPOSITORY_AUTHORITY_SCHEMA_VERSION;
+        snapshot.materialized_graph = None;
+        snapshot.version = snapshot.wire_version();
+        assert_eq!(snapshot.version, 13);
+        let aged = scratch.path().join("aged");
+        let metadata_files = inventory(&source)
+            .unwrap()
+            .into_iter()
+            .filter(|(name, _)| !name.starts_with("kindb/"))
+            .collect();
+        copy_checked(&source, &aged, &metadata_files).unwrap();
+        fs::create_dir(aged.join("kindb")).unwrap();
+        let backend = kin_db::LocalFileBackend::new(aged.join("kindb"));
+        backend
+            .save_snapshot(
+                &binding.repository_id().to_string(),
+                &snapshot.to_bytes().unwrap(),
+                0,
+            )
+            .unwrap();
+        let carrier = scratch.path().join("carrier");
+        super::super::backup::create_carrier_at(&kin_core::KinLayout::new(aged.clone()), &carrier)
+            .unwrap();
+        let before = inventory(&aged).unwrap();
+        let restored = scratch.path().join("restored");
+        restore(&carrier, &restored, |_, _| Ok(())).unwrap();
+        let frozen = kin_db::LocalRepositoryAuthorityFreeze::open_existing_read_only(
+            binding.repository_id().clone(),
+            &kin_db::LocalFileBackend::new(restored.join("kindb")),
+        )
+        .unwrap();
+        assert_eq!(frozen.authority().snapshot().version, 13);
+        assert_eq!(
+            frozen.authority().snapshot().repository_authority,
+            snapshot.repository_authority
+        );
+        assert_eq!(inventory(&aged).unwrap(), before);
+    }
+
+    #[tokio::test]
+    async fn command_restores_only_into_an_absent_kin_directory() {
+        let cwd = std::env::current_dir().unwrap();
+        let scratch = tempfile::Builder::new()
+            .prefix(".recovery-cli-test-")
+            .tempdir_in(&cwd)
+            .unwrap();
+        let (source, _) = fixture(scratch.path());
+        let marker = retain_installed_authority_marker(&source);
+        let before = inventory(&source).unwrap();
+        let backup = scratch.path().join("backup");
+        super::super::backup::create_carrier_at(
+            &kin_core::KinLayout::new(source.clone()),
+            backup.strip_prefix(&cwd).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(inventory(&source).unwrap(), before);
+        assert!(marker.exists());
+        let working = scratch.path().join("working");
+        fs::create_dir(&working).unwrap();
+        let destination = working.join(".kin");
+        super::super::backup::restore_carrier(
+            backup.strip_prefix(&cwd).unwrap().to_path_buf(),
+            destination.strip_prefix(&cwd).unwrap().to_path_buf(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            inventory(&source).unwrap(),
+            inventory(&destination).unwrap()
+        );
+        assert!(
+            super::super::backup::restore_carrier(backup.clone(), destination.clone())
+                .await
+                .is_err()
+        );
+        assert!(
+            super::super::backup::restore_carrier(backup, working.join("not-kin"))
+                .await
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn failed_backup_preserves_corrupt_source_and_publishes_nothing() {
+        let scratch = scratch();
+        let (source, manifest) = fixture(scratch.path());
+        fs::write(
+            source
+                .join("kindb")
+                .join(&manifest.repository_id)
+                .join("authority.json"),
+            b"truncated",
+        )
+        .unwrap();
+        let before = inventory(&source).unwrap();
+        let backup = scratch.path().join("backup");
+        assert!(super::super::backup::create_carrier_at(
+            &kin_core::KinLayout::new(source.clone()),
+            &backup
+        )
+        .is_err());
+        assert_eq!(inventory(&source).unwrap(), before);
+        assert!(!backup.exists());
+    }
+
+    #[test]
+    fn unsupported_layouts_remain_intact_without_a_partial_backup() {
+        for version in [1, 99] {
+            let scratch = scratch();
+            let (source, _) = fixture(scratch.path());
+            fs::write(source.join("version"), version.to_string()).unwrap();
+            let before = inventory(&source).unwrap();
+            let backup = scratch.path().join("backup");
+            assert!(super::super::backup::create_carrier_at(
+                &kin_core::KinLayout::new(source.clone()),
+                &backup
+            )
+            .is_err());
+            assert_eq!(inventory(&source).unwrap(), before);
+            assert!(!backup.exists());
+        }
+    }
+
+    #[test]
+    fn corrupt_and_incomplete_carriers_leave_destination_absent() {
+        for victim in ["COMPLETE", "manifest.json", "payload/specs/intent.json"] {
+            let scratch = scratch();
+            let (source, manifest) = fixture(scratch.path());
+            let before = inventory(&source).unwrap();
+            let backup = scratch.path().join("backup");
+            publish(&source, &backup, manifest).unwrap();
+            validate(&backup).unwrap();
+            fs::write(backup.join(victim), b"truncated").unwrap();
+            let destination = scratch.path().join("restored");
+            assert!(restore(&backup, &destination, |_, _| Ok(())).is_err());
+            assert!(!destination.exists());
+            assert_eq!(inventory(&source).unwrap(), before);
+        }
+    }
+
+    #[test]
+    fn failed_validation_and_destination_race_preserve_existing_state() {
+        let scratch = scratch();
+        let (source, manifest) = fixture(scratch.path());
+        let backup = scratch.path().join("backup");
+        publish(&source, &backup, manifest).unwrap();
+        let destination = scratch.path().join("restored");
+        assert!(restore(&backup, &destination, |_, _| bail!(
+            "invalid native authority"
+        ))
+        .is_err());
+        assert!(!destination.exists());
+        assert!(restore(&backup, &destination, |_, _| {
+            fs::create_dir(&destination)?;
+            fs::write(destination.join("sentinel"), b"keep")?;
+            Ok(())
+        })
+        .is_err());
+        assert_eq!(fs::read(destination.join("sentinel")).unwrap(), b"keep");
+    }
+
+    #[test]
+    fn displaced_parent_or_payload_cannot_publish_unverified_state() {
+        for replace_parent in [false, true] {
+            let scratch = scratch();
+            let (source, manifest) = fixture(scratch.path());
+            let backup = scratch.path().join("backup");
+            publish(&source, &backup, manifest).unwrap();
+            let working = scratch.path().join("working");
+            fs::create_dir(&working).unwrap();
+            let destination = working.join(".kin");
+            let moved = scratch.path().join("moved-working");
+            assert!(restore(&backup, &destination, |payload, _| {
+                if replace_parent {
+                    fs::rename(&working, &moved)?;
+                    fs::create_dir(&working)?;
+                } else {
+                    fs::rename(payload, payload.with_file_name("displaced"))?;
+                    fs::create_dir(payload)?;
+                    fs::write(payload.join("unverified"), b"must not publish")?;
+                }
+                Ok(())
+            })
+            .is_err());
+            assert!(!destination.exists());
+            assert!(!moved.join(".kin").exists());
+            validate(&backup).unwrap();
+        }
+    }
+
+    #[test]
+    fn in_place_metadata_changes_cannot_escape_final_validation() {
+        let scratch = scratch();
+        let (source, manifest) = fixture(scratch.path());
+        let backup = scratch.path().join("backup");
+        publish(&source, &backup, manifest).unwrap();
+        let destination = scratch.path().join("restored");
+        let error = restore(&backup, &destination, |payload, _| {
+            fs::write(payload.join("specs/intent.json"), b"truncated")?;
+            Ok(())
+        })
+        .unwrap_err();
+        assert!(error.to_string().contains("payload changed"));
+        assert!(!destination.exists());
+        validate(&backup).unwrap();
+    }
+
+    #[test]
+    fn backup_cannot_complete_with_roots_from_another_generation() {
+        let scratch = scratch();
+        let (source, mut manifest) = fixture(scratch.path());
+        let before = inventory(&source).unwrap();
+        manifest.roots.generation += 1;
+        let backup = scratch.path().join("backup");
+        assert!(publish(&source, &backup, manifest).is_err());
+        assert!(!backup.exists());
+        assert_eq!(inventory(&source).unwrap(), before);
+    }
+
+    #[test]
+    fn rehashed_manifest_cannot_change_repository_identity() {
+        let scratch = scratch();
+        let (source, manifest) = fixture(scratch.path());
+        let backup = scratch.path().join("backup");
+        publish(&source, &backup, manifest).unwrap();
+        let mut manifest = validate(&backup).unwrap();
+        manifest.repository_id = "another-repository".into();
+        let bytes = serde_json::to_vec(&manifest).unwrap();
+        fs::write(backup.join("manifest.json"), &bytes).unwrap();
+        fs::write(backup.join("COMPLETE"), hex::encode(Sha256::digest(&bytes))).unwrap();
+        assert!(validate(&backup)
+            .unwrap_err()
+            .to_string()
+            .contains("identity mismatch"));
+    }
+
+    #[test]
+    fn rehashed_wrong_roots_cannot_publish_a_restore() {
+        let scratch = scratch();
+        let (source, manifest) = fixture(scratch.path());
+        let backup = scratch.path().join("backup");
+        publish(&source, &backup, manifest).unwrap();
+        let mut manifest = validate(&backup).unwrap();
+        manifest.roots.generation += 1;
+        let bytes = serde_json::to_vec(&manifest).unwrap();
+        fs::write(backup.join("manifest.json"), &bytes).unwrap();
+        fs::write(backup.join("COMPLETE"), hex::encode(Sha256::digest(&bytes))).unwrap();
+        validate(&backup).unwrap();
+        assert!(inspect(&backup).is_err());
+        let before = inventory(&backup).unwrap();
+        let destination = scratch.path().join("restored");
+        let error = restore(&backup, &destination, |_, _| Ok(())).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("validate restored native authority"));
+        assert!(!destination.exists());
+        assert_eq!(inventory(&backup).unwrap(), before);
+    }
+
+    #[test]
+    fn payload_omission_and_addition_are_both_rejected() {
+        let scratch = scratch();
+        let (source, manifest) = fixture(scratch.path());
+        let backup = scratch.path().join("backup");
+        publish(&source, &backup, manifest).unwrap();
+        let victim = backup.join("payload/specs/intent.json");
+        let bytes = fs::read(&victim).unwrap();
+        fs::remove_file(&victim).unwrap();
+        assert!(validate(&backup).is_err());
+        fs::write(&victim, bytes).unwrap();
+        validate(&backup).unwrap();
+        fs::write(backup.join("payload/unexpected"), b"extra").unwrap();
+        assert!(validate(&backup).is_err());
+    }
+
+    #[test]
+    fn native_history_refs_reviews_and_audit_survive_restore() {
+        use kin_model::*;
+        let scratch = scratch();
+        let (source, mut manifest) = fixture(scratch.path());
+        let layout = kin_core::KinLayout::new(source.clone());
+        let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout).unwrap();
+        let manager = binding.open_manager().unwrap();
+        let body = b"native bytes absent from Git";
+        let digest = kin_blobs::digest(body);
+        manager.save_source_blob(digest, body).unwrap();
+        let make_change = |parents: Vec<SemanticChangeId>, message: &str| {
+            let root = parents.is_empty();
+            let mut change = SemanticChange {
+                id: SemanticChangeId::from_hash(Hash256::from_bytes([0; 32])),
+                origin: ChangeOrigin::Native,
+                parents,
+                timestamp: Timestamp::now(),
+                author: AuthorId::new("Recovery Test <recovery@example.invalid>"),
+                message: message.into(),
+                entity_deltas: vec![],
+                relation_deltas: vec![],
+                tree_deltas: vec![],
+                admission_policy_delta: root
+                    .then(|| AdmissionPolicyDelta::initialize(SharedAdmissionPolicy::empty(0))),
+                projected_files: vec![],
+                spec_link: None,
+                evidence: vec![],
+                risk_summary: None,
+                external_reference_deltas: vec![],
+            };
+            change.id = kin_core::compute_semantic_change_id(&change).unwrap();
+            change
+        };
+        let first = make_change(vec![], "first native change");
+        let mut second = make_change(vec![first.id], "second native change");
+        second.tree_deltas.push(TreeDelta::Added {
+            artifact_id: ArtifactId::new(),
+            new: LocatedEntry::new(
+                RepoPath::from_utf8("native.txt").unwrap(),
+                TreeEntry::blob(digest, false),
+            ),
+        });
+        second.id = kin_core::compute_semantic_change_id(&second).unwrap();
+        let review = Review {
+            review_id: ReviewId(uuid::Uuid::new_v4()),
+            title: "preserve native review".into(),
+            base_ref: "main".into(),
+            head_ref: "native".into(),
+            state: ReviewDecisionState::Pending,
+            completion: ReviewCompletionState::InReview,
+            created_by: IdentityRef::human("recovery-test"),
+            created_at: Timestamp::now(),
+            updated_at: Timestamp::now(),
+            scopes: vec![],
+        };
+        let roots = manager.read_authority().roots().clone();
+        let workspace = manager.read_authority().metadata().workspaces[0].clone();
+        let next_tree = workspace.tree.apply(&second.tree_deltas).unwrap();
+        let next_tree_hash = compute_resolved_tree_hash(&next_tree).unwrap();
+        let actor = Actor {
+            actor_id: ActorId::new(),
+            kind: ActorKind::Human,
+            display_name: "Recovery Test".into(),
+            external_refs: vec![],
+        };
+        let audit = AuditEvent {
+            event_id: AuditEventId::new(),
+            actor_id: actor.actor_id,
+            action: "review.create".into(),
+            target_scope: None,
+            timestamp: Timestamp::now(),
+            details: Some("native recovery fixture".into()),
+        };
+        let transaction = RepositoryTransaction {
+            schema_version: REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+            operation_id: OperationId::new(),
+            repository_id: binding.repository_id().clone(),
+            expected_generation: roots.generation,
+            expected_roots: roots,
+            actor: second.author.clone(),
+            reason: "record native recovery fixture".into(),
+            external_objects: vec![],
+            git_authority_delta: None,
+            changes: vec![first.clone(), second.clone()],
+            aliases: vec![],
+            ref_mutations: vec![RefMutation {
+                name: RefName::branch(b"native").unwrap(),
+                expected: RefExpectation::MustNotExist,
+                new_target: Some(RefTarget::change(second.id)),
+                policy: RefUpdatePolicy::FastForwardOnly,
+            }],
+            default_ref_mutation: None,
+            workspace_mutation: Some(WorkspaceMutation {
+                workspace_id: workspace.workspace_id,
+                expected: WorkspaceExpectation::MustEqual {
+                    generation: workspace.generation,
+                    head: workspace.head.clone(),
+                    base_target: workspace.base_target.clone(),
+                    base_tree_hash: workspace.base_tree_hash,
+                    tree_hash: workspace.tree_hash,
+                    semantic_overlay_hash: workspace.semantic_overlay_hash,
+                    admission_policy: workspace.admission_policy.clone(),
+                },
+                new_generation: workspace.generation + 1,
+                new_head: WorkspaceHead::Symbolic {
+                    target: RefName::branch(b"native").unwrap(),
+                },
+                new_base_target: Some(RefTarget::change(second.id)),
+                new_base_tree_hash: Some(next_tree_hash),
+                tree_deltas: second.tree_deltas.clone(),
+                new_tree_hash: next_tree_hash,
+                semantic_delta: WorkspaceSemanticDelta::default(),
+                new_shared_admission_policy: workspace.shared_admission_policy.clone(),
+                new_admission_policy: workspace.admission_policy.clone(),
+            }),
+            local_overlay_delta: None,
+            merge_transaction_delta: None,
+            sealed_observation: None,
+            collaboration_delta: Some(CollaborationDelta {
+                reviews: vec![Keyed::new(review.review_id, review.clone())],
+                actors: vec![Keyed::new(actor.actor_id, actor)],
+                audit_events: vec![audit],
+                ..Default::default()
+            }),
+        };
+        manager.commit_repository_transaction(transaction).unwrap();
+        manifest.roots = manager.read_authority().roots().clone();
+        let frozen = manager.freeze_current_authority(&manifest.roots).unwrap();
+        let expected = frozen.authority().snapshot().clone();
+        let backup = scratch.path().join("backup");
+        publish(&source, &backup, manifest).unwrap();
+        drop(frozen);
+        let destination = scratch.path().join("restored");
+        restore(&backup, &destination, |path, manifest| {
+            let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(
+                &kin_core::KinLayout::new(path.to_path_buf()),
+            )?;
+            let manager = binding.open_manager()?;
+            let frozen = manager.freeze_current_authority(&manifest.roots)?;
+            let snapshot = frozen.authority().snapshot();
+            assert_eq!(
+                snapshot.changes.get(&second.id).unwrap().parents,
+                vec![first.id]
+            );
+            assert_eq!(snapshot.changes.len(), expected.changes.len());
+            for (id, change) in expected.changes.iter() {
+                assert_eq!(snapshot.changes.get(id), Some(change));
+            }
+            assert_eq!(snapshot.repository_authority, expected.repository_authority);
+            assert_eq!(snapshot.reviews, expected.reviews);
+            assert_eq!(snapshot.actors, expected.actors);
+            assert_eq!(snapshot.audit_events, expected.audit_events);
+            assert_eq!(frozen.roots(), &manifest.roots);
+            assert_eq!(
+                frozen
+                    .authority()
+                    .resolve_ref_target(&RefName::branch(b"native")?)?,
+                Some(RefTarget::change(second.id))
+            );
+            let restored_workspace = &frozen.authority().metadata().workspaces[0];
+            assert_eq!(restored_workspace.workspace_id, workspace.workspace_id);
+            assert_eq!(restored_workspace.generation, workspace.generation + 1);
+            assert_eq!(restored_workspace.tree_hash, next_tree_hash);
+            drop(frozen);
+            assert_eq!(manager.load_source_blob(digest)?, Some(body.to_vec()));
+            Ok(())
+        })
+        .unwrap();
+        let blob_path = inventory(&source)
+            .unwrap()
+            .keys()
+            .find(|name| name.contains("/source-blobs/"))
+            .expect("referenced content is present")
+            .clone();
+        fs::write(source.join(blob_path), b"corrupt native content").unwrap();
+        let marker = retain_installed_authority_marker(&source);
+        let corrupt_source = inventory(&source).unwrap();
+        let refused = scratch.path().join("refused-backup");
+        assert!(super::super::backup::create_carrier_at(&layout, &refused).is_err());
+        assert_eq!(inventory(&source).unwrap(), corrupt_source);
+        assert!(marker.exists());
+        assert!(!refused.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn substituted_directory_cannot_escape_the_source() {
+        let scratch = scratch();
+        let source = scratch.path().join("source");
+        let outside = scratch.path().join("outside");
+        fs::create_dir(&source).unwrap();
+        fs::create_dir(&outside).unwrap();
+        fs::write(outside.join("secret"), b"outside").unwrap();
+        std::os::unix::fs::symlink(&outside, source.join("subdir")).unwrap();
+        assert!(open_regular(&source.join("subdir/secret")).is_err());
+        assert!(inventory(&source).is_err());
+        assert_eq!(fs::read(outside.join("secret")).unwrap(), b"outside");
+    }
+
+    #[test]
+    fn bounded_inputs_and_nested_restore_are_rejected() {
+        let scratch = scratch();
+        let oversized = scratch.path().join("oversized");
+        fs::write(&oversized, [0u8; 66]).unwrap();
+        assert!(read_bounded(&oversized, 64).is_err());
+        assert_eq!(read_bounded(&oversized, 66).unwrap().len(), 66);
+        let (source, manifest) = fixture(scratch.path());
+        let backup = scratch.path().join("backup");
+        publish(&source, &backup, manifest).unwrap();
+        let before = inventory(&backup).unwrap();
+        let nested = backup.join("restored");
+        assert!(restore(&backup, &nested, |_, _| Ok(())).is_err());
+        assert!(!nested.exists());
+        assert_eq!(inventory(&backup).unwrap(), before);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn payload_symlinks_are_rejected_without_reading_the_target() {
+        let scratch = scratch();
+        let (source, manifest) = fixture(scratch.path());
+        let outside = scratch.path().join("outside");
+        fs::write(&outside, b"untouched").unwrap();
+        std::os::unix::fs::symlink(&outside, source.join("link")).unwrap();
+        let backup = scratch.path().join("backup");
+        assert!(publish(&source, &backup, manifest).is_err());
+        assert!(!backup.exists());
+        assert_eq!(fs::read(&outside).unwrap(), b"untouched");
+    }
+}

--- a/crates/kin-cli/src/commands/recovery_carrier.rs
+++ b/crates/kin-cli/src/commands/recovery_carrier.rs
@@ -88,6 +88,19 @@ fn open_regular(path: &Path) -> Result<File> {
     )
 }
 
+fn open_sync_directory(path: &Path) -> Result<File> {
+    let directory = open_directory(path)?;
+    let mut options = cap_std::fs::OpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    #[cfg(unix)]
+    {
+        use cap_std::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_DIRECTORY);
+    }
+    // Directory traversal capabilities may use O_PATH, which cannot be synced.
+    Ok(directory.open_with(".", &options)?.into_std())
+}
+
 fn open_regular_at(parent: &Dir, name: &Path) -> Result<File> {
     let mut options = cap_std::fs::OpenOptions::new();
     options.read(true).follow(FollowSymlinks::No);
@@ -300,7 +313,7 @@ pub(super) fn publish(source: &Path, target: &Path, mut manifest: Manifest) -> R
     if parent.starts_with(source.canonicalize()?) {
         bail!("backup must be outside the source .kin directory");
     }
-    let parent_handle = open_directory(&parent)?.into_std_file();
+    let parent_handle = open_sync_directory(&parent)?;
     let staging = tempfile::Builder::new()
         .prefix(".kin-backup-incomplete-")
         .tempdir_in(&parent)?;
@@ -496,7 +509,7 @@ pub(super) fn restore(
     if same_source {
         bail!("restore requires a different working-directory path from the original repository; preserve the carrier and choose a fresh location");
     }
-    let parent_handle = open_directory(&parent)?.into_std_file();
+    let parent_handle = open_sync_directory(&parent)?;
     let staging = tempfile::Builder::new()
         .prefix(".kin-restore-incomplete-")
         .tempdir_in(&parent)?;
@@ -535,6 +548,21 @@ mod tests {
 
     fn scratch() -> tempfile::TempDir {
         tempfile::tempdir_in(std::env::temp_dir().canonicalize().unwrap()).unwrap()
+    }
+
+    #[test]
+    fn publication_parent_handle_can_sync_and_retains_directory_identity() {
+        let temp = scratch();
+        let parent = temp.path().join("parent");
+        let moved = temp.path().join("moved");
+        fs::create_dir(&parent).unwrap();
+        let handle = open_sync_directory(&parent).unwrap();
+        handle.sync_all().unwrap();
+        fs::rename(&parent, &moved).unwrap();
+        fs::create_dir(&parent).unwrap();
+        handle.sync_all().unwrap();
+        ensure_directory_identity(&handle, &moved).unwrap();
+        assert!(ensure_directory_identity(&handle, &parent).is_err());
     }
 
     fn retain_installed_authority_marker(source: &Path) -> std::path::PathBuf {

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -964,7 +964,7 @@ enum Command {
         #[arg(long)]
         scope: Option<String>,
     },
-    /// Backup and restore graph snapshots
+    /// Back up and restore complete native repository state
     Backup {
         #[command(subcommand)]
         action: BackupAction,
@@ -1574,29 +1574,41 @@ enum BranchAction {
 
 #[derive(Subcommand)]
 enum BackupAction {
-    /// Create a backup of the current graph snapshot
+    /// Create a complete native recovery backup outside .kin
     Create {
         /// Optional tag to label the backup
         #[arg(short, long)]
         tag: Option<String>,
+        /// Absent carrier directory with an existing parent
+        #[arg(long)]
+        output: Option<PathBuf>,
     },
     /// List available backups
     List {
         /// Output machine-readable JSON
         #[arg(long, default_value_t = false)]
         json: bool,
+        /// Carrier directory to list even if the original repository was lost
+        #[arg(long)]
+        directory: Option<PathBuf>,
     },
-    /// Restore the graph from a backup
+    /// Restore a complete recovery carrier into a fresh .kin directory
     Restore {
-        /// Backup name (partial match supported)
+        /// Legacy graph-only name, retained to report safe recovery guidance
         name: Option<String>,
-        /// Restore from the most recent backup
+        /// Legacy in-place restore, retained to report safe recovery guidance
         #[arg(long)]
         latest: bool,
+        /// Complete recovery carrier directory
+        #[arg(long, requires = "target", conflicts_with_all = ["name", "latest"])]
+        from: Option<PathBuf>,
+        /// Absent .kin directory inside an existing destination working directory
+        #[arg(long, requires = "from")]
+        target: Option<PathBuf>,
     },
     /// Delete a specific backup
     Delete {
-        /// Backup name (partial match supported)
+        /// Exact recovery carrier name from backup list
         name: String,
     },
 }
@@ -3921,11 +3933,24 @@ fn run() -> Result<()> {
                     .await
                 }
                 Command::Backup { action } => match action {
-                    BackupAction::Create { tag } => commands::backup::create(tag).await,
-                    BackupAction::List { json } => commands::backup::list(json).await,
-                    BackupAction::Restore { name, latest } => {
-                        commands::backup::restore(name, latest).await
+                    BackupAction::Create { tag, output } => {
+                        commands::backup::create(tag, output).await
                     }
+                    BackupAction::List { json, directory } => {
+                        commands::backup::list(json, directory).await
+                    }
+                    BackupAction::Restore {
+                        name,
+                        latest,
+                        from,
+                        target,
+                    } => match (from, target) {
+                        (Some(carrier), Some(destination)) => {
+                            commands::backup::restore_carrier(carrier, destination).await
+                        }
+                        (None, None) => commands::backup::restore(name, latest).await,
+                        _ => anyhow::bail!("--from and --target must be supplied together"),
+                    },
                     BackupAction::Delete { name } => commands::backup::delete(name).await,
                 },
                 Command::Approvals { action } => match action {
@@ -4688,6 +4713,65 @@ fn default_filter_directives(command: &str) -> String {
 mod tests {
     use super::*;
     use clap::CommandFactory;
+
+    #[test]
+    fn recovery_restore_requires_a_complete_fresh_target_pair() {
+        std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| {
+                assert!(
+                    Cli::try_parse_from(["kin", "backup", "create", "--output", "backup"]).is_ok()
+                );
+                assert!(Cli::try_parse_from([
+                    "kin",
+                    "backup",
+                    "list",
+                    "--directory",
+                    "backups",
+                    "--json"
+                ])
+                .is_ok());
+                assert!(Cli::try_parse_from([
+                    "kin",
+                    "backup",
+                    "restore",
+                    "--from",
+                    "/backup",
+                    "--target",
+                    "/fresh/.kin"
+                ])
+                .is_ok());
+                for args in [
+                    vec!["kin", "backup", "restore", "--from", "/backup"],
+                    vec!["kin", "backup", "restore", "--target", "/fresh/.kin"],
+                    vec![
+                        "kin",
+                        "backup",
+                        "restore",
+                        "--latest",
+                        "--from",
+                        "/backup",
+                        "--target",
+                        "/fresh/.kin",
+                    ],
+                    vec![
+                        "kin",
+                        "backup",
+                        "restore",
+                        "old-name",
+                        "--from",
+                        "/backup",
+                        "--target",
+                        "/fresh/.kin",
+                    ],
+                ] {
+                    assert!(Cli::try_parse_from(args).is_err());
+                }
+            })
+            .unwrap()
+            .join()
+            .unwrap();
+    }
 
     /// Every flag a doctor fix line tells a user to type must exist.
     ///

--- a/crates/kin-cli/tests/incompatible_store_wall.rs
+++ b/crates/kin-cli/tests/incompatible_store_wall.rs
@@ -96,8 +96,8 @@ fn a_pre_v2_store_refuses_a_command_by_leading_with_the_version_gap() {
         "a refusal that spawns nothing has no cleanup to report: {stderr}"
     );
     assert!(
-        stderr.contains("remove .kin/ and run `kin init`"),
-        "the refusal must name the remedy that works in place: {stderr}"
+        stderr.contains("keep .kin/ intact") && stderr.contains("the Kin version that wrote it"),
+        "the refusal must preserve native state and name the matching binary: {stderr}"
     );
     assert!(
         !stderr.contains("fresh checkout"),
@@ -111,8 +111,7 @@ fn a_pre_v2_store_refuses_a_command_by_leading_with_the_version_gap() {
 
 #[test]
 fn init_over_an_existing_store_names_the_same_remedy_the_wall_does() {
-    // A reader the wall sent to `kin init` runs it in place first. The refusal
-    // they get has to continue that instruction rather than contradict it.
+    // Both entry points must preserve the existing native state.
     let root = tempdir().expect("temp root");
     let repo = root.path().join("pre-v2-init");
     fs::create_dir_all(&repo).expect("create repository directory");
@@ -123,6 +122,7 @@ fn init_over_an_existing_store_names_the_same_remedy_the_wall_does() {
         .kin_command()
         .arg("init")
         .arg(&repo)
+        .current_dir(&repo)
         .output()
         .expect("run kin init over an existing store");
 
@@ -139,43 +139,66 @@ fn init_over_an_existing_store_names_the_same_remedy_the_wall_does() {
         "the refusal must state its condition: {stderr}"
     );
     assert!(
-        stderr.contains("remove .kin/ and run `kin init`"),
+        stderr.contains("keep .kin/ intact") && stderr.contains("the Kin version that wrote it"),
         "the refusal must name the same remedy the store wall does: {stderr}"
     );
 }
 
 #[test]
-fn the_remedy_the_wall_names_rebuilds_the_store_in_place() {
-    // A remedy nothing checks is a guess. This runs the exact instruction the
-    // wall gives, in the directory the reader is standing in, and requires it
-    // to produce a store the current build wrote.
+fn incompatible_native_state_is_preserved_even_with_git_history_and_force() {
     let root = tempdir().expect("temp root");
     let repo = root.path().join("worked-in");
     seed_git_repo(&repo);
     seed_pre_v2_store(&repo);
+    let manifest = fs::read(repo.join(".kin/manifest.json")).unwrap();
+    fs::write(
+        repo.join(".kin/native-state"),
+        b"native state absent from Git",
+    )
+    .unwrap();
 
     let runtime = IsolatedDaemonRuntime::new(&repo);
-    fs::remove_dir_all(repo.join(".kin")).expect("remove the store the wall said to remove");
     let output = runtime
         .kin_command()
         .arg("init")
         .arg(&repo)
+        .current_dir(&repo)
         .output()
-        .expect("run the rebuild the wall names");
+        .expect("run init against mixed Git and incompatible native state");
 
     assert!(
-        output.status.success(),
-        "the named remedy must rebuild the store: stdout={} stderr={}",
+        !output.status.success(),
+        "force must not replace incompatible native state: stdout={} stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+    assert_eq!(fs::read(repo.join(".kin/manifest.json")).unwrap(), manifest);
     assert_eq!(
-        fs::read_to_string(repo.join(".kin/version"))
-            .expect("the rebuilt store carries a layout marker")
-            .trim(),
-        kin_core::layout::KIN_LAYOUT_VERSION.to_string(),
-        "the rebuilt store must be one this build serves"
+        fs::read(repo.join(".kin/native-state")).unwrap(),
+        b"native state absent from Git"
     );
+    assert!(!repo.join(".kin/version").exists());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Git history cannot recover native Kin"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("remove .kin/"), "{stderr}");
+    let forced = runtime
+        .kin_command()
+        .args(["init", "--force"])
+        .arg(&repo)
+        .current_dir(&repo)
+        .output()
+        .unwrap();
+    assert!(!forced.status.success());
+    assert!(String::from_utf8_lossy(&forced.stderr).contains("unexpected argument '--force'"));
+    assert_eq!(fs::read(repo.join(".kin/manifest.json")).unwrap(), manifest);
+    assert_eq!(
+        fs::read(repo.join(".kin/native-state")).unwrap(),
+        b"native state absent from Git"
+    );
+    assert!(!repo.join(".kin/version").exists());
 }
 
 #[test]

--- a/crates/kin-daemon/src/storage_delegate.rs
+++ b/crates/kin-daemon/src/storage_delegate.rs
@@ -62,7 +62,7 @@ use kin_db::{
 /// `storage_backend_surface_is_audited_against_the_pinned_kin_db` fails when
 /// the workspace pin moves past it, which is the only moment a method can have
 /// appeared.
-pub const AUDITED_KIN_DB_VERSION: &str = "0.7.104";
+pub const AUDITED_KIN_DB_VERSION: &str = "0.7.105";
 
 /// Wraps a [`StorageBackendDelegate`] so it can be handed anywhere a
 /// `Box<dyn StorageBackend>` is expected.

--- a/crates/kin-daemon/src/storage_delegate.rs
+++ b/crates/kin-daemon/src/storage_delegate.rs
@@ -62,7 +62,7 @@ use kin_db::{
 /// `storage_backend_surface_is_audited_against_the_pinned_kin_db` fails when
 /// the workspace pin moves past it, which is the only moment a method can have
 /// appeared.
-pub const AUDITED_KIN_DB_VERSION: &str = "0.7.105";
+pub const AUDITED_KIN_DB_VERSION: &str = "0.7.106";
 
 /// Wraps a [`StorageBackendDelegate`] so it can be handed anywhere a
 /// `Box<dyn StorageBackend>` is expected.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2489,7 +2489,7 @@ kin cache gc [options]
 
 ### `kin backup`
 
-Backup and restore graph snapshots
+Create and restore complete native recovery carriers.
 
 ```
 kin backup <subcommand>
@@ -2499,7 +2499,9 @@ Subcommands:
 
 #### `kin backup create`
 
-Create a backup of the current graph snapshot
+Create a complete current-format carrier outside `.kin`. The destination must
+not exist. Without `--output`, a repository-specific backup directory outside
+the working tree is used.
 
 ```
 kin backup create [options]
@@ -2508,34 +2510,37 @@ kin backup create [options]
 | Flag | Default | Description |
 | --- | --- | --- |
 | `-t, --tag <tag>` |  | Optional tag to label the backup |
+| `--output <path>` |  | Absent destination in an existing directory |
 
 #### `kin backup list`
 
 List available backups
 
 ```
-kin backup list
+kin backup list [--json] [--directory <path>]
 ```
+
+Use `--directory` to list carriers after the original repository is lost.
+Invalid or incomplete entries are reported without hiding healthy carriers.
 
 #### `kin backup restore`
 
-Restore the graph from a backup
+Restore native identity, history and metadata into a fresh location. The target
+must be an absent `.kin` directory in an existing working directory at a different
+path from the original repository. Existing
+destinations are never replaced. Old daemon runtime endpoints are not restored.
 
 ```
-kin backup restore [name] [options]
+kin backup restore --from <carrier> --target <working-directory>/.kin
 ```
 
-| Argument | Required | Description |
-| --- | --- | --- |
-| `[name]` | no | Backup name (partial match supported) |
-
-| Flag | Default | Description |
-| --- | --- | --- |
-| `--latest` |  | Restore from the most recent backup |
+Legacy named or `--latest` in-place graph restore is refused without changing
+the repository or old backup. Corrupt, incomplete or unsupported carriers and
+pending path-bound reconciliation journals also refuse safely.
 
 #### `kin backup delete`
 
-Delete a specific backup
+Permanently delete one complete carrier from the default backup directory.
 
 ```
 kin backup delete <name>
@@ -2543,7 +2548,7 @@ kin backup delete <name>
 
 | Argument | Required | Description |
 | --- | --- | --- |
-| `<name>` | yes | Backup name (partial match supported) |
+| `<name>` | yes | Exact carrier directory name; no partial matching |
 
 ### `kin resources`
 
@@ -2976,4 +2981,3 @@ kin completions <shell>
 | Argument | Required | Description |
 | --- | --- | --- |
 | `<shell>` | yes | Shell to generate completions for |
-

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -291,29 +291,58 @@ against your checkout.
 
 ### What survives if you have to rebuild the store
 
-An upcoming release changes Kin's on-disk repo format, and a store created
-before it will not open afterward. Your working tree is never touched, so
-nothing you have on disk is at risk.
+Keep `.kin` intact when a binary refuses its format. Open it with the Kin
+version that created it and preserve a complete backup outside `.kin` before
+attempting recovery. Working files alone cannot restore native history.
 
-What a rebuild recovers depends on where the work came from. Kin writes `.kin`
-and reads `.git`, so deleting the store cannot touch Git history: if you
-admitted this repository from Git, the recovery path is `kin init` again, and it
-is tested. Measured on 0.7.3 against a 261-commit repository, deleting `.kin`
-and re-running `kin init` returned all 261 commits, all 61 refs and every tag,
-each pointing at the same object as before. Keep the `Repository:` id that
-`kin init` printed, though. A rebuild mints a new one and every exact-transfer
-surface is bound to it, so a store that has ever pushed to a Kin remote needs
-`kin init --adopt-repository-id <ID>` to push where the old one could.
+Git can reconstruct the history and refs it holds, but a Git-admitted
+repository can also contain work recorded only in Kin. Re-initialization loses
+that native state and mints a new repository and workspace identity. Record
+the `Repository:` id as well: `kin init --adopt-repository-id <ID>` can preserve
+the repository identity when admitting a separate replica. It does not restore
+native changes or the original workspace identity.
 
-Work that only ever lived in Kin is a different question, because Git never had
-it. `kin commit` records in Kin authority and not in Git, and native commits,
-Kin branches, reviews and specs all live in `.kin` and go when it goes. Today
-the only way to carry any of it out is `kin git export --output <dir>`, which
-writes every imported commit, every ref and your native commits into a fresh Git
-repository. It carries no review, no spec and no entity history, and it refuses
-a destination that already exists, so treat it as a way out rather than as a
-backup. The format change will ship together with an upgrade command that
-carries native state forward, or it will not ship.
+Drafts, native commits, Kin branches, reviews and specs live in `.kin`.
+Use a complete recovery carrier to preserve them, including repository and
+workspace identities, native parentage, referenced content and remote configuration:
+
+```bash
+kin backup create --output /existing-safe-directory/recovery-backup
+mkdir /new-working-directory
+kin backup restore --from /existing-safe-directory/recovery-backup --target /new-working-directory/.kin
+```
+
+The backup destination must not exist and must be outside `.kin`. Without
+`--output`, backups go into a repository-specific `.kin-backups-<identity-hash>`
+directory outside the working tree; `kin backup list` lists those carriers and
+marks corrupt entries explicitly. If the original repository is unavailable,
+use `kin backup list --directory <backup-directory>`. Restore requires an existing destination working
+directory at a different path from the original and an absent `.kin`. The
+carrier records the original location to enforce that rule. It validates file checksums, identity, native
+authority, referenced content and roots before publication. It never replaces
+an existing repository. A failed staged restore leaves the backup intact and
+does not publish a partial destination.
+
+For an upgrade, keep the original store and its matching binary. Make a carrier,
+then use the newer binary to restore it into a separate working directory and
+check that copy before switching. Compatible older storage remains readable;
+an unsupported format is refused without deleting or re-initializing the source.
+This is not a conversion through Git. `kin git export` does not carry reviews,
+specs or all native authority and is not a recovery backup.
+
+Native authority and source content cannot be discarded. Search indexes and
+other derived caches can be rebuilt, but a rebuilt index cannot recreate native
+history. Restore omits old daemon endpoint, token and process-lock files so the
+new location does not reuse the original daemon's normal discovery route. An
+explicit `KIN_DAEMON_URL` override remains the operator's responsibility. The carrier retains those
+regular files as evidence. Reconciliation authority keys remain intact. Pending
+path-bound reconciliation transactions or exact-eject journals cause backup and
+restore to refuse; preserve the original and recover it with its matching binary
+first.
+
+The carrier conservatively copies regular state files; empty directories
+and runtime sockets are not native authority. A socket or unsupported special file
+in the input is refused rather than followed or silently omitted.
 
 ### Profiling a slow command
 

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -1,6 +1,33 @@
 {
   "allowlist": [
     {
+      "file": "crates/kin-cli/src/commands/recovery_carrier.rs",
+      "reason": "Explicit recovery input/output boundary. These helpers copy and verify a caller-selected frozen repository state into an outside carrier or an absent restore destination. Filesystem hashes establish artifact completeness, never semantic query answers; native authority, roots and referenced content are validated through KinDB before publication. Only the recovery boundary functions are exempt.",
+      "owner": "kin-cli",
+      "expiration": "2027-01-29",
+      "allow_match": [
+        "use std::fs::{self, File, OpenOptions};",
+        "use cap_std::fs::Dir;"
+      ],
+      "allow_fn": [
+        "ensure_directory_identity",
+        "open_directory",
+        "open_regular",
+        "open_regular_at",
+        "digest_open_file",
+        "inventory",
+        "write_new",
+        "sync_directory",
+        "publish_absent",
+        "copy_checked",
+        "publish",
+        "validate",
+        "verify_staged_authority",
+        "refuse_path_bound_recovery",
+        "restore"
+      ]
+    },
+    {
       "file": "crates/kin-cli/src/capability.rs",
       "reason": "Hardware check: reads /proc/meminfo for system stats",
       "owner": "kin-cli",

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -12,6 +12,7 @@
       "allow_fn": [
         "ensure_directory_identity",
         "open_directory",
+        "open_sync_directory",
         "open_regular",
         "open_regular_at",
         "digest_open_file",


### PR DESCRIPTION
## Summary

Replace graph-only recovery with complete, hash-verified native-state carriers. Restore into a fresh, different working directory without replacing an existing store. Preserve native history, repository and workspace identities, refs, reviews, specifications, audit records, CAS and remote configuration while excluding stale daemon endpoints.

Reject incomplete, corrupted, mismatched or path-bound pending recovery state before publication. Keep incompatible stores intact and correct doctor detection of managed installations under another home. Pin published kin-db 0.7.106 and record the reviewed unchanged storage delegation contract.

## Verification

Final head: 2118e305890d4b4ceef04584ce1872588efcd194.

- Matching CLI and daemon build passed. Final precheck: 21 gates ran, 21 passed, 0 failed.
- Carrier and backup regressions: 27 passed. Incompatible-store integrations: 13 passed. Storage delegation audit: 2 passed.
- Full hosted rollup concluded with no failures or pending checks. Linux nextest shards passed 3168, 3095 and 3056 tests. Windows cross-check passed.
- Initial Linux CI exposed an O_PATH directory fsync error. The final directory-relative readable handle fix passed its new sync and renamed-inode regression on Linux, along with the formerly failing carrier tests.

Actual local command and results:

```text
cargo test --locked -p kin-cli --no-fail-fast --quiet
library: 2275 passed; 0 failed; 1 ignored
parser: 46 passed; 0 failed
 doctests: 1 passed; 0 failed; 1 ignored
exit 101: repository_merge_resolution and symlinked_repository_root_admission
```

The first failure occurred during fixture init with daemon-killed exit 7, before merge assertions. The second timed out waiting for a symlinked-root host write to be admitted. Both exact cases passed unchanged with one test thread. Both complete targets then passed unchanged at the original four-test concurrency:

```text
cargo test --locked -p kin-cli --test repository_merge_resolution --test symlinked_repository_root_admission --no-fail-fast --quiet
37 passed; 0 failed (71.78s)
10 passed; 0 failed (8.70s)
exit 0
```

These reruns do not relabel the original full run as green or establish the intermittent failure cause. The watcher follow-up and final gate disposition remain explicit holds.

Development CPU parity before the follow-up was PASS-WITH-ALLOWANCES: magic 27 passed; brownfield 12 passed and 1 unreadable; first-run 10 passed, 1 failed and 1 unreadable. Existing allowances were unchanged. This is not released-byte or production acceptance.

Adversarial identity, inventory, source-preservation, runtime-filtering and late-journal controls failed as intended, then were restored and retested.

## Landing

Hold for final gate disposition and the coordinated landing slot. Do not enable auto-merge.

Kin-Release-Intent: patch