### PR TITLE
Stream complete history admission and bound ordinary commit memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3295,9 +3295,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.104"
+version = "0.7.107"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "cddb9f8689824e1884b1cbc234e105865571a1a266ec2c702983f6f61412e818"
+checksum = "ea7a90f134f9c07260181b22f50ec86a24c7579c20636075c56ef9c992c255a3"
 dependencies = [
  "bincode",
  "bstr",
@@ -3515,9 +3515,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.26"
+version = "0.7.27"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "0f0295dfced192fee9cd6b636109f919254f08b0148def52e95f8eb815863931"
+checksum = "e2891f63e0a229fc4ad2fa3ac22f393a17cfdf3285412adced1693654a283128"
 dependencies = [
  "chrono",
  "gix-hash",
@@ -6683,7 +6683,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ pretty_assertions = "1"
 serial_test = "4"
 
 # Internal crates
-kin-model = { version = "=0.7.26", registry = "kin" }
+kin-model = { version = "=0.7.27", registry = "kin" }
 kin-blobs = { version = "=0.1.5", registry = "kin" }
 kin-core = { path = "crates/kin-core" }
 kin-parser = { path = "crates/kin-parser" }
@@ -158,7 +158,7 @@ kin-lsp = { version = "=0.7.16", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.104", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.107", registry = "kin", default-features = false }
 # Pinned to the exact version kin-db builds its name-token index with. A
 # per-token name query hits that index only when the token came out of the same
 # tokenizer, so a version skew here would be a silent recall loss rather than a

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -6297,7 +6297,7 @@ mod tests {
                 found.detail
             );
             assert!(
-                found.detail.contains(" KB of staging"),
+                found.detail.contains(" KiB of staging"),
                 "run {where_from}, the row must name the size in bytes it measured: {}",
                 found.detail
             );

--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -498,7 +498,7 @@ fn init_from_git_with_hooks(
     let workspace_base_change_id = admitted.workspace_base_change_id();
 
     progress.begin("build bootstrap transaction");
-    let transaction = {
+    let (transaction, changes) = {
         let _span = info_span!(
             "kin.init.build_bootstrap_transaction",
             observed_trees = sealed_observation.observed_trees,
@@ -514,8 +514,8 @@ fn init_from_git_with_hooks(
         let _beat = progress.heartbeat(format!(
             "{admitted_tracked_artifacts} files, {admitted_changes} changes"
         ));
-        let mut transaction = admitted
-            .into_generation_zero_repository_transaction(
+        let (mut transaction, captured_changes) = admitted
+            .into_generation_zero_repository_transaction_streaming(
                 &capture_store,
                 OperationId::new(),
                 prepared.initial_roots().clone(),
@@ -523,8 +523,17 @@ fn init_from_git_with_hooks(
                 "admit exact Git repository authority",
             )
             .map_err(|error| git_boundary_error("construct Git bootstrap transaction", error))?;
+        let mut changes = kin_db::storage::ChangeMap::new();
+        for change in captured_changes.iter() {
+            changes
+                .append_change(
+                    change.map_err(|error| git_boundary_error("read captured change", error))?,
+                )
+                .map_err(|error| KinError::Graph(error.to_string()))?;
+        }
         bind_workspace_authority(
             &mut transaction,
+            Some(&changes),
             prepared.workspace_id(),
             workspace_seed,
             workspace_policy,
@@ -532,15 +541,13 @@ fn init_from_git_with_hooks(
         )?;
         transaction.git_authority_delta =
             Some(GitExternalAuthorityDelta::initialize(git_authority));
-        transaction
+        (transaction, changes)
     };
 
     progress.begin("validate bootstrap transaction");
     {
         let _span = info_span!("kin.init.validate_bootstrap_transaction").entered();
-        transaction.validate().map_err(|error| {
-            KinError::Other(format!("invalid Git bootstrap transaction: {error}"))
-        })?;
+        crate::init::bootstrap_transaction_hash(&transaction, Some(&changes))?;
     }
 
     progress.begin("commit bootstrap transaction");
@@ -554,10 +561,10 @@ fn init_from_git_with_hooks(
         // that keeps moving is this one.
         let _beat = progress.heartbeat(format!(
             "{admitted_tracked_artifacts} files, {} changes, {} objects",
-            transaction.changes.len(),
+            changes.len(),
             transaction.external_objects.len()
         ));
-        prepared.commit_repository_bootstrap(transaction)?;
+        prepared.commit_git_bootstrap_with_changes(transaction, changes)?;
     }
 
     let mut result = publish_repository_layout_linearized(prepared, |publication| {
@@ -1015,6 +1022,7 @@ fn seal_observed_content(
 
 fn bind_workspace_authority(
     transaction: &mut RepositoryTransaction,
+    changes: Option<&kin_db::storage::ChangeMap>,
     workspace_id: kin_model::WorkspaceId,
     workspace_seed: kin_git::GitWorkspaceSeed,
     workspace_policy: kin_model::SharedAdmissionPolicy,
@@ -1062,7 +1070,7 @@ fn bind_workspace_authority(
         // invisible inside it: the phase read as one opaque number while a
         // whole second history sat underneath.
         let _span = info_span!("kin.init.derive_workspace_semantics").entered();
-        imported_workspace_semantic_delta(transaction, &workspace_seed)?
+        imported_workspace_semantic_delta(transaction, changes, &workspace_seed)?
     };
     transaction.workspace_mutation = Some(WorkspaceMutation {
         workspace_id,
@@ -1155,6 +1163,7 @@ impl ChangeStore for BootstrapHistoryView<'_> {
 
 fn imported_workspace_semantic_delta(
     transaction: &RepositoryTransaction,
+    changes: Option<&kin_db::storage::ChangeMap>,
     workspace_seed: &kin_git::GitWorkspaceSeed,
 ) -> Result<WorkspaceSemanticDelta> {
     let Some(base_target) = &workspace_seed.base_target else {
@@ -1181,15 +1190,28 @@ fn imported_workspace_semantic_delta(
         }
     };
 
-    let history = BootstrapHistoryView::new(&transaction.changes);
-    let target = history.resolve_graph_at(&change_id).map_err(|error| {
-        KinError::Other(format!("resolve imported workspace semantics: {error}"))
-    })?;
+    let (entities, relations) = match changes {
+        Some(changes) => {
+            let target =
+                kin_db::storage::resolve_current_graph(changes, &change_id).map_err(|error| {
+                    KinError::Graph(format!("resolve imported workspace semantics: {error}"))
+                })?;
+            (target.entities, target.relations)
+        }
+        None => {
+            let target = BootstrapHistoryView::new(&transaction.changes)
+                .resolve_graph_at(&change_id)
+                .map_err(|error| {
+                    KinError::Other(format!("resolve imported workspace semantics: {error}"))
+                })?;
+            (target.entities, target.relations)
+        }
+    };
     crate::diff_workspace_semantics(
         &Default::default(),
         &Default::default(),
-        &target.entities,
-        &target.relations,
+        &entities,
+        &relations,
     )
     .map_err(|error| KinError::Other(format!("derive imported workspace semantics: {error}")))
 }
@@ -1260,7 +1282,7 @@ fn bind_historical_semantics(
     plan: kin_git::SemanticGitImportPlan,
     capture_store: &BlobStore,
 ) -> Result<kin_git::SemanticGitImportPlan> {
-    let mut fold = kin_index::HistoricalSemanticFold::new(&plan.changes)
+    let mut fold = kin_index::HistoricalSemanticFold::from_change_stream(plan.changes.iter())
         .map_err(|error| git_boundary_error("derive historical semantics", error))?;
     // Handed over rather than copied. The fold has no further use for what it
     // derived, and the plan is where those deltas are going.
@@ -2788,6 +2810,42 @@ mod tests {
             }
         }
         false
+    }
+
+    #[test]
+    fn enrichment_summary_reads_spooled_history_without_materializing_it() {
+        let directory = tempfile::tempdir().unwrap();
+        let source = directory.path().join("source");
+        std::fs::create_dir(&source).unwrap();
+        initialize_git(&source);
+        for value in [1, 2] {
+            std::fs::write(
+                source.join("lib.rs"),
+                format!("pub fn value() -> u32 {{ {value} }}\n"),
+            )
+            .unwrap();
+            git(&source, ["add", "lib.rs"]);
+            git(&source, ["commit", "-m", "update value"]);
+        }
+        let initialized = init_from_git(&source).unwrap();
+        let binding =
+            crate::LocalRepositoryAuthorityBinding::from_layout(&initialized.layout).unwrap();
+        let manager = binding.open_manager().unwrap();
+        let authority = manager.read_authority();
+        assert_eq!(authority.snapshot().changes.len(), 2);
+        assert!(!authority.snapshot().changes.is_decoded());
+        let summary =
+            crate::durable_semantic_enrichment_summary(&authority, &binding.workspace_id())
+                .unwrap();
+        assert!(summary.entity_count > 0);
+        assert_eq!(summary.semantic_change_count, 2);
+        assert!(!authority.snapshot().changes.is_decoded());
+        authority.snapshot().changes.decoded().unwrap();
+        assert_eq!(
+            summary,
+            crate::durable_semantic_enrichment_summary(&authority, &binding.workspace_id())
+                .unwrap()
+        );
     }
 
     fn initialize_git(source: &Path) {

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -5086,7 +5086,7 @@ mod tests {
 
         let (detail, fix) =
             stranded_stage_doctor_row(&survey).expect("a stranded stage is a finding");
-        assert!(detail.contains("1.5 GB"), "{detail}");
+        assert!(detail.contains("1.5 GiB"), "{detail}");
         assert!(
             detail.contains("/scratchpad/.kin.init-62f59472-4ba7-41ec-bb31-b55ad3feec9e"),
             "{detail}"
@@ -5139,10 +5139,10 @@ mod tests {
             detail.contains("its filesystem identity is not provable"),
             "{detail}"
         );
-        assert!(detail.contains("4.0 KB"), "{detail}");
+        assert!(detail.contains("4.0 KiB"), "{detail}");
         // The reclaimable one is still the headline, and the declined one is
         // not counted into the number that comes back.
-        assert!(detail.contains("1.5 GB of staging"), "{detail}");
+        assert!(detail.contains("1.5 GiB of staging"), "{detail}");
         assert_eq!(survey.reclaimable_bytes(), 1_610_612_736);
     }
 

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -336,10 +336,29 @@ impl PreparedRepositoryInit {
         self.commit_bootstrap(transaction, None)
     }
 
+    /// Admit a complete captured Git history as one bootstrap operation while
+    /// keeping immutable change bodies in their disk-backed store.
+    pub fn commit_git_bootstrap_with_changes(
+        &mut self,
+        transaction: RepositoryTransaction,
+        changes: kin_db::storage::ChangeMap,
+    ) -> Result<&RepositoryBootstrap> {
+        self.commit_bootstrap_with_changes(transaction, None, Some(changes))
+    }
+
     fn commit_bootstrap(
         &mut self,
         transaction: RepositoryTransaction,
         receiver_case: Option<AdmissionCase>,
+    ) -> Result<&RepositoryBootstrap> {
+        self.commit_bootstrap_with_changes(transaction, receiver_case, None)
+    }
+
+    fn commit_bootstrap_with_changes(
+        &mut self,
+        transaction: RepositoryTransaction,
+        receiver_case: Option<AdmissionCase>,
+        changes: Option<kin_db::storage::ChangeMap>,
     ) -> Result<&RepositoryBootstrap> {
         verify_metadata_seal(&self.layout, &self.metadata_seal)?;
         let operation_id = transaction.operation_id;
@@ -360,9 +379,7 @@ impl PreparedRepositoryInit {
                 // The first-commit arm below never used the value and paid for it
                 // on every init, and it also validated twice, once here and once
                 // in `validate_bootstrap_transaction`.
-                let transaction_hash = transaction
-                    .transaction_hash()
-                    .map_err(|error| KinError::Other(error.to_string()))?;
+                let transaction_hash = bootstrap_transaction_hash(&transaction, changes.as_ref())?;
                 if bootstrap.receipt.transaction_hash != transaction_hash
                     || bootstrap.receipt.operation_id != operation_id
                 {
@@ -377,17 +394,19 @@ impl PreparedRepositoryInit {
                 {
                     crate::report_admission_progress("validating transaction");
                     let _span = info_span!("kin.init.commit.validate_bootstrap").entered();
-                    validate_bootstrap_transaction(
+                    validate_bootstrap_transaction_with_changes(
                         &transaction,
+                        changes.as_ref(),
                         repository_id,
                         workspace_id,
                         default_ref,
                         initial_roots,
                     )?;
                 }
-                let bootstrap = commit_bootstrap_transaction(
+                let bootstrap = commit_bootstrap_transaction_with_changes(
                     authority,
                     transaction,
+                    changes,
                     repository_id,
                     workspace_id,
                     receiver_case,
@@ -1611,6 +1630,27 @@ fn commit_bootstrap_transaction<B>(
 where
     B: StorageBackend + 'static,
 {
+    commit_bootstrap_transaction_with_changes(
+        authority,
+        transaction,
+        None,
+        repository_id,
+        workspace_id,
+        receiver_case,
+    )
+}
+
+fn commit_bootstrap_transaction_with_changes<B>(
+    authority: &RepositoryAuthorityManager<B>,
+    transaction: RepositoryTransaction,
+    changes: Option<kin_db::storage::ChangeMap>,
+    repository_id: &RepositoryId,
+    workspace_id: WorkspaceId,
+    receiver_case: Option<AdmissionCase>,
+) -> Result<RepositoryBootstrap>
+where
+    B: StorageBackend + 'static,
+{
     // A bootstrap transaction carries every reachable external object and every
     // change in history, so on a repository with real history a copy taken to
     // satisfy the owned-parameter commit is a second whole-history allocation,
@@ -1630,22 +1670,33 @@ where
     // callback, so between entering this phase and leaving it the line would
     // otherwise sit unchanged for minutes, which reads as a hang. What kin-db
     // reports from inside its own replay arrives through the same sink.
+    let change_count = changes
+        .as_ref()
+        .map_or(transaction.changes.len(), |changes| changes.len());
     let receipt = {
         crate::report_admission_progress(&format!(
             "committing {} changes to authority",
-            transaction.changes.len()
+            change_count
         ));
         let _span = info_span!(
             "kin.init.commit.authority_commit",
             external_objects = transaction.external_objects.len(),
-            changes = transaction.changes.len()
+            changes = change_count
         )
         .entered();
-        match receiver_case {
-            Some(case) => {
+        match (receiver_case, changes) {
+            (Some(_), Some(_)) => {
+                return Err(KinError::Other(
+                    "streamed Git bootstrap cannot use transfer admission".into(),
+                ))
+            }
+            (None, Some(changes)) => {
+                authority.commit_git_bootstrap_with_changes(transaction, changes)
+            }
+            (Some(case), None) => {
                 authority.commit_transferred_repository_transaction(transaction, Some(case))
             }
-            None => authority.commit_repository_transaction(transaction),
+            (None, None) => authority.commit_repository_transaction(transaction),
         }
         .map_err(graph_error)?
     };
@@ -1696,9 +1747,49 @@ fn validate_bootstrap_transaction(
     default_ref: &RefName,
     initial_roots: &RootBundle,
 ) -> Result<()> {
-    transaction
-        .validate()
-        .map_err(|error| KinError::Other(error.to_string()))?;
+    validate_bootstrap_transaction_with_changes(
+        transaction,
+        None,
+        repository_id,
+        workspace_id,
+        default_ref,
+        initial_roots,
+    )
+}
+
+pub(crate) fn bootstrap_transaction_hash(
+    transaction: &RepositoryTransaction,
+    changes: Option<&kin_db::storage::ChangeMap>,
+) -> Result<kin_model::Hash256> {
+    match changes {
+        None => transaction.transaction_hash(),
+        Some(changes) => transaction.transaction_hash_with_changes(changes.len(), || {
+            Ok(changes.change_ids().into_iter().map(|id| {
+                changes
+                    .read_change(&id)
+                    .map_err(|error| kin_model::ModelError::InvalidOperation(error.to_string()))?
+                    .ok_or_else(|| kin_model::ModelError::ChangeNotFound(id.to_string()))
+            }))
+        }),
+    }
+    .map_err(|error| KinError::Other(error.to_string()))
+}
+
+fn validate_bootstrap_transaction_with_changes(
+    transaction: &RepositoryTransaction,
+    changes: Option<&kin_db::storage::ChangeMap>,
+    repository_id: &RepositoryId,
+    workspace_id: WorkspaceId,
+    default_ref: &RefName,
+    initial_roots: &RootBundle,
+) -> Result<()> {
+    if changes.is_some() {
+        bootstrap_transaction_hash(transaction, changes)?;
+    } else {
+        transaction
+            .validate()
+            .map_err(|error| KinError::Other(error.to_string()))?;
+    }
     if initial_roots.generation != 0
         || transaction.expected_generation != 0
         || &transaction.expected_roots != initial_roots

--- a/crates/kin-core/src/init_attempt.rs
+++ b/crates/kin-core/src/init_attempt.rs
@@ -498,9 +498,9 @@ pub(crate) fn occupied_bytes(metadata: &std::fs::Metadata) -> u64 {
 /// Render a byte count the way a person reads one.
 pub fn human_bytes(bytes: u64) -> String {
     const UNITS: [(&str, u64); 4] = [
-        ("GB", 1024 * 1024 * 1024),
-        ("MB", 1024 * 1024),
-        ("KB", 1024),
+        ("GiB", 1024 * 1024 * 1024),
+        ("MiB", 1024 * 1024),
+        ("KiB", 1024),
         ("bytes", 1),
     ];
     for (unit, scale) in UNITS {
@@ -1058,7 +1058,7 @@ mod tests {
             "elapsed to the last phase must be reported: {rendered}"
         );
         assert!(
-            rendered.contains("under a 12.0 GB memory ceiling, read from the container"),
+            rendered.contains("under a 12.0 GiB memory ceiling, read from the container"),
             "the measured ceiling must be named: {rendered}"
         );
         assert!(
@@ -1066,7 +1066,7 @@ mod tests {
             "a kill the kernel recorded must be named: {rendered}"
         );
         assert!(
-            rendered.contains("420.0 MB of staging"),
+            rendered.contains("420.0 MiB of staging"),
             "the reclaimable total must be named: {rendered}"
         );
         assert!(
@@ -1193,7 +1193,7 @@ mod tests {
         );
         assert!(
             ceiling_advice(&record(), Some(&reading(Some(1))))
-                .is_some_and(|line| line.contains("12.0 GB")),
+                .is_some_and(|line| line.contains("12.0 GiB")),
             "advice quotes the measured ceiling"
         );
         assert!(
@@ -1506,7 +1506,7 @@ mod tests {
         );
 
         let all_gone = reclaim_lines(std::slice::from_ref(&freed)).join("\n");
-        assert!(all_gone.contains("reclaimed 1.0 KB"), "{all_gone}");
+        assert!(all_gone.contains("reclaimed 1.0 KiB"), "{all_gone}");
         assert!(
             !all_gone.contains("still on disk"),
             "a clean reclaim must not claim something was left: {all_gone}"
@@ -1518,14 +1518,14 @@ mod tests {
             "nothing was freed, so nothing may be reported as reclaimed: {none_gone}"
         );
         assert!(
-            none_gone.contains("2.0 KB is still on disk")
+            none_gone.contains("2.0 KiB is still on disk")
                 && none_gone.contains(&held_path.display().to_string()),
             "what stayed must be named with its size: {none_gone}"
         );
 
         let mixed = reclaim_lines(&[freed, held]).join("\n");
         assert!(
-            mixed.contains("reclaimed 1.0 KB") && mixed.contains("2.0 KB is still on disk"),
+            mixed.contains("reclaimed 1.0 KiB") && mixed.contains("2.0 KiB is still on disk"),
             "a partial reclaim must report both halves: {mixed}"
         );
 
@@ -1550,7 +1550,7 @@ mod tests {
             detail.contains("phase 13 of 17, commit bootstrap transaction"),
             "{detail}"
         );
-        assert!(detail.contains("420.0 MB"), "{detail}");
+        assert!(detail.contains("420.0 MiB"), "{detail}");
         assert!(fix.contains("kin init"), "{fix}");
         assert!(fix.contains("/work/.kin.init-22ef96e2.owner"), "{fix}");
 
@@ -1595,9 +1595,13 @@ mod tests {
     fn byte_and_second_rendering_reads_the_way_a_person_says_it() {
         assert_eq!(human_bytes(0), "0 bytes");
         assert_eq!(human_bytes(512), "512 bytes");
-        assert_eq!(human_bytes(2048), "2.0 KB");
-        assert_eq!(human_bytes(210 * 1024 * 1024), "210.0 MB");
-        assert_eq!(human_bytes(12 * 1024 * 1024 * 1024), "12.0 GB");
+        assert_eq!(human_bytes(1023), "1023 bytes");
+        assert_eq!(human_bytes(1024), "1.0 KiB");
+        assert_eq!(human_bytes(2048), "2.0 KiB");
+        assert_eq!(human_bytes(1024 * 1024), "1.0 MiB");
+        assert_eq!(human_bytes(1024 * 1024 * 1024), "1.0 GiB");
+        assert_eq!(human_bytes(210 * 1024 * 1024), "210.0 MiB");
+        assert_eq!(human_bytes(12 * 1024 * 1024 * 1024), "12.0 GiB");
         assert_eq!(human_seconds(0), "0 s");
         assert_eq!(human_seconds(89), "89 s");
         assert_eq!(human_seconds(90), "1 min 30 s");

--- a/crates/kin-core/src/init_budget.rs
+++ b/crates/kin-core/src/init_budget.rs
@@ -87,9 +87,10 @@ const BYTES_PER_COMMIT: u64 = 700_000;
 /// those diffs produced, so the peak tracks this volume more closely than it
 /// tracks the commit count. Measured on the frontier walk across four
 /// repositories, resident bytes held at the whole-run peak per reachable blob
-/// byte: hiredis 55.5 (27,715,552 bytes of history, 1,538,834,432 held),
-/// requests 49.5 (112,476,293 against 5,568,004,096), kin 19.6 (1,400,991,245
-/// against 27,428,945,920), react 18.1 (2,187,539,173 against 39,584,645,120).
+/// byte reachable from HEAD: hiredis 57.91 (26,570,319 bytes of history,
+/// 1,538,834,432 held), requests 49.51 (112,474,615 against 5,568,004,096),
+/// kin 19.81 (1,384,861,259 against 27,428,945,920), react 18.0955
+/// (2,187,539,173 against 39,584,645,120).
 /// Eighteen is the floor of that spread, so a hiredis-shaped history can hold
 /// three times this forecast and react holds it almost exactly; the spread is
 /// what makes this a floor and not a prediction.
@@ -1228,9 +1229,9 @@ mod tests {
     /// completion in 1 h 47 min on a 128 GB host and was not killed, so its
     /// peak is a held figure like the other three.
     const MEASURED_HISTORIES: [(&str, u64, u64, u64, u64); 4] = [
-        ("hiredis", 1_141, 79, 27_715_552, 1_538_834_432),
-        ("requests", 6_493, 130, 112_476_293, 5_568_004_096),
-        ("kin", 2_924, 1_033, 1_400_991_245, 27_428_945_920),
+        ("hiredis", 1_141, 79, 26_570_319, 1_538_834_432),
+        ("requests", 6_493, 130, 112_474_615, 5_568_004_096),
+        ("kin", 2_924, 1_033, 1_384_861_259, 27_428_945_920),
         ("react", 21_679, 7_213, 2_187_539_173, 39_584_645_120),
     ];
 
@@ -1762,21 +1763,21 @@ mod tests {
                 "requests frontier walk",
                 6_493,
                 130,
-                112_476_293,
+                112_474_615,
                 5_568_004_096,
             ),
             (
                 "hiredis frontier walk",
                 1_141,
                 79,
-                27_715_552,
+                26_570_319,
                 1_538_834_432,
             ),
             (
                 "kin frontier walk",
                 2_924,
                 1_033,
-                1_400_991_245,
+                1_384_861_259,
                 27_428_945_920,
             ),
             // A normal clone of facebook/react at its September 2026 pin: the

--- a/crates/kin-core/src/init_budget.rs
+++ b/crates/kin-core/src/init_budget.rs
@@ -443,7 +443,7 @@ impl BudgetVerdict {
                     .to_string(),
                 format!(
                     "  set it to a byte count, for example {INIT_MEMORY_CEILING_ENV}=17179869184 \
-                     for 16 GB, or unset it to let Kin measure this machine"
+                     for 16 GiB, or unset it to let Kin measure this machine"
                 ),
             ];
         }
@@ -1259,7 +1259,7 @@ mod tests {
                 "kin must be refused on {gb} GB, got {verdict:?}"
             );
             let text = verdict.refusal_lines().join("\n");
-            assert!(text.contains("1.3 GB of history"), "text was:\n{text}");
+            assert!(text.contains("1.3 GiB of history"), "text was:\n{text}");
             assert!(
                 text.contains("the bytes of history decide it"),
                 "the refusal has to name the term that decided it: {text}"
@@ -1642,7 +1642,7 @@ mod tests {
             text.contains("the commit count decides it"),
             "the refusal has to name the term that decided it: {text}"
         );
-        assert!(text.contains("8.0 GB"), "text was:\n{text}");
+        assert!(text.contains("8.0 GiB"), "text was:\n{text}");
         assert!(
             text.contains("entity and relation deltas"),
             "the refusal has to name what a conversion holds per commit: {text}"

--- a/crates/kin-core/src/repository_authority.rs
+++ b/crates/kin-core/src/repository_authority.rs
@@ -231,16 +231,27 @@ fn replay_first_parent_semantic_ids(
                 "cycle in durable first-parent history at change {change_id}"
             )));
         }
-        let change = changes.get(&change_id).ok_or_else(|| {
-            KinError::Graph(format!(
-                "durable first-parent history is missing change {change_id}"
-            ))
-        })?;
-        current = change.parents.first().copied();
-        reverse_lineage.push(change);
+        let parents = changes
+            .change_parents(&change_id)
+            .map_err(|error| KinError::Graph(error.to_string()))?
+            .ok_or_else(|| {
+                KinError::Graph(format!(
+                    "durable first-parent history is missing change {change_id}"
+                ))
+            })?;
+        current = parents.first().copied();
+        reverse_lineage.push(change_id);
     }
 
-    for change in reverse_lineage.into_iter().rev() {
+    for change_id in reverse_lineage.into_iter().rev() {
+        let change = changes
+            .read_change(&change_id)
+            .map_err(|error| KinError::Graph(error.to_string()))?
+            .ok_or_else(|| {
+                KinError::Graph(format!(
+                    "durable first-parent history is missing change {change_id}"
+                ))
+            })?;
         let context = format!("semantic change {}", change.id);
         apply_entity_deltas(entity_ids, &change.entity_deltas, &context)?;
         apply_relation_deltas(relation_ids, &change.relation_deltas, &context)?;

--- a/crates/kin-core/tests/init_deep_history_heap_ceiling.rs
+++ b/crates/kin-core/tests/init_deep_history_heap_ceiling.rs
@@ -1,43 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-//! Peak-heap ceiling for admitting DEEP Git history.
+//! Peak-heap ceiling for admitting deep Git history.
 //!
-//! `init_peak_heap_ceiling` guards a 32-commit fixture, which is deep enough to
-//! catch a new whole-history structure but not deep enough to price one. The
-//! structures that decide whether a real repository converts at all scale with
-//! commits multiplied by tree size, so at 32 commits they are a rounding error
-//! against init's fixed cost and a change that doubles them barely moves the
-//! number.
+//! This fixture rewrites every module across 256 commits so retaining decoded
+//! history has a measurable cost. Admission must spool and stream change bodies;
+//! opening the resulting authority must preserve the complete history without
+//! decoding it. Explicit materialization after admission supplies a positive
+//! control for phase residency and bootstrap peak growth.
 //!
-//! This fixture buys the depth that prices them. A full-history psf/requests
-//! conversion measured 11.72 GiB of resident set inside a 12 GiB container,
-//! hitting the cgroup limit 871 times, because a conversion proved its import
-//! plan by rebuilding the whole plan and comparing the two, six times over,
-//! holding as many as four whole histories at once. That class is invisible to
-//! every functional test in this workspace: a re-derivation that materializes a
-//! second copy of history produces exactly the same verdict as one that streams
-//! it, and fails no assertion until the machine runs out of memory.
+//! Admission's peak and phase measurements are captured before the control.
+//! The proof-growth ceiling guards transient proof allocations, while the total
+//! heap ceiling is a coarse backstop. Live heap counts outstanding allocations,
+//! unlike resident set, which also counts freed pages retained by the allocator.
 //!
-//! Read `PROOF_PEAK_GROWTH_CEILING` as the guard and `PEAK_HEAP_CEILING` as a
-//! backstop, and do not reverse them. The total is set by the bootstrap
-//! transaction, built and then committed after every proof has run, so it does
-//! NOT move when a proof stops copying history: the base commit and the fix
-//! both measure 995.3 MiB here. Measuring that, rather than assuming it, is
-//! what stopped this file from shipping a ceiling that could not fail.
-//!
-//! What the guard asserts is therefore one phase, not one number: proof 1
-//! revalidates the whole import plan and keeps nothing, so whatever it adds to
-//! the peak is a second copy of history built to check the first. It added
-//! 88,146,432 bytes before the re-derivation was made to stream and 0 after.
-//!
-//! Live heap, not resident set, for the reason spelled out in
-//! `init_peak_heap_ceiling`: RSS keeps counting memory that was freed but not
-//! returned, so it is reproducible only within one allocator on one platform,
-//! while live heap moves when and only when the code allocates differently.
-//!
-//! This binary installs a counting global allocator, so it holds exactly one
-//! test on purpose.
+//! This binary installs a counting global allocator and holds exactly one test.
 
 mod support;
 
@@ -48,9 +25,6 @@ use std::process::Command;
 static ALLOC: support::Counting = support::Counting;
 
 /// Commits in the fixture history.
-///
-/// Eight times the shallow fixture's depth, which is what moves the
-/// whole-history structures from a rounding error to the dominant term.
 const COMMITS: usize = 256;
 
 /// Modules rewritten on every commit.
@@ -59,133 +33,28 @@ const MODULES: usize = 8;
 /// Types defined in each module.
 const ITEMS_PER_MODULE: usize = 4;
 
-/// The phase whose entire job is proving, and therefore the one that must not
-/// pay for a copy of history to do it.
-///
-/// `source_proof_staged` is proof 1 of 3. It revalidates the plan structurally
-/// and then observes the Git source twice; it keeps nothing at all. Whatever it
-/// adds to the peak is memory the machine has to survive so that a check can
-/// reach a verdict it was always going to reach.
+/// Structural and source revalidation must not materialize another history.
 const PROOF_PHASE: &str = "kin.init.source_proof_staged";
 
-/// Ceiling on what proof 1 may add to the running peak.
-///
-/// Measured on this fixture, release, one host, both numbers quoted in the pull
-/// request that introduced this guard: 88,146,432 bytes (84.1 MiB) on the base
-/// commit and 0 bytes after the re-derivation was made to stream. The ceiling
-/// sits at 16 MiB, which is far below the pre-fix figure and far above the
-/// post-fix one, and there is nothing in between that a legitimate change
-/// should produce: either a re-derivation materializes a second history or it
-/// does not.
-///
-/// This is the assertion that carries the class. The total below is a coarser
-/// backstop.
+/// Backstop on transient peak growth during the first source proof.
 const PROOF_PEAK_GROWTH_CEILING: usize = 16 * 1024 * 1024;
 
-/// The phase that binds every imported change's historical semantics.
-///
-/// It derives one set of entity and relation deltas per commit and writes them
-/// into the plan. Those two are the same values, so the phase legitimately ends
-/// up holding one copy; what it must not do is hold two, which is what it did
-/// while the derived set was collected into owned vectors, copied into the
-/// plan, and then dropped unread.
+/// Historical semantics must be spooled without retaining decoded history.
 const BIND_PHASE: &str = "kin.init.bind_historical_semantics";
 
-/// How far past what it retains the binding phase may push the running peak,
-/// in percent.
-///
-/// Calibrated inside the run rather than against a constant, deliberately.
-/// Both figures scale with commits multiplied by per-commit semantic churn, and
-/// a byte ceiling written for this fixture would say nothing about a repository
-/// and would have to be retuned whenever the fixture moved. The ratio is the
-/// invariant: a phase that produces one copy of a structure and keeps it should
-/// not lift the peak by two of them.
-///
-/// Measured on this fixture, release, one host: 218 percent with the derived
-/// deltas alive beside the copy, and 118 percent without. The gate sits at 175,
-/// which is below the first and above the second, and there is nothing
-/// legitimate in between: either the derived deltas exist twice at once or they
-/// do not. The 218 figure is from a build of that mutant rather than from an
-/// earlier report, because the earlier report's base carried a different
-/// dependency pin.
-const BIND_PEAK_GROWTH_PERCENT_OF_RETAINED: usize = 175;
-
-/// The phase that gives up the import plan's change bodies.
-///
-/// Proof 1 is the last reader of a change's body. Everything after it reads the
-/// plan's proved facts, so the phase below converts the plan into a closure
-/// carrying those facts and drops the bodies. It exists as a named phase
-/// precisely so this guard can watch the live heap fall across it.
+/// Consuming the disk-backed plan need not produce a measurable heap drop.
 const RELEASE_PHASE: &str = "kin.init.release_plan_bodies";
 
-/// How much of what the binding phase retained must actually be given back,
-/// in percent.
-///
-/// Calibrated inside the run rather than against a constant, for the reason
-/// `BIND_PEAK_GROWTH_PERCENT_OF_RETAINED` gives: both figures scale with
-/// commits multiplied by per-commit churn, so a byte floor written for this
-/// fixture would say nothing about a repository. The binding phase produces one
-/// copy of every commit's entity, relation and tree deltas and retains it; once
-/// proof 1 has read them for the last time, that copy is what this phase hands
-/// back.
-///
-/// The floor sits at 50 percent, well under what a working release gives back
-/// and far above the zero a build that keeps the bodies produces. There is
-/// nothing legitimate in between: either the plan is consumed into a closure
-/// without the bodies or it is not.
-const RELEASE_DROP_PERCENT_OF_BIND_RETAINED: usize = 50;
-
-/// The phase that builds the bootstrap transaction.
-///
-/// It re-proves the admitted plan, moves that plan's fields into a transaction,
-/// and derives the imported workspace's semantics. Everything it allocates is
-/// transient: it retains 0.2 MiB on this fixture, so whatever it adds to the
-/// peak is memory a machine has to survive for a step that keeps nothing.
+/// Bootstrap construction must avoid materializing the full admitted history.
 const BUILD_PHASE: &str = "kin.init.build_bootstrap_transaction";
 
-/// The phase whose retained bytes are one copy of the admitted history.
-///
-/// The denominator, for the reason the binding ratio above gives: a byte
-/// ceiling written for this fixture would say nothing about a repository, and
-/// both figures scale with commits multiplied by per-commit churn.
+/// Admission must retain bounded state while preserving every imported change.
 const ADMIT_PHASE: &str = "kin.init.admit_semantic_import";
 
-/// How far past one copy of the admitted history the bootstrap build may push
-/// the peak, in percent.
-///
-/// Measured on this fixture, release, one host, and quoted in the pull request
-/// that introduced this guard: 450 percent (377.0 MiB of growth against
-/// 83.7 MiB retained) while that phase re-proved the admitted plan by building
-/// a third complete import plan and staged the whole history into a second
-/// in-memory graph to derive the workspace's semantics, and 128 percent
-/// (107.8 MiB) once both were replaced by streaming and borrowed reads. The
-/// gate sits at 250, below the first and above the second.
-///
-/// A phase that proves and keeps nothing should not need several copies of
-/// what it is proving. This is the class the number carries; the total below
-/// stays a backstop and does not move when this one does, because on this
-/// fixture the run's peak is set by the commit phase after it.
-const BUILD_PEAK_GROWTH_PERCENT_OF_ADMITTED: usize = 250;
+/// The enrichment summary must read history without retaining decoded bodies.
+const SUMMARY_PHASE: &str = "kin.init.commit.enrichment_summary";
 
-/// Backstop on total peak live heap for admitting `COMMITS` commits.
-///
-/// Deliberately loose, and deliberately NOT the headline. The total is set by
-/// the bootstrap transaction, which is built and then committed after every
-/// proof has run, so removing a proof's cost moves the phase table without
-/// moving this number: base and the first fix commit both measured 995.3 MiB,
-/// 904 bytes apart. Anyone tuning this constant should read the phase table
-/// first, and should read `PROOF_PEAK_GROWTH_CEILING` as the real guard.
-///
-/// What this one catches is a gross regression: a new whole-history structure
-/// large enough to move even a bootstrap-dominated total.
-///
-/// Tightened from 1400 MiB once two whole-history holders came out of a
-/// conversion. Measured on this fixture, release, one host: 660.9 MiB before
-/// the import plan's change bodies were released after proof 1 and 577.5 MiB
-/// after. 900 MiB stays a loose backstop rather than a discriminator, which is
-/// deliberate: the release floor below is what carries this class, and a total
-/// tuned tight enough to grade it would fail on a different allocator instead
-/// of on a defect.
+/// Coarse backstop on total peak live heap, independent of the positive control.
 const PEAK_HEAP_CEILING: usize = 900 * 1024 * 1024;
 
 fn git(repo: &Path, args: &[&str]) {
@@ -264,205 +133,99 @@ fn proving_deep_history_does_not_cost_another_copy_of_it() {
     support::reset_peak();
     let baseline = support::live();
 
-    kin_core::init_from_git(&repo).expect("admit the fixture repository");
+    let initialized = kin_core::init_from_git(&repo).expect("admit the fixture repository");
 
+    // Freeze admission measurements before opening or materializing the control.
     let peak = support::peak().saturating_sub(baseline);
     let growth = support::peak_growth_by_phase();
-    let proof_growth = growth
-        .iter()
-        .find(|(phase, _, _)| *phase == PROOF_PHASE)
-        .map(|(_, grew, _)| *grew);
-    let bind = growth
-        .iter()
-        .find(|(phase, _, _)| *phase == BIND_PHASE)
-        .map(|(_, grew, retained)| (*grew, *retained));
-    let build = growth
-        .iter()
-        .find(|(phase, _, _)| *phase == BUILD_PHASE)
-        .map(|(_, grew, _)| *grew);
-    let admitted = growth
-        .iter()
-        .find(|(phase, _, _)| *phase == ADMIT_PHASE)
-        .map(|(_, _, retained)| *retained);
-    // The release phase gives memory BACK, and `peak_growth_by_phase` reports
-    // what a phase retained with a saturating subtraction, so a phase that
-    // frees reads zero there and says nothing. Read the entry and exit samples
-    // directly instead, and measure the drop.
-    let release_drop = support::samples()
-        .iter()
-        .position(|sample| sample.phase == RELEASE_PHASE && sample.entering)
-        .and_then(|entered| {
-            let samples = support::samples();
-            let entry = samples[entered];
-            samples[entered + 1..]
-                .iter()
-                .find(|sample| sample.phase == RELEASE_PHASE && !sample.entering)
-                .map(|exit| entry.live.saturating_sub(exit.live))
-        });
+    let phase_table = support::phase_attribution_table();
+    let phase = |name| {
+        growth
+            .iter()
+            .find(|(phase, _, _)| *phase == name)
+            .map(|(_, grew, retained)| (*grew, *retained))
+            .unwrap_or_else(|| {
+                panic!(
+                    "no {name} sample was recorded; phase coverage is required.\n\n{phase_table}"
+                )
+            })
+    };
+    let (proof_growth, _) = phase(PROOF_PHASE);
+    let (_, bind_retained) = phase(BIND_PHASE);
+    let (build_growth, _) = phase(BUILD_PHASE);
+    let (_, admit_retained) = phase(ADMIT_PHASE);
+    let (_, summary_retained) = phase(SUMMARY_PHASE);
+    let _ = phase(RELEASE_PHASE);
+
+    let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&initialized.layout)
+        .expect("bind the initialized repository");
+    let manager = binding
+        .open_manager()
+        .expect("open the repository authority");
+    let authority = manager.read_authority();
+    let changes = &authority.snapshot().changes;
+    assert_eq!(
+        changes.len(),
+        COMMITS,
+        "admission must preserve full history"
+    );
+    assert!(
+        !changes.is_decoded(),
+        "opening the authority must not materialize history"
+    );
+    let before_materialization = support::live();
+    let decoded = changes
+        .decoded()
+        .expect("materialize history for the control");
+    let materialized_history_bytes = support::live().saturating_sub(before_materialization);
+    std::hint::black_box(decoded);
+    assert!(
+        materialized_history_bytes > 0,
+        "explicit history materialization retained no bytes, so the control measured nothing"
+    );
 
     println!(
         "peak live heap admitting {COMMITS} commits: {peak} bytes ({:.1} MiB), backstop {} MiB",
         peak as f64 / 1024.0 / 1024.0,
         PEAK_HEAP_CEILING / 1024 / 1024
     );
-    // Printed on every run, not only on a breach. A guard that shows its
-    // working only when it fails leaves the number that is about to become a
-    // failure invisible until it is one, and this table is the only view of
-    // what a conversion holds and where.
-    println!("{}", support::phase_attribution_table());
+    println!("{phase_table}");
+    println!("explicit history materialization retained {materialized_history_bytes} bytes");
     println!(
-        "{PROOF_PHASE} added {} bytes to the peak, ceiling {} MiB",
-        proof_growth
-            .map(|bytes| bytes.to_string())
-            .unwrap_or_else(|| "NO SAMPLE".to_string()),
-        PROOF_PEAK_GROWTH_CEILING / 1024 / 1024
+        "{PROOF_PHASE} peak growth: {proof_growth} bytes; \
+         {BUILD_PHASE} peak growth: {build_growth} bytes"
     );
     println!(
-        "{BIND_PHASE} grew the peak by {} bytes while retaining {} bytes, ceiling {} percent",
-        bind.map(|(grew, _)| grew.to_string())
-            .unwrap_or_else(|| "NO SAMPLE".to_string()),
-        bind.map(|(_, retained)| retained.to_string())
-            .unwrap_or_else(|| "NO SAMPLE".to_string()),
-        BIND_PEAK_GROWTH_PERCENT_OF_RETAINED
-    );
-    println!(
-        "{BUILD_PHASE} grew the peak by {} bytes against the {} bytes {ADMIT_PHASE} retained, \
-         ceiling {} percent",
-        build
-            .map(|bytes| bytes.to_string())
-            .unwrap_or_else(|| "NO SAMPLE".to_string()),
-        admitted
-            .map(|bytes| bytes.to_string())
-            .unwrap_or_else(|| "NO SAMPLE".to_string()),
-        BUILD_PEAK_GROWTH_PERCENT_OF_ADMITTED
-    );
-    println!(
-        "{RELEASE_PHASE} gave back {} bytes of the {} bytes {BIND_PHASE} retained, floor {} percent",
-        release_drop
-            .map(|bytes| bytes.to_string())
-            .unwrap_or_else(|| "NO SAMPLE".to_string()),
-        bind.map(|(_, retained)| retained.to_string())
-            .unwrap_or_else(|| "NO SAMPLE".to_string()),
-        RELEASE_DROP_PERCENT_OF_BIND_RETAINED
+        "retained bytes: {BIND_PHASE}={bind_retained}, \
+         {ADMIT_PHASE}={admit_retained}, {SUMMARY_PHASE}={summary_retained}"
     );
 
-    // An absent sample is not a pass. If the phase never opened, the guard
-    // measured nothing and has to say so rather than report the zero that a
-    // missing entry would otherwise look like.
-    let proof_growth = proof_growth.unwrap_or_else(|| {
-        panic!(
-            "no {PROOF_PHASE} sample was recorded, so this run proved nothing about \
-             what proving costs. Either the phase span was renamed or the probe was not \
-             installed before the measured call.\n\n{}",
-            support::phase_attribution_table()
-        )
-    });
     assert!(
         proof_growth < PROOF_PEAK_GROWTH_CEILING,
-        "proof 1 added {proof_growth} bytes to the peak, over the \
-         {PROOF_PEAK_GROWTH_CEILING} byte ceiling. That phase revalidates the import plan \
-         and keeps nothing, so anything it adds is a second copy of history built to check \
-         the first. This is the defect that put a full-history conversion at the ceiling of \
-         a 12 GiB container.\n\n{}",
-        support::phase_attribution_table()
+        "{PROOF_PHASE} added {proof_growth} bytes to the peak, at or over the \
+         {PROOF_PEAK_GROWTH_CEILING} byte ceiling.\n\n{phase_table}"
     );
-    // Two states this refuses to grade, for the same reason the proof sample
-    // does: a phase that never opened measured nothing, and a phase that
-    // retained nothing gives the ratio no denominator, so the comparison would
-    // pass on any growth at all.
-    let (bind_growth, bind_retained) = bind.unwrap_or_else(|| {
-        panic!(
-            "no {BIND_PHASE} sample was recorded, so this run proved nothing about what \
-             binding historical semantics holds. Either the phase span was renamed or the \
-             probe was not installed before the measured call.\n\n{}",
-            support::phase_attribution_table()
-        )
-    });
+    for (name, retained) in [
+        (BIND_PHASE, bind_retained),
+        (ADMIT_PHASE, admit_retained),
+        (SUMMARY_PHASE, summary_retained),
+    ] {
+        assert!(
+            retained < materialized_history_bytes / 4,
+            "{name} retained {retained} bytes, at or over one quarter of the \
+             {materialized_history_bytes} bytes retained by explicit history materialization. \
+             The phase must stream history with bounded residency.\n\n{phase_table}"
+        );
+    }
     assert!(
-        bind_retained > 0,
-        "{BIND_PHASE} retained nothing, so there is no copy to compare its peak growth \
-         against and this check graded nothing. The phase writes one set of entity and \
-         relation deltas per commit into the plan, so a fixture where it keeps zero bytes \
-         is not exercising it.\n\n{}",
-        support::phase_attribution_table()
-    );
-    let bind_percent = bind_growth.saturating_mul(100) / bind_retained;
-    assert!(
-        bind_percent < BIND_PEAK_GROWTH_PERCENT_OF_RETAINED,
-        "{BIND_PHASE} grew the peak by {bind_growth} bytes while retaining {bind_retained}, \
-         {bind_percent} percent, at or over the {BIND_PEAK_GROWTH_PERCENT_OF_RETAINED} percent \
-         ceiling. That phase derives one set of deltas per commit and keeps exactly one copy \
-         of them, so growth of about two copies means the derived set and the plan's set are \
-         alive at the same time. On a real conversion that is gigabytes.\n\n{}",
-        support::phase_attribution_table()
-    );
-    // Same two refusals as above, for the same reasons: an absent phase measured
-    // nothing, and a zero denominator would let any drop at all pass.
-    let release_drop = release_drop.unwrap_or_else(|| {
-        panic!(
-            "no {RELEASE_PHASE} sample was recorded, so this run proved nothing about \
-             whether the import plan's change bodies are given back after proof 1. Either \
-             the phase span was renamed or the conversion no longer releases them.\n\n{}",
-            support::phase_attribution_table()
-        )
-    });
-    let release_percent = release_drop.saturating_mul(100) / bind_retained;
-    assert!(
-        release_percent >= RELEASE_DROP_PERCENT_OF_BIND_RETAINED,
-        "{RELEASE_PHASE} gave back {release_drop} bytes, {release_percent} percent of the \
-         {bind_retained} bytes {BIND_PHASE} retained, under the \
-         {RELEASE_DROP_PERCENT_OF_BIND_RETAINED} percent floor. Proof 1 is the last reader \
-         of a change's body, so past that point the plan's entity, relation and tree deltas \
-         for every commit in history answer no question and must be released. Holding them \
-         to the end of a conversion is over a gigabyte live across the peak on a mid-size \
-         repository.\n\n{}",
-        support::phase_attribution_table()
-    );
-    // Same two refusals as every ratio above: an absent phase measured nothing,
-    // and a zero denominator would let any growth at all pass.
-    let build = build.unwrap_or_else(|| {
-        panic!(
-            "no {BUILD_PHASE} sample was recorded, so this run proved nothing about what \
-             building the bootstrap transaction costs. Either the phase span was renamed or \
-             the probe was not installed before the measured call.\n\n{}",
-            support::phase_attribution_table()
-        )
-    });
-    let admitted = admitted.unwrap_or_else(|| {
-        panic!(
-            "no {ADMIT_PHASE} sample was recorded, so the bootstrap build has no copy of the \
-             admitted history to be measured against.\n\n{}",
-            support::phase_attribution_table()
-        )
-    });
-    assert!(
-        admitted > 0,
-        "{ADMIT_PHASE} retained nothing, so there is no copy of the admitted history to \
-         compare the bootstrap build's peak growth against and this check graded nothing.\n\n{}",
-        support::phase_attribution_table()
-    );
-    let build_percent = build.saturating_mul(100) / admitted;
-    assert!(
-        build_percent < BUILD_PEAK_GROWTH_PERCENT_OF_ADMITTED,
-        "{BUILD_PHASE} grew the peak by {build} bytes against the {admitted} bytes \
-         {ADMIT_PHASE} retained, {build_percent} percent, at or over the \
-         {BUILD_PEAK_GROWTH_PERCENT_OF_ADMITTED} percent ceiling. That phase re-proves the \
-         admitted plan and derives the imported workspace's semantics, and it keeps almost \
-         nothing, so growth of several copies of the history means it built one to prove or \
-         to read the other. On a real conversion that is gigabytes a machine has to survive \
-         for a step that retains nothing.\n\n{}",
-        support::phase_attribution_table()
+        build_growth < materialized_history_bytes / 2,
+        "{BUILD_PHASE} added {build_growth} bytes to the peak, at or over one half of the \
+         {materialized_history_bytes} bytes retained by explicit history materialization. \
+         Bootstrap construction must avoid whole-history materialization.\n\n{phase_table}"
     );
     assert!(
         peak < PEAK_HEAP_CEILING,
-        "admitting {COMMITS} commits peaked at {peak} bytes of live heap, over the \
-         {PEAK_HEAP_CEILING} byte backstop. This total is normally set by the bootstrap \
-         transaction rather than by any proof, so a breach here is a gross regression: a \
-         new whole-history structure large enough to move a bootstrap-dominated \
-         number.\n\n{}\n\
-         Read the grew column to find which phase moved, and the retained column to tell a \
-         structure held too long from allocation churn inside one phase. They need opposite \
-         fixes.",
-        support::phase_attribution_table()
+        "admitting {COMMITS} commits peaked at {peak} bytes of live heap, at or over the \
+         {PEAK_HEAP_CEILING} byte backstop.\n\n{phase_table}"
     );
 }

--- a/crates/kin-core/tests/init_deep_history_heap_ceiling.rs
+++ b/crates/kin-core/tests/init_deep_history_heap_ceiling.rs
@@ -61,6 +61,18 @@ const BIND_PHASE: &str = "kin.init.bind_historical_semantics";
 /// 0 bytes clean, and one whole history under the mutant.
 const BIND_PEAK_GROWTH_DIVISOR: usize = 4;
 
+/// Share of one materialized history a streaming phase may still be holding
+/// when it ends.
+///
+/// Named rather than written inline at each assertion, because the acceptance
+/// suite grades the ceiling this guard PRINTS. A number that appears twice is a
+/// number that can disagree with itself, and the disagreement would be a suite
+/// grading a ceiling this guard no longer uses.
+const RETENTION_DIVISOR: usize = 4;
+
+/// Share of one materialized history the bootstrap build may add to the peak.
+const BUILD_PEAK_GROWTH_DIVISOR: usize = 2;
+
 /// Consuming the disk-backed plan need not produce a measurable heap drop.
 const RELEASE_PHASE: &str = "kin.init.release_plan_bodies";
 
@@ -210,14 +222,27 @@ fn proving_deep_history_does_not_cost_another_copy_of_it() {
     );
     println!("{phase_table}");
     println!("explicit history materialization retained {materialized_history_bytes} bytes");
+    // One line per graded assertion, each carrying the ceiling it is graded
+    // against. `scripts/acceptance/init_memory_repro.py` parses these lines and
+    // grades what this guard prints rather than ceilings of its own, so a
+    // ceiling moved here moves there with no second edit and nothing to drift.
+    // The lines are also what an operator reads when a run goes red, which is
+    // why each names its phase rather than its position.
+    let bind_growth_ceiling = materialized_history_bytes / BIND_PEAK_GROWTH_DIVISOR;
+    let build_growth_ceiling = materialized_history_bytes / BUILD_PEAK_GROWTH_DIVISOR;
+    let retention_ceiling = materialized_history_bytes / RETENTION_DIVISOR;
     println!(
-        "{PROOF_PHASE} peak growth: {proof_growth} bytes; \
-         {BUILD_PHASE} peak growth: {build_growth} bytes; \
-         {BIND_PHASE} peak growth: {bind_growth} bytes"
+        "{PROOF_PHASE} peak growth: {proof_growth} bytes, ceiling \
+         {PROOF_PEAK_GROWTH_CEILING} bytes"
+    );
+    println!("{BIND_PHASE} peak growth: {bind_growth} bytes, ceiling {bind_growth_ceiling} bytes");
+    println!(
+        "{BUILD_PHASE} peak growth: {build_growth} bytes, ceiling {build_growth_ceiling} bytes"
     );
     println!(
         "retained bytes: {BIND_PHASE}={bind_retained}, \
-         {ADMIT_PHASE}={admit_retained}, {SUMMARY_PHASE}={summary_retained}"
+         {ADMIT_PHASE}={admit_retained}, {SUMMARY_PHASE}={summary_retained}, \
+         ceiling {retention_ceiling} bytes"
     );
 
     assert!(
@@ -231,14 +256,14 @@ fn proving_deep_history_does_not_cost_another_copy_of_it() {
         (SUMMARY_PHASE, summary_retained),
     ] {
         assert!(
-            retained < materialized_history_bytes / 4,
+            retained < retention_ceiling,
             "{name} retained {retained} bytes, at or over one quarter of the \
              {materialized_history_bytes} bytes retained by explicit history materialization. \
              The phase must stream history with bounded residency.\n\n{phase_table}"
         );
     }
     assert!(
-        bind_growth < materialized_history_bytes / BIND_PEAK_GROWTH_DIVISOR,
+        bind_growth < bind_growth_ceiling,
         "{BIND_PHASE} added {bind_growth} bytes to the peak, at or over one quarter of the \
          {materialized_history_bytes} bytes retained by explicit history materialization. That \
          phase derives one set of deltas per commit and hands each straight to the spool, so \
@@ -248,7 +273,7 @@ fn proving_deep_history_does_not_cost_another_copy_of_it() {
          this history is far under the total backstop.\n\n{phase_table}"
     );
     assert!(
-        build_growth < materialized_history_bytes / 2,
+        build_growth < build_growth_ceiling,
         "{BUILD_PHASE} added {build_growth} bytes to the peak, at or over one half of the \
          {materialized_history_bytes} bytes retained by explicit history materialization. \
          Bootstrap construction must avoid whole-history materialization.\n\n{phase_table}"

--- a/crates/kin-core/tests/init_deep_history_heap_ceiling.rs
+++ b/crates/kin-core/tests/init_deep_history_heap_ceiling.rs
@@ -42,6 +42,25 @@ const PROOF_PEAK_GROWTH_CEILING: usize = 16 * 1024 * 1024;
 /// Historical semantics must be spooled without retaining decoded history.
 const BIND_PHASE: &str = "kin.init.bind_historical_semantics";
 
+/// Share of one materialized history the binding phase may add to the peak.
+///
+/// This is `BIND_PEAK_GROWTH_PERCENT_OF_RETAINED` restored on a denominator
+/// that still means something. The old ceiling compared the phase's growth
+/// against what the phase retained, and that worked while binding kept one copy
+/// of every commit's deltas: two copies alive at once measured 218 percent and
+/// one measured 118, so the gate sat at 175 between them. Binding now spools
+/// each commit and drops it, so it retains 0.1 MiB on this fixture instead of a
+/// history, and a ratio against that denominator would refuse every clean run.
+///
+/// The class that ceiling caught is still real and nothing else here grades it:
+/// the derived deltas alive beside the copy, transiently, dropped before the
+/// phase ends. The retention check below cannot see it, precisely because it is
+/// dropped, and the 900 MiB backstop cannot see it either, because one copy of
+/// this fixture's history is 87 MiB. So growth is graded against the same
+/// materialized history the retention checks use. Measured release on one host:
+/// 0 bytes clean, and one whole history under the mutant.
+const BIND_PEAK_GROWTH_DIVISOR: usize = 4;
+
 /// Consuming the disk-backed plan need not produce a measurable heap drop.
 const RELEASE_PHASE: &str = "kin.init.release_plan_bodies";
 
@@ -151,7 +170,7 @@ fn proving_deep_history_does_not_cost_another_copy_of_it() {
             })
     };
     let (proof_growth, _) = phase(PROOF_PHASE);
-    let (_, bind_retained) = phase(BIND_PHASE);
+    let (bind_growth, bind_retained) = phase(BIND_PHASE);
     let (build_growth, _) = phase(BUILD_PHASE);
     let (_, admit_retained) = phase(ADMIT_PHASE);
     let (_, summary_retained) = phase(SUMMARY_PHASE);
@@ -193,7 +212,8 @@ fn proving_deep_history_does_not_cost_another_copy_of_it() {
     println!("explicit history materialization retained {materialized_history_bytes} bytes");
     println!(
         "{PROOF_PHASE} peak growth: {proof_growth} bytes; \
-         {BUILD_PHASE} peak growth: {build_growth} bytes"
+         {BUILD_PHASE} peak growth: {build_growth} bytes; \
+         {BIND_PHASE} peak growth: {bind_growth} bytes"
     );
     println!(
         "retained bytes: {BIND_PHASE}={bind_retained}, \
@@ -217,6 +237,16 @@ fn proving_deep_history_does_not_cost_another_copy_of_it() {
              The phase must stream history with bounded residency.\n\n{phase_table}"
         );
     }
+    assert!(
+        bind_growth < materialized_history_bytes / BIND_PEAK_GROWTH_DIVISOR,
+        "{BIND_PHASE} added {bind_growth} bytes to the peak, at or over one quarter of the \
+         {materialized_history_bytes} bytes retained by explicit history materialization. That \
+         phase derives one set of deltas per commit and hands each straight to the spool, so \
+         growth on the order of a history means the derived set and the spooled copy are alive at \
+         the same time. On a real conversion that is gigabytes, and nothing else here sees it: a \
+         copy dropped before the phase ends never moves the phase's retention, and one copy of \
+         this history is far under the total backstop.\n\n{phase_table}"
+    );
     assert!(
         build_growth < materialized_history_bytes / 2,
         "{BUILD_PHASE} added {build_growth} bytes to the peak, at or over one half of the \

--- a/crates/kin-daemon/src/commit_deltas.rs
+++ b/crates/kin-daemon/src/commit_deltas.rs
@@ -2700,7 +2700,7 @@ mod tests {
             assert_eq!(
                 actual.expected_tree,
                 ResolvedTree::default()
-                    .apply(&[tree_delta.clone()])
+                    .apply(std::slice::from_ref(&tree_delta))
                     .unwrap()
             );
             assert!(!snapshot.changes.is_decoded());

--- a/crates/kin-daemon/src/commit_deltas.rs
+++ b/crates/kin-daemon/src/commit_deltas.rs
@@ -131,11 +131,9 @@ fn baseline_from_materialized_section<'a>(
 
 /// Fold the parent out of persisted history, borrowing the change map.
 ///
-/// `resolve_graph_at` reaches its store through `get_change` and nothing else
-/// (`kin_model::graph::collect_changes_first_parent`), so the graph this used to
-/// construct served one lookup loop. Borrowing does still decode the change map,
-/// because `ChangeMap` derefs through `force()`; what it drops is the throwaway
-/// graph, its lexical index, and the whole-history entity-revision derivation.
+/// Each lookup decodes one change through the fallible history reader. This
+/// public full-state path preserves revision output; ordinary commit comparison
+/// uses a current-state projection instead.
 fn baseline_from_history(
     authority_snapshot: &GraphSnapshot,
     parent: &SemanticChangeId,
@@ -158,19 +156,33 @@ pub fn compute_deltas_vs_repository_authority(
     authority_snapshot: &GraphSnapshot,
     parent: Option<&SemanticChangeId>,
 ) -> Result<CommitDeltas> {
-    let committed = match parent {
-        Some(parent) => resolve_authority_baseline(authority_snapshot, parent)?,
-        None => Cow::Owned(ResolvedGraphState {
-            entities: Default::default(),
-            relations: Default::default(),
-            entity_revisions: Default::default(),
-            tree: ResolvedTree::default(),
-            entity_tombstones: Default::default(),
-            relation_tombstones: Default::default(),
-            external_references: HashMap::new(),
-        }),
+    let Some(parent) = parent else {
+        return compute_deltas_from_current_state(
+            graph,
+            &HashMap::new(),
+            &HashMap::new(),
+            &ResolvedTree::default(),
+        );
     };
-    compute_deltas_from_resolved_state(graph, &committed)
+    match baseline_from_materialized_section(authority_snapshot, parent) {
+        Ok(committed) => compute_deltas_from_resolved_state(graph, committed),
+        Err(refusal) => {
+            tracing::debug!(
+                %parent,
+                %refusal,
+                "folding the commit parent current state from history"
+            );
+            let committed =
+                kin_db::storage::resolve_current_graph(&authority_snapshot.changes, parent)
+                    .map_err(DaemonError::Graph)?;
+            compute_deltas_from_current_state(
+                graph,
+                &committed.entities,
+                &committed.relations,
+                &committed.tree,
+            )
+        }
+    }
 }
 
 /// Build the complete derived-graph transition for one selected-path checkout.
@@ -519,13 +531,27 @@ fn compute_deltas_from_resolved_state(
     graph: &InMemoryGraph,
     committed: &ResolvedGraphState,
 ) -> Result<CommitDeltas> {
+    compute_deltas_from_current_state(
+        graph,
+        &committed.entities,
+        &committed.relations,
+        &committed.tree,
+    )
+}
+
+fn compute_deltas_from_current_state(
+    graph: &InMemoryGraph,
+    committed_entities: &HashMap<EntityId, Entity>,
+    committed_relations: &HashMap<RelationId, Relation>,
+    committed_tree: &ResolvedTree,
+) -> Result<CommitDeltas> {
     // One coherent live snapshot keeps entity, relation, and exact-tree deltas
     // on the same graph generation.
-    let current = graph.to_snapshot();
+    let current = graph.workspace_graph_facts();
 
     let mut entity_deltas = Vec::new();
     for entity in current.entities.values() {
-        match committed.entities.get(&entity.id) {
+        match committed_entities.get(&entity.id) {
             None => {
                 entity_deltas.push(EntityDelta::Added {
                     new: entity.clone(),
@@ -552,7 +578,7 @@ fn compute_deltas_from_resolved_state(
             _ => {}
         }
     }
-    for (entity_id, entity) in &committed.entities {
+    for (entity_id, entity) in committed_entities {
         if !current.entities.contains_key(entity_id) {
             entity_deltas.push(EntityDelta::Removed {
                 old: entity.clone(),
@@ -563,7 +589,7 @@ fn compute_deltas_from_resolved_state(
 
     let mut relation_deltas = Vec::new();
     for relation in current.relations.values() {
-        match committed.relations.get(&relation.id) {
+        match committed_relations.get(&relation.id) {
             None => relation_deltas.push(RelationDelta::Added {
                 new: relation.clone(),
             }),
@@ -576,7 +602,7 @@ fn compute_deltas_from_resolved_state(
             _ => {}
         }
     }
-    for (relation_id, relation) in &committed.relations {
+    for (relation_id, relation) in committed_relations {
         if !current.relations.contains_key(relation_id) {
             relation_deltas.push(RelationDelta::Removed {
                 old: relation.clone(),
@@ -586,7 +612,7 @@ fn compute_deltas_from_resolved_state(
     relation_deltas.sort_by_key(RelationDelta::target_id);
 
     let expected_tree = current.resolved_tree;
-    let tree_deltas = kin_core::exact_tree_correction(&committed.tree, &expected_tree)?;
+    let tree_deltas = kin_core::exact_tree_correction(committed_tree, &expected_tree)?;
 
     Ok(CommitDeltas {
         entity_deltas,
@@ -2617,6 +2643,70 @@ mod tests {
             resolved_at,
             state,
         }
+    }
+
+    #[test]
+    fn ordinary_commit_projection_matches_the_full_state_delta_oracle() {
+        let (mut snapshot, head) = authority_like_snapshot(8);
+        let graph = InMemoryGraph::from_snapshot(snapshot.clone()).unwrap();
+        let original = snapshot.entities.values().next().unwrap().clone();
+        let mut changed = original.clone();
+        changed.signature.push_str(" changed");
+        graph.upsert_entity(&changed).unwrap();
+        let added_relation = relation(
+            RelationId::new(),
+            GraphNodeId::Entity(changed.id),
+            GraphNodeId::Entity(changed.id),
+            RelationKind::Calls,
+        );
+        let relation_delta = RelationDelta::Added {
+            new: added_relation,
+        };
+        let tree_delta = TreeDelta::Added {
+            artifact_id: ArtifactId::new(),
+            new: LocatedEntry::new(
+                RepoPath::from_utf8("new.bin").unwrap(),
+                TreeEntry::blob(Hash256::from_bytes([0x72; 32]), true),
+            ),
+        };
+        graph
+            .apply_transaction_delta(&TransactionDelta {
+                relation_deltas: vec![relation_delta.clone()],
+                tree_deltas: vec![tree_delta.clone()],
+                ..TransactionDelta::default()
+            })
+            .unwrap();
+        let full = baseline_from_history(&snapshot, &head).unwrap();
+        assert!(!full.entity_revisions.is_empty());
+        let stale = SemanticChangeId::from_hash(Hash256::from_bytes([0x5a; 32]));
+        for section_target in [None, Some(head), Some(stale)] {
+            snapshot.materialized_graph =
+                section_target.map(|target| Arc::new(marked_section(target, full.clone())));
+            let baseline = resolve_authority_baseline(&snapshot, &head).unwrap();
+            let expected = compute_deltas_from_resolved_state(&graph, &baseline).unwrap();
+            let actual =
+                compute_deltas_vs_repository_authority(&graph, &snapshot, Some(&head)).unwrap();
+            assert!(!actual.entity_deltas.is_empty());
+            assert_eq!(actual.entity_deltas, expected.entity_deltas);
+            assert_eq!(actual.relation_deltas, expected.relation_deltas);
+            assert_eq!(actual.tree_deltas, expected.tree_deltas);
+            assert_eq!(actual.expected_tree, expected.expected_tree);
+            assert!(actual.entity_deltas.contains(&EntityDelta::Modified {
+                old: original.clone(),
+                new: changed.clone(),
+            }));
+            assert_eq!(actual.relation_deltas, vec![relation_delta.clone()]);
+            assert_eq!(actual.tree_deltas, vec![tree_delta.clone()]);
+            assert_eq!(
+                actual.expected_tree,
+                ResolvedTree::default()
+                    .apply(&[tree_delta.clone()])
+                    .unwrap()
+            );
+            assert!(!snapshot.changes.is_decoded());
+        }
+        snapshot.materialized_graph = None;
+        assert!(compute_deltas_vs_repository_authority(&graph, &snapshot, Some(&stale)).is_err());
     }
 
     #[test]

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -44,13 +44,14 @@ use crate::session_registry::SessionCoordinator;
 /// Repository-v6 snapshots intentionally leave their top-level graph domains
 /// empty. `ChangeStore::resolve_graph_at` needs only `get_change`, so borrowing
 /// the admitted change map avoids cloning the payload-heavy history into a
-/// throwaway graph before every hosted load.
+/// throwaway graph before every hosted load. Individual fallible reads preserve
+/// the map's lazy decoding instead of materializing the entire history.
 ///
 /// `pub(crate)` for the second caller with that same shape: the native commit
 /// planner resolves its baseline at the parent change and reads nothing else
 /// from the graph it was building for it (`commit_deltas.rs`).
 pub(crate) struct HostedAuthorityHistory<'a> {
-    pub(crate) changes: &'a HashMap<SemanticChangeId, SemanticChange>,
+    pub(crate) changes: &'a kin_db::storage::ChangeMap,
 }
 
 impl HostedAuthorityHistory<'_> {
@@ -68,7 +69,7 @@ impl ChangeStore for HostedAuthorityHistory<'_> {
         &self,
         id: &SemanticChangeId,
     ) -> std::result::Result<Option<SemanticChange>, Self::Error> {
-        Ok(self.changes.get(id).cloned())
+        self.changes.read_change(id)
     }
 
     fn get_entity_history(

--- a/crates/kin-daemon/src/storage_delegate.rs
+++ b/crates/kin-daemon/src/storage_delegate.rs
@@ -62,7 +62,7 @@ use kin_db::{
 /// `storage_backend_surface_is_audited_against_the_pinned_kin_db` fails when
 /// the workspace pin moves past it, which is the only moment a method can have
 /// appeared.
-pub const AUDITED_KIN_DB_VERSION: &str = "0.7.106";
+pub const AUDITED_KIN_DB_VERSION: &str = "0.7.107";
 
 /// Wraps a [`StorageBackendDelegate`] so it can be handed anywhere a
 /// `Box<dyn StorageBackend>` is expected.

--- a/crates/kin-daemon/src/storage_delegate.rs
+++ b/crates/kin-daemon/src/storage_delegate.rs
@@ -62,7 +62,7 @@ use kin_db::{
 /// `storage_backend_surface_is_audited_against_the_pinned_kin_db` fails when
 /// the workspace pin moves past it, which is the only moment a method can have
 /// appeared.
-pub const AUDITED_KIN_DB_VERSION: &str = "0.7.104";
+pub const AUDITED_KIN_DB_VERSION: &str = "0.7.106";
 
 /// Wraps a [`StorageBackendDelegate`] so it can be handed anywhere a
 /// `Box<dyn StorageBackend>` is expected.

--- a/crates/kin-daemon/tests/commit_baseline_heap_ceiling.rs
+++ b/crates/kin-daemon/tests/commit_baseline_heap_ceiling.rs
@@ -236,11 +236,13 @@ fn baseline_by_building_a_graph(snapshot: &GraphSnapshot, head: &SemanticChangeI
 #[test]
 fn resolving_a_commit_baseline_does_not_pay_for_a_graph_it_drops() {
     let (snapshot, head) = authority_like_snapshot();
+    assert!(!snapshot.changes.is_decoded());
 
     reset_peak();
     let before = live();
     let folded = resolve_authority_baseline(&snapshot, &head).expect("baseline");
     let borrowed_peak = peak() - before;
+    assert!(!snapshot.changes.is_decoded());
     assert_eq!(
         folded.entities.len(),
         ENTITIES,
@@ -257,7 +259,35 @@ fn resolving_a_commit_baseline_does_not_pay_for_a_graph_it_drops() {
         "the control must resolve the same graph, or it is not a control"
     );
 
-    eprintln!("borrowed_peak_bytes={borrowed_peak} graph_peak_bytes={graph_peak}");
+    let graph = InMemoryGraph::from_snapshot(snapshot.clone()).expect("live comparison graph");
+    reset_peak();
+    let before = live();
+    let deltas = kin_daemon::commit_deltas::compute_deltas_vs_repository_authority(
+        &graph,
+        &snapshot,
+        Some(&head),
+    )
+    .expect("ordinary commit comparison");
+    let comparison_peak = peak() - before;
+    assert!(deltas.entity_deltas.is_empty());
+    assert!(deltas.relation_deltas.is_empty());
+    assert!(deltas.tree_deltas.is_empty());
+    assert!(!snapshot.changes.is_decoded());
+
+    eprintln!(
+        "borrowed_peak_bytes={borrowed_peak} graph_peak_bytes={graph_peak} comparison_peak_bytes={comparison_peak}"
+    );
+
+    assert!(
+        comparison_peak < PEAK_HEAP_CEILING,
+        "ordinary comparison allocated {comparison_peak} bytes, over the unchanged \
+         {PEAK_HEAP_CEILING} ceiling; unused history or revision output is being copied"
+    );
+    assert!(
+        comparison_peak < borrowed_peak / 2,
+        "ordinary comparison allocated {comparison_peak} bytes against the full-state \
+         baseline control of {borrowed_peak}; private comparison must not retain revision output"
+    );
 
     assert!(
         borrowed_peak < PEAK_HEAP_CEILING,

--- a/crates/kin-git/Cargo.toml
+++ b/crates/kin-git/Cargo.toml
@@ -29,6 +29,7 @@ rayon = { workspace = true }
 uuid = { workspace = true, features = ["v5"] }
 rustix = { workspace = true }
 tempfile = { workspace = true }
+serde_json = { workspace = true }
 which = { version = "8", optional = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/kin-git/src/admission_history.rs
+++ b/crates/kin-git/src/admission_history.rs
@@ -449,7 +449,7 @@ fn build_admitted_semantic_git_import_plan(
     plan: &SemanticGitImportPlan,
     blob_store: &BlobStore,
 ) -> Result<AdmittedSemanticGitImportPlan> {
-    let mut changes = SemanticChangeSpoolWriter::new()?;
+    let mut changes = SemanticChangeSpoolWriter::new_in(blob_store.root())?;
     let mut aliases = Vec::with_capacity(plan.aliases.len());
     let derived =
         derive_admitted_semantic_git_history(plan, blob_store, &mut |_oid, admitted, alias| {

--- a/crates/kin-git/src/admission_history.rs
+++ b/crates/kin-git/src/admission_history.rs
@@ -13,7 +13,7 @@ use std::collections::BTreeMap;
 use kin_blobs::BlobStore;
 use kin_model::{
     compute_semantic_change_id, validate_semantic_change_id, AdmissionPolicyDelta,
-    AdmissionRuleSource, AdmissionRuleSourceKind, AuthorId, ChangeOrigin, DefaultRefMutation,
+    AdmissionRuleSource, AdmissionRuleSourceKind, AuthorId, DefaultRefMutation,
     ExternalChangeAlias, ExternalObjectRecord, GitObjectId, Hash256, OperationId, RefMutation,
     RepositoryId, RepositoryRefState, RepositoryTransaction, ResolvedTree, RootBundle,
     SemanticChange, SemanticChangeId, SharedAdmissionPolicy, TreeEntry, WorkspaceHead,
@@ -21,6 +21,7 @@ use kin_model::{
 };
 
 use crate::error::{GitError, Result};
+use crate::history_spool::{SemanticChangeSpool, SemanticChangeSpoolWriter};
 use crate::lossless::{GitObjectFormat, LosslessGitRepository};
 use crate::sealed_observation::AdmittedContentSummary;
 use crate::semantic_import::{
@@ -39,7 +40,7 @@ pub struct AdmittedSemanticGitImportPlan {
     pub repository_id: RepositoryId,
     pub object_format: GitObjectFormat,
     pub external_objects: Vec<ExternalObjectRecord>,
-    pub changes: Vec<SemanticChange>,
+    pub changes: SemanticChangeSpool,
     pub aliases: Vec<ExternalChangeAlias>,
     /// The same tree identities the pre-admission plan holds.
     pub commit_tree_hashes: BTreeMap<GitObjectId, Hash256>,
@@ -109,29 +110,11 @@ impl AdmittedSemanticGitImportPlan {
             refs: self.refs.clone(),
             head: self.head.clone(),
         };
-        let mut by_oid = BTreeMap::new();
-        for change in &self.changes {
-            let ChangeOrigin::GitCommit { oid } = change.origin else {
-                return Err(GitError::InvalidSnapshot(
-                    "admitted semantic Git import contains a native-origin change".to_string(),
-                ));
-            };
-            if by_oid.insert(oid, change).is_some() {
-                return Err(GitError::InvalidSnapshot(format!(
-                    "admitted semantic Git import repeats commit {oid}"
-                )));
-            }
-        }
-        // Lent, not copied. These deltas live in `self`, which outlives the
-        // call, and the walk below only reads them on their way into the one
-        // commit it is about to check and drop.
         let held_semantics = |oid: GitObjectId| {
-            by_oid.get(&oid).map(|change| {
-                (
-                    change.entity_deltas.as_slice(),
-                    change.relation_deltas.as_slice(),
-                )
-            })
+            Ok(self
+                .changes
+                .read_by_oid(&oid)?
+                .map(|change| (change.entity_deltas, change.relation_deltas)))
         };
 
         let mut admission = AdmittedCommitDeriver::new(self.repository_id.clone());
@@ -147,7 +130,7 @@ impl AdmittedSemanticGitImportPlan {
                 // flag to the end. A plan that has already failed can go on to
                 // trip a structural error further down the walk, and reporting
                 // that instead would name the wrong thing.
-                if self.changes.get(checked) != Some(&admitted)
+                if self.changes.read_at(checked)?.as_ref() != Some(&admitted)
                     || self.aliases.get(checked) != Some(&alias)
                     || self.commit_tree_hashes.get(&oid) != Some(&facts.tree_hash)
                     || self.content.trees.get(&oid) != Some(&facts.content)
@@ -205,6 +188,30 @@ impl AdmittedSemanticGitImportPlan {
         actor: AuthorId,
         reason: impl Into<String>,
     ) -> Result<RepositoryTransaction> {
+        let (mut transaction, changes) = self
+            .into_generation_zero_repository_transaction_streaming(
+                blob_store,
+                operation_id,
+                expected_roots,
+                actor,
+                reason,
+            )?;
+        transaction.changes = changes.iter().collect::<Result<Vec<_>>>()?;
+        transaction.validate()?;
+        Ok(transaction)
+    }
+
+    /// Return validated admitted history and its transaction metadata.
+    /// The caller must validate the complete transaction through its streaming
+    /// bootstrap boundary before publishing it.
+    pub fn into_generation_zero_repository_transaction_streaming(
+        self,
+        blob_store: &BlobStore,
+        operation_id: OperationId,
+        expected_roots: RootBundle,
+        actor: AuthorId,
+        reason: impl Into<String>,
+    ) -> Result<(RepositoryTransaction, SemanticChangeSpool)> {
         self.validate(blob_store)?;
         if expected_roots.generation != 0 {
             return Err(GitError::InvalidSnapshot(format!(
@@ -222,7 +229,7 @@ impl AdmittedSemanticGitImportPlan {
             reason: reason.into(),
             external_objects: self.external_objects,
             git_authority_delta: None,
-            changes: self.changes,
+            changes: Vec::new(),
             aliases: self.aliases,
             ref_mutations: self.ref_mutations,
             default_ref_mutation: self.default_ref_mutation,
@@ -232,8 +239,7 @@ impl AdmittedSemanticGitImportPlan {
             sealed_observation: None,
             collaboration_delta: None,
         };
-        transaction.validate()?;
-        Ok(transaction)
+        Ok((transaction, self.changes))
     }
 }
 
@@ -382,26 +388,11 @@ fn derive_admitted_semantic_git_history(
         refs: plan.refs.clone(),
         head: plan.head.clone(),
     };
-    let mut by_oid = BTreeMap::new();
-    for change in &plan.changes {
-        let ChangeOrigin::GitCommit { oid } = change.origin else {
-            return Err(GitError::InvalidSnapshot(
-                "semantic Git import contains a native-origin change".to_string(),
-            ));
-        };
-        if by_oid.insert(oid, change).is_some() {
-            return Err(GitError::InvalidSnapshot(format!(
-                "semantic Git import repeats commit {oid}"
-            )));
-        }
-    }
     let held_semantics = |oid: GitObjectId| {
-        by_oid.get(&oid).map(|change| {
-            (
-                change.entity_deltas.as_slice(),
-                change.relation_deltas.as_slice(),
-            )
-        })
+        Ok(plan
+            .changes
+            .read_by_oid(&oid)?
+            .map(|change| (change.entity_deltas, change.relation_deltas)))
     };
 
     let mut deriver = AdmittedCommitDeriver::new(plan.repository_id.clone());
@@ -425,7 +416,7 @@ fn derive_admitted_semantic_git_history(
             // graded where they are produced, by the enrichment fold's own
             // tests and by the change-id equality of an admitted store.
             let index = deriver.derived;
-            if plan.changes.get(index) != Some(&enriched)
+            if plan.changes.read_at(index)?.as_ref() != Some(&enriched)
                 || plan.aliases.get(index) != Some(&enriched_alias)
                 || plan.commit_tree_hashes.get(&oid) != Some(&facts.tree_hash)
                 || plan.content.trees.get(&oid) != Some(&facts.content)
@@ -458,11 +449,11 @@ fn build_admitted_semantic_git_import_plan(
     plan: &SemanticGitImportPlan,
     blob_store: &BlobStore,
 ) -> Result<AdmittedSemanticGitImportPlan> {
-    let mut changes = Vec::with_capacity(plan.changes.len());
+    let mut changes = SemanticChangeSpoolWriter::new()?;
     let mut aliases = Vec::with_capacity(plan.aliases.len());
     let derived =
         derive_admitted_semantic_git_history(plan, blob_store, &mut |_oid, admitted, alias| {
-            changes.push(admitted);
+            changes.append(admitted)?;
             aliases.push(alias);
             Ok(())
         })?;
@@ -476,7 +467,7 @@ fn build_admitted_semantic_git_import_plan(
         repository_id: plan.repository_id.clone(),
         object_format: plan.object_format,
         external_objects: plan.external_objects.clone(),
-        changes,
+        changes: changes.finish()?,
         aliases,
         commit_tree_hashes: plan.commit_tree_hashes.clone(),
         content: plan.content.clone(),

--- a/crates/kin-git/src/history_spool.rs
+++ b/crates/kin-git/src/history_spool.rs
@@ -5,6 +5,7 @@
 
 use std::collections::BTreeMap;
 use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::Path;
 use std::sync::Arc;
 
 use kin_model::{ChangeOrigin, GitObjectId, SemanticChange, SemanticChangeId};
@@ -12,6 +13,14 @@ use sha2::{Digest, Sha256};
 use tempfile::NamedTempFile;
 
 use crate::error::{GitError, Result};
+
+/// Names a spool on disk for whoever finds one a kill left behind.
+///
+/// `NamedTempFile` unlinks on drop and a `SIGKILL` runs no destructor, so the
+/// file this prefix names is exactly what an out-of-memory kill strands. The
+/// kill this whole spool exists to prevent is the one that strands it, so the
+/// name has to be legible without a process to ask.
+const SPOOL_PREFIX: &str = ".kin-history-spool-";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct Record {
@@ -111,8 +120,14 @@ impl SemanticChangeSpool {
         Ok(Some(change))
     }
     /// Explicit compatibility adapter for callers which already own a history.
-    pub fn from_changes(changes: impl IntoIterator<Item = SemanticChange>) -> Result<Self> {
-        let mut writer = SemanticChangeSpoolWriter::new()?;
+    ///
+    /// `directory` is where the spool file is written, and it carries the same
+    /// requirement [`SemanticChangeSpoolWriter::new_in`] states.
+    pub fn from_changes(
+        directory: &Path,
+        changes: impl IntoIterator<Item = SemanticChange>,
+    ) -> Result<Self> {
+        let mut writer = SemanticChangeSpoolWriter::new_in(directory)?;
         for change in changes {
             writer.append(change)?;
         }
@@ -123,10 +138,33 @@ impl SemanticChangeSpool {
 pub(crate) struct SemanticChangeSpoolWriter(Storage);
 
 impl SemanticChangeSpoolWriter {
-    pub(crate) fn new() -> Result<Self> {
+    /// Spool into `directory`, which the caller chooses and owns.
+    ///
+    /// Deliberately not `std::env::temp_dir()`. This spool exists to keep a
+    /// history off the heap, and on a host where `/tmp` is tmpfs, which is the
+    /// default on most Linux distributions and inside most containers, writing
+    /// it there puts every byte back in RAM and undoes the change. The caller
+    /// knows which filesystem it is converting on; this constructor does not,
+    /// and guessing is what makes the defect invisible. The bodies are also the
+    /// size of the history being imported, so a small `/tmp` is a second way to
+    /// fail on a conversion that would otherwise succeed.
+    ///
+    /// Every caller inside this crate passes its blob store's root, which for
+    /// a `kin init` conversion is the per-init `.kin-git-capture-<uuid>`
+    /// staging directory beside the source repository. That puts the spool on
+    /// the repository's own filesystem and inside the one tree the next init's
+    /// reap and `kin doctor --reclaim-staging` already scan by name, so a
+    /// conversion the kernel kills strands nothing invisible.
+    ///
+    /// A blob store's root is safe to write into: it addresses content under
+    /// two-hex-character shard directories and documents that every other
+    /// top-level entry is ignored, by enumeration and by compaction alike.
+    pub(crate) fn new_in(directory: &Path) -> Result<Self> {
         Ok(Self(Storage {
-            file: NamedTempFile::new()
-                .map_err(|error| GitError::io(std::env::temp_dir(), error))?,
+            file: tempfile::Builder::new()
+                .prefix(SPOOL_PREFIX)
+                .tempfile_in(directory)
+                .map_err(|error| GitError::io(directory, error))?,
             records: Vec::new(),
             by_id: BTreeMap::new(),
             by_oid: BTreeMap::new(),
@@ -185,6 +223,16 @@ mod tests {
     use super::*;
     use kin_model::{AuthorId, Hash256, Timestamp};
 
+    /// One spool directory for this module's cases, alive for the whole binary.
+    ///
+    /// A `TempDir` bound to the call would be removed the moment the statement
+    /// ended, and `read_at` reopens the spool by path, so every later read
+    /// would fail on a directory that is no longer there.
+    fn spool_dir() -> &'static Path {
+        static DIR: std::sync::OnceLock<tempfile::TempDir> = std::sync::OnceLock::new();
+        DIR.get_or_init(|| tempfile::tempdir().unwrap()).path()
+    }
+
     fn change(seed: u8) -> SemanticChange {
         SemanticChange {
             id: SemanticChangeId::from_hash(Hash256::from_bytes([seed; 32])),
@@ -207,10 +255,47 @@ mod tests {
         }
     }
 
+    /// The spool goes where the caller said, and says so on disk.
+    ///
+    /// The default `std::env::temp_dir()` this replaced was two defects at
+    /// once. On a host where `/tmp` is tmpfs, spooling a history there puts it
+    /// straight back in RAM, which is the exact cost this spool exists to
+    /// avoid, and it is invisible: every test passes and the conversion simply
+    /// runs out of memory on the machine it was meant to fit. And a
+    /// `NamedTempFile` unlinks on drop, which `SIGKILL` never runs, so an
+    /// out-of-memory kill strands a history-sized file under a name
+    /// `kin doctor --reclaim-staging` does not scan for.
+    ///
+    /// Breaking it: put `NamedTempFile::new()` back in `new_in` and this fails
+    /// on an empty directory.
+    #[test]
+    fn a_spool_is_written_where_its_caller_put_it_and_is_named_for_a_reader() {
+        let directory = tempfile::tempdir().unwrap();
+        let spool = SemanticChangeSpool::from_changes(directory.path(), [change(1)]).unwrap();
+
+        let names = std::fs::read_dir(directory.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            names.len(),
+            1,
+            "the spool must be the one thing in the directory it was given: {names:?}"
+        );
+        assert!(
+            names[0].starts_with(SPOOL_PREFIX),
+            "a stranded spool has to be identifiable by name alone: {}",
+            names[0]
+        );
+        // Named where the caller put it AND still readable from there, so this
+        // cannot pass on a file the spool no longer uses.
+        assert_eq!(spool.read_at(0).unwrap(), Some(change(1)));
+    }
+
     #[test]
     fn spool_preserves_owned_records_order_and_indexes() {
         let records = vec![change(1), change(2)];
-        let spool = SemanticChangeSpool::from_changes(records.clone()).unwrap();
+        let spool = SemanticChangeSpool::from_changes(spool_dir(), records.clone()).unwrap();
         assert_eq!(spool.iter().collect::<Result<Vec<_>>>().unwrap(), records);
         assert_eq!(
             spool.ids().collect::<Vec<_>>(),
@@ -230,16 +315,16 @@ mod tests {
 
     #[test]
     fn spool_refuses_duplicate_ids_and_duplicate_oids() {
-        assert!(SemanticChangeSpool::from_changes([change(1), change(1)]).is_err());
+        assert!(SemanticChangeSpool::from_changes(spool_dir(), [change(1), change(1)]).is_err());
         let mut duplicate_oid = change(2);
         duplicate_oid.origin = change(1).origin;
-        assert!(SemanticChangeSpool::from_changes([change(1), duplicate_oid]).is_err());
+        assert!(SemanticChangeSpool::from_changes(spool_dir(), [change(1), duplicate_oid]).is_err());
     }
 
     #[test]
     fn spool_refuses_valid_same_length_message_tampering() {
         let original = change(1);
-        let spool = SemanticChangeSpool::from_changes([original.clone()]).unwrap();
+        let spool = SemanticChangeSpool::from_changes(spool_dir(), [original.clone()]).unwrap();
         assert_eq!(spool.read_at(0).unwrap(), Some(original.clone()));
         let mut tampered = original;
         tampered.message = "9".to_string();
@@ -263,7 +348,7 @@ mod tests {
     fn spool_refuses_index_identity_corruption_with_intact_digest() {
         for corrupt_oid in [false, true] {
             let original = change(1);
-            let mut spool = SemanticChangeSpool::from_changes([original.clone()]).unwrap();
+            let mut spool = SemanticChangeSpool::from_changes(spool_dir(), [original.clone()]).unwrap();
             assert_eq!(spool.read_at(0).unwrap(), Some(original.clone()));
             let storage = Arc::get_mut(&mut spool.0).unwrap();
             let record = &mut storage.records[0];
@@ -296,7 +381,7 @@ mod tests {
     #[test]
     fn spool_refuses_missing_truncated_tampered_and_appended_bodies() {
         for mode in 0..4 {
-            let spool = SemanticChangeSpool::from_changes([change(1)]).unwrap();
+            let spool = SemanticChangeSpool::from_changes(spool_dir(), [change(1)]).unwrap();
             let path = spool.0.file.path();
             match mode {
                 0 => std::fs::remove_file(path).unwrap(),
@@ -313,7 +398,7 @@ mod tests {
 
     #[test]
     fn spool_refuses_reordered_record_bytes() {
-        let spool = SemanticChangeSpool::from_changes([change(1), change(2)]).unwrap();
+        let spool = SemanticChangeSpool::from_changes(spool_dir(), [change(1), change(2)]).unwrap();
         let mut file = spool.0.file.reopen().unwrap();
         let mut bytes = Vec::new();
         file.read_to_end(&mut bytes).unwrap();

--- a/crates/kin-git/src/history_spool.rs
+++ b/crates/kin-git/src/history_spool.rs
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Private temporary storage for ordered import changes, verified on every read.
+
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::sync::Arc;
+
+use kin_model::{ChangeOrigin, GitObjectId, SemanticChange, SemanticChangeId};
+use sha2::{Digest, Sha256};
+use tempfile::NamedTempFile;
+
+use crate::error::{GitError, Result};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Record {
+    offset: u64,
+    len: u64,
+    digest: [u8; 32],
+    id: SemanticChangeId,
+    oid: GitObjectId,
+}
+
+#[derive(Debug)]
+struct Storage {
+    file: NamedTempFile,
+    records: Vec<Record>,
+    by_id: BTreeMap<SemanticChangeId, usize>,
+    by_oid: BTreeMap<GitObjectId, usize>,
+    bytes: u64,
+}
+
+/// Immutable, cloneable history. Only record indexes remain resident in memory.
+#[derive(Debug, Clone)]
+pub struct SemanticChangeSpool(Arc<Storage>);
+
+impl PartialEq for SemanticChangeSpool {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.records == other.0.records
+            && self
+                .iter()
+                .zip(other.iter())
+                .all(|(a, b)| matches!((a, b), (Ok(a), Ok(b)) if a == b))
+    }
+}
+
+impl SemanticChangeSpool {
+    pub fn len(&self) -> usize {
+        self.0.records.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.0.records.is_empty()
+    }
+    pub fn ids(&self) -> impl ExactSizeIterator<Item = SemanticChangeId> + '_ {
+        self.0.records.iter().map(|record| record.id)
+    }
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = Result<SemanticChange>> + '_ {
+        (0..self.len()).map(|index| {
+            self.read_at(index)?
+                .ok_or_else(|| invalid("missing indexed record"))
+        })
+    }
+    pub fn read_by_id(&self, id: &SemanticChangeId) -> Result<Option<SemanticChange>> {
+        self.0
+            .by_id
+            .get(id)
+            .map_or(Ok(None), |index| self.read_at(*index))
+    }
+    pub fn read_by_oid(&self, oid: &GitObjectId) -> Result<Option<SemanticChange>> {
+        self.0
+            .by_oid
+            .get(oid)
+            .map_or(Ok(None), |index| self.read_at(*index))
+    }
+    pub fn read_at(&self, index: usize) -> Result<Option<SemanticChange>> {
+        let Some(record) = self.0.records.get(index) else {
+            return Ok(None);
+        };
+        let path = self.0.file.path();
+        let mut file = self
+            .0
+            .file
+            .reopen()
+            .map_err(|error| GitError::io(path, error))?;
+        if file
+            .metadata()
+            .map_err(|error| GitError::io(path, error))?
+            .len()
+            != self.0.bytes
+        {
+            return Err(invalid("history spool length changed"));
+        }
+        file.seek(SeekFrom::Start(record.offset))
+            .map_err(|error| GitError::io(path, error))?;
+        let len = usize::try_from(record.len)
+            .map_err(|_| invalid("record length exceeds address space"))?;
+        let mut bytes = vec![0; len];
+        file.read_exact(&mut bytes)
+            .map_err(|error| GitError::io(path, error))?;
+        let digest: [u8; 32] = Sha256::digest(&bytes).into();
+        if digest != record.digest {
+            return Err(invalid("history spool checksum mismatch"));
+        }
+        let change: SemanticChange =
+            serde_json::from_slice(&bytes).map_err(|error| invalid(&error.to_string()))?;
+        if change.id != record.id || change.origin != (ChangeOrigin::GitCommit { oid: record.oid })
+        {
+            return Err(invalid("history spool identity mismatch"));
+        }
+        Ok(Some(change))
+    }
+    /// Explicit compatibility adapter for callers which already own a history.
+    pub fn from_changes(changes: impl IntoIterator<Item = SemanticChange>) -> Result<Self> {
+        let mut writer = SemanticChangeSpoolWriter::new()?;
+        for change in changes {
+            writer.append(change)?;
+        }
+        writer.finish()
+    }
+}
+
+pub(crate) struct SemanticChangeSpoolWriter(Storage);
+
+impl SemanticChangeSpoolWriter {
+    pub(crate) fn new() -> Result<Self> {
+        Ok(Self(Storage {
+            file: NamedTempFile::new()
+                .map_err(|error| GitError::io(std::env::temp_dir(), error))?,
+            records: Vec::new(),
+            by_id: BTreeMap::new(),
+            by_oid: BTreeMap::new(),
+            bytes: 0,
+        }))
+    }
+    pub(crate) fn len(&self) -> usize {
+        self.0.records.len()
+    }
+    pub(crate) fn append(&mut self, change: SemanticChange) -> Result<()> {
+        let ChangeOrigin::GitCommit { oid } = change.origin else {
+            return Err(invalid("native origin in imported history"));
+        };
+        if self.0.by_id.contains_key(&change.id) || self.0.by_oid.contains_key(&oid) {
+            return Err(invalid("duplicate identity in imported history"));
+        }
+        let bytes = serde_json::to_vec(&change).map_err(|error| invalid(&error.to_string()))?;
+        let len = u64::try_from(bytes.len()).map_err(|_| invalid("record length overflow"))?;
+        let end = self
+            .0
+            .bytes
+            .checked_add(len)
+            .ok_or_else(|| invalid("history length overflow"))?;
+        self.0
+            .file
+            .write_all(&bytes)
+            .map_err(|error| GitError::io(self.0.file.path(), error))?;
+        let index = self.0.records.len();
+        self.0.records.push(Record {
+            offset: self.0.bytes,
+            len,
+            digest: Sha256::digest(&bytes).into(),
+            id: change.id,
+            oid,
+        });
+        self.0.by_id.insert(change.id, index);
+        self.0.by_oid.insert(oid, index);
+        self.0.bytes = end;
+        Ok(())
+    }
+    pub(crate) fn finish(mut self) -> Result<SemanticChangeSpool> {
+        self.0
+            .file
+            .flush()
+            .map_err(|error| GitError::io(self.0.file.path(), error))?;
+        Ok(SemanticChangeSpool(Arc::new(self.0)))
+    }
+}
+
+fn invalid(message: &str) -> GitError {
+    GitError::InvalidSnapshot(message.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kin_model::{AuthorId, Hash256, Timestamp};
+
+    fn change(seed: u8) -> SemanticChange {
+        SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([seed; 32])),
+            origin: ChangeOrigin::GitCommit {
+                oid: GitObjectId::sha1([seed; 20]),
+            },
+            parents: Vec::new(),
+            timestamp: Timestamp::from(chrono::DateTime::from_timestamp(0, 0).unwrap()),
+            author: AuthorId::new("spool-test"),
+            message: seed.to_string(),
+            entity_deltas: Vec::new(),
+            relation_deltas: Vec::new(),
+            tree_deltas: Vec::new(),
+            admission_policy_delta: None,
+            projected_files: Vec::new(),
+            spec_link: None,
+            evidence: Vec::new(),
+            risk_summary: None,
+            external_reference_deltas: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn spool_preserves_owned_records_order_and_indexes() {
+        let records = vec![change(1), change(2)];
+        let spool = SemanticChangeSpool::from_changes(records.clone()).unwrap();
+        assert_eq!(spool.iter().collect::<Result<Vec<_>>>().unwrap(), records);
+        assert_eq!(
+            spool.ids().collect::<Vec<_>>(),
+            records.iter().map(|c| c.id).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            spool.read_by_id(&records[1].id).unwrap(),
+            Some(records[1].clone())
+        );
+        assert_eq!(
+            spool.read_by_oid(&GitObjectId::sha1([1; 20])).unwrap(),
+            Some(records[0].clone())
+        );
+        assert_eq!(spool.read_at(2).unwrap(), None);
+        assert_eq!(spool.read_by_id(&change(3).id).unwrap(), None);
+    }
+
+    #[test]
+    fn spool_refuses_duplicate_ids_and_duplicate_oids() {
+        assert!(SemanticChangeSpool::from_changes([change(1), change(1)]).is_err());
+        let mut duplicate_oid = change(2);
+        duplicate_oid.origin = change(1).origin;
+        assert!(SemanticChangeSpool::from_changes([change(1), duplicate_oid]).is_err());
+    }
+
+    #[test]
+    fn spool_refuses_valid_same_length_message_tampering() {
+        let original = change(1);
+        let spool = SemanticChangeSpool::from_changes([original.clone()]).unwrap();
+        assert_eq!(spool.read_at(0).unwrap(), Some(original.clone()));
+        let mut tampered = original;
+        tampered.message = "9".to_string();
+        let bytes = serde_json::to_vec(&tampered).unwrap();
+        assert_eq!(bytes.len() as u64, spool.0.records[0].len);
+        assert_eq!(
+            serde_json::from_slice::<SemanticChange>(&bytes).unwrap(),
+            tampered
+        );
+        let mut file = spool.0.file.reopen().unwrap();
+        file.seek(SeekFrom::Start(0)).unwrap();
+        file.write_all(&bytes).unwrap();
+        file.flush().unwrap();
+        assert!(
+            matches!(spool.read_at(0), Err(GitError::InvalidSnapshot(message))
+            if message == "history spool checksum mismatch")
+        );
+    }
+
+    #[test]
+    fn spool_refuses_index_identity_corruption_with_intact_digest() {
+        for corrupt_oid in [false, true] {
+            let original = change(1);
+            let mut spool = SemanticChangeSpool::from_changes([original.clone()]).unwrap();
+            assert_eq!(spool.read_at(0).unwrap(), Some(original.clone()));
+            let storage = Arc::get_mut(&mut spool.0).unwrap();
+            let record = &mut storage.records[0];
+            let digest = record.digest;
+            if corrupt_oid {
+                record.oid = GitObjectId::sha1([2; 20]);
+            } else {
+                record.id = change(2).id;
+            }
+            assert_eq!(record.digest, digest);
+            let mut bytes = Vec::new();
+            storage
+                .file
+                .reopen()
+                .unwrap()
+                .read_to_end(&mut bytes)
+                .unwrap();
+            assert_eq!(<[u8; 32]>::from(Sha256::digest(&bytes)), digest);
+            assert_eq!(
+                serde_json::from_slice::<SemanticChange>(&bytes).unwrap(),
+                original
+            );
+            assert!(
+                matches!(spool.read_at(0), Err(GitError::InvalidSnapshot(message))
+                if message == "history spool identity mismatch")
+            );
+        }
+    }
+
+    #[test]
+    fn spool_refuses_missing_truncated_tampered_and_appended_bodies() {
+        for mode in 0..4 {
+            let spool = SemanticChangeSpool::from_changes([change(1)]).unwrap();
+            let path = spool.0.file.path();
+            match mode {
+                0 => std::fs::remove_file(path).unwrap(),
+                1 => spool.0.file.as_file().set_len(1).unwrap(),
+                2 => {
+                    let mut file = spool.0.file.reopen().unwrap();
+                    file.write_all(b"!").unwrap();
+                }
+                _ => spool.0.file.as_file().set_len(spool.0.bytes + 1).unwrap(),
+            }
+            assert!(spool.read_at(0).is_err(), "corruption mode {mode}");
+        }
+    }
+
+    #[test]
+    fn spool_refuses_reordered_record_bytes() {
+        let spool = SemanticChangeSpool::from_changes([change(1), change(2)]).unwrap();
+        let mut file = spool.0.file.reopen().unwrap();
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes).unwrap();
+        let split = spool.0.records[0].len as usize;
+        bytes.rotate_left(split);
+        file.seek(SeekFrom::Start(0)).unwrap();
+        file.write_all(&bytes).unwrap();
+        assert!(spool.read_at(0).is_err());
+    }
+}

--- a/crates/kin-git/src/history_spool.rs
+++ b/crates/kin-git/src/history_spool.rs
@@ -318,7 +318,9 @@ mod tests {
         assert!(SemanticChangeSpool::from_changes(spool_dir(), [change(1), change(1)]).is_err());
         let mut duplicate_oid = change(2);
         duplicate_oid.origin = change(1).origin;
-        assert!(SemanticChangeSpool::from_changes(spool_dir(), [change(1), duplicate_oid]).is_err());
+        assert!(
+            SemanticChangeSpool::from_changes(spool_dir(), [change(1), duplicate_oid]).is_err()
+        );
     }
 
     #[test]
@@ -348,7 +350,8 @@ mod tests {
     fn spool_refuses_index_identity_corruption_with_intact_digest() {
         for corrupt_oid in [false, true] {
             let original = change(1);
-            let mut spool = SemanticChangeSpool::from_changes(spool_dir(), [original.clone()]).unwrap();
+            let mut spool =
+                SemanticChangeSpool::from_changes(spool_dir(), [original.clone()]).unwrap();
             assert_eq!(spool.read_at(0).unwrap(), Some(original.clone()));
             let storage = Arc::get_mut(&mut spool.0).unwrap();
             let record = &mut storage.records[0];

--- a/crates/kin-git/src/lib.rs
+++ b/crates/kin-git/src/lib.rs
@@ -26,6 +26,8 @@ pub mod admission_history;
 pub mod authority;
 pub mod error;
 pub mod global_config;
+pub mod history_spool;
+pub use history_spool::SemanticChangeSpool;
 pub mod lossless;
 pub mod preflight;
 pub mod repository_export;

--- a/crates/kin-git/src/repository_export.rs
+++ b/crates/kin-git/src/repository_export.rs
@@ -610,10 +610,8 @@ where
             )));
         }
     }
-    let historical_deltas = rebuilt
-        .changes
-        .iter()
-        .map(|base_change| {
+    let rebuilt =
+        rebuilt.enrich_with_historical_semantics(&proof_store, &mut |base_change, _tree| {
             let ChangeOrigin::GitCommit { oid } = base_change.origin else {
                 unreachable!("the exact Git planner only emits Git-origin changes");
             };
@@ -622,27 +620,26 @@ where
                     "Git export omits imported semantic history for commit {oid}"
                 ))
             })?;
-            Ok(HistoricalSemanticBinding::borrowed(
+            Ok(HistoricalSemanticBinding::owned(
                 base_change.id,
-                &supplied.entity_deltas,
-                &supplied.relation_deltas,
+                supplied.entity_deltas.clone(),
+                supplied.relation_deltas.clone(),
             ))
-        })
-        .collect::<Result<Vec<_>>>()?;
-    let rebuilt = rebuilt.with_historical_semantics(&proof_store, historical_deltas)?;
+        })?;
     let rebuilt = admit_semantic_git_import(&rebuilt, &proof_store)?;
-    let expected_changes = rebuilt
-        .changes
-        .into_iter()
-        .map(|change| (change.id, change))
-        .collect::<BTreeMap<_, _>>();
     let supplied_changes = plan
         .changes
         .iter()
         .filter(|change| matches!(change.origin, ChangeOrigin::GitCommit { .. }))
-        .cloned()
         .map(|change| (change.id, change))
         .collect::<BTreeMap<_, _>>();
+    let mut changes_match = supplied_changes.len() == rebuilt.changes.len();
+    for expected in rebuilt.changes.iter() {
+        let expected = expected?;
+        if supplied_changes.get(&expected.id).copied() != Some(&expected) {
+            changes_match = false;
+        }
+    }
     let expected_aliases = rebuilt
         .aliases
         .into_iter()
@@ -654,7 +651,7 @@ where
         .cloned()
         .map(|alias| (alias.oid, alias))
         .collect::<BTreeMap<_, _>>();
-    if supplied_changes != expected_changes || supplied_aliases != expected_aliases {
+    if !changes_match || supplied_aliases != expected_aliases {
         return Err(GitError::InvalidSnapshot(
             "imported semantic history does not rebuild exactly from stored Git authority"
                 .to_string(),
@@ -1170,7 +1167,11 @@ mod tests {
         )
         .unwrap();
         let authority = build_git_external_authority(&snapshot, &store).unwrap();
-        let imported_change = imported.changes.last().unwrap().clone();
+        let imported_change = imported
+            .changes
+            .read_at(imported.changes.len() - 1)
+            .unwrap()
+            .unwrap();
         let commit_trees = crate::semantic_import::derive_commit_trees(&snapshot, &store).unwrap();
         let base_tree = commit_trees
             .get(&match imported_change.origin {
@@ -1272,7 +1273,7 @@ mod tests {
             changes: imported
                 .changes
                 .iter()
-                .cloned()
+                .map(Result::unwrap)
                 .chain(std::iter::once(native.clone()))
                 .collect(),
             aliases: imported.aliases.clone(),
@@ -1406,7 +1407,7 @@ mod tests {
             "unexpected export proof error: {error}"
         );
 
-        let mut tampered_change = imported.changes[0].clone();
+        let mut tampered_change = imported.changes.read_at(0).unwrap().unwrap();
         tampered_change.message.push_str(" but not from raw Git");
         tampered_change.id = compute_semantic_change_id(&tampered_change).unwrap();
         let mut tampered_alias = imported.aliases[0].clone();

--- a/crates/kin-git/src/semantic_import.rs
+++ b/crates/kin-git/src/semantic_import.rs
@@ -25,6 +25,7 @@ use kin_model::{
 use uuid::Uuid;
 
 use crate::error::{GitError, Result};
+use crate::history_spool::{SemanticChangeSpool, SemanticChangeSpoolWriter};
 use crate::lossless::{validate_snapshot, GitObjectFormat, LosslessGitRepository};
 use crate::sealed_observation::{AdmittedContentSummary, SealedTreeObservation};
 
@@ -59,14 +60,9 @@ pub struct GitWorkspaceSeed {
 
 /// One imported change's historical semantics, owned or lent.
 ///
-/// The deltas exist twice at the moment they are bound: once in whatever
-/// derived them and once in the plan they are written into. Both callers that
-/// run at whole-repository scale used to pay for that, and they cannot pay for
-/// it the same way. The enrichment fold owns what it derived and never reads it
-/// again, so it can hand the deltas over; the admitted plan's self-check reads
-/// them out of the very structure it is checking, so it must lend them and must
-/// not copy the structure to do it. `Cow` is what lets one signature serve both
-/// with exactly one copy where there were two.
+/// Streaming enrichment moves owned deltas into one change before it is
+/// spooled. The compatibility binding API also accepts borrowed deltas from
+/// callers that already hold a history.
 #[derive(Debug, Clone, PartialEq)]
 pub struct HistoricalSemanticBinding<'a> {
     pub change_id: SemanticChangeId,
@@ -114,7 +110,7 @@ pub struct SemanticGitImportPlan {
     pub repository_id: RepositoryId,
     pub object_format: GitObjectFormat,
     pub external_objects: Vec<ExternalObjectRecord>,
-    pub changes: Vec<SemanticChange>,
+    pub changes: SemanticChangeSpool,
     pub aliases: Vec<ExternalChangeAlias>,
     /// The canonical identity of every imported commit's exact tree, keyed by
     /// commit: thirty-two bytes where a conversion used to hold the tree
@@ -174,7 +170,7 @@ impl ProvedPlanFacts for SemanticGitImportPlan {
         self.changes.len()
     }
     fn proved_change_ids(&self) -> impl Iterator<Item = SemanticChangeId> + '_ {
-        self.changes.iter().map(|change| change.id)
+        self.changes.ids()
     }
     fn proved_aliases(&self) -> &[ExternalChangeAlias] {
         &self.aliases
@@ -236,7 +232,7 @@ impl ProvedImportClosure {
     /// dropped at this call instead of living on beside a copy of everything
     /// else.
     pub fn from_proved_plan(plan: SemanticGitImportPlan) -> Self {
-        let change_ids = plan.changes.iter().map(|change| change.id).collect();
+        let change_ids = plan.changes.ids().collect();
         Self {
             repository_id: plan.repository_id,
             object_format: plan.object_format,
@@ -347,20 +343,52 @@ impl SemanticGitImportPlan {
     ) -> Result<Self> {
         let snapshot = self.raw_snapshot();
         let mut comparison = HeldPlanComparison::new(&self, Enrichment::None, EXACT_UNENRICHED)?;
-        let mut bindings = Vec::with_capacity(self.changes.len());
+        let mut changes = SemanticChangeSpoolWriter::new()?;
+        let mut aliases = Vec::with_capacity(self.aliases.len());
+        let mut old_to_new = BTreeMap::new();
         let derived = derive_semantic_git_history(
             &snapshot,
             blob_store,
             TreeRetention::Frontier,
             &mut |oid, change, alias, tree, facts| {
                 comparison.check_commit(oid, change, alias, facts)?;
-                let held = comparison.held_change(oid)?;
-                bindings.push(enrich(held, tree)?);
+                let mut held = comparison.held_change(oid)?;
+                let binding = enrich(&held, tree)?;
+                if binding.change_id != held.id {
+                    return Err(GitError::InvalidSnapshot(
+                        "historical semantic deltas name a different change".to_string(),
+                    ));
+                }
+                let old_id = held.id;
+                held.parents = held
+                    .parents
+                    .iter()
+                    .map(|parent| {
+                        old_to_new.get(parent).copied().ok_or_else(|| {
+                            GitError::InvalidSnapshot(format!(
+                                "parent {parent} was not reidentified before change {old_id}"
+                            ))
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                held.entity_deltas = binding.entity_deltas.into_owned();
+                held.relation_deltas = binding.relation_deltas.into_owned();
+                held.id = placeholder_change_id();
+                held.id = compute_semantic_change_id(&held)?;
+                validate_semantic_change_id(&held)?;
+                let alias = ExternalChangeAlias::new(self.repository_id.clone(), oid, held.id);
+                alias.validate_change(&held)?;
+                old_to_new.insert(old_id, held.id);
+                changes.append(held)?;
+                aliases.push(alias);
                 Ok(())
             },
         )?;
         comparison.finish(&derived)?;
-        apply_historical_semantic_deltas_unchecked(self, bindings)
+        let mut plan = self;
+        plan.changes = changes.finish()?;
+        plan.aliases = aliases;
+        Ok(plan)
     }
 
     /// Bind deterministic CAS-native semantic deltas and recompute every
@@ -430,10 +458,10 @@ pub(crate) struct DerivedEnrichedHistory {
 /// one. Only the visitor decides what survives the commit it was handed; this
 /// walk keeps the frontier trees the derivation itself needs, plus one identity
 /// pair per commit, and nothing else.
-pub(crate) fn derive_enriched_semantic_git_history<'held>(
+pub(crate) fn derive_enriched_semantic_git_history(
     snapshot: &LosslessGitRepository,
     blob_store: &BlobStore,
-    held_semantics: &dyn Fn(GitObjectId) -> Option<(&'held [EntityDelta], &'held [RelationDelta])>,
+    held_semantics: &dyn Fn(GitObjectId) -> Result<Option<(Vec<EntityDelta>, Vec<RelationDelta>)>>,
     visit: &mut dyn FnMut(
         GitObjectId,
         &[GitObjectId],
@@ -466,14 +494,14 @@ pub(crate) fn derive_enriched_semantic_git_history<'held>(
                 parent_oids.push(parent_oid);
                 parents.push(parent_id);
             }
-            let Some((entity_deltas, relation_deltas)) = held_semantics(oid) else {
+            let Some((entity_deltas, relation_deltas)) = held_semantics(oid)? else {
                 return Err(GitError::InvalidSnapshot(format!(
                     "historical semantic deltas omit Git commit {oid}"
                 )));
             };
             change.parents = parents;
-            change.entity_deltas = entity_deltas.to_vec();
-            change.relation_deltas = relation_deltas.to_vec();
+            change.entity_deltas = entity_deltas;
+            change.relation_deltas = relation_deltas;
             change.id = placeholder_change_id();
             change.id = compute_semantic_change_id(&change)?;
             validate_semantic_change_id(&change)?;
@@ -523,9 +551,10 @@ fn apply_historical_semantic_deltas_unchecked(
     }
 
     let mut old_to_new = BTreeMap::<SemanticChangeId, SemanticChangeId>::new();
-    let mut changes = Vec::with_capacity(plan.changes.len());
+    let mut changes = SemanticChangeSpoolWriter::new()?;
     let mut aliases = Vec::with_capacity(plan.changes.len());
-    for mut change in plan.changes {
+    for change in plan.changes.iter() {
+        let mut change = change?;
         let old_id = change.id;
         let delta = delta_by_change.remove(&old_id).ok_or_else(|| {
             GitError::InvalidSnapshot(format!("historical semantic deltas omit change {old_id}"))
@@ -567,7 +596,7 @@ fn apply_historical_semantic_deltas_unchecked(
         let alias = ExternalChangeAlias::new(plan.repository_id.clone(), oid, change.id);
         alias.validate_change(&change)?;
         old_to_new.insert(old_id, change.id);
-        changes.push(change);
+        changes.append(change)?;
         aliases.push(alias);
     }
     if !delta_by_change.is_empty() {
@@ -575,7 +604,7 @@ fn apply_historical_semantic_deltas_unchecked(
             "historical semantic deltas contain unknown changes".to_string(),
         ));
     }
-    plan.changes = changes;
+    plan.changes = changes.finish()?;
     plan.aliases = aliases;
     Ok(plan)
 }
@@ -641,6 +670,7 @@ impl<'a> HeldPlanComparison<'a> {
     ) -> Result<Self> {
         let mut held_by_oid = BTreeMap::new();
         for (index, change) in plan.changes.iter().enumerate() {
+            let change = change?;
             let ChangeOrigin::GitCommit { oid } = change.origin else {
                 return Err(GitError::InvalidSnapshot(
                     "semantic Git import contains a native-origin change".to_string(),
@@ -667,13 +697,16 @@ impl<'a> HeldPlanComparison<'a> {
     }
 
     /// The held change for one Git commit, wherever it sits in the plan.
-    fn held_change(&self, oid: GitObjectId) -> Result<&'a SemanticChange> {
+    fn held_change(&self, oid: GitObjectId) -> Result<SemanticChange> {
         let index = *self.held_by_oid.get(&oid).ok_or_else(|| {
             GitError::InvalidSnapshot(format!(
                 "semantic Git import is missing enriched commit {oid}"
             ))
         })?;
-        self.plan.changes.get(index).ok_or_else(|| self.refuse())
+        self.plan
+            .changes
+            .read_at(index)?
+            .ok_or_else(|| self.refuse())
     }
 
     fn check_commit(
@@ -693,7 +726,7 @@ impl<'a> HeldPlanComparison<'a> {
             let held = self
                 .plan
                 .changes
-                .get(held_index)
+                .read_at(held_index)?
                 .ok_or_else(|| self.refuse())?;
             let old_id = change.id;
             change.parents = change
@@ -707,8 +740,8 @@ impl<'a> HeldPlanComparison<'a> {
                     })
                 })
                 .collect::<Result<Vec<_>>>()?;
-            change.entity_deltas = held.entity_deltas.clone();
-            change.relation_deltas = held.relation_deltas.clone();
+            change.entity_deltas = held.entity_deltas;
+            change.relation_deltas = held.relation_deltas;
             change.id = placeholder_change_id();
             change.id = compute_semantic_change_id(&change)?;
             validate_semantic_change_id(&change)?;
@@ -726,7 +759,7 @@ impl<'a> HeldPlanComparison<'a> {
         // held plan whose tree hash or content summary was altered fails at
         // the commit it was altered for.
         let index = self.checked;
-        if self.plan.changes.get(index) != Some(&change)
+        if self.plan.changes.read_at(index)?.as_ref() != Some(&change)
             || self.plan.aliases.get(index) != Some(&alias)
             || self.plan.commit_tree_hashes.get(&oid) != Some(&facts.tree_hash)
             || self.plan.content.trees.get(&oid) != Some(&facts.content)
@@ -1067,14 +1100,14 @@ fn build_semantic_git_import_plan(
     snapshot: &LosslessGitRepository,
     blob_store: &BlobStore,
 ) -> Result<SemanticGitImportPlan> {
-    let mut changes = Vec::new();
+    let mut changes = SemanticChangeSpoolWriter::new()?;
     let mut aliases = Vec::new();
     let derived = derive_semantic_git_history(
         snapshot,
         blob_store,
         TreeRetention::Frontier,
         &mut |_oid, change, alias, _tree, _facts| {
-            changes.push(change);
+            changes.append(change)?;
             aliases.push(alias);
             Ok(())
         },
@@ -1094,7 +1127,7 @@ fn build_semantic_git_import_plan(
         repository_id: snapshot.repository_id.clone(),
         object_format: snapshot.object_format,
         external_objects: snapshot.objects.clone(),
-        changes,
+        changes: changes.finish()?,
         aliases,
         commit_tree_hashes: derived.commit_tree_hashes,
         content: derived.content,
@@ -2147,6 +2180,72 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn spooled_history_preserves_enrichment_and_refuses_missing_or_reordered_records() {
+        let fixture = SemanticFixture::octopus_polyglot();
+        let snapshot = capture_lossless_git_repository(
+            &fixture.repo,
+            RepositoryId::new("spooled-history").unwrap(),
+            &fixture.blob_store,
+        )
+        .unwrap();
+        let plan = plan_semantic_git_import(&snapshot, &fixture.blob_store).unwrap();
+        let bindings = plan
+            .changes
+            .ids()
+            .map(|id| HistoricalSemanticBinding::owned(id, Vec::new(), Vec::new()))
+            .collect();
+        let legacy = plan
+            .clone()
+            .with_historical_semantics(&fixture.blob_store, bindings)
+            .unwrap();
+        let streamed = plan
+            .clone()
+            .enrich_with_historical_semantics(&fixture.blob_store, &mut |change, _tree| {
+                Ok(HistoricalSemanticBinding::owned(
+                    change.id,
+                    Vec::new(),
+                    Vec::new(),
+                ))
+            })
+            .unwrap();
+        assert_eq!(streamed, legacy);
+        streamed.validate(&fixture.blob_store).unwrap();
+        let admitted = admit_semantic_git_import(&streamed, &fixture.blob_store).unwrap();
+        admitted.validate(&fixture.blob_store).unwrap();
+
+        for remove in [false, true] {
+            let mut malformed = plan.clone();
+            let mut records = malformed
+                .changes
+                .iter()
+                .collect::<Result<Vec<_>>>()
+                .unwrap();
+            if remove {
+                records.pop();
+            } else {
+                records.swap(0, 1);
+            }
+            malformed.changes = SemanticChangeSpool::from_changes(records).unwrap();
+            assert!(malformed.validate(&fixture.blob_store).is_err());
+
+            let mut malformed = admitted.clone();
+            let mut records = malformed
+                .changes
+                .iter()
+                .collect::<Result<Vec<_>>>()
+                .unwrap();
+            if remove {
+                records.pop();
+            } else {
+                records.swap(0, 1);
+            }
+            malformed.changes = SemanticChangeSpool::from_changes(records).unwrap();
+            assert!(malformed.validate(&fixture.blob_store).is_err());
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn plans_exact_polyglot_octopus_history_without_repository_access() {
         let fixture = SemanticFixture::octopus_polyglot();
         let snapshot = capture_lossless_git_repository(
@@ -2183,6 +2282,7 @@ mod tests {
             );
         }
         assert!(second.changes.iter().all(|change| {
+            let change = change.unwrap();
             matches!(change.origin, ChangeOrigin::GitCommit { .. })
                 && change.entity_deltas.is_empty()
                 && change.relation_deltas.is_empty()
@@ -2473,7 +2573,6 @@ mod tests {
         }
         let initial_delta = admitted_change_for_oid(&admitted, fixture.initial)
             .admission_policy_delta
-            .as_ref()
             .unwrap();
         assert_eq!(initial_delta.old, None);
         assert_eq!(initial_delta.new.as_ref(), Some(initial_policy));
@@ -2494,7 +2593,6 @@ mod tests {
         assert_ne!(branch_one_policy.hash, initial_policy.hash);
         let branch_one_delta = admitted_change_for_oid(&admitted, fixture.one)
             .admission_policy_delta
-            .as_ref()
             .unwrap();
         assert_eq!(branch_one_delta.old.as_ref(), Some(initial_policy));
         assert_eq!(branch_one_delta.new.as_ref(), Some(branch_one_policy));
@@ -2519,7 +2617,6 @@ mod tests {
         assert_eq!(merge_policy.generation, 1);
         let merge_delta = admitted_change_for_oid(&admitted, fixture.merge)
             .admission_policy_delta
-            .as_ref()
             .unwrap();
         assert_eq!(merge_delta.old.as_ref(), Some(empty_policy));
         assert_eq!(merge_delta.new.as_ref(), Some(merge_policy));
@@ -2561,7 +2658,10 @@ mod tests {
                 "admit branch-versioned Git history",
             )
             .unwrap();
-        assert_eq!(transaction.changes, admitted.changes);
+        assert_eq!(
+            transaction.changes,
+            admitted.changes.iter().collect::<Result<Vec<_>>>().unwrap()
+        );
         assert_eq!(transaction.aliases, admitted.aliases);
         assert!(transaction.git_authority_delta.is_none());
         assert!(transaction.workspace_mutation.is_none());
@@ -2672,7 +2772,9 @@ mod tests {
         let admitted = admit_semantic_git_import(&plan, &blob_store).unwrap();
 
         let mut mutated = plan.clone();
-        mutated.changes[0].message.push_str("tampered");
+        let mut changes = mutated.changes.iter().collect::<Result<Vec<_>>>().unwrap();
+        changes[0].message.push_str("tampered");
+        mutated.changes = SemanticChangeSpool::from_changes(changes).unwrap();
         assert!(matches!(
             mutated.validate(&blob_store),
             Err(GitError::InvalidSnapshot(_))
@@ -3090,11 +3192,8 @@ mod tests {
     }
 
     #[cfg(unix)]
-    fn change_for_oid(plan: &SemanticGitImportPlan, oid: GitObjectId) -> &SemanticChange {
-        plan.changes
-            .iter()
-            .find(|change| change.origin == ChangeOrigin::GitCommit { oid })
-            .unwrap()
+    fn change_for_oid(plan: &SemanticGitImportPlan, oid: GitObjectId) -> SemanticChange {
+        plan.changes.read_by_oid(&oid).unwrap().unwrap()
     }
 
     #[cfg(unix)]
@@ -3106,11 +3205,8 @@ mod tests {
     fn admitted_change_for_oid(
         plan: &AdmittedSemanticGitImportPlan,
         oid: GitObjectId,
-    ) -> &SemanticChange {
-        plan.changes
-            .iter()
-            .find(|change| change.origin == ChangeOrigin::GitCommit { oid })
-            .unwrap()
+    ) -> SemanticChange {
+        plan.changes.read_by_oid(&oid).unwrap().unwrap()
     }
 
     #[cfg(unix)]

--- a/crates/kin-git/src/semantic_import.rs
+++ b/crates/kin-git/src/semantic_import.rs
@@ -341,54 +341,7 @@ impl SemanticGitImportPlan {
             &ResolvedTree,
         ) -> Result<HistoricalSemanticBinding<'static>>,
     ) -> Result<Self> {
-        let snapshot = self.raw_snapshot();
-        let mut comparison = HeldPlanComparison::new(&self, Enrichment::None, EXACT_UNENRICHED)?;
-        let mut changes = SemanticChangeSpoolWriter::new()?;
-        let mut aliases = Vec::with_capacity(self.aliases.len());
-        let mut old_to_new = BTreeMap::new();
-        let derived = derive_semantic_git_history(
-            &snapshot,
-            blob_store,
-            TreeRetention::Frontier,
-            &mut |oid, change, alias, tree, facts| {
-                comparison.check_commit(oid, change, alias, facts)?;
-                let mut held = comparison.held_change(oid)?;
-                let binding = enrich(&held, tree)?;
-                if binding.change_id != held.id {
-                    return Err(GitError::InvalidSnapshot(
-                        "historical semantic deltas name a different change".to_string(),
-                    ));
-                }
-                let old_id = held.id;
-                held.parents = held
-                    .parents
-                    .iter()
-                    .map(|parent| {
-                        old_to_new.get(parent).copied().ok_or_else(|| {
-                            GitError::InvalidSnapshot(format!(
-                                "parent {parent} was not reidentified before change {old_id}"
-                            ))
-                        })
-                    })
-                    .collect::<Result<Vec<_>>>()?;
-                held.entity_deltas = binding.entity_deltas.into_owned();
-                held.relation_deltas = binding.relation_deltas.into_owned();
-                held.id = placeholder_change_id();
-                held.id = compute_semantic_change_id(&held)?;
-                validate_semantic_change_id(&held)?;
-                let alias = ExternalChangeAlias::new(self.repository_id.clone(), oid, held.id);
-                alias.validate_change(&held)?;
-                old_to_new.insert(old_id, held.id);
-                changes.append(held)?;
-                aliases.push(alias);
-                Ok(())
-            },
-        )?;
-        comparison.finish(&derived)?;
-        let mut plan = self;
-        plan.changes = changes.finish()?;
-        plan.aliases = aliases;
-        Ok(plan)
+        enrich_with_historical_semantics(self, blob_store, enrich)
     }
 
     /// Bind deterministic CAS-native semantic deltas and recompute every
@@ -417,6 +370,64 @@ impl SemanticGitImportPlan {
         comparison.finish(&derived)?;
         apply_historical_semantic_deltas_unchecked(self, bindings)
     }
+}
+
+fn enrich_with_historical_semantics(
+    plan: SemanticGitImportPlan,
+    blob_store: &BlobStore,
+    enrich: &mut dyn FnMut(
+        &SemanticChange,
+        &ResolvedTree,
+    ) -> Result<HistoricalSemanticBinding<'static>>,
+) -> Result<SemanticGitImportPlan> {
+    let snapshot = plan.raw_snapshot();
+    let mut comparison = HeldPlanComparison::new(&plan, Enrichment::None, EXACT_UNENRICHED)?;
+    let mut changes = SemanticChangeSpoolWriter::new()?;
+    let mut aliases = Vec::with_capacity(plan.aliases.len());
+    let mut old_to_new = BTreeMap::new();
+    let derived = derive_semantic_git_history(
+        &snapshot,
+        blob_store,
+        TreeRetention::Frontier,
+        &mut |oid, change, alias, tree, facts| {
+            comparison.check_commit(oid, change, alias, facts)?;
+            let mut held = comparison.held_change(oid)?;
+            let binding = enrich(&held, tree)?;
+            if binding.change_id != held.id {
+                return Err(GitError::InvalidSnapshot(
+                    "historical semantic deltas name a different change".to_string(),
+                ));
+            }
+            let old_id = held.id;
+            held.parents = held
+                .parents
+                .iter()
+                .map(|parent| {
+                    old_to_new.get(parent).copied().ok_or_else(|| {
+                        GitError::InvalidSnapshot(format!(
+                            "parent {parent} was not reidentified before change {old_id}"
+                        ))
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            held.entity_deltas = binding.entity_deltas.into_owned();
+            held.relation_deltas = binding.relation_deltas.into_owned();
+            held.id = placeholder_change_id();
+            held.id = compute_semantic_change_id(&held)?;
+            validate_semantic_change_id(&held)?;
+            let alias = ExternalChangeAlias::new(plan.repository_id.clone(), oid, held.id);
+            alias.validate_change(&held)?;
+            old_to_new.insert(old_id, held.id);
+            changes.append(held)?;
+            aliases.push(alias);
+            Ok(())
+        },
+    )?;
+    comparison.finish(&derived)?;
+    let mut plan = plan;
+    plan.changes = changes.finish()?;
+    plan.aliases = aliases;
+    Ok(plan)
 }
 
 /// Build semantic Git history using only a lossless snapshot and its CAS.

--- a/crates/kin-git/src/semantic_import.rs
+++ b/crates/kin-git/src/semantic_import.rs
@@ -2336,7 +2336,8 @@ mod tests {
             } else {
                 records.swap(0, 1);
             }
-            malformed.changes = SemanticChangeSpool::from_changes(fixture.blob_store.root(), records).unwrap();
+            malformed.changes =
+                SemanticChangeSpool::from_changes(fixture.blob_store.root(), records).unwrap();
             assert!(malformed.validate(&fixture.blob_store).is_err());
 
             let mut malformed = admitted.clone();
@@ -2350,7 +2351,8 @@ mod tests {
             } else {
                 records.swap(0, 1);
             }
-            malformed.changes = SemanticChangeSpool::from_changes(fixture.blob_store.root(), records).unwrap();
+            malformed.changes =
+                SemanticChangeSpool::from_changes(fixture.blob_store.root(), records).unwrap();
             assert!(malformed.validate(&fixture.blob_store).is_err());
         }
     }

--- a/crates/kin-git/src/semantic_import.rs
+++ b/crates/kin-git/src/semantic_import.rs
@@ -2190,6 +2190,76 @@ mod tests {
         }
     }
 
+    /// Deterministic historical semantics for one change, so the two
+    /// enrichment paths can be handed exactly the same deltas.
+    ///
+    /// Empty deltas cannot tell those paths apart. `entity_deltas` and
+    /// `relation_deltas` are part of what `compute_semantic_change_id` seals,
+    /// so a comparison that leaves both empty grades every id as an
+    /// unenriched change's id and proves nothing about enrichment itself.
+    /// These carry real content, and the ids fall out of it.
+    #[cfg(unix)]
+    fn historical_deltas_for(index: usize) -> (Vec<EntityDelta>, Vec<RelationDelta>) {
+        use kin_model::{
+            Entity, EntityId, EntityKind, EntityMetadata, EntityRole, FilePathId,
+            FingerprintAlgorithm, GraphNodeId, LanguageId, Relation, RelationId, RelationKind,
+            RelationOrigin, SemanticFingerprint, Visibility,
+        };
+
+        let file = format!("src/commit_{index}.rs");
+        let entity = |name: &str, line: u32, seed: u8| Entity {
+            id: EntityId::from_content(&file, name, "function", line),
+            kind: EntityKind::Function,
+            name: name.to_string(),
+            language: LanguageId::Rust,
+            fingerprint: SemanticFingerprint {
+                algorithm: FingerprintAlgorithm::V1TreeSitter,
+                ast_hash: Hash256::from_bytes([seed; 32]),
+                signature_hash: Hash256::from_bytes([seed ^ 0x11; 32]),
+                behavior_hash: Hash256::from_bytes([seed ^ 0x22; 32]),
+                equivalence_hash: Hash256::from_bytes([seed ^ 0x33; 32]),
+                stability_score: 1.0,
+            },
+            file_origin: Some(FilePathId::new(file.clone())),
+            span: None,
+            signature: format!("fn {name}()"),
+            visibility: Visibility::Private,
+            role: EntityRole::Source,
+            doc_summary: None,
+            metadata: EntityMetadata::default(),
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        };
+
+        let seed = u8::try_from(index).unwrap_or(u8::MAX);
+        let added = entity("added", 1, 0x10 ^ seed);
+        let before = entity("edited", 9, 0x40);
+        let after = entity("edited", 9, 0x50 ^ seed);
+        let relation = Relation {
+            id: RelationId::from_content(&added.id.to_string(), &after.id.to_string(), "calls"),
+            kind: RelationKind::Calls,
+            src: GraphNodeId::Entity(added.id),
+            dst: GraphNodeId::Entity(after.id),
+            confidence: 1.0,
+            origin: RelationOrigin::Parsed,
+            created_in: None,
+            import_source: None,
+            evidence: Vec::new(),
+        };
+
+        (
+            vec![
+                EntityDelta::Added { new: added },
+                EntityDelta::Modified {
+                    old: before,
+                    new: after,
+                },
+            ],
+            vec![RelationDelta::Added { new: relation }],
+        )
+    }
+
     #[cfg(unix)]
     #[test]
     fn spooled_history_preserves_enrichment_and_refuses_missing_or_reordered_records() {
@@ -2201,10 +2271,24 @@ mod tests {
         )
         .unwrap();
         let plan = plan_semantic_git_import(&snapshot, &fixture.blob_store).unwrap();
-        let bindings = plan
+        // Keyed by change id, not by position, so the whole-plan arm and the
+        // streaming arm bind the same deltas to the same change however each
+        // one reaches it.
+        let deltas_by_change = plan
             .changes
             .ids()
-            .map(|id| HistoricalSemanticBinding::owned(id, Vec::new(), Vec::new()))
+            .enumerate()
+            .map(|(index, id)| (id, historical_deltas_for(index)))
+            .collect::<BTreeMap<_, _>>();
+        let bindings = deltas_by_change
+            .iter()
+            .map(|(id, (entity_deltas, relation_deltas))| {
+                HistoricalSemanticBinding::owned(
+                    *id,
+                    entity_deltas.clone(),
+                    relation_deltas.clone(),
+                )
+            })
             .collect();
         let legacy = plan
             .clone()
@@ -2213,14 +2297,29 @@ mod tests {
         let streamed = plan
             .clone()
             .enrich_with_historical_semantics(&fixture.blob_store, &mut |change, _tree| {
+                let (entity_deltas, relation_deltas) = deltas_by_change
+                    .get(&change.id)
+                    .expect("every held change was given deltas")
+                    .clone();
                 Ok(HistoricalSemanticBinding::owned(
                     change.id,
-                    Vec::new(),
-                    Vec::new(),
+                    entity_deltas,
+                    relation_deltas,
                 ))
             })
             .unwrap();
         assert_eq!(streamed, legacy);
+        // The equality above is only worth its name while the deltas it
+        // compares are real. Without this, a future edit that empties them
+        // leaves a green test grading the unenriched case again.
+        for change in streamed.changes.iter() {
+            let change = change.unwrap();
+            assert!(
+                !change.entity_deltas.is_empty() && !change.relation_deltas.is_empty(),
+                "change {} was compared without enrichment",
+                change.id
+            );
+        }
         streamed.validate(&fixture.blob_store).unwrap();
         let admitted = admit_semantic_git_import(&streamed, &fixture.blob_store).unwrap();
         admitted.validate(&fixture.blob_store).unwrap();

--- a/crates/kin-git/src/semantic_import.rs
+++ b/crates/kin-git/src/semantic_import.rs
@@ -368,7 +368,7 @@ impl SemanticGitImportPlan {
             },
         )?;
         comparison.finish(&derived)?;
-        apply_historical_semantic_deltas_unchecked(self, bindings)
+        apply_historical_semantic_deltas_unchecked(self, blob_store, bindings)
     }
 }
 
@@ -382,7 +382,7 @@ fn enrich_with_historical_semantics(
 ) -> Result<SemanticGitImportPlan> {
     let snapshot = plan.raw_snapshot();
     let mut comparison = HeldPlanComparison::new(&plan, Enrichment::None, EXACT_UNENRICHED)?;
-    let mut changes = SemanticChangeSpoolWriter::new()?;
+    let mut changes = SemanticChangeSpoolWriter::new_in(blob_store.root())?;
     let mut aliases = Vec::with_capacity(plan.aliases.len());
     let mut old_to_new = BTreeMap::new();
     let derived = derive_semantic_git_history(
@@ -538,6 +538,7 @@ pub(crate) fn derive_enriched_semantic_git_history(
 
 fn apply_historical_semantic_deltas_unchecked(
     mut plan: SemanticGitImportPlan,
+    blob_store: &BlobStore,
     bindings: Vec<HistoricalSemanticBinding<'_>>,
 ) -> Result<SemanticGitImportPlan> {
     let mut delta_by_change = BTreeMap::new();
@@ -562,7 +563,7 @@ fn apply_historical_semantic_deltas_unchecked(
     }
 
     let mut old_to_new = BTreeMap::<SemanticChangeId, SemanticChangeId>::new();
-    let mut changes = SemanticChangeSpoolWriter::new()?;
+    let mut changes = SemanticChangeSpoolWriter::new_in(blob_store.root())?;
     let mut aliases = Vec::with_capacity(plan.changes.len());
     for change in plan.changes.iter() {
         let mut change = change?;
@@ -1111,7 +1112,7 @@ fn build_semantic_git_import_plan(
     snapshot: &LosslessGitRepository,
     blob_store: &BlobStore,
 ) -> Result<SemanticGitImportPlan> {
-    let mut changes = SemanticChangeSpoolWriter::new()?;
+    let mut changes = SemanticChangeSpoolWriter::new_in(blob_store.root())?;
     let mut aliases = Vec::new();
     let derived = derive_semantic_git_history(
         snapshot,
@@ -2236,7 +2237,7 @@ mod tests {
             } else {
                 records.swap(0, 1);
             }
-            malformed.changes = SemanticChangeSpool::from_changes(records).unwrap();
+            malformed.changes = SemanticChangeSpool::from_changes(fixture.blob_store.root(), records).unwrap();
             assert!(malformed.validate(&fixture.blob_store).is_err());
 
             let mut malformed = admitted.clone();
@@ -2250,7 +2251,7 @@ mod tests {
             } else {
                 records.swap(0, 1);
             }
-            malformed.changes = SemanticChangeSpool::from_changes(records).unwrap();
+            malformed.changes = SemanticChangeSpool::from_changes(fixture.blob_store.root(), records).unwrap();
             assert!(malformed.validate(&fixture.blob_store).is_err());
         }
     }
@@ -2785,7 +2786,7 @@ mod tests {
         let mut mutated = plan.clone();
         let mut changes = mutated.changes.iter().collect::<Result<Vec<_>>>().unwrap();
         changes[0].message.push_str("tampered");
-        mutated.changes = SemanticChangeSpool::from_changes(changes).unwrap();
+        mutated.changes = SemanticChangeSpool::from_changes(blob_store.root(), changes).unwrap();
         assert!(matches!(
             mutated.validate(&blob_store),
             Err(GitError::InvalidSnapshot(_))

--- a/crates/kin-index/src/history.rs
+++ b/crates/kin-index/src/history.rs
@@ -171,9 +171,24 @@ impl HistoricalSemanticFold {
     /// taken from the whole history, which is why the fold has to see it
     /// before it enriches anything.
     pub fn new(changes: &[SemanticChange]) -> Result<Self> {
-        let mut pending = HashSet::with_capacity(changes.len());
+        Self::from_change_stream(changes.iter().map(Ok::<_, std::convert::Infallible>))
+    }
+
+    /// Inspect complete history one record at a time, retaining only identity
+    /// and parent-use metadata needed by the subsequent semantic fold.
+    pub fn from_change_stream<C, E>(
+        changes: impl IntoIterator<Item = std::result::Result<C, E>>,
+    ) -> Result<Self>
+    where
+        C: std::borrow::Borrow<SemanticChange>,
+        E: std::fmt::Display,
+    {
+        let mut pending = HashSet::new();
         let mut remaining_child_uses = BTreeMap::<SemanticChangeId, usize>::new();
         for change in changes {
+            let change =
+                change.map_err(|error| invalid(format!("read historical change: {error}")))?;
+            let change = change.borrow();
             if !matches!(change.origin, ChangeOrigin::GitCommit { .. }) {
                 return Err(invalid(format!(
                     "historical Git enrichment received native change {}",
@@ -936,8 +951,13 @@ mod tests {
         let plan = plan_semantic_git_import(&snapshot, &blob_store).unwrap();
         let trees = trees_by_change(&plan, &snapshot, &blob_store);
 
-        let first = derive_historical_semantic_deltas(&plan.changes, &trees, &blob_store).unwrap();
-        let second = derive_historical_semantic_deltas(&plan.changes, &trees, &blob_store).unwrap();
+        let changes = plan
+            .changes
+            .iter()
+            .collect::<kin_git::Result<Vec<_>>>()
+            .unwrap();
+        let first = derive_historical_semantic_deltas(&changes, &trees, &blob_store).unwrap();
+        let second = derive_historical_semantic_deltas(&changes, &trees, &blob_store).unwrap();
         assert_eq!(second, first);
         assert_eq!(first.len(), 2);
 
@@ -960,13 +980,13 @@ mod tests {
         admitted.validate(&blob_store).unwrap();
         assert_ne!(enriched.aliases, plan.aliases);
         assert_eq!(
-            enriched.changes[1].parents,
-            vec![enriched.changes[0].id],
+            enriched.changes.read_at(1).unwrap().unwrap().parents,
+            vec![enriched.changes.read_at(0).unwrap().unwrap().id],
             "semantic binding must reidentify parent edges"
         );
         assert_eq!(
-            admitted.changes[0].entity_deltas,
-            enriched.changes[0].entity_deltas
+            admitted.changes.read_at(0).unwrap().unwrap().entity_deltas,
+            enriched.changes.read_at(0).unwrap().unwrap().entity_deltas
         );
 
         let initial_entities = first[0]
@@ -1003,7 +1023,7 @@ mod tests {
         assert_eq!(modified_answer.0.id, initial_answer.id);
         assert_eq!(modified_answer.1.id, initial_answer.id);
 
-        let tip = trees.get(&plan.changes[1].id).unwrap();
+        let tip = trees.get(&changes[1].id).unwrap();
         assert!(tip
             .artifact_at_path(&kin_model::RepoPath::from_utf8("compose.yaml").unwrap())
             .is_some());
@@ -1055,7 +1075,12 @@ mod tests {
         .unwrap();
         let plan = plan_semantic_git_import(&snapshot, &blob_store).unwrap();
         let trees = trees_by_change(&plan, &snapshot, &blob_store);
-        let deltas = derive_historical_semantic_deltas(&plan.changes, &trees, &blob_store).unwrap();
+        let changes = plan
+            .changes
+            .iter()
+            .collect::<kin_git::Result<Vec<_>>>()
+            .unwrap();
+        let deltas = derive_historical_semantic_deltas(&changes, &trees, &blob_store).unwrap();
 
         let feature_id = deltas
             .iter()
@@ -1067,7 +1092,7 @@ mod tests {
         let merge_index = plan
             .changes
             .iter()
-            .position(|change| change.parents.len() == 2)
+            .position(|change| change.unwrap().parents.len() == 2)
             .unwrap();
         let merged_feature = deltas[merge_index]
             .entity_deltas
@@ -1146,7 +1171,12 @@ mod tests {
         .unwrap();
         let plan = plan_semantic_git_import(&snapshot, &blob_store).unwrap();
         let trees = trees_by_change(&plan, &snapshot, &blob_store);
-        let deltas = derive_historical_semantic_deltas(&plan.changes, &trees, &blob_store).unwrap();
+        let changes = plan
+            .changes
+            .iter()
+            .collect::<kin_git::Result<Vec<_>>>()
+            .unwrap();
+        let deltas = derive_historical_semantic_deltas(&changes, &trees, &blob_store).unwrap();
 
         let bindings = deltas
             .iter()
@@ -1164,15 +1194,18 @@ mod tests {
         enriched.validate(&blob_store).unwrap();
         let admitted = admit_semantic_git_import(&enriched, &blob_store).unwrap();
 
-        let entity_ids = admitted
+        let admitted_changes = admitted
             .changes
+            .iter()
+            .collect::<kin_git::Result<Vec<_>>>()
+            .unwrap();
+        let entity_ids = admitted_changes
             .iter()
             .flat_map(|change| &change.entity_deltas)
             .filter_map(EntityDelta::new_state)
             .map(|entity| entity.id)
             .collect::<HashSet<_>>();
-        let bound_relations = admitted
-            .changes
+        let bound_relations = admitted_changes
             .iter()
             .flat_map(|change| &change.relation_deltas)
             .filter_map(RelationDelta::new_state)
@@ -1188,8 +1221,7 @@ mod tests {
             .find(|relation| is_external_import_placeholder(relation))
             .expect("the cross-repo reference must survive admission as change-owned truth");
         let target = external.dst.as_entity().and_then(|id| {
-            admitted
-                .changes
+            admitted_changes
                 .iter()
                 .flat_map(|change| &change.entity_deltas)
                 .filter_map(EntityDelta::new_state)
@@ -1215,16 +1247,14 @@ mod tests {
         }
 
         let graph = kin_db::InMemoryGraph::new();
-        for change in &admitted.changes {
+        for change in &admitted_changes {
             graph.create_change(change).unwrap();
         }
-        let head = admitted
-            .changes
+        let head = admitted_changes
             .iter()
             .map(|change| change.id)
             .find(|candidate| {
-                !admitted
-                    .changes
+                !admitted_changes
                     .iter()
                     .any(|change| change.parents.contains(candidate))
             })
@@ -1308,7 +1338,12 @@ mod tests {
         .unwrap();
         let plan = plan_semantic_git_import(&snapshot, &blob_store).unwrap();
         let trees = trees_by_change(&plan, &snapshot, &blob_store);
-        let deltas = derive_historical_semantic_deltas(&plan.changes, &trees, &blob_store).unwrap();
+        let changes = plan
+            .changes
+            .iter()
+            .collect::<kin_git::Result<Vec<_>>>()
+            .unwrap();
+        let deltas = derive_historical_semantic_deltas(&changes, &trees, &blob_store).unwrap();
 
         let tip = deltas
             .last()
@@ -1375,7 +1410,12 @@ mod tests {
         .unwrap();
         let plan = plan_semantic_git_import(&snapshot, &blob_store).unwrap();
         let trees = trees_by_change(&plan, &snapshot, &blob_store);
-        let reversed = plan.changes.iter().cloned().rev().collect::<Vec<_>>();
+        let mut reversed = plan
+            .changes
+            .iter()
+            .collect::<kin_git::Result<Vec<_>>>()
+            .unwrap();
+        reversed.reverse();
 
         let error = derive_historical_semantic_deltas(&reversed, &trees, &blob_store).unwrap_err();
         assert!(
@@ -1433,7 +1473,12 @@ mod tests {
             "src/sessions.py",
             b"def unrelated_checkout():\n    pass\n",
         );
-        let deltas = derive_historical_semantic_deltas(&plan.changes, &trees, &blob_store).unwrap();
+        let changes = plan
+            .changes
+            .iter()
+            .collect::<kin_git::Result<Vec<_>>>()
+            .unwrap();
+        let deltas = derive_historical_semantic_deltas(&changes, &trees, &blob_store).unwrap();
         assert_eq!(deltas.len(), 3);
         let mut entities = BTreeMap::new();
         for delta in &deltas {
@@ -1512,7 +1557,10 @@ mod tests {
             .unwrap();
         let admitted = admit_semantic_git_import(&enriched, &blob_store).unwrap();
         admitted.validate(&blob_store).unwrap();
-        assert_eq!(admitted.changes[1].entity_deltas, deltas[1].entity_deltas);
+        assert_eq!(
+            admitted.changes.read_at(1).unwrap().unwrap().entity_deltas,
+            deltas[1].entity_deltas
+        );
     }
 
     fn trees_by_change(

--- a/crates/kin-index/tests/cross_repo_xref_admission.rs
+++ b/crates/kin-index/tests/cross_repo_xref_admission.rs
@@ -187,7 +187,8 @@ fn admit_repository(dir: &Path, repository_id: &str, files: &[(&str, &str)]) -> 
             )
         })
         .collect::<BTreeMap<_, _>>();
-    let bindings = derive_historical_semantic_deltas(&plan.changes, &trees, &blob_store)
+    let planned_changes = plan.changes.iter().collect::<Result<Vec<_>, _>>().unwrap();
+    let bindings = derive_historical_semantic_deltas(&planned_changes, &trees, &blob_store)
         .unwrap()
         .into_iter()
         .map(|delta| {
@@ -206,21 +207,24 @@ fn admit_repository(dir: &Path, repository_id: &str, files: &[(&str, &str)]) -> 
     )
     .unwrap();
     admitted.validate(&blob_store).unwrap();
+    let admitted_changes = admitted
+        .changes
+        .iter()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
 
     // Admitted history must still replay. An external reference that made
     // `resolve_graph_at` fail would trade a cross-repo answer for a broken
     // history surface.
     let graph = kin_db::InMemoryGraph::new();
-    for change in &admitted.changes {
+    for change in &admitted_changes {
         graph.create_change(change).unwrap();
     }
-    let head = admitted
-        .changes
+    let head = admitted_changes
         .iter()
         .map(|change| change.id)
         .find(|candidate| {
-            !admitted
-                .changes
+            !admitted_changes
                 .iter()
                 .any(|change| change.parents.contains(candidate))
         })
@@ -229,7 +233,7 @@ fn admit_repository(dir: &Path, repository_id: &str, files: &[(&str, &str)]) -> 
         .resolve_graph_at(&head)
         .expect("admitted history must replay");
 
-    replay_first_parent(&admitted.changes)
+    replay_first_parent(&admitted_changes)
 }
 
 /// Apply every change's deltas in parent-first order, the way durable authority

--- a/crates/kin-index/tests/module_entities_are_declarations.rs
+++ b/crates/kin-index/tests/module_entities_are_declarations.rs
@@ -347,7 +347,8 @@ fn admit_repository(dir: &Path, repository_id: &str, files: &[(&str, &str)]) -> 
             )
         })
         .collect::<BTreeMap<_, _>>();
-    let bindings = derive_historical_semantic_deltas(&plan.changes, &trees, &blob_store)
+    let planned_changes = plan.changes.iter().collect::<Result<Vec<_>, _>>().unwrap();
+    let bindings = derive_historical_semantic_deltas(&planned_changes, &trees, &blob_store)
         .unwrap()
         .into_iter()
         .map(|delta| {
@@ -366,6 +367,11 @@ fn admit_repository(dir: &Path, repository_id: &str, files: &[(&str, &str)]) -> 
     )
     .unwrap();
     admitted.validate(&blob_store).unwrap();
+    let admitted_changes = admitted
+        .changes
+        .iter()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
 
     // Admission fails closed on a relation naming a destination entity the tree
     // does not define, so this replay is also the assertion that removing the
@@ -373,16 +379,14 @@ fn admit_repository(dir: &Path, repository_id: &str, files: &[(&str, &str)]) -> 
     // placeholder edge makes `derive_historical_semantic_deltas` return an
     // error above rather than reaching here.
     let graph = kin_db::InMemoryGraph::new();
-    for change in &admitted.changes {
+    for change in &admitted_changes {
         graph.create_change(change).unwrap();
     }
-    let head = admitted
-        .changes
+    let head = admitted_changes
         .iter()
         .map(|change| change.id)
         .find(|candidate| {
-            !admitted
-                .changes
+            !admitted_changes
                 .iter()
                 .any(|change| change.parents.contains(candidate))
         })
@@ -391,7 +395,7 @@ fn admit_repository(dir: &Path, repository_id: &str, files: &[(&str, &str)]) -> 
         .resolve_graph_at(&head)
         .expect("admitted history must replay");
 
-    replay_first_parent(&admitted.changes)
+    replay_first_parent(&admitted_changes)
 }
 
 /// Apply every change's deltas in parent-first order, the way durable authority

--- a/crates/kin-index/tests/parse_side_call_counts_reach_a_converted_store.rs
+++ b/crates/kin-index/tests/parse_side_call_counts_reach_a_converted_store.rs
@@ -447,7 +447,8 @@ fn admit_repository(dir: &Path, repository_id: &str, files: &[(&str, &str)]) -> 
             )
         })
         .collect::<BTreeMap<_, _>>();
-    let bindings = derive_historical_semantic_deltas(&plan.changes, &trees, &blob_store)
+    let planned_changes = plan.changes.iter().collect::<Result<Vec<_>, _>>().unwrap();
+    let bindings = derive_historical_semantic_deltas(&planned_changes, &trees, &blob_store)
         .unwrap()
         .into_iter()
         .map(|delta| {
@@ -466,18 +467,21 @@ fn admit_repository(dir: &Path, repository_id: &str, files: &[(&str, &str)]) -> 
     )
     .unwrap();
     admitted.validate(&blob_store).unwrap();
+    let admitted_changes = admitted
+        .changes
+        .iter()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
 
     let graph = kin_db::InMemoryGraph::new();
-    for change in &admitted.changes {
+    for change in &admitted_changes {
         graph.create_change(change).unwrap();
     }
-    let head = admitted
-        .changes
+    let head = admitted_changes
         .iter()
         .map(|change| change.id)
         .find(|candidate| {
-            !admitted
-                .changes
+            !admitted_changes
                 .iter()
                 .any(|change| change.parents.contains(candidate))
         })
@@ -486,7 +490,7 @@ fn admit_repository(dir: &Path, repository_id: &str, files: &[(&str, &str)]) -> 
         .resolve_graph_at(&head)
         .expect("admitted history must replay");
 
-    replay_first_parent(&admitted.changes)
+    replay_first_parent(&admitted_changes)
 }
 
 /// Apply every change's deltas in parent-first order, the way durable authority

--- a/crates/kin-index/tests/real_repository_enrichment.rs
+++ b/crates/kin-index/tests/real_repository_enrichment.rs
@@ -57,7 +57,8 @@ fn a_real_repository_enriches_into_replayable_history() {
         })
         .collect::<BTreeMap<_, _>>();
 
-    let deltas = derive_historical_semantic_deltas(&plan.changes, &trees, &blob_store).unwrap();
+    let planned_changes = plan.changes.iter().collect::<Result<Vec<_>, _>>().unwrap();
+    let deltas = derive_historical_semantic_deltas(&planned_changes, &trees, &blob_store).unwrap();
     let bindings = deltas
         .into_iter()
         .map(|delta| {
@@ -76,20 +77,23 @@ fn a_real_repository_enriches_into_replayable_history() {
     )
     .unwrap();
     admitted.validate(&blob_store).unwrap();
+    let admitted_changes = admitted
+        .changes
+        .iter()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
 
     // The graph must never publish a change its own replay rejects, so every
     // head is resolved rather than only the tip of the default branch.
     let graph = kin_db::InMemoryGraph::new();
-    for change in &admitted.changes {
+    for change in &admitted_changes {
         graph.create_change(change).unwrap();
     }
-    let heads = admitted
-        .changes
+    let heads = admitted_changes
         .iter()
         .map(|change| change.id)
         .filter(|candidate| {
-            !admitted
-                .changes
+            !admitted_changes
                 .iter()
                 .any(|change| change.parents.contains(candidate))
         })

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.26"
+version = "0.7.27"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "0f0295dfced192fee9cd6b636109f919254f08b0148def52e95f8eb815863931"
+checksum = "e2891f63e0a229fc4ad2fa3ac22f393a17cfdf3285412adced1693654a283128"
 dependencies = [
  "chrono",
  "gix-hash",

--- a/scripts/acceptance/init_memory_repro.py
+++ b/scripts/acceptance/init_memory_repro.py
@@ -38,12 +38,34 @@ equal to `memory.max`, so there the number is the ceiling rather than the demand
 A cap over either figure would have been a check that cannot fail, or worse, one
 that fails the wrong way.
 
-The graded figure is what proof 1 adds to the running peak. That phase
-revalidates the whole import plan and keeps nothing, so anything it adds is a
-second copy of history built to check the first, which is exactly the defect.
-The total peak is graded too, as a coarse backstop: it is normally set by the
-bootstrap transaction rather than by any proof, so it does NOT move when a proof
-stops copying, and it must not be read as the class gate.
+Five figures are graded, and every one of them is read together with the
+ceiling the guard printed beside it. That is deliberate: a ceiling copied into
+this file is a second number that can disagree with the guard's, and the
+disagreement would be this suite reporting a pass against a bound the guard
+stopped using.
+
+  0. What proof 1 adds to the running peak. That phase revalidates the whole
+     import plan and keeps nothing, so anything it adds is a second copy of
+     history built to check the first, which is exactly the defect.
+  1. The total peak, as a coarse backstop. It is normally set by the bootstrap
+     transaction rather than by any proof, so it does NOT move when a proof
+     stops copying, and it must not be read as the class gate.
+  2. What binding historical semantics adds to the peak. Binding derives one set
+     of deltas per commit and hands each straight to the spool, so growth on the
+     order of a history means the derived set and the spooled copy are alive at
+     once. This is the transient half, and it is separate from 3 because a copy
+     dropped before the phase ends never moves what the phase retained.
+  3. What each streaming phase is still holding when it ends, on all three of
+     binding, admission and the enrichment summary. Whatever a phase still holds
+     after streaming is what a real conversion pays on a real repository.
+  4. What building the bootstrap transaction adds to the peak.
+
+Checks 2 and 3 replaced a growth-against-retention ratio and a release-drop
+floor when admission moved to a disk spool. The ratio's denominator became a
+tenth of a megabyte, so every clean run would have failed it, and the floor
+asked how many bytes the plan gave back after proof 1, which is nothing now that
+change bodies never live in memory. Both were replaced rather than dropped: the
+class each guarded is still real, and it is still graded here.
 
 Each check prints one line:
 
@@ -112,145 +134,103 @@ def run(cmd, cwd=None, env=None, timeout=1800):
 
 
 PROOF_LINE = re.compile(
-    r"kin\.init\.source_proof_staged added (\d+) bytes to the peak, ceiling (\d+) MiB"
+    r"kin\.init\.source_proof_staged peak growth: (\d+) bytes, ceiling (\d+) bytes"
 )
 TOTAL_LINE = re.compile(
     r"peak live heap admitting (\d+) commits: (\d+) bytes .*backstop (\d+) MiB"
 )
-BIND_LINE = re.compile(
-    r"kin\.init\.bind_historical_semantics grew the peak by (\d+) bytes "
-    r"while retaining (\d+) bytes, ceiling (\d+) percent"
+BIND_GROWTH_LINE = re.compile(
+    r"kin\.init\.bind_historical_semantics peak growth: (\d+) bytes, ceiling (\d+) bytes"
 )
-RELEASE_LINE = re.compile(
-    r"kin\.init\.release_plan_bodies gave back (\d+) bytes of the (\d+) bytes "
-    r"kin\.init\.bind_historical_semantics retained, floor (\d+) percent"
+BUILD_GROWTH_LINE = re.compile(
+    r"kin\.init\.build_bootstrap_transaction peak growth: (\d+) bytes, ceiling (\d+) bytes"
 )
-BUILD_LINE = re.compile(
-    r"kin\.init\.build_bootstrap_transaction grew the peak by (\d+) bytes against "
-    r"the (\d+) bytes kin\.init\.admit_semantic_import retained, ceiling (\d+) percent"
+RETENTION_LINE = re.compile(
+    r"retained bytes: kin\.init\.bind_historical_semantics=(\d+), "
+    r"kin\.init\.admit_semantic_import=(\d+), "
+    r"kin\.init\.commit\.enrichment_summary=(\d+), ceiling (\d+) bytes"
 )
 
 
-def read_guard_output(text):
-    """Pull the two graded figures out of the guard's own printed lines.
+def read_pair(pattern, text):
+    """Pull a measured figure and the ceiling it was graded against.
 
-    Returns (proof_bytes, proof_cap_mib, total_bytes, total_cap_mib), with None
-    for anything the output did not carry. A missing figure is UNREADABLE
-    downstream and never a pass: a guard that printed nothing measured nothing.
+    Every line this suite reads carries its own ceiling, so the ceiling is the
+    guard's rather than a constant copied here. A copied ceiling is a second
+    number that can disagree with the first, and the disagreement is a suite
+    reporting a pass against a bound the guard stopped using.
     """
-    proof = PROOF_LINE.search(text or "")
+    found = pattern.search(text or "")
+    if not found:
+        return (None, None)
+    return (int(found.group(1)), int(found.group(2)))
+
+
+def read_proof_figures(text):
+    """What proof 1 added to the running peak, and its ceiling."""
+    return read_pair(PROOF_LINE, text)
+
+
+def read_bind_growth_figures(text):
+    """What binding added to the running peak, and its ceiling.
+
+    This is the transient half of the binding phase, and it is a separate
+    reading from the retention below on purpose: a copy of the derived deltas
+    that is dropped before the phase ends never moves what the phase retained,
+    so a suite that read only the retention would report a pass over exactly
+    the defect this figure exists to catch.
+    """
+    return read_pair(BIND_GROWTH_LINE, text)
+
+
+def read_build_growth_figures(text):
+    """What building the bootstrap transaction added to the peak, and its ceiling."""
+    return read_pair(BUILD_GROWTH_LINE, text)
+
+
+def read_total_figures(text):
+    """The whole run's peak live heap and its coarse backstop, in MiB."""
     total = TOTAL_LINE.search(text or "")
+    if not total:
+        return (None, None)
+    return (int(total.group(2)), int(total.group(3)))
+
+
+def read_retention_figures(text):
+    """What each streaming phase was still holding when it ended, and the bound.
+
+    Three figures and one ceiling, because the three phases are graded against
+    the same fraction of one materialized history: whatever a phase still holds
+    after streaming it is what a real conversion pays on a real repository.
+    """
+    found = RETENTION_LINE.search(text or "")
+    if not found:
+        return (None, None, None, None)
     return (
-        int(proof.group(1)) if proof else None,
-        int(proof.group(2)) if proof else None,
-        int(total.group(2)) if total else None,
-        int(total.group(3)) if total else None,
+        int(found.group(1)),
+        int(found.group(2)),
+        int(found.group(3)),
+        int(found.group(4)),
     )
 
 
-def read_bind_figures(text):
-    """Pull the binding phase's growth, what it retained, and its ceiling.
+def grade_under(measured, ceiling, what):
+    """PASS under the ceiling, FAIL at or over it, UNREADABLE with no numbers.
 
-    Separate from `read_guard_output` because it grades a ratio rather than a
-    byte count, and because it exists so a guard that fails on THIS assertion
-    cannot be reported as a pass. Every figure the guard prints is printed
-    before any assertion runs, so a suite that grades only the first two would
-    report both of them PASS over a red guard.
+    Pure, so `--self-test` drives it against its own inverse without admitting
+    a repository. An absent figure is never a pass: a guard that printed no
+    number measured nothing, and that is a different fact from a number under
+    the ceiling. A zero ceiling is UNREADABLE for the same reason a zero
+    denominator was: nothing can be under it, so the comparison would report
+    FAIL on a run that measured nothing at all.
     """
-    bind = BIND_LINE.search(text or "")
-    if not bind:
-        return (None, None, None)
-    return (int(bind.group(1)), int(bind.group(2)), int(bind.group(3)))
-
-
-def grade_ratio(grew, retained, cap_percent):
-    """PASS under the ceiling, FAIL at or over it, UNREADABLE with no denominator.
-
-    A phase that retained nothing gives the ratio no denominator, so the
-    comparison would pass on any growth at all. That is UNREADABLE, not a pass.
-    """
-    if grew is None or retained is None or cap_percent is None:
-        return UNREADABLE, "the guard printed no binding-phase figures, so nothing was graded"
-    if retained == 0:
-        return UNREADABLE, ("the binding phase retained nothing, so its growth had nothing "
-                            "to be measured against and this graded nothing")
-    percent = grew * 100 // retained
-    detail = ("binding historical semantics grew the peak by %d percent of what it retained "
-              "(%d over %d bytes), ceiling %d percent" % (percent, grew, retained, cap_percent))
-    if percent >= cap_percent:
-        return FAIL, detail
-    return PASS, detail
-
-
-def read_release_figures(text):
-    """Pull what the release phase gave back, against what binding retained.
-
-    Separate from the two readers above for the same reason they are separate
-    from each other: it grades a FLOOR rather than a ceiling, and a suite that
-    graded only the earlier figures would report them PASS over a guard that
-    went red on this one.
-    """
-    release = RELEASE_LINE.search(text or "")
-    if not release:
-        return (None, None, None)
-    return (int(release.group(1)), int(release.group(2)), int(release.group(3)))
-
-
-def read_build_figures(text):
-    """Pull the bootstrap build's growth, one copy of the admitted history, and its ceiling.
-
-    Its own reader for the reason every reader here has one: a suite that
-    grades only the earlier figures reports them PASS over a guard that went
-    red on this one, because the guard prints every figure before any
-    assertion runs.
-    """
-    build = BUILD_LINE.search(text or "")
-    if not build:
-        return (None, None, None)
-    return (int(build.group(1)), int(build.group(2)), int(build.group(3)))
-
-
-def grade_build_ratio(grew, retained, cap_percent):
-    """PASS under the ceiling, FAIL at or over it, UNREADABLE with no denominator.
-
-    Same direction as `grade_ratio` and a separate function because it names a
-    different phase and a different denominator. A phase that admitted nothing
-    gives the ratio no denominator, so the comparison would pass on any growth
-    at all. That is UNREADABLE, not a pass.
-    """
-    if grew is None or retained is None or cap_percent is None:
-        return UNREADABLE, "the guard printed no bootstrap-build figures, so nothing was graded"
-    if retained == 0:
-        return UNREADABLE, ("the admission phase retained nothing, so the bootstrap build's "
-                            "growth had no copy of the history to be measured against and "
-                            "this graded nothing")
-    percent = grew * 100 // retained
-    detail = ("building the bootstrap transaction grew the peak by %d percent of one copy of "
-              "the admitted history (%d over %d bytes), ceiling %d percent"
-              % (percent, grew, retained, cap_percent))
-    if percent >= cap_percent:
-        return FAIL, detail
-    return PASS, detail
-
-
-def grade_floor(given_back, retained, floor_percent):
-    """PASS at or over the floor, FAIL under it, UNREADABLE with no denominator.
-
-    The direction is the opposite of `grade_ratio` on purpose. This one asks
-    whether enough memory came BACK, so more is better and the comparison is
-    the other way round. A phase that retained nothing gives the ratio no
-    denominator, which is UNREADABLE rather than a pass, exactly as there.
-    """
-    if given_back is None or retained is None or floor_percent is None:
-        return UNREADABLE, "the guard printed no release-phase figures, so nothing was graded"
-    if retained == 0:
-        return UNREADABLE, ("the binding phase retained nothing, so there was nothing for the "
-                            "release to give back and this graded nothing")
-    percent = given_back * 100 // retained
-    detail = ("releasing the plan's change bodies gave back %d percent of what binding "
-              "retained (%d of %d bytes), floor %d percent"
-              % (percent, given_back, retained, floor_percent))
-    if percent < floor_percent:
+    if measured is None or ceiling is None:
+        return UNREADABLE, "the guard printed no %s figures, so nothing was graded" % what
+    if ceiling == 0:
+        return UNREADABLE, ("the guard printed a zero ceiling for %s, so there was nothing "
+                            "to grade against and this graded nothing" % what)
+    detail = "%s is %d bytes against a %d byte ceiling" % (what, measured, ceiling)
+    if measured >= ceiling:
         return FAIL, detail
     return PASS, detail
 
@@ -352,11 +332,12 @@ def check_0(suite):
     """Proving the import plan does not cost a copy of it."""
     result = Result("0", "proof 1 does not allocate a second history")
     code, out = suite.guard_output()
-    proof, proof_cap, total, total_cap = read_guard_output(out)
-    if proof is None and code != 0 and total is None:
-        result.unknown("the guard produced no figures and exited %d: %s" % (code, tail(out)))
+    grew, ceiling = read_proof_figures(out)
+    if grew is None and code != 0:
+        result.unknown("the guard produced no proof figures and exited %d: %s"
+                       % (code, tail(out)))
         return result
-    status, detail = grade_bytes(proof, proof_cap, "proof 1 peak growth")
+    status, detail = grade_under(grew, ceiling, "proof 1 peak growth")
     {PASS: result.ok, FAIL: result.bad, UNREADABLE: result.unknown}[status](detail)
     return result
 
@@ -365,11 +346,11 @@ def check_1(suite):
     """Total peak live heap stays under its coarse backstop."""
     result = Result("1", "total admission peak stays under its backstop")
     code, out = suite.guard_output()
-    _, _, total, total_cap = read_guard_output(out)
+    total, total_cap = read_total_figures(out)
     if total is None and code != 0:
         result.unknown("the guard produced no total and exited %d: %s" % (code, tail(out)))
         return result
-    status, detail = grade_bytes(total, total_cap, "total peak live heap")
+    status, detail = grade_bytes(total, total_cap, "total admission peak")
     {PASS: result.ok, FAIL: result.bad, UNREADABLE: result.unknown}[status](detail)
     return result
 
@@ -378,27 +359,35 @@ def check_2(suite):
     """Binding historical semantics keeps one copy of what it derives, not two."""
     result = Result("2", "binding historical semantics does not hold two copies")
     code, out = suite.guard_output()
-    grew, retained, cap = read_bind_figures(out)
+    grew, ceiling = read_bind_growth_figures(out)
     if grew is None and code != 0:
         result.unknown("the guard produced no binding figures and exited %d: %s"
                        % (code, tail(out)))
         return result
-    status, detail = grade_ratio(grew, retained, cap)
+    status, detail = grade_under(grew, ceiling, "binding peak growth")
     {PASS: result.ok, FAIL: result.bad, UNREADABLE: result.unknown}[status](detail)
     return result
 
 
 def check_3(suite):
-    """The import plan's change bodies are given back once proof 1 has read them."""
-    result = Result("3", "the plan's change bodies are released after proof 1")
+    """Every streaming phase ends holding a bounded share of the history."""
+    result = Result("3", "streaming phases end with bounded residency")
     code, out = suite.guard_output()
-    given_back, retained, floor = read_release_figures(out)
-    if given_back is None and code != 0:
-        result.unknown("the guard produced no release figures and exited %d: %s"
+    bind, admit, summary, ceiling = read_retention_figures(out)
+    if bind is None and code != 0:
+        result.unknown("the guard produced no retention figures and exited %d: %s"
                        % (code, tail(out)))
         return result
-    status, detail = grade_floor(given_back, retained, floor)
-    {PASS: result.ok, FAIL: result.bad, UNREADABLE: result.unknown}[status](detail)
+    # All three, not the largest. A suite that graded one phase would report a
+    # pass over a regression in either of the others, and each of the three is
+    # a separate place a whole history can be kept by accident.
+    for what, retained in (
+        ("binding retention", bind),
+        ("admission retention", admit),
+        ("enrichment-summary retention", summary),
+    ):
+        status, detail = grade_under(retained, ceiling, what)
+        {PASS: result.ok, FAIL: result.bad, UNREADABLE: result.unknown}[status](detail)
     return result
 
 
@@ -406,12 +395,12 @@ def check_4(suite):
     """Building the bootstrap transaction does not copy the history to prove or to read it."""
     result = Result("4", "the bootstrap build holds no extra copy of the history")
     code, out = suite.guard_output()
-    grew, retained, cap = read_build_figures(out)
+    grew, ceiling = read_build_growth_figures(out)
     if grew is None and code != 0:
         result.unknown("the guard produced no bootstrap-build figures and exited %d: %s"
                        % (code, tail(out)))
         return result
-    status, detail = grade_build_ratio(grew, retained, cap)
+    status, detail = grade_under(grew, ceiling, "bootstrap build peak growth")
     {PASS: result.ok, FAIL: result.bad, UNREADABLE: result.unknown}[status](detail)
     return result
 
@@ -420,131 +409,91 @@ CHECKS = [check_0, check_1, check_2, check_3, check_4]
 
 
 def self_test():
-    """Falsify this suite's graders against their own inverses."""
+    """Falsify this suite's graders and parsers against their own inverses."""
     failures = []
-    cases = [
-        ("under the ceiling passes", 50 * 1024 * 1024, 100, PASS),
-        ("at the ceiling fails", 100 * 1024 * 1024, 100, FAIL),
-        ("over the ceiling fails", 400 * 1024 * 1024, 100, FAIL),
-        ("nothing measured is unreadable", None, 100, UNREADABLE),
-        ("no ceiling is unreadable", 1, None, UNREADABLE),
-    ]
-    for title, measured, cap, wanted in cases:
-        got, detail = grade_bytes(measured, cap, "probe")
+
+    def expect(title, got, wanted, detail=""):
         if got != wanted:
             failures.append("%s: wanted %s, got %s (%s)" % (title, wanted, got, detail))
 
-    # The parser is the other half that can silently pass. Drive it against the
-    # guard's real output shape, and against output that carries no figures at
-    # all, which is what a crashed or renamed guard produces.
-    good = ("peak live heap admitting 256 commits: 1043605740 bytes (995.3 MiB), "
-            "backstop 1400 MiB\n"
-            "kin.init.source_proof_staged added 0 bytes to the peak, ceiling 16 MiB\n")
-    proof, proof_cap, total, total_cap = read_guard_output(good)
-    if (proof, proof_cap, total, total_cap) != (0, 16, 1043605740, 1400):
-        failures.append("parser misread the guard's own output: %r"
-                        % ((proof, proof_cap, total, total_cap),))
-    if read_guard_output("error: could not compile") != (None, None, None, None):
-        failures.append("parser invented figures from output that carries none")
-    if read_guard_output("") != (None, None, None, None):
-        failures.append("parser invented figures from empty output")
+    # The byte-cap grader, which grades the coarse total against a MiB backstop.
+    byte_cases = [
+        ("under the backstop passes", 50 * 1024 * 1024, 100, PASS),
+        ("at the backstop fails", 100 * 1024 * 1024, 100, FAIL),
+        ("over the backstop fails", 400 * 1024 * 1024, 100, FAIL),
+        ("nothing measured is unreadable", None, 100, UNREADABLE),
+        ("no backstop is unreadable", 1, None, UNREADABLE),
+    ]
+    for title, measured, cap, wanted in byte_cases:
+        got, detail = grade_bytes(measured, cap, "probe")
+        expect(title, got, wanted, detail)
+
+    # The ceiling grader every other check runs through. One red case per
+    # direction, so none of them can go quiet: at the ceiling, over it, absent
+    # figures, and a zero ceiling that nothing could ever be under.
+    under_cases = [
+        ("under the ceiling passes", 0, 22791156, PASS),
+        ("at the ceiling fails", 22791156, 22791156, FAIL),
+        ("one whole history fails", 89749184, 22791156, FAIL),
+        ("nothing measured is unreadable", None, 22791156, UNREADABLE),
+        ("no ceiling is unreadable", 100, None, UNREADABLE),
+        ("a zero ceiling is unreadable", 0, 0, UNREADABLE),
+    ]
+    for title, measured, ceiling, wanted in under_cases:
+        got, detail = grade_under(measured, ceiling, "probe")
+        expect(title, got, wanted, detail)
+
+    # The parsers are the other half that can silently pass. Drive each against
+    # the guard's real printed shape, and against output that carries no figures
+    # at all, which is what a crashed or renamed guard produces.
+    measured = (
+        "peak live heap admitting 256 commits: 19203259 bytes (18.3 MiB), backstop 900 MiB\n"
+        "explicit history materialization retained 91164626 bytes\n"
+        "kin.init.source_proof_staged peak growth: 0 bytes, ceiling 16777216 bytes\n"
+        "kin.init.bind_historical_semantics peak growth: 0 bytes, ceiling 22791156 bytes\n"
+        "kin.init.build_bootstrap_transaction peak growth: 0 bytes, ceiling 45582313 bytes\n"
+        "retained bytes: kin.init.bind_historical_semantics=138072, "
+        "kin.init.admit_semantic_import=628883, "
+        "kin.init.commit.enrichment_summary=0, ceiling 22791156 bytes\n"
+    )
+    parsers = [
+        ("proof", read_proof_figures, (0, 16777216), (None, None)),
+        ("total", read_total_figures, (19203259, 900), (None, None)),
+        ("binding growth", read_bind_growth_figures, (0, 22791156), (None, None)),
+        ("bootstrap-build growth", read_build_growth_figures, (0, 45582313), (None, None)),
+        ("retention", read_retention_figures,
+         (138072, 628883, 0, 22791156), (None, None, None, None)),
+    ]
+    for name, reader, wanted, empty in parsers:
+        expect("the %s parser reads the guard's own output" % name, reader(measured), wanted)
+        expect("the %s parser invents nothing from a crash" % name,
+               reader("error: could not compile"), empty)
+        expect("the %s parser invents nothing from empty output" % name, reader(""), empty)
 
     # A ceiling that cannot reject the defect is not a ceiling. Drive the real
-    # pre-fix figure through the real pre-fix ceiling.
-    got, _ = grade_bytes(88146432, 16, "proof 1 peak growth")
-    if got != FAIL:
-        failures.append("the shipped proof ceiling does not reject the pre-fix figure")
-    got, _ = grade_bytes(0, 16, "proof 1 peak growth")
-    if got != PASS:
-        failures.append("the shipped proof ceiling rejects the post-fix figure")
+    # measured figures, on both sides of each fix, through the shipped bounds.
+    expect("the shipped proof ceiling rejects the pre-fix figure",
+           grade_under(88146432, 16777216, "proof 1 peak growth")[0], FAIL)
+    expect("the shipped proof ceiling accepts the post-fix figure",
+           grade_under(0, 16777216, "proof 1 peak growth")[0], PASS)
+    expect("the shipped binding ceiling rejects a transient second copy",
+           grade_under(89749184, 22791156, "binding peak growth")[0], FAIL)
+    expect("the shipped binding ceiling accepts a streamed bind",
+           grade_under(0, 22791156, "binding peak growth")[0], PASS)
+    expect("the shipped retention ceiling rejects a retained history",
+           grade_under(90590904, 22791156, "binding retention")[0], FAIL)
+    expect("the shipped retention ceiling accepts a streamed bind",
+           grade_under(138072, 22791156, "binding retention")[0], PASS)
+    expect("the shipped bootstrap ceiling rejects a materialized history",
+           grade_under(89567459, 45582313, "bootstrap build peak growth")[0], FAIL)
+    expect("the shipped bootstrap ceiling accepts a streamed build",
+           grade_under(0, 45582313, "bootstrap build peak growth")[0], PASS)
 
-    # The ratio grader and its parser, falsified the same way. A phase that
-    # retained nothing is the case that would otherwise pass on any growth.
-    ratio_cases = [
-        ("one copy passes", 103226981, 100882320, 175, PASS),
-        ("two copies fail", 197043712, 90177536, 175, FAIL),
-        ("exactly at the ceiling fails", 175, 100, 175, FAIL),
-        ("nothing retained is unreadable", 100, 0, 175, UNREADABLE),
-        ("nothing measured is unreadable", None, None, None, UNREADABLE),
-    ]
-    for title, grew, retained, cap, wanted in ratio_cases:
-        got, detail = grade_ratio(grew, retained, cap)
-        if got != wanted:
-            failures.append("%s: wanted %s, got %s (%s)" % (title, wanted, got, detail))
-
-    bind_line = ("kin.init.bind_historical_semantics grew the peak by 103226981 bytes "
-                 "while retaining 100882320 bytes, ceiling 175 percent\n")
-    if read_bind_figures(bind_line) != (103226981, 100882320, 175):
-        failures.append("parser misread the binding line: %r" % (read_bind_figures(bind_line),))
-    if read_bind_figures("error: could not compile") != (None, None, None):
-        failures.append("parser invented binding figures from output that carries none")
-    if read_bind_figures("") != (None, None, None):
-        failures.append("parser invented binding figures from empty output")
-
-    # The bootstrap-build grader and its parser, falsified against the real
-    # figures on both sides of the fix.
-    build_cases = [
-        ("one copy passes", 113059227, 87718554, 250, PASS),
-        ("the pre-fix figure fails", 395427091, 87722946, 250, FAIL),
-        ("exactly at the ceiling fails", 250, 100, 250, FAIL),
-        ("nothing admitted is unreadable", 100, 0, 250, UNREADABLE),
-        ("nothing measured is unreadable", None, None, None, UNREADABLE),
-    ]
-    for title, grew, retained, cap, wanted in build_cases:
-        got, detail = grade_build_ratio(grew, retained, cap)
-        if got != wanted:
-            failures.append("%s: wanted %s, got %s (%s)" % (title, wanted, got, detail))
-
-    build_line = ("kin.init.build_bootstrap_transaction grew the peak by 113059227 bytes "
-                  "against the 87718554 bytes kin.init.admit_semantic_import retained, "
-                  "ceiling 250 percent\n")
-    if read_build_figures(build_line) != (113059227, 87718554, 250):
-        failures.append("parser misread the build line: %r" % (read_build_figures(build_line),))
-    if read_build_figures("error: could not compile") != (None, None, None):
-        failures.append("parser invented build figures from output that carries none")
-    if read_build_figures("") != (None, None, None):
-        failures.append("parser invented build figures from empty output")
-
-    # The floor grader runs the comparison the other way round, so its own
-    # inverse is the case that would pass if the direction were flipped: a
-    # release that gave back nothing.
-    floor_cases = [
-        ("everything given back passes", 87404386, 86996112, 50, PASS),
-        ("exactly at the floor passes", 50, 100, 50, PASS),
-        ("nothing given back fails", 0, 86996112, 50, FAIL),
-        ("under the floor fails", 40, 100, 50, FAIL),
-        ("nothing retained is unreadable", 100, 0, 50, UNREADABLE),
-        ("nothing measured is unreadable", None, None, None, UNREADABLE),
-    ]
-    for title, given_back, retained, floor, wanted in floor_cases:
-        got, detail = grade_floor(given_back, retained, floor)
-        if got != wanted:
-            failures.append("%s: wanted %s, got %s (%s)" % (title, wanted, got, detail))
-
-    release_line = ("kin.init.release_plan_bodies gave back 87404386 bytes of the 86996112 "
-                    "bytes kin.init.bind_historical_semantics retained, floor 50 percent\n")
-    if read_release_figures(release_line) != (87404386, 86996112, 50):
-        failures.append("parser misread the release line: %r"
-                        % (read_release_figures(release_line),))
-    if read_release_figures("error: could not compile") != (None, None, None):
-        failures.append("parser invented release figures from output that carries none")
-    if read_release_figures("") != (None, None, None):
-        failures.append("parser invented release figures from empty output")
-
-    # A floor that cannot reject the defect is not a floor. Drive the measured
-    # pre-fix and post-fix figures through the shipped floor.
-    got, _ = grade_floor(0, 86996112, 50)
-    if got != FAIL:
-        failures.append("the shipped release floor does not reject the pre-fix figure")
-    got, _ = grade_floor(87404386, 86996112, 50)
-    if got != PASS:
-        failures.append("the shipped release floor rejects the post-fix figure")
-
+    graded = len(byte_cases) + len(under_cases) + len(parsers) * 3 + 8
     for failure in failures:
         print("SELFTEST FAIL %s" % failure)
     print("kin-init-memory-repro self-test: %d case(s), %d failure(s)"
-          % (len(cases) + len(ratio_cases) + len(build_cases) + len(floor_cases) + 16,
-             len(failures)))
+          % (graded, len(failures)))
     return 1 if failures else 0
 
 

--- a/scripts/hydration-semantics-manifest.json
+++ b/scripts/hydration-semantics-manifest.json
@@ -81,15 +81,22 @@
     },
     {
       "file": "crates/kin-git/src/semantic_import.rs",
+      "function": "enrich_with_historical_semantics",
+      "digest": "sha256:38aa38ef488a0c21844cc711b37124c1c65e61bcfe712d6b28bae46de14754b7",
+      "reason": "Authors streamed historical changes by assigning derived entity and relation deltas, remapping ordered parents and recomputing each change identity before appending it to the immutable import spool.",
+      "owner": "kin-git"
+    },
+    {
+      "file": "crates/kin-git/src/semantic_import.rs",
       "function": "apply_historical_semantic_deltas_unchecked",
-      "digest": "sha256:00011e7492e9b4ef835399341902828cd7f2b2d6a9c9acd6ed9cb30736740599",
+      "digest": "sha256:cf1f204da633e222f1a27c7f9e1555ef4135da600f0865da5a98cdb41a608588",
       "reason": "Writes the derived deltas onto the imported changes and recomputes their identities. This is the step that makes replayed semantics the persisted historical record.",
       "owner": "kin-git"
     },
     {
       "file": "crates/kin-git/src/semantic_import.rs",
       "function": "build_semantic_git_import_plan",
-      "digest": "sha256:ed93f0f407020066a009c3199882636dfd58f5c970e249241e0719beb341f875",
+      "digest": "sha256:5df22147f07d0647033a9ccc9638c3d4b9392aafa883b5e7bb1c9b9d1576654b",
       "reason": "Builds the parent-first change sequence replay consumes, walking under frontier retention so a tree is held only while a later commit still resolves against it. Its ordering and tree selection decide the baseline every historical delta is computed against.",
       "owner": "kin-git"
     },

--- a/scripts/hydration-semantics-manifest.json
+++ b/scripts/hydration-semantics-manifest.json
@@ -82,21 +82,21 @@
     {
       "file": "crates/kin-git/src/semantic_import.rs",
       "function": "enrich_with_historical_semantics",
-      "digest": "sha256:38aa38ef488a0c21844cc711b37124c1c65e61bcfe712d6b28bae46de14754b7",
+      "digest": "sha256:55c0a72caa42c1e3007ae05e585218b937f9e0a98725292af2c16d9f9749bae7",
       "reason": "Authors streamed historical changes by assigning derived entity and relation deltas, remapping ordered parents and recomputing each change identity before appending it to the immutable import spool.",
       "owner": "kin-git"
     },
     {
       "file": "crates/kin-git/src/semantic_import.rs",
       "function": "apply_historical_semantic_deltas_unchecked",
-      "digest": "sha256:cf1f204da633e222f1a27c7f9e1555ef4135da600f0865da5a98cdb41a608588",
+      "digest": "sha256:081473c61df5a77661c8a568040bb68df6fd98f651ac6c86010e2d5907a08bda",
       "reason": "Writes the derived deltas onto the imported changes and recomputes their identities. This is the step that makes replayed semantics the persisted historical record.",
       "owner": "kin-git"
     },
     {
       "file": "crates/kin-git/src/semantic_import.rs",
       "function": "build_semantic_git_import_plan",
-      "digest": "sha256:5df22147f07d0647033a9ccc9638c3d4b9392aafa883b5e7bb1c9b9d1576654b",
+      "digest": "sha256:2ed27a40851d26425c5611377b624fadf1417ba575c8d8eb567dc3f6c768e803",
       "reason": "Builds the parent-first change sequence replay consumes, walking under frontier retention so a tree is held only while a later commit still resolves against it. Its ordering and tree selection decide the baseline every historical delta is computed against.",
       "owner": "kin-git"
     },

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -1102,13 +1102,13 @@
     },
     {
       "file": "crates/kin-git/src/history_spool.rs",
-      "reason": "Temporary Git ingestion storage, not a semantic answer path. The import owns this temporary file and appends only captured semantic change records. Each read checks the exact file length, record checksum and identity before admission. These four single-occurrence pins cover the temporary-file type, construction and length probe only; they permit no repository walk, raw-file search or answer fallback.",
+      "reason": "Temporary Git ingestion storage, not a semantic answer path. The import owns this temporary file and appends only captured semantic change records. Each read checks the exact file length, record checksum and identity before admission. These single-occurrence pins cover the temporary-file type, its construction in the directory the caller owns, and the length probe only; they permit no repository walk, raw-file search or answer fallback. The construction pin moved from NamedTempFile::new() to tempfile_in on 2026-09-08: the default temporary directory is tmpfs on most Linux hosts, which put the spooled history back in RAM and defeated the whole point of spooling it, so the caller now names the directory.",
       "owner": "kin-git",
       "expiration": "2027-03-31",
       "allow_match": [
         "use tempfile::NamedTempFile;",
         "file: NamedTempFile,",
-        "file: NamedTempFile::new()",
+        ".tempfile_in(directory)",
         ".metadata()"
       ]
     },

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -1073,6 +1073,18 @@
       "expiration": "2027-02-26"
     },
     {
+      "file": "crates/kin-git/src/history_spool.rs",
+      "reason": "Temporary Git ingestion storage, not a semantic answer path. The import owns this temporary file and appends only captured semantic change records. Each read checks the exact file length, record checksum and identity before admission. These four single-occurrence pins cover the temporary-file type, construction and length probe only; they permit no repository walk, raw-file search or answer fallback.",
+      "owner": "kin-git",
+      "expiration": "2027-03-31",
+      "allow_match": [
+        "use tempfile::NamedTempFile;",
+        "file: NamedTempFile,",
+        "file: NamedTempFile::new()",
+        ".metadata()"
+      ]
+    },
+    {
       "file": "crates/kin-git/src/lossless.rs",
       "reason": "The lossless Git migration boundary, per the module's own doc: it preserves Git as an exact external format without making it an authority path inside Kin. Capturing a Git repository from disk is the entire point of an import boundary. Migrated from BOUNDARY_DIRS on 2026-09-03, where this path carried no owner, no expiry and no reason field. Whole-file preserves exactly the scope it already had rather than re-arguing it; narrowing to expression pins is the follow-up, and the expiry is when that has to happen or the exemption has to be defended again.",
       "owner": "kin-git",


### PR DESCRIPTION
## Summary

Keep imported semantic change bodies in an owned checksummed disk spool, then admit them through one streamed generation-zero transaction. Preserve complete history, ordered parents, exact identities, selected refs and publication uncertainty semantics.

Read ordinary commit baselines through a current-state projection and compare them with one coherent workspace-facts export. Public full revision results remain unchanged. Update the storage delegation audit for the unchanged 33-method backend surface.

The calibration and binary-unit changes are separate commits. Calibration rows now describe measured HEAD inputs; the coefficient remains unchanged.

## Compatibility

Consumes kin-db 0.7.107 and kin-model 0.7.27. The existing snapshot and authority-frame formats remain unchanged. No repository reinitialization or data migration is required.

The detached fuzz workspace also resolves kin-model 0.7.27. Its two-line lock update passed `cargo +nightly-2026-06-17 metadata --locked --format-version 1 --manifest-path fuzz/Cargo.toml`. This follow-up changes no product source or root dependency resolution.

## Local verification evidence

The implementation checks below used a development-only local kin-db107 override while publication was pending. They are source evidence, not released-byte lifecycle acceptance. Final registry-only checks at `4add95cb1fb10fbf9334bf218609dc6e77828b08` passed precheck (21/21) and the storage delegation audit (2/2). The lock resolves published kin-db 0.7.107 and kin-model 0.7.27 without local overrides.

Development-profile parity completed in 850.7 seconds with the harness verdict `PASS-WITH-ALLOWANCES`: magic 27/0/0, brownfield 12/0/1, first-run 10/1/1 (pass/fail/unreadable). The existing allowances are the truncated brownfield walk, the first-run projection health reading and the first-run daemon-stop behavior. This is explicitly non-citable development evidence, not release or full-scale acceptance. The run's daemon PIDs were absent after cleanup.

The final composition includes recovery main `bffd6adda2eb46a37d0481a8b1aba8ef8759ce54`. Its merge did not change the owned import, daily comparison or storage-audit source.

### Source policy falsification

The hydration guard passed with 16 pinned functions. Its isolated-copy falsifier caught all 18 probes, including the newly pinned historical enrichment helper. The complete zero-file-search falsifier passed all 71 enforced answer modules at four insertion sites and its additional negative controls. These ran on `3a1ba55eecc4fb9da92440e29d1b8369d9f7d9d8`; the owned source is unchanged in the final composition.

An additional unpinned filesystem read adjacent to the ingestion spool was rejected:

```text
[VIOLATION] crates/kin-git/src/history_spool.rs contains forbidden filesystem access:
  Line 81: let _unapproved = std::fs::read_to_string(path); (filesystem module namespace reach, fs API usage)
Verification FAILED: Found 1 zero-file-search violations.
```

The isolated copy was restored, its checksum matched the worktree, and the clean guard passed. All falsification processes exited. The temporary copies were moved to Trash; no mutation remains in the submitted source.

With `KIN_EMBED_BACKEND=cpu HF_HUB_OFFLINE=1`, through the serialized build gate:

```sh
cargo test -p kin-git --lib
```

```text
test result: ok. 133 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 17.78s
```

```sh
cargo test -p kin-core --test init_deep_history_heap_ceiling -- --ignored --nocapture
```

```text
peak live heap admitting 256 commits: 19213233 bytes (18.3 MiB), backstop 900 MiB
explicit history materialization retained 91164626 bytes
kin.init.source_proof_staged peak growth: 778 bytes; kin.init.build_bootstrap_transaction peak growth: 29153 bytes
retained bytes: kin.init.bind_historical_semantics=137616, kin.init.admit_semantic_import=649043, kin.init.commit.enrichment_summary=0
test proving_deep_history_does_not_cost_another_copy_of_it ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 326.45s
```

A temporary full-history bootstrap materialization mutation failed the same command at the positive-control assertion, without raising the 900 MiB backstop:

```text
kin.init.build_bootstrap_transaction added 89567459 bytes to the peak, at or over one half of the 91164626 bytes retained by explicit history materialization. Bootstrap construction must avoid whole-history materialization.
```

The source mutation was restored and its process exited. This synthetic live-heap result does not establish React RSS or the 12 GiB released two-repository lifecycle.

### Daily-path regression controls

The lazy history adapter control temporarily restored the previous borrowed HashMap and cloned lookup, then ran:

```sh
cargo test -p kin-daemon --lib ordinary_commit_projection_matches_the_full_state_delta_oracle -- --nocapture
```

```text
assertion failed: !snapshot.changes.is_decoded()
test commit_deltas::tests::ordinary_commit_projection_matches_the_full_state_delta_oracle ... FAILED
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1550 filtered out; finished in 0.04s
```

Two separate allocation controls replaced the private current-state baseline with full revision replay, then replaced the narrow live facts export with a complete snapshot. Each ran:

```sh
cargo test -p kin-daemon --test commit_baseline_heap_ceiling -- --nocapture
```

Full revision replay:

```text
borrowed_peak_bytes=1610386 graph_peak_bytes=2808440 comparison_peak_bytes=1610386
ordinary comparison allocated 1610386 bytes against the full-state baseline control of 1610386; private comparison must not retain revision output
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.63s
```

Full snapshot export:

```text
borrowed_peak_bytes=1610386 graph_peak_bytes=2807528 comparison_peak_bytes=998946
ordinary comparison allocated 998946 bytes against the full-state baseline control of 1610386; private comparison must not retain revision output
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.71s
```

Each test returned 101. All three source mutations were restored and their processes exited before the final verification run. The original absolute ceiling remains 2,100,000 bytes; the new relative guard distinguishes ordinary comparison from full revision replay using the same fixture in the same process.

Restored source, after adding explicit nonempty entity/relation/tree expectations:

```sh
cargo fmt --all
cargo test -p kin-daemon --lib commit_deltas::tests -- --quiet
cargo test -p kin-daemon --test commit_baseline_heap_ceiling -- --nocapture
```

```text
test result: ok. 31 passed; 0 failed; 0 ignored; 0 measured; 1520 filtered out; finished in 5.69s
borrowed_peak_bytes=1610386 graph_peak_bytes=2809448 comparison_peak_bytes=385723
test resolving_a_commit_baseline_does_not_pay_for_a_graph_it_drops ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.40s
```


---

## Fix round (memorypath2 lane, 2026-09-08)

The author lane died before pushing its last two fixes. This round rebases onto `origin/main`
`46950fa39`, lands both, and answers the three review findings that were open. Every claim below is
a command and its output tail.

### Rebase

`origin/main` `46950fa39` merged into `4add95cb1`, and later `9e45cc6c8` merged in on top when main
moved twice under this round. The first auto-merge took `CHANGELOG.md`,
`crates/kin-daemon/src/daemon.rs` and `crates/kin-daemon/src/state.rs` with no conflicts, and the
second had no conflicts either: those two commits touch no file this PR touches.
`#1592`'s hosted-vector surface survives it under `#1600`'s retyped field: 24
`retrieval_authority_hash` sites, 3 `rebind_hosted_vector_after_graph_commit`, 19
`hosted_vector_binding_refusal`, and both
`a_refused_hosted_binding_stands_the_worker_down_and_releases_its_stranded_vectors` and
`a_hosted_worker_survives_refusal_and_observes_rebind`, all beside
`pub(crate) changes: &'a kin_db::storage::ChangeMap` at `state.rs:54`.

### The red required check

`crates/kin-cli/src/commands/health.rs:6300` asserted ` KB of staging` against a row this PR moved
to binary suffixes. It was the last one fed by `kin_core::init_attempt::human_bytes`:
`git grep 'contains(" \(KB\|MB\|GB\)' -- crates/` now exits 1 with no output, and the same grep
shape still finds the new ` KiB` assertion, so that is an empty result rather than a pattern that
cannot match.

```sh
cargo test -p kin-cli --lib commands::health::tests::the_interrupted_conversion_row_scans_the_working_directory_and_its_parent
```

```text
running 1 test
test commands::health::tests::the_interrupted_conversion_row_scans_the_working_directory_and_its_parent ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2281 filtered out; finished in 1.40s
```

### The fuzz lock

Correcting the Compatibility section above: at `4add95cb1` that two-line lock update was NOT in the
diff, and both cargo-fuzz jobs were red on it. It is in the diff now.

```sh
cargo +nightly-2026-06-17 metadata --locked --format-version 1 --manifest-path fuzz/Cargo.toml
```

exits 0. Reverting the pin to `kin-model 0.7.26` reproduces the CI failure exactly:

```text
error: cannot update the lock file .../fuzz/Cargo.lock because --locked was passed to prevent this
rc=101
```

### Enrichment equality, under real deltas

`spooled_history_preserves_enrichment_and_refuses_missing_or_reordered_records` bound
`Vec::new()` on both arms, so `compute_semantic_change_id` never saw a delta and the equality
graded unenriched ids. Both arms now bind the same deterministic nonempty entity and relation
deltas, keyed by change id so each arm reaches them by its own route, and a residency loop refuses
a run that goes back to empty.

```text
test semantic_import::tests::spooled_history_preserves_enrichment_and_refuses_missing_or_reordered_records ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 132 filtered out; finished in 2.96s
```

Falsified two ways. Dropping one entity delta on the streamed arm only:

```text
panicked at crates/kin-git/src/semantic_import.rs:2312:9:
assertion failed: `(left == right)`
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 132 filtered out
```

Reverting both arms to `Vec::new()`, which is the shape this fix replaces:

```text
panicked at crates/kin-git/src/semantic_import.rs:2316:13:
change ed33e6b3002458e2a5c9f47cb176d7f2049f0145f2890a783ebf61b16bfdd5c3 was compared without enrichment
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 132 filtered out
```

### The spool's home

`SemanticChangeSpoolWriter::new()` used `std::env::temp_dir()`. That is tmpfs on most Linux
distributions and inside most containers, so on exactly the hosts this change exists for it put the
spooled history straight back in RAM, invisibly: every test passes and the conversion runs out of
memory anyway. A `NamedTempFile` also unlinks on drop and `SIGKILL` runs no destructor, so an
out-of-memory kill stranded a history-sized file under a name no reclaim path scans for.

`new_in(directory)` now takes the directory, and every caller inside kin-git passes its blob store's
root. For a `kin init` conversion that root is `capture_dir.path().join("objects")`
(`git_init.rs:316`), inside the per-init `.kin-git-capture-<uuid>` stage beside the source
repository. `reap_abandoned_git_captures` (`init_staging.rs:191`) `remove_dir_all`s that stage on
the next init once its lease proves abandoned, and `kin doctor`'s interrupted-conversion row
reports it read-only through `abandoned_init_attempts` (`init_attempt.rs:305`); both filter on
`GIT_CAPTURE_PREFIX`. Writing into a blob store's root is safe by that store's own documented
contract: `list_hashes` and `prune_empty_shards` both skip every top-level entry that is not a
two-hex-character shard directory.

The class has a scripted check that runs on every pull request, rather than a comment:
`history_spool::tests::a_spool_is_written_where_its_caller_put_it_and_is_named_for_a_reader`
asserts the given directory holds exactly one entry, that its name carries the
`.kin-history-spool-` prefix, and that the spool still reads back from there, so it cannot pass on
a file the spool has stopped using.

```sh
cargo test -p kin-git
```

```text
test result: ok. 133 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 23.52s
```

`scripts/zero-file-search-allowlist.json` moved its `history_spool.rs` construction pin from
`file: NamedTempFile::new()` to `.tempfile_in(directory)`. The verifier found that itself:

```text
Allowlist validation FAILED:
  entry crates/kin-git/src/history_spool.rs allow_match 'file: NamedTempFile::new()' occurs 0 times in scanned code (want 1)
```

and after the pin moved, `Verification PASSED: Zero File-Search Invariant holds.`

### The deleted bind guard, and why it came back

The review flagged that `BIND_PEAK_GROWTH_PERCENT_OF_RETAINED` was deleted with no replacement, so
the binding phase's transient peak is no longer graded, only its retention. Before writing a new
ceiling I ran the mutant the old one was calibrated for, against the assertions exactly as they
stood, because a ceiling written first and never seen to fail is not evidence.

The mutant keeps every derived set of entity and relation deltas alive in a `Vec` beside the copy
handed to the spool, inside `bind_historical_semantics` (`git_init.rs:1281`), and drops it before the
phase ends. That is the class in its transient form: derived deltas alive beside the copy.

Nothing caught it.

```text
peak live heap admitting 256 commits: 95925104 bytes (91.5 MiB), backstop 900 MiB
peak growth by phase (MiB grew / MiB retained):
      85.6 /      0.1  kin.init.bind_historical_semantics
       3.2 /      0.5  kin.init.build_git_authority
       2.4 /      2.1  kin.init.capture_git_repository
retained bytes: kin.init.bind_historical_semantics=137712, kin.init.admit_semantic_import=648683, kin.init.commit.enrichment_summary=0
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 125.45s
```

The phase added 85.6 MiB to the peak against 0.0 clean, the run's live peak went from 19,203,259
bytes to 95,925,104, and the test passed. It had to: the retention check is blind to a copy dropped
inside the phase, `bind_retained` barely moved (137,712 against 138,072 clean), and one copy of this
fixture's history is 87 MiB against a 900 MiB backstop. On React that transient doubling is
gigabytes.

So the guard is restored on a denominator that still means something. The old ratio compared the
phase's growth against what the phase retained, which worked while binding kept one copy of every
commit's deltas: two alive measured 218 percent, one measured 118, and the gate sat at 175. Binding
now spools each commit and drops it, so it retains 0.1 MiB rather than a history and that
denominator would refuse every clean run. `BIND_PEAK_GROWTH_DIVISOR` grades growth against the same
`materialized_history_bytes` the retention checks already use, at one quarter: 0 bytes clean against
a 22,791,156 byte ceiling.

With the guard in, the same mutant goes red:

```text
panicked at crates/kin-core/tests/init_deep_history_heap_ceiling.rs:240:5:
kin.init.bind_historical_semantics added 89749184 bytes to the peak, at or over one quarter of the
91164626 bytes retained by explicit history materialization. That phase derives one set of deltas
per commit and hands each straight to the spool, so growth on the order of a history means the
derived set and the spooled copy are alive at the same time. [...]
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 47.64s
```

### The three retention checks, falsified

The `retained < materialized_history_bytes / 4` checks on BIND, ADMIT and SUMMARY had no named
mutant in the body. One each, all against the same 256-commit fixture in release, each run alone
with nothing else touching the tree.


**BIND retention.** Hold every derived set of deltas past the phase.

```text
kin.init.bind_historical_semantics retained 90590904 bytes, at or over one quarter of the
91164626 bytes retained by explicit history materialization. The phase must stream history with
bounded residency.
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 47.96s
```

**ADMIT retention.** Keep one decoded copy of the admitted history past
`kin.init.admit_semantic_import`.

```text
kin.init.admit_semantic_import retained 105546309 bytes, at or over one quarter of the 91164626
bytes retained by explicit history materialization. The phase must stream history with bounded
residency.
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 49.13s
```

**SUMMARY retention.** Call `ChangeMap::decoded()` inside `kin.init.commit.enrichment_summary`. One
line, and the sharpest of the three: `decoded()` caches into a `OnceCell` the authority owns, so
the copy outlives the phase.

```text
kin.init.commit.enrichment_summary retained 91148268 bytes, at or over one quarter of the 91164626
bytes retained by explicit history materialization. The phase must stream history with bounded
residency.
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 52.64s
```

All three exit 101, all three were restored, and `git grep MUTANT -- crates/` over the committed
tree exits 1 with no output.

### The acceptance suite this PR would have silenced

Found in this round, and it is the one thing here that would have turned main red rather than a
pull request. `scripts/acceptance/init_memory_repro.py` grades the deep-history guard by parsing
the lines the guard prints, and this PR rewrote them. Four of its five regexes stopped matching.
Proved by importing the suite's own module and running its compiled regexes over a real guard run,
with the pre-PR line shapes as the positive control:

```text
against this PR's guard output            against the pre-PR shape
PROOF_LINE  : False                        PROOF_LINE  : True
TOTAL_LINE  : True                         TOTAL_LINE  : True
BIND_LINE   : False                        BIND_LINE   : True
RELEASE_LINE: False                        RELEASE_LINE: True
BUILD_LINE  : False                        BUILD_LINE  : True
```

Each of those four reads its figure as `None`, which the suite grades UNREADABLE rather than FAIL,
and `main()` returns 2 when anything is unreadable. So the suite would have reported "5 checks,
1 pass, 0 FAIL, 4 UNREADABLE" and exited 2 inside `Product Acceptance`, which runs it at
`acceptance.yml:805` and grades main after the landing rather than the pull request before it.

Restoring the old printed lines was the small fix and the wrong one, because two of those graders
are obsolete by this PR's own design: the release floor asks how many bytes the plan gave back
after proof 1, and change bodies never live in memory now, so a correct run gives back nothing and
that check would fail honestly.

So the guard now prints one line per graded assertion, each carrying the ceiling it is graded
against, and the suite grades what the guard prints rather than ceilings copied into it. The two
obsolete graders are replaced rather than removed: the binding ratio becomes the binding phase's
transient growth against one quarter of a materialized history, and the release floor becomes the
residency bound every streaming phase has to end under, graded on all three of BIND, ADMIT and
SUMMARY rather than the largest. `--self-test` gains a red case per grader and a
reads-nothing-from-a-crash case per parser.

```text
kin-init-memory-repro self-test: 34 case(s), 0 failure(s)
```

Falsified, because a self-test that cannot fail is the same trap one level up. Flipping
`grade_under`'s boundary from `>=` to `>`:

```text
SELFTEST FAIL at the ceiling fails: wanted FAIL, got PASS (probe is 22791156 bytes against a 22791156 byte ceiling)
kin-init-memory-repro self-test: 34 case(s), 1 failure(s)
```

And the suite against a real guard run, exit 0:

```text
CHECK 0 FIR-2539 PASS proof 1 peak growth is 0 bytes against a 16777216 byte ceiling
CHECK 1 FIR-2539 PASS total admission peak is 18.3 MiB, under the 900 MiB ceiling
CHECK 2 FIR-2539 PASS binding peak growth is 0 bytes against a 22791156 byte ceiling
CHECK 3 FIR-2539 PASS enrichment-summary retention is 0 bytes against a 22791156 byte ceiling
CHECK 4 FIR-2539 PASS bootstrap build peak growth is 6245 bytes against a 45582313 byte ceiling
kin-init-memory-repro: 5 checks, 5 pass, 0 FAIL, 0 UNREADABLE
```

Check 3 grades three figures and prints the last of them, so its other two are in the JSON report:
binding retention 139,536 bytes and admission retention 640,547 bytes, both against the same
22,791,156 byte ceiling.

Said plainly, because it is the whole reason this section carries commands and tails rather than
prose: no check on this pull request grades any of the above. `Product Acceptance` carries
`if: ${{ github.event_name != 'pull_request' }}`, so the suite, its self-test and the deep-history
guard all run for the first time on main's own push run after this lands. The evidence here is the
commands and their output, and there is nothing on the PR surface that confirms it.

### Gates

`bin/kin-precheck kin --repo-dir kin=<lane worktree>` through heavy-slot, on the exact tree:

```text
kin-precheck: repo=kin tree=.../worktrees/memorypath2-kin sha=cd2dbf9978c6762eaca4a5c6775bc535da8d3ef0 branch=chore/lane-memorypath2-kin
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin cd2dbf9978c6762eaca4a5c6775bc535da8d3ef0
```

```sh
cargo test -p kin-git
cargo test -p kin-core
```

```text
test result: ok. 134 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 15.62s
test result: ok. 879 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 27.81s
```

kin-git is 134 rather than the 133 above; the extra one is the spool-home test. kin-core's eight
integration binaries are all ok with zero failures.

`cargo test -p kin-daemon --lib` went red once, and it was not this PR. 1557 passed, 1 failed:

```text
---- loop_runner::tests::reconcile_empty_delta_does_not_dirty_a_settled_graph stdout ----
panicked at crates/kin-daemon/src/loop_runner.rs:4224:9:
the real watcher must process the controlled write
test result: FAILED. 1557 passed; 1 failed; 4 ignored; 0 measured; 0 filtered out; finished in 358.83s
```

It reproduced alone in 12.07 s, so it is not host load. This PR touches no line of
`loop_runner.rs`; the failing test body is one line, `check_reconcile_dirty_work(false, 0, false)`;
`origin/main` at `9e45cc6c8` no longer contains that assertion string at all; and that commit,
#1596, says in its own message that rewriting `check_reconcile_dirty_work` "is the fix for the two
failures firelock-ai/kin#1599's body raised as an open question", naming two sibling tests that
both panic at `loop_runner.rs:4224` with that exact string. This is a third test through the same
helper. Hosted CI already agreed, because it grades the merge of this head with main rather than
this head alone: every check on `cd2dbf997` concluded with zero failures. `9e45cc6c8` is merged in
here rather than left as a caveat, so the figures below grade the tree that lands.

On the merged tree, `cargo test -p kin-daemon --lib` is 1563 passed and 1 failed, and the watcher
test is green: #1596's rewrite fixed it exactly as its message said. The one failure moved to a
different test that also arrived while this round ran:

```text
---- api::tests::repo_scoped_cursor_is_bound_to_repo_authority_and_process_incarnation stdout ----
panicked at crates/kin-daemon/src/api.rs:26181:9:
assertion `left == right` failed: {"capability":"repo_scoped_semantic_tools_v1","error":{"code":"repo_hydration_busy","message":"repository hydration capacity is busy; retry later",...}}
  left: 503
 right: 200
```

That one is load, and it is provable. `git log -S repo_hydration_busy -- crates/kin-daemon/src/api.rs`
names exactly one author: `72414aa80`, "Bound cold hosted repository hydration admission (#1599)",
which landed while this round ran. None of this lane's seven non-merge commits touches a line of
`api.rs`; each one's `git show --stat -- crates/kin-daemon/src/api.rs` is empty. And run alone on a
quiet slot the test passes:

```text
test api::tests::repo_scoped_cursor_is_bound_to_repo_authority_and_process_incarnation ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1567 filtered out; finished in 3.89s
```

The failure is #1599's own capacity refusal firing because a whole crate's tests were running in
parallel beside four cargo build jobs. Worth a note to the release captain rather than a ticket
from this lane, since it is a day-old test on someone else's PR.

`bin/kin-parity --checkout <this worktree>`, release profile, through heavy-slot, with nothing
touching the tree:

```text
kin-parity: magic       UNREADABLE      160.4s  25 pass / 0 fail / 2 unreadable
kin-parity:             2 check(s) unreadable: 10 FIR-2598 UNREADABLE, 11 FIR-2598 UNREADABLE
kin-parity: brownfield  PASS-WITH-ALLOWANCES  309.7s  12 pass / 1 fail / 0 unreadable
kin-parity: firstrun    PASS-WITH-ALLOWANCES  104.8s  10 pass / 1 fail / 1 unreadable
kin-parity: ALLOWED   firstrun check 9 FAIL, tracked as FIR-2580
kin-parity: ALLOWED   firstrun check 3 UNREADABLE, tracked as FIR-2501 (the check's own ticket is FIR-2554)
kin-parity: ALLOWED   brownfield check 4 FAIL, tracked as FIR-2464
kin-parity: FINAL UNREADABLE in 1215.9s  (NON-CITABLE)
PARITY rc=2
```

That is the FIR-3396 flake by the brief's own definition: two FIR-2598 magic checks UNREADABLE with
zero FAILs. The brief says re-run the magic suite alone on the same stamp before believing it, so I
did, with `--only magic --skip-build` against the binaries the run above had just built:

```text
kin-parity: magic       PASS            156.7s  27 pass / 0 fail / 0 unreadable
kin-parity: FINAL PASS in 157.3s  (NON-CITABLE)
PARITY-MAGIC rc=0
```

Twenty-seven of twenty-seven, zero unreadable. So the whole-run verdict rests on three allowances,
all pre-existing and all tracked by ticket: FIR-2580 and FIR-2501 on first-run, FIR-2464 on
brownfield. None of them is this PR's, and they are the same three the author's development-profile
run carried.

### The spool-home test, falsified

```text
panicked at crates/kin-git/src/history_spool.rs:277:9:
assertion `left == right` failed: the spool must be the one thing in the directory it was given: []
test result: FAILED. 6 passed; 1 failed; 0 ignored; 0 measured; 127 filtered out
spool-falsify rc=101
```

The directory comes back empty, which is the defect exactly: the spool went to `TMPDIR` and the
caller's directory holds nothing.
