### PR TITLE
Adopt kin-db 0.7.110 and audit the StorageBackend surface with it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3295,9 +3295,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.109"
+version = "0.7.110"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "ac055989b509fc8a9d40337dd15102cb15dabfc7d49bbad5516dde88c4d862b1"
+checksum = "8dec6290998b6f6f76fa86e3ac944cea5c37593aadc13a9146093aabaf71b021"
 dependencies = [
  "bincode",
  "bstr",
@@ -6684,7 +6684,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ kin-lsp = { version = "=0.7.19", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.109", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.110", registry = "kin", default-features = false }
 # Pinned to the exact version kin-db builds its name-token index with. A
 # per-token name query hits that index only when the token came out of the same
 # tokenizer, so a version skew here would be a silent recall loss rather than a

--- a/crates/kin-daemon/src/storage_delegate.rs
+++ b/crates/kin-daemon/src/storage_delegate.rs
@@ -62,7 +62,7 @@ use kin_db::{
 /// `storage_backend_surface_is_audited_against_the_pinned_kin_db` fails when
 /// the workspace pin moves past it, which is the only moment a method can have
 /// appeared.
-pub const AUDITED_KIN_DB_VERSION: &str = "0.7.109";
+pub const AUDITED_KIN_DB_VERSION: &str = "0.7.110";
 
 /// Wraps a [`StorageBackendDelegate`] so it can be handed anywhere a
 /// `Box<dyn StorageBackend>` is expected.


### PR DESCRIPTION
The registry dependency wave cannot land this pin on its own, so it goes through the ordinary path
here with its audit in the same tree.

Moving the pin turns `storage_backend_surface_is_audited_against_the_pinned_kin_db` red until
`AUDITED_KIN_DB_VERSION` moves in the **same tree**, and the wave receiver writes only `Cargo.lock`,
`Cargo.toml` and `fuzz/Cargo.lock`, so it can never carry that constant. Pushing the constant onto
the wave branch by hand instead moves the head past every release-App attestation, which the
admission gate refuses by design. FIR-3468 carries the full shape and three directions for fixing
it. This PR is the unblock, not the fix.

## The audit

No method is new, none removed, none changed. All 33 unchanged, so the `storage_backend_surface!`
table needs no new row and only the constant advances. The guard exists because 24 of the 33 carry
defaults, so a downstream impl can inherit a new one silently.

The evidence is a blob comparison rather than a diff read by eye.

`crates/kin-db/src/storage/backend.rs` carries git blob
`6c976cba701b86be60fcb74ddd1bb7044941d13d`, 582820 bytes, at v0.7.109 **and the identical sha** at
v0.7.110. A byte-identical file cannot hold a changed trait.

The control that the repo tag stands in faithfully for the published crate, which is what actually
compiles: `git hash-object` on the `backend.rs` inside the cached `kin-db-0.7.109.crate` returns
that same `6c976cba701b`.

`StorageBackend` is declared in exactly one place, `backend.rs:2772`, with supertraits
`Send + Sync` alone, so no method-bearing supertrait could have changed in another file.

What 0.7.110 does change, from the compare API: two commits touching `crates/kin-db/src/engine/graph.rs`
(+150/-3) and `crates/kin-db/src/storage/snapshot.rs` (+86/-0), three CI workflows and the version.
`backend.rs` is absent from that list, which agrees independently with the blob read.

## Falsification

The guard's red is already on the record and needed no manufacturing. Run `34417907990`, shard 1, on
the wave branch before the constant moved:

```
panicked at crates/kin-daemon/src/storage_delegate.rs:297:
assertion `left == right` failed: kin-db moved from 0.7.109 to 0.7.110 and the
StorageBackend table in crates/kin-daemon/src/storage_delegate.rs has not been re-read.
```

Same test, same tree, the constant the only difference, red then and green now.

## Local runs, on this exact head

Both through `.kin-coord/bin/heavy-slot.sh`, on a lane whose printed worktree path was read back
before believing the tally.

```
$ cargo test -p kin-daemon --lib storage_delegate
test storage_delegate::tests::storage_backend_surface_is_audited_against_the_pinned_kin_db ... ok
test storage_delegate::tests::the_bridged_method_roster_names_each_method_once ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 1624 filtered out

$ cargo test -p kin-daemon
test result: ok. 1622 passed; 0 failed; 4 ignored; 0 measured; finished in 261.01s
eleven "test result: ok" lines across the crate's binaries, zero FAILED
heavy-slot: command exit rc=0 at 2026-09-10T00:50:09Z
```

## Why this commit is authored rather than cherry-picked

`Cargo.toml` and `Cargo.lock` here are byte-identical to what the wave generated at `673474dfa`,
proven by `git diff 673474dfa -- Cargo.toml Cargo.lock` printing nothing. The lock delta includes
the `windows-sys 0.48.0` to `0.61.2` move the wave's own resolution produced.

The wave's commit could not be cherry-picked. Its message carries the reserved line
`Kin-Registry-Dependency-Wave: v1`, and `verify-kin-registry-wave-head.py` refuses any non-wave pull
request carrying a commit that holds it. That marker is an anti-impersonation control for commits
claiming to be App-generated wave heads, and this is an ordinary dependency bump that runs kin's
seven required contexts including the guard test above, so it is authored instead.

Checked by running the gate's own logic rather than reading it: `COMMIT_MARKER` is
`"Kin-Registry-Dependency-Wave: v1"` and `marked_commits()` uses `list.count()`, so it needs a line
equal to that string. This commit counts 0; the control, the wave's own `673474dfa`, counts 1.
