### PR TITLE
Refresh verified C declarations during incomplete parsing

### DIFF
--- a/crates/kin-core/src/reference_coverage.rs
+++ b/crates/kin-core/src/reference_coverage.rs
@@ -1184,10 +1184,10 @@ impl LanguageParseCoverage {
             )
         };
         format!(
-            "{}: {} of {} admitted {} files did not parse as written, so any entities the graph \
-             still holds for them came from an earlier parse of bytes that are gone, and a file \
-             the graph never parsed is absent from it entirely{named}. Fix the syntax and the \
-             next admission re-derives them.",
+            "{}: {} of {} admitted {} files did not parse as written{named}. Some entities may \
+             be retained from earlier parses while independently verified entities are current. \
+             File coverage remains incomplete. Fix the syntax and the next admission re-derives \
+             the complete file.",
             crate::retained_parse::RETAINED_OBSERVATION,
             self.retained,
             self.tracked,
@@ -2617,7 +2617,8 @@ mod tests {
         // True of both populations. A file created with a typo has no earlier
         // parse, so the clause about what the graph holds has to be conditional.
         assert!(
-            lines.contains("any entities the graph still holds"),
+            lines.contains("Some entities may")
+                && lines.contains("File coverage remains incomplete"),
             "the sentence may not diagnose one member of the set: {lines}"
         );
 

--- a/crates/kin-core/src/reference_coverage.rs
+++ b/crates/kin-core/src/reference_coverage.rs
@@ -1186,8 +1186,8 @@ impl LanguageParseCoverage {
         format!(
             "{}: {} of {} admitted {} files did not parse as written{named}. Some entities may \
              be retained from earlier parses while independently verified entities are current. \
-             File coverage remains incomplete. Fix the syntax and the next admission re-derives \
-             the complete file.",
+             File coverage remains incomplete. Once a complete parse is available, admission \
+             re-derives the complete file.",
             crate::retained_parse::RETAINED_OBSERVATION,
             self.retained,
             self.tracked,

--- a/crates/kin-core/src/retained_parse.rs
+++ b/crates/kin-core/src/retained_parse.rs
@@ -162,8 +162,8 @@ impl RetainedParseRead {
                     "Did not parse as written: {named}{and_more}. Some entities may be retained \
                      from earlier parses while independently verified entities are current. \
                      File coverage remains incomplete, and declarations that were never admitted \
-                     remain absent. Fix the syntax and the next admission re-derives the complete \
-                     file. Observed {age} ago."
+                     remain absent. Once a complete parse is available, admission re-derives \
+                     the complete file. Observed {age} ago."
                 ))
             }
             Self::Absent => None,

--- a/crates/kin-core/src/retained_parse.rs
+++ b/crates/kin-core/src/retained_parse.rs
@@ -158,20 +158,12 @@ impl RetainedParseRead {
                     String::new()
                 };
                 let age = crate::last_admission::humanize_age(age_seconds(recorded.at, now));
-                // Established half first, conditional half second, and the split
-                // is the point. The seam knows which of the two populations a
-                // path is in; this record does not, and widening it to carry
-                // that is a change to the on-disk shape rather than to a
-                // sentence. So the line asserts only what is true of both: the
-                // bytes on disk do not parse. What the graph still holds for
-                // them is stated as a conditional, because a file created with
-                // a typo has no earlier parse to hold.
                 Some(format!(
-                    "Did not parse as written: {named}{and_more}. The bytes on disk do not parse, \
-                     so any entities the graph still holds for these paths came from an earlier \
-                     parse of bytes that are gone, and a path the graph never parsed is absent \
-                     from it entirely. Fix the syntax and the next admission re-derives them. \
-                     Observed {age} ago."
+                    "Did not parse as written: {named}{and_more}. Some entities may be retained \
+                     from earlier parses while independently verified entities are current. \
+                     File coverage remains incomplete, and declarations that were never admitted \
+                     remain absent. Fix the syntax and the next admission re-derives the complete \
+                     file. Observed {age} ago."
                 ))
             }
             Self::Absent => None,
@@ -407,7 +399,7 @@ mod tests {
         let line = read_back.describe(at()).expect("a retained path speaks");
         assert!(line.contains("search.py (4 parse errors)"), "{line}");
         assert!(
-            line.contains("The bytes on disk do not parse"),
+            line.contains("Did not parse as written"),
             "the established half leads: {line}"
         );
         // The half a brand-new file with a typo makes load-bearing. `FileEvent`
@@ -415,7 +407,8 @@ mod tests {
         // this set holds paths with no earlier parse at all. A sentence that
         // asserted one would be a false diagnosis on five surfaces.
         assert!(
-            line.contains("any entities the graph still holds"),
+            line.contains("Some entities may be retained")
+                && line.contains("File coverage remains incomplete"),
             "what the graph holds is a conditional, not an assertion: {line}"
         );
         assert!(

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -149,12 +149,8 @@ pub(crate) enum EnrichmentFacet {
 /// What one reconcile outcome says about the path's current bytes, for the
 /// durable record every reporting surface reads.
 ///
-/// `BrokenAst` is the one outcome that means the graph has started answering
-/// about this path from an earlier parse: it derives nothing, retains what the
-/// last good parse left, and the daemon reconciles under
-/// `ReconcilePolicy::FallbackToLkg`, so it is the ordinary case rather than an
-/// edge. `Updated` and `FileRemoved` settle the path, because both re-derived
-/// from the bytes this pass just read.
+/// `BrokenAst` and `PartiallyUpdated` preserve incomplete file coverage. Only
+/// a clean `Updated` or a confirmed `FileRemoved` settles the path.
 ///
 /// `Conflict` also retains last-known-good state and is deliberately not
 /// recorded. It is a held merge rather than a file whose syntax is broken, it
@@ -163,7 +159,7 @@ pub(crate) enum EnrichmentFacet {
 ///
 /// A path the tree admits without a UTF-8 spelling yields nothing, because the
 /// record is keyed by the path string every reporting surface renders.
-fn observed_parse_of(
+pub(crate) fn observed_parse_of(
     repo_path: &RepoPath,
     outcome: &kin_reconcile::ReconcileOutcome,
 ) -> Option<kin_core::retained_parse::ObservedParse> {
@@ -171,7 +167,8 @@ fn observed_parse_of(
     use kin_reconcile::ReconcileOutcome;
     let path = repo_path.as_utf8()?;
     match outcome {
-        ReconcileOutcome::BrokenAst { error_ranges, .. } => {
+        ReconcileOutcome::BrokenAst { error_ranges, .. }
+        | ReconcileOutcome::PartiallyUpdated { error_ranges, .. } => {
             Some(ObservedParse::retained(path, error_ranges.len()))
         }
         ReconcileOutcome::Updated { .. } | ReconcileOutcome::FileRemoved { .. } => {
@@ -179,6 +176,38 @@ fn observed_parse_of(
         }
         ReconcileOutcome::Conflict(_) => None,
     }
+}
+
+/// Persist incomplete coverage before publishing a mixed entity transaction.
+/// Failure refuses partial admission instead of publishing fresh entities with
+/// a stale clean disclosure. A later clean pass settles the durable record.
+pub(crate) fn persist_partial_observation(
+    layout: &kin_core::KinLayout,
+    outcome: &kin_reconcile::ReconcileOutcome,
+) -> Result<()> {
+    let kin_reconcile::ReconcileOutcome::PartiallyUpdated {
+        file_id,
+        error_ranges,
+        ..
+    } = outcome
+    else {
+        return Ok(());
+    };
+    let previous = kin_core::retained_parse::read(layout);
+    if let kin_core::retained_parse::RetainedParseRead::Unreadable(reason) = &previous {
+        return Err(DaemonError::Io(std::io::Error::other(format!(
+            "partial admission cannot preserve incomplete coverage: {reason}"
+        ))));
+    }
+    let record = kin_core::retained_parse::fold(
+        previous.paths(),
+        &[kin_core::retained_parse::ObservedParse::retained(
+            &file_id.0,
+            error_ranges.len(),
+        )],
+        chrono::Utc::now(),
+    );
+    kin_core::retained_parse::write(layout, &record).map_err(DaemonError::Io)
 }
 
 #[derive(Debug, Default)]
@@ -3630,12 +3659,13 @@ pub async fn run_loop_armed(
                 Ok(result) => {
                     let (outcome, delta) = result.into_parts();
                     debug!(?outcome, "reconcile outcome");
-                    observed_parses.extend(observed_parse_of(&semantic_repo_path, &outcome));
 
                     use kin_reconcile::ReconcileOutcome;
                     let should_apply = matches!(
                         &outcome,
-                        ReconcileOutcome::Updated { .. } | ReconcileOutcome::FileRemoved { .. }
+                        ReconcileOutcome::Updated { .. }
+                            | ReconcileOutcome::PartiallyUpdated { .. }
+                            | ReconcileOutcome::FileRemoved { .. }
                     );
                     let mut reconciled_graph_changed = false;
                     if should_apply {
@@ -3670,6 +3700,10 @@ pub async fn run_loop_armed(
                             }
                         }
                         let derived_entities = !delta.entity_deltas.is_empty();
+                        if let Err(error) = persist_partial_observation(&state.layout, &outcome) {
+                            warn!(%error, "partial admission retained all entities because coverage could not persist");
+                            continue;
+                        }
                         let applied = match apply_reconcile_delta(&delta, |delta| {
                             state.graph.apply_transaction_delta(delta)
                         }) {
@@ -3702,6 +3736,8 @@ pub async fn run_loop_armed(
                         reconciled_graph_changed = applied || layout_changed;
                         graph_changed |= reconciled_graph_changed;
                     }
+
+                    observed_parses.extend(observed_parse_of(&semantic_repo_path, &outcome));
 
                     if let ReconcileOutcome::Updated {
                         file_id,
@@ -3784,6 +3820,20 @@ pub async fn run_loop_armed(
                                 pass_delta.count(&event);
                                 state.emit_event(event);
                             }
+                        }
+                    } else if let ReconcileOutcome::PartiallyUpdated { modified, .. } = &outcome {
+                        pass_delta.nodes_modified += modified.len();
+                        for id in modified {
+                            state.emit_event(DaemonEvent::EntityChanged {
+                                entity_id: *id,
+                                node: crate::state::graph_node_summary(state.graph.as_ref(), id),
+                                change_type: ChangeType::Modified,
+                                file_path: Some(path.to_string_lossy().to_string()),
+                                session_id: None,
+                            });
+                        }
+                        if reconciled_graph_changed || tree_changed {
+                            state.bump_version();
                         }
                     } else if let ReconcileOutcome::FileRemoved {
                         removed, file_id, ..
@@ -4010,6 +4060,100 @@ fn take_file_event_batch(pending: &mut VecDeque<FileEvent>, batch_size: usize) -
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    #[test]
+    fn partial_c_disclosure_persists_and_only_clean_outcomes_settle() {
+        let parent = tempfile::tempdir().unwrap();
+        let repo = tempfile::tempdir_in(parent.path()).unwrap();
+        let init = kin_core::init(repo.path()).unwrap();
+        let file_id = FilePathId::new("test.c");
+        let outcome = kin_reconcile::ReconcileOutcome::PartiallyUpdated {
+            file_id: file_id.clone(),
+            modified: vec![EntityId::new()],
+            retained: vec![EntityId::new()],
+            error_ranges: vec![(12, 12)],
+            collision_warnings: vec![],
+        };
+        persist_partial_observation(&init.layout, &outcome).unwrap();
+        assert_eq!(
+            kin_core::retained_parse::read(&init.layout).errors_for("test.c"),
+            Some(1)
+        );
+        let clean = kin_reconcile::ReconcileOutcome::Updated {
+            file_id,
+            added: vec![],
+            modified: vec![],
+            removed: vec![],
+            collision_warnings: vec![],
+        };
+        let path = RepoPath::from_utf8("test.c").unwrap();
+        kin_core::retained_parse::record(
+            &init.layout,
+            &[observed_parse_of(&path, &clean).unwrap()],
+        );
+        assert_eq!(
+            kin_core::retained_parse::read(&init.layout).errors_for("test.c"),
+            None
+        );
+        std::fs::write(init.layout.kindb_retained_parse_path(), b"invalid").unwrap();
+        assert!(persist_partial_observation(&init.layout, &outcome).is_err());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn partial_c_readmission_preserves_unreadable_disclosure_before_apply() {
+        let parent = tempfile::tempdir().unwrap();
+        let repo = tempfile::tempdir_in(parent.path()).unwrap();
+        let state = open_test_state(&repo);
+        state.is_initialized.store(true, Ordering::Relaxed);
+        let before =
+            "int good(void) { int value=1; return value; }\nint bad(void) { test_cond(1) }\n";
+        let after = before.replace("value", "next");
+        let host = state.layout.working_dir().join("test.c");
+        let paths = BTreeSet::from([RepoPath::from_utf8("test.c").unwrap()]);
+        std::fs::write(&host, before).unwrap();
+        ambient_admission_for_test(&state, &paths).unwrap();
+        let indexed = IndexPipeline::new()
+            .index_file_content_with_tests(
+                &FilePathId::new("test.c"),
+                before.as_bytes(),
+                state.blobs.write(before.as_bytes()).unwrap(),
+            )
+            .unwrap()
+            .indexed_file;
+        for entity in &indexed.entities {
+            state.graph.upsert_entity(entity).unwrap();
+        }
+        let old = indexed.entities.iter().find(|e| e.name == "good").unwrap();
+        std::fs::write(&host, &after).unwrap();
+        ambient_admission_for_test(&state, &paths).unwrap();
+        let record = state.layout.kindb_retained_parse_path();
+        std::fs::write(&record, b"invalid").unwrap();
+        let failed = readmit_semantics_for_paths(&state, &paths).await;
+        assert_eq!(failed.enriched, 0);
+        assert_eq!(failed.failed.len(), 1);
+        assert_eq!(state.graph.get_entity(&old.id).unwrap().as_ref(), Some(old));
+        assert_eq!(std::fs::read(&record).unwrap(), b"invalid");
+        kin_core::retained_parse::write(
+            &state.layout,
+            &kin_core::retained_parse::RetainedParse::new(chrono::Utc::now(), vec![]),
+        )
+        .unwrap();
+        let partial = readmit_semantics_for_paths(&state, &paths).await;
+        assert_eq!(
+            partial.enriched, 0,
+            "partial must never count as full-file enrichment"
+        );
+        assert_eq!(partial.failed.len(), 1);
+        let current = state.graph.get_entity(&old.id).unwrap().unwrap();
+        assert_eq!(
+            current.metadata.extra["blob_hash"],
+            kin_blobs::digest(after.as_bytes()).to_string()
+        );
+        assert!(kin_core::retained_parse::read(&state.layout)
+            .errors_for("test.c")
+            .is_some());
+    }
 
     fn open_test_state(repo: &tempfile::TempDir) -> Arc<DaemonState> {
         let init = kin_core::init(repo.path()).unwrap();
@@ -9712,10 +9856,21 @@ pub(crate) async fn readmit_semantics_for_paths(
         match reconciler.reconcile_file_change(&event, &state.blobs, state.graph.as_ref()) {
             Ok(result) => {
                 let (reconciled, delta) = result.into_parts();
+                if matches!(
+                    reconciled,
+                    kin_reconcile::ReconcileOutcome::BrokenAst { .. }
+                ) {
+                    if let Some(observation) = observed_parse_of(repo_path, &reconciled) {
+                        kin_core::retained_parse::record(&state.layout, &[observation]);
+                    }
+                }
+
                 use kin_reconcile::ReconcileOutcome;
                 let should_apply = matches!(
                     &reconciled,
-                    ReconcileOutcome::Updated { .. } | ReconcileOutcome::FileRemoved { .. }
+                    ReconcileOutcome::Updated { .. }
+                        | ReconcileOutcome::PartiallyUpdated { .. }
+                        | ReconcileOutcome::FileRemoved { .. }
                 );
                 // `BrokenAst` and `Conflict` retain last-known-good state and
                 // derive nothing, so the file keeps the spans its previous parse
@@ -9743,6 +9898,13 @@ pub(crate) async fn readmit_semantics_for_paths(
                 }
                 {
                     let derived_entities = !delta.entity_deltas.is_empty();
+                    if let Err(error) = persist_partial_observation(&state.layout, &reconciled) {
+                        warn!(%error, "partial admission retained all entities because coverage could not persist");
+                        outcome
+                            .failed
+                            .push(SemanticFailure::unresolved(file_id.0.clone()));
+                        continue;
+                    }
                     if let Err(error) = state.graph.apply_transaction_delta(&delta) {
                         warn!(
                             file = %file_id,
@@ -9754,6 +9916,9 @@ pub(crate) async fn readmit_semantics_for_paths(
                             .failed
                             .push(SemanticFailure::unresolved(file_id.0.clone()));
                         continue;
+                    }
+                    if let Some(observation) = observed_parse_of(repo_path, &reconciled) {
+                        kin_core::retained_parse::record(&state.layout, &[observation]);
                     }
                     if derived_entities {
                         mark_enrichment_unpublished(state, &file_id);
@@ -9789,7 +9954,13 @@ pub(crate) async fn readmit_semantics_for_paths(
                         }
                     }
                     graph_changed = true;
-                    outcome.enriched += 1;
+                    if matches!(reconciled, ReconcileOutcome::PartiallyUpdated { .. }) {
+                        outcome
+                            .failed
+                            .push(SemanticFailure::unparseable(file_id.0.clone()));
+                    } else {
+                        outcome.enriched += 1;
+                    }
                 }
             }
             Err(error) => {
@@ -10224,11 +10395,19 @@ async fn sync_filesystem_with_graph_publishing_inner(
         {
             Ok(result) => {
                 let (outcome, delta) = result.into_parts();
-                observed_parses.extend(observed_parse_of(&semantic_repo_path, &outcome));
+                if !matches!(
+                    outcome,
+                    kin_reconcile::ReconcileOutcome::Updated { .. }
+                        | kin_reconcile::ReconcileOutcome::FileRemoved { .. }
+                ) {
+                    observed_parses.extend(observed_parse_of(&semantic_repo_path, &outcome));
+                }
                 use kin_reconcile::ReconcileOutcome;
                 let should_apply = matches!(
                     &outcome,
-                    ReconcileOutcome::Updated { .. } | ReconcileOutcome::FileRemoved { .. }
+                    ReconcileOutcome::Updated { .. }
+                        | ReconcileOutcome::PartiallyUpdated { .. }
+                        | ReconcileOutcome::FileRemoved { .. }
                 );
                 if should_apply {
                     if !host_entry_matches_graph(state, path, &semantic_repo_path)? {
@@ -10238,10 +10417,12 @@ async fn sync_filesystem_with_graph_publishing_inner(
                         ))));
                     }
                     let derived_entities = !delta.entity_deltas.is_empty();
+                    persist_partial_observation(&state.layout, &outcome)?;
                     if let Err(e) = state.graph.apply_transaction_delta(&delta) {
                         warn!(error = %e, "failed to apply synced transaction into primary graph");
                         continue;
                     }
+                    observed_parses.extend(observed_parse_of(&semantic_repo_path, &outcome));
                     // Marked here for the same reason as on the ambient tick.
                     // This seam runs under a commit as often as not, and a
                     // commit publishes what it derived, so most entries written

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -3832,6 +3832,15 @@ pub async fn run_loop_armed(
                                 session_id: None,
                             });
                         }
+                        if should_apply {
+                            for event in crate::state::relation_change_events(
+                                &delta,
+                                Some(path.to_string_lossy().as_ref()),
+                            ) {
+                                pass_delta.count(&event);
+                                state.emit_event(event);
+                            }
+                        }
                         if reconciled_graph_changed || tree_changed {
                             state.bump_version();
                         }

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -1603,6 +1603,13 @@ pub(crate) fn paths_whose_semantics_the_sealed_bytes_do_not_reproduce(
                     continue;
                 }
                 if current {
+                    let held_relations = kin_model::EntityStore::traverse(
+                        graph,
+                        &kin_model::GraphNodeId::Entity(entity.id),
+                        &[],
+                        1,
+                    )?
+                    .relations;
                     // A partial admission claims only this declaration. Recheck
                     // the old CAS context and the exact new payload, not a
                     // complete-set equality over an incomplete file.
@@ -1650,7 +1657,18 @@ pub(crate) fn paths_whose_semantics_the_sealed_bytes_do_not_reproduce(
                                                 "error_ranges": error_ranges,
                                             }),
                                         );
-                                        expected == *entity
+                                        let mut original = originals[0].clone();
+                                        original.id = entity.id;
+                                        let declaration = candidates[0].span.as_ref()?;
+                                        expected == *entity && held_relations.iter().all(|relation| {
+                                            let associated = relation.evidence.iter().filter_map(|e| e.source_span.as_ref()).any(|span| {
+                                                span.file == declaration.file && (relation.src == kin_model::GraphNodeId::Entity(entity.id)
+                                                    || (declaration.start_line <= span.start_line && span.end_line <= declaration.end_line))
+                                            });
+                                            !associated || pipeline.verifies_partial_relation(
+                                                &original, candidates[0], previous.body(), content, relation, &held,
+                                            )
+                                        })
                                     },
                             )
                         })
@@ -1668,12 +1686,44 @@ pub(crate) fn paths_whose_semantics_the_sealed_bytes_do_not_reproduce(
                     if let Some(previous) = previous.and_then(|previous| {
                         read_publishable_source(blobs, authority, previous).ok()
                     }) {
+                        let relations = kin_model::EntityStore::traverse(
+                            graph,
+                            &kin_model::GraphNodeId::Entity(entity.id),
+                            &[],
+                            1,
+                        )?
+                        .relations;
                         stale |= pipeline.supports_partial_refresh(
                             entity,
                             candidates[0],
                             previous.body(),
                             content,
-                        );
+                        ) && relations.iter().all(|relation| {
+                            let associated = entity.span.as_ref().is_some_and(|declaration| {
+                                relation
+                                    .evidence
+                                    .iter()
+                                    .filter_map(|e| e.source_span.as_ref())
+                                    .any(|span| {
+                                        span.file == declaration.file
+                                            && (relation.src
+                                                == kin_model::GraphNodeId::Entity(entity.id)
+                                                || (declaration.start_line <= span.start_line
+                                                    && span.end_line <= declaration.end_line))
+                                    })
+                            });
+                            !associated
+                                || pipeline
+                                    .rebase_partial_relation(
+                                        entity,
+                                        candidates[0],
+                                        previous.body(),
+                                        content,
+                                        relation,
+                                        &held,
+                                    )
+                                    .is_some()
+                        });
                     }
                 }
             }
@@ -4875,6 +4925,160 @@ mod tests {
             .summary_lines()
             .join("\n")
             .contains("retained_last_good_parse"));
+    }
+
+    #[test]
+    fn partial_c_call_evidence_commits_and_reopens_at_the_current_call_site() {
+        let before = "int helper(void) { return 7; }\nint good(void) {\n  int value=1;\n  return helper();\n}\nint bad(void) { test_cond(1) }\n";
+        let site = |source: &str, zero_bytes: bool| {
+            let start = source.find("helper()").unwrap();
+            let end = start + "helper".len();
+            let line = source[..start]
+                .bytes()
+                .filter(|byte| *byte == b'\n')
+                .count() as u32;
+            let column = start - source[..start].rfind('\n').map_or(0, |offset| offset + 1);
+            kin_model::SourceSpan {
+                file: kin_model::FilePathId::new("test.c"),
+                start_byte: if zero_bytes { 0 } else { start },
+                end_byte: if zero_bytes { 0 } else { end },
+                start_line: line,
+                end_line: line,
+                start_col: column as u32,
+                end_col: (column + end - start) as u32,
+            }
+        };
+        for (prefix, unsupported) in [(true, false), (false, false), (true, true)] {
+            let parent = tempfile::tempdir().unwrap();
+            let root = tempfile::tempdir_in(parent.path()).unwrap();
+            let init = kin_core::init(root.path()).unwrap();
+            let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+            let graph = kin_db::InMemoryGraph::new();
+            let artifact = add_artifact(&graph, &blobs, b"test.c", before.as_bytes(), |hash| {
+                TreeEntry::blob(hash, false)
+            });
+            let held = derive_entities_into_graph(&graph, &blobs, "test.c", before.as_bytes());
+            let caller = held.iter().find(|entity| entity.name == "good").unwrap();
+            let callee = held.iter().find(|entity| entity.name == "helper").unwrap();
+            let mut relation = kin_model::Relation {
+                id: kin_model::RelationId::new(),
+                kind: kin_model::RelationKind::Calls,
+                src: kin_model::GraphNodeId::Entity(caller.id),
+                dst: kin_model::GraphNodeId::Entity(callee.id),
+                confidence: 0.75,
+                origin: kin_model::RelationOrigin::Lsp,
+                created_in: None,
+                import_source: None,
+                evidence: vec![kin_model::RelationEvidence {
+                    source_span: Some(site(before, prefix)),
+                    ..Default::default()
+                }],
+            };
+            if unsupported {
+                relation.evidence[0].source_span = caller.span.clone();
+            }
+            graph.upsert_relation(&relation).unwrap();
+            let plan = || {
+                plan_native_commit(
+                    &init.layout,
+                    &graph,
+                    &blobs,
+                    OperationId::new(),
+                    fixed_timestamp(),
+                    AuthorId::new("tests"),
+                    "Record current call evidence".into(),
+                )
+            };
+            commit_native_plan_with_projection(&init.layout, &blobs, plan().unwrap()).unwrap();
+            let after = if prefix {
+                format!("// prefix\n{before}")
+            } else {
+                before.replace("int value=1;", "int renamed=1;\n\n")
+            };
+            update_artifact_bytes(&graph, &blobs, &artifact, after.as_bytes());
+            let indexed = kin_index::IndexPipeline::new()
+                .index_file_content_with_tests(
+                    &kin_model::FilePathId::new("test.c"),
+                    after.as_bytes(),
+                    blobs.write(after.as_bytes()).unwrap(),
+                )
+                .unwrap()
+                .indexed_file;
+            let mut reconciler = kin_reconcile::Reconciler::new(root.path().to_path_buf());
+            let result = reconciler
+                .reconcile_indexed_content(&indexed, &blobs, &graph)
+                .unwrap();
+            assert!(
+                matches!(&result.outcome, kin_reconcile::ReconcileOutcome::PartiallyUpdated { modified, .. } if modified.contains(&caller.id) != unsupported),
+                "{:?}",
+                result.outcome
+            );
+            crate::loop_runner::persist_partial_observation(&init.layout, &result.outcome).unwrap();
+            graph.apply_transaction_delta(&result.delta).unwrap();
+            if unsupported {
+                assert_eq!(graph.get_entity(&caller.id).unwrap().as_ref(), Some(caller));
+                commit_native_plan_with_projection(&init.layout, &blobs, plan().unwrap()).unwrap();
+                let authority = reopen(&init);
+                let lease = authority.read_authority();
+                let snapshot = lease
+                    .workspace_graph_snapshot(&init.workspace_id)
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(snapshot.entities.get(&caller.id), Some(caller));
+                assert_eq!(snapshot.relations.get(&relation.id), Some(&relation));
+                assert_eq!(
+                    kin_core::retained_parse::read(&init.layout).errors_for("test.c"),
+                    Some(1)
+                );
+                continue;
+            }
+            let mut expected = relation.clone();
+            expected.evidence[0].source_span = Some(site(&after, false));
+            let updated = graph
+                .get_all_relations_for_entity(&caller.id)
+                .unwrap()
+                .into_iter()
+                .find(|held| held.id == relation.id)
+                .unwrap();
+            assert_eq!(
+                updated, expected,
+                "the partial transaction must move the existing call evidence"
+            );
+            graph.upsert_relation(&relation).unwrap();
+            assert!(
+                plan().is_err(),
+                "commit accepted retained old call-site coordinates for a current caller"
+            );
+            graph.upsert_relation(&updated).unwrap();
+            commit_native_plan_with_projection(&init.layout, &blobs, plan().unwrap()).unwrap();
+            let authority = reopen(&init);
+            let lease = authority.read_authority();
+            let snapshot = lease
+                .workspace_graph_snapshot(&init.workspace_id)
+                .unwrap()
+                .unwrap();
+            let current = snapshot.entities.get(&caller.id).unwrap();
+            assert_eq!(
+                current.metadata.extra["blob_hash"],
+                kin_blobs::digest(after.as_bytes()).to_string()
+            );
+            let reopened = snapshot.relations.get(&relation.id).unwrap();
+            assert_eq!(reopened, &expected);
+            let lines = kin_mcp::handlers::common::relation_reference_lines(
+                reopened,
+                Some(&kin_model::FilePathId::new("test.c")),
+            );
+            assert_eq!(lines.lines, vec![site(&after, false).start_line + 1]);
+            assert!(after
+                .lines()
+                .nth(lines.lines[0] as usize - 1)
+                .unwrap()
+                .contains("helper()"));
+            assert_eq!(
+                kin_core::retained_parse::read(&init.layout).errors_for("test.c"),
+                Some(1)
+            );
+        }
     }
 
     /// A commit must not seal a tree delta over a path whose graph entities a

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -1575,7 +1575,7 @@ pub(crate) fn paths_whose_semantics_the_sealed_bytes_do_not_reproduce(
             file_path: Some(file_id.clone()),
             ..Default::default()
         })?;
-        if !matches!(indexed.parse_state, kin_model::ParseState::Valid) {
+        if let kin_model::ParseState::Incomplete { error_ranges } = &indexed.parse_state {
             let mut stale = false;
             for entity in &held {
                 let candidates: Vec<_> = indexed
@@ -1642,12 +1642,14 @@ pub(crate) fn paths_whose_semantics_the_sealed_bytes_do_not_reproduce(
                                         expected.id = entity.id;
                                         expected.created_in = entity.created_in;
                                         expected.lineage_parent = entity.lineage_parent;
-                                        if let Some(proof) = proof {
-                                            expected.metadata.extra.insert(
-                                                "partial_parse_admission".into(),
-                                                proof.clone(),
-                                            );
-                                        }
+                                        expected.metadata.extra.insert(
+                                            "partial_parse_admission".into(),
+                                            serde_json::json!({
+                                                "previous_blob_hash": kin_blobs::digest(previous.body()).to_string(),
+                                                "source_blob_hash": hash.to_string(),
+                                                "error_ranges": error_ranges,
+                                            }),
+                                        );
                                         expected == *entity
                                     },
                             )
@@ -4792,11 +4794,25 @@ mod tests {
         .unwrap();
         kin_core::retained_parse::record(&init.layout, &[observation]);
         let good = graph.get_entity(&target.id).unwrap().unwrap();
-        for corruption in ["proof", "span", "digest", "signature", "body"] {
+        for corruption in [
+            "proof",
+            "error_ranges",
+            "span",
+            "digest",
+            "signature",
+            "body",
+        ] {
             let mut corrupt = good.clone();
             match corruption {
                 "proof" => {
                     corrupt.metadata.extra.remove("partial_parse_admission");
+                }
+                "error_ranges" => {
+                    corrupt
+                        .metadata
+                        .extra
+                        .get_mut("partial_parse_admission")
+                        .unwrap()["error_ranges"] = serde_json::json!([]);
                 }
                 "span" => {
                     corrupt.span.as_mut().unwrap().start_byte += 1;

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -1571,22 +1571,115 @@ pub(crate) fn paths_whose_semantics_the_sealed_bytes_do_not_reproduce(
             continue;
         };
         let indexed = indexed.indexed_file;
-        // Only a clean parse can say the graph's entities are wrong. A file the
-        // parser could not read whole keeps the entities its last readable
-        // version produced, deliberately: the daemon reconciles under
-        // `ReconcilePolicy::FallbackToLkg`, an author mid-edit produces this
-        // constantly, and a fresh parse of a half-written file disagrees with
-        // the graph for a reason that has nothing to do with the window this
-        // check exists to close. Refusing on it would leave a caller holding one
-        // broken file unable to record anything at all, which is the outcome
-        // `drain_semantic_debt` already declines to produce for the same reason.
-        if !matches!(indexed.parse_state, kin_model::ParseState::Valid) {
-            continue;
-        }
         let held = graph.query_entities(&kin_model::EntityFilter {
             file_path: Some(file_id.clone()),
             ..Default::default()
         })?;
+        if !matches!(indexed.parse_state, kin_model::ParseState::Valid) {
+            let mut stale = false;
+            for entity in &held {
+                let candidates: Vec<_> = indexed
+                    .entities
+                    .iter()
+                    .filter(|e| e.name == entity.name && e.kind == entity.kind)
+                    .collect();
+                let unique = candidates.len() == 1
+                    && held
+                        .iter()
+                        .filter(|e| e.name == entity.name && e.kind == entity.kind)
+                        .count()
+                        == 1;
+                let current = entity
+                    .metadata
+                    .extra
+                    .get("blob_hash")
+                    .and_then(|v| v.as_str())
+                    == Some(hash.to_string().as_str());
+                let proof = entity.metadata.extra.get("partial_parse_admission");
+                if proof.is_some_and(|proof| {
+                    proof.get("source_blob_hash") != entity.metadata.extra.get("blob_hash")
+                }) {
+                    stale = true;
+                    continue;
+                }
+                if current {
+                    // A partial admission claims only this declaration. Recheck
+                    // the old CAS context and the exact new payload, not a
+                    // complete-set equality over an incomplete file.
+                    let previous = proof
+                        .and_then(|v| v.get("previous_blob_hash"))
+                        .and_then(|v| v.as_str())
+                        .and_then(|v| kin_model::Hash256::from_hex(v).ok());
+                    let verified = previous
+                        .and_then(|previous| {
+                            read_publishable_source(blobs, authority, previous).ok()
+                        })
+                        .and_then(|previous| {
+                            let before = pipeline
+                                .index_file_content_with_tests(
+                                    &file_id,
+                                    previous.body(),
+                                    kin_blobs::digest(previous.body()),
+                                )
+                                .ok()?;
+                            let originals: Vec<_> = before
+                                .indexed_file
+                                .entities
+                                .iter()
+                                .filter(|e| e.name == entity.name && e.kind == entity.kind)
+                                .collect();
+                            Some(
+                                unique
+                                    && originals.len() == 1
+                                    && pipeline.supports_partial_refresh(
+                                        originals[0],
+                                        candidates[0],
+                                        previous.body(),
+                                        content,
+                                    )
+                                    && {
+                                        let mut expected = candidates[0].clone();
+                                        expected.id = entity.id;
+                                        expected.created_in = entity.created_in;
+                                        expected.lineage_parent = entity.lineage_parent;
+                                        if let Some(proof) = proof {
+                                            expected.metadata.extra.insert(
+                                                "partial_parse_admission".into(),
+                                                proof.clone(),
+                                            );
+                                        }
+                                        expected == *entity
+                                    },
+                            )
+                        })
+                        .unwrap_or(false);
+                    stale |= !verified;
+                } else if !current && unique {
+                    // Do not seal a refreshable declaration in the window
+                    // before its partial transaction reaches graph truth.
+                    let previous = entity
+                        .metadata
+                        .extra
+                        .get("blob_hash")
+                        .and_then(|v| v.as_str())
+                        .and_then(|v| kin_model::Hash256::from_hex(v).ok());
+                    if let Some(previous) = previous.and_then(|previous| {
+                        read_publishable_source(blobs, authority, previous).ok()
+                    }) {
+                        stale |= pipeline.supports_partial_refresh(
+                            entity,
+                            candidates[0],
+                            previous.body(),
+                            content,
+                        );
+                    }
+                }
+            }
+            if stale {
+                behind.push(new.path.clone());
+            }
+            continue;
+        }
         // No skip for a path the graph holds nothing at: a clean parse that
         // produces entities where the graph has none is the same defect one step
         // further along, and the comparison below already says so.
@@ -4626,6 +4719,146 @@ mod tests {
         commit_native_plan_with_projection(&init.layout, blobs, plan).unwrap();
         update_artifact_bytes(graph, blobs, &artifact, after);
         held
+    }
+
+    #[test]
+    fn partial_c_commit_reopens_current_identity_and_retains_incomplete_coverage() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir_in(parent.path()).unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+        let before = include_str!("../../kin-parser/tests/fixtures/c/hiredis-sds.c");
+        let after = before.replacen("reqlen", "required_len", 3);
+        let artifact = add_artifact(&graph, &blobs, b"sds.c", before.as_bytes(), |hash| {
+            TreeEntry::blob(hash, false)
+        });
+        let held = derive_entities_into_graph(&graph, &blobs, "sds.c", before.as_bytes());
+        let target = held.iter().find(|e| e.name == "sdsMakeRoomFor").unwrap();
+        let initial = plan_native_commit(
+            &init.layout,
+            &graph,
+            &blobs,
+            OperationId::new(),
+            fixed_timestamp(),
+            AuthorId::new("tests"),
+            "Record C source".into(),
+        )
+        .unwrap();
+        commit_native_plan_with_projection(&init.layout, &blobs, initial).unwrap();
+        update_artifact_bytes(&graph, &blobs, &artifact, after.as_bytes());
+        let plan = || {
+            plan_native_commit(
+                &init.layout,
+                &graph,
+                &blobs,
+                OperationId::new(),
+                fixed_timestamp(),
+                AuthorId::new("tests"),
+                "Refresh C declaration".into(),
+            )
+        };
+        assert!(
+            plan().is_err(),
+            "a refreshable entity must not be sealed before admission"
+        );
+        let indexed = kin_index::IndexPipeline::new()
+            .index_file_content_with_tests(
+                &kin_model::FilePathId::new("sds.c"),
+                after.as_bytes(),
+                blobs.write(after.as_bytes()).unwrap(),
+            )
+            .unwrap()
+            .indexed_file;
+        let mut reconciler = kin_reconcile::Reconciler::new(root.path().to_path_buf());
+        let result = reconciler
+            .reconcile_indexed_content(&indexed, &blobs, &graph)
+            .unwrap();
+        let kin_reconcile::ReconcileOutcome::PartiallyUpdated {
+            retained,
+            error_ranges,
+            ..
+        } = &result.outcome
+        else {
+            panic!("{:?}", result.outcome);
+        };
+        assert_eq!(error_ranges.len(), 25);
+        crate::loop_runner::persist_partial_observation(&init.layout, &result.outcome).unwrap();
+        graph.apply_transaction_delta(&result.delta).unwrap();
+        let observation = crate::loop_runner::observed_parse_of(
+            &RepoPath::from_utf8("sds.c").unwrap(),
+            &result.outcome,
+        )
+        .unwrap();
+        kin_core::retained_parse::record(&init.layout, &[observation]);
+        let good = graph.get_entity(&target.id).unwrap().unwrap();
+        for corruption in ["proof", "span", "digest", "signature", "body"] {
+            let mut corrupt = good.clone();
+            match corruption {
+                "proof" => {
+                    corrupt.metadata.extra.remove("partial_parse_admission");
+                }
+                "span" => {
+                    corrupt.span.as_mut().unwrap().start_byte += 1;
+                }
+                "signature" => {
+                    corrupt.signature.push_str(" invalid");
+                }
+                "digest" => {
+                    corrupt.metadata.extra.insert(
+                        "blob_hash".into(),
+                        kin_blobs::digest(before.as_bytes()).to_string().into(),
+                    );
+                }
+                _ => {
+                    corrupt.fingerprint.behavior_hash = Hash256::from_bytes([0; 32]);
+                }
+            }
+            graph.upsert_entity(&corrupt).unwrap();
+            assert!(
+                plan().is_err(),
+                "commit accepted corrupted {corruption} proof"
+            );
+            graph.upsert_entity(&good).unwrap();
+        }
+        commit_native_plan_with_projection(&init.layout, &blobs, plan().unwrap()).unwrap();
+        let authority = reopen(&init);
+        let lease = authority.read_authority();
+        let snapshot = lease
+            .workspace_graph_snapshot(&init.workspace_id)
+            .unwrap()
+            .unwrap();
+        let current = snapshot.entities.get(&target.id).unwrap();
+        assert_eq!(current, &good);
+        let digest = Hash256::from_bytes(kin_blobs::digest(after.as_bytes()).0);
+        kin_mcp::handlers::common::span_source_coherence(current, &digest, "sds.c").unwrap();
+        let source = read_publishable_source(&blobs, &authority, digest).unwrap();
+        let span = current.span.as_ref().unwrap();
+        assert!(
+            std::str::from_utf8(&source.body()[span.start_byte..span.end_byte])
+                .unwrap()
+                .contains("required_len")
+        );
+        for id in retained {
+            let old = held.iter().find(|e| e.id == *id).unwrap();
+            assert_eq!(snapshot.entities.get(id), Some(old));
+            assert!(
+                kin_mcp::handlers::common::span_source_coherence(old, &digest, "sds.c").is_err()
+            );
+        }
+        let disclosure = kin_core::retained_parse::read(&init.layout);
+        assert_eq!(disclosure.errors_for("sds.c"), Some(25));
+        let entities: Vec<_> = snapshot.entities.values().cloned().collect();
+        let coverage = kin_core::reference_coverage::collect_parse_coverage_from(
+            &snapshot.resolved_tree,
+            &entities,
+            &disclosure,
+        );
+        assert!(coverage.any_retained());
+        assert!(coverage
+            .summary_lines()
+            .join("\n")
+            .contains("retained_last_good_parse"));
     }
 
     /// A commit must not seal a tree delta over a path whose graph entities a

--- a/crates/kin-index/src/pipeline.rs
+++ b/crates/kin-index/src/pipeline.rs
@@ -158,6 +158,196 @@ impl IndexPipeline {
         true
     }
 
+    /// Move only uniquely identified direct-call evidence through a proven
+    /// partial declaration refresh. Resolution must name one stable, complete
+    /// function in this same file; all other located evidence refuses admission.
+    pub fn rebase_partial_relation(
+        &self,
+        old: &Entity,
+        new: &Entity,
+        old_source: &[u8],
+        source: &[u8],
+        relation: &Relation,
+        file_entities: &[Entity],
+    ) -> Option<Relation> {
+        self.partial_relation_evidence(old, new, old_source, source, relation, file_entities, false)
+    }
+
+    /// Verify the coordinates persisted for an already admitted declaration.
+    pub fn verifies_partial_relation(
+        &self,
+        old: &Entity,
+        new: &Entity,
+        old_source: &[u8],
+        source: &[u8],
+        relation: &Relation,
+        file_entities: &[Entity],
+    ) -> bool {
+        self.partial_relation_evidence(old, new, old_source, source, relation, file_entities, true)
+            .is_some_and(|expected| expected == *relation)
+    }
+
+    fn partial_relation_evidence(
+        &self,
+        old: &Entity,
+        new: &Entity,
+        old_source: &[u8],
+        source: &[u8],
+        relation: &Relation,
+        file_entities: &[Entity],
+        current: bool,
+    ) -> Option<Relation> {
+        use kin_parser::adapter::LanguageAdapter;
+        let was = old.span.as_ref()?;
+        let now = new.span.as_ref()?;
+        if !relation
+            .evidence
+            .iter()
+            .any(|e| e.source_span.as_ref().is_some_and(|s| s.file == was.file))
+        {
+            return Some(relation.clone());
+        }
+        if relation.src.as_entity() != Some(old.id)
+            || relation.kind != kin_model::RelationKind::Calls
+            || !self.supports_partial_refresh(old, new, old_source, source)
+        {
+            return None;
+        }
+        let target_id = relation.dst.as_entity()?;
+        let target = file_entities.iter().find(|entity| entity.id == target_id)?;
+        if target.kind != kin_model::EntityKind::Function || target.span.as_ref()?.file != was.file
+        {
+            return None;
+        }
+        let adapter = kin_parser::languages::CAdapter;
+        let before = adapter.parse(old_source).ok()?;
+        let after = adapter.parse(source).ok()?;
+        let old_sites =
+            kin_parser::languages::c_lang::partial_call_sites(&before, old_source, was)?;
+        let new_sites = kin_parser::languages::c_lang::partial_call_sites(&after, source, now)?;
+        let before_entities: Vec<_> = adapter
+            .extract(&before, old_source, &was.file)
+            .ok()?
+            .entities
+            .into_iter()
+            .map(|entity| {
+                entity.into_entity_with_source(LanguageId::C, &was.file, Some(old_source))
+            })
+            .collect();
+        let after_entities: Vec<_> = adapter
+            .extract(&after, source, &was.file)
+            .ok()?
+            .entities
+            .into_iter()
+            .map(|entity| entity.into_entity_with_source(LanguageId::C, &was.file, Some(source)))
+            .collect();
+        for entities in [
+            file_entities,
+            before_entities.as_slice(),
+            after_entities.as_slice(),
+        ] {
+            let matched: Vec<_> = entities
+                .iter()
+                .filter(|entity| entity.name == target.name && entity.kind == target.kind)
+                .collect();
+            if matched.len() != 1 || matched[0].signature != target.signature {
+                return None;
+            }
+        }
+        for (tree, bytes, entities) in [
+            (&before, old_source, &before_entities),
+            (&after, source, &after_entities),
+        ] {
+            let declaration = entities
+                .iter()
+                .find(|entity| entity.name == target.name && entity.kind == target.kind)?
+                .span
+                .as_ref()?;
+            kin_parser::languages::c_lang::partial_function_context(
+                tree,
+                bytes,
+                declaration.start_byte,
+                declaration.end_byte,
+            )?;
+        }
+        let span_matches =
+            |observed: &kin_model::SourceSpan, syntax: &kin_model::SourceSpan, bytes: &[u8]| {
+                if observed.start_byte != 0 || observed.end_byte != 0 {
+                    return observed == syntax;
+                }
+                let coordinates_match = observed.file == syntax.file
+                    && observed.start_line == syntax.start_line
+                    && observed.end_line == syntax.end_line
+                    && observed.start_col == syntax.start_col
+                    && observed.end_col == syntax.end_col;
+                // Zero-byte LSP positions can use UTF-16 columns. ASCII prefixes
+                // make that representation identical to parser byte columns.
+                coordinates_match
+                    && [
+                        (syntax.start_line, syntax.start_col),
+                        (syntax.end_line, syntax.end_col),
+                    ]
+                    .iter()
+                    .all(|(line, column)| {
+                        bytes
+                            .split(|byte| *byte == b'\n')
+                            .nth(*line as usize)
+                            .and_then(|line| line.get(..*column as usize))
+                            .is_some_and(|prefix| prefix.is_ascii())
+                    })
+            };
+        let mut updated = relation.clone();
+        for evidence in &mut updated.evidence {
+            let Some(span) = evidence.source_span.as_ref() else {
+                continue;
+            };
+            if span.file != was.file {
+                continue;
+            }
+            let (sites, bytes) = if current {
+                (&new_sites, source)
+            } else {
+                (&old_sites, old_source)
+            };
+            let matched: Vec<_> = sites
+                .iter()
+                .filter_map(|site| {
+                    if span_matches(span, &site.call_span, bytes) {
+                        Some((site, true))
+                    } else if span_matches(span, &site.callee_span, bytes) {
+                        Some((site, false))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            if matched.len() != 1 {
+                return None;
+            }
+            let (site, whole_call) = matched[0];
+            if site.callee != target.name {
+                return None;
+            }
+            let same_call = |candidate: &&kin_parser::languages::c_lang::PartialCallSite| {
+                candidate.callee == site.callee && candidate.expression == site.expression
+            };
+            if old_sites.iter().filter(same_call).count() != 1
+                || new_sites.iter().filter(same_call).count() != 1
+            {
+                return None;
+            }
+            let placed = new_sites.iter().find(|candidate| {
+                candidate.callee == site.callee && candidate.expression == site.expression
+            })?;
+            evidence.source_span = Some(if whole_call {
+                placed.call_span.clone()
+            } else {
+                placed.callee_span.clone()
+            });
+        }
+        Some(updated)
+    }
+
     pub fn new() -> Self {
         Self {
             registry: AdapterRegistry::new(),

--- a/crates/kin-index/src/pipeline.rs
+++ b/crates/kin-index/src/pipeline.rs
@@ -73,6 +73,91 @@ pub struct IndexPipeline {
 }
 
 impl IndexPipeline {
+    /// Verify a conservative refresh against both complete, digest-bound C
+    /// inputs. This proves only one existing declaration, never file coverage.
+    pub fn supports_partial_refresh(
+        &self,
+        old: &Entity,
+        new: &Entity,
+        old_source: &[u8],
+        source: &[u8],
+    ) -> bool {
+        use kin_parser::adapter::LanguageAdapter;
+        if old.language != LanguageId::C
+            || new.language != LanguageId::C
+            || old.kind != kin_model::EntityKind::Function
+            || new.kind != old.kind
+            || old.name != new.name
+            || old.signature != new.signature
+            || old.file_origin != new.file_origin
+        {
+            return false;
+        }
+        let (Some(was), Some(now)) = (&old.span, &new.span) else {
+            return false;
+        };
+        if was.file != now.file {
+            return false;
+        }
+        let digest_matches = |entity: &Entity, bytes: &[u8]| {
+            entity
+                .metadata
+                .extra
+                .get("blob_hash")
+                .and_then(|v| v.as_str())
+                == Some(kin_blobs::digest(bytes).to_string().as_str())
+        };
+        if !digest_matches(old, old_source) || !digest_matches(new, source) {
+            return false;
+        }
+        let adapter = kin_parser::languages::CAdapter;
+        let (Ok(before), Ok(after)) = (adapter.parse(old_source), adapter.parse(source)) else {
+            return false;
+        };
+        let before_context = kin_parser::languages::c_lang::partial_function_context(
+            &before,
+            old_source,
+            was.start_byte,
+            was.end_byte,
+        );
+        let after_context = kin_parser::languages::c_lang::partial_function_context(
+            &after,
+            source,
+            now.start_byte,
+            now.end_byte,
+        );
+        if before_context.is_none() || before_context != after_context {
+            return false;
+        }
+        // Old graph identity must actually describe its claimed source, rather
+        // than a stale span coincidentally landing on another declaration.
+        for (tree, bytes, entity) in [(&before, old_source, old), (&after, source, new)] {
+            let Ok(parsed) = adapter.extract(tree, bytes, &was.file) else {
+                return false;
+            };
+            let matches: Vec<_> = parsed
+                .entities
+                .into_iter()
+                .filter(|e| e.name == entity.name && e.kind == entity.kind)
+                .collect();
+            if matches.len() != 1 {
+                return false;
+            }
+            let verified = matches.into_iter().next().unwrap().into_entity_with_source(
+                LanguageId::C,
+                &was.file,
+                Some(bytes),
+            );
+            if verified.span != entity.span
+                || verified.signature != entity.signature
+                || verified.fingerprint.behavior_hash != entity.fingerprint.behavior_hash
+            {
+                return false;
+            }
+        }
+        true
+    }
+
     pub fn new() -> Self {
         Self {
             registry: AdapterRegistry::new(),

--- a/crates/kin-parser/src/languages/c_lang.rs
+++ b/crates/kin-parser/src/languages/c_lang.rs
@@ -12,6 +12,86 @@ use crate::extract::{ExtractedEntity, ExtractedRelation, FileImport, ImportedNam
 
 pub struct CAdapter;
 
+/// A direct call whose complete syntax and callee position are known.
+#[derive(Debug, Clone)]
+pub struct PartialCallSite {
+    pub callee: String,
+    pub expression: String,
+    pub call_span: kin_model::SourceSpan,
+    pub callee_span: kin_model::SourceSpan,
+}
+
+/// Direct calls inside a complete declaration, excluding names shadowed by
+/// local bindings or defined macros. The enclosing full-file proof is required.
+pub fn partial_call_sites(
+    tree: &Tree,
+    source: &[u8],
+    declaration: &kin_model::SourceSpan,
+) -> Option<Vec<PartialCallSite>> {
+    partial_function_context(tree, source, declaration.start_byte, declaration.end_byte)?;
+    let root = tree.root_node();
+    let mut cursor = root.walk();
+    let function = root.children(&mut cursor).find(|node| {
+        node.kind() == "function_definition"
+            && node.start_byte() == declaration.start_byte
+            && node.end_byte() == declaration.end_byte
+    })?;
+    let mut unavailable = std::collections::HashSet::new();
+    let mut pending = vec![root];
+    while let Some(node) = pending.pop() {
+        if matches!(node.kind(), "preproc_def" | "preproc_function_def") {
+            if let Some(name) = node.child_by_field_name("name") {
+                unavailable.insert(name.utf8_text(source).ok()?.to_owned());
+            }
+        }
+        let mut cursor = node.walk();
+        pending.extend(node.named_children(&mut cursor));
+    }
+    let mut pending = vec![function];
+    while let Some(node) = pending.pop() {
+        if matches!(node.kind(), "declaration" | "parameter_declaration") {
+            let mut cursor = node.walk();
+            for (index, child) in node.children(&mut cursor).enumerate() {
+                if node.field_name_for_child(index as u32) != Some("declarator") {
+                    continue;
+                }
+                let mut names = vec![child];
+                while let Some(name) = names.pop() {
+                    if name.kind() == "init_declarator" {
+                        names.push(name.child_by_field_name("declarator")?);
+                    } else if name.kind() == "identifier" {
+                        unavailable.insert(name.utf8_text(source).ok()?.to_owned());
+                    } else {
+                        let mut cursor = name.walk();
+                        names.extend(name.named_children(&mut cursor));
+                    }
+                }
+            }
+        }
+        let mut cursor = node.walk();
+        pending.extend(node.named_children(&mut cursor));
+    }
+    let mut sites = Vec::new();
+    let mut pending = vec![function];
+    while let Some(node) = pending.pop() {
+        if node.kind() == "call_expression" {
+            let callee = node.child_by_field_name("function")?;
+            let name = callee.utf8_text(source).ok()?;
+            if callee.kind() == "identifier" && !unavailable.contains(name) {
+                sites.push(PartialCallSite {
+                    callee: name.to_owned(),
+                    expression: node.utf8_text(source).ok()?.to_owned(),
+                    call_span: span_from_node(&node, &declaration.file),
+                    callee_span: span_from_node(&callee, &declaration.file),
+                });
+            }
+        }
+        let mut cursor = node.walk();
+        pending.extend(node.named_children(&mut cursor));
+    }
+    Some(sites)
+}
+
 /// Context that must remain identical before refreshing one declaration in an
 /// incomplete C file. Only direct, complete function definitions qualify. The
 /// full-file tree, including zero-width recovery nodes at either boundary, is

--- a/crates/kin-parser/src/languages/c_lang.rs
+++ b/crates/kin-parser/src/languages/c_lang.rs
@@ -12,6 +12,212 @@ use crate::extract::{ExtractedEntity, ExtractedRelation, FileImport, ImportedNam
 
 pub struct CAdapter;
 
+/// Context that must remain identical before refreshing one declaration in an
+/// incomplete C file. Only direct, complete function definitions qualify. The
+/// full-file tree, including zero-width recovery nodes at either boundary, is
+/// authoritative; parsing an isolated body cannot establish this evidence.
+pub fn partial_function_context(
+    tree: &Tree,
+    source: &[u8],
+    start: usize,
+    end: usize,
+) -> Option<Vec<String>> {
+    let root = tree.root_node();
+    let mut cursor = root.walk();
+    let node = root.children(&mut cursor).find(|node| {
+        node.kind() == "function_definition" && node.start_byte() == start && node.end_byte() == end
+    })?;
+    if node.has_error()
+        || collect_error_ranges(tree).iter().any(|&(a, b)| {
+            if a == b {
+                start <= a && a <= end
+            } else {
+                a < end && start < b
+            }
+        })
+    {
+        return None;
+    }
+    let body = node.child_by_field_name("body")?;
+    if body.kind() != "compound_statement"
+        || body.child(0)?.kind() != "{"
+        || body
+            .child(u32::try_from(body.child_count().checked_sub(1)?).ok()?)?
+            .kind()
+            != "}"
+    {
+        return None;
+    }
+    let mut context = Vec::new();
+    // Declaration and preprocessing context cannot change while its resolver
+    // dependencies are unavailable. Function bodies are independently scoped.
+    let mut cursor = root.walk();
+    for sibling in root.children(&mut cursor) {
+        if sibling.kind() == "comment" {
+            continue;
+        }
+        let stop = if sibling.kind() == "function_definition" {
+            sibling.child_by_field_name("body")?.start_byte()
+        } else {
+            sibling.end_byte()
+        };
+        context.push(
+            std::str::from_utf8(source.get(sibling.start_byte()..stop)?)
+                .ok()?
+                .to_owned(),
+        );
+    }
+    fn locals(
+        node: tree_sitter::Node<'_>,
+        body: tree_sitter::Node<'_>,
+        source: &[u8],
+        names: &mut std::collections::HashMap<String, (usize, usize, usize, usize)>,
+    ) -> Option<()> {
+        if matches!(node.kind(), "declaration" | "parameter_declaration") {
+            let mut scope = node;
+            while !matches!(
+                scope.kind(),
+                "compound_statement" | "for_statement" | "function_definition"
+            ) {
+                scope = scope.parent()?;
+            }
+            let mut cursor = node.walk();
+            if node.children(&mut cursor).any(|child| {
+                child.kind() == "storage_class_specifier"
+                    && child.utf8_text(source).ok() == Some("extern")
+            }) {
+                return None;
+            }
+            fn declaration_name(node: tree_sitter::Node<'_>) -> Option<tree_sitter::Node<'_>> {
+                if node.kind() == "identifier" {
+                    Some(node)
+                } else {
+                    declaration_name(node.child_by_field_name("declarator")?)
+                }
+            }
+            let mut cursor = node.walk();
+            for declarator in node.children_by_field_name("declarator", &mut cursor) {
+                if has_function_declarator(&declarator) {
+                    return None;
+                }
+                let bare = if declarator.kind() == "init_declarator" {
+                    declarator.child_by_field_name("declarator")?
+                } else {
+                    declarator
+                };
+                let identifier = declaration_name(bare)?;
+                let name = identifier.utf8_text(source).ok()?.to_owned();
+                let start = if node.kind() == "parameter_declaration" {
+                    body.start_byte()
+                } else {
+                    bare.end_byte()
+                };
+                if is_all_caps_macro(&name)
+                    || names
+                        .insert(
+                            name,
+                            (
+                                start,
+                                scope.end_byte(),
+                                identifier.start_byte(),
+                                identifier.end_byte(),
+                            ),
+                        )
+                        .is_some()
+                {
+                    return None;
+                }
+            }
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            locals(child, body, source, names)?;
+        }
+        Some(())
+    }
+    let mut local_names = std::collections::HashMap::new();
+    locals(node, body, source, &mut local_names)?;
+    fn directives(
+        node: tree_sitter::Node<'_>,
+        source: &[u8],
+        names: &std::collections::HashMap<String, (usize, usize, usize, usize)>,
+        out: &mut Vec<String>,
+    ) -> Option<()> {
+        if node.kind().starts_with("preproc_") {
+            if node
+                .child_by_field_name("name")
+                .and_then(|n| n.utf8_text(source).ok())
+                .is_some_and(|name| names.contains_key(name))
+            {
+                return None;
+            }
+            out.push(node.utf8_text(source).ok()?.to_owned());
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            directives(child, source, names, out)?;
+        }
+        Some(())
+    }
+    directives(root, source, &local_names, &mut context)?;
+    fn dependencies(
+        node: tree_sitter::Node<'_>,
+        source: &[u8],
+        body_start: usize,
+        locals: &std::collections::HashMap<String, (usize, usize, usize, usize)>,
+        out: &mut Vec<String>,
+    ) -> Option<()> {
+        if node.kind().starts_with("preproc_") || node.kind() == "macro_type_specifier" {
+            return None;
+        }
+        let text = node.utf8_text(source).ok()?;
+        let is_local =
+            locals
+                .get(text)
+                .is_some_and(|&(start, end, declaration_start, declaration_end)| {
+                    (start <= node.start_byte() && node.end_byte() <= end)
+                        || (node.start_byte() == declaration_start
+                            && node.end_byte() == declaration_end)
+                });
+        if matches!(
+            node.kind(),
+            "call_expression"
+                | "type_identifier"
+                | "primitive_type"
+                | "field_identifier"
+                | "statement_identifier"
+        ) || (node.kind() == "identifier" && !is_local)
+        {
+            out.push(format!("{}:{text}", node.kind()));
+            if node.kind() == "identifier" && node.start_byte() >= body_start && !is_local {
+                let mut expression = node;
+                while let Some(parent) = expression.parent() {
+                    if matches!(
+                        parent.kind(),
+                        "compound_statement"
+                            | "if_statement"
+                            | "while_statement"
+                            | "for_statement"
+                            | "switch_statement"
+                            | "function_definition"
+                    ) {
+                        break;
+                    }
+                    expression = parent;
+                }
+                out.push(expression.utf8_text(source).ok()?.to_owned());
+            }
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            dependencies(child, source, body_start, locals, out)?;
+        }
+        Some(())
+    }
+    dependencies(node, source, body.start_byte(), &local_names, &mut context)?;
+    Some(context)
+}
+
 impl LanguageAdapter for CAdapter {
     fn language_id(&self) -> LanguageId {
         LanguageId::C

--- a/crates/kin-parser/tests/fixtures/c/hiredis-sds.c
+++ b/crates/kin-parser/tests/fixtures/c/hiredis-sds.c
@@ -1,0 +1,1292 @@
+/* SDSLib 2.0 -- A C dynamic strings library
+ *
+ * Copyright (c) 2006-2015, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2015, Oran Agra
+ * Copyright (c) 2015, Redis Labs, Inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fmacros.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <assert.h>
+#include <limits.h>
+#include "sds.h"
+#include "sdsalloc.h"
+
+static inline int sdsHdrSize(char type) {
+    switch(type&SDS_TYPE_MASK) {
+        case SDS_TYPE_5:
+            return sizeof(struct sdshdr5);
+        case SDS_TYPE_8:
+            return sizeof(struct sdshdr8);
+        case SDS_TYPE_16:
+            return sizeof(struct sdshdr16);
+        case SDS_TYPE_32:
+            return sizeof(struct sdshdr32);
+        case SDS_TYPE_64:
+            return sizeof(struct sdshdr64);
+    }
+    return 0;
+}
+
+static inline char sdsReqType(size_t string_size) {
+    if (string_size < 32)
+        return SDS_TYPE_5;
+    if (string_size < 0xff)
+        return SDS_TYPE_8;
+    if (string_size < 0xffff)
+        return SDS_TYPE_16;
+    if (string_size < 0xffffffff)
+        return SDS_TYPE_32;
+    return SDS_TYPE_64;
+}
+
+/* Create a new sds string with the content specified by the 'init' pointer
+ * and 'initlen'.
+ * If NULL is used for 'init' the string is initialized with zero bytes.
+ *
+ * The string is always null-terminated (all the sds strings are, always) so
+ * even if you create an sds string with:
+ *
+ * mystring = sdsnewlen("abc",3);
+ *
+ * You can print the string with printf() as there is an implicit \0 at the
+ * end of the string. However the string is binary safe and can contain
+ * \0 characters in the middle, as the length is stored in the sds header. */
+sds sdsnewlen(const void *init, size_t initlen) {
+    void *sh;
+    sds s;
+    char type = sdsReqType(initlen);
+    /* Empty strings are usually created in order to append. Use type 8
+     * since type 5 is not good at this. */
+    if (type == SDS_TYPE_5 && initlen == 0) type = SDS_TYPE_8;
+    int hdrlen = sdsHdrSize(type);
+    unsigned char *fp; /* flags pointer. */
+
+    if (hdrlen+initlen+1 <= initlen) return NULL; /* Catch size_t overflow */
+    sh = s_malloc(hdrlen+initlen+1);
+    if (sh == NULL) return NULL;
+    if (!init)
+        memset(sh, 0, hdrlen+initlen+1);
+    s = (char*)sh+hdrlen;
+    fp = ((unsigned char*)s)-1;
+    switch(type) {
+        case SDS_TYPE_5: {
+            *fp = type | (initlen << SDS_TYPE_BITS);
+            break;
+        }
+        case SDS_TYPE_8: {
+            SDS_HDR_VAR(8,s);
+            sh->len = initlen;
+            sh->alloc = initlen;
+            *fp = type;
+            break;
+        }
+        case SDS_TYPE_16: {
+            SDS_HDR_VAR(16,s);
+            sh->len = initlen;
+            sh->alloc = initlen;
+            *fp = type;
+            break;
+        }
+        case SDS_TYPE_32: {
+            SDS_HDR_VAR(32,s);
+            sh->len = initlen;
+            sh->alloc = initlen;
+            *fp = type;
+            break;
+        }
+        case SDS_TYPE_64: {
+            SDS_HDR_VAR(64,s);
+            sh->len = initlen;
+            sh->alloc = initlen;
+            *fp = type;
+            break;
+        }
+    }
+    if (initlen && init)
+        memcpy(s, init, initlen);
+    s[initlen] = '\0';
+    return s;
+}
+
+/* Create an empty (zero length) sds string. Even in this case the string
+ * always has an implicit null term. */
+sds sdsempty(void) {
+    return sdsnewlen("",0);
+}
+
+/* Create a new sds string starting from a null terminated C string. */
+sds sdsnew(const char *init) {
+    size_t initlen = (init == NULL) ? 0 : strlen(init);
+    return sdsnewlen(init, initlen);
+}
+
+/* Duplicate an sds string. */
+sds sdsdup(const sds s) {
+    return sdsnewlen(s, sdslen(s));
+}
+
+/* Free an sds string. No operation is performed if 's' is NULL. */
+void sdsfree(sds s) {
+    if (s == NULL) return;
+    s_free((char*)s-sdsHdrSize(s[-1]));
+}
+
+/* Set the sds string length to the length as obtained with strlen(), so
+ * considering as content only up to the first null term character.
+ *
+ * This function is useful when the sds string is hacked manually in some
+ * way, like in the following example:
+ *
+ * s = sdsnew("foobar");
+ * s[2] = '\0';
+ * sdsupdatelen(s);
+ * printf("%d\n", sdslen(s));
+ *
+ * The output will be "2", but if we comment out the call to sdsupdatelen()
+ * the output will be "6" as the string was modified but the logical length
+ * remains 6 bytes. */
+void sdsupdatelen(sds s) {
+    size_t reallen = strlen(s);
+    sdssetlen(s, reallen);
+}
+
+/* Modify an sds string in-place to make it empty (zero length).
+ * However all the existing buffer is not discarded but set as free space
+ * so that next append operations will not require allocations up to the
+ * number of bytes previously available. */
+void sdsclear(sds s) {
+    sdssetlen(s, 0);
+    s[0] = '\0';
+}
+
+/* Enlarge the free space at the end of the sds string so that the caller
+ * is sure that after calling this function can overwrite up to addlen
+ * bytes after the end of the string, plus one more byte for nul term.
+ *
+ * Note: this does not change the *length* of the sds string as returned
+ * by sdslen(), but only the free buffer space we have. */
+sds sdsMakeRoomFor(sds s, size_t addlen) {
+    void *sh, *newsh;
+    size_t avail = sdsavail(s);
+    size_t len, newlen, reqlen;
+    char type, oldtype = s[-1] & SDS_TYPE_MASK;
+    int hdrlen;
+
+    /* Return ASAP if there is enough space left. */
+    if (avail >= addlen) return s;
+
+    len = sdslen(s);
+    sh = (char*)s-sdsHdrSize(oldtype);
+    reqlen = newlen = (len+addlen);
+    if (newlen <= len) return NULL; /* Catch size_t overflow */
+    if (newlen < SDS_MAX_PREALLOC)
+        newlen *= 2;
+    else
+        newlen += SDS_MAX_PREALLOC;
+
+    type = sdsReqType(newlen);
+
+    /* Don't use type 5: the user is appending to the string and type 5 is
+     * not able to remember empty space, so sdsMakeRoomFor() must be called
+     * at every appending operation. */
+    if (type == SDS_TYPE_5) type = SDS_TYPE_8;
+
+    hdrlen = sdsHdrSize(type);
+    if (hdrlen+newlen+1 <= reqlen) return NULL; /* Catch size_t overflow */
+    if (oldtype==type) {
+        newsh = s_realloc(sh, hdrlen+newlen+1);
+        if (newsh == NULL) return NULL;
+        s = (char*)newsh+hdrlen;
+    } else {
+        /* Since the header size changes, need to move the string forward,
+         * and can't use realloc */
+        newsh = s_malloc(hdrlen+newlen+1);
+        if (newsh == NULL) return NULL;
+        memcpy((char*)newsh+hdrlen, s, len+1);
+        s_free(sh);
+        s = (char*)newsh+hdrlen;
+        s[-1] = type;
+        sdssetlen(s, len);
+    }
+    sdssetalloc(s, newlen);
+    return s;
+}
+
+/* Reallocate the sds string so that it has no free space at the end. The
+ * contained string remains not altered, but next concatenation operations
+ * will require a reallocation.
+ *
+ * After the call, the passed sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdsRemoveFreeSpace(sds s) {
+    void *sh, *newsh;
+    char type, oldtype = s[-1] & SDS_TYPE_MASK;
+    int hdrlen;
+    size_t len = sdslen(s);
+    sh = (char*)s-sdsHdrSize(oldtype);
+
+    type = sdsReqType(len);
+    hdrlen = sdsHdrSize(type);
+    if (oldtype==type) {
+        newsh = s_realloc(sh, hdrlen+len+1);
+        if (newsh == NULL) return NULL;
+        s = (char*)newsh+hdrlen;
+    } else {
+        newsh = s_malloc(hdrlen+len+1);
+        if (newsh == NULL) return NULL;
+        memcpy((char*)newsh+hdrlen, s, len+1);
+        s_free(sh);
+        s = (char*)newsh+hdrlen;
+        s[-1] = type;
+        sdssetlen(s, len);
+    }
+    sdssetalloc(s, len);
+    return s;
+}
+
+/* Return the total size of the allocation of the specifed sds string,
+ * including:
+ * 1) The sds header before the pointer.
+ * 2) The string.
+ * 3) The free buffer at the end if any.
+ * 4) The implicit null term.
+ */
+size_t sdsAllocSize(sds s) {
+    size_t alloc = sdsalloc(s);
+    return sdsHdrSize(s[-1])+alloc+1;
+}
+
+/* Return the pointer of the actual SDS allocation (normally SDS strings
+ * are referenced by the start of the string buffer). */
+void *sdsAllocPtr(sds s) {
+    return (void*) (s-sdsHdrSize(s[-1]));
+}
+
+/* Increment the sds length and decrements the left free space at the
+ * end of the string according to 'incr'. Also set the null term
+ * in the new end of the string.
+ *
+ * This function is used in order to fix the string length after the
+ * user calls sdsMakeRoomFor(), writes something after the end of
+ * the current string, and finally needs to set the new length.
+ *
+ * Note: it is possible to use a negative increment in order to
+ * right-trim the string.
+ *
+ * Usage example:
+ *
+ * Using sdsIncrLen() and sdsMakeRoomFor() it is possible to mount the
+ * following schema, to cat bytes coming from the kernel to the end of an
+ * sds string without copying into an intermediate buffer:
+ *
+ * oldlen = sdslen(s);
+ * s = sdsMakeRoomFor(s, BUFFER_SIZE);
+ * nread = read(fd, s+oldlen, BUFFER_SIZE);
+ * ... check for nread <= 0 and handle it ...
+ * sdsIncrLen(s, nread);
+ */
+void sdsIncrLen(sds s, int incr) {
+    unsigned char flags = s[-1];
+    size_t len;
+    switch(flags&SDS_TYPE_MASK) {
+        case SDS_TYPE_5: {
+            unsigned char *fp = ((unsigned char*)s)-1;
+            unsigned char oldlen = SDS_TYPE_5_LEN(flags);
+            assert((incr > 0 && oldlen+incr < 32) || (incr < 0 && oldlen >= (unsigned int)(-incr)));
+            *fp = SDS_TYPE_5 | ((oldlen+incr) << SDS_TYPE_BITS);
+            len = oldlen+incr;
+            break;
+        }
+        case SDS_TYPE_8: {
+            SDS_HDR_VAR(8,s);
+            assert((incr >= 0 && sh->alloc-sh->len >= incr) || (incr < 0 && sh->len >= (unsigned int)(-incr)));
+            len = (sh->len += incr);
+            break;
+        }
+        case SDS_TYPE_16: {
+            SDS_HDR_VAR(16,s);
+            assert((incr >= 0 && sh->alloc-sh->len >= incr) || (incr < 0 && sh->len >= (unsigned int)(-incr)));
+            len = (sh->len += incr);
+            break;
+        }
+        case SDS_TYPE_32: {
+            SDS_HDR_VAR(32,s);
+            assert((incr >= 0 && sh->alloc-sh->len >= (unsigned int)incr) || (incr < 0 && sh->len >= (unsigned int)(-incr)));
+            len = (sh->len += incr);
+            break;
+        }
+        case SDS_TYPE_64: {
+            SDS_HDR_VAR(64,s);
+            assert((incr >= 0 && sh->alloc-sh->len >= (uint64_t)incr) || (incr < 0 && sh->len >= (uint64_t)(-incr)));
+            len = (sh->len += incr);
+            break;
+        }
+        default: len = 0; /* Just to avoid compilation warnings. */
+    }
+    s[len] = '\0';
+}
+
+/* Grow the sds to have the specified length. Bytes that were not part of
+ * the original length of the sds will be set to zero.
+ *
+ * if the specified length is smaller than the current length, no operation
+ * is performed. */
+sds sdsgrowzero(sds s, size_t len) {
+    size_t curlen = sdslen(s);
+
+    if (len <= curlen) return s;
+    s = sdsMakeRoomFor(s,len-curlen);
+    if (s == NULL) return NULL;
+
+    /* Make sure added region doesn't contain garbage */
+    memset(s+curlen,0,(len-curlen+1)); /* also set trailing \0 byte */
+    sdssetlen(s, len);
+    return s;
+}
+
+/* Append the specified binary-safe string pointed by 't' of 'len' bytes to the
+ * end of the specified sds string 's'.
+ *
+ * After the call, the passed sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdscatlen(sds s, const void *t, size_t len) {
+    size_t curlen = sdslen(s);
+
+    s = sdsMakeRoomFor(s,len);
+    if (s == NULL) return NULL;
+    memcpy(s+curlen, t, len);
+    sdssetlen(s, curlen+len);
+    s[curlen+len] = '\0';
+    return s;
+}
+
+/* Append the specified null termianted C string to the sds string 's'.
+ *
+ * After the call, the passed sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdscat(sds s, const char *t) {
+    return sdscatlen(s, t, strlen(t));
+}
+
+/* Append the specified sds 't' to the existing sds 's'.
+ *
+ * After the call, the modified sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdscatsds(sds s, const sds t) {
+    return sdscatlen(s, t, sdslen(t));
+}
+
+/* Destructively modify the sds string 's' to hold the specified binary
+ * safe string pointed by 't' of length 'len' bytes. */
+sds sdscpylen(sds s, const char *t, size_t len) {
+    if (sdsalloc(s) < len) {
+        s = sdsMakeRoomFor(s,len-sdslen(s));
+        if (s == NULL) return NULL;
+    }
+    memcpy(s, t, len);
+    s[len] = '\0';
+    sdssetlen(s, len);
+    return s;
+}
+
+/* Like sdscpylen() but 't' must be a null-terminated string so that the length
+ * of the string is obtained with strlen(). */
+sds sdscpy(sds s, const char *t) {
+    return sdscpylen(s, t, strlen(t));
+}
+
+/* Helper for sdscatlonglong() doing the actual number -> string
+ * conversion. 's' must point to a string with room for at least
+ * SDS_LLSTR_SIZE bytes.
+ *
+ * The function returns the length of the null-terminated string
+ * representation stored at 's'. */
+#define SDS_LLSTR_SIZE 21
+int sdsll2str(char *s, long long value) {
+    char *p, aux;
+    unsigned long long v;
+    size_t l;
+
+    /* Generate the string representation, this method produces
+     * an reversed string. */
+    v = (value < 0) ? -value : value;
+    p = s;
+    do {
+        *p++ = '0'+(v%10);
+        v /= 10;
+    } while(v);
+    if (value < 0) *p++ = '-';
+
+    /* Compute length and add null term. */
+    l = p-s;
+    *p = '\0';
+
+    /* Reverse the string. */
+    p--;
+    while(s < p) {
+        aux = *s;
+        *s = *p;
+        *p = aux;
+        s++;
+        p--;
+    }
+    return l;
+}
+
+/* Identical sdsll2str(), but for unsigned long long type. */
+int sdsull2str(char *s, unsigned long long v) {
+    char *p, aux;
+    size_t l;
+
+    /* Generate the string representation, this method produces
+     * an reversed string. */
+    p = s;
+    do {
+        *p++ = '0'+(v%10);
+        v /= 10;
+    } while(v);
+
+    /* Compute length and add null term. */
+    l = p-s;
+    *p = '\0';
+
+    /* Reverse the string. */
+    p--;
+    while(s < p) {
+        aux = *s;
+        *s = *p;
+        *p = aux;
+        s++;
+        p--;
+    }
+    return l;
+}
+
+/* Create an sds string from a long long value. It is much faster than:
+ *
+ * sdscatprintf(sdsempty(),"%lld\n", value);
+ */
+sds sdsfromlonglong(long long value) {
+    char buf[SDS_LLSTR_SIZE];
+    int len = sdsll2str(buf,value);
+
+    return sdsnewlen(buf,len);
+}
+
+/* Like sdscatprintf() but gets va_list instead of being variadic. */
+sds sdscatvprintf(sds s, const char *fmt, va_list ap) {
+    va_list cpy;
+    char staticbuf[1024], *buf = staticbuf, *t;
+    size_t buflen = strlen(fmt)*2;
+
+    /* We try to start using a static buffer for speed.
+     * If not possible we revert to heap allocation. */
+    if (buflen > sizeof(staticbuf)) {
+        buf = s_malloc(buflen);
+        if (buf == NULL) return NULL;
+    } else {
+        buflen = sizeof(staticbuf);
+    }
+
+    /* Try with buffers two times bigger every time we fail to
+     * fit the string in the current buffer size. */
+    while(1) {
+        buf[buflen-2] = '\0';
+        va_copy(cpy,ap);
+        vsnprintf(buf, buflen, fmt, cpy);
+        va_end(cpy);
+        if (buf[buflen-2] != '\0') {
+            if (buf != staticbuf) s_free(buf);
+            buflen *= 2;
+            buf = s_malloc(buflen);
+            if (buf == NULL) return NULL;
+            continue;
+        }
+        break;
+    }
+
+    /* Finally concat the obtained string to the SDS string and return it. */
+    t = sdscat(s, buf);
+    if (buf != staticbuf) s_free(buf);
+    return t;
+}
+
+/* Append to the sds string 's' a string obtained using printf-alike format
+ * specifier.
+ *
+ * After the call, the modified sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call.
+ *
+ * Example:
+ *
+ * s = sdsnew("Sum is: ");
+ * s = sdscatprintf(s,"%d+%d = %d",a,b,a+b).
+ *
+ * Often you need to create a string from scratch with the printf-alike
+ * format. When this is the need, just use sdsempty() as the target string:
+ *
+ * s = sdscatprintf(sdsempty(), "... your format ...", args);
+ */
+sds sdscatprintf(sds s, const char *fmt, ...) {
+    va_list ap;
+    char *t;
+    va_start(ap, fmt);
+    t = sdscatvprintf(s,fmt,ap);
+    va_end(ap);
+    return t;
+}
+
+/* This function is similar to sdscatprintf, but much faster as it does
+ * not rely on sprintf() family functions implemented by the libc that
+ * are often very slow. Moreover directly handling the sds string as
+ * new data is concatenated provides a performance improvement.
+ *
+ * However this function only handles an incompatible subset of printf-alike
+ * format specifiers:
+ *
+ * %s - C String
+ * %S - SDS string
+ * %i - signed int
+ * %I - 64 bit signed integer (long long, int64_t)
+ * %u - unsigned int
+ * %U - 64 bit unsigned integer (unsigned long long, uint64_t)
+ * %% - Verbatim "%" character.
+ */
+sds sdscatfmt(sds s, char const *fmt, ...) {
+    const char *f = fmt;
+    long i;
+    va_list ap;
+
+    va_start(ap,fmt);
+    i = sdslen(s); /* Position of the next byte to write to dest str. */
+    while(*f) {
+        char next, *str;
+        size_t l;
+        long long num;
+        unsigned long long unum;
+
+        /* Make sure there is always space for at least 1 char. */
+        if (sdsavail(s)==0) {
+            s = sdsMakeRoomFor(s,1);
+            if (s == NULL) goto fmt_error;
+        }
+
+        switch(*f) {
+        case '%':
+            next = *(f+1);
+            f++;
+            switch(next) {
+            case 's':
+            case 'S':
+                str = va_arg(ap,char*);
+                l = (next == 's') ? strlen(str) : sdslen(str);
+                if (sdsavail(s) < l) {
+                    s = sdsMakeRoomFor(s,l);
+                    if (s == NULL) goto fmt_error;
+                }
+                memcpy(s+i,str,l);
+                sdsinclen(s,l);
+                i += l;
+                break;
+            case 'i':
+            case 'I':
+                if (next == 'i')
+                    num = va_arg(ap,int);
+                else
+                    num = va_arg(ap,long long);
+                {
+                    char buf[SDS_LLSTR_SIZE];
+                    l = sdsll2str(buf,num);
+                    if (sdsavail(s) < l) {
+                        s = sdsMakeRoomFor(s,l);
+                        if (s == NULL) goto fmt_error;
+                    }
+                    memcpy(s+i,buf,l);
+                    sdsinclen(s,l);
+                    i += l;
+                }
+                break;
+            case 'u':
+            case 'U':
+                if (next == 'u')
+                    unum = va_arg(ap,unsigned int);
+                else
+                    unum = va_arg(ap,unsigned long long);
+                {
+                    char buf[SDS_LLSTR_SIZE];
+                    l = sdsull2str(buf,unum);
+                    if (sdsavail(s) < l) {
+                        s = sdsMakeRoomFor(s,l);
+                        if (s == NULL) goto fmt_error;
+                    }
+                    memcpy(s+i,buf,l);
+                    sdsinclen(s,l);
+                    i += l;
+                }
+                break;
+            default: /* Handle %% and generally %<unknown>. */
+                s[i++] = next;
+                sdsinclen(s,1);
+                break;
+            }
+            break;
+        default:
+            s[i++] = *f;
+            sdsinclen(s,1);
+            break;
+        }
+        f++;
+    }
+    va_end(ap);
+
+    /* Add null-term */
+    s[i] = '\0';
+    return s;
+
+fmt_error:
+    va_end(ap);
+    return NULL;
+}
+
+/* Remove the part of the string from left and from right composed just of
+ * contiguous characters found in 'cset', that is a null terminted C string.
+ *
+ * After the call, the modified sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call.
+ *
+ * Example:
+ *
+ * s = sdsnew("AA...AA.a.aa.aHelloWorld     :::");
+ * s = sdstrim(s,"Aa. :");
+ * printf("%s\n", s);
+ *
+ * Output will be just "Hello World".
+ */
+sds sdstrim(sds s, const char *cset) {
+    char *end, *sp, *ep;
+    size_t len;
+
+    sp = s;
+    ep = end = s+sdslen(s)-1;
+    while(sp <= end && strchr(cset, *sp)) sp++;
+    while(ep > sp && strchr(cset, *ep)) ep--;
+    len = (sp > ep) ? 0 : ((ep-sp)+1);
+    if (s != sp) memmove(s, sp, len);
+    s[len] = '\0';
+    sdssetlen(s,len);
+    return s;
+}
+
+/* Turn the string into a smaller (or equal) string containing only the
+ * substring specified by the 'start' and 'end' indexes.
+ *
+ * start and end can be negative, where -1 means the last character of the
+ * string, -2 the penultimate character, and so forth.
+ *
+ * The interval is inclusive, so the start and end characters will be part
+ * of the resulting string.
+ *
+ * The string is modified in-place.
+ *
+ * Return value:
+ * -1 (error) if sdslen(s) is larger than maximum positive ssize_t value.
+ *  0 on success.
+ *
+ * Example:
+ *
+ * s = sdsnew("Hello World");
+ * sdsrange(s,1,-1); => "ello World"
+ */
+int sdsrange(sds s, ssize_t start, ssize_t end) {
+    size_t newlen, len = sdslen(s);
+    if (len > SSIZE_MAX) return -1;
+
+    if (len == 0) return 0;
+    if (start < 0) {
+        start = len+start;
+        if (start < 0) start = 0;
+    }
+    if (end < 0) {
+        end = len+end;
+        if (end < 0) end = 0;
+    }
+    newlen = (start > end) ? 0 : (end-start)+1;
+    if (newlen != 0) {
+        if (start >= (ssize_t)len) {
+            newlen = 0;
+        } else if (end >= (ssize_t)len) {
+            end = len-1;
+            newlen = (start > end) ? 0 : (end-start)+1;
+        }
+    } else {
+        start = 0;
+    }
+    if (start && newlen) memmove(s, s+start, newlen);
+    s[newlen] = 0;
+    sdssetlen(s,newlen);
+    return 0;
+}
+
+/* Apply tolower() to every character of the sds string 's'. */
+void sdstolower(sds s) {
+    size_t len = sdslen(s), j;
+
+    for (j = 0; j < len; j++) s[j] = tolower(s[j]);
+}
+
+/* Apply toupper() to every character of the sds string 's'. */
+void sdstoupper(sds s) {
+    size_t len = sdslen(s), j;
+
+    for (j = 0; j < len; j++) s[j] = toupper(s[j]);
+}
+
+/* Compare two sds strings s1 and s2 with memcmp().
+ *
+ * Return value:
+ *
+ *     positive if s1 > s2.
+ *     negative if s1 < s2.
+ *     0 if s1 and s2 are exactly the same binary string.
+ *
+ * If two strings share exactly the same prefix, but one of the two has
+ * additional characters, the longer string is considered to be greater than
+ * the smaller one. */
+int sdscmp(const sds s1, const sds s2) {
+    size_t l1, l2, minlen;
+    int cmp;
+
+    l1 = sdslen(s1);
+    l2 = sdslen(s2);
+    minlen = (l1 < l2) ? l1 : l2;
+    cmp = memcmp(s1,s2,minlen);
+    if (cmp == 0) return l1-l2;
+    return cmp;
+}
+
+/* Split 's' with separator in 'sep'. An array
+ * of sds strings is returned. *count will be set
+ * by reference to the number of tokens returned.
+ *
+ * On out of memory, zero length string, zero length
+ * separator, NULL is returned.
+ *
+ * Note that 'sep' is able to split a string using
+ * a multi-character separator. For example
+ * sdssplit("foo_-_bar","_-_"); will return two
+ * elements "foo" and "bar".
+ *
+ * This version of the function is binary-safe but
+ * requires length arguments. sdssplit() is just the
+ * same function but for zero-terminated strings.
+ */
+sds *sdssplitlen(const char *s, int len, const char *sep, int seplen, int *count) {
+    int elements = 0, slots = 5, start = 0, j;
+    sds *tokens;
+
+    if (seplen < 1 || len < 0) return NULL;
+
+    tokens = s_malloc(sizeof(sds)*slots);
+    if (tokens == NULL) return NULL;
+
+    if (len == 0) {
+        *count = 0;
+        return tokens;
+    }
+    for (j = 0; j < (len-(seplen-1)); j++) {
+        /* make sure there is room for the next element and the final one */
+        if (slots < elements+2) {
+            sds *newtokens;
+
+            slots *= 2;
+            newtokens = s_realloc(tokens,sizeof(sds)*slots);
+            if (newtokens == NULL) goto cleanup;
+            tokens = newtokens;
+        }
+        /* search the separator */
+        if ((seplen == 1 && *(s+j) == sep[0]) || (memcmp(s+j,sep,seplen) == 0)) {
+            tokens[elements] = sdsnewlen(s+start,j-start);
+            if (tokens[elements] == NULL) goto cleanup;
+            elements++;
+            start = j+seplen;
+            j = j+seplen-1; /* skip the separator */
+        }
+    }
+    /* Add the final element. We are sure there is room in the tokens array. */
+    tokens[elements] = sdsnewlen(s+start,len-start);
+    if (tokens[elements] == NULL) goto cleanup;
+    elements++;
+    *count = elements;
+    return tokens;
+
+cleanup:
+    {
+        int i;
+        for (i = 0; i < elements; i++) sdsfree(tokens[i]);
+        s_free(tokens);
+        *count = 0;
+        return NULL;
+    }
+}
+
+/* Free the result returned by sdssplitlen(), or do nothing if 'tokens' is NULL. */
+void sdsfreesplitres(sds *tokens, int count) {
+    if (!tokens) return;
+    while(count--)
+        sdsfree(tokens[count]);
+    s_free(tokens);
+}
+
+/* Append to the sds string "s" an escaped string representation where
+ * all the non-printable characters (tested with isprint()) are turned into
+ * escapes in the form "\n\r\a...." or "\x<hex-number>".
+ *
+ * After the call, the modified sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdscatrepr(sds s, const char *p, size_t len) {
+    s = sdscatlen(s,"\"",1);
+    while(len--) {
+        switch(*p) {
+        case '\\':
+        case '"':
+            s = sdscatprintf(s,"\\%c",*p);
+            break;
+        case '\n': s = sdscatlen(s,"\\n",2); break;
+        case '\r': s = sdscatlen(s,"\\r",2); break;
+        case '\t': s = sdscatlen(s,"\\t",2); break;
+        case '\a': s = sdscatlen(s,"\\a",2); break;
+        case '\b': s = sdscatlen(s,"\\b",2); break;
+        default:
+            if (isprint((int) *p))
+                s = sdscatprintf(s,"%c",*p);
+            else
+                s = sdscatprintf(s,"\\x%02x",(unsigned char)*p);
+            break;
+        }
+        p++;
+    }
+    return sdscatlen(s,"\"",1);
+}
+
+/* Helper function for sdssplitargs() that converts a hex digit into an
+ * integer from 0 to 15 */
+int hex_digit_to_int(char c) {
+    switch(c) {
+    case '0': return 0;
+    case '1': return 1;
+    case '2': return 2;
+    case '3': return 3;
+    case '4': return 4;
+    case '5': return 5;
+    case '6': return 6;
+    case '7': return 7;
+    case '8': return 8;
+    case '9': return 9;
+    case 'a': case 'A': return 10;
+    case 'b': case 'B': return 11;
+    case 'c': case 'C': return 12;
+    case 'd': case 'D': return 13;
+    case 'e': case 'E': return 14;
+    case 'f': case 'F': return 15;
+    default: return 0;
+    }
+}
+
+/* Split a line into arguments, where every argument can be in the
+ * following programming-language REPL-alike form:
+ *
+ * foo bar "newline are supported\n" and "\xff\x00otherstuff"
+ *
+ * The number of arguments is stored into *argc, and an array
+ * of sds is returned.
+ *
+ * The caller should free the resulting array of sds strings with
+ * sdsfreesplitres().
+ *
+ * Note that sdscatrepr() is able to convert back a string into
+ * a quoted string in the same format sdssplitargs() is able to parse.
+ *
+ * The function returns the allocated tokens on success, even when the
+ * input string is empty, or NULL if the input contains unbalanced
+ * quotes or closed quotes followed by non space characters
+ * as in: "foo"bar or "foo'
+ */
+sds *sdssplitargs(const char *line, int *argc) {
+    const char *p = line;
+    char *current = NULL;
+    char **vector = NULL;
+
+    *argc = 0;
+    while(1) {
+        /* skip blanks */
+        while(*p && isspace((int) *p)) p++;
+        if (*p) {
+            /* get a token */
+            int inq=0;  /* set to 1 if we are in "quotes" */
+            int insq=0; /* set to 1 if we are in 'single quotes' */
+            int done=0;
+
+            if (current == NULL) current = sdsempty();
+            while(!done) {
+                if (inq) {
+                    if (*p == '\\' && *(p+1) == 'x' &&
+                                             isxdigit((int) *(p+2)) &&
+                                             isxdigit((int) *(p+3)))
+                    {
+                        unsigned char byte;
+
+                        byte = (hex_digit_to_int(*(p+2))*16)+
+                                hex_digit_to_int(*(p+3));
+                        current = sdscatlen(current,(char*)&byte,1);
+                        p += 3;
+                    } else if (*p == '\\' && *(p+1)) {
+                        char c;
+
+                        p++;
+                        switch(*p) {
+                        case 'n': c = '\n'; break;
+                        case 'r': c = '\r'; break;
+                        case 't': c = '\t'; break;
+                        case 'b': c = '\b'; break;
+                        case 'a': c = '\a'; break;
+                        default: c = *p; break;
+                        }
+                        current = sdscatlen(current,&c,1);
+                    } else if (*p == '"') {
+                        /* closing quote must be followed by a space or
+                         * nothing at all. */
+                        if (*(p+1) && !isspace((int) *(p+1))) goto err;
+                        done=1;
+                    } else if (!*p) {
+                        /* unterminated quotes */
+                        goto err;
+                    } else {
+                        current = sdscatlen(current,p,1);
+                    }
+                } else if (insq) {
+                    if (*p == '\\' && *(p+1) == '\'') {
+                        p++;
+                        current = sdscatlen(current,"'",1);
+                    } else if (*p == '\'') {
+                        /* closing quote must be followed by a space or
+                         * nothing at all. */
+                        if (*(p+1) && !isspace((int) *(p+1))) goto err;
+                        done=1;
+                    } else if (!*p) {
+                        /* unterminated quotes */
+                        goto err;
+                    } else {
+                        current = sdscatlen(current,p,1);
+                    }
+                } else {
+                    switch(*p) {
+                    case ' ':
+                    case '\n':
+                    case '\r':
+                    case '\t':
+                    case '\0':
+                        done=1;
+                        break;
+                    case '"':
+                        inq=1;
+                        break;
+                    case '\'':
+                        insq=1;
+                        break;
+                    default:
+                        current = sdscatlen(current,p,1);
+                        break;
+                    }
+                }
+                if (*p) p++;
+            }
+            /* add the token to the vector */
+            {
+                char **new_vector = s_realloc(vector,((*argc)+1)*sizeof(char*));
+                if (new_vector == NULL) {
+                    s_free(vector);
+                    return NULL;
+                }
+
+                vector = new_vector;
+                vector[*argc] = current;
+                (*argc)++;
+                current = NULL;
+            }
+        } else {
+            /* Even on empty input string return something not NULL. */
+            if (vector == NULL) vector = s_malloc(sizeof(void*));
+            return vector;
+        }
+    }
+
+err:
+    while((*argc)--)
+        sdsfree(vector[*argc]);
+    s_free(vector);
+    if (current) sdsfree(current);
+    *argc = 0;
+    return NULL;
+}
+
+/* Modify the string substituting all the occurrences of the set of
+ * characters specified in the 'from' string to the corresponding character
+ * in the 'to' array.
+ *
+ * For instance: sdsmapchars(mystring, "ho", "01", 2)
+ * will have the effect of turning the string "hello" into "0ell1".
+ *
+ * The function returns the sds string pointer, that is always the same
+ * as the input pointer since no resize is needed. */
+sds sdsmapchars(sds s, const char *from, const char *to, size_t setlen) {
+    size_t j, i, l = sdslen(s);
+
+    for (j = 0; j < l; j++) {
+        for (i = 0; i < setlen; i++) {
+            if (s[j] == from[i]) {
+                s[j] = to[i];
+                break;
+            }
+        }
+    }
+    return s;
+}
+
+/* Join an array of C strings using the specified separator (also a C string).
+ * Returns the result as an sds string. */
+sds sdsjoin(char **argv, int argc, char *sep) {
+    sds join = sdsempty();
+    int j;
+
+    for (j = 0; j < argc; j++) {
+        join = sdscat(join, argv[j]);
+        if (j != argc-1) join = sdscat(join,sep);
+    }
+    return join;
+}
+
+/* Like sdsjoin, but joins an array of SDS strings. */
+sds sdsjoinsds(sds *argv, int argc, const char *sep, size_t seplen) {
+    sds join = sdsempty();
+    int j;
+
+    for (j = 0; j < argc; j++) {
+        join = sdscatsds(join, argv[j]);
+        if (j != argc-1) join = sdscatlen(join,sep,seplen);
+    }
+    return join;
+}
+
+/* Wrappers to the allocators used by SDS. Note that SDS will actually
+ * just use the macros defined into sdsalloc.h in order to avoid to pay
+ * the overhead of function calls. Here we define these wrappers only for
+ * the programs SDS is linked to, if they want to touch the SDS internals
+ * even if they use a different allocator. */
+void *sds_malloc(size_t size) { return s_malloc(size); }
+void *sds_realloc(void *ptr, size_t size) { return s_realloc(ptr,size); }
+void sds_free(void *ptr) { s_free(ptr); }
+
+#if defined(SDS_TEST_MAIN)
+#include <stdio.h>
+#include "testhelp.h"
+#include "limits.h"
+
+#define UNUSED(x) (void)(x)
+int sdsTest(void) {
+    {
+        sds x = sdsnew("foo"), y;
+
+        test_cond("Create a string and obtain the length",
+            sdslen(x) == 3 && memcmp(x,"foo\0",4) == 0)
+
+        sdsfree(x);
+        x = sdsnewlen("foo",2);
+        test_cond("Create a string with specified length",
+            sdslen(x) == 2 && memcmp(x,"fo\0",3) == 0)
+
+        x = sdscat(x,"bar");
+        test_cond("Strings concatenation",
+            sdslen(x) == 5 && memcmp(x,"fobar\0",6) == 0);
+
+        x = sdscpy(x,"a");
+        test_cond("sdscpy() against an originally longer string",
+            sdslen(x) == 1 && memcmp(x,"a\0",2) == 0)
+
+        x = sdscpy(x,"xyzxxxxxxxxxxyyyyyyyyyykkkkkkkkkk");
+        test_cond("sdscpy() against an originally shorter string",
+            sdslen(x) == 33 &&
+            memcmp(x,"xyzxxxxxxxxxxyyyyyyyyyykkkkkkkkkk\0",33) == 0)
+
+        sdsfree(x);
+        x = sdscatprintf(sdsempty(),"%d",123);
+        test_cond("sdscatprintf() seems working in the base case",
+            sdslen(x) == 3 && memcmp(x,"123\0",4) == 0)
+
+        sdsfree(x);
+        x = sdsnew("--");
+        x = sdscatfmt(x, "Hello %s World %I,%I--", "Hi!", LLONG_MIN,LLONG_MAX);
+        test_cond("sdscatfmt() seems working in the base case",
+            sdslen(x) == 60 &&
+            memcmp(x,"--Hello Hi! World -9223372036854775808,"
+                     "9223372036854775807--",60) == 0)
+        printf("[%s]\n",x);
+
+        sdsfree(x);
+        x = sdsnew("--");
+        x = sdscatfmt(x, "%u,%U--", UINT_MAX, ULLONG_MAX);
+        test_cond("sdscatfmt() seems working with unsigned numbers",
+            sdslen(x) == 35 &&
+            memcmp(x,"--4294967295,18446744073709551615--",35) == 0)
+
+        sdsfree(x);
+        x = sdsnew(" x ");
+        sdstrim(x," x");
+        test_cond("sdstrim() works when all chars match",
+            sdslen(x) == 0)
+
+        sdsfree(x);
+        x = sdsnew(" x ");
+        sdstrim(x," ");
+        test_cond("sdstrim() works when a single char remains",
+            sdslen(x) == 1 && x[0] == 'x')
+
+        sdsfree(x);
+        x = sdsnew("xxciaoyyy");
+        sdstrim(x,"xy");
+        test_cond("sdstrim() correctly trims characters",
+            sdslen(x) == 4 && memcmp(x,"ciao\0",5) == 0)
+
+        y = sdsdup(x);
+        sdsrange(y,1,1);
+        test_cond("sdsrange(...,1,1)",
+            sdslen(y) == 1 && memcmp(y,"i\0",2) == 0)
+
+        sdsfree(y);
+        y = sdsdup(x);
+        sdsrange(y,1,-1);
+        test_cond("sdsrange(...,1,-1)",
+            sdslen(y) == 3 && memcmp(y,"iao\0",4) == 0)
+
+        sdsfree(y);
+        y = sdsdup(x);
+        sdsrange(y,-2,-1);
+        test_cond("sdsrange(...,-2,-1)",
+            sdslen(y) == 2 && memcmp(y,"ao\0",3) == 0)
+
+        sdsfree(y);
+        y = sdsdup(x);
+        sdsrange(y,2,1);
+        test_cond("sdsrange(...,2,1)",
+            sdslen(y) == 0 && memcmp(y,"\0",1) == 0)
+
+        sdsfree(y);
+        y = sdsdup(x);
+        sdsrange(y,1,100);
+        test_cond("sdsrange(...,1,100)",
+            sdslen(y) == 3 && memcmp(y,"iao\0",4) == 0)
+
+        sdsfree(y);
+        y = sdsdup(x);
+        sdsrange(y,100,100);
+        test_cond("sdsrange(...,100,100)",
+            sdslen(y) == 0 && memcmp(y,"\0",1) == 0)
+
+        sdsfree(y);
+        sdsfree(x);
+        x = sdsnew("foo");
+        y = sdsnew("foa");
+        test_cond("sdscmp(foo,foa)", sdscmp(x,y) > 0)
+
+        sdsfree(y);
+        sdsfree(x);
+        x = sdsnew("bar");
+        y = sdsnew("bar");
+        test_cond("sdscmp(bar,bar)", sdscmp(x,y) == 0)
+
+        sdsfree(y);
+        sdsfree(x);
+        x = sdsnew("aar");
+        y = sdsnew("bar");
+        test_cond("sdscmp(bar,bar)", sdscmp(x,y) < 0)
+
+        sdsfree(y);
+        sdsfree(x);
+        x = sdsnewlen("\a\n\0foo\r",7);
+        y = sdscatrepr(sdsempty(),x,sdslen(x));
+        test_cond("sdscatrepr(...data...)",
+            memcmp(y,"\"\\a\\n\\x00foo\\r\"",15) == 0)
+
+        {
+            unsigned int oldfree;
+            char *p;
+            int step = 10, j, i;
+
+            sdsfree(x);
+            sdsfree(y);
+            x = sdsnew("0");
+            test_cond("sdsnew() free/len buffers", sdslen(x) == 1 && sdsavail(x) == 0);
+
+            /* Run the test a few times in order to hit the first two
+             * SDS header types. */
+            for (i = 0; i < 10; i++) {
+                int oldlen = sdslen(x);
+                x = sdsMakeRoomFor(x,step);
+                int type = x[-1]&SDS_TYPE_MASK;
+
+                test_cond("sdsMakeRoomFor() len", sdslen(x) == oldlen);
+                if (type != SDS_TYPE_5) {
+                    test_cond("sdsMakeRoomFor() free", sdsavail(x) >= step);
+                    oldfree = sdsavail(x);
+                }
+                p = x+oldlen;
+                for (j = 0; j < step; j++) {
+                    p[j] = 'A'+j;
+                }
+                sdsIncrLen(x,step);
+            }
+            test_cond("sdsMakeRoomFor() content",
+                memcmp("0ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJ",x,101) == 0);
+            test_cond("sdsMakeRoomFor() final length",sdslen(x)==101);
+
+            sdsfree(x);
+        }
+    }
+    test_report()
+    return 0;
+}
+#endif
+
+#ifdef SDS_TEST_MAIN
+int main(void) {
+    return sdsTest();
+}
+#endif

--- a/crates/kin-reconcile/src/reconciler.rs
+++ b/crates/kin-reconcile/src/reconciler.rs
@@ -246,6 +246,15 @@ pub enum ReconcileOutcome {
         /// Collision warnings from the traffic checker (soft locks).
         collision_warnings: Vec<IntentSummary>,
     },
+    /// Only independently verified existing declarations were refreshed. The
+    /// file remains incomplete and every other entity and relation is retained.
+    PartiallyUpdated {
+        file_id: FilePathId,
+        modified: Vec<EntityId>,
+        retained: Vec<EntityId>,
+        error_ranges: Vec<(usize, usize)>,
+        collision_warnings: Vec<IntentSummary>,
+    },
     /// File had parse errors; LKG state retained, no graph changes.
     BrokenAst {
         file_id: FilePathId,
@@ -566,37 +575,6 @@ impl Reconciler {
 
         let result_file_id = indexed.file_id.clone();
 
-        // Check for broken AST — behavior depends on policy.
-        if let ParseState::Incomplete { error_ranges } = &indexed.parse_state {
-            match self.policy.broken_ast_behavior {
-                BrokenAstBehavior::Reject => {
-                    warn!(
-                        file = %path.display(),
-                        errors = error_ranges.len(),
-                        "broken AST rejected by policy"
-                    );
-                    return Err(ReconcileError::BrokenAstRejected {
-                        file_id: result_file_id,
-                        error_ranges: error_ranges.clone(),
-                    });
-                }
-                BrokenAstBehavior::FallbackToLkg => {
-                    warn!(
-                        file = %path.display(),
-                        errors = error_ranges.len(),
-                        "broken AST, retaining LKG state"
-                    );
-                    // Still cache the tree even on broken AST — it's valid for
-                    // incremental parse even if the content has errors.
-                    self.tree_cache.insert(file_id, tree);
-                    return ReconcileResult::unchanged(ReconcileOutcome::BrokenAst {
-                        file_id: result_file_id,
-                        error_ranges: error_ranges.clone(),
-                    });
-                }
-            }
-        }
-
         // RACE CONDITION HARDENING: Verify the file hasn't changed since we
         // indexed it. If modified mid-reconcile, defer to the next tick.
         match std::fs::read(path) {
@@ -660,34 +638,6 @@ impl Reconciler {
             .pipeline
             .index_file_relative(path, blob_store, &self.working_dir)?;
         let file_id = indexed.file_id.clone();
-
-        // Check for broken AST — behavior depends on policy.
-        if let ParseState::Incomplete { error_ranges } = &indexed.parse_state {
-            match self.policy.broken_ast_behavior {
-                BrokenAstBehavior::Reject => {
-                    warn!(
-                        file = %path.display(),
-                        errors = error_ranges.len(),
-                        "broken AST rejected by policy"
-                    );
-                    return Err(ReconcileError::BrokenAstRejected {
-                        file_id,
-                        error_ranges: error_ranges.clone(),
-                    });
-                }
-                BrokenAstBehavior::FallbackToLkg => {
-                    warn!(
-                        file = %path.display(),
-                        errors = error_ranges.len(),
-                        "broken AST, retaining LKG state"
-                    );
-                    return ReconcileResult::unchanged(ReconcileOutcome::BrokenAst {
-                        file_id,
-                        error_ranges: error_ranges.clone(),
-                    });
-                }
-            }
-        }
 
         // RACE CONDITION HARDENING: Verify the file hasn't changed since we
         // indexed it. If the file was modified between the index read and now,
@@ -782,6 +732,15 @@ impl Reconciler {
         blob_store: &BlobStore,
         graph: &G,
     ) -> Result<ReconcileResult> {
+        if let ParseState::Incomplete { error_ranges } = &indexed.parse_state {
+            if matches!(self.policy.broken_ast_behavior, BrokenAstBehavior::Reject) {
+                return Err(ReconcileError::BrokenAstRejected {
+                    file_id: file_id.clone(),
+                    error_ranges: error_ranges.clone(),
+                });
+            }
+            return self.reconcile_partial(indexed, blob_store, graph, error_ranges);
+        }
         // Get existing entities for this file from the graph
         let existing = self.get_file_entities(graph, file_id)?;
 
@@ -1527,6 +1486,111 @@ impl Reconciler {
             "reconciled file edit"
         );
 
+        Ok(result)
+    }
+
+    fn reconcile_partial<G: GraphStore>(
+        &mut self,
+        indexed: &kin_index::IndexedFile,
+        blobs: &BlobStore,
+        graph: &G,
+        error_ranges: &[(usize, usize)],
+    ) -> Result<ReconcileResult> {
+        let existing = self.get_file_entities(graph, &indexed.file_id)?;
+        let source = blobs.read(&indexed.blob_hash)?;
+        let mut delta = TransactionDelta::default();
+        let mut modified = Vec::new();
+        let mut old_sources = HashMap::new();
+        for candidate in &indexed.entities {
+            if validate_entity(candidate).is_some() {
+                continue;
+            }
+            let same_identity =
+                |entity: &&Entity| entity.name == candidate.name && entity.kind == candidate.kind;
+            let mut previous = existing.iter().filter(same_identity);
+            let Some(old) = previous.next() else {
+                continue;
+            };
+            if previous.next().is_some()
+                || indexed.entities.iter().filter(same_identity).count() != 1
+            {
+                continue;
+            }
+            let Some(hash) = old.metadata.extra.get("blob_hash").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            if !old_sources.contains_key(hash) {
+                let Ok(digest) = kin_blobs::Hash256::from_hex(hash) else {
+                    continue;
+                };
+                let Ok(bytes) = blobs.read(&digest) else {
+                    continue;
+                };
+                old_sources.insert(hash.to_owned(), bytes);
+            }
+            if !self
+                .pipeline
+                .supports_partial_refresh(old, candidate, &old_sources[hash], &source)
+            {
+                continue;
+            }
+            let mut new = candidate.clone();
+            new.id = old.id;
+            new.lineage_parent = old.lineage_parent;
+            new.created_in = old.created_in;
+            new.metadata.extra.insert(
+                "partial_parse_admission".into(),
+                serde_json::json!({
+                    "previous_blob_hash": hash,
+                    "source_blob_hash": indexed.blob_hash.to_string(),
+                    "error_ranges": error_ranges,
+                }),
+            );
+            // Retrying the same incomplete bytes does not mint another proof
+            // chain or dirty an already admitted declaration.
+            if old.metadata.extra.get("blob_hash") == candidate.metadata.extra.get("blob_hash")
+                && old.span == candidate.span
+                && old.fingerprint == candidate.fingerprint
+            {
+                continue;
+            }
+            modified.push(old.id);
+            delta.entity_deltas.push(EntityDelta::Modified {
+                old: old.clone(),
+                new,
+            });
+        }
+        if modified.is_empty() {
+            return ReconcileResult::unchanged(ReconcileOutcome::BrokenAst {
+                file_id: indexed.file_id.clone(),
+                error_ranges: error_ranges.to_vec(),
+            });
+        }
+        let mut scopes: Vec<_> = modified.iter().copied().map(IntentScope::Entity).collect();
+        scopes.push(IntentScope::Artifact(indexed.file_id.clone()));
+        let collision_warnings = self.check_scopes(&scopes)?;
+        let retained = existing
+            .iter()
+            .filter(|e| !modified.contains(&e.id))
+            .map(|e| e.id)
+            .collect();
+        let result = ReconcileResult::validated(
+            ReconcileOutcome::PartiallyUpdated {
+                file_id: indexed.file_id.clone(),
+                modified,
+                retained,
+                error_ranges: error_ranges.to_vec(),
+                collision_warnings,
+            },
+            delta,
+        )?;
+        // No layout, link-universe, or relation retirement: this pass has no
+        // complete-file enumeration or verified resolution dependencies.
+        for change in &result.delta.entity_deltas {
+            if let EntityDelta::Modified { new, .. } = change {
+                self.lkg.record(new);
+            }
+        }
         Ok(result)
     }
 
@@ -2559,6 +2623,316 @@ mod tests {
         EntityKind, EntityMetadata, EntityRole, EntityStore, FingerprintAlgorithm, Hash256,
         LanguageId, SemanticFingerprint, Visibility,
     };
+
+    const PARTIAL_C: &str =
+        "int good(void) { int value = 1; return value; }\nint bad(void) { test_cond(1) }\n";
+
+    fn partial_tree(graph: &kin_db::InMemoryGraph, bytes: &[u8]) {
+        let path = kin_model::RepoPath::from_utf8("test.c").unwrap();
+        let entry = kin_model::TreeEntry::blob(
+            kin_model::Hash256::from_bytes(kin_blobs::digest(bytes).0),
+            false,
+        );
+        let tree = graph.resolved_tree();
+        let change = match tree.artifact_at_path(&path) {
+            Some(old) if old.entry == entry => return,
+            Some(old) => kin_model::TreeDelta::Updated {
+                artifact_id: old.artifact_id,
+                old: kin_model::LocatedEntry::new(path.clone(), old.entry),
+                new: kin_model::LocatedEntry::new(path, entry),
+            },
+            None => kin_model::TreeDelta::Added {
+                artifact_id: kin_model::ArtifactId::new(),
+                new: kin_model::LocatedEntry::new(path, entry),
+            },
+        };
+        graph
+            .apply_transaction_delta(&TransactionDelta {
+                tree_deltas: vec![change],
+                ..Default::default()
+            })
+            .unwrap();
+    }
+
+    fn partial_fixture(
+        before: &str,
+    ) -> (
+        tempfile::TempDir,
+        BlobStore,
+        kin_db::InMemoryGraph,
+        Reconciler,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let blobs = BlobStore::new(dir.path().join("blobs")).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+        let indexed = IndexPipeline::new()
+            .index_file_content_with_tests(
+                &FilePathId::new("test.c"),
+                before.as_bytes(),
+                blobs.write(before.as_bytes()).unwrap(),
+            )
+            .unwrap()
+            .indexed_file;
+        partial_tree(&graph, before.as_bytes());
+        for entity in &indexed.entities {
+            graph.upsert_entity(entity).unwrap();
+        }
+        for relation in &indexed.relations {
+            graph.upsert_relation(relation).unwrap();
+        }
+        let reconciler = Reconciler::new(dir.path().to_path_buf());
+        (dir, blobs, graph, reconciler)
+    }
+
+    fn partial_pass(
+        reconciler: &mut Reconciler,
+        blobs: &BlobStore,
+        graph: &kin_db::InMemoryGraph,
+        source: &str,
+    ) -> ReconcileResult {
+        let indexed = IndexPipeline::new()
+            .index_file_content_with_tests(
+                &FilePathId::new("test.c"),
+                source.as_bytes(),
+                blobs.write(source.as_bytes()).unwrap(),
+            )
+            .unwrap()
+            .indexed_file;
+        partial_tree(graph, source.as_bytes());
+        reconciler
+            .reconcile_indexed_content(&indexed, blobs, graph)
+            .unwrap()
+    }
+
+    #[test]
+    fn partial_c_refreshes_retained_hiredis_identity_from_full_cas() {
+        let before = include_str!("../../kin-parser/tests/fixtures/c/hiredis-sds.c");
+        let after = before.replacen("reqlen", "required_len", 3);
+        let (_dir, blobs, graph, mut reconciler) = partial_fixture(before);
+        let old = graph.list_all_entities().unwrap();
+        let target = old.iter().find(|e| e.name == "sdsMakeRoomFor").unwrap();
+        let result = partial_pass(&mut reconciler, &blobs, &graph, &after);
+        let ReconcileOutcome::PartiallyUpdated {
+            modified,
+            error_ranges,
+            retained,
+            ..
+        } = &result.outcome
+        else {
+            panic!("{:?}", result.outcome);
+        };
+        assert!(modified.contains(&target.id));
+        assert_eq!(error_ranges.len(), 25);
+        assert!(!retained.is_empty());
+        assert!(result.delta.relation_deltas.is_empty());
+        assert!(result
+            .delta
+            .entity_deltas
+            .iter()
+            .all(|d| matches!(d, EntityDelta::Modified { .. })));
+        graph.apply_transaction_delta(&result.delta).unwrap();
+        let updated = graph.get_entity(&target.id).unwrap().unwrap();
+        let span = updated.span.as_ref().unwrap();
+        assert!(after[span.start_byte..span.end_byte].contains("required_len"));
+        assert_eq!(
+            updated.metadata.extra["blob_hash"],
+            blobs.write(after.as_bytes()).unwrap().to_string()
+        );
+        for entity in old.iter().filter(|e| retained.contains(&e.id)) {
+            assert_eq!(graph.get_entity(&entity.id).unwrap().unwrap(), *entity);
+        }
+        assert!(reconciler
+            .projection()
+            .get_layout(&FilePathId::new("test.c"))
+            .is_none());
+        let repeat = partial_pass(&mut reconciler, &blobs, &graph, &after);
+        assert!(repeat.delta.entity_deltas.is_empty());
+    }
+
+    #[test]
+    fn partial_c_rejects_body_recovery_boundaries_and_macro_context_changes() {
+        for after in [
+            PARTIAL_C.replace("return value;", "return value"),
+            PARTIAL_C.replace("return value; }", "return value;"),
+            format!(
+                "#if CHOICE\n{}\n#endif\n",
+                PARTIAL_C.replace("value", "next")
+            ),
+            PARTIAL_C
+                .replace("int good", "API int good")
+                .replace("value", "next"),
+            PARTIAL_C.replace("return value;", "test_cond(value) return value;"),
+        ] {
+            let (_dir, blobs, graph, mut reconciler) = partial_fixture(PARTIAL_C);
+            let result = partial_pass(&mut reconciler, &blobs, &graph, &after);
+            assert!(
+                result.delta.entity_deltas.is_empty(),
+                "unexpected admission for {after}: {:?}",
+                result.delta
+            );
+        }
+    }
+
+    #[test]
+    fn partial_c_error_count_equality_never_authorizes_affected_body() {
+        let before = "int good(void) { return 1; }\nint bad(void) { test_cond(1) }\n";
+        let after = "int good(void) { test_cond(1) }\nint bad(void) { return 1; }\n";
+        let (_dir, blobs, graph, mut reconciler) = partial_fixture(before);
+        let pipeline = IndexPipeline::new();
+        let errors = |source: &str| match pipeline
+            .index_file_content_with_tests(
+                &FilePathId::new("test.c"),
+                source.as_bytes(),
+                kin_blobs::digest(source.as_bytes()),
+            )
+            .unwrap()
+            .indexed_file
+            .parse_state
+        {
+            ParseState::Incomplete { error_ranges } => error_ranges.len(),
+            _ => 0,
+        };
+        assert_eq!(errors(before), errors(after));
+        let result = partial_pass(&mut reconciler, &blobs, &graph, after);
+        assert!(result.delta.entity_deltas.is_empty());
+    }
+
+    #[test]
+    fn partial_c_ambiguous_and_omitted_declarations_are_retained() {
+        let (_dir, blobs, graph, mut reconciler) = partial_fixture(PARTIAL_C);
+        let mut duplicate = graph
+            .list_all_entities()
+            .unwrap()
+            .into_iter()
+            .find(|e| e.name == "good")
+            .unwrap();
+        duplicate.id = EntityId::new();
+        graph.upsert_entity(&duplicate).unwrap();
+        let result = partial_pass(
+            &mut reconciler,
+            &blobs,
+            &graph,
+            &PARTIAL_C.replace("value", "next"),
+        );
+        assert!(result.delta.entity_deltas.is_empty());
+        let after = "int bad(void) { test_cond(1) }\n";
+        let result = partial_pass(&mut reconciler, &blobs, &graph, after);
+        assert!(result.delta.entity_deltas.is_empty());
+        assert_eq!(graph.list_all_entities().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn partial_c_never_admits_macro_or_broken_call_regions() {
+        for before in [
+            "#define test_cond(x) do { (void)(x); } while (0);\nint good(void) { test_cond(1) return 0; }\n",
+            "void test_cond(int);\nint good(void) { test_cond(1) return 0; }\n",
+        ] {
+            let (_dir, blobs, graph, mut reconciler) = partial_fixture(before);
+            let result = partial_pass(&mut reconciler, &blobs, &graph, &before.replace("return 0", "return 2"));
+            assert!(result.delta.entity_deltas.is_empty());
+        }
+    }
+
+    #[test]
+    fn partial_c_macro_dependencies_and_nonlocal_names_cannot_change() {
+        for before in [
+            "#define selected 1\nint good(void) { return selected; }\nint bad(void) { test_cond(1) }\n",
+            "#include <macros.h>\nint good(void) { return selected; }\nint bad(void) { test_cond(1) }\n",
+            "void setup(void) {\n#define selected 1\n}\nint good(void) { int local = 1; return selected + local; }\nint bad(void) { test_cond(1) }\n",
+        ] {
+            let (_dir, blobs, graph, mut reconciler) = partial_fixture(before);
+            let after = if before.contains("void setup") { before.replace("selected 1", "selected 2").replace("local = 1", "local = 3") } else { before.replace("return selected", "return other") };
+            let result = partial_pass(&mut reconciler, &blobs, &graph, &after);
+            assert!(result.delta.entity_deltas.is_empty(), "{:?}", result.outcome);
+        }
+    }
+
+    #[test]
+    fn partial_c_local_bindings_respect_scope_and_declaration_order() {
+        for before in [
+            "int selected; int other;\nint good(void) { selected++; { int selected=0; int other=0; } return 0; }\nint bad(void) { test_cond(1) }\n",
+            "int selected; int other;\nint good(void) { { int selected=0; int other=0; } selected++; return 0; }\nint bad(void) { test_cond(1) }\n",
+            "int selected; int other;\nint good(void) { selected++; int selected=0; int other=0; return 0; }\nint bad(void) { test_cond(1) }\n",
+        ] {
+            let (_dir, blobs, graph, mut reconciler) = partial_fixture(before);
+            let after = before.replace("selected++", "other++");
+            let result = partial_pass(&mut reconciler, &blobs, &graph, &after);
+            assert!(result.delta.entity_deltas.is_empty(), "{:?}", result.outcome);
+        }
+    }
+
+    #[test]
+    fn partial_c_external_bindings_members_and_declarator_bounds_are_not_locals() {
+        for (before, from, to) in [
+            ("int good(void) { extern int selected; extern int other; return selected; }\nint bad(void) { test_cond(1) }\n", "return selected", "return other"),
+            ("struct item { int first; int second; };\nint good(void) { struct item local; return local.first; }\nint bad(void) { test_cond(1) }\n", "local.first", "local.second"),
+            ("int selected; int other;\nint good(void) { int selected[sizeof selected]; int other; return 0; }\nint bad(void) { test_cond(1) }\n", "sizeof selected", "sizeof other"),
+        ] {
+            let (_dir, blobs, graph, mut reconciler) = partial_fixture(before);
+            let result = partial_pass(&mut reconciler, &blobs, &graph, &before.replace(from, to));
+            assert!(result.delta.entity_deltas.is_empty(), "{:?}", result.outcome);
+        }
+    }
+
+    #[test]
+    fn partial_c_moved_declaration_keeps_identity_and_uses_current_span() {
+        let (_dir, blobs, graph, mut reconciler) = partial_fixture(PARTIAL_C);
+        let old = graph
+            .list_all_entities()
+            .unwrap()
+            .into_iter()
+            .find(|e| e.name == "good")
+            .unwrap();
+        let after = format!("// prefix\n{}", PARTIAL_C.replace("value", "longer_name"));
+        let result = partial_pass(&mut reconciler, &blobs, &graph, &after);
+        assert!(
+            matches!(&result.outcome, ReconcileOutcome::PartiallyUpdated { modified, .. } if modified.contains(&old.id))
+        );
+        graph.apply_transaction_delta(&result.delta).unwrap();
+        let current = graph.get_entity(&old.id).unwrap().unwrap();
+        let span = current.span.as_ref().unwrap();
+        assert!(span.start_byte > old.span.as_ref().unwrap().start_byte);
+        assert_eq!(
+            &after[span.start_byte..span.end_byte],
+            "int good(void) { int longer_name = 1; return longer_name; }"
+        );
+    }
+
+    #[test]
+    fn partial_c_clean_followup_removes_omitted_entities_and_restores_layout() {
+        let (_dir, blobs, graph, mut reconciler) = partial_fixture(PARTIAL_C);
+        let partial = partial_pass(
+            &mut reconciler,
+            &blobs,
+            &graph,
+            &PARTIAL_C.replace("value", "next"),
+        );
+        assert!(matches!(
+            partial.outcome,
+            ReconcileOutcome::PartiallyUpdated { .. }
+        ));
+        graph.apply_transaction_delta(&partial.delta).unwrap();
+        let clean = partial_pass(
+            &mut reconciler,
+            &blobs,
+            &graph,
+            "int good(void) { return 2; }\n",
+        );
+        assert!(
+            matches!(&clean.outcome, ReconcileOutcome::Updated { removed, .. } if removed.len() == 1)
+        );
+        graph.apply_transaction_delta(&clean.delta).unwrap();
+        let held = graph.list_all_entities().unwrap();
+        assert_eq!(held.len(), 1);
+        assert!(!held[0]
+            .metadata
+            .extra
+            .contains_key("partial_parse_admission"));
+        assert!(reconciler
+            .projection()
+            .get_layout(&FilePathId::new("test.c"))
+            .is_some());
+    }
 
     fn make_entity(name: &str, file: &str) -> Entity {
         Entity {

--- a/crates/kin-reconcile/src/reconciler.rs
+++ b/crates/kin-reconcile/src/reconciler.rs
@@ -1501,6 +1501,7 @@ impl Reconciler {
         let mut delta = TransactionDelta::default();
         let mut modified = Vec::new();
         let mut old_sources = HashMap::new();
+        let mut held_relations = HashMap::new();
         for candidate in &indexed.entities {
             if validate_entity(candidate).is_some() {
                 continue;
@@ -1534,6 +1535,49 @@ impl Reconciler {
             {
                 continue;
             }
+            let declaration = old
+                .span
+                .as_ref()
+                .expect("the source proof checked the span");
+            let mut relation_changes = Vec::new();
+            let mut evidence_verified = true;
+            for relation in
+                relations_held_at(graph, &mut held_relations, GraphNodeId::Entity(old.id))?.values()
+            {
+                let associated = relation
+                    .evidence
+                    .iter()
+                    .filter_map(|e| e.source_span.as_ref())
+                    .any(|span| {
+                        span.file == declaration.file
+                            && (relation.src == GraphNodeId::Entity(old.id)
+                                || (declaration.start_line <= span.start_line
+                                    && span.end_line <= declaration.end_line))
+                    });
+                if !associated {
+                    continue;
+                }
+                let Some(updated) = self.pipeline.rebase_partial_relation(
+                    old,
+                    candidate,
+                    &old_sources[hash],
+                    &source,
+                    relation,
+                    &existing,
+                ) else {
+                    evidence_verified = false;
+                    break;
+                };
+                if updated != *relation {
+                    relation_changes.push(RelationDelta::Modified {
+                        old: relation.clone(),
+                        new: updated,
+                    });
+                }
+            }
+            if !evidence_verified {
+                continue;
+            }
             let mut new = candidate.clone();
             new.id = old.id;
             new.lineage_parent = old.lineage_parent;
@@ -1555,6 +1599,7 @@ impl Reconciler {
                 continue;
             }
             modified.push(old.id);
+            delta.relation_deltas.extend(relation_changes);
             delta.entity_deltas.push(EntityDelta::Modified {
                 old: old.clone(),
                 new,
@@ -1584,8 +1629,8 @@ impl Reconciler {
             },
             delta,
         )?;
-        // No layout, link-universe, or relation retirement: this pass has no
-        // complete-file enumeration or verified resolution dependencies.
+        // No layout, link-universe, or relation retirement: only exact call
+        // locations with stable same-file resolution were refreshed.
         for change in &result.delta.entity_deltas {
             if let EntityDelta::Modified { new, .. } = change {
                 self.lkg.record(new);
@@ -2896,6 +2941,170 @@ mod tests {
             &after[span.start_byte..span.end_byte],
             "int good(void) { int longer_name = 1; return longer_name; }"
         );
+    }
+
+    const PARTIAL_CALL_C: &str = "int helper(void) { return 7; }\nint good(void) {\n  int value=1;\n  return helper();\n}\nint bad(void) { test_cond(1) }\n";
+
+    fn partial_call_span(source: &str, whole: bool, zero_bytes: bool) -> kin_model::SourceSpan {
+        let start = source.find("helper()").unwrap();
+        let end = start
+            + if whole {
+                "helper()".len()
+            } else {
+                "helper".len()
+            };
+        let line = source[..start]
+            .bytes()
+            .filter(|byte| *byte == b'\n')
+            .count() as u32;
+        let column = start - source[..start].rfind('\n').map_or(0, |offset| offset + 1);
+        kin_model::SourceSpan {
+            file: FilePathId::new("test.c"),
+            start_byte: if zero_bytes { 0 } else { start },
+            end_byte: if zero_bytes { 0 } else { end },
+            start_line: line,
+            end_line: line,
+            start_col: column as u32,
+            end_col: (column + end - start) as u32,
+        }
+    }
+
+    fn partial_enriched_call(
+        graph: &kin_db::InMemoryGraph,
+        source: &str,
+        whole: bool,
+        zero_bytes: bool,
+    ) -> (Entity, Relation) {
+        let entities = graph.list_all_entities().unwrap();
+        let caller = entities
+            .iter()
+            .find(|entity| entity.name == "good")
+            .unwrap()
+            .clone();
+        let callee = entities
+            .iter()
+            .find(|entity| entity.name == "helper")
+            .unwrap();
+        let mut relation = relation_of(kin_model::RelationOrigin::Lsp);
+        relation.src = GraphNodeId::Entity(caller.id);
+        relation.dst = GraphNodeId::Entity(callee.id);
+        relation.confidence = 0.75;
+        relation.evidence = vec![kin_model::RelationEvidence {
+            source_span: Some(partial_call_span(source, whole, zero_bytes)),
+            ..Default::default()
+        }];
+        graph.upsert_relation(&relation).unwrap();
+        (caller, relation)
+    }
+
+    #[test]
+    fn partial_c_rebases_unique_call_evidence_without_changing_relation_identity() {
+        for (whole, zero_bytes) in [(false, false), (false, true), (true, false), (true, true)] {
+            let (_dir, blobs, graph, mut reconciler) = partial_fixture(PARTIAL_CALL_C);
+            let (caller, relation) =
+                partial_enriched_call(&graph, PARTIAL_CALL_C, whole, zero_bytes);
+            let after = format!(
+                "// prefix\n{}",
+                PARTIAL_CALL_C.replace("int value=1;", "int renamed=1;\n\n")
+            );
+            let result = partial_pass(&mut reconciler, &blobs, &graph, &after);
+            assert!(
+                matches!(&result.outcome, ReconcileOutcome::PartiallyUpdated { modified, .. } if modified.contains(&caller.id)),
+                "{:?}",
+                result.outcome
+            );
+            assert!(result
+                .delta
+                .relation_deltas
+                .iter()
+                .all(|delta| matches!(delta, RelationDelta::Modified { .. })));
+            graph.apply_transaction_delta(&result.delta).unwrap();
+            let actual = graph
+                .get_all_relations_for_entity(&caller.id)
+                .unwrap()
+                .into_iter()
+                .find(|held| held.id == relation.id)
+                .unwrap();
+            let mut expected = relation.clone();
+            expected.evidence[0].source_span = Some(partial_call_span(&after, whole, false));
+            assert_eq!(actual, expected, "only the proven coordinates may change");
+            assert_eq!(
+                graph
+                    .get_entity(&caller.id)
+                    .unwrap()
+                    .unwrap()
+                    .metadata
+                    .extra["blob_hash"],
+                kin_blobs::digest(after.as_bytes()).to_string()
+            );
+        }
+    }
+
+    #[test]
+    fn partial_c_refuses_ambiguous_or_unsupported_located_evidence_atomically() {
+        for failure in [
+            "duplicate",
+            "range",
+            "coordinates",
+            "multiple",
+            "kind",
+            "binding",
+        ] {
+            let before = if failure == "duplicate" {
+                PARTIAL_CALL_C.replace("return helper();", "helper(); return helper();")
+            } else {
+                PARTIAL_CALL_C.into()
+            };
+            let (_dir, blobs, graph, mut reconciler) = partial_fixture(&before);
+            let (caller, mut relation) = partial_enriched_call(&graph, &before, false, false);
+            match failure {
+                "range" => relation.evidence[0].source_span = caller.span.clone(),
+                "coordinates" => relation.evidence[0].source_span.as_mut().unwrap().start_col += 1,
+                "multiple" => relation.evidence.push(kin_model::RelationEvidence {
+                    source_span: caller.span.clone(),
+                    ..Default::default()
+                }),
+                "kind" => relation.kind = RelationKind::References,
+                _ => {}
+            }
+            graph.upsert_relation(&relation).unwrap();
+            let after = format!(
+                "// prefix\n{}",
+                if failure == "binding" {
+                    before.replace("int value=1;", "int helper=1;")
+                } else {
+                    before.replace("int value=1;", "int renamed=1;\n\n")
+                }
+            );
+            let result = partial_pass(&mut reconciler, &blobs, &graph, &after);
+            assert!(
+                !result
+                    .delta
+                    .entity_deltas
+                    .iter()
+                    .any(|delta| delta.target_id() == caller.id),
+                "{failure}: {:?}",
+                result.outcome
+            );
+            assert!(
+                !result
+                    .delta
+                    .relation_deltas
+                    .iter()
+                    .any(|delta| delta.target_id() == relation.id),
+                "{failure}"
+            );
+            graph.apply_transaction_delta(&result.delta).unwrap();
+            assert_eq!(graph.get_entity(&caller.id).unwrap(), Some(caller));
+            assert_eq!(
+                graph
+                    .get_all_relations_for_entity(&relation.src.as_entity().unwrap())
+                    .unwrap()
+                    .into_iter()
+                    .find(|held| held.id == relation.id),
+                Some(relation)
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
A local-variable rename in hiredis `sds.c` previously left every entity on the old source digest because unrelated C constructs still produced parse errors. Refresh an existing function only when old and new full-file CAS parses prove a complete, unambiguous declaration with stable declaration and preprocessing context. The retained fixture has 25 errors both before and after the rename; none are suppressed.

Introduce `PartiallyUpdated` so admitted functions retain their identity and use the current CAS span and body while file coverage remains incomplete. Unmatched and error-affected entities retain their previous payloads. Partial admission adds or removes no entities and performs no whole-file relation retirement. Existing direct-call evidence moves only when its old and new sites and same-file resolution are independently proven unique. Unsupported or ambiguous evidence retains the entire old caller. Relation identity and non-location evidence remain unchanged, and subscribers receive the modified relation after its entity event.

Persist incomplete coverage before graph publication and independently verify admitted payloads, proof metadata and call coordinates at commit. Commit/reopen controls check the current `sdsMakeRoomFor` body, stable identity, current reference lines, retained errors and unchanged refusal of stale retained source. Intentionally retained callers still allow artifact continuity. A later clean parse restores complete coverage and normal removal behavior.

At `ce1861502cb7b5f6f4c6b7289cf37570c6bd4e8c`, precheck passed all 21 gates, including formatting, clippy and source-search policy. Affected-crate suites are running. Focused partial-admission tests pass: 4 daemon and 12 reconcile tests. Thirteen mutation controls were caught by real test failures and explicitly restored, including old call coordinates, skipped commit-time coordinate verification and an incorrectly blocked retained-caller commit. Full touched-crate tests on the preceding head had 3681 passes, three watcher failures and 20 ignored tests. Its precheck passed 21/21; parity failed brownfield check 9 because an unreferenced initialization staging directory survived. These failures remain recorded and are not waived.
