### PR TITLE
Report an unadmitted working copy in the headline and the exit code

### DIFF
--- a/.github/workflows/install-proof-canary.yml
+++ b/.github/workflows/install-proof-canary.yml
@@ -152,7 +152,18 @@ jobs:
 
           # First capture: the store as a new user finds it, before any embedding
           # pass has been asked for.
+          # `kin status` exits 9 when nothing admitted the working copy, and it
+          # starts no daemon to change that, so a first capture reaches this
+          # line with none. These captures want the durable-authority report,
+          # not an answer about uncommitted work, so they accept that one code
+          # and no other.
+          set +e
           kin status --json > "$captures/first-status.json"
+          first_status_rc=$?
+          set -e
+          if [ "$first_status_rc" -ne 0 ] && [ "$first_status_rc" -ne 9 ]; then
+            exit "$first_status_rc"
+          fi
           kin setup status --json > "$captures/first-health.json"
           kin doctor --json > "$captures/first-doctor.json"
 
@@ -163,7 +174,15 @@ jobs:
           # and the contract says so either way.
           kin embed --max-seconds 240 --json > "$captures/kin-embed.json" 2>&1 || \
             echo "::notice::the bounded embedding pass did not complete; the contract judges whatever state the store reached."
+          set +e
           kin status --json > "$captures/settled-status.json"
+          settled_status_rc=$?
+          set -e
+          printf 'first rc=%s / settled rc=%s (9 = working copy unmeasured)\n' \
+            "$first_status_rc" "$settled_status_rc" > "$captures/kin-status-exit.txt"
+          if [ "$settled_status_rc" -ne 0 ] && [ "$settled_status_rc" -ne 9 ]; then
+            exit "$settled_status_rc"
+          fi
           kin setup status --json > "$captures/settled-health.json"
           kin doctor --json > "$captures/settled-doctor.json"
           echo "KIN_CANARY_CAPTURES=$captures" >> "$GITHUB_ENV"

--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -898,10 +898,28 @@ jobs:
           # Do not pipe this command through tee. On Windows, the daemon child
           # inherits the pipe and keeps it open until idle shutdown, which makes
           # the shell wait for the daemon and then tests a process that just exited.
+          #
+          # `kin status` exits 9 when nothing admitted the working copy, and it
+          # never starts a daemon to change that, so a first-run capture reaches
+          # this line with no daemon and gets 9. These captures want the
+          # durable-authority report, not an answer about uncommitted work, so
+          # they accept that one code and no other. `set +e` around the pair
+          # rather than `|| true` on each: the redirect stays byte-identical, and
+          # every other non-zero is still checked below instead of swallowed.
+          set +e
           kin status > "$captures/kin-status.txt" 2>&1
-          cat "$captures/kin-status.txt"
+          status_rc=$?
           kin status --json > "$captures/kin-status.json" 2>&1
+          status_json_rc=$?
+          set -e
+          cat "$captures/kin-status.txt"
           cat "$captures/kin-status.json"
+          printf 'kin status rc=%s / kin status --json rc=%s (9 = working copy unmeasured)\n' \
+            "$status_rc" "$status_json_rc" > "$captures/kin-status-exit.txt"
+          cat "$captures/kin-status-exit.txt"
+          for rc in "$status_rc" "$status_json_rc"; do
+            if [ "$rc" -ne 0 ] && [ "$rc" -ne 9 ]; then exit "$rc"; fi
+          done
           kin bench-meta --json > "$captures/kin-build-meta.json"
           cat "$captures/kin-build-meta.json"
           # Prove every supported agent-client config writer without requiring
@@ -1635,14 +1653,26 @@ jobs:
             *--wait-quiesce*)
               printf 'bounded settle (kin status --wait-quiesce 60)\n' \
                 | tee "$captures/kin-status-settle-mode.txt"
+              set +e
               kin status --json --wait-quiesce 60 | tee "$captures/kin-embedded-status.json"
+              settle_rc=$?
+              set -e
               ;;
             *)
               printf 'single sample (installed kin has no --wait-quiesce)\n' \
                 | tee "$captures/kin-status-settle-mode.txt" >&2
+              set +e
               kin status --json | tee "$captures/kin-embedded-status.json"
+              settle_rc=$?
+              set -e
               ;;
           esac
+          # Same acceptance as the first-run capture above, and here `pipefail`
+          # is the reason it has to be explicit: it promotes `kin status`'s exit
+          # 9 to the pipeline's status, so an unguarded `| tee` would fail this
+          # leg over a working copy nothing admitted. 9 is accepted; anything
+          # else is a real failure and still stops the leg.
+          if [ "$settle_rc" -ne 0 ] && [ "$settle_rc" -ne 9 ]; then exit "$settle_rc"; fi
           kin setup status --json | tee "$captures/kin-embedded-health.json"
           kin doctor --json | tee "$captures/kin-embedded-doctor.json"
           kin search hello --semantic --json | tee "$captures/kin-semantic-search.json"

--- a/.github/workflows/windows-vector-proof.yml
+++ b/.github/workflows/windows-vector-proof.yml
@@ -203,7 +203,19 @@ jobs:
           # not read the placement as buying coverage under either answer.
           # Nothing here depends on it: the read is captured as a diagnostic and
           # every assertion below runs off `kin embed`'s own report instead.
+          #
+          # `kin status` also exits 9 when nothing admitted the working copy,
+          # which is the same absent daemon seen from the other side, and under
+          # `pipefail` that would fail this leg over a diagnostic it does not
+          # gate on. Accept 9 by number and nothing else, and record which code
+          # this run got, so the reading above stops being an assumption.
+          set +e
           kin.exe status --json | tee "$RUNNER_TEMP/kin-status.json"
+          status_rc=$?
+          set -e
+          printf 'kin status rc=%s (9 = working copy unmeasured)\n' "$status_rc" \
+            | tee "$RUNNER_TEMP/kin-status-exit.txt"
+          if [ "$status_rc" -ne 0 ] && [ "$status_rc" -ne 9 ]; then exit "$status_rc"; fi
 
       - name: Assert the runtime proved semantic search
         shell: bash

--- a/crates/kin-cli/src/commands/diff.rs
+++ b/crates/kin-cli/src/commands/diff.rs
@@ -765,12 +765,26 @@ fn summarize(
     summary
 }
 
+/// `kin diff`, and the exit code it owes a caller.
+///
+/// Non-zero is [`crate::commands::status::EXIT_WORKING_COPY_UNMEASURED`] and
+/// nothing else, and only a workspace endpoint can produce it: a diff between
+/// two changes is history on both sides and needs no admission to be about the
+/// thing it says it is about.
+///
+/// The counts are still printed and are still true about durable authority. What
+/// the code says is that the workspace side of the comparison is whatever the
+/// last admission left, so `Artifacts: +0 ~0 -0` is a gap rather than an answer.
+/// A stranger read exactly that over a file it had edited a moment earlier, at
+/// exit 0, and called it the most serious defect it met. The `--json` arm
+/// returns the same code, and there it is the only signal at all: the scope
+/// lines below are rendered on the text path alone.
 pub async fn run(
     base: Option<String>,
     head: Option<String>,
     json: bool,
     full_bodies: bool,
-) -> Result<()> {
+) -> Result<i32> {
     let layout = crate::commands::require_repository_layout()?;
     let workspace_endpoint =
         endpoint_is_workspace(base.as_deref()) || endpoint_is_workspace(head.as_deref());
@@ -805,7 +819,22 @@ pub async fn run(
     if !json && workspace_endpoint {
         if let Some(response) = daemon_diff(&layout, &base, &head, full_bodies).await {
             let content_rendered = response.artifact_content_rendered;
-            for line in response.lines {
+            // Under the heading and above every count, on this route too. A
+            // daemon answering does not mean an admission ran: it can refuse the
+            // pass, fail it, answer it with no report, or find no author to name,
+            // and each of those leaves the workspace side as stale as an absent
+            // daemon does. Spliced after the responder's first line rather than
+            // printed before it, so the banner sits where the local route puts
+            // it and the daemon's own rendering is otherwise untouched.
+            let mut lines = response.lines;
+            if let Some(crate::commands::status::StatusAdmission::Skipped(why)) = pass.as_ref() {
+                let under_heading = lines.len().min(1);
+                lines.insert(
+                    under_heading,
+                    crate::commands::status::unmeasured_working_copy_banner(why),
+                );
+            }
+            for line in lines {
                 println!("{line}");
             }
             if let Some(report) = response.report.as_ref() {
@@ -854,7 +883,7 @@ pub async fn run(
                     crate::commands::repository_authority::AuthoritySource::RunningDaemonAndOwnOpen
                 })
             );
-            return Ok(());
+            return Ok(exit_code_for(pass.as_ref()));
         }
     }
     let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout)?;
@@ -876,7 +905,19 @@ pub async fn run(
     if json {
         println!("{}", serde_json::to_string_pretty(&report)?);
     } else {
-        for line in render_lines(&report) {
+        let mut lines = render_lines(&report);
+        // Under the heading and above every count, for the reason
+        // `unmeasured_working_copy_banner` states: the `Semantic scope:` and
+        // `Admission scope:` lines below say the same thing correctly, four and
+        // five lines beneath the number a reader has already believed.
+        if let Some(crate::commands::status::StatusAdmission::Skipped(why)) = pass.as_ref() {
+            let under_heading = lines.len().min(1);
+            lines.insert(
+                under_heading,
+                crate::commands::status::unmeasured_working_copy_banner(why),
+            );
+        }
+        for line in lines {
             println!("{line}");
         }
         for row in &report.artifact_content {
@@ -901,7 +942,17 @@ pub async fn run(
             )
         );
     }
-    Ok(())
+    Ok(exit_code_for(pass.as_ref()))
+}
+
+/// The exit code a diff owes its caller for the admission it got.
+///
+/// `None` is a diff between two changes, which took no admission because it
+/// needed none: both endpoints are durable authority and the answer is about
+/// exactly what it claims to be about. Only a workspace endpoint can be
+/// unmeasured, and only that case is non-zero.
+fn exit_code_for(pass: Option<&crate::commands::status::StatusAdmission>) -> i32 {
+    pass.map_or(0, crate::commands::status::exit_code_for_admission)
 }
 
 /// The paths this diff's entity counts were derived from an earlier parse for.

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -1067,7 +1067,15 @@ where
     }
 }
 
-pub async fn run(json: bool, wait_quiesce: std::time::Duration) -> Result<()> {
+/// `kin status`, and the exit code it owes a caller.
+///
+/// Non-zero is [`EXIT_WORKING_COPY_UNMEASURED`] and nothing else. The report is
+/// still printed and every line in it is still true; what the code says is that
+/// no pass took the working copy, so none of it describes the files on disk.
+/// The `--json` arm returns the same code, and there it is the ONLY signal: the
+/// payload cannot carry the gap, because `StatusReportWire` denies unknown
+/// fields and a new key there makes an older CLI reject a newer daemon's report.
+pub async fn run(json: bool, wait_quiesce: std::time::Duration) -> Result<i32> {
     let layout = crate::commands::require_repository_layout()?;
     // Admit, THEN read. The order is the whole point: a report read before the
     // admission describes the graph as it was, which is exactly the answer
@@ -1149,7 +1157,7 @@ pub async fn run(json: bool, wait_quiesce: std::time::Duration) -> Result<()> {
         // "there are none".
         println!("{}", untracked_host_content_line(&pass));
     }
-    Ok(())
+    Ok(exit_code_for_admission(&pass))
 }
 
 /// The `kin status` reading of host content graph truth does not carry.
@@ -1415,6 +1423,61 @@ pub enum StatusAdmission {
     Skipped(String),
 }
 
+/// Nothing measured the working copy, so no number below describes it.
+///
+/// Kept apart from 1, which is an error, for the reason `kin path` keeps
+/// [`crate::commands::path::NO_ROUTE_EXIT_CODE`] apart from 1: a caller has to
+/// be able to tell "the question was not answered" from "the command failed".
+/// This one says the first, and the report it rides on is still true about
+/// durable authority.
+///
+/// It is the only signal a machine consumer can get. Both commands that use it
+/// print their qualifications on the text path alone, and the JSON payload
+/// cannot carry the gap: `StatusReportWire` denies unknown fields, so a new key
+/// there makes an older CLI reject a newer daemon's report outright, which the
+/// status module already records as a deliberate wire decision rather than a
+/// field to slip in.
+pub const EXIT_WORKING_COPY_UNMEASURED: i32 = 9;
+
+/// The line a surface prints ABOVE its numbers when no admission took the
+/// working copy.
+///
+/// Its position is the whole point and is the lesson of the two tickets under
+/// this one. FIR-2961 put the basis beside the verdict and FIR-2820 added the
+/// untracked line, and both are correct sentences that a reader meets after the
+/// number they qualify. A stranger running the everyday loop with no daemon read
+/// `Artifacts: +0 ~0 -0` over a tree it had just edited, called it the most
+/// serious defect it met, and said so about output that already carried three
+/// accurate footers. `merge_line` sits directly under the heading for the same
+/// reason, in its own words: a reader who does not already suspect the state
+/// will not scroll for it.
+///
+/// So this goes under the heading and above every count, it says what the
+/// numbers are NOT about before they are read, and it names the exit code the
+/// way `kin merge` names its own, so a reader who sees a non-zero status has the
+/// sentence that explains it in the same output.
+pub fn unmeasured_working_copy_banner(why: &str) -> String {
+    format!(
+        "Working copy: NOT MEASURED, so no count below describes the files on disk: {why}. Exit          {EXIT_WORKING_COPY_UNMEASURED}: the numbers below are durable authority truth and are          not an answer about uncommitted work."
+    )
+}
+
+/// The exit code a surface owes its caller for the admission it got.
+///
+/// One predicate for both commands and all eight [`StatusAdmission::Skipped`]
+/// arms, because every one of them means the same thing: no pass took the
+/// working copy, so the workspace side of every comparison below is whatever
+/// the last admission left. A daemon that is absent, one still opening
+/// authority, one that refused, an author this store cannot name, and an
+/// admission that failed or answered with no report are different news for a
+/// reader and the same news for a script.
+pub fn exit_code_for_admission(pass: &StatusAdmission) -> i32 {
+    match pass {
+        StatusAdmission::Took(_) => 0,
+        StatusAdmission::Skipped(_) => EXIT_WORKING_COPY_UNMEASURED,
+    }
+}
+
 impl StatusAdmission {
     /// The reconcile probes the pass reported, when one ran.
     pub fn reconcile(&self) -> Option<&crate::commands::resources::ReconcileHealth> {
@@ -1665,8 +1728,17 @@ fn render_text_with_tip(
         SemanticEnrichmentPresence::Absent => "absent",
         SemanticEnrichmentPresence::Present => "present",
     };
-    let mut lines = vec![
-        "Kin repository-v6 status".to_string(),
+    let mut lines = vec!["Kin repository-v6 status".to_string()];
+    // Directly under the heading and above every number, for the reason
+    // [`unmeasured_working_copy_banner`] states: the two footers this repository
+    // already prints about an unadmitted working copy are both correct and both
+    // arrive after the count they qualify, and a stranger read `0 artifacts` as
+    // "nothing to commit" over three untracked files anyway. `merge_line` below
+    // is placed here on the same argument.
+    if let StatusAdmission::Skipped(why) = pass {
+        lines.push(unmeasured_working_copy_banner(why));
+    }
+    lines.extend([
         format!("Repository: {}", report.repository.repository_id),
         format!("Authority generation: {}", report.repository.generation),
         format!("Workspace: {}", report.workspace.workspace_id),
@@ -1724,7 +1796,7 @@ fn render_text_with_tip(
             ),
             None => "Authority payload read: none (generation zero built in memory)".to_string(),
         },
-    ];
+    ]);
     // Beside the head it qualifies, not appended at the end. A workspace whose
     // branch has moved past it reads as a clean tree in every line below, and a
     // reader who does not already suspect the gap will not scroll for the one

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -2562,6 +2562,11 @@ mod tests {
         // The control, and it is the half that matters: no merge, no banner, and
         // the line under the heading is the one that was always there. A fix that
         // printed the banner unconditionally would pass the assertion above.
+        //
+        // Takes an admitted pass, because a skipped one now legitimately puts
+        // the unmeasured-working-copy banner in this position and the control
+        // would then be grading that instead of the merge banner. The skipped
+        // arm has its own assertion below rather than being lost.
         let quiet = render_text(
             &report,
             None,
@@ -2569,7 +2574,7 @@ mod tests {
             None,
             &LastAdmissionRead::Absent,
             &kin_core::retained_parse::RetainedParseRead::Absent,
-            &skipped_pass(),
+            &took_pass(),
             None,
         );
         assert!(
@@ -2581,6 +2586,33 @@ mod tests {
             quiet_lines[1].starts_with("Repository: "),
             "{}",
             quiet_lines[1]
+        );
+
+        // The two banners share one position and this is the order they take.
+        // With no merge and no admission, the working-copy gap is the line under
+        // the heading; with both, the merge leads and the gap follows it. Stated
+        // here because two `insert` calls into one vector is exactly the kind of
+        // ordering that drifts silently.
+        let unmeasured = render_text(
+            &report,
+            None,
+            None,
+            None,
+            &LastAdmissionRead::Absent,
+            &kin_core::retained_parse::RetainedParseRead::Absent,
+            &skipped_pass(),
+            None,
+        );
+        let unmeasured_lines: Vec<&str> = unmeasured.lines().collect();
+        assert!(
+            unmeasured_lines[1].starts_with("Working copy: NOT MEASURED"),
+            "an unmeasured read must lead with its gap: {}",
+            unmeasured_lines[1]
+        );
+        assert!(
+            lines[2].starts_with("Working copy: NOT MEASURED"),
+            "with a merge open the gap follows the merge banner: {}",
+            lines[2]
         );
     }
 

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -3011,7 +3011,18 @@ fn run() -> Result<()> {
                     Ok(())
                 }
                 Command::Status { json, wait_quiesce } => {
-                    commands::status::run(json, std::time::Duration::from_secs(wait_quiesce)).await
+                    // A working copy nothing admitted is an answer, not an
+                    // error, and it travels in the exit code the way a parked
+                    // merge and an unrouted `kin path` already do. The report is
+                    // printed either way; the code says whether any of it
+                    // describes the files on disk.
+                    let code =
+                        commands::status::run(json, std::time::Duration::from_secs(wait_quiesce))
+                            .await?;
+                    if code != 0 {
+                        std::process::exit(code);
+                    }
+                    Ok(())
                 }
                 Command::Resources { action } => match action {
                     ResourcesAction::Set {
@@ -3061,7 +3072,15 @@ fn run() -> Result<()> {
                     head,
                     json,
                     full_bodies,
-                } => commands::diff::run(base, head, json, full_bodies).await,
+                } => {
+                    // Same code and the same reason as `kin status` above, and
+                    // only a workspace endpoint can produce it.
+                    let code = commands::diff::run(base, head, json, full_bodies).await?;
+                    if code != 0 {
+                        std::process::exit(code);
+                    }
+                    Ok(())
+                }
                 Command::Eject { yes } => commands::eject::run(yes).await,
                 Command::Impact {
                     entity,

--- a/crates/kin-cli/tests/cli_broken_pipe.rs
+++ b/crates/kin-cli/tests/cli_broken_pipe.rs
@@ -108,10 +108,40 @@ fn assert_clean_exit(args: &[&str], status: ExitStatus, stderr: &str) {
     );
 }
 
+/// The pipe arm held to the code the FILE arm produced, rather than to a
+/// constant.
+///
+/// This file is about one property: a reader going away must not change the
+/// answer. A constant 0 expressed that as long as every command in the fixture
+/// answered 0, and two of them stopped: `kin status` and `kin diff HEAD
+/// WORKSPACE` answer 9 here, because no daemon holds this store and nothing
+/// admitted the working copy. That is the command's verdict about the working
+/// copy and not a failure of the pipe, so the file arm sets the expectation and
+/// the pipe arm has to match it. Reading the code off the control is also the
+/// stronger test: it would catch a pipe arm that answered 0 where the command
+/// itself answers 9, which the constant could not.
+fn assert_pipe_matches_the_file_arm(
+    args: &[&str],
+    status: ExitStatus,
+    stderr: &str,
+    file: &Output,
+) {
+    assert_eq!(
+        status.code(),
+        file.status.code(),
+        "kin {args:?} answered differently with its reader gone than with it present: \
+         stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("panicked at"),
+        "kin {args:?} into a closed pipe must not panic: stderr={stderr}"
+    );
+}
+
 fn assert_full_output(args: &[&str], output: &Output) {
     assert!(
-        output.status.success(),
-        "kin {args:?} into a file must still succeed: stdout={} stderr={}",
+        matches!(output.status.code(), Some(0) | Some(9)),
+        "kin {args:?} into a file must still answer: stdout={} stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
@@ -255,8 +285,11 @@ fn every_repository_command_survives_a_reader_that_is_gone() {
     ];
     for (index, args) in commands.iter().enumerate() {
         let stderr_path = root.path().join(format!("pipe-{index}.stderr"));
+        // The control runs FIRST here, because it is what says which code this
+        // command answers in this fixture. Two of the six answer 9.
+        let file = run_into_files(&runtime, &repo, args);
+        assert_full_output(args, &file);
         let (status, stderr) = run_with_reader_gone(&runtime, &repo, args, &stderr_path);
-        assert_clean_exit(args, status, &stderr);
-        assert_full_output(args, &run_into_files(&runtime, &repo, args));
+        assert_pipe_matches_the_file_arm(args, status, &stderr, &file);
     }
 }

--- a/crates/kin-cli/tests/graph_status_after_admission.rs
+++ b/crates/kin-cli/tests/graph_status_after_admission.rs
@@ -869,9 +869,15 @@ fn init_status_and_graph_status_use_their_real_durable_and_live_routes() {
         .current_dir(&repo)
         .output()
         .expect("run production kin status route");
+    // No daemon holds this store yet, so nothing admits the working copy and
+    // status answers 9 beside a report that is complete and true about durable
+    // authority. This case is about the enrichment view that report carries, so
+    // it takes the report and ignores that code; any other non-zero is still a
+    // failure.
     assert!(
-        status.status.success(),
-        "status stdout={} stderr={}",
+        matches!(status.status.code(), Some(0) | Some(9)),
+        "status answered {:?}: stdout={} stderr={}",
+        status.status.code(),
         String::from_utf8_lossy(&status.stdout),
         String::from_utf8_lossy(&status.stderr)
     );

--- a/crates/kin-cli/tests/init_json.rs
+++ b/crates/kin-cli/tests/init_json.rs
@@ -452,9 +452,14 @@ fn init_and_status_report_the_same_admission_enrichment() {
         .current_dir(&repo)
         .output()
         .expect("run kin status");
+    // No daemon holds this store, so nothing admits the working copy and status
+    // answers 9 beside a report that is complete and true about durable
+    // authority. This case compares that report against `kin init`'s, which the
+    // code does not touch; any other non-zero is still a failure.
     assert!(
-        status.status.success(),
-        "stdout={} stderr={}",
+        matches!(status.status.code(), Some(0) | Some(9)),
+        "status answered {:?}: stdout={} stderr={}",
+        status.status.code(),
         String::from_utf8_lossy(&status.stdout),
         String::from_utf8_lossy(&status.stderr)
     );

--- a/crates/kin-cli/tests/native_clone.rs
+++ b/crates/kin-cli/tests/native_clone.rs
@@ -124,8 +124,21 @@ fn run(runtime: &common::IsolatedDaemonRuntime, repo: &Path, args: &[&str]) -> O
 }
 
 fn status(runtime: &common::IsolatedDaemonRuntime, repo: &Path) -> Value {
-    serde_json::from_slice(&require_success(run(runtime, repo, &["status", "--json"])).stdout)
-        .expect("status JSON")
+    // Not `require_success`. Every case here reads status with no daemon
+    // holding the store, so nothing admits the working copy and status answers
+    // 9: the report is complete and true about durable authority, and the code
+    // says none of it describes the files on disk. What this file asserts about
+    // a clone is the report's contents, which that code does not touch. Any
+    // other non-zero is still a failure.
+    let output = run(runtime, repo, &["status", "--json"]);
+    assert!(
+        matches!(output.status.code(), Some(0) | Some(9)),
+        "kin status --json answered {:?}: stdout={} stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("status JSON")
 }
 
 fn history(runtime: &common::IsolatedDaemonRuntime, repo: &Path) -> Value {

--- a/crates/kin-cli/tests/quickstart_smoke.rs
+++ b/crates/kin-cli/tests/quickstart_smoke.rs
@@ -117,15 +117,23 @@ fn public_quickstart_reads_one_fixture_from_graph_authority() {
     );
     require_success(init, "kin init");
 
-    let status = require_success(
-        run(
-            kin_command(&runtime, &daemon_bin)
-                .args(["status", "--json"])
-                .current_dir(repo.path()),
-            deadline,
-            "kin status --json",
-        ),
+    // Not `require_success`. No daemon holds this store, so nothing admits the
+    // working copy and status answers 9 beside a report that is complete and
+    // true about durable authority. This smoke reads that report; any other
+    // non-zero is still a failure.
+    let status = run(
+        kin_command(&runtime, &daemon_bin)
+            .args(["status", "--json"])
+            .current_dir(repo.path()),
+        deadline,
         "kin status --json",
+    );
+    assert!(
+        matches!(status.status.code(), Some(0) | Some(9)),
+        "kin status --json answered {:?}: stdout={} stderr={}",
+        status.status.code(),
+        String::from_utf8_lossy(&status.stdout),
+        String::from_utf8_lossy(&status.stderr)
     );
     let status: serde_json::Value =
         serde_json::from_slice(&status.stdout).expect("status is one JSON document");

--- a/crates/kin-cli/tests/repository_diff.rs
+++ b/crates/kin-cli/tests/repository_diff.rs
@@ -80,6 +80,24 @@ fn require_kin_json(repo: &Path, home: &Path, args: &[&str]) -> Value {
     serde_json::from_slice(&output.stdout).expect("Kin stdout should be JSON")
 }
 
+/// A WORKSPACE-endpoint diff, which answers 9 with no daemon holding the store.
+///
+/// Separate from [`require_kin_json`] on purpose rather than by loosening it.
+/// Only a workspace endpoint can be unmeasured; a diff between two changes reads
+/// durable authority on both sides and must still exit 0, so relaxing the strict
+/// helper would stop those cases noticing if they ever started answering 9.
+fn require_workspace_diff_json(repo: &Path, home: &Path, args: &[&str]) -> Value {
+    let output = run_kin(repo, home, args);
+    assert!(
+        matches!(output.status.code(), Some(0) | Some(9)),
+        "kin {args:?} answered {:?}: stdout={} stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("Kin stdout should be JSON")
+}
+
 fn path_hex(path: &[u8]) -> String {
     path.iter().map(|byte| format!("{byte:02x}")).collect()
 }
@@ -365,7 +383,8 @@ fn diff_is_exact_for_polyglot_non_code_binary_modes_symlinks_gitlinks_and_raw_pa
 
     // A single endpoint compares that immutable authority target to the exact
     // graph-owned workspace, not to checkout files.
-    let workspace_report = require_kin_json(&repo, &home, &["diff", &base_oid, "--json"]);
+    let workspace_report =
+        require_workspace_diff_json(&repo, &home, &["diff", &base_oid, "--json"]);
     assert_eq!(workspace_report["head"]["source"], "workspace");
     assert_eq!(
         workspace_report["artifact_deltas"],
@@ -382,7 +401,7 @@ fn diff_is_exact_for_polyglot_non_code_binary_modes_symlinks_gitlinks_and_raw_pa
     assert_eq!(ref_report["head"]["source"], "ref");
     assert_eq!(ref_report["artifact_deltas"], report["artifact_deltas"]);
 
-    let clean = require_kin_json(&repo, &home, &["diff", "--json"]);
+    let clean = require_workspace_diff_json(&repo, &home, &["diff", "--json"]);
     assert_eq!(clean["base"]["source"], "head");
     assert_eq!(clean["head"]["source"], "workspace");
     assert!(clean["artifact_deltas"].as_array().unwrap().is_empty());

--- a/crates/kin-cli/tests/repository_status.rs
+++ b/crates/kin-cli/tests/repository_status.rs
@@ -80,9 +80,16 @@ fn status_is_one_exact_authority_lease_and_ignores_checkout_and_git_drift() {
     );
 
     let before = run_kin(&repo, &home, &["status", "--json"]);
+    // No daemon holds this repository, which is the state this case is about
+    // and which the coverage assertions below name outright, so status answers
+    // 9: the report is complete and true about durable authority and the code
+    // says none of it describes the files on disk. This case compares two such
+    // reports for equality across checkout and Git drift, which that code does
+    // not touch. Any other non-zero is still a failure.
     assert!(
-        before.status.success(),
-        "stdout={} stderr={}",
+        matches!(before.status.code(), Some(0) | Some(9)),
+        "status answered {:?}: stdout={} stderr={}",
+        before.status.code(),
         String::from_utf8_lossy(&before.stdout),
         String::from_utf8_lossy(&before.stderr)
     );
@@ -158,9 +165,16 @@ fn status_is_one_exact_authority_lease_and_ignores_checkout_and_git_drift() {
     .expect("add unrelated file");
 
     let after = run_kin(&repo, &home, &["status", "--json"]);
+    // No daemon holds this repository, which is the state this case is about
+    // and which the coverage assertions below name outright, so status answers
+    // 9: the report is complete and true about durable authority and the code
+    // says none of it describes the files on disk. This case compares two such
+    // reports for equality across checkout and Git drift, which that code does
+    // not touch. Any other non-zero is still a failure.
     assert!(
-        after.status.success(),
-        "stdout={} stderr={}",
+        matches!(after.status.code(), Some(0) | Some(9)),
+        "status answered {:?}: stdout={} stderr={}",
+        after.status.code(),
         String::from_utf8_lossy(&after.stdout),
         String::from_utf8_lossy(&after.stderr)
     );

--- a/crates/kin-cli/tests/unmeasured_working_copy.rs
+++ b/crates/kin-cli/tests/unmeasured_working_copy.rs
@@ -1,0 +1,467 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! A working copy nothing admitted must not read as a clean one.
+//!
+//! FIR-3420. With no daemon holding the repository, `kin diff HEAD WORKSPACE`
+//! printed `Artifacts: +0 ~0 -0` over a tree that had just been edited, at exit
+//! 0, and `kin status` over three brand-new untracked files printed output
+//! byte-identical to the same command on the empty repository, also at exit 0.
+//! Both answers are correct about the graph: with nothing admitting the working
+//! copy, the workspace side of every comparison is whatever the last admission
+//! left. Both read as a statement about the files on disk.
+//!
+//! Two earlier fixes put that gap into words. FIR-2961 added the basis to the
+//! `Tree:` verdict and the `Semantic scope:` line to a workspace diff, and
+//! FIR-2820 added `Untracked host content:`. All three sentences are accurate
+//! and all three arrive AFTER the number they qualify, which is why a stranger
+//! running the everyday loop read `0 artifacts` as "nothing to commit" over a
+//! repository holding three modules the graph had never met. So this suite
+//! grades the two things prose cannot carry: whether the gap is above the count
+//! a reader meets first, and whether the exit code says anything at all.
+//!
+//! Every case forces the daemon-absent state through the product's own surface
+//! and then PROVES it reached that state with `kin daemon status`, because a
+//! fixture that quietly had a daemon would satisfy these assertions for the
+//! wrong reason. The all-clear cases are not decoration either: a build that
+//! returned 9 from every read, or printed the banner unconditionally, would
+//! pass every negative assertion here and be worse than what it replaced.
+
+// The fixture drives the retained no-follow projection, which only Unix
+// implements, so the whole binary is scoped to that platform, exactly as its
+// sibling `repository_status.rs` is.
+#![cfg(unix)]
+
+use serde_json::Value;
+use std::fs;
+use std::net::{SocketAddr, TcpStream};
+use std::path::Path;
+use std::process::{Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+use tempfile::tempdir;
+
+mod common;
+
+use common::Command;
+
+/// The exit code `kin status` and `kin diff <base> WORKSPACE` return when no
+/// pass took the working copy.
+///
+/// Written as a literal rather than imported from `kin_cli`, on purpose. The
+/// constant is a published contract that scripts and CI steps branch on, and a
+/// test that reads it from the same crate would follow the value silently if
+/// someone changed it. This is the number, and changing it has to break here.
+const EXIT_WORKING_COPY_UNMEASURED: i32 = 9;
+
+fn run_git(path: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
+        .current_dir(path)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn run_kin(repo: &Path, home: &Path, args: &[&str]) -> Output {
+    run_kin_with(repo, home, args, None)
+}
+
+/// Like [`run_kin`], but pointed at a daemon this test is holding open.
+///
+/// Only the all-clear control uses it, and it needs it. Measured while writing
+/// this suite: `kin admit` starts a daemon, takes the tree, ends its session,
+/// and that daemon can be gone before the very next process starts, at which
+/// point the read after it is unmeasured again and correctly says so. That is
+/// the product behaving, and it has its own case below. A control that means "a
+/// pass ran AND a daemon is still serving" has to hold that state rather than
+/// hope for it, so it spawns its own daemon the way the sibling suites do and
+/// names it explicitly.
+fn run_kin_served_by(repo: &Path, home: &Path, args: &[&str], port: u16) -> Output {
+    run_kin_with(repo, home, args, Some(port))
+}
+
+fn run_kin_with(repo: &Path, home: &Path, args: &[&str], daemon_port: Option<u16>) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_kin"));
+    command
+        .args(args)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        // Embedding is not what any case here is about, and a first embed pass
+        // fetches a model this test must never depend on.
+        .env("KIN_DAEMON_AUTO_EMBED", "0")
+        .env("KIN_EMBED_BACKEND", "cpu")
+        .env_remove("KIN_VFS_WORKSPACE")
+        .current_dir(repo);
+    match daemon_port {
+        Some(port) => {
+            command.env("KIN_DAEMON_URL", format!("http://127.0.0.1:{port}"));
+        }
+        None => {
+            command.env_remove("KIN_DAEMON_URL");
+        }
+    }
+    command.output().expect("run kin")
+}
+
+/// A daemon this test owns, started and stopped explicitly.
+///
+/// Copied in shape from `graph_status_after_admission.rs`, which needs the same
+/// thing for the same reason: a daemon whose lifetime is bounded by evidence
+/// rather than by an idle clock the test would be racing.
+struct HeldDaemon {
+    child: Option<common::RuntimeOwnedChild>,
+}
+
+impl HeldDaemon {
+    fn spawn(repo: &Path, runtime: &common::IsolatedDaemonRuntime) -> Self {
+        let child = runtime
+            .daemon_command()
+            .arg("--repo")
+            .arg(repo)
+            .arg("--port")
+            .arg("0")
+            .env("KIN_DAEMON_DISABLE_LSP", "1")
+            .env("KIN_DAEMON_IDLE_TIMEOUT_SECS", "0")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn_owned()
+            .expect("spawn the held kin-daemon");
+        Self { child: Some(child) }
+    }
+
+    fn wait_until_serving(&mut self, kin_root: &Path) -> u16 {
+        let deadline = Instant::now() + Duration::from_secs(60);
+        loop {
+            let child = self.child.as_mut().expect("daemon child exists");
+            if let Some(status) = child.try_wait().expect("inspect daemon child") {
+                panic!("the held daemon exited before readiness: {status}");
+            }
+            if let Some(port) = fs::read_to_string(kin_root.join("daemon.port"))
+                .ok()
+                .and_then(|value| value.trim().parse::<u16>().ok())
+            {
+                let address = SocketAddr::from(([127, 0, 0, 1], port));
+                if TcpStream::connect_timeout(&address, Duration::from_millis(200)).is_ok() {
+                    return port;
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "the held daemon did not become ready"
+            );
+            thread::sleep(Duration::from_millis(50));
+        }
+    }
+}
+
+impl Drop for HeldDaemon {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+fn stdout_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn code_of(output: &Output) -> i32 {
+    output
+        .status
+        .code()
+        .expect("kin should exit rather than die on a signal")
+}
+
+/// Bring the repository to the state every case here is about, and prove it got
+/// there.
+///
+/// The proof is the point. `kin daemon stop` reports success whether or not one
+/// was running, so a fixture that believed it had stopped a daemon it had not
+/// would satisfy every assertion below for a reason unrelated to the defect.
+/// `kin daemon status` names this repository's worker directly, and that
+/// sentence is what the cases stand on.
+fn require_no_daemon(repo: &Path, home: &Path) {
+    run_kin(repo, home, &["daemon", "stop"]);
+    let status = run_kin(repo, home, &["daemon", "status"]);
+    let text = stdout_of(&status) + &String::from_utf8_lossy(&status.stderr);
+    assert!(
+        text.contains("worker daemon not running"),
+        "the fixture still has a daemon for this repository, so nothing below is about the \
+         daemon-absent shape: {text}"
+    );
+}
+
+/// A repository with one commit behind it, and no daemon.
+fn seeded_repo(root: &Path) -> (std::path::PathBuf, std::path::PathBuf) {
+    let home = root.join("home");
+    let repo = root.join("repo");
+    fs::create_dir_all(&home).expect("create home");
+    fs::create_dir_all(&repo).expect("create repo");
+    run_git(&repo, &["init", "--initial-branch=main"]);
+    run_git(&repo, &["config", "user.email", "kin@example.invalid"]);
+    run_git(&repo, &["config", "user.name", "Kin"]);
+    fs::write(
+        repo.join("storage.py"),
+        b"def append(entry, path):\n    open(path, 'a').write(repr(entry))\n",
+    )
+    .expect("write module");
+    run_git(&repo, &["add", "--all"]);
+    run_git(&repo, &["commit", "-m", "seed"]);
+    let init = run_kin(&repo, &home, &["init", "."]);
+    assert!(
+        init.status.success(),
+        "kin init failed: stdout={} stderr={}",
+        stdout_of(&init),
+        String::from_utf8_lossy(&init.stderr)
+    );
+    (repo, home)
+}
+
+/// The index of a line starting with `prefix`, or a failure naming the page.
+fn line_index(text: &str, prefix: &str) -> usize {
+    text.lines()
+        .position(|line| line.starts_with(prefix))
+        .unwrap_or_else(|| panic!("no line starting {prefix:?} in:\n{text}"))
+}
+
+const BANNER: &str = "Working copy: NOT MEASURED";
+
+#[test]
+fn workspace_diff_with_no_daemon_exits_unmeasured_with_the_gap_above_the_count() {
+    let root = tempdir().expect("temp root");
+    let (repo, home) = seeded_repo(root.path());
+
+    // Dirty the tree the way the stranger did: a one-line docstring into a
+    // tracked function, which moves the artifact and nothing else.
+    fs::write(
+        repo.join("storage.py"),
+        b"def append(entry, path):\n    \"\"\"Append one entry.\"\"\"\n    open(path, 'a').write(repr(entry))\n",
+    )
+    .expect("edit module");
+    require_no_daemon(&repo, &home);
+
+    let diff = run_kin(&repo, &home, &["diff", "HEAD", "WORKSPACE"]);
+    let text = stdout_of(&diff);
+
+    assert_eq!(
+        code_of(&diff),
+        EXIT_WORKING_COPY_UNMEASURED,
+        "a workspace diff that measured nothing exited as though it had answered:\n{text}"
+    );
+    assert!(
+        text.contains(BANNER),
+        "a workspace diff that measured nothing printed no headline gap:\n{text}"
+    );
+    // The whole finding in one assertion. `Artifacts: +0 ~0 -0` is where a
+    // reader stops, so the gap has to be above it rather than in the footer
+    // that already carried this sentence correctly and was read past.
+    assert!(
+        line_index(&text, BANNER) < line_index(&text, "Artifacts:"),
+        "the gap is printed BELOW the count it qualifies, which is the defect:\n{text}"
+    );
+}
+
+#[test]
+fn status_over_untracked_work_with_no_daemon_exits_unmeasured_with_the_gap_above_the_tree_line() {
+    let root = tempdir().expect("temp root");
+    let (repo, home) = seeded_repo(root.path());
+
+    // Three brand-new untracked modules, the shape that produced output
+    // byte-identical to the empty repository.
+    fs::write(
+        repo.join("parsing.py"),
+        b"def parse_line(line):\n    return line\n",
+    )
+    .expect("write parsing");
+    fs::write(
+        repo.join("reporting.py"),
+        b"def totals_by(entries):\n    return {}\n",
+    )
+    .expect("write reporting");
+    fs::write(repo.join("cli.py"), b"def main():\n    return 0\n").expect("write cli");
+    require_no_daemon(&repo, &home);
+
+    let status = run_kin(&repo, &home, &["status"]);
+    let text = stdout_of(&status);
+
+    assert_eq!(
+        code_of(&status),
+        EXIT_WORKING_COPY_UNMEASURED,
+        "status over an unmeasured working copy exited as though it had measured it:\n{text}"
+    );
+    assert!(
+        line_index(&text, BANNER) < line_index(&text, "Tree:"),
+        "the gap is printed below the Tree: verdict a reader takes for the answer:\n{text}"
+    );
+}
+
+#[test]
+fn the_json_arm_carries_the_gap_in_its_exit_code_and_still_parses() {
+    let root = tempdir().expect("temp root");
+    let (repo, home) = seeded_repo(root.path());
+    fs::write(repo.join("untracked.py"), b"VALUE = 1\n").expect("write untracked");
+    require_no_daemon(&repo, &home);
+
+    // The arm with no other channel. `StatusReportWire` denies unknown fields,
+    // so the gap cannot be a key in this payload, and the text banner is not
+    // rendered here at all. If the exit code does not carry it, nothing does.
+    let status = run_kin(&repo, &home, &["status", "--json"]);
+    let text = stdout_of(&status);
+    assert_eq!(
+        code_of(&status),
+        EXIT_WORKING_COPY_UNMEASURED,
+        "the JSON arm gave a machine consumer no signal at all:\n{text}"
+    );
+    let report: Value =
+        serde_json::from_str(&text).expect("the JSON arm must still print a parseable report");
+    assert_eq!(
+        report["authority"], "repository-v6",
+        "the report itself must be unchanged by the exit code: {report}"
+    );
+
+    let diff = run_kin(&repo, &home, &["diff", "HEAD", "WORKSPACE", "--json"]);
+    let diff_text = stdout_of(&diff);
+    assert_eq!(
+        code_of(&diff),
+        EXIT_WORKING_COPY_UNMEASURED,
+        "the JSON diff arm gave a machine consumer no signal at all:\n{diff_text}"
+    );
+    serde_json::from_str::<Value>(&diff_text)
+        .expect("the JSON diff arm must still print a parseable report");
+}
+
+#[test]
+fn a_diff_between_two_changes_needs_no_admission_and_still_exits_zero() {
+    // The control that stops this fix from being "return 9 everywhere". A diff
+    // whose endpoints are both durable authority is about exactly what it says
+    // it is about, with or without a daemon, so it must keep its clean exit and
+    // must not carry the banner.
+    let root = tempdir().expect("temp root");
+    let (repo, home) = seeded_repo(root.path());
+    require_no_daemon(&repo, &home);
+
+    let diff = run_kin(&repo, &home, &["diff", "HEAD", "HEAD"]);
+    let text = stdout_of(&diff);
+    assert_eq!(
+        code_of(&diff),
+        0,
+        "a change-to-change diff was refused for a working copy it never claimed to read:\n{text}"
+    );
+    assert!(
+        !text.contains(BANNER),
+        "a change-to-change diff printed a working-copy gap it does not have:\n{text}"
+    );
+}
+
+/// Edit the seeded module, so the tree is one artifact ahead of its base.
+fn dirty_the_tracked_module(repo: &Path) {
+    fs::write(
+        repo.join("storage.py"),
+        b"def append(entry, path):\n    \"\"\"Append one entry.\"\"\"\n    open(path, 'a').write(repr(entry))\n",
+    )
+    .expect("edit module");
+}
+
+#[test]
+fn a_measured_working_copy_still_gets_its_clean_exit_and_no_banner() {
+    // The control that stops this fix from being "hedge every answer", and the
+    // one that would catch a build that simply stopped admitting. With a daemon
+    // serving, both commands admit the tree themselves, so the answer IS about
+    // the working copy and has to say so by being silent and exiting 0.
+    let root = tempdir().expect("temp root");
+    let (repo, home) = seeded_repo(root.path());
+    dirty_the_tracked_module(&repo);
+
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    let mut daemon = HeldDaemon::spawn(&repo, &runtime);
+    let port = daemon.wait_until_serving(&repo.join(".kin"));
+
+    let diff = run_kin_served_by(&repo, &home, &["diff", "HEAD", "WORKSPACE"], port);
+    let text = stdout_of(&diff);
+    assert_eq!(
+        code_of(&diff),
+        0,
+        "a working copy this command admitted was reported as unmeasured:\n{text}"
+    );
+    assert!(
+        !text.contains(BANNER),
+        "a measured working copy carried the unmeasured banner:\n{text}"
+    );
+    // And the answer is the one the stranger only got after running `kin admit`
+    // by hand: the edit, not a zero.
+    assert!(
+        text.contains("Artifacts: +0 ~1 -0"),
+        "the measured diff did not report the one edited artifact:\n{text}"
+    );
+
+    let status = run_kin_served_by(&repo, &home, &["status"], port);
+    let status_text = stdout_of(&status);
+    assert_eq!(
+        code_of(&status),
+        0,
+        "a working copy this status admitted was reported as unmeasured:\n{status_text}"
+    );
+    assert!(
+        !status_text.contains(BANNER),
+        "a measured status carried the unmeasured banner:\n{status_text}"
+    );
+}
+
+#[test]
+fn a_correct_answer_from_a_stale_graph_is_still_reported_as_unmeasured() {
+    // The subtle arm, and the reason the predicate is "did a pass run here"
+    // rather than "does the answer look right". Measured while writing this
+    // suite: `kin admit` takes the tree and its daemon can be gone before the
+    // next process starts. The diff that follows then prints the exact edit,
+    // because durable authority now holds it, while nothing has looked at the
+    // working copy since. The number is right by luck and Kin cannot know that:
+    // any edit made in between is invisible to it.
+    //
+    // This is FIR-2961's lesson in exit-code form. A verdict with nothing
+    // behind it is not a verdict about the working copy, however well it reads,
+    // and a build that decided to trust a fresh-looking answer would put the
+    // whole defect back one layer down.
+    let root = tempdir().expect("temp root");
+    let (repo, home) = seeded_repo(root.path());
+    dirty_the_tracked_module(&repo);
+
+    let admit = run_kin(&repo, &home, &["admit"]);
+    assert!(
+        admit.status.success(),
+        "kin admit failed, so this case never reached the state it is about: stdout={} stderr={}",
+        stdout_of(&admit),
+        String::from_utf8_lossy(&admit.stderr)
+    );
+    require_no_daemon(&repo, &home);
+
+    let diff = run_kin(&repo, &home, &["diff", "HEAD", "WORKSPACE"]);
+    let text = stdout_of(&diff);
+    // The positive control for the state: without this the case is satisfied by
+    // a fixture whose admission never landed, which is the ordinary arm again.
+    assert!(
+        text.contains("Artifacts: +0 ~1 -0"),
+        "the graph does not hold the admitted edit, so this fixture is the ordinary \
+         daemon-absent case rather than the stale-but-correct one:\n{text}"
+    );
+    assert_eq!(
+        code_of(&diff),
+        EXIT_WORKING_COPY_UNMEASURED,
+        "a right-looking answer from a graph nothing has refreshed exited as measured:\n{text}"
+    );
+    assert!(
+        text.contains(BANNER),
+        "a right-looking answer from a stale graph printed no headline gap:\n{text}"
+    );
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -111,6 +111,8 @@ kin status [options]
 | `--json` |  | Output machine-readable JSON for editor integrations |
 | `--wait-quiesce <seconds>` | `0` | Seconds to keep re-reading while embedding coverage is only momentarily unobservable, such as an embedding pass or a graph mutation batch spanning the sample. Never waits on a coverage that was observed, nor on an absence a re-read cannot clear. 0 reads once |
 
+Exit 9 means nothing admitted the working copy, so no count in the report describes the files on disk. It is not a failure: every line is still true about durable authority, and the reading is printed either way. It happens when no daemon is holding the repository, because neither command starts one, and `kin admit` is what takes the working copy. The banner at the top of the output says the same thing, and the exit code is the only place the `--json` form can carry it.
+
 ### `kin commit`
 
 Create an exact semantic and artifact commit
@@ -160,6 +162,8 @@ kin diff [base] [head] [options]
 | Flag | Default | Description |
 | --- | --- | --- |
 | `--json` |  | Output the exact authority-backed report as JSON |
+
+Exit 9 means the same thing here as it does for `kin status`, and only a workspace endpoint can produce it. A diff between two changes reads durable authority on both sides, needs no admission, and exits 0 with or without a daemon.
 
 ## Ask the graph
 

--- a/scripts/acceptance/vcs_read_surfaces_repro.py
+++ b/scripts/acceptance/vcs_read_surfaces_repro.py
@@ -29,8 +29,19 @@ here, and it grades both directions: a surface that qualifies every answer it
 gives is as useless as one that qualifies none, so the all-clear has its own
 check and must still arrive.
 
-Seven checks, one seeded repository, run in order because the experiment is
-destructive: each one sets up the next, and the last stops the daemon.
+FIR-3420 is the next chapter of the same story and the last three checks are
+its. The stranger that read those qualifications read past them: with no daemon,
+`kin diff HEAD WORKSPACE` printed `Artifacts: +0 ~0 -0` over a tree it had just
+edited and `kin status` over three untracked files printed output byte-identical
+to the empty repository, both at exit 0. Prose below a number is not where a
+reader meets it, and an exit code is the only thing a script reads at all. So
+the gap now leads the page and travels in the exit code, and these checks grade
+the position and the code rather than the wording, because the wording was
+already right.
+
+Nine checks, one seeded repository, run in order because the experiment is
+destructive: each one sets up the next, and the last three run after the daemon
+has stopped.
 
   basis        the `Tree:` line names when graph truth last caught up, rather
                than rendering a bare verdict a reader takes for a statement
@@ -63,6 +74,15 @@ destructive: each one sets up the next, and the last stops the daemon.
                marker beside no admission at all is the most convincing form of
                the defect, and its self-test row is the literal line the earlier
                fix would have printed
+  status_loud  the same reading graded as a caller meets it: the gap is ABOVE
+               the `Tree:` verdict a reader takes for the answer, and the exit
+               code is non-zero so a script has a signal at all. Runs after
+               `unadmitted`, which created the state and needs the daemon gone
+  diff_loud    the same two properties on the workspace diff, where the count a
+               reader stops at is `Artifacts:`. This is the exact reading the
+               stranger called the most serious defect it met, and it is the
+               only one of the nine that grades an exit code on a command that
+               printed a correct-looking answer
 
 Exit status is 0 when every check passed, 1 when one failed, 2 when none failed
 but one could not be read, and 3 when the run could not be set up. `--self-test`
@@ -320,6 +340,68 @@ def grade_diff_discloses_its_semantic_scope(text):
     return PASS, "the workspace diff names what its semantic counts cannot show"
 
 
+UNMEASURED_BANNER = "Working copy: NOT MEASURED"
+
+
+def grade_unmeasured_read_leads_with_its_gap(rc, text, count_prefix):
+    """The gap above the count, and a non-zero exit beside it.
+
+    Both halves are the finding and neither is sufficient. FIR-2961 and FIR-2820
+    already put accurate sentences into this output and a stranger read past
+    them, because they arrive after the number: `Artifacts: +0 ~0 -0` and
+    `0 artifacts` are where a reader stops. So position is graded, not presence.
+
+    And the exit code, because prose fixes nothing for a script. `--json` renders
+    none of these lines, and the status wire schema denies unknown fields, so for
+    a machine consumer the code is the only channel there is.
+
+    `count_prefix` is the line a reader takes for the answer on this surface:
+    `Tree:` in status, `Artifacts:` in a workspace diff. UNREADABLE when it is
+    absent, because a page without it is a fixture failure rather than a product
+    defect.
+    """
+    body = text or ""
+    lines = body.splitlines()
+    count_at = next(
+        (i for i, line in enumerate(lines) if line.startswith(count_prefix)), None
+    )
+    if count_at is None:
+        return UNREADABLE, (
+            "this reading carries no %r line, so the fixture never reached the state "
+            "this check is about" % count_prefix
+        )
+    banner_at = next(
+        (i for i, line in enumerate(lines) if line.startswith(UNMEASURED_BANNER)), None
+    )
+    if banner_at is None:
+        return FAIL, (
+            "an unmeasured reading printed %s with nothing above it saying the working copy "
+            "was never read: %s" % (count_prefix, lines[count_at].strip()[:160])
+        )
+    if banner_at > count_at:
+        return FAIL, (
+            "the gap is printed BELOW the count it qualifies (banner on line %d, %s on line "
+            "%d), which is the defect rather than the fix" % (banner_at, count_prefix, count_at)
+        )
+    if rc == 0:
+        return FAIL, (
+            "an unmeasured reading exited 0, so a script cannot tell it from a measured one, "
+            "however well the page reads"
+        )
+    return PASS, (
+        "the gap leads the page (line %d, above %s on line %d) and the exit code is %s"
+        % (banner_at, count_prefix, count_at, rc)
+    )
+
+
+def grade_unmeasured_status_leads_with_its_gap(rc, text):
+    return grade_unmeasured_read_leads_with_its_gap(rc, text, "Tree:")
+
+
+def grade_unmeasured_diff_leads_with_its_gap(rc, text):
+    return grade_unmeasured_read_leads_with_its_gap(rc, text, "Artifacts:")
+
+
 def grade_admit_left_the_graph_holding_the_edit(before_text, after_text):
     """Whether the graph holds the edit once the pass is done, read as two hashes.
 
@@ -532,6 +614,30 @@ def check_unadmitted(suite):
     return Result("unadmitted", status, "%s %s" % (TICKET, detail))
 
 
+def check_status_loud(suite):
+    """The unadmitted status graded as a caller meets it, page and exit code.
+
+    Runs after `unadmitted`, which stopped the daemon, and takes its own reading
+    rather than reusing that one, because `suite.status_text` hides the exit code
+    this check is half about.
+    """
+    rc, out, err = suite.kin_run(["status"])
+    status, detail = grade_unmeasured_status_leads_with_its_gap(rc, out or err)
+    return Result("status_loud", status, "FIR-3420 %s" % detail)
+
+
+def check_diff_loud(suite):
+    """The reading the stranger called the most serious defect it met.
+
+    `Artifacts: +0 ~0 -0` over a dirty tree at exit 0. The zero is correct about
+    the graph and wrong as an answer, so this grades where the gap sits and what
+    the exit code says, never the counts.
+    """
+    rc, out, err = suite.kin_run(["diff", "HEAD", "WORKSPACE"])
+    status, detail = grade_unmeasured_diff_leads_with_its_gap(rc, out or err)
+    return Result("diff_loud", status, "FIR-3420 %s" % detail)
+
+
 def check_diff_scope(suite):
     rc, out, err = suite.kin_run(["diff", "HEAD", "WORKSPACE"])
     if rc != 0:
@@ -591,6 +697,12 @@ CHECKS = (
     ("diff_scope", check_diff_scope),
     ("held_merge", check_held_merge),
     ("unadmitted", check_unadmitted),
+    # FIR-3420's two, and they run last for the same reason `unadmitted` does:
+    # they are about the daemon-absent shape, and `unadmitted` is what creates
+    # it. Neither restarts a daemon, because neither `kin status` nor `kin diff`
+    # ever starts one.
+    ("status_loud", check_status_loud),
+    ("diff_loud", check_diff_loud),
 )
 
 
@@ -723,6 +835,45 @@ ADMIT_UNMEASURED = (
 )
 ADMIT_REFUSED = "Complete exact-tree admission failed: host entry changed\n"
 
+# The literal shapes FIR-3420 is about, quoted from a run of the built binary
+# rather than invented, and the fixed shapes beside them.
+UNMEASURED_BANNER_LINE = (
+    "Working copy: NOT MEASURED, so no count below describes the files on disk: no daemon is running for this repository, so nothing admitted the working copy and this reports durable authority alone; `kin admit` takes what the working copy holds. Exit 9: the numbers below are durable authority truth and are not an answer about uncommitted work."
+)
+DIFF_ZERO_WITH_FOOTER_ONLY = (
+    "Kin repository-v6 diff\n"
+    "Authority generation: 2\n"
+    "Artifacts: +0 ~0 -0\n"
+    "Entities: +0 ~0 -0\n"
+    "Relations: +0 ~0 -0\n"
+    "Semantic scope: no live graph was reachable, so the entity and relation counts above are "
+    "the admitted overlay's and cannot move for work in the working copy.\n"
+    "Admission scope: this diff was not measured against the working copy: no daemon is running "
+    "for this repository, so nothing admitted the working copy\n"
+)
+DIFF_LED_BY_THE_GAP = (
+    "Kin repository-v6 diff\n"
+    + UNMEASURED_BANNER_LINE + "\n"
+    "Authority generation: 2\n"
+    "Artifacts: +0 ~0 -0\n"
+    "Entities: +0 ~0 -0\n"
+    "Relations: +0 ~0 -0\n"
+)
+# The banner present but under the count, which is the shape this check exists
+# to reject: every word of it is true and a reader still meets the zero first.
+DIFF_GAP_BELOW_THE_COUNT = (
+    "Kin repository-v6 diff\n"
+    "Artifacts: +0 ~0 -0\n"
+    + UNMEASURED_BANNER_LINE + "\n"
+)
+DIFF_NO_ARTIFACTS_LINE = "Kin repository-v6 diff\nEntities: +0 ~0 -0\n"
+STATUS_LED_BY_THE_GAP = (
+    "Kin repository-v6 status\n"
+    + UNMEASURED_BANNER_LINE + "\n"
+    "Tree: 6e22e604 (0 artifacts, matching its base change as last admitted, not measured "
+    "against the working copy: no daemon is running for this repository)\n"
+)
+
 
 def check_the_gate_reads_this_suites_report():
     """Hand this suite's own report to `gate.py`'s loader and require it back.
@@ -848,6 +999,32 @@ def self_test():
         ("settled/moved", grade_admit_still_reports_a_true_no_op, ADMIT_CONTENT_MOVED, FAIL),
         ("settled/unmeasured", grade_admit_still_reports_a_true_no_op, ADMIT_UNMEASURED, FAIL),
         ("settled/refused", grade_admit_still_reports_a_true_no_op, ADMIT_REFUSED, UNREADABLE),
+        # FIR-3420. The pre-fix payload is the literal shape the stranger read,
+        # footers and all, and it must FAIL: every sentence in it is true and the
+        # reader still meets the zero first at exit 0.
+        ("diffloud/footer-only", grade_unmeasured_diff_leads_with_its_gap,
+         (0, DIFF_ZERO_WITH_FOOTER_ONLY), FAIL),
+        ("diffloud/led-and-nonzero", grade_unmeasured_diff_leads_with_its_gap,
+         (9, DIFF_LED_BY_THE_GAP), PASS),
+        # Half a fix each, and both must fail. A banner under the count is the
+        # defect with better wording, and a banner above it at exit 0 leaves
+        # every script exactly where it was.
+        ("diffloud/banner-below-the-count", grade_unmeasured_diff_leads_with_its_gap,
+         (9, DIFF_GAP_BELOW_THE_COUNT), FAIL),
+        ("diffloud/led-but-exit-zero", grade_unmeasured_diff_leads_with_its_gap,
+         (0, DIFF_LED_BY_THE_GAP), FAIL),
+        ("diffloud/no-artifacts-line", grade_unmeasured_diff_leads_with_its_gap,
+         (0, DIFF_NO_ARTIFACTS_LINE), UNREADABLE),
+        ("statusloud/led-and-nonzero", grade_unmeasured_status_leads_with_its_gap,
+         (9, STATUS_LED_BY_THE_GAP), PASS),
+        # The literal pre-fix reading: byte-identical to the empty repository,
+        # correctly qualified in its own footer, exit 0.
+        ("statusloud/unmeasured-verdict-only", grade_unmeasured_status_leads_with_its_gap,
+         (0, STATUS_UNMEASURED_VERDICT), FAIL),
+        ("statusloud/led-but-exit-zero", grade_unmeasured_status_leads_with_its_gap,
+         (0, STATUS_LED_BY_THE_GAP), FAIL),
+        ("statusloud/no-tree-line", grade_unmeasured_status_leads_with_its_gap,
+         (0, STATUS_NO_TREE), UNREADABLE),
     ]
     # The two-hash grader takes a pair, so its rows carry a tuple and are unpacked
     # here. A grader that ignored one side would pass its own table, which is why

--- a/scripts/release-proof/VENDORED.json
+++ b/scripts/release-proof/VENDORED.json
@@ -6,7 +6,7 @@
     "bin/kin-release-preflight": {"source": "bin/kin-release-preflight", "sha256": "aedf49d66f774ff5fc34c84a4efccbe913278478281ece0917d50b8d910dd235"},
     "bin/kin-release-preflight.d/Dockerfile": {"source": "bin/kin-release-preflight.d/Dockerfile", "sha256": "e6c0e30c2bf46fc889484fb7e32c73163c3cf315d60351be3acd2428d22d12f6"},
     "bin/kin-release-preflight.d/proof-flow.sh": {"source": "bin/kin-release-preflight.d/proof-flow.sh", "sha256": "943160afa4bb1f2aa58e0e1639c1cb81dccba20e1566bec80757f452834b4ef1"},
-    "bin/kin-release-preflight.d/validate.mjs": {"source": "bin/kin-release-preflight.d/validate.mjs", "sha256": "81b0170a317d881cd05195edf2904baff24be05b8a9db6d56edd2d8483810494"},
+    "bin/kin-release-preflight.d/validate.mjs": {"source": "bin/kin-release-preflight.d/validate.mjs", "sha256": "fc9c482ce588b0c78d59e08dfda8382f1e31615592d721dcd00625c6ba0917a2"},
     "bin/kin-evidence-publish": {"source": "bin/kin-evidence-publish", "sha256": "8912fd933ba37e2570ea2ff685a885551543f2a01e3baeb394876121f8811679"},
     "bin/kin-acceptance-suite": {"source": "bin/kin-acceptance-suite", "sha256": "7ce214e6563e227695cf02411762ca5e8d01edf8898634db465ee30f455918f7"}
   }

--- a/scripts/release-proof/bin/kin-release-preflight.d/validate.mjs
+++ b/scripts/release-proof/bin/kin-release-preflight.d/validate.mjs
@@ -91,13 +91,17 @@ import path from "node:path";
 //
 // The drift above was found by the driver refusing a cut, hours after kin#1652
 // landed, which is the fourth time this pin has gone stale outside the
-// mirrored step. `assert_ported_validator_pin_tracks_install_proof` in
+// mirrored step. The fifth was the working-copy exit-code change, which edited
+// the first-run and settle captures and left the "Validate installed capability
+// proof" step untouched: 411 lines, sha256
+// f2b88473c0ce233badb97decebbf21b05c84cb798d5de11710119e309258d5e9, identical at
+// both whole-file shas. Nothing was ported that time; only the pin moved. `assert_ported_validator_pin_tracks_install_proof` in
 // scripts/test-release-workflow-authority.py now fails the pull request that
 // moves install-proof.yml without moving this pin, so the next drift is caught
 // by that pull request rather than by a release.
 export const PORTED_FROM = {
   file: ".github/workflows/install-proof.yml",
-  sha256: "c4b55da81b9d74d955b7e9165b162c67e355246640398b6f7468e5a7c11d67aa",
+  sha256: "a92d64226a0ed4e99b8078cb3469a1b4027503eb0cc9e013b79d4477e8de6f26",
 };
 
 class Unreadable extends Error {}


### PR DESCRIPTION
A version control tool that answers clean over a dirty tree is the one thing it must never do. With no daemon holding the repository, `kin diff HEAD WORKSPACE` printed `Artifacts: +0 ~0 -0` over a tree that had just been edited, at exit 0, and `kin status` over three brand-new untracked files printed output byte-identical to the same command on the empty repository, also at exit 0. This puts the gap above the count and into the exit code.

FIR-3420. Full report, with every transcript: `.kin-coord/reports/dirtytree-20260910.md`.

## Ten tests in kin's own suite were passing on an unmeasured status

That is the strongest evidence this ticket has, and it comes from this repository rather than from any stranger transcript. `cargo test -p kin-cli --no-fail-fast` with the exit code in place, before any test was touched: **3265 passed, 10 failed across 7 binaries.** Every one of the ten asserts that `kin status` or a workspace `kin diff` succeeds while no daemon holds the store, which is precisely the state that answers wrongly.

```
cli_broken_pipe               every_repository_command_survives_a_reader_that_is_gone
graph_status_after_admission  init_status_and_graph_status_use_their_real_durable_and_live_routes
init_json                     init_and_status_report_the_same_admission_enrichment
native_clone                  four cases, all through one `status` helper
quickstart_smoke              public_quickstart_reads_one_fixture_from_graph_authority
repository_diff               diff_is_exact_for_polyglot_non_code_binary_modes_symlinks_gitlinks_and_raw_paths
repository_status             status_is_one_exact_authority_lease_and_ignores_checkout_and_git_drift
```

The tests that should have caught this defect were themselves reading the unmeasured zero and grading it a pass. It is invisible by construction, which is why three releases of accurate footer prose did not fix it.

**A reviewer seeing ten tests loosened should read the two that got stronger instead.** `cli_broken_pipe` asserted a constant 0 for six commands into a closed pipe; its subject is the pipe, so it now runs the file arm FIRST and requires the pipe arm to answer the SAME code, which catches a pipe arm answering 0 where the command answers 9 and a constant never could. `repository_diff` keeps its strict JSON helper for change-to-change diffs and gets a separate one only for the two workspace-endpoint calls, because only a workspace endpoint can be unmeasured and loosening the shared helper would have stopped the history diffs noticing if they ever started answering 9. The other eight accept 0 or 9 and nothing else, each with a comment saying why that case does not ask about uncommitted work.

## And CI has been recording it in writing on every run

`.github/workflows/windows-vector-proof.yml` says so in its own comment, measured on a native Windows guest:

> this read reports `state=unobserved reason=no_running_daemon` wherever it is placed

> Every archived artifact from this job and from the guest reports unobserved/no_running_daemon.

That step reaches its `kin status` with no daemon every single time, and exit 0 is the only reason nobody noticed.

## What was measured before anything changed

Reproduced on a dev build of `origin/main` at `4cd043186`, whose commit subject is "Release Kin v0.7.10 (#1664)" and whose workspace version is 0.7.10. **That sha carries no tag**: `git describe --tags --exact-match` refuses it and the newest tag on origin is v0.7.9, so no claim here is about a shipped 0.7.10.

```
$ kin daemon status
Repo daemons: none registered
Current repo (ledger): worker daemon not running
# exit 0

$ kin diff HEAD WORKSPACE
Kin repository-v6 diff
Artifacts: +0 ~0 -0
Entities: +0 ~0 -0
Relations: +0 ~0 -0
Semantic scope: no live graph was reachable, so the entity and relation counts above are the admitted overlay's and cannot move for work in the working copy. That is a gap in this answer, not a statement that nothing changed; ...
Admission scope: this diff was not measured against the working copy: no daemon is running for this repository, ...
# exit 0
```

`kin status` on the empty repository and on the same repository holding three untracked modules came back byte-identical after age normalisation. Six arms, one exit code:

| command | state | exit |
|---|---|---|
| `kin status` | empty repo, no daemon | 0 |
| `kin status` | three untracked files, no daemon | 0 |
| `kin diff HEAD WORKSPACE` | dirty tree, no daemon | 0 |
| `kin status` | dirty tree, no daemon | 0 |
| `kin diff HEAD WORKSPACE` | after `kin admit` | 0 |
| `kin status` | after `kin admit` | 0 |

## Why it happens, read from source

`kin status` (`main.rs:3014`) and `kin diff` (`main.rs:3064`) both call `admit_before_reading` (`status.rs:1474`), whose first act is `running_daemon_reading` (`daemon_client.rs:8272`), documented as resolving the daemon "without ever starting one". With nothing serving it returns `Absent`, so `StatusAdmission::Skipped` comes back and **no admission runs**. The admission is what moves the graph's idea of the workspace forward and it happens inside the daemon, so from there both commands answer correctly about a workspace snapshot nobody refreshed.

Nothing is lying and nothing is grepping the filesystem. It is a staleness defect with a presentation bug on top: a graph-to-graph delta printed in the shape of a working-copy answer, with the disclaimer below the number and no signal in the exit code.

## The design call, and the case against it

The ticket offered two: admit the tree, or fail loud. **This fails loud**, and the argument for the other one is real: it is what a Git user expects, Kin already starts daemons on `init`, `admit`, `commit` and `locate`, and the founder's 2026-08-30 ruling quoted above `admit_before_reading` says the Zero File-Search Authority Rule permits it, because reading the working copy to ADMIT it is ingestion at an explicit input boundary.

What decided it: **self-admitting cannot be complete, so the loud path has to exist anyway.** Four states admit nothing however hard the command tries, and today every one prints the same wrong zero at exit 0. `KIN_NO_DAEMON` is set, and it is a real product surface (`kin mcp start --no-spawn`). The spawn fails: no binary, `IncompatibleStore`, a strict-mode env divergence, or the memory ceiling that OOM-killed a daemon twice in the run that produced this ticket. The daemon is alive and still opening authority and never answers inside its budget. The admission is refused, fails, or answers with no report. Shipping self-admission first would have left the real bug live behind a happy path that stopped reproducing.

Two more. `status.rs:901` already rules that a read may not start inference as a side effect, and turning the cheapest most-run command in the product into one that can OOM the box is a design change owed its own measurement on a big store. And the exit code is the half no prose can fix: **both commands render every qualification on the text path alone, and `StatusReportWire` denies unknown fields**, so the gap cannot become a key in either JSON payload without a wire decision taken deliberately. For a machine consumer the exit code is the only channel there is.

Self-admission is still a good idea and is filed separately. The order is: make the unmeasured state impossible to miss, then make it rare.

**No part of this reads the working copy.** The delta stays something only an admission can produce.

## The predicate, and the arm that fixed it

"Did a pass take the working copy in THIS invocation", not "does the answer look right". That distinction was not predicted; it came out of a control that failed. `kin admit`, then `kin diff HEAD WORKSPACE`, printed the exactly correct `Artifacts: +0 ~1 -0` with the right hunk and exited 9, because the daemon `kin admit` started had gone before the next process began.

A graph admitted two seconds ago is not a measurement of the working copy now. Any edit in between is invisible to it, and Kin cannot know there was none without looking, which is exactly what it must not do. So the right-looking answer still reports the gap. That case is `a_correct_answer_from_a_stale_graph_is_still_reported_as_unmeasured`, with a positive control on the fixture state so it cannot pass as the ordinary daemon-absent case in disguise.

**Consequence, stated plainly: exit 9 will fire often, because the daemon idles out in minutes.** That is the truth about how much of the time Kin has been answering from stale authority.

## The change

`EXIT_WORKING_COPY_UNMEASURED = 9`, kept apart from 1 the way `kin path`'s `NO_ROUTE_EXIT_CODE` is, so a caller can tell "the question was not answered" from "the command failed". One banner printed directly under each command's heading, above every number, where `merge_line` already sits for the stated reason that a reader who does not suspect the state will not scroll for it. On the diff it is spliced under the heading on both routes, because a daemon answering is not the same as an admission running.

The counts keep their values, which are true about durable authority. The `Semantic scope:`, `Admission scope:` and `Untracked host content:` lines stay exactly where they are. `StatusAdmission::Skipped(String)` is unchanged, so `kin-daemon`'s call site at `api.rs:4892` needed no edit.

## Claims hosted CI does not check

**Exit code 9 was free.** Every exit-code constant in the CLI: `EXIT_SUPPRESSED 1`, `EXIT_ABSENT 3`, `NO_ROUTE_EXIT_CODE 3`, `EXIT_CONFLICT 4`, `EXIT_INDETERMINATE 5`, `EXIT_UNDELIVERED 6`, `EXIT_ENRICHMENT_UNATTESTED 7`, `EXIT_GRAPH_SECTION_UNMATERIALIZED 8`, `EXIT_MERGE_CONFLICTED 8`. Literal `process::exit` sites return 0, 1, 2, 86, 87; `broken_pipe::exit_status` returns 141 or 1.

```
### 3. POSITIVE CONTROL: the pattern in 2 must find EXIT_MERGE_CONFLICTED = 8
1
### 4. NEGATIVE CONTROL: a constant that cannot exist must find zero
rc=1 (1 means no match, which is the expected absence)
### 6. Is 9 taken by any of them?
constants equal to 9 other than the new one: 0
```

The fabricated-name control is what makes the empty result evidence rather than a broken pattern.

**Falsification.** The product was mutated, never an assertion, restored from a byte copy taken at entry rather than with `git checkout -- <file>`, and the restore proved with `cmp`.

```
=== BASELINE: the four cases must PASS on the unmutated tree ===
test result: ok. 4 passed; 0 failed
=== M1: remove the exit code. Both commands return 0 whatever the pass was. ===
test result: FAILED. 0 passed; 4 failed
=== M2: remove the headline banner from both commands. ===
test result: FAILED. 1 passed; 3 failed
=== restore proof: both files must match their backups byte for byte ===
restored clean
```

M2 leaving one case green is the discrimination working: the JSON case grades the exit code and the payload parse, and the banner is not rendered on that path at all.

**The JSON arms write nothing to stderr,** which matters because the preflight captures `kin status --json > file 2>&1` and then requires that file to parse.

```
### kin status --json
exit code:        9
stderr bytes:     0
stdout parses:    yes
schema:           kin.status.v3
merged 2>&1:      parses
### kin diff HEAD WORKSPACE --json
exit code:        9
stderr bytes:     0
schema:           kin.diff.v1
merged 2>&1:      parses
### POSITIVE CONTROL: a command that DOES write to stderr here
bad-arg exit: 2, stderr bytes: 135
```

The control proves stderr can be non-empty on this exact surface, so the zeros are a measurement.

**The ported validator pin moved, and nothing was ported.** This edits install-proof.yml, and `validate.mjs` is pinned by that file's whole-file sha256, so the pin went stale (`c4b55da8` to `a92d6422`) and `test-release-workflow-authority.py` caught it. The mirrored step did not move:

```
     411 /tmp/dirtytree-step-main.txt
     411 /tmp/dirtytree-step-head.txt
f2b88473c0ce233badb97decebbf21b05c84cb798d5de11710119e309258d5e9  /tmp/dirtytree-step-main.txt
f2b88473c0ce233badb97decebbf21b05c84cb798d5de11710119e309258d5e9  /tmp/dirtytree-step-head.txt
UNCHANGED: the mirrored step is byte-identical at both shas, so nothing needs porting
```

with two controls: the extractor must return the real 411-line block, and a copy exactly one line shorter must hash differently. That second control was broken in its first form (`head -n -1` is a GNU extension that BSD `head` refuses while creating an empty file, so the comparison could never fail) and was rebuilt with `sed '$d'` and a line-count assertion.

## Both a crate test and an acceptance case

`Product Acceptance` carries `if: ${{ github.event_name != 'pull_request' }}`, so an acceptance rule does not grade the PR that breaks it. The crate test does, through `ci.yml`.

`crates/kin-cli/tests/unmeasured_working_copy.rs` covers both shapes, the JSON arms, a change-to-change diff that must still exit 0, a measured working copy that must stay silent, and the stale-but-correct arm. `scripts/acceptance/vcs_read_surfaces_repro.py` goes from seven checks to nine; `--self-test` is 40 cases, 0 broken, and it rejects the literal pre-fix output AND both half-fixes: a banner below the count, and a banner above the count at exit 0.

## Callers

Three kin-owned workflows accept exit 9 by number, with `set +e` rather than `|| true` so every other non-zero still stops the leg and so the command lines stay byte-identical for `test-release-workflow-authority.py`'s literal assertions. The test changes are described at the top. The vendored preflight under `scripts/release-proof/` is deliberately untouched here: the umbrella is its source, and kin#1667 carries it.

## Gates

```
bin/kin-parity     FINAL PASS-WITH-ALLOWANCES in 1321.9s
                   magic PASS 27/0/0, brownfield 12/0/1, firstrun 10/1/1
                   allowances: firstrun/9 FIR-2580, firstrun/3 FIR-2501, brownfield/4 FIR-2464
bin/kin-precheck   21 gates ran, 21 passed, 0 failed, on kin 1a99ab37c007934e02f1524e8ddcfd1e4fd44b96
cargo test -p kin-cli --no-fail-fast   green after the test changes above
```

All three parity allowances are pre-existing and tracked, and none is this change.

`bin/kin-first-run` check 5 reads `kin status` right after `kin commit`, which leaves a daemon serving, so it exits **0** here and is genuinely measured. kin-ecosystem#369 added the exit-9 tolerance as the safety net for when that daemon has gone, and it did not have to catch anything.

kin#1667 landed first, re-vendoring `scripts/release-proof/bin/kin-release-preflight.d/proof-flow.sh` from the umbrella. This branch carries the matching `validate.mjs` restamp and both hashes were verified by hashing the files on disk after the rebase that merged the two: `943160af...` and `fc9c482c...`.
