### PR TITLE
Land the three items held out of the v0.7.6 cut

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1583,14 +1583,21 @@ jobs:
       # musl steps in `check` check for their targets too. Not `--workspace`:
       # `kin-notifier-macos` is a macOS-only member and `tests/integration` is a
       # test crate, and neither is in a shipped Windows binary. `cargo check`
-      # with no target flags takes libs and bins, and both matter here, because
-      # the two call sites kin#1410 exists for are in `kin-cli/src/main.rs` and
+      # with no target flags took libs and bins only, because the two call
+      # sites kin#1410 exists for are in `kin-cli/src/main.rs` and
       # `kin-daemon/src/bin/kin-daemon.rs` while the dead helper was in the
       # `kin-core` lib beneath them.
+      #
+      # `--tests` now compiles the test targets too, closing the gap that let
+      # kin#1626 land a Windows-only `libc` reference with no Windows arm in
+      # `kin-cli/tests/init_non_tty_output.rs`: `Windows authority tests` only
+      # runs on push to main, so no pull request saw that break before kin#1629
+      # fixed it. Measured at 74 seconds against these same two packages,
+      # cheap enough to add to the ten-minute open-to-merge path.
       - name: Check the Windows target compiles
         run: |
           cargo check --locked --target x86_64-pc-windows-gnu \
-            -p kin-cli -p kin-daemon
+            -p kin-cli -p kin-daemon --tests
 
   # The required context, and the only job that publishes it. It always runs, on
   # every event, because a required context that is never reported is a silent

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,9 +83,10 @@ fleet's login shell hits a VFS wrapper function that shadows the product binary.
 
 **The release version lives in several files at once,** and `scripts/release-intent.mjs` with
 `scripts/check-release-version.mjs` are what hold them in lockstep; the `Release version gate` job
-runs them on every PR. Its `classifyPath` treats `.github/`, `docs/`, `AGENTS.md`, `CLAUDE.md`, any
-markdown, and anything under a test or fixture directory as non-release, so a docs-only change needs
-no bump.
+runs them on pull requests from `automation/release-next` or labelled `release:automated`, and an
+ordinary pull request is not graded by it. Its `classifyPath` treats `.github/`, `docs/`,
+`AGENTS.md`, `CLAUDE.md`, any markdown, and anything under a test or fixture directory as
+non-release, so a docs-only change needs no bump.
 
 ## Landing
 

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -665,8 +665,8 @@ enum Command {
         /// keeps instead of proximity deciding it.
         #[arg(long = "target", value_name = "ENTITY")]
         target: Option<String>,
-        /// Return the chain's shape — names, kinds, roles, spans, edges —
-        /// without inlining any source body.
+        /// Return the chain's shape, meaning names, kinds, roles, spans and
+        /// edges, without inlining any source body.
         #[arg(long = "no-bodies", default_value_t = false)]
         no_bodies: bool,
         /// Serialized characters this response may occupy before the tool cuts
@@ -2597,8 +2597,9 @@ enum PipelineAction {
 ///
 /// `plan`/`apply`/`intent` read registry truth + the local sibling manifests and
 /// drive the bottom-up front (primitives -> kin-model -> kin-db -> kin -> bench/
-/// vfs/lsp) deliberately. They never publish — publishing stays in CI behind the
-/// version gate. `snapshot` is the original `kin release <tag>` graph snapshot.
+/// vfs/lsp) deliberately. They never publish, because publishing stays in CI
+/// behind the version gate. `snapshot` is the original `kin release <tag>`
+/// graph snapshot.
 #[derive(Subcommand)]
 enum ReleaseAction {
     /// Read-only bottom-up release plan: which crates need publishing and which

--- a/crates/kin-cli/tests/init_non_tty_output.rs
+++ b/crates/kin-cli/tests/init_non_tty_output.rs
@@ -195,15 +195,22 @@ fn the_conversion_phase_leaves_no_daemon_behind_when_it_exits_early() {
     // The daemon record is the evidence. A phase that stopped what it started
     // leaves either no pid file or a pid that is gone; a leaked daemon leaves a
     // live one, which is exactly what blocked the next daemon on the runner.
-    let pid_file = repo.join(".kin").join("daemon.pid");
-    if let Ok(recorded) = fs::read_to_string(&pid_file) {
-        if let Ok(pid) = recorded.trim().parse::<i32>() {
-            let alive = unsafe { libc::kill(pid, 0) } == 0;
-            assert!(
-                !alive,
-                "kin init left daemon pid {pid} running; the conversion phase must stop the \
-                 daemon it started on every exit, including its early ones"
-            );
+    //
+    // Unix only: `libc` is a `cfg(unix)` dependency, so the whole check
+    // compiles out on a target that does not carry the crate rather than fail
+    // to find it.
+    #[cfg(unix)]
+    {
+        let pid_file = repo.join(".kin").join("daemon.pid");
+        if let Ok(recorded) = fs::read_to_string(&pid_file) {
+            if let Ok(pid) = recorded.trim().parse::<i32>() {
+                let alive = unsafe { libc::kill(pid, 0) } == 0;
+                assert!(
+                    !alive,
+                    "kin init left daemon pid {pid} running; the conversion phase must stop the \
+                     daemon it started on every exit, including its early ones"
+                );
+            }
         }
     }
 }

--- a/crates/kin-cli/tests/repository_branches.rs
+++ b/crates/kin-cli/tests/repository_branches.rs
@@ -111,6 +111,7 @@ fn open_authority(
 /// its base for as long as it takes the loop to drain a tick, and several
 /// repository transitions refuse over exactly that state. Polling authority is
 /// how a test asks "has the loop finished" without asserting on a clock.
+#[cfg(unix)]
 fn wait_for_level_workspace(layout: &kin_core::KinLayout, budget: Duration) -> bool {
     let deadline = Instant::now() + budget;
     loop {

--- a/crates/kin-cli/tests/symlinked_repository_root_admission.rs
+++ b/crates/kin-cli/tests/symlinked_repository_root_admission.rs
@@ -1,6 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
+// This file's one test exercises symlink resolution through
+// `std::os::unix::fs::symlink`, and every helper below exists only to serve
+// it, so the whole binary is scoped to that platform rather than leaving
+// unreachable helpers behind on others.
+#![cfg(unix)]
+
 //! Ambient admission through a repository root reached by a symbolic link.
 //!
 //! A repository is reached through symlinked paths far more often than it looks.
@@ -189,7 +195,6 @@ fn live_entity_count(repo: &Path, home: &Path, port: u16) -> u64 {
 
 /// FIR-2442. A repository reached through a symbolic link admits host writes
 /// ambiently, exactly as the same repository reached directly does.
-#[cfg(unix)]
 #[test]
 fn a_repository_bound_through_a_symlinked_root_admits_a_host_write() {
     let root = tempdir().expect("temp root");


### PR DESCRIPTION
Three small, independent fixes held out of the v0.7.6 candidate (release/v0.7.6-candidate at
64174f30) so they land after the tag instead of inside it. Each is its own commit. This stays a
draft until the tag mints. Do not enable auto-merge or land it before then.

## Em dashes in the generated CLI help

`crates/kin-cli/src/main.rs` carried two em dashes in doc comments that clap renders as `--help`
text: the `TraceDataFlow` subcommand's `--no-bodies` field, and the `ReleaseAction` enum's own
about text. Both rewritten, meaning unchanged.

Searched every doc comment and help string under `crates/kin-cli` and `crates/kin-daemon` for the
em dash character:

```
$ git grep -n $'—' -- crates/kin-cli crates/kin-daemon | wc -l
952
$ command grep -rn $'—' <same two trees> | wc -l
952
```

Both tools agree exactly, which is the cross-check. A second, independent search tool landing on
the identical total is what a search that has not gone silently empty looks like. Of the 952,
exactly 2 are in `main.rs` (`git grep -c` confirms the per-file count), both directly above
`#[derive(Subcommand)]` items, which is what clap turns into `--help`. Those are the two fixed
here. `kin-daemon`'s own CLI (`crates/kin-daemon/src/bin/kin-daemon.rs`, `struct Args`) carries
zero em dashes inside its args struct. Its own 7 hits are all plain `//` comments outside it. The
remaining ~943 hits are internal engineering comments or runtime strings in files this PR does not
touch (mostly `locate.rs`, `daemon_client.rs`, `setup.rs`, `health.rs`). Flagged to the captain as
separable follow-up work rather than folded in here.

Post-fix: `git grep -n $'—' -- crates/kin-cli/src/main.rs` returns nothing (exit 1). The same
command found the same two real hits before the edit, which is the positive control proving the
search still works rather than having gone quietly empty.

No checked-in help snapshot references the `no-bodies` flag in either spelling
(`git grep -n 'no-bodies'` / `'no_bodies' -- crates tests docs` both return only the flag's own
definition sites and an unrelated same-named helper in `graph_health.rs`), so there is nothing to
regenerate.

## Widen the Windows cross-check job with `--tests`

`cargo check` with no target flags took libs and bins only, so kin#1626's Windows-only `libc`
reference in a test file compiled clean on every pull request. Only `Windows authority tests`,
which runs on push to main, ever saw it break. This adds `--tests` to the Windows cross-check
compile step:

```
cargo check --locked --target x86_64-pc-windows-gnu -p kin-cli -p kin-daemon --tests
```

Measured previously at 74 seconds (`.kin-coord/reports/maincifix-20260909.md`, "Third change").
The job runs under `RUSTFLAGS: -D warnings` (set workflow-wide), so two prerequisite fixes are
included:

- `init_non_tty_output.rs`: the `libc::kill` liveness check, and the bindings that feed it, now
  live inside `#[cfg(unix)]`. `libc` is a `cfg(unix)`-only dependency.
- `symlinked_repository_root_admission.rs`: the whole file now carries `#![cfg(unix)]`, matching
  five sibling files in the same directory (`daemon_runtime_hermeticity.rs`,
  `daemon_start_lock_recovery.rs`, `projection_modes.rs`, `registry_authority.rs`,
  `stock_macos_file_limit.rs`). Its one test was already unix-only and every helper in the file
  exists only to serve it.

This job is proven by its own run on this PR, not a local cross-build. Result below once it
concludes.

### A pre-existing miss the widened job caught on its own first run

This PR's first `Windows cross-check` run failed, and that failure is the widened job working
exactly as intended: `crates/kin-cli/tests/repository_branches.rs`'s `wait_for_level_workspace`
(line 114) has exactly one caller, a test already `#[cfg(unix)]`, and every sibling helper in that
file that exists only to serve a unix-only test is already gated the same way. This one was missed,
before this PR and unrelated to it. The reason nothing ever caught it: the `libc` E0433 error the
compile-step commit above fixes aborted the windows-gnu compile before it reached this test binary,
so the gap was latent rather than visible. Fixed with the same `#[cfg(unix)]` pattern, in a fourth
commit, `bcae8a84b`. Verified locally first, since this host carries the `x86_64-pc-windows-gnu`
target and the mingw-w64 cross toolchain:

```
$ RUSTFLAGS="-D warnings" cargo check --locked --target x86_64-pc-windows-gnu \
    -p kin-cli -p kin-daemon --tests
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 31s
```

## AGENTS.md: correct when the Release version gate runs

AGENTS.md said the job runs on every PR. `ci.yml` scopes it to pull requests from
`automation/release-next` or labelled `release:automated`. Matched the doc to the workflow. Doc
only, one sentence.

## Local verification (all through `.kin-coord/bin/heavy-slot.sh postcut077 kin`)

```
$ cargo fmt --all -- --check
(clean, rc=0)

$ cargo test -p kin-cli --locked
test result: ok. (repeated for every binary: 80 `test result:` blocks total, all ok, 0 failed)
...
test a_repository_bound_through_a_symlinked_root_admits_a_host_write ... ok
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.60s
...
test the_conversion_phase_leaves_no_daemon_behind_when_it_exits_early ... ok
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 10.88s

$ bin/kin-precheck kin --repo-dir kin=<worktree>
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows>
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
PASS     guard:verify-hydration-semantics.py  python3 scripts/verify-hydration-semantics.py
(17 more guard/node-test gates, all PASS)
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 64174f30e9ffa107510bbebb8072f1be375cd77f DIRTY
```

## Windows cross-check on this PR

First run (before `bcae8a84b`): failed at 1m53s on the pre-existing miss described above.
Current run, on `bcae8a84b`: **pass, 1m56s**
(https://github.com/firelock-ai/kin/actions/runs/34325640394/job/102382267782). The widened job is
green on its own head.
