### PR TITLE
fix: include resolver dependencies in release guard probes

### DIFF
--- a/scripts/falsify-release-version-guards.py
+++ b/scripts/falsify-release-version-guards.py
@@ -47,6 +47,9 @@ PROOF_SUITE = "scripts/check-release-proof-artifacts.test.mjs"
 COPIED = (
     INTENT,
     INTENT_SUITE,
+    "scripts/resolve-release-intent.mjs",
+    "scripts/resolve-release-intent.test.mjs",
+    "scripts/release-intent-attestations.json",
     VERSION,
     VERSION_SUITE,
     PREPARE,
@@ -273,6 +276,16 @@ PROBES: tuple[tuple[str, str, str, Callable[[Path], None]], ...] = (
 def main() -> int:
     lines: list[str] = []
     try:
+        with tempfile.TemporaryDirectory() as temp:
+            tree = probe_tree(Path(temp))
+            for suite in dict.fromkeys(probe[1] for probe in PROBES):
+                result = run_suite(tree, suite)
+                if result.returncode != 0:
+                    raise FalsificationError(
+                        f"unmodified probe suite {suite} failed; mutations cannot "
+                        "be graded without a passing baseline\n"
+                        + f"{result.stdout}{result.stderr}"[-4000:]
+                    )
         for label, suite, expected, mutate in PROBES:
             lines.append(expect_failure(label, suite, expected, mutate))
     except FalsificationError as error:

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import copy
 import difflib
 import hashlib
+import importlib.util
 import json
 import os
 import re
@@ -10573,7 +10574,34 @@ def setup_buildx_mirror_input(job_block: str, label: str) -> str:
     return "\n".join(body)
 
 
+def assert_release_probe_fixtures() -> None:
+    spec = importlib.util.spec_from_file_location("release_probes", RELEASE_VERSION_FALSIFIER)
+    assert spec is not None and spec.loader is not None
+    probes = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(probes)
+    with tempfile.TemporaryDirectory() as temporary:
+        tree = probes.probe_tree(Path(temporary))
+        result = probes.run_suite(tree, probes.INTENT_SUITE)
+        assert result.returncode == 0, (
+            "release intent probe baseline failed\n" + result.stdout + result.stderr
+        )
+        for name in (
+            "resolve-release-intent.mjs",
+            "resolve-release-intent.test.mjs",
+            "release-intent-attestations.json",
+        ):
+            fixture = tree / "scripts" / name
+            original = fixture.read_bytes()
+            fixture.unlink()
+            try:
+                broken = probes.run_suite(tree, probes.INTENT_SUITE)
+                assert broken.returncode != 0, f"missing {name} did not fail the probe suite"
+            finally:
+                fixture.write_bytes(original)
+
+
 def main() -> None:
+    assert_release_probe_fixtures()
     retired = (
         "auto-tag-release.yml",
         "daemon-image.yml",


### PR DESCRIPTION
Release guard falsification could not run after the intent suite began importing resolver tests: the sandbox omitted the resolver, its test module and attestation fixture. Copy those dependencies into each probe tree. Require every unmodified suite to pass before applying any mutation so missing fixtures or unrelated failures cannot masquerade as falsification evidence.

Validation:
```text
node --test scripts/release-intent.test.mjs
# tests 28
# pass 28
# fail 0
python3 scripts/falsify-release-version-guards.py
the release version guards rejected all 11 poisoned trees:
  the mint stops refusing a release whose bump never landed -> a release-affecting commit stranded behind an existing tag refuses loudly
  the mint refuses a quiet cycle it should have passed -> documentation stranded behind an existing tag stays a green no-op
  the copied classifier drifts from the one the version gate uses -> the copied classifier agrees with the version gate on every branch
  a relative import creeps into the file the mint copies alone -> the gate imports nothing relative, so a single-file copy still runs
  the entry point goes back to comparing unresolved paths -> the gate runs from a copy reached through a symlinked directory
  the version gate stops refusing a release-affecting diff with no bump -> a release-affecting change with no bump is refused end to end
  the version gate stops refusing a bump that skips a version -> a bump that skips a version is refused end to end
  the version gate's entry point goes back to unresolved paths -> the gate runs from a copy reached through a symlinked directory
  the version gate starts demanding a bump for documentation -> a documentation-only release pull request needs no bump
  the release generator's entry point goes back to unresolved paths -> the generator runs from a copy reached through a symlinked directory
  the proof-artifact gate's entry point goes back to unresolved paths -> the gate runs from a copy reached through a symlinked directory
```

Negative control: remove the attestation fixture from COPIED in an imported in-memory module and run main(). It returns 1 naming the unmodified baseline failure; restored source passes. The existing PR-tested workflow authority suite now builds the real probe sandbox, runs the intent suite successfully, and removes each of its three dependencies in turn to prove the suite fails. `python3 scripts/test-release-workflow-authority.py` exits 0 with these controls. Precheck passed 21/21 on the initial fixture repair; the subsequent change only adds this separately verified authority regression case.

Kin-Release-Intent: patch
