### PR TITLE
Re-vendor kin-evidence-publish, fixing manifest drift from kin-ecosystem#311

### DIFF
--- a/scripts/release-proof/VENDORED.json
+++ b/scripts/release-proof/VENDORED.json
@@ -7,7 +7,7 @@
     "bin/kin-release-preflight.d/Dockerfile": {"source": "bin/kin-release-preflight.d/Dockerfile", "sha256": "e6c0e30c2bf46fc889484fb7e32c73163c3cf315d60351be3acd2428d22d12f6"},
     "bin/kin-release-preflight.d/proof-flow.sh": {"source": "bin/kin-release-preflight.d/proof-flow.sh", "sha256": "3a44e377a8c6bfcdfb688608ae5b9ba64293e3a955b711afe20ee237e2516b2b"},
     "bin/kin-release-preflight.d/validate.mjs": {"source": "bin/kin-release-preflight.d/validate.mjs", "sha256": "53badad40150ee0a4d8c817af77f48f04ad2ae89616dce33686532b82afa35b9"},
-    "bin/kin-evidence-publish": {"source": "bin/kin-evidence-publish", "sha256": "4e85d110c89b37ee80f0cb3739b89acf3e361f2dee1009c02d80fdf850092222"},
+    "bin/kin-evidence-publish": {"source": "bin/kin-evidence-publish", "sha256": "8912fd933ba37e2570ea2ff685a885551543f2a01e3baeb394876121f8811679"},
     "bin/kin-acceptance-suite": {"source": "bin/kin-acceptance-suite", "sha256": "7ce214e6563e227695cf02411762ca5e8d01edf8898634db465ee30f455918f7"}
   }
 }

--- a/scripts/release-proof/bin/kin-evidence-publish
+++ b/scripts/release-proof/bin/kin-evidence-publish
@@ -52,6 +52,13 @@ const DEFAULT_REPO = 'firelock-ai/kin';
 const COMMIT_SHA = /^[0-9a-f]{40}$/;
 const PREFLIGHT_RECORD = 'preflight.json';
 const STRANGER_RECORD = 'stranger.env';
+// The release's own receipt, and the second record that can link a stranger
+// run to a candidate's bytes. kin's release.yml publishes it onto every release
+// and other jobs verify its attestation; nothing in this tool does, so it
+// counts here as a trusted release receipt, a record the release chain wrote,
+// and never as signature-verified proof.
+const PROVENANCE_ASSET = 'release-provenance.json';
+const ARCHIVE_SHA = /^[0-9a-f]{64}$/;
 const RECORDS = new Set([PREFLIGHT_RECORD, STRANGER_RECORD]);
 
 function usage(message) {
@@ -93,9 +100,9 @@ function parseArgs(argv) {
   return args;
 }
 
-async function call(token, method, route, body) {
+async function call(token, method, route, body, accept = 'application/vnd.github+json') {
   const headers = {
-    accept: 'application/vnd.github+json',
+    accept,
     'user-agent': 'kin-evidence-publish',
     'x-github-api-version': '2022-11-28',
   };
@@ -146,12 +153,164 @@ async function createOrphanBranch(token, repo, filePath, content, message) {
   return commit.body.sha;
 }
 
+// One read that fails closed. readExisting turns a 404 into "nothing here
+// yet", which is the right answer for a record that may not have been
+// published; the release surface is not that shape, so an unreadable answer
+// there raises rather than being reported as an empty listing.
+async function readOrThrow(token, repo, route, what, accept) {
+  let response;
+  try {
+    response = await call(token, 'GET', route, undefined, accept);
+  } catch (cause) {
+    // A rejected request is not an HTTP answer, and without this it would
+    // surface as a bare "fetch failed" with nothing naming which read died.
+    throw new Error(
+      `could not reach GitHub to ${what} on ${repo}: ${cause.message}`,
+      { cause },
+    );
+  }
+  if (!response.ok) {
+    throw new Error(
+      `could not ${what} on ${repo}: HTTP ${response.status} ${response.text.slice(0, 200)}`,
+    );
+  }
+  return response;
+}
+
+// Resolve a tag to the commit it names, dereferencing an annotated tag. The
+// same two steps kin's scripts/check-release-proof-artifacts.mjs takes, because
+// the write-time guard here and that read-time judge must agree about which
+// release belongs to a candidate. A ref that resolves to no commit sha answers
+// null: the caller is searching a listing for the ONE tag that names this
+// candidate, and a ref it cannot resolve is not that tag.
+async function resolveReleaseTagCommit(token, repo, tag) {
+  const ref = (await readOrThrow(
+    token,
+    repo,
+    `/repos/${repo}/git/ref/tags/${encodeURIComponent(tag)}`,
+    `resolve the tag ${tag}`,
+  )).body;
+  let sha = ref?.object?.sha;
+  if (ref?.object?.type === 'tag' && COMMIT_SHA.test(sha ?? '')) {
+    sha = (await readOrThrow(
+      token,
+      repo,
+      `/repos/${repo}/git/tags/${sha}`,
+      `dereference the annotated tag ${tag}`,
+    )).body?.object?.sha;
+  }
+  return COMMIT_SHA.test(sha ?? '') ? sha : null;
+}
+
+// The bytes the release of this candidate shipped, and the second thing that
+// can link a stranger run to it.
+//
+// A preflight leg judges an rc-build archive. kin's release.yml rebuilds fresh
+// bytes at the tag, so the archive a developer downloads from a published
+// release is by construction never a preflight leg, and a guard that knows only
+// the preflight cannot file a stranger record measured on released bytes.
+//
+// The read-time judge in kin accepts either receipt, so this one must too, or
+// the two disagree about the same record and the disagreement only surfaces at
+// a release window.
+//
+// Two statements have to agree: the release's TAG must resolve to the
+// candidate, and the record itself must say it is about that commit, at
+// kin.commit and on every artifact. A release whose tag points here while its
+// provenance describes another build is refused rather than passed over,
+// because a receipt that disagrees with the release carrying it is tampering,
+// not absence.
+async function releaseArchives(token, repo, sha) {
+  for (let page = 1; ; page += 1) {
+    const releases = (await readOrThrow(
+      token,
+      repo,
+      `/repos/${repo}/releases?per_page=100&page=${page}`,
+      `list the releases`,
+    )).body;
+    if (!Array.isArray(releases)) {
+      throw new Error(
+        `release listing page ${page} of ${repo} did not come back as an ` +
+        `array, so no release can be resolved to ${sha}`,
+      );
+    }
+    for (const release of releases) {
+      // A draft is not published, so nothing about it is a claim yet, and a
+      // release carrying no receipt cannot be the second link. Both are
+      // skipped BEFORE a tag is resolved, which keeps this search at one extra
+      // request in the ordinary case: the candidate's own release is newest.
+      if (release?.draft === true) continue;
+      const tag = typeof release?.tag_name === 'string' ? release.tag_name : '';
+      if (!tag) continue;
+      const asset = (Array.isArray(release?.assets) ? release.assets : []).find(
+        (entry) => entry?.name === PROVENANCE_ASSET && entry?.id !== undefined,
+      );
+      if (!asset) continue;
+      if ((await resolveReleaseTagCommit(token, repo, tag)) !== sha) continue;
+      const record = (await readOrThrow(
+        token,
+        repo,
+        `/repos/${repo}/releases/assets/${asset.id}`,
+        `read ${PROVENANCE_ASSET} from release ${tag}`,
+        'application/octet-stream',
+      )).body;
+      if (!record || typeof record !== 'object' || Array.isArray(record)) {
+        throw new Error(
+          `${PROVENANCE_ASSET} on release ${tag} did not parse as a release provenance record`,
+        );
+      }
+      if (record?.kin?.commit !== sha) {
+        throw new Error(
+          `${PROVENANCE_ASSET} on release ${tag} records commit ` +
+          `${record?.kin?.commit ?? '<none>'}, not ${sha}; the release exists ` +
+          'but its provenance is about a different build',
+        );
+      }
+      const archives = [];
+      for (const [index, artifact] of (Array.isArray(record.artifacts) ? record.artifacts : []).entries()) {
+        const name = artifact?.artifact ?? artifact?.target ?? `artifact ${index}`;
+        if (artifact?.kin?.commit !== sha) {
+          throw new Error(
+            `${PROVENANCE_ASSET} on release ${tag} artifact "${name}" records ` +
+            `commit ${artifact?.kin?.commit ?? '<none>'}, not ${sha}; the ` +
+            'record exists but that artifact is about a different build',
+          );
+        }
+        const built = artifact?.archive?.sha256;
+        if (typeof built !== 'string' || !ARCHIVE_SHA.test(built)) {
+          throw new Error(
+            `${PROVENANCE_ASSET} on release ${tag} artifact "${name}" records ` +
+            'no archive sha256, so nothing can link a stranger run to the ' +
+            'bytes it shipped',
+          );
+        }
+        archives.push(built);
+      }
+      if (archives.length === 0) {
+        throw new Error(
+          `${PROVENANCE_ASSET} on release ${tag} lists no artifacts, so it ` +
+          'names no released bytes',
+        );
+      }
+      return { tag, archives };
+    }
+    // A full final page is indistinguishable from a truncated listing without
+    // one more request.
+    if (releases.length < 100) return { tag: null, archives: [] };
+  }
+}
+
 // The chain, enforced at write time as well as read time. A stranger record is
 // only meaningful under a candidate whose preflight judged the very archive the
-// stranger ran, so publishing one under any other candidate is refused here
-// rather than discovered by the gate at release time. It also turns an
-// operator's mistyped candidate sha into an immediate, named failure instead of
-// a record that sits unread until a release is held by it.
+// stranger ran, or whose RELEASE shipped it, so publishing one under any other
+// candidate is refused here rather than discovered by the gate at release time.
+// It also turns an operator's mistyped candidate sha into an immediate, named
+// failure instead of a record that sits unread until a release is held by it.
+//
+// Both receipts, in the same order and on the same terms kin's
+// scripts/check-release-proof-artifacts.mjs uses them. The preflight is still
+// required to EXIST: a candidate with no machine proof establishes nothing, and
+// a release alone is not that proof.
 async function assertArchiveJudged(token, repo, sha, archive) {
   const route = `/repos/${repo}/contents/evidence/${sha}/preflight.json?ref=${BRANCH}`;
   const record = await readExisting(token, repo, route);
@@ -171,13 +330,20 @@ async function assertArchiveJudged(token, repo, sha, archive) {
   const judged = (Array.isArray(parsed.legs) ? parsed.legs : [])
     .map((leg) => leg?.result?.archive?.sha256)
     .filter(Boolean);
-  if (!judged.includes(archive)) {
-    throw new Error(
-      `archive ${archive} is not one the published preflight for ${sha} judged ` +
-      `(${judged.join(', ') || 'none'}). Either the candidate sha is wrong or ` +
-      'the stranger ran on a different build; both need a human, not a retry.',
-    );
-  }
+  if (judged.includes(archive)) return;
+  // Only now, and only for this candidate. The preflight legs answer for a
+  // stranger run on the rc-build archive, which is the ordinary case and costs
+  // no extra request.
+  const shipped = await releaseArchives(token, repo, sha);
+  if (shipped.archives.includes(archive)) return;
+  const alsoNot = shipped.tag === null
+    ? `, and no published release of ${sha} carries a ${PROVENANCE_ASSET}`
+    : `, nor one release ${shipped.tag} shipped (${shipped.archives.join(', ')})`;
+  throw new Error(
+    `archive ${archive} is not one the published preflight for ${sha} judged ` +
+    `(${judged.join(', ') || 'none'})${alsoNot}. Either the candidate sha is ` +
+    'wrong or the stranger ran on a different build; both need a human, not a retry.',
+  );
 }
 
 // Name what is being filed, before filing it.


### PR DESCRIPTION
## What this does

Re-vendors `scripts/release-proof/bin/kin-evidence-publish` from kin-ecosystem's current
`origin/main` (c1cbeeb25f6070e59178badb401e9195537d91de). This file drifted independently of the
kin-release-preflight fix: kin-ecosystem#311 ("Accept the release's own receipt in the evidence
write guard", commit 7abf4122, already an ancestor of c1cbeeb2) changed the umbrella's copy, but
the last re-vendor (kin#1636) only copied `bin/kin-release-preflight` and missed this file, so
kin's manifest still recorded the pre-#311 sha256.

## What changed

- `scripts/release-proof/bin/kin-evidence-publish`: byte-for-byte copy of the umbrella's file at
  c1cbeeb2 (diffed against a fresh `git show origin/main:...` and confirmed identical), executable
  bit preserved.
- `scripts/release-proof/VENDORED.json`: `files["bin/kin-evidence-publish"].sha256` moved from
  `4e85d110c89b37ee80f0cb3739b89acf3e361f2dee1009c02d80fdf850092222` to
  `8912fd933ba37e2570ea2ff685a885551543f2a01e3baeb394876121f8811679`. `source_commit` was already
  c1cbeeb2 from the kin-release-preflight re-vendor and needed no change; nothing else in the
  manifest touched.

## The diff itself, read directly rather than assumed

Purely additive except for one function. New: `PROVENANCE_ASSET`/`ARCHIVE_SHA` constants,
`readOrThrow`, `resolveReleaseTagCommit`, `releaseArchives`; `call()` gains an optional `accept`
parameter defaulting to its old value, so every existing caller is unaffected. The one function
that actually changes behavior is `assertArchiveJudged`: it still returns immediately, exactly as
before, when the archive is among the ones the published preflight judged; only when that check
fails does it now also check whether a published release's `release-provenance.json` names the
same archive for the same candidate, before refusing. No previously-accepting path changes; a
previously-always-refusing path sometimes now accepts.

## Which of the two release-cut.yml call sites can reach the new fallback

Read both directly rather than repeat the question's framing. `assertArchiveJudged` is only called
from `publish()`, and only `if (requireArchive)` (i.e., only when `--require-archive` is passed).

- **Preflight publish** ("Publish preflight.json for the candidate", release-cut.yml:626-636)
  passes `--sha --name preflight.json --file --repo` and nothing else. It never passes
  `--require-archive`, so `assertArchiveJudged` is never called from this call site at all, not
  today and not after this PR. (The question described both call sites as passing
  `--require-archive`; only one does. Correcting that here rather than repeating it.)
- **Stranger publish** ("Publish stranger.env for the candidate", release-cut.yml:956-973) does
  pass `--require-archive "$archive"`, where `$archive` is read from the stranger record's own
  `archive_sha256` line, so this call site does invoke `assertArchiveJudged`. In the ordinary flow
  that archive is exactly the one the paired preflight already judged (the stranger command the
  selector hands out always names the same rc-build archive the preflight leg used), so the first
  check succeeds and returns before ever reaching the new `releaseArchives` fallback. The fallback
  would only engage in an off-path recovery case: a stranger record naming an archive the recorded
  preflight did not judge. Separately, this job does not run at all today on any candidate: every
  observed run this cycle took "Report the stranger a runner cannot take" because no
  `KIN_STRANGER_RUNNER` is configured.

So: neither call site reaches the new code path today, for two different reasons.

## Verification

`node --test scripts/release-proof/vendored.test.mjs`, full tail:

```
1..5
# tests 5
# suites 0
# pass 5
# fail 0
# cancelled 0
# skipped 0
# todo 0
```

Falsified by flipping the last hex digit of the new sha256: failed with "bin/kin-evidence-publish
drifted from VENDORED.json" (4 passed, 1 failed) as expected, restored, re-ran clean.

`bin/kin-precheck kin` (through the fleet's heavy slot): workflow/script-only change, same 21-gate
set as the prior two PRs in this chain.

Does not touch `.github/workflows/release-cut.yml` or `bin/kin-release-preflight`.
