### PR TITLE
Replace the superseded category line on every surface kin ships

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "kin",
-  "description": "Firelock's marketplace for Kin, the system of record for AI-written software. Ships the Kin plugin: the bundled MCP server plus skills for graph-backed retrieval and blast-radius review.",
+  "description": "Firelock's marketplace for Kin, a graph-native code repository for people and AI agents. Ships the Kin plugin: the bundled MCP server plus skills for graph-backed retrieval and blast-radius review.",
   "owner": {
     "name": "Firelock",
     "url": "https://kinlab.ai"

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "url": "https://kinlab.ai"
   },
   "metadata": {
-    "description": "Firelock's marketplace for Kin, the system of record for AI-written software.",
+    "description": "Firelock's marketplace for Kin, a graph-native code repository for people and AI agents.",
     "version": "0.1.0"
   },
   "plugins": [

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Kin
-The system of record for AI-written software.
+A graph-native code repository for people and AI agents.
 Copyright 2026 Firelock, LLC
 
 Licensed under the Apache License, Version 2.0 (the "License").

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -44,7 +44,7 @@ kin_buildinfo::embed_update_build_identity!(
 /// locked line rather than getting a new one, so this is that line and not a
 /// rewrite of it.
 const ORIENTATION: &str = "\
-The system of record for AI-written software.
+A graph-native code repository for people and AI agents.
 
 Start here:
   kin init            admit an existing or new repository
@@ -2817,7 +2817,7 @@ fn version_lines(version: &str) -> Vec<String> {
 }
 
 /// The canon Category line, shared by `--help` and `--version`.
-const CATEGORY_LINE: &str = "The system of record for AI-written software.";
+const CATEGORY_LINE: &str = "A graph-native code repository for people and AI agents.";
 
 /// What `kin --version` prints.
 ///
@@ -5501,7 +5501,10 @@ mod tests {
         // The literal, not the constant. Comparing the constant against itself
         // is an assertion that cannot fail, and it would sit here looking like
         // one that could.
-        assert_eq!(lines[2], "The system of record for AI-written software.");
+        assert_eq!(
+            lines[2],
+            "A graph-native code repository for people and AI agents."
+        );
         assert_eq!(lines[3], "dca8e950e99f6a1cb9afe4359611e2da288004f2");
         assert_eq!(lines[4], "detached 2026-09-06T08:24:29Z");
 
@@ -6244,7 +6247,7 @@ mod tests {
             let mut command = Cli::command();
             let help = command.render_long_help().to_string();
             assert!(
-                help.starts_with("The system of record for AI-written software."),
+                help.starts_with("A graph-native code repository for people and AI agents."),
                 "help opens with {:?}",
                 help.lines().next().unwrap_or_default()
             );

--- a/crates/kin-cli/src/mark.rs
+++ b/crates/kin-cli/src/mark.rs
@@ -433,7 +433,7 @@ mod tests {
         let text = [
             "",
             "kin 0.7.2",
-            "The system of record for AI-written software.",
+            "A graph-native code repository for people and AI agents.",
             "",
         ];
         for style in [

--- a/docs/ecosystem-manifest.json
+++ b/docs/ecosystem-manifest.json
@@ -7,7 +7,7 @@
     "summary": "Firelock (the company) builds Kin (the semantic repo and collaboration substrate). KinLab is the hosted collaboration product; @kinlab is the shared package and registry scope.",
     "product": {
       "name": "Kin",
-      "descriptor": "The semantic repo and collaboration substrate, the system of record for AI-written software.",
+      "descriptor": "The semantic repo and collaboration substrate, a graph-native code repository for people and AI agents.",
       "github": "https://github.com/firelock-ai/kin"
     },
     "company": {

--- a/llms.txt
+++ b/llms.txt
@@ -1,40 +1,40 @@
 # Kin
 
-> Kin is the system of record for AI-written software — a graph-native repository and collaboration substrate that replaces the file-first, diff-first model. Code becomes a graph of entities, relations, and intents that AI agents and humans navigate semantically.
+> Kin is a graph-native code repository for people and AI agents. It replaces the file-first, diff-first model with a repository and collaboration substrate built on a graph: code becomes entities, relations and intents that AI agents and humans navigate semantically.
 
 Kin coexists with Git and projects graph-owned truth back to a normal filesystem through a transparent VFS, so any tool or agent works unchanged. The fastest way for an agent to use Kin is the MCP server, which exposes semantic tools (locate, context, trace) backed by the graph rather than filesystem heuristics.
 
 ## Install
 
-- [Install script — macOS/Linux](https://get.kinlab.dev/install): `curl -fsSL https://get.kinlab.dev/install | sh`
-- [Install script — Windows](https://get.kinlab.dev/install.ps1): `irm https://get.kinlab.dev/install.ps1 | iex`
+- [Install script for macOS and Linux](https://get.kinlab.dev/install): `curl -fsSL https://get.kinlab.dev/install | sh`
+- [Install script for Windows](https://get.kinlab.dev/install.ps1): `irm https://get.kinlab.dev/install.ps1 | iex`
 - [Homebrew](https://github.com/firelock-ai/homebrew-kin): `brew install firelock-ai/kin/kin`
-- [npm — MCP wrapper](https://www.npmjs.com/package/@kinlab/kin-mcp): `npx @kinlab/kin-mcp`
+- [npm MCP wrapper](https://www.npmjs.com/package/@kinlab/kin-mcp): `npx @kinlab/kin-mcp`
 - [GitHub Releases](https://github.com/firelock-ai/kin/releases): prebuilt binaries + checksums for macOS, Linux, and Windows
 
 Native Windows x86_64 support is early. Repository admission works: `kin init` imports a Git repository and publishes graph authority, and graph, lexical, and daemon-backed queries answer natively. Transparent filesystem projection is not shipped on Windows, and the end-to-end install proof does not yet cover MCP or review workflows there, so WSL2 remains the recommended path for the full Kin experience.
 
 ## First run (macOS, Linux, or WSL2)
 
-- `kin setup` — configure your shell and connect agents (Claude, Cursor, Codex, Gemini) to the MCP server.
-- `kin doctor` — verify the install and daemon health.
+- `kin setup`: configure your shell and connect agents (Claude, Cursor, Codex, Gemini) to the MCP server.
+- `kin doctor`: verify the install and daemon health.
 - `kin init` turns a Git repo into a Kin workspace. `kin status` and `kin search` require the bundled `kin-daemon` runtime (installed by every channel above).
 - `kin exec -- <cmd>` runs ordinary project tools (npm, make, docker) through a graph-backed session workspace; `kin shell` opens an interactive one; `kin with <assistant>` launches an agent inside one.
 
 ## For AI agents (MCP)
 
-Kin ships an MCP server exposing semantic tools that answer from graph-owned truth, not raw file search — prefer them:
+Kin ships an MCP server exposing semantic tools that answer from graph-owned truth, not raw file search. Prefer them:
 
-- `semantic_locate` — find symbols, functions, and types by meaning.
+- `semantic_locate`: find symbols, functions, and types by meaning.
 - `list_file_entities` lists every entity in one file, with a completeness flag saying whether the list is whole.
-- `get_context_pack` — a structured context bundle around one entity, by id.
-- `trace_data_flow` — cross-file data lineage and dependencies.
+- `get_context_pack`: a structured context bundle around one entity, by id.
+- `trace_data_flow`: cross-file data lineage and dependencies.
 
 `kin setup` auto-configures the MCP server for supported agents.
 
 ## Source and docs
 
-- [kin — CLI, daemon, MCP](https://github.com/firelock-ai/kin)
-- [kin-vfs — transparent filesystem projection](https://github.com/firelock-ai/kin-vfs)
-- [kin-editor — VS Code extension](https://github.com/firelock-ai/kin-editor)
+- [kin: CLI, daemon, MCP](https://github.com/firelock-ai/kin)
+- [kin-vfs: transparent filesystem projection](https://github.com/firelock-ai/kin-vfs)
+- [kin-editor: VS Code extension](https://github.com/firelock-ai/kin-editor)
 - [Quickstart](https://github.com/firelock-ai/kin/blob/main/docs/quickstart.md)

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -2,7 +2,7 @@
   "name": "@kinlab/kin-mcp",
   "version": "0.7.11",
   "mcpName": "ai.kinlab/kin",
-  "description": "Start Kin's MCP server, the system of record for AI-written software, through an npm-friendly wrapper.",
+  "description": "Start the MCP server for Kin, a graph-native code repository for people and AI agents, through an npm-friendly wrapper.",
   "type": "module",
   "bin": {
     "kin-mcp": "./bin/kin-mcp.js"

--- a/packages/kin/README.md
+++ b/packages/kin/README.md
@@ -1,7 +1,7 @@
 # @kinlab/kin
 
-The canonical npm install surface for [Kin](https://github.com/firelock-ai/kin), the
-system of record for AI-written software.
+The canonical npm install surface for [Kin](https://github.com/firelock-ai/kin), a
+graph-native code repository for people and AI agents.
 
 Install it without root, without `sudo`, and without a writable global npm prefix. This
 is the default path because it is the one that works everywhere, including the container

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kinlab/kin",
   "version": "0.7.11",
-  "description": "Canonical installer and launcher for Kin, the system of record for AI-written software. Provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
+  "description": "Canonical installer and launcher for Kin, a graph-native code repository for people and AI agents. Provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",
   "bin": {

--- a/scripts/record-demos.sh
+++ b/scripts/record-demos.sh
@@ -294,7 +294,7 @@ record_full() {
     set -e
     KIN=\"$KIN\"
 
-    echo \"# Kin: semantic system of record for software\"
+    echo \"# Kin: a graph-native code repository for people and AI agents\"
     sleep 2
 
     echo \"\$ kin init .\"

--- a/scripts/write-release-archive-docs.mjs
+++ b/scripts/write-release-archive-docs.mjs
@@ -135,7 +135,7 @@ for the full Kin experience, including projection.`;
 
 const readme = `# Kin ${version} (${target})
 
-Kin is the semantic system of record for software work. It answers questions
+Kin is a graph-native code repository for people and AI agents. It answers questions
 about a repository from a graph rather than from raw file search.
 
 This archive carries these runtime files:

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "ai.kinlab/kin",
   "title": "Kin",
-  "description": "The system of record for AI-written software.",
+  "description": "A graph-native code repository for people and AI agents.",
   "websiteUrl": "https://kinlab.ai",
   "repository": {
     "url": "https://github.com/firelock-ai/kin",


### PR DESCRIPTION
Kin's own surfaces still printed the category line the canon locked in August, "The system of record for AI-written software.", after the September canon replaced it and the 2026-09-10 README pass cleared it from every satellite repo. This lands the canon's current category line, "A graph-native code repository for people and AI agents.", on every surface kin ships, and nothing else.

Resolves FIR-3513.

## Surfaces changed

- `kin --help` header and the version block: `crates/kin-cli/src/main.rs` (`ORIENTATION`, `CATEGORY_LINE`, and the two exact-value tests that pin the literal), `crates/kin-cli/src/mark.rs` (the width fixture).
- `NOTICE`, `server.json` (MCP registry descriptor), `llms.txt` (also drops the file's em dashes, which the prose rule bans on every surface).
- Plugin and package listings: `.claude-plugin/marketplace.json`, `.cursor-plugin/marketplace.json`, `packages/kin/package.json`, `packages/kin/README.md`, `packages/kin-mcp/package.json`.
- `docs/ecosystem-manifest.json` product descriptor.
- `scripts/write-release-archive-docs.mjs` (the README written into every release archive) and `scripts/record-demos.sh` (the demo recording title card).

Left alone on purpose: `scripts/test-homebrew-release-gate.py`, because the Homebrew desc moves in lockstep with homebrew-kin's formula renderer and README and is sequenced by the release rail (FIR-3514). "Semantic system of record" as kin's role in a repo table is not the retired phrase and is untouched.

## Falsification

The two exact-value tests grade this pull request (the `check` job that runs the whole workspace carries `github.event_name != 'pull_request'`), so both were broken on purpose and watched go red.

Red arm: `ORIENTATION` and `CATEGORY_LINE` put back on the old sentence, the tests left on the new literal, `cargo test -p kin-cli --bins -- help_leads_with_the_canon_category_line the_version_block_keeps_every_fact_and_fits_eighty_columns` through `heavy-slot.sh`:

```
test tests::the_version_block_keeps_every_fact_and_fits_eighty_columns ... FAILED
test tests::help_leads_with_the_canon_category_line ... FAILED
thread 'tests::the_version_block_keeps_every_fact_and_fits_eighty_columns' (53948523) panicked at crates/kin-cli/src/main.rs:5504:9:
  left: "The system of record for AI-written software."
 right: "A graph-native code repository for people and AI agents."
thread '<unnamed>' (53948524) panicked at crates/kin-cli/src/main.rs:6249:13:
help opens with "The system of record for AI-written software."
thread 'tests::help_leads_with_the_canon_category_line' (53948522) panicked at crates/kin-cli/src/main.rs:5676:14:
test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 45 filtered out; finished in 0.00s
```

Restored, same command:

```
test tests::the_version_block_keeps_every_fact_and_fits_eighty_columns ... ok
test tests::help_leads_with_the_canon_category_line ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 45 filtered out; finished in 0.01s
```

The mark width fixture in `mark.rs`, which only needs the longer line to still fit 80 and 120 columns beside the mark:

```
test mark::tests::the_block_fits_eighty_and_one_hundred_and_twenty_columns ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2298 filtered out; finished in 0.00s
```

## Gates

`bin/kin-precheck kin --repo-dir kin=<worktree>` through `heavy-slot.sh`, on the umbrella at 47c3b1e6 (after kin-ecosystem #375 classified the sentinel scripts), graded the tree at 457d070a with this change applied; the commit was cut from that same tree with no further edits:

```
kin-precheck: repo=kin tree=/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/canonkin-kin sha=457d070a4c043bb363c020083266ee0c07a4cb9c branch=chore/lane-canonkin-kin DIRTY
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 457d070a4c043bb363c020083266ee0c07a4cb9c DIRTY
```

An earlier run on the pre-#375 umbrella enumerated 24 gates, 21 PASS and 3 NOT RUN (the three sentinel scripts, then unclassified), and printed no tally by design.

## Positive control

After the change, `git grep -n -e "AI-written software" -e "system of record for software"` over the worktree returns only the five Homebrew gate fixture lines:

```
scripts/test-homebrew-release-gate.py:327:  desc "Semantic system of record for AI-written software"
scripts/test-homebrew-release-gate.py:725:        '  desc "Semantic system of record for AI-written software"',
scripts/test-homebrew-release-gate.py:726:        '  desc "Semantic system of record for AI-written software"; '
scripts/test-homebrew-release-gate.py:746:        '  desc "Semantic system of record for AI-written software"',
scripts/test-homebrew-release-gate.py:748:        'Semantic system of record for AI-written software"',
```

