### PR TITLE
Remove em dashes from kin-cli and kin-daemon runtime strings

### DIFF
--- a/crates/kin-cli/src/commands/assistant.rs
+++ b/crates/kin-cli/src/commands/assistant.rs
@@ -230,7 +230,7 @@ pub async fn sync() -> Result<()> {
         } else {
             "unchanged"
         };
-        println!("  {} — {}", result.path.display(), status);
+        println!("  {}: {}", result.path.display(), status);
     }
 
     let updated_count = results.iter().filter(|r| r.updated || r.created).count();

--- a/crates/kin-cli/src/commands/cache.rs
+++ b/crates/kin-cli/src/commands/cache.rs
@@ -413,7 +413,7 @@ fn print_status_body(stats: &CacheStats, budget: Option<u64>, now: SystemTime, b
             let tag = if sv.is_current {
                 "current".to_string()
             } else {
-                "stale — reclaim with: kin cache gc --prune-stale-schema".to_string()
+                "stale; reclaim with: kin cache gc --prune-stale-schema".to_string()
             };
             println!(
                 "    {:<20} {:>10}  {:>12} entries  ({tag})",
@@ -447,7 +447,7 @@ fn print_status_body(stats: &CacheStats, budget: Option<u64>, now: SystemTime, b
             if stats.total_bytes > budget_bytes {
                 let over = stats.total_bytes - budget_bytes;
                 println!(
-                    "  WARNING: cache is OVER BUDGET by {} — run `kin cache gc` to reclaim space",
+                    "  WARNING: cache is OVER BUDGET by {}; run `kin cache gc` to reclaim space",
                     human_bytes(over)
                 );
             } else {
@@ -456,7 +456,7 @@ fn print_status_body(stats: &CacheStats, budget: Option<u64>, now: SystemTime, b
         }
         None => {
             println!(
-                "  budget:   not set — eviction is opt-in (set {} or pass `kin cache gc --budget-gb N`)",
+                "  budget:   not set; eviction is opt-in (set {} or pass `kin cache gc --budget-gb N`)",
                 cache_admin::BUDGET_ENV
             );
         }
@@ -526,7 +526,7 @@ pub async fn gc(dry_run: bool, budget_gb: Option<f64>, prune_stale_schema: bool)
     let budget_bytes = resolve_budget(budget_gb);
 
     if budget_bytes.is_none() && !prune_stale_schema {
-        println!("kin cache gc: nothing to do — non-destructive default.");
+        println!("kin cache gc: nothing to do (non-destructive default).");
         println!(
             "  set a budget (`--budget-gb N` or {}) to evict oldest entries,",
             cache_admin::BUDGET_ENV
@@ -605,7 +605,7 @@ fn print_gc_report(report: &GcReport) {
             );
         } else {
             println!(
-                "  within budget ({}) — no entries evicted",
+                "  within budget ({}); no entries evicted",
                 human_bytes(budget)
             );
         }

--- a/crates/kin-cli/src/commands/daemon.rs
+++ b/crates/kin-cli/src/commands/daemon.rs
@@ -1204,7 +1204,7 @@ async fn stop_current_repo(json: bool, quiet: bool, kin_root: Option<&Path>) -> 
     };
     let Some(layout) = layout else {
         bail!(
-            "not inside a Kin repository — run `kin daemon stop` from a repo, or \
+            "not inside a Kin repository; run `kin daemon stop` from a repo, or \
              `kin daemon stop --all` to stop every daemon"
         );
     };

--- a/crates/kin-cli/src/commands/embed.rs
+++ b/crates/kin-cli/src/commands/embed.rs
@@ -679,7 +679,7 @@ pub async fn run(
         );
     } else if budget_stopped {
         println!(
-            "Time budget reached after {:.0}s ({pass} pass(es), {:.2} ent/s): {} entities + {} artifacts still pending{}. Progress is persisted — re-run `kin embed` to continue.",
+            "Time budget reached after {:.0}s ({pass} pass(es), {:.2} ent/s): {} entities + {} artifacts still pending{}. Progress is persisted; re-run `kin embed` to continue.",
             elapsed,
             rate,
             final_result.pending_entities,
@@ -688,7 +688,7 @@ pub async fn run(
         );
     } else {
         println!(
-            "Stopped with {} entities + {} artifacts still pending after {pass} pass(es) — the daemon made no progress on the last pass. Re-run `kin embed` or inspect the daemon log.",
+            "Stopped with {} entities + {} artifacts still pending after {pass} pass(es); the daemon made no progress on the last pass. Re-run `kin embed` or inspect the daemon log.",
             final_result.pending_entities, final_result.pending_artifacts
         );
     }

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -1112,11 +1112,11 @@ fn build_graph_status_response_for_store(
         .semantic_relation_count
         .saturating_add(health.cochange_relation_count);
     if entity_count > 0 && all_relation_count == 0 {
-        warnings.push("no relations in graph — cross-file linking may have failed".to_string());
+        warnings.push("no relations in graph; cross-file linking may have failed".to_string());
     }
     if entity_count > 0 && role_counts.len() == 1 && role_counts.contains_key(&EntityRole::Source) {
         warnings
-            .push("all entities are Source — role classification may not be working".to_string());
+            .push("all entities are Source; role classification may not be working".to_string());
     }
     let entity_rels_per_ent = if entity_count == 0 {
         0.0
@@ -1125,7 +1125,7 @@ fn build_graph_status_response_for_store(
     };
     if entity_rels_per_ent < 0.1 && entity_count > 100 {
         warnings.push(format!(
-            "very low entity-to-entity relation density ({:.2} rels/entity) — entity linker may be failing",
+            "very low entity-to-entity relation density ({:.2} rels/entity); entity linker may be failing",
             entity_rels_per_ent
         ));
     }
@@ -1135,7 +1135,7 @@ fn build_graph_status_response_for_store(
     // `kin graph status` nonzero for every caller scripting it. Killing the
     // false all-clear is the requirement; changing an exit code is not.
     for reason in reconcile.degraded_reasons() {
-        warnings.push(format!("reconcile loop degraded — {reason}"));
+        warnings.push(format!("reconcile loop degraded: {reason}"));
     }
     // Warnings rather than criticals, for the reason stated directly above:
     // criticals set the response error and would turn `kin graph status`
@@ -1769,7 +1769,7 @@ fn entity_source_not_found_message(entity_query: &str) -> String {
     let trimmed = entity_query.trim();
     if uuid::Uuid::parse_str(trimmed).is_ok() {
         format!(
-            "no entity exists with ID '{trimmed}'. This entity ID is invalid or stale — it is \
+            "no entity exists with ID '{trimmed}'. This entity ID is invalid or stale: it is \
              not present in the graph, so retrying the same ID will not succeed. Use \
              semantic_locate or semantic_search to obtain a current entity ID."
         )
@@ -1787,7 +1787,7 @@ fn entity_source_not_found_message(entity_query: &str) -> String {
 fn entity_no_source_message(entity: &Entity, reason: &str) -> String {
     format!(
         "entity '{}' ({}) exists in the graph but has no retrievable source: {reason}. The \
-         entity ID is valid — this is not a missing or stale ID — there is simply no source \
+         entity ID is valid (not missing or stale); there is simply no source \
          body attached to return.",
         entity.name, entity.id
     )

--- a/crates/kin-cli/src/commands/intent.rs
+++ b/crates/kin-cli/src/commands/intent.rs
@@ -94,7 +94,7 @@ pub async fn register(
                     let vendor = c["vendor"].as_str().unwrap_or("unknown");
                     let desc = c["task_description"].as_str().unwrap_or("");
                     let cid = c["intent_id"].as_str().unwrap_or("-");
-                    println!("  [{vendor}] {cid} — {desc}");
+                    println!("  [{vendor}] {cid}: {desc}");
                 }
             }
         }

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -2948,7 +2948,7 @@ fn emit_telemetry_disclosure_once() {
     DISCLOSED.call_once(|| {
         eprintln!(
             "ℹ kin locate telemetry is ON (you opted in). Recording queries + results \
-+ funnel traces to .kin/telemetry/ — local only, never uploaded. Disable: delete \
++ funnel traces to .kin/telemetry/; local only, never uploaded. Disable: delete \
 .kin/telemetry/consent (or KIN_LOCATE_TELEMETRY=0). Purge: delete .kin/telemetry/."
         );
     });
@@ -17788,7 +17788,7 @@ fn bounded_entity_body_with_note(
         if total_lines > shown {
             let remaining = total_lines - shown;
             return Some(format!(
-                "{body}\n… (+{remaining} more line{} — get_entity_source {} for the full body)",
+                "{body}\n… (+{remaining} more line{}: get_entity_source {} for the full body)",
                 if remaining == 1 { "" } else { "s" },
                 entity.id
             ));
@@ -19048,7 +19048,7 @@ fn coverage_banner(coverage: &SemanticCoverage) -> Option<String> {
     Some(coverage.note.clone().unwrap_or_else(|| {
         format!(
             "semantic (embedding) signal incomplete: {}/{} entities indexed, \
-             {} pending — lexical + graph signals still ran",
+             {} pending; lexical + graph signals still ran",
             coverage.indexed, coverage.total, coverage.pending
         )
     }))
@@ -19216,7 +19216,7 @@ fn coverage_notes(result: &LocateResult) -> Vec<CoverageNote> {
             format!("{}: {}", degradation.component, degradation.detail)
         } else {
             format!(
-                "{}: {} — {}",
+                "{}: {}; {}",
                 degradation.component, degradation.detail, degradation.remediation
             )
         };

--- a/crates/kin-cli/src/commands/locate_debug.rs
+++ b/crates/kin-cli/src/commands/locate_debug.rs
@@ -380,7 +380,7 @@ fn print_human_report(report: &DebugReport) {
                 .rank
                 .map(|r| format!("rank #{}", r))
                 .unwrap_or_else(|| "NOT FOUND".to_string());
-            println!("  {} {} — {}", status_icon, g.path, rank_str);
+            println!("  {} {}: {}", status_icon, g.path, rank_str);
 
             if g.rank.is_some() {
                 println!(

--- a/crates/kin-cli/src/commands/pipeline.rs
+++ b/crates/kin-cli/src/commands/pipeline.rs
@@ -18,7 +18,7 @@ fn resolve_org_id() -> Result<String> {
     std::env::var("KIN_ORG_ID")
         .ok()
         .filter(|v| !v.trim().is_empty())
-        .ok_or_else(|| anyhow::anyhow!("KIN_ORG_ID not set — set it or configure a native remote"))
+        .ok_or_else(|| anyhow::anyhow!("KIN_ORG_ID not set; set it or configure a native remote"))
 }
 
 fn resolve_repo_id() -> Result<String> {

--- a/crates/kin-cli/src/commands/release_cmd.rs
+++ b/crates/kin-cli/src/commands/release_cmd.rs
@@ -18,7 +18,7 @@ fn resolve_org_id() -> Result<String> {
     std::env::var("KIN_ORG_ID")
         .ok()
         .filter(|v| !v.trim().is_empty())
-        .ok_or_else(|| anyhow::anyhow!("KIN_ORG_ID not set — set it or configure a native remote"))
+        .ok_or_else(|| anyhow::anyhow!("KIN_ORG_ID not set; set it or configure a native remote"))
 }
 
 fn resolve_repo_id() -> Result<String> {
@@ -128,7 +128,7 @@ pub async fn list() -> Result<()> {
         let name = rel.get("name").and_then(|n| n.as_str()).unwrap_or(tag);
         let created = rel.get("createdAt").and_then(|c| c.as_str()).unwrap_or("");
         let id = rel.get("id").and_then(|i| i.as_str()).unwrap_or("");
-        println!("  {} ({}) [{}] — {}", name, tag, id, created);
+        println!("  {} ({}) [{}]: {}", name, tag, id, created);
     }
 
     Ok(())

--- a/crates/kin-cli/src/commands/release_orch.rs
+++ b/crates/kin-cli/src/commands/release_orch.rs
@@ -90,7 +90,7 @@ fn workspace_root() -> Result<PathBuf> {
         }
     }
     bail!(
-        "could not locate the umbrella workspace root above {} — run from inside the \
+        "could not locate the umbrella workspace root above {}; run from inside the \
          kin-ecosystem checkout or set KIN_WORKSPACE_ROOT",
         start.display()
     )
@@ -358,9 +358,9 @@ pub async fn plan(offline: bool) -> Result<()> {
     // ── render ────────────────────────────────────────────────────────────────
     println!();
     if offline {
-        println!("Kin release plan — bottom-up  (offline: registry not queried)");
+        println!("Kin release plan: bottom-up  (offline: registry not queried)");
     } else {
-        println!("Kin release plan — bottom-up");
+        println!("Kin release plan: bottom-up");
     }
     println!("{}", "=".repeat(64));
     println!(
@@ -385,7 +385,7 @@ pub async fn plan(offline: bool) -> Result<()> {
                 Published::Error => ("<error>".to_string(), "registry error".to_string()),
                 Published::Unpublished => (
                     "<unpublished>".to_string(),
-                    "UNPUBLISHED — first publish pending".to_string(),
+                    "UNPUBLISHED: first publish pending".to_string(),
                 ),
                 Published::Version(nv) => {
                     let status = match &lv {
@@ -394,7 +394,7 @@ pub async fn plan(offline: bool) -> Result<()> {
                             let l = parse_version(lv);
                             let n = parse_version(nv);
                             if l > n {
-                                format!("NEEDS PUBLISH — local ahead of {nv}")
+                                format!("NEEDS PUBLISH: local ahead of {nv}")
                             } else if l < n {
                                 format!("BEHIND registry {nv} (?)")
                             } else {
@@ -449,7 +449,7 @@ pub async fn plan(offline: bool) -> Result<()> {
     println!("Downstream pin status");
     println!("  {}", "-".repeat(60));
     if offline {
-        println!("  (skipped — registry not queried in offline mode)");
+        println!("  (skipped, registry not queried in offline mode)");
     } else if stale.is_empty() {
         println!("  all registry pins are at the newest published version");
     } else {
@@ -465,7 +465,7 @@ pub async fn plan(offline: bool) -> Result<()> {
     if offline {
         println!("  run without --offline to compare against the registry");
     } else if needs_publish.is_empty() && stale.is_empty() {
-        println!("  nothing pending — every registry crate is published and every pin is current");
+        println!("  nothing pending: every registry crate is published and every pin is current");
     } else {
         let repo_of: BTreeMap<&str, &str> = REGISTRY_CRATES.iter().copied().collect();
         let mut n = 1;
@@ -477,7 +477,7 @@ pub async fn plan(offline: bool) -> Result<()> {
                 .flatten()
                 .unwrap_or_else(|| "?".to_string());
             println!(
-                "  {n}. publish {crate_name} ({lv}) — merge {repo} to main; CI publishes \
+                "  {n}. publish {crate_name} ({lv}): merge {repo} to main; CI publishes \
                  behind the version gate"
             );
             n += 1;
@@ -540,7 +540,7 @@ pub async fn apply(
         eprintln!("kin release apply: no repo pinned {crate_name}; nothing changed.");
     } else {
         println!(
-            "kin release apply: complete — {changed} repo(s) updated. Nothing was \
+            "kin release apply: complete; {changed} repo(s) updated. Nothing was \
              committed or pushed."
         );
         eprintln!(

--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -820,7 +820,7 @@ fn render_daemon_work_lines(
             .then(|| model_fetch.download_phase())
             .flatten();
         let detail = match (&pass.stopped_reason, downloading, pass.working_seconds) {
-            (Some(reason), _, _) => format!("stopped — {reason}"),
+            (Some(reason), _, _) => format!("stopped: {reason}"),
             (None, Some(phase), Some(working)) => format!("{phase}, working {working}s"),
             (None, Some(phase), None) => phase,
             (None, None, Some(working)) => format!("working {working}s"),

--- a/crates/kin-cli/src/commands/secret.rs
+++ b/crates/kin-cli/src/commands/secret.rs
@@ -19,7 +19,7 @@ fn resolve_org_id() -> Result<String> {
     std::env::var("KIN_ORG_ID")
         .ok()
         .filter(|v| !v.trim().is_empty())
-        .ok_or_else(|| anyhow::anyhow!("KIN_ORG_ID not set — set it or configure a native remote"))
+        .ok_or_else(|| anyhow::anyhow!("KIN_ORG_ID not set; set it or configure a native remote"))
 }
 
 fn resolve_repo_id() -> Result<String> {

--- a/crates/kin-cli/src/commands/setup_ledger.rs
+++ b/crates/kin-cli/src/commands/setup_ledger.rs
@@ -209,7 +209,7 @@ impl SetupLedger {
         };
         let ledger: SetupLedger = serde_json::from_slice(bytes).with_context(|| {
             format!(
-                "install ledger {} is not valid JSON — fix or remove it and re-run `kin setup`",
+                "install ledger {} is not valid JSON; fix or remove it and re-run `kin setup`",
                 path.display()
             )
         })?;
@@ -359,7 +359,7 @@ pub(crate) fn verify_entry_locked(
         Some(_) => (
             EntryState::Modified,
             format!(
-                "{} at {} changed since install — Kin will not touch it",
+                "{} at {} changed since install; Kin will not touch it",
                 entry.kind.label(),
                 entry.path.display()
             ),
@@ -386,7 +386,7 @@ pub fn verify_entry(entry: &LedgerEntry) -> EntryVerification {
             // mistake the object for an absent or verified artifact.
             state: EntryState::Modified,
             detail: format!(
-                "{} at {} could not be safely verified — Kin will not trust or touch it: {error:#}",
+                "{} at {} could not be safely verified; Kin will not trust or touch it: {error:#}",
                 entry.kind.label(),
                 entry.path.display()
             ),
@@ -487,7 +487,7 @@ fn uninstall_entry_with_verification(
             entry: entry.clone(),
             action: RemovalAction::SkippedModified,
             detail: format!(
-                "{} at {} was modified since install — left in place (re-run with --force to remove)",
+                "{} at {} was modified since install; left in place (re-run with --force to remove)",
                 entry.kind.label(),
                 entry.path.display()
             ),

--- a/crates/kin-cli/src/commands/telemetry.rs
+++ b/crates/kin-cli/src/commands/telemetry.rs
@@ -20,7 +20,7 @@ pub async fn run_status() -> Result<()> {
     println!();
 
     if let Some(ref val) = env_val {
-        println!("  KIN_LOCATE_TELEMETRY={val}  (env override — takes precedence)");
+        println!("  KIN_LOCATE_TELEMETRY={val}  (env override, takes precedence)");
     }
 
     if consent_marker {
@@ -89,7 +89,7 @@ pub async fn run_revoke() -> Result<()> {
         })?;
         println!("Telemetry consent revoked. No further queries will be spooled.");
     } else {
-        println!("No consent marker found — telemetry was already off.");
+        println!("No consent marker found; telemetry was already off.");
     }
 
     println!(

--- a/crates/kin-cli/src/commands/update.rs
+++ b/crates/kin-cli/src/commands/update.rs
@@ -10512,7 +10512,7 @@ async fn fetch_archive_checksum(
         .iter()
         .find(|a| a.name == CHECKSUMS_ASSET)
         .with_context(|| {
-            format!("release is missing '{CHECKSUMS_ASSET}' — cannot verify the download")
+            format!("release is missing '{CHECKSUMS_ASSET}'; cannot verify the download")
         })?;
 
     let response = client

--- a/crates/kin-cli/src/commands/verify.rs
+++ b/crates/kin-cli/src/commands/verify.rs
@@ -211,7 +211,7 @@ fn build_entity_verify_response(
         } else {
             covered_count += 1;
             lines.push(format!(
-                "  COVERED  {} ({:?}) — {} test(s)",
+                "  COVERED  {} ({:?}): {} test(s)",
                 ent.name,
                 ent.kind,
                 tests.len()
@@ -690,7 +690,7 @@ fn verification_plan_lines(plan: &VerificationPlan) -> Vec<String> {
         lines.push("  Impacted dependents:".to_string());
         for slice in &plan.impacted {
             lines.push(format!(
-                "    - {} ({:?}) — {} test(s), {} work item(s)",
+                "    - {} ({:?}): {} test(s), {} work item(s)",
                 slice.entity.name,
                 slice.entity.kind,
                 slice.tests.len(),
@@ -745,7 +745,7 @@ fn change_verification_plan_lines(plan: &ChangeVerificationPlan) -> Vec<String> 
         lines.push("  Entity plans:".to_string());
         for entity_plan in &plan.entity_plans {
             lines.push(format!(
-                "    - {} ({:?}) — {} selected test(s), {} impacted dependents",
+                "    - {} ({:?}): {} selected test(s), {} impacted dependents",
                 entity_plan.entity.name,
                 entity_plan.entity.kind,
                 entity_plan.tests.len(),

--- a/crates/kin-cli/src/commands/work.rs
+++ b/crates/kin-cli/src/commands/work.rs
@@ -615,7 +615,7 @@ fn render_work_verification(graph: &kin_db::InMemoryGraph, work_id: String) -> R
         writeln!(out, "  Targeted test set: none")?;
         writeln!(
             out,
-            "  Completion: INCOMPLETE — no targeted proof exists for this work item"
+            "  Completion: INCOMPLETE; no targeted proof exists for this work item"
         )?;
         return Ok(out);
     }
@@ -644,12 +644,12 @@ fn render_work_verification(graph: &kin_db::InMemoryGraph, work_id: String) -> R
     {
         writeln!(
             out,
-            "  Completion: VERIFIED — targeted proof set is passing for this work item"
+            "  Completion: VERIFIED; targeted proof set is passing for this work item"
         )?;
     } else {
         writeln!(
             out,
-            "  Completion: PARTIAL — {} targeted test(s) lack a passing run, {} scope(s) still lack proof",
+            "  Completion: PARTIAL; {} targeted test(s) lack a passing run, {} scope(s) still lack proof",
             report.tests_without_passing_run,
             report.missing_scope_proof.len()
         )?;

--- a/crates/kin-cli/src/commands/xref.rs
+++ b/crates/kin-cli/src/commands/xref.rs
@@ -157,7 +157,7 @@ fn spine_xref_lines(
                     lines.push("  No cross-repo references found in the spine.".to_string());
                 } else {
                     lines.push(
-                        "  The spine returned no cross-repo edges, but its authority is incomplete — this is not the same as 'no references found'."
+                        "  The spine returned no cross-repo edges, but its authority is incomplete; this is not the same as 'no references found'."
                             .to_string(),
                     );
                 }
@@ -192,7 +192,7 @@ fn spine_xref_lines(
             lines
         }
         ::kin_spine::SpineQuery::Unavailable(reason) => vec![format!(
-            "  Cross-repo spine unavailable ({reason}) — this is not the same as 'no references found'."
+            "  Cross-repo spine unavailable ({reason}); this is not the same as 'no references found'."
         )],
         ::kin_spine::SpineQuery::NotConfigured => vec![
             "  Cross-repo spine not configured (no daemon endpoint available).".to_string(),
@@ -212,7 +212,7 @@ fn spine_xref_lines(
 fn xref_not_found_guidance(entity: &str) -> Vec<String> {
     vec![
         format!(
-            "Entity '{entity}' not found in this repo's graph — xref has no local anchor for the lookup."
+            "Entity '{entity}' not found in this repo's graph; xref has no local anchor for the lookup."
         ),
         "hint: `kin xref` finds cross-repo references by first resolving the symbol in THIS repo's"
             .to_string(),

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -2217,7 +2217,7 @@ fn behavior_env_divergence_message(divergences: &[kin_core::behavior_env::Diverg
         message.push_str(&d.describe());
     }
     message.push_str(
-        "\nremedy: restart the daemon so it re-inherits the current environment — stop it with \
+        "\nremedy: restart the daemon so it re-inherits the current environment: stop it with \
          `kin daemon stop` (or `kill $(cat .kin/daemon.pid)`; it also self-stops after its \
          KIN_DAEMON_IDLE_TIMEOUT_SECS idle window) and the next kin command respawns it. \
          Set KIN_STRICT_BEHAVIOR_ENV=1 to make this a hard error.",

--- a/crates/kin-cli/tests/no_em_dash_in_runtime_strings.rs
+++ b/crates/kin-cli/tests/no_em_dash_in_runtime_strings.rs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Guards the founder's no-em-dash rule for kin-cli's runtime-facing strings:
+//! println/eprintln status lines, anyhow/bail error text, warnings pushed
+//! into reports, clap help text and log lines. Comments and doc comments
+//! stay out of scope on purpose, so this scans every `.rs` file under
+//! `src/` and skips any line whose trimmed text starts with `//`, which
+//! covers `//`, `///` and `//!` alike.
+//!
+//! That line-start check cannot tell a trailing `// comment` on a code line
+//! from a real string, so the two lines below are a content-keyed allowlist
+//! of the trailing comments already known to carry an em dash. Add to it
+//! only for a genuine comment, never to silence a real user-facing string,
+//! and key by the trimmed line text (not a line number) so an unrelated
+//! edit earlier in the file cannot make the allowlist miss its target.
+
+use std::path::{Path, PathBuf};
+
+const ALLOWED_TRAILING_COMMENTS: &[(&str, &str)] = &[
+    (
+        "commands/locate.rs",
+        "return; // No clear majority — skip affinity.",
+    ),
+    (
+        "commands/trace.rs",
+        "continue; // skip same-file deps — agent already has the file",
+    ),
+];
+
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rs_files(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+#[test]
+fn no_em_dash_outside_comments_in_src() {
+    let src_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut files = Vec::new();
+    collect_rs_files(&src_dir, &mut files);
+    assert!(!files.is_empty(), "expected to find kin-cli's src/ tree");
+
+    let mut violations = Vec::new();
+    for file in &files {
+        let rel = file
+            .strip_prefix(&src_dir)
+            .unwrap()
+            .to_string_lossy()
+            .replace('\\', "/");
+        let Ok(contents) = std::fs::read_to_string(file) else {
+            continue;
+        };
+        for (idx, line) in contents.lines().enumerate() {
+            if !line.contains('—') {
+                continue;
+            }
+            let trimmed = line.trim();
+            if trimmed.starts_with("//") {
+                continue;
+            }
+            if ALLOWED_TRAILING_COMMENTS.contains(&(rel.as_str(), trimmed)) {
+                continue;
+            }
+            violations.push(format!("{rel}:{}: {trimmed}", idx + 1));
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "em dash found in a kin-cli runtime string (println/eprintln/anyhow/bail/log/warning \
+         text). Restructure the sentence instead (a comma, colon, semicolon, or two sentences), \
+         never a bare hyphen swap. If this is a new trailing comment rather than a real string, \
+         add its (path, trimmed line) to ALLOWED_TRAILING_COMMENTS in this file instead.\n{}",
+        violations.join("\n")
+    );
+}

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -53997,7 +53997,7 @@ mod tests {
             let status = response.status();
             assert!(
                 status != StatusCode::UNAUTHORIZED && status != StatusCode::FORBIDDEN,
-                "path {path} returned {status} — public route should not require auth"
+                "path {path} returned {status}; public route should not require auth"
             );
         }
     }
@@ -54071,7 +54071,7 @@ mod tests {
             // 401/403, which would mean daemon_auth wrongly gated the registry.
             assert!(
                 status != StatusCode::UNAUTHORIZED && status != StatusCode::FORBIDDEN,
-                "registry path {path} returned {status} — registry must be public"
+                "registry path {path} returned {status}; registry must be public"
             );
         }
 

--- a/crates/kin-daemon/src/commit_deltas.rs
+++ b/crates/kin-daemon/src/commit_deltas.rs
@@ -1518,7 +1518,7 @@ mod tests {
 
         assert!(
             deltas.entity_deltas.is_empty(),
-            "no entity changes since the commit — deltas must be empty"
+            "no entity changes since the commit; deltas must be empty"
         );
         assert!(deltas.tree_deltas.is_empty());
     }

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -797,7 +797,7 @@ pub(crate) async fn run_shutdown_persistence(state: &Arc<DaemonState>) {
                     .persisted_entity_count
                     .load(std::sync::atomic::Ordering::SeqCst),
                 current = state.graph.entity_count(),
-                "skipping final graph flush on shutdown — in-memory entity count collapsed vs on-disk snapshot; preserving the larger snapshot"
+                "skipping final graph flush on shutdown: in-memory entity count collapsed vs on-disk snapshot; preserving the larger snapshot"
             );
         } else {
             info!("final persistence flush on shutdown");
@@ -1732,7 +1732,7 @@ pub fn spawn_shutdown_escalation_watchdog<F>(
             // process down so a stop request always results in actual
             // termination — no zombie, and no unbounded stop.
             eprintln!(
-                "kin-daemon: graceful shutdown exceeded {}s grace — forcing process exit to prevent a CPU zombie",
+                "kin-daemon: graceful shutdown exceeded {}s grace; forcing process exit to prevent a CPU zombie",
                 grace.as_secs()
             );
              std::process::exit(0);
@@ -4571,7 +4571,7 @@ pub async fn run_with_authority_on(
                 }
                 warn!(
                     owner_pid,
-                    "owner process is gone — shutting down orphaned daemon"
+                    "owner process is gone; shutting down orphaned daemon"
                 );
                 // Arm the force-exit backstop here, not via the propagation
                 // task: an orphaned daemon is exactly the case where the async
@@ -4639,7 +4639,7 @@ pub async fn run_with_authority_on(
             if elapsed >= init_timeout {
                 error!(
                     elapsed_s = elapsed.as_secs(),
-                    "daemon initialization timed out — first reconciliation did not complete within 120s; check snapshot or repo state"
+                    "daemon initialization timed out: first reconciliation did not complete within 120s; check snapshot or repo state"
                 );
                 return;
             }
@@ -4847,7 +4847,7 @@ pub async fn run_with_authority_on(
                                 error = %e,
                                 consecutive_failures,
                                 next_retry_s = backoff_secs,
-                                "daemon persistence unhealthy — check disk space and permissions"
+                                "daemon persistence unhealthy: check disk space and permissions"
                             );
                         } else {
                             tracing::warn!(
@@ -5204,7 +5204,7 @@ pub async fn run_with_authority_on(
                                 path = %rel_path,
                                 count = request.changed_entity_ids.len(),
                                 max = MAX_ENTITIES_PER_REQUEST,
-                                "skipping LSP enrichment — too many changed entities (likely full re-parse)"
+                                "skipping LSP enrichment: too many changed entities (likely full re-parse)"
                             );
                             continue;
                         }
@@ -5274,7 +5274,7 @@ pub async fn run_with_authority_on(
                             info!(
                                 path = %rel_path,
                                 entities_queried = file_entities.len(),
-                                "LSP enrichment completed — no new relations found"
+                                "LSP enrichment completed: no new relations found"
                             );
                         }
                         if failed_queries == 0
@@ -6774,13 +6774,13 @@ pub(crate) fn spawn_background_embedding_worker(
                     Ok(BackgroundEmbeddingBatchOutcome::ResetAfterIndexError(e)) => {
                         warn!(
                             error = %e,
-                            "embedding worker hit a vector-index error — reset vector index and re-queued once"
+                            "embedding worker hit a vector-index error; reset vector index and re-queued once"
                         );
                         index_reset_triggered = true;
                         error_backoff = None;
                         error!(
                             error = %e,
-                            "embedding worker error — reset vector index, retrying next interval"
+                            "embedding worker error: reset vector index, retrying next interval"
                         );
                         break;
                     }
@@ -6805,7 +6805,7 @@ pub(crate) fn spawn_background_embedding_worker(
                         error!(
                             error = %e,
                             backoff_s = next.as_secs(),
-                            "embedding worker error — backing off"
+                            "embedding worker error: backing off"
                         );
                         // Backoff bounds how fast this ladder retries and not how
                         // long it retries for, so a failure that never clears
@@ -6820,7 +6820,7 @@ pub(crate) fn spawn_background_embedding_worker(
                         ) {
                             error!(
                                 budget_s = embed_retry_budget.as_secs(),
-                                "embedding worker parked — cumulative retry budget exhausted (see /health background_passes)"
+                                "embedding worker parked: cumulative retry budget exhausted (see /health background_passes)"
                             );
                         }
                         break;
@@ -6847,7 +6847,7 @@ pub(crate) fn spawn_background_embedding_worker(
                             error!(
                                 error = %e,
                                 consecutive_panics,
-                                "embedding worker permanently failed — vector index will not update until daemon restart; daemon continues in embed-degraded mode (see /health embed_worker_failed)"
+                                "embedding worker permanently failed: vector index will not update until daemon restart; daemon continues in embed-degraded mode (see /health embed_worker_failed)"
                             );
                             drain_embed_flush(
                                 &mut pending_flush,
@@ -8349,7 +8349,7 @@ mod tests {
         );
         assert!(
             !is_shutdown.load(Ordering::Relaxed),
-            "is_shutdown was never set — the backstop must not depend on it"
+            "is_shutdown was never set; the backstop must not depend on it"
         );
     }
 

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -3300,7 +3300,7 @@ pub async fn run_loop_armed(
                 warn!(
                     pending = event_count,
                     base_batch = base_batch_size,
-                    "event queue backpressure — retaining bounded batches for fair catch-up"
+                    "event queue backpressure: retaining bounded batches for fair catch-up"
                 );
                 backlog_warning_active = true;
             }

--- a/crates/kin-daemon/src/supervisor.rs
+++ b/crates/kin-daemon/src/supervisor.rs
@@ -2127,7 +2127,7 @@ async fn reaper_sweep(
                 .ok()
                 .and_then(|v| v.trim().parse::<u64>().ok());
             if should_reexec_self(start, mtime, policy.redeploy_grace_secs, reexeced_for_mtime) {
-                warn!("supervisor binary is stale — re-execing into new build");
+                warn!("supervisor binary is stale; re-execing into new build");
                 let error = reexec_self(mtime);
                 warn!(error = %error, "supervisor self-re-exec failed; continuing on current binary");
             }
@@ -2248,7 +2248,7 @@ async fn reaper_sweep(
                             warn!(
                                 pid = daemon.pid,
                                 repo = %daemon.repo_root,
-                                "two live daemons claim one repo_root; keeping both (split-brain) — not reaping active daemon"
+                                "two live daemons claim one repo_root; keeping both (split-brain): not reaping active daemon"
                             );
                         }
                     }
@@ -2513,7 +2513,7 @@ async fn graceful_terminate(pid: u32, repo_root: &str, action: &str, reason: &st
             pid,
             repo = %repo_root,
             reason,
-            "daemon survived SIGTERM grace — sending SIGKILL"
+            "daemon survived SIGTERM grace; sending SIGKILL"
         );
         unsafe {
             libc::kill(pid as libc::pid_t, libc::SIGKILL);
@@ -2587,7 +2587,7 @@ async fn reap_daemon(observation: &DaemonObservation, reason: ReapReason) {
             transaction = %summary,
             reason = ?reason,
             "reaping a daemon that has a write transaction open; its beat went stale, so it is \
-             wedged rather than busy — the caller waiting on this transaction will lose it"
+             wedged rather than busy: the caller waiting on this transaction will lose it"
         );
     }
     graceful_terminate(

--- a/crates/kin-daemon/tests/no_em_dash_in_runtime_strings.rs
+++ b/crates/kin-daemon/tests/no_em_dash_in_runtime_strings.rs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Guards the founder's no-em-dash rule for kin-daemon's runtime-facing
+//! strings: log lines (warn!/error!/info!/debug!), eprintln status lines,
+//! and JSON string values a user reads. Comments and doc comments stay out
+//! of scope on purpose, so this scans every `.rs` file under `src/` and
+//! skips any line whose trimmed text starts with `//`, which covers `//`,
+//! `///` and `//!` alike.
+//!
+//! That line-start check cannot tell a trailing `// comment` on a code line
+//! from a real string, so the two lines below are a content-keyed allowlist
+//! of the trailing comments already known to carry an em dash. Add to it
+//! only for a genuine comment, never to silence a real user-facing string,
+//! and key by the trimmed line text (not a line number) so an unrelated
+//! edit earlier in the file cannot make the allowlist miss its target.
+
+use std::path::{Path, PathBuf};
+
+const ALLOWED_TRAILING_COMMENTS: &[(&str, &str)] = &[
+    ("api.rs", "} // state dropped — models daemon shutdown."),
+    (
+        "lifecycle.rs",
+        "None // PID alive but port not open — daemon still starting or wedged",
+    ),
+];
+
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rs_files(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+#[test]
+fn no_em_dash_outside_comments_in_src() {
+    let src_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut files = Vec::new();
+    collect_rs_files(&src_dir, &mut files);
+    assert!(!files.is_empty(), "expected to find kin-daemon's src/ tree");
+
+    let mut violations = Vec::new();
+    for file in &files {
+        let rel = file
+            .strip_prefix(&src_dir)
+            .unwrap()
+            .to_string_lossy()
+            .replace('\\', "/");
+        let Ok(contents) = std::fs::read_to_string(file) else {
+            continue;
+        };
+        for (idx, line) in contents.lines().enumerate() {
+            if !line.contains('—') {
+                continue;
+            }
+            let trimmed = line.trim();
+            if trimmed.starts_with("//") {
+                continue;
+            }
+            if ALLOWED_TRAILING_COMMENTS.contains(&(rel.as_str(), trimmed)) {
+                continue;
+            }
+            violations.push(format!("{rel}:{}: {trimmed}", idx + 1));
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "em dash found in a kin-daemon runtime string (log line, eprintln status line, or a \
+         JSON string value a user reads). Restructure the sentence instead (a comma, colon, \
+         semicolon, or two sentences), never a bare hyphen swap. If this is a new trailing \
+         comment rather than a real string, add its (path, trimmed line) to \
+         ALLOWED_TRAILING_COMMENTS in this file instead.\n{}",
+        violations.join("\n")
+    );
+}


### PR DESCRIPTION
## What

Removes every em dash from a string a user can read at runtime in `crates/kin-cli` and
`crates/kin-daemon`: println/eprintln status lines, anyhow/bail error text, warnings pushed into
reports, tracing log lines, and JSON-serialized detail fields. Comments and doc comments are
untouched by design; a change there would be diff noise the founder's no-em-dash rule was never
aimed at.

Follow-up to kin#1633 (the postcut077 lane), which fixed the two em dashes in `main.rs`'s generated
CLI help and left a 952-hit baseline across both crates in
`.kin-coord/reports/postcut077-20260909.md` for a later lane to triage.

## Before and after

**949 total** at this branch's start (three fewer than postcut077's 952-hit baseline, from ordinary
main drift since that lane's sweep). Every hit was read in full context and triaged individually
rather than trusted from a file-level sample: one 140-hit file read as "entirely comment" on a spot
check but actually held five real user-facing strings.

**73 lines across 25 files were user-facing strings.** All 73 fixed, all 25 files touched:

```
crates/kin-cli/src/commands/assistant.rs        1
crates/kin-cli/src/commands/cache.rs            5
crates/kin-cli/src/commands/daemon.rs           1
crates/kin-cli/src/commands/embed.rs            2
crates/kin-cli/src/commands/graph.rs            6
crates/kin-cli/src/commands/intent.rs           1
crates/kin-cli/src/commands/locate.rs           4
crates/kin-cli/src/commands/locate_debug.rs     1
crates/kin-cli/src/commands/pipeline.rs         1
crates/kin-cli/src/commands/release_cmd.rs      2
crates/kin-cli/src/commands/release_orch.rs     9
crates/kin-cli/src/commands/resources.rs        1
crates/kin-cli/src/commands/secret.rs           1
crates/kin-cli/src/commands/setup_ledger.rs     4
crates/kin-cli/src/commands/telemetry.rs        2
crates/kin-cli/src/commands/update.rs           1
crates/kin-cli/src/commands/verify.rs           3
crates/kin-cli/src/commands/work.rs             3
crates/kin-cli/src/commands/xref.rs             3
crates/kin-cli/src/daemon_client.rs             1
crates/kin-daemon/src/api.rs                    2
crates/kin-daemon/src/commit_deltas.rs          1
crates/kin-daemon/src/daemon.rs                13
crates/kin-daemon/src/loop_runner.rs            1
crates/kin-daemon/src/supervisor.rs             4
                                            -------
                                       total    73
```

Every rewrite restructures the sentence (a semicolon, a colon, a comma, or once, for a string that
carried two em dashes, parentheses around the middle clause), never a bare hyphen swap.

**876 remain, all comments.** 866 were caught by a conservative heuristic (trimmed line starts with
`//`, covering `//`, `///` and `//!` alike); the other 10 are trailing `// comment`s on a code line
that heuristic can't see on its own and were confirmed by hand: a `#` comment in `Cargo.toml`, five
JS legend comments in `assets/graph_viz/app.js`, and four Rust trailing comments (`locate.rs:13823`,
`trace.rs:539`, `kin-daemon/src/api.rs:43945`, `kin-daemon/src/lifecycle.rs:961`).

Three `assert!` messages inside `#[test]` functions (`kin-daemon/src/api.rs:54000`, `:54074`,
`kin-daemon/src/commit_deltas.rs:1521`) are fixed too, on the reasoning that an `assert!` message is
a string that surfaces only when a condition is met, structurally the same as a `bail!` message,
even though it fires only under `cargo test` rather than at product runtime. Captain confirmed this
reading before this PR opened.

No test or snapshot pinned the old text: neither crate depends on `insta`, neither has a `.snap`
file, and a substring search across both crate trees for the changed phrases found exactly one test
touching a changed string (`crates/kin-cli/tests/doctor_language_servers.rs:133`), whose
`stderr.contains("not inside a Kin repository")` check sits entirely before the changed punctuation
and needed no update.

## Regression guard

Added `crates/kin-cli/tests/no_em_dash_in_runtime_strings.rs` and
`crates/kin-daemon/tests/no_em_dash_in_runtime_strings.rs`. Each walks that crate's own `src/` tree,
flags any line containing an em dash whose trimmed text does not start with `//`, and fails naming
the offending file, line and text, unless the line is one of that crate's two known trailing
comments (matched by exact trimmed text, not line number, so an unrelated edit elsewhere in the file
can't make the allowlist silently stop matching). Both need no new dependency and run under the
existing `cargo nextest run` gate. No CI wiring was added or needed.

Falsified by reverting `crates/kin-cli/src/commands/assistant.rs:233` to its original em-dash form
and running `cargo test -p kin-cli --locked no_em_dash_outside_comments_in_src`:

```
thread 'no_em_dash_outside_comments_in_src' (728992500) panicked at crates/kin-cli/tests/no_em_dash_in_runtime_strings.rs:77:5:
em dash found in a kin-cli runtime string (println/eprintln/anyhow/bail/log/warning text). Restructure the sentence instead (a comma, colon, semicolon, or two sentences), never a bare hyphen swap. If this is a new trailing comment rather than a real string, add its (path, trimmed line) to ALLOWED_TRAILING_COMMENTS in this file instead.
commands/assistant.rs:233: println!("  {} — {}", result.path.display(), status);
test no_em_dash_outside_comments_in_src ... FAILED

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s
```

Restored immediately after. Both guard tests pass green now and ran clean inside the full suite
below.

## Gates

All run through `.kin-coord/bin/heavy-slot.sh emdash kin -- <command>`:

- `cargo fmt --all -- --check`: clean, rc=0.
- `cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>`
  (ci.yml's own Clippy step, reproduced exactly): clean, rc=0, full workspace.
- `cargo test -p kin-cli -p kin-daemon --locked`: clean, rc=0. 92 `test result:` blocks, every one
  `ok`, zero `FAILED`. Both new guard tests ran and passed inside this run.
- `bin/kin-precheck kin --repo-dir kin=<worktree>`: `21 gates enumerated from the check job of
  .github/workflows/ci.yml`, closed with `21 gates ran, 21 passed, 0 failed`.

Landing held for the captain's go-ahead per this lane's brief.
