### PR TITLE
Repair unreadable release intent and reconciliation failure alarms

### DIFF
--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -904,6 +904,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           CURRENT_MARKER: ${{ needs.reconcile.outputs.marker }}
+          RECONCILE_RESULT: ${{ needs.reconcile.result }}
           THRESHOLD: "4"
         run: |
           set -euo pipefail
@@ -917,7 +918,19 @@ jobs:
           # push, and counting those as observations would let a quiet stretch of
           # skips stand in for a rail nobody watched.
           current="$work/current.json"
-          if [ -n "${CURRENT_MARKER:-}" ] && jq -e . >/dev/null 2>&1 <<< "$CURRENT_MARKER"; then
+          if [ "$RECONCILE_RESULT" = failure ] || [ "$RECONCILE_RESULT" = cancelled ]; then
+            # Job timeout, runner loss, or marker-upload failure can happen
+            # after (or instead of) the in-job finalizer. The job result wins
+            # over an absent marker or an earlier all-clear.
+            jq -n --arg run_id "$GITHUB_RUN_ID" \
+              --arg run_url "${GITHUB_SERVER_URL}/${REPO}/actions/runs/${GITHUB_RUN_ID}" \
+              --arg result "$RECONCILE_RESULT" \
+              '{schema: "kin.release-hold.v1", state: "failed",
+                reason: "reconcile_failed", drift: null,
+                detail: ("Release reconciliation concluded " + $result),
+                run_id: $run_id, run_url: $run_url,
+                observed_at: (now | todateiso8601)}' > "$current"
+          elif [ -n "${CURRENT_MARKER:-}" ] && jq -e . >/dev/null 2>&1 <<< "$CURRENT_MARKER"; then
             printf '%s\n' "$CURRENT_MARKER" > "$current"
           else
             jq -n --arg run "$GITHUB_RUN_ID" '{unreadable: true, run_id: $run}' > "$current"
@@ -1004,7 +1017,7 @@ jobs:
               body="$work/body.md"
               jq -er .body "$decision" > "$body"
               gh issue create --repo "$REPO" --title "$title" --body-file "$body" >/dev/null
-              echo "::error::The release rail has held with releasable drift for $(jq -er .consecutive "$decision") consecutive cycles. Opened the tracking issue that names the blocking tag and the two ways out."
+              echo "::error::Release rail requires attention (${reason}). Opened the tracking issue with the observed failure or hold and its recovery path."
               exit 1
               ;;
             update)
@@ -1012,7 +1025,7 @@ jobs:
               jq -er .body "$decision" > "$body"
               number="$(jq -er .issue "$decision")"
               gh issue edit "$number" --repo "$REPO" --body-file "$body" >/dev/null
-              echo "::error::The release rail is still held with releasable drift after $(jq -er .consecutive "$decision") consecutive cycles; issue #${number} carries the current state."
+              echo "::error::Release rail still requires attention (${reason}); issue #${number} carries the current failure or hold."
               exit 1
               ;;
             close)

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -58,7 +58,7 @@ jobs:
       # reads exactly like one that never came, which is the reading that keeps
       # the alarm quiet. The artifact stays, because later cycles need this run
       # to be readable from outside it.
-      marker: ${{ steps.plan.outputs.marker }}
+      marker: ${{ steps.report.outputs.marker }}
     steps:
       - name: Mint repository-scoped release branch token
         id: app-token
@@ -359,8 +359,12 @@ jobs:
           intent_policy="$RUNNER_TEMP/resolve-release-intent.mjs"
           git show "refs/remotes/origin/main:scripts/resolve-release-intent.mjs" \
             > "$intent_policy"
+          attestations="$RUNNER_TEMP/release-intent-attestations.json"
+          git show "refs/remotes/origin/main:scripts/release-intent-attestations.json" \
+            > "$attestations"
           bump="$(
             node "$intent_policy" \
+              --attestations "$attestations" \
               --base-ref "$tag" \
               --head-ref refs/remotes/origin/main \
               | jq -er .intent
@@ -801,6 +805,35 @@ jobs:
             echo "- merge: armed only after protected checks"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Record this cycle's final outcome
+        id: report
+        if: always()
+        env:
+          RECONCILE_STATUS: ${{ job.status }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          marker="$RUNNER_TEMP/release-hold-marker.json"
+          if [ "$RECONCILE_STATUS" = failure ]; then
+            # A later failed step supersedes an earlier all-clear. This also
+            # covers failures before checkout or before drift can be measured.
+            jq -n \
+              --arg run_id "$GITHUB_RUN_ID" \
+              --arg run_url "${GITHUB_SERVER_URL}/${REPO}/actions/runs/${GITHUB_RUN_ID}" \
+              '{schema: "kin.release-hold.v1", state: "failed",
+                reason: "reconcile_failed", drift: null,
+                detail: "Release reconciliation exited nonzero; inspect the failed step in this run.",
+                run_id: $run_id, run_url: $run_url,
+                observed_at: (now | todateiso8601)}' > "$marker"
+          fi
+          if [ -s "$marker" ]; then
+            {
+              echo "marker<<KIN_RELEASE_HOLD_MARKER"
+              jq -c . "$marker"
+              echo "KIN_RELEASE_HOLD_MARKER"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
       # Uploaded on every path, including the ones that stood down and the ones
       # that failed. Later cycles read this to learn what this cycle saw, and a
       # cycle that uploaded nothing is read as an observation that could not be
@@ -829,9 +862,8 @@ jobs:
   hold-alarm:
     name: Report a held rail
     needs: reconcile
-    # Runs when the reconcile job ran, whatever it concluded. A failed train run
-    # is already loud, and its absent marker reads as unreadable here, which
-    # neither opens an alarm nor closes one.
+    # Runs when reconciliation ran, including a nonzero exit. The final marker
+    # makes that failure actionable even if no drift could be measured.
     #
     # It deliberately stands down when reconcile was SKIPPED, and that condition
     # is load-bearing rather than tidiness. The workflow_run trigger fires on

--- a/docs/release-bot.md
+++ b/docs/release-bot.md
@@ -66,7 +66,17 @@ train asserts the squash-only PR_TITLE + PR_BODY policy before trusting the
 resolution, and refuses a mention of the key that git does not parse as a
 trailer, a duplicate trailer, or an unsupported value.
 
-Nothing editable resolves the bump. Labels are applied to describe the resolved
+If a historical commit mentions intent but Git cannot parse any intent trailer,
+`scripts/release-intent-attestations.json` can record its full 40-character SHA,
+intent and reason through a reviewed PR. The resolver reads the committed file
+from the same main snapshot as its policy and includes the reason in its evidence.
+An entry cannot override readable intent, duplicate or unsupported trailers, or a
+commit with no mention. Missing attestation for malformed evidence still fails.
+A nonzero reconciliation outcome writes a failed marker, including failures before
+drift resolution and failures after an all-clear. That marker opens or updates the
+rail alarm immediately; ordinary holds retain their four-cycle threshold.
+
+Nothing editable outside reviewed main resolves the bump. Labels are applied to describe the resolved
 intent and are never read back, and the reconcile dispatch carries no bump
 override. A merged pull request's labels can be changed afterwards, so reading
 them would let a later scheduled run resolve a lower bump than an earlier one

--- a/docs/release-bot.md
+++ b/docs/release-bot.md
@@ -66,12 +66,14 @@ train asserts the squash-only PR_TITLE + PR_BODY policy before trusting the
 resolution, and refuses a mention of the key that git does not parse as a
 trailer, a duplicate trailer, or an unsupported value.
 
-If a historical commit mentions intent but Git cannot parse any intent trailer,
+If a historical commit records one valid intent but Git cannot parse it as a trailer,
 `scripts/release-intent-attestations.json` can record its full 40-character SHA,
 intent and reason through a reviewed PR. The resolver reads the committed file
 from the same main snapshot as its policy and includes the reason in its evidence.
 An entry cannot override readable intent, duplicate or unsupported trailers, or a
-commit with no mention. Missing attestation for malformed evidence still fails.
+commit with no mention. The attested intent must equal the single recorded value;
+ambiguous or unsupported raw values still fail. Missing attestation for malformed
+evidence still fails.
 A nonzero reconciliation outcome writes a failed marker, including failures before
 drift resolution and failures after an all-clear. That marker opens or updates the
 rail alarm immediately; ordinary holds retain their four-cycle threshold.
@@ -82,7 +84,7 @@ override. A merged pull request's labels can be changed afterwards, so reading
 them would let a later scheduled run resolve a lower bump than an earlier one
 and rewrite a prepared minor or major release back to a patch. A commit message
 on protected main cannot change, and the first-parent range only grows, so the
-resolution is stable and monotone.
+resolution is stable and monotone for a fixed reviewed attestation set.
 
 The release App has repository Contents permission but no `main` bypass. It can
 only update `automation/release-next`; the repository `GITHUB_TOKEN` opens the

--- a/scripts/release-hold-alarm.mjs
+++ b/scripts/release-hold-alarm.mjs
@@ -216,7 +216,7 @@ export function decide({ markers, issue, threshold = DEFAULT_THRESHOLD }) {
       reason: "reconcile_failed",
       ...(open ? { issue: open.number } : {}),
       title: ALARM_TITLE,
-      body: `Release reconciliation exited nonzero. No release progress is established by this cycle.\n\n` +
+      body: `Release reconciliation did not complete successfully. No release progress is established by this cycle.\n\n` +
         `Inspect the failed step in ${newest.run_url || `run ${newest.run_id ?? "unknown"}`}.\n\n` +
         `Repair that failure through the reviewed release workflow. This alarm does not authorize a new candidate, retry or tag abandonment.`,
     };

--- a/scripts/release-hold-alarm.mjs
+++ b/scripts/release-hold-alarm.mjs
@@ -37,6 +37,7 @@ function classify(marker) {
   if (!marker || typeof marker !== "object") return "unreadable";
   if (marker.unreadable === true) return "unreadable";
   if (marker.schema !== MARKER_SCHEMA) return "unreadable";
+  if (marker.state === "failed" && marker.reason === "reconcile_failed") return "failed";
   if (marker.state === "clear") return "clear";
   if (marker.state !== "held") return "unreadable";
   if (!Number.isInteger(marker.drift) || marker.drift < 0) return "unreadable";
@@ -206,6 +207,18 @@ export function decide({ markers, issue, threshold = DEFAULT_THRESHOLD }) {
       detail:
         "The newest release-train hold marker could not be read, so the rail's " +
         "state is unknown. An unknown never opens an alarm and never closes one.",
+    };
+  }
+
+  if (state === "failed") {
+    return {
+      action: open ? "update" : "open",
+      reason: "reconcile_failed",
+      ...(open ? { issue: open.number } : {}),
+      title: ALARM_TITLE,
+      body: `Release reconciliation exited nonzero. No release progress is established by this cycle.\n\n` +
+        `Inspect the failed step in ${newest.run_url || `run ${newest.run_id ?? "unknown"}`}.\n\n` +
+        `Repair that failure through the reviewed release workflow. This alarm does not authorize a new candidate, retry or tag abandonment.`,
     };
   }
 

--- a/scripts/release-hold-alarm.test.mjs
+++ b/scripts/release-hold-alarm.test.mjs
@@ -306,3 +306,55 @@ test('a successful final outcome preserves the observed marker', () => {
     assert.deepEqual(JSON.parse(fs.readFileSync(path.join(root, 'release-hold-marker.json'), 'utf8')), marker);
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
+
+test('the workflow opens and updates crash alarms with a loud accurate diagnostic', () => {
+  const workflow = fs.readFileSync(new URL('../.github/workflows/release-train.yml', import.meta.url), 'utf8');
+  const arm = workflow.split('          case "$action" in\n')[1]?.split('          esac')[0];
+  assert.ok(arm, 'alarm dispatch case must exist');
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-release-alarm-'));
+  try {
+    const marker = { schema: MARKER_SCHEMA, state: 'failed', reason: 'reconcile_failed', run_id: '123', drift: null };
+    for (const issue of [null, OPEN_ISSUE]) {
+      const decision = decide({ markers: [marker], issue });
+      const filename = path.join(root, 'decision.json');
+      fs.writeFileSync(filename, JSON.stringify(decision));
+      const script = 'set -euo pipefail\ngh() { printf "%s\\n" "$*" >> "$work/gh-calls"; }\n' +
+        'case "$action" in\n' + arm + '\nesac\n';
+      const result = spawnSync('bash', ['-c', script], { encoding: 'utf8', env: {
+        ...process.env, work: root, decision: filename, action: decision.action, reason: decision.reason,
+        REPO: 'firelock-ai/kin', title: ALARM_TITLE,
+      } });
+      assert.equal(result.status, 1, result.stdout + result.stderr);
+      assert.equal(result.stderr, '');
+      assert.match(result.stdout, /::error::Release rail.*reconcile_failed/);
+      assert.doesNotMatch(result.stdout, /consecutive cycles|blocking tag|two ways out/);
+      assert.match(fs.readFileSync(path.join(root, 'gh-calls'), 'utf8'), issue ? /issue edit 4242/ : /issue create/);
+    }
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('the alarm job result overrides missing or stale markers after finalizer or upload failure', () => {
+  const workflow = fs.readFileSync(new URL('../.github/workflows/release-train.yml', import.meta.url), 'utf8');
+  const section = workflow.split('      - name: Gather this cycle')[1]?.split('          prior_ids=')[0];
+  assert.ok(section, 'alarm history step must exist');
+  assert.match(section, /RECONCILE_RESULT: \$\{\{ needs.reconcile.result \}\}/);
+  const script = section.split('        run: |\n')[1].split('\n').map(line => line.replace(/^          /, '')).join('\n');
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-release-result-'));
+  try {
+    for (const result of ['failure', 'cancelled', 'success']) {
+      for (const previous of ['', JSON.stringify(clear())]) {
+        execFileSync('bash', ['-c', script], { env: {
+          ...process.env, RUNNER_TEMP: root, RECONCILE_RESULT: result, CURRENT_MARKER: previous,
+          GITHUB_RUN_ID: '123', GITHUB_SERVER_URL: 'https://github.com', REPO: 'firelock-ai/kin',
+        } });
+        const marker = JSON.parse(fs.readFileSync(path.join(root, 'release-hold-history/current.json'), 'utf8'));
+        if (result === 'success') {
+          assert.equal(marker.state ?? 'unreadable', previous ? 'clear' : 'unreadable');
+        } else {
+          assert.equal(marker.state, 'failed');
+          assert.equal(decide({ markers: [marker], issue: OPEN_ISSUE }).action, 'update');
+        }
+      }
+    }
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});

--- a/scripts/release-hold-alarm.test.mjs
+++ b/scripts/release-hold-alarm.test.mjs
@@ -6,7 +6,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
 import {
@@ -250,4 +250,59 @@ test('the command line refuses a threshold it cannot honour', () => {
   assert.throws(() =>
     execFileSync('node', [SCRIPT, '--markers', markersPath, '--threshold', '0'], { stdio: 'pipe' }),
   );
+});
+
+function finalOutcomeScript() {
+  const workflow = fs.readFileSync(new URL('../.github/workflows/release-train.yml', import.meta.url), 'utf8');
+  const section = workflow.split("      - name: Record this cycle's final outcome\n")[1]?.split("      # Uploaded on every path")[0];
+  assert.ok(section, 'the final outcome step must exist');
+  assert.match(section, /id: report/);
+  assert.match(section, /if: always\(\)/);
+  assert.match(section, /RECONCILE_STATUS: \$\{\{ job.status \}\}/);
+  assert.match(workflow, /marker: \$\{\{ steps.report.outputs.marker \}\}/);
+  assert.match(workflow, /CURRENT_MARKER: \$\{\{ needs.reconcile.outputs.marker \}\}/);
+  return section.split('        run: |\n')[1].split('\n').map(line => line.replace(/^          /, '')).join('\n');
+}
+
+for (const previous of [null, clear(), held()]) {
+  test(`a nonzero step produces an actionable final marker after ${previous?.state ?? 'no marker'}`, () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-release-outcome-'));
+    try {
+      const markerPath = path.join(root, 'release-hold-marker.json');
+      if (previous) fs.writeFileSync(markerPath, JSON.stringify(previous));
+      const failed = spawnSync('bash', ['-c', 'set -e; exit 4']);
+      assert.equal(failed.status, 4);
+      const output = path.join(root, 'output');
+      const outcome = spawnSync('bash', ['-c', finalOutcomeScript()], { encoding: 'utf8', env: {
+        ...process.env, RUNNER_TEMP: root, GITHUB_OUTPUT: output,
+        RECONCILE_STATUS: failed.status === 0 ? 'success' : 'failure',
+        REPO: 'firelock-ai/kin', GITHUB_RUN_ID: '123', GITHUB_SERVER_URL: 'https://github.com',
+      } });
+      assert.equal(outcome.status, 0, outcome.stderr);
+      const marker = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
+      assert.equal(marker.state, 'failed');
+      assert.equal(marker.drift, null);
+      assert.match(fs.readFileSync(output, 'utf8'), /"state":"failed"/);
+      const decision = decide({ markers: [marker], issue: null });
+      assert.equal(decision.action, 'open');
+      assert.equal(decision.reason, 'reconcile_failed');
+      assert.match(decision.body, /actions\/runs\/123/);
+      assert.doesNotMatch(decision.body, /runs concluded success/);
+      const existing = decide({ markers: [marker], issue: OPEN_ISSUE });
+      assert.equal(existing.action, 'update');
+      assert.equal(existing.issue, OPEN_ISSUE.number);
+    } finally { fs.rmSync(root, { recursive: true, force: true }); }
+  });
+}
+
+test('a successful final outcome preserves the observed marker', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-release-outcome-'));
+  try {
+    const marker = clear();
+    fs.writeFileSync(path.join(root, 'release-hold-marker.json'), JSON.stringify(marker));
+    execFileSync('bash', ['-c', finalOutcomeScript()], { env: {
+      ...process.env, RUNNER_TEMP: root, GITHUB_OUTPUT: path.join(root, 'output'), RECONCILE_STATUS: 'success',
+    } });
+    assert.deepEqual(JSON.parse(fs.readFileSync(path.join(root, 'release-hold-marker.json'), 'utf8')), marker);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });

--- a/scripts/release-intent-attestations.json
+++ b/scripts/release-intent-attestations.json
@@ -1,0 +1,25 @@
+{
+  "schema": "kin.release-intent-attestations.v1",
+  "attestations": [
+    {
+      "sha": "bffd6adda2eb46a37d0481a8b1aba8ef8759ce54",
+      "intent": "patch",
+      "reason": "FIR-3412: The immutable squash commit records Kin-Release-Intent: patch in its Landing section before a divider. Git parses only Signed-off-by as the footer. Attest that explicit patch intent without changing history or inferring intent from prose."
+    },
+    {
+      "sha": "72414aa80531e7adee1ab360eacb28d56a621c6a",
+      "intent": "patch",
+      "reason": "FIR-3412: This immutable squash commit explicitly records Kin-Release-Intent: patch before the footer divider. Git parses only Signed-off-by. Attest the recorded patch intent so resolution can traverse the complete release range without guessing or editing history."
+    },
+    {
+      "sha": "9e45cc6c89b12c72e519c86517ac38a8a79a7cea",
+      "intent": "patch",
+      "reason": "FIR-3412: This immutable squash commit explicitly records Kin-Release-Intent: patch before the footer divider. Git parses only Signed-off-by. Attest the recorded patch intent so resolution can traverse the complete release range without guessing or editing history."
+    },
+    {
+      "sha": "c67efaa2c737ab0b7ac15d0057c8a3ec5a8041cc",
+      "intent": "patch",
+      "reason": "FIR-3412: This immutable squash commit explicitly records Kin-Release-Intent: patch before the footer divider. Git parses only Signed-off-by. Attest the recorded patch intent so resolution can traverse the complete release range without guessing or editing history."
+    }
+  ]
+}

--- a/scripts/release-intent.test.mjs
+++ b/scripts/release-intent.test.mjs
@@ -6,6 +6,8 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+// Keep immutable range resolution in the release policy suite CI already runs.
+import './resolve-release-intent.test.mjs';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 

--- a/scripts/resolve-release-intent.mjs
+++ b/scripts/resolve-release-intent.mjs
@@ -53,7 +53,25 @@ function git(args, options = {}) {
   });
 }
 
-function commitIntent(root, commit) {
+function validateAttestations(document) {
+  if (document?.schema !== 'kin.release-intent-attestations.v1' ||
+      !Array.isArray(document.attestations)) {
+    throw new Error('invalid release intent attestation document');
+  }
+  const byCommit = new Map();
+  for (const entry of document.attestations) {
+    if (!entry || !/^[0-9a-f]{40}$/.test(entry.sha ?? '') ||
+        !RANK.has(entry.intent) || typeof entry.reason !== 'string' ||
+        !entry.reason.trim()) {
+      throw new Error('attestation requires a full 40-character SHA, valid intent and reason');
+    }
+    if (byCommit.has(entry.sha)) throw new Error(`duplicate attestation for ${entry.sha}`);
+    byCommit.set(entry.sha, entry);
+  }
+  return byCommit;
+}
+
+function commitIntent(root, commit, attestation) {
   const message = git(['show', '-s', '--format=%B', commit], { root });
   const mentions = message.match(RAW_MENTION) ?? [];
   const parsed = execFileSync('git', ['interpret-trailers', '--parse'], {
@@ -69,7 +87,11 @@ function commitIntent(root, commit) {
     return match ? [match[1].toLowerCase()] : [];
   });
 
+  if (attestation && (intents.length !== 0 || mentions.length === 0)) {
+    throw new Error(`${commit} attestation requires unreadable trailer evidence; readable or absent evidence cannot be overridden`);
+  }
   if (mentions.length !== intents.length) {
+    if (attestation) return attestation.intent;
     throw new Error(`${commit} has malformed or non-footer ${TRAILER_KEY} evidence`);
   }
   if (intents.length > 1) {
@@ -84,7 +106,9 @@ function commitIntent(root, commit) {
   return intent;
 }
 
-export function resolveReleaseIntent({ root = process.cwd(), baseRef, headRef = 'HEAD' }) {
+export function resolveReleaseIntent({ root = process.cwd(), baseRef, headRef = 'HEAD',
+  attestations = { schema: 'kin.release-intent-attestations.v1', attestations: [] } }) {
+  const byCommit = validateAttestations(attestations);
   const ancestor = spawnSync(
     'git',
     ['--no-replace-objects', 'merge-base', '--is-ancestor', baseRef, headRef],
@@ -105,9 +129,11 @@ export function resolveReleaseIntent({ root = process.cwd(), baseRef, headRef = 
   const evidence = [];
   let intent = 'patch';
   for (const commit of commits) {
-    const found = commitIntent(root, commit);
+    const attestation = byCommit.get(commit);
+    const found = commitIntent(root, commit, attestation);
     if (found === null) continue;
-    evidence.push({ commit, intent: found });
+    evidence.push({ commit, intent: found,
+      ...(attestation ? { source: 'attestation', reason: attestation.reason } : {}) });
     if (RANK.get(found) > RANK.get(intent)) intent = found;
   }
   return { baseRef, headRef, intent, evidence };
@@ -127,7 +153,10 @@ function main() {
   const baseRef = args.get('base-ref');
   const headRef = args.get('head-ref') ?? 'HEAD';
   if (!baseRef) throw new Error('--base-ref is required');
-  const result = resolveReleaseIntent({ baseRef, headRef });
+  const attestationPath = args.get('attestations');
+  const attestations = attestationPath
+    ? JSON.parse(fs.readFileSync(attestationPath, 'utf8')) : undefined;
+  const result = resolveReleaseIntent({ baseRef, headRef, attestations });
   emitOutputs(result);
   process.stdout.write(`${JSON.stringify(result)}\n`);
 }

--- a/scripts/resolve-release-intent.mjs
+++ b/scripts/resolve-release-intent.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-// resolve-release-intent.mjs — resolve the SemVer intent for the next Kin
+// resolve-release-intent.mjs: resolve the SemVer intent for the next Kin
 // release from immutable evidence only.
 //
 // The intent is read from `Kin-Release-Intent:` git trailers on the
@@ -9,7 +9,7 @@
 // editable after a merge, so a later scheduled run could resolve a lower bump
 // than an earlier one and quietly rewrite a prepared minor or major release
 // back to a patch. A commit message cannot be edited once it is on protected
-// main, so the same range always resolves to the same intent.
+// main. Misplaced valid intent needs an explicit reviewed SHA attestation.
 //
 // The trailer reaches the commit through the pull-request body, which the
 // repository's squash-only PR_TITLE + PR_BODY merge policy copies verbatim into
@@ -17,7 +17,7 @@
 // this resolution.
 //
 // Absent evidence means `patch`. The highest intent in the range wins, and the
-// range only grows, so the resolution is monotone by construction.
+// range only grows. With a fixed attestation set, resolution is monotone.
 
 import fs from 'node:fs';
 import { execFileSync, spawnSync } from 'node:child_process';
@@ -91,7 +91,14 @@ function commitIntent(root, commit, attestation) {
     throw new Error(`${commit} attestation requires unreadable trailer evidence; readable or absent evidence cannot be overridden`);
   }
   if (mentions.length !== intents.length) {
-    if (attestation) return attestation.intent;
+    if (attestation) {
+      const recorded = mentions.length === 1 ? PARSED_TRAILER.exec(mentions[0].trim()) : null;
+      if (!recorded || !RANK.has(recorded[1].toLowerCase()) ||
+          recorded[1].toLowerCase() !== attestation.intent) {
+        throw new Error(`${commit} attestation requires one explicit valid intent matching the recorded value`);
+      }
+      return attestation.intent;
+    }
     throw new Error(`${commit} has malformed or non-footer ${TRAILER_KEY} evidence`);
   }
   if (intents.length > 1) {

--- a/scripts/resolve-release-intent.test.mjs
+++ b/scripts/resolve-release-intent.test.mjs
@@ -110,3 +110,69 @@ test('only first-parent history is evidence', () => {
   git(root, ['merge', '--quiet', '--no-ff', '-m', 'merge side', 'side']);
   assert.equal(resolveReleaseIntent({ root, baseRef: 'v1.2.3' }).intent, 'patch');
 });
+
+const malformed = 'change\n\nKin-Release-Intent: patch\n\n---------\n\nSigned-off-by: Test <test@example.invalid>\n';
+function attested(root, changes = {}) {
+  return { schema: 'kin.release-intent-attestations.v1', attestations: [{
+    sha: git(root, ['rev-parse', 'HEAD']).trim(), intent: 'patch',
+    reason: 'The recorded patch intent precedes the footer divider.', ...changes,
+  }] };
+}
+
+test('an explicit full-SHA attestation resolves the divider case and records its reason', () => {
+  const root = repository([malformed]);
+  const attestations = attested(root);
+  const result = resolveReleaseIntent({ root, baseRef: 'v1.2.3', attestations });
+  assert.equal(result.intent, 'patch');
+  assert.deepEqual(result.evidence, [{ commit: attestations.attestations[0].sha,
+    intent: 'patch', source: 'attestation', reason: attestations.attestations[0].reason }]);
+  assert.throws(() => resolveReleaseIntent({ root, baseRef: 'v1.2.3' }), /malformed or non-footer/);
+});
+
+test('attestations cannot replace readable, duplicate, invalid or absent intent', () => {
+  for (const message of [
+    'change\n\nKin-Release-Intent: major\n',
+    'change\n\nKin-Release-Intent: patch\nKin-Release-Intent: minor\n',
+    'change\n\nKin-Release-Intent: enormous\n',
+    'change without any intent mention',
+    'Kin-Release-Intent: patch in prose\n\nbody\n\nKin-Release-Intent: major\n',
+  ]) {
+    const root = repository([message]);
+    assert.throws(() => resolveReleaseIntent({ root, baseRef: 'v1.2.3',
+      attestations: attested(root) }), /attestation requires unreadable trailer evidence/);
+  }
+});
+
+test('attestation schema, full SHA, intent, reason and uniqueness are required', () => {
+  const root = repository([malformed]);
+  for (const change of [{ sha: 'bffd6adda' }, { sha: 'x'.repeat(40) },
+    { intent: 'enormous' }, { reason: '' }, { reason: '   ' }]) {
+    assert.throws(() => resolveReleaseIntent({ root, baseRef: 'v1.2.3',
+      attestations: attested(root, change) }), /attestation requires/);
+  }
+  const document = attested(root);
+  document.attestations.push(document.attestations[0]);
+  assert.throws(() => resolveReleaseIntent({ root, baseRef: 'v1.2.3', attestations: document }), /duplicate attestation/);
+  assert.throws(() => resolveReleaseIntent({ root, baseRef: 'v1.2.3', attestations: {} }), /invalid release intent attestation document/);
+});
+
+test('an attestation for another commit does not repair unreadable evidence', () => {
+  const root = repository([malformed]);
+  assert.throws(() => resolveReleaseIntent({ root, baseRef: 'v1.2.3',
+    attestations: attested(root, { sha: 'a'.repeat(40) }) }), /malformed or non-footer/);
+});
+
+test('a repaired patch does not lower a readable major in the same range', () => {
+  const root = repository([malformed]);
+  const attestations = attested(root);
+  git(root, ['commit', '--allow-empty', '--quiet', '-F', '-'], 'change\n\nKin-Release-Intent: major\n');
+  assert.equal(resolveReleaseIntent({ root, baseRef: 'v1.2.3', attestations }).intent, 'major');
+});
+
+test('the committed historical attestation binds only the recorded full SHA', () => {
+  const document = JSON.parse(fs.readFileSync(new URL('./release-intent-attestations.json', import.meta.url), 'utf8'));
+  assert.equal(document.schema, 'kin.release-intent-attestations.v1');
+  const entry = document.attestations.find(({ sha }) => sha === 'bffd6adda2eb46a37d0481a8b1aba8ef8759ce54');
+  assert.equal(entry?.intent, 'patch');
+  assert.match(entry.reason, /FIR-3412/);
+});

--- a/scripts/resolve-release-intent.test.mjs
+++ b/scripts/resolve-release-intent.test.mjs
@@ -172,7 +172,28 @@ test('a repaired patch does not lower a readable major in the same range', () =>
 test('the committed historical attestation binds only the recorded full SHA', () => {
   const document = JSON.parse(fs.readFileSync(new URL('./release-intent-attestations.json', import.meta.url), 'utf8'));
   assert.equal(document.schema, 'kin.release-intent-attestations.v1');
-  const entry = document.attestations.find(({ sha }) => sha === 'bffd6adda2eb46a37d0481a8b1aba8ef8759ce54');
-  assert.equal(entry?.intent, 'patch');
-  assert.match(entry.reason, /FIR-3412/);
+  for (const expected of [
+    'bffd6adda2eb46a37d0481a8b1aba8ef8759ce54',
+    '72414aa80531e7adee1ab360eacb28d56a621c6a',
+    '9e45cc6c89b12c72e519c86517ac38a8a79a7cea',
+    'c67efaa2c737ab0b7ac15d0057c8a3ec5a8041cc',
+  ]) {
+    const entry = document.attestations.find(({ sha }) => sha === expected);
+    assert.equal(entry?.intent, 'patch', expected);
+    assert.match(entry.reason, /FIR-3412/);
+  }
+});
+
+test('attestation cannot invent, change or disambiguate malformed raw intent', () => {
+  for (const message of [
+    malformed.replace('Intent: patch', 'Intent: enormous'),
+    malformed.replace('Intent: patch', 'Intent: major'),
+    malformed.replace('Intent: patch', 'Intent: patch\nKin-Release-Intent: minor'),
+    malformed.replace('Intent: patch', 'Intent: patch\nKin-Release-Intent: patch'),
+    malformed.replace('Intent: patch', 'Intent patch'),
+  ]) {
+    const root = repository([message]);
+    assert.throws(() => resolveReleaseIntent({ root, baseRef: 'v1.2.3', attestations: attested(root) }),
+      /attestation requires one explicit valid intent/);
+  }
 });

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -11970,13 +11970,11 @@ def main() -> None:
         "must also fail its run",
         lambda: assert_release_hold_marker_contract(
             release_train.replace(
-                '              echo "::error::The release rail has held with releasable drift '
-                'for $(jq -er .consecutive "$decision") consecutive cycles. Opened the tracking '
-                'issue that names the blocking tag and the two ways out."\n'
+                '              echo "::error::Release rail requires attention (${reason}). '
+                'Opened the tracking issue with the observed failure or hold and its recovery path."\n'
                 "              exit 1\n",
-                '              echo "::error::The release rail has held with releasable drift '
-                'for $(jq -er .consecutive "$decision") consecutive cycles. Opened the tracking '
-                'issue that names the blocking tag and the two ways out."\n',
+                '              echo "::error::Release rail requires attention (${reason}). '
+                'Opened the tracking issue with the observed failure or hold and its recovery path."\n',
                 1,
             ),
             release_sentinel,


### PR DESCRIPTION
The release train fails on immutable squash messages whose explicit patch intent appears before the footer divider. It repeatedly reads the same commits and cannot open the next release PR. A reconciliation failure can also leave no marker, or an earlier all-clear, so the rail alarm misses the failure.

Resolve FIR-3412 with reviewed full-SHA attestations for the four affected commits. Each record carries a reason, and the resolver requires exactly one valid recorded intent equal to its attestation. Readable or absent intent cannot be overridden; duplicates, unsupported values, mismatches and unattested malformed evidence fail. Ordinary no-mention commits retain the existing patch default. The attestation document follows the train's committed JSON policy inputs and is read from the same main snapshot as the resolver.

Record failed reconciliation before marker publication, and let the downstream alarm use the completed job result to cover timeout, cancellation, finalizer and upload failures. Failure opens or updates the existing alarm immediately. Ordinary holds retain their threshold.

Verification:

```text
node --test scripts/release-intent.test.mjs scripts/release-hold-alarm.test.mjs
Node 22.22.0: 55 tests, 55 passed, 0 failed

actionlint .github/workflows/release-train.yml
exit 0

python3 scripts/test-release-workflow-authority.py
release workflow authority is reviewed-PR to App-tag automatic, protected,
pinned, GCP-free on release writes, cross-platform byte-canonical,
with dev-only Artifact Registry OIDC and npm automatic through
short-lived OIDC with post-public proof
exit 0

bin/kin-precheck kin --repo-dir kin=<isolated checkout>
21 gates ran, 21 passed, 0 failed
```

The final precheck tally covers b48d772485db59663c7cf4d8e41ac90e8b9b0abb. The policy tests, workflow authority suite and workflow lint also passed after review. No crates or acceptance definitions changed.

Isolated falsification removed or weakened 12 protections: readable override refusal, attestation consumption, malformed refusal, full-SHA validation, reason validation, duplicate entry refusal, failure marker creation, final-output binding, failure alarm handling, existing-issue update, raw intent agreement, and downstream job-result override. All 12 caused assertion failures; restored suites passed 43/43.

The actual first-parent range from v0.7.5 to c67efaa2c737ab0b7ac15d0057c8a3ec5a8041cc resolves patch. Deleting each attestation independently produced:

```text
bffd6adda2eb46a37d0481a8b1aba8ef8759ce54: exit 1, malformed or non-footer evidence
72414aa80531e7adee1ab360eacb28d56a621c6a: exit 1, malformed or non-footer evidence
9e45cc6c89b12c72e519c86517ac38a8a79a7cea: exit 1, malformed or non-footer evidence
c67efaa2c737ab0b7ac15d0057c8a3ec5a8041cc: exit 1, malformed or non-footer evidence
```

The alarm tests execute the workflow's marker writer, downstream result handling and issue-action shell branches. Runtime parity on the clean final commit completed PASS-WITH-ALLOWANCES, exit0, DEV-LOCAL/non-citable. Magic27passed. Existing allowances were brownfield check4 (FIR-2464/FIR-2593 truncation), firstrun check3 (FIR-2501/FIR-2554 projection unreadable), and firstrun check9 (FIR-2580 daemon stop). This PR does not establish a new release, archive identity, Latest promotion or production adoption.
