### PR TITLE
Wire relation-census hold into the /commands/refs daemon route

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -5458,7 +5458,10 @@ async fn command_refs(
     // impact route builds one (FIR-2524): only the daemon holds it, and a
     // thinner envelope is the shortcut that makes the CLI MORE confident than
     // MCP on exactly the degraded daemon nobody exercises.
-    let envelope = kin_mcp::Envelope::daemon().with_health(&daemon_health_snapshot(&state).await);
+    let census_hold = kin_core::relation_census::CensusHold::read(state.layout.root());
+    let envelope = kin_mcp::Envelope::daemon()
+        .with_health(&daemon_health_snapshot(&state).await)
+        .with_relation_census_loss(census_hold.as_ref());
     let response = kin_cli::commands::refs::build_refs_response(
         &state.layout,
         graph.as_ref(),
@@ -46164,6 +46167,89 @@ mod tests {
             .unwrap();
         assert_eq!(annotations.len(), 1);
         assert!(state.is_dirty());
+    }
+
+    #[tokio::test]
+    async fn refs_endpoint_tracks_census_hold_without_qualifying_populated_answers() {
+        let state = test_state();
+        seed_cross_file_call_witness(&state);
+        state
+            .graph
+            .upsert_entity(&test_entity("unused_probe", "src/unused.py"))
+            .unwrap();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let app = router(Arc::clone(&state));
+        let hold_path = kin_core::relation_census::census_hold_path(state.layout.root());
+        for (held, query, empty) in [
+            (false, "unused_probe", true),
+            (true, "unused_probe", true),
+            (true, "witness_callee", false),
+            (false, "unused_probe", true),
+        ] {
+            if held {
+                std::fs::write(
+                    &hold_path,
+                    serde_json::to_vec(&json!({
+                        "held_at": "2026-09-08T00:00:00Z",
+                        "held_source": "test census",
+                        "losses": ["Calls decreased from 2 to 1"]
+                    }))
+                    .unwrap(),
+                )
+                .unwrap();
+            } else if hold_path.exists() {
+                std::fs::remove_file(&hold_path).unwrap();
+            }
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::post("/commands/refs")
+                        .header("content-type", "application/json")
+                        .body(Body::from(
+                            json!({"entity": query, "kind": "all"}).to_string(),
+                        ))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            let status = response.status();
+            let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+                .await
+                .unwrap();
+            assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+            let result: kin_cli::commands::refs::RefsResponse =
+                serde_json::from_slice(&body).unwrap();
+            let text = result.lines.join("\n");
+            assert_eq!(text.contains("No incoming"), empty, "{text}");
+            assert_eq!(
+                text.contains("Kin cannot rule out"),
+                held && empty,
+                "{text}"
+            );
+            if empty {
+                let negative = result.negative.unwrap();
+                assert_eq!(
+                    negative["safe_to_conclude_absent"],
+                    json!(!held),
+                    "{negative}"
+                );
+                assert_eq!(
+                    negative["degraded_signals"]
+                        .as_array()
+                        .unwrap()
+                        .iter()
+                        .any(|v| v == "relation_census_loss"),
+                    held,
+                    "{negative}"
+                );
+            } else {
+                assert!(text.contains("referenced by"), "{text}");
+                assert!(text.contains("witness_caller"), "{text}");
+                assert!(result.negative.is_none());
+            }
+        }
     }
 
     #[tokio::test]

--- a/scripts/acceptance/magic_repro.py
+++ b/scripts/acceptance/magic_repro.py
@@ -2858,6 +2858,12 @@ def check_16(suite):
         res.ok("references returned (%d), so the refusing arm is not exercised here"
                % len(payload.get("references") or []))
 
+    res.asserts[-1]["receipt"] = {
+        "query": "parse_note", "mcp_payload": payload,
+        "cli": {"args": ["refs", "parse_note"], "exit_code": rc,
+                "stdout": out, "stderr": err},
+    }
+
     # ARM B, the positive control. An answer holding rows is not an absence, so
     # it carries no qualifier. This is the arm a fix that stamps everything
     # uncertain fails.
@@ -2873,14 +2879,18 @@ def check_16(suite):
     else:
         res.ok("positive control: an answer holding rows stays unqualified")
 
+    res.asserts[-1]["receipt"] = {"cli": {
+        "args": ["refs", "normalize_title"], "exit_code": rc_b,
+        "stdout": out_b, "stderr": err_b}}
+
     # ARM C, the negative control on the ruled exclusion, second row-group
     # command. `dead_code`'s empty result is the INVERSE claim, so kin_mcp gives
     # it no cross-file classes and no language scope; only the SUBSTRATE can put
     # it in doubt. On a sound daemon it certifies, so a clean scan says nothing
     # extra. This arm fails if a future change bolts a coverage refusal onto the
     # inverse claim.
-    dead = suite.dead_code(repo)
-    dead_text = dead.get("raw") or ""
+    rc_c, out_c, err_c = suite.kin_run(["dead-code"], repo)
+    dead_text = out_c + "\n" + err_c
     if not dead_text.strip():
         res.unknown("kin dead-code produced no output, so the negative control cannot "
                     "be evaluated")
@@ -2897,6 +2907,82 @@ def check_16(suite):
                 "is not an absence claim: %s" % dead_text.strip()[:240])
     else:
         res.ok("group=partial-vocabulary dead-code: a populated scan stays unqualified")
+    res.asserts[-1]["receipt"] = {"cli": {
+        "args": ["dead-code"], "exit_code": rc_c,
+        "stdout": out_c, "stderr": err_c}}
+
+    # An isolated unused focal makes the empty arm mandatory, independent of
+    # the shared fixture's incoming references. A raised census is the same
+    # deterministic substrate hold exercised by check 20.
+    isolated = tempfile.mkdtemp(prefix="absence-refusal-", dir=suite.workdir)
+    suite.fixtures["absence-refusal-" + os.path.basename(isolated)] = isolated
+    focal = "unused_absence_probe"
+    suite.git(["init", "-q", "."], isolated)
+    suite._write(isolated, "callee.py", "def called_probe():\n    return 1\n\ndef unused_absence_probe():\n    return 2\n")
+    suite._write(isolated, "caller.py", "from callee import called_probe\n\ndef caller_probe():\n    return called_probe()\n")
+    suite._kin_init(isolated)
+    suite._kin_commit(isolated, "Add absence control fixture")
+    args = ["refs", focal, "--kind", "calls"]
+
+    def paired_probe():
+        answer = suite.references(isolated, focal, relation_kinds=["calls"])
+        code, stdout, stderr = suite.kin_run(args, isolated)
+        return answer, {"query": focal, "mcp_payload": answer,
+                        "cli": {"args": args, "exit_code": code,
+                                "stdout": stdout, "stderr": stderr}}
+
+    before, receipt = paired_probe()
+    if resolution_miss(before, focal) or before.get("references"):
+        res.bad("isolated empty control did not resolve an unreferenced focal")
+    elif ((before.get("negative") or {}).get("safe_to_conclude_absent") is not True
+          or receipt["cli"]["exit_code"] != 0
+          or "No incoming Calls relations." not in receipt["cli"]["stdout"]
+          or CANNOT_RULE_OUT.search(receipt["cli"]["stdout"] + receipt["cli"]["stderr"])):
+        res.bad("healthy isolated empty control did not certify plainly on both surfaces")
+    else:
+        res.ok("healthy isolated empty control certifies plainly on both surfaces")
+    res.asserts[-1]["receipt"] = receipt
+    if res.asserts[-1]["status"] != PASS:
+        return res
+
+    record = os.path.join(isolated, ".kin", "kindb", "relation-census")
+    try:
+        with open(record) as handle:
+            raised = json.load(handle)
+        status = suite.graph_status(isolated)
+        calls = status["relation_kinds"].get("Calls", 0)
+        if not calls or status["entities"] is None:
+            res.unknown("isolated control has no measurable Calls census")
+            return res
+        raised["kinds"] = dict(raised.get("kinds") or {})
+        raised["kinds"]["Calls"] = calls + 1
+        raised["total"] = sum(raised["kinds"].values())
+        raised["entities"] = status["entities"]
+        with open(record, "w") as handle:
+            json.dump(raised, handle)
+        with open(os.path.join(isolated, "caller.py"), "a") as handle:
+            handle.write("\n# Preserve the caller.\n")
+        suite._kin_commit(isolated, "Note the preserved caller")
+    except (ValueError, OSError, RuntimeError) as exc:
+        res.unknown("isolated refusal fixture could not establish its census hold: %s" % exc)
+        return res
+
+    after, receipt = paired_probe()
+    degraded = ((after.get("_kin") or {}).get("degraded") or {})
+    same_focal = ((after.get("focal_entity") or {}).get("id")
+                  == before["focal_entity"]["id"])
+    if not same_focal or after.get("references"):
+        res.bad("isolated refusing arm did not preserve the resolved empty focal")
+    elif not degraded.get("relation_census_loss"):
+        res.bad("isolated refusing arm did not publish the required census hold")
+    elif (after.get("negative") or {}).get("safe_to_conclude_absent") is not False:
+        res.bad("MCP certified the isolated absence despite the census hold")
+    elif (receipt["cli"]["exit_code"] != 0
+          or not CANNOT_RULE_OUT.search(receipt["cli"]["stdout"] + receipt["cli"]["stderr"])):
+        res.bad("CLI did not carry the isolated empty-reference refusal")
+    else:
+        res.ok("isolated empty-reference arm refuses on both surfaces under census hold")
+    res.asserts[-1]["receipt"] = receipt
     return res
 
 


### PR DESCRIPTION
## Summary

- `command_refs` now reads `CensusHold` and calls `.with_relation_census_loss(...)` on its response
  envelope, matching existing MCP behavior, so a census hold is disclosed on the daemon HTTP route
  the same way it already is over MCP.
- Adds `refs_endpoint_tracks_census_hold_without_qualifying_populated_answers`, walking four
  held/query combinations: an empty answer under a hold reports "Kin cannot rule out" with
  `degraded_signals: ["relation_census_loss"]`, while a populated answer stays unqualified
  regardless of the hold.
- `scripts/acceptance/magic_repro.py` gains matching `check_16` receipts plus an isolated
  `absence-refusal-*` fixture proving the isolated empty-reference arm refuses identically on both
  the CLI and MCP surfaces.

## Origin

Cherry-picked from the preserved branch `chore/lane-queryquality-kin` at its tip
`d13f19dfe70f3356ce45aeba3a8bcfd0d0016001`. That branch's bulk already landed as kin #1598 ("Fit
exact graph context to complete response budgets", merged 2026-09-08T22:29:58Z); this tip commit
was staged locally but never folded into that PR before the lane went idle under a usage limit on
2026-09-08, then preserved and pushed to origin by a later cleanup lane. This PR carries only that
one unlanded commit, cherry-picked onto current main.

## Testing

- `cargo test -p kin-daemon --lib refs_endpoint_tracks_census_hold_without_qualifying_populated_answers`: ok, 1 passed
- `cargo test -p kin-daemon` (full crate): 4 test binaries, all passed, 0 failed
- `cargo fmt --all -- --check`: clean
- `cargo clippy --all-targets --all-features` with this repo's allow-list and `RUSTFLAGS=-D warnings`: clean
- `bin/kin-precheck kin`: 21 gates enumerated, 21 passed, 0 failed
