### PR TITLE
Move the immutable kin-vfs release checkout to the tree that builds 0.4.25

### DIFF
--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -191,7 +191,7 @@ jobs:
           repository: firelock-ai/kin-vfs
           path: kin-vfs
           # Release inputs must never move under an unchanged Kin tag.
-          ref: 4ff5262bb345d2d08846b0e8e09abc9fad639aed
+          ref: 199818f0d1d9ff934de76b73b353183352db08b3
           persist-credentials: false
 
       - name: Verify canonical release input bytes
@@ -665,7 +665,7 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: 4ff5262bb345d2d08846b0e8e09abc9fad639aed
+          EXPECTED_VFS_COMMIT: 199818f0d1d9ff934de76b73b353183352db08b3
         run: |
           set -euo pipefail
           node <<'NODE'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -583,7 +583,7 @@ jobs:
           repository: firelock-ai/kin-vfs
           path: kin-vfs
           # Release inputs must never move under an unchanged Kin tag.
-          ref: 4ff5262bb345d2d08846b0e8e09abc9fad639aed
+          ref: 199818f0d1d9ff934de76b73b353183352db08b3
           persist-credentials: false
 
       - name: Verify canonical release input bytes
@@ -1209,7 +1209,7 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: 4ff5262bb345d2d08846b0e8e09abc9fad639aed
+          EXPECTED_VFS_COMMIT: 199818f0d1d9ff934de76b73b353183352db08b3
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1501,7 +1501,7 @@ jobs:
         with:
           repository: firelock-ai/kin-vfs
           path: release-inputs/kin-vfs
-          ref: 4ff5262bb345d2d08846b0e8e09abc9fad639aed
+          ref: 199818f0d1d9ff934de76b73b353183352db08b3
           persist-credentials: false
 
       - name: Download all artifacts
@@ -1569,7 +1569,7 @@ jobs:
 
       - name: Verify and aggregate release provenance
         env:
-          EXPECTED_VFS_COMMIT: 4ff5262bb345d2d08846b0e8e09abc9fad639aed
+          EXPECTED_VFS_COMMIT: 199818f0d1d9ff934de76b73b353183352db08b3
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1943,7 +1943,7 @@ jobs:
     uses: ./.github/workflows/install-proof.yml
     with:
       release_tag: ${{ github.ref_name }}
-      expected_vfs_commit: 4ff5262bb345d2d08846b0e8e09abc9fad639aed
+      expected_vfs_commit: 199818f0d1d9ff934de76b73b353183352db08b3
     permissions:
       contents: read
       attestations: read

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3797,9 +3797,9 @@ dependencies = [
 
 [[package]]
 name = "kin-vfs-core"
-version = "0.4.24"
+version = "0.4.25"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "6c1247c07fd55f47e11390c74df6f5cb643f2a4e789cbf60cde58fb0bdf98e7d"
+checksum = "b0c08d92d479665b8a4c0df4ed78ea081aab2c189e8a4a93c040d41d083efd0c"
 dependencies = [
  "lru",
  "parking_lot",
@@ -6684,7 +6684,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,7 +164,7 @@ kin-db = { version = "=0.7.110", registry = "kin", default-features = false }
 # tokenizer, so a version skew here would be a silent recall loss rather than a
 # build failure.
 kin-search = { version = "=0.1.9", registry = "kin" }
-kin-vfs-core = { version = "=0.4.24", registry = "kin" }
+kin-vfs-core = { version = "=0.4.25", registry = "kin" }
 
 [profile.release]
 opt-level = 3

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -17894,7 +17894,7 @@ jobs:
         "always()",
         "needs.publish.result == 'success'",
         "uses: ./.github/workflows/install-proof.yml",
-        "expected_vfs_commit: 4ff5262bb345d2d08846b0e8e09abc9fad639aed",
+        "expected_vfs_commit: 199818f0d1d9ff934de76b73b353183352db08b3",
     ):
         require(install_proof_job, policy, "mandatory public install proof")
 


### PR DESCRIPTION
## Ticket

FIR-3494

## What this does

Advances the immutable kin-vfs release input from `4ff5262bb345d2d08846b0e8e09abc9fad639aed`, which builds `kin-vfs-core 0.4.24`, to `199818f0d1d9ff934de76b73b353183352db08b3`, which builds `0.4.25`, and moves Kin's registry requirement to `=0.4.25` in the same commit.

Both halves move together because `scripts/check-kin-vfs-compat.mjs` compares them and refuses on disagreement, under the required `Fast gate lint and policy` context. A pull request that moved only one side would red itself. This is the same five-file shape #1223, #1344 and #1431 used.

kin-vfs `199818f0` is the landing of kin-vfs#143, which published `kin-vfs-core 0.4.25` at 2026-09-10T16:27:08Z. It is an ancestor of kin-vfs `main`, which is one commit ahead of it (a README change, kin-vfs#153). That commit's own `Cargo.lock` records `kin-vfs-core 0.4.25`, read over the API rather than assumed.

## Every pin site, counted

The apply script asserts the count per file before it writes, so a replacement that matched nothing cannot read as a clean run.

```
.github/workflows/release.yml                 5 site(s)  (2 checkout refs, 2 EXPECTED_VFS_COMMIT, 1 expected_vfs_commit)
.github/workflows/rc-build.yml                2 site(s)  (1 checkout ref, 1 EXPECTED_VFS_COMMIT)
scripts/test-release-workflow-authority.py    1 site      (the install-proof policy literal)
```

Eight sites, which is what `check-kin-vfs-compat.mjs` discovers rather than what anyone listed: it scans `.github/workflows` and `scripts`, extracts every kin-vfs checkout `ref:` and every expected-commit literal, and refuses if they disagree. Half-updating the pin is red, not quiet.

## Why this is a separate pull request

#1668 stopped the wave from manufacturing this drift. It did not repair the drift that already exists, and it deliberately cannot: the pin is a reviewed release input, and a bot that advanced it would ship a kin-vfs tree nobody read. This is the review.

## What it unblocks

#1665, the open wave pull request, moves `kin-vfs-core` to `=0.4.25` and nothing else. Its whole delta is `Cargo.toml +1 -1`, `Cargo.lock +3 -3`, `fuzz/Cargo.lock +5 -5`. Once this lands, that delta is already on `main`, so the landing judge takes its "the wave's pins are already on main; nothing to merge" branch and the receiver's next refresh reconciles the pull request. This retires #1665 rather than merely unblocking it.

And the next wave rolls `kin-vfs-core` normally again, because #1668's decision rolls whenever the registry's newest installable version equals what the pinned checkout builds, which after this is `0.4.25` on both sides.

## Rebased behind #1663

kin#1663 landed at 18:39:18Z as `ec9418867` and edits `scripts/test-release-workflow-authority.py` in its README badge policy region. This is rebased onto that main and re-verified there rather than merged over it, because a squash onto a main that moved is graded by nothing. The pin literal now sits at line 17897 in that file, and `python3 scripts/test-release-workflow-authority.py` passes on the rebased tree.

## Verification

Run against the tree this pull request produces:

```
$ node scripts/check-kin-vfs-compat.mjs
Verified Kin/kin-vfs compatibility at kin-vfs-core 0.4.25 (pinned kin-vfs
199818f0d1d9ff934de76b73b353183352db08b3, agreed across 8 site(s) in 3 file(s):
.github/workflows/rc-build.yml, .github/workflows/release.yml,
scripts/test-release-workflow-authority.py)

$ node scripts/wave-kin-vfs-core-hold.mjs
ROLL kin-vfs-core: the Kin registry's newest installable kin-vfs-core is 0.4.25,
which is what the pinned firelock-ai/kin-vfs checkout
199818f0d1d9ff934de76b73b353183352db08b3 builds
```

The second line is the one that closes the loop. Before this change the decision HELD, naming registry 0.4.25 against a pin building 0.4.24. After it, it ROLLS, because the two agree.

```
kin-precheck: repo=kin tree=.../worktrees/wavepin-kin sha=1f4acceb4eab9984f5150d7057e1e5666b54ce77
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 21 gates ran, 21 passed, 0 failed
```
