### PR TITLE
Replace the retired category line in the architecture overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,8 +391,8 @@ Kin is one system with a few clear public surfaces:
 
 ## How the pieces fit
 
-Kin is the system of record for AI-written software, and everything in the map
-below either reaches that authority or supports it. Humans and AI agents come in
+The graph is the repository, and everything in the map below either reaches
+that authority or supports it. Humans and AI agents come in
 through the CLI, the bundled MCP server, or the VS Code extension. All
 three ask the same daemon, and the daemon answers from graph authority rather
 than by re-reading the tree. `kin-vfs` projects that same graph back through


### PR DESCRIPTION
The "How the pieces fit" section opened with "Kin is the system of record for AI-written software", a line `docs/brand/tokens/canon.json` no longer holds and that KIN-MESSAGING reserves for enterprise and investor conversations rather than a public label. The same string is being removed from the kinlab site tonight.

Replaced with the thesis language the README already carries, so the architecture overview agrees with the canon and with the site.

One sentence, no behavior change.