### PR TITLE
Stop re-enriching an unchanged non-entity record on every reconcile tick

### DIFF
--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -1713,10 +1713,79 @@ fn shallow_tracked_file(shallow: kin_parser::ShallowFile) -> ShallowTrackedFile 
     }
 }
 
+/// Whether persisting one non-entity enrichment record actually wrote it.
+///
+/// The distinction is not bookkeeping. kin-db's three artifact upserts each end
+/// in `invalidate_artifact_for_embedding`, which REMOVES the artifact's vector
+/// and re-queues it, so a rewrite is destructive rather than idempotent. A
+/// caller handed one of these unchanged records on every tick leaves an artifact
+/// key that embedding coverage counts and that can never keep a vector, while
+/// every counter sits still. That is the cost #1626 introduced and #1630 removed
+/// for a path that is not entity source BY NAME; this is the same cost for a
+/// source-named path whose BYTES are not source, which name classification
+/// cannot see and which therefore still reaches the drain on every tick.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EnrichmentPersistence {
+    /// The record was written, so the artifact's vector was discarded.
+    Written,
+    /// The stored record already described these exact bytes, so nothing was
+    /// written and the artifact kept whatever vector it had.
+    AlreadyCurrent,
+}
+
+/// Whether the stored record already says everything the fresh one would.
+///
+/// Compared field by field rather than on `content_hash` alone, and that is the
+/// point rather than caution. Equal bytes are not by themselves equal records: a
+/// pipeline that changes how a preview or a kind is derived produces a different
+/// record for the same hash, and a skip keyed on the hash would leave that stale
+/// record standing with no later tick able to repair it. Comparing every field
+/// makes the skipped write provably a no-op, because the write it avoids would
+/// have stored exactly what is stored.
+fn shallow_file_is_current(stored: &ShallowTrackedFile, fresh: &ShallowTrackedFile) -> bool {
+    stored.file_id == fresh.file_id
+        && stored.language_hint == fresh.language_hint
+        && stored.declaration_count == fresh.declaration_count
+        && stored.import_count == fresh.import_count
+        && stored.syntax_hash == fresh.syntax_hash
+        && stored.signature_hash == fresh.signature_hash
+        && stored.declaration_names == fresh.declaration_names
+        && stored.import_paths == fresh.import_paths
+}
+
+/// The same whole-record comparison for a structured artifact.
+fn structured_artifact_is_current(
+    stored: &kin_model::StructuredArtifact,
+    fresh: &kin_model::StructuredArtifact,
+) -> bool {
+    stored.file_id == fresh.file_id
+        && stored.kind == fresh.kind
+        && stored.content_hash == fresh.content_hash
+        && stored.text_preview == fresh.text_preview
+}
+
+/// The same whole-record comparison for an opaque artifact.
+fn opaque_artifact_is_current(
+    stored: &kin_model::OpaqueArtifact,
+    fresh: &kin_model::OpaqueArtifact,
+) -> bool {
+    stored.file_id == fresh.file_id
+        && stored.content_hash == fresh.content_hash
+        && stored.mime_type == fresh.mime_type
+        && stored.text_preview == fresh.text_preview
+}
+
+/// Persist one non-entity enrichment record, additively.
+///
+/// Incompatible facets are cleared unconditionally, because an entity layout
+/// left beside a current artifact record is a real repair and skipping it would
+/// trade one defect for another. Only the write is conditional: a record that
+/// already describes these exact bytes is left alone, so the artifact keeps its
+/// vector and the drain stops churning a store that never commits.
 fn persist_non_entity_enrichment(
     state: &DaemonState,
     indexed: IndexedAny,
-) -> Result<(FilePathId, FacetCleanup)> {
+) -> Result<(FilePathId, FacetCleanup, EnrichmentPersistence)> {
     match indexed {
         IndexedAny::EntitySource(_) => Err(DaemonError::Io(std::io::Error::other(
             "entity source reached non-entity enrichment path",
@@ -1725,8 +1794,19 @@ fn persist_non_entity_enrichment(
             let shallow = shallow_tracked_file(shallow);
             let cleanup =
                 clear_incompatible_facets(state, &shallow.file_id, EnrichmentFacet::ShallowSyntax)?;
+            if state
+                .graph
+                .get_shallow_file(&shallow.file_id)?
+                .is_some_and(|stored| shallow_file_is_current(&stored, &shallow))
+            {
+                return Ok((
+                    shallow.file_id,
+                    cleanup,
+                    EnrichmentPersistence::AlreadyCurrent,
+                ));
+            }
             state.graph.upsert_shallow_file(&shallow)?;
-            Ok((shallow.file_id, cleanup))
+            Ok((shallow.file_id, cleanup, EnrichmentPersistence::Written))
         }
         IndexedAny::StructuredArtifact(artifact) => {
             let cleanup = clear_incompatible_facets(
@@ -1734,8 +1814,19 @@ fn persist_non_entity_enrichment(
                 &artifact.file_id,
                 EnrichmentFacet::StructuredArtifact,
             )?;
+            if state
+                .graph
+                .get_structured_artifact(&artifact.file_id)?
+                .is_some_and(|stored| structured_artifact_is_current(&stored, &artifact))
+            {
+                return Ok((
+                    artifact.file_id,
+                    cleanup,
+                    EnrichmentPersistence::AlreadyCurrent,
+                ));
+            }
             state.graph.upsert_structured_artifact(&artifact)?;
-            Ok((artifact.file_id, cleanup))
+            Ok((artifact.file_id, cleanup, EnrichmentPersistence::Written))
         }
         IndexedAny::OpaqueArtifact(artifact) => {
             let cleanup = clear_incompatible_facets(
@@ -1743,8 +1834,19 @@ fn persist_non_entity_enrichment(
                 &artifact.file_id,
                 EnrichmentFacet::OpaqueArtifact,
             )?;
+            if state
+                .graph
+                .get_opaque_artifact(&artifact.file_id)?
+                .is_some_and(|stored| opaque_artifact_is_current(&stored, &artifact))
+            {
+                return Ok((
+                    artifact.file_id,
+                    cleanup,
+                    EnrichmentPersistence::AlreadyCurrent,
+                ));
+            }
             state.graph.upsert_opaque_artifact(&artifact)?;
-            Ok((artifact.file_id, cleanup))
+            Ok((artifact.file_id, cleanup, EnrichmentPersistence::Written))
         }
     }
 }
@@ -1828,7 +1930,11 @@ pub(crate) fn ensure_non_entity_enrichment_coverage(state: &DaemonState) -> Resu
 
         match pipeline.index_any_content(&file_id, &content, hash) {
             Ok(indexed) => match persist_non_entity_enrichment(state, indexed) {
-                Ok(_) => created += 1,
+                // The guard above admits only paths carrying no facet at all,
+                // so this pass always writes. Counting the write rather than
+                // the call keeps `created` honest if that guard ever loosens.
+                Ok((_, _, EnrichmentPersistence::Written)) => created += 1,
+                Ok((_, _, EnrichmentPersistence::AlreadyCurrent)) => {}
                 Err(error) => warn!(
                     file = %file_id,
                     error = %error,
@@ -3568,7 +3674,10 @@ pub async fn run_loop_armed(
                     if classification != FileClassification::EntitySource {
                         match enrichment_pipeline.index_any_content(&file_id, &content, blob_hash) {
                             Ok(indexed) => match persist_non_entity_enrichment(&state, indexed) {
-                                Ok((file_id, cleanup)) => {
+                                // The admission that reached here moved the
+                                // tree, so this arm reports a graph change
+                                // whether or not the facet needed rewriting.
+                                Ok((file_id, cleanup, _)) => {
                                     for id in cleanup.removed_entities {
                                         state.emit_event(DaemonEvent::EntityChanged {
                                             entity_id: id,
@@ -4138,6 +4247,7 @@ mod tests {
     use std::path::PathBuf;
 
     include!("loop_runner/tests/startup_recovery.rs");
+    include!("loop_runner/tests/enrichment_churn.rs");
 
     #[test]
     fn partial_c_disclosure_persists_and_only_clean_outcomes_settle() {
@@ -10068,7 +10178,8 @@ pub(crate) async fn readmit_semantics_for_paths(
         if classification != FileClassification::EntitySource {
             match enrichment_pipeline.index_any_content(&file_id, &content, body_hash) {
                 Ok(indexed) => match persist_non_entity_enrichment(state, indexed) {
-                    Ok((persisted, cleanup)) => {
+                    Ok((persisted, cleanup, persistence)) => {
+                        let cleanup_changed = cleanup.changed;
                         for id in cleanup.removed_entities {
                             state.emit_event(DaemonEvent::EntityChanged {
                                 entity_id: id,
@@ -10078,7 +10189,18 @@ pub(crate) async fn readmit_semantics_for_paths(
                                 session_id: None,
                             });
                         }
-                        graph_changed = true;
+                        // This is the repeating caller. A debt entry is settled
+                        // only by a commit, so on a store that never commits
+                        // every tick hands the same unchanged paths back here.
+                        // Claiming a graph change for a record nothing wrote
+                        // bumps the VFS version, retires every client's cached
+                        // materialization and arms a persistence pass, all for a
+                        // graph that did not move.
+                        graph_changed |=
+                            cleanup_changed || persistence == EnrichmentPersistence::Written;
+                        // Counted as readmitted either way: the caller asked
+                        // whether this path's semantics now describe its bytes,
+                        // and they do. Only `failed` means they do not.
                         outcome.enriched += 1;
                     }
                     Err(error) => {
@@ -10560,7 +10682,9 @@ async fn sync_filesystem_with_graph_publishing_inner(
                 if classification != FileClassification::EntitySource {
                     match enrichment_pipeline.index_any_content(&file_id, &content, blob_hash) {
                         Ok(indexed) => match persist_non_entity_enrichment(state, indexed) {
-                            Ok((file_id, cleanup)) => {
+                            // As above: the tree moved to get here, so the
+                            // change is reported whatever the facet needed.
+                            Ok((file_id, cleanup, _)) => {
                                 for id in cleanup.removed_entities {
                                     state.emit_event(DaemonEvent::EntityChanged {
                                         entity_id: id,

--- a/crates/kin-daemon/src/loop_runner/tests/enrichment_churn.rs
+++ b/crates/kin-daemon/src/loop_runner/tests/enrichment_churn.rs
@@ -1,0 +1,275 @@
+/// Additions the pending snapshot delta is carrying for the three artifact
+/// facets, as `(shallow, structured, opaque)`.
+///
+/// This is the exact instrument for "was the record written", and the two
+/// obvious alternatives are both checks that cannot fail. The artifact
+/// embedding queue is a set keyed by `ArtifactId`, so the second and every
+/// later invalidation of one artifact leave its depth unchanged, and nothing
+/// short of a real embedder can drain it. A count of
+/// `invalidate_artifact_for_embedding` calls is not separately observable at
+/// all, and does not need to be: kin-db's three artifact upserts each end in
+/// one (0.7.107 `src/engine/graph.rs:8520`, `:8551`, `:8606`), so invalidations
+/// per tick equal rewrites per tick by construction.
+///
+/// The delta is also where the cost is sharpest. `delta_vec_upsert_by_key`
+/// (`graph.rs:1579`) drops a key's pending `added` entry BEFORE it returns
+/// early on an identical value, so re-persisting an unchanged record does not
+/// merely record nothing: it erases that record's creation from the delta the
+/// daemon may persist (`state.rs` -> `backend.save_delta`).
+fn pending_artifact_additions(state: &DaemonState) -> (usize, usize, usize) {
+    match state.graph.pending_delta_snapshot(0) {
+        Some(delta) => (
+            delta.shallow_files.added.len(),
+            delta.structured_artifacts.added.len(),
+            delta.opaque_artifacts.added.len(),
+        ),
+        None => (0, 0, 0),
+    }
+}
+
+/// An idle tick must not rewrite the enrichment record of a source-NAMED path
+/// whose BYTES are not source.
+///
+/// #1630 stopped `semantic_debt::owed_by` recording a path that is not entity
+/// source, but it classifies by NAME, because a tree delta carries no body. A
+/// source-named path whose bytes are binary is still recorded, is still handed
+/// to [`readmit_semantics_for_paths`] by every drain, and there is re-classified
+/// WITH content into the non-source branch. Nothing but a commit settles a debt
+/// entry, so on a store that never commits that is every tick, forever.
+///
+/// Measured on 6697b8f9 before the fix, three drains over this fixture: three
+/// rewrites, three vector invalidations, three `vfs_version` bumps, and the
+/// opaque record's creation already erased from the pending delta by the drain
+/// that runs inside `sync_filesystem_with_graph` itself.
+///
+/// The fixture carries no ordinary source file on purpose. A source file's debt
+/// is unsettled too and is legitimately re-parsed on every tick, which moves
+/// `vfs_version` and would make every assertion here vacuous.
+#[cfg(unix)]
+#[tokio::test]
+#[serial_test::serial(commit_phase_capture)]
+async fn an_idle_drain_does_not_rewrite_an_unchanged_opaque_record_under_a_source_name() {
+    let repo = tempfile::tempdir().unwrap();
+    let state = open_test_state(&repo);
+    // `.py` is an entity-source extension, so `classify` says parse me; a NUL
+    // makes `classify_with_content` route the same path to the opaque facet.
+    std::fs::write(repo.path().join("probe.py"), b"\x00\x01binary payload\n").unwrap();
+    sync_filesystem_with_graph(&state).await.unwrap();
+
+    let probe = FilePathId::new("probe.py");
+    assert!(
+        state.graph.get_opaque_artifact(&probe).unwrap().is_some(),
+        "the fixture must reach the opaque facet or every assertion below is vacuous"
+    );
+    let recorded = crate::semantic_debt::outstanding(&state);
+    let (owed, _spent) = crate::semantic_debt::partition_against_tree(&state, &recorded);
+    assert!(
+        owed.iter().any(|path| path.as_utf8() == Some("probe.py")),
+        "the drain must actually be handed this path, or nothing here is being exercised: \
+         {owed:?}"
+    );
+    let version = state.vfs_version.load(Ordering::SeqCst);
+    for tick in 1..=3 {
+        drain_semantic_debt(&state).await.unwrap();
+        assert_eq!(
+            state.vfs_version.load(Ordering::SeqCst),
+            version,
+            "tick {tick} claimed a graph change for a record nothing wrote, which retires every \
+             VFS client's cached materialization and arms a persistence pass for a graph that \
+             did not move"
+        );
+        assert_eq!(
+            pending_artifact_additions(&state).2,
+            1,
+            "tick {tick} re-persisted the unchanged opaque record, which discards its vector and \
+             erases its creation from the pending delta"
+        );
+    }
+    assert!(
+        state.graph.get_opaque_artifact(&probe).unwrap().is_some(),
+        "skipping the rewrite must not lose the record"
+    );
+}
+
+/// The control for the arm above: when the bytes really do move, the record
+/// follows them.
+///
+/// Without this, a comparison that always answered "already current" would pass
+/// every assertion in the test above while silently freezing every artifact
+/// record in the store at its first body.
+#[cfg(unix)]
+#[tokio::test]
+#[serial_test::serial(commit_phase_capture)]
+async fn a_changed_opaque_body_under_a_source_name_is_still_rewritten() {
+    let repo = tempfile::tempdir().unwrap();
+    let state = open_test_state(&repo);
+    let probe_path = repo.path().join("probe.py");
+    std::fs::write(&probe_path, b"\x00\x01binary payload\n").unwrap();
+    sync_filesystem_with_graph(&state).await.unwrap();
+
+    let probe = FilePathId::new("probe.py");
+    let first = state
+        .graph
+        .get_opaque_artifact(&probe)
+        .unwrap()
+        .expect("the fixture must reach the opaque facet");
+
+    std::fs::write(&probe_path, b"\x00\x02a different binary payload\n").unwrap();
+    sync_filesystem_with_graph(&state).await.unwrap();
+    let second = state
+        .graph
+        .get_opaque_artifact(&probe)
+        .unwrap()
+        .expect("the record must survive the second admission");
+    assert_ne!(
+        second.content_hash, first.content_hash,
+        "an additive persist must still write a record whose body moved"
+    );
+    assert_eq!(
+        second.content_hash.to_string(),
+        kin_blobs::digest(b"\x00\x02a different binary payload\n").to_string(),
+        "and the record it writes must describe the bytes the tree now holds"
+    );
+}
+
+/// The same additive rule for a structured artifact, driven through the seam
+/// that can be handed one with an unchanged body.
+///
+/// A structured artifact is not entity source by NAME either, so #1630 already
+/// keeps it out of the debt record and the drain never reaches it from there.
+/// `readmit_semantics_for_paths` is still called with whole published path sets
+/// elsewhere (`api.rs`, the reconcile gate), so the arm has a live caller and
+/// pays the same cost when the body has not moved.
+#[cfg(unix)]
+#[tokio::test]
+#[serial_test::serial(commit_phase_capture)]
+async fn readmitting_an_unchanged_structured_artifact_writes_nothing() {
+    let repo = tempfile::tempdir().unwrap();
+    let state = open_test_state(&repo);
+    let makefile_path = repo.path().join("Makefile");
+    std::fs::write(&makefile_path, b"build:\n\tcargo build\n").unwrap();
+    sync_filesystem_with_graph(&state).await.unwrap();
+
+    let makefile = FilePathId::new("Makefile");
+    let first = state
+        .graph
+        .get_structured_artifact(&makefile)
+        .unwrap()
+        .expect("the fixture must reach the structured facet");
+    assert_eq!(
+        pending_artifact_additions(&state).1,
+        1,
+        "the delta must be carrying the record's creation before a rewrite could erase it"
+    );
+
+    let version = state.vfs_version.load(Ordering::SeqCst);
+    let artifacts = BTreeSet::from([test_repo_path("Makefile")]);
+    for tick in 1..=3 {
+        let readmitted = readmit_semantics_for_paths(&state, &artifacts).await;
+        assert_eq!(
+            readmitted.enriched, 1,
+            "tick {tick}: the path must actually reach the non-entity persist seam, or this \
+             test asserts nothing"
+        );
+        assert!(readmitted.failed.is_empty(), "{:?}", readmitted.failed);
+        assert_eq!(
+            state.vfs_version.load(Ordering::SeqCst),
+            version,
+            "tick {tick} claimed a graph change for a record nothing wrote"
+        );
+        assert_eq!(
+            pending_artifact_additions(&state).1,
+            1,
+            "tick {tick} re-persisted the unchanged structured record, which discards its vector \
+             and erases its creation from the pending delta"
+        );
+    }
+
+    // The control, as above: a body that moves is still written.
+    std::fs::write(&makefile_path, b"build:\n\tcargo build --release\n").unwrap();
+    sync_filesystem_with_graph(&state).await.unwrap();
+    let second = state
+        .graph
+        .get_structured_artifact(&makefile)
+        .unwrap()
+        .expect("the record must survive the second admission");
+    assert_ne!(
+        second.content_hash, first.content_hash,
+        "an additive persist must still write a record whose body moved"
+    );
+}
+
+/// The same additive rule for the shallow arm.
+///
+/// This one is driven at the seam rather than through a fixture file, because
+/// the arm has no live producer: `SHALLOW_SYNTAX_EXTENSIONS` is empty by design
+/// (`kin-index/src/classifier.rs`), so no path classifies as `ShallowSyntax`
+/// today and `index_any_content` cannot produce one. The arm is still reachable
+/// the moment an extension is added there, and `ShallowTrackedFile` is the one
+/// record of the three that carries no `content_hash`, so its comparison is a
+/// whole-value one and needs a guard of its own.
+#[cfg(unix)]
+#[tokio::test]
+#[serial_test::serial(commit_phase_capture)]
+async fn persisting_an_unchanged_shallow_record_writes_nothing() {
+    let repo = tempfile::tempdir().unwrap();
+    let state = open_test_state(&repo);
+    // Any admitted path will do; the graph needs an artifact id for it before
+    // an enrichment record can be written against it.
+    std::fs::write(repo.path().join("notes.dat"), b"opaque by name\n").unwrap();
+    sync_filesystem_with_graph(&state).await.unwrap();
+
+    let file_id = FilePathId::new("notes.dat");
+    let shallow = |name: &str| {
+        IndexedAny::ShallowSyntax(kin_parser::ShallowFile {
+            file_id: file_id.clone(),
+            language_hint: Some("erlang".to_string()),
+            parse_state: kin_model::ParseState::Valid,
+            declarations: vec![kin_parser::ShallowDecl {
+                kind: kin_parser::ShallowDeclKind::FunctionLike,
+                name: name.to_string(),
+                start_line: 1,
+                end_line: 2,
+            }],
+            imports: Vec::new(),
+            fingerprint: kin_parser::ShallowFingerprint {
+                syntax_hash: Hash256::from_bytes([7; 32]),
+                signature_hash: None,
+            },
+        })
+    };
+
+    persist_non_entity_enrichment(&state, shallow("run")).unwrap();
+    assert!(
+        state.graph.get_shallow_file(&file_id).unwrap().is_some(),
+        "the first persist must write the record or nothing below is being exercised"
+    );
+    assert_eq!(
+        pending_artifact_additions(&state).0,
+        1,
+        "the delta must be carrying the record's creation before a rewrite could erase it"
+    );
+
+    persist_non_entity_enrichment(&state, shallow("run")).unwrap();
+    assert_eq!(
+        pending_artifact_additions(&state).0,
+        1,
+        "re-persisting the unchanged shallow record discards its vector and erases its creation \
+         from the pending delta"
+    );
+
+    // The control: a shallow record whose declarations moved is still written,
+    // and `ShallowTrackedFile` carries no content hash, so only the whole-value
+    // comparison can tell these two apart.
+    persist_non_entity_enrichment(&state, shallow("walk")).unwrap();
+    assert_eq!(
+        state
+            .graph
+            .get_shallow_file(&file_id)
+            .unwrap()
+            .expect("the record must survive")
+            .declaration_names,
+        vec!["walk".to_string()],
+        "an additive persist must still write a shallow record whose declarations moved"
+    );
+}

--- a/crates/kin-daemon/src/loop_runner/tests/enrichment_churn.rs
+++ b/crates/kin-daemon/src/loop_runner/tests/enrichment_churn.rs
@@ -16,6 +16,12 @@
 /// early on an identical value, so re-persisting an unchanged record does not
 /// merely record nothing: it erases that record's creation from the delta the
 /// daemon may persist (`state.rs` -> `backend.save_delta`).
+///
+/// Gated with the tests that call it, all four of which are `#[cfg(unix)]`
+/// because their fixtures publish through the host filesystem. Without the gate
+/// this helper is dead code on the Windows cross-check, which builds test
+/// targets under `-D warnings`.
+#[cfg(unix)]
 fn pending_artifact_additions(state: &DaemonState) -> (usize, usize, usize) {
     match state.graph.pending_delta_snapshot(0) {
         Some(delta) => (

--- a/crates/kin-daemon/src/loop_runner/tests/startup_recovery.rs
+++ b/crates/kin-daemon/src/loop_runner/tests/startup_recovery.rs
@@ -1143,13 +1143,21 @@ async fn a_standalone_publication_owes_no_parse_for_a_non_source_artifact() {
 
     // What the drain would do if the record named them, so the cost above is
     // demonstrated rather than asserted. Asking for the two artifacts directly
-    // re-persists both facets, which is the upsert that discards their vectors.
+    // re-reads both bodies from CAS and re-indexes them.
+    //
+    // It no longer re-persists their facets. `persist_non_entity_enrichment` is
+    // additive since the follow-up to this change, so a record that already
+    // describes these exact bytes is left alone and keeps its vector. That
+    // removes the sharpest half of the reason a debt entry must never name a
+    // path that is not entity source, and leaves the rest: every tick still
+    // pays a CAS read, a re-classification and a re-index for a path that owes
+    // no parse, and still counts it as enriched.
     let artifacts = BTreeSet::from([test_repo_path(config), test_repo_path(lock)]);
     let readmitted = readmit_semantics_for_paths(&state, &artifacts).await;
     assert_eq!(
         readmitted.enriched, 2,
-        "control: the drain does re-persist a non-source facet when it is asked to, \
-         which is why the debt record must never name one"
+        "control: the drain does take a non-source facet through the whole re-index when it is \
+         asked to, which is why the debt record must never name one"
     );
     assert!(readmitted.failed.is_empty(), "{:?}", readmitted.failed);
 }


### PR DESCRIPTION
Ticket: FIR-3436.

## What this is

#1630 stopped the semantic-debt record naming a path that is not entity source, but `owed_by`
classifies by NAME, because a tree delta carries no body. A source-named path whose bytes are
binary is still recorded, is still handed to `readmit_semantics_for_paths` by every drain, and is
there re-classified WITH content into the non-source branch, which re-persisted its artifact
record. kin-db's three artifact upserts each end in `invalidate_artifact_for_embedding`, which
removes the artifact's vector and re-queues it (0.7.107 `src/engine/graph.rs:8520`, `:8551`,
`:8606`, and `:3851`). Nothing but a commit settles a debt entry, so on a store that never commits
that is every tick, forever.

`persist_non_entity_enrichment` is now additive. Incompatible facets are still cleared
unconditionally, because a stale entity layout beside a current artifact record is a real repair
and skipping it would trade one defect for another. Only the write is conditional, one arm per
record kind.

Compared whole-record rather than on `content_hash` alone, including for the two records that
carry one. Equal bytes are not equal records: a pipeline that changes how a preview or a kind is
derived produces a different record for the same hash, and a skip keyed on the hash would leave
that stale record standing with no later tick able to repair it. `ShallowTrackedFile` carries no
`content_hash` at all, so that arm had to be a whole-value comparison anyway.

`readmit_semantics_for_paths` reports a graph change only when the cleanup changed something or
the record was written. The two admission callers keep reporting one either way, because the tree
moved to reach them.

## Measured before anything was changed

Fixture: a temp store published through `sync_filesystem_with_graph` and never committed, holding
`probe.py` with bytes `\x00\x01binary payload\n` (source name, non-source bytes), an ordinary
`real.py`, and a `Makefile`. On 6697b8f9 with production code untouched:

```
MEASURE fixture opaque(probe.py)=true structured(Makefile)=true entities=2
MEASURE owed_after_publication=["probe.py", "real.py"]
MEASURE pending_delta_after_publication opaque_added=(0, 1, 0) vfs_version=3 artifact_queue=2
MEASURE tick=1 owed=2 enriched=2 failed=0 vfs_version 3->4 artifact_queue 2->2 delta(opaque,structured,shallow) (0, 1, 0)->(0, 1, 0) dirty true->true
MEASURE tick=2 owed=2 enriched=2 failed=0 vfs_version 4->5 artifact_queue 2->2 delta(opaque,structured,shallow) (0, 1, 0)->(0, 1, 0) dirty true->true
MEASURE tick=3 owed=2 enriched=2 failed=0 vfs_version 5->6 artifact_queue 2->2 delta(opaque,structured,shallow) (0, 1, 0)->(0, 1, 0) dirty true->true
MEASURE drain_tick=4 vfs_version 6->7 delta(opaque,structured,shallow) (0, 1, 0)->(0, 1, 0) artifact_queue=2
MEASURE drain_tick=5 vfs_version 7->8 delta(opaque,structured,shallow) (0, 1, 0)->(0, 1, 0) artifact_queue=2
MEASURE drain_tick=6 vfs_version 8->9 delta(opaque,structured,shallow) (0, 1, 0)->(0, 1, 0) artifact_queue=2
MEASURE structured_tick=7 enriched=1 vfs_version 9->10 delta(opaque,structured,shallow) (0, 1, 0)->(0, 0, 0)
MEASURE structured_tick=8 enriched=1 vfs_version 10->11 delta(opaque,structured,shallow) (0, 0, 0)->(0, 0, 0)
```

The same harness with this change:

```
MEASURE pending_delta_after_publication opaque_added=(1, 1, 0) vfs_version=3 artifact_queue=2
MEASURE tick=1..3   unchanged: owed=2 enriched=2 failed=0, delta stays (1, 1, 0)
MEASURE drain_tick=4..6  unchanged: delta stays (1, 1, 0)
MEASURE structured_tick=7 enriched=1 vfs_version 9->9 delta (1, 1, 0)->(1, 1, 0)
MEASURE structured_tick=8 enriched=1 vfs_version 9->9 delta (1, 1, 0)->(1, 1, 0)
```

Read the drain rows carefully. This fixture also carries `real.py`, whose source debt no commit
settles, so every drain legitimately re-parses it and bumps the version both before and after.
That is designed behaviour and this change does not touch it, which is exactly why the isolating
assertion lives in a test whose fixture carries only the source-named binary file.

Two counters that would have lied, and why neither is used here. A pending-delta instrument reads
zero churn while the vector is still being discarded, because `delta_vec_upsert_by_key`
(`graph.rs:1573`) returns early when the new value serializes identically to the old. The artifact
embedding queue is a set keyed by `ArtifactId`, so repeat invalidations of one artifact leave its
depth unchanged and nothing short of a real embedder can drain it. There is no separate
invalidation counter to read, and none is needed: each of the three upserts ends in one, so
invalidations per tick equal rewrites per tick by construction.

## A second measured finding (FIR-3437), which this change removes the exposure to

An identical re-upsert does not merely fail to record a delta. It DELETES the record's pending
`added` entry: `delta_vec_upsert_by_key` runs `delta.added.retain(key != new_key)` before it
returns early on equality (`graph.rs:1579-1601`). Tick 7 above shows it, the structured delta going
from 1 to 0, and `probe.py`'s opaque record is already absent from the pending delta immediately
after the first sync, because the drain inside `sync_filesystem_with_graph`
(`loop_runner.rs:10471`) re-persists it in the same tick that created it.

kin-daemon has a real delta-persistence arm (`state.rs` -> `backend.save_delta`), so a store
persisted by delta rather than by full snapshot could be missing that artifact record. I did not
prove that end to end and am not claiming it; proving it needs a persist-and-reopen test, which is
outside this change and is the done condition on FIR-3437. What this change does is stop kin
entering that kin-db path from the enrichment seam, and the fixture's opaque record now survives
in the delta.

## What the comparison costs

Debug build, 2000 persists of a structured artifact through the seam, timed with and without the
guard:

```
                       without the guard    with the guard
body changed           78.726 us/call       81.143 us/call     +2.4 us   (+3%)
body unchanged         71.482 us/call        3.028 us/call    -68.5 us   (-96%)
```

So the comparison does not cost more than the rewrite it avoids. It adds about three percent to
the path where the body really moved and removes about ninety-six percent of the path where it
did not.

## Falsification, one arm at a time

Each arm removed in turn, which is exactly what main does for that arm. One test red per arm, on
its own named assertion, with the other three green, which is what shows the arms are independent.

Opaque arm removed:

```
test loop_runner::tests::an_idle_drain_does_not_rewrite_an_unchanged_opaque_record_under_a_source_name ... FAILED
panicked at crates/kin-daemon/src/loop_runner/tests/enrichment_churn.rs:74:9:
assertion `left == right` failed: tick 1 claimed a graph change for a record nothing wrote, which retires every VFS client's cached materialization and arms a persistence pass for a graph that did not move
  left: 4
 right: 3
test result: FAILED. 3 passed; 1 failed
```

Structured arm removed:

```
test loop_runner::tests::readmitting_an_unchanged_structured_artifact_writes_nothing ... FAILED
panicked at crates/kin-daemon/src/loop_runner/tests/enrichment_churn.rs:175:9:
assertion `left == right` failed: tick 1 claimed a graph change for a record nothing wrote
  left: 3
 right: 2
test result: FAILED. 3 passed; 1 failed
```

Shallow arm removed:

```
test loop_runner::tests::persisting_an_unchanged_shallow_record_writes_nothing ... FAILED
panicked at crates/kin-daemon/src/loop_runner/tests/enrichment_churn.rs:254:5:
assertion `left == right` failed: re-persisting the unchanged shallow record discards its vector and erases its creation from the pending delta
  left: 0
 right: 1
test result: FAILED. 3 passed; 1 failed
```

Because removing an arm is exactly main's behaviour, those three red runs are also the evidence
that each test fails on current main.

In the other direction, `a_changed_opaque_body_under_a_source_name_is_still_rewritten` and the
changed-body controls inside the structured and shallow tests catch a comparison that always
answered "already current", which would otherwise pass every no-rewrite assertion above while
freezing every artifact record in the store at its first body.

The shallow arm is driven at the seam rather than through a fixture file because it has no live
producer: `SHALLOW_SYNTAX_EXTENSIONS` is empty by design, so nothing classifies as `ShallowSyntax`
today. The guard is there for the moment an extension is added.

#1630's own control is updated rather than left to read falsely. Its `enriched == 2` assertion
still holds, because the drain still takes both artifacts through the whole CAS read, re-classify
and re-index; the comment beside it no longer claims the drain discards their vectors, and says
plainly that this change removes the sharpest half of the reason a debt entry must never name a
non-source path.

## Verification

- `cargo test -p kin-daemon`: 1621 passed, 0 failed, 4 ignored on the lib, plus nine integration
  suites all green.
- `bin/kin-precheck kin --repo-dir kin=<lane worktree>`, by absolute path through the fleet's
  heavy-slot wrapper: **21 gates enumerated, 21 ran, 21 passed, 0 failed**, on kin
  6697b8f99d072fd6221d47babbb263effd954c89 DIRTY. That covers `cargo fmt -- --check`, `cargo
  clippy --all-targets --all-features` with the 45 allows from
  `.github/clippy-allowed-lints.txt`, `scripts/zero_file_search_guard.sh` and
  `scripts/verify-zero-file-search.py`. Tail:

```
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 6697b8f99d072fd6221d47babbb263effd954c89 DIRTY
```

No daemon was started and no gpu lock was taken at any point.

The measurement harness is not committed, because the four regression tests assert what it
printed. Its source is in the lane report at `.kin-coord/reports/enrichment-20260909.md` so anyone
can reproduce these numbers.
