### PR TITLE
fix(cli): use IEC labels for binary byte counts

### DIFF
--- a/crates/kin-cli/src/commands/byte_fmt.rs
+++ b/crates/kin-cli/src/commands/byte_fmt.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Shared byte formatting for daemon memory diagnostics.
+
+/// Render a byte count the way daemon-memory diagnostics read it: whole
+/// mebibytes below a gibibyte, one decimal place at and above it.
+pub(super) fn human_bytes(bytes: u64) -> String {
+    const GIB: u64 = 1024 * 1024 * 1024;
+    const MIB: u64 = 1024 * 1024;
+    if bytes >= GIB {
+        format!("{:.1} GiB", bytes as f64 / GIB as f64)
+    } else {
+        format!("{} MiB", bytes / MIB)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sub_gib_values_are_whole_mebibytes() {
+        assert_eq!(human_bytes(0), "0 MiB");
+        assert_eq!(human_bytes(82 * 1024 * 1024), "82 MiB");
+    }
+
+    #[test]
+    fn gib_and_above_carry_one_decimal() {
+        assert_eq!(human_bytes(1024 * 1024 * 1024), "1.0 GiB");
+        assert_eq!(human_bytes(12 * 1024 * 1024 * 1024), "12.0 GiB");
+    }
+}

--- a/crates/kin-cli/src/commands/cache.rs
+++ b/crates/kin-cli/src/commands/cache.rs
@@ -36,10 +36,10 @@ use kin_db::embed::cache_admin::{
     self, AgeBucket, CacheStats, GcOptions, GcReport, SchemaVersionStats,
 };
 
-/// Render a byte count as a short human-readable string.
+/// Render a binary byte count with IEC unit labels.
 #[cfg(feature = "embeddings")]
 fn human_bytes(bytes: u64) -> String {
-    const UNITS: [&str; 6] = ["B", "KB", "MB", "GB", "TB", "PB"];
+    const UNITS: [&str; 6] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"];
     let mut value = bytes as f64;
     let mut unit = 0;
     while value >= 1024.0 && unit < UNITS.len() - 1 {
@@ -643,8 +643,8 @@ mod tests {
     #[test]
     fn human_bytes_formats_units() {
         assert_eq!(human_bytes(512), "512 B");
-        assert_eq!(human_bytes(1536), "1.5 KB");
-        assert_eq!(human_bytes(1024 * 1024 * 1024), "1.0 GB");
+        assert_eq!(human_bytes(1536), "1.5 KiB");
+        assert_eq!(human_bytes(1024 * 1024 * 1024), "1.0 GiB");
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/commit_progress.rs
+++ b/crates/kin-cli/src/commands/commit_progress.rs
@@ -20,6 +20,8 @@
 use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
+use super::byte_fmt::human_bytes;
+
 /// One phase line lifted out of the daemon log.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PhaseLine {
@@ -195,16 +197,6 @@ pub fn daemon_death_explanation(kin_root: &Path) -> Option<String> {
 /// loses a little time, while one that really was killed at 92% and is told
 /// nothing sends its user back to reading a socket error.
 const NEAR_CEILING_FRACTION: f64 = 0.90;
-
-fn human_bytes(bytes: u64) -> String {
-    const GIB: u64 = 1024 * 1024 * 1024;
-    const MIB: u64 = 1024 * 1024;
-    if bytes >= GIB {
-        format!("{:.1} GiB", bytes as f64 / GIB as f64)
-    } else {
-        format!("{} MiB", bytes / MIB)
-    }
-}
 
 /// What the daemon's own abandoned marker says about how the commit ended.
 ///

--- a/crates/kin-cli/src/commands/embed.rs
+++ b/crates/kin-cli/src/commands/embed.rs
@@ -4,6 +4,8 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
+use super::byte_fmt::human_bytes;
+
 /// Default embed command batch.
 ///
 /// The embedder already groups individual texts by token budget inside each
@@ -348,16 +350,6 @@ fn lost_the_daemon_mid_request(rendered: &str) -> bool {
     LOST_CONNECTION_MARKERS
         .iter()
         .any(|marker| rendered.contains(marker))
-}
-
-fn human_bytes(bytes: u64) -> String {
-    const GIB: u64 = 1024 * 1024 * 1024;
-    const MIB: u64 = 1024 * 1024;
-    if bytes >= GIB {
-        format!("{:.1} GiB", bytes as f64 / GIB as f64)
-    } else {
-        format!("{} MiB", bytes / MIB)
-    }
 }
 
 /// Guidance for an embed that lost the daemon under memory pressure, or `None`

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod bench;
 pub mod bench_meta;
 pub mod blame;
 pub mod branch;
+mod byte_fmt;
 pub mod cache;
 pub mod capabilities;
 pub mod checkout;


### PR DESCRIPTION
## What

Label binary cache sizes with IEC units and share the daemon memory formatter used by embed and commit progress.

## Why

Cache output divided by 1024 but called the result KB, MB and GB. The two daemon diagnostics duplicated the same MiB/GiB formatter.

Part of FIR-3400.

## How

Cache keeps its six-tier formatter with corrected unit labels. Embed and commit progress share the existing two-tier formatting behavior unchanged.

## Testing

`cargo test --locked -p kin-cli human_bytes`:

```text
test commands::cache::tests::human_bytes_formats_units ... ok
test result: ok. 1 passed; 0 failed
```

The two shared formatter tests passed. Restoring the incorrect cache KB label made the cache test fail with exit 101; restoring the correct label passed.

The combined implementation tree passed `bin/kin-precheck kin --repo-dir kin=<checkout>`: `21 gates ran, 21 passed, 0 failed`, including workflow clippy and both zero-file-search guards. Focused branches contain the same implementation bytes. DEV-LOCAL parity results: magic 27 passed; first-run PASS-WITH-ALLOWANCES (existing FIR-2580 and FIR-2501/FIR-2554); corrected brownfield rerun PASS-WITH-ALLOWANCES in 422.9 seconds (12 passed, one existing FIR-2464/FIR-2593 failure, zero unreadable). No allowance was added. The Express failure remains a real missing-edge finding under the existing allowance. These local results do not establish hosted CI, released-byte acceptance or production acceptance. Exact-head hosted CI completed without failures.

Falsification output, with each mutation restored afterward:

```text
cache-unit:
test commands::cache::tests::human_bytes_formats_units ... FAILED
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2283 filtered out; finished in 0.02s
shared-byte-labels:
test commands::byte_fmt::tests::gib_and_above_carry_one_decimal ... FAILED
test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 2282 filtered out; finished in 0.02s
```

Hosted verification at `2b86f1e52642e9483dc30a7796c9fe660212383b`: the complete set of 48 check runs and all associated workflows concluded without failures, including explicitly skipped and neutral checks. Product Acceptance is skipped on PRs and remains a main-branch gate. This draft remains held for release sequencing; no landing or released-byte acceptance is claimed.
