### PR TITLE
Hold the coupled kin-vfs-core pin until the release input backs it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1329,6 +1329,7 @@ jobs:
             scripts/release-proof/vendored.test.mjs \
             scripts/check-glibc-floor.test.mjs \
             scripts/check-kin-vfs-compat.test.mjs \
+            scripts/wave-kin-vfs-core-hold.test.mjs \
             scripts/check-rc-build-drift.test.mjs \
             scripts/check-release-proof-artifacts.test.mjs \
             scripts/release-promotion-plan.test.mjs \
@@ -2026,6 +2027,7 @@ jobs:
             scripts/release-proof/vendored.test.mjs \
             scripts/check-glibc-floor.test.mjs \
             scripts/check-kin-vfs-compat.test.mjs \
+            scripts/wave-kin-vfs-core-hold.test.mjs \
             scripts/check-rc-build-drift.test.mjs \
             scripts/check-release-proof-artifacts.test.mjs \
             scripts/release-promotion-plan.test.mjs \

--- a/.github/workflows/kin-registry-release.yml
+++ b/.github/workflows/kin-registry-release.yml
@@ -195,11 +195,41 @@ jobs:
             'index = "sparse+https://kinlab.ai/registry/cargo/"' \
             > "$cargo_home/config.toml"
 
+      # kin-vfs-core is the one crate in the roll below with two authorities
+      # that have to agree. Its registry requirement is what the Kin binary
+      # links against; the immutable kin-vfs checkout commit, a literal in
+      # release.yml and rc-build.yml, is the tree the release builds the kin-vfs
+      # binary from. check-kin-vfs-compat.mjs refuses when they disagree and it
+      # carries the required `Fast gate lint and policy` context.
+      #
+      # This wave can write Cargo.toml, Cargo.lock and fuzz/Cargo.lock and
+      # nothing else, and its App token has no `workflows` scope, so it can move
+      # the requirement and can never move the pin. Rolling on every publish
+      # moved one of the two and produced a pull request that could not pass its
+      # own required gate: eight wave heads across four version steps between
+      # 2026-08-31 and 2026-09-10, each cleared by a hand-written pull request
+      # (kin#1223, kin#1344, kin#1431) that moved both together. Widening the
+      # write set is the wrong repair. The pin is a reviewed release input, and a
+      # bot that advanced it would ship a kin-vfs tree nobody read.
+      #
+      # So the coupled crate holds instead, and every other crate rolls as
+      # before, which keeps the wave landing. The reviewed pull request that
+      # advances the pin is what releases the next kin-vfs-core roll.
+      - name: Decide whether the coupled kin-vfs-core pin may roll
+        id: vfs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          node scripts/wave-kin-vfs-core-hold.mjs
+
       - name: Update the allowed root-manifest pins
         id: update
         env:
           EVENT_CRATE: ${{ github.event.client_payload.crate_name }}
           EVENT_VERSION: ${{ github.event.client_payload.crate_version }}
+          VFS_CORE_ROLL: ${{ steps.vfs.outputs.kin_vfs_core_roll }}
+          VFS_CORE_REASON: ${{ steps.vfs.outputs.kin_vfs_core_reason }}
         run: |
           set -uo pipefail
           crate_args=(
@@ -208,8 +238,14 @@ jobs:
             --crate kin-db
             --crate kin-lsp
             --crate kin-search
-            --crate kin-vfs-core
           )
+          # Anything but the exact string "true" holds, so a step that failed to
+          # emit its decision holds rather than rolling on an empty value.
+          if [ "$VFS_CORE_ROLL" = "true" ]; then
+            crate_args+=( --crate kin-vfs-core )
+          else
+            echo "::notice title=Kin dependency wave holds kin-vfs-core::$VFS_CORE_REASON"
+          fi
           title="refresh Kin registry dependency pins"
           case "$GITHUB_EVENT_NAME" in
             repository_dispatch)
@@ -217,11 +253,20 @@ jobs:
                 echo "::error::validated dispatch lost its crate or version"
                 exit 1
               fi
-              crate_args+=(
-                --event-crate "$EVENT_CRATE"
-                --version "$EVENT_VERSION"
-              )
-              title="refresh Kin registry pins after ${EVENT_CRATE}@${EVENT_VERSION}"
+              # The updater rejects an event crate outside the requested set, so
+              # a dispatch naming the held crate drops its event arguments and
+              # refreshes the rest. That is the whole dispatch when kin-vfs-core
+              # is the only crate with something new: the updater then reports
+              # nothing changed and no pull request is written.
+              if [ "$EVENT_CRATE" = "kin-vfs-core" ] && [ "$VFS_CORE_ROLL" != "true" ]; then
+                echo "::notice title=Kin dependency wave holds the dispatched crate::${EVENT_CRATE}@${EVENT_VERSION} is held; refreshing the rest of the set"
+              else
+                crate_args+=(
+                  --event-crate "$EVENT_CRATE"
+                  --version "$EVENT_VERSION"
+                )
+                title="refresh Kin registry pins after ${EVENT_CRATE}@${EVENT_VERSION}"
+              fi
               ;;
             schedule) ;;
             *)

--- a/scripts/test-kin-registry-release-receiver.py
+++ b/scripts/test-kin-registry-release-receiver.py
@@ -2387,6 +2387,78 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn('--version "$EVENT_VERSION"', update)
         self.assertNotIn('--crate "$EVENT_CRATE"', update)
 
+    def test_kin_vfs_core_rolls_only_behind_the_pin_decision(self) -> None:
+        """The coupled crate is gated, and the gate runs before the update.
+
+        kin-vfs-core has two authorities that a required context makes agree:
+        the registry requirement this wave writes, and the immutable kin-vfs
+        checkout commit it cannot write. Rolling it unconditionally moved one of
+        the two on every publish and produced a wave head that could not pass
+        its own gate. The gate below holds it unless the decision step says the
+        registry and the pin already agree, and an unconditional
+        `--crate kin-vfs-core` beside the other five takes this red.
+        """
+
+        decision = step_block(
+            self.workflow, "Decide whether the coupled kin-vfs-core pin may roll"
+        )
+        self.assertIn("node scripts/wave-kin-vfs-core-hold.mjs", decision)
+        self.assertIn("GH_TOKEN: ${{ github.token }}", decision)
+        self.assertIn("id: vfs", decision)
+
+        # Ordered: the decision has to be an earlier step than the update, or
+        # the update reads an output that does not exist yet and every value is
+        # the empty string, which reads as a hold forever with nothing said.
+        self.assertLess(
+            self.prepare_job.index(
+                "- name: Decide whether the coupled kin-vfs-core pin may roll"
+            ),
+            self.prepare_job.index("- name: Update the allowed root-manifest pins"),
+        )
+
+        update = step_block(self.workflow, "Update the allowed root-manifest pins")
+        self.assertIn(
+            "VFS_CORE_ROLL: ${{ steps.vfs.outputs.kin_vfs_core_roll }}", update
+        )
+        self.assertIn(
+            "VFS_CORE_REASON: ${{ steps.vfs.outputs.kin_vfs_core_reason }}", update
+        )
+        self.assertIn('if [ "$VFS_CORE_ROLL" = "true" ]; then', update)
+        self.assertIn("crate_args+=( --crate kin-vfs-core )", update)
+
+        # The five uncoupled crates are in the unconditional array; the coupled
+        # one is not. Reading the array literal rather than the whole step is
+        # what makes an unconditional kin-vfs-core visible here.
+        array = update.split("crate_args=(", 1)[1].split(")", 1)[0]
+        for crate in validator.ALLOWED_SOURCES:
+            if crate == "kin-vfs-core":
+                self.assertNotIn(crate, array)
+            else:
+                self.assertIn(f"--crate {crate}", array)
+
+        # A dispatch naming the held crate drops its event arguments, because
+        # the updater rejects an event crate outside the requested set.
+        self.assertIn('if [ "$EVENT_CRATE" = "kin-vfs-core" ]', update)
+
+    def test_kin_vfs_core_hold_gate_runs_on_every_pull_request(self) -> None:
+        """The hold decision's own tests grade the pull request, not just main.
+
+        `Product Acceptance` carries `github.event_name != 'pull_request'`, so a
+        rule added there does not run on the pull request that breaks it. The
+        fast gate does, and `release-policy-gate.sh` hard-fails any change under
+        `.github/` or `scripts/`, which is every change that could break this.
+        """
+
+        self.assertIn("scripts/wave-kin-vfs-core-hold.test.mjs", self.fast_gate)
+        self.assertTrue(
+            (ROOT / "scripts" / "wave-kin-vfs-core-hold.mjs").is_file(),
+            "the decision script the receiver runs is missing",
+        )
+        self.assertTrue(
+            (ROOT / "scripts" / "wave-kin-vfs-core-hold.test.mjs").is_file(),
+            "the decision script has no tests",
+        )
+
     def test_generated_smoke_and_admission_order_is_exact(self) -> None:
         snapshot = step_block(
             self.workflow, "Snapshot the exact generated dependency delta"

--- a/scripts/wave-kin-vfs-core-hold.mjs
+++ b/scripts/wave-kin-vfs-core-hold.mjs
@@ -1,0 +1,327 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+// Decides whether the Kin registry dependency wave may roll `kin-vfs-core`.
+//
+// Every other crate in that wave's roll list has one authority: the version the
+// Kin registry publishes. `kin-vfs-core` has two, and they must agree, because
+// a Kin release ships both halves. The registry requirement in `Cargo.toml` is
+// what the Kin binary links against. The immutable kin-vfs checkout commit,
+// recorded as a literal in `release.yml` and `rc-build.yml`, is the tree the
+// release builds the kin-vfs binary from. `scripts/check-kin-vfs-compat.mjs`
+// refuses when they disagree, and it is a required context on every pull
+// request.
+//
+// The wave can write only `Cargo.toml`, `Cargo.lock` and `fuzz/Cargo.lock`
+// (`ALLOWED_PATHS` in `scripts/verify-kin-registry-wave-head.py`, enforced by
+// the generated snapshot, the admission validator and the landing judge), and
+// its App token carries no `workflows` scope. So it can move the registry
+// requirement and it can never move the pin. Left alone, it moved one of two
+// coupled authorities on every kin-vfs-core publish and produced a pull request
+// that could not pass its own required gate: eight wave heads across four
+// version steps between 2026-08-31 and 2026-09-10, each ending in a hand-written
+// pull request (kin#1223, kin#1344, kin#1431) that moved both together.
+//
+// The pin is not something a bot should move anyway. It is a reviewed release
+// input, and a wave that advanced it would ship a kin-vfs tree nobody read. So
+// this holds the coupled crate instead: `kin-vfs-core` joins the roll only when
+// the registry's newest installable version is exactly the version the pinned
+// checkout builds. The other crates roll either way, so the wave still lands,
+// and the reviewed pull request that advances the pin is what releases the next
+// kin-vfs-core roll.
+//
+// The pin is read through `check-kin-vfs-compat.mjs`'s own discovery rather
+// than a second reader, so this and the gate it exists to satisfy cannot
+// disagree about where the pin lives or what it says.
+
+import fs from 'node:fs/promises';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+import {
+  VFS_CORE,
+  VFS_REPOSITORY,
+  fetchPinnedLock,
+  lockPackages,
+  readPinSources,
+  readPinnedVfsCommit,
+} from './check-kin-vfs-compat.mjs';
+
+export { VFS_CORE, VFS_REPOSITORY };
+
+// The receiver's `--registry-url`, whose default is the same value
+// `.kin-actions/scripts/update-cargo-registry-deps.py` uses. The index path
+// below is appended to it exactly as `kin_registry_index.fetch_index` does, so
+// this reads the same rows the updater resolves from.
+export const REGISTRY_URL = 'https://kinlab.ai';
+
+const SEMVER =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+
+// Cargo's sparse-index layout, mirroring `kin_registry_index.sparse_index_path`
+// so a crate whose name length crosses one of these boundaries is looked up at
+// the path the registry actually serves it from.
+export function sparseIndexPath(name) {
+  const lower = name.toLowerCase();
+  if (lower.length === 1) {
+    return `1/${lower}`;
+  }
+  if (lower.length === 2) {
+    return `2/${lower}`;
+  }
+  if (lower.length === 3) {
+    return `3/${lower[0]}/${lower}`;
+  }
+  return `${lower.slice(0, 2)}/${lower.slice(2, 4)}/${lower}`;
+}
+
+// A SemVer precedence key, build metadata ignored, a release ordering above any
+// prerelease of the same core. Comparable with `compareVersions` below.
+export function parseVersion(version) {
+  const match = SEMVER.exec(version);
+  if (match === null) {
+    throw new Error(`invalid SemVer: ${JSON.stringify(version)}`);
+  }
+  const prerelease = match[4];
+  const identifiers =
+    prerelease === undefined
+      ? []
+      : prerelease.split('.').map((identifier) =>
+          /^\d+$/.test(identifier) ? [0, Number(identifier)] : [1, identifier],
+        );
+  return {
+    core: [Number(match[1]), Number(match[2]), Number(match[3])],
+    release: prerelease === undefined,
+    identifiers,
+  };
+}
+
+export function compareVersions(left, right) {
+  const a = parseVersion(left);
+  const b = parseVersion(right);
+  for (let index = 0; index < 3; index += 1) {
+    if (a.core[index] !== b.core[index]) {
+      return a.core[index] < b.core[index] ? -1 : 1;
+    }
+  }
+  if (a.release !== b.release) {
+    return a.release ? 1 : -1;
+  }
+  const length = Math.max(a.identifiers.length, b.identifiers.length);
+  for (let index = 0; index < length; index += 1) {
+    const left_ = a.identifiers[index];
+    const right_ = b.identifiers[index];
+    if (left_ === undefined) {
+      return -1;
+    }
+    if (right_ === undefined) {
+      return 1;
+    }
+    if (left_[0] !== right_[0]) {
+      return left_[0] < right_[0] ? -1 : 1;
+    }
+    if (left_[1] !== right_[1]) {
+      return left_[1] < right_[1] ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+// Parses one sparse-index body. Strict on purpose, and for the same reason the
+// compat gate is strict: a row this cannot read is a registry answer this
+// cannot be trusted to have understood, and reading it loosely would let the
+// wave roll to a version nobody validated. An empty successful body is an
+// error rather than "no versions", because an unpublished crate returns 404.
+export function parseIndex(text, { crate, source }) {
+  const records = [];
+  const lines = text.split('\n');
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (line.trim() === '') {
+      continue;
+    }
+    let row;
+    try {
+      row = JSON.parse(line);
+    } catch (cause) {
+      throw new Error(
+        `malformed registry index row ${index + 1} at ${source}: invalid JSON (${cause.message})`,
+        { cause },
+      );
+    }
+    if (row === null || typeof row !== 'object' || Array.isArray(row)) {
+      throw new Error(
+        `malformed registry index row ${index + 1} at ${source}: expected an object`,
+      );
+    }
+    if (typeof row.name !== 'string' || row.name !== crate) {
+      throw new Error(
+        `malformed registry index row ${index + 1} at ${source}: crate name ` +
+        `${JSON.stringify(row.name)} does not match ${JSON.stringify(crate)}`,
+      );
+    }
+    if (typeof row.vers !== 'string' || row.vers === '') {
+      throw new Error(
+        `malformed registry index row ${index + 1} at ${source}: missing string 'vers'`,
+      );
+    }
+    parseVersion(row.vers);
+    if (typeof row.yanked !== 'boolean') {
+      throw new Error(
+        `malformed registry index row ${index + 1} at ${source}: missing boolean 'yanked'`,
+      );
+    }
+    records.push({ name: row.name, version: row.vers, yanked: row.yanked });
+  }
+  if (records.length === 0) {
+    throw new Error(
+      `malformed registry index at ${source}: empty successful response; an ` +
+      'unpublished crate must return HTTP 404',
+    );
+  }
+  return records;
+}
+
+// The newest version a consumer could install, so a yanked head does not read
+// as the version the pin has to match. Null when every published version is
+// yanked, which holds rather than rolling.
+export function latestInstallable(records) {
+  const installable = records.filter((record) => !record.yanked);
+  if (installable.length === 0) {
+    return null;
+  }
+  return installable
+    .map((record) => record.version)
+    .reduce((best, version) => (compareVersions(version, best) > 0 ? version : best));
+}
+
+// Fails closed on anything but a 404. An unreadable registry is not a licence
+// to guess: the caller turns a throw into a failed step, never into a roll.
+export async function fetchRegistryLatest(
+  crate,
+  { registryUrl = REGISTRY_URL, fetchImpl = fetch } = {},
+) {
+  const url = `${registryUrl.replace(/\/+$/, '')}/registry/cargo/${sparseIndexPath(crate)}`;
+  let response;
+  try {
+    response = await fetchImpl(url, {
+      headers: { accept: 'text/plain', 'user-agent': 'kin-wave-vfs-core-hold' },
+    });
+  } catch (cause) {
+    throw new Error(`could not read registry index ${url}: ${cause.message}`, { cause });
+  }
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(
+      `could not read registry index ${url}: HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+  return latestInstallable(parseIndex(await response.text(), { crate, source: url }));
+}
+
+// The version the pinned kin-vfs checkout builds: its own local package, the
+// one lock entry with no source. Mirrors `compareVfsCore`'s pinned side,
+// including its refusal when the count is not exactly one, so the two cannot
+// read one lock differently.
+export function pinnedCoreVersion(pinnedLock) {
+  const pinned = lockPackages(pinnedLock).filter(
+    (pkg) => pkg.name === VFS_CORE && pkg.source === null,
+  );
+  if (pinned.length !== 1) {
+    throw new Error(
+      `expected one pinned local ${VFS_CORE} in the ${VFS_REPOSITORY} lock; found ${pinned.length}`,
+    );
+  }
+  return pinned[0].version;
+}
+
+// The whole rule, pure and separately testable. Roll only on exact agreement.
+// "Newer than the pin" is the drift this exists to stop. "Older than the pin"
+// is a pin a person moved ahead of a publish, and rolling to something the
+// registry happens to have would move the requirement to a third value, so it
+// holds too and reports what it saw.
+export function decide({ registryLatest, pinnedVersion, pinnedCommit }) {
+  if (registryLatest === null) {
+    return {
+      roll: false,
+      reason:
+        `the Kin registry publishes no installable ${VFS_CORE}, so there is nothing ` +
+        `to roll to; the pinned ${VFS_REPOSITORY} checkout ${pinnedCommit} builds ${pinnedVersion}`,
+    };
+  }
+  if (registryLatest === pinnedVersion) {
+    return {
+      roll: true,
+      reason:
+        `the Kin registry's newest installable ${VFS_CORE} is ${registryLatest}, which is ` +
+        `what the pinned ${VFS_REPOSITORY} checkout ${pinnedCommit} builds`,
+    };
+  }
+  return {
+    roll: false,
+    reason:
+      `holding ${VFS_CORE} at the pin: the Kin registry's newest installable version is ` +
+      `${registryLatest}, but the pinned ${VFS_REPOSITORY} checkout ${pinnedCommit} builds ` +
+      `${pinnedVersion}. Rolling would make the requirement disagree with the immutable ` +
+      'release input, which is a required gate. Advance the pin in ' +
+      '.github/workflows/release.yml and .github/workflows/rc-build.yml to a kin-vfs ' +
+      `commit that builds ${registryLatest}, and the next wave rolls it.`,
+  };
+}
+
+// GitHub reads GITHUB_OUTPUT one key per line, so a value carrying a newline
+// would silently become a second key. Reasons are composed on one line above;
+// this collapses any control character rather than trusting that.
+function outputLine(key, value) {
+  return `${key}=${String(value).replace(/[\r\n\t]+/g, ' ').trim()}\n`;
+}
+
+export async function main({
+  root = process.cwd(),
+  env = process.env,
+  fetchImpl = fetch,
+  log = console.log,
+  writeOutput = null,
+} = {}) {
+  const sources = await readPinSources(root);
+  const pinnedCommit = readPinnedVfsCommit(sources);
+  const pinnedLock = await fetchPinnedLock(pinnedCommit, {
+    token: env.GH_TOKEN || env.GITHUB_TOKEN,
+    fetchImpl,
+  });
+  const pinnedVersion = pinnedCoreVersion(pinnedLock);
+  const registryLatest = await fetchRegistryLatest(VFS_CORE, {
+    registryUrl: env.KIN_REGISTRY_URL || REGISTRY_URL,
+    fetchImpl,
+  });
+  const verdict = decide({ registryLatest, pinnedVersion, pinnedCommit });
+
+  const emit =
+    writeOutput ??
+    (env.GITHUB_OUTPUT
+      ? async (text) => fs.appendFile(env.GITHUB_OUTPUT, text, 'utf8')
+      : async () => {});
+  await emit(
+    outputLine('kin_vfs_core_roll', verdict.roll ? 'true' : 'false') +
+      outputLine('kin_vfs_core_reason', verdict.reason) +
+      outputLine('kin_vfs_core_pinned', pinnedVersion) +
+      outputLine('kin_vfs_core_registry', registryLatest ?? ''),
+  );
+  log(
+    `${verdict.roll ? 'ROLL' : 'HOLD'} ${VFS_CORE}: ${verdict.reason}`,
+  );
+  return verdict;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  // Resolved from the working directory, exactly as check-kin-vfs-compat.mjs
+  // resolves it, so both read the same tree when the workflow runs them from
+  // GITHUB_WORKSPACE.
+  main().catch((error) => {
+    console.error(`::error::${error.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/wave-kin-vfs-core-hold.test.mjs
+++ b/scripts/wave-kin-vfs-core-hold.test.mjs
@@ -1,0 +1,409 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  REGISTRY_URL,
+  VFS_CORE,
+  VFS_REPOSITORY,
+  compareVersions,
+  decide,
+  fetchRegistryLatest,
+  latestInstallable,
+  main,
+  parseIndex,
+  parseVersion,
+  pinnedCoreVersion,
+  sparseIndexPath,
+} from './wave-kin-vfs-core-hold.mjs';
+
+const PIN = 'a'.repeat(40);
+const INDEX_URL = `${REGISTRY_URL}/registry/cargo/${sparseIndexPath(VFS_CORE)}`;
+
+const row = (version, yanked = false) =>
+  JSON.stringify({
+    name: VFS_CORE,
+    vers: version,
+    yanked,
+    cksum: '0'.repeat(64),
+    deps: [],
+    features: {},
+  });
+
+const indexBody = (...rows) => `${rows.join('\n')}\n`;
+
+const lockWith = (entries) =>
+  entries
+    .map(
+      ({ name, version, source }) =>
+        `[[package]]\nname = "${name}"\nversion = "${version}"\n` +
+        (source === null ? '' : `source = "${source}"\n`),
+    )
+    .join('\n');
+
+const releaseYamlWith = (commit) => `
+jobs:
+  build:
+    steps:
+      - name: Checkout kin-vfs
+        uses: actions/checkout@0000000000000000000000000000000000000000 # v7.0.0
+        with:
+          repository: ${VFS_REPOSITORY}
+          ref: ${commit}
+          persist-credentials: false
+
+      - name: Generate artifact provenance manifest
+        env:
+          EXPECTED_VFS_COMMIT: ${commit}
+        run: node ./provenance.mjs
+`;
+
+// One stub for both reads main makes: the pinned kin-vfs lock from the GitHub
+// contents API, and the sparse index from the Kin registry. Routing on the URL
+// rather than on call order means a change that reorders them still exercises
+// the same responses instead of silently swapping them.
+const stubFetch = ({ lock, index, indexStatus = 200 }) => {
+  const seen = [];
+  const impl = async (url) => {
+    seen.push(url);
+    if (url.startsWith('https://api.github.com/')) {
+      return { ok: true, status: 200, statusText: 'OK', text: async () => lock };
+    }
+    if (url === INDEX_URL) {
+      if (indexStatus !== 200) {
+        return {
+          ok: false,
+          status: indexStatus,
+          statusText: 'Not Found',
+          text: async () => '',
+        };
+      }
+      return { ok: true, status: 200, statusText: 'OK', text: async () => index };
+    }
+    throw new Error(`unexpected fetch of ${url}`);
+  };
+  impl.seen = seen;
+  return impl;
+};
+
+// A tree carrying only what readPinSources needs, so main's discovery runs for
+// real rather than through a stub of the thing this exists to share.
+const treeWithPin = (commit) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wave-vfs-hold-'));
+  fs.mkdirSync(path.join(root, '.github', 'workflows'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, '.github', 'workflows', 'release.yml'),
+    releaseYamlWith(commit),
+    'utf8',
+  );
+  return root;
+};
+
+// ---------------------------------------------------------------------------
+// The rule itself. These two are the arms the whole change rests on: an
+// obvious mutation of `decide` (always roll, always hold, or `!==` for `===`)
+// takes one of them red.
+// ---------------------------------------------------------------------------
+
+test('rolls when the registry latest is exactly what the pinned checkout builds', () => {
+  const verdict = decide({
+    registryLatest: '0.4.24',
+    pinnedVersion: '0.4.24',
+    pinnedCommit: PIN,
+  });
+  assert.equal(verdict.roll, true);
+  assert.match(verdict.reason, /0\.4\.24/);
+});
+
+test('holds when the registry has published past the pinned checkout', () => {
+  const verdict = decide({
+    registryLatest: '0.4.25',
+    pinnedVersion: '0.4.24',
+    pinnedCommit: PIN,
+  });
+  assert.equal(verdict.roll, false);
+  assert.match(verdict.reason, /newest installable version is 0\.4\.25/);
+  assert.match(verdict.reason, /builds 0\.4\.24/);
+  assert.match(verdict.reason, /release\.yml/);
+});
+
+test('holds when the pin was moved ahead of the registry', () => {
+  const verdict = decide({
+    registryLatest: '0.4.24',
+    pinnedVersion: '0.4.25',
+    pinnedCommit: PIN,
+  });
+  assert.equal(verdict.roll, false);
+});
+
+test('holds when the registry publishes no installable version at all', () => {
+  const verdict = decide({
+    registryLatest: null,
+    pinnedVersion: '0.4.24',
+    pinnedCommit: PIN,
+  });
+  assert.equal(verdict.roll, false);
+  assert.match(verdict.reason, /no installable/);
+});
+
+// The exact state of 2026-09-10 that produced kin#1665's red required context:
+// kin-vfs published 0.4.25 while the pin still built 0.4.24. A regression that
+// re-enables the roll in that state takes this red.
+test('holds on the kin#1665 state that reds Fast gate lint and policy', () => {
+  assert.equal(
+    decide({ registryLatest: '0.4.25', pinnedVersion: '0.4.24', pinnedCommit: PIN }).roll,
+    false,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Yank authority, which decides what "latest" even means.
+// ---------------------------------------------------------------------------
+
+test('the newest yanked version is not the version the pin has to match', () => {
+  assert.equal(
+    latestInstallable([
+      { version: '0.4.24', yanked: false },
+      { version: '0.4.25', yanked: true },
+    ]),
+    '0.4.24',
+  );
+});
+
+test('every version yanked is no installable version', () => {
+  assert.equal(latestInstallable([{ version: '0.4.24', yanked: true }]), null);
+});
+
+test('latest is by SemVer precedence, not by row order or string order', () => {
+  assert.equal(
+    latestInstallable([
+      { version: '0.4.10', yanked: false },
+      { version: '0.4.9', yanked: false },
+    ]),
+    '0.4.10',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Version ordering, the piece a string comparison would get wrong.
+// ---------------------------------------------------------------------------
+
+test('orders double-digit patches above single-digit ones', () => {
+  assert.equal(compareVersions('0.4.10', '0.4.9') > 0, true);
+});
+
+test('orders a release above its own prereleases', () => {
+  assert.equal(compareVersions('0.4.25', '0.4.25-rc.1') > 0, true);
+  assert.equal(compareVersions('0.4.25-rc.2', '0.4.25-rc.1') > 0, true);
+  assert.equal(compareVersions('0.4.25-rc.1', '0.4.25-rc.1') === 0, true);
+});
+
+test('ignores build metadata in precedence', () => {
+  assert.equal(compareVersions('0.4.25+abc', '0.4.25') === 0, true);
+});
+
+test('refuses a version the registry should never have served', () => {
+  assert.throws(() => parseVersion('0.4'), /invalid SemVer/);
+  assert.throws(() => parseVersion('0.04.1'), /invalid SemVer/);
+});
+
+// ---------------------------------------------------------------------------
+// Where the index lives. Getting this wrong reads a 404 as "unpublished" and
+// holds forever, which is quiet, so it is asserted rather than assumed.
+// ---------------------------------------------------------------------------
+
+test('mirrors the sparse-index layout for every name length', () => {
+  assert.equal(sparseIndexPath('a'), '1/a');
+  assert.equal(sparseIndexPath('ab'), '2/ab');
+  assert.equal(sparseIndexPath('abc'), '3/a/abc');
+  assert.equal(sparseIndexPath('kin-vfs-core'), 'ki/n-/kin-vfs-core');
+  assert.equal(sparseIndexPath('KIN-DB'), 'ki/n-/kin-db');
+});
+
+// ---------------------------------------------------------------------------
+// Reading the index. Strict, because a row this cannot read is a registry
+// answer it cannot claim to have understood.
+// ---------------------------------------------------------------------------
+
+test('reads a well-formed index', () => {
+  const records = parseIndex(indexBody(row('0.4.24'), row('0.4.25', true)), {
+    crate: VFS_CORE,
+    source: INDEX_URL,
+  });
+  assert.deepEqual(records, [
+    { name: VFS_CORE, version: '0.4.24', yanked: false },
+    { name: VFS_CORE, version: '0.4.25', yanked: true },
+  ]);
+});
+
+test('refuses a row that is not JSON', () => {
+  assert.throws(
+    () => parseIndex('{not json\n', { crate: VFS_CORE, source: INDEX_URL }),
+    /invalid JSON/,
+  );
+});
+
+test('refuses a row for another crate', () => {
+  const foreign = JSON.stringify({
+    name: 'kin-db',
+    vers: '0.7.0',
+    yanked: false,
+    cksum: '0'.repeat(64),
+    deps: [],
+    features: {},
+  });
+  assert.throws(
+    () => parseIndex(`${foreign}\n`, { crate: VFS_CORE, source: INDEX_URL }),
+    /does not match/,
+  );
+});
+
+test('refuses a row with no yank authority', () => {
+  const missing = JSON.stringify({ name: VFS_CORE, vers: '0.4.24' });
+  assert.throws(
+    () => parseIndex(`${missing}\n`, { crate: VFS_CORE, source: INDEX_URL }),
+    /missing boolean 'yanked'/,
+  );
+});
+
+test('refuses an empty successful body rather than reading it as no versions', () => {
+  assert.throws(
+    () => parseIndex('\n\n', { crate: VFS_CORE, source: INDEX_URL }),
+    /empty successful response/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Transport. Fails closed: only a 404 is an answer.
+// ---------------------------------------------------------------------------
+
+test('a 404 is an unpublished crate, which holds', async () => {
+  const impl = stubFetch({ lock: '', index: '', indexStatus: 404 });
+  assert.equal(await fetchRegistryLatest(VFS_CORE, { fetchImpl: impl }), null);
+});
+
+test('a 500 is not a roll and not a hold, it is a failed step', async () => {
+  const impl = stubFetch({ lock: '', index: '', indexStatus: 500 });
+  await assert.rejects(
+    fetchRegistryLatest(VFS_CORE, { fetchImpl: impl }),
+    /HTTP 500/,
+  );
+});
+
+test('an unreachable registry is a failed step', async () => {
+  await assert.rejects(
+    fetchRegistryLatest(VFS_CORE, {
+      fetchImpl: async () => {
+        throw new Error('ECONNRESET');
+      },
+    }),
+    /could not read registry index .*ECONNRESET/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The pinned side, read the way the compat gate reads it.
+// ---------------------------------------------------------------------------
+
+test('reads the pinned checkout version from its own local lock entry', () => {
+  const lock = lockWith([
+    { name: VFS_CORE, version: '0.4.24', source: null },
+    { name: 'lru', version: '0.12.0', source: 'registry+https://crates.io' },
+  ]);
+  assert.equal(pinnedCoreVersion(lock), '0.4.24');
+});
+
+test('refuses a pinned lock that does not carry exactly one local kin-vfs-core', () => {
+  assert.throws(() => pinnedCoreVersion(lockWith([])), /found 0/);
+  assert.throws(
+    () =>
+      pinnedCoreVersion(
+        lockWith([
+          { name: VFS_CORE, version: '0.4.24', source: null },
+          { name: VFS_CORE, version: '0.4.25', source: null },
+        ]),
+      ),
+    /found 2/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// End to end, through the real pin discovery, writing the outputs the workflow
+// branches on. A workflow reading a key this never writes would hold forever
+// and never say so, so the key names are asserted here.
+// ---------------------------------------------------------------------------
+
+test('holds end to end and writes the outputs the receiver branches on', async () => {
+  const root = treeWithPin(PIN);
+  const written = [];
+  const verdict = await main({
+    root,
+    env: {},
+    fetchImpl: stubFetch({
+      lock: lockWith([{ name: VFS_CORE, version: '0.4.24', source: null }]),
+      index: indexBody(row('0.4.24'), row('0.4.25')),
+    }),
+    log: () => {},
+    writeOutput: async (text) => written.push(text),
+  });
+  assert.equal(verdict.roll, false);
+  const text = written.join('');
+  assert.match(text, /^kin_vfs_core_roll=false$/m);
+  assert.match(text, /^kin_vfs_core_pinned=0\.4\.24$/m);
+  assert.match(text, /^kin_vfs_core_registry=0\.4\.25$/m);
+  assert.match(text, /^kin_vfs_core_reason=holding kin-vfs-core at the pin: /m);
+  assert.equal(text.split('\n').filter((line) => line !== '').length, 4);
+});
+
+test('rolls end to end when the registry and the pin agree', async () => {
+  const root = treeWithPin(PIN);
+  const written = [];
+  const verdict = await main({
+    root,
+    env: {},
+    fetchImpl: stubFetch({
+      lock: lockWith([{ name: VFS_CORE, version: '0.4.25', source: null }]),
+      index: indexBody(row('0.4.24'), row('0.4.25')),
+    }),
+    log: () => {},
+    writeOutput: async (text) => written.push(text),
+  });
+  assert.equal(verdict.roll, true);
+  assert.match(written.join(''), /^kin_vfs_core_roll=true$/m);
+});
+
+test('reads the pin through the shared discovery, so a floating ref refuses', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wave-vfs-hold-'));
+  fs.mkdirSync(path.join(root, '.github', 'workflows'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, '.github', 'workflows', 'release.yml'),
+    releaseYamlWith('main'),
+    'utf8',
+  );
+  await assert.rejects(
+    main({
+      root,
+      env: {},
+      fetchImpl: async () => {
+        throw new Error('should never reach the network');
+      },
+      log: () => {},
+      writeOutput: async () => {},
+    }),
+    /not a 40-character commit sha/,
+  );
+});
+
+test('a reason never carries a newline, which would forge a second output key', () => {
+  const verdict = decide({
+    registryLatest: '0.4.25',
+    pinnedVersion: '0.4.24',
+    pinnedCommit: PIN,
+  });
+  assert.equal(/[\r\n]/.test(verdict.reason), false);
+});


### PR DESCRIPTION
## What this fixes

`kin-vfs-core` is the one crate in the Kin registry dependency wave with two authorities that a required context makes agree.

- Its registry requirement in `Cargo.toml` is what the Kin binary links against.
- The immutable kin-vfs checkout commit, a literal in `release.yml` and `rc-build.yml`, is the tree the release builds the kin-vfs binary from.
- `scripts/check-kin-vfs-compat.mjs` refuses when they disagree, under the required `Fast gate lint and policy` context.

The wave can write `Cargo.toml`, `Cargo.lock` and `fuzz/Cargo.lock` and nothing else (`ALLOWED_PATHS` in `scripts/verify-kin-registry-wave-head.py`, enforced by the generated snapshot, the admission validator and the landing judge), and its App token carries no `workflows` scope. So it can move the requirement and it can never move the pin. Rolling on every publish moved one of two coupled authorities and produced a wave head that could not pass its own required gate.

## Measured, not assumed

Eight wave heads across four version steps, read from the failure annotations on `ci.yml` runs for `automation/kin-registry-dependency-wave`:

```
2026-08-31  Kin resolves kin-vfs-core 0.4.22, pinned checkout builds 0.4.21   2 heads
2026-09-01  Kin resolves kin-vfs-core 0.4.23, pinned checkout builds 0.4.22   2 heads
2026-09-03  Kin resolves kin-vfs-core 0.4.24, pinned checkout builds 0.4.23   3 heads
2026-09-10  Kin resolves kin-vfs-core 0.4.25, pinned checkout builds 0.4.24   1 head  (#1665)
```

Each earlier episode ended in a hand-written pull request that moved both authorities together: #1223, #1344, #1431, each changing exactly `release.yml`, `rc-build.yml`, `Cargo.toml`, `Cargo.lock` and `scripts/test-release-workflow-authority.py`. Today's has no repair yet, which is why #1665 is red.

## Why hold rather than move both

Widening the write set so the wave rewrites the pin is the wrong repair on three counts. The receiver is a data-only handoff by design, because newly resolved registry code runs build scripts and proc macros on that runner. The write set is the receiver's core safety property and is enforced three times over. And the pin is a reviewed release input, so a bot that advanced it would ship a kin-vfs tree nobody read.

So the coupled crate holds. `scripts/wave-kin-vfs-core-hold.mjs` reads the pin through `check-kin-vfs-compat.mjs`'s own discovery, so this and the gate it exists to satisfy cannot disagree about where the pin lives or what it says. It reads the registry's newest installable version through the same sparse index the updater resolves from. It rolls only on exact agreement. The other five crates roll as before, so the wave still lands, and the reviewed pull request that advances the pin is what releases the next `kin-vfs-core` roll.

It fails closed. A registry answering anything but 404 or a well-formed index fails the step rather than guessing, an empty output value holds rather than rolls, and a yanked head is not the version the pin has to match.

## Where the check lives, and why

Under `node --test` in `fast-gate-lint`, not under `scripts/acceptance/`. `Product Acceptance` carries `if: ${{ github.event_name != 'pull_request' }}`, so a rule added there would not grade the pull request that breaks this. `release-policy-gate.sh` hard-fails any change touching `.github/` or `scripts/`, which is every change that could break it. The test file is added to both `node --test` lists for the reason those lists are already duplicated: `bin/kin-precheck` enumerates the gate plan out of the `check` job by name.

## Falsification

Eight arms, each red on its own, with the control green before and after. Harness and full output kept at `.kin-coord/reports/wavepin-data/falsify-a.sh` and `falsify-a.out`.

```
=== positive control: unmutated tree ===
PASS  control node --test (rc=0) # pass 27 # fail 0
PASS  control receiver tests (rc=0) Ran 61 tests  OK

arm 1  decide always rolls                        rc=1  # pass 21 # fail 6
arm 2  decide always holds                        rc=1  # pass 22 # fail 5
arm 3  the equality test inverted                 rc=1  # pass 21 # fail 6
arm 4  yank authority dropped                     rc=1  # pass 25 # fail 2
arm 5  the registry read fails open               rc=1  # pass 26 # fail 1
arm 6  workflow rolls kin-vfs-core unconditionally rc=1  Ran 61 tests  FAILED (failures=2)
arm 7  the decision step deleted                  rc=1  Ran 61 tests  FAILED (failures=1)
arm 8  the test dropped from the fast gate        rc=1  Ran 61 tests  FAILED (failures=1)

=== restored: control again ===
PASS  restore node --test (rc=0) # pass 27 # fail 0
PASS  restore receiver tests (rc=0) Ran 61 tests  OK
```

Arms 1 and 2 are the pair that matters: a `decide` that always rolls takes every hold assertion red, and one that always holds takes every roll assertion red.

## Replayed against all four historical episodes

The version pairs come from the wave branch's own CI failure annotations, replayed through the new decision. Script and output kept at `.kin-coord/reports/wavepin-data/replay-history.mjs` and `replay-history.out`.

```
2026-08-31  registry 0.4.22 vs pin 0.4.21 (2 wave head(s))  ->  HOLD (prevented)
2026-09-01  registry 0.4.23 vs pin 0.4.22 (2 wave head(s))  ->  HOLD (prevented)
2026-09-03  registry 0.4.24 vs pin 0.4.23 (3 wave head(s))  ->  HOLD (prevented)
2026-09-10  registry 0.4.25 vs pin 0.4.24 (1 wave head(s))  ->  HOLD (prevented)

after the repair, registry 0.4.21 == pin 0.4.21  ->  ROLL
after the repair, registry 0.4.22 == pin 0.4.22  ->  ROLL
after the repair, registry 0.4.23 == pin 0.4.23  ->  ROLL
after the repair, registry 0.4.24 == pin 0.4.24  ->  ROLL
after the repair, registry 0.4.25 == pin 0.4.25  ->  ROLL

8 of 8 drifted wave heads prevented; the roll resumes at every repair
rc=0
```

The second half is the one that keeps this from being a freeze: the crate rolls again the moment a reviewed pull request advances the pin, so the requirement always catches up.

## Local verification

`bin/kin-precheck kin` against this worktree, run through the umbrella:

```
kin-precheck: repo=kin tree=.../worktrees/wavepin-kin sha=57901bda41025830f82f79beb065dff3250766a9 branch=chore/lane-wavepin-kin
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 57901bda41025830f82f79beb065dff3250766a9
```

And the decision run live against this tree, which is the state that reds #1665:

```
$ node scripts/wave-kin-vfs-core-hold.mjs
HOLD kin-vfs-core: holding kin-vfs-core at the pin: the Kin registry's newest
installable version is 0.4.25, but the pinned firelock-ai/kin-vfs checkout
4ff5262bb345d2d08846b0e8e09abc9fad639aed builds 0.4.24. Rolling would make the
requirement disagree with the immutable release input, which is a required gate.
Advance the pin in .github/workflows/release.yml and .github/workflows/rc-build.yml
to a kin-vfs commit that builds 0.4.25, and the next wave rolls it.
rc=0
```

## What this does not do

It does not repair #1665. That needs the pin advanced to a kin-vfs commit building 0.4.25, which is a separate reviewed pull request. Once this lands, the next wave regenerates #1665 with `kin-vfs-core` held at 0.4.24 and it goes green on its own.
