### PR TITLE
ci(install-proof): prove the real update path moves a real installation

### DIFF
--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -2140,10 +2140,27 @@ jobs:
   # filesystem and a real installed binary.
   update-proof:
     name: Update proof (N-1 to Latest)
-    # A pull request has no published release to update FROM, so this is for the
-    # release, schedule and dispatch paths. Guarding on the input rather than the
-    # event name matches the matrix above, which uses the same signal.
-    if: ${{ !inputs.local_artifact }}
+    # The weekly schedule and a manual dispatch are this job's witnesses, and
+    # the release path is excluded on purpose.
+    #
+    # release.yml creates every tag `prerelease: true, make_latest: false` and
+    # promotes it to Latest only after this workflow succeeds, then calls this
+    # workflow with `release_tag: ${{ github.ref_name }}`. So at the moment the
+    # job would run, the tag under test is not Latest yet, while `kin update`
+    # on the default stable channel resolves `/releases/latest`, which never
+    # returns a pre-release (crates/kin-cli/src/commands/update.rs,
+    # `resolve_release`). The updater would report "Already up to date" at N-1,
+    # correctly, the final assertion below would exit 1, and every job that
+    # needs `install_proof` to succeed would skip with it: npm publish, the
+    # boundary contracts, the version-tag image, and the promotion that makes
+    # the tag Latest in the first place. The job would fail every stable cut
+    # while proving nothing about the updater.
+    #
+    # A called workflow reads the CALLING run's `github` context, so this
+    # filter also excludes ci.yml's pull-request call, which arrives as `push`
+    # or `merge_group`, and the `release: published` trigger, which arrives as
+    # `release`.
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -2158,9 +2175,25 @@ jobs:
           # Ordered by publication date, which is what "the release before it"
           # has to mean here: an installation falls behind in publication order,
           # not in semver order.
-          mapfile -t tags < <(gh release list --repo "$GITHUB_REPOSITORY" \
+          #
+          # gh's exit code is captured on its own line, before the guard below
+          # can read it. `mapfile -t tags < <(gh ...)` runs gh in a subshell
+          # whose status neither `set -e` nor `pipefail` observes, so a 403 or a
+          # network flake yields an empty array that is indistinguishable from a
+          # repository with one published release, and the guard would then name
+          # the wrong cause.
+          rc=0
+          listing="$(gh release list --repo "$GITHUB_REPOSITORY" \
             --exclude-drafts --exclude-pre-releases --limit 5 \
-            --json tagName --jq '.[].tagName')
+            --json tagName --jq '.[].tagName')" || rc=$?
+          if [ "$rc" -ne 0 ]; then
+            echo "::error title=release listing failed::gh release list exited $rc"
+            echo "The GitHub release listing failed. That is an API failure, not" >&2
+            echo "an absent previous release, and reporting it as the latter would" >&2
+            echo "send a reader looking for a release that is published." >&2
+            exit 1
+          fi
+          mapfile -t tags < <(printf '%s' "$listing")
           latest="${RELEASE_EVENT_TAG:-${tags[0]:-}}"
           previous=""
           for t in "${tags[@]}"; do
@@ -2182,9 +2215,13 @@ jobs:
         env:
           PREVIOUS: ${{ steps.tags.outputs.previous }}
         run: |
-          set -eu
+          set -euo pipefail
           # Same installer and the same env contract as the proof above.
-          # KIN_NO_SETUP binds to `sh`, not to `curl`.
+          # KIN_NO_SETUP binds to `sh`, not to `curl`. pipefail is what makes a
+          # failed `curl` fail this step: `sh` reading an empty or truncated
+          # script exits 0, so without it the break surfaces a step later as a
+          # missing `kin` and reads as a broken binary rather than a dead
+          # endpoint.
           curl -fsSL https://get.kinlab.dev/install | \
             KIN_NO_SETUP=1 KIN_VERSION="${PREVIOUS#v}" sh
           echo "$HOME/.kin/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -2124,3 +2124,125 @@ jobs:
             kin-install-proof/.agents/mcp_config.json
             kin-install-proof/*.json
             kin-install-proof/*.log
+
+  # The founder's third directive for FIR-3442: prove the REAL update path moves
+  # a real installation, not just that its logic is right.
+  #
+  # Deliberately a separate job rather than a step in the one above. That job
+  # runs fifteen proof steps written against the release it installed, so
+  # installing N-1 at its top would falsify every one of them.
+  #
+  # What this proves that no crate test can: that real published bytes of the
+  # PREVIOUS release, installed by the real public installer, are moved to
+  # Latest by the real updater. The window arithmetic, the drift counting and
+  # the activity gate underneath are covered by crate tests on every pull
+  # request; this covers only the part that needs real archives, a real
+  # filesystem and a real installed binary.
+  update-proof:
+    name: Update proof (N-1 to Latest)
+    # A pull request has no published release to update FROM, so this is for the
+    # release, schedule and dispatch paths. Guarding on the input rather than the
+    # event name matches the matrix above, which uses the same signal.
+    if: ${{ !inputs.local_artifact }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Resolve Latest and the release published before it
+        id: tags
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_EVENT_TAG: ${{ inputs.release_tag || github.event.release.tag_name || '' }}
+        run: |
+          set -euo pipefail
+          # Ordered by publication date, which is what "the release before it"
+          # has to mean here: an installation falls behind in publication order,
+          # not in semver order.
+          mapfile -t tags < <(gh release list --repo "$GITHUB_REPOSITORY" \
+            --exclude-drafts --exclude-pre-releases --limit 5 \
+            --json tagName --jq '.[].tagName')
+          latest="${RELEASE_EVENT_TAG:-${tags[0]:-}}"
+          previous=""
+          for t in "${tags[@]}"; do
+            if [ "$t" != "$latest" ]; then previous="$t"; break; fi
+          done
+          if [ -z "$latest" ] || [ -z "$previous" ]; then
+            echo "::error title=no N-1 to prove against::latest='$latest' previous='$previous'"
+            echo "This job needs two published releases. Reporting the gap rather" >&2
+            echo "than passing quietly, because a silent skip here is how an" >&2
+            echo "updater regression reaches users." >&2
+            exit 1
+          fi
+          echo "latest=$latest" >> "$GITHUB_OUTPUT"
+          echo "previous=$previous" >> "$GITHUB_OUTPUT"
+          echo "proving $previous -> $latest"
+
+      - name: Install the PREVIOUS release through the real public installer
+        shell: bash
+        env:
+          PREVIOUS: ${{ steps.tags.outputs.previous }}
+        run: |
+          set -eu
+          # Same installer and the same env contract as the proof above.
+          # KIN_NO_SETUP binds to `sh`, not to `curl`.
+          curl -fsSL https://get.kinlab.dev/install | \
+            KIN_NO_SETUP=1 KIN_VERSION="${PREVIOUS#v}" sh
+          echo "$HOME/.kin/bin" >> "$GITHUB_PATH"
+
+      - name: Assert the installation really starts behind
+        shell: bash
+        env:
+          PREVIOUS: ${{ steps.tags.outputs.previous }}
+        run: |
+          set -euo pipefail
+          got="$(kin --version)"
+          echo "installed: $got"
+          # Without this assertion a no-op passes. If the installer quietly
+          # served Latest, the update below would "succeed" having moved
+          # nothing, and this job would report a working updater forever.
+          case "$got" in
+            *"${PREVIOUS#v}"*) echo "starts at ${PREVIOUS}, as required" ;;
+            *) echo "::error title=did not start from N-1::wanted ${PREVIOUS#v}, got '$got'"
+               exit 1 ;;
+          esac
+
+      - name: Run the real update path
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The product command the update watchdog invokes. No --force-window:
+          # a runner holds no managed daemon or VFS server, so the activity gate
+          # says proceed and this exercises the NATURAL path. A forced arm is
+          # worth adding beside it later; it is a different code path.
+          kin update --unattended | tee update-record.json
+          echo "--- ledger ---"
+          cat "$HOME/.kin/update-ledger.jsonl" || true
+
+      - name: Assert the installation actually moved to Latest
+        shell: bash
+        env:
+          LATEST: ${{ steps.tags.outputs.latest }}
+          PREVIOUS: ${{ steps.tags.outputs.previous }}
+        run: |
+          set -euo pipefail
+          got="$(kin --version)"
+          echo "after update: $got"
+          case "$got" in
+            *"${LATEST#v}"*)
+              echo "the real update path moved ${PREVIOUS} to ${LATEST}" ;;
+            *)
+              echo "::error title=update did not converge::still '$got', wanted ${LATEST#v}"
+              echo "The updater ran and the installed binary did not move. That is" >&2
+              echo "the FIR-3442 failure, and catching it here is why this job" >&2
+              echo "exists." >&2
+              exit 1 ;;
+          esac
+
+      - name: Preserve the update record
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: kin-update-proof
+          path: |
+            update-record.json
+          if-no-files-found: warn

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -805,9 +805,12 @@ EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
         "install-proof": "${{ matrix.os }}",
         # FIR-3442. Proves the real update path moves a real installation from
         # the previously published release to Latest. It produces no required
-        # check context; it gates the release the way every other leg of this
-        # workflow does, which is the point: a broken updater matters most at
-        # exactly the moment a release is cut.
+        # check context, and unlike every other leg of this workflow it does
+        # not gate a release: its witnesses are the weekly schedule and a
+        # manual dispatch. A release tag is still a pre-release while this
+        # workflow runs, so the stable channel would correctly refuse to move
+        # and the job would fail every cut.
+        # `assert_update_proof_stays_off_the_release_path` holds that scoping.
         "update-proof": "Update proof (N-1 to Latest)",
     },
     # The dependency receiver validates the exact payload, prepares and compiles
@@ -4023,6 +4026,126 @@ def assert_install_proof_every_leg_gates_the_release(install_proof: str) -> None
         raise AssertionError(
             "install-proof release matrix must gate exactly "
             f"{expected_platforms}; found {release_platforms}"
+        )
+
+
+# The one admitted scoping for the N-1 update proof, spelled exactly so a
+# condition written any other way fails rather than passing as "some filter".
+UPDATE_PROOF_ADMITTED_EVENT_FILTER = (
+    "${{ github.event_name == 'schedule' "
+    "|| github.event_name == 'workflow_dispatch' }}"
+)
+
+
+def assert_update_proof_stays_off_the_release_path(install_proof: str) -> None:
+    """Keep the N-1 update proof on schedule and dispatch, never on a release.
+
+    The job installs the previously published release and requires the real
+    updater to move it to Latest. On the release path that assertion cannot
+    hold, and is not supposed to. release.yml creates every tag
+    ``prerelease: true, make_latest: false`` and promotes it to Latest only
+    after this workflow succeeds, while ``kin update`` on the default stable
+    channel resolves ``/releases/latest``, which never returns a pre-release.
+    The tag under test is therefore not Latest while the job runs, the updater
+    correctly reports the installation already current at N-1, the final
+    assertion exits 1, and every job needing ``install_proof`` to succeed skips
+    with it: npm publish, the boundary contracts, the version-tag image, and
+    the promotion that would have made the tag Latest. The job would fail every
+    stable cut while proving nothing about the updater.
+
+    So the scoping is the property, pinned as the exact expression. A filter
+    written any other way, including one that also admitted ``push``, returns
+    the job to the release path, and a called workflow reads the CALLING run's
+    ``github`` context, so ``push`` is exactly what the release arrives as.
+
+    Two smaller properties of the same job ride here, because each is the
+    difference between a true report and a plausible one. The release listing
+    captures gh's exit code on its own line: ``mapfile -t tags < <(gh ...)``
+    runs gh in a subshell whose status neither ``set -e`` nor ``pipefail``
+    observes, so a 403 would produce an empty array and report an absent
+    previous release for what is really an API failure. And the installer step
+    runs under ``pipefail``, because ``sh`` reading a truncated download exits
+    0 and a dead endpoint would surface a step later as a missing binary.
+    """
+
+    jobs = workflow_job_blocks(install_proof)
+    update_proof = jobs.get("update-proof")
+    if update_proof is None:
+        raise AssertionError(
+            "install-proof must keep the update-proof job; it is the only "
+            "witness that the real updater moves a real installation"
+        )
+    conditions = [
+        value.strip()
+        for key, value in job_top_level_mapping_fields(update_proof)
+        if key == "if"
+    ]
+    if conditions != [UPDATE_PROOF_ADMITTED_EVENT_FILTER]:
+        raise AssertionError(
+            "the update proof runs on the weekly schedule and on a manual "
+            "dispatch and on nothing else. On the release path the tag under "
+            "test is still a pre-release, so the updater refuses to move and "
+            "the job fails every cut; admitted "
+            f"{[UPDATE_PROOF_ADMITTED_EVENT_FILTER]}, found {conditions}"
+        )
+
+    resolve = install_proof_step(
+        install_proof, "Resolve Latest and the release published before it"
+    )
+    resolve_lines = active_lines(resolve)
+    hidden_listing = [
+        line for line in resolve_lines if "mapfile" in line and "gh release list" in line
+    ]
+    if hidden_listing:
+        raise AssertionError(
+            "the release listing must not run gh inside a process "
+            "substitution: neither `set -e` nor `pipefail` sees its status, so "
+            "an API failure becomes an empty array and reads as an absent "
+            f"previous release; found {hidden_listing}"
+        )
+    rc_capture = "--json tagName --jq '.[].tagName')\" || rc=$?"
+    rc_guard = 'if [ "$rc" -ne 0 ]; then'
+    for policy in (rc_capture, rc_guard):
+        if policy not in resolve_lines:
+            raise AssertionError(
+                "the release listing must capture gh's exit code on its own "
+                f"line and refuse on it; missing `{policy}`"
+            )
+    gap_guard = [line for line in resolve_lines if "no N-1 to prove against" in line]
+    if not gap_guard:
+        raise AssertionError(
+            "the release listing must still report an absent previous release; "
+            "an API guard that swallowed that case would trade one wrong cause "
+            "for another"
+        )
+    if resolve_lines.index(rc_guard) > resolve_lines.index(gap_guard[0]):
+        raise AssertionError(
+            "the API-failure refusal must come before the absent-release "
+            "refusal, or a failed listing still reports the wrong cause"
+        )
+
+    install = install_proof_step(
+        install_proof,
+        "Install the PREVIOUS release through the real public installer",
+    )
+    install_lines = active_lines(install)
+    piped_install = [
+        line
+        for line in install_lines
+        if line.startswith("curl ") and line.endswith("| \\")
+    ]
+    if not piped_install:
+        raise AssertionError(
+            "the update proof must install through the real public installer "
+            "piped into `sh`; without that pipe the pipefail requirement below "
+            "guards nothing"
+        )
+    if "set -euo pipefail" not in install_lines:
+        raise AssertionError(
+            "the update proof's installer step runs under pipefail: `sh` "
+            "reading a truncated download exits 0, so a dead endpoint would "
+            "surface a step later as a missing `kin` and read as a broken "
+            f"binary; found {[line for line in install_lines if line.startswith('set ')]}"
         )
 
 
@@ -12828,6 +12951,91 @@ def main() -> None:
             expected,
             lambda mutated=install_proof.replace(original, mutation, 1): (
                 assert_install_proof_every_leg_gates_the_release(mutated)
+            ),
+        )
+
+    assert_update_proof_stays_off_the_release_path(install_proof)
+    update_proof_job = workflow_job_blocks(install_proof)["update-proof"]
+    for label, original, mutation, expected in (
+        (
+            "the update proof loses its scoping and returns to every cut",
+            "    if: ${{ github.event_name == 'schedule' "
+            "|| github.event_name == 'workflow_dispatch' }}\n",
+            "",
+            "and on nothing else",
+        ),
+        (
+            "the release path is admitted beside the two witnesses",
+            "|| github.event_name == 'workflow_dispatch' }}\n",
+            "|| github.event_name == 'workflow_dispatch' "
+            "|| github.event_name == 'push' }}\n",
+            "and on nothing else",
+        ),
+        (
+            "the scoping is spelled as an exclusion instead",
+            "    if: ${{ github.event_name == 'schedule' "
+            "|| github.event_name == 'workflow_dispatch' }}\n",
+            "    if: ${{ github.event_name != 'pull_request' }}\n",
+            "and on nothing else",
+        ),
+        (
+            "the whole update proof is dropped rather than scoped",
+            update_proof_job,
+            "",
+            "must keep the update-proof job",
+        ),
+        (
+            "the release listing goes back inside a process substitution",
+            '          rc=0\n          listing="$(gh release list',
+            "          mapfile -t tags < <(gh release list",
+            "must not run gh inside a process",
+        ),
+        (
+            "the API-failure refusal stops refusing",
+            '          if [ "$rc" -ne 0 ]; then\n',
+            "          if false; then\n",
+            "capture gh's exit code on its own line",
+        ),
+        (
+            "the API guard swallows the absent-release report",
+            '            echo "::error title=no N-1 to prove against::'
+            "latest='$latest' previous='$previous'\"\n",
+            "",
+            "must still report an absent previous release",
+        ),
+        (
+            "the API refusal is moved below the absent-release refusal",
+            "          rc=0\n",
+            '          echo "::error title=no N-1 to prove against::moved"\n'
+            "          rc=0\n",
+            "must come before the absent-release refusal",
+        ),
+        (
+            "the installer step loses pipefail and swallows a dead endpoint",
+            "          set -euo pipefail\n"
+            "          # Same installer and the same env contract as the proof above.\n",
+            "          set -eu\n"
+            "          # Same installer and the same env contract as the proof above.\n",
+            "runs under pipefail",
+        ),
+        (
+            "the installer stops piping the real download into sh",
+            "          curl -fsSL https://get.kinlab.dev/install | \\\n"
+            '            KIN_NO_SETUP=1 KIN_VERSION="${PREVIOUS#v}" sh\n',
+            '          KIN_NO_SETUP=1 KIN_VERSION="${PREVIOUS#v}" sh ./install.sh\n',
+            "piped into `sh`",
+        ),
+    ):
+        if original not in install_proof:
+            raise AssertionError(
+                "update-proof scoping falsification lost fixture for "
+                f"{label}: {original!r}"
+            )
+        expect_assertion(
+            label,
+            expected,
+            lambda mutated=install_proof.replace(original, mutation, 1): (
+                assert_update_proof_stays_off_the_release_path(mutated)
             ),
         )
 

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -803,6 +803,12 @@ EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
     },
     ".github/workflows/install-proof.yml": {
         "install-proof": "${{ matrix.os }}",
+        # FIR-3442. Proves the real update path moves a real installation from
+        # the previously published release to Latest. It produces no required
+        # check context; it gates the release the way every other leg of this
+        # workflow does, which is the point: a broken updater matters most at
+        # exactly the moment a release is cut.
+        "update-proof": "Update proof (N-1 to Latest)",
     },
     # The dependency receiver validates the exact payload, prepares and compiles
     # candidate registry bytes without a write credential, then admits only the


### PR DESCRIPTION
Refs FIR-3442. Draft: opened for review of the shape, with a real dispatched run
as its evidence rather than prose.

#1650 closed the reason an installed kin stopped converging across releases, and
its logic is guarded by crate tests that run on every pull request. What no crate
test can show is that real published bytes of the previous release, installed by
the real public installer, are actually moved to Latest by the real updater. That
is the half needing real archives, a real filesystem and a real installed binary,
and it is the founder's third directive on this ticket.

## Why a job and not a step

The existing `install-proof` job runs fifteen proof steps written against the
release it installed: the admission contract, first-run repository and daemon,
graph query and MCP tool calls, VFS projection, embedding and semantic retrieval,
capability validation. Installing N-1 at the top of that job would falsify every
one of them. So this is a sibling job.

## What it asserts, and the one assertion that matters

Resolve Latest and the release published before it, install the previous one
through the same `get.kinlab.dev` installer the public proof already uses, assert
the binary really reports N-1, run `kin update --unattended`, then assert it now
reports Latest.

The middle assertion is load-bearing. Without it a no-op passes: if the installer
quietly served Latest, the update would "succeed" having moved nothing and this
job would report a working updater forever. That is the same class of defect as
the bug being guarded, a check that cannot fail, so it is worth stating plainly
rather than leaving to a reader to notice.

Ordering is by publication date, not semver, because an installation falls behind
in publication order. With fewer than two published releases the job fails loudly
rather than skipping, since a silent skip is how an updater regression reaches
users.

No `--force-window`. A runner holds no managed daemon or VFS server, so the
activity gate says proceed and this exercises the NATURAL path, which is the one
that never once fired on the incident machine. A forced arm is worth adding
beside it later; it is a different code path and deserves its own assertions.

## Where it runs, and why not on a release

The job is scoped to the weekly schedule and a manual dispatch. It is NOT on the
release path, and that is the correction this branch carries over its first
revision.

The first revision ran on every path this workflow reaches, which would have
failed every stable cut. `release.yml` creates each tag with `prerelease: true`
and `make_latest: false` and promotes it to Latest only after `install_proof`
succeeds, then calls this workflow with that same tag. `kin update` on the
default stable channel resolves `/releases/latest`, which by
`crates/kin-cli/src/commands/update.rs` never returns a pre-release. So at the
instant the job would have run, Latest is still N-1, which is the exact release
the job had just installed. The updater would have correctly reported the
installation already current, the final assertion would have exited 1, and
`install_proof` failing would have skipped npm publish, the boundary contracts,
the version-tag image and the promotion itself. The job would have failed every
cut while proving nothing about the updater.

The scoping is one line:

```yaml
    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
```

Two smaller fixes ride with it, each the difference between a true report and a
plausible one. The release listing now captures gh's exit code on its own line,
because `mapfile -t tags < <(gh ...)` runs gh in a subshell whose status neither
`set -e` nor `pipefail` observes, so a 403 produced an empty array and reported
an absent previous release. And the installer step runs under `pipefail`, because
`sh` reading a truncated download exits 0 and a dead endpoint surfaced a step
later as a missing binary.

## The job census

`assert_workflow_job_census` in `scripts/test-release-workflow-authority.py` pins
every job in every workflow so a second required-check producer cannot appear
unreviewed. It refused this change until the new job was added to that census
explicitly, which is the guard working. The job produces no required context, and
unlike every other leg of this workflow it does not gate a release; the census
comment beside it now says so.

## Evidence

`install-proof.yml` has no `pull_request` trigger, so this arm cannot be
exercised by the pull request itself. Per the Lane Contract, every claim below is
a command and its output rather than prose.

### 1. The scoping is pinned by a check that goes red without it

`assert_update_proof_stays_off_the_release_path` was added to
`scripts/test-release-workflow-authority.py`, which three ci.yml jobs run:
`npm launcher tests` (`ci.yml:126`), `Fast gate lint and policy` (`:1314`) and
`check` (`:2011`). The first two carry no job-level `if`, and
`Fast gate lint and policy` is one of the seven required contexts on `main`. So
unlike the job it guards, this check IS graded on the pull request, by a
required context.

Removed the `if:` from the workflow, ran the suite, put it back, ran it again:

```
$ python3 scripts/test-release-workflow-authority.py     # if: removed
PROOF_ASSET_HASHES_VERIFIED
STARTUP_PROOF_READINESS_AND_PRECONDITION_CONTROLS_PASS
Traceback (most recent call last):
  File ".../scripts/test-release-workflow-authority.py", line 17866, in <module>
    main()
  File ".../scripts/test-release-workflow-authority.py", line 12957, in main
    assert_update_proof_stays_off_the_release_path(install_proof)
  File ".../scripts/test-release-workflow-authority.py", line 4084, in assert_update_proof_stays_off_the_release_path
    raise AssertionError(
AssertionError: the update proof runs on the weekly schedule and on a manual dispatch and on nothing else. On the release path the tag under test is still a pre-release, so the updater refuses to move and the job fails every cut; admitted ["${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}"], found []
EXIT: 1

$ python3 scripts/test-release-workflow-authority.py     # restored
PROOF_ASSET_HASHES_VERIFIED
STARTUP_PROOF_READINESS_AND_PRECONDITION_CONTROLS_PASS
release workflow authority is reviewed-PR to App-tag automatic, protected, pinned, GCP-free on release writes, cross-platform byte-canonical, with dev-only Artifact Registry OIDC and npm automatic through short-lived OIDC with post-public proof
EXIT: 0
```

The green run is not merely a pass. `expect_assertion` raises "falsification did
not fail" when a mutation does not go red, so exit 0 means all ten arms went red
under mutation: the `if` deleted, `push` admitted beside the two witnesses, the
filter rewritten as `!= 'pull_request'`, the whole job dropped, gh put back
inside a process substitution, the rc refusal neutered, the absent-release report
swallowed, the rc refusal moved below it, `pipefail` dropped, and the curl pipe
replaced by a local `sh ./install.sh`.

### 2. The release path really does arrive as `push`

The scoping only works if a called workflow's jobs see the caller's event. They
do, and two completed runs are the receipt:

```
$ gh api repos/firelock-ai/kin/actions/runs/34358902503 \
    --jq '"run \(.id)  event=\(.event)  name=\(.name)  head_branch=\(.head_branch)"'
run 34358902503  event=push  name=Release  head_branch=v0.7.7

$ gh api "repos/firelock-ai/kin/actions/runs/34358902503/jobs?per_page=100" \
    --jq '.jobs[] | select(.name | test("Install Proof")) | "\(.name)  \(.conclusion)"'
Public Install Proof / ubuntu-latest  success
Public Install Proof / windows-latest  success
Public Install Proof / macos-15-intel  success
Public Install Proof / macos-latest  success
Public Install Proof / ubuntu-24.04-arm  success

$ gh api repos/firelock-ai/kin/actions/runs/34419252963 --jq '...'
run 34419252963  event=push  name=CI  head_branch=main

$ gh api "repos/firelock-ai/kin/actions/runs/34419252963/jobs?per_page=100" \
    --jq '.jobs[] | select(.name | test("Install Proof \\(PR\\) /")) | "\(.name)  \(.conclusion)"'
Install Proof (PR) / ubuntu-latest  success
```

This workflow's legs execute inside the caller's run, and both callers' runs
carry `event=push`. Neither is `schedule` nor `workflow_dispatch`, so both are
skipped.

### 3. The live witness on this head

```
$ gh workflow run install-proof.yml --repo firelock-ai/kin --ref chore/lane-updater-installproof
https://github.com/firelock-ai/kin/actions/runs/34422467122

$ gh api repos/firelock-ai/kin/actions/runs/34422467122 \
    --jq '"run \(.id)  event=\(.event)  head_sha=\(.head_sha)"'
run 34422467122  event=workflow_dispatch  head_sha=989b0c3b1d28b1e5b7e9abe6466a7df27ef94700

$ gh api "repos/firelock-ai/kin/actions/runs/34422467122/jobs?per_page=100" \
    --jq '.jobs[] | select(.name | test("Update proof")) | "job \(.id)  \(.name)  \(.conclusion)  \(.started_at) -> \(.completed_at)"'
job 102700670052  Update proof (N-1 to Latest)  success  2026-09-10T00:43:10Z -> 2026-09-10T00:43:28Z
```

Log lines from `gh api repos/firelock-ai/kin/actions/jobs/102700670052/logs`,
line numbers kept, timestamps stripped:

```
 77  proving v0.7.6 -> v0.7.7
135  installed: kin 0.7.6 (64174f30e9ffa107510bbebb8072f1be375cd77f detached 2026-09-09T08:49:59Z)
136  starts at v0.7.6, as required
222  {"schema":"kin.update-unattended.v1","at":"2026-09-10T00:43:16.470952093+00:00","policy":"auto","decision":"proceed","forced":false,"from_version":"0.7.6","to_version":"0.7.7","update_available":true,"window_seconds":86400,"steps":["stopped managed daemons and supervisor cooperatively","install the release","acknowledge the restart fence","repair agent configs"],"outcome":"applied"}
244  after update: kin 0.7.7 (6697b8f99d072fd6221d47babbb263effd954c89 detached 2026-09-09T13:47:14Z)
245  the real update path moved v0.7.6 to v0.7.7
```

`"decision":"proceed"` with `"forced":false` is the NATURAL path converging,
which is precisely what never happened on the incident machine: across 37 ledger
entries there was not one `proceed`, and every convergence was a forced one. The
install step ran under the new `pipefail` and the job still passed, so the added
`-o pipefail` did not break the real installer.

### 4. A gh failure now names itself instead of wearing an absent release

The step body was extracted from the workflow rather than retyped, and run in a
`bash:5.2` container, because macOS ships bash 3.2 and `mapfile` does not exist
there. One stub `gh` per arm; `step-before.sh` comes from `git show HEAD~1:`.

```
$ bash falsify-rc-capture.sh
=== ARM: BEFORE the fix, gh fails (step=step-before.sh, gh=fail) ===
gh: HTTP 403: API rate limit exceeded
::error title=no N-1 to prove against::latest='' previous=''
This job needs two published releases. Reporting the gap rather
than passing quietly, because a silent skip here is how an
updater regression reaches users.
--- exit: 1 ---

=== ARM: AFTER the fix, gh fails (step=step-after.sh, gh=fail) ===
gh: HTTP 403: API rate limit exceeded
The GitHub release listing failed. That is an API failure, not
an absent previous release, and reporting it as the latter would
send a reader looking for a release that is published.
::error title=release listing failed::gh release list exited 1
--- exit: 1 ---

=== ARM: AFTER the fix, one published release (step=step-after.sh, gh=one) ===
::error title=no N-1 to prove against::latest='v0.7.7' previous=''
This job needs two published releases. Reporting the gap rather
than passing quietly, because a silent skip here is how an
updater regression reaches users.
--- exit: 1 ---

=== ARM: AFTER the fix, two published releases (step=step-after.sh, gh=two) ===
proving v0.7.6 -> v0.7.7
--- exit: 0 ---
```

Arm 1 is the defect. Arm 2 is the fix. Arm 3 is the positive control that the new
API guard did not swallow the real absent-release case, and arm 4 is the happy
path. The `::error` line is stdout and the explanation beneath it is stderr, so
the two interleave differently between runs; the lines themselves do not.

### 5. Local gates

```
$ bin/kin-precheck kin --repo-dir kin=<this worktree>
kin-precheck: repo=kin tree=.../worktrees/updater-kin sha=989b0c3b1d28b1e5b7e9abe6466a7df27ef94700 branch=chore/lane-updater-installproof
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
...
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 989b0c3b1d28b1e5b7e9abe6466a7df27ef94700
```

## The pin label discrepancy, now resolved

Still not fixed here, because it is unrelated to this change, but it is no longer
open as a question. `actions/upload-artifact` is pinned to the same commit
`043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` across this repo, and the git refs say
which label is right:

```
$ gh api repos/actions/upload-artifact/git/ref/tags/v7.0.1 --jq .object.sha
043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
$ gh api repos/actions/upload-artifact/git/ref/tags/v7.0.0 --jq .object.sha
bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
```

So `install-proof.yml`'s `# v7.0.1` is correct and `release.yml`, `rc-build.yml`
and `release-cut.yml` carry the wrong label on that sha. The sha is what pins, so
nothing is unsafe. It belongs in a hygiene pass, not in this diff.

## One hazard, flagged rather than buried

The apply chain calls `kin setup doctor --fix`, which rewrites agent MCP configs
in `$HOME`. On a disposable runner that is harmless, and it is another reason
install-proof is the right home for this and a developer box is the wrong one.
Anyone who later wants to run this locally needs an isolated `HOME`, not just an
isolated `KIN_HOME`.
