### PR TITLE
test: respect Windows spool handle lifetime after unlink

### DIFF
--- a/crates/kin-git/src/history_spool.rs
+++ b/crates/kin-git/src/history_spool.rs
@@ -381,13 +381,30 @@ mod tests {
         }
     }
 
+    #[cfg(not(windows))]
     #[test]
-    fn spool_refuses_missing_truncated_tampered_and_appended_bodies() {
-        for mode in 0..4 {
+    fn spool_refuses_removed_path() {
+        let spool = SemanticChangeSpool::from_changes(spool_dir(), [change(1)]).unwrap();
+        std::fs::remove_file(spool.0.file.path()).unwrap();
+        assert!(spool.read_at(0).is_err());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn spool_reads_authenticated_handle_after_path_removal() {
+        let original = change(1);
+        let spool = SemanticChangeSpool::from_changes(spool_dir(), [original.clone()]).unwrap();
+        std::fs::remove_file(spool.0.file.path()).unwrap();
+        assert_eq!(spool.read_at(0).unwrap(), Some(original));
+        spool.0.file.as_file().set_len(1).unwrap();
+        assert!(spool.read_at(0).is_err());
+    }
+
+    #[test]
+    fn spool_refuses_truncated_tampered_and_appended_bodies() {
+        for mode in 1..4 {
             let spool = SemanticChangeSpool::from_changes(spool_dir(), [change(1)]).unwrap();
-            let path = spool.0.file.path();
             match mode {
-                0 => std::fs::remove_file(path).unwrap(),
                 1 => spool.0.file.as_file().set_len(1).unwrap(),
                 2 => {
                     let mut file = spool.0.file.reopen().unwrap();


### PR DESCRIPTION
Main's native Windows authority job fails when the spool test treats removing a pathname as invalidating the held file. tempfile 3.27.0 reopens the authenticated Windows handle with ReOpenFile, so reading the unchanged record remains valid after unlink.

Split the removal test by platform. Unix still rejects the missing pathname. Windows must return the exact original change through the retained handle and then reject truncation through that handle. The shared truncation, tampering, append, checksum and identity tests remain. Production code is unchanged.

Validation:

- Repeated failing main evidence: [Windows authority tests](https://github.com/firelock-ai/kin/actions/runs/34279726212/job/102241304269), corruption mode 0, 45 passed and 1 failed.
- Local `cargo test --locked -p kin-git --lib` through the shared heavy-slot wrapper: `135 passed; 0 failed`.
- Falsification: changing missing-path handling to return `Ok(None)` makes `cargo test --locked -p kin-git --lib history_spool::tests::spool_refuses_removed_path -- --exact` fail with `0 passed; 1 failed` and exit 101. Restoring exact source bytes and running all spool tests gives `8 passed; 0 failed`.
- Worktree-scoped `kin-precheck kin --repo-dir kin=<checkout>` through heavy-slot: `21 gates ran, 21 passed, 0 failed`, including fmt, workflow clippy and guards.

Native Windows authority tests intentionally run on main after landing. The PR cross-check is separate evidence; the resulting main Windows run remains the release gate. This correction contains no held memory, calibration or positioned-read optimization changes.
