### PR TITLE
Attest the appended-signoff squash and verify final footers

### DIFF
--- a/docs/release-bot.md
+++ b/docs/release-bot.md
@@ -53,20 +53,22 @@ or updates one automation-owned PR.
 
 The SemVer bump is resolved only from `Kin-Release-Intent:` git trailers on the
 first-parent commits between the prior stable tag and `main`. Patch is the
-default, and the highest intent found in the range wins. Write the trailer as
-the last block of the pull-request body, adjacent to the actual author sign-off:
+default, and the highest intent found in the range wins. Ordinary patch changes
+can omit the optional intent line. For an explicit intent, the final commit must
+keep it in the same trailer block as any sign-off:
 
 ```
 Kin-Release-Intent: minor
 Signed-off-by: Author Name <author@example.com>
 ```
 
-Use the same sign-off as the signed commits. If the body omits it, GitHub can
-append the sign-off below a divider when squashing, leaving the intent outside
-the parsed trailer block. Keep both lines together with no divider or blank
-line between them. Check the final squash with `git show -s --format=%B <sha> |
-git interpret-trailers --parse`; both trailers must appear. A misplaced intent
-on an immutable commit requires the explicit SHA attestation below.
+Placing both lines together in the pull-request body does not guarantee that
+the merge path preserves that block. A separately appended sign-off, after a
+blank line or divider, leaves the earlier intent outside the parsed footer even
+if the body already contains a sign-off. Check the actual final squash with
+`git show -s --format=%B <sha> | git interpret-trailers --parse`; an explicit
+intent must appear there. A misplaced intent on an immutable commit requires
+the explicit SHA attestation below. Do not infer success from the body preview.
 
 Because the repository merges by squash with the pull-request body as the
 commit message, that line becomes part of the immutable commit on `main`. The

--- a/scripts/release-intent-attestations.json
+++ b/scripts/release-intent-attestations.json
@@ -30,6 +30,11 @@
       "sha": "8525c7751716b1c5304cd2d62da1aa8235e2e077",
       "intent": "patch",
       "reason": "FIR-3412: This immutable squash commit explicitly records Kin-Release-Intent: patch before the divider preceding its sign-off. Git parses only Signed-off-by. Attest the recorded patch intent without changing history or accepting malformed evidence implicitly."
+    },
+    {
+      "sha": "48bafa7911ccde08f64c14a002a8a991ffefd7a2",
+      "intent": "patch",
+      "reason": "FIR-3412: The immutable squash commit records an explicit patch intent adjacent to its first sign-off, but a second sign-off follows a blank line. Git parses only that final sign-off. Attest the recorded patch intent without changing history or relaxing footer validation."
     }
   ]
 }

--- a/scripts/resolve-release-intent.test.mjs
+++ b/scripts/resolve-release-intent.test.mjs
@@ -129,6 +129,17 @@ test('an explicit full-SHA attestation resolves the divider case and records its
   assert.throws(() => resolveReleaseIntent({ root, baseRef: 'v1.2.3' }), /malformed or non-footer/);
 });
 
+test('a separately appended sign-off makes the earlier intent require attestation', () => {
+  const footer = 'Kin-Release-Intent: patch\nSigned-off-by: Test <test@example.invalid>\n';
+  const readable = repository(['change\n\n' + footer]);
+  assert.equal(resolveReleaseIntent({ root: readable, baseRef: 'v1.2.3' }).evidence[0].intent, 'patch');
+  const root = repository(['change\n\n' + footer + '\nSigned-off-by: Test <test@example.invalid>\n']);
+  assert.throws(() => resolveReleaseIntent({ root, baseRef: 'v1.2.3' }), /malformed or non-footer/);
+  const result = resolveReleaseIntent({ root, baseRef: 'v1.2.3', attestations: attested(root) });
+  assert.equal(result.evidence[0].source, 'attestation');
+  assert.equal(result.intent, 'patch');
+});
+
 test('attestations cannot replace readable, duplicate, invalid or absent intent', () => {
   for (const message of [
     'change\n\nKin-Release-Intent: major\n',
@@ -179,6 +190,7 @@ test('the committed historical attestation binds only the recorded full SHA', ()
     'c67efaa2c737ab0b7ac15d0057c8a3ec5a8041cc',
     '1b11fda4c870245f2575363adcf1031699580969',
     '8525c7751716b1c5304cd2d62da1aa8235e2e077',
+    '48bafa7911ccde08f64c14a002a8a991ffefd7a2',
   ]) {
     const entry = document.attestations.find(({ sha }) => sha === expected);
     assert.equal(entry?.intent, 'patch', expected);


### PR DESCRIPTION
The final squash for #1620 appended a second sign-off after a blank line. Git parses only the last block, so its explicit patch intent became unreadable even though the pull-request body kept the first sign-off beside it.

Attest that immutable full SHA with its recorded patch intent and reason. Correct the documentation to require inspection of the actual final commit, and add a regression covering a readable adjacent footer followed by a separately appended sign-off. Resolver policy is unchanged. Ordinary patch changes can already omit optional intent.

Validation:

```text
Node 22: node --test scripts/resolve-release-intent.test.mjs
17 tests, 17 passed, 0 failed
Actual v0.7.5..48bafa7911ccde08f64c14a002a8a991ffefd7a2 with committed attestations
exit 0, patch, seven recorded attestations
Same range with the new attestation removed
exit 1, names 48bafa7911ccde08f64c14a002a8a991ffefd7a2 as malformed or non-footer
Isolated copy with footer rejection disabled
new appended-signoff regression fails: Missing expected exception
Isolated copy with the new attestation removed
committed-record regression fails
```

Additional local validation at the signed head:

```text
python3 scripts/test-release-workflow-authority.py
exit 0
PATH=<Node 22> python3 scripts/falsify-release-version-guards.py
11 poisoned trees rejected, exit 0
bin/kin-precheck kin --repo-dir kin=<owned checkout>, through heavy-slot
21 gates ran, 21 passed, 0 failed, on kin 2f24b3b11370444c73c30efe023c138f0a41f8f3
```

Independent source review found no blocker. All local checks are complete; hosted checks remain the landing gate.

FIR-3412
