### PR TITLE
Fail loud on watcher event loss until an explicit admission clears it

### DIFF
--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -435,6 +435,10 @@ pub struct ReconcileHealth {
     /// accepted, and only a restart clears it. Absent on every other daemon.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deferred_tree_wedge: Option<DeferredTreeWedge>,
+    /// The filesystem watcher told this daemon it lost events, and no complete
+    /// admission has covered that loss yet. Absent on every other daemon.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub watcher_loss: Option<WatcherLossState>,
 }
 
 /// The background-work supervisor's account of a parked reconciliation loop.
@@ -500,6 +504,39 @@ pub struct DeferredTreeWedge {
     pub at: Option<String>,
 }
 
+/// A watcher-reported loss of events that no complete admission has covered.
+///
+/// The backends report lost events without naming a single path: notify emits a
+/// pathless `EventKind::Other` carrying its `Rescan` flag, from inotify on
+/// kernel queue overflow and from FSEvents on `MUST_SCAN_SUBDIRS`. So no
+/// per-path recovery can be derived from it, and no ambient tick can close it:
+/// the loop admits what it was told about, and it was told nothing.
+///
+/// Reported rather than counted for the same reason every other field here is.
+/// A store that lost a subtree kept answering that it had no issues, because the
+/// only surface the signal ever reached was a probe that withheld a readiness
+/// acknowledgment.
+///
+/// Withdrawn only by a completed complete-exact-tree admission that covered the
+/// generation standing when it began. An ordinary watch tick never withdraws it.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WatcherLossState {
+    /// Every loss signal this store has been told about, durably and across
+    /// daemon lives.
+    #[serde(default)]
+    pub generation: u64,
+    /// The highest generation a completed full admission covered.
+    #[serde(default)]
+    pub recovered_through: u64,
+    /// Wall-clock time of the newest loss, RFC 3339. Absent when the durable
+    /// record could not be read, which is itself a reported state.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub at: Option<String>,
+    /// The whole disclosure, verbatim, so one producer states this on every
+    /// surface rather than three renderers composing three sentences.
+    pub disclosure: String,
+}
+
 impl ReconcileHealth {
     /// Every reason this reconcile state is degraded, worst first, empty when
     /// it is not.
@@ -543,6 +580,15 @@ impl ReconcileHealth {
                  threshold {}s)",
                 parked.reason, parked.progress, parked.stall_threshold_seconds
             ));
+        }
+        // Above the counters below because it is the only fault here that no
+        // counter can see. Every reading under this one is about work the loop
+        // attempted; this is about work it was never told existed, so a store
+        // carrying it can report a clean streak, an empty backlog and no skipped
+        // events while an unknown region of the working copy is missing from the
+        // graph entirely.
+        if let Some(loss) = &self.watcher_loss {
+            reasons.push(loss.disclosure.clone());
         }
         if self.admission_failure_streak >= ADMISSION_FAILURE_STREAK_ATTENTION {
             let since = match self.last_admission_success_age_seconds {

--- a/crates/kin-daemon/src/background_work.rs
+++ b/crates/kin-daemon/src/background_work.rs
@@ -35,7 +35,9 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
 use std::time::{Duration, Instant};
 
-use kin_cli::commands::resources::{BackgroundPassReport, DaemonWorkState, ReconcileHealth};
+use kin_cli::commands::resources::{
+    BackgroundPassReport, DaemonWorkState, ReconcileHealth, WatcherLossState,
+};
 
 /// The background embedding worker.
 pub const PASS_EMBED: &str = "embed";
@@ -811,6 +813,14 @@ struct ReconcileProbesInner {
     /// it is set, every admission failure recorded below is a refusal against
     /// the mismatched tree rather than an independent fault.
     deferred_tree_wedge: Option<RecordedFault>,
+    /// The watcher loss standing against this store, as the durable record last
+    /// read.
+    ///
+    /// Mirrored here rather than owned here. The record is on disk, because a
+    /// loss outlives the daemon that observed it, and these probes deliberately
+    /// know nothing about the store's layout. So the loop and the explicit
+    /// admission path push what they read, and this is what the surfaces see.
+    watcher_loss: Option<WatcherLossState>,
 }
 
 /// Host content one complete walk declined to observe at all.
@@ -872,6 +882,17 @@ impl ReconcileProbes {
         let mut inner = self.lock();
         inner.skipped_events = inner.skipped_events.saturating_add(1);
         inner.last_error = Some(RecordedFault::new(error.to_string(), now));
+    }
+
+    /// Publish, or withdraw, the watcher loss standing against this store.
+    ///
+    /// Pushed rather than read, because the record that decides it lives on disk
+    /// and these probes hold no layout. `None` withdraws it, and the only caller
+    /// that can produce a `None` after a `Some` is a completed complete-exact-tree
+    /// admission: the ambient tick reads the same record and pushes whatever it
+    /// still says.
+    pub fn record_watcher_loss(&self, standing: Option<WatcherLossState>) {
+        self.lock().watcher_loss = standing;
     }
 
     /// A complete exact-tree admission attempt failed. Extends the streak.
@@ -1089,6 +1110,7 @@ impl ReconcileProbes {
                     at: Some(fault.wall_clock.to_rfc3339()),
                 }
             }),
+            watcher_loss: inner.watcher_loss.clone(),
         }
     }
 }

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -159,6 +159,7 @@ pub mod state;
 pub mod storage_delegate;
 pub mod supervisor;
 pub mod traffic_adapter;
+pub mod watcher_loss;
 pub mod write_veto;
 
 pub use daemon::{

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -2830,6 +2830,20 @@ pub async fn run_loop_armed(
     // repository, as this loop last disclosed it. Held so a standing count is
     // reported once per rise rather than once per tick.
     let mut disclosed_events_outside_root = 0_u64;
+    // The same for the watcher's own reports that it LOST events. Held against
+    // the watcher's in-memory count, which restarts with each backend
+    // registration; the generation a store recovers against is durable and is
+    // advanced by the rise this sees rather than assigned from it.
+    let mut disclosed_watcher_loss = 0_u64;
+    // A loss outlives the daemon that observed it, so the durable record is
+    // republished onto this daemon's surfaces before the loop answers anything.
+    // Without this a restart would erase the one state saying an unknown region
+    // of the working copy is described by nothing, and the store would come up
+    // reporting itself well while still blind.
+    state
+        .background_work
+        .reconcile()
+        .record_watcher_loss(crate::watcher_loss::standing(&state.layout, working_dir));
 
     info!(
         poll_ms = config.poll_interval_ms,
@@ -3108,6 +3122,29 @@ pub async fn run_loop_armed(
                 .background_work
                 .reconcile()
                 .record_event_skipped(disclosure, tick_started);
+        }
+        // A backend that lost events names no path, so nothing in the drain
+        // above carries it and nothing below will ever hear about the writes it
+        // stands for. This loop admits what it is told about, so no later tick
+        // closes the gap however long it runs: only a complete exact-tree
+        // admission can, and the founder's contract is that a person or an agent
+        // asks for one rather than the daemon healing quietly.
+        //
+        // Persisted before it is disclosed. The disclosure dies with this
+        // daemon; the loss does not.
+        let lost_events = watcher.lost_events();
+        if lost_events.generation > disclosed_watcher_loss {
+            let signals = lost_events.generation - disclosed_watcher_loss;
+            disclosed_watcher_loss = lost_events.generation;
+            crate::watcher_loss::record_loss(
+                &state.layout,
+                signals,
+                lost_events.last_reason.as_deref(),
+            );
+            state
+                .background_work
+                .reconcile()
+                .record_watcher_loss(crate::watcher_loss::standing(&state.layout, working_dir));
         }
         // A graph-only repository member owns its own host subtree. Admission
         // already refuses to traverse one, so an event beneath it carries no
@@ -5215,6 +5252,74 @@ mod tests {
         assert!(
             reasons.contains("/private/var/repo/main.rs"),
             "the degraded reason names the dropped path: {reasons}"
+        );
+    }
+
+    /// Fail loud, and stay loud until an admission clears it. A store whose
+    /// watcher reported lost events stops every surface reporting a healthy
+    /// loop, names the generation and the time, and says what clears it.
+    ///
+    /// The withdrawal at the end is the half that makes the rest mean something:
+    /// a surface that could never clear would be a permanent alarm, and an
+    /// operator learns to read past those.
+    #[test]
+    fn a_standing_watcher_loss_degrades_the_reconcile_surface_until_an_admission_clears_it() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let working_dir = state.layout.working_dir().to_path_buf();
+        let probes = crate::background_work::ReconcileProbes::default();
+        let now = Instant::now();
+
+        probes.record_watcher_loss(crate::watcher_loss::standing(&state.layout, &working_dir));
+        assert!(
+            !probes.report(now).degraded(),
+            "a loop whose watcher has lost nothing is not degraded"
+        );
+
+        crate::watcher_loss::record_loss(&state.layout, 1, Some("rescan: kernel dropped"));
+        probes.record_watcher_loss(crate::watcher_loss::standing(&state.layout, &working_dir));
+
+        let report = probes.report(now);
+        assert!(
+            report.degraded(),
+            "a watcher that reported lost events is a degraded loop"
+        );
+        let reasons = report.degraded_reasons().join(" ");
+        assert!(
+            reasons.contains("generation 1"),
+            "the degraded reason carries the generation: {reasons}"
+        );
+        assert!(
+            reasons.contains("kin admit"),
+            "the degraded reason names what clears it: {reasons}"
+        );
+        assert!(
+            reasons.contains("rescan: kernel dropped"),
+            "the degraded reason carries the backend's own reason: {reasons}"
+        );
+        assert_eq!(
+            report.watcher_loss.as_ref().map(|loss| loss.generation),
+            Some(1),
+            "the machine-readable field carries it too, not only the prose"
+        );
+        assert!(
+            report
+                .watcher_loss
+                .as_ref()
+                .and_then(|loss| loss.at.as_ref())
+                .is_some(),
+            "the surface names the time of loss"
+        );
+
+        crate::watcher_loss::record_recovery(
+            &state.layout,
+            crate::watcher_loss::RecoveryCapture::Through(1),
+        );
+        probes.record_watcher_loss(crate::watcher_loss::standing(&state.layout, &working_dir));
+
+        assert!(
+            !probes.report(now).degraded(),
+            "the surface clears when a completed full admission clears the record"
         );
     }
 

--- a/crates/kin-daemon/src/repository_admit.rs
+++ b/crates/kin-daemon/src/repository_admit.rs
@@ -198,12 +198,41 @@ pub(crate) async fn execute(state: &Arc<DaemonState>) -> Result<AdmitResponse> {
     }
 }
 
+/// The watcher loss this pass is entitled to clear, captured before it runs.
+///
+/// Two rules, and both of them are about a pass clearing a loss it never
+/// covered.
+///
+/// Captured BEFORE the seam, because the pass observes the working copy when it
+/// starts. A loss signal that arrives while it runs stands for writes its tree
+/// observation may never have reached, so reading the record afterwards would
+/// clear a loss nothing recovered.
+///
+/// And nothing at all when the seam will walk nothing.
+/// `sync_filesystem_with_graph` returns `Ok(())` on two conditions without
+/// touching the working copy, filesystem reconcile disabled and a bare Git
+/// repository, so a pass over either reports a clean success having looked at
+/// no file. Both endpoints that reach this module refuse those conditions ahead
+/// of the pass, and that is exactly why this does not depend on them: a
+/// recovery that leaned on a caller's guard would be one refactor away from
+/// healing a blind store. The predicates are the seam's own rather than a copy,
+/// so the two cannot drift apart.
+fn watcher_loss_this_pass_can_cover(state: &DaemonState) -> crate::watcher_loss::RecoveryCapture {
+    if state.filesystem_reconcile_disabled()
+        || crate::loop_runner::is_bare_repository(state.layout.working_dir())
+    {
+        return crate::watcher_loss::RecoveryCapture::Clean;
+    }
+    crate::watcher_loss::capture(&state.layout)
+}
+
 async fn run_pass(state: &DaemonState) -> Result<AdmitResponse> {
     let repository_id =
         crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(state)?
             .repository_id()
             .clone();
     let before = census(state);
+    let watcher_loss = watcher_loss_this_pass_can_cover(state);
 
     // The same seam `/commands/commit` calls. It takes the coordination gate
     // itself, so this must not already hold it.
@@ -257,7 +286,23 @@ async fn run_pass(state: &DaemonState) -> Result<AdmitResponse> {
     // freshness this marker exists to prevent, reached by the other door.
     if failure.is_none() {
         crate::background_work::record_durable_admission(&state.layout, after.tracked as u64);
+        // The only path in the product that clears a watcher loss, and
+        // deliberately not the line above it. The ambient watch tick reaches
+        // `record_durable_admission` too, and an ambient tick admits what the
+        // watcher told it about, which for a loss that named no path is nothing
+        // at all. Putting the clear there would let every 100ms tick heal a gap
+        // no tick ever observed. This module is the explicit request, which is
+        // what the contract requires: fail loud, and let a person or an agent
+        // decide to admit.
+        crate::watcher_loss::record_recovery(&state.layout, watcher_loss);
     }
+    // Refreshed whatever the outcome, and before the report below reads the
+    // reconcile surface, so `kin admit` answers with the state its own pass
+    // left rather than the state it found.
+    probes.record_watcher_loss(crate::watcher_loss::standing(
+        &state.layout,
+        state.layout.working_dir(),
+    ));
 
     let embeddings = state.graph.embedding_status();
     let report = AdmitReport {
@@ -306,5 +351,157 @@ fn annotate_admission_failure(cause: String) -> String {
         )
     } else {
         cause
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::watcher_loss::{self, RecoveryCapture};
+
+    fn open_test_state(repo: &tempfile::TempDir) -> Arc<DaemonState> {
+        let init = kin_core::init(repo.path()).unwrap();
+        Arc::new(DaemonState::open(init.layout).unwrap())
+    }
+
+    /// The founder's contract in one test: rescan loss fails loud, and only an
+    /// explicit `kin admit` clears it.
+    ///
+    /// The bounded half is driven through the SAME seam and the SAME success
+    /// bookkeeping the watch loop runs, `sync_filesystem_with_graph` followed by
+    /// `record_admission_success` and `record_durable_admission`, because that
+    /// is where a clearing call would most naturally be put and where it must
+    /// not be. Both paths reach that bookkeeping; only this module is the
+    /// explicit one.
+    #[tokio::test]
+    async fn only_an_explicit_full_admission_clears_a_watcher_loss() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        std::fs::write(
+            state.layout.working_dir().join("admitted.rs"),
+            "pub fn admitted() -> u8 {\n    7\n}\n",
+        )
+        .unwrap();
+
+        watcher_loss::record_loss(&state.layout, 1, Some("rescan: kernel dropped"));
+        assert!(
+            watcher_loss::read(&state.layout).recovery_required(),
+            "the fixture must start with a loss standing, or neither half below can fail"
+        );
+
+        // One ambient reconcile round, ending exactly as the loop's own
+        // successful tick ends.
+        crate::loop_runner::sync_filesystem_with_graph(&state)
+            .await
+            .expect("the ambient seam admits the fixture");
+        let now = Instant::now();
+        state
+            .background_work
+            .reconcile()
+            .record_admission_success(now);
+        crate::background_work::record_durable_admission(
+            &state.layout,
+            state.graph.resolved_tree().len() as u64,
+        );
+
+        assert!(
+            watcher_loss::read(&state.layout).recovery_required(),
+            "an ordinary bounded watch tick must not clear a watcher loss"
+        );
+
+        let response = execute(&state).await.expect("the pass reported an outcome");
+        let report = response.report.expect("a reported pass carries its report");
+        assert!(report.admitted, "{:?}", report.failure);
+
+        assert!(
+            !watcher_loss::read(&state.layout).recovery_required(),
+            "a completed explicit admission clears the generation it covered"
+        );
+    }
+
+    /// A pass that FAILED clears nothing. Clearing before the outcome is known
+    /// would report a recovered store on the one path where no recovery
+    /// happened.
+    ///
+    /// The failure is the mass-deletion guard, which refuses a walk that removes
+    /// more than three quarters of a baseline of at least sixteen files. It is
+    /// used here because it fails the seam itself rather than a layer above it,
+    /// which is the shape a real refused recovery has.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_failed_pass_leaves_the_loss_standing() {
+        let repo = tempfile::tempdir().unwrap();
+        for index in 0..20 {
+            std::fs::write(
+                repo.path().join(format!("member{index}.txt")),
+                format!("admitted {index}\n"),
+            )
+            .unwrap();
+        }
+        let state = open_test_state(&repo);
+        crate::loop_runner::sync_filesystem_with_graph(&state)
+            .await
+            .expect("the fixture admits its twenty members");
+
+        for index in 0..20 {
+            std::fs::remove_file(repo.path().join(format!("member{index}.txt"))).unwrap();
+        }
+        watcher_loss::record_loss(&state.layout, 1, None);
+
+        let response = execute(&state).await.expect("the pass reported an outcome");
+        let report = response.report.expect("a reported pass carries its report");
+        assert!(
+            !report.admitted,
+            "the fixture must actually fail the pass, or this asserts nothing"
+        );
+
+        assert!(
+            watcher_loss::read(&state.layout).recovery_required(),
+            "a pass that did not succeed must leave the loss standing"
+        );
+    }
+
+    /// A pass over a store the admission seam will not walk clears nothing.
+    ///
+    /// `sync_filesystem_with_graph` returns `Ok(())` without touching the
+    /// working copy when filesystem reconcile is disabled, so the pass reports a
+    /// clean success having observed no file at all. A recovery keyed only on
+    /// that success would heal a blind store from a pass that never looked.
+    #[tokio::test]
+    async fn a_pass_whose_seam_walks_nothing_clears_nothing() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        std::fs::write(
+            state.layout.working_dir().join("unseen.rs"),
+            "pub fn unseen() {}\n",
+        )
+        .unwrap();
+        state
+            .filesystem_reconcile_disabled
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        watcher_loss::record_loss(&state.layout, 1, None);
+        assert_eq!(
+            watcher_loss_this_pass_can_cover(&state),
+            RecoveryCapture::Clean,
+            "a seam that will walk nothing covers nothing"
+        );
+
+        let response = execute(&state).await.expect("the pass reported an outcome");
+        let report = response.report.expect("a reported pass carries its report");
+        assert!(
+            report.admitted,
+            "the seam skips silently, so the pass still reports success: {:?}",
+            report.failure
+        );
+        assert_eq!(
+            report.tracked_after, 0,
+            "the fixture must exercise a pass that observed nothing"
+        );
+
+        assert!(
+            watcher_loss::read(&state.layout).recovery_required(),
+            "a pass that observed no file must not clear a watcher loss"
+        );
     }
 }

--- a/crates/kin-daemon/src/watcher_loss.rs
+++ b/crates/kin-daemon/src/watcher_loss.rs
@@ -1,0 +1,571 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Durable record of filesystem-watcher event loss, and the one thing that
+//! clears it.
+//!
+//! A watcher backend can tell Kin that it lost events: inotify on kernel queue
+//! overflow, FSEvents on `MUST_SCAN_SUBDIRS`. Both spell it as a pathless
+//! `EventKind::Other` carrying notify's `Rescan` flag, so nothing about the
+//! signal names a file and no per-path recovery can be derived from it. An
+//! unknown region of the working copy changed and nothing will ever report it.
+//!
+//! Ambient admission cannot recover that. The watch loop admits what it is told
+//! about, and it was told nothing, so every later tick succeeds, stamps a fresh
+//! last-admission marker, and leaves the graph exactly as far behind as the loss
+//! left it. That is the failure this record exists to end: a store that lost a
+//! whole subtree while every health surface printed the all-clear.
+//!
+//! So the state is durable rather than held in daemon memory. The loss outlives
+//! the daemon that observed it, and a restart that erased it would turn a
+//! recoverable gap into a permanent silent one.
+//!
+//! Two monotonic counters rather than a flag. `generation` counts every loss
+//! signal this store has been told about; `recovered_through` is the highest
+//! generation a COMPLETED full admission covered. Recovery is required while the
+//! first exceeds the second. That shape is what makes the clearing rule
+//! expressible at all: a pass captures the generation standing against the store
+//! before it runs and clears only that one, so a loss arriving while the pass
+//! ran is still standing when it finishes. A boolean would be cleared by the
+//! same pass that never observed the newer loss.
+//!
+//! Only an explicit full admission clears it. The ambient watch tick shares the
+//! admission seam with `kin admit` and records the same success on the same
+//! probes, so the clearing call deliberately does NOT live beside
+//! [`crate::background_work::record_durable_admission`], which both of them
+//! reach. It lives in [`crate::repository_admit`], which is only the explicit
+//! path. This is the founder's contract: fail loud, and let a person or an agent
+//! decide to admit.
+//!
+//! Reads are three-way for the same reason [`kin_core::last_admission`] reads
+//! are, with the direction reversed: an unreadable record is treated as recovery
+//! required. A read error must never be able to present as a healthy store.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::sync::{Mutex, PoisonError};
+
+/// Schema token carried in the record so a future format change is legible
+/// rather than silently misparsed.
+pub const WATCHER_LOSS_SCHEMA: &str = "kin.watcher-loss.v1";
+
+/// Serializes every read-modify-write of one store's record within this process.
+///
+/// The loop's tick records a loss and an explicit admission records a recovery,
+/// and both rewrite the whole file. Without this, a lost update could drop the
+/// loss, which is the one direction that must not be possible: a dropped
+/// recovery merely leaves a healthy store asking for an admission it does not
+/// need, while a dropped loss leaves a blind store reporting itself well.
+///
+/// Process-wide rather than per store, because the writes are rare and short,
+/// and a daemon serves one store. Cross-process concurrency is out of scope here
+/// exactly as it is for the last-admission marker beside it.
+static WRITE_GATE: Mutex<()> = Mutex::new(());
+
+/// What a store has been told it lost, and how much of that a completed full
+/// admission has covered.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WatcherLoss {
+    pub schema: String,
+    /// Every loss signal this store has ever been told about.
+    ///
+    /// Durable and monotonic across daemon lives, unlike the watcher's own
+    /// in-memory count, which restarts with each backend registration. The loop
+    /// advances this by the rise it observes rather than assigning the watcher's
+    /// count, so a restart cannot walk the generation backwards past a recovery
+    /// that already cleared it.
+    pub generation: u64,
+    /// The highest generation a completed full admission covered.
+    pub recovered_through: u64,
+    /// Wall-clock time of the newest loss, so a surface can say when.
+    pub at: DateTime<Utc>,
+    /// The backend's own hint for the newest loss, when it gave one.
+    pub reason: Option<String>,
+}
+
+impl WatcherLoss {
+    fn new(generation: u64, recovered_through: u64, reason: Option<String>) -> Self {
+        Self {
+            schema: WATCHER_LOSS_SCHEMA.to_string(),
+            generation,
+            recovered_through,
+            at: Utc::now(),
+            reason,
+        }
+    }
+
+    /// Whether this store still owes a complete exact-tree admission.
+    pub fn recovery_required(&self) -> bool {
+        self.generation > self.recovered_through
+    }
+}
+
+/// The outcome of consulting the record.
+///
+/// Three variants rather than an `Option`, and unreadable is the loud one. A
+/// record that exists and will not parse means something wrote or truncated it,
+/// and collapsing that into "no loss recorded" would hand a blind store a clean
+/// bill of health through the one door this record was built to close.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WatcherLossRead {
+    Recorded(WatcherLoss),
+    Absent,
+    Unreadable(String),
+}
+
+impl WatcherLossRead {
+    /// Whether this store still owes a complete exact-tree admission.
+    pub fn recovery_required(&self) -> bool {
+        match self {
+            Self::Recorded(recorded) => recorded.recovery_required(),
+            Self::Absent => false,
+            Self::Unreadable(_) => true,
+        }
+    }
+
+    /// One line naming what was lost, when, and what clears it, or nothing when
+    /// this store owes no recovery.
+    ///
+    /// Every state that owes a recovery produces a line, including the
+    /// unreadable one. A surface that printed nothing there would be
+    /// indistinguishable from one reporting a healthy store.
+    pub fn describe(&self, working_dir: &Path) -> Option<String> {
+        match self {
+            Self::Absent => None,
+            Self::Recorded(recorded) if !recorded.recovery_required() => None,
+            Self::Recorded(recorded) => {
+                let reason = match recorded.reason.as_deref() {
+                    Some(reason) => format!(", backend reason: {reason}"),
+                    None => ", the backend named no reason".to_string(),
+                };
+                Some(format!(
+                    "the filesystem watcher lost events (loss generation {}, recovered through \
+                     {}, most recently {}{reason}); an unknown set of paths under {} changed with \
+                     no notification, so ambient admission cannot recover them and this graph may \
+                     be behind its working copy. Run `kin admit` to admit the complete exact tree; \
+                     ordinary watch ticks do not clear this",
+                    recorded.generation,
+                    recorded.recovered_through,
+                    recorded.at.to_rfc3339(),
+                    working_dir.display(),
+                ))
+            }
+            Self::Unreadable(reason) => Some(format!(
+                "the watcher-loss record for {} could not be read ({reason}), so whether this \
+                 watcher lost events is unknown rather than no. Run `kin admit` to admit the \
+                 complete exact tree and rewrite it",
+                working_dir.display(),
+            )),
+        }
+    }
+}
+
+/// What stood against the store when a full admission began.
+///
+/// Captured before the pass rather than read after it, because the pass observes
+/// the tree at its start. A loss signal that arrives while it runs describes
+/// writes the pass may never have seen, so it is not covered by definition, and
+/// reading the generation afterwards would clear it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoveryCapture {
+    /// No loss stood against the store when the pass began.
+    Clean,
+    /// This generation stood against the store when the pass began.
+    Through(u64),
+    /// The record could not be read when the pass began.
+    Unreadable,
+}
+
+fn record_path(layout: &kin_core::KinLayout) -> std::path::PathBuf {
+    layout.kindb_dir().join("watcher-loss")
+}
+
+/// Read the durable record for `layout`.
+///
+/// Never fails. A missing record is [`WatcherLossRead::Absent`] and anything
+/// unparseable is [`WatcherLossRead::Unreadable`], and only the first of those
+/// means the store is well.
+pub fn read(layout: &kin_core::KinLayout) -> WatcherLossRead {
+    let path = record_path(layout);
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return WatcherLossRead::Absent
+        }
+        Err(error) => return WatcherLossRead::Unreadable(error.to_string()),
+    };
+    match serde_json::from_str::<WatcherLoss>(&raw) {
+        Ok(recorded) if recorded.schema == WATCHER_LOSS_SCHEMA => {
+            WatcherLossRead::Recorded(recorded)
+        }
+        Ok(recorded) => WatcherLossRead::Unreadable(format!(
+            "schema {} is not {WATCHER_LOSS_SCHEMA}",
+            recorded.schema
+        )),
+        Err(error) => WatcherLossRead::Unreadable(error.to_string()),
+    }
+}
+
+/// Advance the durable loss generation by `signals`, whatever it held before.
+///
+/// Advancing rather than assigning is what keeps the generation monotonic across
+/// daemon lives. The watcher's own count restarts at zero with every backend
+/// registration, so a daemon that assigned it would walk the generation back
+/// below a recovery that had already cleared it and turn a standing loss into a
+/// healthy store.
+///
+/// An unreadable record is replaced rather than preserved. Its contents told
+/// nobody anything, and the replacement starts at `recovered_through: 0`, so the
+/// store keeps owing an admission. That is the safe direction: the only outcome
+/// this must never produce is a record that reads as recovered.
+///
+/// A write failure is logged and swallowed, in the one place where that is the
+/// wrong direction and there is no better one: failing the tick would stop the
+/// loop admitting, and the in-memory disclosure recorded beside this call still
+/// degrades every health surface for the life of this daemon.
+pub fn record_loss(layout: &kin_core::KinLayout, signals: u64, reason: Option<&str>) {
+    if signals == 0 {
+        return;
+    }
+    let _gate = WRITE_GATE.lock().unwrap_or_else(PoisonError::into_inner);
+    let recorded = match read(layout) {
+        WatcherLossRead::Recorded(previous) => WatcherLoss::new(
+            previous.generation.saturating_add(signals),
+            previous.recovered_through,
+            reason.map(str::to_string),
+        ),
+        WatcherLossRead::Absent | WatcherLossRead::Unreadable(_) => {
+            WatcherLoss::new(signals, 0, reason.map(str::to_string))
+        }
+    };
+    if let Err(error) = write(layout, &recorded) {
+        tracing::error!(
+            error = %error,
+            generation = recorded.generation,
+            "could not persist the watcher-loss record; this daemon still reports the loss on \
+             every health surface, but a restart before the next successful write would lose it"
+        );
+    }
+}
+
+/// Read what stands against the store, for a full admission that is about to
+/// begin.
+pub fn capture(layout: &kin_core::KinLayout) -> RecoveryCapture {
+    match read(layout) {
+        WatcherLossRead::Recorded(recorded) if recorded.recovery_required() => {
+            RecoveryCapture::Through(recorded.generation)
+        }
+        WatcherLossRead::Recorded(_) | WatcherLossRead::Absent => RecoveryCapture::Clean,
+        WatcherLossRead::Unreadable(_) => RecoveryCapture::Unreadable,
+    }
+}
+
+/// Clear the loss a COMPLETED full admission covered, and nothing else.
+///
+/// Called only from the explicit admission path, and only after that pass
+/// succeeded. Every refusal below is a rule the contract needs:
+///
+/// - `Clean` writes nothing, so a loss that arrived during a pass that began on
+///   a well store is still standing when it ends.
+/// - `Through(g)` clears only when the record still reads exactly `g`. A newer
+///   loss has moved it past `g`, and that loss describes writes this pass was
+///   never told about, so it survives its own recovery.
+/// - `Unreadable` rewrites a healthy record only if the record is STILL
+///   unreadable. A complete exact-tree admission observes the whole working
+///   copy, so it covers whatever the unrecoverable record described; but if the
+///   record became readable while the pass ran, a real loss landed and is not
+///   covered.
+///
+/// A write failure is logged and swallowed in the safe direction: an uncleared
+/// record leaves the store asking for an admission it has already had, which
+/// costs a pass and never a silence.
+pub fn record_recovery(layout: &kin_core::KinLayout, captured: RecoveryCapture) {
+    let _gate = WRITE_GATE.lock().unwrap_or_else(PoisonError::into_inner);
+    let recorded = match (captured, read(layout)) {
+        (RecoveryCapture::Clean, _) => return,
+        (RecoveryCapture::Through(covered), WatcherLossRead::Recorded(standing))
+            if standing.generation == covered =>
+        {
+            WatcherLoss {
+                recovered_through: covered,
+                ..standing
+            }
+        }
+        (RecoveryCapture::Unreadable, WatcherLossRead::Unreadable(_)) => {
+            WatcherLoss::new(0, 0, None)
+        }
+        (RecoveryCapture::Through(_) | RecoveryCapture::Unreadable, _) => {
+            tracing::warn!(
+                "a complete exact-tree admission succeeded, but the watcher loss standing against \
+                 this store is not the one it covered; the store keeps owing a recovery"
+            );
+            return;
+        }
+    };
+    if let Err(error) = write(layout, &recorded) {
+        tracing::warn!(
+            error = %error,
+            "could not clear the watcher-loss record after a complete admission; the store will \
+             keep reporting that it owes one until a later pass rewrites it"
+        );
+    }
+}
+
+/// The health-surface view of the durable record, or nothing when this store
+/// owes no recovery.
+///
+/// One producer, so `/health`, `kin graph status` and every other surface that
+/// reads the reconcile report state this identically. Two independently written
+/// renderings of the same record drift into the exact failure this whole record
+/// exists to end, one surface reporting a blind store and another reporting a
+/// well one.
+pub fn standing(
+    layout: &kin_core::KinLayout,
+    working_dir: &Path,
+) -> Option<kin_cli::commands::resources::WatcherLossState> {
+    let read_back = read(layout);
+    let disclosure = read_back.describe(working_dir)?;
+    // An unreadable record names no generation, and zero is what a healthy store
+    // reports. The disclosure above carries what is actually known, so the
+    // numbers stay at their floor rather than inventing a reading.
+    let (generation, recovered_through, at) = match &read_back {
+        WatcherLossRead::Recorded(recorded) => (
+            recorded.generation,
+            recorded.recovered_through,
+            Some(recorded.at.to_rfc3339()),
+        ),
+        WatcherLossRead::Absent | WatcherLossRead::Unreadable(_) => (0, 0, None),
+    };
+    Some(kin_cli::commands::resources::WatcherLossState {
+        generation,
+        recovered_through,
+        at,
+        disclosure,
+    })
+}
+
+/// Write the durable record for `layout`, atomically.
+///
+/// Staged beside the target and renamed into place after an fsync, then the
+/// directory metadata is synced, so a crash mid-write leaves either the previous
+/// record or the new one and never a truncated file. This mirrors how the
+/// last-admission marker beside it is published.
+pub fn write(layout: &kin_core::KinLayout, recorded: &WatcherLoss) -> std::io::Result<()> {
+    use std::io::Write;
+
+    let path = record_path(layout);
+    let parent = path
+        .parent()
+        .ok_or_else(|| std::io::Error::other("watcher-loss path has no parent directory"))?;
+    std::fs::create_dir_all(parent)?;
+    let staged = path.with_extension(format!("tmp-{}", std::process::id()));
+    let body = serde_json::to_vec(recorded).map_err(std::io::Error::other)?;
+    {
+        let mut file = std::fs::File::create(&staged)?;
+        file.write_all(&body)?;
+        file.sync_all()?;
+    }
+    if let Err(error) = std::fs::rename(&staged, &path) {
+        let _ = std::fs::remove_file(&staged);
+        return Err(error);
+    }
+    crate::state::sync_directory_metadata(parent)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn layout_in(dir: &Path) -> kin_core::KinLayout {
+        let kin_dir = dir.join(".kin");
+        std::fs::create_dir_all(kin_dir.join("kindb")).unwrap();
+        kin_core::KinLayout::new(kin_dir)
+    }
+
+    /// The negative control for every assertion below. A store nothing has told
+    /// about a loss owes no recovery and says nothing, so a later `Some` is
+    /// evidence rather than the function's only behaviour.
+    #[test]
+    fn a_store_with_no_recorded_loss_owes_no_recovery_and_discloses_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = layout_in(dir.path());
+
+        assert_eq!(read(&layout), WatcherLossRead::Absent);
+        assert!(!read(&layout).recovery_required());
+        assert_eq!(read(&layout).describe(dir.path()), None);
+        assert_eq!(capture(&layout), RecoveryCapture::Clean);
+    }
+
+    /// The whole point of the file: the loss outlives the daemon that saw it.
+    /// A fresh read is what a restarted daemon performs.
+    #[test]
+    fn a_recorded_loss_requires_recovery_and_survives_a_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = layout_in(dir.path());
+
+        record_loss(&layout, 1, Some("rescan: kernel dropped"));
+
+        let read_back = read(&layout);
+        assert!(read_back.recovery_required());
+        let disclosure = read_back
+            .describe(dir.path())
+            .expect("a standing loss discloses");
+        assert!(
+            disclosure.contains("kin admit"),
+            "the disclosure names what clears it: {disclosure}"
+        );
+        assert!(
+            disclosure.contains("rescan: kernel dropped"),
+            "the disclosure names the backend's reason: {disclosure}"
+        );
+        assert!(
+            disclosure.contains("generation 1"),
+            "the disclosure carries the generation: {disclosure}"
+        );
+    }
+
+    /// The generation advances rather than being assigned, so a watcher whose
+    /// own count restarted at one cannot walk a store back to recovered.
+    #[test]
+    fn the_durable_generation_advances_and_never_restarts() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = layout_in(dir.path());
+
+        record_loss(&layout, 2, None);
+        record_recovery(&layout, RecoveryCapture::Through(2));
+        assert!(!read(&layout).recovery_required());
+
+        // A restarted daemon's watcher reports its first signal as generation 1.
+        record_loss(&layout, 1, None);
+
+        let recorded = match read(&layout) {
+            WatcherLossRead::Recorded(recorded) => recorded,
+            other => panic!("expected a record, got {other:?}"),
+        };
+        assert_eq!(recorded.generation, 3, "the durable generation advanced");
+        assert_eq!(recorded.recovered_through, 2);
+        assert!(recorded.recovery_required());
+    }
+
+    /// Only a full admission clears, and only the generation it captured.
+    #[test]
+    fn a_full_admission_clears_the_generation_it_captured() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = layout_in(dir.path());
+
+        record_loss(&layout, 1, None);
+        let captured = capture(&layout);
+        assert_eq!(captured, RecoveryCapture::Through(1));
+
+        record_recovery(&layout, captured);
+
+        assert!(!read(&layout).recovery_required());
+        assert_eq!(read(&layout).describe(dir.path()), None);
+    }
+
+    /// A loss that lands WHILE a pass runs is not covered by it. The pass
+    /// observed the tree when it started, so the writes the newer signal stands
+    /// for may never have reached it.
+    #[test]
+    fn a_loss_that_arrives_during_a_pass_survives_that_pass() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = layout_in(dir.path());
+
+        record_loss(&layout, 1, None);
+        let captured = capture(&layout);
+
+        // The pass is running. The loop's tick records a second signal.
+        record_loss(&layout, 1, Some("rescan: user dropped"));
+
+        record_recovery(&layout, captured);
+
+        assert!(
+            read(&layout).recovery_required(),
+            "a newer loss must survive the recovery of an older one"
+        );
+        let recorded = match read(&layout) {
+            WatcherLossRead::Recorded(recorded) => recorded,
+            other => panic!("expected a record, got {other:?}"),
+        };
+        assert_eq!(recorded.generation, 2);
+        assert_eq!(
+            recorded.recovered_through, 0,
+            "the pass covered neither generation, so it cleared neither"
+        );
+    }
+
+    /// A pass that began on a well store clears nothing, so a loss that arrives
+    /// mid-pass is still standing when it ends.
+    #[test]
+    fn a_pass_that_began_clean_clears_a_loss_that_arrived_under_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = layout_in(dir.path());
+
+        let captured = capture(&layout);
+        assert_eq!(captured, RecoveryCapture::Clean);
+
+        record_loss(&layout, 1, None);
+        record_recovery(&layout, captured);
+
+        assert!(
+            read(&layout).recovery_required(),
+            "a pass that captured nothing must clear nothing"
+        );
+    }
+
+    /// An unreadable record is a loud state, not a quiet one, and a completed
+    /// admission is what rewrites it.
+    #[test]
+    fn an_unreadable_record_never_reads_as_healthy() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = layout_in(dir.path());
+        std::fs::write(record_path(&layout), b"{ truncated").unwrap();
+
+        let read_back = read(&layout);
+        assert!(matches!(read_back, WatcherLossRead::Unreadable(_)));
+        assert!(read_back.recovery_required());
+        assert!(read_back.describe(dir.path()).is_some());
+        assert_eq!(capture(&layout), RecoveryCapture::Unreadable);
+
+        record_recovery(&layout, RecoveryCapture::Unreadable);
+        assert!(
+            !read(&layout).recovery_required(),
+            "a complete exact-tree admission observes the whole working copy, so it covers \
+             whatever the unreadable record described"
+        );
+    }
+
+    /// A real loss landing on top of an unreadable record is not covered by the
+    /// pass that captured only the unreadable one.
+    #[test]
+    fn a_loss_recorded_over_an_unreadable_record_survives_its_recovery() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = layout_in(dir.path());
+        std::fs::write(record_path(&layout), b"{ truncated").unwrap();
+        let captured = capture(&layout);
+
+        record_loss(&layout, 1, None);
+        record_recovery(&layout, captured);
+
+        assert!(read(&layout).recovery_required());
+    }
+
+    /// A record whose schema token is not this one is unreadable rather than
+    /// silently reinterpreted.
+    #[test]
+    fn a_foreign_schema_is_unreadable_rather_than_misparsed() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = layout_in(dir.path());
+        std::fs::write(
+            record_path(&layout),
+            br#"{"schema":"kin.watcher-loss.v99","generation":4,"recovered_through":4,"at":"2026-09-09T00:00:00Z","reason":null}"#,
+        )
+        .unwrap();
+
+        assert!(matches!(read(&layout), WatcherLossRead::Unreadable(_)));
+        assert!(read(&layout).recovery_required());
+    }
+}

--- a/crates/kin-index/src/lib.rs
+++ b/crates/kin-index/src/lib.rs
@@ -83,7 +83,7 @@ pub use repository::{
 };
 pub use resolution::{RelationResolution, RESOLUTION_FIELD, RESOLUTION_TIER_LADDER};
 pub use support::{compute_coverage_report, CoverageReport};
-pub use watcher::{EventsOutsideRoot, FileEvent, FileWatcher};
+pub use watcher::{EventsOutsideRoot, FileEvent, FileWatcher, LostEvents};
 
 use std::path::Path;
 

--- a/crates/kin-index/src/watcher.rs
+++ b/crates/kin-index/src/watcher.rs
@@ -32,6 +32,38 @@ pub struct EventsOutsideRoot {
     pub last_path: Option<PathBuf>,
 }
 
+/// A watcher backend's own report that it lost events.
+///
+/// Both backends spell this the same way and neither spelling survives
+/// classification. notify 8.2 emits `EventKind::Other` carrying the `Rescan`
+/// flag and NO paths at all, from `inotify.rs` when the kernel queue overflows
+/// and from `fsevent.rs` on `MUST_SCAN_SUBDIRS`. `classify_event` filters
+/// `event.paths` first and returns on an empty result before it ever matches
+/// `event.kind`, so a loss signal that reaches the filter is already gone, and
+/// `_ => {}` would drop it a second time if it got past. Nothing downstream saw
+/// it, so the loop could not notice its own blindness and every surface asking
+/// the loop how it is doing got a healthy answer.
+///
+/// This is therefore recorded from the callback, before the delivery probe and
+/// before classification. Placing it one line later is the whole defect.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LostEvents {
+    /// How many loss signals this watcher has reported.
+    ///
+    /// Monotonic within one watcher's life and reset with it, because a new
+    /// `FileWatcher` is a new backend registration that has observed nothing.
+    /// The generation a store recovers against is durable and lives in the
+    /// daemon; it advances from rises in this one and never restarts.
+    pub generation: u64,
+    /// The backend's own hint for the most recent loss, when it gave one.
+    ///
+    /// FSEvents distinguishes a user-dropped queue from a kernel-dropped one
+    /// and passes the distinction through `Event::info`; inotify's overflow
+    /// carries nothing. Held rather than derived so a report names the cause
+    /// the backend named instead of guessing at it.
+    pub last_reason: Option<String>,
+}
+
 /// Every form of the repository root a host event may legitimately arrive under.
 ///
 /// The backends do not agree on which form they report, and none of them is
@@ -123,6 +155,36 @@ fn record_outside_root(
     }
 }
 
+/// Record one backend report that events were lost, or decline an event that
+/// reports no loss.
+///
+/// Returns whether this event was a loss signal, so a caller cannot record one
+/// and classify it as an ordinary change too.
+///
+/// Loud every time, unlike [`record_outside_root`] beside it, which warns once
+/// and counts the rest. A foreign path can churn in the thousands, so a warning
+/// per event there would bury the one that explains the daemon. A rescan cannot
+/// churn that way: it is emitted once per queue overflow, and every one of them
+/// means an unknown region of the working copy is no longer described by
+/// anything this watcher will report.
+fn record_lost_events(lost: &Mutex<LostEvents>, event: &Event) -> bool {
+    if !event.need_rescan() {
+        return false;
+    }
+    let reason = event.info().map(str::to_string);
+    let mut recorded = lost.lock().unwrap_or_else(PoisonError::into_inner);
+    recorded.generation = recorded.generation.saturating_add(1);
+    recorded.last_reason.clone_from(&reason);
+    warn!(
+        generation = recorded.generation,
+        reason = reason.as_deref().unwrap_or("the backend named none"),
+        "the filesystem watcher backend reports that it lost events; an unknown set of paths \
+         changed without any notification, so ambient admission cannot recover them and only a \
+         complete exact-tree admission can"
+    );
+    true
+}
+
 /// An excluded control-file event proves delivery through this watcher's callback.
 struct DeliveryProbe {
     relative_path: PathBuf,
@@ -173,6 +235,7 @@ pub struct FileWatcher {
     _watcher: RecommendedWatcher,
     receiver: mpsc::Receiver<FileEvent>,
     outside_root: Arc<Mutex<EventsOutsideRoot>>,
+    lost: Arc<Mutex<LostEvents>>,
 }
 
 impl FileWatcher {
@@ -292,10 +355,25 @@ impl FileWatcher {
         let event_roots = RepositoryRoots::bind(&root);
         let outside_root = Arc::new(Mutex::new(EventsOutsideRoot::default()));
         let event_outside_root = Arc::clone(&outside_root);
+        let lost = Arc::new(Mutex::new(LostEvents::default()));
+        let event_lost = Arc::clone(&lost);
 
         let callback: WatchCallback = Box::new(
             move |res: std::result::Result<Event, notify::Error>| match res {
                 Ok(mut event) => {
+                    // First, before the delivery probe and before any path
+                    // filtering. A backend that lost events reports it with no
+                    // paths at all, so every step below discards it: the probe
+                    // ignores rescans by design, and `classify_event` returns on
+                    // an empty `relevant_paths` before it ever matches
+                    // `event.kind`. Recorded one line later is recorded nowhere.
+                    //
+                    // Classification still runs on the same event rather than
+                    // this returning early. Notify documents that it may set the
+                    // flag on an event of its own making, and a rescan that did
+                    // carry paths would lose them here; the pathless shape both
+                    // backends emit classifies to nothing anyway.
+                    record_lost_events(&event_lost, &event);
                     if let Some(probe) = &delivery_probe {
                         let mut probe = probe.lock().unwrap_or_else(PoisonError::into_inner);
                         probe.observe(&event, &event_roots);
@@ -328,6 +406,7 @@ impl FileWatcher {
             _watcher: watcher,
             receiver: rx,
             outside_root,
+            lost,
         })
     }
 
@@ -335,6 +414,15 @@ impl FileWatcher {
     /// watches, so a caller can disclose its own blind spot.
     pub fn events_outside_root(&self) -> EventsOutsideRoot {
         self.outside_root
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone()
+    }
+
+    /// What this watcher's backend has told it that it lost, so a caller can
+    /// disclose a blind spot no path in any event can name.
+    pub fn lost_events(&self) -> LostEvents {
+        self.lost
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .clone()
@@ -789,6 +877,130 @@ mod tests {
             watcher.events_outside_root().count,
             0,
             "no event from inside the repository may be dropped as foreign"
+        );
+    }
+
+    /// The exact event both notify backends emit when they lose events.
+    ///
+    /// `EventKind::Other`, the `Rescan` flag, and no paths at all: notify 8.2's
+    /// `inotify.rs` builds it on `Q_OVERFLOW` and its `fsevent.rs` builds it on
+    /// `MUST_SCAN_SUBDIRS`, the latter adding the backend's own hint.
+    fn backend_loss_signal(reason: Option<&str>) -> Event {
+        let event = Event::new(EventKind::Other).set_flag(notify::event::Flag::Rescan);
+        match reason {
+            Some(reason) => event.set_info(reason),
+            None => event,
+        }
+    }
+
+    /// A loss signal advances the generation and an ordinary edit does not.
+    ///
+    /// Both arms on purpose. A recorder that advanced on every event would pass
+    /// the first assertion alone while making the generation meaningless, so the
+    /// ordinary edit beside it is what gives the first arm any content.
+    #[test]
+    fn a_backend_loss_signal_advances_the_generation_and_an_ordinary_edit_does_not() {
+        let lost = Mutex::new(LostEvents::default());
+
+        assert!(
+            !record_lost_events(&lost, &content_change(vec![PathBuf::from("/tmp/main.rs")])),
+            "an ordinary content change is not a loss signal"
+        );
+        assert_eq!(
+            lost.lock().unwrap().generation,
+            0,
+            "an ordinary content change must not advance the loss generation"
+        );
+
+        assert!(
+            record_lost_events(&lost, &backend_loss_signal(Some("rescan: kernel dropped"))),
+            "the shape both backends emit is a loss signal"
+        );
+        assert_eq!(lost.lock().unwrap().generation, 1);
+        assert_eq!(
+            lost.lock().unwrap().last_reason.as_deref(),
+            Some("rescan: kernel dropped"),
+            "the backend's own hint is carried rather than guessed at"
+        );
+
+        assert!(record_lost_events(&lost, &backend_loss_signal(None)));
+        assert_eq!(
+            lost.lock().unwrap().generation,
+            2,
+            "the generation is monotonic across signals"
+        );
+        assert_eq!(
+            lost.lock().unwrap().last_reason,
+            None,
+            "a backend that named no reason must not leave the previous one standing"
+        );
+    }
+
+    /// The seam that matters: the real callback records the loss, and it does so
+    /// before path filtering.
+    ///
+    /// `classify_event` is asserted here to still yield nothing for the same
+    /// event, which is the positive control for the whole class. If
+    /// classification ever did carry it, the record would be redundant; because
+    /// it does not, the record is the only thing between a lost region of the
+    /// working copy and a daemon that reports itself healthy. A recorder moved
+    /// below the path filter fails this test and passes the unit test above.
+    #[test]
+    fn the_watcher_callback_records_a_loss_signal_that_classification_discards() {
+        let repo = tempfile::tempdir().unwrap();
+        let source = repo.path().join("kept.rs");
+        std::fs::write(&source, "pub fn kept() {}\n").unwrap();
+
+        let callback_slot = Arc::new(Mutex::new(None::<WatchCallback>));
+        let captured = Arc::clone(&callback_slot);
+        let watcher =
+            FileWatcher::new_with_delivery_probe_using(repo.path(), None, move |_, callback| {
+                *captured.lock().unwrap() = Some(callback);
+                // Driven by hand below. This unregistered backend owns no host
+                // stream and no filesystem watch.
+                notify::recommended_watcher(|_: std::result::Result<Event, notify::Error>| {})
+                    .map_err(|error| IndexError::Watcher(error.to_string()))
+            })
+            .unwrap();
+        let mut callback = callback_slot.lock().unwrap().take().unwrap();
+
+        // Positive control. The callback under test is the one this watcher
+        // classifies through, so a later empty drain means "discarded" rather
+        // than "never delivered".
+        callback(Ok(content_change(vec![source.clone()])));
+        assert!(
+            watcher
+                .drain()
+                .iter()
+                .any(|event| matches!(event, FileEvent::Changed(path) if path == &source)),
+            "the fixture must drive the callback this watcher classifies through"
+        );
+        assert_eq!(
+            watcher.lost_events().generation,
+            0,
+            "an ordinary edit through the real callback is not a loss"
+        );
+
+        let signal = backend_loss_signal(Some("rescan: user dropped"));
+        assert!(
+            signal.paths.is_empty(),
+            "the fixture must carry the pathless shape the backends emit"
+        );
+        callback(Ok(signal));
+
+        assert!(
+            watcher.drain().is_empty(),
+            "classification still yields nothing for a pathless rescan, which is why the record \
+             is the only thing that can carry it downstream"
+        );
+        assert_eq!(
+            watcher.lost_events().generation,
+            1,
+            "the callback must record the loss before it filters paths"
+        );
+        assert_eq!(
+            watcher.lost_events().last_reason.as_deref(),
+            Some("rescan: user dropped")
         );
     }
 }

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -1525,6 +1525,103 @@ fn embedding_class_states(envelope: &Envelope) -> (Map<String, Value>, Vec<Strin
     (classes, vec!["embeddings".to_string()], limits)
 }
 
+/// A watcher-reported loss of events standing against the store that answered.
+///
+/// A positive observation of missing input, which is what makes it a verdict
+/// input rather than a note. The watcher's own backend reported that it dropped
+/// events: notify emits a pathless `EventKind::Other` carrying its `Rescan`
+/// flag, from inotify on kernel queue overflow and from FSEvents on
+/// `MUST_SCAN_SUBDIRS`. No path is named, so nothing derives a per-path
+/// recovery from it and no ambient watch tick can close it. Until a complete
+/// exact-tree admission runs, an unknown set of paths changed without reaching
+/// graph truth, and no absence over this store is trustworthy.
+///
+/// Absent when the daemon reported no reconcile block, and absent when it
+/// reported one carrying no standing loss. The producer omits the field
+/// entirely on a store that owes no recovery, so the field's PRESENCE is the
+/// observation and nothing here has to re-derive it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WatcherLossObservation {
+    /// Every loss signal this store has been told about, durably and across
+    /// daemon lives.
+    #[serde(default)]
+    pub generation: u64,
+    /// The highest generation a completed full admission covered.
+    #[serde(default)]
+    pub recovered_through: u64,
+    /// Wall-clock time of the newest loss, RFC 3339, when the record named one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub at: Option<String>,
+    /// The daemon's own disclosure, carried verbatim rather than rewritten, so
+    /// the sentence `kin graph status` prints and the one this verdict refuses
+    /// beside cannot drift apart.
+    pub disclosure: String,
+}
+
+impl WatcherLossObservation {
+    /// Read the standing loss out of a daemon `/health` body.
+    ///
+    /// `None` for a body with no reconcile block and for one whose reconcile
+    /// block carries no loss. Neither is evidence of a loss and neither may
+    /// manufacture one.
+    pub fn from_health(health: &Value) -> Option<Self> {
+        let loss = health.get("reconcile")?.get("watcher_loss")?;
+        if loss.is_null() {
+            return None;
+        }
+        let generation = loss
+            .get("generation")
+            .and_then(Value::as_u64)
+            .unwrap_or_default();
+        let recovered_through = loss
+            .get("recovered_through")
+            .and_then(Value::as_u64)
+            .unwrap_or_default();
+        // The producer already omits the block on a store that owes no
+        // recovery, so this is not the only gate. It is what makes the two
+        // sides agree by construction rather than by convention: a reader keyed
+        // on the block's mere presence would refuse forever the day any
+        // producer published a settled record, and nothing in this crate would
+        // notice.
+        if generation <= recovered_through {
+            return None;
+        }
+        Some(Self {
+            generation,
+            recovered_through,
+            at: loss.get("at").and_then(Value::as_str).map(str::to_string),
+            // A block that arrived without its own sentence still has to say
+            // something. Falling silent here would turn an unreadable
+            // disclosure into a store with no loss.
+            disclosure: loss
+                .get("disclosure")
+                .and_then(Value::as_str)
+                .unwrap_or("the daemon reported a watcher loss it did not describe")
+                .to_string(),
+        })
+    }
+
+    /// The factor this store carries into the single verdict.
+    ///
+    /// Names the generation, the recovery point and the one command that clears
+    /// it, because a reader told only that an answer is inconclusive has nothing
+    /// to do about it.
+    pub fn limiting_factor(&self) -> String {
+        let at = match self.at.as_deref() {
+            Some(at) => format!(", most recently {at}"),
+            None => String::new(),
+        };
+        format!(
+            "watcher_events_lost: the filesystem watcher reported that it lost events (loss \
+             generation {}, recovered through {}{at}) and no complete admission has covered them, \
+             so an unknown set of paths changed without reaching graph truth and no absence in \
+             this answer is authoritative; run `kin admit` on the repository to admit the complete \
+             exact tree and clear it",
+            self.generation, self.recovered_through
+        )
+    }
+}
+
 /// The graph class state, from the freshness signals the envelope observed.
 ///
 /// Both halves have to be affirmatively true. `initialized` says first
@@ -1962,6 +2059,14 @@ pub struct Envelope {
     /// certifying an all-clear.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub freshness: Option<GraphFreshness>,
+    /// Whether the watcher that fed graph truth admits it lost events, beside
+    /// `freshness` rather than inside it because the two answer different
+    /// questions. `freshness` answers "was the graph ever brought level"; this
+    /// answers "did the mechanism that keeps it level go blind". A store can be
+    /// admitted seconds ago and still be missing whatever changed during a queue
+    /// overflow, and nothing else on this envelope can see that.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub watcher_loss: Option<WatcherLossObservation>,
     /// Honest graph freshness context; omitted entirely when nothing is known.
     #[serde(default, skip_serializing_if = "GraphState::is_empty")]
     pub graph_state: GraphState,
@@ -2009,6 +2114,7 @@ impl Envelope {
             durability: None,
             behind: None,
             freshness: None,
+            watcher_loss: None,
             graph_state: GraphState::default(),
             degraded: Degraded {
                 offline_fallback: Some(true),
@@ -2033,6 +2139,7 @@ impl Envelope {
             durability: None,
             behind: None,
             freshness: None,
+            watcher_loss: None,
             graph_state: GraphState::default(),
             degraded: Degraded::default(),
             hydration_semantics: None,
@@ -2293,6 +2400,7 @@ impl Envelope {
             durability: None,
             behind: None,
             freshness: None,
+            watcher_loss: None,
             graph_state: GraphState::default(),
             degraded: Degraded {
                 daemon_unreachable: Some(true),
@@ -2322,6 +2430,7 @@ impl Envelope {
             durability: None,
             behind: None,
             freshness: None,
+            watcher_loss: None,
             graph_state: GraphState::default(),
             degraded: Degraded {
                 workspace_mismatch: Some(true),
@@ -2394,6 +2503,11 @@ impl Envelope {
         // `behind`: the count gates that object off on a clean working copy, and
         // the clock is a fact about the graph rather than about the disk.
         self.freshness = GraphFreshness::from_health(health);
+        // Read from the same reconcile block, and separately from every reading
+        // above it: a store can be durable, level and holding zero unadmitted
+        // paths while an unknown region of it is missing because the watcher's
+        // backend dropped the events that would have named it.
+        self.watcher_loss = WatcherLossObservation::from_health(health);
         if let Some(behind) = self.behind.as_ref() {
             self.durability = self
                 .durability
@@ -2432,6 +2546,11 @@ impl Envelope {
     pub fn with_working_copy_health(mut self, health: &Value) -> Self {
         self.behind = GraphBehind::from_health(health);
         self.freshness = GraphFreshness::from_health(health);
+        // Read from the same reconcile block, and separately from every reading
+        // above it: a store can be durable, level and holding zero unadmitted
+        // paths while an unknown region of it is missing because the watcher's
+        // backend dropped the events that would have named it.
+        self.watcher_loss = WatcherLossObservation::from_health(health);
         if let Some(behind) = self.behind.as_ref() {
             self.durability = self
                 .durability

--- a/crates/kin-mcp/src/verdict.rs
+++ b/crates/kin-mcp/src/verdict.rs
@@ -245,6 +245,12 @@ impl Verdict {
             negative.get("interpretation").and_then(Value::as_str) != Some("qualified_answer")
         });
         let readings = [
+            // First, because it is the only input here that says the SUBSTRATE
+            // was fed incompletely. Every other reading below is about what this
+            // answer could see in graph truth; this one says graph truth itself
+            // is missing an unknown set of paths, which is the fact that
+            // qualifies all of them.
+            ("watcher_loss", watcher_loss_reading(envelope)),
             (
                 "absence_gate",
                 absence_gate_reading(tool, payload, negative),
@@ -834,6 +840,35 @@ fn degradations_reading(payload: &Value) -> Reading {
 /// staleness separate and the clock becomes a real input too. Until then,
 /// silence is the only honest reading of it, and a silent input never
 /// contributes agreement, so nothing there can license an answer either.
+/// A watcher-reported loss of events as a verdict input.
+///
+/// The one reading here that rests on a positive observation of missing input
+/// rather than on an inference from an absence, which is why it refuses where
+/// the admission clock beside it stays silent. The watcher's backend said it
+/// dropped events and named no path, so the graph is missing an unknown set of
+/// them and no absence over this store can be authoritative until a complete
+/// exact-tree admission runs.
+///
+/// The consequence is deliberate and worth stating plainly: every answer over
+/// an affected store reads `inconclusive` until someone runs `kin admit`. That
+/// is the founder's contract for this class, fail loud plus an explicit
+/// admission, and the alternative is the silent healthy read this whole module
+/// exists to stop. It is bounded in exactly the way a permanent floor would not
+/// be: the record clears, so the verdict returns.
+///
+/// Silent when nothing stands. The producer omits the block entirely on a store
+/// that owes no recovery, and a silent input never contributes agreement, so
+/// this can never license an answer either.
+fn watcher_loss_reading(envelope: &Envelope) -> Reading {
+    match envelope.watcher_loss.as_ref() {
+        // Taken from the observation rather than written again here, so the
+        // sentence the daemon publishes and the one the verdict refuses with
+        // cannot drift apart.
+        Some(loss) => Reading::Inconclusive(vec![loss.limiting_factor()]),
+        None => Reading::Silent,
+    }
+}
+
 fn graph_freshness_reading(envelope: &Envelope) -> Reading {
     match envelope.freshness.as_ref() {
         // The clause is taken from the type rather than written again here, so
@@ -1162,6 +1197,149 @@ mod tests {
     /// field names, and both are `skip_serializing_if = "Option::is_none"`
     /// there, which is why the no-clock arm omits the key rather than setting it
     /// null.
+    /// Fail loud on the agent-facing surface, and stop being loud once the
+    /// recovery has happened.
+    ///
+    /// Three arms because two of them would prove nothing. `inconclusive` on a
+    /// lossy store means nothing without the healthy control that certifies on
+    /// the same payload, and neither means anything without the settled arm,
+    /// which is what stops this being a permanent floor over every store that
+    /// ever dropped an event.
+    ///
+    /// The fixtures spell the wire shape by hand because this crate does not
+    /// depend on the producer's. The producer is
+    /// `kin_cli::commands::resources::WatcherLossState`, written by the daemon's
+    /// `watcher_loss::standing`, and the daemon-side test that grades the pair
+    /// is `repository_admit::tests::only_an_explicit_full_admission_clears_a_watcher_loss`.
+    mod watcher_loss {
+        use super::*;
+
+        fn envelope_with(watcher_loss: Option<Value>) -> Envelope {
+            let mut reconcile = json!({
+                "untracked_path_count": 0,
+                "untracked_observed_age_seconds": 0,
+                "last_admission_success_at": "2026-09-09T00:00:00Z",
+                "last_admission_success_age_seconds": 12,
+            });
+            if let Some(loss) = watcher_loss {
+                reconcile["watcher_loss"] = loss;
+            }
+            Envelope::daemon().with_health(&json!({
+                "graph_loaded": true,
+                "initialized": true,
+                "reconcile": reconcile,
+            }))
+        }
+
+        fn standing_loss() -> Value {
+            json!({
+                "generation": 2,
+                "recovered_through": 0,
+                "at": "2026-09-09T06:00:00Z",
+                "disclosure": "the filesystem watcher lost events (loss generation 2, recovered \
+                               through 0)",
+            })
+        }
+
+        /// The control. Without it, `inconclusive` below could come from
+        /// anything on this fixture and would say nothing about the loss.
+        #[test]
+        fn a_store_with_no_watcher_loss_certifies_on_the_same_payload() {
+            let envelope = envelope_with(None);
+            assert!(
+                envelope.watcher_loss.is_none(),
+                "the control fixture must carry no loss: {:?}",
+                envelope.watcher_loss
+            );
+            assert!(matches!(watcher_loss_reading(&envelope), Reading::Silent));
+
+            let verdict = Verdict::compute(
+                "find_references",
+                &populated_reference_payload("present"),
+                &envelope,
+                None,
+            )
+            .expect("the readings are not all silent");
+            assert!(
+                verdict.certified,
+                "the control must certify, or the arm below proves nothing: {:?}",
+                verdict.limiting_factor
+            );
+        }
+
+        /// A store whose watcher lost events answers inconclusive, and the
+        /// reader is told the generation and the one command that clears it.
+        #[test]
+        fn a_standing_loss_refuses_the_verdict_and_names_the_recovery() {
+            let envelope = envelope_with(Some(standing_loss()));
+            let observed = envelope
+                .watcher_loss
+                .as_ref()
+                .expect("a standing loss is read off the wire");
+            assert_eq!(observed.generation, 2);
+            assert_eq!(observed.recovered_through, 0);
+
+            let verdict = Verdict::compute(
+                "find_references",
+                &populated_reference_payload("present"),
+                &envelope,
+                None,
+            )
+            .expect("the readings are not all silent")
+            .to_value();
+
+            assert_eq!(verdict["state"], json!(INCONCLUSIVE), "{verdict}");
+            assert_eq!(
+                verdict["inputs"]["watcher_loss"],
+                json!(INCONCLUSIVE),
+                "{verdict}"
+            );
+            let factor = verdict["limiting_factor"]
+                .as_str()
+                .expect("a refusing verdict names its factor");
+            assert!(
+                factor.contains("watcher_events_lost:"),
+                "the clause is labelled so it survives composition: {factor}"
+            );
+            assert!(
+                factor.contains("generation 2"),
+                "the factor carries the generation: {factor}"
+            );
+            assert!(
+                factor.contains("kin admit"),
+                "a reader told only that this is inconclusive has nothing to do: {factor}"
+            );
+        }
+
+        /// The bound on all of it. A record a completed full admission covered
+        /// stops refusing, so this is a state a store leaves rather than a floor
+        /// it lives under.
+        #[test]
+        fn a_record_a_full_admission_covered_stops_refusing() {
+            let mut settled = standing_loss();
+            settled["recovered_through"] = json!(2);
+            let envelope = envelope_with(Some(settled));
+
+            assert!(
+                envelope.watcher_loss.is_none(),
+                "a covered generation is not a standing loss: {:?}",
+                envelope.watcher_loss
+            );
+            let verdict = Verdict::compute(
+                "find_references",
+                &populated_reference_payload("present"),
+                &envelope,
+                None,
+            )
+            .expect("the readings are not all silent");
+            assert!(
+                verdict.certified,
+                "the verdict returns once the recovery has happened: {:?}",
+                verdict.limiting_factor
+            );
+        }
+    }
+
     mod graph_freshness {
         use super::*;
 

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -1561,6 +1561,16 @@
           "count": 2
         }
       ]
+    },
+    {
+      "file": "crates/kin-daemon/src/watcher_loss.rs",
+      "reason": "Durable bookkeeping record published beside the last-admission marker, not an answer authority. The excused bodies read and write .kin/kindb/watcher-loss, which records how many times a filesystem watcher backend reported that it LOST events and how much of that a completed exact-tree admission has covered. Both backends report the loss the same way and neither names a path: notify emits a pathless EventKind::Other carrying its Rescan flag, from inotify on kernel queue overflow and from FSEvents on MUST_SCAN_SUBDIRS. The record therefore holds two counters and a timestamp, names no entity, carries no repository content, and is read only by health surfaces and by the explicit admission path. It cannot change what any query returns: a reader that lied in either direction would change whether kin graph status, /health and the _kin verdict report that this store owes a `kin admit`, never a locate, search, context, trace, review, xref or rename answer. It is durable rather than in-daemon memory precisely because the loss outlives the daemon that observed it, and a restart that erased it would turn a recoverable gap into a permanent silent one. Publication is a temp-and-rename with an fsync of the staged file and then of the containing directory, through crate::state::sync_directory_metadata, which is the same shape write_generation_marker in crates/kin-daemon/src/state.rs uses for the authority head marker and the same shape kin_core::last_admission uses for the marker this record sits beside; routing through a shared boundary helper instead was not available, because neither kin-core nor kin-daemon exposes a public atomic-write path and each site open-codes its own. Function-scoped rather than whole-file so the rest of the module stays scanned, including the three-way read classification, the advance-never-assign rule on the generation and the three refusals in record_recovery, and so any newly added filesystem primitive here fails the guard until it is justified.",
+      "owner": "kin-daemon",
+      "expiration": "2027-10-29",
+      "allow_fn": [
+        "read",
+        "write"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Tracker: FIR-3416

## The class

A filesystem watcher backend can report that it lost events, and nothing in Kin could carry that
report. The signal reached the callback and died there.

This is confirmed in the vendored dependency rather than inferred. Both backends spell it
identically and neither spelling carries a path:

```
notify-8.2.0/src/inotify.rs:213:  let ev = Ok(Event::new(EventKind::Other).set_flag(Flag::Rescan));   # Q_OVERFLOW
notify-8.2.0/src/fsevent.rs:117:  let e = Event::new(EventKind::Other).set_flag(Flag::Rescan);        # MUST_SCAN_SUBDIRS
notify-types-2.1.0/src/event.rs:648:  pub fn need_rescan(&self) -> bool { matches!(self.flag(), Some(Flag::Rescan)) }
```

FSEvents adds `info` of `rescan: user dropped` or `rescan: kernel dropped` when the kernel gives
the hint; inotify's overflow carries nothing. That is why `need_rescan()` is the one predicate
this keys on: it covers both backends, and the pathless shape is the reason the signal vanished.

At `64174f30`, `FileEvent` (`kin-index/src/watcher.rs:14`) had only `Changed` and `Removed`, so no
variant could carry a loss. `classify_event` (`:363`) filtered `event.paths` and returned at
`relevant_paths.is_empty()` (`:391`) before it ever matched `event.kind` (`:395`), so a pathless
event was discarded before classification and the `_ => {}` arm would have discarded it again.
`need_rescan()` appeared once in production code, at `:134` inside the readiness probe, where it
only withholds a probe acknowledgment; the test comment at `:639` says so outright. So a store
could lose an unknown region of its working copy while every surface asking the loop how it was
doing printed the all-clear.

## The contract

The founder's words: rescan loss fails loud, plus an explicit `kin admit`.

Record the signal before path filtering into a durable, monotonic generation. Report it wherever
the daemon reports repository health. Clear it only from a COMPLETED full admission, and only the
generation that stood when that pass began.

Two counters rather than a flag. `generation` counts every loss signal the store has been told
about; `recovered_through` is the highest generation a completed full admission covered; recovery
is required while the first exceeds the second. That pair is what makes the clearing rule
expressible at all, because a boolean would be cleared by the same pass that never observed the
newer loss.

The durable generation ADVANCES by the rise the loop observes and is never assigned from the
watcher's in-memory count, which restarts with every backend registration. Assigning it would walk
the generation back below a recovery that had already cleared it.

## Two things worth reading closely

**The clear is not beside `record_durable_admission`.** That is the tempting place, because it is
the shared "an admission succeeded" hook. The ambient watch tick reaches it too
(`loop_runner.rs:3384`), and an ambient tick admits what the watcher told it about, which for a
loss that named no path is nothing at all. The clear lives in `repository_admit::run_pass`, which
is only the explicit request. Falsification arm 3 is that exact mutation and it goes red.

**A pass whose seam walks nothing clears nothing.** `sync_filesystem_with_graph` returns `Ok(())`
WITHOUT touching the working copy on two conditions, filesystem reconcile disabled
(`loop_runner.rs:10434`) and a bare Git repository (`:10443`). Both production callers of
`repository_admit::execute` refuse those ahead of the pass, at `api.rs:6039` and at the
branch-switch retry at `api.rs:5728`, and that is exactly why the guard does not lean on them: a
recovery that depends on a caller is one refactor from healing a blind store from a walk that
never happened. `watcher_loss_this_pass_can_cover` uses the seam's own predicates so the two
cannot drift.

## The `_kin` envelope verdict

`WatcherLossObservation::from_health` reads `reconcile.watcher_loss` off the daemon health body,
and `watcher_loss_reading` is the FIRST entry in `Verdict::compute`'s readings array, because it is
the only input there that says the substrate itself was fed incompletely rather than that this
answer could not see something in it. Pessimistic-wins composition is unchanged.

**Every MCP answer over an affected store reads `inconclusive` until someone runs `kin admit`.**
That is deliberate, and it is stated here so no reader is surprised by it. After a pathless loss,
no absence over that store is trustworthy, and a conclusive verdict there is the silent healthy
read this change exists to end. It is bounded rather than a floor: the record clears, the verdict
returns, and `a_record_a_full_admission_covered_stops_refusing` is the test that holds the bound.

The reader refuses only when `generation > recovered_through`, not on the block's mere presence.
The producer already omits the block on a settled store, so presence alone would work today. The
gate is what makes the bound arm mean anything: a reader keyed on presence would refuse forever
the day any producer published a settled record, and nothing in kin-mcp would notice. Arm 9 removes
the gate and turns the bound arm red.

## Surfaces

One producer, `watcher_loss::standing`, builds the health-surface view. It reaches `kin graph
status` (`kin-cli/src/commands/graph.rs:1137`), `/health` (`kin-cli/src/commands/health.rs:3413`,
which moves off `Healthy` on any non-empty reasons list), the `kin admit` response, a daemon
restart, and the `_kin` verdict. The probes hold the state and never read it, because they
deliberately know nothing about the store's layout.

## Zero-file-search exemption

`crates/kin-daemon/src/watcher_loss.rs` takes a FUNCTION-SCOPED exemption on `read` and `write`,
the same shape the four sibling durable markers carry (`kin_core::last_admission`,
`relation_census`, `retained_parse`, `hydration_semantics`). The record holds two counters and a
timestamp, names no entity, and cannot change what any query returns.

Proven function-scoped rather than a blanket, by adding an unexempt call inside `record_loss`:

```
$ python3 scripts/verify-zero-file-search.py     # with `let _falsify = std::fs::read_dir(...)` in record_loss
[VIOLATION] crates/kin-daemon/src/watcher_loss.rs contains forbidden filesystem access:
  Line  232: let _falsify = std::fs::read_dir(layout.kindb_dir()); (directory traversal (read_dir), filesystem module namespace reach, fs API usage)
Verification FAILED: Found 1 zero-file-search violations.
rc=1
```

Restored byte-identical (sha256 `c2e2c048...` before and after), and clean:

```
$ python3 scripts/verify-zero-file-search.py
Scanned 331 source files (16 with function-scoped exemptions, 80 exempt whole-file).
Deny-set self-test passed: 30 matcher cases (6 negative controls) and 6 binding-learner cases (2 negative controls).
Verification PASSED: Zero File-Search Invariant holds.
rc=0
```

## Measurement before the fix

Both tests were shown red before the wiring existed. On `64174f30` with no edits neither test
compiles, so the red was staged one step in: types, recorder, durable record and tests present,
the three wiring points absent. That tree compiles, so every assertion runs and each failure names
the missing behaviour.

```
$ cargo test -p kin-index --lib watcher::
test watcher::tests::the_watcher_callback_records_a_loss_signal_that_classification_discards ... FAILED
thread ... panicked at crates/kin-index/src/watcher.rs:983:9:
assertion `left == right` failed: the callback must record the loss before it filters paths
  left: 0
 right: 1
test result: FAILED. 13 passed; 1 failed; 0 ignored; 0 measured; 366 filtered out
```

Both positive controls inside that test passed before the failing line: the fixture callback did
deliver an ordinary edit into the queue, and `classify_event` did yield an empty drain for the
pathless rescan. So the red is the guard, not a broken fixture.

```
$ cargo test -p kin-daemon --lib -- watcher_loss:: repository_admit::
test repository_admit::tests::only_an_explicit_full_admission_clears_a_watcher_loss ... FAILED
thread ... panicked at crates/kin-daemon/src/repository_admit.rs:371:9:
a completed explicit admission clears the generation it covered
test result: FAILED. 10 passed; 1 failed; 0 ignored; 0 measured; 1608 filtered out
```

## Falsification: ten arms, every one red

Harness: `.kin-coord/scratch/rescanloss-falsify.py`. Each arm is a single-site string swap asserted
to appear exactly the expected number of times, so a mutation whose target moved reports ARM BROKEN
rather than passing silently. The tree is restored from a byte snapshot and the sha256 compared
afterwards, never with `git checkout -- <file>`.

```
$ python3 .kin-coord/scratch/rescanloss-falsify.py
1-drop-the-loss: RED as required
2-record-after-path-filtering: RED as required
3-clear-on-any-tick: RED as required
4-clear-before-success: RED as required
5-clear-a-newer-generation: RED as required
6-cover-a-seam-that-walked-nothing: RED as required
7-assign-the-generation-instead-of-advancing-it: RED as required
8-verdict-never-reads-the-loss: RED as required
9-refuse-on-presence-alone: RED as required
10-envelope-never-reads-the-health-block: RED as required

arms that did not behave: none
```

| Arm | Guard it breaks | Test that went red |
|---|---|---|
| 1 | the callback records the signal at all | `watcher::the_watcher_callback_records_a_loss_signal_that_classification_discards` |
| 2 | it records BEFORE path filtering | the same test; arm 2 leaves the unit test green, which is the point |
| 3 | the clear is not in the shared success hook | `repository_admit::only_an_explicit_full_admission_clears_a_watcher_loss` and `a_pass_whose_seam_walks_nothing_clears_nothing` |
| 4 | the clear runs only after success | `repository_admit::a_failed_pass_leaves_the_loss_standing` |
| 5 | it clears only the generation it captured | `watcher_loss::a_loss_that_arrives_during_a_pass_survives_that_pass` |
| 6 | a seam that walked nothing covers nothing | `repository_admit::a_pass_whose_seam_walks_nothing_clears_nothing` |
| 7 | the durable generation advances, never assigns | `watcher_loss::the_durable_generation_advances_and_never_restarts` and `a_loss_that_arrives_during_a_pass_survives_that_pass` |
| 8 | the verdict reads the loss | `verdict::watcher_loss::a_standing_loss_refuses_the_verdict_and_names_the_recovery` |
| 9 | a covered record stops refusing | `verdict::watcher_loss::a_record_a_full_admission_covered_stops_refusing` |
| 10 | the envelope reads the health block | `verdict::watcher_loss::a_standing_loss_refuses_the_verdict_and_names_the_recovery` |

Arm 3 is what gives the bounded-admission assertion its content. On the unwired tree that
assertion could not fail, because nothing cleared at all. Under arm 3 the clear sits in
`record_durable_admission`, the ambient tick reaches it, and the assertion goes red.

Arm 4 needed a second attempt: my first mutation was invalid Rust and the harness reported
`MUTANT DID NOT COMPILE` rather than counting a compile error as a red test. The corrected
mutation moved the clear out of the `failure.is_none()` block and the arm went red. A harness that
treated a non-compiling mutant as a pass would have reported ten of ten on a guard it never
exercised.

## Local gates

Every cargo command ran through the fleet's heavy-slot wrapper.

```
$ cargo fmt --all -- --check
FMT CHECK rc=0

$ cargo clippy --all-targets --all-features -- $allows    # allows from .github/clippy-allowed-lints.txt
clippy debt allow-list words: 90
CLIPPY rc=0

$ cargo test -p kin-index -p kin-daemon -p kin-mcp -p kin-cli --lib
kin-cli     29 passed; 0 failed
kin-daemon  15 passed; 0 failed
kin-index   14 passed; 0 failed
kin-mcp    112 passed; 0 failed
TESTS rc=0
```

The kin-mcp 112 and kin-daemon 15 include every pre-existing verdict, envelope and outside-root
test in those filters, so the new inputs regressed none of them.

```
$ bin/kin-precheck kin --repo-dir kin=<lane worktree>
kin-precheck: repo=kin tree=.../worktrees/rescanloss-kin sha=64174f30e9ffa107510bbebb8072f1be375cd77f branch=chore/lane-rescanloss-kin DIRTY
kin-precheck: behind origin/main 0 commit(s)
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 64174f30e9ffa107510bbebb8072f1be375cd77f DIRTY
precheck rc=0
```

Hosted CI remains the gate of record for the full workspace, and `Product Acceptance` grades main
rather than this pull request.

## Host note

The native watcher tests ran on a healthy host. `fseventsd` at 2026-09-09T07:00:59Z:

```
  PID    RSS  %CPU COMM
40895  14096   2.6 .../fseventsd
```

## Not in this change

The notify `Err(e)` branch in the watch callback still only logs. A transport error from the
backend is not the documented lost-events signal and folding it in would need its own contract.

