### PR TITLE
perf(git): use positioned history spool reads

### DIFF
--- a/crates/kin-core/env_var_allowlist.txt
+++ b/crates/kin-core/env_var_allowlist.txt
@@ -24,6 +24,9 @@ KIN_AGENT_TEST_KIN_BIN
 # KIN_GCS_ENDPOINT, which is registered.
 KIN_GCS_TEST_BUCKET
 KIN_GIT_TEST_NO_SYMLINK_PRIVILEGE
+# Read only by the ignored history-spool wall-time benchmark. This selects
+# a disposable measurement corpus; no product runtime reads it.
+KIN_SPOOL_BENCH_REPO
 # Read only by the admission memory tests' shared probe, to print a per-phase
 # live-heap line during a passing run. Recording is unconditional; this only
 # controls whether the run also narrates. No runtime behaviour keys on it and

--- a/crates/kin-git/src/history_spool.rs
+++ b/crates/kin-git/src/history_spool.rs
@@ -89,15 +89,11 @@ impl SemanticChangeSpool {
             return Ok(None);
         };
         let path = self.0.file.path();
-        // Keep pathname disappearance and replacement observable even though
-        // positioned reads use the original held file on Unix.
-        let metadata = std::fs::metadata(path).map_err(|error| GitError::io(path, error))?;
-        if metadata.len() != self.0.bytes {
-            return Err(invalid("history spool length changed"));
-        }
         #[cfg(unix)]
-        let file = {
+        let (file, metadata) = {
             use std::os::unix::fs::MetadataExt;
+            // Authenticate the pathname before reading from the held file.
+            let metadata = std::fs::metadata(path).map_err(|error| GitError::io(path, error))?;
             let held = self
                 .0
                 .file
@@ -107,7 +103,7 @@ impl SemanticChangeSpool {
             if (metadata.dev(), metadata.ino()) != (held.dev(), held.ino()) {
                 return Err(invalid("history spool file replaced"));
             }
-            self.0.file.as_file()
+            (self.0.file.as_file(), metadata)
         };
         #[cfg(windows)]
         let reopened = self
@@ -116,7 +112,15 @@ impl SemanticChangeSpool {
             .reopen()
             .map_err(|error| GitError::io(path, error))?;
         #[cfg(windows)]
-        let file = &reopened;
+        let (file, metadata) = (
+            &reopened,
+            reopened
+                .metadata()
+                .map_err(|error| GitError::io(path, error))?,
+        );
+        if metadata.len() != self.0.bytes {
+            return Err(invalid("history spool length changed"));
+        }
         let len = usize::try_from(record.len)
             .map_err(|_| invalid("record length exceeds address space"))?;
         let mut bytes = vec![0; len];

--- a/crates/kin-git/src/history_spool.rs
+++ b/crates/kin-git/src/history_spool.rs
@@ -4,7 +4,9 @@
 //! Private temporary storage for ordered import changes, verified on every read.
 
 use std::collections::BTreeMap;
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::Write;
+#[cfg(test)]
+use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -87,25 +89,38 @@ impl SemanticChangeSpool {
             return Ok(None);
         };
         let path = self.0.file.path();
-        let mut file = self
+        // Keep pathname disappearance and replacement observable even though
+        // positioned reads use the original held file on Unix.
+        let metadata = std::fs::metadata(path).map_err(|error| GitError::io(path, error))?;
+        if metadata.len() != self.0.bytes {
+            return Err(invalid("history spool length changed"));
+        }
+        #[cfg(unix)]
+        let file = {
+            use std::os::unix::fs::MetadataExt;
+            let held = self
+                .0
+                .file
+                .as_file()
+                .metadata()
+                .map_err(|error| GitError::io(path, error))?;
+            if (metadata.dev(), metadata.ino()) != (held.dev(), held.ino()) {
+                return Err(invalid("history spool file replaced"));
+            }
+            self.0.file.as_file()
+        };
+        #[cfg(windows)]
+        let reopened = self
             .0
             .file
             .reopen()
             .map_err(|error| GitError::io(path, error))?;
-        if file
-            .metadata()
-            .map_err(|error| GitError::io(path, error))?
-            .len()
-            != self.0.bytes
-        {
-            return Err(invalid("history spool length changed"));
-        }
-        file.seek(SeekFrom::Start(record.offset))
-            .map_err(|error| GitError::io(path, error))?;
+        #[cfg(windows)]
+        let file = &reopened;
         let len = usize::try_from(record.len)
             .map_err(|_| invalid("record length exceeds address space"))?;
         let mut bytes = vec![0; len];
-        file.read_exact(&mut bytes)
+        read_at_offset(file, &mut bytes, record.offset)
             .map_err(|error| GitError::io(path, error))?;
         let digest: [u8; 32] = Sha256::digest(&bytes).into();
         if digest != record.digest {
@@ -133,6 +148,33 @@ impl SemanticChangeSpool {
         }
         writer.finish()
     }
+}
+
+/// Read one record without sharing a seek cursor between concurrent readers.
+#[cfg(unix)]
+fn read_at_offset(file: &std::fs::File, buffer: &mut [u8], offset: u64) -> std::io::Result<()> {
+    use std::os::unix::fs::FileExt;
+    file.read_exact_at(buffer, offset)
+}
+
+#[cfg(windows)]
+fn read_at_offset(file: &std::fs::File, buffer: &mut [u8], offset: u64) -> std::io::Result<()> {
+    use std::os::windows::fs::FileExt;
+    let mut filled = 0usize;
+    while filled < buffer.len() {
+        let read = match file.seek_read(&mut buffer[filled..], offset + filled as u64) {
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            result => result?,
+        };
+        if read == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "history spool record ended before its recorded length",
+            ));
+        }
+        filled += read;
+    }
+    Ok(())
 }
 
 pub(crate) struct SemanticChangeSpoolWriter(Storage);
@@ -226,8 +268,8 @@ mod tests {
     /// One spool directory for this module's cases, alive for the whole binary.
     ///
     /// A `TempDir` bound to the call would be removed the moment the statement
-    /// ended, and `read_at` reopens the spool by path, so every later read
-    /// would fail on a directory that is no longer there.
+    /// ended, and `read_at` stats the spool by path on every call, so every
+    /// later read would fail on a directory that is no longer there.
     fn spool_dir() -> &'static Path {
         static DIR: std::sync::OnceLock<tempfile::TempDir> = std::sync::OnceLock::new();
         DIR.get_or_init(|| tempfile::tempdir().unwrap()).path()
@@ -311,6 +353,44 @@ mod tests {
         );
         assert_eq!(spool.read_at(2).unwrap(), None);
         assert_eq!(spool.read_by_id(&change(3).id).unwrap(), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn spool_refuses_same_length_path_replacement() {
+        let directory = tempfile::tempdir().unwrap();
+        let spool = SemanticChangeSpool::from_changes(directory.path(), [change(1)]).unwrap();
+        assert_eq!(spool.read_at(0).unwrap(), Some(change(1)));
+        let path = spool.0.file.path();
+        let replacement = directory.path().join("replacement");
+        std::fs::copy(path, &replacement).unwrap();
+        std::fs::rename(replacement, path).unwrap();
+        assert_eq!(std::fs::metadata(path).unwrap().len(), spool.0.bytes);
+        assert!(
+            spool.read_at(0).is_err(),
+            "a replacement cannot authenticate the held file"
+        );
+    }
+
+    #[test]
+    fn spool_clones_read_independent_offsets_concurrently() {
+        let records = (1..=16).map(change).collect::<Vec<_>>();
+        let spool = SemanticChangeSpool::from_changes(spool_dir(), records.clone()).unwrap();
+        std::thread::scope(|scope| {
+            for worker in 0..4 {
+                let spool = spool.clone();
+                let records = &records;
+                scope.spawn(move || {
+                    for round in 0..64 {
+                        let index = (round * 7 + worker) % records.len();
+                        assert_eq!(
+                            spool.read_at(index).unwrap().as_ref(),
+                            Some(&records[index])
+                        );
+                    }
+                });
+            }
+        });
     }
 
     #[test]

--- a/crates/kin-git/tests/history_spool_wall_time.rs
+++ b/crates/kin-git/tests/history_spool_wall_time.rs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Wall time to read every record out of a [`SemanticChangeSpool`] sized and
+//! named after this repository's own commit history.
+//!
+//! Measures indexed reads of synthetic records carrying real commit IDs and
+//! subjects. Tree and semantic deltas are empty, so this isolates spool read
+//! overhead rather than measuring a full repository conversion.
+//!
+//! ```text
+//! KIN_SPOOL_BENCH_REPO=/path/to/kin cargo test --release -p kin-git \
+//!     --test history_spool_wall_time -- --ignored --nocapture
+//! ```
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Instant;
+
+use chrono::DateTime;
+use kin_git::SemanticChangeSpool;
+use kin_model::{
+    AuthorId, ChangeOrigin, GitObjectId, Hash256, SemanticChange, SemanticChangeId, Timestamp,
+};
+use sha2::{Digest, Sha256};
+
+/// A synthetic record carrying a real commit ID and subject, with empty deltas.
+fn change_for_commit(oid_hex: &str, subject: &str) -> SemanticChange {
+    let oid_vec = hex::decode(oid_hex).expect("git log %H must be valid hex");
+    let oid_bytes: [u8; 20] = oid_vec
+        .try_into()
+        .expect("this repository's commit oids must be 20-byte sha1");
+    let id_hash: [u8; 32] = Sha256::digest(oid_hex.as_bytes()).into();
+    SemanticChange {
+        id: SemanticChangeId::from_hash(Hash256::from_bytes(id_hash)),
+        origin: ChangeOrigin::GitCommit {
+            oid: GitObjectId::sha1(oid_bytes),
+        },
+        parents: Vec::new(),
+        timestamp: Timestamp::from(DateTime::from_timestamp(0, 0).unwrap()),
+        author: AuthorId::new("history-spool-wall-time"),
+        message: subject.to_string(),
+        entity_deltas: Vec::new(),
+        relation_deltas: Vec::new(),
+        tree_deltas: Vec::new(),
+        admission_policy_delta: None,
+        projected_files: Vec::new(),
+        spec_link: None,
+        evidence: Vec::new(),
+        risk_summary: None,
+        external_reference_deltas: Vec::new(),
+    }
+}
+
+/// `(oid, subject)` for every commit reachable from HEAD, oldest first.
+fn real_commits(repo: &std::path::Path) -> Vec<(String, String)> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["log", "--format=%H %s", "--reverse", "HEAD"])
+        .output()
+        .expect("git log must start");
+    assert!(
+        output.status.success(),
+        "git log failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("git log output must be UTF-8")
+        .lines()
+        .map(|line| {
+            let (oid, subject) = line
+                .split_once(' ')
+                .expect("git log emitted an ID and subject");
+            (oid.to_string(), subject.to_string())
+        })
+        .collect()
+}
+
+#[test]
+#[ignore = "reads a real repository named by KIN_SPOOL_BENCH_REPO and takes real wall time to be worth measuring"]
+fn read_at_wall_time_across_kins_own_history() {
+    let Some(repo) = std::env::var_os("KIN_SPOOL_BENCH_REPO") else {
+        panic!("KIN_SPOOL_BENCH_REPO must name a non-shallow Git clone to read commits from");
+    };
+    let repo = PathBuf::from(repo);
+    let commits = real_commits(&repo);
+    assert!(
+        !commits.is_empty(),
+        "{repo:?} produced no commits from `git log`"
+    );
+    let count = commits.len();
+
+    let changes: Vec<SemanticChange> = commits
+        .iter()
+        .map(|(oid, subject)| change_for_commit(oid, subject))
+        .collect();
+
+    let directory = tempfile::tempdir().expect("scratch spool directory");
+    let spool = SemanticChangeSpool::from_changes(directory.path(), changes)
+        .expect("build a spool from every real commit");
+
+    let started = Instant::now();
+    let mut read_count = 0usize;
+    for record in spool.iter() {
+        record.expect("read every spooled record");
+        read_count += 1;
+    }
+    let elapsed = started.elapsed();
+
+    assert_eq!(read_count, count);
+    println!(
+        "read_at: {count} records from {repo:?} in {:.3}s ({:.1} us/record)",
+        elapsed.as_secs_f64(),
+        elapsed.as_secs_f64() * 1_000_000.0 / count as f64,
+    );
+}

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -1103,14 +1103,22 @@
     },
     {
       "file": "crates/kin-git/src/history_spool.rs",
-      "reason": "Temporary Git ingestion storage, not a semantic answer path. The import owns this temporary file and appends only captured semantic change records. Each read checks the exact file length, record checksum and identity before admission. These single-occurrence pins cover the temporary-file type, its construction in the directory the caller owns, and the length probe only; they permit no repository walk, raw-file search or answer fallback. The construction pin moved from NamedTempFile::new() to tempfile_in on 2026-09-08: the default temporary directory is tmpfs on most Linux hosts, which put the spooled history back in RAM and defeated the whole point of spooling it, so the caller now names the directory.",
+      "reason": "Temporary Git ingestion storage, not a semantic answer path. The import owns this temporary file and appends only captured semantic change records. Reads verify pathname identity, file length, record checksum and record identity before admission. Exact occurrence-counted pins cover the temporary-file type and construction, the pathname and held-descriptor metadata checks, and platform-specific file traits and parameters for positioned reads. Function bodies remain scanned: these pins permit no repository walk, raw-file search or answer fallback. The caller chooses the spool directory so the history is not silently placed on a RAM-backed temporary filesystem.",
       "owner": "kin-git",
       "expiration": "2027-03-31",
       "allow_match": [
         "use tempfile::NamedTempFile;",
         "file: NamedTempFile,",
         ".tempfile_in(directory)",
-        ".metadata()"
+        ".metadata()",
+        "std::fs::metadata(path)",
+        "use std::os::unix::fs::MetadataExt;",
+        {
+          "expr": "file: &std::fs::File",
+          "count": 2
+        },
+        "use std::os::unix::fs::FileExt;",
+        "use std::os::windows::fs::FileExt;"
       ]
     },
     {

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -1103,14 +1103,17 @@
     },
     {
       "file": "crates/kin-git/src/history_spool.rs",
-      "reason": "Temporary Git ingestion storage, not a semantic answer path. The import owns this temporary file and appends only captured semantic change records. Reads verify pathname identity, file length, record checksum and record identity before admission. Exact occurrence-counted pins cover the temporary-file type and construction, the pathname and held-descriptor metadata checks, and platform-specific file traits and parameters for positioned reads. Function bodies remain scanned: these pins permit no repository walk, raw-file search or answer fallback. The caller chooses the spool directory so the history is not silently placed on a RAM-backed temporary filesystem.",
+      "reason": "Temporary Git ingestion storage, not a semantic answer path. The import owns this temporary file and appends only captured semantic change records. Reads authenticate pathname identity on Unix and reopen the retained authenticated handle on Windows, then verify file length, record checksum and record identity before admission. Exact occurrence-counted pins cover the temporary-file type and construction, the pathname and held-descriptor metadata checks, and platform-specific file traits and parameters for positioned reads. Function bodies remain scanned: these pins permit no repository walk, raw-file search or answer fallback. The caller chooses the spool directory so the history is not silently placed on a RAM-backed temporary filesystem.",
       "owner": "kin-git",
       "expiration": "2027-03-31",
       "allow_match": [
         "use tempfile::NamedTempFile;",
         "file: NamedTempFile,",
         ".tempfile_in(directory)",
-        ".metadata()",
+        {
+          "expr": ".metadata()",
+          "count": 2
+        },
         "std::fs::metadata(path)",
         "use std::os::unix::fs::MetadataExt;",
         {


### PR DESCRIPTION
## What

Read history spool records through a held Unix file descriptor with positioned reads, while preserving file identity, length, checksum and record identity checks.

## Why

Every indexed record read reopened and sought the same temporary file. This overhead repeats across history traversals.

Part of FIR-3400.

## How

Unix checks the path's device/inode against the held file before reading. This keeps same-length replacement detectable, which a length-only path check misses. Windows retains authenticated reopen, checks length through the reopened handle rather than the removed pathname, and uses a positioned read loop with interrupted-read handling. Its platform regression must read the exact original record after unlink and then reject truncation through the retained handle, matching the contract established in #1618. Concurrent readers do not share a seek cursor. New ingestion I/O sites are declared with exact occurrence-counted guard pins; function bodies remain scanned. A forbidden read on the same line as an allowed expression and a duplicate allowed expression were both rejected by the verifier.

## Testing

`cargo test --locked -p kin-git --lib`:

```text
test result: ok. 136 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 19.18s
```

The replacement guard failed when the inode comparison was disabled. The concurrent-read guard failed when reads always used offset zero. Both mutations were restored.

The paired benchmark uses synthetic records carrying real commit IDs and subjects, with empty deltas. It measures spool read overhead, not full-conversion speed. Five release-profile runs per arm over 2,937 records gave 20.0, 23.8, 23.4, 21.9, 20.9 microseconds/record before and 4.3, 4.8, 5.1, 4.3, 4.4 after. Medians were 21.9 and 4.4 microseconds/record. The corpus was pinned at e9ebaa1184517ca5fc23a78f100901087f2a38d2. All ten runs passed. The combined implementation tree passed `bin/kin-precheck kin --repo-dir kin=<checkout>`: `21 gates ran, 21 passed, 0 failed`, including workflow clippy and both zero-file-search guards. These measurements and parity results cover the original implementation before the later Windows handle-metadata correction. DEV-LOCAL parity results: magic 27 passed; first-run PASS-WITH-ALLOWANCES (existing FIR-2580 and FIR-2501/FIR-2554); corrected brownfield rerun PASS-WITH-ALLOWANCES in 422.9 seconds (12 passed, one existing FIR-2464/FIR-2593 failure, zero unreadable). No allowance was added. The Express failure remains a real missing-edge finding under the existing allowance. These local results do not establish hosted CI, released-byte acceptance or production acceptance. The original published head passed hosted CI; the follow-up requires its own exact-head results.

Falsification output, with each mutation restored afterward:

```text
spool-replacement:
test history_spool::tests::spool_refuses_same_length_path_replacement ... FAILED
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 135 filtered out; finished in 0.00s
spool-offset:
test history_spool::tests::spool_clones_read_independent_offsets_concurrently ... FAILED
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 135 filtered out; finished in 0.01s
```

The ignored measurement input is declared in the exact test-only environment allowlist; the production registry and completeness scanner are unchanged. Hosted CI first exposed the missing spool declaration. The actual failing test was rerun locally after correction: `cargo test --locked -p kin-core --lib env_registry::tests::every_kin_env_read_in_workspace_is_registered -- --exact` returned `1 passed; 0 failed; 880 filtered out` in 0.12 seconds. Hosted CI graded this follow-up head.

At 2026-09-08T21:09:57.874380+00:00, all 47 check runs and associated workflows on `00af0638e7b158660eb0eb92198b92a90ada2205` had concluded without failure. Skipped and neutral checks are included; Product Acceptance remains a main-branch gate. The draft remains held for release sequencing.

The Windows follow-up carries #1618's platform-specific tests and moves pathname metadata into the Unix branch. Windows obtains length from its authenticated reopened file. The additional handle metadata read is pinned as exactly two `.metadata()` occurrences in the ingestion allowlist; function bodies remain scanned. `cargo test --locked -p kin-git --lib` on this owned follow-up tree returned `137 passed; 0 failed` in 16.31 seconds. Fresh worktree precheck returned `21 gates ran, 21 passed, 0 failed`, including workflow clippy and the occurrence-counted ingestion guards. At 2026-09-08T22:29:25Z, all 47 check runs and associated workflows for follow-up head `68f961c78de3ab89e6f15064f7a665376c2385b3` had concluded without failures, including the Windows cross-check and Rust CodeQL. Native authority and Product Acceptance jobs remain main-branch gates. This draft remains held for release sequencing, and its native Windows runtime change still requires main acceptance after its eventual landing.
