### PR TITLE
Attest misplaced release intents and document signed footers

### DIFF
--- a/docs/release-bot.md
+++ b/docs/release-bot.md
@@ -54,11 +54,19 @@ or updates one automation-owned PR.
 The SemVer bump is resolved only from `Kin-Release-Intent:` git trailers on the
 first-parent commits between the prior stable tag and `main`. Patch is the
 default, and the highest intent found in the range wins. Write the trailer as
-the last block of the pull-request body:
+the last block of the pull-request body, adjacent to the actual author sign-off:
 
 ```
 Kin-Release-Intent: minor
+Signed-off-by: Author Name <author@example.com>
 ```
+
+Use the same sign-off as the signed commits. If the body omits it, GitHub can
+append the sign-off below a divider when squashing, leaving the intent outside
+the parsed trailer block. Keep both lines together with no divider or blank
+line between them. Check the final squash with `git show -s --format=%B <sha> |
+git interpret-trailers --parse`; both trailers must appear. A misplaced intent
+on an immutable commit requires the explicit SHA attestation below.
 
 Because the repository merges by squash with the pull-request body as the
 commit message, that line becomes part of the immutable commit on `main`. The

--- a/scripts/release-intent-attestations.json
+++ b/scripts/release-intent-attestations.json
@@ -20,6 +20,16 @@
       "sha": "c67efaa2c737ab0b7ac15d0057c8a3ec5a8041cc",
       "intent": "patch",
       "reason": "FIR-3412: This immutable squash commit explicitly records Kin-Release-Intent: patch before the footer divider. Git parses only Signed-off-by. Attest the recorded patch intent so resolution can traverse the complete release range without guessing or editing history."
+    },
+    {
+      "sha": "1b11fda4c870245f2575363adcf1031699580969",
+      "intent": "patch",
+      "reason": "FIR-3412: This immutable squash commit explicitly records Kin-Release-Intent: patch before the divider preceding its sign-off. Git parses only Signed-off-by. Attest the recorded patch intent without changing history or accepting malformed evidence implicitly."
+    },
+    {
+      "sha": "8525c7751716b1c5304cd2d62da1aa8235e2e077",
+      "intent": "patch",
+      "reason": "FIR-3412: This immutable squash commit explicitly records Kin-Release-Intent: patch before the divider preceding its sign-off. Git parses only Signed-off-by. Attest the recorded patch intent without changing history or accepting malformed evidence implicitly."
     }
   ]
 }

--- a/scripts/resolve-release-intent.test.mjs
+++ b/scripts/resolve-release-intent.test.mjs
@@ -177,6 +177,8 @@ test('the committed historical attestation binds only the recorded full SHA', ()
     '72414aa80531e7adee1ab360eacb28d56a621c6a',
     '9e45cc6c89b12c72e519c86517ac38a8a79a7cea',
     'c67efaa2c737ab0b7ac15d0057c8a3ec5a8041cc',
+    '1b11fda4c870245f2575363adcf1031699580969',
+    '8525c7751716b1c5304cd2d62da1aa8235e2e077',
   ]) {
     const entry = document.attestations.find(({ sha }) => sha === expected);
     assert.equal(entry?.intent, 'patch', expected);


### PR DESCRIPTION
The squash messages for #1617 and #1598 record patch intent above a divider preceding their sign-offs. Git does not parse those intent lines as trailers, so the strict release resolver rejects the immutable commits.

Add explicit full-SHA patch attestations for both commits, preserving their recorded intent and explaining the unreadable footer. Extend the existing committed-record regression to require both entries. Document adjacent intent and author sign-off lines, plus verification of the final squash footer. Resolver policy is unchanged.

Validation against the actual v0.7.5 through 8525c775 history:

```text
node scripts/resolve-release-intent.mjs --base-ref v0.7.5 --head-ref 8525c7751716b1c5304cd2d62da1aa8235e2e077 --attestations scripts/release-intent-attestations.json
exit 0, intent patch, six explicit attestation records
omit 1b11fda4c870245f2575363adcf1031699580969: exit 1, malformed or non-footer evidence at that SHA
omit 8525c7751716b1c5304cd2d62da1aa8235e2e077: exit 1, malformed or non-footer evidence at that SHA
```

The committed-record test passes with all records and fails with either new record removed in an isolated fixture. The resolver suite passes 16/16. Workflow authority and all 11 release falsifiers pass under Node 22. Workflow-derived precheck passed 21/21 on the parent checkout with this patch applied; it reported the parent SHA and DIRTY, so this is local patch evidence rather than a clean final-commit claim. All 49 exact-head checks concluded without failure: 32 success and 17 skipped. No Rust production code changed. This PR follows #1606, #1608 and #1609 in the coordinated sequence before the final feature-gate correction.

```text
node --test scripts/resolve-release-intent.test.mjs
tests 16, pass 16, fail 0
python3 scripts/test-release-workflow-authority.py
exit 0
python3 scripts/falsify-release-version-guards.py
11 poisoned trees rejected, exit 0
bin/kin-precheck kin --repo-dir kin=<checkout>
21 gates ran, 21 passed, 0 failed, on kin 8525c7751716b1c5304cd2d62da1aa8235e2e077 DIRTY
```

FIR-3412

Kin-Release-Intent: patch
Signed-off-by: Troy Fortin <troy@firelock.ai>
