### PR TITLE
Alarm the release sentinel instead of skipping it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1168,6 +1168,23 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: python3 scripts/check-required-contexts.py
 
+      # Grades release-sentinel.yml's own shape and the two scripts it calls, so a
+      # future edit that reintroduces a quietly-skipped patrol (or re-couples the
+      # mechanical patrol to the Claude credential) is caught on the pull request
+      # that does it rather than discovered a release later. ADDED here as well as
+      # in the `check` job below, for the reason the comment beside
+      # check-required-contexts.py's own self-test gives: `bin/kin-precheck`
+      # enumerates guard scripts out of `check` by name, and only this job runs on
+      # a pull request.
+      - name: Falsify release-sentinel credential alarm
+        run: python3 scripts/release-sentinel-credential-alarm.py --self-test
+
+      - name: Falsify release-sentinel parked-rail patrol
+        run: python3 scripts/release-rail-parked-alarm.py --self-test
+
+      - name: Check release-sentinel.yml's own shape
+        run: python3 scripts/check-release-sentinel-shape.py --self-test
+
       # Byte-identical to the `check` job's clippy step, deliberately. The two
       # run on different events now and there is no event on which neither runs,
       # so the workspace is linted exactly once per event rather than twice.
@@ -2083,6 +2100,23 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: python3 scripts/check-required-contexts.py
+
+      # Duplicated from `fast-gate-lint`, same reason as the required-contexts
+      # self-test above: this job carries `github.event_name != 'pull_request'`, so
+      # this copy buys every lane's local `bin/kin-precheck kin` and a second look
+      # on push to main, while the `fast-gate-lint` copy is what actually grades a
+      # pull request.
+      - name: Falsify release-sentinel credential alarm
+        if: runner.os == 'Linux' && matrix.shard == 1
+        run: python3 scripts/release-sentinel-credential-alarm.py --self-test
+
+      - name: Falsify release-sentinel parked-rail patrol
+        if: runner.os == 'Linux' && matrix.shard == 1
+        run: python3 scripts/release-rail-parked-alarm.py --self-test
+
+      - name: Check release-sentinel.yml's own shape
+        if: runner.os == 'Linux' && matrix.shard == 1
+        run: python3 scripts/check-release-sentinel-shape.py --self-test
 
       - name: Install Rust toolchain
         uses: ./.github/actions/rust-toolchain

--- a/.github/workflows/release-sentinel.yml
+++ b/.github/workflows/release-sentinel.yml
@@ -17,16 +17,38 @@ name: Release Sentinel
 # that only works once a human wires a secret is a reporting path that was still
 # silent the day it was needed.
 #
-# ACTIVATION IS ONE FOUNDER STEP. This workflow reads
+# A fourth failure, a parked RC-Build-to-Release-Cut handoff, is patrolled by
+# `mechanical-patrol` below rather than by the agent duties above, for exactly
+# that same reason. Measured live on this repository: RC Build run 34485474934
+# concluded success for the v0.7.10 candidate on `release/v0.7.10-candidate` at
+# 2026-09-10T14:43:07Z, and the first Release Cut run of any kind was not
+# created until 2026-09-10T16:35:09Z, 112 minutes later; v0.7.9 sat parked the
+# same way earlier the same day. `mechanical-patrol` reads no secret and needs
+# no output from `preflight`, so it cannot go dark for the reason the agent
+# duties can.
+#
+# A fifth failure was this file itself. `preflight` printed a `::notice::` and
+# exited 0 on an absent secret, `patrol` below simply skipped, and the run's own
+# conclusion read `success`. Run 34506462232 at 2026-09-10T17:09:20Z is exactly
+# that shape: a green run that patrolled nothing. A skipped step reads as green
+# to anyone scanning the workflow list, the same failure this whole file exists
+# to catch elsewhere in the rail, aimed at itself. `credential-alarm` below is
+# the fix: it runs on every tick regardless of `preflight`'s output and fails
+# the run loud, with a tracking issue, exactly when the agent duties have
+# nothing to authenticate with.
+#
+# ACTIVATION IS ONE FOUNDER STEP, for the agent duties only. This workflow reads
 # `secrets.CLAUDE_CODE_OAUTH_TOKEN_TROY_FIRELOCK_AI`, which only the founder can mint because
 # `claude setup-token` is interactive:
 #
 #   claude setup-token
 #   gh secret set CLAUDE_CODE_OAUTH_TOKEN_TROY_FIRELOCK_AI --org firelock-ai --visibility all
 #
-# Until that secret exists the preflight job below reports it and the patrol is
-# skipped, so this file is inert rather than red. Nothing else about the rail
-# changes while it is unwired.
+# Until that secret exists, `credential-alarm` fails this run and opens a
+# tracking issue saying so, and `patrol`'s three agent duties stay skipped
+# because there is nothing for them to authenticate with. The run itself now
+# reads red rather than quietly green, and `mechanical-patrol` keeps watching
+# the handoff above regardless of whether the founder has minted anything.
 #
 # The guardrails that matter are structural, not promises made in the prompt.
 # The allowlist can express `gh pr create --draft` and `gh pr merge --auto
@@ -44,8 +66,11 @@ on:
     - cron: "11,41 * * * *"
   workflow_dispatch:
 
-# Read-only by default, so a job that says nothing can do nothing. The patrol
-# escalates on its own job below and the credential check never does.
+# Read-only by default, so a job that says nothing can do nothing. `patrol`
+# escalates on its own job below and the credential check never does;
+# `credential-alarm` and `mechanical-patrol` each escalate only to what their
+# own alarm needs (issues: write, plus actions: read for the mechanical
+# patrol's run lookups).
 permissions:
   contents: read
 
@@ -81,7 +106,41 @@ jobs:
             exit 0
           fi
           echo "enabled=false" >> "$GITHUB_OUTPUT"
-          echo "::notice::CLAUDE_CODE_OAUTH_TOKEN_TROY_FIRELOCK_AI is not set, so the release sentinel is skipped. Mint it with 'claude setup-token' and store it with 'gh secret set CLAUDE_CODE_OAUTH_TOKEN_TROY_FIRELOCK_AI --org firelock-ai --visibility all' to activate the patrol. This run is a success on purpose: an unwired sentinel must not read as a broken rail."
+          echo "::notice::CLAUDE_CODE_OAUTH_TOKEN_TROY_FIRELOCK_AI is not set, so the agent patrol below is skipped. Mint it with 'claude setup-token' and store it with 'gh secret set CLAUDE_CODE_OAUTH_TOKEN_TROY_FIRELOCK_AI --org firelock-ai --visibility all' to activate it. This step still succeeds on purpose: it only tests the secret's presence, and credential-alarm below is what turns an absent secret into a failed run rather than a quiet one."
+
+  # A missing credential must alarm, never quietly succeed; see "A fifth failure"
+  # above. This job's only job is to say so: it changes nothing about what
+  # `preflight` reports or what gates `patrol`.
+  credential-alarm:
+    name: Alarm when the sentinel has no credential to patrol with
+    needs: preflight
+    # always(), never the default success()-only gate: this job exists to report
+    # on preflight's output regardless of preflight's own conclusion (which is
+    # always success; only the meaning of a 'false' output changes here, from
+    # quiet to loud).
+    if: always()
+    permissions:
+      contents: read
+      issues: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout the alarm script
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: scripts
+
+      - name: Prove the judge still grades its own fixtures
+        run: python3 scripts/release-sentinel-credential-alarm.py --self-test
+
+      - name: Alarm or clear, based on whether the patrol has a credential
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/release-sentinel-credential-alarm.py \
+            --repo "${{ github.repository }}" \
+            --enabled "${{ needs.preflight.outputs.enabled }}" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   patrol:
     name: Patrol the release rail
@@ -289,3 +348,30 @@ jobs:
             --max-turns 60
             --allowedTools "Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh pr merge --auto --squash:*),Bash(gh pr create --draft:*),Bash(gh run list:*),Bash(gh run view:*),Bash(gh run download:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue create:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh issue close:*),Bash(git ls-remote:*),Bash(git checkout:*),Bash(git switch:*),Bash(git add:*),Bash(git commit:*),Bash(git push --set-upstream origin automation/abandon-:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git rev-parse:*),Bash(python3 scripts/select-admissible-release-tag.py:*),Bash(jq:*),Read,Edit,Write"
             --disallowedTools "WebFetch,WebSearch"
+
+  # The mechanical layer, independent of everything above. See "A fourth
+  # failure" in the header: nothing that depends on a Claude credential can be
+  # the only thing watching for a parked rail, because the credential itself
+  # can be the reason nothing is watching. This job reads no secret, sets no
+  # `needs:` on `preflight`, and never gates on its output.
+  mechanical-patrol:
+    name: Patrol the RC-Build-to-Release-Cut handoff mechanically
+    permissions:
+      contents: read
+      issues: write
+      actions: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout the patrol script
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: scripts
+
+      - name: Prove the judge still grades its own fixtures
+        run: python3 scripts/release-rail-parked-alarm.py --self-test
+
+      - name: Patrol RC Build for a parked rail
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/release-rail-parked-alarm.py --repo "${{ github.repository }}"

--- a/scripts/check-release-sentinel-shape.py
+++ b/scripts/check-release-sentinel-shape.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Fail a pull request that reintroduces a quietly-skipped Release Sentinel.
+
+`release-sentinel-credential-alarm.py` and `release-rail-parked-alarm.py` each
+falsify their own judgment logic against fixtures. Neither can prove the WORKFLOW
+actually wires them the way this ticket requires: that the job which alarms on a
+missing credential cannot itself be skipped by the same condition it exists to
+report on, and that the mechanical patrol carries no dependency on the credential
+job at all. A script's self-test cannot see its own workflow file, so this is a
+separate, narrow check over `.github/workflows/release-sentinel.yml`'s raw text,
+in the same spirit as `check-rc-build-drift.mjs`: no YAML library, just enough
+line-based structure to answer four questions no amount of judge-logic testing
+can:
+
+  1. Do `preflight`, `credential-alarm`, `patrol` and `mechanical-patrol` all
+     still exist as jobs?
+  2. Does `credential-alarm` carry `if: always()` (so it cannot be skipped by
+     `preflight`'s own conclusion, which is what let the original bug read as a
+     skipped step rather than a failed job) and call the credential-alarm
+     script, with no `continue-on-error` that would swallow its exit code?
+  3. Does `patrol` still gate on `needs.preflight.outputs.enabled == 'true'`,
+     unchanged, so it never runs the agent duties without a credential?
+  4. Does `mechanical-patrol` call the parked-rail script while mentioning
+     neither `preflight` nor anything Claude-credential-shaped anywhere in its
+     own job body, so it truly cannot go dark for the reason the agent duties
+     can?
+
+Falsified with `--self-test` against small synthetic workflow-shaped text
+fixtures, one good and one broken per question above, so each assertion is
+proven to actually fire rather than being a check that cannot fail.
+"""
+
+import os
+import sys
+
+WORKFLOW_PATH = ".github/workflows/release-sentinel.yml"
+
+REQUIRED_JOBS = ("preflight", "credential-alarm", "patrol", "mechanical-patrol")
+
+# Anything in this list appearing anywhere in mechanical-patrol's own job body is a
+# defect: that job must need no Claude credential and no output from preflight.
+FORBIDDEN_IN_MECHANICAL_PATROL = (
+    "preflight",
+    "CLAUDE_CODE_OAUTH_TOKEN_TROY_FIRELOCK_AI",
+    "claude_code_oauth_token",
+    "anthropics/claude-code-action",
+)
+
+
+def repo_root():
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def split_jobs(text):
+    """Return {job_name: body_text} for every top-level job under `jobs:`.
+
+    A job key is a two-space-indented identifier immediately followed by a colon
+    with nothing else on the line, e.g. '  patrol:'. Scanning starts only AFTER
+    the top-level 'jobs:' line, because 'on:' carries its own two-space-indented
+    colon-only keys ('  schedule:', '  workflow_dispatch:') that are not jobs and
+    would otherwise be misread as some.
+    """
+    lines = text.split("\n")
+    try:
+        jobs_at = lines.index("jobs:")
+    except ValueError:
+        return None
+
+    starts = []
+    for i in range(jobs_at + 1, len(lines)):
+        line = lines[i]
+        if line.startswith("  ") and not line.startswith("   ") and line.rstrip().endswith(":"):
+            key = line.strip()[:-1]
+            if key and (key[0].isalpha() or key[0] == "_"):
+                starts.append((i, key))
+    if not starts:
+        return {}
+
+    jobs = {}
+    for idx, (start, key) in enumerate(starts):
+        end = starts[idx + 1][0] if idx + 1 < len(starts) else len(lines)
+        jobs[key] = "\n".join(lines[start:end])
+    return jobs
+
+
+def check(text):
+    """Return a list of problems; empty means the shape holds."""
+    jobs = split_jobs(text)
+    if jobs is None:
+        return ["no top-level 'jobs:' key found"]
+    if not jobs:
+        return ["'jobs:' exists but no job keys were found under it"]
+
+    problems = [
+        "expected job '%s' is missing" % name
+        for name in REQUIRED_JOBS
+        if name not in jobs
+    ]
+    if problems:
+        # Can't meaningfully inspect a job body that does not exist.
+        return problems
+
+    cred_alarm = jobs["credential-alarm"]
+    if "if: always()" not in cred_alarm:
+        problems.append(
+            "credential-alarm carries no 'if: always()': without it, a future edit "
+            "(a needs: chain, a changed gate) can make this job skip exactly when it "
+            "exists to report, reproducing the original silent-skip shape"
+        )
+    if "release-sentinel-credential-alarm.py" not in cred_alarm:
+        problems.append("credential-alarm does not call release-sentinel-credential-alarm.py")
+    if "continue-on-error" in cred_alarm:
+        problems.append(
+            "credential-alarm sets continue-on-error, which would keep the run green "
+            "even when the alarm script fails, exactly the quiet-success shape this "
+            "job exists to end"
+        )
+
+    patrol = jobs["patrol"]
+    if "needs.preflight.outputs.enabled == 'true'" not in patrol:
+        problems.append(
+            "patrol no longer gates on needs.preflight.outputs.enabled == 'true'; it "
+            "would run the agent duties with no credential, or never run them even "
+            "with one"
+        )
+
+    mech = jobs["mechanical-patrol"]
+    if "release-rail-parked-alarm.py" not in mech:
+        problems.append("mechanical-patrol does not call release-rail-parked-alarm.py")
+    for forbidden in FORBIDDEN_IN_MECHANICAL_PATROL:
+        if forbidden in mech:
+            problems.append(
+                "mechanical-patrol's job body mentions %r; it must need no Claude "
+                "credential and no output from preflight, or it can go dark for the "
+                "same reason the agent duties can" % forbidden
+            )
+
+    return problems
+
+
+# ─── Controls ───────────────────────────────────────────────────────────────
+
+GOOD_FIXTURE = """\
+name: Release Sentinel
+on:
+  schedule:
+    - cron: "11,41 * * * *"
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: kin-release-sentinel
+  cancel-in-progress: false
+jobs:
+  preflight:
+    name: Resolve sentinel credential
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.credential.outputs.enabled }}
+    steps:
+      - run: echo resolve
+
+  credential-alarm:
+    name: Alarm when the sentinel has no credential to patrol with
+    needs: preflight
+    if: always()
+    steps:
+      - run: python3 scripts/release-sentinel-credential-alarm.py --self-test
+      - run: python3 scripts/release-sentinel-credential-alarm.py --repo x --enabled y
+
+  patrol:
+    name: Patrol the release rail
+    needs: preflight
+    if: needs.preflight.outputs.enabled == 'true'
+    steps:
+      - run: echo patrol
+
+  mechanical-patrol:
+    name: Patrol the RC-Build-to-Release-Cut handoff mechanically
+    steps:
+      - run: python3 scripts/release-rail-parked-alarm.py --self-test
+      - run: python3 scripts/release-rail-parked-alarm.py --repo x
+"""
+
+
+def _replace_once(text, old, new, label):
+    if text.count(old) != 1:
+        raise AssertionError("fixture setup %r matched %d times, expected 1" % (label, text.count(old)))
+    return text.replace(old, new)
+
+
+def self_test():
+    failures = []
+
+    def check_control(name, cond):
+        print("CONTROL %s %s" % ("PASS" if cond else "FAIL", name))
+        if not cond:
+            failures.append(name)
+
+    check_control("the good fixture has no problems", check(GOOD_FIXTURE) == [])
+
+    missing_job = GOOD_FIXTURE.replace(
+        "  mechanical-patrol:\n"
+        "    name: Patrol the RC-Build-to-Release-Cut handoff mechanically\n"
+        "    steps:\n"
+        "      - run: python3 scripts/release-rail-parked-alarm.py --self-test\n"
+        "      - run: python3 scripts/release-rail-parked-alarm.py --repo x\n",
+        "",
+    )
+    problems = check(missing_job)
+    check_control("a removed mechanical-patrol job is caught",
+                   any("mechanical-patrol" in p and "missing" in p for p in problems))
+
+    no_always = _replace_once(
+        GOOD_FIXTURE, "    if: always()\n", "    if: needs.preflight.result == 'success'\n",
+        "credential-alarm if: always()",
+    )
+    problems = check(no_always)
+    check_control("credential-alarm losing 'if: always()' is caught",
+                   any("if: always()" in p for p in problems))
+
+    continue_on_error = _replace_once(
+        GOOD_FIXTURE,
+        "    needs: preflight\n    if: always()\n",
+        "    needs: preflight\n    if: always()\n    continue-on-error: true\n",
+        "credential-alarm continue-on-error insertion",
+    )
+    problems = check(continue_on_error)
+    check_control("credential-alarm gaining continue-on-error is caught",
+                   any("continue-on-error" in p for p in problems))
+
+    no_script_call = _replace_once(
+        GOOD_FIXTURE,
+        "      - run: python3 scripts/release-sentinel-credential-alarm.py --self-test\n"
+        "      - run: python3 scripts/release-sentinel-credential-alarm.py --repo x --enabled y\n",
+        "      - run: echo nothing\n",
+        "credential-alarm script calls",
+    )
+    problems = check(no_script_call)
+    check_control("credential-alarm no longer calling the alarm script is caught",
+                   any("does not call release-sentinel-credential-alarm.py" in p for p in problems))
+
+    patrol_ungated = _replace_once(
+        GOOD_FIXTURE,
+        "    if: needs.preflight.outputs.enabled == 'true'\n",
+        "    if: always()\n",
+        "patrol gate",
+    )
+    problems = check(patrol_ungated)
+    check_control("patrol losing its enabled == 'true' gate is caught",
+                   any("patrol no longer gates" in p for p in problems))
+
+    mech_needs_preflight = _replace_once(
+        GOOD_FIXTURE,
+        "  mechanical-patrol:\n"
+        "    name: Patrol the RC-Build-to-Release-Cut handoff mechanically\n",
+        "  mechanical-patrol:\n"
+        "    name: Patrol the RC-Build-to-Release-Cut handoff mechanically\n"
+        "    needs: preflight\n"
+        "    if: needs.preflight.outputs.enabled == 'true'\n",
+        "mechanical-patrol needs: preflight insertion",
+    )
+    problems = check(mech_needs_preflight)
+    check_control("mechanical-patrol regaining a dependency on preflight is caught",
+                   any("'preflight'" in p for p in problems))
+
+    mech_uses_token = _replace_once(
+        GOOD_FIXTURE,
+        "      - run: python3 scripts/release-rail-parked-alarm.py --repo x\n",
+        "      - run: python3 scripts/release-rail-parked-alarm.py --repo x\n"
+        "      - env:\n"
+        "          T: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_TROY_FIRELOCK_AI }}\n"
+        "        run: echo hi\n",
+        "mechanical-patrol token insertion",
+    )
+    problems = check(mech_uses_token)
+    check_control("mechanical-patrol referencing the Claude token is caught",
+                   any("CLAUDE_CODE_OAUTH_TOKEN_TROY_FIRELOCK_AI" in p for p in problems))
+
+    # THE REGRESSION this whole script exists for: the ORIGINAL shape (preflight
+    # exits 0, patrol gated, nothing else) must be reported as missing jobs, never
+    # silently accepted as "fine, nothing to alarm on".
+    original_shape = """\
+jobs:
+  preflight:
+    name: Resolve sentinel credential
+    outputs:
+      enabled: ${{ steps.credential.outputs.enabled }}
+    steps:
+      - run: echo resolve
+
+  patrol:
+    name: Patrol the release rail
+    needs: preflight
+    if: needs.preflight.outputs.enabled == 'true'
+    steps:
+      - run: echo patrol
+"""
+    problems = check(original_shape)
+    check_control("THE REGRESSION: the pre-fix shape (no alarm, no mechanical patrol) is rejected",
+                   len(problems) >= 2
+                   and any("credential-alarm" in p for p in problems)
+                   and any("mechanical-patrol" in p for p in problems))
+
+    print("check-release-sentinel-shape: self-test %s"
+          % ("PASSED" if not failures else "FAILED on %s" % ", ".join(failures)))
+    return 1 if failures else 0
+
+
+def main(argv):
+    if "--self-test" in argv[1:]:
+        return self_test()
+
+    path = os.path.join(repo_root(), WORKFLOW_PATH)
+    try:
+        with open(path, encoding="utf-8") as handle:
+            text = handle.read()
+    except OSError as exc:
+        print("::error::could not read %s: %s" % (path, exc))
+        return 1
+
+    problems = check(text)
+    if problems:
+        for problem in problems:
+            print("::error::%s" % problem)
+        return 1
+    print(
+        "%s: shape holds (preflight, credential-alarm, patrol and mechanical-patrol "
+        "all present and correctly wired)" % WORKFLOW_PATH
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/release-rail-parked-alarm.py
+++ b/scripts/release-rail-parked-alarm.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Alarm on a parked release rail without needing any Claude credential.
+
+release-sentinel.yml's agent-driven `patrol` job reads the release train's own hold
+marker and re-arms disarmed pull requests, but it only runs when
+`secrets.CLAUDE_CODE_OAUTH_TOKEN_TROY_FIRELOCK_AI` is wired, and even wired it has never
+watched the specific handoff this script watches. `release-cut.yml` triggers on
+`workflow_run` completions of RC Build, and that trigger is exactly the kind
+docs/traps.md's "workflow_run trigger that fires after an upstream workflow completes"
+entry already named as slow and sometimes silent: an occasion can simply never arrive.
+Measured live on this repository: RC Build run 34485474934 concluded success for the
+v0.7.10 candidate on `release/v0.7.10-candidate` at 2026-09-10T14:43:07Z, and the first
+Release Cut run of ANY kind after it was not created until 2026-09-10T16:35:09Z, 112
+minutes later, a `repository_dispatch` at 17:28:38Z reading as the actual recovery
+(matching the remedy docs/traps.md already names: `release-cut.yml` has no
+`workflow_dispatch` of its own, so re-firing it is a `repository_dispatch` of type
+`release_cut`, not a `gh workflow run`). v0.7.9 sat parked the same way earlier the same
+day. Nothing that depends on a Claude credential can be the ONLY thing watching for
+this, because the credential itself can be the reason nothing is watching (see
+`release-sentinel-credential-alarm.py`), so this check needs none.
+
+A parked rail, for this script, is exactly what was measured: an RC Build run that
+concluded `success` on a `release/v*` branch (matching `release-cut.yml`'s own `select`
+job trigger filter, so a manual dispatch on some other branch is correctly never judged
+a parked rail) with no Release Cut run of any kind created within
+PARKED_RAIL_WINDOW_MINUTES of its conclusion. "Any kind" is deliberate: this checks for
+a follow-on run EXISTING, not for proof that its `select` job actually decided
+something, because the GitHub API gives no cheap way to prove a specific Release Cut
+run was caused by a specific RC Build run's completion. A Release Cut run that gets
+created within the window but then skips every job (the OTHER shape docs/traps.md's
+entry documents, from 2026-09-06) reads CLEAR here; that is a narrower, real gap in this
+specific check, left for a future patrol rather than silently claimed as covered.
+
+Verdicts:
+
+  CLEAR      no RC Build run needs following up (none qualify, or one already has a
+             follow-on inside the window).
+  PENDING    the newest qualifying RC Build run concluded less than
+             PARKED_RAIL_WINDOW_MINUTES ago with no follow-on YET. Too soon to judge;
+             not an alarm.
+  PARKED     the window fully elapsed with no follow-on ever. Open or update the
+             tracking issue and fail the job.
+  RECOVERED  the window elapsed with nothing inside it, but a follow-on has since
+             appeared later. The immediate problem resolved (by hand or by a later
+             schedule tick); close the tracking issue rather than re-alarming forever
+             on a candidate the rail has already moved past.
+
+Only PARKED fails the job. Falsified with `--self-test`, fully offline: both RC Build
+and Release Cut run lists are plain Python data, `now` is an explicit timestamp, and
+`gh` is a self-test-only in-memory fake, so the state machine and its two negative
+controls (branch prefix, conclusion) are graded without touching a real repository or
+the real clock. Wired into `ci.yml`'s `fast-gate-lint` and `check` jobs alongside
+`check-required-contexts.py --self-test`, for the reason the comment beside that one
+gives: `bin/kin-precheck` enumerates guard scripts out of the `check` job by name, and
+only `fast-gate-lint` runs on a pull request.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+
+# The one named constant the window is measured against. Chosen to match
+# release-cut.yml's own schedule fallback (cron "3,18,33,48 * * * *", every 15
+# minutes): if that fallback tick is healthy, a stuck workflow_run occasion should
+# still be covered by the next one inside this window, so 15 minutes is "give the
+# system's own designed recovery path one full cycle", not an arbitrary guess.
+PARKED_RAIL_WINDOW_MINUTES = 15
+
+RC_BUILD_WORKFLOW_FILE = "rc-build.yml"
+RELEASE_CUT_WORKFLOW_FILE = "release-cut.yml"
+
+CLEAR = "CLEAR"
+PENDING = "PENDING"
+PARKED = "PARKED"
+RECOVERED = "RECOVERED"
+
+ALARM_TITLE = "Release rail is parked: RC Build has no follow-on Release Cut run"
+
+
+class Unreadable(Exception):
+    """A `gh` call failed, or answered with a shape this script does not recognize."""
+
+
+def gh(args, capture=True):
+    """Run gh, refusing an empty answer rather than treating it as a zero (same idiom
+    as acceptance_red_alarm.py and release-sentinel-credential-alarm.py: a gh call can
+    go out unauthenticated and its 403 wears a quota costume)."""
+    proc = subprocess.run(["gh"] + args, capture_output=capture, text=True, check=False)
+    if proc.returncode != 0:
+        raise Unreadable(
+            "gh %s exited %d: %s" % (" ".join(args), proc.returncode, (proc.stderr or "").strip()[:400])
+        )
+    return proc.stdout
+
+
+def gh_json(args, gh_fn):
+    out = gh_fn(args)
+    if not out.strip():
+        raise Unreadable("gh %s returned no bytes" % " ".join(args))
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError as exc:
+        raise Unreadable("gh %s did not return JSON: %s" % (" ".join(args), exc))
+
+
+def parse_iso8601(ts):
+    """GitHub's REST API timestamps are UTC and always end in Z, e.g.
+    '2026-09-10T14:43:07Z'. Naive strptime would silently accept a non-UTC-looking
+    string too, so this is the one place that shape is enforced."""
+    return datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+
+
+def fetch_rc_build_runs(repo, gh_fn):
+    data = gh_json(
+        ["api", "repos/%s/actions/workflows/%s/runs?event=workflow_dispatch&status=success&per_page=100"
+         % (repo, RC_BUILD_WORKFLOW_FILE)],
+        gh_fn,
+    )
+    runs = data.get("workflow_runs") if isinstance(data, dict) else None
+    if runs is None:
+        raise Unreadable("RC Build runs listing did not answer with a workflow_runs list")
+    return runs
+
+
+def fetch_release_cut_runs(repo, gh_fn):
+    data = gh_json(
+        ["api", "repos/%s/actions/workflows/%s/runs?per_page=100" % (repo, RELEASE_CUT_WORKFLOW_FILE)],
+        gh_fn,
+    )
+    runs = data.get("workflow_runs") if isinstance(data, dict) else None
+    if runs is None:
+        raise Unreadable("Release Cut runs listing did not answer with a workflow_runs list")
+    return runs
+
+
+def select_newest_qualifying_rc_build(rc_build_runs):
+    """release-cut.yml's own `select` job only reacts to an RC Build completion that is
+    `event == 'workflow_dispatch'` on a branch `startsWith('release/v')`; a manual
+    dispatch on any other branch was never going to get a Release Cut follow-on and
+    must not be judged a parked rail. Restricted to `conclusion == 'success'` to match
+    the ticket's own definition; a failed candidate build has a different, separate
+    remediation (retry the build)."""
+    candidates = [
+        r for r in rc_build_runs
+        if r.get("conclusion") == "success" and str(r.get("head_branch") or "").startswith("release/v")
+    ]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda r: parse_iso8601(r["updated_at"]))
+
+
+def classify_rc_build(rc_build, release_cut_runs, now):
+    """Pure. `rc_build` carries at least 'updated_at' (its conclusion time) and
+    'html_url'; `release_cut_runs` each carry at least 'created_at' and 'html_url';
+    `now` is an aware UTC datetime. Returns (verdict, detail)."""
+    concluded_at = parse_iso8601(rc_build["updated_at"])
+    window = timedelta(minutes=PARKED_RAIL_WINDOW_MINUTES)
+    window_end = concluded_at + window
+    elapsed = now - concluded_at
+
+    in_window = [
+        r for r in release_cut_runs
+        if concluded_at <= parse_iso8601(r["created_at"]) <= window_end
+    ]
+    if in_window:
+        newest = max(in_window, key=lambda r: parse_iso8601(r["created_at"]))
+        minutes = (parse_iso8601(newest["created_at"]) - concluded_at).total_seconds() / 60
+        return CLEAR, (
+            "a Release Cut run appeared %.1f minute(s) after RC Build concluded, inside "
+            "the %d-minute window (%s)" % (minutes, PARKED_RAIL_WINDOW_MINUTES, newest.get("html_url", "?"))
+        )
+
+    if elapsed < window:
+        return PENDING, (
+            "only %.1f minute(s) have passed since RC Build concluded; the %d-minute "
+            "window is not up yet" % (elapsed.total_seconds() / 60, PARKED_RAIL_WINDOW_MINUTES)
+        )
+
+    after_at_all = [r for r in release_cut_runs if parse_iso8601(r["created_at"]) > concluded_at]
+    if after_at_all:
+        # The FIRST one to appear after the window closed is what actually ended the
+        # parked state, not whichever is newest right now; a run picked by max() here
+        # would report the most recent tick's timestamp forever, no matter how long
+        # ago the rail actually recovered.
+        first = min(after_at_all, key=lambda r: parse_iso8601(r["created_at"]))
+        minutes = (parse_iso8601(first["created_at"]) - concluded_at).total_seconds() / 60
+        return RECOVERED, (
+            "no Release Cut run appeared within %d minutes, but one appeared %.1f "
+            "minute(s) later (%s); the rail has since moved"
+            % (PARKED_RAIL_WINDOW_MINUTES, minutes, first.get("html_url", "?"))
+        )
+
+    return PARKED, (
+        "%.1f minute(s) have passed since RC Build concluded with no follow-on Release "
+        "Cut run at all" % (elapsed.total_seconds() / 60)
+    )
+
+
+def decide(rc_build_runs, release_cut_runs, now):
+    """Returns (verdict, detail, rc_build_or_None). Only the single newest qualifying
+    RC Build run is judged: once a newer candidate exists, an older one going
+    unfollowed is moot, and re-alarming on it forever would be noise about a rail that
+    has already moved on to the next candidate."""
+    rc_build = select_newest_qualifying_rc_build(rc_build_runs)
+    if rc_build is None:
+        return CLEAR, "no RC Build run on a release/v* branch has concluded success yet", None
+    verdict, detail = classify_rc_build(rc_build, release_cut_runs, now)
+    return verdict, detail, rc_build
+
+
+def find_issue(repo, gh_fn=gh):
+    """Exact-title lookup, matching the sibling alarm scripts in this repository."""
+    out = gh_fn(["issue", "list", "--repo", repo, "--state", "open", "--limit", "100",
+                 "--json", "number,title"])
+    rows = json.loads(out or "[]")
+    for row in rows:
+        if row.get("title") == ALARM_TITLE:
+            return row.get("number")
+    return None
+
+
+def render_alarm_body(repo, rc_build, detail):
+    lines = [
+        "The release rail looks parked.",
+        "",
+        "RC Build run [%s](%s) concluded success on `%s`, and %s."
+        % (rc_build.get("id"), rc_build.get("html_url", "?"), rc_build.get("head_branch", "?"), detail),
+        "",
+        "Release Cut has no `workflow_dispatch` trigger of its own (every arm resolves "
+        "its workflow code from protected main, and a workflow_dispatch takes a ref, so "
+        "it would let a branch select the code that runs beside the release App's key); "
+        "the recovery is a `repository_dispatch`:",
+        "",
+        "```",
+        "gh api repos/%s/dispatches -f event_type=release_cut" % repo,
+        "```",
+        "",
+        "This closes on the next patrol tick once a Release Cut run shows up after the "
+        "RC Build run named above, whether that is this command, the next schedule "
+        "tick, or a workflow_run occasion that was just slow.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def run_alarm(repo, rc_build_runs, release_cut_runs, now, dry_run=False, gh_fn=gh):
+    verdict, detail, rc_build = decide(rc_build_runs, release_cut_runs, now)
+    label = "RC Build %s" % rc_build.get("id") if rc_build else "no qualifying RC Build run"
+    print("VERDICT %s (%s): %s" % (verdict, label, detail))
+
+    if dry_run:
+        if verdict == PARKED:
+            print("--- body ---")
+            print(render_alarm_body(repo, rc_build, detail))
+        return verdict
+
+    existing = find_issue(repo, gh_fn=gh_fn)
+    if verdict == PARKED:
+        body = render_alarm_body(repo, rc_build, detail)
+        if existing:
+            gh_fn(["issue", "comment", str(existing), "--repo", repo, "--body", body])
+            print("updated tracking issue #%s" % existing)
+        else:
+            number = gh_fn(["issue", "create", "--repo", repo, "--title", ALARM_TITLE, "--body", body])
+            print("opened tracking issue %s" % number.strip())
+    else:
+        if existing:
+            gh_fn(["issue", "close", str(existing), "--repo", repo, "--comment",
+                   "The rail is no longer parked: %s" % detail])
+            print("closed tracking issue #%s" % existing)
+        else:
+            print("nothing open to close")
+    return verdict
+
+
+# ─── Controls ───────────────────────────────────────────────────────────────
+#
+# The first two fixtures are the real, measured incident this check exists for:
+# RC Build 34485474934 (v0.7.10) and the six real Release Cut runs read back from
+# `gh api` on 2026-09-10 between 16:35:09Z and 18:05:20Z. Everything else is
+# synthetic, built to isolate one behaviour each, including both negative controls a
+# check like this must carry (see docs/traps.md's "checks that cannot fail" doctrine):
+# a manual dispatch on a non-release branch, and a failed candidate build, must both
+# read CLEAR rather than PARKED, or the filters that are supposed to exclude them are
+# not actually excluding anything.
+
+REAL_RC_BUILD_V0_7_10 = {
+    "id": 34485474934,
+    "conclusion": "success",
+    "head_branch": "release/v0.7.10-candidate",
+    "updated_at": "2026-09-10T14:43:07Z",
+    "html_url": "https://github.com/firelock-ai/kin/actions/runs/34485474934",
+}
+
+# The real Release Cut runs observed after it, earliest first. The gap between
+# 14:43:07Z and 16:35:09Z (the first of these) is 112 minutes, the actual parked
+# window this ticket measured.
+REAL_RELEASE_CUT_FOLLOWUPS = [
+    {"id": 34503004278, "created_at": "2026-09-10T16:35:09Z", "html_url": "https://x/34503004278"},
+    {"id": 34504140482, "created_at": "2026-09-10T16:46:25Z", "html_url": "https://x/34504140482"},
+    {"id": 34508449033, "created_at": "2026-09-10T17:28:38Z", "html_url": "https://x/34508449033"},
+    {"id": 34509491534, "created_at": "2026-09-10T17:38:53Z", "html_url": "https://x/34509491534"},
+    {"id": 34510058702, "created_at": "2026-09-10T17:44:33Z", "html_url": "https://x/34510058702"},
+    {"id": 34512168539, "created_at": "2026-09-10T18:05:20Z", "html_url": "https://x/34512168539"},
+]
+
+
+class _FakeGh:
+    """Records every call and answers `issue list`/`issue create` from in-memory
+    state, matching release-sentinel-credential-alarm.py's fake."""
+
+    def __init__(self, existing_issue=None):
+        self.calls = []
+        self.next_number = 202
+        self.open_issue = existing_issue
+        self.closed_issue = None
+        self.comments = []
+
+    def __call__(self, args):
+        self.calls.append(args)
+        if args[0] == "issue" and args[1] == "list":
+            rows = [{"number": self.open_issue, "title": ALARM_TITLE}] if self.open_issue else []
+            return json.dumps(rows)
+        if args[0] == "issue" and args[1] == "create":
+            self.open_issue = self.next_number
+            return str(self.next_number)
+        if args[0] == "issue" and args[1] == "comment":
+            self.comments.append(args[2])
+            return ""
+        if args[0] == "issue" and args[1] == "close":
+            self.closed_issue = self.open_issue
+            self.open_issue = None
+            return ""
+        raise AssertionError("unexpected gh call in self-test: %r" % (args,))
+
+
+def self_test():
+    failures = []
+
+    def check(name, cond):
+        print("CONTROL %s %s" % ("PASS" if cond else "FAIL", name))
+        if not cond:
+            failures.append(name)
+
+    # THE REGRESSION, replayed on real data: nothing at all inside the window, judged
+    # 32 minutes after RC Build concluded, must read PARKED.
+    now_soon_after = parse_iso8601("2026-09-10T15:15:00Z")
+    verdict, detail, rc_build = decide([REAL_RC_BUILD_V0_7_10], [], now_soon_after)
+    check("THE REGRESSION: v0.7.10's RC Build with nothing following reads PARKED",
+          verdict == PARKED)
+    check("PARKED names the real RC Build run", rc_build is not None and rc_build["id"] == 34485474934)
+    check("PARKED's detail names an elapsed time consistent with 32 minutes",
+          "32" in detail or "31.9" in detail or "32.0" in detail)
+
+    # Same real RC Build, judged now with the real follow-ups on record: the window
+    # itself still saw nothing (112 minutes to the first), but a follow-on did show up
+    # later, so this must read RECOVERED, not a permanent PARKED.
+    now_much_later = parse_iso8601("2026-09-10T18:17:00Z")
+    verdict, detail, rc_build = decide([REAL_RC_BUILD_V0_7_10], REAL_RELEASE_CUT_FOLLOWUPS, now_much_later)
+    check("the same RC Build, judged after real follow-ups exist, reads RECOVERED",
+          verdict == RECOVERED)
+    check("RECOVERED names the ~112-minute gap", "112" in detail)
+
+    # Synthetic CLEAR: a follow-on inside the window.
+    t0 = parse_iso8601("2026-01-01T00:00:00Z")
+    healthy_rc = {"id": 1, "conclusion": "success", "head_branch": "release/v1.0.0-candidate",
+                  "updated_at": "2026-01-01T00:00:00Z", "html_url": "https://x/1"}
+    healthy_followup = [{"id": 2, "created_at": "2026-01-01T00:05:00Z", "html_url": "https://x/2"}]
+    verdict, detail, _ = decide([healthy_rc], healthy_followup, t0 + timedelta(minutes=20))
+    check("a follow-on inside the window reads CLEAR", verdict == CLEAR)
+
+    # Synthetic PENDING: too soon to tell, must not alarm on a totally fresh success.
+    verdict, detail, _ = decide([healthy_rc], [], t0 + timedelta(minutes=5))
+    check("a fresh RC Build with no follow-on YET reads PENDING, not PARKED", verdict == PENDING)
+
+    # Boundary: just under the window is PENDING, at/over the window with nothing is PARKED.
+    verdict, _, _ = decide([healthy_rc], [], t0 + timedelta(minutes=14, seconds=59))
+    check("14:59 elapsed with nothing yet is still PENDING", verdict == PENDING)
+    verdict, _, _ = decide([healthy_rc], [], t0 + timedelta(minutes=15))
+    check("exactly 15:00 elapsed with nothing yet tips into PARKED", verdict == PARKED)
+
+    # No qualifying RC Build run at all: CLEAR, not an error and not PARKED.
+    verdict, detail, rc_build = decide([], [], t0)
+    check("no RC Build runs at all reads CLEAR", verdict == CLEAR and rc_build is None)
+
+    # Negative control: a manual dispatch on a non-release branch must never be judged,
+    # even with no follow-on ever and the window long elapsed. Without this control the
+    # branch-prefix filter could be silently absent and every fixture above would still
+    # pass.
+    off_branch_rc = {"id": 3, "conclusion": "success", "head_branch": "some-feature-branch",
+                      "updated_at": "2026-01-01T00:00:00Z", "html_url": "https://x/3"}
+    verdict, detail, rc_build = decide([off_branch_rc], [], t0 + timedelta(hours=5))
+    check("a manual dispatch off a release/v* branch is excluded, reading CLEAR",
+          verdict == CLEAR and rc_build is None)
+
+    # Negative control: a failed candidate build must never be judged either.
+    failed_rc = {"id": 4, "conclusion": "failure", "head_branch": "release/v1.0.1-candidate",
+                 "updated_at": "2026-01-01T00:00:00Z", "html_url": "https://x/4"}
+    verdict, detail, rc_build = decide([failed_rc], [], t0 + timedelta(hours=5))
+    check("a failed RC Build is excluded, reading CLEAR", verdict == CLEAR and rc_build is None)
+
+    # Superseded-candidate control: an older PARKED-shaped RC Build must not win over a
+    # newer, healthy one. Only the newest qualifying run is ever judged.
+    older_parked = {"id": 5, "conclusion": "success", "head_branch": "release/v1.0.0-candidate",
+                    "updated_at": "2026-01-01T00:00:00Z", "html_url": "https://x/5"}
+    newer_healthy = {"id": 6, "conclusion": "success", "head_branch": "release/v1.0.1-candidate",
+                     "updated_at": "2026-01-01T01:00:00Z", "html_url": "https://x/6"}
+    newer_followup = [{"id": 7, "created_at": "2026-01-01T01:03:00Z", "html_url": "https://x/7"}]
+    verdict, detail, rc_build = decide(
+        [older_parked, newer_healthy], newer_followup, t0 + timedelta(hours=5)
+    )
+    check("a superseded older RC Build never blocks judgment of the newer one",
+          verdict == CLEAR and rc_build is not None and rc_build["id"] == 6)
+
+    # run_alarm's issue-mutation branching, same shape as the credential alarm's own
+    # controls: create on first PARKED, comment (never duplicate) on repeat PARKED,
+    # close on the next non-PARKED verdict, no-op when nothing is open and nothing
+    # needs closing.
+    fake = _FakeGh(existing_issue=None)
+    verdict = run_alarm("firelock-ai/kin", [REAL_RC_BUILD_V0_7_10], [], now_soon_after, gh_fn=fake)
+    check("first PARKED creates an issue", fake.open_issue == fake.next_number and verdict == PARKED)
+    check("first PARKED never closes", fake.closed_issue is None)
+
+    fake2 = _FakeGh(existing_issue=888)
+    run_alarm("firelock-ai/kin", [REAL_RC_BUILD_V0_7_10], [], now_soon_after, gh_fn=fake2)
+    check("repeat PARKED comments rather than duplicating", fake2.open_issue == 888 and len(fake2.comments) == 1)
+    check("repeat PARKED never calls issue create",
+          [c for c in fake2.calls if c[:2] == ["issue", "create"]] == [])
+
+    fake3 = _FakeGh(existing_issue=999)
+    verdict = run_alarm("firelock-ai/kin", [REAL_RC_BUILD_V0_7_10], REAL_RELEASE_CUT_FOLLOWUPS,
+                         now_much_later, gh_fn=fake3)
+    check("RECOVERED closes the open issue", fake3.closed_issue == 999 and verdict == RECOVERED)
+
+    fake4 = _FakeGh(existing_issue=None)
+    verdict = run_alarm("firelock-ai/kin", [], [], t0, gh_fn=fake4)
+    check("CLEAR with nothing open performs no mutation",
+          [c for c in fake4.calls if c[1] in ("create", "comment", "close")] == [] and verdict == CLEAR)
+
+    print("release-rail-parked-alarm: self-test %s"
+          % ("PASSED" if not failures else "FAILED on %s" % ", ".join(failures)))
+    return 1 if failures else 0
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", "firelock-ai/kin"))
+    parser.add_argument("--dry-run", action="store_true", help="judge and print, touch no issue")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args(argv[1:])
+
+    if args.self_test:
+        return self_test()
+
+    try:
+        rc_build_runs = fetch_rc_build_runs(args.repo, gh)
+        release_cut_runs = fetch_release_cut_runs(args.repo, gh)
+        verdict = run_alarm(args.repo, rc_build_runs, release_cut_runs,
+                             datetime.now(timezone.utc), dry_run=args.dry_run)
+    except Unreadable as exc:
+        print("VERDICT UNREADABLE %s" % exc)
+        return 2
+    return 0 if verdict != PARKED else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/release-sentinel-credential-alarm.py
+++ b/scripts/release-sentinel-credential-alarm.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Fail the Release Sentinel run loud when it has no credential to patrol with.
+
+release-sentinel.yml's `preflight` job reads
+`secrets.CLAUDE_CODE_OAUTH_TOKEN_TROY_FIRELOCK_AI` and, when it is absent, printed a
+`::notice::` and exited 0 "on purpose", so the downstream `patrol` job simply skipped.
+Run 34506462232 (2026-09-10T17:09:20Z) is exactly that shape: `Resolve sentinel
+credential` succeeded, `Patrol the release rail` shows SKIPPED, and the run's own
+conclusion reads `success`. A skipped step reads as green to anyone scanning the
+workflow list, so the one workflow whose entire job is to notice a silent release rail
+was itself silent about being unable to run, for as long as nobody happened to open the
+run and read the grey job. That is the same shape the sentinel exists to catch elsewhere
+in the rail, just aimed at the sentinel itself.
+
+This script is what a new `credential-alarm` job in release-sentinel.yml calls right
+after `preflight`. It does not change what `preflight` reports (still a silent,
+value-never-printed presence check) or what gates `patrol` (still
+`needs.preflight.outputs.enabled`). It changes what happens on the disabled branch: the
+job that runs this script now fails the run and opens or updates a single, exact-titled
+tracking issue rather than letting a quiet `::notice::` be the only record. On the
+enabled branch it closes that issue if one is open, so activating the credential is what
+clears the alarm rather than a separate manual step.
+
+Verdicts:
+
+  ALARM   no credential. Open or update the tracking issue, fail the job.
+  CLEAR   a credential is present. Close the tracking issue if one is open, succeed.
+
+Falsified with `--self-test`, offline: every `gh` call is a self-test-only in-memory
+fake, so the state machine (open on first ALARM, comment rather than duplicate on a
+second ALARM, close on the next CLEAR, no-op when already clear) is graded without
+touching a real repository. Wired into `ci.yml`'s `fast-gate-lint` and `check` jobs
+alongside `check-required-contexts.py --self-test`, for the reason the comment beside
+that one gives: `bin/kin-precheck` enumerates guard scripts out of the `check` job by
+name, and only `fast-gate-lint` runs on a pull request, so a self-test living in only
+one of them is invisible to the other.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+ALARM = "ALARM"
+CLEAR = "CLEAR"
+
+ALARM_TITLE = "Release Sentinel has no credential to patrol with"
+
+
+class Unreadable(Exception):
+    """A `gh` call failed or answered with nothing usable."""
+
+
+def gh(args, capture=True):
+    """Run gh, refusing an empty answer rather than treating it as a zero.
+
+    A gh call can go out unauthenticated and its 403 wears a quota costume (see
+    docs/traps.md's "A gh call can go out unauthenticated" entry), so an empty read is
+    Unreadable here rather than "nothing found".
+    """
+    proc = subprocess.run(["gh"] + args, capture_output=capture, text=True, check=False)
+    if proc.returncode != 0:
+        raise Unreadable(
+            "gh %s exited %d: %s" % (" ".join(args), proc.returncode, (proc.stderr or "").strip()[:400])
+        )
+    return proc.stdout
+
+
+def find_issue(repo, gh_fn=gh):
+    """Exact-title lookup, matching acceptance_red_alarm.py's find_issue.
+
+    A search expression could widen into an unrelated issue, so the title is compared
+    for equality rather than passed to GitHub's fuzzy issue search.
+    """
+    out = gh_fn(["issue", "list", "--repo", repo, "--state", "open", "--limit", "100",
+                 "--json", "number,title"])
+    rows = json.loads(out or "[]")
+    for row in rows:
+        if row.get("title") == ALARM_TITLE:
+            return row.get("number")
+    return None
+
+
+def judge(enabled):
+    """Pure. `enabled` is the exact string release-sentinel.yml's `preflight` job
+    outputs: 'true' when the secret is present, anything else otherwise."""
+    return CLEAR if enabled == "true" else ALARM
+
+
+def render_alarm_body(run_url):
+    lines = [
+        "The Release Sentinel has no credential to patrol with.",
+        "",
+        "`secrets.CLAUDE_CODE_OAUTH_TOKEN_TROY_FIRELOCK_AI` is not set, so `patrol` in "
+        "`.github/workflows/release-sentinel.yml` is skipped this run and the three "
+        "agent duties (re-arming a disarmed green pull request, judging a held release "
+        "train, drafting an abandonment for a structurally dead tag) did not run.",
+        "",
+        "- run: %s" % run_url,
+        "",
+        "Mint the credential and wire it, which closes this issue on the next scheduled run:",
+        "",
+        "```",
+        "claude setup-token",
+        "gh secret set CLAUDE_CODE_OAUTH_TOKEN_TROY_FIRELOCK_AI --org firelock-ai --visibility all",
+        "```",
+        "",
+        "The mechanical patrol in the same workflow (`release-rail-parked-alarm.py`) needs "
+        "no credential and keeps watching the RC-Build-to-Release-Cut handoff either way; "
+        "this issue is only about the agent duties above being unable to run.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def run_alarm(repo, enabled, run_url, dry_run=False, gh_fn=gh):
+    verdict = judge(enabled)
+    print("VERDICT %s (preflight enabled=%r)" % (verdict, enabled))
+
+    if dry_run:
+        if verdict == ALARM:
+            print("--- body ---")
+            print(render_alarm_body(run_url))
+        return verdict
+
+    existing = find_issue(repo, gh_fn=gh_fn)
+    if verdict == ALARM:
+        body = render_alarm_body(run_url)
+        if existing:
+            gh_fn(["issue", "comment", str(existing), "--repo", repo, "--body", body])
+            print("updated tracking issue #%s" % existing)
+        else:
+            number = gh_fn(["issue", "create", "--repo", repo, "--title", ALARM_TITLE, "--body", body])
+            print("opened tracking issue %s" % number.strip())
+    else:
+        if existing:
+            gh_fn([
+                "issue", "close", str(existing), "--repo", repo, "--comment",
+                "A credential is wired again, verified by %s. The agent patrol duties resume "
+                "on the next scheduled run." % run_url,
+            ])
+            print("closed tracking issue #%s" % existing)
+        else:
+            print("nothing open to close")
+    return verdict
+
+
+# ─── Controls ───────────────────────────────────────────────────────────────
+#
+# Every `gh` call in self-test goes through _FakeGh, never a subprocess, so this is
+# deterministic in a network-denied sandbox and exercises the actual open/comment/close
+# branching rather than only the boolean judge.
+
+class _FakeGh:
+    """Records every call and answers `issue list`/`issue create` from in-memory state,
+    so a control can assert both the final state and which mutation actually fired."""
+
+    def __init__(self, existing_issue=None):
+        self.calls = []
+        self.next_number = 101
+        self.open_issue = existing_issue  # None, or an int issue number
+        self.closed_issue = None
+        self.comments = []
+
+    def __call__(self, args):
+        self.calls.append(args)
+        cmd = args[0] if args else ""
+        if cmd == "issue" and args[1] == "list":
+            rows = [{"number": self.open_issue, "title": ALARM_TITLE}] if self.open_issue else []
+            return json.dumps(rows)
+        if cmd == "issue" and args[1] == "create":
+            self.open_issue = self.next_number
+            return str(self.next_number)
+        if cmd == "issue" and args[1] == "comment":
+            self.comments.append(args[2])
+            return ""
+        if cmd == "issue" and args[1] == "close":
+            self.closed_issue = self.open_issue
+            self.open_issue = None
+            return ""
+        raise AssertionError("unexpected gh call in self-test: %r" % (args,))
+
+
+def self_test():
+    failures = []
+
+    def check(name, cond):
+        print("CONTROL %s %s" % ("PASS" if cond else "FAIL", name))
+        if not cond:
+            failures.append(name)
+
+    # judge() is the load-bearing boolean: this is the exact string comparison that
+    # decides whether the job that calls this script fails or succeeds.
+    check("judge('true') is CLEAR", judge("true") == CLEAR)
+    check("judge('false') is ALARM", judge("false") == ALARM)
+    check("judge('') is ALARM (an empty output reads as disabled, never as enabled)", judge("") == ALARM)
+    check("judge(None) is ALARM", judge(None) == ALARM)
+
+    # First ALARM with nothing open: creates exactly one issue, never a comment or close.
+    fake = _FakeGh(existing_issue=None)
+    verdict = run_alarm("firelock-ai/kin", "false", "https://example/runs/1", gh_fn=fake)
+    check("first ALARM returns ALARM", verdict == ALARM)
+    check("first ALARM creates an issue", fake.open_issue == fake.next_number)
+    check("first ALARM never closes", fake.closed_issue is None)
+    check("first ALARM posts no comment (nothing existed to comment on)", fake.comments == [])
+
+    # A second ALARM while one is already open: comments on it, creates no duplicate.
+    fake2 = _FakeGh(existing_issue=555)
+    verdict = run_alarm("firelock-ai/kin", "false", "https://example/runs/2", gh_fn=fake2)
+    check("repeat ALARM returns ALARM", verdict == ALARM)
+    check("repeat ALARM does not open a second issue", fake2.open_issue == 555)
+    check("repeat ALARM comments on the existing issue rather than duplicating it",
+          len(fake2.comments) == 1)
+    create_calls = [c for c in fake2.calls if c[:2] == ["issue", "create"]]
+    check("repeat ALARM never calls issue create", create_calls == [])
+
+    # CLEAR with an issue open: closes it.
+    fake3 = _FakeGh(existing_issue=777)
+    verdict = run_alarm("firelock-ai/kin", "true", "https://example/runs/3", gh_fn=fake3)
+    check("CLEAR with an open issue returns CLEAR", verdict == CLEAR)
+    check("CLEAR closes the open issue", fake3.closed_issue == 777)
+    check("CLEAR leaves nothing open afterward", fake3.open_issue is None)
+
+    # CLEAR with nothing open: a true no-op, no gh mutation at all.
+    fake4 = _FakeGh(existing_issue=None)
+    verdict = run_alarm("firelock-ai/kin", "true", "https://example/runs/4", gh_fn=fake4)
+    check("CLEAR with nothing open returns CLEAR", verdict == CLEAR)
+    mutating_calls = [c for c in fake4.calls if c[1] in ("create", "comment", "close")]
+    check("CLEAR with nothing open performs no mutation", mutating_calls == [])
+
+    # THE REGRESSION this script exists to prevent: an absent credential must never
+    # read as a job that quietly does nothing and succeeds. If a future edit reintroduces
+    # "exit 0 regardless", this control catches it independent of anything gh-shaped.
+    check(
+        "THE REGRESSION: a missing credential never judges CLEAR",
+        judge("false") != CLEAR and judge("") != CLEAR and judge(None) != CLEAR,
+    )
+
+    print("release-sentinel-credential-alarm: self-test %s"
+          % ("PASSED" if not failures else "FAILED on %s" % ", ".join(failures)))
+    return 1 if failures else 0
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", "firelock-ai/kin"))
+    parser.add_argument("--enabled", default=None,
+                         help="the exact string release-sentinel.yml's preflight job output; "
+                              "'true' means a credential is present")
+    parser.add_argument("--run-url", default="")
+    parser.add_argument("--dry-run", action="store_true", help="judge and print, touch no issue")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args(argv[1:])
+
+    if args.self_test:
+        return self_test()
+    if args.enabled is None:
+        parser.error("--enabled is required unless --self-test")
+
+    try:
+        verdict = run_alarm(args.repo, args.enabled, args.run_url, dry_run=args.dry_run)
+    except Unreadable as exc:
+        print("VERDICT UNREADABLE %s" % exc)
+        return 2
+    return 0 if verdict == CLEAR else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -918,7 +918,9 @@ EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
     },
     ".github/workflows/release-sentinel.yml": {
         "preflight": "Resolve sentinel credential",
+        "credential-alarm": "Alarm when the sentinel has no credential to patrol with",
         "patrol": "Patrol the release rail",
+        "mechanical-patrol": "Patrol the RC-Build-to-Release-Cut handoff mechanically",
     },
     ".github/workflows/install-proof-canary.yml": {
         "capability-canary": "Capability Contract Canary",


### PR DESCRIPTION
Ticket: FIR-3490 (https://linear.app/firelock-ai/issue/FIR-3490)

## What was silent

Release Sentinel exists to notice a silent release rail, and it was silent about two
things at once.

First, about itself. `preflight`'s credential check tested
`secrets.CLAUDE_CODE_OAUTH_TOKEN_TROY_FIRELOCK_AI`, printed a `::notice::` on an absent
secret, and exited 0 "on purpose." The downstream `patrol` job then skipped, and the
run's own conclusion read `success`. Run 34506462232 (2026-09-10T17:09:20Z) is exactly
that shape: a green run that patrolled nothing.

Second, about the rail itself. `RC Build` has no follow-on trigger of its own; `Release
Cut`'s `select` job is what's supposed to react via `workflow_run` when an RC Build
completes on a `release/v*` branch. Measured live: RC Build 34485474934 concluded
success for the v0.7.10 candidate at 2026-09-10T14:43:07Z, and the first Release Cut
run of any kind was not created until 2026-09-10T16:35:09Z, 112 minutes later. v0.7.9
sat parked the same way earlier the same day.

## The fix

**`credential-alarm`** (new job, `needs: preflight`, `if: always()`): fails the run and
opens/updates one exact-titled tracking issue when the credential is absent; closes it
when the credential is present. `preflight` and `patrol` are unchanged (same silent
presence test, same `needs.preflight.outputs.enabled == 'true'` gate).

**`mechanical-patrol`** (new job, no dependency on `preflight`, no Claude credential
anywhere in its body): reads the newest RC Build run that concluded success on a
`release/v*` branch and checks for any Release Cut run created within
`PARKED_RAIL_WINDOW_MINUTES = 15` of its conclusion (matching Release Cut's own
15-minute schedule fallback cadence). CLEAR/PENDING/PARKED/RECOVERED; only PARKED
alarms and fails.

**`check-release-sentinel-shape.py`** (new, third guard): a script's self-test can't
see its own workflow file, so this parses `release-sentinel.yml`'s raw text (no YAML
library, same approach as `check-rc-build-drift.mjs`) and asserts the wiring itself:
`credential-alarm` carries `if: always()` and no `continue-on-error`; `patrol` still
gates on the enabled output; `mechanical-patrol` mentions neither `preflight` nor
anything Claude-credential-shaped.

All three ship as `--self-test` only, wired into both `fast-gate-lint` (pull-request
coverage) and `check` (what `bin/kin-precheck` enumerates), mirroring
`check-required-contexts.py`'s existing duplication for the same stated reason.

**Also fixed**: `test-release-workflow-authority.py` keeps a hardcoded per-workflow job
census so no new job can silently start producing a required check under an unreviewed
name. Adding `credential-alarm` and `mechanical-patrol` tripped it, exactly as
designed; added both job ids and their exact display-name strings to the census entry.

## Falsification (both arms, plus the shape check)

Each guard was mutated to disable it, run to confirm red, restored, run to confirm
green.

**Arm (a) — credential unset reports cannot-patrol, not skip.** `judge()` mutated to
always return `CLEAR`:

```
CONTROL FAIL judge('false') is ALARM
CONTROL FAIL first ALARM returns ALARM
CONTROL FAIL THE REGRESSION: a missing credential never judges CLEAR
release-sentinel-credential-alarm: self-test FAILED on judge('false') is ALARM, ... (9 total)
EXIT=1
```

Restored:

```
release-sentinel-credential-alarm: self-test PASSED
EXIT=0
```

**Arm (b) — mechanical patrol alarms on a parked shape, quiet on a healthy one.** The
`PARKED` return in `classify_rc_build()` mutated to `CLEAR`, judged against the real
RC Build 34485474934 fixture:

```
CONTROL FAIL THE REGRESSION: v0.7.10's RC Build with nothing following reads PARKED
CONTROL FAIL exactly 15:00 elapsed with nothing yet tips into PARKED
CONTROL FAIL first PARKED creates an issue
release-rail-parked-alarm: self-test FAILED on ... (5 total)
EXIT=1
```

Restored:

```
VERDICT PARKED (RC Build 34485474934): 31.9 minute(s) have passed since RC Build
concluded with no follow-on Release Cut run at all
release-rail-parked-alarm: self-test PASSED
EXIT=0
```

The healthy-shape side of arm (b) is in the same run: a follow-on inside the window
reads CLEAR, a fresh RC Build with nothing yet reads PENDING (never alarms), and two
negative controls (a manual dispatch off a `release/v*` branch, a failed candidate
build) prove the filters actually exclude something rather than being checks that
cannot fail.

**Shape arm.** `if: always()` on `credential-alarm` reverted to the original skippable
gate:

```
::error::credential-alarm carries no 'if: always()': without it, a future edit (a
needs: chain, a changed gate) can make this job skip exactly when it exists to report,
reproducing the original silent-skip shape
EXIT=1
```

Restored: shape check passes against its own 9 synthetic controls and against the
real, live `release-sentinel.yml`.

While building arm (b)'s real-data fixture, the self-test itself caught a real bug
before it ever ran live: `RECOVERED` was picking the newest follow-on run (202 minutes
after conclusion) instead of the first one that actually broke the parked state (112
minutes). Fixed in the same commit.

## Verification

```
$ bin/kin-precheck kin --repo-dir kin=<worktree>
kin-precheck: 24 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt / clippy / all 18 other guard: scripts / node-test
NOT RUN  guard:check-release-sentinel-shape.py      (UNCLASSIFIED in bin/kin-precheck)
NOT RUN  guard:release-rail-parked-alarm.py         (UNCLASSIFIED in bin/kin-precheck)
NOT RUN  guard:release-sentinel-credential-alarm.py (UNCLASSIFIED in bin/kin-precheck)
kin-precheck: NO TALLY. 3 of 24 gates could not run.
```

`bin/kin-precheck` lives in the kin-ecosystem umbrella, outside this repo, and doesn't
yet classify the 3 new scripts (same message any brand-new guard script gets there
before someone adds it to `LOCAL`). All three were verified directly instead
(`python3 scripts/<name>.py --self-test`, exit 0; see falsification section above), and
hosted CI is unaffected: `fast-gate-lint` and `check` run these scripts directly from
their own `run:` lines, not through `bin/kin-precheck`. The umbrella-side classification
is being handled separately; this PR is not armed to auto-merge until that lands, so no
kin lane sees a broken local precheck in the meantime.

Also ran `actionlint .github/workflows/release-sentinel.yml .github/workflows/ci.yml`:
clean, exit 0.
