### PR TITLE
Preserve typed missing-entity errors through the daemon

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -12577,6 +12577,7 @@ where
 }
 
 fn repo_scoped_mcp_error(repo_id: &str, failure: RepoScopedMcpFailure) -> Response {
+    let refusal_code = failure.code;
     let mut response = (
         failure.status,
         Json(RepoScopedMcpErrorResponse {
@@ -12594,6 +12595,10 @@ fn repo_scoped_mcp_error(repo_id: &str, failure: RepoScopedMcpFailure) -> Respon
     response.headers_mut().insert(
         HeaderName::from_static("x-kin-semantic-capability"),
         HeaderValue::from_static(REPO_SCOPED_SEMANTIC_CAPABILITY),
+    );
+    response.headers_mut().insert(
+        HeaderName::from_static("x-kin-semantic-refusal"),
+        HeaderValue::from_static(refusal_code),
     );
     response
 }
@@ -13271,6 +13276,7 @@ fn bind_repo_semantic_cursor(
 
 fn repo_scoped_handler_failure(error: kin_mcp::McpError) -> RepoScopedMcpFailure {
     let (status, code, retryable) = match &error {
+        kin_mcp::McpError::EntityNotFound(_) => (StatusCode::NOT_FOUND, "entity_not_found", false),
         kin_mcp::McpError::InvalidParams(_)
         | kin_mcp::McpError::WorkspaceAbsent(_)
         | kin_mcp::McpError::ToolNotFound(_)
@@ -25310,15 +25316,37 @@ mod tests {
         // one of them is the envelope this endpoint publishes, and a caller
         // that has to parse a success to learn it was refused is the shape the
         // typed error schema exists to replace.
+        assert_eq!(status, StatusCode::NOT_FOUND, "{wrong_repository_entity}");
         assert_eq!(
-            status,
-            StatusCode::UNPROCESSABLE_ENTITY,
-            "{wrong_repository_entity}"
-        );
-        assert_eq!(
-            wrong_repository_entity["error"]["code"], "invalid_semantic_tool_call",
+            wrong_repository_entity["error"]["code"], "entity_not_found",
             "an entity from repository A must not resolve through repository B: {wrong_repository_entity}"
         );
+        assert_eq!(wrong_repository_entity["error"]["retryable"], false);
+        let missing_id = Uuid::new_v4().to_string();
+        let (status, headers, missing) = call_repo_mcp_tool(
+            app.clone(),
+            &repo_b,
+            "get_context_pack",
+            json!({ "entity_id": missing_id }),
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "{missing}");
+        assert_eq!(missing["error"]["code"], "entity_not_found");
+        assert_eq!(missing["error"]["retryable"], false);
+        assert_eq!(headers["x-kin-semantic-refusal"], "entity_not_found");
+
+        let (status, _, malformed) = call_repo_mcp_tool(
+            app.clone(),
+            &repo_b,
+            "get_context_pack",
+            json!({ "entity_id": "not-a-uuid" }),
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "{malformed}");
+        assert_eq!(malformed["error"]["code"], "invalid_semantic_tool_call");
+
         // The load-bearing half, unchanged: whatever shape the refusal takes,
         // no byte of repository A's source may travel in it.
         assert!(

--- a/crates/kin-mcp/src/error.rs
+++ b/crates/kin-mcp/src/error.rs
@@ -18,6 +18,9 @@ pub enum McpError {
     #[error("context error: {0}")]
     Context(String),
 
+    #[error("entity not found: {0}")]
+    EntityNotFound(String),
+
     /// An entity's recorded source path does not exist at the workspace's
     /// current generation.
     ///
@@ -96,6 +99,15 @@ impl McpError {
             McpError::Json(_) => -32700,          // Parse error
             McpError::Protocol(_) => -32600,      // Invalid request / transport
             _ => -32603,                          // Internal error
+        }
+    }
+}
+
+impl From<kin_context::ContextError> for McpError {
+    fn from(error: kin_context::ContextError) -> Self {
+        match error {
+            kin_context::ContextError::EntityNotFound(id) => Self::EntityNotFound(id),
+            other => Self::Context(other.to_string()),
         }
     }
 }

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -908,7 +908,7 @@ pub fn handle_get_context_pack<G: GraphStore>(
 
     let (traffic_pack, _) =
         build_context_pack_with_traffic_and_provenance(store, &entity_id, &opts, &nearby_intents)
-            .map_err(|e| McpError::Context(e.to_string()))?;
+            .map_err(McpError::from)?;
     let held = HeldSourceAuthority::new(store, repository_authority);
     let fields = ContextSourceFields::default();
     let mut provider = ContextSourceProvider {
@@ -948,7 +948,7 @@ pub fn handle_get_context_pack<G: GraphStore>(
             Ok(kin_context::estimate_tokens(&json))
         },
     )
-    .map_err(|error| McpError::Context(error.to_string()))?;
+    .map_err(McpError::from)?;
     let mut result = render.render(&pack, &selection, &projections, &fields)?;
     Ok(ToolCallResult::text(serialize_with_measured_tokens(
         &mut result,
@@ -1608,7 +1608,7 @@ fn multi_focal_pack_result<G: GraphStore>(
             Ok(kin_context::estimate_tokens(&json))
         },
     )
-    .map_err(|error| McpError::Context(error.to_string()))?;
+    .map_err(McpError::from)?;
     let mut result =
         render_multi_context(store, &pack, report, &unresolved, &fields, &projections)?;
     Ok(Some(ToolCallResult::text(serialize_with_measured_tokens(


### PR DESCRIPTION
A well formed entity id the selected repository's graph does not carry left the hosted semantic route as 422 `invalid_semantic_tool_call`, non-retryable, shared with a genuinely malformed call. `kin_context::ContextError::EntityNotFound` was flattened into `McpError::Context` by `.map_err(|e| McpError::Context(e.to_string()))` at the context-builder call sites, so by the time `repo_scoped_handler_failure` classified it there was nothing left to classify on. The hosted gateway then read a 422 on a request it had composed correctly and reclassified it as a retryable 503, which no retry could ever clear.

An absent entity is now `McpError::EntityNotFound`, and the route answers 404 `entity_not_found` with `retryable: false` and an `x-kin-semantic-refusal` header naming the code. A malformed `entity_id` still answers 422, because `parse_entity_id` refuses ahead of any lookup.

## Composition on #1598

Rebased onto 8a80e00ca. `api.rs` merged cleanly. `entities.rs` conflicted because #1598 replaced both context builders with budget-aware ones taking a measuring closure. The resolution keeps that budget structure whole and changes only the outer conversion at the three sites, now `.map_err(McpError::from)?` at entities.rs:911, 951 and 1611.

That is the part worth reading twice. Authority failure and caller mistake share the `Context` variant, and only the message separates them, which `is_graph_authority_gap` reads. Both builders' closures still map render failures to `kin_context::ContextError::Other`, and the new `From` impl sends `Other` to `McpError::Context` carrying the same string, so a wrapped authority-gap message classifies exactly as it did before. Nothing else in the enum's handling moves: `error_code()`'s catch-all gives the new variant the same JSON-RPC code `Context` gave it.

## The regression is on the real route

`api::tests::repo_scoped_hosted_tools_answer_only_from_the_selected_repository` drives the real axum router against a real replica state with a real published change, so a call goes through the hosted repo-scoped route into kin-mcp into kin-context. It now covers a random uuid, an entity belonging to the other repository, and a malformed id, and asserts the header as well as the body.

## Falsification

Two arms, each breaking production behavior rather than an assertion.

```text
ARM=A-daemon-classification   rc=101
  (drop the typed arm, so EntityNotFound falls through to the 422 arm)
  assertion `left == right` failed: {"error":{"code":"invalid_semantic_tool_call",...}}
    left: 422
   right: 404

ARM=B-flattened-context-error rc=101
  (restore .map_err(|e| McpError::Context(e.to_string())) at the single-focal site)

ARM=C-restored                rc=0
  test api::tests::repo_scoped_hosted_tools_answer_only_from_the_selected_repository ... ok
  test result: ok. 1 passed; 0 failed
```

## Local gates

```text
$ bin/kin-precheck kin --repo-dir kin=<lane worktree>
kin-precheck: repo=kin sha=1d7c9e7f3ff73b79f30fa2cea3c4cd3ae248ee98 branch=fix/hosted-entity-errors
kin-precheck: behind origin/main 0 commit(s)
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 21 gates ran, 21 passed, 0 failed

$ cargo test -p kin-mcp --locked
test result: ok. 995 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 29.33s

$ cargo test -p kin-daemon --locked --lib
test result: FAILED. 1593 passed; 10 failed; 4 ignored; 0 measured; finished in 435.35s
```

Those 10 are all `loop_runner::tests`, the native watcher suite this Mac's FSEvents is diagnosed unhealthy for and which the release owner has asked not be re-run broadly here. They are not this diff: `loop_runner.rs` contains zero references to any symbol this PR touches (`repo_scoped_handler_failure`, `repo_scoped_mcp_error`, `EntityNotFound`, `x-kin-semantic-refusal`, `build_context_pack`), against a control term the same file carries 240 times. Hosted CI on Linux is the grader that settles it, and it is what this PR is read against.

## Paired change

kinlab #507 classifies this refusal on the hosted gateway. It reads both this typed 404 and the 422 shape every daemon before v0.7.6 answers, so it does not wait on this landing to improve production.
