### PR TITLE
Re-vendor kin-release-preflight with the FLOW_PATH language-server fix

### DIFF
--- a/scripts/release-proof/VENDORED.json
+++ b/scripts/release-proof/VENDORED.json
@@ -1,9 +1,9 @@
 {
   "source_repository": "firelock-ai/kin-ecosystem",
-  "source_commit": "2a0d6d265ca2035c0683d2dbc291968610e0b4b3",
+  "source_commit": "c1cbeeb25f6070e59178badb401e9195537d91de",
   "note": "Byte-identical copies of the umbrella proof tooling so the hosted preflight runs from kin alone; bin/kin-lane is a single-host lock shim written for this tree, not a copy. scripts/release-proof/vendored.test.mjs refuses a file whose sha256 left this manifest.",
   "files": {
-    "bin/kin-release-preflight": {"source": "bin/kin-release-preflight", "sha256": "d42617e79966bf6d3548e00a9d303c38cf4689f6ff33610b6d9526019a028854"},
+    "bin/kin-release-preflight": {"source": "bin/kin-release-preflight", "sha256": "aedf49d66f774ff5fc34c84a4efccbe913278478281ece0917d50b8d910dd235"},
     "bin/kin-release-preflight.d/Dockerfile": {"source": "bin/kin-release-preflight.d/Dockerfile", "sha256": "e6c0e30c2bf46fc889484fb7e32c73163c3cf315d60351be3acd2428d22d12f6"},
     "bin/kin-release-preflight.d/proof-flow.sh": {"source": "bin/kin-release-preflight.d/proof-flow.sh", "sha256": "3a44e377a8c6bfcdfb688608ae5b9ba64293e3a955b711afe20ee237e2516b2b"},
     "bin/kin-release-preflight.d/validate.mjs": {"source": "bin/kin-release-preflight.d/validate.mjs", "sha256": "53badad40150ee0a4d8c817af77f48f04ad2ae89616dce33686532b82afa35b9"},

--- a/scripts/release-proof/bin/kin-release-preflight
+++ b/scripts/release-proof/bin/kin-release-preflight
@@ -202,6 +202,24 @@ resolve_tomllib_python() {
   return 1
 }
 
+# Print, one per line, the real directory of each enrichment language server
+# found on PATH. FLOW_PATH below is a fixed, hermetic allowlist rather than
+# the ambient PATH, on purpose: only what a hosted runner actually has should
+# reach the daemon this flow starts. acceptance.yml installs pyright and
+# typescript-language-server onto that ambient PATH before its own enrichment
+# checks, which is exactly what this resolves, the same way NODE_DIR and
+# GIT_DIR_ already are. Returns 1 and prints nothing when neither is found,
+# which is how the caller decides whether to warn.
+resolve_language_server_dirs() {
+  local tool bin rc=1
+  for tool in pyright-langserver typescript-language-server; do
+    bin="$(command -v "$tool" 2>/dev/null)" || continue
+    printf '%s\n' "$(cd -P "$(dirname "$bin")" && pwd)"
+    rc=0
+  done
+  return "$rc"
+}
+
 # Sourcing this file with KIN_PREFLIGHT_DEFINITIONS_ONLY=1 stops here, with the
 # helpers defined and nothing run, so the behavioral suite can drive
 # publish_record against a stub publisher. Set KIN_PREFLIGHT_ORIGIN too, or the
@@ -294,6 +312,21 @@ FLOW_PATH="$NODE_DIR:$PY_DIR:/usr/bin:/bin:/usr/sbin:/sbin"
 if [ -n "$TIMEOUT_BIN" ]; then FLOW_PATH="$FLOW_PATH:$(dirname "$TIMEOUT_BIN")"; fi
 GIT_DIR_="$(cd -P "$(dirname "$(command -v git)")" && pwd)"
 case ":$FLOW_PATH:" in *":$GIT_DIR_:"*) ;; *) FLOW_PATH="$FLOW_PATH:$GIT_DIR_" ;; esac
+
+# FIR-2598's magic-repro checks 10 and 11 need a language server on PATH when
+# the daemon starts, or they read UNREADABLE: runs 34323687836 and
+# 34325966701 both did, on kin-linux-x86_64 and kin-linux-aarch64, "enrichment
+# worker is unavailable: ... this daemon found no language server for any
+# language it enriches ... reason: no_language_server", even after the CI
+# install step ran, because that step only extends GITHUB_PATH and this flow
+# does not inherit it here; only FLOW_PATH reaches the daemon.
+if LSP_DIRS="$(resolve_language_server_dirs)"; then
+  while IFS= read -r lsp_dir; do
+    case ":$FLOW_PATH:" in *":$lsp_dir:"*) ;; *) FLOW_PATH="$FLOW_PATH:$lsp_dir" ;; esac
+  done <<<"$LSP_DIRS"
+else
+  warn "no pyright-langserver or typescript-language-server on PATH; the enrichment checks (FIR-2598, magic-repro 10 and 11) will read UNREADABLE on a Python or TypeScript fixture"
+fi
 
 # ---------------------------------------------------------------- run layout
 STAMP="$(date -u +%Y%m%dT%H%M%SZ)"


### PR DESCRIPTION
## What this does

Vendors kin-ecosystem's fix for the release-cut preflight's UNREADABLE failure
(kin-ecosystem#355, "Put the enrichment language servers on the preflight flow PATH", merged as
c1cbeeb25f6070e59178badb401e9195537d91de) into `scripts/release-proof/bin/kin-release-preflight`.

Release Cut runs 34323687836 and 34325966701 both stalled the v0.7.6 cut: kin-linux-aarch64 and
kin-linux-x86_64 exited 2 UNREADABLE on the FIR-2598 magic-repro enrichment checks, "enrichment
worker is unavailable ... no language server for any language it enriches ... reason:
no_language_server", even after kin#1634 added the acceptance.yml-style install step to
release-cut.yml. Root cause: `kin-release-preflight` builds `FLOW_PATH`, a fixed, hermetic PATH
allowlist, from individually resolved directories, then starts the daemon the enrichment check
runs against under `env -i PATH="$FLOW_PATH"`, discarding the CI step's GITHUB_PATH addition
entirely. The umbrella fix resolves `pyright-langserver` and `typescript-language-server` the same
way `NODE_DIR`/`PY_DIR`/git's dir already are and folds them into `FLOW_PATH`.

## What changed here

- `scripts/release-proof/bin/kin-release-preflight`: byte-for-byte copy of the umbrella's file at
  c1cbeeb2 (diffed against a fresh `git show origin/main:...` and confirmed identical).
- `scripts/release-proof/VENDORED.json`: `source_commit` to c1cbeeb25f6070e59178badb401e9195537d91de,
  `files["bin/kin-release-preflight"].sha256` to the new bytes' sha256. Nothing else in the
  manifest touched.

One pre-existing gap this surfaced and is not fixing: `bin/kin-evidence-publish`'s vendored
sha256 in this manifest (4e85d110...) already does not match the umbrella's current main
(8912fd93..., from kin-ecosystem#311, unrelated to this fix); resyncing it is a separate follow-up
that reviews #311's guard change against the release-cut publish job first, not part of this PR.

## Verification

`node --test scripts/release-proof/vendored.test.mjs`: 5/5 passed. Falsified by flipping the last
hex digit of the new sha256: failed with "bin/kin-release-preflight drifted from VENDORED.json"
(4 passed, 1 failed) as expected, restored, re-ran clean.

`bin/kin-precheck kin` (through the fleet's heavy slot): 21 gates enumerated from ci.yml's check
job, 21 passed, 0 failed, vendored.test.mjs included in the node-test aggregate.

Does not touch `.github/workflows/release-cut.yml`; the install step kin#1634 landed there is
correct and stays.
