### PR TITLE
Install the macOS preflight leg's language servers and keep its receipts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1042,6 +1042,15 @@ jobs:
       - name: Test bounded brownfield trace witnesses
         run: python3 scripts/acceptance/test_brownfield_trace_witness.py
 
+      # magic-repro case 16 reads two surfaces and decides whether they agree,
+      # and acceptance.yml never grades that reading on a pull request. kin#1642
+      # added the arm and the daemon route it exercises in one commit, and the
+      # first thing to run it was a release cut, which then failed three times
+      # on a correct answer. The reading is pure and needs no repo or daemon,
+      # so it is graded here, where a pull request can see it.
+      - name: Test magic-repro case 16's surface reading
+        run: python3 scripts/acceptance/test_magic_repro_case16.py
+
       # Here rather than in `check`, for the reason the step above records: a
       # script step in `check` is a gate `bin/kin-precheck` enumerates and must
       # classify by name, and one wired there without the matching umbrella

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -359,6 +359,40 @@ jobs:
       # shape running once an untrusted artifact is already in the workspace
       # (alert firelock-ai/kin#145). This step never reads the archive, so
       # there is no reason for it to run after it lands.
+      # Was inline in "Judge the archive" below, which is one step too late.
+      # The language-server install underneath bounds npm with GNU timeout, a
+      # macOS runner has none, and on run 34395244305 all three of its attempts
+      # died on `timeout: command not found` between 19:28:56Z and 19:29:26Z.
+      # Six seconds after it gave up, the judge step installed coreutils. The
+      # leg then ran its whole acceptance suite with no language server, and
+      # magic-repro case 16 correctly refused to certify a Python absence Kin
+      # could never have linked, which read as a product regression and stopped
+      # three consecutive cuts. Hoisting it costs six measured seconds and the
+      # judge step still re-checks, so a future edit that drops this one
+      # degrades rather than breaks.
+      - name: Give the runner a GNU timeout
+        if: runner.os == 'macOS'
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: |
+          set -euo pipefail
+          if timeout --version >/dev/null 2>&1; then
+            echo "GNU timeout already present: $(command -v timeout)"
+            exit 0
+          fi
+          brew install coreutils
+          # Homebrew installs GNU timeout as `gtimeout` unless gnubin is on
+          # PATH, and the consumers below resolve either name, so prove one of
+          # them answers rather than trusting the install's exit code.
+          for candidate in timeout gtimeout; do
+            if "$candidate" --version 2>/dev/null | grep -q GNU; then
+              echo "GNU timeout available as ${candidate}"
+              exit 0
+            fi
+          done
+          echo "::error::coreutils installed but neither timeout nor gtimeout answers as GNU"
+          exit 1
+
       - name: Install language servers for the enrichment checks
         run: bash scripts/ci-install-language-servers.sh
 

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -477,6 +477,60 @@ jobs:
           mkdir -p "$RUNNER_TEMP/leg"
           cp "$record" "$RUNNER_TEMP/leg/preflight.json"
 
+      # The leg's receipts, not just its verdict. A published record
+      # (kin.release-preflight.leg.v1) keeps only {id, ticket, status, detail}
+      # per magic-repro check, and a failing leg publishes no record at all, so
+      # a failing check's own evidence lived on the runner's temp disk and died
+      # with it. On 2026-09-09 three cuts failed naming "16/FIR-2524 FAIL:
+      # healthy isolated empty control did not certify plainly on both
+      # surfaces" and nobody could say which surface disagreed, because the MCP
+      # payload and CLI stdout that check stores in its own receipt were never
+      # uploaded. `repro.json` carries them under results[].asserts[].receipt.
+      # `always()`, because a failing leg is the one whose receipts are wanted.
+      - name: Preserve this leg's preflight receipts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: kin-preflight-receipts-${{ matrix.artifact }}
+          path: |
+            ${{ runner.temp }}/kpf/preflight.log
+            ${{ runner.temp }}/kpf/preflight.json
+            ${{ runner.temp }}/kpf/legs/*/repro.json
+            ${{ runner.temp }}/kpf/legs/*/repro.log
+            ${{ runner.temp }}/kpf/legs/*/result.json
+            ${{ runner.temp }}/kpf/legs/*/steps.tsv
+            ${{ runner.temp }}/kpf/legs/*/validate.json
+            ${{ runner.temp }}/kpf/legs/*/logs/*.log
+          if-no-files-found: warn
+          retention-days: 7
+
+      # `if-no-files-found: warn` above cannot tell a wrong glob from a leg
+      # that never started, and a silent miss costs another cut cycle to
+      # notice. So say plainly what was there to collect, on the same
+      # condition, and treat an empty run root as its own annotation.
+      - name: Say which receipts this leg produced
+        if: always()
+        run: |
+          set -uo pipefail
+          root="$RUNNER_TEMP/kpf"
+          if [ ! -d "$root" ]; then
+            echo "::warning::the preflight created no run root at ${root}, so no receipt was collected"
+            exit 0
+          fi
+          found=0
+          while IFS= read -r file; do
+            found=$((found + 1))
+            echo "receipt: ${file#"$root"/} ($(wc -c < "$file" | tr -d ' ') bytes)"
+          done < <(find "$root" -maxdepth 4 -type f \
+            \( -name 'repro.json' -o -name 'repro.log' -o -name 'result.json' \
+               -o -name 'steps.tsv' -o -name 'validate.json' -o -name 'preflight.*' \
+               -o -path '*/legs/*/logs/*.log' \) | sort)
+          if [ "$found" -eq 0 ]; then
+            echo "::warning::${root} exists but holds none of the receipt files this job uploads"
+          else
+            echo "${found} receipt file(s) under ${root}"
+          fi
+
       - name: Prove startup recovery across native daemon restarts
         if: matrix.artifact == 'kin-macos-aarch64'
         run: |

--- a/scripts/acceptance/magic_repro.py
+++ b/scripts/acceptance/magic_repro.py
@@ -2793,6 +2793,94 @@ def check_15(suite):
 # that answers an absence question (crates/kin-cli/src/commands/absence_qualifier.rs).
 CANNOT_RULE_OUT = re.compile(r"Kin cannot rule out ", re.I)
 
+# The one enrichment gap that belongs to the HOST rather than to the build.
+# `crates/kin-mcp/src/verdict.rs` publishes this sentence when an adapter IS
+# wired for the language and no server for it is installed here, and the
+# neighbouring `reference_enrichment_unsupported:` when the build wires no
+# adapter at all. Only the first is an environment fact; the second would be a
+# real regression if it appeared for a language Kin ships an adapter for.
+#
+# The `edge_coverage:` label cannot be the key, because
+# `crates/kin-mcp/src/negative.rs` pushes one string,
+# `edge_coverage:reference_enrichment_unsupported`, for BOTH states. That label
+# is all the CLI carries, so the MCP verdict is what tells the two apart and
+# the CLI is only asked to agree that its refusal is the same class.
+NO_LANGUAGE_SERVER = "reference_enrichment_no_language_server"
+ENRICHMENT_CLASS = "reference_enrichment_unsupported"
+
+
+def host_lacks_reference_enrichment(payload, cli_text):
+    """Both surfaces name THIS HOST's missing language server, in agreement.
+
+    Returns the verdict's own sentence, so a caller quotes a reason it read
+    rather than one it composed, or None. Both surfaces are required: half of
+    this is the surface disagreement FIR-2524 exists to catch, and must stay a
+    failure rather than become an excuse.
+    """
+    verdict = (payload.get("_kin") or {}).get("verdict") or {}
+    negative = payload.get("negative") or {}
+    limiting = str(verdict.get("limiting_factor") or "")
+    trust = str(negative.get("trust_reason") or "")
+    if NO_LANGUAGE_SERVER not in limiting and NO_LANGUAGE_SERVER not in trust:
+        return None
+    if not CANNOT_RULE_OUT.search(cli_text) or ENRICHMENT_CLASS not in cli_text:
+        return None
+    return limiting or trust
+
+
+def certification_arm_reading(payload, cli):
+    """Read the healthy empty control's two surfaces: (status, detail).
+
+    Every condition that gated a PASS still gates one, and the conditions are
+    unchanged. What changed is the two ways the arm used to lie about a
+    non-pass, both of which it told on 2026-09-09 while three Release Cut runs
+    failed on a correct answer.
+
+    It reported "did not certify plainly on both surfaces" whichever condition
+    tripped, which reads as a disagreement between the surfaces. There was
+    none: both refused, together, for the same reason. So a failure now names
+    the conditions that actually tripped.
+
+    And it reported FAIL on a host that could never have produced the edge the
+    arm asks about, because no language server for the fixture's language was
+    installed on it. Refusing to certify there is Kin answering correctly. An
+    arm whose own premise the host cannot satisfy was not graded, so it reads
+    UNREADABLE, which still stops a release cut and no longer blames the
+    product for the runner. The gap branch demands that everything else about
+    the answer be right and that BOTH surfaces refuse in agreement, so the only
+    difference between it and a PASS is the shared qualifier.
+    """
+    stdout = cli.get("stdout") or ""
+    text = stdout + (cli.get("stderr") or "")
+    certified = (payload.get("negative") or {}).get("safe_to_conclude_absent")
+    named_absence = "No incoming Calls relations." in stdout
+    qualifier = CANNOT_RULE_OUT.search(text)
+
+    tripped = []
+    if certified is not True:
+        tripped.append("MCP negative.safe_to_conclude_absent is %s, not true"
+                       % json.dumps(certified))
+    if cli.get("exit_code") != 0:
+        tripped.append("the CLI exited %s" % json.dumps(cli.get("exit_code")))
+    if not named_absence:
+        tripped.append('the CLI never printed "No incoming Calls relations."')
+    if qualifier:
+        tripped.append("the CLI qualified the answer: %s"
+                       % text[qualifier.start():qualifier.start() + 160].strip())
+    if not tripped:
+        return PASS, "healthy isolated empty control certifies plainly on both surfaces"
+
+    gap = host_lacks_reference_enrichment(payload, text)
+    if (gap and certified is False and qualifier
+            and cli.get("exit_code") == 0 and named_absence):
+        return UNREADABLE, (
+            "this host cannot satisfy the arm's own premise, so the arm was not graded: both "
+            "surfaces refuse the absence in agreement and the verdict says %s. Install a "
+            "language server for the fixture's language on this runner "
+            "(scripts/ci-install-language-servers.sh) and the arm grades again." % gap)
+    return FAIL, ("healthy isolated empty control did not certify plainly on both surfaces: %s"
+                  % "; ".join(tripped))
+
 
 def check_16(suite):
     """FIR-2524 rung three: the CLI must carry the verdict MCP publishes, on the
@@ -2934,13 +3022,8 @@ def check_16(suite):
     before, receipt = paired_probe()
     if resolution_miss(before, focal) or before.get("references"):
         res.bad("isolated empty control did not resolve an unreferenced focal")
-    elif ((before.get("negative") or {}).get("safe_to_conclude_absent") is not True
-          or receipt["cli"]["exit_code"] != 0
-          or "No incoming Calls relations." not in receipt["cli"]["stdout"]
-          or CANNOT_RULE_OUT.search(receipt["cli"]["stdout"] + receipt["cli"]["stderr"])):
-        res.bad("healthy isolated empty control did not certify plainly on both surfaces")
     else:
-        res.ok("healthy isolated empty control certifies plainly on both surfaces")
+        res.add(*certification_arm_reading(before, receipt["cli"]))
     res.asserts[-1]["receipt"] = receipt
     if res.asserts[-1]["status"] != PASS:
         return res

--- a/scripts/acceptance/test_magic_repro_case16.py
+++ b/scripts/acceptance/test_magic_repro_case16.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+"""Grade how magic-repro case 16 reads its two surfaces, no repo, no daemon.
+
+Why this file exists
+--------------------
+On 2026-09-09 the release train stopped for an evening. Release Cut failed
+three times running on `Preflight kin-macos-aarch64` with
+
+    16/FIR-2524 FAIL: healthy isolated empty control did not certify plainly
+    on both surfaces
+
+and both Linux legs passed every time. The message reads as a disagreement
+between the CLI and MCP. There was none. Both surfaces refused the absence,
+together, for one reason: the hosted macOS runner had no Python language
+server, so Kin could never have produced a cross-file Calls edge for the
+fixture and correctly declined to certify that the symbol was unused. Kin was
+right and the cut failed on a right answer.
+
+Two defects, and this file grades the second.
+
+The first was environmental: `scripts/ci-install-language-servers.sh` bounded
+its npm install with GNU `timeout`, macOS has none, and all three attempts died
+on `timeout: command not found` sixty-five seconds before the next step in the
+same job installed coreutils.
+
+The second is the one a check can hold: the arm blamed the product for its
+host, and named a disagreement rather than the condition that tripped. Nobody
+could tell which surface was wrong, because the arm's own receipt never left
+the runner. Reading the code was the only way to learn there was no
+disagreement to find.
+
+Where it runs, and why here
+---------------------------
+`scripts/acceptance/magic_repro.py` is graded by acceptance.yml, whose
+`Product Acceptance` job carries `if: github.event_name != 'pull_request'`, so
+it never runs on the pull request that could break it. kin#1642 added the arm
+this file grades and the daemon route it exercises in one commit, and no
+acceptance suite ran before that commit merged. This file is wired into
+`ci.yml`'s fast-gate-lint job, which does run on a pull request and carries the
+required `Fast gate lint and policy` context, so the class is refused at the
+pull request rather than a release later.
+"""
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(
+        name, Path(__file__).with_name(name + ".py"))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+m = _load("magic_repro")
+
+# Verbatim from a real receipt, read out of repro.json on 2026-09-09 running
+# the v0.7.8 candidate archive (08490e9f3) against an isolated store on a macOS
+# host with no Python language server. Paraphrasing these would let the fixture
+# drift away from what the product actually prints, which is the whole failure
+# mode this file guards.
+ABSENCE_LINE = "No incoming Calls relations."
+CLEAN_STDOUT = (
+    "References to 'unused_absence_probe' -> unused_absence_probe (Function) @ callee.py\n"
+    + ABSENCE_LINE + "\n")
+HEDGED_STDOUT = CLEAN_STDOUT + (
+    "Kin cannot rule out references it did not see: this answer carries "
+    "[edge_coverage:reference_enrichment_unsupported], so it may not reflect current truth.\n")
+HOST_GAP = (
+    "reference_enrichment_unsupported: no language server for Python is installed on this "
+    "host, so no cross-file reference or override edge was ever produced for it, so an empty "
+    "result cannot separate a symbol nothing uses from one this graph could never have "
+    "linked; reference_enrichment_no_language_server: an adapter is wired for Python but no "
+    "language server for it is installed on this host")
+# The neighbouring state in crates/kin-mcp/src/verdict.rs, and the one that is
+# NOT a host fact: a build that ships no adapter for a language Kin claims to
+# enrich is a regression, and must never be excused as somebody's laptop.
+BUILD_GAP = (
+    "reference_enrichment_unsupported: this build wires no language-server adapter for "
+    "Python, so cross-file reference and override edges cannot exist for it at all")
+
+
+def payload(certified, limiting=""):
+    return {
+        "focal_entity": {"id": "e1"},
+        "references": [],
+        "negative": {"safe_to_conclude_absent": certified,
+                     "kind": "no_references",
+                     "trust_reason": limiting},
+        "_kin": {"verdict": {"safe_to_conclude_absent": certified,
+                             "limiting_factor": limiting}},
+    }
+
+
+def cli(stdout, exit_code=0, stderr=""):
+    return {"args": ["refs", "unused_absence_probe", "--kind", "calls"],
+            "exit_code": exit_code, "stdout": stdout, "stderr": stderr}
+
+
+class HealthyControlArm(unittest.TestCase):
+    """The arm's four original conditions, unchanged, plus what a non-pass says."""
+
+    def test_both_surfaces_certifying_passes(self):
+        status, detail = m.certification_arm_reading(payload(True), cli(CLEAN_STDOUT))
+        self.assertEqual(status, m.PASS, detail)
+        self.assertIn("certifies plainly on both surfaces", detail)
+
+    def test_a_host_with_no_language_server_is_not_graded(self):
+        # The macOS leg, exactly. UNREADABLE rather than FAIL, and the detail
+        # quotes the verdict's own sentence rather than composing one.
+        status, detail = m.certification_arm_reading(
+            payload(False, HOST_GAP), cli(HEDGED_STDOUT))
+        self.assertEqual(status, m.UNREADABLE, detail)
+        self.assertIn("no language server for it is installed on this host", detail)
+        self.assertIn("scripts/ci-install-language-servers.sh", detail)
+        self.assertNotIn("did not certify plainly", detail)
+
+    def test_mcp_refusing_while_the_cli_certifies_still_fails(self):
+        # Half of the excuse is the surface disagreement FIR-2524 exists to
+        # catch. The host gap is present in the verdict and must not buy it.
+        status, detail = m.certification_arm_reading(
+            payload(False, HOST_GAP), cli(CLEAN_STDOUT))
+        self.assertEqual(status, m.FAIL, detail)
+        self.assertIn("safe_to_conclude_absent is false, not true", detail)
+
+    def test_the_cli_qualifying_while_mcp_certifies_still_fails(self):
+        status, detail = m.certification_arm_reading(
+            payload(True, HOST_GAP), cli(HEDGED_STDOUT))
+        self.assertEqual(status, m.FAIL, detail)
+        self.assertIn("the CLI qualified the answer", detail)
+
+    def test_a_build_that_wires_no_adapter_is_not_excused(self):
+        # Same shape as the macOS leg, one token different, and that token is
+        # the difference between a runner nobody provisioned and a build that
+        # lost an adapter it ships.
+        status, detail = m.certification_arm_reading(
+            payload(False, BUILD_GAP), cli(HEDGED_STDOUT))
+        self.assertEqual(status, m.FAIL, detail)
+
+    def test_a_nonzero_exit_is_never_the_hosts_fault(self):
+        status, detail = m.certification_arm_reading(
+            payload(False, HOST_GAP), cli(HEDGED_STDOUT, exit_code=2))
+        self.assertEqual(status, m.FAIL, detail)
+        self.assertIn("the CLI exited 2", detail)
+
+    def test_a_missing_absence_line_is_never_the_hosts_fault(self):
+        status, detail = m.certification_arm_reading(
+            payload(False, HOST_GAP), cli(HEDGED_STDOUT.replace(ABSENCE_LINE, "")))
+        self.assertEqual(status, m.FAIL, detail)
+        self.assertIn(ABSENCE_LINE, detail)
+
+    def test_a_failure_names_every_condition_that_tripped(self):
+        # The misdiagnosis class itself. A reader of the release log must learn
+        # what went wrong from the line, not from reading the check.
+        status, detail = m.certification_arm_reading(
+            payload(None), cli("", exit_code=1))
+        self.assertEqual(status, m.FAIL, detail)
+        for expected in ("safe_to_conclude_absent is null",
+                         "the CLI exited 1",
+                         ABSENCE_LINE):
+            self.assertIn(expected, detail)
+
+
+class GapPredicate(unittest.TestCase):
+    """Both surfaces, or it is not a host gap."""
+
+    def test_both_surfaces_naming_the_gap_reads_it(self):
+        self.assertTrue(m.host_lacks_reference_enrichment(
+            payload(False, HOST_GAP), HEDGED_STDOUT))
+
+    def test_a_quiet_cli_is_not_agreement(self):
+        self.assertIsNone(m.host_lacks_reference_enrichment(
+            payload(False, HOST_GAP), CLEAN_STDOUT))
+
+    def test_a_quiet_verdict_is_not_agreement(self):
+        self.assertIsNone(m.host_lacks_reference_enrichment(
+            payload(False, ""), HEDGED_STDOUT))
+
+    def test_a_cli_hedging_about_something_else_is_not_this_class(self):
+        other = CLEAN_STDOUT + (
+            "Kin cannot rule out references it did not see: this answer carries "
+            "[edge_coverage:cross_file_edges_unproduced], so it may not reflect current truth.\n")
+        self.assertIsNone(m.host_lacks_reference_enrichment(
+            payload(False, HOST_GAP), other))
+
+
+class TokensStillExistInTheProduct(unittest.TestCase):
+    """The check keys on two product strings, so a rename must be loud.
+
+    Without this, renaming either token in `kin-mcp` would leave the predicate
+    matching nothing: the UNREADABLE branch would quietly go dead and the macOS
+    leg would be back to blaming the product for its runner, with nothing red
+    to say so.
+    """
+
+    def _verdict_source(self):
+        source = (Path(__file__).resolve().parents[2]
+                  / "crates" / "kin-mcp" / "src" / "verdict.rs")
+        self.assertTrue(source.is_file(), "kin-mcp verdict.rs moved: %s" % source)
+        return source.read_text(encoding="utf-8")
+
+    def test_the_two_enrichment_tokens_are_still_published(self):
+        text = self._verdict_source()
+        for token in (m.NO_LANGUAGE_SERVER, m.ENRICHMENT_CLASS):
+            self.assertIn(token, text,
+                          "%s no longer appears in kin-mcp's verdict, so case 16's host-gap "
+                          "reading matches nothing and must be rewired" % token)
+
+    def test_the_positive_control_would_notice_a_dead_read(self):
+        # Proves the search above can fail: a token the file cannot contain
+        # must not be found by the same read.
+        self.assertNotIn("reference_enrichment_this_token_cannot_exist",
+                         self._verdict_source())
+
+
+class QualifierRegex(unittest.TestCase):
+    """The hedge the CLI actually prints, matched by the pattern in use."""
+
+    def test_the_product_sentence_matches(self):
+        self.assertTrue(m.CANNOT_RULE_OUT.search(HEDGED_STDOUT))
+
+    def test_a_clean_answer_does_not(self):
+        self.assertFalse(m.CANNOT_RULE_OUT.search(CLEAN_STDOUT))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci-install-language-servers.sh
+++ b/scripts/ci-install-language-servers.sh
@@ -14,7 +14,10 @@
 #
 # The install is bounded and retried, for the same reason `ci-apt-install.sh`
 # is: a stalled registry that holds a job to the runner's one-hour timeout
-# ejects a merge-group entry without marking the pull request it ejected.
+# ejects a merge-group entry without marking the pull request it ejected. The
+# bound needs GNU timeout, and where a host has none the install runs unbounded
+# and says so, because not installing at all is the worse failure; the block
+# above the retry loop carries what that cost.
 #
 # A failure warns and exits 0 rather than failing the gate. A registry outage is
 # not a defect in the change under review, and blocking the whole fleet on npm's
@@ -40,10 +43,55 @@ if ! command -v npm >/dev/null 2>&1; then
   exit 0
 fi
 
+# The bound above needs GNU timeout, and a macOS runner ships none, so a bare
+# `timeout` there is not an unbounded install: it is no install at all. On
+# release-cut.yml run 34395244305, job "Preflight kin-macos-aarch64", all three
+# attempts died on `line 46: timeout: command not found` between 19:28:56Z and
+# 19:29:26Z, this script warned that "3 bounded attempts" had failed when none
+# of them had started, and the leg then ran its whole acceptance suite with no
+# language server. magic-repro case 16 (FIR-2524) reads that host as one where
+# Kin can never produce a Python cross-file Calls edge, refuses to certify the
+# absence on both surfaces exactly as it should, and the release cut failed on
+# a correct answer three times in a row.
+#
+# So resolve the binary the way scripts/release-proof/bin/kin-release-preflight
+# already does, and check for GNU rather than trusting the name: macOS carries
+# no `timeout` at all today, but a BSD one appearing later would take different
+# arguments and fail just as quietly.
+TIMEOUT_BIN=""
+for candidate in timeout gtimeout; do
+  if command -v "$candidate" >/dev/null 2>&1 \
+    && "$candidate" --version 2>/dev/null | grep -q GNU; then
+    TIMEOUT_BIN="$(command -v "$candidate")"
+    break
+  fi
+done
+
+# With no GNU timeout, install unbounded rather than not at all. That is the
+# same trade `bounded()` in kin-release-preflight already makes, and it is the
+# right one here: an unbounded install risks holding the job, while no install
+# guarantees the enrichment proof does not run. The warning says which happened
+# so a reader never has to infer it, and ATTEMPT_KIND keeps the failure line
+# below from claiming a bound that was never applied.
+ATTEMPT_KIND=bounded
+if [ -z "$TIMEOUT_BIN" ]; then
+  ATTEMPT_KIND=unbounded
+  echo "::warning::no GNU timeout on this runner, so the language-server install runs \
+unbounded; install coreutils before this step to restore the bound" >&2
+fi
+
+bounded_npm() { # <npm args...>: run under GNU timeout when this host has one
+  if [ -n "$TIMEOUT_BIN" ]; then
+    "$TIMEOUT_BIN" "$INSTALL_BOUND" npm "$@"
+  else
+    npm "$@"
+  fi
+}
+
 mkdir -p "$PREFIX"
 
 for attempt in 1 2 3; do
-  if timeout "$INSTALL_BOUND" npm install \
+  if bounded_npm install \
     --prefix "$PREFIX" \
     --no-fund --no-audit --no-progress \
     "pyright@${PYRIGHT_VERSION}" \
@@ -76,6 +124,6 @@ for attempt in 1 2 3; do
   sleep $((attempt * 10))
 done
 
-echo "::warning::could not install language servers after 3 bounded attempts; the \
+echo "::warning::could not install language servers after 3 ${ATTEMPT_KIND} attempts; the \
 reference-enrichment proof will skip and say so per test" >&2
 exit 0


### PR DESCRIPTION
Release Cut has failed three times tonight on `Preflight kin-macos-aarch64` with
`16/FIR-2524 FAIL: healthy isolated empty control did not certify plainly on both surfaces`,
both Linux legs green every time. The cut stops before it can publish a preflight record, so
release-tag.yml has no candidate and v0.7.8 cannot mint.

**Kin was right and the check's premise was false.** Neither surface disagreed. Both refused the
absence, in agreement, because the hosted macOS runner had no Python language server, so Kin could
never have produced a cross-file Calls edge for the fixture and correctly declined to certify that
an unused symbol was unused. The runner had no language server because
`scripts/ci-install-language-servers.sh` bounds its npm install with GNU `timeout`, macOS has none,
and all three attempts died on `timeout: command not found` sixty-five seconds before the next step
in the same job installed coreutils.

So this fixes the install, not the assertion. Every condition that gated a PASS in case 16 still
gates one.

## Which surface disagreed

Neither. This is the question no artifact could answer, because a published leg record
(`kin.release-preflight.leg.v1`) keeps only `{id, ticket, status, detail}` per check and a failing
leg publishes no record at all. The receipt the check already computes, read out of `repro.json`
from a local run against the same candidate archive:

```
CLI, exit 0:
  References to 'unused_absence_probe' -> unused_absence_probe (Function) @ callee.py
  No incoming Calls relations.
  Kin cannot rule out references it did not see: this answer carries
  [edge_coverage:reference_enrichment_unsupported], so it may not reflect current truth.

MCP:
  negative.safe_to_conclude_absent: false
  negative.trust: inconclusive
  negative.trust_reason: reference_enrichment_unsupported: no language server for Python is
    installed on this host, so no cross-file reference or override edge was ever produced for it
  _kin.verdict.limiting_factor: ... reference_enrichment_no_language_server: an adapter is wired
    for Python but no language server for it is installed on this host
```

Two of the arm's four conditions tripped, both on one cause, and both surfaces carry the same
qualifier. "did not certify plainly on both surfaces" reads as a disagreement and there was none.

## The CI cause, from the real job log

Run `34395244305`, job `102613355195`. Positive control on the same log: `grep -c "PASS"` returns 8.

```
19:28:56  scripts/ci-install-language-servers.sh: line 46: timeout: command not found
19:28:56  npm attempt 1 of 3 failed for the language servers
19:29:06  scripts/ci-install-language-servers.sh: line 46: timeout: command not found
19:29:06  npm attempt 2 of 3 failed for the language servers
19:29:26  scripts/ci-install-language-servers.sh: line 46: timeout: command not found
19:29:26  npm attempt 3 of 3 failed for the language servers
19:29:57  ##[warning]could not install language servers after 3 bounded attempts; ...
19:30:01  # coreutils gives the preflight the GNU timeout its leg bound needs;
19:30:07  Cellar/coreutils/9.11: 443 files, 12.6MB
19:30:07  [preflight] WARNING: no pyright-langserver or typescript-language-server on PATH
```

The script called those "3 bounded attempts" when none of them started. Six seconds later the next
step has GNU timeout.

The v0.7.7 macOS leg carried the identical `timeout` gap and still scored 27 of 27, and the first
read of this ruled the gap out on that basis. Both facts hold at once: the gap was always there,
and kin#1642 added the arm that trips over it, so v0.7.7 never ran it.

## Local reproduction, both directions

Same Mac, same candidate archive, same CPU embed backend, same isolated HOME. Only PATH differs.
Archive `kin-macos-aarch64.tar.gz` from rc-build `34375657720`, sha256
`fb8d9f08331c20c27a3cf63dc507c69bbbba557a31bcdbca3724639e1e287c13`, matching its published sidecar.
Version line from the binary itself:
`kin 0.7.8 (08490e9f3ced9821247e7baa4d64eaf5d89754c7 release/v0.7.8-candidate 2026-09-09T16:21:43Z)`.

Before this change, no language server on PATH, which is the hosted macOS leg:

```
CHECK 16 FIR-2524 FAIL healthy isolated empty control did not certify plainly on both surfaces
      FAIL        healthy isolated empty control did not certify plainly on both surfaces
kin-magic-repro: 1 pass, 1 fail, 0 unreadable
magic_repro exit 1
```

Before this change, language servers on PATH, which is both Linux legs:

```
CHECK 16 FIR-2524 PASS isolated empty-reference arm refuses on both surfaces under census hold
      PASS        healthy isolated empty control certifies plainly on both surfaces
      PASS        isolated empty-reference arm refuses on both surfaces under census hold
kin-magic-repro: 2 pass, 0 fail, 0 unreadable
magic_repro exit 0
```

After this change, no language server, reads UNREADABLE with the true reason and still stops a cut:

```
CHECK 16 FIR-2524 UNREADABLE this host cannot satisfy the arm's own premise, so the arm was not
graded: both surfaces refuse the absence in agreement and the verdict says
reference_enrichment_unsupported: no language server for Python is installed on this host ...;
reference_enrichment_no_language_server: an adapter is wired for Python but no language server for
it is installed on this host. Install a language server for the fixture's language on this runner
(scripts/ci-install-language-servers.sh) and the arm grades again.
kin-magic-repro: 1 pass, 0 fail, 1 unreadable
magic_repro exit 2
```

After this change, language servers on PATH, all five arms:

```
CHECK 16 FIR-2524 PASS isolated empty-reference arm refuses on both surfaces under census hold
      PASS        references returned (2), so the refusing arm is not exercised here
      PASS        positive control: an answer holding rows stays unqualified
      PASS        group=partial-vocabulary dead-code: a clean scan on a sound substrate stays unqualified
      PASS        healthy isolated empty control certifies plainly on both surfaces
      PASS        isolated empty-reference arm refuses on both surfaces under census hold
kin-magic-repro: 2 pass, 0 fail, 0 unreadable
magic_repro exit 0
```

## UNREADABLE still stops the cut, traced end to end

`magic_repro.py` returns 2 on any unreadable. `proof-flow.sh`'s `step_magic_repro` returns that
through `${PIPESTATUS[0]}`. The leg's result node computes `magic_repro.verdict` from `repro.json`'s
own counts, giving `UNREADABLE`. `kin-release-preflight` folds it in with
`UNREADABLE*) [ "$overall" = FAIL ] || overall=UNREADABLE`. release-cut.yml's own comment maps the
driver's exit: `0 PASS, 1 a leg FAILED, 2 UNREADABLE`, and it exits non-zero, so
`Upload this leg's record` is skipped and `publish` never sees three green legs. The gate is
exactly as strong as before.

## Why UNREADABLE and not a weaker assertion

The refuse-to-grade branch is narrower than the failure it replaces. It fires only when everything
else about the answer is right and BOTH surfaces refuse in agreement, so the only difference from a
PASS is the shared qualifier. A one-sided refusal is still a failure, which the old code could not
tell apart at all.

It keys on the verdict's host-only token, never the `edge_coverage:` label.
`crates/kin-mcp/src/negative.rs:1137-1142` pushes one label,
`edge_coverage:reference_enrichment_unsupported`, for two different states, while
`crates/kin-mcp/src/verdict.rs:566-580` keeps them apart: `no_language_server` is a host fact, and
`unsupported` means the build wires no adapter at all, which for a language Kin does wire one for
would be a real regression and must never be excused as somebody's runner.

## Falsification: the install script

`scripts/ci-install-language-servers.sh`, three arms, same npm, differing only in whether GNU
timeout is reachable.

```
### PATH probe
no-GNU arm, timeout resolves to: (neither, as intended)
GNU arm, timeout resolves to:    /opt/homebrew/bin/timeout

### ARM 1  origin/main, no GNU timeout: must fail every attempt
/private/tmp/preflight16/falsify/old.sh: line 46: timeout: command not found
npm attempt 1 of 3 failed for the language servers
/private/tmp/preflight16/falsify/old.sh: line 46: timeout: command not found
npm attempt 2 of 3 failed for the language servers
/private/tmp/preflight16/falsify/old.sh: line 46: timeout: command not found
npm attempt 3 of 3 failed for the language servers
::warning::could not install language servers after 3 bounded attempts; ...
--- installed binaries ---
(none)

### ARM 2  fixed, no GNU timeout: must install, warn unbounded
::warning::no GNU timeout on this runner, so the language-server install runs unbounded;
install coreutils before this step to restore the bound
added 3 packages in 3s
language servers installed at .../prefix-new/node_modules/.bin
--- installed binaries ---
pyright-langserver
typescript-language-server

### ARM 3  fixed, GNU timeout present: must install, no unbounded warning
added 3 packages in 1s
language servers installed at .../prefix-gnu/node_modules/.bin
--- installed binaries ---
pyright-langserver
typescript-language-server
```

## Falsification: the new check

`scripts/acceptance/test_magic_repro_case16.py`, 16 tests. Ten mutations, applied to the
product-side helper on a copy of the tree, never to the test.

```
BASELINE (no mutation)                                    OK, 16 tests, exit 0
MUTANT 1   gap no longer requires BOTH surfaces to refuse
           red: test_the_cli_qualifying_while_mcp_certifies_still_fails
MUTANT 2   gap keyed on the conflated label, not the host token
           red: test_a_build_that_wires_no_adapter_is_not_excused
MUTANT 3   failure stops naming which condition tripped
           red: test_a_failure_names_every_condition_that_tripped and 4 more
MUTANT 4   a nonzero CLI exit becomes excusable as a host gap
           red: test_a_nonzero_exit_is_never_the_hosts_fault
MUTANT 5   the arm certifies everything
           red: 7 arms
MUTANT 6   the product renames the host-gap token
           red: test_the_two_enrichment_tokens_are_still_published and 2 more
MUTANT 7   both defences against a one-sided refusal removed
           red: test_mcp_refusing_while_the_cli_certifies_still_fails, test_a_quiet_cli_is_not_agreement
MUTANT 8   the arm can never certify
           red: test_both_surfaces_certifying_passes
MUTANT 9   the CLI qualifier pattern stops matching what the CLI prints
           red: test_the_product_sentence_matches and 3 more
MUTANT 10  the predicate stops reading the verdict and trusts the CLI alone
           red: test_a_quiet_verdict_is_not_agreement and 1 more
```

Every mutant exits 1 and reds its target. 14 of the 16 tests go red under at least one mutant. The
two that do not are `test_a_clean_answer_does_not`, a negative boundary on the qualifier pattern,
and `test_the_positive_control_would_notice_a_dead_read`, which is itself the positive control
proving the source grep beside it can fail.

Mutant 1 is worth naming. It did not red the arm predicted for it, because a second defence inside
the predicate catches that input one step earlier. Mutant 7 removes both defences and reds it, so
that assertion decides the outcome on its own rather than sitting behind another one.

## Falsification: the receipt step

The listing step is the positive control the upload glob cannot be. Three arms, run under
`/bin/bash` 3.2, which is what a macOS runner has:

```
### ARM A  a real leg layout: must list every file the upload globs
receipt: legs/host/logs/03-install.log (2 bytes)
receipt: legs/host/repro.json (14 bytes)
receipt: legs/host/repro.log (2 bytes)
receipt: legs/host/result.json (2 bytes)
receipt: legs/host/steps.tsv (8 bytes)
receipt: legs/host/validate.json (2 bytes)
receipt: preflight.json (2 bytes)
receipt: preflight.log (2 bytes)
8 receipt file(s) under .../t1/kpf
exit=0

### ARM B  run root exists but empty: must warn, not stay silent
::warning::.../t2/kpf exists but holds none of the receipt files this job uploads
exit=0

### ARM C  no run root at all: must warn, not stay silent
::warning::the preflight created no run root at .../t3/kpf, so no receipt was collected
exit=0
```

## Where the new check runs

`scripts/acceptance/magic_repro.py` is graded by acceptance.yml, whose `Product Acceptance` job
carries `if: github.event_name != 'pull_request'`, so it never runs on the pull request that could
break it. kin#1642 added this arm and the daemon route it exercises in one commit, and the first
thing to execute the pairing was a release cut. The reading is pure, so the new test drives it with
no repo and no daemon from `ci.yml`'s fast-gate-lint job, under the required
`Fast gate lint and policy` context. Verified on python 3.9 and 3.13; `actionlint` is clean on both
edited workflows and on their `origin/main` baselines.

## What else this touches

`ci.yml` runs the install script under `if: runner.os == 'Linux'`, where GNU timeout has always been
present, so no Linux gate changes behaviour. The only host that reaches the new fallback today is
release-cut.yml's macOS preflight leg, and the coreutils hoist means it takes the bounded path
rather than the fallback.
