### PR TITLE
Resolve the CLI's local graph open through the daemon's own namespace rule (FIR-3498)

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -403,6 +403,16 @@ jobs:
       - name: Falsify the detached-head commit graders
         run: python3 scripts/acceptance/detached_head_commit_repro.py --self-test
 
+      # `kin graph viz` served an empty payload at exit 0 over a 20,298-entity
+      # store, and an empty answer nobody is told about is the one shape that
+      # never gets investigated. Each grader is driven against the exact payload
+      # that shipped, against the pre-fix payload shape that draws without
+      # saying how much it drew, and against a refusal that names the repository
+      # id and not the directory. Each mutation must red exactly one grader, or
+      # a defect is being caught by the wrong assertion.
+      - name: Falsify the graph-viz render graders
+        run: python3 scripts/acceptance/graph_viz_local_render.py --self-test
+
       - name: Install Rust toolchain
         uses: ./.github/actions/rust-toolchain
 
@@ -1273,6 +1283,31 @@ jobs:
             echo "::warning title=Detached-head commit acceptance suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
           fi
 
+      - name: Graph viz local render acceptance suite (verdict comes from the gate step)
+        id: graphvizrender
+        if: always()
+        run: |
+          set -uo pipefail
+          mkdir -p acceptance
+          rc=0
+          python3 scripts/acceptance/graph_viz_local_render.py \
+            --kin target/release/kin \
+            --daemon target/release/kin-daemon \
+            --json acceptance/graph_viz_render.json \
+            --verbose >acceptance/graph_viz_render.log 2>&1 || rc=$?
+          cat acceptance/graph_viz_render.log
+          {
+            echo "### Graph viz local render acceptance suite (exit $rc)"
+            echo ''
+            echo '```'
+            grep -E '^CHECK ' acceptance/graph_viz_render.log || echo '(no CHECK line was printed)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning title=Graph viz local render acceptance suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
+          fi
+
       # Always, including on a cancelled or timed-out run: the reports are how a
       # failure is diagnosed without re-running the job.
       - name: Upload the acceptance reports
@@ -1335,5 +1370,6 @@ jobs:
             --report prose_parity=acceptance/prose_parity.json \
             --report merge_precedence=acceptance/merge_precedence.json \
             --report detached_head=acceptance/detached_head.json \
+            --report graph_viz_render=acceptance/graph_viz_render.json \
             --allow-unreadable 'brownfield:4=FIR-2593: the express app.handle walk comes back truncated, and a clip nothing can witness leaves the check unable to tell an absent required edge from a dropped one. A clip whose complete neighborhood witness re-supplies the dropped rows is readable and is graded on its merits, so this line now covers only the unwitnessable case and the FAIL allowance beside it covers the graded one. Any other UNREADABLE still fails the gate, and the moment this check passes both allowances announce themselves stale and can go.' \
             --allow-fail 'brownfield:4=FIR-2464|the hand-off this.router.handle at lib/application.js:177|Measured on the red main run 34225725954 and reproduced locally on 2026-09-08. The absence is real and no truncation causes it: app.handle offers eight callees against a per-step cap of 25 and was never clipped, and the one clip in the walk is on application, whose complete witness carries 45 relations and no matching name either. express is pinned at 5.2.1, where the router is a dependency rather than lib/router/index.js, so this hand-off targets Router.prototype.handle in node_modules/router/index.js while the fixture admits the repository only, 140 of 140 files. The graph has an entity for Router and none for its handle member. Surfacing that hand-off is FIR-2464 itself and is unfixed, and bin/kin-parity has tolerated this same FAIL under this same ticket since it was written, so this line stops the two graders of one report disagreeing.'

--- a/crates/kin-cli/assets/graph_viz/app.js
+++ b/crates/kin-cli/assets/graph_viz/app.js
@@ -63,6 +63,14 @@
   // the resting page still says the drawing is partial rather than implying
   // every relation is on screen.
   let withheldRelations = 0;
+  // What the payload said about the population it was drawn from. The export is
+  // capped and sampled server side, so a page that showed only its own counts
+  // would read as the whole graph. These keep the resting line honest.
+  let scope = {
+    entityCount: 0,
+    relationCount: 0,
+    sampled: false,
+  };
   let neighbors = new Map();
   let quadtree = null;
 
@@ -327,6 +335,39 @@
     );
   }
 
+  // What this canvas is, in one sentence, always shown.
+  //
+  // The server caps and samples the export, so the drawn counts alone would
+  // read as the whole repository. Saying "1,400 of 20,298" is the difference
+  // between a picture and a picture that lies about itself. When nothing was
+  // capped it says so instead of going quiet, because a silent page and a
+  // complete one must not look the same.
+  function scopeNote() {
+    const n = (value) => (value || 0).toLocaleString();
+    let line;
+    if (scope.sampled) {
+      line =
+        "showing " +
+        n(nodes.length) +
+        " of " +
+        n(scope.entityCount) +
+        " entities and " +
+        n(links.length) +
+        " of " +
+        n(scope.relationCount) +
+        " relations (sampled; run with --limit 0 to draw them all)";
+    } else {
+      line =
+        "showing all " +
+        n(nodes.length) +
+        " entities and " +
+        n(links.length) +
+        " relations";
+    }
+    const withheld = partialNote().trim();
+    return withheld ? line + "; " + withheld : line;
+  }
+
   async function load() {
     setStatus("loading graph...");
     let data;
@@ -352,9 +393,25 @@
       .map((l) => Object.assign({}, l));
     const droppedHere = raw.length - links.length;
     withheldRelations = (data.unresolved_links || 0) + droppedHere;
+    scope = {
+      entityCount: data.entity_count || 0,
+      relationCount: data.relation_count || 0,
+      sampled: !!data.sampled,
+    };
 
-    nodeCountEl.textContent = nodes.length.toLocaleString();
-    edgeCountEl.textContent = links.length.toLocaleString();
+    // The population, not the sample, beside each count. A panel reading
+    // "nodes 1,400" on a 20,298-entity repository is the same lie the sampled
+    // status line exists to prevent.
+    nodeCountEl.textContent = scope.sampled
+      ? nodes.length.toLocaleString() +
+        " of " +
+        scope.entityCount.toLocaleString()
+      : nodes.length.toLocaleString();
+    edgeCountEl.textContent = scope.sampled
+      ? links.length.toLocaleString() +
+        " of " +
+        scope.relationCount.toLocaleString()
+      : links.length.toLocaleString();
 
     if (nodes.length === 0) {
       setStatus("graph is empty", false);
@@ -419,7 +476,7 @@
     simulation.on("end", () => {
       rebuildQuadtree();
       draw();
-      setStatus(partialNote().trim());
+      setStatus(scopeNote());
     });
 
     setTimeout(() => {
@@ -427,7 +484,7 @@
         simulation.alpha(0).stop();
         rebuildQuadtree();
         draw();
-        setStatus(partialNote().trim());
+        setStatus(scopeNote());
       }
     }, 20000);
   }

--- a/crates/kin-cli/src/backend.rs
+++ b/crates/kin-cli/src/backend.rs
@@ -41,12 +41,6 @@ pub fn open_kindb_snapshot(
     open_kindb_snapshot_with_mode(layout, false)
 }
 
-pub fn open_kindb_snapshot_read_only(
-    layout: &kin_core::KinLayout,
-) -> std::result::Result<kin_db::SnapshotManager, kin_db::KinDbError> {
-    open_kindb_snapshot_with_mode(layout, true)
-}
-
 fn open_kindb_snapshot_with_mode(
     layout: &kin_core::KinLayout,
     read_only: bool,
@@ -125,25 +119,19 @@ pub fn open_snapshot_local(
         ))
     };
 
-    // The same bounded retry the flat open carried. A CLI reader racing a
-    // maintenance process for the namespace's recovery lock is a transient
-    // condition, and reporting it as a broken store would be a false diagnosis.
-    let mut attempts = 0usize;
-    let mut delay = Duration::from_millis(SNAPSHOT_OPEN_INITIAL_DELAY_MS);
-    let manager = loop {
-        match binding.open_manager() {
-            Ok(manager) => break manager,
-            Err(kin_db::KinDbError::LockError(message))
-                if attempts + 1 < SNAPSHOT_OPEN_MAX_ATTEMPTS
-                    && is_transient_lock_error(&message) =>
-            {
-                attempts += 1;
-                thread::sleep(delay);
-                delay = std::cmp::min(delay.saturating_mul(2), Duration::from_millis(100));
-            }
-            Err(error) => return Err(describe("cannot open repository authority", &error)),
-        }
-    };
+    // No retry loop here, deliberately, and this is the reason rather than an
+    // omission. The flat open above retries `KinDbError::LockError` because
+    // `SnapshotManager` reports contention that way. The repository-authority
+    // path does not: kin-db takes the namespace lock with a BLOCKING
+    // `lock_exclusive()`, so a reader racing another process waits rather than
+    // erroring, and the one failure that call can return arrives as a
+    // `StorageError` (kin-db 0.7.110 `storage/backend.rs:6038-6043`), which
+    // `is_transient_lock_error` never matches because it only ever sees
+    // `LockError`. A retry carried over here would be a loop that cannot fire,
+    // reading as protection while providing none.
+    let manager = binding
+        .open_manager()
+        .map_err(|error| describe("cannot open repository authority", &error))?;
 
     let lease = manager.read_authority();
     let snapshot = lease

--- a/crates/kin-cli/src/backend.rs
+++ b/crates/kin-cli/src/backend.rs
@@ -6,7 +6,9 @@
 //! The primary entry point is [`open_snapshot_daemon_first`] which auto-starts
 //! the daemon if needed, then fetches the warm graph from the daemon's
 //! `/graph/bootstrap` endpoint. Direct local snapshot reads are only for
-//! daemon internals and lower-level storage tests.
+//! daemon internals and lower-level storage tests, and they resolve the
+//! repository's storage namespace through the same binding the daemon uses
+//! rather than addressing a fixed file name.
 //!
 //! The synchronous [`open_kindb_snapshot`] is kept for daemon internals
 //! and tests that cannot use the async runtime.
@@ -85,24 +87,86 @@ pub fn vector_index_path(layout: &kin_core::KinLayout) -> PathBuf {
     layout.kindb_vector_index_path()
 }
 
-/// Open snapshot directly from disk without involving the daemon.
-/// Keep this out of product command paths; it exists for daemon bootstrap,
-/// maintenance internals, and lower-level storage tests.
+/// Open this repository's graph directly from disk, without a daemon.
+///
+/// Resolves the namespace exactly the way the daemon resolves it, through the
+/// one binding both use: the repository id out of `.kin/manifest.json`, then
+/// `.kin/kindb/<repository-id>/`, then that namespace's persisted authority and
+/// the workspace graph it names. No second path is tried and no empty graph is
+/// invented. A namespace carrying no authority record is an error naming the
+/// directory that was read and the identity that named it.
+///
+/// This used to open the fixed `.kin/kindb/graph.kndb` instead. Nothing has
+/// written that file since repository-v6, and KinDB answers a path with no
+/// artifacts under it with a valid EMPTY graph rather than an error, because for
+/// an uninitialized namespace that is the right answer. So `kin graph viz` drew
+/// a blank canvas against a 20,298-entity store, at exit 0, with no message.
+/// See `kin_core::KinLayout::kindb_namespace_path`.
+///
+/// Keep this out of product command paths; it exists for the explicit
+/// offline/admin escape hatch, maintenance internals, and storage tests.
 pub fn open_snapshot_local(
     layout: &kin_core::KinLayout,
 ) -> std::result::Result<kin_db::SnapshotManager, kin_db::KinDbError> {
-    let snap = open_kindb_snapshot_with_mode(layout, true)?;
-    load_vector_index_if_exists(&snap, layout);
-    Ok(snap)
-}
+    let binding =
+        kin_core::LocalRepositoryAuthorityBinding::from_layout(layout).map_err(|error| {
+            kin_db::KinDbError::StorageError(format!(
+                "cannot bind the local repository under {}: {error}",
+                layout.kindb_dir().display()
+            ))
+        })?;
+    let namespace = binding.namespace_path();
+    let repository_id = binding.repository_id().clone();
+    let workspace_id = binding.workspace_id();
+    let describe = |what: &str, error: &dyn std::fmt::Display| {
+        kin_db::KinDbError::StorageError(format!(
+            "{what} for repository {repository_id} at {}: {error}",
+            namespace.display()
+        ))
+    };
 
-/// Open snapshot directly from disk using the lightweight locate-only
-/// read path. Keep this out of product command paths; `kin locate` itself
-/// runs through the daemon.
-pub fn open_snapshot_local_for_locate(
-    layout: &kin_core::KinLayout,
-) -> std::result::Result<kin_db::SnapshotManager, kin_db::KinDbError> {
-    let snap = kin_db::SnapshotManager::open_read_only_for_locate(kindb_snapshot_path(layout))?;
+    // The same bounded retry the flat open carried. A CLI reader racing a
+    // maintenance process for the namespace's recovery lock is a transient
+    // condition, and reporting it as a broken store would be a false diagnosis.
+    let mut attempts = 0usize;
+    let mut delay = Duration::from_millis(SNAPSHOT_OPEN_INITIAL_DELAY_MS);
+    let manager = loop {
+        match binding.open_manager() {
+            Ok(manager) => break manager,
+            Err(kin_db::KinDbError::LockError(message))
+                if attempts + 1 < SNAPSHOT_OPEN_MAX_ATTEMPTS
+                    && is_transient_lock_error(&message) =>
+            {
+                attempts += 1;
+                thread::sleep(delay);
+                delay = std::cmp::min(delay.saturating_mul(2), Duration::from_millis(100));
+            }
+            Err(error) => return Err(describe("cannot open repository authority", &error)),
+        }
+    };
+
+    let lease = manager.read_authority();
+    let snapshot = lease
+        .workspace_graph_snapshot(&workspace_id)
+        .map_err(|error| describe("cannot read the workspace graph", &error))?
+        .ok_or_else(|| {
+            describe(
+                "the repository authority holds no such workspace",
+                &workspace_id,
+            )
+        })?;
+    drop(lease);
+    drop(manager);
+
+    let graph = kin_db::InMemoryGraph::from_snapshot_with_text_index_read_only(
+        snapshot,
+        layout.text_index_dir(),
+    )
+    .map_err(|error| describe("cannot materialize the workspace graph", &error))?;
+    // The sidecar anchor, not the graph: `graph.kvec` and `graph.kidx` are named
+    // by suffixing this path, and the loader below reads them from it.
+    let snap =
+        kin_db::SnapshotManager::from_bootstrap_graph_read_only(kindb_snapshot_path(layout), graph);
     load_vector_index_if_exists(&snap, layout);
     Ok(snap)
 }
@@ -110,8 +174,8 @@ pub fn open_snapshot_local_for_locate(
 /// Daemon-required graph open for legacy read-only callers.
 ///
 /// This fetches an in-memory bootstrap snapshot from the repo daemon and never
-/// opens `.kin/kindb/graph.kndb` in the CLI process. Writable product paths must
-/// use daemon endpoints instead of asking the CLI for a local `SnapshotManager`.
+/// opens local storage in the CLI process. Writable product paths must use
+/// daemon endpoints instead of asking the CLI for a local `SnapshotManager`.
 pub async fn open_snapshot_daemon_first(
     layout: &kin_core::KinLayout,
 ) -> std::result::Result<kin_db::SnapshotManager, kin_db::KinDbError> {
@@ -185,7 +249,11 @@ fn daemon_resolution_storage_error(error: anyhow::Error) -> kin_db::KinDbError {
 }
 
 /// Whether the offline/admin local-snapshot escape hatch is enabled.
-fn daemon_bootstrap_admin_allowed() -> bool {
+///
+/// Crate-visible so a command reading the graph through a route other than the
+/// bootstrap open still asks the same question in the same words. A second
+/// reading of this variable is a second policy.
+pub(crate) fn daemon_bootstrap_admin_allowed() -> bool {
     std::env::var("KIN_ALLOW_DAEMON_BOOTSTRAP_ADMIN")
         .ok()
         .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))

--- a/crates/kin-cli/src/commands/graph_export.rs
+++ b/crates/kin-cli/src/commands/graph_export.rs
@@ -122,6 +122,25 @@ impl IncludeFields {
     }
 }
 
+/// Turn a caller's `limit` argument into the cap the export applies.
+///
+/// Three requests, not two: an explicit `0` asks for every entity, an explicit
+/// `n` asks for that cap, and an absent value asks for a drawable default.
+/// Collapsing the first two loses the whole-graph request, and collapsing the
+/// last two makes an uncapped export the default for a renderer.
+///
+/// One function rather than one `match` per entry point. The daemon's export
+/// route and the CLI commands that build an [`ExportOptions`] of their own both
+/// resolve it here, so a page and the route it asks cannot disagree about what
+/// `--limit 0` means.
+pub fn resolve_limit(limit: Option<usize>) -> Option<usize> {
+    match limit {
+        Some(0) => None,
+        Some(limit) => Some(limit),
+        None => Some(DEFAULT_NODE_LIMIT),
+    }
+}
+
 /// A resolved export request.
 #[derive(Debug, Clone, Default)]
 pub struct ExportOptions {
@@ -915,6 +934,104 @@ mod tests {
             "the a->b edge lost its target to the kind filter, a property of this request"
         );
         assert!(payload.links.is_empty());
+    }
+
+    /// Degree drives node radius on the page, so it counts the edges actually
+    /// drawn and not the relations the graph reported.
+    ///
+    /// Counting withheld relations would inflate a node the layout never
+    /// connects to anything, which reads to a viewer as a hub.
+    #[test]
+    fn degree_counts_only_the_edges_that_survive_to_the_payload() {
+        let metas = vec![
+            meta("a", "alpha", "Function", Some("src/a.rs")),
+            meta("b", "beta", "Function", Some("src/b.rs")),
+        ];
+        let known = all_ids(&metas);
+        let edges = vec![
+            ("a".to_string(), "b".to_string(), "Calls".to_string()),
+            ("a".to_string(), "gone".to_string(), "Imports".to_string()),
+            (
+                "a".to_string(),
+                "also-gone".to_string(),
+                "Imports".to_string(),
+            ),
+        ];
+
+        let payload = assemble_payload(
+            "root".to_string(),
+            0,
+            metas,
+            &known,
+            edges,
+            &ExportOptions::default(),
+        );
+
+        let degree_of = |id: &str| {
+            payload
+                .nodes
+                .iter()
+                .find(|node| node.id == id)
+                .map(|node| node.degree)
+                .expect("node present")
+        };
+        assert_eq!(degree_of("a"), 1, "two of a's three relations are withheld");
+        assert_eq!(degree_of("b"), 1);
+        assert_eq!(payload.unresolved_links, 2);
+    }
+
+    /// The page reads this payload by field name, so the names it reads must
+    /// survive serialization.
+    ///
+    /// `kin graph viz` serves this exact object at `/api/graph.json` and its
+    /// script reads `nodes`, `links`, `unresolved_links`, `entity_count`,
+    /// `relation_count` and `sampled`. A renamed field would not fail a Rust
+    /// test that only inspects the struct: the page would silently draw a
+    /// complete-looking canvas with `undefined` counts behind it.
+    #[test]
+    fn the_payload_serializes_every_field_the_page_reads() {
+        let metas = vec![
+            meta("a", "alpha", "Function", Some("src/a.rs")),
+            meta("b", "beta", "Function", Some("src/b.rs")),
+        ];
+        let known = all_ids(&metas);
+        let edges = vec![
+            ("a".to_string(), "b".to_string(), "Calls".to_string()),
+            (
+                "a".to_string(),
+                "outside".to_string(),
+                "Imports".to_string(),
+            ),
+        ];
+
+        let payload = assemble_payload(
+            "root".to_string(),
+            0,
+            metas,
+            &known,
+            edges,
+            &ExportOptions::default(),
+        );
+        let json = serde_json::to_value(&payload).unwrap();
+
+        assert_eq!(json["nodes"].as_array().unwrap().len(), 2);
+        assert_eq!(json["links"].as_array().unwrap().len(), 1);
+        assert_eq!(json["unresolved_links"], 1);
+        assert_eq!(json["entity_count"], 2);
+        assert_eq!(json["relation_count"], 1);
+        assert_eq!(json["sampled"], false);
+    }
+
+    /// The three limit requests stay three.
+    ///
+    /// An explicit zero and an absent value are opposite asks, and collapsing
+    /// either into the other is how a renderer ends up pulling a whole
+    /// repository or a caller asking for one gets 1,400 nodes instead.
+    #[test]
+    fn a_limit_of_zero_is_the_whole_graph_and_an_absent_one_is_the_default() {
+        assert_eq!(resolve_limit(Some(0)), None);
+        assert_eq!(resolve_limit(Some(25)), Some(25));
+        assert_eq!(resolve_limit(None), Some(DEFAULT_NODE_LIMIT));
     }
 
     /// One graph edge is one edge, however many times the store reported it.

--- a/crates/kin-cli/src/commands/graph_viz.rs
+++ b/crates/kin-cli/src/commands/graph_viz.rs
@@ -1,7 +1,28 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+//! `kin graph viz` — serve the live graph as an interactive page.
+//!
+//! The page draws the payload `GET /graph/export` serves, which is the same
+//! projection and the same sample every other drawing consumer gets. It used to
+//! ask `/graph/bootstrap` instead and shape a payload of its own, and both
+//! halves of that were wrong at repository scale.
+//!
+//! `/graph/bootstrap` exports the whole binary snapshot with no cap. This
+//! repository's own measurement of the two routes, recorded beside the export
+//! handler, is 119.6 MiB against 1.0 MiB on a 23,098-entity repository, and the
+//! CLI gave that transfer a 30-second budget. On the 20,298-entity store this
+//! was reported against, the request failed before a pixel was drawn. Nothing
+//! about a bigger timeout or a streaming body makes moving 119.6 MiB to draw
+//! 1,400 nodes the right shape, so it asks for the drawable projection: capped and
+//! sampled server side, off the request thread, and outside the one-at-a-time
+//! whole-snapshot semaphore `/graph/bootstrap` holds.
+//!
+//! The cap is why the page says what it is showing. A sampled export that
+//! reported only its own size would read as the whole graph, so the payload
+//! carries the population it was drawn from and the page renders that line.
+//! `--limit 0` asks for every entity, for a caller willing to wait.
+
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 
@@ -11,144 +32,13 @@ use axum::http::{header, HeaderValue};
 use axum::response::Response;
 use axum::routing::get;
 use axum::Router;
-use kin_model::{EntityStore, GraphNodeId};
-use serde::Serialize;
 use tokio::net::TcpListener;
+
+use crate::commands::graph_export::{self, GraphExportPayload};
 
 const INDEX_HTML: &str = include_str!("../../assets/graph_viz/index.html");
 const APP_JS: &str = include_str!("../../assets/graph_viz/app.js");
 const STYLE_CSS: &str = include_str!("../../assets/graph_viz/style.css");
-
-#[derive(Debug, Serialize)]
-struct GraphNode {
-    id: String,
-    name: String,
-    kind: String,
-    file: Option<String>,
-    degree: usize,
-}
-
-#[derive(Debug, Serialize)]
-struct GraphLink {
-    source: String,
-    target: String,
-    kind: String,
-}
-
-#[derive(Debug, Serialize)]
-struct GraphPayload {
-    nodes: Vec<GraphNode>,
-    links: Vec<GraphLink>,
-    /// Relations whose other endpoint is not itself an entity in this graph,
-    /// counted rather than emitted. A link naming an absent node is not a
-    /// drawable edge, and emitting one made the whole render die.
-    unresolved_links: usize,
-}
-
-/// One node's graph-owned identity, split out from the store so payload
-/// assembly is a pure function over what the graph reported.
-struct NodeMeta {
-    id: String,
-    name: String,
-    kind: String,
-    file: Option<String>,
-}
-
-/// Assemble the render payload, dropping every edge whose endpoints are not
-/// both present in the node set.
-///
-/// Relations legitimately point outside the entity set — an import of an
-/// external crate resolves to a placeholder destination that is no entity in
-/// this graph. The renderer joins edges to nodes by id and throws on the first
-/// unmatched one, so a single such relation used to abort the whole layout and
-/// leave a blank canvas. Withheld edges are counted and reported instead of
-/// dropped silently, so the page can say the graph is partial rather than
-/// implying every relation is drawn.
-fn assemble_payload(
-    node_meta: Vec<NodeMeta>,
-    edges: impl IntoIterator<Item = (String, String, String)>,
-) -> GraphPayload {
-    let node_ids: HashSet<&str> = node_meta.iter().map(|meta| meta.id.as_str()).collect();
-
-    let mut link_keys: BTreeSet<(String, String, String)> = BTreeSet::new();
-    let mut unresolved_links = 0usize;
-    for (a, b, kind) in edges {
-        if !node_ids.contains(a.as_str()) || !node_ids.contains(b.as_str()) {
-            unresolved_links += 1;
-            continue;
-        }
-        let (a, b) = if a <= b { (a, b) } else { (b, a) };
-        link_keys.insert((a, b, kind));
-    }
-
-    let mut degrees: HashMap<&str, usize> = HashMap::with_capacity(node_meta.len());
-    for (a, b, _kind) in &link_keys {
-        *degrees.entry(a.as_str()).or_insert(0) += 1;
-        *degrees.entry(b.as_str()).or_insert(0) += 1;
-    }
-
-    let nodes: Vec<GraphNode> = node_meta
-        .iter()
-        .map(|meta| GraphNode {
-            id: meta.id.clone(),
-            name: meta.name.clone(),
-            kind: meta.kind.clone(),
-            file: meta.file.clone(),
-            degree: degrees.get(meta.id.as_str()).copied().unwrap_or(0),
-        })
-        .collect();
-
-    let links: Vec<GraphLink> = link_keys
-        .into_iter()
-        .map(|(source, target, kind)| GraphLink {
-            source,
-            target,
-            kind,
-        })
-        .collect();
-
-    GraphPayload {
-        nodes,
-        links,
-        unresolved_links,
-    }
-}
-
-fn build_payload_from_snapshot(snap: &kin_db::SnapshotManager) -> Result<GraphPayload> {
-    let graph = snap.graph();
-    let entities = graph.list_all_entities()?;
-
-    let mut edges: Vec<(String, String, String)> = Vec::new();
-    for e in &entities {
-        let src_id = e.id.to_string();
-        let rels = graph.get_all_relations_for_entity(&e.id)?;
-        for rel in rels {
-            let other_id = match (&rel.src, &rel.dst) {
-                (GraphNodeId::Entity(s), GraphNodeId::Entity(d)) => {
-                    if *s == e.id {
-                        d.to_string()
-                    } else {
-                        s.to_string()
-                    }
-                }
-                _ => continue,
-            };
-            edges.push((src_id.clone(), other_id, format!("{:?}", rel.kind)));
-        }
-    }
-
-    let node_meta = entities
-        .iter()
-        .map(|e| NodeMeta {
-            id: e.id.to_string(),
-            name: e.name.clone(),
-            kind: format!("{:?}", e.kind),
-            file: e.file_origin.as_ref().map(|f| f.0.clone()),
-        })
-        .collect();
-
-    Ok(assemble_payload(node_meta, edges))
-}
 
 async fn serve_index() -> Response {
     static_response(INDEX_HTML.as_bytes().to_vec(), "text/html; charset=utf-8")
@@ -181,12 +71,101 @@ async fn serve_graph_json(State(json): State<Arc<String>>) -> Response {
     resp
 }
 
+/// Build the export payload from local storage, for the offline/admin arm.
+///
+/// The same projection and the same sampling rule the daemon applies, run in
+/// this process against the store's own graph, so the page cannot draw one
+/// picture through the daemon and a different one beside it.
+fn payload_from_local_store(
+    layout: &kin_core::KinLayout,
+    options: &graph_export::ExportOptions,
+) -> Result<GraphExportPayload> {
+    let snap = crate::backend::open_snapshot_local(layout)?;
+    let graph = snap.graph();
+    let root_hash = hex::encode(graph.compute_root_hash());
+    let (node_meta, all_entity_ids, edges) = graph_export::read_graph(graph.as_ref())?;
+    // Sequence zero rather than a borrowed cursor. An offline read holds no
+    // position in the daemon's event stream, and a client discards every event
+    // at or below this number; zero discards none, so a page that later
+    // subscribes re-applies what it already has instead of skipping what it
+    // does not. An invented cursor would silently lose the difference.
+    Ok(graph_export::assemble_payload(
+        root_hash,
+        0,
+        node_meta,
+        &all_entity_ids,
+        edges,
+        options,
+    ))
+}
+
+/// Resolve the payload the page will draw.
+///
+/// The authority order every read-only graph command follows: the daemon first,
+/// then an explicit offline/admin local read behind
+/// `KIN_ALLOW_DAEMON_BOOTSTRAP_ADMIN`, then an actionable refusal. Neither arm
+/// may answer with an empty graph it did not actually read. That is what the old
+/// local arm did, opening a retired file name, finding nothing, and serving a
+/// blank canvas at exit 0 against a store holding 20,298 entities.
+async fn resolve_payload(
+    layout: &kin_core::KinLayout,
+    options: &graph_export::ExportOptions,
+    query: &str,
+) -> Result<GraphExportPayload> {
+    let daemon_error =
+        match crate::daemon_client::DaemonClient::connect_for_command("graph viz", layout).await {
+            Ok(client) => match client.graph_export(query).await {
+                Ok(payload) => return Ok(payload),
+                Err(error) => error,
+            },
+            Err(error) => error,
+        };
+
+    if crate::backend::daemon_bootstrap_admin_allowed() {
+        tracing::warn!(
+            command = "kin graph viz",
+            error = %daemon_error,
+            "daemon unavailable; drawing from the local store directly (KIN_ALLOW_DAEMON_BOOTSTRAP_ADMIN)"
+        );
+        return payload_from_local_store(layout, options);
+    }
+
+    Err(daemon_error.context(
+        "kin graph viz needs the Kin daemon, which could not be reached.\n\
+         Start it with `kin status` (it auto-starts the daemon), then retry.\n\
+         For offline/admin use only, set KIN_ALLOW_DAEMON_BOOTSTRAP_ADMIN=1 to read the local store directly.",
+    ))
+}
+
 /// `kin graph viz` — serve an interactive force-directed graph over HTTP.
-pub async fn run(port: u16, open_browser: bool) -> Result<()> {
+///
+/// `limit` caps the drawn node count: `None` uses the export's default cap and
+/// `Some(0)` asks for every entity. The server binds only after a payload has
+/// actually been resolved, so a failure to read the graph refuses the command
+/// rather than serving a page with nothing on it.
+pub async fn run(port: u16, open_browser: bool, limit: Option<usize>) -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
-    let snap =
-        crate::backend::open_snapshot_explicit_admin_read_only(&layout, "kin graph viz").await?;
-    let payload = build_payload_from_snapshot(&snap)?;
+    let args = graph_export::ExportArgs {
+        limit,
+        ..Default::default()
+    };
+    let options = graph_export::ExportOptions {
+        limit: graph_export::resolve_limit(limit),
+        ..Default::default()
+    };
+    let payload =
+        resolve_payload(&layout, &options, &graph_export::export_query_string(&args)).await?;
+
+    // The same line `kin graph export` prints, on the terminal that started the
+    // server, so what the page claims and what the command reported are one
+    // sentence rather than two that can drift.
+    println!("{}", graph_export::export_summary_line(&payload, None));
+    if payload.nodes.is_empty() {
+        println!(
+            "This repository's graph holds no entities matching the request, so the page will be blank."
+        );
+    }
+
     let json_body = serde_json::to_string(&payload).context("failed to serialize graph JSON")?;
     let shared: Arc<String> = Arc::new(json_body);
 
@@ -218,120 +197,4 @@ pub async fn run(port: u16, open_browser: bool) -> Result<()> {
         .await
         .context("kin graph viz server error")?;
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{assemble_payload, NodeMeta};
-
-    fn node(id: &str) -> NodeMeta {
-        NodeMeta {
-            id: id.to_string(),
-            name: format!("entity_{id}"),
-            kind: "Function".to_string(),
-            file: Some("src/lib.rs".to_string()),
-        }
-    }
-
-    fn edge(a: &str, b: &str, kind: &str) -> (String, String, String) {
-        (a.to_string(), b.to_string(), kind.to_string())
-    }
-
-    /// The empty-canvas defect in miniature. A relation pointing at an id that
-    /// is no entity in this graph must never reach the payload: the renderer
-    /// joins links to nodes by id and aborts the whole layout on the first
-    /// unmatched one.
-    #[test]
-    fn links_naming_an_absent_node_are_withheld_and_counted() {
-        let payload = assemble_payload(
-            vec![node("a"), node("b")],
-            vec![
-                edge("a", "b", "Calls"),
-                edge("a", "external-placeholder", "Imports"),
-                edge("missing", "b", "Calls"),
-            ],
-        );
-
-        assert_eq!(payload.links.len(), 1);
-        assert_eq!(payload.links[0].source, "a");
-        assert_eq!(payload.links[0].target, "b");
-        assert_eq!(payload.unresolved_links, 2);
-
-        let ids: Vec<&str> = payload.nodes.iter().map(|n| n.id.as_str()).collect();
-        for link in &payload.links {
-            assert!(
-                ids.contains(&link.source.as_str()),
-                "{link:?} source absent"
-            );
-            assert!(
-                ids.contains(&link.target.as_str()),
-                "{link:?} target absent"
-            );
-        }
-    }
-
-    /// Falsification: a graph whose relations all resolve must withhold
-    /// nothing, so a passing test above cannot be explained by the filter
-    /// simply dropping everything.
-    #[test]
-    fn a_fully_resolvable_graph_withholds_no_links() {
-        let payload = assemble_payload(
-            vec![node("a"), node("b"), node("c")],
-            vec![edge("a", "b", "Calls"), edge("b", "c", "Contains")],
-        );
-
-        assert_eq!(payload.unresolved_links, 0);
-        assert_eq!(payload.links.len(), 2);
-    }
-
-    /// Degree drives node radius, so it must count the edges actually drawn.
-    /// Counting withheld relations would inflate a node the layout never
-    /// connects to anything.
-    #[test]
-    fn degree_counts_only_drawn_edges() {
-        let payload = assemble_payload(
-            vec![node("a"), node("b")],
-            vec![
-                edge("a", "b", "Calls"),
-                edge("a", "gone", "Imports"),
-                edge("a", "also-gone", "Imports"),
-            ],
-        );
-
-        let degree_of = |id: &str| {
-            payload
-                .nodes
-                .iter()
-                .find(|n| n.id == id)
-                .map(|n| n.degree)
-                .expect("node present")
-        };
-        assert_eq!(degree_of("a"), 1);
-        assert_eq!(degree_of("b"), 1);
-    }
-
-    /// The same relation observed from both endpoints is one edge, and an
-    /// undirected key must not depend on which endpoint reported it.
-    #[test]
-    fn reciprocal_observations_collapse_to_one_link() {
-        let payload = assemble_payload(
-            vec![node("a"), node("b")],
-            vec![edge("a", "b", "Calls"), edge("b", "a", "Calls")],
-        );
-
-        assert_eq!(payload.links.len(), 1);
-        assert_eq!(payload.unresolved_links, 0);
-    }
-
-    /// The page reports the withheld count, so it must survive serialization
-    /// under the name the page reads.
-    #[test]
-    fn payload_serializes_the_withheld_count_for_the_page() {
-        let payload = assemble_payload(vec![node("a")], vec![edge("a", "gone", "Imports")]);
-        let json = serde_json::to_value(&payload).unwrap();
-
-        assert_eq!(json["unresolved_links"], 1);
-        assert_eq!(json["links"].as_array().unwrap().len(), 0);
-        assert_eq!(json["nodes"].as_array().unwrap().len(), 1);
-    }
 }

--- a/crates/kin-cli/src/commands/recovery_carrier.rs
+++ b/crates/kin-cli/src/commands/recovery_carrier.rs
@@ -877,9 +877,7 @@ mod tests {
         let scratch = scratch();
         let (source, manifest) = fixture(scratch.path());
         fs::write(
-            source
-                .join("kindb")
-                .join(&manifest.repository_id)
+            kin_core::kindb_namespace_in(&source.join("kindb"), &manifest.repository_id)
                 .join("authority.json"),
             b"truncated",
         )

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -1736,6 +1736,10 @@ enum GraphAction {
         /// Open the visualization in the system default browser
         #[arg(long, default_value_t = false)]
         open: bool,
+        /// Cap the drawn node count, sampled by degree with per-module quotas.
+        /// 0 draws every entity; omitted uses the default cap
+        #[arg(long, value_name = "N")]
+        limit: Option<usize>,
     },
 }
 
@@ -4071,7 +4075,9 @@ fn run() -> Result<()> {
                         })
                         .await
                     }
-                    GraphAction::Viz { port, open } => commands::graph_viz::run(port, open).await,
+                    GraphAction::Viz { port, open, limit } => {
+                        commands::graph_viz::run(port, open, limit).await
+                    }
                 },
                 Command::Git { action } => match action {
                     GitAction::Export { output } => commands::git::export(output),

--- a/crates/kin-cli/tests/local_graph_namespace_resolution.rs
+++ b/crates/kin-cli/tests/local_graph_namespace_resolution.rs
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Where the CLI looks for graph truth when it reads local storage directly.
+//!
+//! `kin graph viz`, `kin locate-debug` and `kin remote` share one offline/admin
+//! open, and it used to address the fixed `.kin/kindb/graph.kndb`. Repository-v6
+//! stopped writing that file: graph truth lives in `.kin/kindb/<repository-id>/`,
+//! which is where the daemon's backend puts it. KinDB answers a path holding no
+//! artifacts with a valid EMPTY graph and no error, because for an
+//! uninitialized namespace that is the right answer, so the CLI drew a blank
+//! canvas at exit 0 against a store holding 20,298 entities and said nothing.
+//!
+//! Every case here admits a real Git repository through the real import
+//! boundary, so the namespace under test is the one the product writes rather
+//! than a directory a test built to match its own expectation.
+
+use std::path::Path;
+
+use kin_model::{EntityStore, RepositoryId};
+use tempfile::{tempdir, TempDir};
+
+mod common;
+
+use common::Command;
+
+/// A real admitted store, plus the identity and layout that name it.
+struct Fixture {
+    _working: TempDir,
+    layout: kin_core::KinLayout,
+    repository_id: RepositoryId,
+}
+
+impl Fixture {
+    fn namespace(&self) -> std::path::PathBuf {
+        self.layout
+            .kindb_namespace_path(self.repository_id.as_str())
+    }
+}
+
+/// Run one git command in the fixture, with the developer's own configuration
+/// held off.
+///
+/// The `-c` flags are not decoration. This machine's global git configuration
+/// carries hooks and commit signing, and a fixture that inherited either would
+/// fail for a reason that has nothing to do with the property under test. The
+/// bounded `common::Command` is the harness every other kin-cli integration
+/// test uses; `kin_git::test_support::fixture_git_in` cannot spawn its
+/// process-group guardian from this test binary.
+fn git(repository: &Path, args: &[&str]) {
+    let base = [
+        "-c",
+        "core.hooksPath=/dev/null",
+        "-c",
+        "commit.gpgsign=false",
+        "-c",
+        "user.name=Kin Fixture",
+        "-c",
+        "user.email=kin@example.invalid",
+    ];
+    let output = Command::new("git")
+        .args(base.iter().copied().chain(args.iter().copied()))
+        .current_dir(repository)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Admit a two-function Rust file through the real Git import.
+///
+/// Two functions and a call between them rather than an empty tree: the whole
+/// property under test is "non-empty", and a fixture that admits nothing would
+/// make the defect and the fix indistinguishable.
+fn admitted_store() -> Fixture {
+    let working = tempdir().expect("temp working directory");
+    std::fs::create_dir_all(working.path().join("src")).expect("create src");
+    std::fs::write(
+        working.path().join("src/lib.rs"),
+        b"pub fn greeting(name: &str) -> String { format!(\"hello {name}\") }\n\
+          pub fn greet_world() -> String { greeting(\"world\") }\n",
+    )
+    .expect("write fixture source");
+    git(working.path(), &["init", "--initial-branch=main"]);
+    git(working.path(), &["add", "--all"]);
+    git(working.path(), &["commit", "-m", "import semantic fixture"]);
+
+    let repository_id =
+        RepositoryId::new(format!("viz-namespace-{}", uuid::Uuid::new_v4().simple()))
+            .expect("valid repository identity");
+    let initialized = kin_core::init_from_git_adopting(working.path(), &repository_id)
+        .expect("the fixture must be admitted through the real Git import");
+
+    Fixture {
+        _working: working,
+        layout: initialized.layout,
+        repository_id,
+    }
+}
+
+/// Open the fixture's store expecting a refusal, and return the refusal text.
+///
+/// A match rather than `expect_err`, for two reasons. `SnapshotManager` is not
+/// `Debug`, so `expect_err` will not compile over it at all. More usefully, the
+/// regression this guards against does not return a broken graph, it returns a
+/// perfectly good EMPTY one, so the panic reports the entity count it opened
+/// with. "it answered a graph of 0 entities rather than refusing" names the
+/// defect; "expected Err" would only say an assertion failed.
+fn refusal_or_panic(fixture: &Fixture, what: &str) -> String {
+    match kin_cli::backend::open_snapshot_local(&fixture.layout) {
+        Ok(snapshot) => {
+            let entities = snapshot
+                .graph()
+                .list_all_entities()
+                .map(|entities| entities.len());
+            panic!(
+                "{what} must refuse rather than answer; it opened {} at {} and reported {entities:?} entities",
+                fixture.repository_id,
+                fixture.namespace().display(),
+            )
+        }
+        Err(error) => error.to_string(),
+    }
+}
+
+/// The local open reads the namespace the product actually writes, and reads it
+/// non-empty.
+///
+/// The third assertion is the falsification, and it is the reason this test can
+/// fail. Opening the retired flat path is pinned here as returning a valid,
+/// silent, EMPTY graph on this same store: so if the local open ever addresses
+/// that path again, the non-empty assertion goes red while the empty one stays
+/// green, and the failure names the exact regression rather than a vague
+/// "graph was empty".
+#[test]
+fn the_local_open_reads_the_repository_id_namespace_not_the_retired_flat_path() {
+    let fixture = admitted_store();
+    let namespace = fixture.namespace();
+
+    assert!(
+        namespace.join("authority.json").is_file(),
+        "the real import must write authority into {}",
+        namespace.display()
+    );
+    assert!(
+        !fixture.layout.kindb_snapshot_path().exists(),
+        "nothing writes the retired flat snapshot {}; if this file appeared, \
+         the premise of this test changed",
+        fixture.layout.kindb_snapshot_path().display()
+    );
+
+    let snapshot = kin_cli::backend::open_snapshot_local(&fixture.layout)
+        .expect("the local open must find the admitted namespace");
+    let entities = snapshot
+        .graph()
+        .list_all_entities()
+        .expect("list entities from the opened graph");
+    assert!(
+        !entities.is_empty(),
+        "the local open resolved a namespace but reported no entities; the \
+         fixture admitted two functions"
+    );
+
+    // The defect's mechanism, pinned. This is not a bug being asserted as
+    // correct: it is KinDB's documented answer for a namespace with nothing in
+    // it, and the whole point is that the CLI must not ask it that question.
+    let flat = kin_db::SnapshotManager::open_read_only(fixture.layout.kindb_snapshot_path())
+        .expect("kin-db answers a bare path with an empty graph rather than an error");
+    assert!(
+        flat.graph()
+            .list_all_entities()
+            .expect("list entities from the flat path")
+            .is_empty(),
+        "the retired flat path must answer empty on a populated store; if it \
+         answered non-empty, this test no longer discriminates the two paths"
+    );
+}
+
+/// A namespace that is not there is an error naming the directory and the
+/// identity, never an empty graph.
+#[test]
+fn an_absent_namespace_fails_loud_and_names_the_path_it_read() {
+    let fixture = admitted_store();
+    let namespace = fixture.namespace();
+    std::fs::remove_dir_all(&namespace).expect("remove the resolved namespace");
+
+    let error = refusal_or_panic(&fixture, "an absent namespace");
+
+    assert!(
+        error.contains(&namespace.display().to_string()),
+        "the refusal must name the directory it looked at: {error}"
+    );
+    assert!(
+        error.contains(fixture.repository_id.as_str()),
+        "the refusal must name the repository id it resolved: {error}"
+    );
+}
+
+/// A namespace whose authority record is gone is an error naming the directory
+/// and the identity, never an empty graph.
+///
+/// Separate from the absent-directory case because the two reach different
+/// refusals, and because this is the shape a half-written or truncated store
+/// takes: everything present except the record that says what is authoritative.
+#[test]
+fn a_namespace_without_its_authority_record_fails_loud_and_names_the_path() {
+    let fixture = admitted_store();
+    let namespace = fixture.namespace();
+    std::fs::remove_file(namespace.join("authority.json"))
+        .expect("remove the namespace authority record");
+
+    let error = refusal_or_panic(&fixture, "a namespace with no authority record");
+
+    assert!(
+        error.contains(&namespace.display().to_string()),
+        "the refusal must name the directory it looked at: {error}"
+    );
+    assert!(
+        error.contains(fixture.repository_id.as_str()),
+        "the refusal must name the repository id it resolved: {error}"
+    );
+}
+
+/// The resolver and the backend spell the namespace the same way.
+///
+/// Both halves of the original defect were path rules that disagreed while each
+/// looked reasonable on its own, so this asserts the agreement directly against
+/// a directory the import actually created.
+#[test]
+fn the_layout_resolver_names_the_directory_the_import_created() {
+    let fixture = admitted_store();
+
+    assert_eq!(
+        fixture.namespace(),
+        fixture
+            .layout
+            .kindb_dir()
+            .join(fixture.repository_id.as_str())
+    );
+    assert!(
+        fixture.namespace().is_dir(),
+        "the resolver must name a directory that exists after a real import: {}",
+        fixture.namespace().display()
+    );
+}

--- a/crates/kin-cli/tests/local_graph_namespace_resolution.rs
+++ b/crates/kin-cli/tests/local_graph_namespace_resolution.rs
@@ -225,25 +225,40 @@ fn a_namespace_without_its_authority_record_fails_loud_and_names_the_path() {
     );
 }
 
-/// The resolver and the backend spell the namespace the same way.
+/// The resolver names the directory the import actually wrote, found without
+/// asking the resolver.
 ///
-/// Both halves of the original defect were path rules that disagreed while each
-/// looked reasonable on its own, so this asserts the agreement directly against
-/// a directory the import actually created.
+/// Both halves of the original defect were path rules that each looked
+/// reasonable alone and disagreed with the product, so the expectation here is
+/// discovered from the store rather than restated: scan `.kin/kindb/` for the
+/// one directory carrying an `authority.json` and require the resolver to name
+/// exactly it. Comparing `kindb_namespace_path(id)` against
+/// `kindb_dir().join(id)` would only restate that function's own body and could
+/// not fail; the exact-path spelling is pinned by the unit test in
+/// `kin_core::layout` instead. This case exists to catch the resolver drifting
+/// away from the product, which is the failure that actually happened.
 #[test]
 fn the_layout_resolver_names_the_directory_the_import_created() {
     let fixture = admitted_store();
 
+    let kindb = fixture.layout.kindb_dir();
+    let mut written: Vec<std::path::PathBuf> = std::fs::read_dir(&kindb)
+        .expect("read the kindb directory")
+        .map(|entry| entry.expect("read a kindb entry").path())
+        .filter(|path| path.join("authority.json").is_file())
+        .collect();
+    written.sort();
+
+    assert_eq!(
+        written.len(),
+        1,
+        "a single-repository store must hold exactly one authority namespace \
+         under {}, found {written:?}",
+        kindb.display()
+    );
     assert_eq!(
         fixture.namespace(),
-        fixture
-            .layout
-            .kindb_dir()
-            .join(fixture.repository_id.as_str())
-    );
-    assert!(
-        fixture.namespace().is_dir(),
-        "the resolver must name a directory that exists after a real import: {}",
-        fixture.namespace().display()
+        written[0],
+        "the resolver must name the namespace the import wrote"
     );
 }

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -6430,7 +6430,7 @@ mod tests {
             .to_string()
             .contains("changed since this backend opened"));
         assert!(
-            !kindb.join(repository_id.as_str()).exists(),
+            !crate::kindb_namespace_in(&kindb, repository_id.as_str()).exists(),
             "replacement root must remain untouched"
         );
         assert!(

--- a/crates/kin-core/src/layout.rs
+++ b/crates/kin-core/src/layout.rs
@@ -117,7 +117,38 @@ impl KinLayout {
         self.kindb_dir().join("ingest-cas")
     }
 
-    /// `.kin/kindb/graph.kndb` — KinDB snapshot file.
+    /// `.kin/kindb/<repository-id>/` — the storage namespace holding one
+    /// repository's authority record, deltas, snapshots and source blobs.
+    ///
+    /// This is where graph truth actually lives, and it is the only rule for
+    /// finding it. KinDB's `LocalFileBackend` joins the same component onto its
+    /// base path for every artifact it addresses, so a caller that resolves a
+    /// namespace by hand and a caller that hands the backend a repository id
+    /// must agree by construction rather than by two copies of one convention.
+    ///
+    /// The repository id comes from `.kin/manifest.json`; see
+    /// [`crate::manifest::resolve_repo_id`]. A caller that already holds a
+    /// bound repository asks its binding for
+    /// [`crate::LocalRepositoryAuthorityBinding::namespace_path`] instead of
+    /// re-deriving the id.
+    pub fn kindb_namespace_path(&self, repo_id: &str) -> PathBuf {
+        kindb_namespace_in(&self.kindb_dir(), repo_id)
+    }
+
+    /// `.kin/kindb/graph.kndb` — the anchor the derived sidecars are named
+    /// from, and NOT the graph.
+    ///
+    /// The single-file snapshot this path once addressed is retired: nothing
+    /// writes it, and repository-v6 keeps graph truth under
+    /// [`Self::kindb_namespace_path`] instead. What still lives at this name is
+    /// the derived vector and text sidecar set (`graph.kvec`, `graph.kidx`),
+    /// which kin-db addresses by suffixing this path.
+    ///
+    /// Opening a graph here answers with a valid EMPTY graph rather than an
+    /// error, because an absent namespace is legitimately how an uninitialized
+    /// one looks from this path's point of view. `kin graph viz` did exactly
+    /// that on a 20,298-entity store and drew a blank canvas at exit 0. Resolve
+    /// the namespace, not this file, for anything that is an answer.
     pub fn kindb_snapshot_path(&self) -> PathBuf {
         self.kindb_dir().join("graph.kndb")
     }
@@ -433,6 +464,19 @@ impl KinLayout {
     }
 }
 
+/// Join a repository id onto a KinDB base directory to name that repository's
+/// storage namespace.
+///
+/// The one place the `<base>/<repository-id>` rule is written down. A caller
+/// holding a [`KinLayout`] goes through [`KinLayout::kindb_namespace_path`];
+/// this exists for the callers that hold a backend's base path instead of a
+/// layout, so that both spell the namespace the same way and a change to the
+/// rule reaches both. Two independent copies of it are what let the CLI look
+/// for graph truth at a path the daemon never writes.
+pub fn kindb_namespace_in(kindb_dir: &Path, repo_id: &str) -> PathBuf {
+    kindb_dir.join(repo_id)
+}
+
 /// The real home's `.kin`, which is an install-root identity rather than a
 /// servable repo. Returns `None` when no home directory is resolvable.
 ///
@@ -654,6 +698,30 @@ mod tests {
             PathBuf::from("/repo/.kin/kindb/head-generation")
         );
         assert_eq!(layout.working_dir(), Path::new("/repo"));
+    }
+
+    /// The namespace resolver names the repository-id directory, and it agrees
+    /// with the free function the backend-holding callers use.
+    ///
+    /// Pinned as an exact path rather than as "somewhere under kindb" because
+    /// the defect this replaced was a second, plausible-looking path under the
+    /// same directory that nothing writes.
+    #[test]
+    fn kindb_namespace_is_the_repository_id_directory() {
+        let layout = KinLayout::new(PathBuf::from("/repo/.kin"));
+        let repo_id = "c2fd2519-1d5a-4292-8511-7e9196accade";
+        assert_eq!(
+            layout.kindb_namespace_path(repo_id),
+            PathBuf::from("/repo/.kin/kindb/c2fd2519-1d5a-4292-8511-7e9196accade")
+        );
+        assert_eq!(
+            layout.kindb_namespace_path(repo_id),
+            kindb_namespace_in(&layout.kindb_dir(), repo_id)
+        );
+        assert_ne!(
+            layout.kindb_namespace_path(repo_id),
+            layout.kindb_snapshot_path()
+        );
     }
 
     #[test]

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -94,7 +94,7 @@ pub use init::{
     RepositoryIdentityOrigin, RepositoryPublication, StrandedRepositoryStage, StrandedStageSurvey,
     StrandedStageVerdict,
 };
-pub use layout::KinLayout;
+pub use layout::{kindb_namespace_in, KinLayout};
 pub use manifest::KinManifest;
 pub use paging::LocateCursor;
 pub use resolver::{ImportResolver, PythonResolver, SymbolTable, TypeScriptResolver};

--- a/crates/kin-core/src/repository_authority.rs
+++ b/crates/kin-core/src/repository_authority.rs
@@ -10,6 +10,7 @@
 
 use std::collections::HashSet;
 use std::fmt;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use kin_db::{
@@ -384,8 +385,14 @@ impl LocalRepositoryAuthorityBinding {
             Arc::new(LocalFileBackend::new(layout.kindb_dir())),
         );
         binding.revalidate_pinned_namespace().map_err(|error| {
+            // Name the directory and the identity that produced it. A refusal
+            // that carried neither was indistinguishable from a store that is
+            // simply empty, and the caller could not tell whether it had
+            // resolved the wrong namespace or found the right one bare.
             KinError::Other(format!(
-                "cannot pin repository authority namespace at startup: {error}"
+                "cannot pin repository authority namespace {} for repository {} at startup: {error}",
+                binding.namespace_path().display(),
+                binding.repository_id(),
             ))
         })?;
         Ok(binding)
@@ -393,6 +400,17 @@ impl LocalRepositoryAuthorityBinding {
 
     pub fn repository_id(&self) -> &RepositoryId {
         &self.repository_id
+    }
+
+    /// The directory this binding's graph truth lives in.
+    ///
+    /// Resolved through [`crate::kindb_namespace_in`], the same rule KinDB's
+    /// backend applies to every artifact it addresses, so this is the path that
+    /// was actually consulted rather than a second guess at it. Callers report
+    /// it when an open finds nothing: an operator needs the directory that was
+    /// looked at, not only the id that named it.
+    pub fn namespace_path(&self) -> PathBuf {
+        crate::kindb_namespace_in(self.backend.base_path(), self.repository_id.as_str())
     }
 
     pub fn workspace_id(&self) -> WorkspaceId {
@@ -739,7 +757,9 @@ mod payload_receipt_tests {
                 .repo_id,
         )
         .unwrap();
-        let namespace = initialized.layout.kindb_dir().join(repository_id.as_str());
+        let namespace = initialized
+            .layout
+            .kindb_namespace_path(repository_id.as_str());
         let snapshots = namespace.join("snapshots");
         assert!(
             std::fs::read_dir(&snapshots).unwrap().any(|entry| entry
@@ -852,8 +872,7 @@ mod tests {
 
         let namespace = initialized
             .layout
-            .kindb_dir()
-            .join(binding.repository_id().as_str());
+            .kindb_namespace_path(binding.repository_id().as_str());
         let replacement = initialized.layout.root().join("namespace-replacement");
         let original = initialized.layout.root().join("namespace-original");
         copy_directory(&namespace, &replacement);
@@ -887,8 +906,7 @@ mod tests {
 
         let namespace = initialized
             .layout
-            .kindb_dir()
-            .join(binding.repository_id().as_str());
+            .kindb_namespace_path(binding.repository_id().as_str());
         std::fs::rename(
             &namespace,
             initialized.layout.root().join("namespace-detached"),
@@ -959,8 +977,7 @@ mod tests {
 
         let namespace = initialized
             .layout
-            .kindb_dir()
-            .join(binding.repository_id().as_str());
+            .kindb_namespace_path(binding.repository_id().as_str());
         std::fs::write(namespace.join("authority.json"), b"{ truncated").unwrap();
         for entry in std::fs::read_dir(namespace.join("snapshots")).unwrap() {
             let entry = entry.unwrap();
@@ -988,8 +1005,7 @@ mod tests {
 
         let namespace = initialized
             .layout
-            .kindb_dir()
-            .join(binding.repository_id().as_str());
+            .kindb_namespace_path(binding.repository_id().as_str());
         let replacement = initialized.layout.root().join("namespace-replacement");
         copy_directory(&namespace, &replacement);
         std::fs::rename(
@@ -1024,8 +1040,7 @@ mod tests {
 
         let namespace = initialized
             .layout
-            .kindb_dir()
-            .join(binding.repository_id().as_str());
+            .kindb_namespace_path(binding.repository_id().as_str());
         std::fs::rename(
             &namespace,
             initialized.layout.root().join("namespace-detached"),

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -163,9 +163,7 @@ fn read_local_publication_identity(
 ) -> Result<LocalPublicationIdentity, (StatusCode, String)> {
     use std::io::Read as _;
 
-    let record = backend
-        .base_path()
-        .join(repository_id.as_str())
+    let record = kin_core::kindb_namespace_in(backend.base_path(), repository_id.as_str())
         .join(AUTHORITY_PUBLICATION_RECORD);
     let record_error = |error: std::io::Error| {
         repository_authority_error(format!(
@@ -7783,13 +7781,11 @@ async fn export_graph_projection(
     use kin_cli::commands::graph_export as export;
 
     let options = export::ExportOptions {
-        limit: match params.limit {
-            // An explicit 0 is the request for every entity. Absent is a
-            // request for a drawable default, which is a different question.
-            Some(0) => None,
-            Some(limit) => Some(limit),
-            None => Some(export::DEFAULT_NODE_LIMIT),
-        },
+        // An explicit 0 is the request for every entity. Absent is a request for
+        // a drawable default, which is a different question. The rule lives in
+        // `export::resolve_limit` so every caller that builds these options
+        // reads it the same way.
+        limit: export::resolve_limit(params.limit),
         kinds: params
             .kinds
             .as_deref()
@@ -22745,8 +22741,7 @@ mod tests {
     ) -> PathBuf {
         let digest = digest.to_string();
         layout
-            .kindb_dir()
-            .join(repository_id)
+            .kindb_namespace_path(repository_id)
             .join("source-blobs")
             .join("sha256")
             .join(&digest[..2])
@@ -22868,7 +22863,7 @@ mod tests {
     }
 
     fn remove_local_authority_after_startup(state: &DaemonState) -> PathBuf {
-        let namespace = state.layout.kindb_dir().join(&state.cached_repo_id);
+        let namespace = state.layout.kindb_namespace_path(&state.cached_repo_id);
         assert!(
             std::fs::read_dir(namespace.join("snapshots"))
                 .unwrap()
@@ -34134,7 +34129,7 @@ mod tests {
     fn pinned_repository_namespace(state: &DaemonState) -> PathBuf {
         let manifest =
             kin_core::manifest::KinManifest::load(&state.layout.manifest_path()).unwrap();
-        state.layout.kindb_dir().join(manifest.repo_id)
+        state.layout.kindb_namespace_path(&manifest.repo_id)
     }
 
     /// Prove the retained per-repository capability, not only the storage root,

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -17455,7 +17455,7 @@ mod tests {
         let init = kin_core::init(repo_dir.path()).unwrap();
         let layout = init.layout;
         let manifest = kin_core::manifest::KinManifest::load(&layout.manifest_path()).unwrap();
-        let repository_dir = layout.kindb_dir().join(&manifest.repo_id);
+        let repository_dir = layout.kindb_namespace_path(&manifest.repo_id);
         let authority: serde_json::Value =
             serde_json::from_slice(&std::fs::read(repository_dir.join("authority.json")).unwrap())
                 .unwrap();
@@ -17484,7 +17484,7 @@ mod tests {
         let init = kin_core::init(repo_dir.path()).unwrap();
         let layout = init.layout;
         let manifest = kin_core::manifest::KinManifest::load(&layout.manifest_path()).unwrap();
-        let repository_dir = layout.kindb_dir().join(&manifest.repo_id);
+        let repository_dir = layout.kindb_namespace_path(&manifest.repo_id);
         assert!(
             std::fs::read_dir(repository_dir.join("snapshots"))
                 .unwrap()

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -498,9 +498,7 @@ mod tests {
         let manifest =
             kin_core::KinManifest::load(&root.join(".kin").join("manifest.json")).unwrap();
         let digest = hash.to_string();
-        root.join(".kin")
-            .join("kindb")
-            .join(manifest.repo_id)
+        kin_core::kindb_namespace_in(&root.join(".kin").join("kindb"), &manifest.repo_id)
             .join("source-blobs")
             .join("sha256")
             .join(&digest[..2])

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2438,6 +2438,13 @@ kin graph viz [options]
 | --- | --- | --- |
 | `--port <port>` | `4220` | Port to bind the local HTTP server to |
 | `--open` |  | Open the visualization in the system default browser |
+| `--limit <N>` | `1400` | Cap the drawn node count, sampled by degree with per-module quotas. `0` draws every entity |
+
+The page draws the same payload `kin graph export` prints, so it is capped and
+sampled the same way, and it says which it is: a sampled canvas reads "showing
+1,400 of 20,298 entities", and a complete one says so instead of going quiet.
+The command refuses rather than serving a blank page when it cannot read the
+graph, and the refusal names the storage namespace it looked at.
 
 ### `kin embed`
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2406,7 +2406,7 @@ kin graph export [options]
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `--limit <n>` | `1400` | Cap the exported node count, sampled by degree with per-module quotas. `0` exports every entity |
+| `--limit <N>` | `1400` | Cap the exported node count, sampled by degree with per-module quotas. `0` exports every entity |
 | `--kinds <kinds>` |  | Keep only these entity kinds, comma-separated (`function,class`). Any spelling of a kind name matches |
 | `--path <prefix>` |  | Keep only entities whose file starts with this repository path prefix |
 | `--include <fields>` |  | Attach optional node fields, comma-separated (`signature,line`) |

--- a/docs/graph-feed.md
+++ b/docs/graph-feed.md
@@ -12,6 +12,11 @@ reuse. The other option was `GET /graph/bootstrap`, which is the whole binary
 snapshot: on a 23,098-entity repository that is 119.6 MiB, against the 1.0 MiB a
 renderer actually draws.
 
+`kin graph viz` now draws this export itself rather than shaping a payload of its
+own, so its page and any other consumer see the same graph and the same sample.
+It asked `/graph/bootstrap` until FIR-3498, and on a 20,298-entity store that
+request did not finish inside the 30-second budget the CLI gave it.
+
 ## The export
 
 `GET /graph/export` on the daemon, or `kin graph export --json`.

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -572,6 +572,24 @@ reading `tree=0` must fail, a one-parent change must read UNREADABLE rather than
 graded, and a refusal that names the file but neither entity, or both entities
 but only one side, must each fail on their own assertion.
 
+`graph_viz_local_render.py` grades whether `kin graph viz` draws the store it was
+pointed at. It served `{"nodes": [], "links": [], "unresolved_links": 0}` on a
+20,298-entity repository at exit 0 and said nothing, which is the one shape
+nobody investigates, because it is what a genuinely fresh repository looks like.
+Check 1 asks the page's own `/api/graph.json` for nodes over a store `kin init`
+just admitted; check 2 asks whether the payload says what population it sampled,
+because the export is capped and a payload carrying only its own counts lets the
+page imply it drew everything. Checks 3 and 4 take the resolved namespace away
+and require a non-zero exit and a refusal that names the directory it read, kept
+apart because a build that refuses without naming the path reds only the second
+and is the harder failure to act on.
+
+The self-test drives each grader against the payload that shipped, the pre-fix
+payload shape that draws without saying how much it drew, and a refusal naming
+the repository id but not the directory. The crate test beside it,
+`crates/kin-cli/tests/local_graph_namespace_resolution.rs`, is what grades the
+pull request, since nothing here runs on one.
+
 `mcp_surface_contract.py` is the one suite here that runs per pull request, and
 it exists because the other suites do not. Five assertions in this repository
 read the served `agent-default` MCP surface and all five are graded only on

--- a/scripts/acceptance/graph_viz_local_render.py
+++ b/scripts/acceptance/graph_viz_local_render.py
@@ -34,14 +34,31 @@ fault above lived in the seam between those pieces, and each piece was fine.
 What it grades
 
     CHECK 1 FIR-3498 PASS|FAIL|UNREADABLE the page's payload carries nodes
-    CHECK 2 FIR-3498 PASS|FAIL|UNREADABLE the payload reports the population it sampled
+    CHECK 2 FIR-3498 PASS|FAIL|UNREADABLE the payload carries a coherent population field
     CHECK 3 FIR-3498 PASS|FAIL|UNREADABLE a resolvable-nothing store refuses, non-zero
     CHECK 4 FIR-3498 PASS|FAIL|UNREADABLE that refusal names the directory it read
+    CHECK 5 FIR-3498 PASS|FAIL|UNREADABLE the offline admin read draws a populated store
+    CHECK 6 FIR-3498 PASS|FAIL|UNREADABLE that draw came from the local arm, not a daemon
 
 Checks 3 and 4 are separate because they fail differently. A build that refused
 without naming the path reds 4 alone, and that is the failure that matters most:
 a refusal nobody can act on sends the reader back to guessing, which is where
 this whole class started.
+
+Checks 5 and 6 are the reported symptom itself, and they are the reason this
+suite is not only Arm A. Arm A exercises the daemon export and Arm B a refusal,
+so the one path that actually served the founder an empty canvas, a populated
+store with no daemon reachable and the admin escape hatch set, would otherwise
+be graded here by nothing. Check 6 is check 5's identity control: a daemon that
+came up anyway would satisfy the node count while proving nothing, so check 5
+reports UNREADABLE rather than PASS unless the run announced the fallback.
+
+What check 2 can and cannot prove. On a fixture this size the export never
+crosses its 1,400-node cap, so `sampled` is always false and the grader reduces
+to "the field is present and is at least the drawn count". That is exactly the
+pre-fix shape it exists to catch, a payload with no population at all, and it is
+not a test of the sampling arithmetic, which the `graph_export` unit tests own.
+The title says field rather than sample for that reason.
 """
 
 import argparse
@@ -161,10 +178,23 @@ def refusal_is_nonzero(rc):
     return isinstance(rc, int) and rc != 0
 
 
+def drew_from_the_local_arm(text):
+    """The run took the offline/admin local read, not the daemon.
+
+    Arm C's whole subject is the local arm, so it has to prove which path drew
+    the page. Without this, a daemon that came up anyway would satisfy the
+    non-empty check and the arm would report a local read it never performed.
+    The sentence is the one `graph_viz.rs` logs before it falls back, and the
+    arm sets `RUST_LOG` so it reaches stderr.
+    """
+    return "drawing from the local store directly" in (text or "")
+
+
 GRADERS = {
     "payload_has_nodes": payload_has_nodes,
     "payload_reports_population": payload_reports_population,
     "refusal_is_nonzero": refusal_is_nonzero,
+    "drew_from_the_local_arm": drew_from_the_local_arm,
 }
 
 
@@ -192,6 +222,18 @@ GOOD_PAYLOAD = {
 # A sample larger than the population it claims to come from is not a smaller
 # graph, it is an incoherent one, and it must not read as a healthy payload.
 INCOHERENT_PAYLOAD = dict(GOOD_PAYLOAD, entity_count=0)
+
+# What the CLI logs on each arm, as `graph_viz.rs` writes it.
+LOCAL_ARM_LOG = (
+    "Serving kin graph at http://127.0.0.1:4220/\n"
+    "WARN kin_cli::commands::graph_viz: daemon unavailable; drawing from the "
+    "local store directly (KIN_ALLOW_DAEMON_BOOTSTRAP_ADMIN) "
+    "command=\"kin graph viz\"\n"
+)
+DAEMON_ARM_LOG = (
+    "1,400 of 20,298 entities and 3,102 of 86,814 relations (sampled) at root abc seq 12\n"
+    "Serving kin graph at http://127.0.0.1:4220/\n"
+)
 
 NAMESPACE = "/tmp/store/.kin/kindb/c2fd2519-1d5a-4292-8511-7e9196accade"
 REFUSAL_WITH_PATH = (
@@ -230,6 +272,12 @@ def self_test():
         # server still listening over a namespace that is not there is the
         # regression, not evidence against it.
         ("refusal_is_nonzero", False, None),
+        ("drew_from_the_local_arm", True, LOCAL_ARM_LOG),
+        # A daemon that came up anyway. The page would still be non-empty, so
+        # without this row Arm C would report a local read it never took.
+        ("drew_from_the_local_arm", False, DAEMON_ARM_LOG),
+        ("drew_from_the_local_arm", False, ""),
+        ("drew_from_the_local_arm", False, None),
     ]
     failures = []
     for name, want, value in cases:
@@ -386,6 +434,12 @@ def namespace_of(work):
 def fetch_payload(kin, env, work, port, timeout=180):
     """Start `kin graph viz`, read `/api/graph.json`, stop it.
 
+    Returns `(payload, text, rc)`. `text` is everything the server printed, and
+    it is collected on every path rather than only on an early exit, because an
+    arm has to be able to prove WHICH path drew the page. A run that only
+    checked the payload could not tell a local admin draw from a daemon one, and
+    an arm whose identity rests on silence is not an arm.
+
     The process is killed in a `finally`: a server left listening would hold the
     port and make the next arm's failure look like a bind error.
     """
@@ -397,23 +451,34 @@ def fetch_payload(kin, env, work, port, timeout=180):
         stderr=subprocess.STDOUT,
         text=True,
     )
+    payload = None
+    rc = None
     deadline = time.time() + timeout
     try:
         while time.time() < deadline:
             if process.poll() is not None:
-                return None, process.communicate()[0], process.returncode
+                rc = process.returncode
+                break
             try:
                 with urllib.request.urlopen(
                     "http://127.0.0.1:%d/api/graph.json" % port, timeout=5
                 ) as response:
-                    return json.loads(response.read().decode("utf-8")), "", 0
+                    payload = json.loads(response.read().decode("utf-8"))
+                    rc = 0
+                    break
             except (urllib.error.URLError, OSError, ValueError):
                 time.sleep(0.25)
-        return None, "the page never answered within %ds" % timeout, None
     finally:
         if process.poll() is None:
             process.kill()
             process.wait(timeout=30)
+        try:
+            text = process.communicate(timeout=30)[0] or ""
+        except subprocess.TimeoutExpired:
+            text = ""
+    if payload is None and rc is None:
+        text = "the page never answered within %ds. %s" % (timeout, text)
+    return payload, text, rc
 
 
 def run_refusal(kin, env, work, port, timeout=180):
@@ -467,10 +532,12 @@ def main():
     daemon = Path(args.daemon).resolve() if args.daemon else None
 
     drawn = Result(1, "the page's payload carries nodes")
-    population = Result(2, "the payload reports the population it sampled")
+    population = Result(2, "the payload carries a coherent population field")
     refuses = Result(3, "an unresolvable store refuses, non-zero")
     names_path = Result(4, "that refusal names the directory it read")
-    results = [drawn, population, refuses, names_path]
+    local_draw = Result(5, "the offline admin read draws a populated store")
+    local_arm = Result(6, "that draw came from the local arm, not a daemon")
+    results = [drawn, population, refuses, names_path, local_draw, local_arm]
 
     with tempfile.TemporaryDirectory() as raw:
         tmp = Path(raw)
@@ -564,6 +631,76 @@ def main():
                     names_path.bad(
                         "the refusal does not name %s, so a reader cannot act on "
                         "it: %s" % (namespace, text[-400:])
+                    )
+
+        # Arm C: the exact shape the founder hit. A populated store, no daemon
+        # to answer, the admin escape hatch set, and the page must still draw.
+        #
+        # Arm A grades the daemon export and Arm B grades a refusal, so without
+        # this the one path that actually served the empty canvas is graded by
+        # nothing here. The daemon is made unreachable by pointing
+        # `KIN_DAEMON_URL` at a port nothing listens on rather than by killing a
+        # process: `connect_for_command` honours that variable first and would
+        # otherwise auto-start a daemon and quietly turn this back into Arm A.
+        home_c = tmp / "home-c"
+        home_c.mkdir()
+        work_c = tmp / "work-c"
+        env_c = suite_env(home_c, daemon)
+        init_c = build_store(kin, env_c, work_c)
+        if init_c.returncode != 0:
+            note = "kin init failed on the local-draw fixture: %s" % (
+                (init_c.stdout + init_c.stderr)[-400:]
+            )
+            local_draw.unknown(note)
+            local_arm.unknown(note)
+        else:
+            subprocess.run(
+                [str(kin), "daemon", "stop"],
+                cwd=str(work_c),
+                env=env_c,
+                capture_output=True,
+                text=True,
+            )
+            offline_env = dict(
+                env_c,
+                KIN_ALLOW_DAEMON_BOOTSTRAP_ADMIN="1",
+                KIN_DAEMON_URL="http://127.0.0.1:%d" % free_port(),
+                # The fallback is announced at warn level and the arm's identity
+                # rests on reading it, so ask for it explicitly rather than
+                # hoping the default filter carries it.
+                RUST_LOG="kin_cli=warn",
+            )
+            payload, text, rc = fetch_payload(kin, offline_env, work_c, free_port())
+            if payload is None:
+                note = "no payload from the offline admin draw (exit %r): %s" % (
+                    rc,
+                    (text or "")[-400:],
+                )
+                local_draw.unknown(note)
+                local_arm.unknown(note)
+            elif not drew_from_the_local_arm(text):
+                # Identity first. A page drawn by a daemon that came up anyway
+                # would satisfy the node count while proving nothing about the
+                # path under test, so that reads UNREADABLE rather than PASS.
+                note = (
+                    "this run never reported the local fallback, so it is not the "
+                    "local arm and its node count says nothing about it: %s"
+                    % (text or "")[-400:]
+                )
+                local_draw.unknown(note)
+                local_arm.unknown(note)
+            else:
+                local_arm.ok("the run reported the offline admin fallback")
+                node_count = len(payload.get("nodes") or [])
+                if payload_has_nodes(payload):
+                    local_draw.ok(
+                        "the offline admin read drew %d node(s)" % node_count
+                    )
+                else:
+                    local_draw.bad(
+                        "the offline admin read drew %d nodes over a store kin "
+                        "init just admitted; this is the reported defect exactly"
+                        % node_count
                     )
 
     for result in results:

--- a/scripts/acceptance/graph_viz_local_render.py
+++ b/scripts/acceptance/graph_viz_local_render.py
@@ -1,0 +1,587 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+"""Grade whether `kin graph viz` draws the store it was pointed at, or lies quietly.
+
+What this class is
+------------------
+`kin graph viz` served `{"nodes": [], "links": [], "unresolved_links": 0}` at
+`/api/graph.json` on a repository holding 20,298 entities and 86,814 relations,
+at exit 0, with nothing on stdout or stderr saying anything had gone wrong. Two
+independent faults produced it, and each on its own is enough to hand a viewer a
+blank canvas that looks like a small repository:
+
+  1. The local read addressed `.kin/kindb/graph.kndb`, a file repository-v6
+     retired and nothing writes. KinDB answers a path holding no artifacts with a
+     valid EMPTY graph and no error, because for an uninitialized namespace that
+     is the correct answer, so the wrong path produced a successful nothing.
+  2. The daemon read asked `/graph/bootstrap`, an uncapped whole-snapshot export
+     measured at 119.6 MiB against the 1.0 MiB a renderer draws on a
+     23,098-entity repository, under a 30-second client timeout. It failed
+     first, which is what sent the command to fault 1.
+
+An empty answer with a zero exit is the worst possible shape for both. It is
+indistinguishable from a genuinely fresh repository, so nobody investigates.
+
+Why this suite runs the binary
+------------------------------
+A crate test grades the resolver, and that is where the rule belongs. What a
+crate test cannot see is the whole path: a real store admitted by the real
+import, the real binary started against it, a real HTTP request to the page's
+own endpoint, and the real exit status a person or a script would read. Every
+fault above lived in the seam between those pieces, and each piece was fine.
+
+What it grades
+
+    CHECK 1 FIR-3498 PASS|FAIL|UNREADABLE the page's payload carries nodes
+    CHECK 2 FIR-3498 PASS|FAIL|UNREADABLE the payload reports the population it sampled
+    CHECK 3 FIR-3498 PASS|FAIL|UNREADABLE a resolvable-nothing store refuses, non-zero
+    CHECK 4 FIR-3498 PASS|FAIL|UNREADABLE that refusal names the directory it read
+
+Checks 3 and 4 are separate because they fail differently. A build that refused
+without naming the path reds 4 alone, and that is the failure that matters most:
+a refusal nobody can act on sends the reader back to guessing, which is where
+this whole class started.
+"""
+
+import argparse
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+TICKET = "FIR-3498"
+
+PASS = "PASS"
+FAIL = "FAIL"
+UNREADABLE = "UNREADABLE"
+
+CORPUS = {
+    "src/lib.rs": (
+        "pub fn greeting(name: &str) -> String {\n"
+        '    format!("hello {name}")\n'
+        "}\n\n"
+        "pub fn greet_world() -> String {\n"
+        '    greeting("world")\n'
+        "}\n"
+    ),
+    "src/main.rs": (
+        "fn main() {\n"
+        "    println!(\"{}\", kin_viz_fixture::greet_world());\n"
+        "}\n"
+    ),
+}
+
+
+class Result:
+    def __init__(self, ident, title):
+        self.id = ident
+        self.title = title
+        self.status = UNREADABLE
+        self.detail = "not evaluated"
+        self.asserts = []
+
+    def ok(self, detail):
+        self.status = PASS
+        self.detail = detail
+        self.asserts.append(detail)
+
+    def bad(self, detail):
+        self.status = FAIL
+        self.detail = detail
+        self.asserts.append(detail)
+
+    def unknown(self, detail):
+        self.status = UNREADABLE
+        self.detail = detail
+        self.asserts.append(detail)
+
+
+# ── Graders ───────────────────────────────────────────────────────────────────
+#
+# Pure functions over a payload or a refusal, so `--self-test` can drive each
+# against the shape that must flip it. A grader that cannot separate its two
+# cases reports a healthy product over a broken one, which is the same defect
+# this suite was written for, one level up.
+
+
+def payload_has_nodes(payload):
+    """The page has something to draw.
+
+    Not `payload != {}` and not `"nodes" in payload`: the defect served a
+    perfectly well-formed object whose `nodes` was an empty list.
+    """
+    if not isinstance(payload, dict):
+        return False
+    nodes = payload.get("nodes")
+    return isinstance(nodes, list) and len(nodes) > 0
+
+
+def payload_reports_population(payload):
+    """The payload says what population its nodes were drawn from.
+
+    The export is capped and sampled server side, so a payload carrying only its
+    own counts lets the page imply it drew the whole repository. `entity_count`
+    is what makes "showing N of M" possible, and it must be at least the number
+    of nodes drawn or it is describing some other graph.
+    """
+    if not isinstance(payload, dict):
+        return False
+    entity_count = payload.get("entity_count")
+    nodes = payload.get("nodes")
+    if not isinstance(entity_count, int) or not isinstance(nodes, list):
+        return False
+    return entity_count >= len(nodes)
+
+
+def refusal_names_namespace(text, namespace):
+    """The refusal names the directory that was read.
+
+    A refusal naming only the repository id tells the reader an identity they
+    already knew and not the place it resolved to, which is exactly the gap that
+    made the original fault take a source read to diagnose.
+    """
+    return bool(namespace) and namespace in (text or "")
+
+
+def refusal_is_nonzero(rc):
+    """A refusal exits non-zero.
+
+    Stated as its own grader because the original defect's whole signature was a
+    zero exit over a wrong answer: every wrapper, script and eye treats that as
+    success.
+    """
+    return isinstance(rc, int) and rc != 0
+
+
+GRADERS = {
+    "payload_has_nodes": payload_has_nodes,
+    "payload_reports_population": payload_reports_population,
+    "refusal_is_nonzero": refusal_is_nonzero,
+}
+
+
+# The exact payload the defect served, byte for byte as it was reported.
+DEFECT_PAYLOAD = {"nodes": [], "links": [], "unresolved_links": 0}
+# A drawn payload in the shape `kin graph viz` served BEFORE this change: nodes
+# and links, no population. It must red the population grader alone.
+OLD_SHAPE_PAYLOAD = {
+    "nodes": [{"id": "a", "name": "alpha", "kind": "Function", "degree": 1}],
+    "links": [],
+    "unresolved_links": 0,
+}
+GOOD_PAYLOAD = {
+    "root_hash": "abc",
+    "seq": 0,
+    "entity_count": 20298,
+    "relation_count": 86814,
+    "unresolved_links": 4,
+    "filtered_links": 12,
+    "sampled": True,
+    "limit": 1400,
+    "nodes": [{"id": "a", "name": "alpha", "kind": "Function", "degree": 1}],
+    "links": [],
+}
+# A sample larger than the population it claims to come from is not a smaller
+# graph, it is an incoherent one, and it must not read as a healthy payload.
+INCOHERENT_PAYLOAD = dict(GOOD_PAYLOAD, entity_count=0)
+
+NAMESPACE = "/tmp/store/.kin/kindb/c2fd2519-1d5a-4292-8511-7e9196accade"
+REFUSAL_WITH_PATH = (
+    "Error: cannot open repository authority for repository "
+    "c2fd2519-1d5a-4292-8511-7e9196accade at "
+    "/tmp/store/.kin/kindb/c2fd2519-1d5a-4292-8511-7e9196accade: "
+    "local storage authority namespace has no persisted authority record\n"
+)
+REFUSAL_WITHOUT_PATH = (
+    "Error: cannot open repository authority for repository "
+    "c2fd2519-1d5a-4292-8511-7e9196accade: no persisted authority record\n"
+)
+
+
+def self_test():
+    """Falsify every grader against the input that must flip it."""
+    cases = [
+        ("payload_has_nodes", True, GOOD_PAYLOAD),
+        # The defect itself. If this row ever passes, the grader has stopped
+        # being able to see the bug it exists for.
+        ("payload_has_nodes", False, DEFECT_PAYLOAD),
+        ("payload_has_nodes", True, OLD_SHAPE_PAYLOAD),
+        ("payload_has_nodes", False, {}),
+        ("payload_has_nodes", False, "not a payload"),
+        ("payload_reports_population", True, GOOD_PAYLOAD),
+        # The mutation that draws a picture and says nothing about how much of
+        # the graph it is. It must red the population grader ALONE, which is why
+        # the row above asserts the node grader still passes on this same shape.
+        ("payload_reports_population", False, OLD_SHAPE_PAYLOAD),
+        ("payload_reports_population", False, INCOHERENT_PAYLOAD),
+        ("payload_reports_population", False, DEFECT_PAYLOAD),
+        ("refusal_is_nonzero", True, 1),
+        ("refusal_is_nonzero", False, 0),
+        # A build that never exits has no status, and `run_refusal` reports that
+        # as None rather than inventing one. It must not read as a refusal: a
+        # server still listening over a namespace that is not there is the
+        # regression, not evidence against it.
+        ("refusal_is_nonzero", False, None),
+    ]
+    failures = []
+    for name, want, value in cases:
+        got = GRADERS[name](value)
+        if got != want:
+            failures.append("%s(...) = %s, wanted %s" % (name, got, want))
+
+    # The path grader takes two arguments, so it is driven separately rather
+    # than bent into the table above.
+    path_cases = [
+        (True, REFUSAL_WITH_PATH, NAMESPACE),
+        # A refusal that names only the identity. This is the shape that shipped
+        # before the fix and it must not read as an actionable refusal.
+        (False, REFUSAL_WITHOUT_PATH, NAMESPACE),
+        (False, "", NAMESPACE),
+        (False, REFUSAL_WITH_PATH, ""),
+    ]
+    for want, text, namespace in path_cases:
+        got = refusal_names_namespace(text, namespace)
+        if got != want:
+            failures.append(
+                "refusal_names_namespace(%r, %r) = %s, wanted %s"
+                % (text[:40], namespace, got, want)
+            )
+
+    # The report this suite writes must load through the gate's own loader, or
+    # every CHECK line above it is printed over a report the verdict cannot read.
+    sample = Result(1, "a sample check")
+    sample.ok("the shape this suite writes")
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    import gate  # noqa: E402 - located relative to this file on purpose
+
+    with tempfile.TemporaryDirectory() as scratch:
+        written = os.path.join(scratch, "report.json")
+        with open(written, "w") as handle:
+            json.dump(report_payload([sample], None), handle)
+        try:
+            loaded = gate.load_report(written)
+        except Exception as error:  # noqa: BLE001 - the point is that it must not raise
+            failures.append("gate loader refused this suite's own report: %s" % error)
+            loaded = None
+        if not loaded:
+            failures.append("the gate loader read no results from this suite's report")
+
+        # The control. A report keyed the old way must still be refused, or the
+        # row above would pass for a loader that accepts anything.
+        wrong = os.path.join(scratch, "wrong.json")
+        with open(wrong, "w") as handle:
+            json.dump({"ticket": TICKET, "checks": [{"id": 1, "status": PASS}]}, handle)
+        try:
+            gate.load_report(wrong)
+            failures.append("the gate loader accepted a report keyed `checks`")
+        except Exception:  # noqa: BLE001 - refusing is the expected outcome
+            pass
+
+    if failures:
+        for line in failures:
+            print("SELF-TEST FAIL %s" % line)
+        return 1
+    print("SELF-TEST PASS %d grader cases" % (len(cases) + len(path_cases)))
+    return 0
+
+
+# ── Harness ───────────────────────────────────────────────────────────────────
+
+
+def report_payload(results, label):
+    """The report shape `scripts/acceptance/gate.py` reads.
+
+    The key is `results`, not `checks`: the gate calls `payload.get("results")`
+    and refuses anything else. Five suites have shipped the wrong key; the
+    self-test above loads what this returns back through the gate's own loader
+    so this is not the sixth.
+    """
+    return {
+        "label": label,
+        "ticket": TICKET,
+        "results": [
+            {
+                "id": r.id,
+                "title": r.title,
+                "status": r.status,
+                "detail": r.detail,
+                "asserts": r.asserts,
+            }
+            for r in results
+        ],
+    }
+
+
+def free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        return probe.getsockname()[1]
+
+
+def suite_env(home, daemon):
+    env = {
+        "HOME": str(home),
+        "KIN_HOME": str(home),
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "KIN_EMBED_BACKEND": "cpu",
+        "KIN_DAEMON_DISABLE_LSP": "1",
+        "TERM": "dumb",
+    }
+    if daemon:
+        env["KIN_DAEMON_BIN"] = str(daemon)
+    return env
+
+
+def build_store(kin, env, work):
+    """Admit a two-file Rust corpus through the real `kin init`.
+
+    Two functions and a call between them, because the property under test is
+    "non-empty" and a corpus that admits nothing would make the defect and the
+    fix indistinguishable.
+    """
+    work.mkdir(parents=True, exist_ok=True)
+    for rel, body in CORPUS.items():
+        path = work / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body)
+    (work / "Cargo.toml").write_text(
+        '[package]\nname = "kin-viz-fixture"\nversion = "0.0.0"\nedition = "2021"\n'
+    )
+    hooks = work.parent / "nohooks"
+    hooks.mkdir(exist_ok=True)
+    for args in (
+        ["init", "-q", "--initial-branch=main"],
+        ["config", "user.email", "acceptance@example.invalid"],
+        ["config", "user.name", "acceptance"],
+        ["config", "core.hooksPath", str(hooks)],
+        ["config", "commit.gpgsign", "false"],
+        ["add", "-A"],
+        ["commit", "-q", "-m", "corpus"],
+    ):
+        subprocess.run(["git", "-C", str(work)] + args, check=True, env=env)
+    return subprocess.run(
+        [str(kin), "init", "."],
+        cwd=str(work),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=900,
+    )
+
+
+def namespace_of(work):
+    """`.kin/kindb/<repository-id>/`, read the way the product resolves it."""
+    manifest = json.loads((work / ".kin" / "manifest.json").read_text())
+    return work / ".kin" / "kindb" / manifest["repo_id"]
+
+
+def fetch_payload(kin, env, work, port, timeout=180):
+    """Start `kin graph viz`, read `/api/graph.json`, stop it.
+
+    The process is killed in a `finally`: a server left listening would hold the
+    port and make the next arm's failure look like a bind error.
+    """
+    process = subprocess.Popen(
+        [str(kin), "graph", "viz", "--port", str(port)],
+        cwd=str(work),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    deadline = time.time() + timeout
+    try:
+        while time.time() < deadline:
+            if process.poll() is not None:
+                return None, process.communicate()[0], process.returncode
+            try:
+                with urllib.request.urlopen(
+                    "http://127.0.0.1:%d/api/graph.json" % port, timeout=5
+                ) as response:
+                    return json.loads(response.read().decode("utf-8")), "", 0
+            except (urllib.error.URLError, OSError, ValueError):
+                time.sleep(0.25)
+        return None, "the page never answered within %ds" % timeout, None
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=30)
+
+
+def run_refusal(kin, env, work, port, timeout=180):
+    """Run `kin graph viz` where the namespace cannot be resolved.
+
+    The timeout is caught rather than allowed to propagate, and that is the
+    whole reason this is a function. A build carrying the regression this check
+    exists for does not exit at all: it binds its listener and serves an empty
+    canvas forever. An uncaught `TimeoutExpired` would end the suite in a
+    traceback with no CHECK line, which reads as a broken harness rather than as
+    the defect it actually is. `None` here is not an exit status, so
+    `refusal_is_nonzero` rejects it and the check goes red saying why.
+    """
+    try:
+        got = subprocess.run(
+            [str(kin), "graph", "viz", "--port", str(port)],
+            cwd=str(work),
+            env=dict(env, KIN_ALLOW_DAEMON_BOOTSTRAP_ADMIN="1"),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as expired:
+        served = "".join(
+            part.decode("utf-8", "replace") if isinstance(part, bytes) else (part or "")
+            for part in (expired.stdout, expired.stderr)
+        )
+        return None, (
+            "kin graph viz was still serving after %ds over a namespace that is "
+            "not there, so it never refused: %s" % (timeout, served[-400:])
+        )
+    return got.returncode, got.stdout + got.stderr
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--kin", default=os.environ.get("KIN_BIN"))
+    parser.add_argument("--daemon", default=os.environ.get("KIN_DAEMON_BIN"))
+    parser.add_argument("--json", dest="json_path", default=None)
+    parser.add_argument("--label", default=None)
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--self-test", action="store_true", dest="self_test")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.kin or not Path(args.kin).exists():
+        print("graph-viz-local-render: no kin binary. Pass --kin or set KIN_BIN.")
+        return 3
+    kin = Path(args.kin).resolve()
+    daemon = Path(args.daemon).resolve() if args.daemon else None
+
+    drawn = Result(1, "the page's payload carries nodes")
+    population = Result(2, "the payload reports the population it sampled")
+    refuses = Result(3, "an unresolvable store refuses, non-zero")
+    names_path = Result(4, "that refusal names the directory it read")
+    results = [drawn, population, refuses, names_path]
+
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+
+        # Arm A: a real store, served, read over HTTP.
+        home_a = tmp / "home-a"
+        home_a.mkdir()
+        work_a = tmp / "work-a"
+        env_a = suite_env(home_a, daemon)
+        init_a = build_store(kin, env_a, work_a)
+        if init_a.returncode != 0:
+            note = "kin init failed on the fixture: %s" % (
+                (init_a.stdout + init_a.stderr)[-400:]
+            )
+            drawn.unknown(note)
+            population.unknown(note)
+        else:
+            payload, note, rc = fetch_payload(kin, env_a, work_a, free_port())
+            if payload is None:
+                note = "no payload from /api/graph.json (exit %r): %s" % (
+                    rc,
+                    (note or "")[-400:],
+                )
+                drawn.unknown(note)
+                population.unknown(note)
+            else:
+                node_count = len(payload.get("nodes") or [])
+                if payload_has_nodes(payload):
+                    drawn.ok("the page carries %d node(s)" % node_count)
+                else:
+                    drawn.bad(
+                        "the page served %d nodes over a store kin init just "
+                        "admitted; this is the empty-canvas defect" % node_count
+                    )
+                if payload_reports_population(payload):
+                    population.ok(
+                        "%d node(s) drawn out of %s entities"
+                        % (node_count, payload.get("entity_count"))
+                    )
+                else:
+                    population.bad(
+                        "the payload cannot say how much of the graph it drew: "
+                        "entity_count=%r, nodes=%d"
+                        % (payload.get("entity_count"), node_count)
+                    )
+
+        # Arm B: the same shape of store, with the namespace the resolver names
+        # taken away. Nothing about the working tree or the manifest changes, so
+        # this is the exact situation the reported failure was in: a manifest
+        # naming an identity whose graph the reader cannot reach.
+        home_b = tmp / "home-b"
+        home_b.mkdir()
+        work_b = tmp / "work-b"
+        env_b = suite_env(home_b, daemon)
+        init_b = build_store(kin, env_b, work_b)
+        if init_b.returncode != 0:
+            note = "kin init failed on the refusal fixture: %s" % (
+                (init_b.stdout + init_b.stderr)[-400:]
+            )
+            refuses.unknown(note)
+            names_path.unknown(note)
+        else:
+            subprocess.run(
+                [str(kin), "daemon", "stop"],
+                cwd=str(work_b),
+                env=env_b,
+                capture_output=True,
+                text=True,
+            )
+            namespace = namespace_of(work_b)
+            if not namespace.is_dir():
+                note = (
+                    "the resolved namespace %s does not exist after a successful "
+                    "init, so this arm cannot be identified" % namespace
+                )
+                refuses.unknown(note)
+                names_path.unknown(note)
+            else:
+                shutil.rmtree(namespace)
+                rc, text = run_refusal(kin, env_b, work_b, free_port())
+                if refusal_is_nonzero(rc):
+                    refuses.ok("exit %d over an unresolvable namespace" % rc)
+                else:
+                    refuses.bad(
+                        "exit %r over a namespace that is not there; a zero exit "
+                        "over a wrong answer is the whole defect" % rc
+                    )
+                if refusal_names_namespace(text, str(namespace)):
+                    names_path.ok("the refusal names %s" % namespace)
+                else:
+                    names_path.bad(
+                        "the refusal does not name %s, so a reader cannot act on "
+                        "it: %s" % (namespace, text[-400:])
+                    )
+
+    for result in results:
+        print(
+            "CHECK %d %s %s %s" % (result.id, TICKET, result.status, result.detail),
+            flush=True,
+        )
+
+    if args.json_path:
+        with open(args.json_path, "w") as handle:
+            json.dump(report_payload(results, args.label), handle, indent=2)
+
+    if any(r.status == FAIL for r in results):
+        return 1
+    if any(r.status == UNREADABLE for r in results):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/acceptance/test_workflow_step_visibility.py
+++ b/scripts/acceptance/test_workflow_step_visibility.py
@@ -177,6 +177,11 @@ EXPECTED_SUITES = (
         "detached_head",
         "acceptance/detached_head.json",
     ),
+    ExpectedSuite(
+        "scripts/acceptance/graph_viz_local_render.py",
+        "graph_viz_render",
+        "acceptance/graph_viz_render.json",
+    ),
 )
 
 

--- a/scripts/check_runtime_boundaries.sh
+++ b/scripts/check_runtime_boundaries.sh
@@ -288,6 +288,38 @@ if ((${#unexpected_cli_admin_bootstrap_reads[@]} > 0)); then
   exit 1
 fi
 
+# Direct local storage reads from a command module.
+#
+# The scan above governs `open_snapshot_explicit_admin_read_only`, which carries
+# its own daemon-first authority order and env gate. `open_snapshot_local` is the
+# raw local open underneath it, and a command calling it directly gets neither
+# unless it arranges them itself. `graph_viz.rs` does arrange them, at
+# `resolve_payload`: daemon first, then `daemon_bootstrap_admin_allowed()`, then a
+# refusal. It is the one command allowed to, and it is named here so the next one
+# has to be a decision rather than an omission.
+#
+# This scan exists because the allowlist above lost its `graph_viz.rs` entry when
+# that file stopped calling the wrapper, which left its new direct call ungoverned
+# by anything in this script.
+unexpected_cli_direct_local_opens=()
+while IFS=: read -r file line _; do
+  [[ -z "$file" ]] && continue
+  file="${file#"$repo_root/"}"
+  case "$file" in
+    crates/kin-cli/src/commands/graph_viz.rs)
+      ;;
+    *)
+      unexpected_cli_direct_local_opens+=("$file:$line")
+      ;;
+  esac
+done < <(rg -n 'open_snapshot_local\(' "$repo_root/crates/kin-cli/src/commands" -g '*.rs')
+
+if ((${#unexpected_cli_direct_local_opens[@]} > 0)); then
+  echo "Unexpected direct local graph open in a CLI command; route it through the daemon, or add the file here with the authority order it implements:" >&2
+  printf '  %s\n' "${unexpected_cli_direct_local_opens[@]}" >&2
+  exit 1
+fi
+
 unexpected_session_registry_hits=()
 while IFS=: read -r file line _; do
   [[ -z "$file" ]] && continue

--- a/scripts/check_runtime_boundaries.sh
+++ b/scripts/check_runtime_boundaries.sh
@@ -274,7 +274,6 @@ while IFS=: read -r file line _; do
     crates/kin-cli/src/commands/release.rs|\
     crates/kin-cli/src/commands/merge.rs|\
     crates/kin-cli/src/commands/resolve.rs|\
-    crates/kin-cli/src/commands/graph_viz.rs|\
     crates/kin-cli/src/commands/locate_debug.rs)
       ;;
     *)


### PR DESCRIPTION
FIR-3498.

`kin graph viz` served `{"nodes": [], "links": [], "unresolved_links": 0}` at
`/api/graph.json` on a repository holding 20,298 entities and 86,814 relations,
at exit 0, with nothing printed. An empty answer with a zero exit is the one
shape nobody investigates, because it is what a genuinely fresh repository looks
like. Two independent faults produced it.

## Fault 1: the local read looked at a retired path

`open_snapshot_local` opened `.kin/kindb/graph.kndb`. Nothing has written that
file since repository-v6, and this repository says so in its own words at
`crates/kin-cli/src/commands/prepared_state.rs:210` ("The retired single-file
`.kin/kindb/graph.kndb` is never written") and `crates/kin-daemon/src/state.rs:5253`
("the old standalone graph.kndb snapshot is not a fallback"). Graph truth lives
in `.kin/kindb/<repository-id>/`, which kin-db's `LocalFileBackend` joins
internally for every artifact it addresses and which
`LocalRepositoryAuthorityBinding::from_layout` already resolved for every other
offline reader in this CLI: `backup`, `commit`, `diff`, `eject`, `git`, `graph`,
`prepared_state`.

kin-db answers a namespace holding no artifacts with a valid EMPTY graph and no
error, and that is deliberate and documented on its own `open()`: "or create a
new empty graph when the namespace contains no persisted artifacts." For an
uninitialized namespace that is the right answer. The defect was asking that
question at a path the product retired, so a wrong path produced a successful
nothing.

**The rule now lives in one place.** `kin_core::kindb_namespace_in` and
`KinLayout::kindb_namespace_path` are the only spelling of
`<base>/<repository-id>` in production, and the daemon's one hand-join goes
through them. `open_snapshot_local` opens through the same binding the daemon
binds, and every refusal names the directory it read and the repository id that
named it. `kin graph viz` returns that error instead of binding its listener, so
the command exits 1 with a message rather than serving a blank page.
`kin locate-debug` and `kin remote` share that open and are fixed by the same
change.

`kindb_snapshot_path` stays, because the derived sidecars `graph.kvec` and
`graph.kidx` are still named by suffixing it. Its doc comment now says that is
all it is.

## Fault 2: the daemon read asked for 119.6 MiB to draw 1,400 nodes

The daemon arm asked `GET /graph/bootstrap`, an uncapped whole-binary snapshot
export, under a 30-second client budget. This repository's own measurement of
the two routes, in the doc comment beside the export handler, is 119.6 MiB
against 1.0 MiB on a 23,098-entity repository. It failed first, which is what
sent the command into fault 1.

`kin graph viz` now asks `GET /graph/export` through `DaemonClient`, the route
`kin graph export` already uses. Why that rather than a bigger timeout or a
streaming body:

1. The export is capped at 1,400 nodes by default and sampled server side. No
   timeout makes moving 119.6 MiB to draw 1,400 nodes the right shape.
2. The payload carries `entity_count`, `relation_count` and `sampled`, so the
   page can say what it is showing, and it does. The panel reads "1,400 of
   20,298" and the resting line reads "showing 1,400 of 20,298 entities and N of
   M relations (sampled; run with --limit 0 to draw them all)". A complete canvas
   says "showing all N entities" rather than going quiet, so a silent page and a
   complete one do not look alike.
3. The export runs off the request thread and outside the concurrency-1
   semaphore `/graph/bootstrap` holds.
4. `DaemonClient`'s request budget is 300 s against the bootstrap path's 30 s,
   and it is tunable through `KIN_DAEMON_HTTP_TIMEOUT_SECS`.

`graph_export.rs`'s module doc already named `kin graph viz` as the consumer it
was built to replace, so this closes a loop the codebase had opened. Its
duplicate payload assembly in `graph_viz.rs` is gone; the two of its five tests
that `graph_export` did not already cover moved there rather than being deleted.
`--limit N` is new on `kin graph viz`, `--limit 0` draws everything, and
`graph_export::resolve_limit` is now the single place the three limit requests
are told apart.

## Two things that would have rotted, removed

**A retry loop that could not fire.** The local open carried over the flat
path's bounded retry on `KinDbError::LockError`. The repository-authority path
never produces that: kin-db takes the namespace lock with a blocking
`lock_exclusive()`, so a reader racing another process waits rather than
erroring, and the one failure that call can return arrives as a `StorageError`
(kin-db 0.7.110 `storage/backend.rs:6038-6043`). The loop is gone and the reason
is in the code, because a loop that cannot fire reads as protection.

**`open_kindb_snapshot_read_only`**, which had no callers anywhere in the tree
and still answered a missing store with a silent empty graph. That is the exact
shape this change exists to remove.

## Falsification

Two checks, per the rule that a stranger finding class gets a scripted check
before its fix lands. The crate test is the one that grades this pull request:
`Product Acceptance` carries `if: ${{ github.event_name != 'pull_request' }}`
(`acceptance.yml:106`) and the whole-workspace `check` job excludes pull
requests too (`ci.yml:1825-1828`), so the acceptance suite below runs on main's
push.

### The crate test, `crates/kin-cli/tests/local_graph_namespace_resolution.rs`

Every case admits a real two-function Rust fixture through the real Git import,
so the namespace under test is the one the product writes.

```
$ cargo test -p kin-cli --test local_graph_namespace_resolution
test the_layout_resolver_names_the_directory_the_import_created ... ok
test an_absent_namespace_fails_loud_and_names_the_path_it_read ... ok
test a_namespace_without_its_authority_record_fails_loud_and_names_the_path ... ok
test the_local_open_reads_the_repository_id_namespace_not_the_retired_flat_path ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.52s
```

Four mutants, each required to red its own case.

**A, the original defect** (`open_snapshot_local` back on the retired flat path):

```
test the_local_open_reads_the_repository_id_namespace_not_the_retired_flat_path ... FAILED
test an_absent_namespace_fails_loud_and_names_the_path_it_read ... FAILED
test a_namespace_without_its_authority_record_fails_loud_and_names_the_path ... FAILED
test the_layout_resolver_names_the_directory_the_import_created ... ok
panicked at local_graph_namespace_resolution.rs:162:5:
the local open resolved a namespace but reported no entities; the fixture admitted two functions
panicked at local_graph_namespace_resolution.rs:120:13:
an absent namespace must refuse rather than answer; it opened viz-namespace-adb7bc5f... at
/private/var/.../.kin/kindb/viz-namespace-adb7bc5f... and reported Ok(0) entities
test result: FAILED. 10 passed; 3 failed
```

**B**, the `open_manager` refusal stops naming the directory, and **C**, the
`from_layout` refusal stops naming it. The two refusal cases are graded by two
different messages, which is why they are two cases, and each mutant reds only
its own:

```
# B
test a_namespace_without_its_authority_record_fails_loud_and_names_the_path ... FAILED
test result: FAILED. 12 passed; 1 failed
# C
test an_absent_namespace_fails_loud_and_names_the_path_it_read ... FAILED
test result: FAILED. 12 passed; 1 failed
```

**D**, the resolver drifts from the directory the product writes
(`kindb_namespace_in` appends a suffix). All four red, including the resolver
case at its own assertion:

```
test the_layout_resolver_names_the_directory_the_import_created ... FAILED
panicked at local_graph_namespace_resolution.rs:259:5
panicked at local_graph_namespace_resolution.rs:144:5:
the real import must write authority into /private/var/.../viz-namespace-74b9716f...-v2
test result: FAILED. 9 passed; 4 failed
```

Mutant D is why that case changed shape. It used to compare
`kindb_namespace_path(id)` against `kindb_dir().join(id)`, which is that
function's own body, so both sides moved together under D and it could not fail.
It now scans `.kin/kindb/` for the one directory carrying an `authority.json`
and requires the resolver to name exactly it. Control, restored: 13 passed, 0
failed.

### The acceptance suite, run against a binary carrying the defect

`scripts/acceptance/graph_viz_local_render.py`, six checks over the real binary,
a real store and a real HTTP request to `/api/graph.json`. Its graders are
falsified against their own mutants, but the load-bearing evidence is the suite
run end to end against a `kin` built with the original defect:

```
=== suite against the defective binary ===
CHECK 1 FIR-3498 PASS the page carries 3 node(s)
CHECK 2 FIR-3498 PASS 3 node(s) drawn out of 3 entities
CHECK 3 FIR-3498 FAIL exit None over a namespace that is not there; a zero exit over a wrong answer is the whole defect
CHECK 4 FIR-3498 FAIL the refusal does not name /var/.../.kin/kindb/09ef5bf9-...
CHECK 5 FIR-3498 FAIL the offline admin read drew 0 nodes over a store kin init just admitted; this is the reported defect exactly
CHECK 6 FIR-3498 PASS the run reported the offline admin fallback
SUITE_RC=1

=== control: suite against the fixed binary ===
CHECK 1..6 all PASS
CONTROL_RC=0
```

Checks 5 and 6 are new in the review round and are the reported symptom itself:
a populated store, no daemon reachable, `KIN_ALLOW_DAEMON_BOOTSTRAP_ADMIN` set,
and a page that must still draw. Check 6 is check 5's identity control, reading
the fallback the CLI logs, so a daemon that came up anyway reports unreadable
rather than passing on a path it never took. Check 6 staying green on the
defective binary is correct: the run did take the local arm, it just drew
nothing, and check 5 is what says so.

The daemon is made unreachable there by pointing `KIN_DAEMON_URL` at a closed
port rather than by killing a process, because `connect_for_command` would
otherwise auto-start a daemon and quietly turn that arm back into Arm A.

### The new boundary scan

`check_runtime_boundaries.sh` lost its `graph_viz.rs` allowlist entry when that
file stopped calling `open_snapshot_explicit_admin_read_only`, which left its new
direct `open_snapshot_local` call governed by nothing in the script. A scan for
that symbol now covers it, with `graph_viz.rs` as the one permitted caller,
falsified against a poisoned copy that adds a second:

```
$ bash scripts/check_runtime_boundaries.sh          # clean tree
Runtime guardrails check passed.
rc=0
$ bash <poisoned copy>/scripts/check_runtime_boundaries.sh <poisoned copy>
Unexpected direct local graph open in a CLI command; route it through the daemon, or add the
file here with the authority order it implements:
  crates/kin-cli/src/commands/locate_debug.rs:445
rc=1
```

## Local gates

```
$ bin/kin-precheck kin --repo-dir kin=<lane worktree>
kin-precheck: repo=kin tree=<lane worktree> sha=7056608e6f6f branch=chore/lane-vizfix-kin DIRTY
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 21 gates ran, 21 passed, 0 failed
```

fmt and `clippy --all-targets --all-features` are two of those 21.
`cargo test -p kin-core --lib`: 889 passed. The three kin-daemon tests that
exercise `read_local_publication_identity`, the one production hand-join this
converts: 3 passed. `bin/kin-parity` on the first commit: FINAL
PASS-WITH-ALLOWANCES, allowances `firstrun/9 FIR-2580`, `firstrun/3 FIR-2501`,
`brownfield/4 FIR-2464`, all three pre-dating this branch and none touching it.

Nothing here ran against the reporter's own store. The only thing done to it was
`ls` and `cat`.

## Named follow-ups, not done here

- `app.js` does not read `filtered_links`, the count of edges dropped because
  their endpoints were sampled out. "N of M relations" already reports the
  shortfall numerically, so nothing on the page is wrong; the field is unused.
- The local arm can be minutes of silence on a large store, because a full
  authority recovery re-verifies every persisted body. Correct over fast is the
  right trade for an offline escape hatch, but a progress line would help.
- One test-only spelling of the namespace rule survives at
  `crates/kin-remote/src/repository_transfer.rs:4372`. kin-remote does not depend
  on kin-core, and taking that dependency to reach a path helper would cost more
  than the duplication.
