### PR TITLE
Measure the working copy before grading a status read

### DIFF
--- a/scripts/acceptance/detached_head_commit_repro.py
+++ b/scripts/acceptance/detached_head_commit_repro.py
@@ -119,6 +119,12 @@ def run(cmd, cwd=None, env=None, timeout=900):
 # Pure functions, so --self-test can drive every one against the input that must
 # produce the opposite verdict.
 
+# The line `kin status` leads with when nothing admitted the working copy
+# (FIR-3420). Named once so the measured-read control below cannot drift from
+# the product's own wording without this file noticing.
+UNMEASURED_BANNER = "Working copy: NOT MEASURED"
+
+
 def head_line(text):
     """The `Head:` line `kin status` printed, or None when it printed none.
 
@@ -297,6 +303,47 @@ class Suite(object):
             print("  $ kin %s -> rc=%s" % (" ".join(args), rc))
         return rc, out, err
 
+    def measured_status(self, repo):
+        """`kin status` over a working copy something actually admitted.
+
+        A bare `kin status` never starts a daemon, so with none serving it
+        reports durable authority alone and exits
+        `EXIT_WORKING_COPY_UNMEASURED`. That is the product being honest and it
+        is not what this suite grades: every check here is about the HEAD an
+        authority read reports, and a read that measured nothing is the wrong
+        instrument for that question rather than a defect in it.
+
+        So the read is made measured instead of tolerated. `kin admit` starts
+        the daemon and takes the working copy, exactly as
+        `vcs_read_surfaces_repro.py` does, and the status after it answers about
+        a working copy the graph has actually seen. The admission is a no-op on
+        an unmodified fixture and never moves HEAD, which is the only thing the
+        graders below read.
+
+        Returns `(rc, text, gap)`. `gap` is the reason the read is not measured,
+        or None when it is, so a caller reports a fixture that could not reach
+        this state as UNREADABLE rather than grading it.
+        """
+        arc, aout, aerr = self.kin_run(repo, ["admit"])
+        if arc != 0:
+            return (arc, (aout or "") + (aerr or ""),
+                    "kin admit exited %s, so nothing admitted the working copy: %s"
+                    % (arc, ((aerr or aout) or "")[-200:]))
+        rc, out, err = self.kin_run(repo, ["status"])
+        text = out or ""
+        if rc != 0:
+            return (rc, text + (err or ""),
+                    "kin status exited %s after an admission that succeeded: %s"
+                    % (rc, ((err or out) or "")[-200:]))
+        # The positive control on the state, not on the answer. If this read
+        # were still unmeasured the banner would say so, and every grader below
+        # would be reading durable authority alone while believing otherwise.
+        if UNMEASURED_BANNER in text:
+            return (rc, text,
+                    "the status after the admission still reports the working copy as "
+                    "unmeasured, so the pass did not take")
+        return (rc, text, None)
+
     def git(self, repo, args, timeout=300):
         rc, out, err = run(["git"] + args, cwd=repo, env=self.env, timeout=timeout)
         if rc != 0:
@@ -375,10 +422,9 @@ def check_branch_control(suite):
 
 def check_head_visible(suite):
     repo = suite.repo("detached", detach=True)
-    rc, out, err = suite.kin_run(repo, ["status"])
-    if rc != 0:
-        return Result("head_visible", UNREADABLE,
-                      "kin status exited %s: %s" % (rc, (err or out)[-200:]))
+    rc, out, gap = suite.measured_status(repo)
+    if gap is not None:
+        return Result("head_visible", UNREADABLE, gap)
     OBSERVED["head_before"] = head_line(out)
     status, detail = grade_head_is_visible(out)
     return Result("head_visible", status, detail)
@@ -404,10 +450,9 @@ def check_head_advanced(suite):
         return Result("head_advanced", UNREADABLE,
                       "the commit did not land, so no head could have moved")
     repo = suite.repo("detached", detach=True)
-    rc, out, err = suite.kin_run(repo, ["status"])
-    if rc != 0:
-        return Result("head_advanced", UNREADABLE,
-                      "kin status exited %s: %s" % (rc, (err or out)[-200:]))
+    rc, out, gap = suite.measured_status(repo)
+    if gap is not None:
+        return Result("head_advanced", UNREADABLE, gap)
     OBSERVED["head_after"] = head_line(out)
     status, detail = grade_head_advanced(OBSERVED.get("head_before"),
                                          OBSERVED.get("head_after"))

--- a/scripts/acceptance/scratch_file_commit_repro.py
+++ b/scripts/acceptance/scratch_file_commit_repro.py
@@ -270,6 +270,9 @@ class Suite(object):
         if daemon:
             self.env["KIN_DAEMON_BIN"] = daemon
         self._repo = None
+        # The transition is destructive and every check asks for it; see
+        # `transition` below.
+        self._transition = None
 
     def kin_run(self, repo, args, timeout=900):
         rc, out, err = run([self.kin] + args, cwd=repo, env=self.env, timeout=timeout)
@@ -308,6 +311,17 @@ class Suite(object):
             raise RuntimeError("kin init failed: %s" % ((err or out)[-400:]))
         # Fixture assertion. If the scratch file was never tracked, deleting it
         # produces no unmatched removal and every arm below passes vacuously.
+        #
+        # `kin admit` first, so the read is measured. A bare `kin status` never
+        # starts a daemon, and `kin init`'s own daemon can be gone by the time
+        # the next process starts, at which point status reports durable
+        # authority alone and exits `EXIT_WORKING_COPY_UNMEASURED` (FIR-3420).
+        # This read would then have raised on a correct answer, and before that
+        # code existed it passed only when a daemon happened to still be alive.
+        arc, aout, aerr = self.kin_run(path, ["admit"])
+        if arc != 0:
+            raise RuntimeError("kin admit failed after init, so the fixture read below "
+                               "could not be measured: %s" % ((aerr or aout)[-400:]))
         rc, out, err = self.kin_run(path, ["status"])
         if rc != 0:
             raise RuntimeError("kin status failed after init: %s" % ((err or out)[-400:]))
@@ -315,12 +329,23 @@ class Suite(object):
         return path
 
     def transition(self):
-        """Delete the scratch file, write the new ones, and commit."""
+        """Delete the scratch file, write the new ones, and commit.
+
+        Memoised, like `repo()` above and for the same reason: this is
+        destructive and all three checks ask for it. Run twice it raises on the
+        scratch file it already deleted, so the second and third checks read
+        UNREADABLE over a fixture that reached the state they wanted. Every
+        caller grades one transition, which is the experiment the suite is
+        about.
+        """
+        if self._transition is not None:
+            return self._transition
         path = self.repo()
         os.remove(os.path.join(path, SCRATCH))
         for relative in ADDITIONS:
             self._write(path, relative, ADDITION_BODIES[relative])
-        return self.kin_run(path, ["commit", "-m", "Add markdown note parser"])
+        self._transition = self.kin_run(path, ["commit", "-m", "Add markdown note parser"])
+        return self._transition
 
     @staticmethod
     def _write(root, relative, body):


### PR DESCRIPTION
Fixes the red `Product Acceptance` on main. Alarm issue kin#1674, run 34515421596, red at 19:22:46Z on `b4f09318`, which is my landing for FIR-3420.

```
detached_head:head_visible   UNREADABLE  kin status exited 9
detached_head:head_advanced  UNREADABLE  one of the two status reads carried no Head line
```

Only the first is a real read. `check_head_visible` reads `kin status` with no daemon serving and returns UNREADABLE on any non-zero exit, so it stops on 9 and never records `OBSERVED["head_before"]`; the second then reports no Head line because that value is None. Both get the fix anyway, because either can be the unmeasured one on a different run.

Nothing here is a defect in the product. The check's subject is the HEAD an authority read reports, and a bare `kin status` with no daemon is now the wrong instrument for that question rather than a broken one.

## Measure the read, do not tolerate the code

A `measured_status(repo)` helper admits the working copy and then reads it, the way `vcs_read_surfaces_repro.py` already does, returning `(rc, text, gap)` so a fixture that could not reach the measured state reads UNREADABLE with its cause instead of being graded.

It carries a **control on the state rather than on the answer**: a status that still leads with `Working copy: NOT MEASURED` after the admission makes the helper refuse. Without that, an admission that silently did not take would leave every grader below reading durable authority alone while believing otherwise, which is the same class of defect this whole ticket is about. The admission is a no-op on the unmodified fixture and never moves HEAD, which is the only line these graders read.

## Falsified against main's own copy

`.kin-coord/reports/dirtytree-acceptfix-driver.sh` runs main's copy and the fixed copy against the SAME binaries, and refuses up front unless that binary actually produces exit 9, so neither arm can mean nothing.

```
### the binary under test carries the exit code this is all about
kin status with no daemon exits 9 (9 is the build this fix is for)

=== ARM A: main's BARE reads (the code that turned Acceptance red) ===
exit 2
  head_visible       UNREADABLE  kin status exited 9: ...
  head_advanced      UNREADABLE  one of the two status reads carried no Head line

=== ARM B: the measured reads ===
exit 0
  branch_control     PASS
  head_visible       PASS  kin status named the head: Head: detached Commit 8871a834...
  detached_commits   PASS
  head_advanced      PASS  the head moved from 'Head: detached Commit 8871a834...' to 'Head: detached change 7aba5707...'
  no_branch_moved    PASS

=== restore proof ===
restored clean
```

Arm A reproduces the alarm's two rows exactly, which is what makes Arm B evidence rather than assertion.

## The sweep found one more, with controls

`.kin-coord/reports/dirtytree-acceptsweep.sh` reads every `kin status` and every `kin diff` under `scripts/acceptance/`, with a positive control that must find the two reads the alarm named and a negative control on a call that cannot exist.

`scratch_file_commit_repro.py:311` is the same shape: a fixture assertion that RAISES on a non-zero status, sitting immediately after `kin init` whose daemon can already be gone. It passed only when one happened to still be alive. It admits first now.

Everything else is safe and each was read rather than assumed. `coverage_read_open.py`, `working_copy_freshness_repro.py`, `merge_precedence_repro.py` and three reads in `memory_pressure_refusal.py` ignore the exit code entirely. `memory_pressure_refusal.py:1525` returns unknown on non-zero and is **correct as written**, because it runs immediately after an explicit `restart_daemon` and its subject IS the live daemon footprint line, so a 9 there means the check genuinely cannot be read; deliberately left alone. `diff_content_repro.py` keeps the text on any exit code for its one `WORKSPACE` call and only ever asks for JSON change-to-change, which cannot be unmeasured. `ref_grammar_repro.py`'s diffs are all change-to-change.

## A pre-existing defect the fix exposed

`scratch_file_commit_repro.py` was **0 of 3 on main** and is 3 of 3 here, and only one of those three was mine:

```
MAIN   commit UNREADABLE (kin status failed after init)   remedy UNREADABLE   exit UNREADABLE
FIXED  commit PASS                                        remedy PASS         exit PASS
```

Once `commit` passed, the other two surfaced their own bug, unrelated to any exit code: `transition()` is destructive and all three checks call it, so the second and third raised on the scratch file the first had deleted. Memoised now, like `repo()` beside it. That suite is not wired into `acceptance.yml` at all, so none of this was grading anything; it is a landmine removed rather than a red turned green.

## Release

The v0.7.11 candidate `d10035e7` predates `b4f09318`, so the cut does not carry the change that turned Acceptance red and nothing about the release is blocked by it.

## Gates

```
bin/kin-precheck   21 gates ran, 21 passed, 0 failed, on kin 2c3128606d592978022578b66df238081f9e4ab5
                   behind origin/main 0 commit(s)
detached_head_commit_repro.py --self-test    0 problem(s)
scratch_file_commit_repro.py  --self-test    PASS, graders inverted
```

Both suites also run against real built binaries above, which is the only place this class shows up: `Product Acceptance` carries `if: ${{ github.event_name != 'pull_request' }}`, so it does not grade this pull request and main's next push run is the grader.

FIR-3420. kin#1674. Report: `.kin-coord/reports/dirtytree-20260910.md`.
