### PR TITLE
perf(core): avoid redundant bootstrap hash validation

### DIFF
--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -544,11 +544,8 @@ fn init_from_git_with_hooks(
         (transaction, changes)
     };
 
-    progress.begin("validate bootstrap transaction");
-    {
-        let _span = info_span!("kin.init.validate_bootstrap_transaction").entered();
-        crate::init::bootstrap_transaction_hash(&transaction, Some(&changes))?;
-    }
+    #[cfg(test)]
+    tests::capture_bootstrap_identity(&transaction, &changes, sealed_observation.fingerprint);
 
     progress.begin("commit bootstrap transaction");
     {
@@ -3049,5 +3046,112 @@ mod tests {
                 "{door} left no file at the path the reader looks in"
             );
         }
+    }
+
+    type BootstrapIdentity = (kin_model::Hash256, kin_model::Hash256);
+
+    thread_local! {
+        static BOOTSTRAP_IDENTITY: std::cell::RefCell<Option<Option<BootstrapIdentity>>> = const { std::cell::RefCell::new(None) };
+    }
+
+    pub(super) fn capture_bootstrap_identity(
+        transaction: &kin_model::RepositoryTransaction,
+        changes: &kin_db::storage::ChangeMap,
+        seal: kin_model::Hash256,
+    ) {
+        BOOTSTRAP_IDENTITY.with(|slot| {
+            if slot.borrow().is_some() {
+                let hash =
+                    crate::init::bootstrap_transaction_hash(transaction, Some(changes)).unwrap();
+                *slot.borrow_mut() = Some(Some((hash, seal)));
+            }
+        });
+    }
+
+    /// Imported changes and the content seal are stable for a pinned repository
+    /// and Git history. The transaction also binds freshly minted workspace and
+    /// operation identities, so its receipt is compared to the pre-commit input.
+    #[test]
+    fn removing_the_discarded_validation_pass_does_not_move_admitted_identity() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        std::fs::create_dir(&source).unwrap();
+        initialize_git(&source);
+        std::fs::write(source.join("a.txt"), b"first\n").unwrap();
+        commit_all_at(&source, "first", "2030-01-01T00:00:00 +0000");
+        std::fs::write(source.join("a.txt"), b"second\n").unwrap();
+        commit_all_at(&source, "second", "2030-01-02T00:00:00 +0000");
+        git(&source, ["checkout", "-b", "side", "HEAD~1"]);
+        std::fs::write(source.join("side.bin"), [0, 255, 17]).unwrap();
+        commit_all_at(&source, "side", "2030-01-03T00:00:00 +0000");
+        git(&source, ["checkout", "main"]);
+        let repository = RepositoryId::new("bootstrap-identity-fixture".to_string()).unwrap();
+        BOOTSTRAP_IDENTITY.with(|slot| *slot.borrow_mut() = Some(None));
+        let result = init_from_git_adopting(&source, &repository);
+        let captured = BOOTSTRAP_IDENTITY.with(|slot| slot.borrow_mut().take());
+        let result = result.unwrap();
+        let (transaction_hash, seal) = captured.flatten().expect("pre-commit identity captured");
+        assert_eq!(result.authority.receipt.transaction_hash, transaction_hash);
+        let binding = crate::LocalRepositoryAuthorityBinding::from_layout(&result.layout).unwrap();
+        let manager = binding.open_manager().unwrap();
+        let lease = manager.read_authority();
+        let mut ids = lease
+            .snapshot()
+            .changes
+            .change_ids()
+            .into_iter()
+            .map(|id| id.to_string())
+            .collect::<Vec<_>>();
+        ids.sort();
+        assert_eq!(
+            ids.len(),
+            3,
+            "include history reachable only through the side branch"
+        );
+        println!(
+            "IDENTITY initial {}",
+            result.authority.initial_change_id.unwrap()
+        );
+        println!("IDENTITY seal {seal}");
+        println!("IDENTITY changes {ids:?}");
+        assert_eq!(
+            seal.to_string(),
+            "9a9c56b8193d5bffdd4f5a8488a345b2624feb1c5d9376aab21717134d796ff1"
+        );
+        assert_eq!(
+            result.authority.initial_change_id.unwrap().to_string(),
+            "2f5b60b25a36cba3a9b10022fc006ff01f8481de7b342886a7e23c5e26339b37"
+        );
+        assert_eq!(
+            ids,
+            [
+                "2f5b60b25a36cba3a9b10022fc006ff01f8481de7b342886a7e23c5e26339b37",
+                "7df071acd75aa91c22fcd0517200af76b97e256b31d7e27a12aa6bacece5a7bb",
+                "8b41366e341722bf4257ce4456fc5e38368c24e049625b9a3d99c0766095322a",
+            ]
+        );
+    }
+
+    fn commit_all_at(repository: &Path, message: &str, stamp: &str) {
+        let output = fixture_git(repository)
+            .args(["add", "--all"])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git add --all failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let output = fixture_git(repository)
+            .args(["commit", "-m", message])
+            .author_date(stamp)
+            .committer_date(stamp)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git commit failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 }

--- a/crates/kin-core/src/init_progress.rs
+++ b/crates/kin-core/src/init_progress.rs
@@ -26,7 +26,7 @@ use crate::init_attempt::InitAttemptJournal;
 /// Number of phases in the exact Git admission ladder. A ladder that completes
 /// on a different count than this is a drift bug that would print `[16/15]` to
 /// a user, so [`PhaseProgress::finish`] asserts the two agree.
-pub(crate) const GIT_ADMISSION_PHASES: usize = 17;
+pub(crate) const GIT_ADMISSION_PHASES: usize = 16;
 
 /// Erase the current line and return to column zero. Only ever written to a
 /// terminal, so a redirected log never receives escape bytes.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -246,13 +246,13 @@ memory while it runs.
 while that happens:
 
 ```
-  [ 1/17] check admission blockers 0.2s
-  [ 2/17] capture Git repository 1.4s
-  [ 3/17] build Git authority 0.2s
-  [ 4/17] plan semantic import 3.1s
-  [ 5/17] derive semantic history 41.7s
+  [ 1/16] check admission blockers 0.2s
+  [ 2/16] capture Git repository 1.4s
+  [ 3/16] build Git authority 0.2s
+  [ 4/16] plan semantic import 3.1s
+  [ 5/16] derive semantic history 41.7s
   ...
-  [17/17] seal published content 12.9s
+  [16/16] seal published content 12.9s
   admitted exact Git repository in 118.3s
 ```
 

--- a/scripts/acceptance/brownfield_repro.py
+++ b/scripts/acceptance/brownfield_repro.py
@@ -1722,7 +1722,7 @@ RESCUE_FIXTURE_COMMITS = 240
 # would not exercise what the fix reclaims.
 RESCUE_KILL_AT_PHASE = 8
 
-RESCUE_PHASE_LINE = re.compile(r"\[\s*(\d+)/17\]")
+RESCUE_PHASE_LINE = re.compile(r"\[\s*(\d+)/16\]")
 
 # What init stages beside the repository, and what a clean disk has none of.
 RESCUE_STAGING_PREFIXES = (".kin.init-", ".kin-git-capture-")
@@ -1867,7 +1867,7 @@ def check_9(suite):
         res.unknown("the kill left no staging behind, so there is nothing for "
                     "a post-mortem to be about")
         return res
-    res.note("killed at phase %d of 17, rc %s, %d staging path(s) stranded: %s"
+    res.note("killed at phase %d of 16, rc %s, %d staging path(s) stranded: %s"
              % (reached, rc, len(stranded),
                 ", ".join(os.path.basename(path) for path in stranded)))
 
@@ -1877,7 +1877,7 @@ def check_9(suite):
     doctor_text = doctor_out + doctor_err
     row = [line for line in doctor_text.splitlines()
            if "Interrupted conversion" in line]
-    phase_in_doctor = re.search(r"phase (\d+) of 17", doctor_text)
+    phase_in_doctor = re.search(r"phase (\d+) of 16", doctor_text)
     if not row:
         res.bad("`kin doctor` after the kill carries no interrupted-conversion "
                 "row, so nothing names the %d staging path(s) left behind"
@@ -1890,7 +1890,7 @@ def check_9(suite):
                 "at phase %d" % (phase_in_doctor.group(1),
                                  RESCUE_KILL_AT_PHASE))
     else:
-        res.ok("`kin doctor` names the kill at phase %s of 17: %s"
+        res.ok("`kin doctor` names the kill at phase %s of 16: %s"
                % (phase_in_doctor.group(1), row[0].strip()[:160]))
 
     # A diagnostic that deletes is one an operator learns not to run, so the
@@ -1913,7 +1913,7 @@ def check_9(suite):
     rerun_text = read_text(rerun_log)
     said_unfinished = "did not finish" in rerun_text
     said_disposition = re.search(r"\b(restarts|resumes|resuming)\b", rerun_text)
-    phase_in_rerun = re.search(r"phase (\d+) of 17", rerun_text)
+    phase_in_rerun = re.search(r"phase (\d+) of 16", rerun_text)
     if not said_unfinished:
         res.bad("the re-run says nothing about the conversion that did not "
                 "finish, so an operator repeats eleven minutes with no idea "
@@ -1926,7 +1926,7 @@ def check_9(suite):
                 "it resumes from it or starts over, which is the one thing an "
                 "operator has to know before waiting again")
     else:
-        res.ok("the re-run names phase %s of 17 and says it %s"
+        res.ok("the re-run names phase %s of 16 and says it %s"
                % (phase_in_rerun.group(1), said_disposition.group(1)))
 
     # ARM 3. Nothing is orphaned silently.


### PR DESCRIPTION
## What

Remove the discarded bootstrap transaction hash pass before commit validation and reduce the admission progress ladder from 17 phases to 16, including the interruption acceptance parser.

## Why

The commit path validates and hashes the same transaction before persistence. The earlier full-history traversal discards its hash without adding validation coverage.

Part of FIR-3400.

## How

Commit validation and staged/published content seals remain intact. A three-commit fixture includes history reachable only through a side branch. Its full change IDs and content seal were captured and verified with the old pass intact, then checked unchanged after removal. The receipt is compared with the same pre-commit transaction input because workspace and operation identities are freshly minted. That probe is test-only and active only for this fixture.

## Testing

`cargo test --locked -p kin-core --lib git_init::tests -- --test-threads=2`:

```text
test result: ok. 29 passed; 0 failed; 0 ignored; 0 measured; 852 filtered out; finished in 31.14s
```

Dropping side-branch history made the golden guard fail; the restored fixture passed. Setting the returned initial change to None and retaining an incorrect phase count both failed the guard. The admission ladder coverage integration test passed (one test, 25.54 seconds). The combined implementation tree passed `bin/kin-precheck kin --repo-dir kin=<checkout>`: `21 gates ran, 21 passed, 0 failed`, including workflow clippy and both zero-file-search guards. Focused branches contain the same implementation bytes. DEV-LOCAL parity results: magic 27 passed; first-run PASS-WITH-ALLOWANCES (existing FIR-2580 and FIR-2501/FIR-2554); corrected brownfield rerun PASS-WITH-ALLOWANCES in 422.9 seconds (12 passed, one existing FIR-2464/FIR-2593 failure, zero unreadable). No allowance was added. The Express failure remains a real missing-edge finding under the existing allowance. These local results do not establish hosted CI, released-byte acceptance or production acceptance. Exact-head hosted CI completed without failures.

The old real Kin profile spent 93.6 seconds in the removed phase. That is measured baseline cost, not a measured end-to-end speedup of this change.

Falsification output, with each mutation restored afterward:

```text
bootstrap-history:
test git_init::tests::removing_the_discarded_validation_pass_does_not_move_admitted_identity ... FAILED
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 880 filtered out; finished in 1.37s
bootstrap-initial:
test git_init::tests::removing_the_discarded_validation_pass_does_not_move_admitted_identity ... FAILED
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 880 filtered out; finished in 1.65s
bootstrap-phases:
test git_init::tests::removing_the_discarded_validation_pass_does_not_move_admitted_identity ... FAILED
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 880 filtered out; finished in 1.77s
```

The old interruption parser observed zero phases against the new 16-phase binary, making check 9 unreadable. The corrected strict 16-phase parser passed a real kill/restart (`--only 9`): `2 pass, 0 fail, 0 unreadable`, including cleanup. The brownfield script self-test also passed.

Hosted verification at `53276c4501f0c934150394d3404a451cca20c931`: the complete set of 47 check runs and all associated workflows concluded without failures, including explicitly skipped and neutral checks. Product Acceptance is skipped on PRs and remains a main-branch gate. This draft remains held for release sequencing; no landing or released-byte acceptance is claimed.
