### PR TITLE
Drop the stale Google Chrome apt list in ci-apt-install.sh

### DIFF
--- a/scripts/ci-apt-install.sh
+++ b/scripts/ci-apt-install.sh
@@ -40,6 +40,9 @@ drop_azure_mirror() {
   fi
 }
 
+# The runner image preinstalls a Google Chrome apt source this script never needs; when dl.google.com regenerates its Release file mid-fetch every mirror serves a stale, hash-mismatched Packages.gz, and no attempt or mirror swap below clears it, so the list is dropped once before the first update.
+sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+
 for attempt in 1 2 3; do
   if [ "$attempt" -ge 2 ]; then
     echo "apt attempt $attempt: dropping the azure mirror in favour of archive.ubuntu.com" >&2

--- a/scripts/ci-apt-install.sh
+++ b/scripts/ci-apt-install.sh
@@ -40,8 +40,27 @@ drop_azure_mirror() {
   fi
 }
 
-# The runner image preinstalls a Google Chrome apt source this script never needs; when dl.google.com regenerates its Release file mid-fetch every mirror serves a stale, hash-mismatched Packages.gz, and no attempt or mirror swap below clears it, so the list is dropped once before the first update.
-sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+# The runner image preinstalls a Google Chrome apt source this script never needs, and it can
+# ship as either sources.list.d/google-chrome.list (classic one-line form) or
+# google-chrome.sources (DEB822);
+# drop_azure_mirror below already treats both extensions as live on this runner fleet. When
+# dl.google.com regenerates its Release file mid-fetch, every mirror serves a stale,
+# hash-mismatched Packages.gz through whichever form is present, and no attempt or mirror swap
+# below clears it, so match and drop it by content once before the first update. A hardcoded
+# filename here (tried first, and it did not clear a live failure on kin#1651's own run) is a
+# guess about which form the image ships; matching content is not.
+chrome_matches=$(grep -l 'dl\.google\.com' /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources /etc/apt/sources.list 2>/dev/null || true)
+if [ -n "$chrome_matches" ]; then
+  echo "dropping the Chrome apt source(s), matched by content:" >&2
+  printf '%s\n' "$chrome_matches" >&2
+  printf '%s\n' "$chrome_matches" | xargs -r sudo rm -f
+  echo "sources.list.d after removal:" >&2
+  ls -la /etc/apt/sources.list.d/ >&2
+else
+  echo "no sources.list.d/sources.list file matched dl.google.com by content; listing what is there so the next attempt starts from a fact, not a guess:" >&2
+  ls -la /etc/apt/sources.list.d/ >&2
+  grep -r 'dl\.google\.com' /etc/apt >&2 2>/dev/null || echo "grep -r dl.google.com /etc/apt found nothing" >&2
+fi
 
 for attempt in 1 2 3; do
   if [ "$attempt" -ge 2 ]; then


### PR DESCRIPTION
## The fault

Since 17:16:59Z today, dl.google.com/linux/chrome-stable's Release file names
a Packages.gz sha (`233e56de...`) that no longer matches what the mirror
actually serves (`bc1428ab...`), both 1405 bytes. `apt-get update` fails
non-zero on that one index, which fails the whole update, which fails every
package this runner needs to install through it, whether or not the caller
ever asked for Chrome. `scripts/ci-apt-install.sh`'s three-attempt retry
swaps only the Azure Ubuntu mirror; the Chrome list is never touched, so
every attempt reproduces the same hash mismatch. It has killed the Windows
cross-check leg of kin #1650's Fast gate build and tests three times today.

## The fix, and why it took two commits

The first commit here removed `sources.list.d/google-chrome.list` before
the first `apt-get update`, the same pattern kinlab's `promote-to-prod.yml`
already carries for its own apt step. It did not clear the fault on this
PR's own Windows cross-check run: dl.google.com was still being fetched,
and still failing the same Hash Sum mismatch, on attempt 1. The actual file
on this runner, proven by the second commit's own diagnostic output below,
is `google-chrome.sources` (the newer DEB822 form), not `.list`.
`ci-apt-install.sh`'s own `drop_azure_mirror` function already globs both
`*.list` and `*.sources` when rewriting mirrors, which is this codebase's
own evidence that both forms are live on this runner fleet; a single
hardcoded filename was a guess about which.

The second commit matches by content instead: any of
`sources.list.d/*.list`, `sources.list.d/*.sources` and `sources.list`
itself, grepped for `dl.google.com`, and prints what it found and removed
(or the full listing and a content grep of `/etc/apt` when nothing
matched), so the run log is evidence rather than another guess.
`ci-apt-install.sh` is the shared wrapper behind every bounded apt install
in this repo (mingw-w64, musl-tools x3, gcc-aarch64-linux-gnu, ripgrep,
python3-venv), so this clears the fault for all of them, not just the
Windows cross-check.

## Evidence

Failing, kin #1650's Windows cross-check today, before either commit
(https://github.com/firelock-ai/kin/actions/runs/34383295748/job/102577710954):

```
Get:8 https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages [1405 B]
Err:8 https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages
  Hash Sum mismatch
  ...
E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz  Hash Sum mismatch
E: Some index files failed to download. They have been ignored, or old ones used instead.
apt attempt 3 of 3 failed for: mingw-w64
##[error]apt could not install after 3 bounded attempts: mingw-w64
```

Passing, this PR's own Windows cross-check, after the content-match commit
(https://github.com/firelock-ai/kin/actions/runs/34386934301/job/102585957106),
the fix's own diagnostic output, proving both the removal and which file it
actually was:

```
dropping the Chrome apt source(s), matched by content:
/etc/apt/sources.list.d/google-chrome.sources
sources.list.d after removal:
total 16
drwxr-xr-x 2 root root 4096 Sep  9 18:07 .
drwxr-xr-x 8 root root 4096 Aug 31 21:05 ..
-rw-r--r-- 1 root root  138 Aug 31 21:19 microsoft-prod.list
-rw-r--r-- 1 root root 2995 Sep  9 18:05 ubuntu.sources
```

A pull_request run uses this PR's own workflow and script files, so the
same step that failed on main's file had to pass here, on this same
Google-side fault, for either claim to mean anything. It did, on the
second commit; the first commit's own run on this PR is the negative
control that shows a plausible-looking fix still failing live.
