### PR TITLE
Propagate change enumeration failures during bootstrap hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3295,9 +3295,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.107"
+version = "0.7.108"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "ea7a90f134f9c07260181b22f50ec86a24c7579c20636075c56ef9c992c255a3"
+checksum = "29b197a86e1dc49ec5271be85002a50bcb31992747a564f31655bb2655bbdd5d"
 dependencies = [
  "bincode",
  "bstr",
@@ -6684,7 +6684,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ kin-lsp = { version = "=0.7.18", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.107", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.108", registry = "kin", default-features = false }
 # Pinned to the exact version kin-db builds its name-token index with. A
 # per-token name query hits that index only when the token came out of the same
 # tokenizer, so a version skew here would be a silent recall loss rather than a

--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -3099,6 +3099,7 @@ mod tests {
             .snapshot()
             .changes
             .change_ids()
+            .unwrap()
             .into_iter()
             .map(|id| id.to_string())
             .collect::<Vec<_>>();

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -1764,7 +1764,10 @@ pub(crate) fn bootstrap_transaction_hash(
     match changes {
         None => transaction.transaction_hash(),
         Some(changes) => transaction.transaction_hash_with_changes(changes.len(), || {
-            Ok(changes.change_ids().into_iter().map(|id| {
+            let ids = changes
+                .change_ids()
+                .map_err(|error| kin_model::ModelError::InvalidOperation(error.to_string()))?;
+            Ok(ids.into_iter().map(|id| {
                 changes
                     .read_change(&id)
                     .map_err(|error| kin_model::ModelError::InvalidOperation(error.to_string()))?
@@ -5509,6 +5512,58 @@ mod tests {
             progress.detail_updates(),
             4,
             "an exact retry returns the existing bootstrap without reporting new work"
+        );
+    }
+
+    #[test]
+    fn streamed_bootstrap_hash_matches_owned_history() {
+        let directory = tempfile::tempdir().unwrap();
+        let (_prepared, mut owned) = prepare_unborn(directory.path(), "hash-identity");
+        let mut changes = kin_db::storage::ChangeMap::new();
+        let mut parent = None;
+        for index in 0..3 {
+            let mut change = SemanticChange {
+                id: SemanticChangeId::from_hash(Hash256::from_bytes([0; 32])),
+                parents: parent.into_iter().collect(),
+                timestamp: Timestamp::now(),
+                author: AuthorId::new("importer"),
+                message: format!("imported history {index}"),
+                entity_deltas: vec![],
+                relation_deltas: vec![],
+                tree_deltas: vec![],
+                projected_files: vec![],
+                spec_link: None,
+                evidence: vec![],
+                risk_summary: None,
+                origin: ChangeOrigin::Native,
+                admission_policy_delta: None,
+                external_reference_deltas: vec![],
+            };
+            change.id = compute_semantic_change_id(&change).unwrap();
+            parent = Some(change.id);
+            changes.append_change(change.clone()).unwrap();
+            owned.changes.push(change);
+        }
+        let expected = owned.transaction_hash().unwrap();
+        assert_eq!(bootstrap_transaction_hash(&owned, None).unwrap(), expected);
+        let mut streamed = owned.clone();
+        streamed.changes.clear();
+        for _ in 0..2 {
+            assert_eq!(
+                bootstrap_transaction_hash(&streamed, Some(&changes)).unwrap(),
+                expected
+            );
+        }
+        for change in &owned.changes {
+            assert_eq!(
+                changes.read_change(&change.id).unwrap().as_ref(),
+                Some(change)
+            );
+            kin_model::validate_semantic_change_id(change).unwrap();
+        }
+        assert_ne!(
+            bootstrap_transaction_hash(&streamed, None).unwrap(),
+            expected
         );
     }
 

--- a/crates/kin-daemon/src/storage_delegate.rs
+++ b/crates/kin-daemon/src/storage_delegate.rs
@@ -62,7 +62,7 @@ use kin_db::{
 /// `storage_backend_surface_is_audited_against_the_pinned_kin_db` fails when
 /// the workspace pin moves past it, which is the only moment a method can have
 /// appeared.
-pub const AUDITED_KIN_DB_VERSION: &str = "0.7.107";
+pub const AUDITED_KIN_DB_VERSION: &str = "0.7.108";
 
 /// Wraps a [`StorageBackendDelegate`] so it can be handed anywhere a
 /// `Box<dyn StorageBackend>` is expected.


### PR DESCRIPTION
Adopts kin-db 0.7.108, published from https://github.com/firelock-ai/kin-db/pull/307 (squash 92fe27750a150900b0493911b2d9e245e6408b2e, tag v0.7.108).

Propagate kin-db history-enumeration errors through bootstrap transaction hashing, and adopt the fallible API. A storage read or decode failure now returns an initialization error instead of being mistaken for an empty stream or unwinding. A nonempty-history control compares the streamed hash with the owned transaction hash and checks unchanged change values and semantic identities.

Two callers take the `Result`. `crates/kin-core/src/init.rs` is the production one and maps the error into `ModelError::InvalidOperation`. `crates/kin-core/src/git_init.rs` is a test that landed after this branch was opened, in "perf(core): avoid redundant bootstrap hash validation" (#1613), and unwraps.

The lock is resolved against the real published bytes, with no path patch committed:

```text
Updating kin-db v0.7.107 (registry `kin`) -> v0.7.108
lock version  = 0.7.108
lock source   = sparse+https://kinlab.ai/registry/cargo/
lock checksum = 29b197a86e1dc49ec5271be85002a50bcb31992747a564f31655bb2655bbdd5d
index checksum= 29b197a86e1dc49ec5271be85002a50bcb31992747a564f31655bb2655bbdd5d
external kin-* lock entries checked: 8, every one keeps a registry source and a checksum
```

The published crate was verified before locking, not taken from the publish workflow's summary. The `.crate` was downloaded (1005114 bytes), its sha256 matched the index checksum above, and the packaged `kin-db-0.7.108/src/storage/change_map.rs` carries the fallible `change_ids` signature and not the infallible one. The same verifier run against 0.7.107 reports the opposite and exits nonzero, so this is a result rather than a check that cannot fail.

Earlier local evidence, from the DEV-LOCAL pass against the exact storage source before publication:

```text
cargo test -p kin-core --lib
test result: ok. 880 passed; 0 failed; 1 ignored

cargo test -p kin-core --lib streamed_bootstrap_hash_matches_owned_history -- --nocapture
# Mutant: drop streamed history from bootstrap hashing
test result: FAILED. 0 passed; 1 failed
MUTANT KILLED rc=101
# Restored
test result: ok. 1 passed; 0 failed
```

Parity at that point finished PASS-WITH-ALLOWANCES and explicitly NON-CITABLE, with magic 27 pass, brownfield 12 pass and one allowed failure (FIR-2464/FIR-2593), and first-run 10 pass with one allowed failure (FIR-2580) and one allowed unreadable check (FIR-2501/FIR-2554). Those are existing trace-truncation, daemon-stop and doctor-projection gaps, not results of this change.

A second commit re-audits kin-daemon's `StorageBackend` bridge table, which pins itself to the kin-db version so a defaulted trait method cannot arrive unnoticed. Bumping the pin turned `storage_backend_surface_is_audited_against_the_pinned_kin_db` red, as designed. The table was audited rather than stamped: the published 0.7.107 and 0.7.108 crates were both downloaded and their `src/storage/backend.rs` is byte-identical, the trait declares exactly 33 methods, and all 33 are named in `storage_delegate.rs`. No row is missing, so only `AUDITED_KIN_DB_VERSION` moves.

Local gates, run through the shared heavy-slot wrapper:

```text
bin/kin-dev release-check kin
kin-dev:   kin-db  0.7.108  up-to-date (registry latest 0.7.108)
kin-dev: kin: RELEASE-CLEAN, resolves from registry with no local patches.
rc=0

cargo test -p kin-core -p kin-git
11 suites, 1028 passed, 0 failed, 6 ignored, none non-ok
  kin-core lib: test result: ok. 882 passed; 0 failed; 1 ignored
  kin-git:      test result: ok. 137 passed; 0 failed; 0 ignored

PATH=<Node20.20.2>/bin:$PATH bin/kin-precheck kin --repo-dir kin=<lane worktree>
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 330c344886f0401c6b44e04bf6399cba1a59b504
```

Node 20 is deliberate. Under the shell's newer Node, `test-release-workflow-authority.py` times out in a `node --check` guard and the run reports 20 of 21 gates, which reads like a failing gate rather than a toolchain mismatch. ci.yml's Node major is 20.

Refs FIR-3399.
