### PR TITLE
Compose final feature gates with native release proof (recompose of #1619)

### DIFF
--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -407,6 +407,7 @@ impl DurableVectorTestBackend {
             .expect("test graph snapshot must publish")
     }
 
+    #[cfg(feature = "embeddings")]
     pub(crate) fn publish_snapshot(
         &self,
         repo_id: &str,
@@ -12511,6 +12512,7 @@ mod tests {
     /// adjacency is what `materialize_hosted_repository_snapshot` rebuilds and
     /// what the retrieval authority folds, and a store with no edges has an
     /// empty one either way and can tell the two apart from nothing.
+    #[cfg(feature = "embeddings")]
     fn publish_hosted_repository_v6_store(
         storage: &std::path::Path,
         label: &str,
@@ -13101,6 +13103,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "vector")]
     #[test]
     fn hosted_graph_commit_rebinds_vectors_to_the_exact_successor_snapshot_cursor() {
         let working = tempfile::tempdir().unwrap();


### PR DESCRIPTION
This is kin#1619's change, recomposed onto current main so it can land. Credit for the fix belongs to that PR and its author on the release lane; #1619 has been a draft since 01:39Z and it is the last thing standing between main and a green Windows leg, so my captain asked this lane to carry it.

The three lines are byte for byte what #1619 proposes and nothing else: `#[cfg(feature = "embeddings")]` on `DurableVectorTestBackend::publish_snapshot`, the same on `publish_hosted_repository_v6_store`, and `#[cfg(feature = "vector")]` on `hosted_graph_commit_rebinds_vectors_to_the_exact_successor_snapshot_cursor`. Carried as that PR's own diff rather than a cherry-pick, because its head is a merge commit and `-m` would have brought the rest of the merge along.

## What it fixes

`Windows authority tests` builds `cargo test --no-run --locked --target x86_64-pc-windows-msvc -p kin-daemon --no-default-features --lib`. With no features, those two helpers and that test have no callers, and their dead-code lints are errors. The job has been red on every main commit since the flip, most recently job 102315702081 on 52170a8e:

```
crates\kin-daemon\src\state.rs:410:19
crates\kin-daemon\src\state.rs:12514:8
error: could not compile `kin-daemon` (lib test) due to 2 previous errors
```

That leg does not run on a pull request (`if: ${{ github.event_name != 'pull_request' }}`, `ci.yml:201`), so this PR's own check set cannot show the fix. The evidence below is the substitute.

## Evidence CI cannot see

Cross-targeted to `x86_64-pc-windows-gnu` because that is the target with a C toolchain on this host; the errors are dead-code lints and do not vary by target. **`RUSTFLAGS="-D warnings"` is load-bearing**: without it these are warnings, the command exits 0, and the check cannot fail.

Red control, on `origin/main` at 52170a8e with none of this applied:

```
$ RUSTFLAGS="-D warnings" cargo test --no-run --locked \
    --target x86_64-pc-windows-gnu -p kin-daemon --no-default-features --lib

error: method `publish_snapshot` is never used
   --> crates/kin-daemon/src/state.rs:410:19
error: function `publish_hosted_repository_v6_store` is never used
     --> crates/kin-daemon/src/state.rs:12514:8
error: could not compile `kin-daemon` (lib test) due to 2 previous errors
rc=101
```

Same two lines, same count, same message as the hosted job. Green arm, same command with this commit applied:

```
    Finished `test` profile [unoptimized + debuginfo] target(s) in 42.67s
  Executable unittests src/lib.rs (.../x86_64-pc-windows-gnu/debug/deps/kin_daemon-4d0b93e279fa219f.exe)
rc=0
```

Compiles and links, no warnings promoted to errors.

## Landing

If the release lane lands #1619 first, this should be closed as superseded rather than merged.

FIR-3412.
