### PR TITLE
Restamp the ported preflight pin and grade its drift on the pull request

### DIFF
--- a/scripts/release-proof/VENDORED.json
+++ b/scripts/release-proof/VENDORED.json
@@ -1,12 +1,12 @@
 {
   "source_repository": "firelock-ai/kin-ecosystem",
   "source_commit": "c1cbeeb25f6070e59178badb401e9195537d91de",
-  "note": "Byte-identical copies of the umbrella proof tooling so the hosted preflight runs from kin alone; bin/kin-lane is a single-host lock shim written for this tree, not a copy. scripts/release-proof/vendored.test.mjs refuses a file whose sha256 left this manifest.",
+  "note": "Byte-identical copies of the umbrella proof tooling so the hosted preflight runs from kin alone; bin/kin-lane is a single-host lock shim written for this tree, not a copy. scripts/release-proof/vendored.test.mjs refuses a file whose sha256 left this manifest. One exception stands against source_commit: bin/kin-release-preflight.d/validate.mjs carries a PORTED_FROM pin restamped in kin first, because kin#1652 moved install-proof.yml and the preflight then refused all three legs of the v0.7.9 cut on the stale pin. kin-ecosystem needs the same one-line restamp before the next re-vendor overwrites it.",
   "files": {
     "bin/kin-release-preflight": {"source": "bin/kin-release-preflight", "sha256": "aedf49d66f774ff5fc34c84a4efccbe913278478281ece0917d50b8d910dd235"},
     "bin/kin-release-preflight.d/Dockerfile": {"source": "bin/kin-release-preflight.d/Dockerfile", "sha256": "e6c0e30c2bf46fc889484fb7e32c73163c3cf315d60351be3acd2428d22d12f6"},
     "bin/kin-release-preflight.d/proof-flow.sh": {"source": "bin/kin-release-preflight.d/proof-flow.sh", "sha256": "3a44e377a8c6bfcdfb688608ae5b9ba64293e3a955b711afe20ee237e2516b2b"},
-    "bin/kin-release-preflight.d/validate.mjs": {"source": "bin/kin-release-preflight.d/validate.mjs", "sha256": "53badad40150ee0a4d8c817af77f48f04ad2ae89616dce33686532b82afa35b9"},
+    "bin/kin-release-preflight.d/validate.mjs": {"source": "bin/kin-release-preflight.d/validate.mjs", "sha256": "81b0170a317d881cd05195edf2904baff24be05b8a9db6d56edd2d8483810494"},
     "bin/kin-evidence-publish": {"source": "bin/kin-evidence-publish", "sha256": "8912fd933ba37e2570ea2ff685a885551543f2a01e3baeb394876121f8811679"},
     "bin/kin-acceptance-suite": {"source": "bin/kin-acceptance-suite", "sha256": "7ce214e6563e227695cf02411762ca5e8d01edf8898634db465ee30f455918f7"}
   }

--- a/scripts/release-proof/bin/kin-release-preflight.d/validate.mjs
+++ b/scripts/release-proof/bin/kin-release-preflight.d/validate.mjs
@@ -75,9 +75,29 @@ import path from "node:path";
 // proof" step is byte for byte identical between the two pins, so this resync
 // moves the pin with no assertion delta, as the kin#1069 (job timeout) and
 // kin#1060 (Windows repo-free provenance step) resyncs before it did.
+//
+// Resynced 2026-09-10 against install-proof.yml carrying kin#1652, which adds
+// the `update-proof` job that installs the previously published release and
+// requires the real updater to move it to Latest. That job is appended whole
+// after the last line of the pin it replaces: that pin's file is a byte-exact
+// prefix of this one, 2126 lines of 2285, so the mirrored "Validate installed
+// capability proof" step at line 1684 did not move a byte. The job is scoped
+// to `github.event_name == 'schedule' || github.event_name ==
+// 'workflow_dispatch'`, so it never runs on the release path this validator
+// mirrors and adds no assertion the release gate runs. This resync moves the
+// pin with no assertion delta, as the kin#1069 and kin#1060 resyncs did. The
+// kin#1238 resync that set the pin being replaced was the other kind, and its
+// relation-census tolerance is ported below.
+//
+// The drift above was found by the driver refusing a cut, hours after kin#1652
+// landed, which is the fourth time this pin has gone stale outside the
+// mirrored step. `assert_ported_validator_pin_tracks_install_proof` in
+// scripts/test-release-workflow-authority.py now fails the pull request that
+// moves install-proof.yml without moving this pin, so the next drift is caught
+// by that pull request rather than by a release.
 export const PORTED_FROM = {
   file: ".github/workflows/install-proof.yml",
-  sha256: "0c469d2871a1a6b02944a2ddc5f12482a1556af4179f8f66bbfa018443ee2878",
+  sha256: "c4b55da81b9d74d955b7e9165b162c67e355246640398b6f7468e5a7c11d67aa",
 };
 
 class Unreadable extends Error {}

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -47,6 +47,15 @@ CAPABILITY_CONTRACT = ROOT / "scripts" / "verify-capability-proof.mjs"
 CAPABILITY_CONTRACT_POLICY = "scripts/verify-capability-proof.mjs"
 RELEASE_BOT_DOC = ROOT / "docs" / "release-bot.md"
 INSTALL_PROOF = WORKFLOWS / "install-proof.yml"
+PORTED_VALIDATOR = (
+    ROOT
+    / "scripts"
+    / "release-proof"
+    / "bin"
+    / "kin-release-preflight.d"
+    / "validate.mjs"
+)
+PREFLIGHT_DRIVER = ROOT / "scripts" / "release-proof" / "bin" / "kin-release-preflight"
 
 # A release tag freezes the workflow that its run will execute. Keep every
 # runner selected by the pretag build, tag mint, tagged release, recovery and
@@ -4147,6 +4156,91 @@ def assert_update_proof_stays_off_the_release_path(install_proof: str) -> None:
             "surface a step later as a missing `kin` and read as a broken "
             f"binary; found {[line for line in install_lines if line.startswith('set ')]}"
         )
+
+
+# The preflight driver refuses to grade a candidate whose install-proof.yml is
+# not the one its ported validator was written against, and it builds that
+# comparison out of these two lines. They are pinned so this test reads the
+# same number the driver reads. A test that recomputed the pin its own way
+# could agree with itself while the driver went on refusing.
+PORTED_PIN_EXTRACTOR = (
+    r"""PORTED_SHA="$(sed -n 's/^  sha256: "\([0-9a-f]\{64\}\)",$/\1/p' """
+    r'''"$HELPERS/validate.mjs" | head -1)"'''
+)
+PORTED_PIN_COMPARISON = 'if [ "$WORKFLOW_SHA" != "$PORTED_SHA" ]; then'
+# That extractor as a Python pattern: any line of validate.mjs, not only the
+# one inside PORTED_FROM, and `head -1` keeps whichever comes first.
+PORTED_PIN_LINE = re.compile(r'(?m)^  sha256: "([0-9a-f]{64})",$')
+PORTED_FROM_BLOCK = re.compile(r"(?ms)^export const PORTED_FROM = \{.*?^\};$")
+
+
+def assert_ported_validator_pin_tracks_install_proof(
+    install_proof: bytes, validator: str, preflight: str
+) -> None:
+    """Fail the pull request that moves install-proof.yml and not the ported pin.
+
+    ``scripts/release-proof/bin/kin-release-preflight.d/validate.mjs`` is a hand
+    port of install-proof.yml's "Validate installed capability proof" step, and
+    it records the sha256 of the workflow it was ported from. The preflight
+    driver compares that pin against the workflow at the ref under test and
+    exits 65, REFUSED, when the two differ, because a PASS from a stale port is
+    a PASS against assertions the release gate no longer runs.
+
+    That refusal is correct and it arrives far too late. It arrives inside
+    Release Cut, on every leg at once, against a candidate already selected,
+    hours after the pull request that moved the workflow merged green. kin#1652
+    appended the update-proof job on 2026-09-09 and all three legs of the
+    v0.7.9 cut refused the next morning, holding a release. It was the fourth
+    drift of this pin, and none of the four was visible to the pull request
+    that caused it. So the driver's own comparison runs here too, where ci.yml
+    runs this file on every pull request, and the author who moves either file
+    restamps the pin in the change that needs it.
+
+    Nothing here judges whether the port is still CORRECT, only whether it
+    still claims to mirror the workflow in this tree. A resync is still a human
+    reading the workflow step assertion by assertion.
+    """
+
+    block = PORTED_FROM_BLOCK.search(validator)
+    if block is None:
+        raise AssertionError(
+            "validate.mjs must export a PORTED_FROM block naming the "
+            "install-proof.yml it was ported from; with no pin the preflight "
+            "has nothing to compare and refuses every leg of the cut"
+        )
+    pins = list(PORTED_PIN_LINE.finditer(validator))
+    inside = [
+        pin for pin in pins if block.start() <= pin.start() and pin.end() <= block.end()
+    ]
+    if len(pins) != 1 or len(inside) != 1:
+        raise AssertionError(
+            "the driver keeps the FIRST line of validate.mjs its sed "
+            "expression matches, so exactly one line may match and it must be "
+            "the one inside PORTED_FROM; a second one earlier in the file "
+            "would be read in its place and this test would still agree with "
+            f"the pin nobody uses. Found {len(pins)} matching, {len(inside)} "
+            "of them in the block"
+        )
+    recorded = inside[0].group(1)
+    actual = hashlib.sha256(install_proof).hexdigest()
+    if recorded != actual:
+        raise AssertionError(
+            "the ported capability validator records install-proof.yml at "
+            f"{recorded}, but the workflow in this tree is {actual}. Read the "
+            '"Validate installed capability proof" step at both shas, port '
+            "every changed assertion into validate.mjs, and move "
+            "PORTED_FROM.sha256 to the new sha. When nothing the validator "
+            "asserts moved, say which hunks you compared and move the pin "
+            "anyway: leaving it behind refuses the next release cut rather "
+            "than this pull request"
+        )
+    for policy in (PORTED_PIN_EXTRACTOR, PORTED_PIN_COMPARISON):
+        if policy not in preflight:
+            raise AssertionError(
+                "the preflight driver must still read the pin and compare it "
+                "to the workflow the way this test mirrors, or the two agree "
+                f"only by luck; missing `{policy}`"
+            )
 
 
 def assert_install_proof_first_run_never_pipes_the_daemon_spawner(
@@ -10796,6 +10890,9 @@ def main() -> None:
     proof_gate = PROOF_GATE.read_text(encoding="utf-8")
     release_bot_doc = RELEASE_BOT_DOC.read_text(encoding="utf-8")
     install_proof = INSTALL_PROOF.read_text(encoding="utf-8")
+    install_proof_bytes = INSTALL_PROOF.read_bytes()
+    ported_validator = PORTED_VALIDATOR.read_text(encoding="utf-8")
+    preflight_driver = PREFLIGHT_DRIVER.read_text(encoding="utf-8")
     install_proof_canary = INSTALL_PROOF_CANARY.read_text(encoding="utf-8")
     capability_contract = CAPABILITY_CONTRACT.read_text(encoding="utf-8")
     readme = README.read_text(encoding="utf-8")
@@ -13036,6 +13133,77 @@ def main() -> None:
             expected,
             lambda mutated=install_proof.replace(original, mutation, 1): (
                 assert_update_proof_stays_off_the_release_path(mutated)
+            ),
+        )
+
+    assert_ported_validator_pin_tracks_install_proof(
+        install_proof_bytes, ported_validator, preflight_driver
+    )
+    ported_pin = PORTED_PIN_LINE.search(ported_validator).group(1)
+    ported_block = PORTED_FROM_BLOCK.search(ported_validator).group(0)
+    decoy_pin = "0" * 64
+    for fixture, source, name in (
+        (ported_pin, ported_validator, "the PORTED_FROM pin"),
+        (ported_block, ported_validator, "the PORTED_FROM block"),
+        (PORTED_PIN_EXTRACTOR, preflight_driver, "the driver's pin extractor"),
+        (PORTED_PIN_COMPARISON, preflight_driver, "the driver's pin comparison"),
+    ):
+        if fixture not in source:
+            raise AssertionError(
+                f"ported-pin falsification lost fixture for {name}: {fixture!r}"
+            )
+    for label, install_bytes, validator_text, preflight_text, expected in (
+        (
+            "install-proof.yml moves and the ported pin stays behind",
+            install_proof_bytes + b"\n# a step the ported validator never saw\n",
+            ported_validator,
+            preflight_driver,
+            "but the workflow in this tree is",
+        ),
+        (
+            "the pin is restamped to a sha that is not the workflow's",
+            install_proof_bytes,
+            ported_validator.replace(ported_pin, "a" * 64, 1),
+            preflight_driver,
+            "but the workflow in this tree is",
+        ),
+        (
+            "the PORTED_FROM export is dropped and nothing is pinned at all",
+            install_proof_bytes,
+            ported_validator.replace(ported_block, "", 1),
+            preflight_driver,
+            "must export a PORTED_FROM block",
+        ),
+        (
+            "a second pin line appears above the block, where the driver's "
+            "first-match extractor reads it instead",
+            install_proof_bytes,
+            ported_validator.replace(
+                ported_block, f'  sha256: "{decoy_pin}",\n{ported_block}', 1
+            ),
+            preflight_driver,
+            "exactly one line may match",
+        ),
+        (
+            "the driver stops extracting the pin the way this test mirrors",
+            install_proof_bytes,
+            ported_validator,
+            preflight_driver.replace(PORTED_PIN_EXTRACTOR, 'PORTED_SHA=""', 1),
+            "must still read the pin",
+        ),
+        (
+            "the driver stops comparing the pin against the workflow",
+            install_proof_bytes,
+            ported_validator,
+            preflight_driver.replace(PORTED_PIN_COMPARISON, "if false; then", 1),
+            "must still read the pin",
+        ),
+    ):
+        expect_assertion(
+            label,
+            expected,
+            lambda i=install_bytes, v=validator_text, p=preflight_text: (
+                assert_ported_validator_pin_tracks_install_proof(i, v, p)
             ),
         )
 


### PR DESCRIPTION
## What this fixes

Release Cut run 34448475629 refused all three preflight legs of the v0.7.9 candidate with exit
65. That is a REFUSED, not a FAIL: the driver declined to grade rather than judging the
candidate bad. Every leg printed the same reason.

```
preflight: REFUSED: install-proof.yml at <runner>/work/kin/kin @ 0f745cc2 is sha256 c4b55da8...,
but .../kin-release-preflight.d/validate.mjs records PORTED_FROM.sha256 0c469d28.... The ported
validator judges a contract the release gate no longer runs, so a PASS here would not be the
workflow's PASS
```

`validate.mjs` is a hand port of install-proof.yml's "Validate installed capability proof" step
and records the sha256 of the workflow it was ported from. #1652 moved the workflow and did not
move the pin, so the driver refused. The guard is right. Its timing is the problem: it fires
inside a release cut, on every leg, hours after the pull request that caused it merged green.

## The contract did not move

#1652 is 159 insertions and zero deletions. It appends the `update-proof` job whole after the
last line of the pinned file. With a positive control:

```
$ git show 1844c8d2:.github/workflows/install-proof.yml | shasum -a 256
0c469d2871a1a6b02944a2ddc5f12482a1556af4179f8f66bbfa018443ee2878
$ head -2126 .github/workflows/install-proof.yml | shasum -a 256
0c469d2871a1a6b02944a2ddc5f12482a1556af4179f8f66bbfa018443ee2878   # matches
$ head -2125 .github/workflows/install-proof.yml | shasum -a 256
11a466a941cf3105f65e323ffd650ec8bcd97d29ee01b66eae8e154b987d3d42   # control: differs
```

The pinned file is a byte-exact prefix of the current one, 2126 lines of 2285. The mirrored step
sits at line 1684, inside that prefix, and did not move a byte. The appended job is also scoped
`if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}`, so it
never runs on the release path the validator mirrors. No hunk changes a behavior the ported
validator asserts, so the pin moves with no assertion delta, the same class as the #1069 and
#1060 resyncs the file's own comment records.

This also explains why v0.7.8 passed the identical preflight. Its candidate `08490e9f` carries
install-proof.yml at exactly the pinned sha, and #1652 is not an ancestor of it. Nothing about
the v0.7.8 tag or its prerelease flag is involved.

## Changes

`validate.mjs`: `PORTED_FROM.sha256` moves to `c4b55da8`, with the evidence above in the comment.

`VENDORED.json`: the validator's own sha256 moves to `81b0170a`, because `vendored.test.mjs`
refuses a vendored file whose bytes left the manifest and release-cut.yml runs that test first.
The note records that this one file is ahead of `source_commit` and that kin-ecosystem needs the
same one-line restamp before its next re-vendor.

`test-release-workflow-authority.py`: new `assert_ported_validator_pin_tracks_install_proof`. It
recomputes install-proof.yml's sha256 over its raw bytes and compares it to the recorded pin. It
reads the pin with the driver's exact sed expression, refuses a second matching line anywhere in
the file because the driver's `head -1` would read that one instead, and pins the two driver
lines it mirrors so the test and the driver cannot drift apart.

## Why the guard lives there

This pin has gone stale four times, always from a change outside the mirrored step, and every
time it surfaced inside a release cut rather than on the pull request. `ci.yml` runs
`test-release-workflow-authority.py` in the `npm-launchers` job, which has no event filter and
runs on every pull request. An acceptance rule would not have caught #1652, because
`Product Acceptance` carries `if: ${{ github.event_name != 'pull_request' }}`.

## Falsification

Six arms run inside the test on every invocation, since `expect_assertion` fails when a mutation
does not raise: the workflow moves and the pin stays behind; the pin is restamped to a sha that
is not the workflow's; the `PORTED_FROM` export is dropped; a second pin line appears above the
block where the driver's first-match extractor would read it; the driver stops extracting the
pin; the driver stops comparing it.

Two more were run by hand and reverted. Restoring the stale pin reproduces the cut's refusal at
pull-request time with the same two shas:

```
$ python3 scripts/test-release-workflow-authority.py
AssertionError: the ported capability validator records install-proof.yml at 0c469d28..., but
the workflow in this tree is c4b55da8...
exit 1
```

Editing install-proof.yml without restamping goes red the same way. The first attempt at that
arm appended a trailing comment and went red for the wrong reason, on an unrelated canonical
indentation assertion that runs earlier, so it was redone as a single appended newline, which is
inert to every other assertion and fires only this one.

## Local verification

```
$ node --test scripts/release-proof/vendored.test.mjs
# pass 5  # fail 0

$ python3 scripts/test-release-workflow-authority.py
release workflow authority is reviewed-PR to App-tag automatic, protected, pinned, GCP-free on
release writes, cross-platform byte-canonical, with dev-only Artifact Registry OIDC and npm
automatic through short-lived OIDC with post-public proof
exit 0
```

`bin/kin-precheck kin` output is appended in a comment once it finishes; it enumerated 21 gates
against this worktree.
