### PR TITLE
Move the language-server install before the archive download

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -348,6 +348,20 @@ jobs:
       - name: Prove the vendored proof tooling is the bytes its manifest names
         run: node --test scripts/release-proof/vendored.test.mjs
 
+      # FIR-2598's magic-repro checks 10 and 11 need enrichment_drained with
+      # worker_available true, which needs a Python language server on PATH
+      # when the daemon starts. Without one here the Linux legs read
+      # UNREADABLE and the cut publishes nothing (run 34323687836); this
+      # mirrors the install acceptance.yml already runs before its own
+      # enrichment checks. Runs before the archive download on purpose: npm
+      # install is package-manager-shaped, and CodeQL's
+      # actions/cache-poisoning/poisonable-step query flags exactly that
+      # shape running once an untrusted artifact is already in the workspace
+      # (alert firelock-ai/kin#145). This step never reads the archive, so
+      # there is no reason for it to run after it lands.
+      - name: Install language servers for the enrichment checks
+        run: bash scripts/ci-install-language-servers.sh
+
       - name: Download the candidate archive
         env:
           GH_TOKEN: ${{ github.token }}
@@ -375,15 +389,6 @@ jobs:
           fi
           echo "KIN_RC_ARCHIVE=$archive" >> "$GITHUB_ENV"
           echo "$ARTIFACT sha256 $have"
-
-      # FIR-2598's magic-repro checks 10 and 11 need enrichment_drained with
-      # worker_available true, which needs a Python language server on PATH
-      # when the daemon starts. Without one here the Linux legs read
-      # UNREADABLE and the cut publishes nothing (run 34323687836); this
-      # mirrors the install acceptance.yml already runs before its own
-      # enrichment checks.
-      - name: Install language servers for the enrichment checks
-        run: bash scripts/ci-install-language-servers.sh
 
       - name: Judge the archive with the release preflight
         env:


### PR DESCRIPTION
## What this does

Moves release-cut.yml's preflight job's "Install language servers for the enrichment checks"
step to run before "Download the candidate archive" instead of after. Pure reorder: same two
steps, same commands, no other step, the matrix, or anything else touched.

## Why

CodeQL flagged `actions/cache-poisoning/poisonable-step` (severity error, alert
firelock-ai/kin#145) on the install step at its old position: it ran `npm install`
(package-manager-shaped) after the untrusted RC archive had already been downloaded into the
runner's workspace, in a job this workflow also runs on a schedule trigger with default-branch
write context. The install step never reads the archive, so there was no reason for the order to
invite that reading.

## Verification

`bash -n` clean. `bin/kin-precheck kin` (through the fleet's heavy slot): workflow-only change,
same gate set as kin#1634 and kin#1636.

## Landing

Held per the captain: opened as a draft and not landed until Latest reads v0.7.6, since kin main
stays closed to any other change until the tag mints. Will confirm the CodeQL alert closes on
this PR's own CodeQL run before asking for it to land.
