### PR TITLE
Read the language table from the README's reference page in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1879,11 +1879,15 @@ jobs:
           set -euo pipefail
 
           readme="README.md"
+          reference="docs/readme-reference.md"
           registry="crates/kin-parser/src/languages/mod.rs"
 
           # The adapter registry is the real count. It is the set the README
           # itself points at, and unlike the tree-sitter Cargo dependencies it
           # cannot be inflated by a grammar-adjacent crate that is no adapter.
+          # The 'Language | Extensions' table lives on the README's reference
+          # page since the README rewrite; the README itself keeps the short
+          # form and may state the number in prose, so both files are read.
           derived="$(awk '
             /adapters: vec!\[/           { inblock = 1; next }
             inblock && /^[[:space:]]*\]/ { inblock = 0; next }
@@ -1908,20 +1912,20 @@ jobs:
             intable && /^\|/                             { n++; next }
             intable                                      { intable = 0 }
             END { if (found) print n + 0; else print "MISSING" }
-          ' "$readme")"
+          ' "$reference")"
 
           if [ "$documented" = "MISSING" ]; then
-            echo "::error::language count: the '| Language | Extensions |' table is gone from $readme"
-            echo "That table is where $readme states how many languages Kin parses, and" >&2
+            echo "::error::language count: the '| Language | Extensions |' table is gone from $reference"
+            echo "That table is where $reference states how many languages Kin parses, and" >&2
             echo "this step reads it to keep the number honest. It was reworded, moved, or" >&2
             echo "removed, so the count is now unchecked. Point this step in" >&2
-            echo ".github/workflows/ci.yml at wherever the README now states the count." >&2
+            echo ".github/workflows/ci.yml at wherever the docs now state the count." >&2
             exit 1
           fi
 
           if [ "$documented" -ne "$derived" ]; then
-            echo "::error::language count: $readme says $documented, the adapter registry says $derived"
-            echo "  $readme, the 'Language | Extensions' table: $documented languages" >&2
+            echo "::error::language count: $reference says $documented, the adapter registry says $derived"
+            echo "  $reference, the 'Language | Extensions' table: $documented languages" >&2
             echo "  $registry, AdapterRegistry::new(): $derived adapters" >&2
             echo "Whichever is wrong, fix it so both state the same number." >&2
             exit 1
@@ -1935,13 +1939,13 @@ jobs:
             [ -n "$phrase" ] || continue
             stated="$(printf '%s' "$phrase" | tr -dc '0-9')"
             if [ "$stated" -ne "$derived" ]; then
-              echo "::error::language count: $readme prose says $stated, the adapter registry says $derived"
-              echo "  $readme says: \"$phrase\"" >&2
+              echo "::error::language count: README prose says $stated, the adapter registry says $derived"
+              echo "  $readme or $reference says: \"$phrase\"" >&2
               echo "  $registry, AdapterRegistry::new(): $derived adapters" >&2
               prose_stale=1
             fi
           done <<EOF
-          $(grep -Eio '(covering|covers|support|supports|supporting|spanning|across)[[:space:]]+[0-9]+([[:space:]]+[a-z]+)?[[:space:]]+languages?' "$readme" || true)
+          $(grep -Eiho '(covering|covers|support|supports|supporting|spanning|across)[[:space:]]+[0-9]+([[:space:]]+[a-z]+)?[[:space:]]+languages?' "$readme" "$reference" || true)
           EOF
 
           if [ "$prose_stale" -ne 0 ]; then
@@ -1949,7 +1953,7 @@ jobs:
             exit 1
           fi
 
-          echo "README and the adapter registry agree on $derived languages."
+          echo "$reference and the adapter registry agree on $derived languages."
 
       - name: Install runtime guard tools
         if: matrix.shard == 1


### PR DESCRIPTION
kin main's push run has been red on "Check & Test ubuntu shard (1)" since ec941886 (#1663, the README rewrite): the language-count step read the "Language | Extensions" table from README.md, and the rewrite moved that table to docs/readme-reference.md. The step runs only inside the check job on push to main, so the PR that moved the table was green and main went red after it landed, and every main run since (c4a79945, c4d88ab3, 8796e499, 457d070a, b36ce356) fails the same step. The last green main run was 68d0fb68 at 18:35Z.

The step now reads the table from docs/readme-reference.md, keeps the adapter registry (`crates/kin-parser/src/languages/mod.rs`) as the real count, and greps both README.md and the reference page for a prose count that must agree with the registry. The step name is unchanged because `scripts/test-release-workflow-authority.py:645` pins it.

The other red job on main, "Windows authority tests", is a different class (the Windows npm proof refusing `kin status` exit 9) and is being fixed separately by the release rail; main goes green when both land.

## Falsification

The step body was extracted from this ci.yml and run in the worktree with `bash`.

Positive run:

```
docs/readme-reference.md and the adapter registry agree on 14 languages.
rc=0
```

Negative control 1, the table source pointed back at README.md:

```
::error::language count: the '| Language | Extensions |' table is gone from README.md
rc=1
```

Negative control 2, one extra row added to the reference page's table and then restored:

```
::error::language count: docs/readme-reference.md says 15, the adapter registry says 14
  docs/readme-reference.md, the 'Language | Extensions' table: 15 languages
  crates/kin-parser/src/languages/mod.rs, AdapterRegistry::new(): 14 adapters
rc=1
```

## Gates

`bin/kin-precheck kin --repo-dir kin=<worktree>` through `heavy-slot.sh`, graded on the tree with this change applied (the commit was cut from that same tree with no further edits):

```
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin b36ce356d7aa3be1b67a4f0fae4ac6660a8ccdc9 DIRTY
```

The language-count step itself is not one of those gates: it runs only inside the `check` job on push to main, which is why the falsification above was run by hand and why main's next push run is the check of record.
