### PR TITLE
Install language servers before the release-cut preflight judge

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -376,6 +376,15 @@ jobs:
           echo "KIN_RC_ARCHIVE=$archive" >> "$GITHUB_ENV"
           echo "$ARTIFACT sha256 $have"
 
+      # FIR-2598's magic-repro checks 10 and 11 need enrichment_drained with
+      # worker_available true, which needs a Python language server on PATH
+      # when the daemon starts. Without one here the Linux legs read
+      # UNREADABLE and the cut publishes nothing (run 34323687836); this
+      # mirrors the install acceptance.yml already runs before its own
+      # enrichment checks.
+      - name: Install language servers for the enrichment checks
+        run: bash scripts/ci-install-language-servers.sh
+
       - name: Judge the archive with the release preflight
         env:
           CANDIDATE: ${{ needs.select.outputs.candidate }}


### PR DESCRIPTION
## What broke

Release Cut run 34323687836 (repository_dispatch 07:24:34Z) decided "proof" for candidate
64174f30 on release/v0.7.6-candidate. The preflight matrix then ran on all three archives:
kin-macos-aarch64 PASSED 27/27; kin-linux-aarch64 and kin-linux-x86_64 both exited 2 UNREADABLE.
From the run's own log (kin-linux-x86_64 / "Judge the archive with the release preflight"):

```
0 PASS, 1 a leg FAILED, 2 UNREADABLE, 65 refused before any leg ran.
Only PASS may produce a leg record: an UNREADABLE run is not a pass
kin-magic-repro: 25 pass, 0 fail, 2 unreadable
10/FIR-2598 UNREADABLE: enrichment readiness: enrichment worker is unavailable: ...
'this daemon found no language server for any language it enriches, and it looks
only at startup', 'reason': 'no_language_server'
(and the same for 11/FIR-2598)
```

So the publish job published nothing and nothing was armed.

## Root cause

The magic-repro fixture is Python (`pkg/sessions.py`). Checks 10 and 11 need enrichment
readiness (`scripts/acceptance/magic_repro.py`, `enrichment_drained`: `worker_available` must be
true and `languages_skipped` empty), which needs a Python language server on PATH when the daemon
starts. `acceptance.yml` already installs one via `bash scripts/ci-install-language-servers.sh`
before its own enrichment checks (acceptance.yml lines 441-447, pinned pyright 1.1.406 and
typescript-language-server 5.0.0). `release-cut.yml`'s preflight job never did. The macOS leg
only passed because that runner image happens to carry something the daemon accepts; nothing
here should rely on that.

## Fix

Add the same install step to the preflight job in `release-cut.yml`, immediately before "Judge
the archive with the release preflight", mirroring `acceptance.yml` exactly. `GITHUB_PATH`
additions take effect starting the next step, so the install has to be its own step ahead of the
judge step. The job is matrixed over all three archives sharing one `steps:` list, so the one
step covers kin-macos-aarch64, kin-linux-aarch64 and kin-linux-x86_64. Nothing else in the file
changed: not the judge step, not the matrix, not scripts/ or crates/.

## Verification

Falsified the install script directly, not just read it:

```
$ KIN_CI_LSP_PREFIX=<scratch dir under the lane's cargo-target> \
  bash scripts/ci-install-language-servers.sh
added 3 packages in 2s
language servers installed at <scratch>/node_modules/.bin
5.0.0
```

Confirmed both `pyright-langserver` and `typescript-language-server` executable before deleting
the scratch dir.

`bin/kin-precheck kin --repo-dir kin=<this worktree>` (through the fleet's heavy slot):

```
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows>
...
PASS     node-test                            node --test <15 file(s) named by the check job>
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 64174f30e... DIRTY
```

No `Lint workflows` job exists in `ci.yml` (checked by name and by listing every top-level job
name); `actionlint` appears only in a comment in `rc-build.yml`, not wired as a gate, so there was
no workflow-lint command to run here.

Required contexts on `main` (read live from branch protection): DCO Sign-off, PR text hygiene,
cargo-deny, gitleaks (full history), Fast gate lint and policy, Fast gate build and tests, MCP
surface contract. This is a workflow-only change; none of them touch the diff beyond the standard
lint and policy scan.
