### PR TITLE
Dispatch RC Build on the App token when granted, and nudge release-tag directly

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -784,7 +784,16 @@ jobs:
       # refuses either), so this sends nothing for it to misread as break
       # glass; `reason` is unread by that workflow and exists only for a
       # person scanning the Actions log.
+      # Best-effort, on purpose. This nudge already has two fallbacks that
+      # need no code here to work: release-tag.yml's own 15-minute schedule,
+      # and CI's workflow_run trigger on the next ordinary push to main. A
+      # transient API failure on this call must not redden the publish job
+      # of a cut that already durably wrote the record this step only
+      # announces; continue-on-error plus the warning below make that true
+      # the same way the dispatch-token mint in the arm job does.
       - name: Nudge release-tag to evaluate now
+        id: nudge-release-tag
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           CANDIDATE: ${{ needs.select.outputs.candidate }}
@@ -793,6 +802,11 @@ jobs:
           gh api --method POST "repos/${GITHUB_REPOSITORY}/dispatches" \
             -f event_type=release_tag_evaluate \
             -f "client_payload[reason]=release-cut run ${GITHUB_RUN_ID} published preflight.json for ${CANDIDATE}"
+
+      - name: Warn when the release-tag nudge did not go out
+        if: steps.nudge-release-tag.outcome != 'success'
+        run: |
+          echo "::warning::the direct nudge to release-tag.yml did not go out for this candidate; release-tag.yml still reaches it through its own 15-minute schedule and through CI's workflow_run trigger, so the mint is not blocked, only slower"
 
       - name: Say what the stranger will run next
         env:

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -250,12 +250,56 @@ jobs:
           fi
           echo "${BRANCH} -> ${CANDIDATE} (${MOVE})"
 
-      # The dispatch goes out on the workflow token, not the App's. rc-build.yml
-      # holds no credential by design and needs none to start, and keeping the
-      # App token off this call keeps its blast radius to the branch write above.
+      # A second, narrower mint: actions:write only, nothing else, so this
+      # token can dispatch rc-build.yml and can do nothing the branch-move
+      # token above already couldn't. kin-release-bot's installation does not
+      # carry the Actions permission today (installation 148381548:
+      # administration:read, contents:write, issues:write, metadata:read,
+      # pull_requests:write; verified live via
+      # `gh api orgs/firelock-ai/installations`), so this mint fails until a
+      # person grants it at
+      # https://github.com/organizations/firelock-ai/settings/installations/148381548.
+      # continue-on-error keeps that failure from reddening this job: the
+      # dispatch step below falls back to today's github.token whenever this
+      # mint did not succeed, so landing this before the grant changes nothing
+      # observable, and the cascade turns on the day the grant lands with no
+      # further edit here.
+      #
+      # rc-build.yml itself gets none of this. It holds no credential by
+      # design, and its workflow_dispatch trigger admits any ref with no actor
+      # gate, so granting it any write permission would hand that same power
+      # to whoever dispatches it on their own branch: workflow_dispatch
+      # resolves both the code that runs and the permissions it runs with from
+      # the dispatched ref, which is exactly why release-cut.yml's own trigger
+      # above avoids workflow_dispatch in the first place. The credential
+      # stays here, on the sender, which is already gated by this job's own
+      # `if:` and the App's repository scope.
+      - name: Mint repository-scoped dispatch token
+        id: dispatch-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.KIN_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.KIN_RELEASE_BOT_PRIVATE_KEY }}
+          owner: firelock-ai
+          repositories: kin
+          permission-actions: write
+
+      - name: Warn when the dispatch cannot yet use the App identity
+        if: steps.dispatch-token.outcome != 'success'
+        run: |
+          echo "::warning::kin-release-bot (installation 148381548) does not yet carry the Actions permission, so RC Build's completion will not cascade into this workflow's own workflow_run trigger; dispatching rc-build.yml on github.token instead, exactly as before this change. Grant kin-release-bot Actions: write at https://github.com/organizations/firelock-ai/settings/installations/148381548 to turn the cascade on with no further change here."
+
+      # The dispatch goes out on the App identity minted just above whenever
+      # that mint succeeded, and on the workflow token exactly as before
+      # otherwise. `steps.dispatch-token.outcome`, never `.conclusion`: the
+      # mint's continue-on-error masks `.conclusion` to success even when it
+      # failed, which is what lets this job stay green either way, but reading
+      # that masked value here would make the dispatch trust a token that was
+      # never actually issued.
       - name: Dispatch the candidate archive build
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.dispatch-token.outcome == 'success' && steps.dispatch-token.outputs.token || github.token }}
           BRANCH: ${{ needs.select.outputs.branch }}
           CANDIDATE: ${{ needs.select.outputs.candidate }}
         run: |
@@ -722,6 +766,33 @@ jobs:
             --name preflight.json \
             --file "$RUNNER_TEMP/preflight.json" \
             --repo "$GITHUB_REPOSITORY"
+
+      # ADDITIVE: release-tag.yml already reaches this candidate through CI's
+      # workflow_run and a 15-minute schedule, both indirect occasions that
+      # wait on an unrelated event. This is the direct nudge, the moment the
+      # record above is durably published: evaluate now instead of waiting on
+      # either fallback. It reuses the App token minted for kin-evidence-publish
+      # rather than github.token, on purpose. Sending a repository_dispatch
+      # needs contents:write, which this job's default token does not carry
+      # (permissions: contents: read at the top of this file); the minted
+      # token already does, scoped to this repository. Its actor also matters:
+      # release-tag.yml's own trigger guard allowlists troyjr4103 and
+      # kin-release-bot[bot] and refuses everything else, including the
+      # github-actions[bot] actor an automated github.token dispatch would
+      # carry, so that dispatch would start a run and then immediately refuse
+      # itself. release_tag_evaluate takes no tag or sha (release-tag.yml
+      # refuses either), so this sends nothing for it to misread as break
+      # glass; `reason` is unread by that workflow and exists only for a
+      # person scanning the Actions log.
+      - name: Nudge release-tag to evaluate now
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          CANDIDATE: ${{ needs.select.outputs.candidate }}
+        run: |
+          set -euo pipefail
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/dispatches" \
+            -f event_type=release_tag_evaluate \
+            -f "client_payload[reason]=release-cut run ${GITHUB_RUN_ID} published preflight.json for ${CANDIDATE}"
 
       - name: Say what the stranger will run next
         env:

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -10980,6 +10980,12 @@ def assert_release_tag_nudge_uses_app_identity(release_cut: str) -> None:
     kin-release-bot token scoped to contents:write for kin-evidence-publish;
     this reuses that exact token rather than minting a second one or reaching
     for github.token.
+
+    The nudge must also be best-effort. It has two fallbacks that need no
+    code here to work at all, release-tag.yml's own 15-minute schedule and
+    CI's workflow_run trigger, so a transient API failure on this one call
+    must not redden the publish job of a cut that already durably wrote the
+    record this step only announces.
     """
 
     step = workflow_step_source(
@@ -10987,6 +10993,7 @@ def assert_release_tag_nudge_uses_app_identity(release_cut: str) -> None:
     )
     require(step, "release_tag_evaluate", "release-tag nudge")
     require(step, "repos/${GITHUB_REPOSITORY}/dispatches", "release-tag nudge")
+    require(step, "continue-on-error: true", "release-tag nudge")
     bindings = [
         match.group("token") for match in STEP_ENV_TOKEN_BINDING.finditer(step)
     ]
@@ -11097,6 +11104,19 @@ def main() -> None:
                     lambda _: f"          GH_TOKEN: {DEFAULT_WORKFLOW_TOKEN}",
                     release_tag_nudge,
                     count=1,
+                ),
+                1,
+            )
+        ),
+    )
+    expect_assertion(
+        "release-tag nudge loses its continue-on-error",
+        "is missing required policy: continue-on-error: true",
+        lambda: assert_release_tag_nudge_uses_app_identity(
+            release_cut.replace(
+                release_tag_nudge,
+                release_tag_nudge.replace(
+                    "        continue-on-error: true\n", "", 1
                 ),
                 1,
             )

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -156,6 +156,21 @@ RELEASE_PR_STEP_ANCHOR = "      - name: Open the protected release PR"
 RELEASE_APP_TOKEN = "${{ steps.app-token.outputs.token }}"
 DEFAULT_WORKFLOW_TOKEN = "${{ github.token }}"
 STEP_ENV_TOKEN_BINDING = re.compile(r"(?m)^\s+GH_TOKEN:\s*(?P<token>\S.*?)\s*$")
+PERMISSION_SCOPE_LINE = re.compile(r"(?m)^\s+(permission-[a-z-]+):")
+# FIR-3503. kin-release-bot's installation does not carry Actions today
+# (verified live via `gh api orgs/firelock-ai/installations`: administration:
+# read, contents:write, issues:write, metadata:read, pull_requests:write, no
+# actions key), so the dispatch token below must degrade to the workflow
+# token whenever the narrower mint failed, never dispatch unconditionally.
+RC_BUILD_DISPATCH_TOKEN_STEP_ANCHOR = (
+    "      - name: Mint repository-scoped dispatch token"
+)
+RC_BUILD_DISPATCH_STEP_ANCHOR = "      - name: Dispatch the candidate archive build"
+RC_BUILD_DISPATCH_TOKEN_EXPR = (
+    "${{ steps.dispatch-token.outcome == 'success' && "
+    "steps.dispatch-token.outputs.token || github.token }}"
+)
+RELEASE_TAG_NUDGE_STEP_ANCHOR = "      - name: Nudge release-tag to evaluate now"
 # Which tag each workflow declares it is about to create. Only the mint creates
 # one, so only the mint names it. The train resolves drift from a base tag it
 # never mints, and handing that base over as mint intent refuses exactly when a
@@ -10904,6 +10919,87 @@ def assert_readme_latest_release_policy(readme: str, readme_reference: str) -> N
         )
 
 
+def assert_rc_build_dispatch_degrades_to_todays_token(release_cut: str) -> None:
+    """RC Build's dispatch may use the App only when the App can actually send it.
+
+    kin-release-bot's installation does not carry the Actions permission today
+    (installation 148381548: administration:read, contents:write,
+    issues:write, metadata:read, pull_requests:write; verified live via
+    `gh api orgs/firelock-ai/installations`), so a token minted against it
+    with permission-actions: write fails until a person grants that
+    permission. The mint step must tolerate that failure without reddening
+    the job, and the dispatch step must fall back to github.token, exactly
+    what ran before this change, whenever the mint did not succeed: landing
+    this ahead of the grant must change nothing observable, and the cascade
+    turns on the moment the grant lands with no further edit here. The mint
+    must also ask for nothing beyond actions: a second permission on this
+    token duplicates scope the contents:write token beside it (for the branch
+    move) already carries, on a token the dispatch never needs to use it
+    through.
+    """
+
+    mint_step = workflow_step_source(
+        "release cut", release_cut, RC_BUILD_DISPATCH_TOKEN_STEP_ANCHOR
+    )
+    require(mint_step, "continue-on-error: true", "RC Build dispatch token mint")
+    require(mint_step, "permission-actions: write", "RC Build dispatch token mint")
+    scopes = {match.group(1) for match in PERMISSION_SCOPE_LINE.finditer(mint_step)}
+    if scopes != {"permission-actions"}:
+        raise AssertionError(
+            "the RC Build dispatch token must be scoped to actions only, and "
+            f"is scoped to {sorted(scopes) or '<nothing>'}; a second "
+            "permission on this token over-grants a credential the dispatch "
+            "never needs"
+        )
+    dispatch_step = workflow_step_source(
+        "release cut", release_cut, RC_BUILD_DISPATCH_STEP_ANCHOR
+    )
+    require(dispatch_step, "gh workflow run rc-build.yml", "RC Build dispatch")
+    bindings = [
+        match.group("token")
+        for match in STEP_ENV_TOKEN_BINDING.finditer(dispatch_step)
+    ]
+    if bindings != [RC_BUILD_DISPATCH_TOKEN_EXPR]:
+        raise AssertionError(
+            "the RC Build dispatch step must bind GH_TOKEN to "
+            f"{RC_BUILD_DISPATCH_TOKEN_EXPR} exactly once, falling back to "
+            f"{DEFAULT_WORKFLOW_TOKEN} whenever the App mint above did not "
+            f"succeed, and binds {bindings or '<nothing>'}"
+        )
+
+
+def assert_release_tag_nudge_uses_app_identity(release_cut: str) -> None:
+    """The nudge to release-tag.yml must carry an actor that workflow accepts.
+
+    release-tag.yml's own trigger guard allowlists troyjr4103 and
+    kin-release-bot[bot] and refuses every other actor, including
+    github-actions[bot], the identity a github.token-authenticated dispatch
+    would carry. Sending a repository_dispatch also needs contents:write,
+    which this job's own default token does not hold (permissions:
+    contents: read at the top of this file). The publish job already mints a
+    kin-release-bot token scoped to contents:write for kin-evidence-publish;
+    this reuses that exact token rather than minting a second one or reaching
+    for github.token.
+    """
+
+    step = workflow_step_source(
+        "release cut", release_cut, RELEASE_TAG_NUDGE_STEP_ANCHOR
+    )
+    require(step, "release_tag_evaluate", "release-tag nudge")
+    require(step, "repos/${GITHUB_REPOSITORY}/dispatches", "release-tag nudge")
+    bindings = [
+        match.group("token") for match in STEP_ENV_TOKEN_BINDING.finditer(step)
+    ]
+    if bindings != [RELEASE_APP_TOKEN]:
+        raise AssertionError(
+            "the release-tag nudge must bind GH_TOKEN to the minted App "
+            f"installation token {RELEASE_APP_TOKEN} exactly once, because "
+            "release-tag.yml's own actor allowlist refuses the identity a "
+            f"{DEFAULT_WORKFLOW_TOKEN} dispatch would carry, and binds "
+            f"{bindings or '<nothing>'}"
+        )
+
+
 def main() -> None:
     assert_release_probe_fixtures()
     retired = (
@@ -10929,6 +11025,84 @@ def main() -> None:
         ("startup evidence lost on failure", "if: always() && matrix.artifact == 'kin-macos-aarch64'", "if: success() && matrix.artifact == 'kin-macos-aarch64'", "must survive"),
     ]:
         expect_assertion(label, error, lambda before=before, after=after: assert_native_startup_release_proof(release_cut.replace(before, after, 1)))
+
+    # FIR-3503. RC Build completing does not cascade into this workflow's own
+    # workflow_run trigger when RC Build was dispatched on github.token, which
+    # it always is: a run started that way completes without producing the
+    # occasion anything is listening for. Both new hops below replace which
+    # credential performs a dispatch, never what a dispatch is allowed to do.
+    assert_rc_build_dispatch_degrades_to_todays_token(release_cut)
+    dispatch_token_mint = workflow_step_source(
+        "release cut", release_cut, RC_BUILD_DISPATCH_TOKEN_STEP_ANCHOR
+    )
+    expect_assertion(
+        "dispatch token mint loses its continue-on-error",
+        "is missing required policy: continue-on-error: true",
+        lambda: assert_rc_build_dispatch_degrades_to_todays_token(
+            release_cut.replace(
+                dispatch_token_mint,
+                dispatch_token_mint.replace(
+                    "        continue-on-error: true\n", "", 1
+                ),
+                1,
+            )
+        ),
+    )
+    expect_assertion(
+        "dispatch token mint gains a contents scope too",
+        "must be scoped to actions only",
+        lambda: assert_rc_build_dispatch_degrades_to_todays_token(
+            release_cut.replace(
+                dispatch_token_mint,
+                dispatch_token_mint.replace(
+                    "          permission-actions: write\n",
+                    "          permission-actions: write\n          permission-contents: write\n",
+                    1,
+                ),
+                1,
+            )
+        ),
+    )
+    rc_build_dispatch = workflow_step_source(
+        "release cut", release_cut, RC_BUILD_DISPATCH_STEP_ANCHOR
+    )
+    expect_assertion(
+        "dispatch step drops its fallback to the workflow token",
+        "must bind GH_TOKEN to",
+        lambda: assert_rc_build_dispatch_degrades_to_todays_token(
+            release_cut.replace(
+                rc_build_dispatch,
+                STEP_ENV_TOKEN_BINDING.sub(
+                    lambda _: "          GH_TOKEN: "
+                    + RELEASE_APP_TOKEN.replace("app-token", "dispatch-token"),
+                    rc_build_dispatch,
+                    count=1,
+                ),
+                1,
+            )
+        ),
+    )
+
+    assert_release_tag_nudge_uses_app_identity(release_cut)
+    release_tag_nudge = workflow_step_source(
+        "release cut", release_cut, RELEASE_TAG_NUDGE_STEP_ANCHOR
+    )
+    expect_assertion(
+        "release-tag nudge reverts to the workflow token",
+        "must bind GH_TOKEN to",
+        lambda: assert_release_tag_nudge_uses_app_identity(
+            release_cut.replace(
+                release_tag_nudge,
+                STEP_ENV_TOKEN_BINDING.sub(
+                    lambda _: f"          GH_TOKEN: {DEFAULT_WORKFLOW_TOKEN}",
+                    release_tag_nudge,
+                    count=1,
+                ),
+                1,
+            )
+        ),
+    )
+
     subprocess.run([sys.executable, str(ROOT / "scripts/release-proof/startup-recovery/run.py"), "--verify-only"], check=True)
     subprocess.run([sys.executable, str(ROOT / "scripts/test-startup-release-proof.py")], check=True)
     release_recovery = RELEASE_RECOVERY.read_text(encoding="utf-8")
@@ -17525,12 +17699,21 @@ def main() -> None:
         ): assert_the_mint_records_the_state_it_tagged_on(mutant),
     )
     assert_the_hosted_stranger_never_reddens_the_rail(release_cut)
+    # Scoped to the stranger job's own block, not a whole-file replace: FIR-3503
+    # gave the arm job a second, step-level `continue-on-error: true` (for the
+    # dispatch-token mint), which sorts earlier in the file and contains this
+    # exact 4-space-indented needle as a substring of its own 8-space line, so
+    # an unanchored `release_cut.replace(..., 1)` strips the wrong one and this
+    # falsification stops failing for the right reason.
+    stranger_block = workflow_job_blocks(release_cut)["stranger"]
     expect_assertion(
         "the hosted stranger can fail a cut run again",
         "must carry continue-on-error: true",
-        lambda mutant=release_cut.replace("    continue-on-error: true\n", "", 1): (
-            assert_the_hosted_stranger_never_reddens_the_rail(mutant)
-        ),
+        lambda mutant=release_cut.replace(
+            stranger_block,
+            stranger_block.replace("    continue-on-error: true\n", "", 1),
+            1,
+        ): assert_the_hosted_stranger_never_reddens_the_rail(mutant),
     )
     expect_assertion(
         "the record publisher trusts a result continue-on-error has masked",


### PR DESCRIPTION
## Why

RC Build's dispatch and release-cut.yml's own nudge to release-tag.yml both ran on `github.token`, which starts a run fine but never produces the `workflow_run` occasion anything downstream listens for. Every release cut parked after RC Build until a person dispatched `release_cut` by hand. It happened twice on 2026-09-10: v0.7.9 at 07:39Z, and v0.7.10 at 14:43Z with a 1h52m repo-wide silence.

## What changed

Two hops, both additive, every existing trigger and guard unchanged.

**RC Build dispatch (arm job).** A second, narrower App-token mint, `permission-actions: write` only, minted after the branch move and marked `continue-on-error: true`. The dispatch step's `GH_TOKEN` reads the App token when that mint actually succeeded and falls back to today's `github.token` otherwise. `kin-release-bot`'s installation does not carry the Actions permission today, verified live:

```
$ gh api orgs/firelock-ai/installations --jq '.installations[] | select(.app_slug=="kin-release-bot")'
"permissions":{"administration":"read","contents":"write","issues":"write","metadata":"read","pull_requests":"write"}
```

No `actions` key. So this mint fails today, the job stays green (`continue-on-error`), a `::warning` names the missing grant and the exact installation URL, and the dispatch runs on `github.token` exactly as before. Landing this changes nothing observable until kin-release-bot is granted `Actions: write`. The cascade turns on the moment it is, with no further edit.

`rc-build.yml` itself is untouched. It holds no credential by design, to keep a dispatch of branch-controlled workflow code away from anything powerful. Its `workflow_dispatch` trigger also has no actor gate, and `workflow_dispatch` resolves both the code and the permissions of a run from the ref being dispatched on. Granting it any write permission would hand that same power to anyone who dispatches it on their own branch. release-cut.yml's own trigger avoids `workflow_dispatch` on itself for the same reason.

**release-tag nudge (publish job).** Once `kin-evidence-publish` writes `preflight.json`, a new step sends `repository_dispatch release_tag_evaluate`, reusing the App token the publish job already mints for `kin-evidence-publish` a few steps earlier (contents:write, already scoped to this repo) instead of minting a new one or using `github.token`. `github.token` can't do this today. This job's default permission is `contents: read`, which isn't enough to send a `repository_dispatch`. Even granted write, release-tag.yml's own actor allowlist (`troyjr4103`, `kin-release-bot[bot]`) would refuse the `github-actions[bot]` actor an automated `github.token` dispatch carries. The reused App token's actor is already on that allowlist.

## Falsification

Two new assertions in `scripts/test-release-workflow-authority.py`: `assert_rc_build_dispatch_degrades_to_todays_token` and `assert_release_tag_nudge_uses_app_identity`, each with `expect_assertion` mutation checks in `main()` (continue-on-error removed, scope widened past actions-only, the dispatch's fallback dropped, the nudge reverted to `github.token`). Isolated first, both directions:

```
=== assert_rc_build_dispatch_degrades_to_todays_token ===
[OK ] original tree (pre-fix): expected RAISED, got RAISED -- release cut no longer carries the step this gate is anchored to: - name: Mint repository-scoped dispatch token
[OK ] fixed tree (my branch): expected PASS, got PASS -- no exception
=== assert_release_tag_nudge_uses_app_identity ===
[OK ] original tree (pre-fix): expected RAISED, got RAISED -- release cut no longer carries the step this gate is anchored to: - name: Nudge release-tag to evaluate now
[OK ] fixed tree (my branch): expected PASS, got PASS -- no exception
```

Running the whole suite caught a real bug this change introduced in an existing, unrelated test. `guard:test-release-workflow-authority.py` came back red under `bin/kin-precheck` with `falsification did not fail: the hosted stranger can fail a cut run again`. That check's own falsification mutated the whole file with an unanchored `release_cut.replace("    continue-on-error: true\n", "", 1)`, written back when the stranger job's 4-space job-level `continue-on-error: true` was the only line shaped like that in the file. This PR's new step-level `continue-on-error: true` (8-space indent, on the dispatch-token mint) sorts earlier in the file and contains that same 4-space string as a substring of its own line, so the unanchored replace stripped mine instead of the stranger job's, and the check stopped failing for the reason it exists to catch. Fixed by scoping the mutation to the stranger job's own block first (`workflow_job_blocks(release_cut)["stranger"]`), the same extract-then-mutate-then-splice idiom every other falsification in this file already uses, mine included. Test fix only. The assertion function and what it checks are untouched.

Full suite, clean, after that fix:

```
$ python3 scripts/test-release-workflow-authority.py
PROOF_ASSET_HASHES_VERIFIED
STARTUP_PROOF_READINESS_AND_PRECONDITION_CONTROLS_PASS
release workflow authority is reviewed-PR to App-tag automatic, protected, pinned, GCP-free on release writes, cross-platform byte-canonical, with dev-only Artifact Registry OIDC and npm automatic through short-lived OIDC with post-public proof
$ echo $?
0
```

## Design history worth knowing before this arms

Reusing `kin-release-bot` unconditionally for the RC Build dispatch, the shape first briefed, would have reddened every arm run at once, because the mint fails with no fallback. Having `rc-build.yml` dispatch release-cut.yml directly would have needed `actions: write` on a workflow that deliberately holds no credential and has no actor gate on its trigger. That's a real security regression. Both were checked against the live App permissions and the live workflow files before this shape replaced them.

## Review round 2

captain-0910-154908 read this PR in full and approved with one required change. The release-tag nudge step was fatal: `set -euo pipefail`, no `continue-on-error`. A transient `gh api` failure there would redden the publish job of a cut whose preflight record was already durably published, over a nudge with two fallbacks that need no help from this call to work (release-tag.yml's own 15-minute schedule, and CI's `workflow_run` trigger on the next ordinary push to main).

Fixed in the same shape as the dispatch-token mint: the step now carries `id: nudge-release-tag` and `continue-on-error: true`, and a following step, `if: steps.nudge-release-tag.outcome != 'success'`, prints a `::warning` naming both fallbacks. `assert_release_tag_nudge_uses_app_identity` now requires `continue-on-error: true` on the step and falsifies its removal the same way the other three arms in this file already falsify their own properties, scoped to the step's own block.

Isolated red/green:

```
positive check (continue-on-error present): PASS
OK: raised as expected -- release-tag nudge is missing required policy: continue-on-error: true
```

Full authority suite, standalone, clean:

```
$ python3 scripts/test-release-workflow-authority.py
PROOF_ASSET_HASHES_VERIFIED
STARTUP_PROOF_READINESS_AND_PRECONDITION_CONTROLS_PASS
release workflow authority is reviewed-PR to App-tag automatic, protected, pinned, GCP-free on release writes, cross-platform byte-canonical, with dev-only Artifact Registry OIDC and npm automatic through short-lived OIDC with post-public proof
$ echo $?
0
```

`bin/kin-precheck kin`, clean on the second commit:

```
$ bin/kin-precheck kin --repo-dir kin=<lane worktree>
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
...
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 8a296f843bbecf90cdd4819957ffad1287074d82 DIRTY
```

(That tally ran with the fix staged as a working-tree change on top of `8a296f843`. The fix then landed as commit `0d4fda445`.) `actionlint` against the updated workflow: clean, exit 0.

## Gates

```
$ bin/kin-precheck kin --repo-dir kin=<lane worktree>
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
...
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin ec9418867178bc46fb9d880107f7fe0a742d6aac DIRTY
```

Also ran `actionlint` directly against the modified workflow file: clean, exit 0.

## Ticket

FIR-3503 (https://linear.app/firelock-ai/issue/FIR-3503)
