### PR TITLE
Compile the startup-recovery coverage helper on every platform

### DIFF
--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -4552,7 +4552,16 @@ mod tests {
         check_reconcile_dirty_work(true, 0, false).await;
     }
 
-    #[cfg(unix)]
+    // Deliberately not `#[cfg(unix)]`, unlike the watcher helpers around it.
+    // `startup_diagnostic_legitimate_empty_parse_still_certifies_from_cas` is a
+    // plain `#[test]` that calls this, so gating the helper leaves that caller
+    // with no callee on Windows and the whole `kin-daemon` lib test target fails
+    // to compile there. Nothing inside it is platform specific: it reads the
+    // graph through the same MCP handler the product answers with. A pull
+    // request cannot see that break, because `Windows authority tests` carries
+    // `if: github.event_name != 'pull_request'` and the `Windows cross-check`
+    // that does run on one checks libs and bins only, so no `#[cfg(test)]` code
+    // is compiled for Windows before a merge.
     fn file_coverage(state: &Arc<DaemonState>, rel_path: &str) -> serde_json::Value {
         let args = HashMap::from([("path".to_string(), serde_json::json!(rel_path))]);
         // No working-copy probe: these arms grade what the LAYOUT and the


### PR DESCRIPTION
kin main has not built its Windows lib test target since #1626, and that is one of the two red legs stopping the v0.7.6 cut from selecting a candidate.

#1626 added `crates/kin-daemon/src/loop_runner/tests/startup_recovery.rs`, which `loop_runner.rs` pulls in with `include!` inside `#[cfg(test)] mod tests`. Its test `startup_diagnostic_legitimate_empty_parse_still_certifies_from_cas` is a plain `#[test]` with no platform gate, and at line 593 it calls `file_coverage`. That helper was `#[cfg(unix)]`, so on Windows the call has no callee and the whole `kin-daemon` lib test target fails to compile with E0425.

The helper is not platform specific. It reads the graph through the same `list_file_entities` MCP handler the product answers with, and it deliberately takes no host reading at all. The gate was inherited from the watcher tests it sits beside, every one of which is `#[cfg(unix)]`. Dropping it lets the ungated caller compile everywhere and changes nothing for the gated callers.

rustc's note that `crate::repository_merge_state::file_coverage` exists but is inaccessible is a red herring worth naming, because it points a reader at the wrong fix. That is an unrelated private function with a different signature (`&MergeTransactionRecord, &MergeInputs, ArtifactId -> BTreeSet<MergeConflictSubject>`). Making it public would fix nothing.

## Why no pull request could see this

`Windows authority tests` carries `if: ${{ github.event_name != 'pull_request' }}` (`ci.yml:201`). The only Windows grading a PR gets is `Windows cross-check`, whose entire compile step is `cargo check --locked --target x86_64-pc-windows-gnu -p kin-cli -p kin-daemon` (`ci.yml:1590-1593`). `cargo check` with no target flags takes libs and bins, so no `#[cfg(test)]` code is ever compiled for Windows before a merge. On 8a80e00c that job reported `success` (job 102302159459) while `Windows authority tests` was red on the same sha (job 102302120993). I have raised widening that cross-check separately rather than bundling a workflow change into a release-blocking fix.

## Evidence CI cannot see

The Windows leg does not run on this PR, so here is the same compile, cross-targeted locally, either side of the one-attribute change. `x86_64-pc-windows-gnu` rather than CI's `msvc` because that is the target with a C toolchain on this host; the error is name resolution and is identical on both.

Red arm, at the parent commit with `#[cfg(unix)]` still on the helper:

```
$ cargo test --no-run --locked --target x86_64-pc-windows-gnu -p kin-daemon --no-default-features --lib

error[E0425]: cannot find function `file_coverage` in this scope
   --> crates/kin-daemon/src/loop_runner/tests/startup_recovery.rs:593:9
    |
593 |         file_coverage(&state, path)["certifies_enumeration"],
    |         ^^^^^^^^^^^^^ not found in this scope
    |
note: function `crate::repository_merge_state::file_coverage` exists but is inaccessible
   --> crates/kin-daemon/src/repository_merge_state.rs:723:1
...
error: could not compile `kin-daemon` (lib test) due to 1 previous error
rc=101
```

Green arm, same command with this commit applied:

```
$ cargo test --no-run --locked --target x86_64-pc-windows-gnu -p kin-daemon --no-default-features --lib

    Finished `test` profile [unoptimized + debuginfo] target(s) in 1m 01s
  Executable unittests src/lib.rs (.../x86_64-pc-windows-gnu/debug/deps/kin_daemon-d685b6b5c0a74215.exe)
rc=0
```

The two `never used` warnings still in that green output are `state.rs:410` and `state.rs:12514`, which #1619 owns and which are the other red leg on main. They are warnings here and errors under the featureless permutation job's `-D warnings`.

Also run locally: `cargo fmt --all -- --check` (clean) and `cargo test -p kin-daemon --lib startup_diagnostic`.

The permanent guard for this class is the existing `Windows authority tests` leg, which compiles this exact target on every commit that reaches main and is what caught it.

FIR-3412.

## Host test note, falsified both ways

`cargo test -p kin-daemon --lib startup_diagnostic` on this development Mac reports 16 passed and 2 failed, and the two failures are a diagnosed host condition rather than anything in this diff. Both are the FSEvents readiness probe, and both fail identically with the parent's `#[cfg(unix)]` put back.

At this commit:

```
$ cargo test -p kin-daemon --lib startup_diagnostic

thread 'loop_runner::tests::startup_diagnostic_watch_arms_before_marked_repair_is_live' panicked at crates/kin-daemon/src/loop_runner/tests/startup_recovery.rs:222:30:
called `Result::unwrap()` on an `Err` value: Index(Watcher("watcher did not acknowledge its readiness probe; filesystem edits are not known to be observed"))
thread 'loop_runner::tests::startup_diagnostic_full_loop_must_not_certify_the_missing_function' panicked at crates/kin-daemon/src/loop_runner/tests/startup_recovery.rs:329:30:
called `Result::unwrap()` on an `Err` value: Index(Watcher("watcher did not acknowledge its readiness probe; filesystem edits are not known to be observed"))

test result: FAILED. 16 passed; 2 failed; 0 ignored; 0 measured; 1589 filtered out; finished in 44.37s
```

Same command on the same box with the parent's version of `loop_runner.rs` restored:

```
failures:
    loop_runner::tests::startup_diagnostic_full_loop_must_not_certify_the_missing_function
    loop_runner::tests::startup_diagnostic_watch_arms_before_marked_repair_is_live

test result: FAILED. 16 passed; 2 failed; 0 ignored; 0 measured; 1589 filtered out; finished in 64.22s
```

Same two tests, same message, same counts. Hosted `Check & Test (ubuntu-latest)` and `(macos-latest)` are the graders for that class and are green on this head.
