### PR TITLE
Accept the two exit codes a status read can correctly return

### DIFF
--- a/scripts/prove-windows-npm-first-run.mjs
+++ b/scripts/prove-windows-npm-first-run.mjs
@@ -37,6 +37,15 @@ import {
 } from '../packages/kin-mcp/src/index.js';
 import { emptyGlobalGitConfig } from '../packages/kin-mcp/test/smoke-first-run.mjs';
 
+// `kin status` exits this when nothing admitted the working copy. It is an
+// answer about the report rather than a failure to produce one, and it is the
+// only signal the `--json` arm can carry, because that arm renders none of the
+// text below. Named here so this proof cannot drift from the CLI's own value
+// silently.
+const EXIT_WORKING_COPY_UNMEASURED = 9;
+// The line that read leads with, so a 9 can be shown to be THAT 9.
+const UNMEASURED_BANNER = 'Working copy: NOT MEASURED';
+
 const scriptPath = fileURLToPath(import.meta.url);
 const repoRoot = path.dirname(path.dirname(scriptPath));
 const canonicalKinLauncher = path.join(repoRoot, 'packages', 'kin', 'bin', 'kin.mjs');
@@ -213,6 +222,33 @@ function runChecked(executable, args, { cwd, env, label, timeout = commandTimeou
   if (result.error || result.status !== 0) {
     throw new Error(
       `${label} failed (status=${result.status}, signal=${result.signal}): ` +
+        `${result.error?.message || ''}\nstdout:\n${result.stdout || ''}\nstderr:\n${result.stderr || ''}`,
+    );
+  }
+  return result;
+}
+
+/// Run a command that has more than one correct exit code, and refuse every
+/// other one.
+///
+/// `allowed` is a list, never a "non-zero is fine" switch. A proof that stopped
+/// checking the code would stop noticing a real failure, and the point here is
+/// the opposite: `kin status` answers 0 when something admitted the working
+/// copy and EXIT_WORKING_COPY_UNMEASURED when nothing did, both are correct
+/// answers about the report it prints, and anything else is still a failure.
+function runAllowing(allowed, executable, args, { cwd, env, label, timeout = commandTimeoutMs }) {
+  const result = cp.spawnSync(executable, args, {
+    cwd,
+    env,
+    encoding: 'utf8',
+    timeout,
+    windowsHide: true,
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  if (result.error || !allowed.includes(result.status)) {
+    throw new Error(
+      `${label} failed (status=${result.status}, signal=${result.signal}, ` +
+        `allowed=${allowed.join(',')}): ` +
         `${result.error?.message || ''}\nstdout:\n${result.stdout || ''}\nstderr:\n${result.stderr || ''}`,
     );
   }
@@ -458,15 +494,56 @@ async function proveCanonical({ workRoot, builtKin, builtDaemon, gitBinary }) {
       env,
       label: '@kinlab/kin init',
     });
-    const status = runChecked(process.execPath, [canonicalKinLauncher, 'status', '--json'], {
-      cwd: repoDir,
-      env,
-      label: '@kinlab/kin repository status',
-    });
+    // Two correct exit codes, and this read accepts exactly those two.
+    //
+    // `kin status` never starts a daemon, and the one `kin init` brings up can
+    // be gone before the next process starts, at which point the read reports
+    // durable authority alone and exits EXIT_WORKING_COPY_UNMEASURED (9). What
+    // this leg asks of the read is that the npm launcher drives the real binary
+    // and gets a well-formed report back, and every assertion below is a
+    // durable-authority fact that the code does not touch. The daemon-backed
+    // half of this flow is proven by the graph search immediately after, which
+    // genuinely cannot answer without one.
+    //
+    // Named codes rather than a blanket non-zero: a proof that stopped reading
+    // the code would stop noticing a real failure.
+    const status = runAllowing(
+      [0, EXIT_WORKING_COPY_UNMEASURED],
+      process.execPath,
+      [canonicalKinLauncher, 'status', '--json'],
+      { cwd: repoDir, env, label: '@kinlab/kin repository status' },
+    );
     const statusJson = JSON.parse(status.stdout);
     assert.equal(statusJson.schema, 'kin.status.v3');
     assert.equal(statusJson.authority, 'repository-v6');
     assert.equal(statusJson.repository?.source_cas_verified, true);
+
+    // When the code is 9, prove it is THAT 9. The `--json` arm renders no
+    // banner, so the claim the code makes is unverifiable from the payload
+    // alone, and a 9 that meant something else entirely would read identically
+    // here. The text arm carries the sentence, and it has to be the line the
+    // reader meets first.
+    if (status.status === EXIT_WORKING_COPY_UNMEASURED) {
+      const text = runAllowing(
+        [EXIT_WORKING_COPY_UNMEASURED],
+        process.execPath,
+        [canonicalKinLauncher, 'status'],
+        { cwd: repoDir, env, label: '@kinlab/kin repository status (text arm)' },
+      );
+      const lines = text.stdout.split(/\r?\n/);
+      const banner = lines.findIndex((line) => line.startsWith(UNMEASURED_BANNER));
+      const tree = lines.findIndex((line) => line.startsWith('Tree:'));
+      assert.ok(
+        banner >= 0,
+        `@kinlab/kin status exited ${EXIT_WORKING_COPY_UNMEASURED} without saying the working ` +
+          `copy was unmeasured:\n${text.stdout}`,
+      );
+      assert.ok(
+        tree >= 0 && banner < tree,
+        `@kinlab/kin status put the unmeasured gap below the Tree line it qualifies:\n${text.stdout}`,
+      );
+      log('@kinlab/kin: status reported the working copy unmeasured, with the gap leading the page');
+    }
 
     const search = runChecked(
       process.execPath,


### PR DESCRIPTION
Fixes kin main's red `ci.yml` push run. Latest red is run 34532032377 on `b36ce356`, and every main push since `b4f09318`, on the `Windows authority tests` job, step `Prove both npm surfaces from built Windows binaries`:

```
WINDOWS NPM PROOF FAIL: Error: @kinlab/kin repository status failed (status=9, signal=null)
```

`scripts/prove-windows-npm-first-run.mjs` reads `kin status --json` through the npm launcher with no daemon serving, and `runChecked` rejects any non-zero. Since #1671 landed, that read correctly exits `EXIT_WORKING_COPY_UNMEASURED` when nothing admitted the working copy.

**This job runs only on push to main, so no pull request can grade it,** including this one. Every arm below was driven locally against a built kin with no daemon, which is the only place this shows up before a landing.

## Measured before deciding

```
$ KIN_NPM_PROOF_ALLOW_HOST=1 KIN_NPM_PROOF_KIN_BIN=.../debug/kin \
    KIN_NPM_PROOF_DAEMON_BIN=.../debug/kin-daemon node ./scripts/prove-windows-npm-first-run.mjs
MAIN_COPY_RC=1
WINDOWS NPM PROOF FAIL: Error: @kinlab/kin repository status failed (status=9, signal=null):
stdout:
{
  "schema": "kin.status.v3",
  "authority": "repository-v6",
  ...
```

The report on stdout is complete and every assertion the proof makes about it would pass. Only the blanket `status !== 0` rejects it.

## This read's subject is not the working copy

Its three assertions are `schema`, `authority` and `repository.source_cas_verified`, all durable-authority facts the exit code does not touch. What the leg asks of the read is that the npm launcher drives the real binary and gets a well-formed report back. The daemon-backed half of the flow is proven by the graph search immediately after, which genuinely cannot answer without a daemon.

I tried the other option first and the measurement rejected it. Admitting before the read would make the header's "daemon-backed status" literally true and would force the PATH-free daemon discovery this leg is about, which is the stronger proof. But `kin admit` needs an author and this fixture deliberately carries none: it sets `GIT_AUTHOR_NAME` and friends in the environment for git's benefit and configures no git identity, so admit refuses with "this store cannot name an author". Making it work means giving the fixture an identity it was built without, which changes what the leg isolates.

So the read accepts both codes a status can correctly return, **by name in a helper that takes the list**, never by relaxing to any non-zero. A proof that stopped reading the code would stop noticing a real failure.

And when the code is 9 the proof now proves it is THAT 9. The `--json` arm renders no banner, so the claim the code makes is unverifiable from the payload alone and an unrelated 9 would read identically. A second read of the text arm requires the unmeasured sentence and requires it above the `Tree:` line it qualifies. That is one assertion more than this leg carried before.

## Falsified both ways

`.kin-coord/reports/dirtytree-winnpm-driver.sh` refuses unless the baseline actually took the exit-9 path, so neither mutation can grade a run that never reached the state.

```
=== BASELINE: the fixed proof must PASS ===
rc=0
[windows-npm-proof] @kinlab/kin: status reported the working copy unmeasured, with the gap leading the page
HOST LOGIC SMOKE PASS (NON-CITABLE)

=== M1: the banner control must be able to FAIL ===
rc=1
WINDOWS NPM PROOF FAIL: AssertionError: @kinlab/kin status exited 9 without saying the working copy was unmeasured

=== M2: main's blanket rule must reproduce the red on main ===
rc=1
WINDOWS NPM PROOF FAIL: Error: @kinlab/kin repository status failed (status=9, signal=null, allowed=0)

=== restore proof ===
restored clean
```

M2 is main's own rule restored and it reproduces the red exactly, which is what makes the baseline evidence rather than assertion. M1 proves the new control can fail rather than being decorative. Both restore from a byte copy taken at entry, never `git checkout -- <file>`, with the restore proven by `cmp`.

## Gates

```
bin/kin-precheck   21 gates ran, 21 passed, 0 failed, on kin 6e078802516a949803351c569fd6f0362891f82c
                   behind origin/main 0 commit(s)
node --check ./scripts/prove-windows-npm-first-run.mjs   ok
```

The ubuntu shard reds on the same runs are a different step (the README language count) and are not this.

FIR-3420. Report: `.kin-coord/reports/dirtytree-20260910.md`.
