### PR TITLE
Bound cold hosted repository hydration admission

### DIFF
--- a/crates/kin-core/src/env_registry.rs
+++ b/crates/kin-core/src/env_registry.rs
@@ -231,6 +231,7 @@ pub const OPERATIONAL: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_DAEMON_STARTUP_LOCK_TIMEOUT_SECS", kind: Kind::Secs, default: "", sensitivity: Sensitivity::Operational, summary: "how long to wait for the daemon startup lock" },
     EnvVarSpec { name: "KIN_DAEMON_BOOTSTRAP_TIMEOUT_SECS", kind: Kind::Secs, default: "", sensitivity: Sensitivity::Operational, summary: "timeout for daemon bootstrap-as-admin" },
     EnvVarSpec { name: "KIN_DAEMON_SCOPE_BUILD_TIMEOUT_SECS", kind: Kind::Secs, default: "", sensitivity: Sensitivity::Operational, summary: "timeout for a daemon-side scope graph build" },
+    EnvVarSpec { name: "KIN_DAEMON_HOSTED_HYDRATION_TIMEOUT_SECS", kind: Kind::Secs, default: "300", sensitivity: Sensitivity::Operational, summary: "budget for one cold hosted-repository hydration before its admission slot is reclaimed" },
     EnvVarSpec { name: "KIN_DAEMON_IDLE_FLUSH_SECS", kind: Kind::Secs, default: "2", sensitivity: Sensitivity::Operational, summary: "idle debounce before a full-graph persistence flush" },
     EnvVarSpec { name: "KIN_DAEMON_PERIODIC_FLUSH_SECS", kind: Kind::Secs, default: "30", sensitivity: Sensitivity::Operational, summary: "maximum interval before dirty graph state is flushed" },
     EnvVarSpec { name: "KIN_DAEMON_SHUTDOWN_GRACE_SECS", kind: Kind::Secs, default: "25", sensitivity: Sensitivity::Operational, summary: "grace before the shutdown watchdog force-exits; 0 escalates immediately" },

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -40,6 +40,13 @@ use uuid::Uuid;
 
 static BOOTSTRAP_EXPORTS: OnceLock<Arc<tokio::sync::Semaphore>> = OnceLock::new();
 static EXACT_SOURCE_ARCHIVE_EXPORTS: OnceLock<Arc<tokio::sync::Semaphore>> = OnceLock::new();
+static HOSTED_REPOSITORY_HYDRATIONS: OnceLock<Arc<tokio::sync::Semaphore>> = OnceLock::new();
+
+fn hosted_repository_hydrations() -> Arc<tokio::sync::Semaphore> {
+    Arc::clone(
+        HOSTED_REPOSITORY_HYDRATIONS.get_or_init(|| Arc::new(tokio::sync::Semaphore::new(2))),
+    )
+}
 
 fn exact_source_archive_exports() -> Arc<tokio::sync::Semaphore> {
     Arc::clone(
@@ -12766,6 +12773,37 @@ fn open_hosted_repository_mcp_view_blocking(
     unreachable!("bounded hosted authority open either returns or reports its second race")
 }
 
+async fn run_hosted_repository_hydration<T: Send + 'static>(
+    slots: Arc<tokio::sync::Semaphore>,
+    repo_id: &str,
+    hydrate: impl FnOnce() -> std::result::Result<T, RepoScopedMcpFailure> + Send + 'static,
+) -> std::result::Result<T, RepoScopedMcpFailure> {
+    let permit = slots.try_acquire_owned().map_err(|_| {
+        RepoScopedMcpFailure::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "repo_hydration_busy",
+            "repository hydration capacity is busy; retry later",
+            true,
+        )
+    })?;
+    let error_repo_id = repo_id.to_string();
+    tokio::task::spawn_blocking(move || {
+        // Cancellation of the request cannot stop a running blocking worker.
+        // Admission belongs to that worker until hydration and retries finish.
+        let _permit = permit;
+        hydrate()
+    })
+    .await
+    .map_err(|error| {
+        RepoScopedMcpFailure::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "repo_authority_unavailable",
+            format!("repository {error_repo_id} authority worker failed: {error}"),
+            true,
+        )
+    })?
+}
+
 async fn load_hosted_repository_mcp_view(
     state: &Arc<DaemonState>,
     repo_id: &str,
@@ -12852,22 +12890,18 @@ async fn load_hosted_repository_mcp_view(
     let worker_repository_id = repository_id;
     let worker_repo_id = repo_id.to_string();
     let error_repo_id = worker_repo_id.clone();
-    let view = tokio::task::spawn_blocking(move || {
-        open_hosted_repository_mcp_view_blocking(
-            worker_backend,
-            worker_repository_id,
-            worker_repo_id,
-        )
-    })
-    .await
-    .map_err(|error| {
-        RepoScopedMcpFailure::new(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "repo_authority_unavailable",
-            format!("repository {error_repo_id} authority worker failed: {error}"),
-            true,
-        )
-    })??;
+    let view = run_hosted_repository_hydration(
+        hosted_repository_hydrations(),
+        &error_repo_id,
+        move || {
+            open_hosted_repository_mcp_view_blocking(
+                worker_backend,
+                worker_repository_id,
+                worker_repo_id,
+            )
+        },
+    )
+    .await?;
     if let Some(detail) = state.derived_views_stale.read().await.clone() {
         return Err(RepoScopedMcpFailure::new(
             StatusCode::SERVICE_UNAVAILABLE,
@@ -25621,6 +25655,146 @@ mod tests {
             faults.cursor_probes(&repo_id) > cursor_probes,
             "the warm hit must still prove the backend publication cursor"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn hosted_hydration_cancelled_requests_retain_worker_admission() {
+        let slots = Arc::new(tokio::sync::Semaphore::new(2));
+        let starts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut resumes = Vec::new();
+        let mut requests = Vec::new();
+        for _ in 0..2 {
+            let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+            let (resume_tx, resume_rx) = tokio::sync::oneshot::channel();
+            resumes.push(resume_tx);
+            let slots = Arc::clone(&slots);
+            let starts = Arc::clone(&starts);
+            requests.push(tokio::spawn(async move {
+                run_hosted_repository_hydration(slots, "fixture", move || {
+                    starts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    started_tx.send(()).unwrap();
+                    resume_rx.blocking_recv().unwrap();
+                    Ok(())
+                })
+                .await
+            }));
+            started_rx.await.unwrap();
+        }
+        for request in requests {
+            request.abort();
+            assert!(request.await.unwrap_err().is_cancelled());
+        }
+        assert_eq!(slots.available_permits(), 0);
+        let third_starts = Arc::clone(&starts);
+        let refused = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            run_hosted_repository_hydration(Arc::clone(&slots), "third", move || {
+                third_starts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(())
+            }),
+        )
+        .await
+        .expect("busy admission must not wait for a worker")
+        .unwrap_err();
+        assert_eq!(refused.status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(refused.code, "repo_hydration_busy");
+        assert!(refused.retryable);
+        assert_eq!(starts.load(std::sync::atomic::Ordering::SeqCst), 2);
+
+        resumes.remove(0).send(()).unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while slots.available_permits() != 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        run_hosted_repository_hydration(Arc::clone(&slots), "successor", || Ok(()))
+            .await
+            .unwrap();
+        resumes.remove(0).send(()).unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while slots.available_permits() != 2 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn hosted_hydration_errors_panics_and_retries_release_admission() {
+        let slots = Arc::new(tokio::sync::Semaphore::new(2));
+        let held = Arc::clone(&slots).try_acquire_owned().unwrap();
+        let observed = Arc::clone(&slots);
+        let error = run_hosted_repository_hydration(Arc::clone(&slots), "error", move || {
+            // Both attempts belong to one admitted hydration, not new workers.
+            for _ in 0..2 {
+                assert_eq!(observed.available_permits(), 0);
+            }
+            Err::<(), _>(RepoScopedMcpFailure::new(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "repo_semantic_unready",
+                "fixture retry exhausted",
+                true,
+            ))
+        })
+        .await
+        .unwrap_err();
+        assert_eq!(error.code, "repo_semantic_unready");
+        assert_eq!(slots.available_permits(), 1);
+        let panic = run_hosted_repository_hydration::<()>(Arc::clone(&slots), "panic", || {
+            panic!("fixture hydration panic")
+        })
+        .await
+        .unwrap_err();
+        assert_eq!(panic.code, "repo_authority_unavailable");
+        assert!(panic.retryable);
+        assert_eq!(slots.available_permits(), 1);
+        run_hosted_repository_hydration(Arc::clone(&slots), "retry", || Ok(()))
+            .await
+            .unwrap();
+        drop(held);
+        assert_eq!(slots.available_permits(), 2);
+    }
+
+    #[tokio::test]
+    async fn hosted_hydration_warm_cache_bypasses_busy_cold_admission() {
+        let slots = hosted_repository_hydrations();
+        assert!(Arc::ptr_eq(&slots, &hosted_repository_hydrations()));
+        assert_eq!(slots.available_permits(), 2);
+        let repo_id = format!("repo-hydration-warm-{}", Uuid::new_v4());
+        let repository_id = RepositoryId::new(repo_id.clone()).unwrap();
+        let (state, _working, storage) = replica_state(&repo_id);
+        publish_hosted_semantic_change(
+            storage.path(),
+            &repository_id,
+            None,
+            0x8ef1,
+            "publish warm admission fixture",
+            &[("warm_symbol", "src/warm.rs", "fn warm_symbol() {}\n")],
+        );
+        let first = load_hosted_repository_mcp_view(&state, &repo_id)
+            .await
+            .unwrap();
+        let held = Arc::clone(&slots).try_acquire_many_owned(2).unwrap();
+        let warm = load_hosted_repository_mcp_view(&state, &repo_id)
+            .await
+            .unwrap();
+        assert!(Arc::ptr_eq(&first, &warm));
+        state.repo_semantic_views.write().await.clear();
+        let refused = load_hosted_repository_mcp_view(&state, &repo_id)
+            .await
+            .err()
+            .expect("a cold request must refuse occupied hydration slots");
+        assert_eq!(refused.status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(refused.code, "repo_hydration_busy");
+        assert!(refused.retryable);
+        drop(held);
+        load_hosted_repository_mcp_view(&state, &repo_id)
+            .await
+            .unwrap();
+        assert_eq!(slots.available_permits(), 2);
     }
 
     #[tokio::test]

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -12773,8 +12773,52 @@ fn open_hosted_repository_mcp_view_blocking(
     unreachable!("bounded hosted authority open either returns or reports its second race")
 }
 
+fn resolve_hosted_repository_hydration_timeout(raw: Option<&str>) -> Duration {
+    let seconds = raw
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .filter(|seconds| *seconds > 0)
+        .unwrap_or(300);
+    Duration::from_secs(seconds)
+}
+
+fn hosted_repository_hydration_timeout() -> Duration {
+    resolve_hosted_repository_hydration_timeout(
+        std::env::var("KIN_DAEMON_HOSTED_HYDRATION_TIMEOUT_SECS")
+            .ok()
+            .as_deref(),
+    )
+}
+
 async fn run_hosted_repository_hydration<T: Send + 'static>(
     slots: Arc<tokio::sync::Semaphore>,
+    repo_id: &str,
+    hydrate: impl FnOnce() -> std::result::Result<T, RepoScopedMcpFailure> + Send + 'static,
+) -> std::result::Result<T, RepoScopedMcpFailure> {
+    run_hosted_repository_hydration_within(
+        slots,
+        hosted_repository_hydration_timeout(),
+        repo_id,
+        hydrate,
+    )
+    .await
+}
+
+/// Admit one cold hydration against `slots`, bounded in time as well as in count.
+///
+/// A detached supervisor owns the permit, not the caller and not the blocking
+/// worker. That placement answers both failure directions at once. Cancelling
+/// the request drops only the caller's half, so an aborted HTTP request cannot
+/// hand a still-running worker's slot to a second one. A worker that never
+/// returns cannot strand the slot either: `budget` elapses, the supervisor
+/// releases the permit and answers a typed refusal, and the abandoned thread
+/// finishes on tokio's much larger blocking pool with its result discarded.
+/// Putting the timeout on the caller's await instead would answer the request
+/// and leak the permit, because dropping a `spawn_blocking` join handle detaches
+/// the thread rather than stopping it, and two such hangs would refuse every
+/// later cold request for the life of the process.
+async fn run_hosted_repository_hydration_within<T: Send + 'static>(
+    slots: Arc<tokio::sync::Semaphore>,
+    budget: Duration,
     repo_id: &str,
     hydrate: impl FnOnce() -> std::result::Result<T, RepoScopedMcpFailure> + Send + 'static,
 ) -> std::result::Result<T, RepoScopedMcpFailure> {
@@ -12787,21 +12831,48 @@ async fn run_hosted_repository_hydration<T: Send + 'static>(
         )
     })?;
     let error_repo_id = repo_id.to_string();
-    tokio::task::spawn_blocking(move || {
-        // Cancellation of the request cannot stop a running blocking worker.
-        // Admission belongs to that worker until hydration and retries finish.
-        let _permit = permit;
-        hydrate()
-    })
-    .await
-    .map_err(|error| {
-        RepoScopedMcpFailure::new(
+    let supervisor_repo_id = error_repo_id.clone();
+    let worker = tokio::task::spawn_blocking(hydrate);
+    let (answer_tx, answer_rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(async move {
+        let answer = match tokio::time::timeout(budget, worker).await {
+            Ok(Ok(hydrated)) => hydrated,
+            Ok(Err(error)) => Err(RepoScopedMcpFailure::new(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "repo_authority_unavailable",
+                format!("repository {supervisor_repo_id} authority worker failed: {error}"),
+                true,
+            )),
+            Err(_) => {
+                warn!(
+                    repo_id = %supervisor_repo_id,
+                    budget_secs = budget.as_secs(),
+                    "hosted repository hydration exceeded its admission budget; releasing the slot and abandoning the worker"
+                );
+                Err(RepoScopedMcpFailure::new(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "repo_hydration_timeout",
+                    format!(
+                        "repository {supervisor_repo_id} hydration exceeded its {}s admission budget; retry later",
+                        budget.as_secs()
+                    ),
+                    true,
+                ))
+            }
+        };
+        // Release admission before answering, so a caller that observes its own
+        // result also observes the slot that result vacated.
+        drop(permit);
+        let _ = answer_tx.send(answer);
+    });
+    answer_rx.await.unwrap_or_else(|_| {
+        Err(RepoScopedMcpFailure::new(
             StatusCode::SERVICE_UNAVAILABLE,
             "repo_authority_unavailable",
-            format!("repository {error_repo_id} authority worker failed: {error}"),
+            format!("repository {error_repo_id} hydration supervisor ended without an answer"),
             true,
-        )
-    })?
+        ))
+    })
 }
 
 async fn load_hosted_repository_mcp_view(
@@ -25758,6 +25829,65 @@ mod tests {
         assert_eq!(slots.available_permits(), 2);
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn hosted_hydration_overrunning_its_budget_releases_admission() {
+        let slots = Arc::new(tokio::sync::Semaphore::new(2));
+        let starts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let budget = Duration::from_millis(150);
+        let worker_starts = Arc::clone(&starts);
+        // The caller's own bound is what turns a stranded permit into a red
+        // assertion instead of a hang: without the admission budget this await
+        // never returns, because a blocking worker cannot be cancelled.
+        let refused = tokio::time::timeout(
+            Duration::from_secs(20),
+            run_hosted_repository_hydration_within(
+                Arc::clone(&slots),
+                budget,
+                "stalled",
+                move || {
+                    worker_starts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    // A hydration that does not return on its own, standing in
+                    // for a backend read that never completes.
+                    let _ = release_rx.blocking_recv();
+                    Ok::<(), RepoScopedMcpFailure>(())
+                },
+            ),
+        )
+        .await
+        .expect("a stalled hydration worker must not hold its caller past the admission budget")
+        .unwrap_err();
+
+        assert_eq!(starts.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert_eq!(refused.status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(refused.code, "repo_hydration_timeout");
+        assert!(refused.retryable);
+        // The stranded permit is the defect this guards. The worker is still
+        // running; the slot it was holding must already be admitting again.
+        assert_eq!(slots.available_permits(), 2);
+        run_hosted_repository_hydration_within(Arc::clone(&slots), budget, "successor", || Ok(()))
+            .await
+            .expect("a cold request must be admitted once the budget reclaims the slot");
+
+        // Let the abandoned worker finish so the runtime can shut down.
+        let _ = release_tx.send(());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn hosted_hydration_within_budget_answers_the_worker_not_the_deadline() {
+        let slots = Arc::new(tokio::sync::Semaphore::new(2));
+        let hydrated = run_hosted_repository_hydration_within(
+            Arc::clone(&slots),
+            Duration::from_secs(20),
+            "prompt",
+            || Ok(7_u32),
+        )
+        .await
+        .unwrap();
+        assert_eq!(hydrated, 7);
+        assert_eq!(slots.available_permits(), 2);
+    }
+
     #[tokio::test]
     async fn hosted_hydration_warm_cache_bypasses_busy_cold_admission() {
         let slots = hosted_repository_hydrations();
@@ -31053,6 +31183,30 @@ mod tests {
         assert_eq!(
             resolve_scope_build_timeout(Some("12")),
             Duration::from_secs(12)
+        );
+    }
+
+    #[test]
+    fn hosted_repository_hydration_timeout_defaults_and_rejects_invalid_values() {
+        assert_eq!(
+            resolve_hosted_repository_hydration_timeout(None),
+            Duration::from_secs(300)
+        );
+        assert_eq!(
+            resolve_hosted_repository_hydration_timeout(Some("")),
+            Duration::from_secs(300)
+        );
+        assert_eq!(
+            resolve_hosted_repository_hydration_timeout(Some("0")),
+            Duration::from_secs(300)
+        );
+        assert_eq!(
+            resolve_hosted_repository_hydration_timeout(Some("nonsense")),
+            Duration::from_secs(300)
+        );
+        assert_eq!(
+            resolve_hosted_repository_hydration_timeout(Some("45")),
+            Duration::from_secs(45)
         );
     }
 

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -3,7 +3,7 @@
 
 # Kin environment variables
 
-This is the authoritative list of supported `KIN_*` environment variables (527 total, 357 correctness-relevant), generated from the central registry in `kin-core`.
+This is the authoritative list of supported `KIN_*` environment variables (528 total, 357 correctness-relevant), generated from the central registry in `kin-core`.
 
 At CLI and daemon startup Kin validates this surface (`KIN_ENV_VALIDATION`, default `warn`):
 
@@ -120,6 +120,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_DAEMON_DISABLE_LSP` | bool | false | correctness | disable LSP enrichment in the daemon, reducing relation coverage |
 | `KIN_DAEMON_EMBED_BATCH_SIZE` | usize | *(unset)* | operational | embedding batch size for daemon-side embed passes |
 | `KIN_DAEMON_EXISTING_READY_TIMEOUT_SECS` | seconds>=0 | 3 | operational | readiness wait for an already-running daemon |
+| `KIN_DAEMON_HOSTED_HYDRATION_TIMEOUT_SECS` | seconds>=0 | 300 | operational | budget for one cold hosted-repository hydration before its admission slot is reclaimed |
 | `KIN_DAEMON_HTTP_TIMEOUT_SECS` | seconds>=0 | 300 | operational | per-request HTTP timeout for the CLI's daemon client; 0 or invalid falls back to 300, and long-running requests (large-repo review) need a higher value |
 | `KIN_DAEMON_IDLE_FLUSH_SECS` | seconds>=0 | 2 | operational | idle debounce before a full-graph persistence flush |
 | `KIN_DAEMON_IDLE_TIMEOUT_SECS` | seconds>=0 | 3600 | operational | auto-shutdown after this idle period; 0 disables idle shutdown |


### PR DESCRIPTION
## Summary

Bound cold hosted repository hydration to two workers per daemon process, in count and in time.
Admission uses an immediate try-acquire and returns retryable HTTP 503 `repo_hydration_busy` when
both slots are occupied. Warm cached views bypass cold admission. Metadata cursor probes keep their
existing behavior and are not covered by this limit.

A detached supervisor owns the permit, not the caller and not the blocking worker, and that
placement is the whole design. Cancelling the request drops only the caller's half, so an aborted
HTTP request still cannot hand a running worker's slot to a second one. A worker that overruns its
budget cannot strand the slot either: the supervisor releases the permit, answers a typed
`repo_hydration_timeout` 503 with `retryable: true`, and abandons the thread to finish on tokio's
much larger blocking pool with its result discarded.

Putting the timeout on the caller's await instead would answer the request and still leak the
permit, because dropping a `spawn_blocking` join handle detaches the thread rather than stopping it.
Two such hangs would then refuse every later cold request for the life of the process, with
`retryable: true` on a retry that could never succeed. That is the failure this bound exists to
prevent, so the budget lives where the permit lives.

The budget is 300 seconds and reads `KIN_DAEMON_HOSTED_HYDRATION_TIMEOUT_SECS`, following this
file's existing `resolve_scope_build_timeout` shape: parse, reject zero and garbage, fall back to the
default.

This is the runtime prerequisite for firelock-ai/kinlab#484. It does not deploy the runtime or claim
a production latency improvement.

## Known limit

There is no per-repository single flight. One repository's own burst of cold requests can take both
process-wide slots and refuse another repository's cold request. Deduplicating them is not a small
change: `HostedRepositoryMcpView` holds a `std::sync::Mutex<Instant>` and is not `Clone`, so the
shared result has to be the `Arc` built after hydration returns, which would pull the stale-views
recheck, the competing-cursor race, the graph-root divergence check and the LRU eviction inside the
single flight and add a keyed in-flight map to `DaemonState`. Deferred deliberately rather than left
silent. With the budget above, a refusal caused by a stuck worker now clears within the budget
instead of lasting the life of the process.

## Verification

Every command below ran through `.kin-coord/bin/heavy-slot.sh kintail kin -- ...` against the exact
committed head this PR pushes, `d5edfc6fd00c811275ab6923dba0b961d88901f5`, with an empty
`git status --porcelain`. The first pass of this evidence ran before the rebase and before the
env-registry commit, so it was re-run in full rather than shipped with tails from a tree that is not
the one landing.

Focused tests:

```
$ cargo test --locked -p kin-daemon --lib hydration -- --nocapture
running 15 tests
test api::tests::hosted_repository_hydration_timeout_defaults_and_rejects_invalid_values ... ok
test api::tests::hosted_hydration_cancelled_requests_retain_worker_admission ... ok
test api::tests::hosted_hydration_within_budget_answers_the_worker_not_the_deadline ... ok
test api::tests::hosted_hydration_errors_panics_and_retries_release_admission ... ok
test api::tests::hosted_hydration_overrunning_its_budget_releases_admission ... ok
test api::tests::hosted_hydration_warm_cache_bypasses_busy_cold_admission ... ok
test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 1552 filtered out; finished in 8.44s
```

Falsification 1, remove the time bound. The supervisor awaits the worker with no deadline:

```
-        let answer = match tokio::time::timeout(budget, worker).await {
+        let answer = match Ok::<_, tokio::time::error::Elapsed>(worker.await) {
```

```
running 1 test
thread 'api::tests::hosted_hydration_overrunning_its_budget_releases_admission' panicked at crates/kin-daemon/src/api.rs:25858:10:
a stalled hydration worker must not hold its caller past the admission budget: Elapsed(())
test api::tests::hosted_hydration_overrunning_its_budget_releases_admission ... FAILED
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1566 filtered out; finished in 20.03s
```

Falsification 2, keep the time bound but strand the permit. The permit goes back inside the blocking
closure, which is where this PR originally put it, and the supervisor's explicit release is removed.
The timeout still fires and still answers a typed refusal, so this isolates the permit-release half:

```
-    let worker = tokio::task::spawn_blocking(hydrate);
+    let worker = tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        hydrate()
+    });
...
-        drop(permit);
```

```
running 1 test
thread 'api::tests::hosted_hydration_overrunning_its_budget_releases_admission' panicked at crates/kin-daemon/src/api.rs:25867:9:
assertion `left == right` failed
  left: 1
 right: 2
test api::tests::hosted_hydration_overrunning_its_budget_releases_admission ... FAILED
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1566 filtered out; finished in 0.18s
```

`api.rs:25867` is `assert_eq!(slots.available_permits(), 2);`. One permit is still held by the
abandoned worker, which is the state this fix exists to prevent.

Both mutations were restored between runs, and the restore was verified byte for byte rather than
assumed: `diff` against the pre-mutant copy of `api.rs` printed nothing, and `git status --porcelain`
was empty afterwards.

Full daemon library, on the same tree:

```
$ cargo test --locked -p kin-daemon --lib
test loop_runner::tests::a_file_rewritten_in_a_tight_loop_still_reaches_graph_truth ... FAILED
test loop_runner::tests::reconcile_empty_delta_real_edit_control ... FAILED
test loop_runner::tests::reconcile_empty_delta_does_not_dirty_a_settled_graph ... FAILED
test loop_runner::tests::reconcile_empty_delta_preserves_pending_dirty_work ... FAILED
test loop_runner::tests::reconcile_empty_delta_still_repairs_a_missing_or_stale_layout ... FAILED
test result: FAILED. 1558 passed; 5 failed; 4 ignored; 0 measured; 0 filtered out; finished in 434.14s
```

Reported, not waived, and none of the five is a hydration test. All five are real-filesystem-watcher
tests in `loop_runner.rs` racing a wall-clock deadline, and this lane measured them flipping on load
alone. Detail in the review note at the end.

Env registry guard, the one hosted CI caught (see below):

```
$ cargo test --locked -p kin-core --lib env_registry
test result: ok. 34 passed; 0 failed; 0 ignored; 0 measured; 845 filtered out; finished in 0.11s
```

Local gate run, against this PR's exact pushed head:

```
$ bin/kin-precheck kin --repo-dir kin=<lane worktree>
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
...
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:verify-hydration-semantics.py  python3 scripts/verify-hydration-semantics.py
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
PASS     node-test                            node --test <15 file(s) named by the check job>
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin d5edfc6fd00c811275ab6923dba0b961d88901f5
=== precheck exit rc=0 ===
```

The tally line names the sha this PR pushed, so the gates graded this tree and not a primary
checkout, and 21 enumerated equals 21 ran, so no gate silently failed to start.

## Landing

The author lane is dead: its last report write was 07:03Z, every registered working pid is gone by
an explicit per-pid check, and the only surviving process under its name is an `agent-sock` presence
listener. Lane `kintail` picked this PR up, re-verified it on its own head, and lands it under the
ledger name that owns the branch, because `merge land` resolves the lane's branch from the live
checkout and requires the PR's head ref to match it. Tracked as FIR-3401.

## A class local gates cannot see, for the next lane

Hosted CI red-flagged this PR's first push on `kin-core
env_registry::tests::every_kin_env_read_in_workspace_is_registered`: the new
`KIN_DAEMON_HOSTED_HYDRATION_TIMEOUT_SECS` read was not in the workspace env registry. That guard
lives in `kin-core` and scans the whole workspace, so a `cargo test -p kin-daemon` run cannot see it,
and `bin/kin-precheck` does not run it either, because it is a `Fast gate build and tests` shard and
not one of the 21 lint and policy gates. It is fixed here, registered beside its sibling
`KIN_DAEMON_SCOPE_BUILD_TIMEOUT_SECS` with the same `Kind::Secs`, with the generated
`docs/env-vars.md` regenerated through the registry's own
`KIN_REGEN_ENV_DOC=1 cargo test -p kin-core env_doc_matches_registry` path rather than edited by
hand.

The rule that follows: after adding any `KIN_*` env read, run `cargo test -p kin-core env_registry`
locally. A crate-scoped run will not tell you.

## What is not claimed

The previous body's development-profile parity bullet is gone rather than restated. This lane did
not run parity on this head, so there is no output tail to attach to that claim, and the umbrella's
rule is that a claim hosted CI does not itself check belongs in the body as its command and output
or not at all. Acceptance grades main's push run after landing, which is this repo's chosen shape.

## Notes for review

The `loop_runner` watcher failures are not this PR's, and this lane measured what actually
moves them.

They are not in this diff. `crates/kin-daemon/src/loop_runner.rs` resolves to the same blob
(`88b9c1ff0c34aab4aa7f8c2f1e0c5852130fa773`) at this PR's base and at `origin/main`, while 17 other
files differ between those commits, so the empty diff is a real absence and not a broken check.

They are load-sensitive rather than deterministic, measured on this branch twice:

- 11:50Z, box load average about 12: `1563 passed; 0 failed`.
- 12:01Z, box load average 15 to 23: `1558 passed; 5 failed`, the five named above.

Those two runs are the same code for these tests. The commits between them add one env-registry row
and one generated documentation row and touch nothing `loop_runner.rs` or `kin-index` can see. What
changed was the load on the box.

Hosted CI is the gate of record here and it disagrees with the loud local run, for a structural
reason rather than by luck: CI runs nextest, one process per test, while `cargo test` runs all 1567
in one process. All three `Fast gate test shard` jobs are `success` at this head, read by name.

The class belongs to firelock-ai/kin#1596, which rewrites the shared helper
`check_reconcile_dirty_work` that four of the five run through. One further data point for that PR,
since this branch does **not** carry its watcher-root change: the fifth failure,
`a_file_rewritten_in_a_tight_loop_still_reaches_graph_truth`, is the test #1596 is being held over,
and it failed here **without** that change present.

Kin-Release-Intent: patch
