### PR TITLE
Owe a parse only for the paths that have one

### DIFF
--- a/crates/kin-daemon/src/loop_runner/tests/startup_recovery.rs
+++ b/crates/kin-daemon/src/loop_runner/tests/startup_recovery.rs
@@ -1039,3 +1039,117 @@ async fn startup_diagnostic_purge_refuses_unrecorded_changed_body() {
     assert_eq!(state.graph.resolved_tree(), previous);
     assert!(marker.is_dir());
 }
+
+/// A standalone publication owes a parse only for the paths that have one.
+///
+/// #1626 began recording semantic debt at `publish_exact_workspace_tree`, the
+/// ambient watcher's own publication seam, for every blob in the exact tree
+/// correction. Nothing but a commit settles a debt entry, so a path recorded
+/// there on a store that never commits is owed on every later reconcile tick,
+/// and every drain hands it to [`readmit_semantics_for_paths`]. For a path that
+/// is not entity source that means re-persisting its artifact facet, and
+/// kin-db's artifact upsert calls `invalidate_artifact_for_embedding`, which
+/// REMOVES the artifact's vector and re-queues it. The store is then left
+/// holding an artifact key that embedding coverage counts and that can never
+/// keep a vector, while every counter sits still.
+///
+/// Measured, not assumed: kin's install proof passed on 18a67fe7 and has failed
+/// on every commit since 4f89f45e, the #1626 squash, freezing at
+/// `indexed 4, pending 2, total 6` across 177 consecutive one-second reads.
+/// `kin setup` leaves exactly two non-source files in the proof's tree,
+/// `.agents/mcp_config.json` and a zero-byte
+/// `.agents/.mcp_config.json.kin-update.lock`, and two is the gap.
+///
+/// The fixture reproduces that pair beside a source file, so the source arm is
+/// the positive control: it must stay owed, because a source file published
+/// without its parse is the whole reason this record exists.
+#[tokio::test]
+#[serial_test::serial(commit_phase_capture)]
+async fn a_standalone_publication_owes_no_parse_for_a_non_source_artifact() {
+    let repo = tempfile::tempdir().unwrap();
+    let state = open_test_state(&repo);
+    std::fs::write(
+        repo.path().join("probe.py"),
+        b"def hello():\n    return 42\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(repo.path().join(".agents")).unwrap();
+    std::fs::write(
+        repo.path().join(".agents/mcp_config.json"),
+        br#"{"mcpServers":{"kin":{"command":"kin","args":["mcp","start"]}}}"#,
+    )
+    .unwrap();
+    // Zero bytes, exactly as `kin setup` leaves its update lock behind.
+    std::fs::write(
+        repo.path().join(".agents/.mcp_config.json.kin-update.lock"),
+        b"",
+    )
+    .unwrap();
+    sync_filesystem_with_graph(&state).await.unwrap();
+
+    let config = ".agents/mcp_config.json";
+    let lock = ".agents/.mcp_config.json.kin-update.lock";
+    let tree_paths: BTreeSet<String> = state
+        .graph
+        .resolved_tree()
+        .artifacts_by_path()
+        .into_iter()
+        .filter_map(|artifact| artifact.path.as_utf8().map(|path| path.to_string()))
+        .collect();
+    assert!(
+        tree_paths.contains("probe.py")
+            && tree_paths.contains(config)
+            && tree_paths.contains(lock),
+        "the fixture must actually reach the tree or every assertion below is vacuous: \
+         {tree_paths:?}"
+    );
+    // Both non-source files carry an enrichment record, which is exactly what
+    // makes them artifact retrieval keys that embedding coverage counts
+    // (kin-db's `collect_artifact_ids` reads those three maps and nothing else).
+    // Asserted through the facet reads rather than through a queue depth,
+    // because the queue is gated on kin-db's `vector` feature and this test has
+    // to mean the same thing in every permutation the feature matrix builds.
+    let enriched = |path: &str| {
+        let file_id = FilePathId::new(path);
+        state.graph.get_shallow_file(&file_id).unwrap().is_some()
+            || state
+                .graph
+                .get_structured_artifact(&file_id)
+                .unwrap()
+                .is_some()
+            || state.graph.get_opaque_artifact(&file_id).unwrap().is_some()
+    };
+    assert!(
+        enriched(config) && enriched(lock),
+        "both non-source files must carry an enrichment record, or they are not artifact \
+         keys and this test asserts nothing"
+    );
+
+    let recorded = crate::semantic_debt::outstanding(&state);
+    let (owed, _spent) = crate::semantic_debt::partition_against_tree(&state, &recorded);
+    let owed_paths: BTreeSet<String> = owed
+        .iter()
+        .filter_map(|path| path.as_utf8().map(|path| path.to_string()))
+        .collect();
+    assert!(
+        owed_paths.contains("probe.py"),
+        "the source file published without its parse must stay owed: {owed_paths:?}"
+    );
+    assert!(
+        !owed_paths.contains(config) && !owed_paths.contains(lock),
+        "a file that is not entity source owes no parse, and an entry a commit never \
+         settles re-enriches it on every tick: {owed_paths:?}"
+    );
+
+    // What the drain would do if the record named them, so the cost above is
+    // demonstrated rather than asserted. Asking for the two artifacts directly
+    // re-persists both facets, which is the upsert that discards their vectors.
+    let artifacts = BTreeSet::from([test_repo_path(config), test_repo_path(lock)]);
+    let readmitted = readmit_semantics_for_paths(&state, &artifacts).await;
+    assert_eq!(
+        readmitted.enriched, 2,
+        "control: the drain does re-persist a non-source facet when it is asked to, \
+         which is why the debt record must never name one"
+    );
+    assert!(readmitted.failed.is_empty(), "{:?}", readmitted.failed);
+}

--- a/crates/kin-daemon/src/semantic_debt.rs
+++ b/crates/kin-daemon/src/semantic_debt.rs
@@ -53,8 +53,9 @@
 
 use std::collections::BTreeSet;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
+use kin_index::{FileClassification, FileClassifier};
 use kin_model::{RepoPath, TreeEntry};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
@@ -98,6 +99,30 @@ pub(crate) fn owed_by(deltas: &[kin_model::TreeDelta]) -> Vec<SemanticDebt> {
         let Some(path) = new.path.as_utf8() else {
             continue;
         };
+        // Only a path that owes a PARSE belongs in this record. A file that is
+        // not entity source owes none: its shallow, structured or opaque record
+        // is written by the same admission that publishes its bytes, so there is
+        // no deferred derivation for a later drain to perform.
+        //
+        // Recording one anyway is not merely waste. Nothing but a commit settles
+        // a debt entry, and the install proof never commits, so such an entry is
+        // owed on every later reconcile tick. Each drain hands the path to
+        // `readmit_semantics_for_paths`, whose non-source branch re-persists the
+        // facet, and kin-db's artifact upsert calls `invalidate_artifact_for_embedding`,
+        // which REMOVES the artifact's vector and re-queues it. The store then
+        // holds an artifact key that is counted in embedding coverage and can
+        // never keep a vector, and the counters sit still while it happens.
+        //
+        // Classification is by name here rather than by content, because a tree
+        // delta carries no body. That admits a source-named path whose bytes are
+        // opaque, which the drain then re-enriches; `readmit_semantics_for_paths`
+        // refuses to rewrite an unchanged non-source record for that reason.
+        if !matches!(
+            FileClassifier::classify(Path::new(path)),
+            FileClassification::EntitySource
+        ) {
+            continue;
+        }
         owed.push(SemanticDebt {
             path: path.to_string(),
             body: hash.to_string(),


### PR DESCRIPTION
kin's install proof has not settled since #1626, and that is the second of the two red legs stopping the v0.7.6 cut from selecting a candidate. This is a nine-line change in `semantic_debt.rs` plus the regression test for it.

## What broke

`Install Proof (PR) / ubuntu-latest` passed on 18a67fe7 (run 34294086817, job 102289362121) and has failed on both commits since, with byte-identical numbers:

```
did not settle within 180s over 177 reads: {"repository_generation":2,"workspace_generation":1,
"authority_generation":2,"enrichment_workspace_generation":1,"entity_count":2,"relation_count":1,
"semantic_change_count":1,"coverage_state":"observed","indexed":4,"pending":2,"total":6}
```

4f89f45e (job 102295944702, 177 reads) and 8a80e00c (job 102304229447, 176 reads). Every counter is frozen for the whole three minutes. #1626 is the only delta between the passing and failing commits.

`kin embed --json` is identical in the passing and failing runs (`total_entities 2, embedded_entities 4, pending_entities 0, total_artifacts 0, coverage {indexed_before 0, indexed_after 4, total 4}`), so the explicit pass does the same work either way. Every pre-embed capture is identical too. The passing run settles three seconds after that pass at `indexed 6, pending 0, total 6`; the failing runs never do.

## The mechanism

`graph_truth_retrievable_keys` in the kin-db this daemon links (`=0.7.107`) extends three sets: `latest_revision_ids`, `entities.keys()`, and `collect_artifact_ids`. So 6 is 2 entity keys plus 2 head revision keys plus 2 artifact keys, and the 2 that never get vectors are the artifacts. The proof's repo holds one source file, and `kin setup` leaves two non-source files beside it: `.agents/mcp_config.json` and a zero-byte `.agents/.mcp_config.json.kin-update.lock`.

Then:

1. #1626 added `record_before_standalone_publication` to `publish_exact_workspace_tree` (`loop_runner.rs:510`), the ambient watcher's own publication seam, and `owed_by` records EVERY blob in the exact tree correction, source or not. Before #1626 that seam recorded no debt at all; the only production recorders were `api.rs:6510` and `api.rs:38151`.
2. Only a commit settles a debt entry, and the install proof never commits, so both `.agents` entries are owed on every later reconcile tick.
3. Every tick's `drain_semantic_debt` hands them to `readmit_semantics_for_paths`, whose non-`EntitySource` branch (`loop_runner.rs:9963`) re-persists the facet through `persist_non_entity_enrichment`.
4. kin-db's `upsert_structured_artifact` and `upsert_opaque_artifact` (`graph.rs:8553`, `8608`) both call `invalidate_artifact_for_embedding` (`graph.rs:3851`), which REMOVES the artifact's retrievable vector and re-queues it.

The embed worker writes those two vectors and the next tick deletes them. Coverage reads `indexed 4, pending 2, total 6` on every read, the worker reports idle at progress 0, and nothing in the fingerprint moves, which is exactly what the proof sees.

## The fix

A file that is not entity source owes no parse. Its shallow, structured or opaque record is written by the same admission that publishes its bytes, so there is no deferred derivation for a later drain to perform, and recording one is not merely waste. `owed_by` now records a path only when `FileClassifier::classify` says `EntitySource`. That restores pre-#1626 behaviour for exactly those paths and leaves #1626's purpose, recoverable SOURCE semantics after a standalone publication, untouched. Nothing in the settle rule is relaxed.

## Evidence CI cannot see

`install-proof-pr` carries `github.event_name != 'pull_request'` (`ci.yml:3074-3082`) and ci.yml runs on push to `main`, pull_request to `main`, `merge_group` and `repository_dispatch`. kin has had no merge_group since the classic flip, so main's push run is the only place that proof ever runs, and it reports `skipped` on this PR. The regression is therefore graded here by a crate test, which `ci.yml` does run on a pull request.

The test drives the real seam in-process: `open_test_state` builds a real `DaemonState` and `sync_filesystem_with_graph` performs the whole admit, publish and drain over the same fixture, one source file plus the `.agents` pair including the zero-byte lock. Its first two assertions are controls, that all three paths reached the tree and that both non-source files carry an enrichment record, so it cannot pass vacuously; and the source file staying owed is the positive control, because a source file published without its parse is the whole reason the record exists.

Red arm, at the parent:

```
$ cargo test -p kin-daemon --lib a_standalone_publication_owes_no_parse_for_a_non_source_artifact

thread '...' panicked at crates/kin-daemon/src/loop_runner/tests/startup_recovery.rs:1125:5:
a file that is not entity source owes no parse, and an entry a commit never settles re-enriches it
on every tick: {".agents/.mcp_config.json.kin-update.lock", ".agents/mcp_config.json", "probe.py"}

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1607 filtered out; finished in 2.10s
```

Green arm, same command with this commit applied:

```
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1607 filtered out; finished in 2.23s
```

`cargo fmt --all -- --check` is clean.

One neighbouring test on this development host is flaky, and it is flaky without this change too.
`a_daemon_start_pays_the_semantic_debt_a_previous_daemon_left` (`loop_runner.rs:5380`) fails
intermittently at `loop_runner.rs:5423` with "the loop exited before paying the debt a previous
daemon left". Three consecutive runs each side of the change, same box:

```
with this commit applied:  FAIL, PASS, FAIL
with it reverted at HEAD:  PASS, FAIL, FAIL
```

One pass and two failures either way. `run_loop` arms a real file watcher, every failing run sits
at 11.9 to 12.8 seconds against a passing run at 3, and the readiness probe waits ten, so this is
the host's FSEvents service rather than the diff. The mechanism rules the change out independently:
the fixture is `shifted.rs`, `.rs` is in `ENTITY_SOURCE_EXTENSIONS`, so `owed_by` records it
identically either way, and the test's own `owed.len() == 1` assertion passes inside the failing
runs. Hosted `Check & Test (ubuntu-latest)` and `(macos-latest)` are the graders for that class.

`bin/kin-precheck kin` is green on this exact head, run through the fleet's heavy slot against the lane worktree:

```
kin-precheck: repo=kin tree=.kin-coord/worktrees/maincifix-kin sha=4cb4a7584218dbe57f253d921b3a0550d1377038 branch=chore/lane-maincifix-kin
kin-precheck: behind origin/main 0 commit(s)
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
...
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 4cb4a7584218dbe57f253d921b3a0550d1377038
```

That set includes `clippy --all-targets --all-features`, `zero_file_search_guard.sh`, `verify-zero-file-search.py` and `verify-hydration-semantics.py`.

## Named follow-up, deliberately not in this PR

Classification in `owed_by` is by NAME, because a tree delta carries no body. That still admits a source-NAMED path whose bytes are shallow or opaque, which the drain then re-enriches on every tick with the same vector churn. The airtight version makes `persist_non_entity_enrichment` additive, skipping the rewrite when the stored record already describes the same body (`StructuredArtifact` and `OpaqueArtifact` carry `content_hash`; `ShallowTrackedFile` does not, so that arm needs a value comparison).

I wrote it and then took it out. It is an unmeasured change to a graph-authority hot path during a release cut, the install proof does not exercise it, and this development host cannot run the daemon to measure it. It belongs in its own PR with its own measurement.

FIR-3412.
