### PR TITLE
Adopt kin-model 0.7.28, kin-lsp 0.7.19 and kin-db 0.7.109

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3295,9 +3295,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.108"
+version = "0.7.109"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "29b197a86e1dc49ec5271be85002a50bcb31992747a564f31655bb2655bbdd5d"
+checksum = "ac055989b509fc8a9d40337dd15102cb15dabfc7d49bbad5516dde88c4d862b1"
 dependencies = [
  "bincode",
  "bstr",
@@ -3439,9 +3439,9 @@ dependencies = [
 
 [[package]]
 name = "kin-lsp"
-version = "0.7.18"
+version = "0.7.19"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "22867b5810dd0654b681b5f00fbdfb141ace138cdc76166250da4055db92a6e7"
+checksum = "16311939984224bbd56291cda462d0e2c19f1b6b698a48528c9ce9ad7dc25b39"
 dependencies = [
  "kin-model",
  "serde",
@@ -3515,9 +3515,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.27"
+version = "0.7.28"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "e2891f63e0a229fc4ad2fa3ac22f393a17cfdf3285412adced1693654a283128"
+checksum = "cb9f808933a290580c0955fd2847bb2097851693a0c20b5f2b6b41bee96bd3ec"
 dependencies = [
  "chrono",
  "gix-hash",
@@ -3776,9 +3776,9 @@ dependencies = [
 
 [[package]]
 name = "kin-vector"
-version = "0.2.0"
+version = "0.2.1"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "2c279bb634aa149fca1e862d4d0e43345409fa2103ecfd644f767ca5f3e51bb2"
+checksum = "9e16f9deab030c0ffd57538c79be0c918135d1a45a37fbc707661e2f01080692"
 dependencies = [
  "fs2",
  "hashbrown 0.15.5",
@@ -6684,7 +6684,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ pretty_assertions = "1"
 serial_test = "4"
 
 # Internal crates
-kin-model = { version = "=0.7.27", registry = "kin" }
+kin-model = { version = "=0.7.28", registry = "kin" }
 kin-blobs = { version = "=0.1.5", registry = "kin" }
 kin-core = { path = "crates/kin-core" }
 kin-parser = { path = "crates/kin-parser" }
@@ -152,13 +152,13 @@ kin-daemon-spawn = { path = "crates/kin-daemon-spawn" }
 kin-mcp = { path = "crates/kin-mcp" }
 kin-spine = { path = "crates/kin-spine" }
 kin-registry = { path = "crates/kin-registry" }
-kin-lsp = { version = "=0.7.18", registry = "kin" }
+kin-lsp = { version = "=0.7.19", registry = "kin" }
 # Cross-platform base: NO "metal" here. `[workspace.dependencies]` entries cannot be
 # `[target.'cfg(...)']`-gated, so listing "metal" here forces the macOS-only kin-infer/metal
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.108", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.109", registry = "kin", default-features = false }
 # Pinned to the exact version kin-db builds its name-token index with. A
 # per-token name query hits that index only when the token came out of the same
 # tokenizer, so a version skew here would be a silent recall loss rather than a

--- a/crates/kin-daemon/src/storage_delegate.rs
+++ b/crates/kin-daemon/src/storage_delegate.rs
@@ -62,7 +62,7 @@ use kin_db::{
 /// `storage_backend_surface_is_audited_against_the_pinned_kin_db` fails when
 /// the workspace pin moves past it, which is the only moment a method can have
 /// appeared.
-pub const AUDITED_KIN_DB_VERSION: &str = "0.7.108";
+pub const AUDITED_KIN_DB_VERSION: &str = "0.7.109";
 
 /// Wraps a [`StorageBackendDelegate`] so it can be handed anywhere a
 /// `Box<dyn StorageBackend>` is expected.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.27"
+version = "0.7.28"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "e2891f63e0a229fc4ad2fa3ac22f393a17cfdf3285412adced1693654a283128"
+checksum = "cb9f808933a290580c0955fd2847bb2097851693a0c20b5f2b6b41bee96bd3ec"
 dependencies = [
  "chrono",
  "gix-hash",
@@ -702,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "kin-vector"
-version = "0.2.0"
+version = "0.2.1"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "2c279bb634aa149fca1e862d4d0e43345409fa2103ecfd644f767ca5f3e51bb2"
+checksum = "9e16f9deab030c0ffd57538c79be0c918135d1a45a37fbc707661e2f01080692"
 dependencies = [
  "fs2",
  "hashbrown 0.15.5",


### PR DESCRIPTION
Adopts the four Kin registry pins that moved together: kin-model `=0.7.28`, kin-lsp `=0.7.19` and
kin-db `=0.7.109`, with kin-vector `0.2.1` arriving transitively, and moves
`AUDITED_KIN_DB_VERSION` to match the new kin-db pin.

This supersedes the receiver's wave PR #1646, which carries the same three pins and is red on
`Fast gate test shard (1)`: it moved the pin and not the constant, so
`storage_backend_surface_is_audited_against_the_pinned_kin_db` fails at
`crates/kin-daemon/src/storage_delegate.rs:297`. A manifest-only wave cannot satisfy that guard by
construction.

kin has no kin-vector dependency of its own. It arrives through kin-model, so 0.2.1 lands here as a
lock entry rather than a manifest edit. Both locks move: `fuzz/Cargo.lock` pins kin-model and
kin-vector from the registry even though it carries no kin-db, which is why the 0.7.108 adoption
left it alone and this one cannot.

## The audit the guard asks for

The guard's message says to count the trait's methods in `kin-db-0.7.109/src/storage/backend.rs`
and add a row for anything new. Done from the two published crates' real bytes, not from the
working tree:

```
0.7.108 crate sha256 29b197a86e1dc49ec5271be85002a50bcb31992747a564f31655bb2655bbdd5d
0.7.109 crate sha256 ac055989b509fc8a9d40337dd15102cb15dabfc7d49bbad5516dde88c4d862b1
backend.rs identical between the two crates: True
backend.rs sha256 (both)  3be4ba4c2a17b685d8bf64dad5b57ee14375c2e1bf03e56fe056ead4155ec5af
StorageBackend methods: 0.7.108 = 33, 0.7.109 = 33
added in 0.7.109: none      removed in 0.7.109: none
control: counted 33 methods, a plausible non-zero count
```

Each crate's checksum was verified against the sparse index before it was unpacked. The methods are
counted by brace depth inside the `pub trait StorageBackend` block rather than by grepping `fn `
across the file, because that file also holds impls and free functions, and the count carries a
control so a broken parse cannot report a confident zero. 33 is what
`the_bridged_method_roster_names_each_method_once` already asserts, so the bridge table is complete
and unchanged.

That is the expected result rather than a lucky one: kin-db 0.7.108 to 0.7.109 is a dependency-pin
roll plus a regenerated schema snapshot, with no change to any Rust source.

## The guard, shown red then green

A one-line constant bump accompanied only by a green test proves nothing, so the guard was
falsified before it was trusted. With the constant put back to 0.7.108 against a 0.7.109 pin:

```
FAIL [0.039s] kin-daemon storage_delegate::tests::storage_backend_surface_is_audited_against_the_pinned_kin_db
assertion `left == right` failed: kin-db moved from 0.7.108 to 0.7.109 and the StorageBackend table
in crates/kin-daemon/src/storage_delegate.rs has not been re-read.
Summary [0.048s] 1 test run: 0 passed, 1 failed        rc=100
```

Restored, with the file asserted byte-identical to its committed state before the second run:

```
PASS [0.012s] kin-daemon storage_delegate::tests::storage_backend_surface_is_audited_against_the_pinned_kin_db
Summary [0.013s] 1 test run: 1 passed                  rc=0
```

## Locks

Regenerated against the sparse registry with no path patch, scoped to the moved crates rather than
relocked wholesale, so no unrelated transitive rides along:

```
root:  Locking 4 packages   kin-db 0.7.108->0.7.109, kin-lsp 0.7.18->0.7.19,
                            kin-model 0.7.27->0.7.28, kin-vector 0.2.0->0.2.1
fuzz:  Locking 2 packages   kin-model 0.7.27->0.7.28, kin-vector 0.2.0->0.2.1
```

Every resulting checksum was read back against the live index rather than trusted: kin-db
`ac055989`, kin-model `cb9f8089`, kin-lsp `16311939`, kin-vector `9e16f9de`, none yanked, every
entry `source = "sparse+https://kinlab.ai/registry/cargo/"`, and a sweep for `source = "path`
across both locks returns nothing.

This lock differs from #1646's by twelve `windows-sys` dependency edges and nothing else. Both
locks carry the identical set of five `windows-sys` versions and the identical total of 38 edges,
so neither adds, removes, or newly compiles anything; the scoped update simply reassigns fewer
edges.

## Verification

`cargo nextest run --locked` over all eighteen crates that pin a moved version, enumerated from the
manifests at run time rather than from a remembered list:

```
Summary [686.847s] 9257 tests run: 9257 passed (4 slow, 2 leaky), 24 skipped     rc=0
```

`bin/kin-precheck kin`, run against this tree by absolute path with `--repo-dir`:

```
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin f60932f203cb087abf6aa74d85a2a73490fb49d3
```

One caveat on an earlier run, recorded rather than buried: a first pass used plain `cargo test`,
which shares one process across a crate's tests, and it reported a kin-core failure that hosted CI
does not show on the same pins. kin's Fast gate runs `cargo nextest run --locked`, which isolates
each test in its own process. That first run is not evidence for anything here; the nextest run
above is.

Refs the kin dependency wave.
