### PR TITLE
test(core): add real repository heap profiling

### DIFF
--- a/crates/kin-core/env_var_allowlist.txt
+++ b/crates/kin-core/env_var_allowlist.txt
@@ -34,6 +34,9 @@ KIN_HEAP_PHASES
 # and no runtime behaviour keys on it. It exists because the synthetic fixtures
 # price a shape rather than a repository.
 KIN_HEAP_REPO
+# Read only by the ignored real-repository admission heap profile. This selects
+# a disposable measurement corpus; no product runtime reads it.
+KIN_HEAP_PROFILE_REPO
 # Size and target the FIR-2729 increment-2 scale measurement, which is #[ignore]d
 # and reports rather than asserting a ceiling. REPO names a real Git worktree to
 # clone and admit, and COMMITS and STEPS size the synthetic arm it falls back to.

--- a/crates/kin-core/tests/init_real_repository_heap_profile.rs
+++ b/crates/kin-core/tests/init_real_repository_heap_profile.rs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Live-heap profile of admitting a real repository through the library API.
+//!
+//! Uses the deep-history guard's `support::Counting` allocator and
+//! `PhaseHeapLayer` to measure outstanding allocations, peak growth and retained
+//! heap. The subject is a disposable repository named by [`REPO_ENV`]. Survey
+//! counts let the caller compare measured demand with history bytes and commits.
+//!
+//! Run under `/usr/bin/time -l` on macOS to capture whole-process maximum RSS
+//! alongside these live-heap columns. RSS includes allocator-retained pages and
+//! other resident memory; the admission live-heap column subtracts its baseline.
+//!
+//! Allocator scope matters for budget calibration: `support::Counting` delegates
+//! to `std::alloc::System`, while the shipped CLI and daemon use mimalloc. The
+//! RSS measurement describes this instrument and needs an allocator-matched
+//! measurement before it can justify a production budget coefficient. The
+//! in-process authority reopen also does not measure a fresh daemon's memory.
+//!
+//! Admission writes `.kin` into the repository it admits and refuses a
+//! repository that already has one, so give this a throwaway copy per run.
+//!
+//! This binary installs a counting global allocator and holds exactly one test.
+
+mod support;
+
+use std::path::PathBuf;
+
+#[global_allocator]
+static ALLOC: support::Counting = support::Counting;
+
+/// The repository to admit.
+const REPO_ENV: &str = "KIN_HEAP_PROFILE_REPO";
+
+/// Ignored in every sweep, because without [`REPO_ENV`] there is no subject.
+///
+/// ```text
+/// KIN_HEAP_PROFILE_REPO=/path/to/a/throwaway/clone \
+///   cargo test --release -p kin-core --test init_real_repository_heap_profile \
+///     -- --ignored --nocapture
+/// ```
+#[test]
+#[ignore = "profiles a named real repository; the calibration driver runs it"]
+fn profiling_what_admitting_a_real_repository_holds() {
+    let raw = std::env::var_os(REPO_ENV)
+        .unwrap_or_else(|| panic!("set {REPO_ENV} to the repository to profile"));
+    let repo = PathBuf::from(&raw)
+        .canonicalize()
+        .unwrap_or_else(|error| panic!("{REPO_ENV}={raw:?} does not resolve: {error}"));
+
+    // Surveyed before the counters are reset, so the survey's own allocation is
+    // not charged to the conversion. This is the same function the budget calls,
+    // so the numbers the coefficients are divided by are the numbers a refusal
+    // would have been computed from rather than a second count of the same repo.
+    let survey = kin_core::init_budget::survey_history(&repo)
+        .unwrap_or_else(|reason| panic!("survey {}: {reason}", repo.display()));
+
+    support::install_phase_layer();
+    support::reset_peak();
+    let baseline = support::live();
+    let started = std::time::Instant::now();
+
+    let initialized = kin_core::init_from_git(&repo)
+        .unwrap_or_else(|error| panic!("admit the repository: {error}"));
+
+    let admission_peak = support::peak().saturating_sub(baseline);
+    let admission_elapsed = started.elapsed();
+    let phase_table = support::phase_attribution_table();
+
+    // Measure in-process authority reopening separately from admission to expose
+    // lazy materialization and retained heap. This is not fresh-daemon RSS and
+    // cannot by itself calibrate DAEMON_BYTES_PER_COMMIT.
+    let before_open = support::live();
+    support::reset_peak();
+    let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&initialized.layout)
+        .expect("bind the initialized repository");
+    let manager = binding
+        .open_manager()
+        .expect("open the repository authority");
+    let authority = manager.read_authority();
+    let changes = &authority.snapshot().changes;
+    let change_count = changes.len();
+    let decoded_on_open = changes.is_decoded();
+    let open_peak = support::peak().saturating_sub(before_open);
+    let open_retained = support::live().saturating_sub(before_open);
+
+    let per_history_byte = |bytes: usize| bytes as f64 / survey.history_bytes.max(1) as f64;
+    let per_commit = |bytes: usize| bytes as f64 / survey.commits.max(1) as f64;
+
+    // One `PROFILE` line per figure, each naming what it is, so the driver reads
+    // this output rather than re-deriving anything of its own. A number computed
+    // twice is a number that can disagree with itself.
+    println!("PROFILE repo {}", repo.display());
+    println!("PROFILE commits {}", survey.commits);
+    println!("PROFILE tracked_artifacts {}", survey.tracked_artifacts);
+    println!("PROFILE history_bytes {}", survey.history_bytes);
+    println!("PROFILE admission_peak_live_heap_bytes {admission_peak}");
+    println!(
+        "PROFILE admission_peak_live_heap_per_history_byte {:.4}",
+        per_history_byte(admission_peak)
+    );
+    println!(
+        "PROFILE admission_peak_live_heap_per_commit {:.1}",
+        per_commit(admission_peak)
+    );
+    println!(
+        "PROFILE admission_seconds {:.1}",
+        admission_elapsed.as_secs_f64()
+    );
+    println!("PROFILE open_peak_live_heap_bytes {open_peak}");
+    println!("PROFILE open_retained_live_heap_bytes {open_retained}");
+    println!(
+        "PROFILE open_peak_live_heap_per_commit {:.1}",
+        per_commit(open_peak)
+    );
+    println!("PROFILE changes {change_count}");
+    println!("PROFILE decoded_on_open {decoded_on_open}");
+    println!("{phase_table}");
+
+    // The profile is not a gate and asserts no ceiling: a ceiling here would be a
+    // number invented before the measurement it exists to take. What it does
+    // assert is that the run measured the repository it was pointed at, because a
+    // profile that admitted nothing would still print a tidy table of zeroes and
+    // a driver would record it.
+    assert_eq!(
+        change_count as u64, survey.commits,
+        "admitted {change_count} changes for {} surveyed commits, so this profile is not about \
+         the history it counted",
+        survey.commits
+    );
+    assert!(
+        admission_peak > 0,
+        "admission peaked at no bytes above its baseline, so the counters measured nothing"
+    );
+}


### PR DESCRIPTION
## What

Add an ignored integration test that profiles admission and reopening of a named real Git repository with the existing counting allocator and phase attribution.

## Why

Memory calibration needs repeatable measurements from actual histories with distinct allocator live-heap and whole-process maximum-RSS evidence.

Part of FIR-3398.

## How

The test surveys the repository, measures admission and in-process authority reopening, reports counts and memory columns, and refuses a mismatched admitted change count. It requires a disposable repository through KIN_HEAP_PROFILE_REPO. External `/usr/bin/time -l` supplies maximum RSS. Counting delegates to `std::alloc::System`; the shipped CLI and daemon use mimalloc. Instrument RSS therefore needs allocator-matched validation before it can calibrate a production budget. In-process reopening is not a fresh daemon RSS measurement.

No forecast coefficients or memory limits change. This work remains held for the deferred React validation: actual full-history conversion within 16 GiB with unchanged seals and change IDs. A lower forecast does not establish that result.

## Testing

The preserved release instrument completed hiredis (1,141 commits), requests (6,494) and Kin (2,937), each with one test passed and zero failed. Peak live heap / maximum RSS in bytes were 134,346,465 / 461,914,112; 542,169,136 / 1,466,138,624; and 3,289,978,387 / 8,824,700,928 respectively. These are measurements of the preserved baseline instrument, not new performance results for this PR's head.

A disposable one-commit fixture passed the instrument smoke test (one passed, zero failed, 1.33 seconds). Its numbers are not calibration inputs. The combined implementation tree passed `bin/kin-precheck kin --repo-dir kin=<checkout>`: `21 gates ran, 21 passed, 0 failed`, including workflow clippy and both zero-file-search guards. Focused branches contain the same implementation bytes. DEV-LOCAL parity results: magic 27 passed; first-run PASS-WITH-ALLOWANCES (existing FIR-2580 and FIR-2501/FIR-2554); corrected brownfield rerun PASS-WITH-ALLOWANCES in 422.9 seconds (12 passed, one existing FIR-2464/FIR-2593 failure, zero unreadable). No allowance was added. The Express failure remains a real missing-edge finding under the existing allowance. These local results do not establish hosted CI, released-byte acceptance or production acceptance. Exact-head hosted CI completed without failures.

Draft hold: do not land until the deferred September 9 quiet-box React capture validates actual full-history conversion within 16 GiB with unchanged seals and change IDs.

A disposable count-mismatch fixture falsified the profiling guard. Running the same compiled instrument against one HEAD commit plus a side-only commit exited 101: `admitted 2 changes for 1 surveyed commits`, followed by `0 passed; 1 failed`. The matched one-commit smoke fixture is the positive control.

The ignored measurement input is declared in the exact test-only environment allowlist; the production registry and completeness scanner are unchanged. Hosted CI first exposed the missing spool declaration. The actual failing test was rerun locally after correction: `cargo test --locked -p kin-core --lib env_registry::tests::every_kin_env_read_in_workspace_is_registered -- --exact` returned `1 passed; 0 failed; 880 filtered out` in 0.12 seconds. Hosted CI graded this follow-up head.

At 2026-09-08T21:11:02.793833+00:00, all 47 check runs and associated workflows on `4501149e58298fd3d7d6e0c5e4bb3332c7681692` had concluded without failure. Skipped and neutral checks are included. Product Acceptance remains a main-branch gate. This CI result does not lift the React full-history, allocator-matched calibration or landing hold.
