### PR TITLE
Stop reporting a red wave pull request as a failure of main

### DIFF
--- a/.github/workflows/kin-registry-wave-land.yml
+++ b/.github/workflows/kin-registry-wave-land.yml
@@ -33,6 +33,12 @@ name: Kin Registry Wave Landing
 # admission chain refuses any server-owned landing state on the wave. There
 # is no manual dispatch arm, because this workflow reaches a release-capable
 # secret; the kick is a repository_dispatch, which cannot select a branch.
+#
+# A failed check on the wave head is a wait, not a refusal, so this workflow's
+# run on main stays green while the red stays on the pull request. The colour
+# is the only thing that changed: land-wave still runs on decision == 'land'.
+# See the failed-checks branch of judge() in scripts/land-kin-registry-wave.py
+# for the twenty red runs from one head that bought the distinction.
 on:
   workflow_run:
     workflows: [CI]

--- a/docs/release-bot.md
+++ b/docs/release-bot.md
@@ -592,8 +592,19 @@ suite awaiting its rerun, an attestation on its way, GitHub still computing
 mergeability, a re-pushed head), so one trigger outlasts the checks it waits
 on. Only then does the land job mint the App token, squash-merge with the pull
 title and body and never the marker line, and prove the squash is on `main`.
-A failed check, a foreign commit, an off-scope file or an unreadable listing
-refuses loudly; everything transient and an open hold wait quietly. A wave
+A foreign commit, an off-scope file, an unreadable listing or an attestation
+that does not verify refuses loudly, because each says something is wrong with
+the automation itself and a red run on main is the right report for it.
+
+A failed check on the wave head does not. It is a property of that pull
+request, never of main, and refusing it repainted main red on every pass of a
+cron that fires four times an hour: one head that failed a test shard on
+2026-09-05 produced about twenty failed runs over three days, and sixty-two of
+the seventy failures in the hundred runs to 2026-09-10 were that shape. A
+permanently red job stops being read. So it is a wait that raises a warning
+naming the pull and the failed contexts, the run stays green, the wave still
+does not land, and the red stays on the pull request where it can be fixed.
+Everything transient and an open hold wait quietly. A wave
 whose pins a lane already carried onto main has nothing to merge and is left
 for the receiver's next refresh, never squashed as an empty diff. GitHub's
 own auto-merge is not the mechanism, because it merges on the six ruleset

--- a/scripts/land-kin-registry-wave.py
+++ b/scripts/land-kin-registry-wave.py
@@ -150,6 +150,11 @@ class Verdict:
     # a judge given a wait budget re-reads until it does. A hold or an empty
     # branch is not transient, and returns at once.
     transient: bool = False
+    # A wait that needs a person, raised as a warning annotation rather than
+    # the quiet notice an ordinary wait prints. It is still a wait, so this
+    # workflow stays green: see the failed-checks branch of `judge` for why a
+    # red pull request is not a red main.
+    alarm: bool = False
 
     def document(self) -> dict[str, Any]:
         return {
@@ -159,6 +164,7 @@ class Verdict:
             "head": self.head,
             "details": self.details,
             "transient": self.transient,
+            "alarm": self.alarm,
         }
 
 
@@ -589,12 +595,38 @@ def judge(snapshot: dict[str, Any]) -> Verdict:
     except LandingError as exc:
         return Verdict(REFUSE, f"check-runs unreadable: {exc}", number, head)
     if checks["failed"]:
+        # A WAIT, not a REFUSE, and this is the whole point of the distinction.
+        #
+        # A failed check on the wave head is a property of that pull request,
+        # never of main. This workflow is triggered by a four-times-an-hour cron
+        # and by every CI completion on the wave branch, so a REFUSE here
+        # repainted main red on every pass for as long as the head stayed red:
+        # the head at 2026-09-05T12:14:53Z failed one test shard and produced
+        # about twenty failed runs of this workflow on main over the three days
+        # before anyone touched it. Sixty-two of the seventy failures in the
+        # hundred runs to 2026-09-10 were that shape.
+        #
+        # A permanently red job stops being read, and the reader who does open
+        # it finds a run about an automation branch and closes the tab, which is
+        # how this became a chronic red nobody owned. The red belongs on the
+        # pull request, where it already is and where it can be fixed. So this
+        # run stays green and raises a warning naming the pull and the contexts.
+        #
+        # Not transient: a concluded failure does not resolve by itself, and
+        # spinning the wait budget on it would burn the runner for nothing.
+        #
+        # Every other refusal below and above stays a refusal. Those are
+        # properties of the machinery (a pull the release App did not open, a
+        # write outside the receiver's set, a commit identity that does not
+        # match, an attestation that does not verify), and a red main is the
+        # right report for each of them.
         return Verdict(
-            REFUSE,
+            WAIT,
             "checks failed: " + ", ".join(checks["failed"]),
             number,
             head,
             checks,
+            alarm=True,
         )
     if checks["pending"]:
         return Verdict(
@@ -865,6 +897,10 @@ def judge_with_wait(
                 verdict.head,
                 {**verdict.details, "passes": passes},
                 verdict.transient,
+                # Rebuilt positionally, so every field has to be named here or
+                # it is silently dropped on the one path a judgment with a wait
+                # budget always takes, which is every real run.
+                verdict.alarm,
             ), snapshot
         print(f"::notice::wave landing waits ({int(remaining)}s left): {verdict.reason}", file=sys.stderr)
         sleep(min(WAIT_POLL_SECONDS, remaining))
@@ -971,7 +1007,17 @@ def _emit(verdict: Verdict) -> int:
         print(f"::error title=Kin registry wave refused::{verdict.reason}", file=sys.stderr)
         return 1
     if verdict.decision == WAIT:
-        print(f"::notice::wave landing waits: {verdict.reason}", file=sys.stderr)
+        if verdict.alarm:
+            # Louder than a notice and quieter than a failed run, which is
+            # exactly the shape this condition has: somebody has to act, and
+            # the thing to act on is the pull request, not main.
+            print(
+                f"::warning title=Kin registry wave is not landable::"
+                f"pull {verdict.pull}: {verdict.reason}",
+                file=sys.stderr,
+            )
+        else:
+            print(f"::notice::wave landing waits: {verdict.reason}", file=sys.stderr)
     return 0
 
 

--- a/scripts/test-kin-registry-wave-landing.py
+++ b/scripts/test-kin-registry-wave-landing.py
@@ -510,22 +510,76 @@ class WaveJudgeTests(unittest.TestCase):
         self.assertEqual(verdict.details["failed"], [])
         self.assertEqual(verdict.details["base"], BASE)
 
-    def test_one_failure_refuses(self) -> None:
+    def test_one_failure_waits_loudly_and_leaves_main_green(self) -> None:
+        """A red wave head is not a red main.
+
+        This workflow is triggered four times an hour by cron and by every CI
+        completion on the wave branch, so refusing a failed check repainted main
+        red on every pass for as long as the head stayed red: the head at
+        2026-09-05T12:14:53Z failed one test shard and produced about twenty
+        failed runs on main over three days. Sixty-two of the seventy failures
+        in the hundred runs to 2026-09-10 were that shape, and a permanently red
+        job stops being read. The wave still does not land; the red stays on the
+        pull request, where it can be fixed.
+
+        Reverting this branch to REFUSE takes the decision assertion red, and
+        dropping `alarm=True` takes the annotation assertion red.
+        """
+
         runs = green_runs() + [check_run("cargo-fuzz (parse_adapter)", "failure")]
         verdict = self.assertVerdict(
             green_snapshot(check_run_pages=pages(runs)),
-            landing.REFUSE,
+            landing.WAIT,
             r"checks failed: cargo-fuzz \(parse_adapter\)=failure",
         )
         self.assertEqual(verdict.pull, 1360)
+        self.assertTrue(verdict.alarm, "a failed check has to be raised, not merely noted")
+        # Not transient. A concluded failure does not resolve by itself, and a
+        # transient wait would spin the whole 1500-second budget on it.
+        self.assertFalse(verdict.transient)
+        self.assertEqual(verdict.details["failed"], ["cargo-fuzz (parse_adapter)=failure"])
         for conclusion in ("timed_out", "action_required", "stale", "startup_failure"):
             with self.subTest(conclusion=conclusion):
                 runs = green_runs() + [check_run("Linux Daemon Smoke", conclusion)]
-                self.assertVerdict(
+                held = self.assertVerdict(
                     green_snapshot(check_run_pages=pages(runs)),
-                    landing.REFUSE,
+                    landing.WAIT,
                     f"checks failed: Linux Daemon Smoke={conclusion}",
                 )
+                self.assertTrue(held.alarm)
+
+    def test_a_failed_check_never_lands_the_wave(self) -> None:
+        """The wave still does not land. Only the colour of the run changed.
+
+        `land-wave` runs on `decision == 'land'`, so a wait is as unlandable as
+        a refusal. A mutation that turned the failed-checks branch into LAND to
+        make the run green would take this red.
+        """
+
+        runs = green_runs() + [check_run("cargo-deny", "failure")]
+        verdict = landing.judge(green_snapshot(check_run_pages=pages(runs)))
+        self.assertNotEqual(verdict.decision, landing.LAND)
+
+    def test_machinery_refusals_stay_red_on_main(self) -> None:
+        """Only the checks-failed branch moved.
+
+        A pull the release App did not open, a write outside the receiver's set,
+        a commit identity that does not match, an attestation that does not
+        verify: each says something is wrong with the automation itself, and a
+        red main is the right report. Widening the wait to those would make this
+        workflow incapable of reporting anything.
+        """
+
+        off_scope = [wave_file("Cargo.toml"), wave_file("Cargo.lock"), wave_file("README.md")]
+        for name, snapshot in (
+            ("off-scope write", green_snapshot(files=off_scope, pull=wave_pull(changed_files=3))),
+            ("two commits", green_snapshot(commits=[bot_commit(), bot_commit()])),
+            ("unverified attestation", green_snapshot(attestation="attestation missing")),
+        ):
+            with self.subTest(refusal=name):
+                verdict = landing.judge(snapshot)
+                self.assertEqual(verdict.decision, landing.REFUSE, verdict.reason)
+                self.assertFalse(verdict.alarm)
 
     def test_cancelled_by_a_repush_waits_instead_of_failing(self) -> None:
         # The receiver's re-push cancels the superseded suite and the attester's
@@ -672,14 +726,15 @@ class WaveJudgeTests(unittest.TestCase):
             green_snapshot(check_run_pages=pages(runs)), landing.LAND, "concluded green"
         )
 
-    def test_newer_failure_after_an_older_success_refuses(self) -> None:
+    def test_newer_failure_after_an_older_success_holds(self) -> None:
         runs = green_runs()
         runs.append(check_run("cargo-deny", "failure", started="2026-09-02T09:40:00Z"))
-        self.assertVerdict(
+        verdict = self.assertVerdict(
             green_snapshot(check_run_pages=pages(runs)),
-            landing.REFUSE,
+            landing.WAIT,
             "checks failed: cargo-deny=failure",
         )
+        self.assertTrue(verdict.alarm)
 
     def test_missing_required_context_waits(self) -> None:
         runs = [run for run in green_runs() if run["name"] != "cargo-deny"]
@@ -855,6 +910,35 @@ class WaveJudgeTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertEqual(json.loads(result.stdout)["decision"], landing.LAND)
 
+            # A machinery refusal still exits 1 and still paints main red.
+            refused = Path(directory) / "refused.json"
+            refused.write_text(
+                json.dumps(
+                    green_snapshot(
+                        files=[
+                            wave_file("Cargo.toml"),
+                            wave_file("Cargo.lock"),
+                            wave_file("README.md"),
+                        ],
+                        pull=wave_pull(changed_files=3),
+                    )
+                ),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [sys.executable, str(LANDING_PATH), "judge-fixture", "--fixture", str(refused)],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertEqual(json.loads(result.stdout)["decision"], landing.REFUSE)
+            self.assertIn("::error title=Kin registry wave refused::", result.stderr)
+
+            # A failed check on the wave head exits 0, so this workflow's run on
+            # main is green, and raises a warning naming the pull. The exit code
+            # is the assertion that matters: it is what GitHub reads as the run
+            # conclusion, and it is what made this a chronic red on main.
             red = Path(directory) / "red.json"
             runs = green_runs() + [check_run("cargo-deny", "failure")]
             red.write_text(
@@ -866,9 +950,15 @@ class WaveJudgeTests(unittest.TestCase):
                 capture_output=True,
                 check=False,
             )
-            self.assertEqual(result.returncode, 1)
-            self.assertEqual(json.loads(result.stdout)["decision"], landing.REFUSE)
-            self.assertIn("::error title=Kin registry wave refused::", result.stderr)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            document = json.loads(result.stdout)
+            self.assertEqual(document["decision"], landing.WAIT)
+            self.assertTrue(document["alarm"])
+            self.assertIn(
+                "::warning title=Kin registry wave is not landable::pull 1360:",
+                result.stderr,
+            )
+            self.assertNotIn("::error", result.stderr)
 
             waiting = Path(directory) / "wait.json"
             waiting.write_text(json.dumps(green_snapshot(open_pulls=[])), encoding="utf-8")
@@ -1032,9 +1122,29 @@ class WaitLoopTests(unittest.TestCase):
     def test_a_hold_and_a_refusal_return_at_once(self) -> None:
         verdict, slept, gathers = self._loop([green_snapshot(freeze="hold")], 600)
         self.assertEqual((verdict.decision, slept, gathers), (landing.WAIT, [], 1))
-        red = green_snapshot(check_run_pages=pages(green_runs() + [check_run("cargo-deny", "failure")]))
-        verdict, slept, gathers = self._loop([red], 600)
+        off_scope = green_snapshot(
+            files=[wave_file("Cargo.toml"), wave_file("Cargo.lock"), wave_file("README.md")],
+            pull=wave_pull(changed_files=3),
+        )
+        verdict, slept, gathers = self._loop([off_scope], 600)
         self.assertEqual((verdict.decision, slept, gathers), (landing.REFUSE, [], 1))
+
+    def test_a_failed_check_returns_at_once_and_keeps_its_alarm(self) -> None:
+        """Two properties on one path, both of which a rebuild can silently lose.
+
+        The wait loop rebuilds the verdict positionally, so a field added to
+        Verdict and not named there is dropped on the one path every real run
+        takes. And a failed check is a final wait, so it must not burn the
+        wait budget: `slept == []` is that assertion.
+        """
+
+        red = green_snapshot(
+            check_run_pages=pages(green_runs() + [check_run("cargo-deny", "failure")])
+        )
+        verdict, slept, gathers = self._loop([red], 600)
+        self.assertEqual((verdict.decision, slept, gathers), (landing.WAIT, [], 1))
+        self.assertTrue(verdict.alarm, "the alarm was dropped by the wait loop's rebuild")
+        self.assertFalse(verdict.transient)
 
     def test_a_repush_during_the_wait_is_judged_on_the_new_head(self) -> None:
         moved = green_snapshot(branch_tip=OTHER)


### PR DESCRIPTION
## What this fixes

`kin-registry-wave-land.yml` concluded `failure` on **70 of its last 100 runs** on `main`, back to 2026-09-04. Main's own CI was green through all of it.

The judge returns exit 1 for a `REFUSE` and exit 0 for a `WAIT`, so a refusal is a failed workflow run on main. Checks failing on the wave head was a refusal, and this workflow is triggered by a `5,20,35,50 * * * *` cron plus every CI completion on the wave branch. So one red head repainted main red on every pass for as long as it stayed red.

## Measured

The longest episode. The wave head `2ccb51a1ad8c` failed `Fast gate test shard (1)` at 2026-09-05T12:14:53Z. This workflow then concluded `failure` on main at:

```
12:15:12  12:25:42  12:44:03  13:30:40  16:12:39  18:21:12  20:40:14  22:20:50
... and on through 09-06 and 09-07 at roughly two-hour intervals
```

**One red head, about twenty red runs on main, over three days.**

Across the last 100 runs, classified by reading each failed job's failure annotations:

| class | failed runs |
|---|---|
| checks failed: `Fast gate build and tests` / `Fast gate test shard (N)` | 62 |
| checks failed: `Fast gate lint and policy` | 3 |
| checks failed: `cargo-fuzz` | 3 |
| `pull carries 2 commits` | 2 |

62 of the 70 are an inherited or flaky test failure on a bot branch, reported as a failure of main.

## Why this is the fix and not a softening

A permanently red job stops being read. The reader who does open it finds a run about an automation branch and closes the tab. That is how this became a chronic red nobody owned.

The condition is real; the surface is wrong. A failed check on the wave head is a property of that pull request, never of main, and the red already sits on the pull request where it can be fixed. So that one branch becomes a wait that raises `::warning title=Kin registry wave is not landable::pull <n>: <contexts>`. The run stays green.

Three things do not change:

- **The wave still does not land.** `land-wave` runs on `decision == 'land'`, and a wait is as unlandable as a refusal. `test_a_failed_check_never_lands_the_wave` asserts it.
- **The wait is not transient**, so a concluded failure returns at once rather than spinning the 1500-second budget.
- **Every other refusal stays a refusal.** A pull the release App did not open, a write outside the receiver's write set, a commit identity that does not match, an attestation that does not verify: each says something is wrong with the automation itself, and a red main is the right report. `test_machinery_refusals_stay_red_on_main` asserts that too.

## One trap this found

`judge_with_wait` rebuilds its `Verdict` **positionally** on the one path every real run takes, so a field added to the dataclass and not named there is present in every unit test that calls `judge()` directly and gone in production. The new `alarm` field is named there, and arm 4 below is that exact mutation.

## Falsification

Seven arms, each red on its own, control green before and after. Harness and full output at `.kin-coord/reports/wavepin-data/falsify-b.sh` and `falsify-b.out`.

```
=== positive control ===  PASS (rc=0) Ran 67 tests  OK

arm 1  the failed-check branch refuses again        rc=1  failures=4
arm 2  the alarm dropped                            rc=1  failures=4
arm 3  the wait made transient                      rc=1  failures=2
arm 4  the wait loop's rebuild drops the alarm      rc=1  failures=1
arm 5  the alarm emitted as a quiet notice          rc=1  failures=1
arm 6  a failed check made to LAND                  rc=1  failures=5
arm 7  a machinery refusal widened into a wait      rc=1  failures=4

=== restored: control again ===  PASS (rc=0) Ran 67 tests  OK
```

Arm 6 is the one that matters most: a mutation that made the run green by LANDING a red wave would be a catastrophe, and it takes five tests red.

## Local verification

```
kin-precheck: repo=kin tree=.../worktrees/wavepin-kin sha=53cfa9f860426f086e488ff82d010293b0f5b2d6
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 21 gates ran, 21 passed, 0 failed
```

The two suites `kin-precheck` cannot reach, because they run in `ci.yml`'s `npm-launchers` job rather than its `check` job, were run directly:

```
python3 scripts/test-kin-registry-wave-landing.py     Ran 67 tests  OK
python3 scripts/test-kin-registry-release-receiver.py Ran 61 tests  OK
```

## Ticket

FIR-3494

## Related

#1668 fixed the other half: the wave was manufacturing a required-gate failure on every `kin-vfs-core` publish. That accounts for 3 of the 70. This accounts for 62.

The remaining test-shard failures on the wave branch are real and still stop the wave landing. They are somebody's tests to fix. They just no longer report as a failure of main.
