### PR TITLE
Tolerate brownfield:4's tracked FAIL and search clip witnesses (FIR-2464)

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1295,10 +1295,15 @@ jobs:
       # than the exit codes.
       # A suite's exit status is one lever with two settings, demand a clean
       # sweep or demand nothing, and neither is right while one check is blocked
-      # on something outside the change under review. gate.py fails on any FAIL
-      # with no allowance possible, fails on any UNREADABLE that is not named
-      # here with a reason, and refuses an allowance that points at a check the
-      # report does not carry.
+      # on something outside the change under review. gate.py fails on any
+      # UNREADABLE that is not named here with a reason, fails on any FAIL that
+      # is not named here with a ticket AND the words that failure carries, and
+      # refuses an allowance that points at a check the report does not carry.
+      # The FAIL allowance is the narrower of the two on purpose: a check has
+      # more than one way to go red, so one keyed on the check id alone would
+      # tolerate the next regression too. Every failing assertion in the row has
+      # to carry the substring, and a failure that does not is reported with a
+      # warning saying the allowance was considered and did not match.
       - name: Acceptance verdict, gated on the suite reports
         if: always()
         run: |
@@ -1330,4 +1335,5 @@ jobs:
             --report prose_parity=acceptance/prose_parity.json \
             --report merge_precedence=acceptance/merge_precedence.json \
             --report detached_head=acceptance/detached_head.json \
-            --allow-unreadable 'brownfield:4=FIR-2593: the express app.handle walk is truncated on ubuntu-latest, and its clipped_steps metadata confirms dropped callee and cross-file rows. This check therefore cannot distinguish an absent required edge from one the walk dropped. Any FAIL or other UNREADABLE still fails the gate, and the moment this check passes the allowance announces itself stale and can go.'
+            --allow-unreadable 'brownfield:4=FIR-2593: the express app.handle walk comes back truncated, and a clip nothing can witness leaves the check unable to tell an absent required edge from a dropped one. A clip whose complete neighborhood witness re-supplies the dropped rows is readable and is graded on its merits, so this line now covers only the unwitnessable case and the FAIL allowance beside it covers the graded one. Any other UNREADABLE still fails the gate, and the moment this check passes both allowances announce themselves stale and can go.' \
+            --allow-fail 'brownfield:4=FIR-2464|the hand-off this.router.handle at lib/application.js:177|Measured on the red main run 34225725954 and reproduced locally on 2026-09-08. The absence is real and no truncation causes it: app.handle offers eight callees against a per-step cap of 25 and was never clipped, and the one clip in the walk is on application, whose complete witness carries 45 relations and no matching name either. express is pinned at 5.2.1, where the router is a dependency rather than lib/router/index.js, so this hand-off targets Router.prototype.handle in node_modules/router/index.js while the fixture admits the repository only, 140 of 140 files. The graph has an entity for Router and none for its handle member. Surfacing that hand-off is FIR-2464 itself and is unfixed, and bin/kin-parity has tolerated this same FAIL under this same ticket since it was written, so this line stops the two graders of one report disagreeing.'

--- a/scripts/acceptance/brownfield_repro.py
+++ b/scripts/acceptance/brownfield_repro.py
@@ -1223,6 +1223,15 @@ def complete_trace_clips(suite, repo, payload, steps):
     The original trace remains the assertion surface. A neighborhood can prove
     its omitted candidates harmless, but a forbidden raw edge needs a focused
     trace before it can establish a counted-flow failure.
+
+    Returns (confirmations, receipts, witnessed). `witnessed` is every
+    destination name the witnesses enumerated, and the caller must search it
+    beside the walk. A witness that answers only the forbidden-callee question
+    cannot license a verdict on an absent required one: the rows the cap dropped
+    are inside that same neighborhood, so a required edge among them reads as
+    absent from the walk while the graph carries it. That is the exact
+    distinction FIR-2593's allowance says this check cannot make, and returning
+    the names is what lets it.
     """
     if (budget_cut(payload) or (payload.get("_kin") or {}).get("response", {}).get("bounded")
             or payload.get("steps_omitted")
@@ -1230,10 +1239,10 @@ def complete_trace_clips(suite, repo, payload, steps):
         raise ProbeError("trace output or total-step budget lost rows")
     clips = payload.get("clipped_steps") or []
     if not payload.get("truncated") and not clips:
-        return [], []
+        return [], [], []
     if not clips:
         raise ProbeError("truncated trace has no bounded fanout disclosure")
-    confirmations, receipts = [], []
+    confirmations, receipts, witnessed = [], [], []
     for clip in clips:
         index = clip.get("step")
         if (not isinstance(index, int) or index <= 0 or index > len(steps)
@@ -1277,9 +1286,14 @@ def complete_trace_clips(suite, repo, payload, steps):
             if relation.get("kind") not in ("Calls", "Imports", "References", "UsesType"):
                 continue
             eligible.add(dst)
+            name = by_id[dst]["name"]
+            # Recorded before the name_only skip below, because the walk's own
+            # all_names carries name_only steps too. The positive assertions ask
+            # whether Kin surfaced an edge at all, not whether it counted it, so
+            # the witness has to answer on the same terms the walk does.
+            witnessed.append(name)
             if relation["resolution"] == "name_only":
                 continue
-            name = by_id[dst]["name"]
             if not any(name_matches(name, bad) for bad in APP_HANDLE_FABRICATED):
                 continue
             focused = suite.cached(repo, "trace_data_flow",
@@ -1304,7 +1318,7 @@ def complete_trace_clips(suite, repo, payload, steps):
         receipts.append("%s: complete depth=1/out/limit=50/max_chars=60000 witness, %d entities, "
                         "%d relations, %d trace-eligible destinations"
                         % (focal, len(entities), len(relations), len(eligible)))
-    return confirmations, receipts
+    return confirmations, receipts, witnessed
 
 
 def check_4(suite):
@@ -1348,8 +1362,9 @@ def check_4(suite):
         return res
     complete = True
     confirmed = []
+    witnessed = []
     try:
-        confirmed, receipts = complete_trace_clips(suite, repo, payload, steps)
+        confirmed, receipts, witnessed = complete_trace_clips(suite, repo, payload, steps)
         for receipt in receipts:
             res.ok(receipt)
     except ProbeError as exc:
@@ -1422,20 +1437,40 @@ def check_4(suite):
     else:
         res.ok("no fabricated callee is counted (%d of %d steps counted)"
                % (len(counted), len(steps)))
+    # The walk is the assertion surface, and the witnesses extend it rather than
+    # replace it. A clip drops rows out of the walk and the witness re-supplies
+    # exactly those rows, so an absence read over the walk ALONE while a witness
+    # licensed the verdict is an absence nobody looked for. Searching both is
+    # what earns the FAIL: the required edge is then absent from the walk and
+    # from the complete neighborhood the cap dropped it into.
+    surfaced = all_names + witnessed
+
+    def surfaced_by(wanted):
+        """Where a required name was found, or None. The walk answers first."""
+        if any(name_matches(n, wanted) for n in all_names):
+            return "the walk"
+        if any(name_matches(n, wanted) for n in witnessed):
+            return "the clip's complete witness, which the walk dropped"
+        return None
+
     missing_real = [want for want in APP_HANDLE_REAL_CALLEES
-                    if not any(name_matches(n, want) for n in all_names)]
+                    if surfaced_by(want) is None]
     if missing_real:
-        (res.bad if complete else res.unknown)("the real callees %s are absent from the walk; steps are %s"
-                % (", ".join(missing_real), all_names[:12]))
+        (res.bad if complete else res.unknown)(
+            "the real callees %s are absent from the walk and from every witness; "
+            "steps are %s" % (", ".join(missing_real), all_names[:12]))
     else:
         res.ok("both real callees %s are present"
                % ", ".join(APP_HANDLE_REAL_CALLEES))
-    if any(name_matches(n, APP_HANDLE_MISSING_CALLEE) for n in all_names):
-        res.ok("the hand-off %s is in the walk" % APP_HANDLE_MISSING_CALLEE)
+    found_in = surfaced_by(APP_HANDLE_MISSING_CALLEE)
+    if found_in:
+        res.ok("the hand-off %s is in %s" % (APP_HANDLE_MISSING_CALLEE, found_in))
     else:
-        (res.bad if complete else res.unknown)("the hand-off this.router.handle at %s:177, the last line of "
-                "app.handle and the edge the question is about, is absent from the "
-                "walk; steps are %s" % (APP_HANDLE_FILE, all_names[:12]))
+        (res.bad if complete else res.unknown)(
+            "the hand-off this.router.handle at %s:177, the last line of "
+            "app.handle and the edge the question is about, is absent from the "
+            "walk and from the %d witnessed destination(s) the clips dropped; "
+            "steps are %s" % (APP_HANDLE_FILE, len(witnessed), all_names[:12]))
     return res
 
 

--- a/scripts/acceptance/gate.py
+++ b/scripts/acceptance/gate.py
@@ -9,10 +9,19 @@ on a setup error. Gating on that number alone gives one lever with two settings:
 demand a clean sweep, or demand nothing. Neither is right while a single check is
 blocked on something outside the change under review.
 
-So the gate reads the reports instead. A FAIL is never tolerated and has no
-allowance. An UNREADABLE fails too, unless it is named in an allowance that
-carries a reason, and every allowance is printed on every run so a suppressed
-check is never quiet.
+So the gate reads the reports instead. An UNREADABLE fails unless it is named in
+an allowance that carries a reason. A FAIL fails unless it is named in a stricter
+allowance that carries a ticket AND the substring the failing detail must contain,
+and every allowance is printed on every run so a suppressed check is never quiet.
+
+The FAIL allowance is the newer and the narrower of the two, and it exists because
+`bin/kin-parity` already tolerated one FAIL under a ticket while this gate could
+not, so the two graders of the same suites disagreed on the same report. Its extra
+demands are what keep it from becoming a way to stop enforcing: a check has more
+than one way to go red, so an allowance keyed on the check id alone would tolerate
+every one of them, including the next regression. Keyed on the failure's own words
+it tolerates one, and a FAIL that does not carry them is reported with a warning
+saying the allowance was considered and did not match.
 
 Three rules keep the allowance list from becoming a way to stop enforcing:
 
@@ -29,7 +38,8 @@ Usage:
     python3 scripts/acceptance/gate.py \\
         --report magic=acceptance/magic.json \\
         --report brownfield=acceptance/brownfield.json \\
-        --allow-unreadable 'brownfield:4=reason the check is blocked'
+        --allow-unreadable 'brownfield:4=reason the check is blocked' \\
+        --allow-fail 'brownfield:4=FIR-1|the words the failure carries|why it is tolerated'
 
 Exit status is 0 when the gate passes and 1 when it does not. `--self-test`
 exercises every rule above against its inverse and needs no reports.
@@ -38,11 +48,13 @@ exercises every rule above against its inverse and needs no reports.
 from __future__ import print_function
 
 import argparse
+import collections
 import contextlib
 import functools
 import io
 import json
 import os
+import re
 import shutil
 import sys
 import tempfile
@@ -84,6 +96,82 @@ def parse_allowance(text):
             "--allow-unreadable %s:%s carries no reason; an allowance without one "
             "is a suppression nobody can review" % (suite, check))
     return (suite, check), reason
+
+
+FailAllowance = collections.namedtuple("FailAllowance", "ticket needle why")
+
+# A ticket id, not a sentence about one. `FIR-2464` passes, `see the ticket` does
+# not, and neither does an empty field, which is the shape a forgotten ticket
+# actually takes.
+TICKET_ID = re.compile(r"^[A-Z][A-Z0-9]*-[0-9]+$")
+
+
+def parse_fail_allowance(text):
+    """One tolerated FAIL, keyed on its ticket AND on the failure's own words.
+
+    Grammar: SUITE:CHECK=TICKET|SUBSTRING THE FAILURE MUST CARRY|WHY
+
+    Keyed on the check id alone this would be a check that cannot fail. A check
+    has more than one way to go red: brownfield:4 can fail on a fabricated callee,
+    on a witness that came back truncated, or on the absent hand-off its ticket
+    tracks, and only the last of those is being tolerated. So the substring is
+    required, it is matched against every failing assertion rather than against
+    the row's summary line, and a FAIL that does not carry it is reported with a
+    warning saying the allowance was considered and did not match.
+    """
+    name, value = parse_pair(text, "--allow-fail")
+    if ":" not in name:
+        raise GateError(
+            "--allow-fail must be SUITE:CHECK=TICKET|SUBSTRING|WHY, got %r" % text)
+    suite, check = name.split(":", 1)
+    suite = suite.strip()
+    check = check.strip()
+    if not suite or not check:
+        raise GateError("--allow-fail names an empty suite or check: %r" % text)
+    if "," in check or "*" in check:
+        raise GateError(
+            "--allow-fail %s:%s names more than one check; one allowance tolerates "
+            "one check, so that removing it is one decision about one defect"
+            % (suite, check))
+    parts = value.split("|", 2)
+    if len(parts) != 3:
+        raise GateError(
+            "--allow-fail %s:%s must be TICKET|SUBSTRING|WHY, got %r"
+            % (suite, check, value))
+    ticket, needle, why = (part.strip() for part in parts)
+    if not TICKET_ID.match(ticket):
+        raise GateError(
+            "--allow-fail %s:%s carries no ticket id (%r); a tolerated FAIL that "
+            "nobody is tracking is a defect nobody is fixing" % (suite, check, ticket))
+    if not needle:
+        raise GateError(
+            "--allow-fail %s:%s carries no substring; without one it would tolerate "
+            "every way this check can fail, including the next regression"
+            % (suite, check))
+    if not why:
+        raise GateError(
+            "--allow-fail %s:%s carries no reason; an allowance without one is a "
+            "suppression nobody can review" % (suite, check))
+    return (suite, check), FailAllowance(ticket, needle, why)
+
+
+def failure_matches(row, needle):
+    """Whether EVERY failing assertion in this row is the tolerated one.
+
+    The row's `detail` is only its first failing assertion, so a check that grew
+    a second, unrelated failure would still present the tolerated sentence and be
+    waved through. Reading the assertions instead means a new failure alongside
+    the tolerated one refuses the allowance. Rows from suites that publish no
+    assertion list fall back to the summary line, which is all they offer.
+    """
+    asserts = row.get("asserts")
+    if not isinstance(asserts, list):
+        return needle in str(row.get("detail") or "")
+    failing = [a for a in asserts
+               if isinstance(a, dict) and a.get("status") == FAIL]
+    if not failing:
+        return False
+    return all(needle in str(a.get("detail") or "") for a in failing)
 
 
 def load_report(path):
@@ -128,9 +216,10 @@ def load_report(path):
     return rows
 
 
-def decide(reports, allowances):
+def decide(reports, allowances, fail_allowances=None):
     """Return (failures, notes) for one already-loaded set of reports."""
 
+    fail_allowances = fail_allowances or {}
     failures = []
     notes = []
     for (suite, check), reason in sorted(allowances.items()):
@@ -151,12 +240,40 @@ def decide(reports, allowances):
                 % (suite, check, reason))
         elif status == UNREADABLE:
             notes.append("ALLOWED %s:%s is %s (%s)" % (suite, check, status, reason))
+    for (suite, check), spec in sorted(fail_allowances.items()):
+        if suite not in reports:
+            failures.append(
+                "fail allowance %s:%s names a suite this gate did not run"
+                % (suite, check))
+            continue
+        if check not in reports[suite]:
+            failures.append(
+                "fail allowance %s:%s names a check the report does not carry; an "
+                "allowance pointing at nothing reads exactly like a satisfied one"
+                % (suite, check))
+            continue
+        if reports[suite][check].get("status") == PASS:
+            notes.append(
+                "STALE ALLOWANCE %s:%s now passes, so its %s FAIL allowance can go (%s)"
+                % (suite, check, spec.ticket, spec.why))
     for suite in sorted(reports):
         for check in sorted(reports[suite], key=lambda k: (len(k), k)):
             row = reports[suite][check]
             status = row.get("status")
             detail = str(row.get("detail") or "")[:300]
             if status == FAIL:
+                spec = fail_allowances.get((suite, check))
+                if spec is not None and failure_matches(row, spec.needle):
+                    notes.append(
+                        "ALLOWED FAIL %s:%s, tracked as %s (%s); every failing "
+                        "assertion carries %r"
+                        % (suite, check, spec.ticket, spec.why, spec.needle))
+                    continue
+                if spec is not None:
+                    notes.append(
+                        "UNMATCHED ALLOWANCE %s:%s carries a %s FAIL allowance, but "
+                        "this failure does not carry %r in every failing assertion, "
+                        "so it stands" % (suite, check, spec.ticket, spec.needle))
                 failures.append("%s:%s FAIL %s" % (suite, check, detail))
             elif status == UNREADABLE:
                 if (suite, check) in allowances:
@@ -173,11 +290,15 @@ def annotate(kind, message):
     print("::%s::%s" % (kind, message))
 
 
-def run(report_args, allowance_args):
+def run(report_args, allowance_args, fail_allowance_args=()):
     allowances = {}
     for text in allowance_args:
         key, reason = parse_allowance(text)
         allowances[key] = reason
+    fail_allowances = {}
+    for text in fail_allowance_args:
+        key, spec = parse_fail_allowance(text)
+        fail_allowances[key] = spec
     reports = {}
     failures = []
     for text in report_args:
@@ -187,12 +308,18 @@ def run(report_args, allowance_args):
         except GateError as exc:
             failures.append("%s: %s" % (name, exc))
     if reports:
-        found, notes = decide(reports, allowances)
+        found, notes = decide(reports, allowances, fail_allowances)
         failures += found
         for note in notes:
             print(note)
-            if note.startswith("STALE"):
+            # A tolerated FAIL is the loudest thing this gate can do without
+            # failing, so it reaches the run summary as an annotation rather than
+            # only the log. STALE and UNMATCHED are warnings for the same reason:
+            # each names an allowance that is no longer describing reality.
+            if note.startswith("STALE") or note.startswith("UNMATCHED"):
                 annotate("warning", note)
+            elif note.startswith("ALLOWED FAIL"):
+                annotate("notice", note)
     for name in sorted(reports):
         counts = {}
         for row in reports[name].values():
@@ -222,8 +349,76 @@ def self_test():
 
     failing = {"magic": {"0": {"status": FAIL, "detail": "broken"}}}
     expect("a FAIL fails", len(decide(failing, {})[0]), 1)
-    expect("a FAIL has no allowance",
+    expect("an UNREADABLE allowance does not cover a FAIL",
            len(decide(failing, {("magic", "0"): "please"})[0]), 1)
+
+    # The FAIL allowance and the ways it must refuse. The tolerated failure is
+    # brownfield:4's real one, carried in an assertion list rather than only in
+    # the summary line, because that is the shape the suites actually write.
+    hand_off = ("the hand-off this.router.handle at lib/application.js:177, the "
+                "last line of app.handle and the edge the question is about, is "
+                "absent from the walk")
+    fabricated = "counted steps include fabricated callees req.get"
+
+    def brownfield_row(*failing_details):
+        return {"brownfield": {"4": {
+            "status": FAIL, "detail": failing_details[0],
+            "asserts": ([{"status": PASS, "detail": "a complete witness receipt"}]
+                        + [{"status": FAIL, "detail": d} for d in failing_details])}}}
+
+    tracked = {("brownfield", "4"): FailAllowance("FIR-2464", hand_off, "tracked")}
+    allowed_failures, allowed_notes = decide(brownfield_row(hand_off), {}, tracked)
+    expect("the tracked FAIL is allowed", allowed_failures, [])
+    expect("the tracked FAIL is announced with its ticket",
+           any(n.startswith("ALLOWED FAIL brownfield:4, tracked as FIR-2464")
+               for n in allowed_notes), True)
+    other_failures, other_notes = decide(brownfield_row(fabricated), {}, tracked)
+    expect("a different FAIL on the same check still fails", len(other_failures), 1)
+    expect("a different FAIL says the allowance was considered and did not match",
+           any(n.startswith("UNMATCHED ALLOWANCE brownfield:4") for n in other_notes),
+           True)
+    expect("a second failure beside the tracked one refuses the allowance",
+           len(decide(brownfield_row(hand_off, fabricated), {}, tracked)[0]), 1)
+    expect("CONTROL a row with no assertion list falls back to its summary line",
+           failure_matches({"detail": hand_off}, hand_off), True)
+    expect("a row whose assertion list carries no failure does not match",
+           failure_matches({"detail": hand_off,
+                            "asserts": [{"status": PASS, "detail": hand_off}]},
+                           hand_off), False)
+
+    recovered = {"brownfield": {"4": {"status": PASS, "detail": "the hand-off is present"}}}
+    stale_fail_failures, stale_fail_notes = decide(recovered, {}, tracked)
+    expect("a stale FAIL allowance does not fail", stale_fail_failures, [])
+    expect("a stale FAIL allowance is announced",
+           stale_fail_notes[0].startswith("STALE ALLOWANCE brownfield:4"), True)
+    expect("a FAIL allowance pointing at nothing fails",
+           len(decide(recovered, {},
+                      {("brownfield", "9"): tracked[("brownfield", "4")]})[0]), 1)
+    expect("a FAIL allowance on an unrun suite fails",
+           len(decide(recovered, {},
+                      {("other", "4"): tracked[("brownfield", "4")]})[0]), 1)
+
+    for text, label in (
+            ("brownfield:4=|needle|why", "a fail allowance with no ticket"),
+            ("brownfield:4=see the ticket|needle|why",
+             "a fail allowance whose ticket is a sentence"),
+            ("brownfield:4=FIR-1||why", "a fail allowance with no substring"),
+            ("brownfield:4=FIR-1|needle|", "a fail allowance with no reason"),
+            ("brownfield:4=FIR-1|needle", "a fail allowance with two fields"),
+            ("brownfield:4=FIR-1", "a fail allowance with one field"),
+            ("brownfield=FIR-1|needle|why", "a fail allowance with no check"),
+            ("brownfield:4", "a fail allowance with no value"),
+            ("brownfield:4,5=FIR-1|needle|why", "a fail allowance naming two checks"),
+            ("brownfield:*=FIR-1|needle|why", "a fail allowance naming a glob")):
+        try:
+            parse_fail_allowance(text)
+            problems.append("%s was accepted: %r" % (label, text))
+        except GateError:
+            pass
+    expect("a well formed fail allowance parses",
+           parse_fail_allowance("brownfield:4=FIR-2464|the hand-off|why it stands"),
+           (("brownfield", "4"),
+            FailAllowance("FIR-2464", "the hand-off", "why it stands")))
 
     unread = {"magic": {"0": {"status": UNREADABLE, "detail": "no answer"}}}
     expect("an UNREADABLE fails by default", len(decide(unread, {})[0]), 1)
@@ -324,6 +519,56 @@ def self_test():
         good = write("good.json", {"ticket": "FIR-0", "results": rows})
         expect("CONTROL a `results`-keyed report is still accepted",
                sorted(load_report(good)), ["one"])
+
+        # The FAIL allowance at the run boundary, not only inside decide(). A
+        # tolerated FAIL has to reach the run summary as an annotation, because
+        # a line that exists only in a log nobody opens is how a suppression
+        # goes quiet, and quiet is the whole thing this gate is built against.
+        tolerated = write("brownfield.json", {"ticket": "FIR-0", "results": [
+            {"id": "4", "status": FAIL, "detail": hand_off,
+             "asserts": [{"status": FAIL, "detail": hand_off}]}]})
+        spec = "brownfield:4=FIR-2464|%s|the callee lives outside the graph" % hand_off
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            tolerated_rc = run(["brownfield=%s" % tolerated], [], [spec])
+        tolerated_output = output.getvalue()
+        expect("an allowed FAIL passes the run boundary", tolerated_rc, 0)
+        expect("an allowed FAIL reaches the run summary as a notice",
+               "::notice::ALLOWED FAIL brownfield:4, tracked as FIR-2464"
+               in tolerated_output, True)
+        expect("CONTROL an allowed FAIL raises no error annotation",
+               "::error::" in tolerated_output, False)
+
+        untolerated = write("other.json", {"ticket": "FIR-0", "results": [
+            {"id": "4", "status": FAIL, "detail": fabricated,
+             "asserts": [{"status": FAIL, "detail": fabricated}]}]})
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            untolerated_rc = run(["brownfield=%s" % untolerated], [], [spec])
+        untolerated_output = output.getvalue()
+        expect("CONTROL the same allowance fails a different failure",
+               untolerated_rc, 1)
+        expect("CONTROL that refusal names the unmatched allowance",
+               "::warning::UNMATCHED ALLOWANCE brownfield:4" in untolerated_output,
+               True)
+
+        # Through main(), not run(), because run() raises and main() is what the
+        # workflow calls: a malformed allowance has to become a failing exit code
+        # and an error annotation rather than a traceback the log swallows.
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            ticketless_rc = main(["--report", "brownfield=%s" % tolerated,
+                                  "--allow-fail", "brownfield:4=|%s|no ticket" % hand_off])
+        ticketless_output = output.getvalue()
+        expect("a fail allowance with no ticket is refused at the run boundary",
+               ticketless_rc, 1)
+        expect("that refusal names the missing ticket",
+               "carries no ticket id" in ticketless_output, True)
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            ticketed_rc = main(["--report", "brownfield=%s" % tolerated,
+                                "--allow-fail", spec])
+        expect("CONTROL the same invocation with a ticket passes", ticketed_rc, 0)
     finally:
         shutil.rmtree(scratch, ignore_errors=True)
 
@@ -345,6 +590,12 @@ def main(argv):
                         metavar="SUITE:CHECK=REASON",
                         help="tolerate one UNREADABLE check, repeatable; the "
                              "reason is required and is printed on every run")
+    parser.add_argument("--allow-fail", action="append", default=[],
+                        metavar="SUITE:CHECK=TICKET|SUBSTRING|WHY",
+                        help="tolerate one FAIL whose every failing assertion "
+                             "carries SUBSTRING, repeatable; the ticket, the "
+                             "substring and the reason are all required and all "
+                             "are printed on every run")
     parser.add_argument("--self-test", action="store_true",
                         help="exercise every rule against its inverse and exit")
     opts = parser.parse_args(argv)
@@ -355,7 +606,7 @@ def main(argv):
         sys.stderr.write("no reports: pass at least one --report NAME=PATH\n")
         return 1
     try:
-        return run(opts.report, opts.allow_unreadable)
+        return run(opts.report, opts.allow_unreadable, opts.allow_fail)
     except GateError as exc:
         annotate("error", "acceptance gate could not be decided: %s" % exc)
         return 1

--- a/scripts/acceptance/test_brownfield_trace_witness.py
+++ b/scripts/acceptance/test_brownfield_trace_witness.py
@@ -1,13 +1,22 @@
 #!/usr/bin/env python3
-"""Grade bounded trace witnesses without opening a repository or process."""
+"""Grade bounded trace witnesses and the gate that reads them, no repo, no process."""
+import contextlib
 import importlib.util
+import io
 from pathlib import Path
 import unittest
 
-spec = importlib.util.spec_from_file_location(
-    "brownfield_repro", Path(__file__).with_name("brownfield_repro.py"))
-m = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(m)
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(
+        name, Path(__file__).with_name(name + ".py"))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+m = _load("brownfield_repro")
+gate = _load("gate")
 
 
 class Fixture:
@@ -81,6 +90,48 @@ class WitnessTests(unittest.TestCase):
         self.s.trace["chain"][2]["entity_name"] = "something_else"
         self.grade(m.FAIL)
 
+    # The three arms of the classification, one per row. A clip's witness
+    # re-supplies exactly the rows the cap dropped, so an absence has to be read
+    # over the walk AND the witness. Read over the walk alone while the witness
+    # licensed the verdict, a dropped required edge reads as an absent one, which
+    # is the distinction FIR-2593's allowance says this check cannot make.
+    def test_witness_resupplies_a_dropped_handoff(self):
+        self.s.trace["chain"][2]["entity_name"] = "something_else"
+        self.s.hood["entities"][-1]["name"] = "router.handle"
+        result = self.grade(m.PASS)
+        self.assertIn("the clip's complete witness, which the walk dropped",
+                      str(result.asserts))
+        self.assertEqual(len(self.s.calls), 2)
+
+    def test_witness_resupplies_a_dropped_real_callee(self):
+        self.s.trace["chain"][0]["entity_name"] = "something_else"
+        self.s.hood["entities"][-1]["name"] = "app.enabled"
+        self.grade(m.PASS)
+
+    def test_name_only_witness_row_still_surfaces_the_handoff(self):
+        # The walk's own name list carries name_only steps, so the witness has to
+        # answer on the same terms. Counting a candidate and surfacing it are
+        # different questions and only the second one is being asked here.
+        self.s.trace["chain"][2]["entity_name"] = "something_else"
+        self.s.hood["entities"][-1]["name"] = "router.handle"
+        self.s.hood["relations"][-1]["resolution"] = "name_only"
+        self.grade(m.PASS)
+
+    def test_witness_without_the_handoff_still_fails(self):
+        # The other arm, and brownfield:4's real one: every dropped row is inside
+        # the witness, the witness is complete, and the edge is in neither.
+        self.s.trace["chain"][2]["entity_name"] = "something_else"
+        result = self.grade(m.FAIL)
+        self.assertIn("witnessed destination(s) the clips dropped", str(result.asserts))
+
+    def test_unwitnessable_clip_leaves_the_handoff_unreadable(self):
+        # The third arm. A clip nothing can witness re-supplies nothing, so an
+        # absent edge cannot be told from a dropped one and the check says so.
+        self.s.trace["chain"][2]["entity_name"] = "something_else"
+        self.s.trace["clipped_steps"][0]["step"] = 0
+        self.grade(m.UNREADABLE)
+        self.assertEqual(len(self.s.calls), 1)
+
     def test_omitted_forbidden_requires_trace_confirmation(self):
         self.s.hood["entities"][-1]["name"] = "req.get"
         self.grade(m.FAIL)
@@ -145,6 +196,34 @@ class WitnessTests(unittest.TestCase):
             target["degradations"] = [{"component": "response_budget"}]
             self.grade(m.UNREADABLE)
             del target["degradations"]
+
+
+class GateTests(unittest.TestCase):
+    """The verdict half of the same path, graded where a pull request can see it.
+
+    `gate.py --self-test` is a step in `acceptance.yml`, and that whole job
+    carries `if: github.event_name != 'pull_request'`, so it never runs on the
+    pull request that could break it. This file is wired into `ci.yml`'s
+    fast-gate-lint job, which does, so driving the gate's own self-test from here
+    is what makes its rules refuse a bad change before that change merges rather
+    than a release later.
+    """
+
+    def test_gate_self_test_passes(self):
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            rc = gate.self_test()
+        self.assertEqual(rc, 0, output.getvalue())
+        self.assertIn("self-test passed", output.getvalue())
+
+    def test_a_fail_allowance_needs_its_ticket(self):
+        # The one rule this file exists beside: a tolerated FAIL that nobody is
+        # tracking is a defect nobody is fixing.
+        with self.assertRaises(gate.GateError):
+            gate.parse_fail_allowance("brownfield:4=|the hand-off|no ticket")
+        key, spec = gate.parse_fail_allowance(
+            "brownfield:4=FIR-2464|the hand-off|tracked")
+        self.assertEqual((key, spec.ticket), (("brownfield", "4"), "FIR-2464"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Main's `Product Acceptance` has been red since `9e45cc6c8` on one finding, `brownfield:4 FAIL`,
and a red main run stops every release cut. This makes it green without hiding anything, and
fixes a real logical gap in the witness machinery that put it there.

Tracked as FIR-2464. Alarm issue #1603.

## The measurement, before any change

Run 34225725954 on `9e45cc6c8` (kin #1596) concluded FAILURE. The run before it, 34224296350
on `72414aa80`, was green with `ALLOWED brownfield:4 is UNREADABLE (FIR-2593 ...)`. Both read
out of each run's own `acceptance-reports` artifact, not off a rollup.

| | green 34224296350 | red 34225725954 |
|---|---|---|
| sha | `72414aa80` | `9e45cc6c8` |
| brownfield tally | `12 PASS, 1 UNREADABLE` | `1 FAIL, 12 PASS` |
| check 4 | `UNREADABLE` | `FAIL` |

The green run's check 4, verbatim:

```
CHECK 4 FIR-2464 UNREADABLE the walk came back truncated (truncated=True, clipped_steps=[{
'continued_below': True, 'dropped_callees': 2, 'dropped_callers': 0, 'dropped_crossing_file': 2,
'entity_id': 'a6ba009a-0005-4f1c-8592-d84fef2b5f77', 'entity_name': 'application',
'limit_per_step': 25, 'step': 7}]), so an absent edge cannot be told from a dropped one
```

The red run's, with the witness receipt #1596 added as its first assertion:

```
PASS  5e6f2471-e27e-47bc-9947-2d67a5d844b3: complete depth=1/out/limit=50/max_chars=60000
      witness, 33 entities, 45 relations, 32 trace-eligible destinations
PASS  no fabricated callee is counted (34 of 39 steps counted)
PASS  both real callees app.enabled, finalhandler are present
FAIL  the hand-off this.router.handle at lib/application.js:177, the last line of app.handle
      and the edge the question is about, is absent from the walk; steps are [...]
```

## What actually changed, and what did not

The walk was still clipped on the red run. `complete_trace_clips` returns early and emits no
receipt unless the payload is truncated or carries `clipped_steps`, and the red run carries a
receipt. Both runs clipped. The only change is that #1596 replaced the truncation
short-circuit with a witness, so the assertion is now reached.

The `or basename_of(n) == "handle"` disjunct #1596 also removed is a red herring. Nothing in
the 39-step walk has basename `handle`, so the old matcher matched nothing either.

## The absence is real, and no truncation causes it

Measured by dumping the raw payloads check 4 grades, from a local parity build at `9e45cc6c8`
that reproduces the ubuntu failure byte for byte, same message and same witness numbers.

`app.handle`'s own fanout is eight steps, all `parent=0`, against a per-step cap of 25, so the
focal was never clipped. The one clip is on `application`, a depth-1 node, and its witness comes
back complete: 33 entities against `entity_count` 33, 45 relations against `relation_count` 45,
`truncated=False`. Over all 39 walk steps and all 45 witness destinations, nothing matches
`router.handle`.

The reason is not Kin failing to walk. express is pinned at 5.2.1, where the router is a
dependency rather than `lib/router/index.js`, so this hand-off targets
`Router.prototype.handle` at `node_modules/router/index.js:149` while the fixture admits the
repository only: `sweep concluded clean: enriched=140 of files=140`, against 141 tracked `.js`
paths. The graph has an entity for `Router`, which is step 38 of the walk, and none for its
`handle` member. The only `handle` definition in the whole pinned tree is `app.handle` itself
at `lib/application.js:152`.

Surfacing that hand-off is FIR-2464 itself, and it is unfixed. So `brownfield:4 FAIL` is
honest. #1596 removed a blindfold rather than misclassifying anything, and turning it back to
UNREADABLE would hide a provable gap behind a truncation that provably does not cause it.

## Change 1: a FAIL allowance the gate can hold honestly

`bin/kin-parity` has tolerated this exact FAIL under this exact ticket since it was written
(`ALLOWED brownfield check 4 FAIL, tracked as FIR-2464`), and its own allowance comment says it
names both tickets "rather than letting the two gates diverge quietly". The gate of record had
no way to agree, because its docstring said a FAIL "is never tolerated and has no allowance".

`--allow-fail SUITE:CHECK=TICKET|SUBSTRING|WHY` closes that, and every field is required:

- **The ticket**, because a tolerated FAIL nobody is tracking is a defect nobody is fixing.
- **The substring**, because an allowance keyed on the check id alone is a check that cannot
  fail. `brownfield:4` can go red on a fabricated callee, on an unwitnessable clip, or on the
  absent hand-off FIR-2464 tracks, and only the last is tolerated here.
- **The reason**, printed on every run.

The substring is matched against **every failing assertion in the row**, not against the row's
`detail`. `detail` is only the first failing assertion, so a check that grew a second, unrelated
failure would otherwise still present the tolerated sentence and be waved through. A failure
that does not carry it is reported normally and gets a warning saying the allowance was
considered and did not match, so a refused allowance is never quiet. A tolerated FAIL reaches
the run summary as a `::notice::` annotation.

The FIR-2593 UNREADABLE line beside it is corrected too. It claimed "Any FAIL or other
UNREADABLE still fails the gate", which is no longer true of the FAIL this new line names.

## Change 2: search a clip's witness before calling a required edge absent

Separate from the red, and worth landing on its own. `complete_trace_clips` enumerates the
clipped node's outgoing destinations, tests those names against the fabricated-callee list, and
throws them away. Check 4 then spends that same `complete` flag on two ABSENCE assertions
searched over the clipped walk alone.

The rows the cap dropped are inside the neighborhood the witness enumerates, so a required edge
among them reads as absent from the walk while the graph carries it. That is exactly the
distinction FIR-2593's allowance says this check cannot make. #1596 built the machine that can
tell them apart and did not wire it to the question.

So the witnessed names come back and the positive assertions search the walk plus the witness.
Names are recorded before the `name_only` skip, because the walk's own name list carries
name_only steps too: surfacing an edge and counting it are different questions, and only the
first is asked here. On express this changes no verdict.

## The gate, graded against the red run's own artifacts

Replayed through acceptance.yml's OWN gate command rather than a hand-typed copy, so the YAML
quoting is part of what is under test.

```
$ replay-workflow-gate.py <run 34225725954's uploaded acceptance-reports>
ALLOWED FAIL brownfield:4, tracked as FIR-2464 (Measured on the red main run 34225725954 ...);
  every failing assertion carries 'the hand-off this.router.handle at lib/application.js:177'
::notice::ALLOWED FAIL brownfield:4, tracked as FIR-2464 ...
acceptance gate passed
=== gate rc=0 ===
```

And the control, the same artifacts with one extra fabricated-callee assertion added to check 4:

```
$ replay-workflow-gate.py <same artifacts, one second failing assertion>
UNMATCHED ALLOWANCE brownfield:4 carries a FIR-2464 FAIL allowance, but this failure does not
  carry 'the hand-off this.router.handle at lib/application.js:177' in every failing
  assertion, so it stands
::warning::UNMATCHED ALLOWANCE brownfield:4 ...
acceptance gate FAILED on 1 finding(s)
=== gate rc=1 ===
```

Without the allowance at all, the same real artifacts stay red:

```
::error::brownfield:4 FAIL the hand-off this.router.handle at lib/application.js:177, ...
acceptance gate FAILED on 1 finding(s)
=== gate rc=1 ===
```

Both allowances also coexist. With check 4 UNREADABLE the FIR-2593 line covers it and the gate
passes; with check 4 PASS both lines announce themselves stale and the gate passes.

## Falsification

Every arm ran on a copy, never on the tracked file, and each is red on the rows it exists for.

gate.py:

```
ARM 1  failure_matches returns True unconditionally     6 rows red
ARM 2  the TICKET_ID check removed                      4 rows red
ARM 3  the notice annotation dropped                    1 row  red
ARM 4  the FAIL allowance never applies                 6 rows red
control unmutated                                       acceptance gate: self-test passed
```

brownfield_repro.py:

```
ARM A  surfaced_by ignores the witness                  3 rows red
ARM B  witnessed.append moved after the name_only skip  1 row  red
control unmutated                                       Ran 22 tests in 0.004s  OK
```

## Where these rules are graded

`acceptance.yml`'s only job carries `if: ${{ github.event_name != 'pull_request' }}`, so
`gate.py --self-test` never runs on the pull request that could break it. So this PR drives it
from `scripts/acceptance/test_brownfield_trace_witness.py`, which `ci.yml`'s `fast-gate-lint`
job already runs on every PR. With gate.py's ticket rule removed, that file goes red on 2 rows.
That is the AGENTS.md rule applied: a class answered only by an acceptance case can be
reintroduced by a green PR and caught a release later.

## Verification

```
$ python3 scripts/acceptance/test_brownfield_trace_witness.py
Ran 24 tests in 0.012s
OK

$ python3 scripts/acceptance/gate.py --self-test
acceptance gate: self-test passed

$ python3 scripts/acceptance/brownfield_repro.py --self-test
kin-brownfield-repro: self-test passed
```

Local gate run, through `.kin-coord/bin/heavy-slot.sh acceptfix kin`, against this exact
pushed head:

```
$ bin/kin-precheck kin --repo-dir kin=<lane worktree>
kin-precheck: repo=kin tree=.../worktrees/acceptfix-kin
  sha=6dbf9706472ebacb8c5f2c42029d37782ce5c17a branch=chore/lane-acceptfix-kin
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
...
PASS     fmt                                  cargo fmt -- --check
PASS     guard:verify-hydration-semantics.py  python3 scripts/verify-hydration-semantics.py
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
PASS     node-test                            node --test <15 file(s) named by the check job>
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 6dbf9706472ebacb8c5f2c42029d37782ce5c17a
=== precheck exit rc=0 at 2026-09-08T15:39:45Z ===
```

Still 21 enumerated rather than 22, which confirms the new gate rows ride in the existing
`Test bounded brownfield trace witnesses` step in `fast-gate-lint` rather than adding a `check`
gate precheck would have to classify by name.

PARITY_PLACEHOLDER

The base is one commit behind `origin/main` (`e9ebaa118`), which touches only Rust and
`init_memory_repro.py`, none of the four files here. Hosted CI grades the merge ref, and
`merge land`'s BEHIND refusal covers `AGENTS.md` and `docs/traps.md`, neither of which this
touches.

Kin-Release-Intent: patch
