### PR TITLE
test: read complete logout requests on blocking sockets

### DIFF
--- a/crates/kin-cli/src/commands/auth.rs
+++ b/crates/kin-cli/src/commands/auth.rs
@@ -1040,6 +1040,113 @@ mod tests {
         );
     }
 
+    fn read_logout_request(connection: &mut std::net::TcpStream) -> std::io::Result<Vec<u8>> {
+        connection.set_nonblocking(false)?;
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        read_logout_headers(|buffer| {
+            let remaining = deadline
+                .checked_duration_since(std::time::Instant::now())
+                .filter(|remaining| !remaining.is_zero())
+                .ok_or_else(|| std::io::Error::from(std::io::ErrorKind::TimedOut))?;
+            connection.set_read_timeout(Some(remaining))?;
+            connection.read(buffer)
+        })
+    }
+
+    fn read_logout_headers(
+        mut read_chunk: impl FnMut(&mut [u8]) -> std::io::Result<usize>,
+    ) -> std::io::Result<Vec<u8>> {
+        let mut buffer = [0; 4096];
+        let mut used = 0;
+        loop {
+            if used == buffer.len() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "logout request headers exceed the fixture limit",
+                ));
+            }
+            let read = match read_chunk(&mut buffer[used..]) {
+                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+                result => result?,
+            };
+            if read == 0 {
+                return Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof));
+            }
+            used += read;
+            if buffer[..used].windows(4).any(|bytes| bytes == b"\r\n\r\n") {
+                return Ok(buffer[..used].to_vec());
+            }
+        }
+    }
+
+    #[test]
+    fn logout_mock_waits_for_request_on_nonblocking_stream() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let mut client = std::net::TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        let (mut connection, _) = listener.accept().unwrap();
+        connection.set_nonblocking(true).unwrap();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (request_tx, request_rx) = mpsc::channel();
+        let server = std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            request_tx
+                .send(read_logout_request(&mut connection))
+                .unwrap();
+        });
+        started_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert!(
+            matches!(
+                request_rx.recv_timeout(Duration::from_millis(100)),
+                Err(mpsc::RecvTimeoutError::Timeout)
+            ),
+            "the reader must wait for bytes on an accepted nonblocking socket"
+        );
+        let expected =
+            b"POST /api/cli/auth/logout HTTP/1.1\r\nAuthorization: Bearer not-a-real-token\r\n\r\n";
+        client.write_all(expected).unwrap();
+        let request = request_rx
+            .recv_timeout(Duration::from_secs(2))
+            .unwrap()
+            .unwrap();
+        server.join().unwrap();
+        assert_eq!(request.as_slice(), expected.as_slice());
+    }
+
+    #[test]
+    fn logout_mock_collects_fragmented_headers() {
+        let fragments: [&[u8]; 2] = [
+            b"POST /api/cli/auth/logout HTTP/1.1\r\nAuthorization: Bearer ",
+            b"not-a-real-token\r\n\r\n",
+        ];
+        let mut chunks = fragments.into_iter();
+        let request = read_logout_headers(|buffer| {
+            let chunk = chunks.next().unwrap_or_default();
+            buffer[..chunk.len()].copy_from_slice(chunk);
+            Ok(chunk.len())
+        })
+        .unwrap();
+        assert_eq!(request, fragments.concat());
+    }
+
+    #[test]
+    fn logout_mock_rejects_incomplete_and_oversized_headers() {
+        for (request, expected) in [
+            (
+                b"POST /api/cli/auth/logout HTTP/1.1\r\n".to_vec(),
+                std::io::ErrorKind::UnexpectedEof,
+            ),
+            (vec![b'x'; 4096], std::io::ErrorKind::InvalidData),
+        ] {
+            let mut reader = std::io::Cursor::new(request);
+            assert_eq!(
+                read_logout_headers(|buffer| reader.read(buffer))
+                    .unwrap_err()
+                    .kind(),
+                expected
+            );
+        }
+    }
+
     #[tokio::test]
     #[serial]
     async fn logout_revokes_on_allowed_transport_and_removes_local_credentials() {
@@ -1064,12 +1171,8 @@ mod tests {
                     Err(error) => panic!("expected revocation request: {error}"),
                 }
             };
-            connection
-                .set_read_timeout(Some(Duration::from_secs(2)))
-                .unwrap();
-            let mut buffer = [0; 4096];
-            let n = connection.read(&mut buffer).unwrap();
-            let request = String::from_utf8_lossy(&buffer[..n]).to_ascii_lowercase();
+            let request = read_logout_request(&mut connection).unwrap();
+            let request = String::from_utf8_lossy(&request).to_ascii_lowercase();
             assert!(request.starts_with("post /api/cli/auth/logout "));
             assert!(request.contains("authorization: bearer not-a-real-token"));
             connection


### PR DESCRIPTION
The logout regression test can panic with `WouldBlock` on macOS because its mock listener is nonblocking and the accepted stream inherits that mode. Setting a read timeout does not restore blocking reads. The mock also assumed one TCP read contained the complete Authorization header.

Configure the accepted stream for blocking reads and collect headers through `CRLFCRLF`, with a two-second overall deadline and a 4096-byte limit. A controlled two-chunk reader covers fragmentation independently of TCP packet coalescing. Separate guards cover delayed input on a nonblocking stream, incomplete headers and oversized headers. The existing POST path, bearer authentication, 204 response, server join and local credential-removal assertions remain. Production auth code is unchanged.

Validation:

- [Original macOS failure](https://github.com/firelock-ai/kin/actions/runs/34287733462/job/102267142968): OS error 35 at the mock read, followed by the failed server join.
- A local Darwin descriptor probe confirmed inherited nonblocking mode and reproduced errno 35 before payload arrival. Explicit blocking mode passed the paired read control. The unchanged original Rust test passed 100/100 repetitions, so that loop is not claimed as reproducing the intermittent failure.
- `cargo test --locked -p kin-cli --lib commands::auth::tests::` on the final source: `24 passed; 0 failed`, finished in 4.62 seconds. Formatting passed. All six final-source mutants failed at their intended assertions with exit 101: omitted blocking reset, one-read completion, missing size cap, accepted incomplete EOF, omitted bearer authentication and skipped credential deletion. Exact source bytes were restored, and the full auth suite passed again.
- Worktree-scoped `kin-precheck kin --repo-dir kin=<checkout>` through the shared heavy-slot wrapper: `21 gates ran, 21 passed, 0 failed`, including workflow clippy and guard scripts.

The socket-delay guard is timing-sensitive under thread starvation; its observed mutation rejection is reported as such. The controlled two-chunk framing guard does not depend on TCP fragmentation timing.

Falsification output after changing behavior, with each mutation restored:

```text
nonblocking: logout_mock_waits_for_request_on_nonblocking_stream ... FAILED
single-read: logout_mock_collects_fragmented_headers ... FAILED
header-cap: logout_mock_rejects_incomplete_and_oversized_headers ... FAILED
incomplete-eof: logout_mock_rejects_incomplete_and_oversized_headers ... FAILED
missing-bearer: logout_revokes_on_allowed_transport_and_removes_local_credentials ... FAILED
retained-credential: logout_revokes_on_allowed_transport_and_removes_local_credentials ... FAILED
Each command: cargo test --locked -p kin-cli --lib commands::auth::tests::<named test> -- --exact
Each result: 0 passed; 1 failed; exit 101
```
