### PR TITLE
Preserve verified declarations through incomplete C parses

### DIFF
--- a/crates/kin-cli/src/commands/absence_qualifier.rs
+++ b/crates/kin-cli/src/commands/absence_qualifier.rs
@@ -285,10 +285,9 @@ fn only_unconfigured_federation(negative: &serde_json::Value) -> bool {
         .filter(|clause| !clause.is_empty())
         .collect();
     !clauses.is_empty()
-        && clauses.iter().all(|clause| {
-            clause.starts_with("cross_repo_not_configured")
-                || clause.starts_with("cross_repo_authority_missing")
-        })
+        && clauses
+            .iter()
+            .all(|clause| clause.starts_with("cross_repo_not_configured"))
 }
 
 /// The verdict's own leading reason, in the words it published.
@@ -429,5 +428,57 @@ fn edge_class_noun(class: &str) -> &'static str {
         "calls" => "call",
         "imports" => "import",
         _ => "reference",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn missing_federation_authority_is_not_an_unconfigured_scope() {
+        for reason in [
+            "cross_repo_authority_missing: no authority observation",
+            "cross_repo_not_configured; cross_repo_authority_missing",
+            "cross_repo_unavailable: lookup failed",
+        ] {
+            assert!(!only_unconfigured_federation(
+                &json!({"trust_reason": reason})
+            ));
+        }
+        assert!(only_unconfigured_federation(&json!({
+            "trust_reason": "cross_repo_not_configured: local repository"
+        })));
+    }
+
+    #[test]
+    fn empty_references_distinguish_missing_authority_from_local_scope() {
+        let envelope = kin_mcp::Envelope::daemon().with_health(&json!({
+            "initialized": true, "graph_loaded": true, "graph_generation": 1
+        }));
+        let mut payload = json!({
+            "focal_entity": {"id": "00000000-0000-0000-0000-000000000001",
+                             "kind": "Function", "name": "unused"},
+            "focal_resolution": {"addressed_by": "name", "same_name_candidates": 1},
+            "references": [],
+            "edge_coverage": {
+                "scope": "language", "language": "Rust",
+                "requested_classes": ["calls", "imports", "references"],
+                "classes": {"calls": "present", "imports": "present", "references": "present"},
+                "cross_file_classes": ["calls", "imports", "references"],
+                "reference_enrichment": "available", "budget_exhausted": false,
+                "entities_examined": 2
+            }
+        });
+        let lines = qualify("find_references", &payload, &envelope, "");
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("find_references did not report cross-repo authority")),
+            "{lines:?}"
+        );
+        payload["cross_repo"] = json!({"status": "not_configured"});
+        assert!(qualify("find_references", &payload, &envelope, "").is_empty());
     }
 }

--- a/crates/kin-cli/src/commands/context.rs
+++ b/crates/kin-cli/src/commands/context.rs
@@ -209,10 +209,9 @@ pub struct ContextResponse {
     /// packs with (`kin_context::estimate_tokens`, a structure-aware count with
     /// a 15 percent margin).
     ///
-    /// Reported on every pack, including the single-focal one, which can exceed
-    /// its budget by design: every section there keeps a row whatever the
-    /// budget says. A caller subtracting a pack from its own context window
-    /// needs the number the bytes cost, not the number it asked for.
+    /// Source-aware responses report the greater cost of complete JSON and
+    /// rendered text, including their accounting fields. Header-only compatibility
+    /// callers retain their rendered-text measurement.
     #[serde(default)]
     pub measured_tokens: usize,
     /// Focal tokens that resolved to nothing, in the caller's own spelling.
@@ -325,12 +324,86 @@ async fn run_daemon_context(
         .context("daemon context failed")
 }
 
+struct GraphContextProvider {
+    authority: std::sync::Arc<super::repository_authority::ActiveRepositoryAuthority>,
+    workspace: kin_model::WorkspaceState,
+}
+
+impl kin_context::ContextProjectionProvider for GraphContextProvider {
+    fn full_body(
+        &mut self,
+        entity: &Entity,
+        limits: kin_context::ProjectionLimits,
+    ) -> kin_context::Result<kin_context::BodyCandidate> {
+        if entity.file_origin.is_none() || entity.span.is_none() {
+            return Ok(kin_context::BodyCandidate::Unavailable {
+                reason: "graph source coordinates are unavailable".into(),
+            });
+        }
+        let limit = limits.max_candidate_bytes.min(limits.max_retained_bytes);
+        let record = super::graph::graph_source_record_bounded_from(
+            &self.authority,
+            &self.workspace,
+            entity,
+            limit,
+        )
+        .map_err(|error| kin_context::ContextError::Other(error.to_string()))?;
+        Ok(match record {
+            Some(record) => kin_context::BodyCandidate::Exact { body: record.body },
+            None => kin_context::BodyCandidate::OverLimit {
+                body_bytes: entity
+                    .span
+                    .as_ref()
+                    .map_or(0, |span| span.end_byte.saturating_sub(span.start_byte)),
+            },
+        })
+    }
+}
+
+pub fn build_context_response_with_authority(
+    graph: &kin_db::InMemoryGraph,
+    request: &ContextRequest,
+    repository_authority: &super::repository_authority::RequestRepositoryAuthority,
+) -> Result<ContextResponse> {
+    let authority = repository_authority.open()?;
+    let workspace = authority.workspace()?;
+    let mut provider = GraphContextProvider {
+        authority,
+        workspace,
+    };
+    build_context_response_inner(graph, request, Some(&mut provider))
+}
+
+fn measure_response(response: &mut ContextResponse) -> kin_context::Result<usize> {
+    for _ in 0..16 {
+        let text = kin_context::estimate_tokens(&response.lines.join("\n"));
+        let json = serde_json::to_string_pretty(response)
+            .map_err(|error| kin_context::ContextError::Other(error.to_string()))?;
+        let measured = text.max(kin_context::estimate_tokens(&json));
+        if measured == response.measured_tokens {
+            return Ok(measured);
+        }
+        response.measured_tokens = measured;
+    }
+    Err(kin_context::ContextError::Other(
+        "context output accounting did not converge".into(),
+    ))
+}
+
 pub fn build_context_response(
     graph: &kin_db::InMemoryGraph,
     request: &ContextRequest,
 ) -> Result<ContextResponse> {
+    build_context_response_inner(graph, request, None)
+}
+
+fn build_context_response_inner(
+    graph: &kin_db::InMemoryGraph,
+    request: &ContextRequest,
+    provider: Option<&mut dyn kin_context::ContextProjectionProvider>,
+) -> Result<ContextResponse> {
     if request.is_multi_focal() {
-        return build_multi_focal_response(graph, request);
+        return build_multi_focal_response(graph, request, provider);
     }
     let token_budget = parse_budget(&request.budget)?;
 
@@ -364,8 +437,51 @@ pub fn build_context_response(
         assistant_hint,
     };
 
+    if let Some(provider) = provider {
+        let (pack, selection, projections) = kin_context::build_context_pack_with_provider(
+            graph,
+            &target.id,
+            &opts,
+            provider,
+            kin_context::ProjectionLimits::default(),
+            false,
+            |pack, selection, projections| {
+                let mut response = render_single_response(
+                    graph,
+                    &target,
+                    token_budget,
+                    pack.clone(),
+                    selection,
+                    Some(projections),
+                )
+                .map_err(|error| kin_context::ContextError::Other(error.to_string()))?;
+                measure_response(&mut response)
+            },
+        )?;
+        let mut response = render_single_response(
+            graph,
+            &target,
+            token_budget,
+            pack,
+            &selection,
+            Some(&projections),
+        )?;
+        measure_response(&mut response)?;
+        return Ok(response);
+    }
     let (pack, selection) =
         kin_context::build_context_pack_with_provenance(graph, &target.id, &opts)?;
+    render_single_response(graph, &target, token_budget, pack, &selection, None)
+}
+
+fn render_single_response(
+    graph: &kin_db::InMemoryGraph,
+    target: &Entity,
+    token_budget: TokenBudget,
+    pack: kin_model::ContextPack,
+    selection: &kin_context::DependencySelection,
+    projections: Option<&kin_context::ProjectionReport>,
+) -> Result<ContextResponse> {
     let dependents_returned = count_dependents(&pack, &selection);
     let dependencies_returned = pack.dependency_signatures.len() - dependents_returned;
 
@@ -484,6 +600,16 @@ pub fn build_context_response(
         ))
     ));
 
+    if let Some(projections) = projections {
+        for entry in &pack.focal_entities {
+            if let Some(reason) = projections.downgrades.get(&entry.entity_id) {
+                lines.push(format!(
+                    "  Source body withheld for {}: {reason}",
+                    entry.entity_id
+                ));
+            }
+        }
+    }
     lines.push(String::new());
     lines.push("--- Context Pack ---".to_string());
 
@@ -930,6 +1056,7 @@ impl FocalSet {
 fn build_multi_focal_response(
     graph: &kin_db::InMemoryGraph,
     request: &ContextRequest,
+    provider: Option<&mut dyn kin_context::ContextProjectionProvider>,
 ) -> Result<ContextResponse> {
     let token_budget = parse_budget(&request.budget)?;
     let limit = request
@@ -1029,16 +1156,73 @@ fn build_multi_focal_response(
         resolutions: focals.resolutions,
         coverage,
     };
+    if let Some(provider) = provider {
+        let (pack, report, projections) = kin_context::build_multi_focal_pack_with_provider(
+            graph,
+            &focals.ids,
+            &opts,
+            provider,
+            kin_context::ProjectionLimits::default(),
+            |pack, report, projections| {
+                let mut response = render_multi_response(
+                    pack.clone(),
+                    report.clone(),
+                    &focals.targets,
+                    &guidance,
+                    &unresolved,
+                    Some(projections),
+                );
+                measure_response(&mut response)
+            },
+        )?;
+        let mut response = render_multi_response(
+            pack,
+            report,
+            &focals.targets,
+            &guidance,
+            &unresolved,
+            Some(&projections),
+        );
+        measure_response(&mut response)?;
+        return Ok(response);
+    }
     let (pack, report) = kin_context::build_multi_focal_pack(graph, &focals.ids, &opts)?;
+    Ok(render_multi_response(
+        pack,
+        report,
+        &focals.targets,
+        &guidance,
+        &unresolved,
+        None,
+    ))
+}
 
+fn render_multi_response(
+    pack: kin_model::ContextPack,
+    report: kin_context::MultiFocalReport,
+    targets: &[ContextTarget],
+    guidance: &[String],
+    unresolved: &[String],
+    projections: Option<&kin_context::ProjectionReport>,
+) -> ContextResponse {
     let mut lines = kin_context::render_multi_focal_lines(&pack, &report);
     if !guidance.is_empty() {
         // The misses go after the pack, so a reader sees the answer first and
         // then what it does not cover.
         lines.push(String::new());
-        lines.extend(guidance);
+        lines.extend_from_slice(guidance);
     }
 
+    if let Some(projections) = projections {
+        for entry in &pack.focal_entities {
+            if let Some(reason) = projections.downgrades.get(&entry.entity_id) {
+                lines.push(format!(
+                    "Source body withheld for {}: {reason}",
+                    entry.entity_id
+                ));
+            }
+        }
+    }
     let budget_elisions = report
         .elisions
         .iter()
@@ -1055,19 +1239,19 @@ fn build_multi_focal_response(
         })
         .collect();
 
-    Ok(ContextResponse {
+    ContextResponse {
         error: None,
         lines,
         schema_version: CONTEXT_RESPONSE_SCHEMA_VERSION.to_string(),
-        target: focals.targets.first().cloned(),
+        target: targets.first().cloned(),
         pack: Some(pack),
         dependency_selection: None,
         budget_elisions,
-        focals: focals.targets,
+        focals: targets.to_vec(),
         measured_tokens: report.measured_tokens,
         multi_focal: Some(report),
-        unresolved,
-    })
+        unresolved: unresolved.to_vec(),
+    }
 }
 
 /// The report a multi-focal request that resolved no focal still carries, so a
@@ -1114,6 +1298,114 @@ mod tests {
         EntityId, EntityKind, EntityMetadata, EntityRole, FingerprintAlgorithm, Hash256,
         LanguageId, SemanticFingerprint, Visibility,
     };
+
+    struct FixtureBodyProvider {
+        bytes: usize,
+        reads: usize,
+    }
+    impl kin_context::ContextProjectionProvider for FixtureBodyProvider {
+        fn full_body(
+            &mut self,
+            entity: &Entity,
+            limits: kin_context::ProjectionLimits,
+        ) -> kin_context::Result<kin_context::BodyCandidate> {
+            self.reads += 1;
+            let body = format!(
+                "fn {}() {{\r\n{}\r\n}}",
+                entity.name,
+                "execute();\n".repeat(self.bytes / 11)
+            );
+            if body.len() > limits.max_candidate_bytes.min(limits.max_retained_bytes) {
+                return Ok(kin_context::BodyCandidate::OverLimit {
+                    body_bytes: body.len(),
+                });
+            }
+            Ok(kin_context::BodyCandidate::Exact { body })
+        }
+    }
+
+    #[test]
+    fn native_4000_prices_bodies_and_both_complete_output_modes() {
+        let (graph, chain) = linked_store();
+        for bytes in [220, 2200, 22000, 62000] {
+            let mut provider = FixtureBodyProvider { bytes, reads: 0 };
+            let request = ContextRequest {
+                entity: "handleKeyboardInput".into(),
+                entities: vec!["TextDocument".into()],
+                budget: "4000".into(),
+                ..Default::default()
+            };
+            let response =
+                build_context_response_inner(&graph, &request, Some(&mut provider)).unwrap();
+            let serialized = serde_json::to_string_pretty(&response).unwrap();
+            let measured = kin_context::estimate_tokens(&serialized)
+                .max(kin_context::estimate_tokens(&response.lines.join("\n")));
+            assert_eq!(response.measured_tokens, measured);
+            assert!(measured <= 4000, "{bytes}: {measured}");
+            let pack = response.pack.as_ref().unwrap();
+            assert!(pack
+                .focal_entities
+                .iter()
+                .any(|entry| entry.entity_id == chain[0].id));
+            assert!(pack
+                .focal_entities
+                .iter()
+                .any(|entry| entry.entity_id == chain[3].id));
+            let report = response.multi_focal.as_ref().unwrap();
+            assert!(report
+                .routes
+                .iter()
+                .any(|route| route.via_names.contains(&"applyEdits".into())
+                    && !route.edges.is_empty()));
+            for entry in &pack.focal_entities {
+                if entry.projection_level == kin_model::ProjectionLevel::FullBody {
+                    assert!(entry.content.contains("execute();"));
+                    assert!(entry.content.ends_with("\r\n}"));
+                }
+            }
+            if bytes == 220 {
+                assert!(pack
+                    .focal_entities
+                    .iter()
+                    .all(|entry| entry.projection_level == kin_model::ProjectionLevel::FullBody));
+            }
+            if bytes >= 22000 {
+                assert!(response
+                    .lines
+                    .iter()
+                    .any(|line| line.contains("Source body withheld")));
+            }
+            assert!(provider.reads <= 4, "measurement must not reread source");
+        }
+    }
+
+    #[test]
+    fn native_single_prices_exact_body_and_refuses_an_impossible_metadata_floor() {
+        let (graph, _) = linked_store();
+        let mut provider = FixtureBodyProvider {
+            bytes: 220,
+            reads: 0,
+        };
+        let response = build_context_response_inner(
+            &graph,
+            &ContextRequest::one("applyEdits", "4000"),
+            Some(&mut provider),
+        )
+        .unwrap();
+        assert!(response.pack.as_ref().unwrap().focal_entities[0]
+            .content
+            .contains("execute();"));
+        assert!(
+            kin_context::estimate_tokens(&serde_json::to_string_pretty(&response).unwrap()) <= 4000
+        );
+        assert_eq!(provider.reads, 1);
+        assert!(build_context_response_inner(
+            &graph,
+            &ContextRequest::one("applyEdits", "1"),
+            Some(&mut provider)
+        )
+        .is_err());
+    }
 
     #[test]
     fn context_not_found_guidance_keeps_signal_and_offers_discovery() {

--- a/crates/kin-cli/src/commands/context.rs
+++ b/crates/kin-cli/src/commands/context.rs
@@ -341,13 +341,22 @@ impl kin_context::ContextProjectionProvider for GraphContextProvider {
             });
         }
         let limit = limits.max_candidate_bytes.min(limits.max_retained_bytes);
-        let record = super::graph::graph_source_record_bounded_from(
+        let record = match super::graph::graph_source_record_bounded_from(
             &self.authority,
             &self.workspace,
             entity,
             limit,
-        )
-        .map_err(|error| kin_context::ContextError::Other(error.to_string()))?;
+        ) {
+            Ok(record) => record,
+            // A historical entity may be absent from the current workspace.
+            // Withhold only its body, preserving the rest of the context pack.
+            Err(error) if super::graph::is_workspace_absent_source(&error) => {
+                return Ok(kin_context::BodyCandidate::Unavailable {
+                    reason: error.to_string(),
+                })
+            }
+            Err(error) => return Err(kin_context::ContextError::Other(error.to_string())),
+        };
         Ok(match record {
             Some(record) => kin_context::BodyCandidate::Exact { body: record.body },
             None => kin_context::BodyCandidate::OverLimit {

--- a/crates/kin-cli/src/commands/diff.rs
+++ b/crates/kin-cli/src/commands/diff.rs
@@ -1651,7 +1651,17 @@ mod tests {
         );
         let line = retained_parse_line(&init.layout).expect("a recorded path speaks");
         assert!(line.contains("search.py (4 parse errors)"), "{line}");
-        assert!(line.contains("The bytes on disk do not parse"), "{line}");
+        // Both halves of the record's own sentence, because this route renders
+        // it from the same store record `kin status` and `kin commit` render.
+        // A partial admission leaves some declarations current and others on an
+        // earlier parse, so the line has to say both, and asserting only the
+        // lead clause would pass on a line that dropped the coverage half.
+        assert!(line.contains("Did not parse as written"), "{line}");
+        assert!(
+            line.contains("Some entities may be retained")
+                && line.contains("File coverage remains incomplete"),
+            "{line}"
+        );
     }
 
     /// The control for the withheld-count test above. A diff that elides

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -1933,6 +1933,25 @@ pub(crate) fn read_entity_file_bytes_with_digest(
     read_entity_file_bytes_with_digest_from(&authority, &workspace, entity)
 }
 
+/// An entity path absent from the selected workspace tree.
+#[derive(Debug)]
+pub(crate) struct WorkspaceAbsentSource(String);
+
+impl std::fmt::Display for WorkspaceAbsentSource {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for WorkspaceAbsentSource {}
+
+/// True when this error is the workspace-absent case above, at any wrapping depth.
+pub(crate) fn is_workspace_absent_source(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .any(|cause| cause.is::<WorkspaceAbsentSource>())
+}
+
 /// The same read against an authority and workspace the caller already holds.
 ///
 /// Split from [`read_entity_file_bytes_with_digest`] so a caller reading many
@@ -1957,12 +1976,10 @@ pub(crate) fn read_entity_file_bytes_with_digest_from(
         )
     })?;
     let artifact = workspace.tree.artifact_at_path(&path).ok_or_else(|| {
-        anyhow::anyhow!(
+        anyhow::Error::new(WorkspaceAbsentSource(format!(
             "entity source '{}' is not in workspace {} at generation {}",
-            file_id.0,
-            workspace.workspace_id,
-            workspace.generation
-        )
+            file_id.0, workspace.workspace_id, workspace.generation
+        )))
     })?;
     let kin_model::TreeEntry::Blob { hash, .. } = artifact.entry else {
         anyhow::bail!(

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -1832,6 +1832,16 @@ pub(crate) fn graph_source_record_from(
     workspace: &kin_model::WorkspaceState,
     entity: &Entity,
 ) -> Result<GraphSourceRecord> {
+    graph_source_record_bounded_from(authority, workspace, entity, usize::MAX)?
+        .ok_or_else(|| anyhow::anyhow!("source body exceeds the allocation limit"))
+}
+
+pub(crate) fn graph_source_record_bounded_from(
+    authority: &super::repository_authority::ActiveRepositoryAuthority,
+    workspace: &kin_model::WorkspaceState,
+    entity: &Entity,
+    max_bytes: usize,
+) -> Result<Option<GraphSourceRecord>> {
     let file_origin = entity
         .file_origin
         .as_ref()
@@ -1871,16 +1881,18 @@ pub(crate) fn graph_source_record_from(
         );
     }
 
-    let body = std::str::from_utf8(&bytes[span.start_byte..span.end_byte])
-        .with_context(|| {
-            format!(
-                "entity '{}' source span {}..{} in '{}' is not valid UTF-8",
-                entity.name, span.start_byte, span.end_byte, file_origin.0
-            )
-        })?
-        .to_string();
+    let body = std::str::from_utf8(&bytes[span.start_byte..span.end_byte]).with_context(|| {
+        format!(
+            "entity '{}' source span {}..{} in '{}' is not valid UTF-8",
+            entity.name, span.start_byte, span.end_byte, file_origin.0
+        )
+    })?;
+    if body.len() > max_bytes {
+        return Ok(None);
+    }
+    let body = body.to_string();
     let (start_line, end_line) = presentation_span_lines(span);
-    Ok(GraphSourceRecord {
+    Ok(Some(GraphSourceRecord {
         id: entity.id.to_string(),
         name: entity.name.clone(),
         kind: format!("{:?}", entity.kind),
@@ -1893,7 +1905,7 @@ pub(crate) fn graph_source_record_from(
         signature: entity.signature.clone(),
         body,
         span_coherence: span_coherence.label().to_string(),
-    })
+    }))
 }
 
 pub(crate) fn read_entity_file_bytes_from_graph(
@@ -4755,6 +4767,42 @@ mod tests {
 
     fn commit_source_entity(fixture: &GraphSourceFixture, entity: &Entity) {
         fixture.graph.upsert_entity(entity).unwrap();
+    }
+
+    #[test]
+    fn bounded_graph_source_validates_before_refusing_allocation() {
+        let text = "fn target() {\r\n    execute();\r\n}";
+        let fixture = graph_source_fixture(Some(text.as_bytes()));
+        let entity = source_entity("target", fixture.file_id.clone(), 0, text.len());
+        commit_source_entity(&fixture, &entity);
+        let authority = fixture.authority().open().unwrap();
+        let workspace = authority.workspace().unwrap();
+        assert!(
+            graph_source_record_bounded_from(&authority, &workspace, &entity, text.len() - 1)
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(
+            graph_source_record_bounded_from(&authority, &workspace, &entity, text.len())
+                .unwrap()
+                .unwrap()
+                .body,
+            text
+        );
+        let mut invalid = entity.clone();
+        invalid.span.as_mut().unwrap().end_byte = 100_000;
+        assert!(
+            graph_source_record_bounded_from(&authority, &workspace, &invalid, 1)
+                .unwrap_err()
+                .to_string()
+                .contains("out of bounds")
+        );
+        let mut stale = entity.clone();
+        stale
+            .metadata
+            .extra
+            .insert("blob_hash".into(), serde_json::json!("ff".repeat(32)));
+        assert!(graph_source_record_bounded_from(&authority, &workspace, &stale, 1).is_err());
     }
 
     #[test]

--- a/crates/kin-context/src/builder.rs
+++ b/crates/kin-context/src/builder.rs
@@ -552,6 +552,174 @@ where
     build_context_pack_with_provenance(graph, focal_id, opts).map(|(pack, _)| pack)
 }
 
+/// Independent byte limits for probing and retaining complete source spans.
+#[derive(Debug, Clone, Copy)]
+pub struct ProjectionLimits {
+    pub max_candidate_bytes: usize,
+    pub max_retained_bytes: usize,
+}
+
+impl Default for ProjectionLimits {
+    fn default() -> Self {
+        Self {
+            max_candidate_bytes: 60_000,
+            max_retained_bytes: 60_000,
+        }
+    }
+}
+
+pub enum BodyCandidate {
+    Exact { body: String },
+    Unavailable { reason: String },
+    OverLimit { body_bytes: usize },
+}
+
+/// A provider must use one pinned source generation for probes and reads.
+pub trait ContextProjectionProvider {
+    fn full_body(&mut self, entity: &Entity, limits: ProjectionLimits) -> Result<BodyCandidate>;
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ProjectionReport {
+    pub full_bodies: HashSet<EntityId>,
+    pub downgrades: HashMap<EntityId, String>,
+    pub budget_withheld: HashSet<EntityId>,
+}
+
+pub(crate) fn source_projection(
+    provider: &mut dyn ContextProjectionProvider,
+    entity: &Entity,
+    limits: ProjectionLimits,
+    remaining_tokens: usize,
+    report: &mut ProjectionReport,
+) -> Result<Option<String>> {
+    let reason = match provider.full_body(entity, limits)? {
+        BodyCandidate::Exact { body } => {
+            if body.len() > limits.max_candidate_bytes.min(limits.max_retained_bytes) {
+                return Err(ContextError::Other(
+                    "source provider exceeded its byte allowance".into(),
+                ));
+            }
+            if estimate_tokens(&body) <= remaining_tokens {
+                report.full_bodies.insert(entity.id);
+                report.downgrades.remove(&entity.id);
+                report.budget_withheld.remove(&entity.id);
+                return Ok(Some(body));
+            }
+            "whole source body exceeds its token allowance".to_string()
+        }
+        BodyCandidate::Unavailable { reason } => {
+            report.downgrades.insert(entity.id, reason);
+            report.budget_withheld.remove(&entity.id);
+            return Ok(None);
+        }
+        BodyCandidate::OverLimit { body_bytes } => {
+            format!(
+                "whole graph-owned span of {body_bytes} bytes exceeds its inline byte allowance"
+            )
+        }
+    };
+    report.downgrades.insert(entity.id, reason);
+    report.budget_withheld.insert(entity.id);
+    Ok(None)
+}
+
+/// Price graph-owned bodies before admission, then fit the caller's rendering.
+pub fn build_context_pack_with_provider<G: GraphStore>(
+    graph: &G,
+    focal_id: &EntityId,
+    opts: &ContextOptions,
+    provider: &mut dyn ContextProjectionProvider,
+    limits: ProjectionLimits,
+    dependency_bodies: bool,
+    mut measure: impl FnMut(&ContextPack, &DependencySelection, &ProjectionReport) -> Result<usize>,
+) -> Result<(ContextPack, DependencySelection, ProjectionReport)> {
+    let (mut pack, mut selection, mut projections) = build_context_pack_inner(
+        graph,
+        focal_id,
+        opts,
+        Some(provider),
+        limits,
+        dependency_bodies,
+    )?;
+    let focal = graph
+        .get_entity(focal_id)
+        .map_err(|e| ContextError::Graph(e.to_string()))?
+        .ok_or_else(|| ContextError::EntityNotFound(focal_id.to_string()))?;
+    loop {
+        let mut settled = None;
+        for _ in 0..16 {
+            let measured = measure(&pack, &selection, &projections)?;
+            if pack.actual_tokens == measured {
+                settled = Some(measured);
+                break;
+            }
+            pack.actual_tokens = measured;
+        }
+        let measured = settled.ok_or_else(|| {
+            ContextError::Other("context response accounting did not converge".into())
+        })?;
+        if measured <= opts.budget.max_tokens() {
+            pack.actual_tokens = measured;
+            return Ok((pack, selection, projections));
+        }
+        if let Some(entry) = pack.annotations.pop() {
+            let _ = entry;
+            selection.refuse(group::ANNOTATIONS, *focal_id);
+            continue;
+        }
+        if pack.work_items.pop().is_some() {
+            selection.refuse(group::WORK_ITEMS, *focal_id);
+            continue;
+        }
+        let removed = if let Some(entry) = pack.tests.pop() {
+            Some((group::TESTS, entry))
+        } else if let Some(entry) = pack.contracts.pop() {
+            Some((group::CONTRACTS, entry))
+        } else if let Some(entry) = pack.transitive_deps.pop() {
+            Some((group::TRANSITIVE_DEPS, entry))
+        } else {
+            pack.dependency_signatures.pop().map(|entry| {
+                let group = if selection.relation_for(&entry.entity_id)
+                    == DependencyRelation::DependentEdge
+                {
+                    group::DEPENDENTS
+                } else {
+                    group::DEPENDENCIES
+                };
+                (group, entry)
+            })
+        };
+        if let Some((group, entry)) = removed {
+            selection.refuse(group, entry.entity_id);
+            projections.full_bodies.remove(&entry.entity_id);
+            continue;
+        }
+        let entry = &mut pack.focal_entities[0];
+        entry.content = match entry.projection_level {
+            ProjectionLevel::FullBody => project_signature_only(&focal),
+            ProjectionLevel::SignatureOnly => project_name_and_kind(&focal),
+            _ => {
+                return Err(ContextError::BudgetExceeded {
+                    actual: measured,
+                    budget: opts.budget.max_tokens(),
+                })
+            }
+        };
+        entry.projection_level = if entry.projection_level == ProjectionLevel::FullBody {
+            ProjectionLevel::SignatureOnly
+        } else {
+            ProjectionLevel::NameAndKind
+        };
+        projections.full_bodies.remove(focal_id);
+        projections.budget_withheld.insert(*focal_id);
+        projections.downgrades.insert(
+            *focal_id,
+            "projection reduced to fit the complete rendered response".into(),
+        );
+    }
+}
+
 /// Build a context pack and report how its dependency section was selected.
 ///
 /// The pack itself cannot carry that: `dependency_signatures` is a flat list of
@@ -567,6 +735,27 @@ pub fn build_context_pack_with_provenance<G>(
 where
     G: GraphStore,
 {
+    build_context_pack_inner(
+        graph,
+        focal_id,
+        opts,
+        None,
+        ProjectionLimits::default(),
+        false,
+    )
+    .map(|(pack, selection, _)| (pack, selection))
+}
+
+fn build_context_pack_inner<G: GraphStore>(
+    graph: &G,
+    focal_id: &EntityId,
+    opts: &ContextOptions,
+    mut provider: Option<&mut dyn ContextProjectionProvider>,
+    limits: ProjectionLimits,
+    dependency_bodies: bool,
+) -> Result<(ContextPack, DependencySelection, ProjectionReport)> {
+    let mut projections = ProjectionReport::default();
+    let mut retained_body_bytes = 0usize;
     let mut selection = DependencySelection::default();
     let budget_max = opts.budget.max_tokens();
     let mut total_tokens = 0;
@@ -584,13 +773,25 @@ where
         .map_err(|e| ContextError::Graph(e.to_string()))?
         .ok_or_else(|| ContextError::EntityNotFound(focal_id.to_string()))?;
 
-    let focal_content = project_full_body(&focal);
+    let (focal_content, focal_level) = if let Some(source) = provider.as_deref_mut() {
+        match source_projection(source, &focal, limits, budget_max, &mut projections)? {
+            Some(body) => {
+                retained_body_bytes += body.len();
+                (body, ProjectionLevel::FullBody)
+            }
+            None => (
+                project_signature_only(&focal),
+                ProjectionLevel::SignatureOnly,
+            ),
+        }
+    } else {
+        (project_full_body(&focal), ProjectionLevel::FullBody)
+    };
     let focal_tokens = estimate_tokens(&focal_content);
     total_tokens += focal_tokens;
-
     let focal_entry = ContextEntry {
         entity_id: focal.id,
-        projection_level: ProjectionLevel::FullBody,
+        projection_level: focal_level,
         content: focal_content,
     };
 
@@ -784,7 +985,35 @@ where
             sorted_entities.iter().map(classify).collect()
         };
 
-    for candidate in candidates.into_iter().flatten() {
+    for mut candidate in candidates.into_iter().flatten() {
+        if dependency_bodies {
+            if let Some(source) = provider.as_deref_mut() {
+                if let Some(entity) = subgraph.entities.get(&candidate.entity_id) {
+                    let remaining = ProjectionLimits {
+                        max_retained_bytes: limits
+                            .max_retained_bytes
+                            .saturating_sub(retained_body_bytes),
+                        ..limits
+                    };
+                    if let Some(body) = source_projection(
+                        source,
+                        entity,
+                        remaining,
+                        match candidate.section {
+                            AssemblySection::Transitive => budget_max
+                                .saturating_sub(total_tokens)
+                                .min(transitive_budget.saturating_sub(transitive_tokens)),
+                            _ => budget_max.saturating_sub(total_tokens),
+                        },
+                        &mut projections,
+                    )? {
+                        candidate.tokens = estimate_tokens(&body);
+                        candidate.content = body;
+                        candidate.projection_level = ProjectionLevel::FullBody;
+                    }
+                }
+            }
+        }
         let AssemblyCandidate {
             entity_id,
             section,
@@ -832,7 +1061,11 @@ where
         // reported, because `actual_tokens` is measured rather than assumed.
         if !fits && admitted_groups.contains(target_group) {
             selection.refuse(target_group, entity_id);
+            projections.full_bodies.remove(&entity_id);
             continue;
+        }
+        if projections.full_bodies.contains(&entity_id) {
+            retained_body_bytes += content.len();
         }
         admitted_groups.insert(target_group);
         total_tokens += tokens;
@@ -979,6 +1212,7 @@ where
             actual_tokens: total_tokens,
         },
         selection,
+        projections,
     ))
 }
 
@@ -1505,6 +1739,87 @@ fn normalize_entity_name(name: &str) -> String {
 mod tests {
     use super::*;
     use kin_model::*;
+
+    struct BoundedProvider {
+        calls: Vec<usize>,
+    }
+    impl ContextProjectionProvider for BoundedProvider {
+        fn full_body(
+            &mut self,
+            _: &Entity,
+            limits: ProjectionLimits,
+        ) -> crate::Result<BodyCandidate> {
+            self.calls.push(limits.max_retained_bytes);
+            if limits.max_candidate_bytes.min(limits.max_retained_bytes) < 150 {
+                return Ok(BodyCandidate::OverLimit { body_bytes: 150 });
+            }
+            Ok(BodyCandidate::Exact {
+                body: "x".repeat(150),
+            })
+        }
+    }
+
+    #[test]
+    fn provider_admission_bounds_retained_bodies_and_keeps_dependency_identities() {
+        let (store, focal) = calling_store(4);
+        let mut provider = BoundedProvider { calls: Vec::new() };
+        let (pack, _, report) = build_context_pack_with_provider(
+            &store,
+            &focal.id,
+            &ContextOptions::default(),
+            &mut provider,
+            ProjectionLimits {
+                max_candidate_bytes: 150,
+                max_retained_bytes: 300,
+            },
+            true,
+            |pack, _, _| Ok(estimate_tokens(&serde_json::to_string(pack).unwrap())),
+        )
+        .unwrap();
+        assert_eq!(report.full_bodies.len(), 2);
+        assert_eq!(pack.dependency_signatures.len(), 4);
+        let retained: usize = pack
+            .focal_entities
+            .iter()
+            .chain(&pack.dependency_signatures)
+            .filter(|entry| report.full_bodies.contains(&entry.entity_id))
+            .map(|entry| entry.content.len())
+            .sum();
+        assert_eq!(retained, 300);
+        assert_eq!(provider.calls, [300, 150, 0, 0, 0]);
+        assert_eq!(report.downgrades.len(), 3);
+    }
+
+    #[test]
+    fn provider_contract_refuses_an_oversized_materialization() {
+        struct InvalidProvider;
+        impl ContextProjectionProvider for InvalidProvider {
+            fn full_body(
+                &mut self,
+                _: &Entity,
+                _: ProjectionLimits,
+            ) -> crate::Result<BodyCandidate> {
+                Ok(BodyCandidate::Exact {
+                    body: "x".repeat(151),
+                })
+            }
+        }
+        let (store, focal) = calling_store(0);
+        let error = build_context_pack_with_provider(
+            &store,
+            &focal.id,
+            &ContextOptions::default(),
+            &mut InvalidProvider,
+            ProjectionLimits {
+                max_candidate_bytes: 150,
+                max_retained_bytes: 300,
+            },
+            false,
+            |_, _, _| Ok(0),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("byte allowance"));
+    }
 
     fn admit_test_artifact(
         store: &kin_db::InMemoryGraph,

--- a/crates/kin-context/src/lib.rs
+++ b/crates/kin-context/src/lib.rs
@@ -10,15 +10,18 @@ pub mod tokens;
 
 pub use builder::{
     build_context_pack, build_context_pack_from_plan, build_context_pack_with_provenance,
-    build_context_pack_with_traffic, build_context_pack_with_traffic_and_provenance, group,
-    AssistantHint, ContextOptions, DependencyRelation, DependencySelection, DependencySource,
-    FULL_BODY_PROJECTION_NAME, SAME_FILE_FALLBACK_MAX, SERVED_BODY_PROJECTION_NAME,
+    build_context_pack_with_provider, build_context_pack_with_traffic,
+    build_context_pack_with_traffic_and_provenance, group, AssistantHint, BodyCandidate,
+    ContextOptions, ContextProjectionProvider, DependencyRelation, DependencySelection,
+    DependencySource, ProjectionLimits, ProjectionReport, FULL_BODY_PROJECTION_NAME,
+    SAME_FILE_FALLBACK_MAX, SERVED_BODY_PROJECTION_NAME,
 };
 pub use error::{ContextError, Result};
 pub use multi::{
-    build_multi_focal_pack, method_line, neighborhood_depth_for, render_multi_focal_lines,
-    water_fill, FocalContribution, FocalResolution, MultiFocalOptions, MultiFocalReport,
-    PackElision, RouteReport, RouteSearch, ELISION_REASON_TOKEN_BUDGET, FOCAL_GROUP, ROUTE_GROUP,
-    ROUTE_MARKER, ROUTE_MAX_HOPS, ROUTE_VISIT_MAX,
+    build_multi_focal_pack, build_multi_focal_pack_with_provider, method_line,
+    neighborhood_depth_for, render_multi_focal_lines, water_fill, FocalContribution,
+    FocalResolution, MultiFocalOptions, MultiFocalReport, PackElision, RouteReport, RouteSearch,
+    ELISION_REASON_TOKEN_BUDGET, FOCAL_GROUP, ROUTE_GROUP, ROUTE_MARKER, ROUTE_MAX_HOPS,
+    ROUTE_VISIT_MAX,
 };
 pub use tokens::estimate_tokens;

--- a/crates/kin-context/src/multi.rs
+++ b/crates/kin-context/src/multi.rs
@@ -42,8 +42,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::builder::{
     build_context_pack_with_provenance, group, is_dependency_edge, project_full_body,
-    project_name_and_kind, project_signature_only, AssistantHint, ContextOptions,
-    DependencyRelation, FULL_BODY_PROJECTION_NAME,
+    project_name_and_kind, project_signature_only, source_projection, AssistantHint, BodyCandidate,
+    ContextOptions, ContextProjectionProvider, DependencyRelation, ProjectionLimits,
+    ProjectionReport, FULL_BODY_PROJECTION_NAME, SERVED_BODY_PROJECTION_NAME,
 };
 use crate::error::{ContextError, Result};
 use crate::tokens::estimate_tokens;
@@ -674,6 +675,49 @@ pub fn build_multi_focal_pack<G>(
 where
     G: GraphStore,
 {
+    build_multi_focal_pack_inner(
+        graph,
+        focal_ids,
+        opts,
+        None,
+        ProjectionLimits::default(),
+        None,
+    )
+    .map(|(pack, report, _)| (pack, report))
+}
+
+type MultiMeasure<'a> =
+    dyn FnMut(&ContextPack, &MultiFocalReport, &ProjectionReport) -> Result<usize> + 'a;
+
+pub fn build_multi_focal_pack_with_provider<G: GraphStore>(
+    graph: &G,
+    focal_ids: &[EntityId],
+    opts: &MultiFocalOptions,
+    provider: &mut dyn ContextProjectionProvider,
+    limits: ProjectionLimits,
+    mut measure: impl FnMut(&ContextPack, &MultiFocalReport, &ProjectionReport) -> Result<usize>,
+) -> Result<(ContextPack, MultiFocalReport, ProjectionReport)> {
+    build_multi_focal_pack_inner(
+        graph,
+        focal_ids,
+        opts,
+        Some(provider),
+        limits,
+        Some(&mut measure),
+    )
+}
+
+fn build_multi_focal_pack_inner<G: GraphStore>(
+    graph: &G,
+    focal_ids: &[EntityId],
+    opts: &MultiFocalOptions,
+    mut provider: Option<&mut dyn ContextProjectionProvider>,
+    limits: ProjectionLimits,
+    measure: Option<&mut MultiMeasure<'_>>,
+) -> Result<(ContextPack, MultiFocalReport, ProjectionReport)> {
+    let mut projections = ProjectionReport::default();
+    let source_aware = provider.is_some();
+    let mut retained_bytes = 0usize;
     let mut ordered: Vec<EntityId> = Vec::new();
     for id in focal_ids {
         if !ordered.contains(id) {
@@ -704,11 +748,47 @@ where
     //    affords. A focal that cannot fit even its name is reported rather than
     //    dropped quietly, because a pack silently missing one end of a chain is
     //    the exact failure this module was written for.
-    let full_bodies: Vec<String> = focals.iter().map(project_full_body).collect();
-    let demands: Vec<usize> = full_bodies
-        .iter()
-        .map(|body| estimate_tokens(body))
-        .collect();
+    let mut full_bodies = Vec::with_capacity(focals.len());
+    let mut demands = Vec::with_capacity(focals.len());
+    let mut exact_demands = Vec::with_capacity(focals.len());
+    for entity in &focals {
+        if let Some(source) = provider.as_deref_mut() {
+            // Probe one candidate at a time. Its allocation is released before
+            // the next probe; only costs survive into water filling.
+            let probe_limits = ProjectionLimits {
+                max_retained_bytes: limits.max_candidate_bytes,
+                ..limits
+            };
+            match source.full_body(entity, probe_limits)? {
+                BodyCandidate::Exact { body } => {
+                    if body.len() > limits.max_candidate_bytes {
+                        return Err(ContextError::Other(
+                            "source provider exceeded its probe byte allowance".into(),
+                        ));
+                    }
+                    demands.push(estimate_tokens(&body));
+                    exact_demands.push(true);
+                }
+                BodyCandidate::Unavailable { reason } => {
+                    projections.downgrades.insert(entity.id, reason);
+                    demands.push(estimate_tokens(&project_signature_only(entity)));
+                    exact_demands.push(false);
+                }
+                BodyCandidate::OverLimit { body_bytes } => {
+                    projections.budget_withheld.insert(entity.id);
+                    projections.downgrades.insert(entity.id, format!("whole graph-owned span of {body_bytes} bytes exceeds its inline byte allowance"));
+                    demands.push(estimate_tokens(&project_signature_only(entity)));
+                    exact_demands.push(false);
+                }
+            }
+            full_bodies.push(None);
+        } else {
+            let body = project_full_body(entity);
+            demands.push(estimate_tokens(&body));
+            full_bodies.push(Some(body));
+            exact_demands.push(false);
+        }
+    }
     let allowances = water_fill(&demands, budget_max);
 
     let mut focal_entries: Vec<ContextEntry> = Vec::new();
@@ -724,11 +804,32 @@ where
         let signature = project_signature_only(entity);
         let name_and_kind = project_name_and_kind(entity);
         ladders.insert(entity.id, (signature.clone(), name_and_kind.clone()));
-        let ladder = [
-            (ProjectionLevel::FullBody, full_bodies[index].clone()),
-            (ProjectionLevel::SignatureOnly, signature),
-            (ProjectionLevel::NameAndKind, name_and_kind),
-        ];
+        let body = if let Some(source) = provider.as_deref_mut() {
+            if exact_demands[index] && demands[index] <= room {
+                let remaining = ProjectionLimits {
+                    max_retained_bytes: limits.max_retained_bytes.saturating_sub(retained_bytes),
+                    ..limits
+                };
+                source_projection(source, entity, remaining, room, &mut projections)?
+            } else {
+                if exact_demands[index] {
+                    projections.budget_withheld.insert(entity.id);
+                    projections.downgrades.insert(
+                        entity.id,
+                        "whole source body exceeds its token allowance".into(),
+                    );
+                }
+                None
+            }
+        } else {
+            full_bodies[index].take()
+        };
+        let mut ladder = Vec::with_capacity(3);
+        if let Some(body) = body {
+            ladder.push((ProjectionLevel::FullBody, body));
+        }
+        ladder.push((ProjectionLevel::SignatureOnly, signature));
+        ladder.push((ProjectionLevel::NameAndKind, name_and_kind));
         let chosen = ladder
             .into_iter()
             .find(|(_, content)| estimate_tokens(content) <= room);
@@ -741,13 +842,24 @@ where
         let (projection, focal_tokens) = match chosen {
             Some((level, content)) => {
                 let cost = estimate_tokens(&content);
+                if source_aware && level == ProjectionLevel::FullBody {
+                    retained_bytes += content.len();
+                }
                 spent += cost;
                 focal_entries.push(ContextEntry {
                     entity_id: entity.id,
                     projection_level: level,
                     content,
                 });
-                (projection_name(level).to_string(), cost)
+                (
+                    if source_aware && level == ProjectionLevel::FullBody {
+                        SERVED_BODY_PROJECTION_NAME
+                    } else {
+                        projection_name(level)
+                    }
+                    .to_string(),
+                    cost,
+                )
             }
             None => {
                 focals_elided += 1;
@@ -1033,9 +1145,10 @@ where
         &mut order,
         &ladders,
         budget_max,
+        (&mut projections, measure),
     )?;
 
-    Ok((assembled, report))
+    Ok((assembled, report, projections))
 }
 
 fn candidate_from(entry: &ContextEntry, group_name: &'static str) -> Candidate {
@@ -1062,12 +1175,49 @@ fn fit_to_budget(
     order: &mut Vec<Admitted>,
     ladders: &HashMap<EntityId, (String, String)>,
     budget_max: usize,
+    fitting: (&mut ProjectionReport, Option<&mut MultiMeasure<'_>>),
 ) -> Result<()> {
+    let (projections, mut measure) = fitting;
     loop {
-        let measured = settle_measurement(pack, report);
+        for entry in &pack.focal_entities {
+            if entry.projection_level != ProjectionLevel::FullBody
+                && projections.full_bodies.remove(&entry.entity_id)
+            {
+                projections.downgrades.insert(
+                    entry.entity_id,
+                    "projection reduced to fit the complete rendered response".into(),
+                );
+                projections.budget_withheld.insert(entry.entity_id);
+            }
+        }
+        let mut measured = settle_measurement(pack, report);
+        if let Some(callback) = measure.as_deref_mut() {
+            let mut settled = None;
+            for _ in 0..MEASURED_TOKEN_PASSES {
+                let current = callback(pack, report, projections)?;
+                if report.measured_tokens == current && pack.actual_tokens == current {
+                    settled = Some(current);
+                    break;
+                }
+                report.measured_tokens = current;
+                pack.actual_tokens = current;
+                report.method = method_line(report);
+            }
+            measured = settled.ok_or_else(|| {
+                ContextError::Other("context response accounting did not converge".into())
+            })?;
+        }
         if measured <= budget_max {
             pack.actual_tokens = measured;
             return Ok(());
+        }
+        if measure.is_some()
+            && order
+                .last()
+                .is_some_and(|entry| matches!(entry.origin, Origin::Route(_)))
+            && shrink_one_focal(pack, report, ladders)
+        {
+            continue;
         }
         let Some(dropped) = order.pop() else {
             // Nothing left to drop. The sentence describing the pack is now

--- a/crates/kin-core/src/reference_coverage.rs
+++ b/crates/kin-core/src/reference_coverage.rs
@@ -1108,8 +1108,11 @@ pub struct LanguageParseCoverage {
     pub with_entities: usize,
     /// Of those, how many produced none.
     pub silent: usize,
-    /// Of those, how many did not parse from their CURRENT bytes, so the
-    /// entities the graph holds for them came from an earlier parse.
+    /// Of those, how many did not parse from their CURRENT bytes, so at least
+    /// some of the entities the graph holds for them came from an earlier
+    /// parse. Partial admission refreshes the declarations it can prove and
+    /// leaves the rest, so a retained file is no longer wholly stale, and the
+    /// bucket still means the file's coverage is incomplete.
     ///
     /// Its own bucket rather than folded into either counter beside it, because
     /// it is neither. Counting a retained file under `with_entities` is the
@@ -1184,10 +1187,10 @@ impl LanguageParseCoverage {
             )
         };
         format!(
-            "{}: {} of {} admitted {} files did not parse as written, so any entities the graph \
-             still holds for them came from an earlier parse of bytes that are gone, and a file \
-             the graph never parsed is absent from it entirely{named}. Fix the syntax and the \
-             next admission re-derives them.",
+            "{}: {} of {} admitted {} files did not parse as written{named}. Some entities may \
+             be retained from earlier parses while independently verified entities are current. \
+             File coverage remains incomplete. Once a complete parse is available, admission \
+             re-derives the complete file.",
             crate::retained_parse::RETAINED_OBSERVATION,
             self.retained,
             self.tracked,
@@ -2617,7 +2620,8 @@ mod tests {
         // True of both populations. A file created with a typo has no earlier
         // parse, so the clause about what the graph holds has to be conditional.
         assert!(
-            lines.contains("any entities the graph still holds"),
+            lines.contains("Some entities may")
+                && lines.contains("File coverage remains incomplete"),
             "the sentence may not diagnose one member of the set: {lines}"
         );
 

--- a/crates/kin-core/src/retained_parse.rs
+++ b/crates/kin-core/src/retained_parse.rs
@@ -158,20 +158,12 @@ impl RetainedParseRead {
                     String::new()
                 };
                 let age = crate::last_admission::humanize_age(age_seconds(recorded.at, now));
-                // Established half first, conditional half second, and the split
-                // is the point. The seam knows which of the two populations a
-                // path is in; this record does not, and widening it to carry
-                // that is a change to the on-disk shape rather than to a
-                // sentence. So the line asserts only what is true of both: the
-                // bytes on disk do not parse. What the graph still holds for
-                // them is stated as a conditional, because a file created with
-                // a typo has no earlier parse to hold.
                 Some(format!(
-                    "Did not parse as written: {named}{and_more}. The bytes on disk do not parse, \
-                     so any entities the graph still holds for these paths came from an earlier \
-                     parse of bytes that are gone, and a path the graph never parsed is absent \
-                     from it entirely. Fix the syntax and the next admission re-derives them. \
-                     Observed {age} ago."
+                    "Did not parse as written: {named}{and_more}. Some entities may be retained \
+                     from earlier parses while independently verified entities are current. \
+                     File coverage remains incomplete, and declarations that were never admitted \
+                     remain absent. Once a complete parse is available, admission re-derives \
+                     the complete file. Observed {age} ago."
                 ))
             }
             Self::Absent => None,
@@ -252,12 +244,27 @@ pub fn fold(
         })
         .cloned()
         .collect();
+    // One row per path, last observation winning. A single pass can observe one
+    // path twice: a partial admission is disclosed before its transaction is
+    // published and again after it lands, so the same path arrives retained
+    // twice. Two rows for one path name that path twice inside the one sentence
+    // `kin status`, `kin diff`, `kin commit`, `kin graph` and `kin doctor` all
+    // print from this record, and `RetainedParse` is what every one of them
+    // reads, so the guarantee belongs here rather than at each caller.
     for observation in observed {
-        if let Some(errors) = observation.errors {
-            paths.push(RetainedPath {
+        let held = paths
+            .iter()
+            .position(|retained| retained.path == observation.path);
+        match (observation.errors, held) {
+            (Some(errors), Some(at)) => paths[at].errors = errors,
+            (Some(errors), None) => paths.push(RetainedPath {
                 path: observation.path.clone(),
                 errors,
-            });
+            }),
+            (None, Some(at)) => {
+                paths.remove(at);
+            }
+            (None, None) => {}
         }
     }
     RetainedParse::new(at, paths)
@@ -407,7 +414,7 @@ mod tests {
         let line = read_back.describe(at()).expect("a retained path speaks");
         assert!(line.contains("search.py (4 parse errors)"), "{line}");
         assert!(
-            line.contains("The bytes on disk do not parse"),
+            line.contains("Did not parse as written"),
             "the established half leads: {line}"
         );
         // The half a brand-new file with a typo makes load-bearing. `FileEvent`
@@ -415,7 +422,8 @@ mod tests {
         // this set holds paths with no earlier parse at all. A sentence that
         // asserted one would be a false diagnosis on five surfaces.
         assert!(
-            line.contains("any entities the graph still holds"),
+            line.contains("Some entities may be retained")
+                && line.contains("File coverage remains incomplete"),
             "what the graph holds is a conditional, not an assertion: {line}"
         );
         assert!(
@@ -493,6 +501,67 @@ mod tests {
             named,
             vec!["newly_broken.ts", "still_broken.py", "untouched.py"],
             "a path the pass settled leaves, one it never observed stays: {folded:?}"
+        );
+    }
+
+    /// One pass, one row per path, whatever that pass observed.
+    ///
+    /// A partial admission discloses incomplete coverage on the way to its
+    /// transaction and again once that transaction lands, so one path can reach
+    /// this function twice inside one pass. Two rows would name the path twice
+    /// inside the single sentence `kin status`, `kin diff`, `kin commit`,
+    /// `kin graph` and `kin doctor` each print from this record. The later
+    /// observation is the fresher read, so it wins, including when it is the
+    /// settled one.
+    #[test]
+    fn one_pass_holds_one_row_per_path_and_the_last_word_wins() {
+        let counted = |folded: &RetainedParse, path: &str| -> Vec<usize> {
+            folded
+                .paths
+                .iter()
+                .filter(|retained| retained.path == path)
+                .map(|retained| retained.errors)
+                .collect()
+        };
+
+        let twice = fold(
+            &[],
+            &[
+                ObservedParse::retained("sds.c", 25),
+                ObservedParse::retained("sds.c", 25),
+            ],
+            at(),
+        );
+        assert_eq!(
+            counted(&twice, "sds.c"),
+            vec![25],
+            "one path may not be named twice in one record: {twice:?}"
+        );
+
+        let corrected = fold(
+            &[],
+            &[
+                ObservedParse::retained("sds.c", 25),
+                ObservedParse::retained("sds.c", 3),
+            ],
+            at(),
+        );
+        assert_eq!(counted(&corrected, "sds.c"), vec![3], "{corrected:?}");
+
+        let settled = fold(
+            &[RetainedPath {
+                path: "sds.c".to_string(),
+                errors: 25,
+            }],
+            &[
+                ObservedParse::retained("sds.c", 25),
+                ObservedParse::settled("sds.c"),
+            ],
+            at(),
+        );
+        assert!(
+            counted(&settled, "sds.c").is_empty(),
+            "a later settled read clears the path: {settled:?}"
         );
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -14537,7 +14537,7 @@ fn bound_mcp_tool_result(
             if tool == "trace_data_flow" {
                 reconcile_trace_body_presence(&mut payload);
             }
-            match serde_json::to_string_pretty(&payload) {
+            match kin_mcp::budget::render(&payload) {
                 Ok(rendered) => kin_mcp::ContentBlock::Text { text: rendered },
                 Err(_) => kin_mcp::ContentBlock::Text { text },
             }
@@ -58291,6 +58291,66 @@ mod tests {
         );
         let payload: serde_json::Value = serde_json::from_str(&bounded).unwrap();
         assert_eq!(payload["total_upstream"], json!(400));
+    }
+
+    #[test]
+    fn the_raw_route_compacts_whitespace_before_withholding_reference_rows() {
+        let payload = json!({
+            "total_upstream": 11,
+            "references": (0..11).map(|index| json!({
+                "entity_id": format!("reference-{index}"),
+                "name": format!("caller_{index}"),
+                "reference_lines": (0..60).collect::<Vec<_>>(),
+            })).collect::<Vec<_>>(),
+        });
+        let original = serde_json::to_string_pretty(&payload).unwrap();
+        let budget = kin_mcp::budget::ResponseBudget {
+            max_chars: 4_000,
+            ..kin_mcp::budget::ResponseBudget::default()
+        };
+        assert!(original.len() > budget.max_chars);
+        let response = bound_mcp_tool_result(
+            kin_mcp::ToolCallResult::text(original.clone()),
+            "find_references",
+            &budget,
+        );
+        let text = mcp_result_text(&response);
+        let mut parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed["references"], payload["references"]);
+        assert_eq!(kin_mcp::budget::measure(&parsed), text.len());
+        assert_eq!(serde_json::to_string(&parsed).unwrap(), text);
+        assert!(text.len() <= budget.max_chars);
+        assert_eq!(
+            parsed.as_object_mut().unwrap().remove("_kin_json_format"),
+            Some(json!("compact"))
+        );
+        assert_eq!(parsed, payload);
+
+        let roomy = kin_mcp::budget::ResponseBudget {
+            max_chars: 60_000,
+            ..budget
+        };
+        let fitting = bound_mcp_tool_result(
+            kin_mcp::ToolCallResult::text(original.clone()),
+            "find_references",
+            &roomy,
+        );
+        assert_eq!(mcp_result_text(&fitting), original);
+
+        let annotated = kin_mcp::envelope::finalize_bounded(
+            response,
+            kin_mcp::envelope::Envelope::daemon(),
+            "find_references",
+            &roomy,
+        );
+        let emitted = mcp_result_text(&annotated);
+        let final_payload: serde_json::Value = serde_json::from_str(&emitted).unwrap();
+        assert_eq!(final_payload["references"], payload["references"]);
+        assert_eq!(
+            final_payload["_kin"]["response"]["chars_after_budget"],
+            emitted.len()
+        );
+        assert_eq!(kin_mcp::budget::measure(&final_payload), emitted.len());
     }
 
     /// A tool the budget does not govern is returned exactly as built. A source

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -8992,8 +8992,14 @@ async fn context(
 
     let session_id = extract_session_id_from_headers(&headers)?;
     let graph = resolve_session_graph(&state, session_id.as_ref()).await;
-    let result = kin_cli::commands::context::build_context_response(graph.as_ref(), &req)
-        .map_err(internal_error)?;
+    let repository_authority =
+        require_mcp_command_repository_authority(&state).map_err(internal_error)?;
+    let result = kin_cli::commands::context::build_context_response_with_authority(
+        graph.as_ref(),
+        &req,
+        &repository_authority,
+    )
+    .map_err(internal_error)?;
     Ok(Json(result))
 }
 
@@ -14522,6 +14528,7 @@ fn bound_mcp_tool_result(
     if !kin_mcp::budget::is_budgeted(tool) {
         return result;
     }
+    let mut is_error = result.is_error;
     let content = result
         .content
         .into_iter()
@@ -14534,6 +14541,10 @@ fn bound_mcp_tool_result(
                 return kin_mcp::ContentBlock::Text { text };
             }
             kin_mcp::budget::enforce(&mut payload, tool, budget);
+            if !kin_mcp::budget::fit_context_payload(&mut payload, tool, budget) {
+                is_error = Some(true);
+                payload = serde_json::json!({"error": "context metadata cannot fit the effective token and byte limits; request fewer focals or a larger budget"});
+            }
             if tool == "trace_data_flow" {
                 reconcile_trace_body_presence(&mut payload);
             }
@@ -14543,10 +14554,7 @@ fn bound_mcp_tool_result(
             }
         })
         .collect();
-    kin_mcp::ToolCallResult {
-        content,
-        is_error: result.is_error,
-    }
+    kin_mcp::ToolCallResult { content, is_error }
 }
 
 /// Keep the trace's body-presence claim aligned with what survives the common
@@ -58291,6 +58299,28 @@ mod tests {
         );
         let payload: serde_json::Value = serde_json::from_str(&bounded).unwrap();
         assert_eq!(payload["total_upstream"], json!(400));
+    }
+
+    #[test]
+    fn the_raw_route_settles_context_tokens_and_refuses_the_metadata_floor() {
+        let budget = kin_mcp::budget::ResponseBudget {
+            max_chars: 60000,
+            ..Default::default()
+        };
+        let payload = serde_json::json!({"token_budget": 8000, "tokens_used": 0, "focal_entity": {"id": "focal", "name": "focal", "body": "execute();\n".repeat(2400), "projection": "FullBody"}});
+        let result = bound_mcp_tool_result(
+            kin_mcp::ToolCallResult::text(payload.to_string()),
+            "get_context_pack",
+            &budget,
+        );
+        assert_ne!(result.is_error, Some(true));
+        let kin_mcp::ContentBlock::Text { text } = &result.content[0];
+        let output: serde_json::Value = serde_json::from_str(text).unwrap();
+        let tokens = output["tokens_used"].as_u64().unwrap();
+        assert!(tokens > 0 && tokens <= 8000);
+        assert!(output["focal_entity"]["body"].is_null());
+        let refusal = bound_mcp_tool_result(kin_mcp::ToolCallResult::text(serde_json::json!({"token_budget": 1, "tokens_used": 0, "focal_entity": {"id": "focal", "name": "focal"}}).to_string()), "get_context_pack", &budget);
+        assert_eq!(refusal.is_error, Some(true));
     }
 
     #[test]

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -14336,7 +14336,7 @@ fn disclose_mcp_local_clamps(
         Some(existing) => existing.extend(entries),
         None => payload["degradations"] = serde_json::Value::Array(entries),
     }
-    match serde_json::to_string_pretty(&payload) {
+    match kin_mcp::budget::render(&payload) {
         Ok(rendered) => kin_mcp::ToolCallResult {
             content: vec![kin_mcp::ContentBlock::Text { text: rendered }],
             is_error: result.is_error,
@@ -14445,11 +14445,10 @@ async fn mcp_tools_call(
         ),
         None => None,
     };
-    Ok(Json(disclose_outside_graph(
-        graph.as_deref(),
-        question.as_deref(),
-        disclosed,
-    )))
+    // Clamp and outside-graph disclosures add bytes after the first fit.
+    // Enforce the ceiling again against the complete emitted payload.
+    let disclosed = disclose_outside_graph(graph.as_deref(), question.as_deref(), disclosed);
+    Ok(Json(bound_mcp_tool_result(disclosed, &tool, &budget)))
 }
 
 /// Disclose an identifier the question named that this graph holds no
@@ -14501,7 +14500,8 @@ fn disclose_outside_graph(
                 kin_mcp::outside_graph::OUTSIDE_GRAPH_KEY.to_string(),
                 block.clone(),
             );
-            match serde_json::to_string_pretty(&payload) {
+            // The caller re-fits after this disclosure adds its bytes.
+            match kin_mcp::budget::render(&payload) {
                 Ok(rendered) => kin_mcp::ContentBlock::Text { text: rendered },
                 Err(_) => kin_mcp::ContentBlock::Text { text },
             }
@@ -46178,8 +46178,9 @@ mod tests {
         );
     }
 
+    /// A missing workspace body preserves the context pack and names the gap.
     #[tokio::test]
-    async fn context_endpoint_refuses_unpublished_source() {
+    async fn context_endpoint_withholds_an_unpublished_source_body_and_answers() {
         let state = test_state();
         let entity = test_entity("handler", "src/lib.py");
         state.graph.upsert_entity(&entity).unwrap();
@@ -46207,8 +46208,30 @@ mod tests {
         let body = axum::body::to_bytes(response.into_body(), 16 * 1024)
             .await
             .unwrap();
-        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
-        assert!(String::from_utf8_lossy(&body).contains("is not in workspace"));
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let result: kin_cli::commands::context::ContextResponse =
+            serde_json::from_slice(&body).unwrap();
+        let withheld: Vec<&String> = result
+            .lines
+            .iter()
+            .filter(|line| line.contains("Source body withheld"))
+            .collect();
+        assert_eq!(withheld.len(), 1, "{:#?}", result.lines);
+        assert!(
+            withheld[0].contains("is not in workspace"),
+            "the row names the graph gap it hit: {}",
+            withheld[0]
+        );
+        // The rest of the answer survives the missing body.
+        assert!(
+            result
+                .lines
+                .iter()
+                .any(|line| line.contains("Context pack for 'handler'")),
+            "{:#?}",
+            result.lines
+        );
+        assert!(result.pack.is_some());
     }
 
     /// The daemon half of the cancellation chain.
@@ -58383,15 +58406,18 @@ mod tests {
             &budget,
         );
         let text = mcp_result_text(&response);
-        let mut parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
         assert_eq!(parsed["references"], payload["references"]);
-        assert_eq!(kin_mcp::budget::measure(&parsed), text.len());
-        assert_eq!(serde_json::to_string(&parsed).unwrap(), text);
         assert!(text.len() <= budget.max_chars);
-        assert_eq!(
-            parsed.as_object_mut().unwrap().remove("_kin_json_format"),
-            Some(json!("compact"))
-        );
+        // Compact, and compact ONLY by whitespace: re-serializing the parsed
+        // answer reproduces the shipped bytes exactly, so nothing was dropped
+        // to make it fit.
+        assert_eq!(serde_json::to_string(&parsed).unwrap(), text);
+        assert!(!text.contains('\n'), "the shipped response is compact");
+        // The serialization control field chose that format and did not ship.
+        // Equality with the untouched payload is the assertion: any extra key
+        // at all, this one included, fails it.
+        assert!(parsed.get("_kin_json_format").is_none(), "{parsed}");
         assert_eq!(parsed, payload);
 
         let roomy = kin_mcp::budget::ResponseBudget {

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -46136,6 +46136,51 @@ mod tests {
     #[tokio::test]
     async fn context_endpoint_uses_live_graph() {
         let state = test_state();
+        let source = "def handler():\n    return 42";
+        install_repository_file(&state, "src/lib.py", source.as_bytes());
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let app = router(state);
+        let response = app
+            .oneshot(
+                Request::post("/context")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "entity": "handler",
+                            "budget": "8k",
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 16 * 1024)
+            .await
+            .unwrap();
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let result: kin_cli::commands::context::ContextResponse =
+            serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            result.pack.as_ref().unwrap().focal_entities[0].content,
+            source
+        );
+        assert!(
+            result
+                .lines
+                .iter()
+                .any(|line| line.contains("Context pack for 'handler'")),
+            "context response should identify the daemon graph entity"
+        );
+    }
+
+    #[tokio::test]
+    async fn context_endpoint_refuses_unpublished_source() {
+        let state = test_state();
         let entity = test_entity("handler", "src/lib.py");
         state.graph.upsert_entity(&entity).unwrap();
         state
@@ -46158,19 +46203,12 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::OK);
+        let status = response.status();
         let body = axum::body::to_bytes(response.into_body(), 16 * 1024)
             .await
             .unwrap();
-        let result: kin_cli::commands::context::ContextResponse =
-            serde_json::from_slice(&body).unwrap();
-        assert!(
-            result
-                .lines
-                .iter()
-                .any(|line| line.contains("Context pack for 'handler'")),
-            "context response should identify the daemon graph entity"
-        );
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(String::from_utf8_lossy(&body).contains("is not in workspace"));
     }
 
     /// The daemon half of the cancellation chain.

--- a/crates/kin-daemon/src/api/tests/outside_graph_disclosure.rs
+++ b/crates/kin-daemon/src/api/tests/outside_graph_disclosure.rs
@@ -31,7 +31,7 @@ use kin_model::entity::{
 use kin_model::graph::EntityStore as _;
 use kin_model::ids::{EntityId, FilePathId, Hash256, LanguageId};
 
-use crate::api::disclose_outside_graph;
+use crate::api::{bound_mcp_tool_result, disclose_outside_graph};
 
 /// The express question, verbatim from the run that found this.
 const EXPRESS_QUESTION: &str = "where router.param callbacks are registered and stored, and how a \
@@ -357,4 +357,146 @@ async fn a_question_under_either_argument_name_is_disclosed_on_the_route() {
             "{tool}: a question naming nothing outside the graph is served untouched: {local}"
         );
     }
+}
+
+/// Fitting a disclosed payload preserves its coverage block.
+#[test]
+fn a_disclosed_payload_is_refitted_rather_than_shipped_over_its_ceiling() {
+    let graph = express_graph();
+    let budget = kin_mcp::budget::ResponseBudget {
+        max_chars: 4_000,
+        ..kin_mcp::budget::ResponseBudget::default()
+    };
+    let payload = json!({
+        "total_upstream": 24,
+        "references": (0..24).map(|index| json!({
+            "entity_id": format!("reference-{index}"),
+            "name": format!("caller_{index}"),
+            "file_path": "lib/application.js",
+            "reference_lines": (0..40).collect::<Vec<_>>(),
+        })).collect::<Vec<_>>(),
+        "degradations": [],
+        "counts": { "receiver_name_candidates": 0 },
+    });
+    let built = result_with(payload);
+    let kin_mcp::ContentBlock::Text { text: raw } =
+        built.content.first().expect("one content block");
+    assert!(
+        raw.len() > budget.max_chars,
+        "the fixture must start over its ceiling: {}",
+        raw.len()
+    );
+
+    let fitted = bound_mcp_tool_result(built, "find_references", &budget);
+    let kin_mcp::ContentBlock::Text { text: after_fit } =
+        fitted.content.first().expect("one content block");
+    assert!(after_fit.len() <= budget.max_chars, "{}", after_fit.len());
+
+    let disclosed = disclose_outside_graph(Some(&graph), Some(EXPRESS_QUESTION), fitted);
+    let block = payload_of(&disclosed);
+    assert!(
+        block.get("outside_graph").is_some(),
+        "the disclosure must fire, or the ceiling below is never pressured: {block}"
+    );
+
+    let emitted = bound_mcp_tool_result(disclosed, "find_references", &budget);
+    let kin_mcp::ContentBlock::Text { text } = emitted.content.first().expect("one content block");
+    assert!(
+        text.len() <= budget.max_chars,
+        "a disclosed response still fits its ceiling: {} > {}",
+        text.len(),
+        budget.max_chars
+    );
+    let shipped: Value = serde_json::from_str(text).expect("the emitted payload is JSON");
+    assert!(shipped.get("outside_graph").is_some(), "{shipped}");
+    assert!(
+        shipped.get("_kin_json_format").is_none(),
+        "the serialization control field does not ship: {shipped}"
+    );
+}
+
+/// The emitted HTTP payload includes the disclosure and still fits its ceiling.
+#[tokio::test]
+async fn a_disclosed_payload_is_refitted_on_the_http_route() {
+    let state = super::test_state();
+    seed_express_entities(&state.graph);
+    for index in 0..24 {
+        state
+            .graph
+            .upsert_entity(&entity(
+                &format!("router_param_callback_{index}"),
+                Some("lib/application.js"),
+                EntityRole::Source,
+                EntityKind::Function,
+            ))
+            .unwrap();
+    }
+    state
+        .is_initialized
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    let tool = "semantic_locate";
+    let mut pressured = 0;
+    // Below this fixture's metadata floor, locate reports a residual budget gap.
+    // These ceilings can retain the answer and its coverage disclosure.
+    for ceiling in [4_000, 6_000, 8_000, 12_000] {
+        let arguments: std::collections::HashMap<String, Value> = serde_json::from_value(json!({
+            "query": EXPRESS_QUESTION,
+            "max_response_chars": ceiling,
+            "limit": 24,
+        }))
+        .unwrap();
+        let budget = kin_mcp::budget::ResponseBudget::from_arguments(&arguments);
+        let axum::Json(raw) = crate::api::mcp_tools_call_inner(
+            axum::http::HeaderMap::new(),
+            axum::extract::State(state.clone()),
+            axum::Json(crate::api::McpToolCallRequest {
+                name: tool.into(),
+                arguments: arguments.clone(),
+            }),
+        )
+        .await
+        .unwrap();
+        assert_ne!(raw.is_error, Some(true));
+        let fitted = bound_mcp_tool_result(raw, tool, &budget);
+        let before_disclosure = payload_of(&fitted);
+        assert!(before_disclosure.get("outside_graph").is_none());
+        let disclosed =
+            disclose_outside_graph(Some(state.graph.as_ref()), Some(EXPRESS_QUESTION), fitted);
+        let block = payload_of(&disclosed);
+        assert!(block.get("outside_graph").is_some());
+        let kin_mcp::ContentBlock::Text { text: unfitted } = &disclosed.content[0];
+        if unfitted.len() <= ceiling {
+            continue;
+        }
+        pressured += 1;
+        let request = axum::http::Request::post("/mcp/tools/call")
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(
+                json!({"name":tool,"arguments":arguments}).to_string(),
+            ))
+            .unwrap();
+        let response = tower::ServiceExt::oneshot(crate::api::router(state.clone()), request)
+            .await
+            .unwrap();
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 4 * 1024 * 1024)
+            .await
+            .unwrap();
+        let result: kin_mcp::ToolCallResult = serde_json::from_slice(&body).unwrap();
+        let kin_mcp::ContentBlock::Text { text } = &result.content[0];
+        assert_ne!(result.is_error, Some(true), "{text}");
+        assert!(
+            text.len() <= ceiling,
+            "HTTP payload is {} bytes against {ceiling}; without the final fit it was {}",
+            text.len(),
+            unfitted.len()
+        );
+        let payload: Value = serde_json::from_str(text).unwrap();
+        assert!(payload.get("outside_graph").is_some(), "{payload}");
+        assert!(payload.get("_kin_json_format").is_none());
+    }
+    assert!(
+        pressured > 0,
+        "the fixture must exceed at least one ceiling after disclosure"
+    );
 }

--- a/crates/kin-daemon/src/api/tests/outside_graph_disclosure.rs
+++ b/crates/kin-daemon/src/api/tests/outside_graph_disclosure.rs
@@ -436,9 +436,9 @@ async fn a_disclosed_payload_is_refitted_on_the_http_route() {
         .store(true, std::sync::atomic::Ordering::Relaxed);
     let tool = "semantic_locate";
     let mut pressured = 0;
-    // Below this fixture's metadata floor, locate reports a residual budget gap.
-    // These ceilings can retain the answer and its coverage disclosure.
-    for ceiling in [4_000, 6_000, 8_000, 12_000] {
+    // Coverage metadata varies by host. Find a ceiling that refitting can meet,
+    // while proving the disclosure alone pushes the emitted payload over it.
+    for ceiling in (4_000..=12_000).step_by(100) {
         let arguments: std::collections::HashMap<String, Value> = serde_json::from_value(json!({
             "query": EXPRESS_QUESTION,
             "max_response_chars": ceiling,
@@ -458,6 +458,10 @@ async fn a_disclosed_payload_is_refitted_on_the_http_route() {
         .unwrap();
         assert_ne!(raw.is_error, Some(true));
         let fitted = bound_mcp_tool_result(raw, tool, &budget);
+        let kin_mcp::ContentBlock::Text { text: initial } = &fitted.content[0];
+        if initial.len() > ceiling {
+            continue;
+        }
         let before_disclosure = payload_of(&fitted);
         assert!(before_disclosure.get("outside_graph").is_none());
         let disclosed =
@@ -466,6 +470,11 @@ async fn a_disclosed_payload_is_refitted_on_the_http_route() {
         assert!(block.get("outside_graph").is_some());
         let kin_mcp::ContentBlock::Text { text: unfitted } = &disclosed.content[0];
         if unfitted.len() <= ceiling {
+            continue;
+        }
+        let control = bound_mcp_tool_result(disclosed.clone(), tool, &budget);
+        let kin_mcp::ContentBlock::Text { text: fitted } = &control.content[0];
+        if fitted.len() > ceiling {
             continue;
         }
         pressured += 1;
@@ -494,6 +503,7 @@ async fn a_disclosed_payload_is_refitted_on_the_http_route() {
         let payload: Value = serde_json::from_str(text).unwrap();
         assert!(payload.get("outside_graph").is_some(), "{payload}");
         assert!(payload.get("_kin_json_format").is_none());
+        break;
     }
     assert!(
         pressured > 0,

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -149,12 +149,8 @@ pub(crate) enum EnrichmentFacet {
 /// What one reconcile outcome says about the path's current bytes, for the
 /// durable record every reporting surface reads.
 ///
-/// `BrokenAst` is the one outcome that means the graph has started answering
-/// about this path from an earlier parse: it derives nothing, retains what the
-/// last good parse left, and the daemon reconciles under
-/// `ReconcilePolicy::FallbackToLkg`, so it is the ordinary case rather than an
-/// edge. `Updated` and `FileRemoved` settle the path, because both re-derived
-/// from the bytes this pass just read.
+/// `BrokenAst` and `PartiallyUpdated` preserve incomplete file coverage. Only
+/// a clean `Updated` or a confirmed `FileRemoved` settles the path.
 ///
 /// `Conflict` also retains last-known-good state and is deliberately not
 /// recorded. It is a held merge rather than a file whose syntax is broken, it
@@ -163,7 +159,7 @@ pub(crate) enum EnrichmentFacet {
 ///
 /// A path the tree admits without a UTF-8 spelling yields nothing, because the
 /// record is keyed by the path string every reporting surface renders.
-fn observed_parse_of(
+pub(crate) fn observed_parse_of(
     repo_path: &RepoPath,
     outcome: &kin_reconcile::ReconcileOutcome,
 ) -> Option<kin_core::retained_parse::ObservedParse> {
@@ -171,7 +167,8 @@ fn observed_parse_of(
     use kin_reconcile::ReconcileOutcome;
     let path = repo_path.as_utf8()?;
     match outcome {
-        ReconcileOutcome::BrokenAst { error_ranges, .. } => {
+        ReconcileOutcome::BrokenAst { error_ranges, .. }
+        | ReconcileOutcome::PartiallyUpdated { error_ranges, .. } => {
             Some(ObservedParse::retained(path, error_ranges.len()))
         }
         ReconcileOutcome::Updated { .. } | ReconcileOutcome::FileRemoved { .. } => {
@@ -179,6 +176,38 @@ fn observed_parse_of(
         }
         ReconcileOutcome::Conflict(_) => None,
     }
+}
+
+/// Persist incomplete coverage before publishing a mixed entity transaction.
+/// Failure refuses partial admission instead of publishing fresh entities with
+/// a stale clean disclosure. A later clean pass settles the durable record.
+pub(crate) fn persist_partial_observation(
+    layout: &kin_core::KinLayout,
+    outcome: &kin_reconcile::ReconcileOutcome,
+) -> Result<()> {
+    let kin_reconcile::ReconcileOutcome::PartiallyUpdated {
+        file_id,
+        error_ranges,
+        ..
+    } = outcome
+    else {
+        return Ok(());
+    };
+    let previous = kin_core::retained_parse::read(layout);
+    if let kin_core::retained_parse::RetainedParseRead::Unreadable(reason) = &previous {
+        return Err(DaemonError::Io(std::io::Error::other(format!(
+            "partial admission cannot preserve incomplete coverage: {reason}"
+        ))));
+    }
+    let record = kin_core::retained_parse::fold(
+        previous.paths(),
+        &[kin_core::retained_parse::ObservedParse::retained(
+            &file_id.0,
+            error_ranges.len(),
+        )],
+        chrono::Utc::now(),
+    );
+    kin_core::retained_parse::write(layout, &record).map_err(DaemonError::Io)
 }
 
 #[derive(Debug, Default)]
@@ -3630,12 +3659,13 @@ pub async fn run_loop_armed(
                 Ok(result) => {
                     let (outcome, delta) = result.into_parts();
                     debug!(?outcome, "reconcile outcome");
-                    observed_parses.extend(observed_parse_of(&semantic_repo_path, &outcome));
 
                     use kin_reconcile::ReconcileOutcome;
                     let should_apply = matches!(
                         &outcome,
-                        ReconcileOutcome::Updated { .. } | ReconcileOutcome::FileRemoved { .. }
+                        ReconcileOutcome::Updated { .. }
+                            | ReconcileOutcome::PartiallyUpdated { .. }
+                            | ReconcileOutcome::FileRemoved { .. }
                     );
                     let mut reconciled_graph_changed = false;
                     if should_apply {
@@ -3670,6 +3700,10 @@ pub async fn run_loop_armed(
                             }
                         }
                         let derived_entities = !delta.entity_deltas.is_empty();
+                        if let Err(error) = persist_partial_observation(&state.layout, &outcome) {
+                            warn!(%error, "partial admission retained all entities because coverage could not persist");
+                            continue;
+                        }
                         let applied = match apply_reconcile_delta(&delta, |delta| {
                             state.graph.apply_transaction_delta(delta)
                         }) {
@@ -3702,6 +3736,8 @@ pub async fn run_loop_armed(
                         reconciled_graph_changed = applied || layout_changed;
                         graph_changed |= reconciled_graph_changed;
                     }
+
+                    observed_parses.extend(observed_parse_of(&semantic_repo_path, &outcome));
 
                     if let ReconcileOutcome::Updated {
                         file_id,
@@ -3784,6 +3820,29 @@ pub async fn run_loop_armed(
                                 pass_delta.count(&event);
                                 state.emit_event(event);
                             }
+                        }
+                    } else if let ReconcileOutcome::PartiallyUpdated { modified, .. } = &outcome {
+                        pass_delta.nodes_modified += modified.len();
+                        for id in modified {
+                            state.emit_event(DaemonEvent::EntityChanged {
+                                entity_id: *id,
+                                node: crate::state::graph_node_summary(state.graph.as_ref(), id),
+                                change_type: ChangeType::Modified,
+                                file_path: Some(path.to_string_lossy().to_string()),
+                                session_id: None,
+                            });
+                        }
+                        if should_apply {
+                            for event in crate::state::relation_change_events(
+                                &delta,
+                                Some(path.to_string_lossy().as_ref()),
+                            ) {
+                                pass_delta.count(&event);
+                                state.emit_event(event);
+                            }
+                        }
+                        if reconciled_graph_changed || tree_changed {
+                            state.bump_version();
                         }
                     } else if let ReconcileOutcome::FileRemoved {
                         removed, file_id, ..
@@ -4010,6 +4069,100 @@ fn take_file_event_batch(pending: &mut VecDeque<FileEvent>, batch_size: usize) -
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    #[test]
+    fn partial_c_disclosure_persists_and_only_clean_outcomes_settle() {
+        let parent = tempfile::tempdir().unwrap();
+        let repo = tempfile::tempdir_in(parent.path()).unwrap();
+        let init = kin_core::init(repo.path()).unwrap();
+        let file_id = FilePathId::new("test.c");
+        let outcome = kin_reconcile::ReconcileOutcome::PartiallyUpdated {
+            file_id: file_id.clone(),
+            modified: vec![EntityId::new()],
+            retained: vec![EntityId::new()],
+            error_ranges: vec![(12, 12)],
+            collision_warnings: vec![],
+        };
+        persist_partial_observation(&init.layout, &outcome).unwrap();
+        assert_eq!(
+            kin_core::retained_parse::read(&init.layout).errors_for("test.c"),
+            Some(1)
+        );
+        let clean = kin_reconcile::ReconcileOutcome::Updated {
+            file_id,
+            added: vec![],
+            modified: vec![],
+            removed: vec![],
+            collision_warnings: vec![],
+        };
+        let path = RepoPath::from_utf8("test.c").unwrap();
+        kin_core::retained_parse::record(
+            &init.layout,
+            &[observed_parse_of(&path, &clean).unwrap()],
+        );
+        assert_eq!(
+            kin_core::retained_parse::read(&init.layout).errors_for("test.c"),
+            None
+        );
+        std::fs::write(init.layout.kindb_retained_parse_path(), b"invalid").unwrap();
+        assert!(persist_partial_observation(&init.layout, &outcome).is_err());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn partial_c_readmission_preserves_unreadable_disclosure_before_apply() {
+        let parent = tempfile::tempdir().unwrap();
+        let repo = tempfile::tempdir_in(parent.path()).unwrap();
+        let state = open_test_state(&repo);
+        state.is_initialized.store(true, Ordering::Relaxed);
+        let before =
+            "int good(void) { int value=1; return value; }\nint bad(void) { test_cond(1) }\n";
+        let after = before.replace("value", "next");
+        let host = state.layout.working_dir().join("test.c");
+        let paths = BTreeSet::from([RepoPath::from_utf8("test.c").unwrap()]);
+        std::fs::write(&host, before).unwrap();
+        ambient_admission_for_test(&state, &paths).unwrap();
+        let indexed = IndexPipeline::new()
+            .index_file_content_with_tests(
+                &FilePathId::new("test.c"),
+                before.as_bytes(),
+                state.blobs.write(before.as_bytes()).unwrap(),
+            )
+            .unwrap()
+            .indexed_file;
+        for entity in &indexed.entities {
+            state.graph.upsert_entity(entity).unwrap();
+        }
+        let old = indexed.entities.iter().find(|e| e.name == "good").unwrap();
+        std::fs::write(&host, &after).unwrap();
+        ambient_admission_for_test(&state, &paths).unwrap();
+        let record = state.layout.kindb_retained_parse_path();
+        std::fs::write(&record, b"invalid").unwrap();
+        let failed = readmit_semantics_for_paths(&state, &paths).await;
+        assert_eq!(failed.enriched, 0);
+        assert_eq!(failed.failed.len(), 1);
+        assert_eq!(state.graph.get_entity(&old.id).unwrap().as_ref(), Some(old));
+        assert_eq!(std::fs::read(&record).unwrap(), b"invalid");
+        kin_core::retained_parse::write(
+            &state.layout,
+            &kin_core::retained_parse::RetainedParse::new(chrono::Utc::now(), vec![]),
+        )
+        .unwrap();
+        let partial = readmit_semantics_for_paths(&state, &paths).await;
+        assert_eq!(
+            partial.enriched, 0,
+            "partial must never count as full-file enrichment"
+        );
+        assert_eq!(partial.failed.len(), 1);
+        let current = state.graph.get_entity(&old.id).unwrap().unwrap();
+        assert_eq!(
+            current.metadata.extra["blob_hash"],
+            kin_blobs::digest(after.as_bytes()).to_string()
+        );
+        assert!(kin_core::retained_parse::read(&state.layout)
+            .errors_for("test.c")
+            .is_some());
+    }
 
     fn open_test_state(repo: &tempfile::TempDir) -> Arc<DaemonState> {
         let init = kin_core::init(repo.path()).unwrap();
@@ -9801,10 +9954,21 @@ pub(crate) async fn readmit_semantics_for_paths(
         match reconciler.reconcile_file_change(&event, &state.blobs, state.graph.as_ref()) {
             Ok(result) => {
                 let (reconciled, delta) = result.into_parts();
+                if matches!(
+                    reconciled,
+                    kin_reconcile::ReconcileOutcome::BrokenAst { .. }
+                ) {
+                    if let Some(observation) = observed_parse_of(repo_path, &reconciled) {
+                        kin_core::retained_parse::record(&state.layout, &[observation]);
+                    }
+                }
+
                 use kin_reconcile::ReconcileOutcome;
                 let should_apply = matches!(
                     &reconciled,
-                    ReconcileOutcome::Updated { .. } | ReconcileOutcome::FileRemoved { .. }
+                    ReconcileOutcome::Updated { .. }
+                        | ReconcileOutcome::PartiallyUpdated { .. }
+                        | ReconcileOutcome::FileRemoved { .. }
                 );
                 // `BrokenAst` and `Conflict` retain last-known-good state and
                 // derive nothing, so the file keeps the spans its previous parse
@@ -9832,6 +9996,13 @@ pub(crate) async fn readmit_semantics_for_paths(
                 }
                 {
                     let derived_entities = !delta.entity_deltas.is_empty();
+                    if let Err(error) = persist_partial_observation(&state.layout, &reconciled) {
+                        warn!(%error, "partial admission retained all entities because coverage could not persist");
+                        outcome
+                            .failed
+                            .push(SemanticFailure::unresolved(file_id.0.clone()));
+                        continue;
+                    }
                     if let Err(error) = state.graph.apply_transaction_delta(&delta) {
                         warn!(
                             file = %file_id,
@@ -9843,6 +10014,9 @@ pub(crate) async fn readmit_semantics_for_paths(
                             .failed
                             .push(SemanticFailure::unresolved(file_id.0.clone()));
                         continue;
+                    }
+                    if let Some(observation) = observed_parse_of(repo_path, &reconciled) {
+                        kin_core::retained_parse::record(&state.layout, &[observation]);
                     }
                     if derived_entities {
                         mark_enrichment_unpublished(state, &file_id);
@@ -9878,7 +10052,13 @@ pub(crate) async fn readmit_semantics_for_paths(
                         }
                     }
                     graph_changed = true;
-                    outcome.enriched += 1;
+                    if matches!(reconciled, ReconcileOutcome::PartiallyUpdated { .. }) {
+                        outcome
+                            .failed
+                            .push(SemanticFailure::unparseable(file_id.0.clone()));
+                    } else {
+                        outcome.enriched += 1;
+                    }
                 }
             }
             Err(error) => {
@@ -10313,11 +10493,27 @@ async fn sync_filesystem_with_graph_publishing_inner(
         {
             Ok(result) => {
                 let (outcome, delta) = result.into_parts();
-                observed_parses.extend(observed_parse_of(&semantic_repo_path, &outcome));
+                // An outcome this pass will APPLY discloses after the apply
+                // lands, a few lines down, so a transaction the graph refused
+                // cannot leave a disclosure claiming it settled. Everything
+                // else discloses here, because nothing further will happen to
+                // it. `PartiallyUpdated` belongs on the applied side with the
+                // other two: recording it here as well would put the same path
+                // in `observed_parses` twice in one pass.
+                if !matches!(
+                    outcome,
+                    kin_reconcile::ReconcileOutcome::Updated { .. }
+                        | kin_reconcile::ReconcileOutcome::PartiallyUpdated { .. }
+                        | kin_reconcile::ReconcileOutcome::FileRemoved { .. }
+                ) {
+                    observed_parses.extend(observed_parse_of(&semantic_repo_path, &outcome));
+                }
                 use kin_reconcile::ReconcileOutcome;
                 let should_apply = matches!(
                     &outcome,
-                    ReconcileOutcome::Updated { .. } | ReconcileOutcome::FileRemoved { .. }
+                    ReconcileOutcome::Updated { .. }
+                        | ReconcileOutcome::PartiallyUpdated { .. }
+                        | ReconcileOutcome::FileRemoved { .. }
                 );
                 if should_apply {
                     if !host_entry_matches_graph(state, path, &semantic_repo_path)? {
@@ -10327,10 +10523,12 @@ async fn sync_filesystem_with_graph_publishing_inner(
                         ))));
                     }
                     let derived_entities = !delta.entity_deltas.is_empty();
+                    persist_partial_observation(&state.layout, &outcome)?;
                     if let Err(e) = state.graph.apply_transaction_delta(&delta) {
                         warn!(error = %e, "failed to apply synced transaction into primary graph");
                         continue;
                     }
+                    observed_parses.extend(observed_parse_of(&semantic_repo_path, &outcome));
                     // Marked here for the same reason as on the ambient tick.
                     // This seam runs under a commit as often as not, and a
                     // commit publishes what it derived, so most entries written

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -3789,6 +3789,119 @@ mod tests {
         );
     }
 
+    #[test]
+    fn incomplete_mcp_replacement_preserves_verified_declarations_and_authority() {
+        let (_dir, state) = test_state();
+        let before = "int value(void) { return 1; }\nint retained(void) { return 9; }\n";
+        let partial = "int value(void) { return 2; }\n/* int retained(void) { return 9; }\n";
+        install_exact_source(&state, "test.c", before.as_bytes(), "value");
+        let base = load_native_commit_base(&state.layout).unwrap();
+        let held = base
+            .graph
+            .query_entities(&EntityFilter {
+                file_path: Some(FilePathId::new("test.c")),
+                ..Default::default()
+            })
+            .unwrap();
+        assert!(held.iter().any(|e| e.name == "retained"));
+        let indexed = kin_index::IndexPipeline::new()
+            .index_file_content_with_tests(
+                &FilePathId::new("test.c"),
+                partial.as_bytes(),
+                kin_blobs::digest(partial.as_bytes()),
+            )
+            .unwrap()
+            .indexed_file;
+        assert!(matches!(
+            indexed.parse_state,
+            kin_model::ParseState::Incomplete { .. }
+        ));
+        assert!(
+            !indexed.entities.iter().any(|e| e.name == "retained"),
+            "the incomplete parse must hide a declaration whose text remains"
+        );
+        let sessions = test_sessions();
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "file:test.c")
+            .unwrap();
+        sessions
+            .stage_transaction(
+                &transaction.transaction_id,
+                vec![replaced_source_file("test.c", partial)],
+            )
+            .unwrap();
+        let result = commit_exact_transaction(
+            &state,
+            &sessions,
+            &HashMap::from([(
+                "transaction_id".to_string(),
+                serde_json::json!(transaction.transaction_id),
+            )]),
+            None,
+        );
+        let after = load_native_commit_base(&state.layout).unwrap();
+        assert_eq!(
+            after.roots,
+            base.roots,
+            "incomplete replacement moved repository authority: {}",
+            result_text(&result)
+        );
+        assert!(semantic_workspace_matches(&after.graph, &base.graph));
+        assert!(semantic_workspace_matches(
+            state.graph.as_ref(),
+            &base.graph
+        ));
+        assert_eq!(
+            std::fs::read_to_string(state.layout.working_dir().join("test.c")).unwrap(),
+            before
+        );
+        assert_eq!(result.is_error, Some(true), "{}", result_text(&result));
+        assert!(
+            result_text(&result).contains("Incomplete parse cannot verify deletion"),
+            "{}",
+            result_text(&result)
+        );
+
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "file:test.c")
+            .unwrap();
+        sessions
+            .stage_transaction(
+                &transaction.transaction_id,
+                vec![replaced_source_file(
+                    "test.c",
+                    "int value(void) { return 2; }\n",
+                )],
+            )
+            .unwrap();
+        let valid = commit_exact_transaction(
+            &state,
+            &sessions,
+            &HashMap::from([(
+                "transaction_id".to_string(),
+                serde_json::json!(transaction.transaction_id),
+            )]),
+            None,
+        );
+        assert_ne!(valid.is_error, Some(true), "{}", result_text(&valid));
+        let valid_base = load_native_commit_base(&state.layout).unwrap();
+        assert!(
+            valid_base
+                .graph
+                .query_entities(&EntityFilter {
+                    name_pattern: Some("retained".into()),
+                    ..Default::default()
+                })
+                .unwrap()
+                .is_empty(),
+            "a complete parse can verify an intentional removal"
+        );
+        assert!(semantic_workspace_matches(
+            state.graph.as_ref(),
+            &valid_base.graph
+        ));
+    }
+
     /// A rewrite of a path repository authority does not track is refused by
     /// name, and told which verb admits one.
     ///

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -1518,6 +1518,7 @@ pub(crate) fn paths_whose_semantics_the_sealed_bytes_do_not_reproduce(
     authority: &RepositoryAuthorityManager<LocalFileBackend>,
     tree_deltas: &[kin_model::TreeDelta],
     scope: SealedPathScope,
+    changed_entities: &BTreeSet<kin_model::EntityId>,
 ) -> Result<Vec<RepoPath>> {
     use kin_model::EntityStore;
 
@@ -1571,22 +1572,172 @@ pub(crate) fn paths_whose_semantics_the_sealed_bytes_do_not_reproduce(
             continue;
         };
         let indexed = indexed.indexed_file;
-        // Only a clean parse can say the graph's entities are wrong. A file the
-        // parser could not read whole keeps the entities its last readable
-        // version produced, deliberately: the daemon reconciles under
-        // `ReconcilePolicy::FallbackToLkg`, an author mid-edit produces this
-        // constantly, and a fresh parse of a half-written file disagrees with
-        // the graph for a reason that has nothing to do with the window this
-        // check exists to close. Refusing on it would leave a caller holding one
-        // broken file unable to record anything at all, which is the outcome
-        // `drain_semantic_debt` already declines to produce for the same reason.
-        if !matches!(indexed.parse_state, kin_model::ParseState::Valid) {
-            continue;
-        }
         let held = graph.query_entities(&kin_model::EntityFilter {
             file_path: Some(file_id.clone()),
             ..Default::default()
         })?;
+        if let kin_model::ParseState::Incomplete { error_ranges } = &indexed.parse_state {
+            let mut stale = false;
+            for entity in &held {
+                let candidates: Vec<_> = indexed
+                    .entities
+                    .iter()
+                    .filter(|e| e.name == entity.name && e.kind == entity.kind)
+                    .collect();
+                let unique = candidates.len() == 1
+                    && held
+                        .iter()
+                        .filter(|e| e.name == entity.name && e.kind == entity.kind)
+                        .count()
+                        == 1;
+                let current = entity
+                    .metadata
+                    .extra
+                    .get("blob_hash")
+                    .and_then(|v| v.as_str())
+                    == Some(hash.to_string().as_str());
+                let proof = entity.metadata.extra.get("partial_parse_admission");
+                if proof.is_some_and(|proof| {
+                    proof.get("source_blob_hash") != entity.metadata.extra.get("blob_hash")
+                }) {
+                    stale = true;
+                    continue;
+                }
+                // An unchanged, previously admitted payload needs no new
+                // partial-refresh proof when its original source is restored.
+                if current && proof.is_none() && !changed_entities.contains(&entity.id) {
+                    continue;
+                }
+                if current {
+                    let held_relations = kin_model::EntityStore::traverse(
+                        graph,
+                        &kin_model::GraphNodeId::Entity(entity.id),
+                        &[],
+                        1,
+                    )?
+                    .relations;
+                    // A partial admission claims only this declaration. Recheck
+                    // the old CAS context and the exact new payload, not a
+                    // complete-set equality over an incomplete file.
+                    let previous = proof
+                        .and_then(|v| v.get("previous_blob_hash"))
+                        .and_then(|v| v.as_str())
+                        .and_then(|v| kin_model::Hash256::from_hex(v).ok());
+                    let verified = previous
+                        .and_then(|previous| {
+                            read_publishable_source(blobs, authority, previous).ok()
+                        })
+                        .and_then(|previous| {
+                            let before = pipeline
+                                .index_file_content_with_tests(
+                                    &file_id,
+                                    previous.body(),
+                                    kin_blobs::digest(previous.body()),
+                                )
+                                .ok()?;
+                            let originals: Vec<_> = before
+                                .indexed_file
+                                .entities
+                                .iter()
+                                .filter(|e| e.name == entity.name && e.kind == entity.kind)
+                                .collect();
+                            Some(
+                                unique
+                                    && originals.len() == 1
+                                    && pipeline.supports_partial_refresh(
+                                        originals[0],
+                                        candidates[0],
+                                        previous.body(),
+                                        content,
+                                    )
+                                    && {
+                                        let mut expected = candidates[0].clone();
+                                        expected.id = entity.id;
+                                        expected.created_in = entity.created_in;
+                                        expected.lineage_parent = entity.lineage_parent;
+                                        expected.metadata.extra.insert(
+                                            "partial_parse_admission".into(),
+                                            serde_json::json!({
+                                                "previous_blob_hash": kin_blobs::digest(previous.body()).to_string(),
+                                                "source_blob_hash": hash.to_string(),
+                                                "error_ranges": error_ranges,
+                                            }),
+                                        );
+                                        let mut original = originals[0].clone();
+                                        original.id = entity.id;
+                                        let declaration = candidates[0].span.as_ref()?;
+                                        expected == *entity && held_relations.iter().all(|relation| {
+                                            let associated = relation.evidence.iter().filter_map(|e| e.source_span.as_ref()).any(|span| {
+                                                span.file == declaration.file && (relation.src == kin_model::GraphNodeId::Entity(entity.id)
+                                                    || (declaration.start_line <= span.start_line && span.end_line <= declaration.end_line))
+                                            });
+                                            !associated || pipeline.verifies_partial_relation(
+                                                &original, candidates[0], previous.body(), content, relation, &held,
+                                            )
+                                        })
+                                    },
+                            )
+                        })
+                        .unwrap_or(false);
+                    stale |= !verified;
+                } else if !current && unique {
+                    // Do not seal a refreshable declaration in the window
+                    // before its partial transaction reaches graph truth.
+                    let previous = entity
+                        .metadata
+                        .extra
+                        .get("blob_hash")
+                        .and_then(|v| v.as_str())
+                        .and_then(|v| kin_model::Hash256::from_hex(v).ok());
+                    if let Some(previous) = previous.and_then(|previous| {
+                        read_publishable_source(blobs, authority, previous).ok()
+                    }) {
+                        let relations = kin_model::EntityStore::traverse(
+                            graph,
+                            &kin_model::GraphNodeId::Entity(entity.id),
+                            &[],
+                            1,
+                        )?
+                        .relations;
+                        stale |= pipeline.supports_partial_refresh(
+                            entity,
+                            candidates[0],
+                            previous.body(),
+                            content,
+                        ) && relations.iter().all(|relation| {
+                            let associated = entity.span.as_ref().is_some_and(|declaration| {
+                                relation
+                                    .evidence
+                                    .iter()
+                                    .filter_map(|e| e.source_span.as_ref())
+                                    .any(|span| {
+                                        span.file == declaration.file
+                                            && (relation.src
+                                                == kin_model::GraphNodeId::Entity(entity.id)
+                                                || (declaration.start_line <= span.start_line
+                                                    && span.end_line <= declaration.end_line))
+                                    })
+                            });
+                            !associated
+                                || pipeline
+                                    .rebase_partial_relation(
+                                        entity,
+                                        candidates[0],
+                                        previous.body(),
+                                        content,
+                                        relation,
+                                        &held,
+                                    )
+                                    .is_some()
+                        });
+                    }
+                }
+            }
+            if stale {
+                behind.push(new.path.clone());
+            }
+            continue;
+        }
         // No skip for a path the graph holds nothing at: a clean parse that
         // produces entities where the graph has none is the same defect one step
         // further along, and the comparison below already says so.
@@ -1759,6 +1910,11 @@ fn plan_native_commit_inner(
                     } else {
                         SealedPathScope::UpdatedOnly
                     },
+                    &workspace_semantic_delta
+                        .entity_deltas()
+                        .iter()
+                        .map(kin_model::EntityDelta::target_id)
+                        .collect(),
                 )
             })?
         }
@@ -1955,6 +2111,24 @@ fn plan_native_commit_inner(
         }
     }
     source_hashes.extend(shared_policy.sources.iter().map(|source| source.body_hash));
+    for entity in change
+        .entity_deltas
+        .iter()
+        .filter_map(kin_model::EntityDelta::new_state)
+    {
+        if let Some(previous) = entity
+            .metadata
+            .extra
+            .get("partial_parse_admission")
+            .and_then(|proof| proof.get("previous_blob_hash"))
+            .and_then(|value| value.as_str())
+        {
+            source_hashes.insert(
+                Hash256::from_hex(previous)
+                    .map_err(|error| invalid(format!("invalid partial proof source: {error}")))?,
+            );
+        }
+    }
 
     // The lease is a read of this authority and the plan carries the authority
     // itself, so the read ends here and the open does not.
@@ -4626,6 +4800,526 @@ mod tests {
         commit_native_plan_with_projection(&init.layout, blobs, plan).unwrap();
         update_artifact_bytes(graph, blobs, &artifact, after);
         held
+    }
+
+    /// An observed rename in an incomplete C file must refresh the independently
+    /// verified declaration while preserving its graph identity.
+    #[test]
+    fn a_semantically_neutral_c_rename_leaves_no_entity_answering_from_bytes_that_are_gone() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir_in(parent.path()).unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+        let before = include_str!("../../kin-parser/tests/fixtures/c/hiredis-sds.c");
+        assert_eq!(
+            before.matches("reqlen").count(),
+            3,
+            "the disclosed edit is three occurrences of one local"
+        );
+        let after = before.replacen("reqlen", "required_len", 3);
+
+        // The premise, asserted rather than assumed. These bytes do not parse
+        // whole either side of the rename, and by the same count, which is what
+        // makes the rename innocent and the retained span inexcusable. If the C
+        // adapter ever reads this file cleanly the class is gone, and this test
+        // must fail loudly saying so instead of passing on a technicality.
+        let errors = |source: &str| {
+            let indexed = kin_index::IndexPipeline::new()
+                .index_file_content_with_tests(
+                    &kin_model::FilePathId::new("sds.c"),
+                    source.as_bytes(),
+                    blobs.write(source.as_bytes()).unwrap(),
+                )
+                .unwrap()
+                .indexed_file;
+            match indexed.parse_state {
+                kin_model::ParseState::Incomplete { error_ranges } => error_ranges.len(),
+                other => panic!("the fixture must not parse whole: {other:?}"),
+            }
+        };
+        assert_eq!(errors(before), 25);
+        assert_eq!(errors(&after), 25, "the rename introduces no parse error");
+
+        // Import admits what a partial parse yields, which is how the disclosed
+        // store came to hold `sdsMakeRoomFor` at all.
+        let working_dir = init.layout.working_dir().to_path_buf();
+        let host = working_dir.join("sds.c");
+        std::fs::write(&host, before).unwrap();
+        let artifact = add_artifact(&graph, &blobs, b"sds.c", before.as_bytes(), |hash| {
+            TreeEntry::blob(hash, false)
+        });
+        let held = derive_entities_into_graph(&graph, &blobs, "sds.c", before.as_bytes());
+        let target = held.iter().find(|e| e.name == "sdsMakeRoomFor").unwrap();
+        let old_digest = Hash256::from_bytes(kin_blobs::digest(before.as_bytes()).0);
+        let new_digest = Hash256::from_bytes(kin_blobs::digest(after.as_bytes()).0);
+
+        // Two controls before the edit, so a change that simply stopped
+        // recording provenance could not satisfy the assertion at the end. The
+        // read is coherent while the path holds the bytes the span came from,
+        // and it is the disclosed refusal the moment those bytes move.
+        kin_mcp::handlers::common::span_source_coherence(target, &old_digest, "sds.c").unwrap();
+        std::fs::write(&host, &after).unwrap();
+        update_artifact_bytes(&graph, &blobs, &artifact, after.as_bytes());
+        let refusal =
+            kin_mcp::handlers::common::span_source_coherence(target, &new_digest, "sds.c")
+                .expect_err("a span derived from other bytes cannot describe these");
+        assert!(
+            refusal
+                .to_string()
+                .contains("does not describe these bytes"),
+            "{refusal}"
+        );
+
+        // One reconcile of the observed write: the whole of what the disclosed
+        // run got between the edit and the refusal.
+        let result = kin_reconcile::Reconciler::new(working_dir)
+            .reconcile_file_change(&kin_index::FileEvent::Changed(host.clone()), &blobs, &graph)
+            .unwrap();
+        graph.apply_transaction_delta(&result.delta).unwrap();
+
+        let current = graph.get_entity(&target.id).unwrap().unwrap();
+        assert_eq!(current.id, target.id, "identity survives the refresh");
+        kin_mcp::handlers::common::span_source_coherence(&current, &new_digest, "sds.c")
+            .expect("the edited declaration must answer about the bytes at its path");
+        let span = current.span.as_ref().unwrap();
+        assert!(
+            after[span.start_byte..span.end_byte].contains("required_len"),
+            "the recorded span must slice the renamed body"
+        );
+    }
+
+    #[test]
+    fn partial_c_commit_reopens_current_identity_and_retains_incomplete_coverage() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir_in(parent.path()).unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+        let before = include_str!("../../kin-parser/tests/fixtures/c/hiredis-sds.c");
+        let after = before.replacen("reqlen", "required_len", 3);
+        let artifact = add_artifact(&graph, &blobs, b"sds.c", before.as_bytes(), |hash| {
+            TreeEntry::blob(hash, false)
+        });
+        let held = derive_entities_into_graph(&graph, &blobs, "sds.c", before.as_bytes());
+        let target = held.iter().find(|e| e.name == "sdsMakeRoomFor").unwrap();
+        let initial = plan_native_commit(
+            &init.layout,
+            &graph,
+            &blobs,
+            OperationId::new(),
+            fixed_timestamp(),
+            AuthorId::new("tests"),
+            "Record C source".into(),
+        )
+        .unwrap();
+        commit_native_plan_with_projection(&init.layout, &blobs, initial).unwrap();
+        let artifact = update_artifact_bytes(&graph, &blobs, &artifact, after.as_bytes());
+        let plan = || {
+            plan_native_commit(
+                &init.layout,
+                &graph,
+                &blobs,
+                OperationId::new(),
+                fixed_timestamp(),
+                AuthorId::new("tests"),
+                "Refresh C declaration".into(),
+            )
+        };
+        assert!(
+            plan().is_err(),
+            "a refreshable entity must not be sealed before admission"
+        );
+        // Through the entrypoint the daemon's watcher uses, which is where the
+        // broken-AST decision is taken. `reconcile_indexed_content` beside it
+        // keeps its full re-derive for the commit paths that need a layout.
+        let host = root.path().join("sds.c");
+        std::fs::write(&host, &after).unwrap();
+        let mut reconciler = kin_reconcile::Reconciler::new(root.path().to_path_buf());
+        let result = reconciler
+            .reconcile_file_change(&kin_index::FileEvent::Changed(host), &blobs, &graph)
+            .unwrap();
+        let kin_reconcile::ReconcileOutcome::PartiallyUpdated {
+            retained,
+            error_ranges,
+            ..
+        } = &result.outcome
+        else {
+            panic!("{:?}", result.outcome);
+        };
+        assert_eq!(error_ranges.len(), 25);
+        crate::loop_runner::persist_partial_observation(&init.layout, &result.outcome).unwrap();
+        graph.apply_transaction_delta(&result.delta).unwrap();
+        let observation = crate::loop_runner::observed_parse_of(
+            &RepoPath::from_utf8("sds.c").unwrap(),
+            &result.outcome,
+        )
+        .unwrap();
+        kin_core::retained_parse::record(&init.layout, &[observation]);
+        let good = graph.get_entity(&target.id).unwrap().unwrap();
+        for corruption in [
+            "proof",
+            "error_ranges",
+            "span",
+            "digest",
+            "signature",
+            "body",
+        ] {
+            let mut corrupt = good.clone();
+            match corruption {
+                "proof" => {
+                    corrupt.metadata.extra.remove("partial_parse_admission");
+                }
+                "error_ranges" => {
+                    corrupt
+                        .metadata
+                        .extra
+                        .get_mut("partial_parse_admission")
+                        .unwrap()["error_ranges"] = serde_json::json!([]);
+                }
+                "span" => {
+                    corrupt.span.as_mut().unwrap().start_byte += 1;
+                }
+                "signature" => {
+                    corrupt.signature.push_str(" invalid");
+                }
+                "digest" => {
+                    corrupt.metadata.extra.insert(
+                        "blob_hash".into(),
+                        kin_blobs::digest(before.as_bytes()).to_string().into(),
+                    );
+                }
+                _ => {
+                    corrupt.fingerprint.behavior_hash = Hash256::from_bytes([0; 32]);
+                }
+            }
+            graph.upsert_entity(&corrupt).unwrap();
+            assert!(
+                plan().is_err(),
+                "commit accepted corrupted {corruption} proof"
+            );
+            graph.upsert_entity(&good).unwrap();
+        }
+        publish_workspace_tree(
+            &init.layout,
+            &blobs,
+            &graph.resolved_tree(),
+            OperationId::new(),
+            AuthorId::new("tests"),
+        )
+        .unwrap();
+        let expected = graph.to_snapshot();
+        commit_native_plan_with_projection(&init.layout, &blobs, plan().unwrap()).unwrap();
+        let authority = reopen(&init);
+        let lease = authority.read_authority();
+        let snapshot = lease
+            .workspace_graph_snapshot(&init.workspace_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(snapshot.entities, expected.entities);
+        assert_eq!(snapshot.relations, expected.relations);
+        assert_eq!(snapshot.resolved_tree, expected.resolved_tree);
+        let current = snapshot.entities.get(&target.id).unwrap();
+        assert_eq!(current, &good);
+        let digest = Hash256::from_bytes(kin_blobs::digest(after.as_bytes()).0);
+        kin_mcp::handlers::common::span_source_coherence(current, &digest, "sds.c").unwrap();
+        let source = read_publishable_source(&blobs, &authority, digest).unwrap();
+        let span = current.span.as_ref().unwrap();
+        assert!(
+            std::str::from_utf8(&source.body()[span.start_byte..span.end_byte])
+                .unwrap()
+                .contains("required_len")
+        );
+        for id in retained {
+            let old = held.iter().find(|e| e.id == *id).unwrap();
+            assert_eq!(snapshot.entities.get(id), Some(old));
+            assert!(
+                kin_mcp::handlers::common::span_source_coherence(old, &digest, "sds.c").is_err()
+            );
+        }
+        let disclosure = kin_core::retained_parse::read(&init.layout);
+        assert_eq!(disclosure.errors_for("sds.c"), Some(25));
+        let entities: Vec<_> = snapshot.entities.values().cloned().collect();
+        let coverage = kin_core::reference_coverage::collect_parse_coverage_from(
+            &snapshot.resolved_tree,
+            &entities,
+            &disclosure,
+        );
+        assert!(coverage.any_retained());
+        assert!(coverage
+            .summary_lines()
+            .join("\n")
+            .contains("retained_last_good_parse"));
+        drop(lease);
+        drop(authority);
+        std::fs::write(root.path().join("sds.c"), before).unwrap();
+        update_artifact_bytes(&graph, &blobs, &artifact, before.as_bytes());
+        let restored = reconciler
+            .reconcile_file_change(
+                &kin_index::FileEvent::Changed(root.path().join("sds.c")),
+                &blobs,
+                &graph,
+            )
+            .unwrap();
+        graph.apply_transaction_delta(&restored.delta).unwrap();
+        publish_workspace_tree(
+            &init.layout,
+            &blobs,
+            &graph.resolved_tree(),
+            OperationId::new(),
+            AuthorId::new("tests"),
+        )
+        .unwrap();
+        commit_native_plan_with_projection(&init.layout, &blobs, plan().unwrap()).expect(
+            "restoring imported incomplete bytes keeps unchanged admitted declarations valid",
+        );
+    }
+
+    #[test]
+    fn partial_c_commit_publishes_intermediate_proof_source() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir_in(parent.path()).unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+        let before = "int good(void){int value=1;return value;}\nint bad(void){test_cond(1)}\n";
+        let middle = before.replace("value", "middle");
+        let after = before.replace("value", "final_value");
+        let mut artifact = add_artifact(&graph, &blobs, b"test.c", before.as_bytes(), |hash| {
+            TreeEntry::blob(hash, false)
+        });
+        derive_entities_into_graph(&graph, &blobs, "test.c", before.as_bytes());
+        let plan = || {
+            plan_native_commit(
+                &init.layout,
+                &graph,
+                &blobs,
+                OperationId::new(),
+                fixed_timestamp(),
+                AuthorId::new("tests"),
+                "Record C source".into(),
+            )
+        };
+        commit_native_plan_with_projection(&init.layout, &blobs, plan().unwrap()).unwrap();
+        let mut reconciler = kin_reconcile::Reconciler::new(root.path().to_path_buf());
+        for body in [&middle, &after] {
+            let host = root.path().join("test.c");
+            std::fs::write(&host, body).unwrap();
+            artifact = update_artifact_bytes(&graph, &blobs, &artifact, body.as_bytes());
+            let result = reconciler
+                .reconcile_file_change(&kin_index::FileEvent::Changed(host), &blobs, &graph)
+                .unwrap();
+            assert!(matches!(
+                result.outcome,
+                kin_reconcile::ReconcileOutcome::PartiallyUpdated { .. }
+            ));
+            graph.apply_transaction_delta(&result.delta).unwrap();
+        }
+        let middle_hash = Hash256::from_bytes(kin_blobs::digest(middle.as_bytes()).0);
+        assert!(reopen(&init)
+            .load_source_blob(middle_hash)
+            .unwrap()
+            .is_none());
+        publish_workspace_tree(
+            &init.layout,
+            &blobs,
+            &graph.resolved_tree(),
+            OperationId::new(),
+            AuthorId::new("tests"),
+        )
+        .unwrap();
+        let expected = graph.to_snapshot();
+        commit_native_plan_with_projection(&init.layout, &blobs, plan().unwrap()).unwrap();
+        let authority = reopen(&init);
+        let empty = tempfile::tempdir().unwrap();
+        let empty_ingest = kin_blobs::BlobStore::new(empty.path().to_path_buf()).unwrap();
+        assert_eq!(
+            read_publishable_source(&empty_ingest, &authority, middle_hash)
+                .unwrap()
+                .body(),
+            middle.as_bytes()
+        );
+        let lease = authority.read_authority();
+        let snapshot = lease
+            .workspace_graph_snapshot(&init.workspace_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(snapshot.entities, expected.entities);
+        assert_eq!(snapshot.relations, expected.relations);
+        assert_eq!(snapshot.resolved_tree, expected.resolved_tree);
+    }
+
+    #[test]
+    fn partial_c_call_evidence_commits_and_reopens_at_the_current_call_site() {
+        let before = "int helper(void) { return 7; }\nint good(void) {\n  int value=1;\n  return helper();\n}\nint bad(void) { test_cond(1) }\n";
+        let site = |source: &str, zero_bytes: bool| {
+            let start = source.find("helper()").unwrap();
+            let end = start + "helper".len();
+            let line = source[..start]
+                .bytes()
+                .filter(|byte| *byte == b'\n')
+                .count() as u32;
+            let column = start - source[..start].rfind('\n').map_or(0, |offset| offset + 1);
+            kin_model::SourceSpan {
+                file: kin_model::FilePathId::new("test.c"),
+                start_byte: if zero_bytes { 0 } else { start },
+                end_byte: if zero_bytes { 0 } else { end },
+                start_line: line,
+                end_line: line,
+                start_col: column as u32,
+                end_col: (column + end - start) as u32,
+            }
+        };
+        for (prefix, unsupported) in [(true, false), (false, false), (true, true)] {
+            let parent = tempfile::tempdir().unwrap();
+            let root = tempfile::tempdir_in(parent.path()).unwrap();
+            let init = kin_core::init(root.path()).unwrap();
+            let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+            let graph = kin_db::InMemoryGraph::new();
+            let artifact = add_artifact(&graph, &blobs, b"test.c", before.as_bytes(), |hash| {
+                TreeEntry::blob(hash, false)
+            });
+            let held = derive_entities_into_graph(&graph, &blobs, "test.c", before.as_bytes());
+            let caller = held.iter().find(|entity| entity.name == "good").unwrap();
+            let callee = held.iter().find(|entity| entity.name == "helper").unwrap();
+            let mut relation = kin_model::Relation {
+                id: kin_model::RelationId::new(),
+                kind: kin_model::RelationKind::Calls,
+                src: kin_model::GraphNodeId::Entity(caller.id),
+                dst: kin_model::GraphNodeId::Entity(callee.id),
+                confidence: 0.75,
+                origin: kin_model::RelationOrigin::Lsp,
+                created_in: None,
+                import_source: None,
+                evidence: vec![kin_model::RelationEvidence {
+                    source_span: Some(site(before, prefix)),
+                    ..Default::default()
+                }],
+            };
+            if unsupported {
+                relation.evidence[0].source_span = caller.span.clone();
+            }
+            graph.upsert_relation(&relation).unwrap();
+            let plan = || {
+                plan_native_commit(
+                    &init.layout,
+                    &graph,
+                    &blobs,
+                    OperationId::new(),
+                    fixed_timestamp(),
+                    AuthorId::new("tests"),
+                    "Record current call evidence".into(),
+                )
+            };
+            std::fs::write(root.path().join("test.c"), before).unwrap();
+            publish_workspace_tree(
+                &init.layout,
+                &blobs,
+                &graph.resolved_tree(),
+                OperationId::new(),
+                AuthorId::new("tests"),
+            )
+            .unwrap();
+            commit_native_plan_with_projection(&init.layout, &blobs, plan().unwrap()).unwrap();
+            let after = if prefix {
+                format!("// prefix\n{before}")
+            } else {
+                before.replace("int value=1;", "int renamed=1;\n\n")
+            };
+            update_artifact_bytes(&graph, &blobs, &artifact, after.as_bytes());
+            let host = root.path().join("test.c");
+            std::fs::write(&host, &after).unwrap();
+            let mut reconciler = kin_reconcile::Reconciler::new(root.path().to_path_buf());
+            let result = reconciler
+                .reconcile_file_change(&kin_index::FileEvent::Changed(host), &blobs, &graph)
+                .unwrap();
+            assert!(
+                matches!(&result.outcome, kin_reconcile::ReconcileOutcome::PartiallyUpdated { modified, .. } if modified.contains(&caller.id) != unsupported),
+                "{:?}",
+                result.outcome
+            );
+            crate::loop_runner::persist_partial_observation(&init.layout, &result.outcome).unwrap();
+            graph.apply_transaction_delta(&result.delta).unwrap();
+            if unsupported {
+                assert_eq!(graph.get_entity(&caller.id).unwrap().as_ref(), Some(caller));
+                publish_workspace_tree(
+                    &init.layout,
+                    &blobs,
+                    &graph.resolved_tree(),
+                    OperationId::new(),
+                    AuthorId::new("tests"),
+                )
+                .unwrap();
+                commit_native_plan_with_projection(&init.layout, &blobs, plan().unwrap()).unwrap();
+                let authority = reopen(&init);
+                let lease = authority.read_authority();
+                let snapshot = lease
+                    .workspace_graph_snapshot(&init.workspace_id)
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(snapshot.entities.get(&caller.id), Some(caller));
+                assert_eq!(snapshot.relations.get(&relation.id), Some(&relation));
+                assert_eq!(
+                    kin_core::retained_parse::read(&init.layout).errors_for("test.c"),
+                    Some(1)
+                );
+                continue;
+            }
+            let mut expected = relation.clone();
+            expected.evidence[0].source_span = Some(site(&after, false));
+            let updated = graph
+                .get_all_relations_for_entity(&caller.id)
+                .unwrap()
+                .into_iter()
+                .find(|held| held.id == relation.id)
+                .unwrap();
+            assert_eq!(
+                updated, expected,
+                "the partial transaction must move the existing call evidence"
+            );
+            graph.upsert_relation(&relation).unwrap();
+            assert!(
+                plan().is_err(),
+                "commit accepted retained old call-site coordinates for a current caller"
+            );
+            graph.upsert_relation(&updated).unwrap();
+            publish_workspace_tree(
+                &init.layout,
+                &blobs,
+                &graph.resolved_tree(),
+                OperationId::new(),
+                AuthorId::new("tests"),
+            )
+            .unwrap();
+            commit_native_plan_with_projection(&init.layout, &blobs, plan().unwrap()).unwrap();
+            let authority = reopen(&init);
+            let lease = authority.read_authority();
+            let snapshot = lease
+                .workspace_graph_snapshot(&init.workspace_id)
+                .unwrap()
+                .unwrap();
+            let current = snapshot.entities.get(&caller.id).unwrap();
+            assert_eq!(
+                current.metadata.extra["blob_hash"],
+                kin_blobs::digest(after.as_bytes()).to_string()
+            );
+            let reopened = snapshot.relations.get(&relation.id).unwrap();
+            assert_eq!(reopened, &expected);
+            let lines = kin_mcp::handlers::common::relation_reference_lines(
+                reopened,
+                Some(&kin_model::FilePathId::new("test.c")),
+            );
+            assert_eq!(lines.lines, vec![site(&after, false).start_line + 1]);
+            assert!(after
+                .lines()
+                .nth(lines.lines[0] as usize - 1)
+                .unwrap()
+                .contains("helper()"));
+            assert_eq!(
+                kin_core::retained_parse::read(&init.layout).errors_for("test.c"),
+                Some(1)
+            );
+        }
     }
 
     /// A commit must not seal a tree delta over a path whose graph entities a

--- a/crates/kin-index/src/pipeline.rs
+++ b/crates/kin-index/src/pipeline.rs
@@ -73,6 +73,281 @@ pub struct IndexPipeline {
 }
 
 impl IndexPipeline {
+    /// Verify a conservative refresh against both complete, digest-bound C
+    /// inputs. This proves only one existing declaration, never file coverage.
+    pub fn supports_partial_refresh(
+        &self,
+        old: &Entity,
+        new: &Entity,
+        old_source: &[u8],
+        source: &[u8],
+    ) -> bool {
+        use kin_parser::adapter::LanguageAdapter;
+        if old.language != LanguageId::C
+            || new.language != LanguageId::C
+            || old.kind != kin_model::EntityKind::Function
+            || new.kind != old.kind
+            || old.name != new.name
+            || old.signature != new.signature
+            || old.file_origin != new.file_origin
+        {
+            return false;
+        }
+        let (Some(was), Some(now)) = (&old.span, &new.span) else {
+            return false;
+        };
+        if was.file != now.file {
+            return false;
+        }
+        let digest_matches = |entity: &Entity, bytes: &[u8]| {
+            entity
+                .metadata
+                .extra
+                .get("blob_hash")
+                .and_then(|v| v.as_str())
+                == Some(kin_blobs::digest(bytes).to_string().as_str())
+        };
+        if !digest_matches(old, old_source) || !digest_matches(new, source) {
+            return false;
+        }
+        let adapter = kin_parser::languages::CAdapter;
+        let (Ok(before), Ok(after)) = (adapter.parse(old_source), adapter.parse(source)) else {
+            return false;
+        };
+        let before_context = kin_parser::languages::c_lang::partial_function_context(
+            &before,
+            old_source,
+            was.start_byte,
+            was.end_byte,
+        );
+        let after_context = kin_parser::languages::c_lang::partial_function_context(
+            &after,
+            source,
+            now.start_byte,
+            now.end_byte,
+        );
+        if before_context.is_none() || before_context != after_context {
+            return false;
+        }
+        // Old graph identity must actually describe its claimed source, rather
+        // than a stale span coincidentally landing on another declaration.
+        for (tree, bytes, entity) in [(&before, old_source, old), (&after, source, new)] {
+            let Ok(parsed) = adapter.extract(tree, bytes, &was.file) else {
+                return false;
+            };
+            let matches: Vec<_> = parsed
+                .entities
+                .into_iter()
+                .filter(|e| e.name == entity.name && e.kind == entity.kind)
+                .collect();
+            if matches.len() != 1 {
+                return false;
+            }
+            let verified = matches.into_iter().next().unwrap().into_entity_with_source(
+                LanguageId::C,
+                &was.file,
+                Some(bytes),
+            );
+            if verified.span != entity.span
+                || verified.signature != entity.signature
+                || verified.fingerprint.behavior_hash != entity.fingerprint.behavior_hash
+            {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Move only uniquely identified direct-call evidence through a proven
+    /// partial declaration refresh. Resolution must name one stable, complete
+    /// function in this same file; all other located evidence refuses admission.
+    pub fn rebase_partial_relation(
+        &self,
+        old: &Entity,
+        new: &Entity,
+        old_source: &[u8],
+        source: &[u8],
+        relation: &Relation,
+        file_entities: &[Entity],
+    ) -> Option<Relation> {
+        self.partial_relation_evidence(old, new, old_source, source, relation, file_entities, false)
+    }
+
+    /// Verify the coordinates persisted for an already admitted declaration.
+    pub fn verifies_partial_relation(
+        &self,
+        old: &Entity,
+        new: &Entity,
+        old_source: &[u8],
+        source: &[u8],
+        relation: &Relation,
+        file_entities: &[Entity],
+    ) -> bool {
+        self.partial_relation_evidence(old, new, old_source, source, relation, file_entities, true)
+            .is_some_and(|expected| expected == *relation)
+    }
+
+    fn partial_relation_evidence(
+        &self,
+        old: &Entity,
+        new: &Entity,
+        old_source: &[u8],
+        source: &[u8],
+        relation: &Relation,
+        file_entities: &[Entity],
+        current: bool,
+    ) -> Option<Relation> {
+        use kin_parser::adapter::LanguageAdapter;
+        let was = old.span.as_ref()?;
+        let now = new.span.as_ref()?;
+        if !relation
+            .evidence
+            .iter()
+            .any(|e| e.source_span.as_ref().is_some_and(|s| s.file == was.file))
+        {
+            return Some(relation.clone());
+        }
+        if relation.src.as_entity() != Some(old.id)
+            || relation.kind != kin_model::RelationKind::Calls
+            || !self.supports_partial_refresh(old, new, old_source, source)
+        {
+            return None;
+        }
+        let target_id = relation.dst.as_entity()?;
+        let target = file_entities.iter().find(|entity| entity.id == target_id)?;
+        if target.kind != kin_model::EntityKind::Function || target.span.as_ref()?.file != was.file
+        {
+            return None;
+        }
+        let adapter = kin_parser::languages::CAdapter;
+        let before = adapter.parse(old_source).ok()?;
+        let after = adapter.parse(source).ok()?;
+        let old_sites =
+            kin_parser::languages::c_lang::partial_call_sites(&before, old_source, was)?;
+        let new_sites = kin_parser::languages::c_lang::partial_call_sites(&after, source, now)?;
+        let before_entities: Vec<_> = adapter
+            .extract(&before, old_source, &was.file)
+            .ok()?
+            .entities
+            .into_iter()
+            .map(|entity| {
+                entity.into_entity_with_source(LanguageId::C, &was.file, Some(old_source))
+            })
+            .collect();
+        let after_entities: Vec<_> = adapter
+            .extract(&after, source, &was.file)
+            .ok()?
+            .entities
+            .into_iter()
+            .map(|entity| entity.into_entity_with_source(LanguageId::C, &was.file, Some(source)))
+            .collect();
+        for entities in [
+            file_entities,
+            before_entities.as_slice(),
+            after_entities.as_slice(),
+        ] {
+            let matched: Vec<_> = entities
+                .iter()
+                .filter(|entity| entity.name == target.name && entity.kind == target.kind)
+                .collect();
+            if matched.len() != 1 || matched[0].signature != target.signature {
+                return None;
+            }
+        }
+        for (tree, bytes, entities) in [
+            (&before, old_source, &before_entities),
+            (&after, source, &after_entities),
+        ] {
+            let declaration = entities
+                .iter()
+                .find(|entity| entity.name == target.name && entity.kind == target.kind)?
+                .span
+                .as_ref()?;
+            kin_parser::languages::c_lang::partial_function_context(
+                tree,
+                bytes,
+                declaration.start_byte,
+                declaration.end_byte,
+            )?;
+        }
+        let span_matches =
+            |observed: &kin_model::SourceSpan, syntax: &kin_model::SourceSpan, bytes: &[u8]| {
+                if observed.start_byte != 0 || observed.end_byte != 0 {
+                    return observed == syntax;
+                }
+                let coordinates_match = observed.file == syntax.file
+                    && observed.start_line == syntax.start_line
+                    && observed.end_line == syntax.end_line
+                    && observed.start_col == syntax.start_col
+                    && observed.end_col == syntax.end_col;
+                // Zero-byte LSP positions can use UTF-16 columns. ASCII prefixes
+                // make that representation identical to parser byte columns.
+                coordinates_match
+                    && [
+                        (syntax.start_line, syntax.start_col),
+                        (syntax.end_line, syntax.end_col),
+                    ]
+                    .iter()
+                    .all(|(line, column)| {
+                        bytes
+                            .split(|byte| *byte == b'\n')
+                            .nth(*line as usize)
+                            .and_then(|line| line.get(..*column as usize))
+                            .is_some_and(|prefix| prefix.is_ascii())
+                    })
+            };
+        let mut updated = relation.clone();
+        for evidence in &mut updated.evidence {
+            let Some(span) = evidence.source_span.as_ref() else {
+                continue;
+            };
+            if span.file != was.file {
+                continue;
+            }
+            let (sites, bytes) = if current {
+                (&new_sites, source)
+            } else {
+                (&old_sites, old_source)
+            };
+            let matched: Vec<_> = sites
+                .iter()
+                .filter_map(|site| {
+                    if span_matches(span, &site.call_span, bytes) {
+                        Some((site, true))
+                    } else if span_matches(span, &site.callee_span, bytes) {
+                        Some((site, false))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            if matched.len() != 1 {
+                return None;
+            }
+            let (site, whole_call) = matched[0];
+            if site.callee != target.name {
+                return None;
+            }
+            let same_call = |candidate: &&kin_parser::languages::c_lang::PartialCallSite| {
+                candidate.callee == site.callee && candidate.expression == site.expression
+            };
+            if old_sites.iter().filter(same_call).count() != 1
+                || new_sites.iter().filter(same_call).count() != 1
+            {
+                return None;
+            }
+            let placed = new_sites.iter().find(|candidate| {
+                candidate.callee == site.callee && candidate.expression == site.expression
+            })?;
+            evidence.source_span = Some(if whole_call {
+                placed.call_span.clone()
+            } else {
+                placed.callee_span.clone()
+            });
+        }
+        Some(updated)
+    }
+
     pub fn new() -> Self {
         Self {
             registry: AdapterRegistry::new(),

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -1710,24 +1710,28 @@ pub const BOUNDED_REASON: &str = "response_bounded";
 /// The reason code a response that stayed over its ceiling carries.
 pub const OVER_BUDGET_REASON: &str = "response_over_budget";
 
+/// The reason code an elision carries when a whole graph-owned body was
+/// withheld before it was copied, rather than cut after.
+///
+/// The elision is written by `disclose_projection_bodies`, which derives it from
+/// the rows themselves. Nothing writes a `degradations` entry under this reason,
+/// so `prior_bound` below does not look for one.
+pub const BODY_HYDRATION_REASON: &str = "whole_body_withheld";
+
 /// What an earlier arm recorded cutting this payload from, if one did.
 ///
 /// A cut discloses itself in the `degradations` channel, and the first such
 /// entry is the earliest arm's, because disclosures are appended. Reading it is
 /// what lets the second arm report the size the answer was built at instead of
 /// the size it inherited.
-pub const BODY_HYDRATION_REASON: &str = "whole_body_withheld";
-
 fn prior_bound(payload: &Value) -> Option<usize> {
     payload
         .get("degradations")?
         .as_array()?
         .iter()
         .find(|entry| {
-            (entry.get("component").and_then(Value::as_str) == Some("response_budget")
-                && entry.get("reason").and_then(Value::as_str) == Some(BOUNDED_REASON))
-                || (entry.get("component").and_then(Value::as_str) == Some("context_body_budget")
-                    && entry.get("reason").and_then(Value::as_str) == Some(BODY_HYDRATION_REASON))
+            entry.get("component").and_then(Value::as_str) == Some("response_budget")
+                && entry.get("reason").and_then(Value::as_str) == Some(BOUNDED_REASON)
         })
         .map(|entry| {
             entry

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -389,14 +389,17 @@ pub fn record_elision_for(
     }
 }
 
-/// The wire-format choice is carried with the payload so every emitter and
-/// accounting pass agrees, even after later cuts make pretty JSON fit again.
+/// Internal format choice retained across budget passes and omitted on emission.
 const JSON_FORMAT_KEY: &str = "_kin_json_format";
 
-/// Serialize a response in the format selected while enforcing its budget.
+/// Serialize in the budget-selected format without emitting its control field.
 pub fn render(value: &Value) -> serde_json::Result<String> {
     if value.get(JSON_FORMAT_KEY).and_then(Value::as_str) == Some("compact") {
-        serde_json::to_string(value)
+        let mut emitted = value.clone();
+        if let Some(object) = emitted.as_object_mut() {
+            object.remove(JSON_FORMAT_KEY);
+        }
+        serde_json::to_string(&emitted)
     } else {
         serde_json::to_string_pretty(value)
     }

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -1051,6 +1051,145 @@ pub fn is_budgeted(tool: &str) -> bool {
 /// through `get_entity_source`. Only then are hits themselves withheld, from the
 /// tail of the least important array first, which is the only cut that removes
 /// an answer rather than a description of one.
+pub fn fit_context_payload(payload: &mut Value, tool: &str, budget: &ResponseBudget) -> bool {
+    if !matches!(tool, "get_context_pack" | "trace_computation") {
+        return true;
+    }
+    let Some(limit) = payload.get("token_budget").and_then(Value::as_u64) else {
+        return true;
+    };
+    loop {
+        let mut settled = false;
+        for _ in 0..16 {
+            let tokens =
+                kin_context::estimate_tokens(&render(payload).expect("JSON serialization"));
+            if payload.get("tokens_used").and_then(Value::as_u64) == Some(tokens as u64) {
+                settled = true;
+                break;
+            }
+            payload["tokens_used"] = json!(tokens);
+        }
+        if !settled {
+            return false;
+        }
+        let output = render(payload).expect("JSON serialization");
+        if output.len() <= budget.max_chars
+            && kin_context::estimate_tokens(&output) <= limit as usize
+        {
+            return true;
+        }
+        let reason = if output.len() > budget.max_chars {
+            ELISION_REASON_BUDGET
+        } else {
+            ELISION_REASON_TOKEN_BUDGET
+        };
+        if !trim_context_output_once(payload, reason) {
+            return false;
+        }
+    }
+}
+
+pub(crate) fn trim_context_output_once(payload: &mut Value, reason: &str) -> bool {
+    let before = measure(payload);
+    if !trim_context_output_inner(payload, reason) {
+        return false;
+    }
+    mark_context_cut(payload, before);
+    true
+}
+
+pub(crate) fn mark_context_cut(payload: &mut Value, before: usize) {
+    let entry = json!({"component": "response_budget", "reason": BOUNDED_REASON, "chars_before_budget": before, "detail": "complete context output was reduced to fit its effective token or byte limit; elisions identify the withheld projections"});
+    let entries = payload
+        .as_object_mut()
+        .expect("context object")
+        .entry("degradations")
+        .or_insert_with(|| json!([]));
+    if let Some(entries) = entries.as_array_mut() {
+        if !entries
+            .iter()
+            .any(|entry| entry.get("reason").and_then(Value::as_str) == Some(BOUNDED_REASON))
+        {
+            entries.push(entry);
+        }
+    }
+}
+
+fn trim_context_output_inner(payload: &mut Value, reason: &str) -> bool {
+    if payload.get("lines").is_some() {
+        payload
+            .as_object_mut()
+            .expect("context object")
+            .remove("lines");
+        payload["lines_note"] =
+            json!("rendered lines withheld to fit the final response; structured entities remain");
+        record_elision_for(payload, "lines", 0, 1, reason);
+        return true;
+    }
+    let shape = shape_for("get_context_pack").expect("context shape");
+    let carrying = rows_carrying(payload, &shape, shape.body_keys);
+    let stripped = strip_keys_marking(payload, &shape, shape.body_keys, &[], true);
+    if stripped > 0 {
+        record_elision_for(
+            payload,
+            "body",
+            carrying.saturating_sub(stripped),
+            stripped,
+            reason,
+        );
+        payload["projection_measurement_scope"] = json!("focal and neighborhood token contributions were measured before final response projection cuts");
+        return true;
+    }
+    for key in [
+        "annotations",
+        "work_items",
+        "contracts",
+        "tests",
+        "transitive_deps",
+        "dependents",
+        "dependencies",
+        "entities",
+    ] {
+        let Some(rows) = payload.get_mut(key).and_then(Value::as_array_mut) else {
+            continue;
+        };
+        let index = if key == "entities" {
+            rows.iter().rposition(|row| {
+                !matches!(
+                    row.get("section").and_then(Value::as_str),
+                    Some("focal" | "route")
+                )
+            })
+        } else {
+            rows.len().checked_sub(1)
+        };
+        let Some(index) = index else {
+            continue;
+        };
+        rows.remove(index);
+        let kept = rows.len();
+        record_elision_for(payload, key, kept, 1, reason);
+        let count = payload
+            .get(format!("{key}_withheld"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        payload[format!("{key}_withheld")] = json!(count + 1);
+        if let Some(selection) = payload.get_mut("dependency_selection") {
+            let field = if key == "dependents" {
+                "dependents_returned"
+            } else {
+                "returned"
+            };
+            if matches!(key, "dependencies" | "dependents") {
+                selection[field] = json!(kept);
+            }
+        }
+        payload["projection_measurement_scope"] = json!("focal and neighborhood contributions describe admission before final response cuts; elisions report withheld output rows");
+        return true;
+    }
+    false
+}
+
 pub fn enforce(
     payload: &mut Value,
     tool: &str,
@@ -1184,6 +1323,17 @@ fn run_ladder(
     // before deciding whether any unique content needs to be withheld.
     point_restated_limiting_factor(payload, budget);
     if measure(payload) <= budget.max_chars {
+        return;
+    }
+
+    if matches!(tool, "get_context_pack" | "trace_computation")
+        && payload.get("token_budget").is_some()
+    {
+        while measure(payload) > budget.max_chars
+            && trim_context_output_once(payload, ELISION_REASON_BUDGET)
+        {
+            accounting.bounded = true;
+        }
         return;
     }
 

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -389,11 +389,28 @@ pub fn record_elision_for(
     }
 }
 
-/// Serialized size of a payload, measured the way every emitter on both
-/// surfaces renders it. Measuring a compact form nobody sends would charge the
-/// budget for a payload no caller receives.
+/// The wire-format choice is carried with the payload so every emitter and
+/// accounting pass agrees, even after later cuts make pretty JSON fit again.
+const JSON_FORMAT_KEY: &str = "_kin_json_format";
+
+/// Serialize a response in the format selected while enforcing its budget.
+pub fn render(value: &Value) -> serde_json::Result<String> {
+    if value.get(JSON_FORMAT_KEY).and_then(Value::as_str) == Some("compact") {
+        serde_json::to_string(value)
+    } else {
+        serde_json::to_string_pretty(value)
+    }
+}
+
+/// Serialized size of the exact response every emitter sends.
 pub fn measure(value: &Value) -> usize {
-    serde_json::to_string_pretty(value).map_or(usize::MAX, |json| json.len())
+    render(value).map_or(usize::MAX, |json| json.len())
+}
+
+fn compact_json_under_pressure(payload: &mut Value, budget: &ResponseBudget) {
+    if measure(payload) > budget.max_chars && payload.is_object() {
+        payload[JSON_FORMAT_KEY] = json!("compact");
+    }
 }
 
 /// Give up a chain's least load-bearing branches until it fits, and hand back
@@ -1068,7 +1085,35 @@ pub fn enforce(
         // Solved after the ladder, which is the only thing that can change it.
         primary_rows: None,
     };
-    run_ladder(payload, tool, &shape, budget, primary, &mut accounting);
+    let original = (chars_before > budget.max_chars).then(|| payload.clone());
+    let initial_accounting = accounting.clone();
+    let mut extra_reserve = 0usize;
+    loop {
+        if extra_reserve > 0 {
+            *payload = original.as_ref().expect("overflow snapshot").clone();
+            accounting = initial_accounting.clone();
+        }
+        run_ladder(
+            payload,
+            tool,
+            &shape,
+            budget,
+            primary,
+            &mut accounting,
+            extra_reserve,
+        );
+        let after = measure(payload);
+        if after <= budget.max_chars || original.is_none() || extra_reserve == budget.max_chars {
+            break;
+        }
+        // Retry from the whole answer when the cut disclosure itself overflowed.
+        // Replaying avoids accumulating disclosures or withholding counts from
+        // unsuccessful attempts. Doubling bounds the number of retries.
+        extra_reserve = extra_reserve
+            .saturating_mul(2)
+            .max(extra_reserve.saturating_add(after - budget.max_chars))
+            .min(budget.max_chars);
+    }
     accounting.chars_after = measure(payload);
 
     // A response the ladder could not bring under its ceiling is the case
@@ -1109,6 +1154,7 @@ fn run_ladder(
     // second derivation is what would let them drift apart.
     primary: Option<&'static str>,
     accounting: &mut BudgetAccounting,
+    extra_reserve: usize,
 ) {
     let started_at = measure(payload);
     let mut cuts: Vec<String> = Vec::new();
@@ -1128,12 +1174,27 @@ fn run_ladder(
         return;
     }
 
+    compact_json_under_pressure(payload, budget);
+    if measure(payload) <= budget.max_chars {
+        return;
+    }
+
+    // Exact qualification pointers preserve the answer. Charge their disclosure
+    // before deciding whether any unique content needs to be withheld.
+    point_restated_limiting_factor(payload, budget);
+    if measure(payload) <= budget.max_chars {
+        return;
+    }
+
     // The reserve holds room for the disclosure the cut adds, but it can never
     // be a fixed number: at the floor of the clamp a flat 1,500 characters would
     // leave a few hundred for the answer, and the ladder would strip a response
     // down to nothing to make room for the note explaining that it had. It
     // scales with the budget instead.
-    let reserve = RESPONSE_DISCLOSURE_RESERVE_CHARS.min(budget.max_chars / 4);
+    let reserve = RESPONSE_DISCLOSURE_RESERVE_CHARS
+        .min(budget.max_chars / 4)
+        .saturating_add(extra_reserve)
+        .min(budget.max_chars);
     let target = budget.max_chars.saturating_sub(reserve);
 
     // A caller that explicitly turned compaction off still cannot be served a
@@ -1296,28 +1357,6 @@ fn run_ladder(
             break;
         }
     }
-    // Before the floor goes, the cheapest bytes in the response: the verbatim
-    // restatements of one sentence.
-    //
-    // Measured on 2026-09-02 (FIR-3107) on a `trace_data_flow` at depth, at the
-    // agent belt's 12,000-character ceiling. The part of that response the
-    // budget never trims was 9,210 characters, and roughly 7,700 of it was FOUR
-    // copies of one 1,900-character limiting-factor sentence:
-    // `_kin.verdict.limiting_factor`, `_kin.verdict.note`, `negative.advice`
-    // and `negative.trust_reason`. No rung above could reach the ceiling
-    // because the answer rows were not what was over it.
-    //
-    // This drops two of the three restatements and leaves a pointer. It never
-    // touches `limiting_factor`, which is the canonical copy every reader is
-    // sent to first, nor `trust_reason`, which is the sentence `negative`
-    // publishes in its own right. Nothing is lost: the statement survives, and
-    // the two places that repeated it now name where it lives.
-    // Applied here so the floor guard below measures the response after the
-    // pointer rather than before it, and applied AGAIN by the envelope
-    // finalizer once its loop settles, because a pass of that loop can rebuild
-    // the verdict and write the long form back over this.
-    point_restated_limiting_factor(payload, budget);
-
     // The floor of one entry per list is absolute, and a response that cannot
     // reach its ceiling with it says so rather than giving it up.
     //
@@ -1382,8 +1421,8 @@ const LIMITING_FACTOR_JOIN: &str = " Limiting factor: ";
 /// Point the restatements at the canonical sentence and say so, on a response
 /// over its ceiling. Returns how many fields were pointed.
 ///
-/// Called twice on the stdio path: once inside the ladder, so the floor rung
-/// below it measures the smaller response, and once by the envelope finalizer
+/// Called twice on the stdio path: once before the ladder withholds content,
+/// so every rung measures the smaller response, and once by the envelope finalizer
 /// after its loop settles, because that loop rebuilds the verdict and would
 /// otherwise write the long form back over the pointer. Both the rewrite and
 /// its disclosure are idempotent, so the second call is free when the first
@@ -1394,13 +1433,13 @@ pub(crate) fn point_restated_limiting_factor(
 ) -> usize {
     let pointed = shed_restated_limiting_factor(payload, budget);
     if pointed > 0 {
-        disclose_restatements_pointed(payload, pointed);
+        disclose_restatements_pointed(payload);
     }
     pointed
 }
 
 /// Replace a verbatim restatement of the limiting factor with a pointer to it,
-/// in the two fields that carry one, and only on a response over its ceiling.
+/// in the fields that carry one, only on a response over its ceiling.
 ///
 /// Returns how many fields were pointed.
 ///
@@ -1412,40 +1451,35 @@ fn shed_restated_limiting_factor(payload: &mut Value, budget: &ResponseBudget) -
     if measure(payload) <= budget.max_chars {
         return 0;
     }
-    // Each row is one field that ends by restating another, and the field it
-    // restates. `_kin.verdict.limiting_factor` and `negative.trust_reason` are
-    // both left whole: the first is the canonical sentence the server tells
-    // every reader to consult first, the second is what `negative` publishes in
-    // its own right and what the acceptance suite grades.
-    const RESTATEMENTS: [(&str, &str, &str, &str); 2] = [
+    const RESTATEMENTS: [(&str, &str, &str); 3] = [
         (
-            crate::envelope::ENVELOPE_KEY,
-            "verdict",
-            "note",
-            "limiting_factor",
+            "/_kin/verdict/note",
+            "/_kin/verdict/limiting_factor",
+            "_kin.verdict.limiting_factor",
         ),
-        (crate::negative::NEGATIVE_KEY, "", "advice", "trust_reason"),
+        (
+            "/negative/advice",
+            "/negative/trust_reason",
+            "negative.trust_reason",
+        ),
+        (
+            "/_kin/completeness/note",
+            "/_kin/verdict/limiting_factor",
+            "_kin.verdict.limiting_factor",
+        ),
     ];
     let mut pointed = 0usize;
-    for (root, section, field, canonical_field) in RESTATEMENTS {
-        fn block<'a>(value: &'a Value, root: &str, section: &str) -> Option<&'a Value> {
-            let block = value.get(root)?;
-            if section.is_empty() {
-                Some(block)
-            } else {
-                block.get(section)
-            }
-        }
-        let Some(canonical) = block(payload, root, section)
-            .and_then(|block| block.get(canonical_field))
+    for (field, canonical_field, owner) in RESTATEMENTS {
+        let Some(canonical) = payload
+            .pointer(canonical_field)
             .and_then(Value::as_str)
             .map(|text| text.trim_end_matches('.').to_string())
             .filter(|text| !text.is_empty())
         else {
             continue;
         };
-        let Some(text) = block(payload, root, section)
-            .and_then(|block| block.get(field))
+        let Some(text) = payload
+            .pointer(field)
             .and_then(Value::as_str)
             .map(str::to_string)
         else {
@@ -1454,28 +1488,17 @@ fn shed_restated_limiting_factor(payload: &mut Value, budget: &ResponseBudget) -
         let Some(at) = text.rfind(LIMITING_FACTOR_JOIN) else {
             continue;
         };
-        // Word for word, or not at all. A tail that says anything of its own is
-        // left alone, which is what keeps this from turning a field with
-        // something to say into a pointer at something else.
         if text[at + LIMITING_FACTOR_JOIN.len()..].trim_end_matches('.') != canonical {
             continue;
         }
-        let mut shortened = text[..at].to_string();
-        let owner = if section.is_empty() {
-            format!("{root}.{canonical_field}")
-        } else {
-            format!("{root}.{section}.{canonical_field}")
-        };
-        shortened.push_str(&format!("{LIMITING_FACTOR_JOIN}see `{owner}`."));
-        let target = if section.is_empty() {
-            payload.get_mut(root).and_then(|block| block.get_mut(field))
-        } else {
-            payload
-                .get_mut(root)
-                .and_then(|block| block.get_mut(section))
-                .and_then(|block| block.get_mut(field))
-        };
-        if let Some(target) = target {
+        // Preserve the original prefix and punctuation so following the pointer
+        // reconstructs the exact field, including an absent terminal full stop.
+        let punctuation = &text[text.trim_end_matches('.').len()..];
+        let shortened = format!(
+            "{}{LIMITING_FACTOR_JOIN}see `{owner}`{punctuation}",
+            &text[..at]
+        );
+        if let Some(target) = payload.pointer_mut(field) {
             *target = Value::String(shortened);
             pointed += 1;
         }
@@ -1489,16 +1512,28 @@ fn shed_restated_limiting_factor(payload: &mut Value, budget: &ResponseBudget) -
 /// reason code means answer rows were withheld and `prior_bound` reads it on
 /// the second arm to decide whether the response was bounded. Nothing was
 /// withheld here.
-fn disclose_restatements_pointed(payload: &mut Value, pointed: usize) {
+fn disclose_restatements_pointed(payload: &mut Value) {
+    let mut owners = Vec::new();
+    for (pointer, owner) in [
+        ("/_kin/verdict/note", "_kin.verdict.limiting_factor"),
+        ("/negative/advice", "negative.trust_reason"),
+        ("/_kin/completeness/note", "_kin.verdict.limiting_factor"),
+    ] {
+        if payload
+            .pointer(pointer)
+            .and_then(Value::as_str)
+            .is_some_and(|text| text.contains(&format!("see `{owner}`")))
+        {
+            let owner = format!("`{owner}`");
+            if !owners.contains(&owner) {
+                owners.push(owner);
+            }
+        }
+    }
     let entry = json!({
         "component": "response_budget",
         "reason": RESTATEMENT_POINTED_REASON,
-        "detail": format!(
-            "this response was over its ceiling, so {pointed} field(s) that restated \
-             another field word for word now point at it instead. Nothing was dropped: \
-             `_kin.verdict.limiting_factor` and `negative.trust_reason` carry the statement \
-             in full, and each pointer names the field it points at"
-        ),
+        "detail": format!("Exact restatements point to unchanged {}.", owners.join(", ")),
     });
     match payload
         .get_mut("degradations")
@@ -3151,6 +3186,8 @@ mod tests {
         };
         let accounting = enforce(&mut payload, "semantic_locate", &budget).expect("budgeted");
         let kept = payload["results"].as_array().unwrap().len();
+        assert!(payload["next_cursor"].is_null());
+        assert_eq!(accounting.chars_after, measure(&payload));
         assert!(
             kept < before,
             "a final page over its ceiling must still be cut: kept {kept} of {before}"

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -826,6 +826,7 @@ fn shape_for(tool: &str) -> Option<ResponseShape> {
             // split by direction, and a group the budget cannot trim is a group
             // that can push a response past its cap on its own.
             collections: &[
+                "entities",
                 "dependencies",
                 "dependents",
                 "transitive_deps",
@@ -833,7 +834,7 @@ fn shape_for(tool: &str) -> Option<ResponseShape> {
                 "contracts",
             ],
             body_keys: &["body"],
-            explain_keys: &["projection"],
+            explain_keys: &[],
             top_explain_keys: &[],
             duplicate_keys: &[],
             bulk_keys: &[],
@@ -1565,14 +1566,18 @@ pub const OVER_BUDGET_REASON: &str = "response_over_budget";
 /// entry is the earliest arm's, because disclosures are appended. Reading it is
 /// what lets the second arm report the size the answer was built at instead of
 /// the size it inherited.
+pub const BODY_HYDRATION_REASON: &str = "whole_body_withheld";
+
 fn prior_bound(payload: &Value) -> Option<usize> {
     payload
         .get("degradations")?
         .as_array()?
         .iter()
         .find(|entry| {
-            entry.get("component").and_then(Value::as_str) == Some("response_budget")
-                && entry.get("reason").and_then(Value::as_str) == Some(BOUNDED_REASON)
+            (entry.get("component").and_then(Value::as_str) == Some("response_budget")
+                && entry.get("reason").and_then(Value::as_str) == Some(BOUNDED_REASON))
+                || (entry.get("component").and_then(Value::as_str) == Some("context_body_budget")
+                    && entry.get("reason").and_then(Value::as_str) == Some(BODY_HYDRATION_REASON))
         })
         .map(|entry| {
             entry
@@ -1723,6 +1728,11 @@ fn strip_keys_marking(
                 // it empty, and the marker beside it says who emptied it.
                 if *key == "body" {
                     map.insert((*key).to_string(), Value::Null);
+                    if map.get("projection").and_then(Value::as_str) == Some("FullBody") {
+                        map.insert("projection".into(), json!("SignatureOnly"));
+                        map.insert("projection_downgraded_from".into(), json!("FullBody"));
+                        map.insert("body_complete".into(), json!(false));
+                    }
                 }
             }
         }
@@ -1754,6 +1764,15 @@ fn strip_keys_marking(
         if let Some(map) = payload.get_mut(focal).and_then(Value::as_object_mut) {
             if strip_row(map) {
                 stripped += 1;
+            }
+        }
+    }
+    if keys.contains(&"body") && stripped > 0 {
+        if let Some(focals) = payload.get_mut("focals").and_then(Value::as_array_mut) {
+            for focal in focals {
+                if focal.get("projection").and_then(Value::as_str) == Some("full_body") {
+                    focal["projection"] = json!("header_and_signature");
+                }
             }
         }
     }
@@ -4130,6 +4149,50 @@ mod tests {
             rows.push(focal.clone());
         }
         rows
+    }
+
+    #[test]
+    fn context_body_elisions_downgrade_single_and_multi_focal_claims() {
+        for multi in [false, true] {
+            let row = json!({
+                "id": "focal", "name": "focal", "signature": "fn focal()",
+                "body": "whole body ".repeat(800), "projection": "FullBody",
+                "body_complete": true, "span_coherence": "digest_verified",
+            });
+            let mut payload = if multi {
+                json!({"entities": [row.clone()], "focals": [{"entity_id": "focal", "projection": "full_body"}]})
+            } else {
+                json!({"focal_entity": row.clone(), "dependencies": [row.clone()]})
+            };
+            let budget = ResponseBudget {
+                max_chars: 4000,
+                ..ResponseBudget::default()
+            };
+            let accounting = enforce(&mut payload, "get_context_pack", &budget).unwrap();
+            let rows = if multi {
+                vec![&payload["entities"][0]]
+            } else {
+                vec![&payload["focal_entity"], &payload["dependencies"][0]]
+            };
+            for row in rows {
+                assert!(row["body"].is_null());
+                assert_eq!(row["projection"], "SignatureOnly");
+                assert_eq!(row["projection_downgraded_from"], "FullBody");
+                assert_eq!(row["body_complete"], false);
+                assert_eq!(row["body_elided"], json!(["body"]));
+                assert_eq!(row["span_coherence"], "digest_verified");
+            }
+            if multi {
+                assert_eq!(payload["focals"][0]["projection"], "header_and_signature");
+            }
+            assert!(accounting.bounded);
+            assert_eq!(accounting.chars_after, render(&payload).unwrap().len());
+            assert!(accounting.chars_after <= budget.max_chars);
+            let mut fitting = json!({"entities": [{"body": "whole\r\n", "projection": "FullBody", "body_complete": true}]});
+            let before = fitting.clone();
+            enforce(&mut fitting, "get_context_pack", &budget).unwrap();
+            assert_eq!(fitting, before);
+        }
     }
 
     #[test]

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -2721,6 +2721,15 @@ pub fn finalize_bounded(
     budget: &ResponseBudget,
 ) -> ToolCallResult {
     let payload = first_payload_value(&result);
+    let context_limit = matches!(tool_name, "get_context_pack" | "trace_computation")
+        .then(|| {
+            payload
+                .as_ref()?
+                .get("token_budget")?
+                .as_u64()
+                .map(|value| value as usize)
+        })
+        .flatten();
     let mut envelope = match &payload {
         Some(payload) => base.with_payload_metadata(payload),
         None => base,
@@ -2759,14 +2768,73 @@ pub fn finalize_bounded(
             envelope.verdict = Some(verdict.to_value());
         }
     }
-    annotate_inner(
+    let annotated = annotate_inner(
         result,
         &envelope,
         negative.as_ref(),
         tool_name,
         budget,
         &edge_coverage_limits,
-    )
+    );
+    match context_limit {
+        Some(limit) if annotated.is_error != Some(true) => {
+            fit_context_output(annotated, tool_name, budget, limit)
+        }
+        _ => annotated,
+    }
+}
+
+fn fit_context_output(
+    mut result: ToolCallResult,
+    tool: &str,
+    budget: &ResponseBudget,
+    token_limit: usize,
+) -> ToolCallResult {
+    for block in &mut result.content {
+        let ContentBlock::Text { text } = block;
+        let Ok(mut payload) = serde_json::from_str::<Value>(text) else {
+            continue;
+        };
+        loop {
+            apply_response_budget(&mut payload, tool, budget);
+            let mut settled = false;
+            for _ in 0..16 {
+                let rendered = crate::budget::render(&payload).expect("JSON value serialization");
+                let tokens = kin_context::estimate_tokens(&rendered);
+                let bytes = rendered.len();
+                if payload.get("tokens_used").and_then(Value::as_u64) == Some(tokens as u64)
+                    && payload
+                        .pointer("/_kin/response/chars_after_budget")
+                        .and_then(Value::as_u64)
+                        == Some(bytes as u64)
+                {
+                    settled = true;
+                    break;
+                }
+                payload["tokens_used"] = serde_json::json!(tokens);
+                payload[ENVELOPE_KEY]["response"]["chars_after_budget"] = serde_json::json!(bytes);
+            }
+            if !settled {
+                return ToolCallResult::error("context response accounting did not converge");
+            }
+            let rendered = crate::budget::render(&payload).expect("JSON value serialization");
+            if rendered.len() <= budget.max_chars
+                && kin_context::estimate_tokens(&rendered) <= token_limit
+            {
+                *text = rendered;
+                break;
+            }
+            let reason = if rendered.len() > budget.max_chars {
+                crate::budget::ELISION_REASON_BUDGET
+            } else {
+                crate::budget::ELISION_REASON_TOKEN_BUDGET
+            };
+            if !crate::budget::trim_context_output_once(&mut payload, reason) {
+                return ToolCallResult::error(format!("context metadata cannot fit the effective {token_limit} token and {} byte limits; request fewer focals or a larger budget", budget.max_chars));
+            }
+        }
+    }
+    result
 }
 
 /// Write the verdict's qualifiers onto the `edge_coverage` block.
@@ -4282,6 +4350,75 @@ mod tests {
             !reasons.contains(&crate::budget::RESTATEMENT_POINTED_REASON),
             "nothing was shortened and the response says it was: {reasons:?}"
         );
+    }
+
+    #[test]
+    fn context_final_ceiling_counts_envelope_and_preserves_named_route() {
+        let mut payload = serde_json::json!({
+            "token_budget": 8000, "tokens_used": 0,
+            "entities": [
+                {"id": "start", "name": "start", "section": "focal", "projection": "FullBody", "body_complete": true, "body": "execute();\n".repeat(1800)},
+                {"id": "middle", "name": "middle", "section": "route", "projection": "SignatureOnly"},
+                {"id": "end", "name": "end", "section": "focal", "projection": "SignatureOnly"}
+            ],
+            "focals": [{"entity_id": "start", "projection": "full_body"}, {"entity_id": "end", "projection": "signature_only"}],
+            "routes": [{"from": "start", "to": "end", "via": ["middle"], "edges": [{"kind": "Calls"}]}],
+            "lines": ["execute(); ".repeat(1800)]
+        });
+        for index in 0..30 {
+            payload["entities"].as_array_mut().unwrap().insert(1, serde_json::json!({"id": format!("neighbor{index}"), "section": "dependencies", "signature": "argument: type; ".repeat(40)}));
+        }
+        for max_chars in [60000, 8000] {
+            let result = finalize_bounded(
+                ToolCallResult::text(payload.to_string()),
+                ready_daemon_envelope(),
+                "get_context_pack",
+                &ResponseBudget {
+                    max_chars,
+                    ..ResponseBudget::default()
+                },
+            );
+            assert_ne!(result.is_error, Some(true));
+            let text = first_message_text(&result).unwrap();
+            let output: Value = serde_json::from_str(text).unwrap();
+            let tokens = kin_context::estimate_tokens(text);
+            assert!(tokens <= 8000, "{tokens}");
+            assert_eq!(output["tokens_used"], tokens);
+            assert_eq!(
+                output.pointer("/_kin/response/chars_after_budget").unwrap(),
+                text.len()
+            );
+            assert!(output["entities"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|row| row["id"] == "middle"));
+            assert_eq!(output["routes"][0]["edges"][0]["kind"], "Calls");
+            assert!(text.len() <= max_chars);
+            assert_eq!(output["_kin"]["response"]["bounded"], true);
+            for id in ["start", "middle", "end"] {
+                assert!(
+                    output["entities"]
+                        .as_array()
+                        .unwrap()
+                        .iter()
+                        .any(|row| row["id"] == id),
+                    "named focal and route remain: {id}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn context_final_ceiling_refuses_an_impossible_metadata_floor() {
+        let payload = serde_json::json!({"token_budget": 1, "tokens_used": 0, "focal_entity": {"id": "start", "name": "start"}});
+        let result = finalize(
+            ToolCallResult::text(payload.to_string()),
+            ready_daemon_envelope(),
+            "get_context_pack",
+        );
+        assert_eq!(result.is_error, Some(true));
+        assert!(first_message_text(&result).unwrap().contains("cannot fit"));
     }
 
     fn ready_daemon_envelope() -> Envelope {

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -2844,8 +2844,7 @@ fn annotate_block(
     };
     let mut annotated = annotated;
     apply_response_budget(&mut annotated, tool_name, budget);
-    let rendered =
-        serde_json::to_string_pretty(&annotated).unwrap_or_else(|_| annotated.to_string());
+    let rendered = crate::budget::render(&annotated).unwrap_or_else(|_| annotated.to_string());
     ContentBlock::Text { text: rendered }
 }
 
@@ -3012,7 +3011,7 @@ fn apply_response_budget(annotated: &mut Value, tool_name: &str, budget: &Respon
 }
 
 /// Write `_kin.response` until its `chars_after_budget` field equals the exact
-/// pretty-serialized size of the object that contains it.
+/// serialized size of the object that contains it.
 fn settle_response_accounting(
     annotated: &mut Value,
     accounting: &mut crate::budget::BudgetAccounting,
@@ -4648,6 +4647,521 @@ mod tests {
             .as_array()
             .unwrap()
             .contains(&json!("edge_coverage:unreported")));
+    }
+
+    fn conservative_reference_fixture() -> Value {
+        let mut payload: Value = serde_json::from_str(r#"{
+  "caller_arrival": {
+    "family_files": 3,
+    "family_measured": 3,
+    "state": "unaccounted",
+    "unaccounted_file_count": 3,
+    "unaccounted_files": [
+      {
+        "file": "packages/react-dom-bindings/src/client/ReactDOMInput.js",
+        "parsed_call_sites": 55,
+        "resolved_call_edges": 46,
+        "shortfall_is_floor": false,
+        "unaccounted_call_sites": 9
+      },
+      {
+        "file": "packages/react-dom-bindings/src/client/ReactDOMSelect.js",
+        "parsed_call_sites": 21,
+        "resolved_call_edges": 16,
+        "shortfall_is_floor": false,
+        "unaccounted_call_sites": 5
+      },
+      {
+        "file": "packages/react-dom-bindings/src/client/ReactDOMTextarea.js",
+        "parsed_call_sites": 15,
+        "resolved_call_edges": 13,
+        "shortfall_is_floor": false,
+        "unaccounted_call_sites": 2
+      }
+    ],
+    "unaccounted_files_truncated": false,
+    "unmeasured_reason": null
+  },
+  "candidates": [],
+  "counts": {
+    "counted": "referencing_entities",
+    "files": 3,
+    "known_reference_sites": 23,
+    "receiver_name_candidates": 0,
+    "reference_sites": 23,
+    "reference_sites_complete": true,
+    "referencing_entities": 11,
+    "upstream_including_unconfirmed": 11
+  },
+  "cross_repo": {
+    "code": "spine_root_stale",
+    "reason": "spine root mismatch for repository 8b3c2487-ed31-4fa8-bed9-c92187a823b7: live/session graph root 672f96cfa6a841c30019a72f9bc82b596a3479d35d330019329ee1529898dadf has advanced past the registered spine root 630b6617a21510112c14e068f87b97492e2b6b33c37988cd5b33268066a0b71a, so cross-repo authority is stale for other repositories and says nothing about references inside this one",
+    "status": "unavailable"
+  },
+  "degradations": [
+    {
+      "attempt_number": 1,
+      "component": "graph_authority",
+      "detail": "a graph-authority write landed while this answer was being read, so the read was abandoned and retried; the answer served here is the second attempt and was confirmed current before it was returned. Every row in it is settled. What it also says is that this store was being written while it was queried, so an absence measured here is an absence measured under contention.",
+      "reason": "retry"
+    }
+  ],
+  "edge_coverage": {
+    "budget_exhausted": false,
+    "classes": {
+      "calls": "present",
+      "imports": "present",
+      "references": "present"
+    },
+    "cross_file_classes": [
+      "calls",
+      "imports",
+      "references"
+    ],
+    "entities_examined": 8,
+    "language": "JavaScript",
+    "limits": [
+      "absence_gate:inconclusive",
+      "cross_repo:inconclusive",
+      "degradations:inconclusive"
+    ],
+    "reference_enrichment": "available",
+    "requested_classes": [
+      "calls",
+      "imports",
+      "references"
+    ],
+    "scan": "ran",
+    "scope": "language",
+    "unproduced_evidence": null,
+    "witnessed_by_answer": [
+      "calls",
+      "imports"
+    ]
+  },
+  "focal_entity": {
+    "file_path": "packages/react-dom-bindings/src/client/ToStringValue.js",
+    "id": "8052d132-596d-4f63-9613-77f5e8f67a44",
+    "kind": "function",
+    "name": "getToStringValue",
+    "signature": "function getToStringValue(value: mixed): ToStringValue"
+  },
+  "focal_resolution": {
+    "addressed_by": "name",
+    "matched": "query_name_pattern",
+    "other_candidates": [],
+    "same_name_candidates": 1
+  },
+  "relation_kinds": [
+    "calls",
+    "imports",
+    "references"
+  ],
+  "total_upstream": 11,
+  "unconfirmed_candidates": 0
+}"#).unwrap();
+        let rows: &[(&str, &str, u64, &[u64], bool)] = &[
+            (
+                "ReactDOMInput",
+                "packages/react-dom-bindings/src/client/ReactDOMInput.js",
+                1,
+                &[14],
+                true,
+            ),
+            (
+                "ReactDOMSelect",
+                "packages/react-dom-bindings/src/client/ReactDOMSelect.js",
+                1,
+                &[13],
+                true,
+            ),
+            (
+                "ReactDOMTextarea",
+                "packages/react-dom-bindings/src/client/ReactDOMTextarea.js",
+                1,
+                &[13],
+                true,
+            ),
+            (
+                "hydrateInput",
+                "packages/react-dom-bindings/src/client/ReactDOMInput.js",
+                363,
+                &[373, 375],
+                false,
+            ),
+            (
+                "initInput",
+                "packages/react-dom-bindings/src/client/ReactDOMInput.js",
+                222,
+                &[258, 260, 277, 278],
+                false,
+            ),
+            (
+                "updateInput",
+                "packages/react-dom-bindings/src/client/ReactDOMInput.js",
+                88,
+                &[133, 135, 136, 149, 170, 172, 175, 216],
+                false,
+            ),
+            (
+                "hydrateSelect",
+                "packages/react-dom-bindings/src/client/ReactDOMSelect.js",
+                161,
+                &[194],
+                false,
+            ),
+            (
+                "updateOptions",
+                "packages/react-dom-bindings/src/client/ReactDOMSelect.js",
+                63,
+                &[90],
+                false,
+            ),
+            (
+                "hydrateTextarea",
+                "packages/react-dom-bindings/src/client/ReactDOMTextarea.js",
+                152,
+                &[168],
+                false,
+            ),
+            (
+                "initTextarea",
+                "packages/react-dom-bindings/src/client/ReactDOMTextarea.js",
+                93,
+                &[130],
+                false,
+            ),
+            (
+                "updateTextarea",
+                "packages/react-dom-bindings/src/client/ReactDOMTextarea.js",
+                64,
+                &[73, 87],
+                false,
+            ),
+        ];
+        payload["references"] = rows
+            .iter()
+            .enumerate()
+            .map(|(index, (name, file, start, lines, import))| {
+                json!({
+                    "entity_id": format!("00000000-0000-4000-8000-{index:012}"),
+                    "file_path": file, "kind": if *import { "Module" } else { "Function" },
+                    "name": name, "reference_line_count": lines.len(), "reference_lines": lines,
+                    "reference_lines_absent_reason": null, "reference_lines_partial_reason": null,
+                    "relation_kinds": [if *import { "imports" } else { "calls" }],
+                    "resolution": "type_resolved", "role": "source", "start_line": start,
+                    "via_override_of": null,
+                })
+            })
+            .collect();
+        payload
+    }
+
+    // A separate synthetic row shape under the same conservative authority
+    // conditions. The full row shape above still needs suffix elisions.
+    fn concise_reference_fixture() -> Value {
+        let mut payload = conservative_reference_fixture();
+        for row in payload["references"].as_array_mut().unwrap() {
+            let file = row["file_path"]
+                .as_str()
+                .unwrap()
+                .rsplit('/')
+                .next()
+                .unwrap()
+                .trim_start_matches("ReactDOM")
+                .to_string();
+            *row = json!({
+                "entity_id": row["entity_id"], "name": row["name"],
+                "file_path": file, "reference_lines": row["reference_lines"],
+                "relation_kinds": row["relation_kinds"],
+            });
+        }
+        payload
+    }
+
+    fn conservative_reference_envelope() -> Envelope {
+        let mut envelope = Envelope::daemon().with_health(&json!({
+            "initialized": true, "graph_loaded": true,
+            "reconciliation_status": "clean", "graph_entity_count": 31909,
+            "graph_relation_count": 57917, "durable_entity_count": 31909,
+            "durable_relation_count": 47848,
+        }));
+        envelope.degraded.memory_pressure = Some(true);
+        envelope
+    }
+
+    fn roomy_reference_response(raw: &Value) -> Value {
+        annotated_value(&finalize_bounded(
+            ToolCallResult::text(raw.to_string()),
+            conservative_reference_envelope(),
+            "find_references",
+            &ResponseBudget {
+                max_chars: 60_000,
+                ..ResponseBudget::default()
+            },
+        ))
+    }
+
+    #[test]
+    fn exact_reference_restatements_are_pointed_before_rows_are_withheld() {
+        let raw = conservative_reference_fixture();
+        let full = roomy_reference_response(&raw);
+        let budget = ResponseBudget {
+            max_chars: 12_000,
+            ..ResponseBudget::default()
+        };
+        let before = crate::budget::measure(&full);
+        assert!(
+            before > budget.max_chars,
+            "fixture must exceed the complete response ceiling"
+        );
+        let mut pointed = full.clone();
+        pointed["_kin_json_format"] = json!("compact");
+        assert!(
+            crate::budget::measure(&pointed) > budget.max_chars,
+            "whitespace alone must not fit the qualification-heavy fixture"
+        );
+        assert_eq!(
+            crate::budget::point_restated_limiting_factor(&mut pointed, &budget),
+            3
+        );
+        let compacted = crate::budget::measure(&pointed);
+        assert!(
+            compacted <= budget.max_chars,
+            "disclosed pointers must fit: {compacted}"
+        );
+
+        let result = finalize_bounded(
+            ToolCallResult::text(raw.to_string()),
+            conservative_reference_envelope(),
+            "find_references",
+            &budget,
+        );
+        let final_payload = annotated_value(&result);
+        let rows = final_payload["references"].as_array().unwrap();
+        assert_eq!(
+            rows.len(),
+            11,
+            "lossless compaction must retain all eleven references"
+        );
+        assert_eq!(final_payload["references"], raw["references"]);
+        assert!(rows[..3]
+            .iter()
+            .all(|row| row["relation_kinds"] == json!(["imports"])));
+        assert_eq!(final_payload["caller_arrival"], full["caller_arrival"]);
+        assert_eq!(final_payload["edge_coverage"], full["edge_coverage"]);
+        assert_eq!(final_payload["cross_repo"], full["cross_repo"]);
+        assert_eq!(
+            rows.iter()
+                .filter(|row| row["relation_kinds"] == json!(["imports"]))
+                .count(),
+            3
+        );
+        assert_eq!(
+            rows.iter()
+                .filter(|row| row["relation_kinds"] == json!(["calls"]))
+                .count(),
+            8
+        );
+        assert_eq!(
+            final_payload["_kin"]["verdict"]["limiting_factor"],
+            full["_kin"]["verdict"]["limiting_factor"]
+        );
+        assert_eq!(
+            final_payload["negative"]["trust_reason"],
+            full["negative"]["trust_reason"]
+        );
+        assert_eq!(final_payload["negative"]["safe_to_conclude_absent"], false);
+        assert_eq!(
+            final_payload["_kin"]["verdict"]["safe_to_conclude_absent"],
+            false
+        );
+        assert_eq!(final_payload["_kin"]["response"]["bounded"], false);
+        assert!(final_payload.get("elisions").is_none());
+        assert!(final_payload["degradations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["reason"] == crate::budget::RESTATEMENT_POINTED_REASON));
+        let mut expanded = final_payload.clone();
+        for (path, owner) in [
+            ("/_kin/verdict/note", "/_kin/verdict/limiting_factor"),
+            ("/negative/advice", "/negative/trust_reason"),
+            ("/_kin/completeness/note", "/_kin/verdict/limiting_factor"),
+        ] {
+            let name = owner.trim_start_matches('/').replace('/', ".");
+            let original = full.pointer(owner).unwrap().as_str().unwrap();
+            let replacement = original.trim_end_matches('.');
+            let text = expanded
+                .pointer(path)
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .replace(&format!("see `{name}`"), replacement);
+            *expanded.pointer_mut(path).unwrap() = json!(text);
+        }
+        expanded.as_object_mut().unwrap().remove("_kin_json_format");
+        expanded["_kin"].as_object_mut().unwrap().remove("response");
+        expanded["degradations"]
+            .as_array_mut()
+            .unwrap()
+            .retain(|entry| entry["reason"] != crate::budget::RESTATEMENT_POINTED_REASON);
+        let mut original = full.clone();
+        original["_kin"].as_object_mut().unwrap().remove("response");
+        assert_eq!(
+            expanded, original,
+            "every pointed field must reconstruct exactly"
+        );
+        let ContentBlock::Text { text } = &result.content[0];
+        assert_eq!(
+            final_payload["_kin"]["response"]["chars_after_budget"],
+            text.len()
+        );
+        assert_eq!(text.len(), crate::budget::measure(&final_payload));
+        assert!(text.len() <= budget.max_chars);
+        println!(
+            "eleven reference rows: before={before} pointed={compacted} shipped={}",
+            text.len()
+        );
+    }
+
+    #[test]
+    fn reference_whitespace_compaction_preserves_the_complete_json_answer() {
+        let raw = concise_reference_fixture();
+        let mut full = roomy_reference_response(&raw);
+        assert!(crate::budget::measure(&full) > 12_000);
+        let result = finalize_bounded(
+            ToolCallResult::text(raw.to_string()),
+            conservative_reference_envelope(),
+            "find_references",
+            &ResponseBudget {
+                max_chars: 12_000,
+                ..ResponseBudget::default()
+            },
+        );
+        let mut payload = annotated_value(&result);
+        assert_eq!(payload["references"].as_array().unwrap().len(), 11);
+        assert_eq!(payload["_kin_json_format"], "compact");
+        assert_eq!(payload["_kin"]["response"]["bounded"], false);
+        let ContentBlock::Text { text } = &result.content[0];
+        assert_eq!(
+            payload["_kin"]["response"]["chars_after_budget"],
+            text.len()
+        );
+        assert_eq!(crate::budget::measure(&payload), text.len());
+        assert_eq!(serde_json::to_string(&payload).unwrap(), *text);
+        assert!(text.len() <= 12_000);
+        payload.as_object_mut().unwrap().remove("_kin_json_format");
+        payload["_kin"].as_object_mut().unwrap().remove("response");
+        full["_kin"].as_object_mut().unwrap().remove("response");
+        assert_eq!(payload, full);
+    }
+
+    #[test]
+    fn unique_reference_content_still_requires_truthful_suffix_elisions() {
+        let mut raw = conservative_reference_fixture();
+        for (index, row) in raw["references"]
+            .as_array_mut()
+            .unwrap()
+            .iter_mut()
+            .enumerate()
+        {
+            row["unique_detail"] = json!(format!(
+                "reference {index}: {}",
+                "unique site qualification ".repeat(35)
+            ));
+        }
+        let full = roomy_reference_response(&raw);
+        let budget = ResponseBudget {
+            max_chars: 12_000,
+            ..ResponseBudget::default()
+        };
+        println!(
+            "full reference JSON before pointers: compact={}",
+            serde_json::to_string(&full).unwrap().len()
+        );
+        let mut pointed = full.clone();
+        pointed["_kin_json_format"] = json!("compact");
+        assert_eq!(
+            crate::budget::point_restated_limiting_factor(&mut pointed, &budget),
+            3
+        );
+        assert!(crate::budget::measure(&pointed) > budget.max_chars);
+        println!(
+            "complete reference JSON: pretty={} compact={}",
+            crate::budget::measure(&pointed),
+            serde_json::to_string(&pointed).unwrap().len()
+        );
+        let result = finalize_bounded(
+            ToolCallResult::text(raw.to_string()),
+            conservative_reference_envelope(),
+            "find_references",
+            &budget,
+        );
+        let payload = annotated_value(&result);
+        let rows = payload["references"].as_array().unwrap();
+        assert!(!rows.is_empty() && rows.len() < 11);
+        assert_eq!(rows, &raw["references"].as_array().unwrap()[..rows.len()]);
+        assert_eq!(payload["elisions"]["references"]["kept"], rows.len());
+        assert_eq!(payload["elisions"]["references"]["elided"], 11 - rows.len());
+        assert_eq!(payload["references_withheld"], 11 - rows.len());
+        assert_eq!(payload["truncated"], true);
+        assert_eq!(payload["_kin"]["response"]["bounded"], true);
+        assert_eq!(payload["negative"]["safe_to_conclude_absent"], false);
+        assert_eq!(payload["_kin"]["completeness"]["bound"], "at_least");
+        assert!(payload["degradations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["reason"] == "response_bounded"
+                && entry["detail"]
+                    .as_str()
+                    .unwrap()
+                    .contains("from the end of the list")));
+        let ContentBlock::Text { text } = &result.content[0];
+        assert_eq!(
+            payload["_kin"]["response"]["chars_after_budget"],
+            text.len()
+        );
+        assert_eq!(text.len(), crate::budget::measure(&payload));
+        assert!(text.len() <= budget.max_chars);
+        println!(
+            "unique reference overflow: before={} pointed={} retained={} shipped={}",
+            crate::budget::measure(&full),
+            crate::budget::measure(&pointed),
+            rows.len(),
+            text.len()
+        );
+    }
+
+    #[test]
+    fn nonmatching_reference_qualifications_are_never_pointed() {
+        let mut payload = roomy_reference_response(&conservative_reference_fixture());
+        for field in [
+            "/_kin/verdict/note",
+            "/negative/advice",
+            "/_kin/completeness/note",
+        ] {
+            let text = payload
+                .pointer(field)
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .to_string();
+            *payload.pointer_mut(field).unwrap() =
+                json!(format!("{text} An additional unique qualification."));
+        }
+        let before = payload.clone();
+        let budget = ResponseBudget {
+            max_chars: 12_000,
+            ..ResponseBudget::default()
+        };
+        assert!(crate::budget::measure(&payload) > budget.max_chars);
+        assert_eq!(
+            crate::budget::point_restated_limiting_factor(&mut payload, &budget),
+            0
+        );
+        assert_eq!(payload, before);
     }
 
     /// The budget removes rows on purpose, and a response it shortened is

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -4858,7 +4858,7 @@ mod tests {
     }
 
     // A separate synthetic row shape under the same conservative authority
-    // conditions. The full row shape above still needs suffix elisions.
+    // conditions, sized to isolate whitespace savings from qualification pointers.
     fn concise_reference_fixture() -> Value {
         let mut payload = conservative_reference_fixture();
         for row in payload["references"].as_array_mut().unwrap() {
@@ -4877,6 +4877,46 @@ mod tests {
             });
         }
         payload
+    }
+
+    #[test]
+    fn finalized_context_cannot_claim_full_bodies_after_elision() {
+        for multi in [false, true] {
+            let row = json!({"id": "focal", "body": "body ".repeat(4000),
+                "projection": "FullBody", "body_complete": true, "signature": "fn focal()"});
+            let raw = if multi {
+                json!({"entities": [row], "focals": [{"entity_id": "focal", "projection": "full_body"}]})
+            } else {
+                json!({"focal_entity": row, "dependencies": []})
+            };
+            let budget = ResponseBudget {
+                max_chars: 12000,
+                ..ResponseBudget::default()
+            };
+            let result = finalize_bounded(
+                ToolCallResult::text(raw.to_string()),
+                Envelope::daemon(),
+                "get_context_pack",
+                &budget,
+            );
+            let payload = annotated_value(&result);
+            let row = if multi {
+                &payload["entities"][0]
+            } else {
+                &payload["focal_entity"]
+            };
+            assert!(row["body"].is_null());
+            assert_eq!(row["projection"], "SignatureOnly");
+            assert_eq!(row["body_complete"], false);
+            assert_eq!(row["body_elided"], json!(["body"]));
+            let crate::types::ContentBlock::Text { text } = &result.content[0];
+            assert!(text.len() <= budget.max_chars);
+            assert_eq!(
+                payload["_kin"]["response"]["chars_after_budget"],
+                text.len()
+            );
+            assert_eq!(payload["_kin"]["response"]["bounded"], true);
+        }
     }
 
     fn conservative_reference_envelope() -> Envelope {

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -4176,7 +4176,13 @@ mod tests {
         })
     }
 
-    fn belt_bounded_deep_trace() -> Value {
+    /// The bytes the belt ships, and the answer parsed out of them.
+    ///
+    /// Both, because the size that ships is the length of those bytes and
+    /// nothing else. Re-measuring the parsed value asks the serializer to guess
+    /// a format it was never told, and the guess is wrong for any response the
+    /// budget compacted.
+    fn belt_bounded_deep_trace() -> (String, Value) {
         let budget = ResponseBudget {
             max_chars: crate::agent_belt::AGENT_DEFAULT_RESPONSE_MAX_CHARS as usize,
             ..ResponseBudget::default()
@@ -4187,7 +4193,8 @@ mod tests {
             "trace_data_flow",
             &budget,
         );
-        annotated_value(&annotated)
+        let ContentBlock::Text { text } = annotated.content.first().expect("one content block");
+        (text.clone(), annotated_value(&annotated))
     }
 
     /// The measured case, and the one the belt advertises a number for.
@@ -4215,8 +4222,8 @@ mod tests {
             "the fixture is {raw} characters, too small to reach the ceiling with an envelope"
         );
 
-        let final_payload = belt_bounded_deep_trace();
-        let shipped = crate::budget::measure(&final_payload);
+        let (text, final_payload) = belt_bounded_deep_trace();
+        let shipped = text.len();
         println!("deep trace ships {shipped} characters against a {CEILING} ceiling");
         assert!(
             shipped <= CEILING,
@@ -5177,7 +5184,6 @@ mod tests {
                 .replace(&format!("see `{name}`"), replacement);
             *expanded.pointer_mut(path).unwrap() = json!(text);
         }
-        expanded.as_object_mut().unwrap().remove("_kin_json_format");
         expanded["_kin"].as_object_mut().unwrap().remove("response");
         expanded["degradations"]
             .as_array_mut()
@@ -5194,7 +5200,6 @@ mod tests {
             final_payload["_kin"]["response"]["chars_after_budget"],
             text.len()
         );
-        assert_eq!(text.len(), crate::budget::measure(&final_payload));
         assert!(text.len() <= budget.max_chars);
         println!(
             "eleven reference rows: before={before} pointed={compacted} shipped={}",
@@ -5218,17 +5223,31 @@ mod tests {
         );
         let mut payload = annotated_value(&result);
         assert_eq!(payload["references"].as_array().unwrap().len(), 11);
-        assert_eq!(payload["_kin_json_format"], "compact");
+        // The switch chose the format and did not ride out on the answer.
+        assert!(
+            payload.get("_kin_json_format").is_none(),
+            "the serialization control field must not ship: {payload}"
+        );
         assert_eq!(payload["_kin"]["response"]["bounded"], false);
         let ContentBlock::Text { text } = &result.content[0];
+        // Positive control on that absence: the response really IS compact, so
+        // the switch was set and read. Without this the absence assertion above
+        // would pass on a response that was never compacted at all.
+        assert!(!text.contains('\n'), "the shipped response is compact");
         assert_eq!(
             payload["_kin"]["response"]["chars_after_budget"],
             text.len()
         );
-        assert_eq!(crate::budget::measure(&payload), text.len());
+        // Re-serializing the parsed answer compactly reproduces the shipped
+        // bytes exactly, so the only thing compaction removed was whitespace.
         assert_eq!(serde_json::to_string(&payload).unwrap(), *text);
         assert!(text.len() <= 12_000);
-        payload.as_object_mut().unwrap().remove("_kin_json_format");
+        // And the switch is genuinely consumed rather than merely hidden: this
+        // payload, read back without it, measures as pretty.
+        assert!(
+            crate::budget::measure(&payload) > text.len(),
+            "the format choice does not survive the round trip"
+        );
         payload["_kin"].as_object_mut().unwrap().remove("response");
         full["_kin"].as_object_mut().unwrap().remove("response");
         assert_eq!(payload, full);
@@ -5300,7 +5319,6 @@ mod tests {
             payload["_kin"]["response"]["chars_after_budget"],
             text.len()
         );
-        assert_eq!(text.len(), crate::budget::measure(&payload));
         assert!(text.len() <= budget.max_chars);
         println!(
             "unique reference overflow: before={} pointed={} retained={} shipped={}",
@@ -5400,10 +5418,9 @@ mod tests {
 
         let ContentBlock::Text { text } = annotated.content.first().unwrap();
         let final_payload: Value = serde_json::from_str(text).unwrap();
-        let final_chars = crate::budget::measure(&final_payload);
         assert_eq!(
             envelope["response"]["chars_after_budget"],
-            json!(final_chars),
+            json!(text.len()),
             "accounting is measured after the downgrade and every disclosure: {final_payload}"
         );
         let residual = final_payload
@@ -5416,7 +5433,7 @@ mod tests {
                 })
             });
         assert!(
-            final_chars <= budget.max_chars || residual,
+            text.len() <= budget.max_chars || residual,
             "a response over the caller ceiling must disclose the residual: {final_payload}"
         );
         assert_eq!(

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -2693,11 +2693,14 @@ impl<G: GraphStore> kin_context::ContextProjectionProvider for ContextSourceProv
     }
 }
 
+/// Attach the source projection result. Rows promising a body must name any gap;
+/// signature-only neighborhood and route rows make no such promise.
 pub fn attach_context_projection(
     entry: &kin_model::ContextEntry,
     fields: &ContextSourceFields,
     report: &kin_context::ProjectionReport,
     row: &mut serde_json::Value,
+    body_expected: bool,
 ) {
     row["projection"] = serde_json::json!(format!("{:?}", entry.projection_level));
     if let Some(metadata) = fields.borrow().get(&entry.entity_id) {
@@ -2714,6 +2717,14 @@ pub fn attach_context_projection(
         if report.budget_withheld.contains(&entry.entity_id) {
             row["body_elided"] = serde_json::json!(["body"]);
         }
+    } else if body_expected {
+        // Recovered dependents were not priced by the projection provider.
+        // Name the gap without claiming a budget cut or a projection downgrade.
+        row["body"] = serde_json::Value::Null;
+        row["body_complete"] = serde_json::json!(false);
+        row["body_unavailable"] = serde_json::json!(
+            "no source body was read for this row: it was not priced by this request's source projection; read it with get_entity_source"
+        );
     }
 }
 

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -2607,6 +2607,137 @@ pub fn read_entity_source_excerpt_detailed_held<G: GraphStore>(
     Ok(Some(source))
 }
 
+/// Read the exact graph span, refusing an oversized body before copying it.
+pub fn read_entity_source_exact<G: GraphStore>(
+    held: &HeldSourceAuthority<'_, G>,
+    entity: &Entity,
+    max_bytes: usize,
+) -> Result<Option<ExactEntitySource>> {
+    let Some((mut source, bytes, span)) =
+        resolve_entity_source_authority(held, entity, EntitySourceScope::WorkspaceHead)?
+    else {
+        return Ok(None);
+    };
+    let body = &bytes[span.start_byte..span.end_byte];
+    if body.len() > max_bytes {
+        return Err(McpError::Context(format!("entity {} whole source span is {} bytes, above the {} byte inline limit; use kin_artifact_read", entity.id, body.len(), max_bytes)));
+    }
+    source.body = std::str::from_utf8(body)
+        .map_err(|error| {
+            graph_source_gap(format!(
+                "entity {} has a source span that is not valid UTF-8: {error}",
+                entity.id
+            ))
+        })?
+        .to_owned();
+    Ok(Some(source))
+}
+
+/// Limits additional inline body allocations across one context request.
+/// The authority cache owns artifact bytes separately; this bounds copied spans.
+pub struct ContextBodyBudget {
+    max_bytes: usize,
+    remaining_bytes: usize,
+    served: usize,
+    withheld: usize,
+}
+
+impl ContextBodyBudget {
+    pub fn new(max_bytes: usize) -> Self {
+        Self {
+            max_bytes: max_bytes.min(crate::budget::RESPONSE_MAX_MAX_CHARS),
+            remaining_bytes: max_bytes.min(crate::budget::RESPONSE_MAX_MAX_CHARS),
+            served: 0,
+            withheld: 0,
+        }
+    }
+
+    pub fn disclose(&self, payload: &mut serde_json::Value) {
+        if self.withheld == 0 {
+            return;
+        }
+        crate::budget::record_elision_for(
+            payload,
+            "body",
+            self.served,
+            self.withheld,
+            crate::budget::BODY_HYDRATION_REASON,
+        );
+        let entry = serde_json::json!({
+            "component": "context_body_budget",
+            "reason": crate::budget::BODY_HYDRATION_REASON,
+            "detail": format!("{} whole source bodies withheld before copying because they did not fit the remaining shared {} byte inline allowance", self.withheld, self.max_bytes),
+            "remediation": "read an omitted body with get_entity_source or narrow the context request",
+            "max_body_bytes": self.max_bytes,
+            "copied_body_bytes": self.max_bytes - self.remaining_bytes,
+        });
+        if let Some(entries) = payload
+            .get_mut("degradations")
+            .and_then(serde_json::Value::as_array_mut)
+        {
+            entries.push(entry);
+        } else {
+            payload["degradations"] = serde_json::json!([entry]);
+        }
+    }
+}
+
+/// Attach an exact graph-owned span or explicitly downgrade the projection.
+/// No excerpt expansion, line normalization, or partial body is permitted here.
+pub fn attach_context_body<G: GraphStore>(
+    held: &HeldSourceAuthority<'_, G>,
+    entity: &Entity,
+    row: &mut serde_json::Value,
+    budget: &mut ContextBodyBudget,
+) -> Result<()> {
+    let resolved =
+        match resolve_entity_source_authority(held, entity, EntitySourceScope::WorkspaceHead) {
+            Ok(source) => source,
+            Err(error) if is_absent_at_generation(&error) => {
+                downgrade_context_body(row, &error.to_string());
+                return Ok(());
+            }
+            Err(error) => return Err(error),
+        };
+    row["source"] = serde_json::json!(LAST_READ_SOURCE.with(|value| value.get()));
+    let Some((source, bytes, span)) = resolved else {
+        downgrade_context_body(row, &entity_body_gap_reason(entity));
+        return Ok(());
+    };
+    if let Some(map) = row.as_object_mut() {
+        map.extend(source_provenance_fields(&source));
+    }
+    let body_bytes = &bytes[span.start_byte..span.end_byte];
+    if body_bytes.len() > budget.remaining_bytes {
+        budget.withheld += 1;
+        downgrade_context_body(row, "whole graph-owned span exceeds the remaining inline body byte budget; use get_entity_source");
+        row["body_elided"] = serde_json::json!(["body"]);
+        row["body_bytes"] = serde_json::json!(body_bytes.len());
+        row["body_budget_remaining_bytes"] = serde_json::json!(budget.remaining_bytes);
+        return Ok(());
+    }
+    let body = std::str::from_utf8(body_bytes).map_err(|error| {
+        graph_source_gap(format!(
+            "entity {} has a source span that is not valid UTF-8: {error}",
+            entity.id
+        ))
+    })?;
+    budget.remaining_bytes -= body.len();
+    budget.served += 1;
+    row["body"] = serde_json::Value::String(body.to_owned());
+    row["body_complete"] = serde_json::json!(true);
+    row["projection"] = serde_json::json!("FullBody");
+    Ok(())
+}
+
+pub fn downgrade_context_body(row: &mut serde_json::Value, reason: &str) {
+    row["body"] = serde_json::Value::Null;
+    row["body_complete"] = serde_json::json!(false);
+    row["projection"] = serde_json::json!("SignatureOnly");
+    row["projection_downgraded_from"] = serde_json::json!("FullBody");
+    row["body_unavailable"] = serde_json::json!(reason);
+}
+
 /// Explain, in agent-actionable terms, why an entity has no graph-owned body.
 ///
 /// Reached only when the projection returned no body without erroring, which is
@@ -2633,17 +2764,14 @@ pub fn entity_body_gap_reason(entity: &Entity) -> String {
 /// Caps for the inline snippet surfaced on a retrieval hit (`kin locate --json`
 /// symbols, `semantic_locate` entity results): a signature plus the first
 /// several body lines, dense enough for an agent to act on without a follow-up
-/// read, but far tighter than the full-body excerpt
-/// ([`MCP_SOURCE_MAX_LINES`]/[`MCP_SOURCE_MAX_CHARS`]) `get_entity_source` and
-/// `get_context_pack` serve. One bound shared by every agent surface so the
+/// read, but far tighter than the whole spans context packs serve. One bound shared by every agent surface so the
 /// snippet is identical wherever it appears.
 pub const RETRIEVAL_SNIPPET_MAX_LINES: usize = 12;
 pub const RETRIEVAL_SNIPPET_MAX_CHARS: usize = 800;
 
 /// Graph-native bounded snippet for an entity. Delegates to the same
 /// content-addressed, hash-verified body projection
-/// ([`read_entity_source_excerpt_detailed`]) that backs `get_entity_source` and
-/// `get_context_pack`, capped to
+/// ([`read_entity_source_excerpt_detailed`]), capped to
 /// [`RETRIEVAL_SNIPPET_MAX_LINES`]/[`RETRIEVAL_SNIPPET_MAX_CHARS`] for inline use
 /// on retrieval hits. Returns `None` only when the entity has no source
 /// coordinates. A tree, identity, span, UTF-8, or blob authority gap is an
@@ -3002,12 +3130,8 @@ pub fn entity_response_json<G: GraphStore>(
 /// fallback the parameter only obliged callers to build a value this function
 /// discards.
 ///
-/// Takes no `compact` flag either. Compact mode used to drop the focal body
-/// while still paying for the read that produced it, which left the one thing
-/// the pack is for out of the cheaper mode: a caller asking for a bounded pack
-/// spent a whole call learning it had to ask again. Compact now bounds the
-/// dependency rows, and the focal body it serves is already capped at
-/// [`MCP_SOURCE_MAX_LINES`]/[`MCP_SOURCE_MAX_CHARS`].
+/// Compact mode keeps the focal body. The request's shared byte budget limits
+/// exact spans without silently converting them into excerpts.
 pub fn focal_context_json<G: GraphStore>(
     store: &G,
     entity: &Entity,
@@ -3026,17 +3150,20 @@ pub fn focal_context_json_held<G: GraphStore>(
     held: &HeldSourceAuthority<'_, G>,
     entity: &Entity,
 ) -> Result<serde_json::Value> {
-    let start_line = entity_presentation_start_line(entity);
-    let end_line = entity_presentation_end_line(entity);
-    let source_excerpt = read_entity_source_excerpt_detailed_held(
+    focal_context_json_bounded(
         held,
         entity,
-        MCP_SOURCE_MAX_LINES,
-        MCP_SOURCE_MAX_CHARS,
-        EntitySourceScope::WorkspaceHead,
-    )?;
-    let source = LAST_READ_SOURCE.with(|f| f.get());
+        &mut ContextBodyBudget::new(crate::budget::RESPONSE_DEFAULT_MAX_CHARS),
+    )
+}
 
+pub fn focal_context_json_bounded<G: GraphStore>(
+    held: &HeldSourceAuthority<'_, G>,
+    entity: &Entity,
+    budget: &mut ContextBodyBudget,
+) -> Result<serde_json::Value> {
+    let start_line = entity_presentation_start_line(entity);
+    let end_line = entity_presentation_end_line(entity);
     let mut obj = serde_json::json!({
         "id": entity.id,
         "name": entity.name,
@@ -3046,21 +3173,9 @@ pub fn focal_context_json_held<G: GraphStore>(
         "read_path": entity_read_path(entity),
         "start_line": start_line,
         "end_line": end_line,
-        "source": source,
     });
 
-    match source_excerpt.as_ref() {
-        Some(source) => obj["body"] = serde_json::json!(source.body),
-        None => {
-            obj["body"] = serde_json::Value::Null;
-            obj["body_unavailable"] = serde_json::json!(entity_body_gap_reason(entity));
-        }
-    }
-    if let Some(source) = source_excerpt {
-        if let Some(map) = obj.as_object_mut() {
-            map.extend(source_provenance_fields(&source));
-        }
-    }
+    attach_context_body(held, entity, &mut obj, budget)?;
 
     Ok(obj)
 }

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -2633,6 +2633,90 @@ pub fn read_entity_source_exact<G: GraphStore>(
     Ok(Some(source))
 }
 
+pub type ContextSourceFields =
+    std::rc::Rc<std::cell::RefCell<HashMap<EntityId, serde_json::Map<String, serde_json::Value>>>>;
+
+pub struct ContextSourceProvider<'a, 'store, G: GraphStore> {
+    pub held: &'a HeldSourceAuthority<'store, G>,
+    pub fields: ContextSourceFields,
+}
+
+impl<G: GraphStore> kin_context::ContextProjectionProvider for ContextSourceProvider<'_, '_, G> {
+    fn full_body(
+        &mut self,
+        entity: &Entity,
+        limits: kin_context::ProjectionLimits,
+    ) -> kin_context::Result<kin_context::BodyCandidate> {
+        let resolved = match resolve_entity_source_authority(
+            self.held,
+            entity,
+            EntitySourceScope::WorkspaceHead,
+        ) {
+            Ok(source) => source,
+            Err(error) if is_absent_at_generation(&error) => {
+                return Ok(kin_context::BodyCandidate::Unavailable {
+                    reason: error.to_string(),
+                })
+            }
+            Err(error) => return Err(kin_context::ContextError::Other(error.to_string())),
+        };
+        let Some((source, bytes, span)) = resolved else {
+            return Ok(kin_context::BodyCandidate::Unavailable {
+                reason: entity_body_gap_reason(entity),
+            });
+        };
+        let mut fields = source_provenance_fields(&source);
+        fields.insert(
+            "source".into(),
+            serde_json::json!(LAST_READ_SOURCE.with(|value| value.get())),
+        );
+        self.fields.borrow_mut().insert(entity.id, fields);
+        let body = &bytes[span.start_byte..span.end_byte];
+        let body_text = std::str::from_utf8(body).map_err(|error| {
+            kin_context::ContextError::Other(format!("source span is not valid UTF-8: {error}"))
+        })?;
+        if body.len() > limits.max_candidate_bytes.min(limits.max_retained_bytes) {
+            if let Some(fields) = self.fields.borrow_mut().get_mut(&entity.id) {
+                fields.insert("body_bytes".into(), serde_json::json!(body.len()));
+                fields.insert(
+                    "body_budget_remaining_bytes".into(),
+                    serde_json::json!(limits.max_retained_bytes),
+                );
+            }
+            return Ok(kin_context::BodyCandidate::OverLimit {
+                body_bytes: body.len(),
+            });
+        }
+        Ok(kin_context::BodyCandidate::Exact {
+            body: body_text.to_owned(),
+        })
+    }
+}
+
+pub fn attach_context_projection(
+    entry: &kin_model::ContextEntry,
+    fields: &ContextSourceFields,
+    report: &kin_context::ProjectionReport,
+    row: &mut serde_json::Value,
+) {
+    row["projection"] = serde_json::json!(format!("{:?}", entry.projection_level));
+    if let Some(metadata) = fields.borrow().get(&entry.entity_id) {
+        if let Some(object) = row.as_object_mut() {
+            object.extend(metadata.clone());
+        }
+    }
+    if report.full_bodies.contains(&entry.entity_id) {
+        row["body"] = serde_json::json!(entry.content);
+        row["body_complete"] = serde_json::json!(true);
+    } else if let Some(reason) = report.downgrades.get(&entry.entity_id) {
+        downgrade_context_body(row, reason);
+        row["projection"] = serde_json::json!(format!("{:?}", entry.projection_level));
+        if report.budget_withheld.contains(&entry.entity_id) {
+            row["body_elided"] = serde_json::json!(["body"]);
+        }
+    }
+}
+
 /// Limits additional inline body allocations across one context request.
 /// The authority cache owns artifact bytes separately; this bounds copied spans.
 pub struct ContextBodyBudget {

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -2719,49 +2719,21 @@ pub fn attach_context_projection(
 
 /// Limits additional inline body allocations across one context request.
 /// The authority cache owns artifact bytes separately; this bounds copied spans.
+///
+/// It carries no served/withheld counters and publishes nothing itself. What it
+/// refuses is disclosed on the row, by `attach_context_body` writing
+/// `body_elided`, `body_bytes` and `body_budget_remaining_bytes`, and the
+/// aggregate is derived from those rows by `disclose_projection_bodies`. One
+/// producer for one fact: a counter kept in parallel with the rows is a second
+/// account of the same cut that can disagree with the first.
 pub struct ContextBodyBudget {
-    max_bytes: usize,
     remaining_bytes: usize,
-    served: usize,
-    withheld: usize,
 }
 
 impl ContextBodyBudget {
     pub fn new(max_bytes: usize) -> Self {
         Self {
-            max_bytes: max_bytes.min(crate::budget::RESPONSE_MAX_MAX_CHARS),
             remaining_bytes: max_bytes.min(crate::budget::RESPONSE_MAX_MAX_CHARS),
-            served: 0,
-            withheld: 0,
-        }
-    }
-
-    pub fn disclose(&self, payload: &mut serde_json::Value) {
-        if self.withheld == 0 {
-            return;
-        }
-        crate::budget::record_elision_for(
-            payload,
-            "body",
-            self.served,
-            self.withheld,
-            crate::budget::BODY_HYDRATION_REASON,
-        );
-        let entry = serde_json::json!({
-            "component": "context_body_budget",
-            "reason": crate::budget::BODY_HYDRATION_REASON,
-            "detail": format!("{} whole source bodies withheld before copying because they did not fit the remaining shared {} byte inline allowance", self.withheld, self.max_bytes),
-            "remediation": "read an omitted body with get_entity_source or narrow the context request",
-            "max_body_bytes": self.max_bytes,
-            "copied_body_bytes": self.max_bytes - self.remaining_bytes,
-        });
-        if let Some(entries) = payload
-            .get_mut("degradations")
-            .and_then(serde_json::Value::as_array_mut)
-        {
-            entries.push(entry);
-        } else {
-            payload["degradations"] = serde_json::json!([entry]);
         }
     }
 }
@@ -2793,7 +2765,6 @@ pub fn attach_context_body<G: GraphStore>(
     }
     let body_bytes = &bytes[span.start_byte..span.end_byte];
     if body_bytes.len() > budget.remaining_bytes {
-        budget.withheld += 1;
         downgrade_context_body(row, "whole graph-owned span exceeds the remaining inline body byte budget; use get_entity_source");
         row["body_elided"] = serde_json::json!(["body"]);
         row["body_bytes"] = serde_json::json!(body_bytes.len());
@@ -2807,7 +2778,6 @@ pub fn attach_context_body<G: GraphStore>(
         ))
     })?;
     budget.remaining_bytes -= body.len();
-    budget.served += 1;
     row["body"] = serde_json::Value::String(body.to_owned());
     row["body_complete"] = serde_json::json!(true);
     row["projection"] = serde_json::json!("FullBody");

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -1739,7 +1739,13 @@ fn disclose_projection_bodies(result: &mut serde_json::Value) {
     }
     visit(result, &mut served, &mut withheld);
     if withheld > 0 {
-        crate::budget::record_elision_for(result, "body", served, withheld, "whole_body_withheld");
+        crate::budget::record_elision_for(
+            result,
+            "body",
+            served,
+            withheld,
+            crate::budget::BODY_HYDRATION_REASON,
+        );
         let before = crate::budget::measure(result);
         crate::budget::mark_context_cut(result, before);
     }

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -808,22 +808,25 @@ pub fn handle_get_entity_sources<G: GraphStore>(
 const CERTIFIED_DEPENDENTS_MAX: usize = 24;
 
 pub const GET_CONTEXT_PACK_DESC: &str = "\
-Assemble a focused, ready-to-read context bundle around one entity, fitted to a token \
-budget. Starting from a focal entity ID, Kin walks the relation graph to gather the \
-nearby code you'd actually need to understand or change it — the focal body plus its \
-direct dependencies (signatures), and optionally transitive deps, linked tests, \
-contracts, work items, and annotations — and returns it all in a single structured \
+Assemble a focused context bundle around one entity, fitted to a token budget. \
+Starting from a focal entity ID, Kin walks the relation graph to gather its body, \
+direct dependency signatures, and optional transitive dependencies, linked tests, \
+contracts, work items and annotations. It returns them in one structured \
 response with the token accounting included. Reach for it when a question is about a \
 unit of code in context (\"what does X do and what does it touch?\") rather than a single \
-isolated body. Its value is that it replaces an open-ended chain of \
-get_entity_source / find_references calls — which burns round-trips and easily blows \
-your context window — with one budgeted call. `token_budget` bounds the content the pack \
-selects, and it cannot bound the envelope that content travels in, so read `tokens_used`, \
-which measures the serialized response this call returns, as what the call costs you. \
-`focal_entity.body` in the response IS the focal entity's exact source text, so this one \
-call already answers \"show me the code\": no follow-up read is needed, and it is the body \
-to edit and stage back, in compact mode too, which drops the dependency bodies and \
-projection levels but never the focal body. The two directions are separate groups, because they answer opposite questions: \
+isolated body. It replaces an open-ended chain of get_entity_source and find_references \
+calls with one pack. `token_budget` and `max_response_chars` bound the \
+serialized context payload, including its envelope. `tokens_used` reports the estimated \
+token cost of that complete payload. \
+`focal_entity.body`, when `body_complete` is true, is the exact graph-owned source span, \
+byte for byte, in compact mode too. A span that cannot be served is absent, never clipped \
+or reconstructed past its recorded boundary. Check `body_complete` and the row's \
+`body_unavailable` reason before relying on a body. `body_elided` containing \
+\"body\" identifies a budget cut; a removed FullBody projection becomes SignatureOnly \
+and `projection_downgraded_from` records that change. Source-sizing metadata such as \
+`body_bytes` is included when available. For a budget cut, raise `max_response_chars` \
+and `token_budget`, or request the source separately with get_entity_source. A missing \
+graph span needs corrected graph coverage. The two directions are separate groups: \
 `dependencies` is what the focal needs to run, and `dependents` is what breaks if you \
 change it. Every row also says why it is there: `relation: \"dependency_edge\"` is an \
 edge leaving the focal, `relation: \"dependent_edge\"` is an edge arriving at it, and \
@@ -1014,7 +1017,7 @@ impl<G: GraphStore> SingleContextRender<'_, G> {
                 "start_line": entity_presentation_start_line(entity),
                 "end_line": entity_presentation_end_line(entity),
             });
-            attach_context_projection(entry, fields, projections, &mut row);
+            attach_context_projection(entry, fields, projections, &mut row, true);
             row
         } else {
             serde_json::Value::Null
@@ -1046,7 +1049,7 @@ impl<G: GraphStore> SingleContextRender<'_, G> {
                 }
                 if !compact {
                     obj["projection"] = serde_json::json!(format!("{:?}", entry.projection_level));
-                    attach_context_projection(entry, fields, projections, &mut obj);
+                    attach_context_projection(entry, fields, projections, &mut obj, true);
                 }
                 Ok(obj)
             } else {
@@ -1203,8 +1206,10 @@ impl<G: GraphStore> SingleContextRender<'_, G> {
         // builder's token budget, or missed by its subgraph walk -- is exactly the
         // shape this defect had. Recovering it here is what makes the group's
         // membership a property of the answer rather than of how much budget was
-        // left, and the recovered rows carry the same shape as the projected ones so
-        // a reader cannot tell which path produced them.
+        // left.
+        //
+        // The projection provider has not read these recovered rows.
+        // attach_context_projection names their missing bodies explicitly.
         let mut dependents_withheld = 0usize;
         for id in certified_ids {
             if packed.contains(id) {
@@ -1648,7 +1653,13 @@ fn render_multi_context<G: GraphStore>(
                 "section": section,
                 "projection": format!("{:?}", entry.projection_level),
             });
-            attach_context_projection(entry, fields, projections, &mut obj);
+            attach_context_projection(
+                entry,
+                fields,
+                projections,
+                &mut obj,
+                entry.projection_level == kin_model::context::ProjectionLevel::FullBody,
+            );
             Ok(obj)
         };
 

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -864,9 +864,7 @@ pub fn handle_get_context_pack<G: GraphStore>(
     sessions: &SessionRegistry,
     repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<ToolCallResult> {
-    use kin_context::{
-        build_context_pack_with_traffic_and_provenance, ContextOptions, DependencyRelation,
-    };
+    use kin_context::{build_context_pack_with_traffic_and_provenance, ContextOptions};
     use kin_model::context::TokenBudget;
 
     // Several focals, or a question the daemon already resolved into them, take
@@ -905,383 +903,521 @@ pub fn handle_get_context_pack<G: GraphStore>(
         vec![]
     };
 
-    let (pack, selection) =
+    let (traffic_pack, _) =
         build_context_pack_with_traffic_and_provenance(store, &entity_id, &opts, &nearby_intents)
             .map_err(|e| McpError::Context(e.to_string()))?;
-
-    // Build structured response JSON. The pack still has to have projected a
-    // focal entry for the focal entity to be worth serializing, but the body
-    // comes from graph truth rather than from that entry.
-    let focal_entry = pack.focal_entities.first();
-    let focal_entity = store.get_entity(&entity_id).map_err(McpError::graph)?;
-
-    // One held authority for the whole pack. A pack projects the focal entity
-    // and then a body per dependency it carries, so deriving authority per
-    // projection multiplies a full recovery by the pack's size.
     let held = HeldSourceAuthority::new(store, repository_authority);
-
-    let mut body_budget =
-        ContextBodyBudget::new(crate::budget::ResponseBudget::from_arguments(args).max_chars);
-
-    let focal_json = if let (Some(_), Some(entity)) = (focal_entry, &focal_entity) {
-        focal_context_json_bounded(&held, entity, &mut body_budget)?
-    } else {
-        serde_json::json!(null)
+    let fields = ContextSourceFields::default();
+    let mut provider = ContextSourceProvider {
+        held: &held,
+        fields: fields.clone(),
     };
-
-    // `relation` is what keeps a same-file neighbour from reading as a
-    // dependency. The builder tags the fallback inside `entry.content`, which
-    // this handler does not serialize, so without the selection travelling
-    // alongside the pack the two are indistinguishable on the wire. Rows in the
-    // sections that are not dependencies (transitive, tests, contracts) pass
-    // `None` and carry no relation at all.
-    let mut project_dep = |entry: &kin_model::context::ContextEntry,
-                           relation: Option<DependencyRelation>|
-     -> Result<serde_json::Value> {
-        // Look up the entity for structured fields.
-        if let Some(e) = store
-            .get_entity(&entry.entity_id)
-            .map_err(McpError::graph)?
-        {
-            let mut obj = serde_json::json!({
-                "id": e.id,
-                "name": e.name,
-                "kind": e.kind,
-                "signature": e.signature,
-                "file_path": e.file_origin.as_ref().map(|p| p.to_string()),
-                "read_path": entity_read_path(&e),
-                "start_line": entity_presentation_start_line(&e),
-                "end_line": entity_presentation_end_line(&e),
-            });
-            if let Some(relation) = relation {
-                obj["relation"] = serde_json::json!(relation.as_str());
-            }
-            if !compact {
-                obj["projection"] = serde_json::json!(format!("{:?}", entry.projection_level));
-                attach_context_body(&held, &e, &mut obj, &mut body_budget)?;
-            }
-            Ok(obj)
-        } else {
-            let mut obj = serde_json::json!({
-                "id": entry.entity_id.to_string(),
-                "content": entry.content,
-            });
-            if let Some(relation) = relation {
-                obj["relation"] = serde_json::json!(relation.as_str());
-            }
-            Ok(obj)
-        }
+    let bytes = crate::budget::ResponseBudget::from_arguments(args).max_chars;
+    let limits = kin_context::ProjectionLimits {
+        max_candidate_bytes: bytes,
+        max_retained_bytes: bytes,
     };
-
-    // Membership of the `dependents` group is decided by the edge authority
-    // `find_references` reads, on the same store, in the same request. The two
-    // surfaces answer the same question about the same entity, so a pack that
-    // decided it independently could disagree with the tool beside it, and it
-    // did: on expressjs/express `res.sendFile` packed `dependents: []` while
-    // `find_references` on that id returned `res.download`, which calls it.
-    //
-    // This is the same call `handle_find_references` makes, not a second
-    // implementation of it. Everything that decides what counts as a reference
-    // -- the allowed edge classes, the self-edge exclusion, composition over
-    // proven overrides, and dropping a caller the workspace no longer contains
-    // -- is that function's, so the two cannot drift apart by being edited
-    // separately.
-    let reference_kinds = default_reference_kinds();
-    let reference_rows =
-        collect_graph_reference_rows(store, &entity_id, &reference_kinds, repository_authority)?;
-    // Observed before the partition, because a candidate row still witnesses the
-    // edge class it arrived on. Same rule as the reference tool's, so the
-    // coverage the pack publishes is the coverage that tool would publish.
-    let witnessed = match &focal_entity {
-        Some(entity) => answer_witnessed_classes(store, entity, &reference_rows),
-        None => Vec::new(),
+    let render = SingleContextRender {
+        store,
+        repository_authority,
+        entity_id,
+        compact,
+        include_traffic,
+        budget,
+        traffic: std::cell::RefCell::new(traffic_pack.traffic),
+        traffic_withheld: std::cell::Cell::new(0),
+        entities: std::cell::RefCell::new(HashMap::new()),
+        references: std::cell::OnceCell::new(),
     };
-    // FIR-1552 again, in the direction that matters here: a row matched on a
-    // bare receiver name with nothing at the site proving the destination is a
-    // candidate, not a caller. `find_references` withholds it from its count,
-    // so a pack that promoted it to a dependent would be certifying what the
-    // reference surface declined to.
-    let mut certified_rows: Vec<ReferenceRow> = reference_rows
-        .into_iter()
-        .filter(|row| !row.receiver_name_guess)
-        .collect();
-    certified_rows.sort_by(|left, right| {
-        left.file_path
-            .cmp(&right.file_path)
-            .then_with(|| left.name.cmp(&right.name))
-            .then_with(|| left.entity_id.cmp(&right.entity_id))
-    });
-    let certified_ids: Vec<kin_model::ids::EntityId> = certified_rows
-        .iter()
-        .filter_map(|row| row.entity_id.as_deref())
-        .filter_map(|id| parse_entity_id(id).ok())
-        .collect();
-    let certified: std::collections::HashSet<kin_model::ids::EntityId> =
-        certified_ids.iter().copied().collect();
-    // What the graph can structurally answer over the classes the group was
-    // built from. An empty `dependents` is only evidence about the code when
-    // this says the focal's language links those classes across files, and
-    // nothing else in a pack reports it.
-    let edge_coverage = match &focal_entity {
-        Some(entity) => crate::edge_coverage::observe_cross_file_reference_coverage_witnessed(
-            store,
-            entity,
-            &reference_kinds,
-            &witnessed,
-        ),
-        None => serde_json::Value::Null,
-    };
-    // Whether a caller could have reached this focal through a call the linker
-    // recorded no edge for (FIR-2775), read exactly as `find_references` reads
-    // it and published under the same key.
-    //
-    // A pack's `dependents` group is built by the same collector over the same
-    // edges, so it inherits the same gap and has to report it the same way. The
-    // method gate beside this one is shared for precisely that reason: gating a
-    // shared gap on the tool name alone was how two surfaces over one graph came
-    // to answer opposite things about one entity, the tool that refused to
-    // certify and the tool that published `[]` reading the identical incomplete
-    // call graph. Adding a new gap to one surface and not the other would
-    // rebuild that disagreement from scratch.
-    let caller_arrival = match &focal_entity {
-        Some(entity) => crate::caller_arrival::observe_caller_arrival(store, entity).to_json(),
-        None => serde_json::Value::Null,
-    };
-
-    // The dependency section carries both directions, so it is served as two
-    // groups named for what they are. Serving it as one list called
-    // `dependencies` reported a focal's callers as things the focal depends on,
-    // which is the opposite claim and the one an agent acts on when it decides
-    // what it may safely change. The builder has already ordered the section so
-    // real dependencies precede dependents and fallback neighbours, and that
-    // order survives the partition.
-    let mut dependencies: Vec<serde_json::Value> = Vec::new();
-    let mut dependents: Vec<serde_json::Value> = Vec::new();
-    let mut packed: std::collections::HashSet<kin_model::ids::EntityId> =
-        std::collections::HashSet::new();
-    for entry in &pack.dependency_signatures {
-        let packed_relation = selection.relation_for(&entry.entity_id);
-        // The union, never the intersection. A certified caller is a dependent
-        // whatever the pack's own section made of it, and an arriving edge of a
-        // class the reference surface does not read -- `UsesType`, `Implements`,
-        // `Extends` -- is still a dependent the pack can see and that surface
-        // cannot. Taking either one alone would drop real blast radius.
-        let relation = if certified.contains(&entry.entity_id) {
-            DependencyRelation::DependentEdge
-        } else {
-            packed_relation
-        };
-        let mut row = project_dep(entry, Some(relation))?;
-        match relation {
-            DependencyRelation::DependentEdge => {
-                // Nothing is lost when a pair is joined both ways. The pack used
-                // to resolve that by calling the neighbour a dependency, which
-                // on a JavaScript object literal spends a weak leaving
-                // `References` edge to erase a real arriving `Calls` -- and
-                // every sibling method has that shape, so a focal lost its whole
-                // caller set at once. The group is decided by the arriving edge
-                // and the other direction is stated on the row.
-                if packed_relation == DependencyRelation::DependencyEdge {
-                    row["bidirectional"] = serde_json::json!(true);
-                }
-                packed.insert(entry.entity_id);
-                dependents.push(row);
-            }
-            DependencyRelation::DependencyEdge | DependencyRelation::SameFileNeighbor => {
-                dependencies.push(row)
-            }
-        }
-    }
-    // A certified caller the pack's own section never reached -- shed by the
-    // builder's token budget, or missed by its subgraph walk -- is exactly the
-    // shape this defect had. Recovering it here is what makes the group's
-    // membership a property of the answer rather than of how much budget was
-    // left, and the recovered rows carry the same shape as the projected ones so
-    // a reader cannot tell which path produced them.
-    let mut dependents_withheld = 0usize;
-    for id in &certified_ids {
-        if packed.contains(id) {
-            continue;
-        }
-        if dependents.len() >= CERTIFIED_DEPENDENTS_MAX {
-            dependents_withheld += 1;
-            continue;
-        }
-        let entry = kin_model::context::ContextEntry {
-            entity_id: *id,
-            projection_level: kin_model::context::ProjectionLevel::SignatureOnly,
-            content: String::new(),
-        };
-        dependents.push(project_dep(
-            &entry,
-            Some(DependencyRelation::DependentEdge),
-        )?);
-        packed.insert(*id);
-    }
-    let transitive: Vec<_> = pack
-        .transitive_deps
-        .iter()
-        .map(|entry| project_dep(entry, None))
-        .collect::<Result<Vec<_>>>()?;
-
-    // The cap and the fallback are both invisible in the rows themselves: six
-    // neighbours out of twenty-four look exactly like six dependencies. This
-    // says which selection ran and what it dropped, in every mode, because a
-    // caller deciding whether to ask again needs it most when the answer is
-    // small.
-    let returned = dependencies.len();
-    let dependents_returned = dependents.len();
-    let mut result = serde_json::json!({
-        "focal_entity": focal_json,
-        "dependencies": dependencies,
-        // Always present, empty included. "no dependents" and "this build does
-        // not report dependents" are different answers, and a group that
-        // appears only when populated cannot tell them apart. What separates
-        // them now is `edge_coverage` and the response's `negative` verdict:
-        // an empty group on a graph that demonstrably links this language's
-        // edges across files is an answer, and an empty group on one that does
-        // not is a gap, and both used to serialize as `[]`.
-        "dependents": dependents,
-        "dependency_selection": {
-            "source": selection.source().as_str(),
-            "returned": returned,
-            "dependents_returned": dependents_returned,
-            // What the reference authority certified, stated beside what the
-            // group returned so the two can be compared. They differ when the
-            // pack sees an arriving edge of a class that authority does not
-            // read, and when the cap below withholds one.
-            "certified_dependents": certified_ids.len(),
-            // The cap's own number, and only the cap's. The top-level
-            // `dependents_withheld` counts every cause together, because a
-            // caller asking "how many rows am I not seeing" wants one answer;
-            // this one stays because a caller already reading it must not have
-            // its meaning changed underneath it.
-            "dependents_withheld": dependents_withheld,
-            "same_file_candidates": selection.same_file_candidates(),
-            "same_file_dropped": selection.same_file_dropped(),
+    let (pack, selection, projections) = kin_context::build_context_pack_with_provider(
+        store,
+        &entity_id,
+        &opts,
+        &mut provider,
+        limits,
+        !compact,
+        |pack, selection, projections| {
+            let mut result = render
+                .render(pack, selection, projections, &fields)
+                .map_err(|error| kin_context::ContextError::Other(error.to_string()))?;
+            let json = serialize_with_measured_tokens(&mut result)
+                .map_err(|error| kin_context::ContextError::Other(error.to_string()))?;
+            Ok(kin_context::estimate_tokens(&json))
         },
-        // The substrate behind the `dependents` group, so an empty group is
-        // read against what this graph can structurally answer for the focal's
-        // language rather than as a bare fact. Computed by the same observer
-        // `find_references` uses, from the same witnesses.
-        crate::edge_coverage::EDGE_COVERAGE_KEY: edge_coverage,
-        crate::caller_arrival::CALLER_ARRIVAL_KEY: caller_arrival,
-        "token_budget": budget.max_tokens(),
-        "tokens_used": pack.actual_tokens,
-    });
+    )
+    .map_err(|error| McpError::Context(error.to_string()))?;
+    let mut result = render.render(&pack, &selection, &projections, &fields)?;
+    Ok(ToolCallResult::text(serialize_with_measured_tokens(
+        &mut result,
+    )?))
+}
 
-    if !compact {
-        if !transitive.is_empty() {
-            result["transitive_deps"] = serde_json::json!(transitive);
+type ContextReferenceSnapshot = (
+    Vec<kin_model::EntityId>,
+    std::collections::HashSet<kin_model::EntityId>,
+    serde_json::Value,
+    serde_json::Value,
+);
+
+struct SingleContextRender<'a, G: GraphStore> {
+    store: &'a G,
+    repository_authority: Option<&'a RequestRepositoryAuthority>,
+    entity_id: kin_model::EntityId,
+    compact: bool,
+    include_traffic: bool,
+    budget: kin_model::TokenBudget,
+    traffic: std::cell::RefCell<Vec<kin_model::TrafficEntry>>,
+    traffic_withheld: std::cell::Cell<usize>,
+    entities: std::cell::RefCell<HashMap<kin_model::EntityId, Option<kin_model::Entity>>>,
+    references: std::cell::OnceCell<std::result::Result<ContextReferenceSnapshot, String>>,
+}
+
+impl<G: GraphStore> SingleContextRender<'_, G> {
+    fn entity(&self, id: &kin_model::EntityId) -> Result<Option<kin_model::Entity>> {
+        if let Some(entity) = self.entities.borrow().get(id) {
+            return Ok(entity.clone());
         }
-        let tests: Vec<_> = pack
-            .tests
+        let entity = self.store.get_entity(id).map_err(McpError::graph)?;
+        self.entities.borrow_mut().insert(*id, entity.clone());
+        Ok(entity)
+    }
+
+    fn render(
+        &self,
+        pack: &kin_model::ContextPack,
+        selection: &kin_context::DependencySelection,
+        projections: &kin_context::ProjectionReport,
+        fields: &ContextSourceFields,
+    ) -> Result<serde_json::Value> {
+        use kin_context::DependencyRelation;
+        let Self {
+            store,
+            repository_authority,
+            entity_id,
+            compact,
+            include_traffic,
+            budget,
+            ..
+        } = *self;
+        // Build structured response JSON. The pack still has to have projected a
+        // focal entry for the focal entity to be worth serializing, but the body
+        // comes from graph truth rather than from that entry.
+        let focal_entry = pack.focal_entities.first();
+        let focal_entity = self.entity(&entity_id)?;
+
+        let focal_json = if let (Some(entry), Some(entity)) = (focal_entry, &focal_entity) {
+            let mut row = serde_json::json!({
+                "id": entity.id, "name": entity.name, "kind": entity.kind,
+                "signature": entity.signature,
+                "file_path": entity.file_origin.as_ref().map(|path| path.to_string()),
+                "read_path": entity_read_path(entity),
+                "start_line": entity_presentation_start_line(entity),
+                "end_line": entity_presentation_end_line(entity),
+            });
+            attach_context_projection(entry, fields, projections, &mut row);
+            row
+        } else {
+            serde_json::Value::Null
+        };
+
+        // `relation` is what keeps a same-file neighbour from reading as a
+        // dependency. The builder tags the fallback inside `entry.content`, which
+        // this handler does not serialize, so without the selection travelling
+        // alongside the pack the two are indistinguishable on the wire. Rows in the
+        // sections that are not dependencies (transitive, tests, contracts) pass
+        // `None` and carry no relation at all.
+        let project_dep = |entry: &kin_model::context::ContextEntry,
+                           relation: Option<DependencyRelation>|
+         -> Result<serde_json::Value> {
+            // Look up the entity for structured fields.
+            if let Some(e) = self.entity(&entry.entity_id)? {
+                let mut obj = serde_json::json!({
+                    "id": e.id,
+                    "name": e.name,
+                    "kind": e.kind,
+                    "signature": e.signature,
+                    "file_path": e.file_origin.as_ref().map(|p| p.to_string()),
+                    "read_path": entity_read_path(&e),
+                    "start_line": entity_presentation_start_line(&e),
+                    "end_line": entity_presentation_end_line(&e),
+                });
+                if let Some(relation) = relation {
+                    obj["relation"] = serde_json::json!(relation.as_str());
+                }
+                if !compact {
+                    obj["projection"] = serde_json::json!(format!("{:?}", entry.projection_level));
+                    attach_context_projection(entry, fields, projections, &mut obj);
+                }
+                Ok(obj)
+            } else {
+                let mut obj = serde_json::json!({
+                    "id": entry.entity_id.to_string(),
+                    "content": entry.content,
+                });
+                if let Some(relation) = relation {
+                    obj["relation"] = serde_json::json!(relation.as_str());
+                }
+                Ok(obj)
+            }
+        };
+
+        let (certified_ids, certified, edge_coverage, caller_arrival) = self
+            .references
+            .get_or_init(|| {
+                (|| -> Result<ContextReferenceSnapshot> {
+                    // Membership of the `dependents` group is decided by the edge authority
+                    // `find_references` reads, on the same store, in the same request. The two
+                    // surfaces answer the same question about the same entity, so a pack that
+                    // decided it independently could disagree with the tool beside it, and it
+                    // did: on expressjs/express `res.sendFile` packed `dependents: []` while
+                    // `find_references` on that id returned `res.download`, which calls it.
+                    //
+                    // This is the same call `handle_find_references` makes, not a second
+                    // implementation of it. Everything that decides what counts as a reference
+                    // -- the allowed edge classes, the self-edge exclusion, composition over
+                    // proven overrides, and dropping a caller the workspace no longer contains
+                    // -- is that function's, so the two cannot drift apart by being edited
+                    // separately.
+                    let reference_kinds = default_reference_kinds();
+                    let reference_rows = collect_graph_reference_rows(
+                        store,
+                        &entity_id,
+                        &reference_kinds,
+                        repository_authority,
+                    )?;
+                    // Observed before the partition, because a candidate row still witnesses the
+                    // edge class it arrived on. Same rule as the reference tool's, so the
+                    // coverage the pack publishes is the coverage that tool would publish.
+                    let witnessed = match &focal_entity {
+                        Some(entity) => answer_witnessed_classes(store, entity, &reference_rows),
+                        None => Vec::new(),
+                    };
+                    // FIR-1552 again, in the direction that matters here: a row matched on a
+                    // bare receiver name with nothing at the site proving the destination is a
+                    // candidate, not a caller. `find_references` withholds it from its count,
+                    // so a pack that promoted it to a dependent would be certifying what the
+                    // reference surface declined to.
+                    let mut certified_rows: Vec<ReferenceRow> = reference_rows
+                        .into_iter()
+                        .filter(|row| !row.receiver_name_guess)
+                        .collect();
+                    certified_rows.sort_by(|left, right| {
+                        left.file_path
+                            .cmp(&right.file_path)
+                            .then_with(|| left.name.cmp(&right.name))
+                            .then_with(|| left.entity_id.cmp(&right.entity_id))
+                    });
+                    let certified_ids: Vec<kin_model::ids::EntityId> = certified_rows
+                        .iter()
+                        .filter_map(|row| row.entity_id.as_deref())
+                        .filter_map(|id| parse_entity_id(id).ok())
+                        .collect();
+                    let certified: std::collections::HashSet<kin_model::ids::EntityId> =
+                        certified_ids.iter().copied().collect();
+                    // What the graph can structurally answer over the classes the group was
+                    // built from. An empty `dependents` is only evidence about the code when
+                    // this says the focal's language links those classes across files, and
+                    // nothing else in a pack reports it.
+                    let edge_coverage = match &focal_entity {
+                        Some(entity) => {
+                            crate::edge_coverage::observe_cross_file_reference_coverage_witnessed(
+                                store,
+                                entity,
+                                &reference_kinds,
+                                &witnessed,
+                            )
+                        }
+                        None => serde_json::Value::Null,
+                    };
+                    // Whether a caller could have reached this focal through a call the linker
+                    // recorded no edge for (FIR-2775), read exactly as `find_references` reads
+                    // it and published under the same key.
+                    //
+                    // A pack's `dependents` group is built by the same collector over the same
+                    // edges, so it inherits the same gap and has to report it the same way. The
+                    // method gate beside this one is shared for precisely that reason: gating a
+                    // shared gap on the tool name alone was how two surfaces over one graph came
+                    // to answer opposite things about one entity, the tool that refused to
+                    // certify and the tool that published `[]` reading the identical incomplete
+                    // call graph. Adding a new gap to one surface and not the other would
+                    // rebuild that disagreement from scratch.
+                    let caller_arrival = match &focal_entity {
+                        Some(entity) => {
+                            crate::caller_arrival::observe_caller_arrival(store, entity).to_json()
+                        }
+                        None => serde_json::Value::Null,
+                    };
+
+                    Ok((certified_ids, certified, edge_coverage, caller_arrival))
+                })()
+                .map_err(|error| error.to_string())
+            })
+            .as_ref()
+            .map_err(|error| McpError::Context(error.clone()))?;
+
+        // The dependency section carries both directions, so it is served as two
+        // groups named for what they are. Serving it as one list called
+        // `dependencies` reported a focal's callers as things the focal depends on,
+        // which is the opposite claim and the one an agent acts on when it decides
+        // what it may safely change. The builder has already ordered the section so
+        // real dependencies precede dependents and fallback neighbours, and that
+        // order survives the partition.
+        let mut dependencies: Vec<serde_json::Value> = Vec::new();
+        let mut dependents: Vec<serde_json::Value> = Vec::new();
+        let mut packed: std::collections::HashSet<kin_model::ids::EntityId> =
+            std::collections::HashSet::new();
+        for entry in &pack.dependency_signatures {
+            let packed_relation = selection.relation_for(&entry.entity_id);
+            // The union, never the intersection. A certified caller is a dependent
+            // whatever the pack's own section made of it, and an arriving edge of a
+            // class the reference surface does not read -- `UsesType`, `Implements`,
+            // `Extends` -- is still a dependent the pack can see and that surface
+            // cannot. Taking either one alone would drop real blast radius.
+            let relation = if certified.contains(&entry.entity_id) {
+                DependencyRelation::DependentEdge
+            } else {
+                packed_relation
+            };
+            let mut row = project_dep(entry, Some(relation))?;
+            match relation {
+                DependencyRelation::DependentEdge => {
+                    // Nothing is lost when a pair is joined both ways. The pack used
+                    // to resolve that by calling the neighbour a dependency, which
+                    // on a JavaScript object literal spends a weak leaving
+                    // `References` edge to erase a real arriving `Calls` -- and
+                    // every sibling method has that shape, so a focal lost its whole
+                    // caller set at once. The group is decided by the arriving edge
+                    // and the other direction is stated on the row.
+                    if packed_relation == DependencyRelation::DependencyEdge {
+                        row["bidirectional"] = serde_json::json!(true);
+                    }
+                    packed.insert(entry.entity_id);
+                    dependents.push(row);
+                }
+                DependencyRelation::DependencyEdge | DependencyRelation::SameFileNeighbor => {
+                    dependencies.push(row)
+                }
+            }
+        }
+        // A certified caller the pack's own section never reached -- shed by the
+        // builder's token budget, or missed by its subgraph walk -- is exactly the
+        // shape this defect had. Recovering it here is what makes the group's
+        // membership a property of the answer rather than of how much budget was
+        // left, and the recovered rows carry the same shape as the projected ones so
+        // a reader cannot tell which path produced them.
+        let mut dependents_withheld = 0usize;
+        for id in certified_ids {
+            if packed.contains(id) {
+                continue;
+            }
+            if dependents.len() >= CERTIFIED_DEPENDENTS_MAX {
+                dependents_withheld += 1;
+                continue;
+            }
+            let entry = kin_model::context::ContextEntry {
+                entity_id: *id,
+                projection_level: kin_model::context::ProjectionLevel::SignatureOnly,
+                content: String::new(),
+            };
+            dependents.push(project_dep(
+                &entry,
+                Some(DependencyRelation::DependentEdge),
+            )?);
+            packed.insert(*id);
+        }
+        let transitive: Vec<_> = pack
+            .transitive_deps
             .iter()
             .map(|entry| project_dep(entry, None))
             .collect::<Result<Vec<_>>>()?;
-        if !tests.is_empty() {
-            result["tests"] = serde_json::json!(tests);
-        }
-        let contracts: Vec<_> = pack
-            .contracts
-            .iter()
-            .map(|entry| project_dep(entry, None))
-            .collect::<Result<Vec<_>>>()?;
-        if !contracts.is_empty() {
-            result["contracts"] = serde_json::json!(contracts);
-        }
-        if !pack.work_items.is_empty() {
-            result["work_items"] =
-                serde_json::to_value(&pack.work_items).map_err(McpError::Json)?;
-        }
-        if !pack.annotations.is_empty() {
-            result["annotations"] =
-                serde_json::to_value(&pack.annotations).map_err(McpError::Json)?;
-        }
-    }
 
-    if include_traffic && !pack.traffic.is_empty() {
-        result["nearby_traffic"] = serde_json::to_value(&pack.traffic).map_err(McpError::Json)?;
-    }
+        // The cap and the fallback are both invisible in the rows themselves: six
+        // neighbours out of twenty-four look exactly like six dependencies. This
+        // says which selection ran and what it dropped, in every mode, because a
+        // caller deciding whether to ask again needs it most when the answer is
+        // small.
+        let returned = dependencies.len();
+        let dependents_returned = dependents.len();
+        let mut result = serde_json::json!({
+            "focal_entity": focal_json,
+            "dependencies": dependencies,
+            // Always present, empty included. "no dependents" and "this build does
+            // not report dependents" are different answers, and a group that
+            // appears only when populated cannot tell them apart. What separates
+            // them now is `edge_coverage` and the response's `negative` verdict:
+            // an empty group on a graph that demonstrably links this language's
+            // edges across files is an answer, and an empty group on one that does
+            // not is a gap, and both used to serialize as `[]`.
+            "dependents": dependents,
+            "dependency_selection": {
+                "source": selection.source().as_str(),
+                "returned": returned,
+                "dependents_returned": dependents_returned,
+                // What the reference authority certified, stated beside what the
+                // group returned so the two can be compared. They differ when the
+                // pack sees an arriving edge of a class that authority does not
+                // read, and when the cap below withholds one.
+                "certified_dependents": certified_ids.len(),
+                // The cap's own number, and only the cap's. The top-level
+                // `dependents_withheld` counts every cause together, because a
+                // caller asking "how many rows am I not seeing" wants one answer;
+                // this one stays because a caller already reading it must not have
+                // its meaning changed underneath it.
+                "dependents_withheld": dependents_withheld,
+                "same_file_candidates": selection.same_file_candidates(),
+                "same_file_dropped": selection.same_file_dropped(),
+            },
+            // The substrate behind the `dependents` group, so an empty group is
+            // read against what this graph can structurally answer for the focal's
+            // language rather than as a bare fact. Computed by the same observer
+            // `find_references` uses, from the same witnesses.
+            crate::edge_coverage::EDGE_COVERAGE_KEY: edge_coverage,
+            crate::caller_arrival::CALLER_ARRIVAL_KEY: caller_arrival,
+            "token_budget": budget.max_tokens(),
+            "tokens_used": pack.actual_tokens,
+        });
 
-    // What the pack's own token budget refused, in the map the response budget
-    // already publishes its cuts to.
-    //
-    // Two budgets cut this answer and only one of them was ever visible. The
-    // token budget runs first, inside the builder, and a dependency section it
-    // trimmed from twelve rows to six serialized exactly like a focal with six:
-    // `returned: 6` beside six rows, and nothing anywhere saying a row had been
-    // a candidate. That is the reading kin#1062 removed from the list case and
-    // kin#1068 from the impact case, arriving here through the earlier budget.
-    //
-    // One map, keyed by the group, with the cause named on each entry: a caller
-    // raises `token_budget` for these and `max_chars` for the response budget's,
-    // and being told the wrong lever costs a round trip that cannot help.
-    let recovered = |id: &kin_model::ids::EntityId| packed.contains(id);
-    let mut budget_groups: Vec<&str> = vec![
-        kin_context::group::DEPENDENCIES,
-        kin_context::group::DEPENDENTS,
-    ];
-    if !compact {
-        // A section `compact` never serves cannot be misread as an empty one,
-        // because dropping it is the documented shape of that mode. A section
-        // this mode does serve is absent only when it holds nothing, which is
-        // exactly the reading a budget cut must not produce.
-        budget_groups.extend([
-            kin_context::group::TRANSITIVE_DEPS,
-            kin_context::group::TESTS,
-            kin_context::group::CONTRACTS,
-            kin_context::group::WORK_ITEMS,
-            kin_context::group::ANNOTATIONS,
-        ]);
-    }
-    for group in budget_groups {
-        let elided = selection.budget_elided_unrecovered(group, recovered);
-        if elided == 0 {
-            continue;
+        if !compact {
+            if !transitive.is_empty() {
+                result["transitive_deps"] = serde_json::json!(transitive);
+            }
+            let tests: Vec<_> = pack
+                .tests
+                .iter()
+                .map(|entry| project_dep(entry, None))
+                .collect::<Result<Vec<_>>>()?;
+            if !tests.is_empty() {
+                result["tests"] = serde_json::json!(tests);
+            }
+            let contracts: Vec<_> = pack
+                .contracts
+                .iter()
+                .map(|entry| project_dep(entry, None))
+                .collect::<Result<Vec<_>>>()?;
+            if !contracts.is_empty() {
+                result["contracts"] = serde_json::json!(contracts);
+            }
+            if !pack.work_items.is_empty() {
+                result["work_items"] =
+                    serde_json::to_value(&pack.work_items).map_err(McpError::Json)?;
+            }
+            if !pack.annotations.is_empty() {
+                result["annotations"] =
+                    serde_json::to_value(&pack.annotations).map_err(McpError::Json)?;
+            }
         }
-        let kept = result
-            .get(group)
-            .and_then(serde_json::Value::as_array)
-            .map_or(0, Vec::len);
-        // The scalar beside the map, written here so the response budget's own
-        // later cut of the same list adds to it rather than replacing it.
-        result[format!("{group}_withheld")] = serde_json::json!(elided);
-        crate::budget::record_elision_for(
-            &mut result,
-            group,
-            kept,
-            elided,
-            crate::budget::ELISION_REASON_TOKEN_BUDGET,
-        );
-    }
-    // The certified-dependents cap is the third cutter on this payload, and it
-    // was disclosed only as a nested counter inside `dependency_selection`,
-    // which is the sibling-counter shape that saved nobody in the stranger
-    // session kin#1062 was filed from. It carries its own reason because no
-    // budget parameter recovers it.
-    if dependents_withheld > 0 {
-        let kept = result
-            .get("dependents")
-            .and_then(serde_json::Value::as_array)
-            .map_or(0, Vec::len);
-        let prior = result
-            .get("dependents_withheld")
-            .and_then(serde_json::Value::as_u64)
-            .unwrap_or(0) as usize;
-        result["dependents_withheld"] = serde_json::json!(prior + dependents_withheld);
-        crate::budget::record_elision_for(
-            &mut result,
-            "dependents",
-            kept,
-            dependents_withheld,
-            crate::budget::ELISION_REASON_DEPENDENTS_CAP,
-        );
-    }
 
-    body_budget.disclose(&mut result);
-    let json = serialize_with_measured_tokens(&mut result)?;
-    Ok(ToolCallResult::text(json))
+        if include_traffic && !self.traffic.borrow().is_empty() {
+            result["nearby_traffic"] =
+                serde_json::to_value(&*self.traffic.borrow()).map_err(McpError::Json)?;
+        }
+        if self.traffic_withheld.get() > 0 {
+            crate::budget::record_elision_for(
+                &mut result,
+                "nearby_traffic",
+                self.traffic.borrow().len(),
+                self.traffic_withheld.get(),
+                crate::budget::ELISION_REASON_TOKEN_BUDGET,
+            );
+        }
+
+        // What the pack's own token budget refused, in the map the response budget
+        // already publishes its cuts to.
+        //
+        // Two budgets cut this answer and only one of them was ever visible. The
+        // token budget runs first, inside the builder, and a dependency section it
+        // trimmed from twelve rows to six serialized exactly like a focal with six:
+        // `returned: 6` beside six rows, and nothing anywhere saying a row had been
+        // a candidate. That is the reading kin#1062 removed from the list case and
+        // kin#1068 from the impact case, arriving here through the earlier budget.
+        //
+        // One map, keyed by the group, with the cause named on each entry: a caller
+        // raises `token_budget` for these and `max_chars` for the response budget's,
+        // and being told the wrong lever costs a round trip that cannot help.
+        let recovered = |id: &kin_model::ids::EntityId| packed.contains(id);
+        let mut budget_groups: Vec<&str> = vec![
+            kin_context::group::DEPENDENCIES,
+            kin_context::group::DEPENDENTS,
+        ];
+        if !compact {
+            // A section `compact` never serves cannot be misread as an empty one,
+            // because dropping it is the documented shape of that mode. A section
+            // this mode does serve is absent only when it holds nothing, which is
+            // exactly the reading a budget cut must not produce.
+            budget_groups.extend([
+                kin_context::group::TRANSITIVE_DEPS,
+                kin_context::group::TESTS,
+                kin_context::group::CONTRACTS,
+                kin_context::group::WORK_ITEMS,
+                kin_context::group::ANNOTATIONS,
+            ]);
+        }
+        for group in budget_groups {
+            let elided = selection.budget_elided_unrecovered(group, recovered);
+            if elided == 0 {
+                continue;
+            }
+            let kept = result
+                .get(group)
+                .and_then(serde_json::Value::as_array)
+                .map_or(0, Vec::len);
+            // The scalar beside the map, written here so the response budget's own
+            // later cut of the same list adds to it rather than replacing it.
+            result[format!("{group}_withheld")] = serde_json::json!(elided);
+            crate::budget::record_elision_for(
+                &mut result,
+                group,
+                kept,
+                elided,
+                crate::budget::ELISION_REASON_TOKEN_BUDGET,
+            );
+        }
+        // The certified-dependents cap is the third cutter on this payload, and it
+        // was disclosed only as a nested counter inside `dependency_selection`,
+        // which is the sibling-counter shape that saved nobody in the stranger
+        // session kin#1062 was filed from. It carries its own reason because no
+        // budget parameter recovers it.
+        if dependents_withheld > 0 {
+            let kept = result
+                .get("dependents")
+                .and_then(serde_json::Value::as_array)
+                .map_or(0, Vec::len);
+            let prior = result
+                .get("dependents_withheld")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0) as usize;
+            result["dependents_withheld"] = serde_json::json!(prior + dependents_withheld);
+            crate::budget::record_elision_for(
+                &mut result,
+                "dependents",
+                kept,
+                dependents_withheld,
+                crate::budget::ELISION_REASON_DEPENDENTS_CAP,
+            );
+        }
+
+        disclose_projection_bodies(&mut result);
+        loop {
+            let rendered = serialize_with_measured_tokens(&mut result)?;
+            if kin_context::estimate_tokens(&rendered) <= budget.max_tokens()
+                || self.traffic.borrow().is_empty()
+            {
+                break;
+            }
+            self.traffic.borrow_mut().pop();
+            self.traffic_withheld.set(self.traffic_withheld.get() + 1);
+            result["nearby_traffic"] =
+                serde_json::to_value(&*self.traffic.borrow()).map_err(McpError::Json)?;
+            crate::budget::record_elision_for(
+                &mut result,
+                "nearby_traffic",
+                self.traffic.borrow().len(),
+                1,
+                crate::budget::ELISION_REASON_TOKEN_BUDGET,
+            );
+        }
+        Ok(result)
+    }
 }
 
 /// The token budget a pack request names, in the tiers the builder takes.
@@ -1435,22 +1571,55 @@ fn multi_focal_pack_result<G: GraphStore>(
         resolutions,
         coverage: get_optional_string_param(args, "coverage"),
     };
-    let (pack, mut report) = kin_context::build_multi_focal_pack(store, &ids, &opts)
-        .map_err(|error| McpError::Context(error.to_string()))?;
-
-    // Bodies come from graph-owned repository authority, exactly as the
-    // single-focal path below reads them. The pack's own focal content is
-    // `kin_context::builder::project_full_body`, which that function's doc
-    // comment says is a HEADER and must never be surfaced as a body, and this
-    // path used to publish it under `projection: "FullBody"` with nothing said.
-    // Measured on psf/requests at v0.7.2: `Session.merge_environment_settings`
-    // came back `FullBody` carrying 85 tokens for a 38-line method, while
-    // `kin graph source` on the same id returned the whole body. It was never a
-    // body gap; it was a path that did not ask.
     let held = HeldSourceAuthority::new(store, repository_authority);
-    let mut body_budget =
-        ContextBodyBudget::new(crate::budget::ResponseBudget::from_arguments(args).max_chars);
-    let mut row =
+    let fields = ContextSourceFields::default();
+    let mut provider = ContextSourceProvider {
+        held: &held,
+        fields: fields.clone(),
+    };
+    let bytes = crate::budget::ResponseBudget::from_arguments(args).max_chars;
+    let limits = kin_context::ProjectionLimits {
+        max_candidate_bytes: bytes,
+        max_retained_bytes: bytes,
+    };
+    let (pack, report, projections) = kin_context::build_multi_focal_pack_with_provider(
+        store,
+        &ids,
+        &opts,
+        &mut provider,
+        limits,
+        |pack, report, projections| {
+            let mut result = render_multi_context(
+                store,
+                pack,
+                report.clone(),
+                &unresolved,
+                &fields,
+                projections,
+            )
+            .map_err(|error| kin_context::ContextError::Other(error.to_string()))?;
+            let json = serialize_with_measured_tokens(&mut result)
+                .map_err(|error| kin_context::ContextError::Other(error.to_string()))?;
+            Ok(kin_context::estimate_tokens(&json))
+        },
+    )
+    .map_err(|error| McpError::Context(error.to_string()))?;
+    let mut result =
+        render_multi_context(store, &pack, report, &unresolved, &fields, &projections)?;
+    Ok(Some(ToolCallResult::text(serialize_with_measured_tokens(
+        &mut result,
+    )?)))
+}
+
+fn render_multi_context<G: GraphStore>(
+    store: &G,
+    pack: &kin_model::ContextPack,
+    report: kin_context::MultiFocalReport,
+    unresolved: &[serde_json::Value],
+    fields: &ContextSourceFields,
+    projections: &kin_context::ProjectionReport,
+) -> Result<serde_json::Value> {
+    let row =
         |entry: &kin_model::context::ContextEntry, section: &str| -> Result<serde_json::Value> {
             let entity = store
                 .get_entity(&entry.entity_id)
@@ -1479,14 +1648,7 @@ fn multi_focal_pack_result<G: GraphStore>(
                 "section": section,
                 "projection": format!("{:?}", entry.projection_level),
             });
-            // Only a row CLAIMING a body has to produce one. A signature-only
-            // dependency already says what it is, and reading a body for every row
-            // in the pack would spend the request's IO on material the caller did
-            // not ask for.
-            if entry.projection_level != kin_model::context::ProjectionLevel::FullBody {
-                return Ok(obj);
-            }
-            attach_context_body(&held, &entity, &mut obj, &mut body_budget)?;
+            attach_context_projection(entry, fields, projections, &mut obj);
             Ok(obj)
         };
 
@@ -1512,33 +1674,6 @@ fn multi_focal_pack_result<G: GraphStore>(
         entities.push(row(entry, kin_context::group::CONTRACTS)?);
     }
 
-    // `focals[]` is the PACK's account of what it rendered, which is a header
-    // either way, so it went on saying `header_and_signature` about a focal
-    // this response had just served a real body for. One focal described two
-    // ways that disagree is the same class of defect as the label this change
-    // exists to fix, one level up.
-    //
-    // Read back off the rows rather than tracked in parallel while building
-    // them: the correction is then derived from the value that was actually
-    // published, and cannot drift from it.
-    let served_bodies: std::collections::HashSet<String> = entities
-        .iter()
-        .filter(|row| {
-            row.get("section").and_then(serde_json::Value::as_str) == Some("focal")
-                && row.get("body").is_some_and(|body| !body.is_null())
-        })
-        .filter_map(|row| {
-            row.get("id")
-                .and_then(serde_json::Value::as_str)
-                .map(str::to_string)
-        })
-        .collect();
-    for contribution in report.focals.iter_mut() {
-        if served_bodies.contains(&contribution.entity_id) {
-            contribution.projection = kin_context::SERVED_BODY_PROJECTION_NAME.to_string();
-        }
-    }
-
     let mut result = serde_json::json!({
         "method": report.method,
         "focals": serde_json::to_value(&report.focals).map_err(McpError::Json)?,
@@ -1546,24 +1681,11 @@ fn multi_focal_pack_result<G: GraphStore>(
         "route_search": serde_json::to_value(&report.route_search).map_err(McpError::Json)?,
         "neighborhood_depth": report.neighborhood_depth,
         "token_budget": report.budget_tokens,
-        // What the rendered pack costs, which is the number a caller subtracts
-        // from its own window. `tokens_used` below is what this JSON payload
-        // costs, and the two are deliberately different measurements of
-        // different bytes.
         "measured_tokens": report.measured_tokens,
+        "measurement_scope": "complete context payload before envelope and response-budget cuts; tokens_used measures the final output",
         "entities": entities,
         "lines": kin_context::render_multi_focal_lines(&pack, &report),
-        // The rendered pack, and what `measured_tokens` counts. It is the
-        // header projection throughout, because kin-context cannot read source;
-        // a focal that served a real body carries it on its own `entities[]`
-        // row and not here. Said out loud, because a reader who finds a header
-        // in `lines` beside a body on the row is otherwise left to guess which
-        // one the response means.
-        "lines_note": format!(
-            "rendered pack at the {} projection kin-context can build; served bodies are on \
-             the entities[] rows",
-            kin_context::FULL_BODY_PROJECTION_NAME
-        ),
+        "lines_note": "rendered selected projections; whole graph source bodies appear only for FullBody entries",
         "tokens_used": 0,
     });
     if !unresolved.is_empty() {
@@ -1579,9 +1701,48 @@ fn multi_focal_pack_result<G: GraphStore>(
         );
     }
 
-    body_budget.disclose(&mut result);
-    let json = serialize_with_measured_tokens(&mut result)?;
-    Ok(Some(ToolCallResult::text(json)))
+    disclose_projection_bodies(&mut result);
+    Ok(result)
+}
+
+fn disclose_projection_bodies(result: &mut serde_json::Value) {
+    let mut served = 0;
+    let mut withheld = 0;
+    fn visit(value: &serde_json::Value, served: &mut usize, withheld: &mut usize) {
+        match value {
+            serde_json::Value::Object(object) => {
+                if object
+                    .get("body_complete")
+                    .and_then(serde_json::Value::as_bool)
+                    == Some(true)
+                {
+                    *served += 1;
+                }
+                if object
+                    .get("body_elided")
+                    .and_then(serde_json::Value::as_array)
+                    .is_some_and(|keys| keys.iter().any(|key| key.as_str() == Some("body")))
+                {
+                    *withheld += 1;
+                }
+                for child in object.values() {
+                    visit(child, served, withheld);
+                }
+            }
+            serde_json::Value::Array(values) => {
+                for child in values {
+                    visit(child, served, withheld);
+                }
+            }
+            _ => {}
+        }
+    }
+    visit(result, &mut served, &mut withheld);
+    if withheld > 0 {
+        crate::budget::record_elision_for(result, "body", served, withheld, "whole_body_withheld");
+        let before = crate::budget::measure(result);
+        crate::budget::mark_context_cut(result, before);
+    }
 }
 
 /// Passes allowed to settle `tokens_used` against the bytes carrying it.

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -420,13 +420,10 @@ pub fn handle_get_entity_source<G: GraphStore>(
 
     match store.get_entity(&entity_id).map_err(McpError::graph)? {
         Some(entity) => {
-            let exact_source = read_entity_source_excerpt_detailed(
-                store,
+            let exact_source = read_entity_source_exact(
+                &HeldSourceAuthority::new(store, repository_authority),
                 &entity,
-                10_000,
                 1_000_000,
-                repository_authority,
-                EntitySourceScope::WorkspaceHead,
             )?
             .ok_or_else(|| McpError::Context("entity source body unavailable".into()))?;
             let source = LAST_READ_SOURCE.with(|f| f.get());
@@ -923,8 +920,11 @@ pub fn handle_get_context_pack<G: GraphStore>(
     // projection multiplies a full recovery by the pack's size.
     let held = HeldSourceAuthority::new(store, repository_authority);
 
+    let mut body_budget =
+        ContextBodyBudget::new(crate::budget::ResponseBudget::from_arguments(args).max_chars);
+
     let focal_json = if let (Some(_), Some(entity)) = (focal_entry, &focal_entity) {
-        focal_context_json_held(&held, entity)?
+        focal_context_json_bounded(&held, entity, &mut body_budget)?
     } else {
         serde_json::json!(null)
     };
@@ -935,8 +935,8 @@ pub fn handle_get_context_pack<G: GraphStore>(
     // alongside the pack the two are indistinguishable on the wire. Rows in the
     // sections that are not dependencies (transitive, tests, contracts) pass
     // `None` and carry no relation at all.
-    let project_dep = |entry: &kin_model::context::ContextEntry,
-                       relation: Option<DependencyRelation>|
+    let mut project_dep = |entry: &kin_model::context::ContextEntry,
+                           relation: Option<DependencyRelation>|
      -> Result<serde_json::Value> {
         // Look up the entity for structured fields.
         if let Some(e) = store
@@ -958,44 +958,7 @@ pub fn handle_get_context_pack<G: GraphStore>(
             }
             if !compact {
                 obj["projection"] = serde_json::json!(format!("{:?}", entry.projection_level));
-                // A dependency whose file the current workspace does not contain
-                // is still a dependency graph truth asserts, so it stays in the
-                // pack and says why it has no body. Dropping it would shrink a
-                // structural answer silently, and failing here would lose the
-                // whole pack over one entity that history explains.
-                let (body, absent_reason) = match read_entity_source_excerpt_detailed_held(
-                    &held,
-                    &e,
-                    MCP_SOURCE_MAX_LINES,
-                    MCP_SOURCE_MAX_CHARS,
-                    EntitySourceScope::WorkspaceHead,
-                ) {
-                    Ok(body) => (body, None),
-                    Err(error) if is_absent_at_generation(&error) => {
-                        (None, Some(error.to_string()))
-                    }
-                    Err(error) => return Err(error),
-                };
-                let source = LAST_READ_SOURCE.with(|f| f.get());
-                obj["source"] = serde_json::json!(source);
-                // Same rule as the focal body: a dependency's `body` is the
-                // graph-owned projection or null. The pack's own `entry.content`
-                // is a token-accounting stub, and serving it here would hand an
-                // agent signature text shaped like an implementation.
-                match body {
-                    Some(source) => {
-                        obj["body"] = serde_json::json!(source.body);
-                        if let Some(map) = obj.as_object_mut() {
-                            map.extend(source_provenance_fields(&source));
-                        }
-                    }
-                    None => {
-                        obj["body"] = serde_json::Value::Null;
-                        obj["body_unavailable"] = serde_json::json!(
-                            absent_reason.unwrap_or_else(|| entity_body_gap_reason(&e))
-                        );
-                    }
-                }
+                attach_context_body(&held, &e, &mut obj, &mut body_budget)?;
             }
             Ok(obj)
         } else {
@@ -1316,6 +1279,7 @@ pub fn handle_get_context_pack<G: GraphStore>(
         );
     }
 
+    body_budget.disclose(&mut result);
     let json = serialize_with_measured_tokens(&mut result)?;
     Ok(ToolCallResult::text(json))
 }
@@ -1484,17 +1448,24 @@ fn multi_focal_pack_result<G: GraphStore>(
     // `kin graph source` on the same id returned the whole body. It was never a
     // body gap; it was a path that did not ask.
     let held = HeldSourceAuthority::new(store, repository_authority);
-    let row =
+    let mut body_budget =
+        ContextBodyBudget::new(crate::budget::ResponseBudget::from_arguments(args).max_chars);
+    let mut row =
         |entry: &kin_model::context::ContextEntry, section: &str| -> Result<serde_json::Value> {
             let entity = store
                 .get_entity(&entry.entity_id)
                 .map_err(McpError::graph)?;
             let Some(entity) = entity else {
-                return Ok(serde_json::json!({
+                let mut row = serde_json::json!({
                     "id": entry.entity_id,
                     "section": section,
                     "projection": format!("{:?}", entry.projection_level),
-                }));
+                });
+                if entry.projection_level == kin_model::context::ProjectionLevel::FullBody {
+                    downgrade_context_body(&mut row, "entity is unavailable in graph truth");
+                    row["projection"] = serde_json::Value::Null;
+                }
+                return Ok(row);
             };
             let mut obj = serde_json::json!({
                 "id": entity.id,
@@ -1515,44 +1486,7 @@ fn multi_focal_pack_result<G: GraphStore>(
             if entry.projection_level != kin_model::context::ProjectionLevel::FullBody {
                 return Ok(obj);
             }
-            let (body, absent_reason) = match read_entity_source_excerpt_detailed_held(
-                &held,
-                &entity,
-                MCP_SOURCE_MAX_LINES,
-                MCP_SOURCE_MAX_CHARS,
-                EntitySourceScope::WorkspaceHead,
-            ) {
-                Ok(body) => (body, None),
-                Err(error) if is_absent_at_generation(&error) => (None, Some(error.to_string())),
-                Err(error) => return Err(error),
-            };
-            // Which authority answered, under the same key the single-focal path
-            // publishes it, so a caller reading one surface is not learning two
-            // vocabularies for one fact.
-            obj["source"] = serde_json::json!(LAST_READ_SOURCE.with(|f| f.get()));
-            match body {
-                Some(source) => {
-                    obj["body"] = serde_json::json!(source.body);
-                    if let Some(map) = obj.as_object_mut() {
-                        map.extend(source_provenance_fields(&source));
-                    }
-                }
-                None => {
-                    // The claim goes with the body. A row that cannot produce one
-                    // reports the level it actually carries, so the label and the
-                    // content cannot disagree the way they did on v0.7.2.
-                    obj["projection"] = serde_json::json!(format!(
-                        "{:?}",
-                        kin_model::context::ProjectionLevel::SignatureOnly
-                    ));
-                    obj["projection_downgraded_from"] =
-                        serde_json::json!(format!("{:?}", entry.projection_level));
-                    obj["body"] = serde_json::Value::Null;
-                    obj["body_unavailable"] = serde_json::json!(
-                        absent_reason.unwrap_or_else(|| entity_body_gap_reason(&entity))
-                    );
-                }
-            }
+            attach_context_body(&held, &entity, &mut obj, &mut body_budget)?;
             Ok(obj)
         };
 
@@ -1645,6 +1579,7 @@ fn multi_focal_pack_result<G: GraphStore>(
         );
     }
 
+    body_budget.disclose(&mut result);
     let json = serialize_with_measured_tokens(&mut result)?;
     Ok(Some(ToolCallResult::text(json)))
 }

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -2749,6 +2749,29 @@ mod tests {
             focal["start_line"].is_null(),
             "a spanless entity has no line to report"
         );
+        let sessions = crate::session::SessionRegistry::empty_for_test();
+        let args = HashMap::from([
+            (
+                "entity_id".into(),
+                serde_json::json!(spanless.id.to_string()),
+            ),
+            ("max_chars".into(), serde_json::json!(60000)),
+        ]);
+        let payload = tool_result_json(
+            entities::handle_get_context_pack(&args, &store, &sessions, Some(&authority)).unwrap(),
+        );
+        assert!(payload["focal_entity"]["body_unavailable"]
+            .as_str()
+            .unwrap()
+            .contains("no source span"));
+        assert!(payload["focal_entity"].get("body_elided").is_none());
+        assert!(
+            payload
+                .get("elisions")
+                .and_then(|value| value.get("body"))
+                .is_none(),
+            "source absence is not a budget cut: {payload}"
+        );
     }
 
     /// The MULTI-focal path serves the same body the single-focal one does.
@@ -3957,6 +3980,42 @@ mod tests {
     }
 
     #[test]
+    fn context_requested_4000_keeps_the_effective_8000_tier_and_exact_final_cost() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let source = make_source_backed_entity("fn exact() {\r\n    execute();\r\n}");
+        let entity = &source.entity;
+        let mut store = EmptyStore::default();
+        store.entities_by_id.insert(entity.id, entity.clone());
+        store
+            .file_hashes
+            .insert(entity.file_origin.clone().unwrap(), source.hash);
+        install_empty_store_exact_tree(&mut store, source._dir.path());
+        let authority = test_repository_authority(source._dir.path());
+        let sessions = crate::session::SessionRegistry::empty_for_test();
+        let args = HashMap::from([
+            ("entity_id".into(), serde_json::json!(entity.id.to_string())),
+            ("token_budget".into(), serde_json::json!(4000)),
+        ]);
+        let raw =
+            entities::handle_get_context_pack(&args, &store, &sessions, Some(&authority)).unwrap();
+        let result =
+            crate::envelope::finalize(raw, crate::envelope::Envelope::daemon(), "get_context_pack");
+        assert_ne!(result.is_error, Some(true));
+        let crate::types::ContentBlock::Text { text } = &result.content[0];
+        let value: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(value["token_budget"], 8000);
+        assert_eq!(value["tokens_used"], kin_context::estimate_tokens(text));
+        assert!(kin_context::estimate_tokens(text) <= 8000);
+        assert_eq!(
+            value["focal_entity"]["body"],
+            "fn exact() {\r\n    execute();\r\n}"
+        );
+    }
+
+    #[test]
     fn context_full_body_omits_an_oversized_single_line_without_clipping() {
         let _lock = ENV_MUTEX
             .get_or_init(|| Mutex::new(()))
@@ -4160,6 +4219,22 @@ mod tests {
         install_empty_store_exact_tree(&mut store, source._dir.path());
         let authority = test_repository_authority(source._dir.path());
         let error = focal_context_json(&store, entity, Some(&authority)).unwrap_err();
+        assert!(error.to_string().contains("not valid UTF-8"));
+        let held = HeldSourceAuthority::new(&store, Some(&authority));
+        let mut provider = ContextSourceProvider {
+            held: &held,
+            fields: ContextSourceFields::default(),
+        };
+        let error = kin_context::ContextProjectionProvider::full_body(
+            &mut provider,
+            entity,
+            kin_context::ProjectionLimits {
+                max_candidate_bytes: 0,
+                max_retained_bytes: 0,
+            },
+        )
+        .err()
+        .expect("invalid UTF-8 remains an error even above the byte allowance");
         assert!(error.to_string().contains("not valid UTF-8"));
     }
 

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -3872,7 +3872,299 @@ mod tests {
     }
 
     #[test]
-    fn focal_context_json_expands_signature_only_python_span() {
+    fn context_full_bodies_preserve_exact_span_bytes_at_excerpt_boundaries() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let mut contents = vec![
+            "constant\n".to_string(),
+            "constant".to_string(),
+            "constant\r\n".to_string(),
+        ];
+        for lines in [39, 40, 41, 46] {
+            contents.push("  return café;\r\n".repeat(lines));
+        }
+        for bytes in [2399, 2400, 2401] {
+            contents.push("x".repeat(bytes));
+        }
+        for content in contents {
+            let source = make_source_backed_entity(&content);
+            let entity = &source.entity;
+            let mut store = EmptyStore::default();
+            store.entities_by_id.insert(entity.id, entity.clone());
+            store
+                .file_hashes
+                .insert(entity.file_origin.clone().unwrap(), source.hash);
+            install_empty_store_exact_tree(&mut store, source._dir.path());
+            let authority = test_repository_authority(source._dir.path());
+            let direct = tool_result_json(
+                entities::handle_get_entity_source(
+                    &HashMap::from([(
+                        "entity_id".into(),
+                        serde_json::json!(entity.id.to_string()),
+                    )]),
+                    &store,
+                    Some(&authority),
+                )
+                .unwrap(),
+            );
+            assert_eq!(direct["body"].as_str(), Some(content.as_str()));
+            let sessions = crate::session::SessionRegistry::empty_for_test();
+            for multi in [false, true] {
+                let mut args = HashMap::from([
+                    ("token_budget".into(), serde_json::json!(8000)),
+                    ("max_chars".into(), serde_json::json!(60000)),
+                ]);
+                if multi {
+                    args.insert(
+                        "question_focals".into(),
+                        serde_json::json!([{"entity_id": entity.id.to_string(), "route": "id"}]),
+                    );
+                } else {
+                    args.insert("entity_id".into(), serde_json::json!(entity.id.to_string()));
+                }
+                let value = tool_result_json(
+                    entities::handle_get_context_pack(&args, &store, &sessions, Some(&authority))
+                        .unwrap(),
+                );
+                let row = if multi {
+                    &value["entities"][0]
+                } else {
+                    &value["focal_entity"]
+                };
+                assert_eq!(
+                    row["body"].as_str(),
+                    Some(content.as_str()),
+                    "multi={multi}, bytes={}",
+                    content.len()
+                );
+                assert_eq!(row["projection"], "FullBody");
+                assert_eq!(row["body_complete"], true);
+            }
+            let held = HeldSourceAuthority::new(&store, Some(&authority));
+            let mut budget = ContextBodyBudget::new(content.len());
+            let mut first = serde_json::json!({});
+            attach_context_body(&held, entity, &mut first, &mut budget).unwrap();
+            assert_eq!(first["body"].as_str(), Some(content.as_str()));
+            let mut second = serde_json::json!({});
+            attach_context_body(&held, entity, &mut second, &mut budget).unwrap();
+            assert!(second["body"].is_null());
+            assert_eq!(second["body_complete"], false);
+            assert_eq!(second["projection"], "SignatureOnly");
+            assert_eq!(second["body_budget_remaining_bytes"], 0);
+        }
+    }
+
+    #[test]
+    fn context_full_body_omits_an_oversized_single_line_without_clipping() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let content = "é".repeat(30_001);
+        let source = make_source_backed_entity(&content);
+        let entity = &source.entity;
+        let mut store = EmptyStore::default();
+        store.entities_by_id.insert(entity.id, entity.clone());
+        store
+            .file_hashes
+            .insert(entity.file_origin.clone().unwrap(), source.hash);
+        install_empty_store_exact_tree(&mut store, source._dir.path());
+        let authority = test_repository_authority(source._dir.path());
+        let sessions = crate::session::SessionRegistry::empty_for_test();
+        for multi in [false, true] {
+            let mut args = HashMap::from([("max_chars".into(), serde_json::json!(60000))]);
+            if multi {
+                args.insert(
+                    "question_focals".into(),
+                    serde_json::json!([{"entity_id": entity.id.to_string(), "route": "id"}]),
+                );
+            } else {
+                args.insert("entity_id".into(), serde_json::json!(entity.id.to_string()));
+            }
+            let value = tool_result_json(
+                entities::handle_get_context_pack(&args, &store, &sessions, Some(&authority))
+                    .unwrap(),
+            );
+            let row = if multi {
+                &value["entities"][0]
+            } else {
+                &value["focal_entity"]
+            };
+            assert!(row["body"].is_null());
+            assert_eq!(row["body_complete"], false);
+            assert_eq!(row["projection"], "SignatureOnly");
+            assert_eq!(row["body_bytes"], content.len());
+            assert_eq!(row["body_elided"], serde_json::json!(["body"]));
+            assert!(row["body_unavailable"]
+                .as_str()
+                .unwrap()
+                .contains("whole graph-owned span"));
+            assert_eq!(value["elisions"]["body"]["elided"], 1);
+            let finalized = crate::envelope::finalize_bounded(
+                crate::types::ToolCallResult::text(value.to_string()),
+                crate::envelope::Envelope::daemon(),
+                "get_context_pack",
+                &crate::budget::ResponseBudget::default(),
+            );
+            let final_value = tool_result_json(finalized);
+            assert_eq!(final_value["_kin"]["response"]["bounded"], true);
+            assert_eq!(final_value["elisions"]["body"]["elided"], 1);
+        }
+    }
+
+    #[test]
+    fn context_dependency_bodies_preserve_the_whole_span() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let content = "return café;\r\n".repeat(46);
+        let source = make_source_backed_entity(&content);
+        let entity = &source.entity;
+        let mut dependency = entity.clone();
+        dependency.id = EntityId::new();
+        dependency.name = "dependency".into();
+        let mut store = EmptyStore::default();
+        store.entities_by_id.insert(entity.id, entity.clone());
+        store
+            .entities_by_id
+            .insert(dependency.id, dependency.clone());
+        store
+            .file_hashes
+            .insert(entity.file_origin.clone().unwrap(), source.hash);
+        store.insert_test_calls_relation(entity, &dependency);
+        install_empty_store_exact_tree(&mut store, source._dir.path());
+        let authority = test_repository_authority(source._dir.path());
+        let sessions = crate::session::SessionRegistry::empty_for_test();
+        let args = HashMap::from([
+            ("entity_id".into(), serde_json::json!(entity.id.to_string())),
+            ("compact".into(), serde_json::json!(false)),
+        ]);
+        let value = tool_result_json(
+            entities::handle_get_context_pack(&args, &store, &sessions, Some(&authority)).unwrap(),
+        );
+        let dep = value["dependencies"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|row| row["id"] == dependency.id.to_string())
+            .expect("dependency retained");
+        assert_eq!(dep["body"].as_str(), Some(content.as_str()));
+        assert_eq!(dep["projection"], "FullBody");
+        assert_eq!(dep["body_complete"], true);
+    }
+
+    #[test]
+    fn context_body_cuts_accumulate_across_hydration_and_finalization() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let content = "x".repeat(60_001);
+        let source = make_source_backed_entity(&content);
+        let mut small = source.entity.clone();
+        small.span.as_mut().unwrap().end_byte = 20_000;
+        let mut large = source.entity.clone();
+        large.id = EntityId::new();
+        large.name = "large".into();
+        let mut store = EmptyStore::default();
+        store.entities_by_id.insert(small.id, small.clone());
+        store.entities_by_id.insert(large.id, large.clone());
+        store
+            .file_hashes
+            .insert(small.file_origin.clone().unwrap(), source.hash);
+        install_empty_store_exact_tree(&mut store, source._dir.path());
+        let authority = test_repository_authority(source._dir.path());
+        let args = HashMap::from([
+            (
+                "question_focals".into(),
+                serde_json::json!([
+                    {"entity_id": small.id.to_string(), "route": "id"},
+                    {"entity_id": large.id.to_string(), "route": "id"}
+                ]),
+            ),
+            ("max_chars".into(), serde_json::json!(60000)),
+        ]);
+        let sessions = crate::session::SessionRegistry::empty_for_test();
+        let result =
+            entities::handle_get_context_pack(&args, &store, &sessions, Some(&authority)).unwrap();
+        let raw = tool_result_json(result.clone());
+        assert_eq!(raw["elisions"]["body"]["kept"], 1);
+        assert_eq!(raw["elisions"]["body"]["elided"], 1);
+        let budget = crate::budget::ResponseBudget {
+            max_chars: 12000,
+            ..crate::budget::ResponseBudget::default()
+        };
+        let final_result = crate::envelope::finalize_bounded(
+            result,
+            crate::envelope::Envelope::daemon(),
+            "get_context_pack",
+            &budget,
+        );
+        let payload = tool_result_json(final_result);
+        assert_eq!(payload["elisions"]["body"]["kept"], 0);
+        assert_eq!(payload["elisions"]["body"]["elided"], 2);
+        let reason = payload["elisions"]["body"]["reason"].as_str().unwrap();
+        assert!(reason.contains(crate::budget::BODY_HYDRATION_REASON));
+        assert!(reason.contains(crate::budget::ELISION_REASON_BUDGET));
+        assert_eq!(payload["_kin"]["response"]["bounded"], true);
+        for row in payload["entities"].as_array().unwrap() {
+            assert!(row["body"].is_null());
+            assert_eq!(row["body_complete"], false);
+            assert_eq!(row["projection"], "SignatureOnly");
+        }
+    }
+
+    #[test]
+    fn direct_source_refuses_a_whole_span_above_its_byte_limit() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let content = "é".repeat(500_001);
+        let source = make_source_backed_entity(&content);
+        let entity = &source.entity;
+        let mut store = EmptyStore::default();
+        store.entities_by_id.insert(entity.id, entity.clone());
+        store
+            .file_hashes
+            .insert(entity.file_origin.clone().unwrap(), source.hash);
+        install_empty_store_exact_tree(&mut store, source._dir.path());
+        let authority = test_repository_authority(source._dir.path());
+        let error = entities::handle_get_entity_source(
+            &HashMap::from([("entity_id".into(), serde_json::json!(entity.id.to_string()))]),
+            &store,
+            Some(&authority),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("1000002 bytes"));
+        assert!(error.to_string().contains("1000000 byte inline limit"));
+    }
+
+    #[test]
+    fn context_full_body_rejects_a_span_splitting_utf8() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let mut source = make_source_backed_entity("éx\n");
+        source.entity.span.as_mut().unwrap().end_byte = 1;
+        let entity = &source.entity;
+        let mut store = EmptyStore::default();
+        store.entities_by_id.insert(entity.id, entity.clone());
+        store
+            .file_hashes
+            .insert(entity.file_origin.clone().unwrap(), source.hash);
+        install_empty_store_exact_tree(&mut store, source._dir.path());
+        let authority = test_repository_authority(source._dir.path());
+        let error = focal_context_json(&store, entity, Some(&authority)).unwrap_err();
+        assert!(error.to_string().contains("not valid UTF-8"));
+    }
+
+    #[test]
+    fn focal_context_json_preserves_a_one_line_graph_span() {
         let _lock = ENV_MUTEX
             .get_or_init(|| Mutex::new(()))
             .lock()
@@ -3893,8 +4185,11 @@ mod tests {
         let object = value.as_object().unwrap();
         let body = object.get("body").and_then(|value| value.as_str()).unwrap();
 
-        assert!(body.contains("value <= max_val"));
-        assert_ne!(body.trim(), entity.signature);
+        let span = entity.span.as_ref().unwrap();
+        assert_eq!(body, &content[span.start_byte..span.end_byte]);
+        assert!(!body.contains("value <= max_val"));
+        assert_eq!(value["body_complete"], true);
+        assert_eq!(value["projection"], "FullBody");
     }
 
     #[test]

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -3979,6 +3979,201 @@ mod tests {
         }
     }
 
+    /// A caller reached through a proven override is recovered without a body claim.
+    #[test]
+    fn a_recovered_unpriced_row_discloses_its_body_gap_on_the_context_surface() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let mut fixture = pack_provenance_fixture();
+        let sender = fixture.sender.clone();
+        let base = fixture.reader.clone();
+        fixture
+            .store
+            .insert_test_relation(RelationKind::Overrides, &sender, &base);
+
+        let opts = kin_context::ContextOptions::default();
+        let (pack, _) =
+            kin_context::build_context_pack_with_provenance(&fixture.store, &sender.id, &opts)
+                .unwrap();
+        assert!(pack
+            .dependency_signatures
+            .iter()
+            .any(|row| row.entity_id == base.id));
+        assert!(
+            !pack
+                .dependency_signatures
+                .iter()
+                .any(|row| row.entity_id == fixture.renderer.id),
+            "the caller must be absent from the builder so the handler recovers it"
+        );
+        let references = collect_graph_reference_rows(
+            &fixture.store,
+            &sender.id,
+            &default_reference_kinds(),
+            Some(&fixture.authority),
+        )
+        .unwrap();
+        assert!(
+            references.iter().any(|row| row.entity_id.as_deref()
+                == Some(fixture.renderer.id.to_string().as_str())
+                && !row.receiver_name_guess),
+            "the override must certify the recovered caller"
+        );
+
+        let direct = tool_result_json(
+            entities::handle_get_entity_source(
+                &HashMap::from([(
+                    "entity_id".into(),
+                    serde_json::json!(fixture.renderer.id.to_string()),
+                )]),
+                &fixture.store,
+                Some(&fixture.authority),
+            )
+            .unwrap(),
+        );
+        assert!(
+            direct["body"].as_str().is_some(),
+            "the recovered caller has readable source: {direct}"
+        );
+        let value = context_pack_json(&fixture, &sender, false);
+        let row = value["dependents"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|row| row["id"] == fixture.renderer.id.to_string())
+            .expect("the context response retains the certified caller");
+        assert_eq!(row.get("body"), Some(&serde_json::Value::Null));
+        assert_eq!(row["body_complete"], false);
+        assert!(row["body_unavailable"]
+            .as_str()
+            .unwrap()
+            .contains("not priced"));
+        assert!(row.get("body_elided").is_none(), "{row}");
+        assert!(row.get("projection_downgraded_from").is_none(), "{row}");
+    }
+
+    /// Unpriced rows disclose missing bodies only when their position promises one.
+    #[test]
+    fn an_unpriced_row_that_promised_a_body_says_none_was_read() {
+        let entry = kin_model::context::ContextEntry {
+            entity_id: EntityId::new(),
+            projection_level: kin_model::context::ProjectionLevel::SignatureOnly,
+            content: String::new(),
+        };
+        let report = kin_context::ProjectionReport::default();
+        assert!(!report.full_bodies.contains(&entry.entity_id));
+        assert!(!report.downgrades.contains_key(&entry.entity_id));
+
+        let mut promised = serde_json::json!({"id": entry.entity_id, "name": "recovered"});
+        attach_context_projection(
+            &entry,
+            &ContextSourceFields::default(),
+            &report,
+            &mut promised,
+            true,
+        );
+        assert!(promised["body"].is_null());
+        assert!(
+            promised.get("body").is_some(),
+            "the key is present and null"
+        );
+        assert_eq!(promised["body_complete"], false);
+        assert!(promised["body_unavailable"]
+            .as_str()
+            .unwrap()
+            .contains("not priced"));
+        // Nothing was downgraded and no budget withheld anything, so it claims
+        // neither. `disclose_projection_bodies` reads `body_elided` to count a
+        // withheld body, and this row is not one.
+        assert!(promised.get("projection_downgraded_from").is_none());
+        assert!(promised.get("body_elided").is_none());
+
+        let mut unpromised = serde_json::json!({"id": entry.entity_id, "name": "neighbour"});
+        attach_context_projection(
+            &entry,
+            &ContextSourceFields::default(),
+            &report,
+            &mut unpromised,
+            false,
+        );
+        assert!(unpromised.get("body").is_none(), "{unpromised}");
+        assert!(unpromised.get("body_complete").is_none(), "{unpromised}");
+        assert!(unpromised.get("body_unavailable").is_none(), "{unpromised}");
+    }
+
+    /// Source and single/multi-focal context return the recorded signature span,
+    /// even when the graph-owned artifact contains a larger function body.
+    #[test]
+    fn context_serves_a_signature_only_span_without_reconstructing_the_block() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let content = "def validate_probe_range_f0cc1f1d(value: float, min_val: float, max_val: float) -> bool:\n    return min_val <= value and value <= max_val\n";
+        let source = make_signature_only_python_entity(content);
+        let entity = &source.entity;
+        let span = entity.span.as_ref().unwrap();
+        let recorded = &content[span.start_byte..span.end_byte];
+        // The fixture is only worth anything if the span really is short.
+        assert!(!recorded.contains("value <= max_val"), "{recorded}");
+        assert!(content.contains("value <= max_val"));
+
+        let mut store = EmptyStore::default();
+        store.entities_by_id.insert(entity.id, entity.clone());
+        store
+            .file_hashes
+            .insert(entity.file_origin.clone().unwrap(), source.hash);
+        install_empty_store_exact_tree(&mut store, source._dir.path());
+        let authority = test_repository_authority(source._dir.path());
+        let sessions = crate::session::SessionRegistry::empty_for_test();
+
+        let direct = tool_result_json(
+            entities::handle_get_entity_source(
+                &HashMap::from([("entity_id".into(), serde_json::json!(entity.id.to_string()))]),
+                &store,
+                Some(&authority),
+            )
+            .unwrap(),
+        );
+        assert_eq!(direct["body"].as_str(), Some(recorded));
+        assert!(!direct["body"]
+            .as_str()
+            .unwrap()
+            .contains("value <= max_val"));
+
+        for multi in [false, true] {
+            let mut args = HashMap::from([
+                ("token_budget".into(), serde_json::json!(8000)),
+                ("max_chars".into(), serde_json::json!(60000)),
+            ]);
+            if multi {
+                args.insert(
+                    "question_focals".into(),
+                    serde_json::json!([{"entity_id": entity.id.to_string(), "route": "id"}]),
+                );
+            } else {
+                args.insert("entity_id".into(), serde_json::json!(entity.id.to_string()));
+            }
+            let value = tool_result_json(
+                entities::handle_get_context_pack(&args, &store, &sessions, Some(&authority))
+                    .unwrap(),
+            );
+            let row = if multi {
+                &value["entities"][0]
+            } else {
+                &value["focal_entity"]
+            };
+            let body = row["body"].as_str().unwrap_or_default();
+            assert_eq!(body, recorded, "multi={multi}");
+            assert!(!body.contains("value <= max_val"), "multi={multi}: {body}");
+            assert!(!body.contains("[truncated]"), "multi={multi}: {body}");
+            assert_eq!(row["projection"], "FullBody", "multi={multi}");
+            assert_eq!(row["body_complete"], true, "multi={multi}");
+        }
+    }
+
     #[test]
     fn context_requested_4000_keeps_the_effective_8000_tier_and_exact_final_cost() {
         let _lock = ENV_MUTEX

--- a/crates/kin-parser/src/languages/c_lang.rs
+++ b/crates/kin-parser/src/languages/c_lang.rs
@@ -12,6 +12,292 @@ use crate::extract::{ExtractedEntity, ExtractedRelation, FileImport, ImportedNam
 
 pub struct CAdapter;
 
+/// A direct call whose complete syntax and callee position are known.
+#[derive(Debug, Clone)]
+pub struct PartialCallSite {
+    pub callee: String,
+    pub expression: String,
+    pub call_span: kin_model::SourceSpan,
+    pub callee_span: kin_model::SourceSpan,
+}
+
+/// Direct calls inside a complete declaration, excluding names shadowed by
+/// local bindings or defined macros. The enclosing full-file proof is required.
+pub fn partial_call_sites(
+    tree: &Tree,
+    source: &[u8],
+    declaration: &kin_model::SourceSpan,
+) -> Option<Vec<PartialCallSite>> {
+    partial_function_context(tree, source, declaration.start_byte, declaration.end_byte)?;
+    let root = tree.root_node();
+    let mut cursor = root.walk();
+    let function = root.children(&mut cursor).find(|node| {
+        node.kind() == "function_definition"
+            && node.start_byte() == declaration.start_byte
+            && node.end_byte() == declaration.end_byte
+    })?;
+    let mut unavailable = std::collections::HashSet::new();
+    let mut pending = vec![root];
+    while let Some(node) = pending.pop() {
+        if matches!(node.kind(), "preproc_def" | "preproc_function_def") {
+            if let Some(name) = node.child_by_field_name("name") {
+                unavailable.insert(name.utf8_text(source).ok()?.to_owned());
+            }
+        }
+        let mut cursor = node.walk();
+        pending.extend(node.named_children(&mut cursor));
+    }
+    let mut pending = vec![function];
+    while let Some(node) = pending.pop() {
+        if matches!(node.kind(), "declaration" | "parameter_declaration") {
+            let mut cursor = node.walk();
+            for (index, child) in node.children(&mut cursor).enumerate() {
+                if node.field_name_for_child(index as u32) != Some("declarator") {
+                    continue;
+                }
+                let mut names = vec![child];
+                while let Some(name) = names.pop() {
+                    if name.kind() == "init_declarator" {
+                        names.push(name.child_by_field_name("declarator")?);
+                    } else if name.kind() == "identifier" {
+                        unavailable.insert(name.utf8_text(source).ok()?.to_owned());
+                    } else {
+                        let mut cursor = name.walk();
+                        names.extend(name.named_children(&mut cursor));
+                    }
+                }
+            }
+        }
+        let mut cursor = node.walk();
+        pending.extend(node.named_children(&mut cursor));
+    }
+    let mut sites = Vec::new();
+    let mut pending = vec![function];
+    while let Some(node) = pending.pop() {
+        if node.kind() == "call_expression" {
+            let callee = node.child_by_field_name("function")?;
+            let name = callee.utf8_text(source).ok()?;
+            if callee.kind() == "identifier" && !unavailable.contains(name) {
+                sites.push(PartialCallSite {
+                    callee: name.to_owned(),
+                    expression: node.utf8_text(source).ok()?.to_owned(),
+                    call_span: span_from_node(&node, &declaration.file),
+                    callee_span: span_from_node(&callee, &declaration.file),
+                });
+            }
+        }
+        let mut cursor = node.walk();
+        pending.extend(node.named_children(&mut cursor));
+    }
+    Some(sites)
+}
+
+/// Context that must remain identical before refreshing one declaration in an
+/// incomplete C file. Only direct, complete function definitions qualify. The
+/// full-file tree, including zero-width recovery nodes at either boundary, is
+/// authoritative; parsing an isolated body cannot establish this evidence.
+pub fn partial_function_context(
+    tree: &Tree,
+    source: &[u8],
+    start: usize,
+    end: usize,
+) -> Option<Vec<String>> {
+    let root = tree.root_node();
+    let mut cursor = root.walk();
+    let node = root.children(&mut cursor).find(|node| {
+        node.kind() == "function_definition" && node.start_byte() == start && node.end_byte() == end
+    })?;
+    if node.has_error()
+        || collect_error_ranges(tree).iter().any(|&(a, b)| {
+            if a == b {
+                start <= a && a <= end
+            } else {
+                a < end && start < b
+            }
+        })
+    {
+        return None;
+    }
+    let body = node.child_by_field_name("body")?;
+    if body.kind() != "compound_statement"
+        || body.child(0)?.kind() != "{"
+        || body
+            .child(u32::try_from(body.child_count().checked_sub(1)?).ok()?)?
+            .kind()
+            != "}"
+    {
+        return None;
+    }
+    let mut context = Vec::new();
+    // Declaration and preprocessing context cannot change while its resolver
+    // dependencies are unavailable. Function bodies are independently scoped.
+    let mut cursor = root.walk();
+    for sibling in root.children(&mut cursor) {
+        if sibling.kind() == "comment" {
+            continue;
+        }
+        let stop = if sibling.kind() == "function_definition" {
+            sibling.child_by_field_name("body")?.start_byte()
+        } else {
+            sibling.end_byte()
+        };
+        context.push(
+            std::str::from_utf8(source.get(sibling.start_byte()..stop)?)
+                .ok()?
+                .to_owned(),
+        );
+    }
+    fn locals(
+        node: tree_sitter::Node<'_>,
+        body: tree_sitter::Node<'_>,
+        source: &[u8],
+        names: &mut std::collections::HashMap<String, (usize, usize, usize, usize)>,
+    ) -> Option<()> {
+        if matches!(node.kind(), "declaration" | "parameter_declaration") {
+            let mut scope = node;
+            while !matches!(
+                scope.kind(),
+                "compound_statement" | "for_statement" | "function_definition"
+            ) {
+                scope = scope.parent()?;
+            }
+            let mut cursor = node.walk();
+            if node.children(&mut cursor).any(|child| {
+                child.kind() == "storage_class_specifier"
+                    && child.utf8_text(source).ok() == Some("extern")
+            }) {
+                return None;
+            }
+            fn declaration_name(node: tree_sitter::Node<'_>) -> Option<tree_sitter::Node<'_>> {
+                if node.kind() == "identifier" {
+                    Some(node)
+                } else {
+                    declaration_name(node.child_by_field_name("declarator")?)
+                }
+            }
+            let mut cursor = node.walk();
+            for declarator in node.children_by_field_name("declarator", &mut cursor) {
+                if has_function_declarator(&declarator) {
+                    return None;
+                }
+                let bare = if declarator.kind() == "init_declarator" {
+                    declarator.child_by_field_name("declarator")?
+                } else {
+                    declarator
+                };
+                let identifier = declaration_name(bare)?;
+                let name = identifier.utf8_text(source).ok()?.to_owned();
+                let start = if node.kind() == "parameter_declaration" {
+                    body.start_byte()
+                } else {
+                    bare.end_byte()
+                };
+                if is_all_caps_macro(&name)
+                    || names
+                        .insert(
+                            name,
+                            (
+                                start,
+                                scope.end_byte(),
+                                identifier.start_byte(),
+                                identifier.end_byte(),
+                            ),
+                        )
+                        .is_some()
+                {
+                    return None;
+                }
+            }
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            locals(child, body, source, names)?;
+        }
+        Some(())
+    }
+    let mut local_names = std::collections::HashMap::new();
+    locals(node, body, source, &mut local_names)?;
+    fn directives(
+        node: tree_sitter::Node<'_>,
+        source: &[u8],
+        names: &std::collections::HashMap<String, (usize, usize, usize, usize)>,
+        out: &mut Vec<String>,
+    ) -> Option<()> {
+        if node.kind().starts_with("preproc_") {
+            if node
+                .child_by_field_name("name")
+                .and_then(|n| n.utf8_text(source).ok())
+                .is_some_and(|name| names.contains_key(name))
+            {
+                return None;
+            }
+            out.push(node.utf8_text(source).ok()?.to_owned());
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            directives(child, source, names, out)?;
+        }
+        Some(())
+    }
+    directives(root, source, &local_names, &mut context)?;
+    fn dependencies(
+        node: tree_sitter::Node<'_>,
+        source: &[u8],
+        body_start: usize,
+        locals: &std::collections::HashMap<String, (usize, usize, usize, usize)>,
+        out: &mut Vec<String>,
+    ) -> Option<()> {
+        if node.kind().starts_with("preproc_") || node.kind() == "macro_type_specifier" {
+            return None;
+        }
+        let text = node.utf8_text(source).ok()?;
+        let is_local =
+            locals
+                .get(text)
+                .is_some_and(|&(start, end, declaration_start, declaration_end)| {
+                    (start <= node.start_byte() && node.end_byte() <= end)
+                        || (node.start_byte() == declaration_start
+                            && node.end_byte() == declaration_end)
+                });
+        if matches!(
+            node.kind(),
+            "call_expression"
+                | "type_identifier"
+                | "primitive_type"
+                | "field_identifier"
+                | "statement_identifier"
+        ) || (node.kind() == "identifier" && !is_local)
+        {
+            out.push(format!("{}:{text}", node.kind()));
+            if node.kind() == "identifier" && node.start_byte() >= body_start && !is_local {
+                let mut expression = node;
+                while let Some(parent) = expression.parent() {
+                    if matches!(
+                        parent.kind(),
+                        "compound_statement"
+                            | "if_statement"
+                            | "while_statement"
+                            | "for_statement"
+                            | "switch_statement"
+                            | "function_definition"
+                    ) {
+                        break;
+                    }
+                    expression = parent;
+                }
+                out.push(expression.utf8_text(source).ok()?.to_owned());
+            }
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            dependencies(child, source, body_start, locals, out)?;
+        }
+        Some(())
+    }
+    dependencies(node, source, body.start_byte(), &local_names, &mut context)?;
+    Some(context)
+}
+
 impl LanguageAdapter for CAdapter {
     fn language_id(&self) -> LanguageId {
         LanguageId::C

--- a/crates/kin-parser/tests/fixtures/c/hiredis-sds.c
+++ b/crates/kin-parser/tests/fixtures/c/hiredis-sds.c
@@ -1,0 +1,1292 @@
+/* SDSLib 2.0 -- A C dynamic strings library
+ *
+ * Copyright (c) 2006-2015, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2015, Oran Agra
+ * Copyright (c) 2015, Redis Labs, Inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fmacros.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <assert.h>
+#include <limits.h>
+#include "sds.h"
+#include "sdsalloc.h"
+
+static inline int sdsHdrSize(char type) {
+    switch(type&SDS_TYPE_MASK) {
+        case SDS_TYPE_5:
+            return sizeof(struct sdshdr5);
+        case SDS_TYPE_8:
+            return sizeof(struct sdshdr8);
+        case SDS_TYPE_16:
+            return sizeof(struct sdshdr16);
+        case SDS_TYPE_32:
+            return sizeof(struct sdshdr32);
+        case SDS_TYPE_64:
+            return sizeof(struct sdshdr64);
+    }
+    return 0;
+}
+
+static inline char sdsReqType(size_t string_size) {
+    if (string_size < 32)
+        return SDS_TYPE_5;
+    if (string_size < 0xff)
+        return SDS_TYPE_8;
+    if (string_size < 0xffff)
+        return SDS_TYPE_16;
+    if (string_size < 0xffffffff)
+        return SDS_TYPE_32;
+    return SDS_TYPE_64;
+}
+
+/* Create a new sds string with the content specified by the 'init' pointer
+ * and 'initlen'.
+ * If NULL is used for 'init' the string is initialized with zero bytes.
+ *
+ * The string is always null-terminated (all the sds strings are, always) so
+ * even if you create an sds string with:
+ *
+ * mystring = sdsnewlen("abc",3);
+ *
+ * You can print the string with printf() as there is an implicit \0 at the
+ * end of the string. However the string is binary safe and can contain
+ * \0 characters in the middle, as the length is stored in the sds header. */
+sds sdsnewlen(const void *init, size_t initlen) {
+    void *sh;
+    sds s;
+    char type = sdsReqType(initlen);
+    /* Empty strings are usually created in order to append. Use type 8
+     * since type 5 is not good at this. */
+    if (type == SDS_TYPE_5 && initlen == 0) type = SDS_TYPE_8;
+    int hdrlen = sdsHdrSize(type);
+    unsigned char *fp; /* flags pointer. */
+
+    if (hdrlen+initlen+1 <= initlen) return NULL; /* Catch size_t overflow */
+    sh = s_malloc(hdrlen+initlen+1);
+    if (sh == NULL) return NULL;
+    if (!init)
+        memset(sh, 0, hdrlen+initlen+1);
+    s = (char*)sh+hdrlen;
+    fp = ((unsigned char*)s)-1;
+    switch(type) {
+        case SDS_TYPE_5: {
+            *fp = type | (initlen << SDS_TYPE_BITS);
+            break;
+        }
+        case SDS_TYPE_8: {
+            SDS_HDR_VAR(8,s);
+            sh->len = initlen;
+            sh->alloc = initlen;
+            *fp = type;
+            break;
+        }
+        case SDS_TYPE_16: {
+            SDS_HDR_VAR(16,s);
+            sh->len = initlen;
+            sh->alloc = initlen;
+            *fp = type;
+            break;
+        }
+        case SDS_TYPE_32: {
+            SDS_HDR_VAR(32,s);
+            sh->len = initlen;
+            sh->alloc = initlen;
+            *fp = type;
+            break;
+        }
+        case SDS_TYPE_64: {
+            SDS_HDR_VAR(64,s);
+            sh->len = initlen;
+            sh->alloc = initlen;
+            *fp = type;
+            break;
+        }
+    }
+    if (initlen && init)
+        memcpy(s, init, initlen);
+    s[initlen] = '\0';
+    return s;
+}
+
+/* Create an empty (zero length) sds string. Even in this case the string
+ * always has an implicit null term. */
+sds sdsempty(void) {
+    return sdsnewlen("",0);
+}
+
+/* Create a new sds string starting from a null terminated C string. */
+sds sdsnew(const char *init) {
+    size_t initlen = (init == NULL) ? 0 : strlen(init);
+    return sdsnewlen(init, initlen);
+}
+
+/* Duplicate an sds string. */
+sds sdsdup(const sds s) {
+    return sdsnewlen(s, sdslen(s));
+}
+
+/* Free an sds string. No operation is performed if 's' is NULL. */
+void sdsfree(sds s) {
+    if (s == NULL) return;
+    s_free((char*)s-sdsHdrSize(s[-1]));
+}
+
+/* Set the sds string length to the length as obtained with strlen(), so
+ * considering as content only up to the first null term character.
+ *
+ * This function is useful when the sds string is hacked manually in some
+ * way, like in the following example:
+ *
+ * s = sdsnew("foobar");
+ * s[2] = '\0';
+ * sdsupdatelen(s);
+ * printf("%d\n", sdslen(s));
+ *
+ * The output will be "2", but if we comment out the call to sdsupdatelen()
+ * the output will be "6" as the string was modified but the logical length
+ * remains 6 bytes. */
+void sdsupdatelen(sds s) {
+    size_t reallen = strlen(s);
+    sdssetlen(s, reallen);
+}
+
+/* Modify an sds string in-place to make it empty (zero length).
+ * However all the existing buffer is not discarded but set as free space
+ * so that next append operations will not require allocations up to the
+ * number of bytes previously available. */
+void sdsclear(sds s) {
+    sdssetlen(s, 0);
+    s[0] = '\0';
+}
+
+/* Enlarge the free space at the end of the sds string so that the caller
+ * is sure that after calling this function can overwrite up to addlen
+ * bytes after the end of the string, plus one more byte for nul term.
+ *
+ * Note: this does not change the *length* of the sds string as returned
+ * by sdslen(), but only the free buffer space we have. */
+sds sdsMakeRoomFor(sds s, size_t addlen) {
+    void *sh, *newsh;
+    size_t avail = sdsavail(s);
+    size_t len, newlen, reqlen;
+    char type, oldtype = s[-1] & SDS_TYPE_MASK;
+    int hdrlen;
+
+    /* Return ASAP if there is enough space left. */
+    if (avail >= addlen) return s;
+
+    len = sdslen(s);
+    sh = (char*)s-sdsHdrSize(oldtype);
+    reqlen = newlen = (len+addlen);
+    if (newlen <= len) return NULL; /* Catch size_t overflow */
+    if (newlen < SDS_MAX_PREALLOC)
+        newlen *= 2;
+    else
+        newlen += SDS_MAX_PREALLOC;
+
+    type = sdsReqType(newlen);
+
+    /* Don't use type 5: the user is appending to the string and type 5 is
+     * not able to remember empty space, so sdsMakeRoomFor() must be called
+     * at every appending operation. */
+    if (type == SDS_TYPE_5) type = SDS_TYPE_8;
+
+    hdrlen = sdsHdrSize(type);
+    if (hdrlen+newlen+1 <= reqlen) return NULL; /* Catch size_t overflow */
+    if (oldtype==type) {
+        newsh = s_realloc(sh, hdrlen+newlen+1);
+        if (newsh == NULL) return NULL;
+        s = (char*)newsh+hdrlen;
+    } else {
+        /* Since the header size changes, need to move the string forward,
+         * and can't use realloc */
+        newsh = s_malloc(hdrlen+newlen+1);
+        if (newsh == NULL) return NULL;
+        memcpy((char*)newsh+hdrlen, s, len+1);
+        s_free(sh);
+        s = (char*)newsh+hdrlen;
+        s[-1] = type;
+        sdssetlen(s, len);
+    }
+    sdssetalloc(s, newlen);
+    return s;
+}
+
+/* Reallocate the sds string so that it has no free space at the end. The
+ * contained string remains not altered, but next concatenation operations
+ * will require a reallocation.
+ *
+ * After the call, the passed sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdsRemoveFreeSpace(sds s) {
+    void *sh, *newsh;
+    char type, oldtype = s[-1] & SDS_TYPE_MASK;
+    int hdrlen;
+    size_t len = sdslen(s);
+    sh = (char*)s-sdsHdrSize(oldtype);
+
+    type = sdsReqType(len);
+    hdrlen = sdsHdrSize(type);
+    if (oldtype==type) {
+        newsh = s_realloc(sh, hdrlen+len+1);
+        if (newsh == NULL) return NULL;
+        s = (char*)newsh+hdrlen;
+    } else {
+        newsh = s_malloc(hdrlen+len+1);
+        if (newsh == NULL) return NULL;
+        memcpy((char*)newsh+hdrlen, s, len+1);
+        s_free(sh);
+        s = (char*)newsh+hdrlen;
+        s[-1] = type;
+        sdssetlen(s, len);
+    }
+    sdssetalloc(s, len);
+    return s;
+}
+
+/* Return the total size of the allocation of the specifed sds string,
+ * including:
+ * 1) The sds header before the pointer.
+ * 2) The string.
+ * 3) The free buffer at the end if any.
+ * 4) The implicit null term.
+ */
+size_t sdsAllocSize(sds s) {
+    size_t alloc = sdsalloc(s);
+    return sdsHdrSize(s[-1])+alloc+1;
+}
+
+/* Return the pointer of the actual SDS allocation (normally SDS strings
+ * are referenced by the start of the string buffer). */
+void *sdsAllocPtr(sds s) {
+    return (void*) (s-sdsHdrSize(s[-1]));
+}
+
+/* Increment the sds length and decrements the left free space at the
+ * end of the string according to 'incr'. Also set the null term
+ * in the new end of the string.
+ *
+ * This function is used in order to fix the string length after the
+ * user calls sdsMakeRoomFor(), writes something after the end of
+ * the current string, and finally needs to set the new length.
+ *
+ * Note: it is possible to use a negative increment in order to
+ * right-trim the string.
+ *
+ * Usage example:
+ *
+ * Using sdsIncrLen() and sdsMakeRoomFor() it is possible to mount the
+ * following schema, to cat bytes coming from the kernel to the end of an
+ * sds string without copying into an intermediate buffer:
+ *
+ * oldlen = sdslen(s);
+ * s = sdsMakeRoomFor(s, BUFFER_SIZE);
+ * nread = read(fd, s+oldlen, BUFFER_SIZE);
+ * ... check for nread <= 0 and handle it ...
+ * sdsIncrLen(s, nread);
+ */
+void sdsIncrLen(sds s, int incr) {
+    unsigned char flags = s[-1];
+    size_t len;
+    switch(flags&SDS_TYPE_MASK) {
+        case SDS_TYPE_5: {
+            unsigned char *fp = ((unsigned char*)s)-1;
+            unsigned char oldlen = SDS_TYPE_5_LEN(flags);
+            assert((incr > 0 && oldlen+incr < 32) || (incr < 0 && oldlen >= (unsigned int)(-incr)));
+            *fp = SDS_TYPE_5 | ((oldlen+incr) << SDS_TYPE_BITS);
+            len = oldlen+incr;
+            break;
+        }
+        case SDS_TYPE_8: {
+            SDS_HDR_VAR(8,s);
+            assert((incr >= 0 && sh->alloc-sh->len >= incr) || (incr < 0 && sh->len >= (unsigned int)(-incr)));
+            len = (sh->len += incr);
+            break;
+        }
+        case SDS_TYPE_16: {
+            SDS_HDR_VAR(16,s);
+            assert((incr >= 0 && sh->alloc-sh->len >= incr) || (incr < 0 && sh->len >= (unsigned int)(-incr)));
+            len = (sh->len += incr);
+            break;
+        }
+        case SDS_TYPE_32: {
+            SDS_HDR_VAR(32,s);
+            assert((incr >= 0 && sh->alloc-sh->len >= (unsigned int)incr) || (incr < 0 && sh->len >= (unsigned int)(-incr)));
+            len = (sh->len += incr);
+            break;
+        }
+        case SDS_TYPE_64: {
+            SDS_HDR_VAR(64,s);
+            assert((incr >= 0 && sh->alloc-sh->len >= (uint64_t)incr) || (incr < 0 && sh->len >= (uint64_t)(-incr)));
+            len = (sh->len += incr);
+            break;
+        }
+        default: len = 0; /* Just to avoid compilation warnings. */
+    }
+    s[len] = '\0';
+}
+
+/* Grow the sds to have the specified length. Bytes that were not part of
+ * the original length of the sds will be set to zero.
+ *
+ * if the specified length is smaller than the current length, no operation
+ * is performed. */
+sds sdsgrowzero(sds s, size_t len) {
+    size_t curlen = sdslen(s);
+
+    if (len <= curlen) return s;
+    s = sdsMakeRoomFor(s,len-curlen);
+    if (s == NULL) return NULL;
+
+    /* Make sure added region doesn't contain garbage */
+    memset(s+curlen,0,(len-curlen+1)); /* also set trailing \0 byte */
+    sdssetlen(s, len);
+    return s;
+}
+
+/* Append the specified binary-safe string pointed by 't' of 'len' bytes to the
+ * end of the specified sds string 's'.
+ *
+ * After the call, the passed sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdscatlen(sds s, const void *t, size_t len) {
+    size_t curlen = sdslen(s);
+
+    s = sdsMakeRoomFor(s,len);
+    if (s == NULL) return NULL;
+    memcpy(s+curlen, t, len);
+    sdssetlen(s, curlen+len);
+    s[curlen+len] = '\0';
+    return s;
+}
+
+/* Append the specified null termianted C string to the sds string 's'.
+ *
+ * After the call, the passed sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdscat(sds s, const char *t) {
+    return sdscatlen(s, t, strlen(t));
+}
+
+/* Append the specified sds 't' to the existing sds 's'.
+ *
+ * After the call, the modified sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdscatsds(sds s, const sds t) {
+    return sdscatlen(s, t, sdslen(t));
+}
+
+/* Destructively modify the sds string 's' to hold the specified binary
+ * safe string pointed by 't' of length 'len' bytes. */
+sds sdscpylen(sds s, const char *t, size_t len) {
+    if (sdsalloc(s) < len) {
+        s = sdsMakeRoomFor(s,len-sdslen(s));
+        if (s == NULL) return NULL;
+    }
+    memcpy(s, t, len);
+    s[len] = '\0';
+    sdssetlen(s, len);
+    return s;
+}
+
+/* Like sdscpylen() but 't' must be a null-terminated string so that the length
+ * of the string is obtained with strlen(). */
+sds sdscpy(sds s, const char *t) {
+    return sdscpylen(s, t, strlen(t));
+}
+
+/* Helper for sdscatlonglong() doing the actual number -> string
+ * conversion. 's' must point to a string with room for at least
+ * SDS_LLSTR_SIZE bytes.
+ *
+ * The function returns the length of the null-terminated string
+ * representation stored at 's'. */
+#define SDS_LLSTR_SIZE 21
+int sdsll2str(char *s, long long value) {
+    char *p, aux;
+    unsigned long long v;
+    size_t l;
+
+    /* Generate the string representation, this method produces
+     * an reversed string. */
+    v = (value < 0) ? -value : value;
+    p = s;
+    do {
+        *p++ = '0'+(v%10);
+        v /= 10;
+    } while(v);
+    if (value < 0) *p++ = '-';
+
+    /* Compute length and add null term. */
+    l = p-s;
+    *p = '\0';
+
+    /* Reverse the string. */
+    p--;
+    while(s < p) {
+        aux = *s;
+        *s = *p;
+        *p = aux;
+        s++;
+        p--;
+    }
+    return l;
+}
+
+/* Identical sdsll2str(), but for unsigned long long type. */
+int sdsull2str(char *s, unsigned long long v) {
+    char *p, aux;
+    size_t l;
+
+    /* Generate the string representation, this method produces
+     * an reversed string. */
+    p = s;
+    do {
+        *p++ = '0'+(v%10);
+        v /= 10;
+    } while(v);
+
+    /* Compute length and add null term. */
+    l = p-s;
+    *p = '\0';
+
+    /* Reverse the string. */
+    p--;
+    while(s < p) {
+        aux = *s;
+        *s = *p;
+        *p = aux;
+        s++;
+        p--;
+    }
+    return l;
+}
+
+/* Create an sds string from a long long value. It is much faster than:
+ *
+ * sdscatprintf(sdsempty(),"%lld\n", value);
+ */
+sds sdsfromlonglong(long long value) {
+    char buf[SDS_LLSTR_SIZE];
+    int len = sdsll2str(buf,value);
+
+    return sdsnewlen(buf,len);
+}
+
+/* Like sdscatprintf() but gets va_list instead of being variadic. */
+sds sdscatvprintf(sds s, const char *fmt, va_list ap) {
+    va_list cpy;
+    char staticbuf[1024], *buf = staticbuf, *t;
+    size_t buflen = strlen(fmt)*2;
+
+    /* We try to start using a static buffer for speed.
+     * If not possible we revert to heap allocation. */
+    if (buflen > sizeof(staticbuf)) {
+        buf = s_malloc(buflen);
+        if (buf == NULL) return NULL;
+    } else {
+        buflen = sizeof(staticbuf);
+    }
+
+    /* Try with buffers two times bigger every time we fail to
+     * fit the string in the current buffer size. */
+    while(1) {
+        buf[buflen-2] = '\0';
+        va_copy(cpy,ap);
+        vsnprintf(buf, buflen, fmt, cpy);
+        va_end(cpy);
+        if (buf[buflen-2] != '\0') {
+            if (buf != staticbuf) s_free(buf);
+            buflen *= 2;
+            buf = s_malloc(buflen);
+            if (buf == NULL) return NULL;
+            continue;
+        }
+        break;
+    }
+
+    /* Finally concat the obtained string to the SDS string and return it. */
+    t = sdscat(s, buf);
+    if (buf != staticbuf) s_free(buf);
+    return t;
+}
+
+/* Append to the sds string 's' a string obtained using printf-alike format
+ * specifier.
+ *
+ * After the call, the modified sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call.
+ *
+ * Example:
+ *
+ * s = sdsnew("Sum is: ");
+ * s = sdscatprintf(s,"%d+%d = %d",a,b,a+b).
+ *
+ * Often you need to create a string from scratch with the printf-alike
+ * format. When this is the need, just use sdsempty() as the target string:
+ *
+ * s = sdscatprintf(sdsempty(), "... your format ...", args);
+ */
+sds sdscatprintf(sds s, const char *fmt, ...) {
+    va_list ap;
+    char *t;
+    va_start(ap, fmt);
+    t = sdscatvprintf(s,fmt,ap);
+    va_end(ap);
+    return t;
+}
+
+/* This function is similar to sdscatprintf, but much faster as it does
+ * not rely on sprintf() family functions implemented by the libc that
+ * are often very slow. Moreover directly handling the sds string as
+ * new data is concatenated provides a performance improvement.
+ *
+ * However this function only handles an incompatible subset of printf-alike
+ * format specifiers:
+ *
+ * %s - C String
+ * %S - SDS string
+ * %i - signed int
+ * %I - 64 bit signed integer (long long, int64_t)
+ * %u - unsigned int
+ * %U - 64 bit unsigned integer (unsigned long long, uint64_t)
+ * %% - Verbatim "%" character.
+ */
+sds sdscatfmt(sds s, char const *fmt, ...) {
+    const char *f = fmt;
+    long i;
+    va_list ap;
+
+    va_start(ap,fmt);
+    i = sdslen(s); /* Position of the next byte to write to dest str. */
+    while(*f) {
+        char next, *str;
+        size_t l;
+        long long num;
+        unsigned long long unum;
+
+        /* Make sure there is always space for at least 1 char. */
+        if (sdsavail(s)==0) {
+            s = sdsMakeRoomFor(s,1);
+            if (s == NULL) goto fmt_error;
+        }
+
+        switch(*f) {
+        case '%':
+            next = *(f+1);
+            f++;
+            switch(next) {
+            case 's':
+            case 'S':
+                str = va_arg(ap,char*);
+                l = (next == 's') ? strlen(str) : sdslen(str);
+                if (sdsavail(s) < l) {
+                    s = sdsMakeRoomFor(s,l);
+                    if (s == NULL) goto fmt_error;
+                }
+                memcpy(s+i,str,l);
+                sdsinclen(s,l);
+                i += l;
+                break;
+            case 'i':
+            case 'I':
+                if (next == 'i')
+                    num = va_arg(ap,int);
+                else
+                    num = va_arg(ap,long long);
+                {
+                    char buf[SDS_LLSTR_SIZE];
+                    l = sdsll2str(buf,num);
+                    if (sdsavail(s) < l) {
+                        s = sdsMakeRoomFor(s,l);
+                        if (s == NULL) goto fmt_error;
+                    }
+                    memcpy(s+i,buf,l);
+                    sdsinclen(s,l);
+                    i += l;
+                }
+                break;
+            case 'u':
+            case 'U':
+                if (next == 'u')
+                    unum = va_arg(ap,unsigned int);
+                else
+                    unum = va_arg(ap,unsigned long long);
+                {
+                    char buf[SDS_LLSTR_SIZE];
+                    l = sdsull2str(buf,unum);
+                    if (sdsavail(s) < l) {
+                        s = sdsMakeRoomFor(s,l);
+                        if (s == NULL) goto fmt_error;
+                    }
+                    memcpy(s+i,buf,l);
+                    sdsinclen(s,l);
+                    i += l;
+                }
+                break;
+            default: /* Handle %% and generally %<unknown>. */
+                s[i++] = next;
+                sdsinclen(s,1);
+                break;
+            }
+            break;
+        default:
+            s[i++] = *f;
+            sdsinclen(s,1);
+            break;
+        }
+        f++;
+    }
+    va_end(ap);
+
+    /* Add null-term */
+    s[i] = '\0';
+    return s;
+
+fmt_error:
+    va_end(ap);
+    return NULL;
+}
+
+/* Remove the part of the string from left and from right composed just of
+ * contiguous characters found in 'cset', that is a null terminted C string.
+ *
+ * After the call, the modified sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call.
+ *
+ * Example:
+ *
+ * s = sdsnew("AA...AA.a.aa.aHelloWorld     :::");
+ * s = sdstrim(s,"Aa. :");
+ * printf("%s\n", s);
+ *
+ * Output will be just "Hello World".
+ */
+sds sdstrim(sds s, const char *cset) {
+    char *end, *sp, *ep;
+    size_t len;
+
+    sp = s;
+    ep = end = s+sdslen(s)-1;
+    while(sp <= end && strchr(cset, *sp)) sp++;
+    while(ep > sp && strchr(cset, *ep)) ep--;
+    len = (sp > ep) ? 0 : ((ep-sp)+1);
+    if (s != sp) memmove(s, sp, len);
+    s[len] = '\0';
+    sdssetlen(s,len);
+    return s;
+}
+
+/* Turn the string into a smaller (or equal) string containing only the
+ * substring specified by the 'start' and 'end' indexes.
+ *
+ * start and end can be negative, where -1 means the last character of the
+ * string, -2 the penultimate character, and so forth.
+ *
+ * The interval is inclusive, so the start and end characters will be part
+ * of the resulting string.
+ *
+ * The string is modified in-place.
+ *
+ * Return value:
+ * -1 (error) if sdslen(s) is larger than maximum positive ssize_t value.
+ *  0 on success.
+ *
+ * Example:
+ *
+ * s = sdsnew("Hello World");
+ * sdsrange(s,1,-1); => "ello World"
+ */
+int sdsrange(sds s, ssize_t start, ssize_t end) {
+    size_t newlen, len = sdslen(s);
+    if (len > SSIZE_MAX) return -1;
+
+    if (len == 0) return 0;
+    if (start < 0) {
+        start = len+start;
+        if (start < 0) start = 0;
+    }
+    if (end < 0) {
+        end = len+end;
+        if (end < 0) end = 0;
+    }
+    newlen = (start > end) ? 0 : (end-start)+1;
+    if (newlen != 0) {
+        if (start >= (ssize_t)len) {
+            newlen = 0;
+        } else if (end >= (ssize_t)len) {
+            end = len-1;
+            newlen = (start > end) ? 0 : (end-start)+1;
+        }
+    } else {
+        start = 0;
+    }
+    if (start && newlen) memmove(s, s+start, newlen);
+    s[newlen] = 0;
+    sdssetlen(s,newlen);
+    return 0;
+}
+
+/* Apply tolower() to every character of the sds string 's'. */
+void sdstolower(sds s) {
+    size_t len = sdslen(s), j;
+
+    for (j = 0; j < len; j++) s[j] = tolower(s[j]);
+}
+
+/* Apply toupper() to every character of the sds string 's'. */
+void sdstoupper(sds s) {
+    size_t len = sdslen(s), j;
+
+    for (j = 0; j < len; j++) s[j] = toupper(s[j]);
+}
+
+/* Compare two sds strings s1 and s2 with memcmp().
+ *
+ * Return value:
+ *
+ *     positive if s1 > s2.
+ *     negative if s1 < s2.
+ *     0 if s1 and s2 are exactly the same binary string.
+ *
+ * If two strings share exactly the same prefix, but one of the two has
+ * additional characters, the longer string is considered to be greater than
+ * the smaller one. */
+int sdscmp(const sds s1, const sds s2) {
+    size_t l1, l2, minlen;
+    int cmp;
+
+    l1 = sdslen(s1);
+    l2 = sdslen(s2);
+    minlen = (l1 < l2) ? l1 : l2;
+    cmp = memcmp(s1,s2,minlen);
+    if (cmp == 0) return l1-l2;
+    return cmp;
+}
+
+/* Split 's' with separator in 'sep'. An array
+ * of sds strings is returned. *count will be set
+ * by reference to the number of tokens returned.
+ *
+ * On out of memory, zero length string, zero length
+ * separator, NULL is returned.
+ *
+ * Note that 'sep' is able to split a string using
+ * a multi-character separator. For example
+ * sdssplit("foo_-_bar","_-_"); will return two
+ * elements "foo" and "bar".
+ *
+ * This version of the function is binary-safe but
+ * requires length arguments. sdssplit() is just the
+ * same function but for zero-terminated strings.
+ */
+sds *sdssplitlen(const char *s, int len, const char *sep, int seplen, int *count) {
+    int elements = 0, slots = 5, start = 0, j;
+    sds *tokens;
+
+    if (seplen < 1 || len < 0) return NULL;
+
+    tokens = s_malloc(sizeof(sds)*slots);
+    if (tokens == NULL) return NULL;
+
+    if (len == 0) {
+        *count = 0;
+        return tokens;
+    }
+    for (j = 0; j < (len-(seplen-1)); j++) {
+        /* make sure there is room for the next element and the final one */
+        if (slots < elements+2) {
+            sds *newtokens;
+
+            slots *= 2;
+            newtokens = s_realloc(tokens,sizeof(sds)*slots);
+            if (newtokens == NULL) goto cleanup;
+            tokens = newtokens;
+        }
+        /* search the separator */
+        if ((seplen == 1 && *(s+j) == sep[0]) || (memcmp(s+j,sep,seplen) == 0)) {
+            tokens[elements] = sdsnewlen(s+start,j-start);
+            if (tokens[elements] == NULL) goto cleanup;
+            elements++;
+            start = j+seplen;
+            j = j+seplen-1; /* skip the separator */
+        }
+    }
+    /* Add the final element. We are sure there is room in the tokens array. */
+    tokens[elements] = sdsnewlen(s+start,len-start);
+    if (tokens[elements] == NULL) goto cleanup;
+    elements++;
+    *count = elements;
+    return tokens;
+
+cleanup:
+    {
+        int i;
+        for (i = 0; i < elements; i++) sdsfree(tokens[i]);
+        s_free(tokens);
+        *count = 0;
+        return NULL;
+    }
+}
+
+/* Free the result returned by sdssplitlen(), or do nothing if 'tokens' is NULL. */
+void sdsfreesplitres(sds *tokens, int count) {
+    if (!tokens) return;
+    while(count--)
+        sdsfree(tokens[count]);
+    s_free(tokens);
+}
+
+/* Append to the sds string "s" an escaped string representation where
+ * all the non-printable characters (tested with isprint()) are turned into
+ * escapes in the form "\n\r\a...." or "\x<hex-number>".
+ *
+ * After the call, the modified sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdscatrepr(sds s, const char *p, size_t len) {
+    s = sdscatlen(s,"\"",1);
+    while(len--) {
+        switch(*p) {
+        case '\\':
+        case '"':
+            s = sdscatprintf(s,"\\%c",*p);
+            break;
+        case '\n': s = sdscatlen(s,"\\n",2); break;
+        case '\r': s = sdscatlen(s,"\\r",2); break;
+        case '\t': s = sdscatlen(s,"\\t",2); break;
+        case '\a': s = sdscatlen(s,"\\a",2); break;
+        case '\b': s = sdscatlen(s,"\\b",2); break;
+        default:
+            if (isprint((int) *p))
+                s = sdscatprintf(s,"%c",*p);
+            else
+                s = sdscatprintf(s,"\\x%02x",(unsigned char)*p);
+            break;
+        }
+        p++;
+    }
+    return sdscatlen(s,"\"",1);
+}
+
+/* Helper function for sdssplitargs() that converts a hex digit into an
+ * integer from 0 to 15 */
+int hex_digit_to_int(char c) {
+    switch(c) {
+    case '0': return 0;
+    case '1': return 1;
+    case '2': return 2;
+    case '3': return 3;
+    case '4': return 4;
+    case '5': return 5;
+    case '6': return 6;
+    case '7': return 7;
+    case '8': return 8;
+    case '9': return 9;
+    case 'a': case 'A': return 10;
+    case 'b': case 'B': return 11;
+    case 'c': case 'C': return 12;
+    case 'd': case 'D': return 13;
+    case 'e': case 'E': return 14;
+    case 'f': case 'F': return 15;
+    default: return 0;
+    }
+}
+
+/* Split a line into arguments, where every argument can be in the
+ * following programming-language REPL-alike form:
+ *
+ * foo bar "newline are supported\n" and "\xff\x00otherstuff"
+ *
+ * The number of arguments is stored into *argc, and an array
+ * of sds is returned.
+ *
+ * The caller should free the resulting array of sds strings with
+ * sdsfreesplitres().
+ *
+ * Note that sdscatrepr() is able to convert back a string into
+ * a quoted string in the same format sdssplitargs() is able to parse.
+ *
+ * The function returns the allocated tokens on success, even when the
+ * input string is empty, or NULL if the input contains unbalanced
+ * quotes or closed quotes followed by non space characters
+ * as in: "foo"bar or "foo'
+ */
+sds *sdssplitargs(const char *line, int *argc) {
+    const char *p = line;
+    char *current = NULL;
+    char **vector = NULL;
+
+    *argc = 0;
+    while(1) {
+        /* skip blanks */
+        while(*p && isspace((int) *p)) p++;
+        if (*p) {
+            /* get a token */
+            int inq=0;  /* set to 1 if we are in "quotes" */
+            int insq=0; /* set to 1 if we are in 'single quotes' */
+            int done=0;
+
+            if (current == NULL) current = sdsempty();
+            while(!done) {
+                if (inq) {
+                    if (*p == '\\' && *(p+1) == 'x' &&
+                                             isxdigit((int) *(p+2)) &&
+                                             isxdigit((int) *(p+3)))
+                    {
+                        unsigned char byte;
+
+                        byte = (hex_digit_to_int(*(p+2))*16)+
+                                hex_digit_to_int(*(p+3));
+                        current = sdscatlen(current,(char*)&byte,1);
+                        p += 3;
+                    } else if (*p == '\\' && *(p+1)) {
+                        char c;
+
+                        p++;
+                        switch(*p) {
+                        case 'n': c = '\n'; break;
+                        case 'r': c = '\r'; break;
+                        case 't': c = '\t'; break;
+                        case 'b': c = '\b'; break;
+                        case 'a': c = '\a'; break;
+                        default: c = *p; break;
+                        }
+                        current = sdscatlen(current,&c,1);
+                    } else if (*p == '"') {
+                        /* closing quote must be followed by a space or
+                         * nothing at all. */
+                        if (*(p+1) && !isspace((int) *(p+1))) goto err;
+                        done=1;
+                    } else if (!*p) {
+                        /* unterminated quotes */
+                        goto err;
+                    } else {
+                        current = sdscatlen(current,p,1);
+                    }
+                } else if (insq) {
+                    if (*p == '\\' && *(p+1) == '\'') {
+                        p++;
+                        current = sdscatlen(current,"'",1);
+                    } else if (*p == '\'') {
+                        /* closing quote must be followed by a space or
+                         * nothing at all. */
+                        if (*(p+1) && !isspace((int) *(p+1))) goto err;
+                        done=1;
+                    } else if (!*p) {
+                        /* unterminated quotes */
+                        goto err;
+                    } else {
+                        current = sdscatlen(current,p,1);
+                    }
+                } else {
+                    switch(*p) {
+                    case ' ':
+                    case '\n':
+                    case '\r':
+                    case '\t':
+                    case '\0':
+                        done=1;
+                        break;
+                    case '"':
+                        inq=1;
+                        break;
+                    case '\'':
+                        insq=1;
+                        break;
+                    default:
+                        current = sdscatlen(current,p,1);
+                        break;
+                    }
+                }
+                if (*p) p++;
+            }
+            /* add the token to the vector */
+            {
+                char **new_vector = s_realloc(vector,((*argc)+1)*sizeof(char*));
+                if (new_vector == NULL) {
+                    s_free(vector);
+                    return NULL;
+                }
+
+                vector = new_vector;
+                vector[*argc] = current;
+                (*argc)++;
+                current = NULL;
+            }
+        } else {
+            /* Even on empty input string return something not NULL. */
+            if (vector == NULL) vector = s_malloc(sizeof(void*));
+            return vector;
+        }
+    }
+
+err:
+    while((*argc)--)
+        sdsfree(vector[*argc]);
+    s_free(vector);
+    if (current) sdsfree(current);
+    *argc = 0;
+    return NULL;
+}
+
+/* Modify the string substituting all the occurrences of the set of
+ * characters specified in the 'from' string to the corresponding character
+ * in the 'to' array.
+ *
+ * For instance: sdsmapchars(mystring, "ho", "01", 2)
+ * will have the effect of turning the string "hello" into "0ell1".
+ *
+ * The function returns the sds string pointer, that is always the same
+ * as the input pointer since no resize is needed. */
+sds sdsmapchars(sds s, const char *from, const char *to, size_t setlen) {
+    size_t j, i, l = sdslen(s);
+
+    for (j = 0; j < l; j++) {
+        for (i = 0; i < setlen; i++) {
+            if (s[j] == from[i]) {
+                s[j] = to[i];
+                break;
+            }
+        }
+    }
+    return s;
+}
+
+/* Join an array of C strings using the specified separator (also a C string).
+ * Returns the result as an sds string. */
+sds sdsjoin(char **argv, int argc, char *sep) {
+    sds join = sdsempty();
+    int j;
+
+    for (j = 0; j < argc; j++) {
+        join = sdscat(join, argv[j]);
+        if (j != argc-1) join = sdscat(join,sep);
+    }
+    return join;
+}
+
+/* Like sdsjoin, but joins an array of SDS strings. */
+sds sdsjoinsds(sds *argv, int argc, const char *sep, size_t seplen) {
+    sds join = sdsempty();
+    int j;
+
+    for (j = 0; j < argc; j++) {
+        join = sdscatsds(join, argv[j]);
+        if (j != argc-1) join = sdscatlen(join,sep,seplen);
+    }
+    return join;
+}
+
+/* Wrappers to the allocators used by SDS. Note that SDS will actually
+ * just use the macros defined into sdsalloc.h in order to avoid to pay
+ * the overhead of function calls. Here we define these wrappers only for
+ * the programs SDS is linked to, if they want to touch the SDS internals
+ * even if they use a different allocator. */
+void *sds_malloc(size_t size) { return s_malloc(size); }
+void *sds_realloc(void *ptr, size_t size) { return s_realloc(ptr,size); }
+void sds_free(void *ptr) { s_free(ptr); }
+
+#if defined(SDS_TEST_MAIN)
+#include <stdio.h>
+#include "testhelp.h"
+#include "limits.h"
+
+#define UNUSED(x) (void)(x)
+int sdsTest(void) {
+    {
+        sds x = sdsnew("foo"), y;
+
+        test_cond("Create a string and obtain the length",
+            sdslen(x) == 3 && memcmp(x,"foo\0",4) == 0)
+
+        sdsfree(x);
+        x = sdsnewlen("foo",2);
+        test_cond("Create a string with specified length",
+            sdslen(x) == 2 && memcmp(x,"fo\0",3) == 0)
+
+        x = sdscat(x,"bar");
+        test_cond("Strings concatenation",
+            sdslen(x) == 5 && memcmp(x,"fobar\0",6) == 0);
+
+        x = sdscpy(x,"a");
+        test_cond("sdscpy() against an originally longer string",
+            sdslen(x) == 1 && memcmp(x,"a\0",2) == 0)
+
+        x = sdscpy(x,"xyzxxxxxxxxxxyyyyyyyyyykkkkkkkkkk");
+        test_cond("sdscpy() against an originally shorter string",
+            sdslen(x) == 33 &&
+            memcmp(x,"xyzxxxxxxxxxxyyyyyyyyyykkkkkkkkkk\0",33) == 0)
+
+        sdsfree(x);
+        x = sdscatprintf(sdsempty(),"%d",123);
+        test_cond("sdscatprintf() seems working in the base case",
+            sdslen(x) == 3 && memcmp(x,"123\0",4) == 0)
+
+        sdsfree(x);
+        x = sdsnew("--");
+        x = sdscatfmt(x, "Hello %s World %I,%I--", "Hi!", LLONG_MIN,LLONG_MAX);
+        test_cond("sdscatfmt() seems working in the base case",
+            sdslen(x) == 60 &&
+            memcmp(x,"--Hello Hi! World -9223372036854775808,"
+                     "9223372036854775807--",60) == 0)
+        printf("[%s]\n",x);
+
+        sdsfree(x);
+        x = sdsnew("--");
+        x = sdscatfmt(x, "%u,%U--", UINT_MAX, ULLONG_MAX);
+        test_cond("sdscatfmt() seems working with unsigned numbers",
+            sdslen(x) == 35 &&
+            memcmp(x,"--4294967295,18446744073709551615--",35) == 0)
+
+        sdsfree(x);
+        x = sdsnew(" x ");
+        sdstrim(x," x");
+        test_cond("sdstrim() works when all chars match",
+            sdslen(x) == 0)
+
+        sdsfree(x);
+        x = sdsnew(" x ");
+        sdstrim(x," ");
+        test_cond("sdstrim() works when a single char remains",
+            sdslen(x) == 1 && x[0] == 'x')
+
+        sdsfree(x);
+        x = sdsnew("xxciaoyyy");
+        sdstrim(x,"xy");
+        test_cond("sdstrim() correctly trims characters",
+            sdslen(x) == 4 && memcmp(x,"ciao\0",5) == 0)
+
+        y = sdsdup(x);
+        sdsrange(y,1,1);
+        test_cond("sdsrange(...,1,1)",
+            sdslen(y) == 1 && memcmp(y,"i\0",2) == 0)
+
+        sdsfree(y);
+        y = sdsdup(x);
+        sdsrange(y,1,-1);
+        test_cond("sdsrange(...,1,-1)",
+            sdslen(y) == 3 && memcmp(y,"iao\0",4) == 0)
+
+        sdsfree(y);
+        y = sdsdup(x);
+        sdsrange(y,-2,-1);
+        test_cond("sdsrange(...,-2,-1)",
+            sdslen(y) == 2 && memcmp(y,"ao\0",3) == 0)
+
+        sdsfree(y);
+        y = sdsdup(x);
+        sdsrange(y,2,1);
+        test_cond("sdsrange(...,2,1)",
+            sdslen(y) == 0 && memcmp(y,"\0",1) == 0)
+
+        sdsfree(y);
+        y = sdsdup(x);
+        sdsrange(y,1,100);
+        test_cond("sdsrange(...,1,100)",
+            sdslen(y) == 3 && memcmp(y,"iao\0",4) == 0)
+
+        sdsfree(y);
+        y = sdsdup(x);
+        sdsrange(y,100,100);
+        test_cond("sdsrange(...,100,100)",
+            sdslen(y) == 0 && memcmp(y,"\0",1) == 0)
+
+        sdsfree(y);
+        sdsfree(x);
+        x = sdsnew("foo");
+        y = sdsnew("foa");
+        test_cond("sdscmp(foo,foa)", sdscmp(x,y) > 0)
+
+        sdsfree(y);
+        sdsfree(x);
+        x = sdsnew("bar");
+        y = sdsnew("bar");
+        test_cond("sdscmp(bar,bar)", sdscmp(x,y) == 0)
+
+        sdsfree(y);
+        sdsfree(x);
+        x = sdsnew("aar");
+        y = sdsnew("bar");
+        test_cond("sdscmp(bar,bar)", sdscmp(x,y) < 0)
+
+        sdsfree(y);
+        sdsfree(x);
+        x = sdsnewlen("\a\n\0foo\r",7);
+        y = sdscatrepr(sdsempty(),x,sdslen(x));
+        test_cond("sdscatrepr(...data...)",
+            memcmp(y,"\"\\a\\n\\x00foo\\r\"",15) == 0)
+
+        {
+            unsigned int oldfree;
+            char *p;
+            int step = 10, j, i;
+
+            sdsfree(x);
+            sdsfree(y);
+            x = sdsnew("0");
+            test_cond("sdsnew() free/len buffers", sdslen(x) == 1 && sdsavail(x) == 0);
+
+            /* Run the test a few times in order to hit the first two
+             * SDS header types. */
+            for (i = 0; i < 10; i++) {
+                int oldlen = sdslen(x);
+                x = sdsMakeRoomFor(x,step);
+                int type = x[-1]&SDS_TYPE_MASK;
+
+                test_cond("sdsMakeRoomFor() len", sdslen(x) == oldlen);
+                if (type != SDS_TYPE_5) {
+                    test_cond("sdsMakeRoomFor() free", sdsavail(x) >= step);
+                    oldfree = sdsavail(x);
+                }
+                p = x+oldlen;
+                for (j = 0; j < step; j++) {
+                    p[j] = 'A'+j;
+                }
+                sdsIncrLen(x,step);
+            }
+            test_cond("sdsMakeRoomFor() content",
+                memcmp("0ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJ",x,101) == 0);
+            test_cond("sdsMakeRoomFor() final length",sdslen(x)==101);
+
+            sdsfree(x);
+        }
+    }
+    test_report()
+    return 0;
+}
+#endif
+
+#ifdef SDS_TEST_MAIN
+int main(void) {
+    return sdsTest();
+}
+#endif

--- a/crates/kin-reconcile/src/error.rs
+++ b/crates/kin-reconcile/src/error.rs
@@ -35,6 +35,9 @@ pub enum ReconcileError {
         reason: String,
     },
 
+    #[error("Incomplete parse cannot verify deletion of declarations in file {file_id}")]
+    IncompleteParseWouldDelete { file_id: kin_model::FilePathId },
+
     #[error("Broken AST rejected by policy for file {file_id}")]
     BrokenAstRejected {
         file_id: kin_model::FilePathId,

--- a/crates/kin-reconcile/src/reconciler.rs
+++ b/crates/kin-reconcile/src/reconciler.rs
@@ -246,6 +246,15 @@ pub enum ReconcileOutcome {
         /// Collision warnings from the traffic checker (soft locks).
         collision_warnings: Vec<IntentSummary>,
     },
+    /// Only independently verified existing declarations were refreshed. The
+    /// file remains incomplete and every other entity and relation is retained.
+    PartiallyUpdated {
+        file_id: FilePathId,
+        modified: Vec<EntityId>,
+        retained: Vec<EntityId>,
+        error_ranges: Vec<(usize, usize)>,
+        collision_warnings: Vec<IntentSummary>,
+    },
     /// File had parse errors; LKG state retained, no graph changes.
     BrokenAst {
         file_id: FilePathId,
@@ -566,37 +575,6 @@ impl Reconciler {
 
         let result_file_id = indexed.file_id.clone();
 
-        // Check for broken AST — behavior depends on policy.
-        if let ParseState::Incomplete { error_ranges } = &indexed.parse_state {
-            match self.policy.broken_ast_behavior {
-                BrokenAstBehavior::Reject => {
-                    warn!(
-                        file = %path.display(),
-                        errors = error_ranges.len(),
-                        "broken AST rejected by policy"
-                    );
-                    return Err(ReconcileError::BrokenAstRejected {
-                        file_id: result_file_id,
-                        error_ranges: error_ranges.clone(),
-                    });
-                }
-                BrokenAstBehavior::FallbackToLkg => {
-                    warn!(
-                        file = %path.display(),
-                        errors = error_ranges.len(),
-                        "broken AST, retaining LKG state"
-                    );
-                    // Still cache the tree even on broken AST — it's valid for
-                    // incremental parse even if the content has errors.
-                    self.tree_cache.insert(file_id, tree);
-                    return ReconcileResult::unchanged(ReconcileOutcome::BrokenAst {
-                        file_id: result_file_id,
-                        error_ranges: error_ranges.clone(),
-                    });
-                }
-            }
-        }
-
         // RACE CONDITION HARDENING: Verify the file hasn't changed since we
         // indexed it. If modified mid-reconcile, defer to the next tick.
         match std::fs::read(path) {
@@ -633,7 +611,7 @@ impl Reconciler {
         let lkg_snapshot = self.lkg.clone();
 
         let result =
-            self.reconcile_file_edit_inner(&indexed, &result_file_id, path, blob_store, graph);
+            self.reconcile_observed_edit(&indexed, &result_file_id, path, blob_store, graph);
 
         // On error, restore LKG to its pre-reconcile state.
         if result.is_err() {
@@ -660,34 +638,6 @@ impl Reconciler {
             .pipeline
             .index_file_relative(path, blob_store, &self.working_dir)?;
         let file_id = indexed.file_id.clone();
-
-        // Check for broken AST — behavior depends on policy.
-        if let ParseState::Incomplete { error_ranges } = &indexed.parse_state {
-            match self.policy.broken_ast_behavior {
-                BrokenAstBehavior::Reject => {
-                    warn!(
-                        file = %path.display(),
-                        errors = error_ranges.len(),
-                        "broken AST rejected by policy"
-                    );
-                    return Err(ReconcileError::BrokenAstRejected {
-                        file_id,
-                        error_ranges: error_ranges.clone(),
-                    });
-                }
-                BrokenAstBehavior::FallbackToLkg => {
-                    warn!(
-                        file = %path.display(),
-                        errors = error_ranges.len(),
-                        "broken AST, retaining LKG state"
-                    );
-                    return ReconcileResult::unchanged(ReconcileOutcome::BrokenAst {
-                        file_id,
-                        error_ranges: error_ranges.clone(),
-                    });
-                }
-            }
-        }
 
         // RACE CONDITION HARDENING: Verify the file hasn't changed since we
         // indexed it. If the file was modified between the index read and now,
@@ -732,7 +682,7 @@ impl Reconciler {
         // partially advanced reconcile state.
         let lkg_snapshot = self.lkg.clone();
 
-        let result = self.reconcile_file_edit_inner(&indexed, &file_id, path, blob_store, graph);
+        let result = self.reconcile_observed_edit(&indexed, &file_id, path, blob_store, graph);
 
         // On error, restore LKG to its pre-reconcile state and drop this file
         // from the cross-file universe. Cloning the universe per write to undo
@@ -770,6 +720,33 @@ impl Reconciler {
             self.cross_file.forget_file(&file_id.0);
         }
         result
+    }
+
+    /// Apply partial admission to observed filesystem edits. Indexed-content
+    /// transactions use a separate path that requires a complete file layout.
+    fn reconcile_observed_edit<G: GraphStore>(
+        &mut self,
+        indexed: &kin_index::IndexedFile,
+        file_id: &FilePathId,
+        path: &Path,
+        blob_store: &BlobStore,
+        graph: &G,
+    ) -> Result<ReconcileResult> {
+        let ParseState::Incomplete { error_ranges } = &indexed.parse_state else {
+            return self.reconcile_file_edit_inner(indexed, file_id, path, blob_store, graph);
+        };
+        if matches!(self.policy.broken_ast_behavior, BrokenAstBehavior::Reject) {
+            warn!(
+                file = %path.display(),
+                errors = error_ranges.len(),
+                "broken AST rejected by policy"
+            );
+            return Err(ReconcileError::BrokenAstRejected {
+                file_id: file_id.clone(),
+                error_ranges: error_ranges.clone(),
+            });
+        }
+        self.reconcile_partial(indexed, blob_store, graph, error_ranges)
     }
 
     /// Inner implementation of reconcile_file_edit, separated so the caller
@@ -1527,6 +1504,156 @@ impl Reconciler {
             "reconciled file edit"
         );
 
+        Ok(result)
+    }
+
+    fn reconcile_partial<G: GraphStore>(
+        &mut self,
+        indexed: &kin_index::IndexedFile,
+        blobs: &BlobStore,
+        graph: &G,
+        error_ranges: &[(usize, usize)],
+    ) -> Result<ReconcileResult> {
+        let existing = self.get_file_entities(graph, &indexed.file_id)?;
+        let source = blobs.read(&indexed.blob_hash)?;
+        let mut delta = TransactionDelta::default();
+        let mut modified = Vec::new();
+        let mut old_sources = HashMap::new();
+        let mut held_relations = HashMap::new();
+        for candidate in &indexed.entities {
+            if validate_entity(candidate).is_some() {
+                continue;
+            }
+            let same_identity =
+                |entity: &&Entity| entity.name == candidate.name && entity.kind == candidate.kind;
+            let mut previous = existing.iter().filter(same_identity);
+            let Some(old) = previous.next() else {
+                continue;
+            };
+            if previous.next().is_some()
+                || indexed.entities.iter().filter(same_identity).count() != 1
+            {
+                continue;
+            }
+            let Some(hash) = old.metadata.extra.get("blob_hash").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            if !old_sources.contains_key(hash) {
+                let Ok(digest) = kin_blobs::Hash256::from_hex(hash) else {
+                    continue;
+                };
+                let Ok(bytes) = blobs.read(&digest) else {
+                    continue;
+                };
+                old_sources.insert(hash.to_owned(), bytes);
+            }
+            if !self
+                .pipeline
+                .supports_partial_refresh(old, candidate, &old_sources[hash], &source)
+            {
+                continue;
+            }
+            let declaration = old
+                .span
+                .as_ref()
+                .expect("the source proof checked the span");
+            let mut relation_changes = Vec::new();
+            let mut evidence_verified = true;
+            for relation in
+                relations_held_at(graph, &mut held_relations, GraphNodeId::Entity(old.id))?.values()
+            {
+                let associated = relation
+                    .evidence
+                    .iter()
+                    .filter_map(|e| e.source_span.as_ref())
+                    .any(|span| {
+                        span.file == declaration.file
+                            && (relation.src == GraphNodeId::Entity(old.id)
+                                || (declaration.start_line <= span.start_line
+                                    && span.end_line <= declaration.end_line))
+                    });
+                if !associated {
+                    continue;
+                }
+                let Some(updated) = self.pipeline.rebase_partial_relation(
+                    old,
+                    candidate,
+                    &old_sources[hash],
+                    &source,
+                    relation,
+                    &existing,
+                ) else {
+                    evidence_verified = false;
+                    break;
+                };
+                if updated != *relation {
+                    relation_changes.push(RelationDelta::Modified {
+                        old: relation.clone(),
+                        new: updated,
+                    });
+                }
+            }
+            if !evidence_verified {
+                continue;
+            }
+            let mut new = candidate.clone();
+            new.id = old.id;
+            new.lineage_parent = old.lineage_parent;
+            new.created_in = old.created_in;
+            new.metadata.extra.insert(
+                "partial_parse_admission".into(),
+                serde_json::json!({
+                    "previous_blob_hash": hash,
+                    "source_blob_hash": indexed.blob_hash.to_string(),
+                    "error_ranges": error_ranges,
+                }),
+            );
+            // Retrying the same incomplete bytes does not mint another proof
+            // chain or dirty an already admitted declaration.
+            if old.metadata.extra.get("blob_hash") == candidate.metadata.extra.get("blob_hash")
+                && old.span == candidate.span
+                && old.fingerprint == candidate.fingerprint
+            {
+                continue;
+            }
+            modified.push(old.id);
+            delta.relation_deltas.extend(relation_changes);
+            delta.entity_deltas.push(EntityDelta::Modified {
+                old: old.clone(),
+                new,
+            });
+        }
+        if modified.is_empty() {
+            return ReconcileResult::unchanged(ReconcileOutcome::BrokenAst {
+                file_id: indexed.file_id.clone(),
+                error_ranges: error_ranges.to_vec(),
+            });
+        }
+        let mut scopes: Vec<_> = modified.iter().copied().map(IntentScope::Entity).collect();
+        scopes.push(IntentScope::Artifact(indexed.file_id.clone()));
+        let collision_warnings = self.check_scopes(&scopes)?;
+        let retained = existing
+            .iter()
+            .filter(|e| !modified.contains(&e.id))
+            .map(|e| e.id)
+            .collect();
+        let result = ReconcileResult::validated(
+            ReconcileOutcome::PartiallyUpdated {
+                file_id: indexed.file_id.clone(),
+                modified,
+                retained,
+                error_ranges: error_ranges.to_vec(),
+                collision_warnings,
+            },
+            delta,
+        )?;
+        // No layout, link-universe, or relation retirement: only exact call
+        // locations with stable same-file resolution were refreshed.
+        for change in &result.delta.entity_deltas {
+            if let EntityDelta::Modified { new, .. } = change {
+                self.lkg.record(new);
+            }
+        }
         Ok(result)
     }
 
@@ -2559,6 +2686,488 @@ mod tests {
         EntityKind, EntityMetadata, EntityRole, EntityStore, FingerprintAlgorithm, Hash256,
         LanguageId, SemanticFingerprint, Visibility,
     };
+
+    const PARTIAL_C: &str =
+        "int good(void) { int value = 1; return value; }\nint bad(void) { test_cond(1) }\n";
+
+    fn partial_tree(graph: &kin_db::InMemoryGraph, bytes: &[u8]) {
+        let path = kin_model::RepoPath::from_utf8("test.c").unwrap();
+        let entry = kin_model::TreeEntry::blob(
+            kin_model::Hash256::from_bytes(kin_blobs::digest(bytes).0),
+            false,
+        );
+        let tree = graph.resolved_tree();
+        let change = match tree.artifact_at_path(&path) {
+            Some(old) if old.entry == entry => return,
+            Some(old) => kin_model::TreeDelta::Updated {
+                artifact_id: old.artifact_id,
+                old: kin_model::LocatedEntry::new(path.clone(), old.entry),
+                new: kin_model::LocatedEntry::new(path, entry),
+            },
+            None => kin_model::TreeDelta::Added {
+                artifact_id: kin_model::ArtifactId::new(),
+                new: kin_model::LocatedEntry::new(path, entry),
+            },
+        };
+        graph
+            .apply_transaction_delta(&TransactionDelta {
+                tree_deltas: vec![change],
+                ..Default::default()
+            })
+            .unwrap();
+    }
+
+    fn partial_fixture(
+        before: &str,
+    ) -> (
+        tempfile::TempDir,
+        BlobStore,
+        kin_db::InMemoryGraph,
+        Reconciler,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let blobs = BlobStore::new(dir.path().join("blobs")).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+        let indexed = IndexPipeline::new()
+            .index_file_content_with_tests(
+                &FilePathId::new("test.c"),
+                before.as_bytes(),
+                blobs.write(before.as_bytes()).unwrap(),
+            )
+            .unwrap()
+            .indexed_file;
+        partial_tree(&graph, before.as_bytes());
+        for entity in &indexed.entities {
+            graph.upsert_entity(entity).unwrap();
+        }
+        for relation in &indexed.relations {
+            graph.upsert_relation(relation).unwrap();
+        }
+        let reconciler = Reconciler::new(dir.path().to_path_buf());
+        (dir, blobs, graph, reconciler)
+    }
+
+    fn partial_pass(
+        reconciler: &mut Reconciler,
+        blobs: &BlobStore,
+        graph: &kin_db::InMemoryGraph,
+        source: &str,
+    ) -> ReconcileResult {
+        let indexed = IndexPipeline::new()
+            .index_file_content_with_tests(
+                &FilePathId::new("test.c"),
+                source.as_bytes(),
+                blobs.write(source.as_bytes()).unwrap(),
+            )
+            .unwrap()
+            .indexed_file;
+        partial_tree(graph, source.as_bytes());
+        // Through the entrypoint the daemon's watcher uses, because that is
+        // where the broken-AST decision is taken. `reconcile_indexed_content`
+        // beside it reaches the inner reconcile without passing that decision,
+        // and the commit paths behind it keep their full re-derive, so driving
+        // these tests through it would grade code the watcher never runs.
+        let host = reconciler.working_dir.join("test.c");
+        std::fs::write(&host, source).unwrap();
+        let _ = indexed;
+        reconciler
+            .reconcile_file_change(&kin_index::FileEvent::Changed(host), blobs, graph)
+            .unwrap()
+    }
+
+    #[test]
+    fn partial_c_refreshes_retained_hiredis_identity_from_full_cas() {
+        let before = include_str!("../../kin-parser/tests/fixtures/c/hiredis-sds.c");
+        let after = before.replacen("reqlen", "required_len", 3);
+        let (_dir, blobs, graph, mut reconciler) = partial_fixture(before);
+        let old = graph.list_all_entities().unwrap();
+        let target = old.iter().find(|e| e.name == "sdsMakeRoomFor").unwrap();
+        let result = partial_pass(&mut reconciler, &blobs, &graph, &after);
+        let ReconcileOutcome::PartiallyUpdated {
+            modified,
+            error_ranges,
+            retained,
+            ..
+        } = &result.outcome
+        else {
+            panic!("{:?}", result.outcome);
+        };
+        assert!(modified.contains(&target.id));
+        assert_eq!(error_ranges.len(), 25);
+        assert!(!retained.is_empty());
+        assert!(result.delta.relation_deltas.is_empty());
+        assert!(result
+            .delta
+            .entity_deltas
+            .iter()
+            .all(|d| matches!(d, EntityDelta::Modified { .. })));
+        graph.apply_transaction_delta(&result.delta).unwrap();
+        let updated = graph.get_entity(&target.id).unwrap().unwrap();
+        let span = updated.span.as_ref().unwrap();
+        assert!(after[span.start_byte..span.end_byte].contains("required_len"));
+        assert_eq!(
+            updated.metadata.extra["blob_hash"],
+            blobs.write(after.as_bytes()).unwrap().to_string()
+        );
+        for entity in old.iter().filter(|e| retained.contains(&e.id)) {
+            assert_eq!(graph.get_entity(&entity.id).unwrap().unwrap(), *entity);
+        }
+        assert!(reconciler
+            .projection()
+            .get_layout(&FilePathId::new("test.c"))
+            .is_none());
+        let repeat = partial_pass(&mut reconciler, &blobs, &graph, &after);
+        assert!(repeat.delta.entity_deltas.is_empty());
+    }
+
+    #[test]
+    fn partial_c_rejects_body_recovery_boundaries_and_macro_context_changes() {
+        for after in [
+            PARTIAL_C.replace("return value;", "return value"),
+            PARTIAL_C.replace("return value; }", "return value;"),
+            format!(
+                "#if CHOICE\n{}\n#endif\n",
+                PARTIAL_C.replace("value", "next")
+            ),
+            PARTIAL_C
+                .replace("int good", "API int good")
+                .replace("value", "next"),
+            PARTIAL_C.replace("return value;", "test_cond(value) return value;"),
+        ] {
+            let (_dir, blobs, graph, mut reconciler) = partial_fixture(PARTIAL_C);
+            let result = partial_pass(&mut reconciler, &blobs, &graph, &after);
+            assert!(
+                result.delta.entity_deltas.is_empty(),
+                "unexpected admission for {after}: {:?}",
+                result.delta
+            );
+        }
+    }
+
+    #[test]
+    fn partial_c_error_count_equality_never_authorizes_affected_body() {
+        let before = "int good(void) { return 1; }\nint bad(void) { test_cond(1) }\n";
+        let after = "int good(void) { test_cond(1) }\nint bad(void) { return 1; }\n";
+        let (_dir, blobs, graph, mut reconciler) = partial_fixture(before);
+        let pipeline = IndexPipeline::new();
+        let errors = |source: &str| match pipeline
+            .index_file_content_with_tests(
+                &FilePathId::new("test.c"),
+                source.as_bytes(),
+                kin_blobs::digest(source.as_bytes()),
+            )
+            .unwrap()
+            .indexed_file
+            .parse_state
+        {
+            ParseState::Incomplete { error_ranges } => error_ranges.len(),
+            _ => 0,
+        };
+        assert_eq!(errors(before), errors(after));
+        let result = partial_pass(&mut reconciler, &blobs, &graph, after);
+        assert!(result.delta.entity_deltas.is_empty());
+    }
+
+    #[test]
+    fn partial_c_ambiguous_and_omitted_declarations_are_retained() {
+        let (_dir, blobs, graph, mut reconciler) = partial_fixture(PARTIAL_C);
+        let mut duplicate = graph
+            .list_all_entities()
+            .unwrap()
+            .into_iter()
+            .find(|e| e.name == "good")
+            .unwrap();
+        duplicate.id = EntityId::new();
+        graph.upsert_entity(&duplicate).unwrap();
+        let result = partial_pass(
+            &mut reconciler,
+            &blobs,
+            &graph,
+            &PARTIAL_C.replace("value", "next"),
+        );
+        assert!(result.delta.entity_deltas.is_empty());
+        let after = "int bad(void) { test_cond(1) }\n";
+        let result = partial_pass(&mut reconciler, &blobs, &graph, after);
+        assert!(result.delta.entity_deltas.is_empty());
+        assert_eq!(graph.list_all_entities().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn partial_c_never_admits_macro_or_broken_call_regions() {
+        for before in [
+            "#define test_cond(x) do { (void)(x); } while (0);\nint good(void) { test_cond(1) return 0; }\n",
+            "void test_cond(int);\nint good(void) { test_cond(1) return 0; }\n",
+        ] {
+            let (_dir, blobs, graph, mut reconciler) = partial_fixture(before);
+            let result = partial_pass(&mut reconciler, &blobs, &graph, &before.replace("return 0", "return 2"));
+            assert!(result.delta.entity_deltas.is_empty());
+        }
+    }
+
+    #[test]
+    fn partial_c_macro_dependencies_and_nonlocal_names_cannot_change() {
+        for before in [
+            "#define selected 1\nint good(void) { return selected; }\nint bad(void) { test_cond(1) }\n",
+            "#include <macros.h>\nint good(void) { return selected; }\nint bad(void) { test_cond(1) }\n",
+            "void setup(void) {\n#define selected 1\n}\nint good(void) { int local = 1; return selected + local; }\nint bad(void) { test_cond(1) }\n",
+        ] {
+            let (_dir, blobs, graph, mut reconciler) = partial_fixture(before);
+            let after = if before.contains("void setup") { before.replace("selected 1", "selected 2").replace("local = 1", "local = 3") } else { before.replace("return selected", "return other") };
+            let result = partial_pass(&mut reconciler, &blobs, &graph, &after);
+            assert!(result.delta.entity_deltas.is_empty(), "{:?}", result.outcome);
+        }
+    }
+
+    #[test]
+    fn partial_c_local_bindings_respect_scope_and_declaration_order() {
+        for before in [
+            "int selected; int other;\nint good(void) { selected++; { int selected=0; int other=0; } return 0; }\nint bad(void) { test_cond(1) }\n",
+            "int selected; int other;\nint good(void) { { int selected=0; int other=0; } selected++; return 0; }\nint bad(void) { test_cond(1) }\n",
+            "int selected; int other;\nint good(void) { selected++; int selected=0; int other=0; return 0; }\nint bad(void) { test_cond(1) }\n",
+        ] {
+            let (_dir, blobs, graph, mut reconciler) = partial_fixture(before);
+            let after = before.replace("selected++", "other++");
+            let result = partial_pass(&mut reconciler, &blobs, &graph, &after);
+            assert!(result.delta.entity_deltas.is_empty(), "{:?}", result.outcome);
+        }
+    }
+
+    #[test]
+    fn partial_c_external_bindings_members_and_declarator_bounds_are_not_locals() {
+        for (before, from, to) in [
+            ("int good(void) { extern int selected; extern int other; return selected; }\nint bad(void) { test_cond(1) }\n", "return selected", "return other"),
+            ("struct item { int first; int second; };\nint good(void) { struct item local; return local.first; }\nint bad(void) { test_cond(1) }\n", "local.first", "local.second"),
+            ("int selected; int other;\nint good(void) { int selected[sizeof selected]; int other; return 0; }\nint bad(void) { test_cond(1) }\n", "sizeof selected", "sizeof other"),
+        ] {
+            let (_dir, blobs, graph, mut reconciler) = partial_fixture(before);
+            let result = partial_pass(&mut reconciler, &blobs, &graph, &before.replace(from, to));
+            assert!(result.delta.entity_deltas.is_empty(), "{:?}", result.outcome);
+        }
+    }
+
+    #[test]
+    fn partial_c_moved_declaration_keeps_identity_and_uses_current_span() {
+        let (_dir, blobs, graph, mut reconciler) = partial_fixture(PARTIAL_C);
+        let old = graph
+            .list_all_entities()
+            .unwrap()
+            .into_iter()
+            .find(|e| e.name == "good")
+            .unwrap();
+        let after = format!("// prefix\n{}", PARTIAL_C.replace("value", "longer_name"));
+        let result = partial_pass(&mut reconciler, &blobs, &graph, &after);
+        assert!(
+            matches!(&result.outcome, ReconcileOutcome::PartiallyUpdated { modified, .. } if modified.contains(&old.id))
+        );
+        graph.apply_transaction_delta(&result.delta).unwrap();
+        let current = graph.get_entity(&old.id).unwrap().unwrap();
+        let span = current.span.as_ref().unwrap();
+        assert!(span.start_byte > old.span.as_ref().unwrap().start_byte);
+        assert_eq!(
+            &after[span.start_byte..span.end_byte],
+            "int good(void) { int longer_name = 1; return longer_name; }"
+        );
+    }
+
+    const PARTIAL_CALL_C: &str = "int helper(void) { return 7; }\nint good(void) {\n  int value=1;\n  return helper();\n}\nint bad(void) { test_cond(1) }\n";
+
+    fn partial_call_span(source: &str, whole: bool, zero_bytes: bool) -> kin_model::SourceSpan {
+        let start = source.find("helper()").unwrap();
+        let end = start
+            + if whole {
+                "helper()".len()
+            } else {
+                "helper".len()
+            };
+        let line = source[..start]
+            .bytes()
+            .filter(|byte| *byte == b'\n')
+            .count() as u32;
+        let column = start - source[..start].rfind('\n').map_or(0, |offset| offset + 1);
+        kin_model::SourceSpan {
+            file: FilePathId::new("test.c"),
+            start_byte: if zero_bytes { 0 } else { start },
+            end_byte: if zero_bytes { 0 } else { end },
+            start_line: line,
+            end_line: line,
+            start_col: column as u32,
+            end_col: (column + end - start) as u32,
+        }
+    }
+
+    fn partial_enriched_call(
+        graph: &kin_db::InMemoryGraph,
+        source: &str,
+        whole: bool,
+        zero_bytes: bool,
+    ) -> (Entity, Relation) {
+        let entities = graph.list_all_entities().unwrap();
+        let caller = entities
+            .iter()
+            .find(|entity| entity.name == "good")
+            .unwrap()
+            .clone();
+        let callee = entities
+            .iter()
+            .find(|entity| entity.name == "helper")
+            .unwrap();
+        let mut relation = relation_of(kin_model::RelationOrigin::Lsp);
+        relation.src = GraphNodeId::Entity(caller.id);
+        relation.dst = GraphNodeId::Entity(callee.id);
+        relation.confidence = 0.75;
+        relation.evidence = vec![kin_model::RelationEvidence {
+            source_span: Some(partial_call_span(source, whole, zero_bytes)),
+            ..Default::default()
+        }];
+        graph.upsert_relation(&relation).unwrap();
+        (caller, relation)
+    }
+
+    #[test]
+    fn partial_c_rebases_unique_call_evidence_without_changing_relation_identity() {
+        for (whole, zero_bytes) in [(false, false), (false, true), (true, false), (true, true)] {
+            let (_dir, blobs, graph, mut reconciler) = partial_fixture(PARTIAL_CALL_C);
+            let (caller, relation) =
+                partial_enriched_call(&graph, PARTIAL_CALL_C, whole, zero_bytes);
+            let after = format!(
+                "// prefix\n{}",
+                PARTIAL_CALL_C.replace("int value=1;", "int renamed=1;\n\n")
+            );
+            let result = partial_pass(&mut reconciler, &blobs, &graph, &after);
+            assert!(
+                matches!(&result.outcome, ReconcileOutcome::PartiallyUpdated { modified, .. } if modified.contains(&caller.id)),
+                "{:?}",
+                result.outcome
+            );
+            assert!(result
+                .delta
+                .relation_deltas
+                .iter()
+                .all(|delta| matches!(delta, RelationDelta::Modified { .. })));
+            graph.apply_transaction_delta(&result.delta).unwrap();
+            let actual = graph
+                .get_all_relations_for_entity(&caller.id)
+                .unwrap()
+                .into_iter()
+                .find(|held| held.id == relation.id)
+                .unwrap();
+            let mut expected = relation.clone();
+            expected.evidence[0].source_span = Some(partial_call_span(&after, whole, false));
+            assert_eq!(actual, expected, "only the proven coordinates may change");
+            assert_eq!(
+                graph
+                    .get_entity(&caller.id)
+                    .unwrap()
+                    .unwrap()
+                    .metadata
+                    .extra["blob_hash"],
+                kin_blobs::digest(after.as_bytes()).to_string()
+            );
+        }
+    }
+
+    #[test]
+    fn partial_c_refuses_ambiguous_or_unsupported_located_evidence_atomically() {
+        for failure in [
+            "duplicate",
+            "range",
+            "coordinates",
+            "multiple",
+            "kind",
+            "binding",
+        ] {
+            let before = if failure == "duplicate" {
+                PARTIAL_CALL_C.replace("return helper();", "helper(); return helper();")
+            } else {
+                PARTIAL_CALL_C.into()
+            };
+            let (_dir, blobs, graph, mut reconciler) = partial_fixture(&before);
+            let (caller, mut relation) = partial_enriched_call(&graph, &before, false, false);
+            match failure {
+                "range" => relation.evidence[0].source_span = caller.span.clone(),
+                "coordinates" => relation.evidence[0].source_span.as_mut().unwrap().start_col += 1,
+                "multiple" => relation.evidence.push(kin_model::RelationEvidence {
+                    source_span: caller.span.clone(),
+                    ..Default::default()
+                }),
+                "kind" => relation.kind = RelationKind::References,
+                _ => {}
+            }
+            graph.upsert_relation(&relation).unwrap();
+            let after = format!(
+                "// prefix\n{}",
+                if failure == "binding" {
+                    before.replace("int value=1;", "int helper=1;")
+                } else {
+                    before.replace("int value=1;", "int renamed=1;\n\n")
+                }
+            );
+            let result = partial_pass(&mut reconciler, &blobs, &graph, &after);
+            assert!(
+                !result
+                    .delta
+                    .entity_deltas
+                    .iter()
+                    .any(|delta| delta.target_id() == caller.id),
+                "{failure}: {:?}",
+                result.outcome
+            );
+            assert!(
+                !result
+                    .delta
+                    .relation_deltas
+                    .iter()
+                    .any(|delta| delta.target_id() == relation.id),
+                "{failure}"
+            );
+            graph.apply_transaction_delta(&result.delta).unwrap();
+            assert_eq!(graph.get_entity(&caller.id).unwrap(), Some(caller));
+            assert_eq!(
+                graph
+                    .get_all_relations_for_entity(&relation.src.as_entity().unwrap())
+                    .unwrap()
+                    .into_iter()
+                    .find(|held| held.id == relation.id),
+                Some(relation)
+            );
+        }
+    }
+
+    #[test]
+    fn partial_c_clean_followup_removes_omitted_entities_and_restores_layout() {
+        let (_dir, blobs, graph, mut reconciler) = partial_fixture(PARTIAL_C);
+        let partial = partial_pass(
+            &mut reconciler,
+            &blobs,
+            &graph,
+            &PARTIAL_C.replace("value", "next"),
+        );
+        assert!(matches!(
+            partial.outcome,
+            ReconcileOutcome::PartiallyUpdated { .. }
+        ));
+        graph.apply_transaction_delta(&partial.delta).unwrap();
+        let clean = partial_pass(
+            &mut reconciler,
+            &blobs,
+            &graph,
+            "int good(void) { return 2; }\n",
+        );
+        assert!(
+            matches!(&clean.outcome, ReconcileOutcome::Updated { removed, .. } if removed.len() == 1)
+        );
+        graph.apply_transaction_delta(&clean.delta).unwrap();
+        let held = graph.list_all_entities().unwrap();
+        assert_eq!(held.len(), 1);
+        assert!(!held[0]
+            .metadata
+            .extra
+            .contains_key("partial_parse_admission"));
+        assert!(reconciler
+            .projection()
+            .get_layout(&FilePathId::new("test.c"))
+            .is_some());
+    }
 
     fn make_entity(name: &str, file: &str) -> Entity {
         Entity {

--- a/crates/kin-reconcile/src/reconciler.rs
+++ b/crates/kin-reconcile/src/reconciler.rs
@@ -958,6 +958,17 @@ impl Reconciler {
             }
         }
 
+        // An incomplete parse cannot establish that an unmatched declaration
+        // was deleted. Refuse before deriving removals or changing projection
+        // state; the entrypoint restores the tentative LKG updates on error.
+        if matches!(indexed.parse_state, ParseState::Incomplete { .. }) {
+            if existing.iter().any(|entity| !claimed.contains(&entity.id)) {
+                return Err(ReconcileError::IncompleteParseWouldDelete {
+                    file_id: file_id.clone(),
+                });
+            }
+        }
+
         // Entities that existed before but are no longer in the file -> removed.
         // Claiming as we go keeps one delta per entity even if graph truth
         // handed back the same entity twice, and walking `existing` rather than


### PR DESCRIPTION
An incomplete C parse can still contain independently verifiable declarations. Watcher reconciliation now refreshes uniquely matched declarations using whole-source and dependency evidence, preserves their identities, and retains declarations the parse cannot verify. Retained declarations and reference coverage continue to disclose the incomplete parse.

Commit verification reconstructs the same admission proof from repository source bytes. It permits unchanged imported declarations when the original incomplete source is restored, and publishes intermediate proof-source blobs when several watcher refreshes occur before one commit. Reopening the committed repository must reproduce the entire entity set, relation set and resolved tree.

The tests cover partial edits, ambiguous identities, retained caller coordinates, incomplete-coverage disclosure, refused unverified commit admission, restored original bytes and intermediate source publication. The recovered diagnostic expectations are updated to the current retained-parse wording. This supersedes draft #1601. The separate MCP mutation refusal is in #1606.

Validation:

```text
cargo test -p kin-daemon -p kin-reconcile -p kin-core -p kin-cli --lib -- partial_c a_semantically_neutral_c_rename the_diff_line_names_a_file one_pass_holds the_section_names_a_retained_file
kin-cli:       2 passed; 0 failed
kin-core:      3 passed; 0 failed
kin-daemon:    6 passed; 0 failed
kin-reconcile:12 passed; 0 failed
```

Fifteen mutations were applied individually, each tested with the relevant named regression using `cargo test -p kin-daemon -p kin-reconcile -p kin-core -p kin-cli --lib <test> -- --nocapture`. Each had to produce an actual failed test assertion; compiler errors were rejected as evidence. The unmutated baseline passed first, and every original file was restored exactly.

```text
unchanged_import_requires_proof KILLED rc 101
missing_proof_source_publication KILLED rc 101
whole_file_rejection KILLED rc 101
unverified_entity_admission KILLED rc 101
ambiguous_identity KILLED rc 101
unstable_identity KILLED rc 101
retained_call_coordinates KILLED rc 101
missing_commit_verification KILLED rc 101
unverified_call_coordinates KILLED rc 101
retained_caller_blocks_commit KILLED rc 101
silent_disclosure KILLED rc 101
partial_clears_coverage KILLED rc 101
duplicate_disclosure_rows KILLED rc 101
old_retained_diagnostic KILLED rc 101
old_coverage_diagnostic KILLED rc 101
All mutants killed; every original file explicitly restored.
```

The complete parser, index and reconcile crate suites also passed:

```text
cargo test -p kin-parser -p kin-index -p kin-reconcile --lib --jobs 2
kin-index:    374 passed; 0 failed
kin-parser:   341 passed; 0 failed
kin-reconcile: 90 passed; 0 failed
```

The broader commit suite and workflow precheck passed:

```text
cargo test -p kin-daemon -p kin-reconcile -p kin-core -p kin-cli --lib --jobs 2 repository_commit::tests
kin-daemon: 38 passed; 0 failed
kin-precheck: 21 gates ran, 21 passed, 0 failed
```

Own-byte dev parity finished PASS-WITH-ALLOWANCES in 765.8 seconds: magic 27 passed, brownfield 12 passed with one existing failure, and first-run 10 passed with one existing failure and one unreadable check. Existing allowances only: first-run check 9 daemon stop (FIR-2580), first-run check 3 unsupported doctor projection (FIR-2501, check FIR-2554), and brownfield check 4 truncated reference walk (FIR-2464, related FIR-2593). No allowances were added. This is DEV-LOCAL verification. This PR remains a draft pending CI and release sequencing. No release or production acceptance claim is made here.


Composition validation at `33ae7482b3805a200fe72752e43acc7192ad2e9e`: preceding query and integrity changes are composed. Focused regressions passed (42 daemon and 12 reconcile tests), including the actual HTTP response-budget route and incomplete MCP transaction. Every workflow-derived precheck gate passed.

```text
kin-precheck: 21 gates ran, 21 passed, 0 failed
kin-parity: PASS-WITH-ALLOWANCES in 888.7s
magic: 27 passed
```

The known brownfield allowance now reports the expected router edge absent from both the returned walk and witnessed clipped destinations; no broad reference-completeness claim follows. Full exact-head hosted checks are green. Landing still requires the actual predecessor and a prospective merge-tree identity check. Original mutation evidence above applies to unchanged fix logic; composed execution is recorded here separately.

The installed CLI/MCP workflow also passed on preserved development binaries: same-ID partial refresh, unchanged declaration ID set and retained entities, exact source, 25-error disclosure, and equality of all 46 entities, 58 relations and the resolved tree through commit and reopen. The verified v0.7.5 archive fails the refresh assertion while its tree receives the edited source. These establish baseline exposure and development behavior, not corrected archive delivery.
