### PR TITLE
Validate and report hosted publication destination services

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -951,7 +951,13 @@ jobs:
     # Read the runner a run actually resolved from the jobs API `labels` field,
     # never from this line.
     runs-on: ${{ vars.KIN_HEAVY_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 20
+    # 20 until the hosted object-store publication step below, which builds
+    # kin-cli under a second feature set that clippy's artifacts cannot serve.
+    # Raised rather than moving that step somewhere cheaper on purpose: the two
+    # names main requires are this one and the sharded test job, so a guard that
+    # lands anywhere else is advisory and an armed auto-merge would land past
+    # it red.
+    timeout-minutes: 30
     # FIR-2744. This job shares `check`'s cargo cache key, and with
     # `add-rust-environment-hash-key` off nothing else would notice the two
     # declaring different cargo profiles, so they must declare the same one or
@@ -1264,6 +1270,55 @@ jobs:
               exit 1
             fi
             cargo test -p kin-remote --features gcs --locked --lib "$test_name" \
+              -- --exact --nocapture --test-threads=1
+          done
+
+      # The other half of the same gap, one crate up. `kin-cli` composes that
+      # validated destination into the subcommand a hosted worker actually runs,
+      # behind the same non-default `gcs` feature, and the same three jobs miss
+      # it for the same three reasons: clippy above compiles the suite without
+      # running it, the nextest job below runs a changed-crate scope with
+      # default features, and docker.yml's real fake-gcs-server acceptance
+      # carries no pull-request trigger since FIR-2815. Without this step the
+      # wiring that lets a hosted worker publish into a bucket at all would be
+      # graded by nothing on the pull request that changes it, and rediscovered
+      # a release later.
+      #
+      # `tests/hosted_publication_object_store.rs` is `#![cfg(feature = "gcs")]`
+      # as a whole file, which is what makes the count below exact: that
+      # binary's listing IS the gated set, so a case added there and not added
+      # here makes the two disagree and this step fails. Same assertion as the
+      # kin-remote step above, and for the same reason: a hand-maintained list
+      # with no count beside it drifts, and the drift is silent.
+      #
+      # It costs a kin-cli build under a second feature set, which clippy's
+      # artifacts cannot serve. That is why this job's timeout moved to 30
+      # minutes with it.
+      - name: Test hosted object-store publication wiring
+        shell: bash
+        run: |
+          set -euo pipefail
+          listing="$(cargo test -p kin-cli --features gcs --locked \
+            --test hosted_publication_object_store -- --list | tr -d '\r')"
+          tests=(
+            an_unreachable_bucket_is_indeterminate_and_names_its_service
+            the_google_convention_alone_points_the_client_at_the_same_endpoint
+            verification_reaches_the_same_object_store_and_records_its_service
+          )
+          listed="$(printf '%s\n' "$listing" | awk '/^[A-Za-z0-9_]+: test$/ { count += 1 } END { print count + 0 }')"
+          if [ "$listed" -ne "${#tests[@]}" ]; then
+            echo "::error title=Ungraded object-store publication test::the suite lists $listed test(s) and this step enumerates ${#tests[@]}; add the new one here or this step grades it by nothing"
+            exit 1
+          fi
+          for test_name in "${tests[@]}"
+          do
+            matches="$(printf '%s\n' "$listing" | awk -v expected="$test_name: test" '$0 == expected { count += 1 } END { print count + 0 }')"
+            if [ "$matches" -ne 1 ]; then
+              echo "::error title=Missing object-store publication test::$test_name listed $matches time(s)"
+              exit 1
+            fi
+            cargo test -p kin-cli --features gcs --locked \
+              --test hosted_publication_object_store "$test_name" \
               -- --exact --nocapture --test-threads=1
           done
 

--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -20,6 +20,13 @@ embeddings = ["kin-db/embeddings"]
 # kin-infer/metal backend on Linux too. The real `kin-db/metal` activation is in the
 # `[target.'cfg(target_os = "macos")'.dependencies]` block below (additive via unification).
 metal = ["embeddings"]
+# Hosted object-store publication for `kin hosted-publication`. Not default: the
+# public binary release.yml builds is a laptop CLI that never publishes into a
+# hosted bucket, and a GCP client in every download is dependency weight and
+# attack surface for a capability only the hosted worker uses. The worker is the
+# container image, and `Dockerfile` already builds `--bin kin` under
+# `--features kin-daemon/gcs`, whose feature list forwards this one on.
+gcs = ["kin-remote/gcs"]
 
 [[bin]]
 name = "kin"

--- a/crates/kin-cli/src/commands/hosted_publication.rs
+++ b/crates/kin-cli/src/commands/hosted_publication.rs
@@ -58,6 +58,7 @@ use kin_remote::first_publication::{
     publish_first_repository_observed, read_pinned_published_authority, FirstPublicationError,
     FirstPublicationIntent, FirstPublicationMode, SourceBodyClosure,
 };
+use kin_remote::first_publication_gcs::{GcsDestination, GcsEndpoint, GcsEndpointOverride};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -387,14 +388,82 @@ pub enum DestinationSpec {
     Gcs { bucket: String, prefix: String },
 }
 
-impl DestinationSpec {
-    /// Open a backend for this destination.
+/// The two operator levers that point a hosted publication somewhere other than
+/// the real object store.
+///
+/// Taken by argument rather than read where it is used. `kin-core`'s
+/// `test_env` module states the reason in full: the process environment is one
+/// table shared by every thread, so a test that mutates it is read by every
+/// test running beside it, and "when the code under test resolves configuration
+/// that other code under test also resolves, the fix is to take that
+/// configuration by argument and leave the environment alone." So this carries
+/// the values and [`DestinationEnv::from_process`] is the one site in this
+/// module that reads them.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DestinationEnv {
+    /// `KIN_GCS_ENDPOINT`, Kin's own lever.
+    pub kin_gcs_endpoint: Option<String>,
+    /// `STORAGE_EMULATOR_HOST`, the Google-client convention.
+    pub storage_emulator_host: Option<String>,
+}
+
+impl DestinationEnv {
+    /// Read both levers out of the process environment.
+    pub fn from_process() -> Self {
+        Self {
+            kin_gcs_endpoint: std::env::var("KIN_GCS_ENDPOINT").ok(),
+            storage_emulator_host: std::env::var("STORAGE_EMULATOR_HOST").ok(),
+        }
+    }
+
+    /// Which endpoint an object-store destination is opened against.
     ///
-    /// Called more than once per run on purpose. The measurement pass builds its
-    /// own handle rather than reusing the one the publication went through, so a
-    /// backend answering from a cache it populated while writing cannot satisfy
-    /// the readback.
-    fn open(&self) -> Result<Arc<dyn StorageBackend>> {
+    /// Precedence deliberately mirrors `kin_daemon::gcs_endpoint::resolve`:
+    /// `KIN_GCS_ENDPOINT` wins, `STORAGE_EMULATOR_HOST` is honoured so one
+    /// exported variable points both halves of a local stack at the same
+    /// emulator, and an empty or whitespace-only value counts as unset the way
+    /// Kin's other read sites treat one. The daemon holds its own copy because
+    /// it also probes the endpoint for reachability at startup and this does
+    /// not; the parsing itself is `kin-remote`'s, so the two agree on what a
+    /// value means even where they disagree on what to do about it.
+    ///
+    /// Neither set is the real service with application default credentials. A
+    /// value that is present and unparseable is a refusal, never a silent
+    /// fall-through to real Google Cloud Storage.
+    fn endpoint(&self) -> Result<GcsEndpoint> {
+        let named = [
+            ("KIN_GCS_ENDPOINT", self.kin_gcs_endpoint.as_deref()),
+            (
+                "STORAGE_EMULATOR_HOST",
+                self.storage_emulator_host.as_deref(),
+            ),
+        ]
+        .into_iter()
+        .find_map(|(source, raw)| {
+            let value = raw.map(str::trim).filter(|value| !value.is_empty())?;
+            Some((source, value))
+        });
+        match named {
+            None => Ok(GcsEndpoint::ProductionAdc),
+            Some((source, value)) => Ok(GcsEndpoint::Emulator(GcsEndpointOverride::parse(
+                value, source,
+            )?)),
+        }
+    }
+}
+
+impl DestinationSpec {
+    /// Validate this destination and settle every choice about where it points,
+    /// without opening anything.
+    ///
+    /// Everything that can be refused is refused here, before a client exists
+    /// and before an import is spent: the filesystem root's shape, the bucket
+    /// and prefix grammar, the endpoint override, and the artifact-identifier
+    /// budget. That last one matters most. The identifier is composed after a
+    /// publication has already committed, so a prefix that cannot compose one
+    /// would otherwise produce a publication that succeeded and a receipt that
+    /// could not be written.
+    fn resolve(&self, env: &DestinationEnv, repository_id: &RepositoryId) -> Result<Destination> {
         match self {
             Self::Filesystem { root } => {
                 if !root.is_absolute() {
@@ -403,21 +472,122 @@ impl DestinationSpec {
                         root.display()
                     );
                 }
+                Ok(Destination::Filesystem { root: root.clone() })
+            }
+            Self::Gcs { bucket, prefix } => {
+                let destination = GcsDestination::new(bucket, prefix)?;
+                destination.check_artifact_id_budget(ARTIFACT_ID_PREFIX, repository_id.as_str())?;
+                Ok(Destination::ObjectStore {
+                    destination,
+                    endpoint: env.endpoint()?,
+                    repository_id: repository_id.as_str().to_string(),
+                })
+            }
+        }
+    }
+}
+
+/// A destination whose every refusal has already been spent, able to hand out a
+/// fresh backend handle.
+#[derive(Debug)]
+enum Destination {
+    Filesystem {
+        root: PathBuf,
+    },
+    ObjectStore {
+        destination: GcsDestination,
+        endpoint: GcsEndpoint,
+        /// Named here because the artifact-identifier budget was checked against
+        /// this exact identity, and opening the destination checks it again.
+        repository_id: String,
+    },
+}
+
+/// A backend handle, and which service it talks to.
+struct OpenedDestination {
+    backend: Arc<dyn StorageBackend>,
+    /// `None` for a filesystem destination, whose scope already names the exact
+    /// root it wrote to.
+    service: Option<DestinationService>,
+}
+
+impl Destination {
+    /// Open a backend for this destination.
+    ///
+    /// Called more than once per run on purpose. The measurement pass builds its
+    /// own handle rather than reusing the one the publication went through, so a
+    /// backend answering from a cache it populated while writing cannot satisfy
+    /// the readback. The object-store arm builds a fresh client each time for
+    /// the same reason.
+    fn open(&self) -> Result<OpenedDestination> {
+        match self {
+            Self::Filesystem { root } => {
                 fs::create_dir_all(root)
                     .with_context(|| format!("create destination root {}", root.display()))?;
-                Ok(Arc::new(LocalFileBackend::new(root.clone())))
+                Ok(OpenedDestination {
+                    backend: Arc::new(LocalFileBackend::new(root.clone())),
+                    service: None,
+                })
             }
-            Self::Gcs { .. } => bail!(
-                "destination_backend_unavailable: this build publishes to a filesystem \
-                 destination only, and hosted object-store publication is a separate acceptance"
+            #[cfg(feature = "gcs")]
+            Self::ObjectStore {
+                destination,
+                endpoint,
+                repository_id,
+            } => {
+                let opened =
+                    destination.open(endpoint, ARTIFACT_ID_PREFIX, repository_id.as_str())?;
+                // The class is read back off the value that built the client
+                // rather than derived a second time here, because a second
+                // derivation site is a second place for an emulator to be
+                // recorded as production. Compared against the endpoint this
+                // run resolved so the two cannot drift apart silently.
+                if opened.endpoint_class != endpoint.class() {
+                    bail!(
+                        "the opened destination reports the {} service while this run resolved \
+                         the {} one",
+                        opened.endpoint_class.as_str(),
+                        endpoint.class().as_str()
+                    );
+                }
+                Ok(OpenedDestination {
+                    backend: opened.backend,
+                    service: Some(DestinationService {
+                        class: opened.endpoint_class.as_str().to_string(),
+                        endpoint_url: opened.endpoint_url,
+                    }),
+                })
+            }
+            // The refusal names what it refused. Every field of the resolved
+            // destination is already validated by the time it gets here, so an
+            // operator who reaches this message learns that their configuration
+            // was fine and their binary was not, which is a different fix from
+            // the one a bare capability refusal sends them looking for.
+            #[cfg(not(feature = "gcs"))]
+            Self::ObjectStore {
+                destination,
+                endpoint,
+                repository_id,
+            } => bail!(
+                "destination_backend_unavailable: this build carries no object-store client, so \
+                 it publishes to a filesystem destination only. The hosted worker is the \
+                 container image, which builds this binary with `--features kin-daemon/gcs`. \
+                 Refused {} for repository {repository_id} against the {} service",
+                destination.scope(),
+                endpoint.class().as_str()
             ),
         }
     }
 
+    /// The destination scope, as it appears inside an artifact identifier.
+    ///
+    /// The object-store arm defers to the validated destination's own rendering
+    /// rather than repeating the format, so the string whose length the budget
+    /// was checked against is the string that reaches the identifier.
     fn scope(&self) -> String {
         match self {
             Self::Filesystem { root } => format!("fs:{}", root.display()),
-            Self::Gcs { bucket, prefix } => format!("gcs:{bucket}/{prefix}"),
+            Self::ObjectStore { destination, .. } => destination.scope(),
         }
     }
 }
@@ -704,6 +874,28 @@ pub struct EchoedInput {
     pub expected_refs: Option<ExpectedRefs>,
 }
 
+/// Which service an object-store destination's handles actually talked to.
+///
+/// Neither measured nor echoed, and kept out of both objects for that reason.
+/// It was not read out of destination storage, and it did not come from the
+/// manifest: it is this process's own resolved configuration, reported by the
+/// value that built the client.
+///
+/// Emitted only for an object-store destination. A filesystem scope already
+/// names the exact root that was written to, while `gcs:<bucket>/<prefix>` says
+/// nothing about whether that bucket was the real service or an emulator
+/// standing in for it, and a receipt that cannot tell those apart is a receipt
+/// for a publication nobody can find.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DestinationService {
+    /// `production-adc` or `emulator`, as `GcsEndpointClass` names them.
+    pub class: String,
+    /// The override's normalized base URL, present only for an emulator.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub endpoint_url: Option<String>,
+}
+
 /// One field on which the destination disagreed with the intent.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -724,6 +916,10 @@ pub struct EvidenceRecord {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub measured: Option<MeasuredAuthority>,
     pub echoed: EchoedInput,
+    /// Present only for an object-store destination, so a filesystem run's
+    /// record is byte-identical to what this adapter has always written.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub destination_service: Option<DestinationService>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub differences: Vec<Difference>,
     /// Why a run without measured authority ended the way it did, verbatim.
@@ -1267,13 +1463,13 @@ enum DestinationReading {
 /// opens a new one from the destination specification, so a backend that would
 /// answer from state it cached while writing cannot satisfy this readback.
 fn measure_destination(
-    destination: &DestinationSpec,
+    destination: &Destination,
     repository_id: &RepositoryId,
     mode: PublicationMode,
     snapshot_sha256: String,
     snapshot_sha256_source: SnapshotDigestSource,
 ) -> Result<DestinationReading> {
-    let backend = destination.open()?;
+    let backend = destination.open()?.backend;
     match backend.load_snapshot_cursor(repository_id.as_str()) {
         Ok(None) => return Ok(DestinationReading::Absent),
         Ok(Some(_)) => {}
@@ -1345,7 +1541,7 @@ fn measure_destination(
 /// refused here when it would exceed what a hosted store accepts, so the reason
 /// is visible in this process rather than as an invalid field at the store.
 fn compose_artifact_id(
-    destination: &DestinationSpec,
+    destination: &Destination,
     repository_id: &RepositoryId,
     generation: u64,
 ) -> Result<String> {
@@ -1587,6 +1783,7 @@ fn resolve_against_intent(
     manifest: &Manifest,
     intent: &IntentRecord,
     reading: DestinationReading,
+    service: Option<DestinationService>,
 ) -> EvidenceRecord {
     let base = EvidenceRecord {
         schema: EVIDENCE_SCHEMA.to_string(),
@@ -1595,6 +1792,7 @@ fn resolve_against_intent(
         operation: manifest.operation.clone(),
         measured: None,
         echoed: echoed_input(manifest),
+        destination_service: service,
         differences: Vec::new(),
         detail: None,
     };
@@ -1637,29 +1835,39 @@ fn resolve_against_intent(
 
 /// Build the reserved repository's durable graph authority.
 pub fn run_publish(args: PublishArgs) -> Result<i32> {
+    run_publish_with_env(args, &DestinationEnv::from_process())
+}
+
+/// [`run_publish`] with the destination's endpoint levers supplied rather than
+/// read, so a test drives them without touching the process environment.
+pub fn run_publish_with_env(args: PublishArgs, env: &DestinationEnv) -> Result<i32> {
     let (manifest, repository_id, mode) = read_checked_manifest(
         &args.manifest,
         &args.expect_repository_id,
         &args.expect_mode,
     )?;
     let expected_intent = reconcile_expected_intent(&manifest, Some(args.intent_out.as_path()))?;
+    let resolved = manifest.destination.resolve(env, &repository_id)?;
     // Opened before any source work, so an unavailable destination is reported
-    // without first spending an import on it.
-    manifest.destination.open()?;
+    // without first spending an import on it. The service it names is carried
+    // through every record this run writes.
+    let service = resolved.open()?.service;
 
     if let Some(intent) = expected_intent.as_ref() {
         let reading = measure_destination(
-            &manifest.destination,
+            &resolved,
             &repository_id,
             mode,
             intent.intended_snapshot_sha256.clone(),
             SnapshotDigestSource::Intent,
         )?;
         if !matches!(reading, DestinationReading::Absent) {
-            let record = resolve_against_intent(&manifest, intent, reading);
+            let record = resolve_against_intent(&manifest, intent, reading, service);
             return finish(&args.evidence_out, record);
         }
-    } else if let Some(record) = refuse_a_stranger(&manifest, &repository_id)? {
+    } else if let Some(record) =
+        refuse_a_stranger(&manifest, &repository_id, &resolved, service.clone())?
+    {
         return finish(&args.evidence_out, record);
     }
 
@@ -1680,7 +1888,7 @@ pub fn run_publish(args: PublishArgs) -> Result<i32> {
         (branch, head, bindings)
     };
 
-    let destination = manifest.destination.open()?;
+    let destination = resolved.open()?.backend;
     let mut written_intent: Option<IntentRecord> = None;
     let result = publish_first_repository_observed(
         source,
@@ -1721,7 +1929,7 @@ pub fn run_publish(args: PublishArgs) -> Result<i32> {
     match (&result, &written_intent) {
         (Ok(receipt), _) => {
             let reading = measure_destination(
-                &manifest.destination,
+                &resolved,
                 &repository_id,
                 mode,
                 receipt.snapshot_sha256.to_string(),
@@ -1778,6 +1986,7 @@ pub fn run_publish(args: PublishArgs) -> Result<i32> {
                     operation: manifest.operation.clone(),
                     measured: Some(*measured),
                     echoed: echoed_input(&manifest),
+                    destination_service: service,
                     differences,
                     detail,
                 },
@@ -1788,13 +1997,13 @@ pub fn run_publish(args: PublishArgs) -> Result<i32> {
         // decides the outcome, not the error text.
         (Err(error), Some(intent)) => {
             let reading = measure_destination(
-                &manifest.destination,
+                &resolved,
                 &repository_id,
                 mode,
                 intent.intended_snapshot_sha256.clone(),
                 SnapshotDigestSource::Intent,
             )?;
-            let mut record = resolve_against_intent(&manifest, intent, reading);
+            let mut record = resolve_against_intent(&manifest, intent, reading, service);
             record.detail = Some(match record.detail.take() {
                 Some(detail) => format!("{detail}; publication reported: {error}"),
                 None => format!("publication reported: {error}"),
@@ -1817,8 +2026,10 @@ pub fn run_publish(args: PublishArgs) -> Result<i32> {
 fn refuse_a_stranger(
     manifest: &Manifest,
     repository_id: &RepositoryId,
+    destination: &Destination,
+    service: Option<DestinationService>,
 ) -> Result<Option<EvidenceRecord>> {
-    let backend = manifest.destination.open()?;
+    let backend = destination.open()?.backend;
     let (outcome, detail) = match backend.load_snapshot_cursor(repository_id.as_str()) {
         Ok(None) => return Ok(None),
         Ok(Some(_)) => (
@@ -1836,6 +2047,7 @@ fn refuse_a_stranger(
         operation: manifest.operation.clone(),
         measured: None,
         echoed: echoed_input(manifest),
+        destination_service: service,
         differences: Vec::new(),
         detail: Some(detail),
     }))
@@ -1843,6 +2055,12 @@ fn refuse_a_stranger(
 
 /// Read a destination against a durable intent, and write nothing.
 pub fn run_verify(args: VerifyArgs) -> Result<i32> {
+    run_verify_with_env(args, &DestinationEnv::from_process())
+}
+
+/// [`run_verify`] with the destination's endpoint levers supplied rather than
+/// read, so a test drives them without touching the process environment.
+pub fn run_verify_with_env(args: VerifyArgs, env: &DestinationEnv) -> Result<i32> {
     let (manifest, repository_id, mode) = read_checked_manifest(
         &args.manifest,
         &args.expect_repository_id,
@@ -1855,13 +2073,369 @@ pub fn run_verify(args: VerifyArgs) -> Result<i32> {
              expected authority or in an intent file"
             )
         })?;
+    let resolved = manifest.destination.resolve(env, &repository_id)?;
+    // One open before the measurement, for the service it names. The
+    // measurement builds its own handle regardless, so this does not become the
+    // handle anything is read through.
+    let service = resolved.open()?.service;
     let reading = measure_destination(
-        &manifest.destination,
+        &resolved,
         &repository_id,
         mode,
         intent.intended_snapshot_sha256.clone(),
         SnapshotDigestSource::Intent,
     )?;
-    let record = resolve_against_intent(&manifest, &intent, reading);
+    let record = resolve_against_intent(&manifest, &intent, reading, service);
     finish(&args.evidence_out, record)
+}
+
+// ---------------------------------------------------------------------------
+// Resolving a destination
+// ---------------------------------------------------------------------------
+
+/// Every refusal a destination can carry, and the endpoint precedence behind an
+/// object-store one.
+///
+/// All of it runs without the `gcs` feature, because none of it needs a client:
+/// `GcsDestination`, `GcsEndpoint` and their refusals are compiled
+/// unconditionally by `kin-remote` and only the client construction is gated. So
+/// these are graded by the ordinary changed-crate test job on every pull
+/// request, and the gated cases beside them in
+/// `tests/hosted_first_publication.rs` are the small remainder that needs a
+/// client.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RESERVED: &str = "9f1c2e04-3b7a-4d21-9c55-0ab61d7e8f30";
+    const BUCKET: &str = "kin-hosted-prod";
+    const PREFIX: &str = "publications/v1";
+
+    fn reserved() -> RepositoryId {
+        RepositoryId::new(RESERVED).expect("the fixture identity is a repository id")
+    }
+
+    fn levers(kin: Option<&str>, google: Option<&str>) -> DestinationEnv {
+        DestinationEnv {
+            kin_gcs_endpoint: kin.map(str::to_owned),
+            storage_emulator_host: google.map(str::to_owned),
+        }
+    }
+
+    fn object_store(bucket: &str, prefix: &str) -> DestinationSpec {
+        DestinationSpec::Gcs {
+            bucket: bucket.to_owned(),
+            prefix: prefix.to_owned(),
+        }
+    }
+
+    fn class_of(endpoint: &GcsEndpoint) -> &'static str {
+        endpoint.class().as_str()
+    }
+
+    #[test]
+    fn neither_lever_set_is_the_real_service() {
+        let endpoint = levers(None, None)
+            .endpoint()
+            .expect("no lever is not an error");
+        assert_eq!(class_of(&endpoint), "production-adc");
+        assert_eq!(endpoint.url(), None, "production carries no override URL");
+    }
+
+    #[test]
+    fn kins_own_lever_wins_over_the_google_convention() {
+        // Both set, pointing at different emulators. The daemon resolves this
+        // the same way, and a run that took the other one would publish
+        // somewhere no reader looks while every message still named the bucket.
+        let endpoint = levers(Some("http://127.0.0.1:4443"), Some("http://127.0.0.1:9199"))
+            .endpoint()
+            .expect("both levers parse");
+        assert_eq!(endpoint.url(), Some("http://127.0.0.1:4443"));
+
+        // Positive control: with Kin's lever absent the Google convention is
+        // honoured, so the assertion above is about precedence and not about
+        // the second lever being ignored altogether.
+        let fallback = levers(None, Some("http://127.0.0.1:9199"))
+            .endpoint()
+            .expect("the google convention parses");
+        assert_eq!(fallback.url(), Some("http://127.0.0.1:9199"));
+        assert_eq!(class_of(&fallback), "emulator");
+    }
+
+    #[test]
+    fn bracketed_ipv6_is_an_emulator_and_invalid_overrides_never_select_adc() {
+        let endpoint = levers(Some("http://[::1]:4443"), None).endpoint().unwrap();
+        assert_eq!(endpoint.url(), Some("http://[::1]:4443"));
+        assert_eq!(class_of(&endpoint), "emulator");
+        for invalid in [
+            "http://[::1",
+            "http://[::1]x:4443",
+            "http://host:0",
+            "http://host/path",
+        ] {
+            assert!(
+                levers(Some(invalid), Some("http://127.0.0.1:4443"))
+                    .endpoint()
+                    .is_err(),
+                "{invalid}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_empty_or_whitespace_lever_counts_as_unset() {
+        for value in ["", "   ", "\t\n"] {
+            let endpoint = levers(Some(value), None)
+                .endpoint()
+                .unwrap_or_else(|error| panic!("{value:?} must count as unset, got {error:#}"));
+            assert_eq!(
+                class_of(&endpoint),
+                "production-adc",
+                "{value:?} must leave the real service selected"
+            );
+        }
+        // The whitespace also falls through to the second lever rather than
+        // shadowing it, which is the case an "is it set" check gets wrong.
+        let endpoint = levers(Some("  "), Some("http://127.0.0.1:9199"))
+            .endpoint()
+            .expect("the google convention parses");
+        assert_eq!(endpoint.url(), Some("http://127.0.0.1:9199"));
+    }
+
+    #[test]
+    fn an_unparseable_lever_never_falls_back_to_the_real_service() {
+        let error = levers(Some("http://host:4443/objects"), None)
+            .endpoint()
+            .expect_err("an endpoint carrying a path is not an endpoint");
+        let rendered = format!("{error:#}");
+        assert!(
+            rendered.contains("KIN_GCS_ENDPOINT"),
+            "the refusal names the variable to fix: {rendered}"
+        );
+        assert!(
+            rendered.contains("carries a path"),
+            "the refusal names what is wrong with it: {rendered}"
+        );
+    }
+
+    #[test]
+    fn a_relative_filesystem_root_is_refused_before_anything_is_opened() {
+        let spec = DestinationSpec::Filesystem {
+            root: PathBuf::from("relative/destination"),
+        };
+        let error = spec
+            .resolve(&DestinationEnv::default(), &reserved())
+            .expect_err("a relative root names a different directory per caller");
+        assert!(
+            format!("{error:#}").contains("must be an absolute path"),
+            "got {error:#}"
+        );
+
+        // Positive control: the same call with an absolute root resolves, so the
+        // refusal above is about the path and not about the arguments.
+        let spec = DestinationSpec::Filesystem {
+            root: PathBuf::from("/tmp/kin-hosted-destination"),
+        };
+        spec.resolve(&DestinationEnv::default(), &reserved())
+            .expect("an absolute root resolves");
+    }
+
+    #[test]
+    fn a_bucket_or_prefix_outside_the_grammar_is_refused_at_resolution() {
+        // A prefix that is not already in normal form names a different object
+        // than it appears to, because the object store drops empty segments
+        // while the scope this adapter renders keeps whatever was written. The
+        // receipt would then name a location that is not the key.
+        let cases = [
+            ("A", PREFIX, "bucket"),
+            (BUCKET, "a//b", "prefix"),
+            (BUCKET, "/leading", "prefix"),
+            (BUCKET, "trailing/", "prefix"),
+        ];
+        for (bucket, prefix, half) in cases {
+            match object_store(bucket, prefix).resolve(&DestinationEnv::default(), &reserved()) {
+                Ok(resolved) => {
+                    panic!("{bucket:?}/{prefix:?} must be refused, resolved to {resolved:?}")
+                }
+                Err(error) => {
+                    let rendered = format!("{error:#}");
+                    assert!(
+                        rendered.contains(half),
+                        "the refusal names which half failed, expected {half:?} in {rendered}"
+                    );
+                }
+            }
+        }
+
+        // Positive control: the same call with both halves in the grammar
+        // resolves, so every refusal above is about the value under test.
+        object_store(BUCKET, PREFIX)
+            .resolve(&DestinationEnv::default(), &reserved())
+            .expect("a well formed bucket and prefix resolve");
+    }
+
+    #[test]
+    fn an_identifier_that_cannot_be_composed_is_refused_before_a_publication_commits() {
+        // The budget is spent here rather than after the compare-and-swap,
+        // because the identifier is composed from the scope once the
+        // publication has already committed. A prefix this long otherwise
+        // produces a publication that succeeded and a receipt nobody can write.
+        let long_prefix = "p".repeat(180);
+        let error = object_store(BUCKET, &long_prefix)
+            .resolve(&DestinationEnv::default(), &reserved())
+            .expect_err("a destination over the identifier budget must not resolve");
+        let rendered = format!("{error:#}");
+        assert!(
+            rendered.contains(&ARTIFACT_ID_MAX_BYTES.to_string()),
+            "the refusal names the budget it broke: {rendered}"
+        );
+
+        // Positive control: one byte under the same shape resolves, so the
+        // refusal is about the length rather than about the prefix's contents.
+        let composed = format!(
+            "{ARTIFACT_ID_PREFIX}:gcs:{BUCKET}/{}/{RESERVED}@{}",
+            "p".repeat(1),
+            u64::MAX
+        );
+        let room = ARTIFACT_ID_MAX_BYTES - (composed.len() - 1);
+        object_store(BUCKET, &"p".repeat(room))
+            .resolve(&DestinationEnv::default(), &reserved())
+            .expect("a destination exactly at the budget resolves");
+    }
+
+    /// One evidence record with no measurement, built by hand so nothing in it
+    /// is a timestamp or a digest over a temporary directory.
+    ///
+    /// A record from a real run cannot be frozen: `observed_at` moves and
+    /// `artifact_id` carries the run's own destination root, so a golden over
+    /// one would be re-blessed on every change rather than read. This is the
+    /// same struct through the same encoder, and it is what makes the assertion
+    /// below a byte comparison rather than a shape comparison.
+    fn absent_record(service: Option<DestinationService>) -> EvidenceRecord {
+        EvidenceRecord {
+            schema: EVIDENCE_SCHEMA.to_string(),
+            outcome: Outcome::Absent,
+            repository_id: RESERVED.to_string(),
+            operation: OperationBinding {
+                org_id: "org-7f3c".to_string(),
+                operation_id: "2a91c3f0-51bd-4e77-9a06-8c4127de35b1".to_string(),
+                operation_revision: 7,
+                request_hash: "5f2c81a3".to_string(),
+                holder_id: "worker-3".to_string(),
+                fencing_token: 4,
+            },
+            measured: None,
+            echoed: EchoedInput {
+                source_input_hash: "a71b0f5c".to_string(),
+                requested_default_branch: "trunk".to_string(),
+                expected_refs: None,
+            },
+            destination_service: service,
+            differences: Vec::new(),
+            detail: Some("destination holds no publication".to_string()),
+        }
+    }
+
+    #[test]
+    fn a_filesystem_evidence_record_is_byte_identical_to_what_this_adapter_has_always_written() {
+        // The hosted control plane's decoder refuses an unknown top-level
+        // field, so every filesystem record this adapter writes has to encode
+        // exactly as it did before object-store publication existed. This is
+        // that guarantee as a byte comparison: no `destination_service` key,
+        // and nothing else moved to make room for it.
+        let rendered =
+            serde_json::to_string_pretty(&absent_record(None)).expect("encode the record");
+        assert_eq!(
+            rendered,
+            r#"{
+  "schema": "kin.hosted-first-publication-evidence.v1",
+  "outcome": "absent",
+  "repository_id": "9f1c2e04-3b7a-4d21-9c55-0ab61d7e8f30",
+  "operation": {
+    "org_id": "org-7f3c",
+    "operation_id": "2a91c3f0-51bd-4e77-9a06-8c4127de35b1",
+    "operation_revision": 7,
+    "request_hash": "5f2c81a3",
+    "holder_id": "worker-3",
+    "fencing_token": 4
+  },
+  "echoed": {
+    "source_input_hash": "a71b0f5c",
+    "requested_default_branch": "trunk",
+    "expected_refs": null
+  },
+  "detail": "destination holds no publication"
+}"#
+        );
+    }
+
+    #[test]
+    fn an_object_store_record_names_the_service_and_adds_nothing_else() {
+        let rendered = serde_json::to_string_pretty(&absent_record(Some(DestinationService {
+            class: "emulator".to_string(),
+            endpoint_url: Some("http://127.0.0.1:4443".to_string()),
+        })))
+        .expect("encode the record");
+        assert_eq!(
+            rendered,
+            r#"{
+  "schema": "kin.hosted-first-publication-evidence.v1",
+  "outcome": "absent",
+  "repository_id": "9f1c2e04-3b7a-4d21-9c55-0ab61d7e8f30",
+  "operation": {
+    "org_id": "org-7f3c",
+    "operation_id": "2a91c3f0-51bd-4e77-9a06-8c4127de35b1",
+    "operation_revision": 7,
+    "request_hash": "5f2c81a3",
+    "holder_id": "worker-3",
+    "fencing_token": 4
+  },
+  "echoed": {
+    "source_input_hash": "a71b0f5c",
+    "requested_default_branch": "trunk",
+    "expected_refs": null
+  },
+  "destination_service": {
+    "class": "emulator",
+    "endpoint_url": "http://127.0.0.1:4443"
+  },
+  "detail": "destination holds no publication"
+}"#
+        );
+
+        // A production destination carries no override URL, and the key is
+        // absent rather than null, so a decoder reading it as optional sees the
+        // same shape a filesystem record has for every other optional field.
+        let production = serde_json::to_string(&absent_record(Some(DestinationService {
+            class: "production-adc".to_string(),
+            endpoint_url: None,
+        })))
+        .expect("encode the record");
+        assert!(
+            production.contains(r#""destination_service":{"class":"production-adc"}"#),
+            "got {production}"
+        );
+    }
+
+    #[test]
+    fn the_resolved_scope_is_the_string_the_budget_was_checked_against() {
+        let resolved = object_store(BUCKET, PREFIX)
+            .resolve(&DestinationEnv::default(), &reserved())
+            .expect("a well formed destination resolves");
+        assert_eq!(resolved.scope(), format!("gcs:{BUCKET}/{PREFIX}"));
+        // The identifier the run will compose after a publication commits, at
+        // the widest generation a bucket can assign. The budget was checked
+        // against exactly this string, so a run that resolves cannot later fail
+        // to write its own receipt.
+        let widest = format!(
+            "{ARTIFACT_ID_PREFIX}:{}/{RESERVED}@{}",
+            resolved.scope(),
+            u64::MAX
+        );
+        assert!(
+            widest.len() <= ARTIFACT_ID_MAX_BYTES,
+            "a resolved destination always fits its identifier, got {} bytes",
+            widest.len()
+        );
+    }
 }

--- a/crates/kin-cli/src/commands/hosted_publication.rs
+++ b/crates/kin-cli/src/commands/hosted_publication.rs
@@ -2293,8 +2293,7 @@ mod tests {
         // Positive control: one byte under the same shape resolves, so the
         // refusal is about the length rather than about the prefix's contents.
         let composed = format!(
-            "{ARTIFACT_ID_PREFIX}:gcs:{BUCKET}/{}/{RESERVED}@{}",
-            "p".repeat(1),
+            "{ARTIFACT_ID_PREFIX}:gcs:{BUCKET}/p/{RESERVED}@{}",
             u64::MAX
         );
         let room = ARTIFACT_ID_MAX_BYTES - (composed.len() - 1);

--- a/crates/kin-cli/tests/hosted_first_publication.rs
+++ b/crates/kin-cli/tests/hosted_first_publication.rs
@@ -820,18 +820,107 @@ fn an_intent_recording_another_publication_is_never_replaced() {
     );
 }
 
-#[test]
-fn a_gcs_destination_is_refused_by_name() {
-    let case = Case::new();
-    let mut manifest = native_manifest(&case.path("destination"), "trunk");
-    manifest["destination"] = json!({ "kind": "gcs", "bucket": "kin-graph", "prefix": "hosted" });
-    write_manifest(&case.path("manifest.json"), &manifest);
+/// A manifest whose destination is a bucket rather than a directory.
+///
+/// Only the build without the object-store client uses it. The build with one
+/// has its own suite, in `hosted_publication_object_store.rs`, because a
+/// feature-gated case inside this ungated binary would be compiled by clippy
+/// and executed by no test job.
+#[cfg(not(feature = "gcs"))]
+fn object_store_manifest(bucket: &str, prefix: &str) -> serde_json::Value {
+    let mut manifest = native_manifest(Path::new("/unused"), "trunk");
+    manifest["destination"] = json!({ "kind": "gcs", "bucket": bucket, "prefix": prefix });
+    manifest
+}
 
-    let error = run_publish(case.publish_args("native-empty"))
-        .expect_err("an object-store destination is not implemented by this build");
+/// Without the client, the destination is refused, and the refusal says which
+/// half is missing.
+///
+/// Every value in the destination was still validated before this point, so the
+/// message names them. An operator who reads it learns their configuration was
+/// fine and their binary was not, which is a different fix from the one a bare
+/// capability refusal sends them looking for.
+#[cfg(not(feature = "gcs"))]
+#[test]
+fn an_object_store_destination_is_refused_by_a_build_without_the_client() {
+    use kin_cli::commands::hosted_publication::{run_publish_with_env, DestinationEnv};
+
+    let case = Case::new();
+    write_manifest(
+        &case.path("manifest.json"),
+        &object_store_manifest("kin-graph", "hosted"),
+    );
+
+    let error = run_publish_with_env(
+        case.publish_args("native-empty"),
+        &DestinationEnv::default(),
+    )
+    .expect_err("an object-store destination needs a client this build does not carry");
+    let rendered = format!("{error:#}");
     assert!(
-        format!("{error:#}").contains("destination_backend_unavailable"),
-        "the refusal names the missing capability: {error:#}"
+        rendered.contains("destination_backend_unavailable"),
+        "the refusal names the missing capability: {rendered}"
+    );
+    assert!(
+        rendered.contains("gcs:kin-graph/hosted"),
+        "the refusal names the destination it refused: {rendered}"
+    );
+    assert!(
+        rendered.contains("production-adc"),
+        "the refusal names the service it would have used: {rendered}"
+    );
+}
+
+/// A filesystem run's record gains nothing from the object-store wiring.
+///
+/// The hosted control plane's decoder refuses an unknown top-level field, so a
+/// record that grew one would be refused at the store rather than read. The
+/// exact encoding is frozen by a unit test in the module itself; this is the
+/// same guarantee over a real publication's output.
+#[test]
+fn a_filesystem_publication_records_no_destination_service() {
+    let case = Case::new();
+    write_manifest(
+        &case.path("manifest.json"),
+        &native_manifest(&case.path("destination"), "trunk"),
+    );
+    assert_eq!(
+        run_publish(case.publish_args("native-empty")).expect("publish"),
+        0
+    );
+
+    let raw = fs::read_to_string(case.path("evidence.json")).expect("read evidence");
+    assert!(
+        !raw.contains("destination_service"),
+        "a filesystem record carries no service field: {raw}"
+    );
+    let rendered: serde_json::Value = serde_json::from_str(&raw).expect("decode evidence");
+    let keys: Vec<&str> = rendered
+        .as_object()
+        .expect("the record is an object")
+        .keys()
+        .map(String::as_str)
+        .collect();
+    // The exact set, not a subset and not one derived from the record itself.
+    // A published run carries no differences and no detail, both of which are
+    // skipped when empty, so this is every key such a record has ever had.
+    //
+    // Sorted, because a decoded `serde_json::Value` holds its object in a
+    // BTreeMap and cannot report the order the bytes carried. Order is asserted
+    // where it can be, over the encoder itself, by
+    // `a_filesystem_evidence_record_is_byte_identical_to_what_this_adapter_has_always_written`
+    // in the module's own tests.
+    assert_eq!(
+        keys,
+        [
+            "echoed",
+            "measured",
+            "operation",
+            "outcome",
+            "repository_id",
+            "schema"
+        ],
+        "the top-level shape is exactly what it was before object-store publication"
     );
 }
 

--- a/crates/kin-cli/tests/hosted_publication_object_store.rs
+++ b/crates/kin-cli/tests/hosted_publication_object_store.rs
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! First publication into an object-store destination, end to end through the
+//! adapter, for a build that carries the client.
+//!
+//! Its own file rather than three more cases beside the filesystem suite,
+//! because the whole file is gated on the `gcs` feature and the workspace's
+//! ordinary test job runs default features. A feature-gated case sitting inside
+//! an ungated binary is compiled by clippy's `--all-features` pass and executed
+//! by nothing, and the CI step that grades this file counts what it lists:
+//! a gated case added here and not added to that step's list would make the
+//! listing and the enumeration disagree, which is the assertion that fires.
+//! Scoping the file to the feature is what makes that count exact.
+//!
+//! Nothing here reaches a bucket. The endpoint points at a port nothing is
+//! listening on, so a real client is built and a real request is made and it
+//! fails, which is enough to exercise the entire dispatch: the feature wiring,
+//! the manifest, the destination's validation, the endpoint precedence, the
+//! client construction, the backend call and the evidence composition. Reaching
+//! an actual emulator is covered by the daemon's ignored GCS round trip; reaching the
+//! real service is production's own acceptance.
+
+#![cfg(feature = "gcs")]
+
+use std::fs;
+use std::net::TcpListener;
+use std::path::PathBuf;
+
+use kin_cli::commands::hosted_publication::{
+    run_publish_with_env, run_verify_with_env, DestinationEnv, EvidenceRecord, IntentRecord,
+    Outcome, PublishArgs, VerifyArgs, EXIT_INDETERMINATE,
+};
+use serde_json::json;
+use tempfile::tempdir;
+
+const RESERVED_ID: &str = "9f1c2e04-3b7a-4d21-9c55-0ab61d7e8f30";
+const SOURCE_INPUT_HASH: &str = "a71b0f5c2d9e4813a6c07f52b8d31e94a05c76fb28d13e0947ab65cf2081d3e7";
+const REQUEST_HASH: &str = "5f2c81a30bd47e6915c8f0234ab7de91c605f3821de74a90bc3f2178e045a6d1";
+const BUCKET: &str = "kin-hosted-prod";
+const PREFIX: &str = "publications/v1";
+
+/// A local port nothing is listening on.
+///
+/// Claimed and released, so it is closed but almost certainly still unclaimed:
+/// a stopped emulator. The same shape the daemon's own endpoint tests use.
+fn closed_endpoint() -> String {
+    let port = {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind a port to claim it");
+        listener
+            .local_addr()
+            .expect("read the claimed address")
+            .port()
+    };
+    format!("http://127.0.0.1:{port}")
+}
+
+struct Case {
+    _temp: tempfile::TempDir,
+    root: PathBuf,
+}
+
+impl Case {
+    fn new() -> Self {
+        let temp = tempdir().expect("temp dir");
+        let root = temp.path().to_path_buf();
+        Self { _temp: temp, root }
+    }
+
+    fn path(&self, name: &str) -> PathBuf {
+        self.root.join(name)
+    }
+
+    /// A manifest whose destination is a bucket rather than a directory.
+    fn write_manifest(&self) {
+        let manifest = json!({
+            "schema": "kin.hosted-first-publication-manifest.v1",
+            "operation": {
+                "org_id": "org-7f3c",
+                "operation_id": "2a91c3f0-51bd-4e77-9a06-8c4127de35b1",
+                "operation_revision": 7,
+                "request_hash": REQUEST_HASH,
+                "holder_id": "worker-3",
+                "fencing_token": 4,
+            },
+            "repository_id": RESERVED_ID,
+            "source": { "kind": "native-empty", "default_branch": "trunk" },
+            "source_input_hash": SOURCE_INPUT_HASH,
+            "destination": { "kind": "gcs", "bucket": BUCKET, "prefix": PREFIX },
+            "expected_authority": serde_json::Value::Null,
+        });
+        fs::write(
+            self.path("manifest.json"),
+            serde_json::to_vec_pretty(&manifest).expect("encode manifest"),
+        )
+        .expect("write manifest");
+    }
+
+    fn publish_args(&self) -> PublishArgs {
+        PublishArgs {
+            manifest: self.path("manifest.json"),
+            source: self.path("source"),
+            intent_out: self.path("intent.json"),
+            evidence_out: self.path("evidence.json"),
+            expect_repository_id: RESERVED_ID.to_string(),
+            expect_mode: "native-empty".to_string(),
+        }
+    }
+
+    fn verify_args(&self) -> VerifyArgs {
+        VerifyArgs {
+            manifest: self.path("manifest.json"),
+            intent: Some(self.path("intent.json")),
+            evidence_out: self.path("verify-evidence.json"),
+            expect_repository_id: RESERVED_ID.to_string(),
+            expect_mode: "native-empty".to_string(),
+        }
+    }
+
+    fn evidence(&self, name: &str) -> EvidenceRecord {
+        let bytes = fs::read(self.path(name)).expect("read evidence");
+        serde_json::from_slice(&bytes).expect("decode evidence")
+    }
+}
+
+/// An intent naming this operation and this destination, so verification has
+/// something to compare a reading against.
+fn write_intent(case: &Case) {
+    let intent = json!({
+        "schema": "kin.hosted-first-publication-intent.v1",
+        "repository_id": RESERVED_ID,
+        "operation": {
+            "org_id": "org-7f3c",
+            "operation_id": "2a91c3f0-51bd-4e77-9a06-8c4127de35b1",
+            "operation_revision": 7,
+            "request_hash": REQUEST_HASH,
+            "holder_id": "worker-3",
+            "fencing_token": 4,
+        },
+        "mode": "native-empty",
+        "intended_snapshot_sha256": SOURCE_INPUT_HASH,
+        "intended_roots": {
+            "version": 1, "generation": 1,
+            "history": { "version": 1, "hash": SOURCE_INPUT_HASH },
+            "ref_state": { "version": 1, "hash": SOURCE_INPUT_HASH },
+            "ref_log": { "version": 1, "hash": SOURCE_INPUT_HASH },
+            "collaboration": { "version": 1, "hash": SOURCE_INPUT_HASH },
+            "replication": { "version": 1, "hash": SOURCE_INPUT_HASH },
+            "local_state": { "version": 1, "hash": SOURCE_INPUT_HASH },
+        },
+        "intended_source_closure": {
+            "algorithm": "kin.first-publication-body-closure.v1",
+            "digest": SOURCE_INPUT_HASH,
+            "body_count": 0,
+            "total_bytes": 0,
+        },
+        "intended_default_branch": "trunk",
+        "intended_head_change_id": serde_json::Value::Null,
+        "intended_ref_bindings": [],
+        "destination": { "kind": "gcs", "bucket": BUCKET, "prefix": PREFIX },
+        "written_at": "2026-09-08T00:00:00Z",
+    });
+    fs::write(
+        case.path("intent.json"),
+        serde_json::to_vec_pretty(&intent).expect("encode intent"),
+    )
+    .expect("write intent");
+    // Decoded back through the adapter's own type, so a fixture that has
+    // drifted from the record's shape fails here rather than as a confusing
+    // refusal inside the run under test.
+    let bytes = fs::read(case.path("intent.json")).expect("read intent");
+    let _: IntentRecord = serde_json::from_slice(&bytes).expect("the fixture intent decodes");
+}
+
+/// A destination the client cannot reach is INDETERMINATE, never ABSENT, and
+/// the record names the service it failed to reach.
+///
+/// Reporting a destination nobody could read as holding no publication is
+/// exactly the mistake that turns an unknown storage state into a second
+/// publication under one reserved identity, so the two outcomes are asserted
+/// apart rather than together.
+#[test]
+fn an_unreachable_bucket_is_indeterminate_and_names_its_service() {
+    let case = Case::new();
+    case.write_manifest();
+    let endpoint = closed_endpoint();
+    let env = DestinationEnv {
+        kin_gcs_endpoint: Some(endpoint.clone()),
+        storage_emulator_host: None,
+    };
+
+    assert_eq!(
+        run_publish_with_env(case.publish_args(), &env).expect("the run completes"),
+        EXIT_INDETERMINATE,
+        "a destination that could not be read is neither published nor absent"
+    );
+
+    let record = case.evidence("evidence.json");
+    assert_eq!(record.outcome, Outcome::Indeterminate);
+    assert!(
+        record.measured.is_none(),
+        "nothing was read back, so nothing is measured"
+    );
+    let service = record
+        .destination_service
+        .expect("an object-store run records the service it talked to");
+    assert_eq!(
+        service.class, "emulator",
+        "an endpoint override is an emulator, never the real service"
+    );
+    assert_eq!(
+        service.endpoint_url.as_deref(),
+        Some(endpoint.as_str()),
+        "the record names the exact endpoint the client was built against"
+    );
+
+    // The source was never materialized: an unreadable destination is reported
+    // before an import is spent on it.
+    assert!(
+        !case.path("source").exists(),
+        "a destination this run could not read must not have cost an import"
+    );
+}
+
+/// The Google-client convention reaches the client, not just the resolver.
+///
+/// `STORAGE_EMULATOR_HOST` is the second lever, and a unit test can only show
+/// that it resolves. This shows the value it resolved to is the one the client
+/// was actually built against, which is the part a resolver test cannot reach.
+#[test]
+fn the_google_convention_alone_points_the_client_at_the_same_endpoint() {
+    let case = Case::new();
+    case.write_manifest();
+    let endpoint = closed_endpoint();
+    let env = DestinationEnv {
+        kin_gcs_endpoint: None,
+        storage_emulator_host: Some(endpoint.clone()),
+    };
+
+    assert_eq!(
+        run_publish_with_env(case.publish_args(), &env).expect("the run completes"),
+        EXIT_INDETERMINATE
+    );
+    let service = case
+        .evidence("evidence.json")
+        .destination_service
+        .expect("an object-store run records its service");
+    assert_eq!(service.endpoint_url.as_deref(), Some(endpoint.as_str()));
+}
+
+/// Verification reaches the same client and writes nothing.
+///
+/// The hosted control plane calls `verify` as well as `publish`, so the arm has
+/// its own dispatch through the same destination and its own record. A wiring
+/// that reached the client on one path and not the other would leave the
+/// recovery half of a hosted operation refusing for a reason nobody could see.
+#[test]
+fn verification_reaches_the_same_object_store_and_records_its_service() {
+    let case = Case::new();
+    case.write_manifest();
+    write_intent(&case);
+    let endpoint = closed_endpoint();
+    let env = DestinationEnv {
+        kin_gcs_endpoint: Some(endpoint.clone()),
+        storage_emulator_host: None,
+    };
+
+    assert_eq!(
+        run_verify_with_env(case.verify_args(), &env).expect("the run completes"),
+        EXIT_INDETERMINATE
+    );
+    let record = case.evidence("verify-evidence.json");
+    assert_eq!(record.outcome, Outcome::Indeterminate);
+    let service = record
+        .destination_service
+        .expect("a verification records the service it read through");
+    assert_eq!(service.class, "emulator");
+    assert_eq!(service.endpoint_url.as_deref(), Some(endpoint.as_str()));
+}

--- a/crates/kin-daemon/Cargo.toml
+++ b/crates/kin-daemon/Cargo.toml
@@ -24,7 +24,13 @@ metal = ["embeddings", "kin-cli/metal"]
 # version so `GcsBackend::from_store` accepts a store this crate built. That is
 # what lets a custom endpoint (see `gcs_endpoint`) redirect the backend at an
 # emulator without a kin-db change.
-gcs = ["kin-db/gcs", "dep:object_store", "object_store/gcp"]
+#
+# `kin-cli/gcs` is here rather than in the Dockerfile because the image builds
+# `--bin kin-daemon --bin kin` from one `--features kin-daemon/gcs` invocation
+# that `scripts/check-docker-daemon-features.sh` pins exactly, so this is the
+# only way the hosted worker's `kin` binary can publish into a bucket. Forwarded
+# the same way `vector`, `embeddings` and `metal` are above.
+gcs = ["kin-db/gcs", "kin-cli/gcs", "dep:object_store", "object_store/gcp"]
 firestore = ["kin-spine/firestore"]
 
 [dependencies]

--- a/crates/kin-daemon/src/gcs_endpoint.rs
+++ b/crates/kin-daemon/src/gcs_endpoint.rs
@@ -54,7 +54,7 @@ pub const DEFAULT_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 pub struct ResolvedEndpoint {
     /// Normalized base URL, scheme included and no trailing slash.
     pub url: String,
-    /// Host as written, for the probe and for error messages.
+    /// Host without IPv6 brackets, suitable for socket address resolution.
     pub host: String,
     /// Port, defaulted from the scheme when the value omitted one.
     pub port: u16,
@@ -97,60 +97,24 @@ pub fn resolve(
 /// that the Google clients also accept for `STORAGE_EMULATOR_HOST`, defaulting
 /// a missing scheme to `http` and a missing port to the scheme's own.
 fn parse_endpoint(value: &str, source: &'static str) -> Result<ResolvedEndpoint, String> {
-    let (scheme, rest) = match value.split_once("://") {
-        None => ("http", value),
-        Some((scheme, rest)) => {
-            let scheme = match scheme.to_ascii_lowercase().as_str() {
-                "http" => "http",
-                "https" => "https",
-                other => {
-                    return Err(format!(
-                        "its scheme {other:?} is not supported (expected http or https)"
-                    ))
-                }
-            };
-            (scheme, rest)
-        }
-    };
-
-    // A base URL is an origin. Anything past the authority would be silently
-    // dropped or silently prepended depending on the caller, so refuse it here
-    // where the operator can still see which variable to fix.
-    let authority = match rest.split_once('/') {
-        None => rest,
-        Some((authority, "")) => authority,
-        Some((_, path)) => {
-            return Err(format!(
-                "it carries a path (/{path}); an endpoint must be scheme, host and port only"
-            ))
-        }
-    };
-
-    if authority.is_empty() {
-        return Err("it has no host".to_string());
-    }
-
-    let (host, port) = match authority.rsplit_once(':') {
-        None => (authority, if scheme == "https" { 443_u16 } else { 80_u16 }),
-        Some((host, port_text)) => {
-            let port = port_text
-                .parse::<u16>()
-                .map_err(|_| format!("its port {port_text:?} is not a number in 1..=65535"))?;
-            if port == 0 {
-                return Err("its port is 0, which cannot be connected to".to_string());
-            }
-            (host, port)
-        }
-    };
-
-    if host.is_empty() {
-        return Err("it has no host".to_string());
-    }
-
+    let validated = kin_remote::first_publication_gcs::GcsEndpointOverride::parse(value, source)
+        .map_err(|error| error.to_string())?;
+    let url = validated.url();
+    // The shared parser always emits a scheme and an explicit numeric port.
+    let (_, authority) = url
+        .split_once("://")
+        .expect("validated endpoint has a scheme");
+    let (host, port) = authority
+        .rsplit_once(':')
+        .expect("validated endpoint has a port");
+    let probe_host = host
+        .strip_prefix('[')
+        .and_then(|host| host.strip_suffix(']'))
+        .unwrap_or(host);
     Ok(ResolvedEndpoint {
-        url: format!("{scheme}://{host}:{port}"),
-        host: host.to_string(),
-        port,
+        url: url.to_owned(),
+        host: probe_host.to_owned(),
+        port: port.parse().expect("validated endpoint has a numeric port"),
         source,
     })
 }
@@ -502,6 +466,34 @@ mod tests {
             .expect("load reaches the emulator")
             .expect("the snapshot just written must be there");
         assert_eq!(loaded, payload, "round trip must preserve the bytes");
+    }
+
+    #[test]
+    fn bracketed_ipv6_endpoint_resolves_and_reaches_a_listener() {
+        let listener = TcpListener::bind("[::1]:0").expect("bind IPv6 loopback");
+        let port = listener.local_addr().expect("address").port();
+        let endpoint = resolve(Some(&format!("http://[::1]:{port}")), None)
+            .expect("parse IPv6 endpoint")
+            .expect("explicit emulator");
+        assert_eq!(endpoint.url, format!("http://[::1]:{port}"));
+        assert_eq!(endpoint.probe_reachable(Duration::from_secs(2)), Ok(()));
+        let default_port = resolve(Some("https://[::1]"), None)
+            .expect("parse IPv6 without port")
+            .expect("explicit emulator");
+        assert_eq!(default_port.url, "https://[::1]:443");
+    }
+
+    #[test]
+    fn malformed_brackets_and_credentials_never_fall_through() {
+        for bad in [
+            "http://[::1",
+            "http://[::1]x:4443",
+            "http://user:pass@host:4443",
+        ] {
+            let error = resolve(Some(bad), Some("http://localhost:4443"))
+                .expect_err("invalid first lever must refuse instead of falling through");
+            assert!(error.contains(KIN_ENDPOINT_VAR), "{error}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
`gcs:<bucket>/<prefix>` says nothing about whether that bucket was the real service or an emulator standing in for it, so a hosted publication receipt could not tell the two apart. Every destination refusal also happened late, after a client existed and sometimes after an import had been spent on a destination nobody could reach.

`DestinationSpec::resolve` now settles every choice about where a publication points before anything is opened: the filesystem root's shape, the bucket and prefix grammar, the endpoint override, and the artifact-identifier budget. That last one is the load-bearing reorder. The identifier is composed from the scope AFTER a publication has already committed, so a prefix that cannot compose one used to produce a publication that succeeded and a receipt nobody could write. The resolved destination then hands out fresh backend handles, and an object-store one reports the service class off the value that built the client rather than deriving it a second time.

`destination_service` is emitted only for an object-store destination, so a filesystem run's record is byte-identical to what this adapter has always written. That matters because the hosted decoder refuses an unknown top-level field.

## Ordering

kinlab #508 teaches the hosted decoder this field and MUST be in production before this lands. #508 is green and waiting in its lane's queue.

## Verified by running, not by reading

```text
$ cargo test -p kin-daemon --features gcs --locked --lib gcs_endpoint
test result: ok. 15 passed; 0 failed; 1 ignored

$ cargo test -p kin-cli --locked --lib commands::hosted_publication
test result: ok. 11 passed; 0 failed

$ cargo test -p kin-cli --features gcs --locked --test hosted_publication_object_store
test result: ok. 3 passed; 0 failed

$ cargo test -p kin-cli --locked --test hosted_first_publication
test result: ok. 26 passed; 0 failed
```

The one ignored case is `a_seeded_emulator_serves_a_snapshot_round_trip`, which needs a running fake-gcs-server. No real object-store publication is claimed here.

Property by property. Production-ADC versus emulator classification, with precedence between the two levers and a positive control that the second is honored when the first is absent. Bracketed IPv6 both resolves and reaches a real IPv6 listener, and `http://[::1`, `http://[::1]x:4443`, `http://user:pass@host:4443`, `http://host:0` and `http://host/path` are each refused rather than falling through. Failure before irreversible publication, asserted as `!case.path("source").exists()` on a run against a closed port. Unchanged filesystem evidence bytes, asserted twice: a byte-exact encoder golden in the module, and an exact top-level key set over a real publication's output. And the object-store cases are behind the `gcs` feature with a CI step that runs them on the pull request, whose exact count assertion matches the file's three `#[test]` today.

## Falsification

Three arms, each breaking production behavior rather than an assertion, each killing exactly the cases written for it, restored green.

```text
ARM=A-invalid-override-selects-production   9 passed, 2 failed
  an_unparseable_lever_never_falls_back_to_the_real_service
  bracketed_ipv6_is_an_emulator_and_invalid_overrides_never_select_adc
ARM=B-budget-not-spent-at-resolution       10 passed, 1 failed
  an_identifier_that_cannot_be_composed_is_refused_before_a_publication_commits
ARM=C-service-key-always-emitted           10 passed, 1 failed  +  25 passed, 1 failed
  a_filesystem_evidence_record_is_byte_identical_to_what_this_adapter_has_always_written
  a_filesystem_publication_records_no_destination_service
ARM=D-restored                             11 passed, 0 failed  +  26 passed, 0 failed
```

Arm C is the one worth reading: dropping `skip_serializing_if` alone makes a filesystem record grow a `"destination_service": null` key, and both the unit golden and the integration key-set assertion catch it.

## The workflow change, called out

This raises `fast-gate-lint` (`Fast gate lint and policy`, one of main's seven required contexts) from 20 to 30 minutes, because the new step builds kin-cli under a second feature set that clippy's artifacts cannot serve. The step lives in that job rather than somewhere cheaper because the two names main requires are that one and the sharded test job, and a guard anywhere else is advisory.
