### PR TITLE
Hold the reconcile loop's own admission after a run of failures (FIR-3504, FIR-3506)

### DIFF
--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -435,6 +435,12 @@ pub struct ReconcileHealth {
     /// accepted, and only a restart clears it. Absent on every other daemon.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deferred_tree_wedge: Option<DeferredTreeWedge>,
+    /// The loop has widened the gap between its own complete-admission
+    /// attempts because a run of them failed. Absent on every daemon whose
+    /// admissions are landing, and on one whose few failures are still what the
+    /// per-path retry ladder is for.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub admission_hold: Option<AdmissionHold>,
     /// The filesystem watcher told this daemon it lost events, and no complete
     /// admission has covered that loss yet. Absent on every other daemon.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -502,6 +508,29 @@ pub struct DeferredTreeWedge {
     /// against the daemon log that carries the failing commit.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub at: Option<String>,
+}
+
+/// The reconcile loop is deliberately not attempting a complete admission yet.
+///
+/// Present only after a run of complete-admission failures long enough that the
+/// daemon has already stopped calling them retries. It is the difference
+/// between a loop that is attempting and failing and one that has widened the
+/// gap between attempts, and without it the two are indistinguishable from
+/// outside: both report the same failure streak and the same last error, while
+/// one is spending a core on a 24-second attempt every half minute and the
+/// other is not.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AdmissionHold {
+    /// Seconds until the next complete admission is attempted. Zero means the
+    /// hold has elapsed and the next tick will try, which is an ordinary state
+    /// rather than a fault.
+    #[serde(default)]
+    pub next_attempt_in_seconds: u64,
+    /// The width of the current hold, which is how far the ladder has climbed.
+    /// A reader compares it with the ceiling to tell a loop still widening from
+    /// one that has settled.
+    #[serde(default)]
+    pub held_for_seconds: u64,
 }
 
 /// A watcher-reported loss of events that no complete admission has covered.
@@ -599,9 +628,23 @@ impl ReconcileHealth {
                 .last_admission_error
                 .as_deref()
                 .unwrap_or("no error recorded");
+            // Said in the same sentence as the streak rather than in one of its
+            // own, because the two are one fact: how many attempts failed, and
+            // what the loop now does about it. A reader who sees only the streak
+            // cannot tell a daemon spending a core on an attempt every half
+            // minute from one that has stood down between attempts, and those
+            // are the two states this whole reading exists to separate.
+            let holding = match &self.admission_hold {
+                Some(hold) => format!(
+                    "; the loop is holding its next attempt {}s (widened to {}s after this run of \
+                     failures), so it is not attempting right now",
+                    hold.next_attempt_in_seconds, hold.held_for_seconds
+                ),
+                None => String::new(),
+            };
             reasons.push(format!(
                 "complete exact-tree admission has failed {} consecutive times (attention at \
-                 {ADMISSION_FAILURE_STREAK_ATTENTION}); {since}; last error: {error}",
+                 {ADMISSION_FAILURE_STREAK_ATTENTION}); {since}; last error: {error}{holding}",
                 self.admission_failure_streak
             ));
         }
@@ -1194,6 +1237,63 @@ mod tests {
         assert!(
             ReconcileHealth::default().notices().is_empty(),
             "a working copy with nothing untracked says nothing"
+        );
+    }
+
+    /// A loop that has stood down between attempts says so, in the same
+    /// sentence as the streak that made it.
+    ///
+    /// The two shapes here are the whole point. Both report the same failure
+    /// streak, the same last error and the same age, and from outside they are
+    /// the same daemon: one is spending a core on a complete admission every
+    /// half minute and the other is not. The hold clause is the only thing that
+    /// separates them, so a build that dropped it would leave a reader unable to
+    /// tell a daemon that had backed off from one that had not.
+    #[test]
+    fn a_held_loop_says_so_and_a_hammering_one_does_not() {
+        let hammering = ReconcileHealth {
+            admission_failure_streak: 9,
+            admission_failures: 9,
+            last_admission_error: Some(
+                "live exact tree does not match workspace authority".to_string(),
+            ),
+            last_admission_success_age_seconds: Some(19_800),
+            ..Default::default()
+        };
+        let held = ReconcileHealth {
+            admission_hold: Some(AdmissionHold {
+                next_attempt_in_seconds: 240,
+                held_for_seconds: 300,
+            }),
+            ..hammering.clone()
+        };
+
+        let hammering_reasons = hammering.degraded_reasons();
+        let held_reasons = held.degraded_reasons();
+        assert!(hammering.degraded() && held.degraded(), "both are faults");
+        assert_eq!(
+            hammering_reasons.len(),
+            held_reasons.len(),
+            "the hold belongs inside the streak's reason, not beside it as a second fault: {:?} \
+             against {:?}",
+            hammering_reasons,
+            held_reasons
+        );
+        assert!(
+            !hammering_reasons[0].contains("holding its next attempt"),
+            "a loop that is attempting every tick must not claim to be holding: {}",
+            hammering_reasons[0]
+        );
+        assert!(
+            held_reasons[0].contains("holding its next attempt 240s")
+                && held_reasons[0].contains("widened to 300s"),
+            "a held loop must name both when it will try again and how far the ladder climbed: {}",
+            held_reasons[0]
+        );
+        assert!(
+            held_reasons[0].contains("live exact tree does not match workspace authority"),
+            "the hold must not displace the error that caused it: {}",
+            held_reasons[0]
         );
     }
 

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -1156,8 +1156,39 @@ pub async fn run(json: bool, wait_quiesce: std::time::Duration) -> Result<i32> {
         // untracked files were named" is exactly the shape a reader takes for
         // "there are none".
         println!("{}", untracked_host_content_line(&pass));
+        // Why the daemon is quiet, when it is deliberately quiet. Every line
+        // above describes what the store holds; this one describes what the
+        // daemon has decided to stop doing about it, which is the question a
+        // reader arrives with when a repository stops keeping up and the daemon
+        // looks busy or looks idle depending on the second they looked.
+        if let Some(line) = admission_hold_line(&pass) {
+            println!("{line}");
+        }
     }
     Ok(exit_code_for_admission(&pass))
+}
+
+/// The `kin status` reading of a reconcile loop that has stood down.
+///
+/// `None` on every daemon that is admitting, and on one whose few failures are
+/// still what the per-path retry ladder is for, so this line appears exactly
+/// when there is something to say. When it appears it names all four facts a
+/// reader needs to act: that the loop is held, how long the streak is, how many
+/// seconds until the next attempt, and the refusal that caused it. A line
+/// carrying only "held" would send the reader back to the daemon log for the
+/// reason, which is where this information used to live and be lost.
+fn admission_hold_line(pass: &StatusAdmission) -> Option<String> {
+    let reconcile = pass.reconcile()?;
+    let hold = reconcile.admission_hold.as_ref()?;
+    let error = reconcile
+        .last_admission_error
+        .as_deref()
+        .unwrap_or("no error recorded");
+    Some(format!(
+        "Admission held: this repository's daemon has stood down between complete admissions \
+         after {} consecutive failures; it tries again in {}s (holding {}s). Refusal: {error}",
+        reconcile.admission_failure_streak, hold.next_attempt_in_seconds, hold.held_for_seconds
+    ))
 }
 
 /// The `kin status` reading of host content graph truth does not carry.
@@ -2483,6 +2514,54 @@ mod tests {
 
     fn skipped_pass() -> StatusAdmission {
         StatusAdmission::Skipped("no daemon is running for this repository".to_string())
+    }
+
+    /// `kin status` says why the daemon is quiet, and only when it is.
+    ///
+    /// The silent case is half the point. This line appears on a daemon that has
+    /// deliberately stood down between complete admissions and on no other, so a
+    /// build that printed it unconditionally would put a fault sentence on every
+    /// healthy repository and teach every reader to skip it. The loud case has
+    /// to carry all four facts, because a reader who learns only that something
+    /// is held goes to the daemon log for the reason, which is the round trip
+    /// this line exists to remove.
+    #[test]
+    fn status_names_a_held_admission_and_stays_quiet_otherwise() {
+        assert_eq!(
+            admission_hold_line(&took_pass()),
+            None,
+            "a daemon that is admitting has nothing to say here"
+        );
+        assert_eq!(
+            admission_hold_line(&skipped_pass()),
+            None,
+            "no daemon means no reading, not a hold"
+        );
+
+        let StatusAdmission::Took(mut report) = took_pass() else {
+            unreachable!("took_pass builds a taken pass")
+        };
+        report.reconcile.admission_failure_streak = 9;
+        report.reconcile.last_admission_error =
+            Some("live exact tree does not match workspace authority".to_string());
+        report.reconcile.admission_hold = Some(crate::commands::resources::AdmissionHold {
+            next_attempt_in_seconds: 240,
+            held_for_seconds: 300,
+        });
+        let line =
+            admission_hold_line(&StatusAdmission::Took(report)).expect("a held daemon must say so");
+        for fact in [
+            "Admission held",
+            "9 consecutive failures",
+            "tries again in 240s",
+            "holding 300s",
+            "live exact tree does not match workspace authority",
+        ] {
+            assert!(
+                line.contains(fact),
+                "the line must carry {fact:?}, got {line}"
+            );
+        }
     }
 
     fn merge_fixture(settled: usize, total: usize) -> MergeInProgress {

--- a/crates/kin-daemon/src/background_work.rs
+++ b/crates/kin-daemon/src/background_work.rs
@@ -813,6 +813,14 @@ struct ReconcileProbesInner {
     /// it is set, every admission failure recorded below is a refusal against
     /// the mismatched tree rather than an independent fault.
     deferred_tree_wedge: Option<RecordedFault>,
+    /// When the loop will next attempt a complete admission, and the hold it is
+    /// serving, once a run of failures stopped looking like retries.
+    ///
+    /// Both halves, because a reader needs different things from each. The
+    /// instant answers "is it about to try again"; the duration answers "how far
+    /// has the ladder widened", which is what says whether the loop has settled
+    /// at its ceiling or is still climbing.
+    admission_hold: Option<(Instant, Duration)>,
     /// The watcher loss standing against this store, as the durable record last
     /// read.
     ///
@@ -896,11 +904,33 @@ impl ReconcileProbes {
     }
 
     /// A complete exact-tree admission attempt failed. Extends the streak.
-    pub fn record_admission_failure(&self, error: impl std::fmt::Display, now: Instant) {
+    ///
+    /// Returns the consecutive-failure count including this one, so the caller
+    /// that just failed can decide what to do about it without taking the lock
+    /// a second time to read a whole report back.
+    pub fn record_admission_failure(&self, error: impl std::fmt::Display, now: Instant) -> u64 {
         let mut inner = self.lock();
         inner.admission_failures = inner.admission_failures.saturating_add(1);
         inner.admission_failure_streak = inner.admission_failure_streak.saturating_add(1);
         inner.last_admission_error = Some(RecordedFault::new(error.to_string(), now));
+        inner.admission_failure_streak
+    }
+
+    /// Record that the loop is holding its next complete admission, and for how
+    /// long.
+    ///
+    /// Published rather than only logged, for the same reason every other fault
+    /// here is: the log line is gone by the time anyone reads a status surface,
+    /// and a daemon that has quietly stopped attempting is indistinguishable
+    /// from one that is attempting and failing unless it says which.
+    pub fn record_admission_hold(&self, held_for: Duration, now: Instant) {
+        let mut inner = self.lock();
+        inner.admission_hold = Some((now + held_for, held_for));
+    }
+
+    /// Forget any admission hold, because an attempt is being made now.
+    pub fn clear_admission_hold(&self) {
+        self.lock().admission_hold = None;
     }
 
     /// A complete exact-tree admission attempt succeeded. Ends the streak.
@@ -911,6 +941,10 @@ impl ReconcileProbes {
     pub fn record_admission_success(&self, now: Instant) {
         let mut inner = self.lock();
         inner.admission_failure_streak = 0;
+        // The hold exists only because the streak did. An admission that landed
+        // is the proof the refusal cleared, so leaving the hold set would make
+        // a recovered store keep reporting that it is waiting to try.
+        inner.admission_hold = None;
         inner.last_admission_success = Some(RecordedFault::new(String::new(), now));
         // A complete admission that succeeded is proof the graph's tree reached
         // repository authority, which is exactly the divergence a wedge names.
@@ -1103,6 +1137,16 @@ impl ReconcileProbes {
             unsupported_path_count: inner.excluded.unsupported,
             policy_excluded_path_count: inner.excluded.policy_excluded,
             parked: None,
+            admission_hold: inner.admission_hold.map(|(until, held_for)| {
+                kin_cli::commands::resources::AdmissionHold {
+                    // Saturating, so a hold whose instant has already passed
+                    // reads as zero seconds rather than as a wrapped eternity.
+                    // A tick between the deadline and the next attempt is a
+                    // normal state, not a fault.
+                    next_attempt_in_seconds: until.saturating_duration_since(now).as_secs(),
+                    held_for_seconds: held_for.as_secs(),
+                }
+            }),
             deferred_tree_wedge: inner.deferred_tree_wedge.as_ref().map(|fault| {
                 kin_cli::commands::resources::DeferredTreeWedge {
                     error: fault.message.clone(),
@@ -1607,6 +1651,76 @@ mod tests {
             Some("ignored churn starved admission")
         );
         assert!(report.degraded(), "eight failures in a row is not healthy");
+    }
+
+    /// A failure hands its caller the streak, and a recorded hold reaches the
+    /// surfaces with both halves a reader needs.
+    ///
+    /// The return value is the point. Without it the loop would have to build a
+    /// whole report under the lock to learn the one number it already caused,
+    /// on the path where it has just spent a complete admission and has the
+    /// least to spare.
+    #[test]
+    fn a_failure_returns_its_streak_and_a_hold_reaches_the_report() {
+        let probes = ReconcileProbes::default();
+        let base = Instant::now();
+        assert_eq!(probes.record_admission_failure("refused", base), 1);
+        assert_eq!(probes.record_admission_failure("refused", base), 2);
+        assert_eq!(probes.record_admission_failure("refused", base), 3);
+        assert_eq!(probes.record_admission_failure("refused", base), 4);
+        assert!(
+            probes.report(base).admission_hold.is_none(),
+            "a loop that has not held anything must not report a hold"
+        );
+
+        probes.record_admission_hold(Duration::from_secs(64), base);
+        let report = probes.report(at(base, 4));
+        let reasons = report.degraded_reasons();
+        let hold = report.admission_hold.expect("the hold was recorded");
+        assert_eq!(
+            hold.held_for_seconds, 64,
+            "the width of the hold is how far the ladder climbed"
+        );
+        assert_eq!(
+            hold.next_attempt_in_seconds, 60,
+            "four seconds into a 64 second hold, sixty remain"
+        );
+        assert!(
+            reasons
+                .iter()
+                .any(|reason| reason.contains("holding its next attempt")),
+            "a held loop must say so on the surface that already carries the streak, got {reasons:?}"
+        );
+    }
+
+    /// A hold outlives neither a success nor an attempt.
+    ///
+    /// Both arms matter and they clear it for different reasons. A success is
+    /// proof the refusal went away, so a hold left standing would have a
+    /// recovered store reporting that it is waiting to try. An attempt is the
+    /// loop deciding to try now, so a hold left standing would have a daemon
+    /// mid-admission reporting that it is not attempting.
+    #[test]
+    fn a_hold_is_cleared_by_a_success_and_by_the_attempt_it_gated() {
+        let probes = ReconcileProbes::default();
+        let base = Instant::now();
+        probes.record_admission_failure("refused", base);
+        probes.record_admission_hold(Duration::from_secs(300), base);
+        assert!(probes.report(base).admission_hold.is_some());
+        probes.record_admission_success(at(base, 1));
+        assert!(
+            probes.report(at(base, 1)).admission_hold.is_none(),
+            "an admission that landed proves the refusal cleared"
+        );
+
+        probes.record_admission_failure("refused", at(base, 2));
+        probes.record_admission_hold(Duration::from_secs(300), at(base, 2));
+        assert!(probes.report(at(base, 2)).admission_hold.is_some());
+        probes.clear_admission_hold();
+        assert!(
+            probes.report(at(base, 3)).admission_hold.is_none(),
+            "the loop clears its own hold when it decides to attempt"
+        );
     }
 
     /// The falsification, and the property that keeps the streak honest: a

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -2067,6 +2067,26 @@ struct AdmissionHoldState {
     marks: RepositoryMarks,
 }
 
+/// One tick of a round that is standing down, whatever the reason.
+///
+/// Both stand-down paths in the loop go through here, and that is the whole
+/// point of it existing: the standing publish below must not be droppable from
+/// one path while the other keeps it. The empty-queue branch paid for exactly
+/// that on 2026-08-29, when a daemon nobody was editing against published no
+/// standing from this loop at all and the record stopped advancing for the life
+/// of the daemon. A HELD daemon is a worse version of the same case, because it
+/// is the one a reader is actively trying to understand: it is holding
+/// gigabytes, refusing to admit, and the record of what it holds is the thing
+/// they came for.
+///
+/// The publisher checks the interval before it reads any pressure, so a held
+/// round costs one lock and one `Instant::elapsed` on the twenty-nine of every
+/// thirty seconds where the answer would be thrown away.
+fn stand_down_tick(state: &DaemonState, pass: &crate::background_work::BackgroundPass) {
+    pass.idle();
+    crate::daemon::publish_footprint_standing_on_idle_tick(state);
+}
+
 /// Whether this round must stand down for the hold the last failure set.
 ///
 /// Pure over the two facts that decide it, for the same reason
@@ -2081,13 +2101,32 @@ struct AdmissionHoldState {
 /// the next one.
 ///
 /// **A hold is interruptible, and this is the half that makes it safe.** The
-/// refusal is a property of the store, so the store changing underneath is
-/// exactly the event that could clear it: a commit landing, a checkout
-/// completing, an operator repairing the working copy. A hold that ignored that
-/// would trade a hot loop for a daemon that ignores its user for up to five
-/// minutes after every wedge, which is a worse product than the one being
-/// fixed. So the marks are compared as well as the clock, and a store that
-/// moved retries on the very next tick.
+/// refusal is a property of the store, so the store changing underneath is what
+/// could clear it, and the marks name exactly which changes those are: anything
+/// that advances the repository generation or the daemon's graph mutation
+/// counter. A commit does, a checkout does, and an explicit admission through
+/// the seam does. A hold that ignored them would trade a hot loop for a daemon
+/// that ignores its user for up to five minutes after every wedge, which is a
+/// worse product than the one being fixed, so the marks are compared as well as
+/// the clock and a store that moved retries on the very next tick.
+///
+/// The two halves of the hold can disagree for one tick, and the marks are why
+/// that is harmless. A commit or an explicit admission calls
+/// `record_admission_success`, which clears the PUBLISHED hold, while this
+/// loop's own local state is untouched until its next tick. Both of those paths
+/// publish a tree, so both advance a mark, so the very next tick reads the hold
+/// as broken and clears the local state before attempting. The disagreement is
+/// therefore bounded by one poll interval, 100 ms at the default, and it falls
+/// on the safe side: the surface says the loop is not holding slightly before
+/// the loop stops holding, never the reverse.
+///
+/// What the marks deliberately do NOT cover is an operator editing the working
+/// copy. Those edits reach the loop as watcher events, and the admission that
+/// would turn them into a moved mark is the very thing being held, so nothing
+/// about them can break the hold early. That is why the ceiling exists and why
+/// it is five minutes rather than an hour: a repair the daemon cannot see is
+/// picked up when the clock runs out, and the clock is the only thing that
+/// picks it up.
 fn admission_is_held(
     hold: Option<AdmissionHoldState>,
     now: Instant,
@@ -3452,7 +3491,6 @@ pub async fn run_loop_armed(
             // deferred clock above is a separate reading and why this state is
             // reported as `waiting_deferred` rather than `idle` whenever the
             // retry lane still holds something.
-            pass.idle();
             // Publish the standing before returning to the top, because the
             // publish at the end of this tick is below the `continue` and a
             // quiet store never reaches it. Measured on 2026-08-29: a daemon
@@ -3466,10 +3504,10 @@ pub async fn run_loop_armed(
             // matters, because the reader wanting it is deciding whether this
             // machine can serve the store at all.
             //
-            // The callee checks the interval before it reads any pressure, so
-            // this costs one lock and one `Instant::elapsed` on the twenty-nine
-            // of every thirty seconds where the answer would be thrown away.
-            crate::daemon::publish_footprint_standing_on_idle_tick(&state);
+            // Shared with the admission-hold branch below through
+            // `stand_down_tick`, so neither stand-down path can lose the
+            // publish on its own.
+            stand_down_tick(&state, &pass);
 
             // No events — sleep briefly then check again.
             tokio::select! {
@@ -3550,7 +3588,15 @@ pub async fn run_loop_armed(
             // bookkeeping: the supervisor parks a pass that spends a working
             // stretch without advancing, and a hold read as a working stretch
             // would have this change park the loop it exists to calm.
-            pass.idle();
+            //
+            // Through the shared tick, so the footprint standing keeps being
+            // published while the loop is held. Without it a held daemon with a
+            // non-empty queue reaches neither the idle publish above nor the
+            // working publish below, and the record of what it is holding stops
+            // advancing for the length of the hold. That is the 2026-08-29 class
+            // arriving by a new route, on the one daemon whose standing a reader
+            // most wants.
+            stand_down_tick(&state, &pass);
             tokio::select! {
                 _ = tokio::time::sleep(interval) => {}
                 _ = cancel.changed() => {
@@ -7883,6 +7929,47 @@ mod tests {
         assert!(
             !admission_is_held(hold(now - Duration::from_secs(1)), now, marks),
             "a hold that elapsed must not keep standing rounds down"
+        );
+    }
+
+    /// A round that stands down still publishes what the daemon is holding.
+    ///
+    /// This is the arm the strong-tier review of this change asked for, and the
+    /// case it is about is the held one. A held daemon with a non-empty queue
+    /// reaches neither the empty-queue publish nor the working publish, so
+    /// without the shared tick its footprint record stops advancing for the
+    /// length of the hold. That is the 2026-08-29 class on the one daemon whose
+    /// standing a reader most wants, because it is holding gigabytes and
+    /// refusing to admit.
+    ///
+    /// Graded against a real store rather than a predicate, because the property
+    /// is that a record reaches disk. Breaking `stand_down_tick` by dropping its
+    /// publish reds this and nothing else.
+    #[test]
+    fn a_round_that_stands_down_publishes_the_footprint_standing() {
+        let repo = tempfile::TempDir::new().unwrap();
+        let state = open_test_state(&repo);
+        let pass = state
+            .background_work
+            .pass(crate::background_work::PASS_RECONCILE);
+        assert!(
+            kin_core::memory_pressure::DaemonFootprint::read(state.layout.root()).is_none(),
+            "a store that has never published must start with no record, or this test cannot \
+             tell a publish from a leftover"
+        );
+
+        stand_down_tick(&state, &pass);
+
+        let published = kin_core::memory_pressure::DaemonFootprint::read(state.layout.root())
+            .expect("a round that stood down must have published a standing");
+        assert_eq!(
+            published.pid,
+            std::process::id(),
+            "the record must be this process's own standing, not an inherited one"
+        );
+        assert!(
+            published.budget_bytes > 0,
+            "a standing with no budget states nothing about what the daemon is allowed to hold"
         );
     }
 

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -1982,6 +1982,120 @@ fn retry_backoff(attempts: u32, base: Duration) -> Duration {
     base.saturating_mul(1u32 << shift)
 }
 
+/// First hold imposed on the loop's own complete-admission attempts once the
+/// failures stop looking like retries.
+///
+/// The ladder above is per PATH and it is the right instrument for the failure
+/// it was built for: a file rewritten while the pass reads it fails one attempt
+/// and succeeds on the next. It is the wrong instrument for a failure that
+/// belongs to the STORE, because no path can clear one and every path then
+/// retries on the same ceiling. Measured on a wedged daemon serving a 2,987
+/// commit repository: one complete exact-tree admission spent 24.3 s in
+/// `publish_workspace_admission` and failed with "live exact tree does not
+/// match workspace authority", the per-path ceiling then let the next attempt
+/// start 6.4 s later, and the pair held a core and about 11 GiB for five and a
+/// half hours.
+const ADMISSION_HOLD_BASE: Duration = Duration::from_secs(2);
+
+/// Ceiling of the loop's own admission hold.
+///
+/// A ceiling rather than a give-up, because the refusal can be cleared from
+/// outside this process: a commit lands, a checkout completes, an operator
+/// fixes the working copy. Five minutes keeps a store that heals queryable
+/// within one coffee, and it takes the duty cycle of an attempt that costs
+/// half a minute from most of a core down to under a tenth of one.
+const ADMISSION_HOLD_CEILING: Duration = Duration::from_secs(300);
+
+/// How long the loop holds its next COMPLETE exact-tree admission, given how
+/// many have failed in a row.
+///
+/// `None` up to and including [`ADMISSION_FAILURE_STREAK_ATTENTION`] failures,
+/// because up to there the failures are still what the retry ladder is for and
+/// holding a working mechanism off is its own defect. Past it, the daemon has
+/// already decided the question: that constant's own rationale is "Three
+/// consecutive failures is no longer a retry: every attempt since the loop last
+/// admitted anything has failed, and whatever is rejecting them is not clearing
+/// on its own." This function is the first place that decision changes what the
+/// loop DOES rather than only what it reports.
+///
+/// Doubling from [`ADMISSION_HOLD_BASE`] to [`ADMISSION_HOLD_CEILING`], so a
+/// store that heals after a handful of failures is picked up in seconds and one
+/// that does not is retried at the ceiling forever rather than abandoned.
+///
+/// Pure, so the ladder is gradeable without a daemon, a store or a clock.
+fn admission_hold(streak: u64, ceiling: Duration) -> Option<Duration> {
+    let over =
+        streak.checked_sub(kin_cli::commands::resources::ADMISSION_FAILURE_STREAK_ATTENTION)?;
+    if over == 0 {
+        return None;
+    }
+    let shift = u32::try_from(over.saturating_sub(1))
+        .unwrap_or(u32::MAX)
+        .min(31);
+    let held = ADMISSION_HOLD_BASE.saturating_mul(1u32 << shift);
+    Some(held.min(ceiling))
+}
+
+/// The repository facts a hold was armed against.
+///
+/// Two atomic loads rather than a read of the store, because this is compared on
+/// every tick of a held loop and a comparison costing a lock or a walk would be
+/// its own reason not to hold at all. `snapshot_generation` is the repository
+/// generation the refusal names; `vfs_version` is the daemon's monotonic
+/// mutation counter, bumped by every commit, checkout and overlay update. A
+/// wedged loop moves neither, because the thing that would move them is the
+/// admission that keeps failing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RepositoryMarks {
+    authority_generation: u64,
+    graph_version: u64,
+}
+
+impl RepositoryMarks {
+    fn read(state: &DaemonState) -> Self {
+        Self {
+            authority_generation: state.snapshot_generation.load(Ordering::SeqCst),
+            graph_version: state.vfs_version.load(Ordering::SeqCst),
+        }
+    }
+}
+
+/// A hold and the repository state it was armed against.
+#[derive(Debug, Clone, Copy)]
+struct AdmissionHoldState {
+    until: Instant,
+    marks: RepositoryMarks,
+}
+
+/// Whether this round must stand down for the hold the last failure set.
+///
+/// Pure over the two facts that decide it, for the same reason
+/// [`admission_hold`] is: a round that stands down when it should have
+/// attempted is the FIR-2606 class, and a round that attempts when it should
+/// have stood down is the loop this change exists to stop. Both are one
+/// boundary, and a boundary that needs a daemon and a broken store to exercise
+/// is a boundary nothing exercises.
+///
+/// `None` is a loop with no hold, which must always attempt. A deadline that
+/// has arrived is not a hold: the round attempts, and only a fresh failure arms
+/// the next one.
+///
+/// **A hold is interruptible, and this is the half that makes it safe.** The
+/// refusal is a property of the store, so the store changing underneath is
+/// exactly the event that could clear it: a commit landing, a checkout
+/// completing, an operator repairing the working copy. A hold that ignored that
+/// would trade a hot loop for a daemon that ignores its user for up to five
+/// minutes after every wedge, which is a worse product than the one being
+/// fixed. So the marks are compared as well as the clock, and a store that
+/// moved retries on the very next tick.
+fn admission_is_held(
+    hold: Option<AdmissionHoldState>,
+    now: Instant,
+    marks: RepositoryMarks,
+) -> bool {
+    hold.is_some_and(|hold| now < hold.until && hold.marks == marks)
+}
+
 /// What one deferral cost the path that caused it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct Deferral {
@@ -3006,6 +3120,13 @@ pub async fn run_loop_armed(
     // Bounded by MAX_CONSECUTIVE_COMMIT_YIELDS so a commit that never leaves the
     // daemon cannot hold ambient admission off forever.
     let mut commit_yields: u32 = 0;
+    // When this loop may next attempt a COMPLETE exact-tree admission, and the
+    // repository state it is waiting on. `None` on every healthy loop and on one
+    // whose failures are still inside the per-path ladder's remit; see
+    // [`admission_hold`] and [`admission_is_held`]. Named for the state rather
+    // than for the function that computes it, because a local called
+    // `admission_hold` shadows that function for the whole body.
+    let mut held_admission: Option<AdmissionHoldState> = None;
 
     // Register with the self-limit supervisor. Registered here rather than at
     // daemon start so a repository that never runs this loop — filesystem
@@ -3392,6 +3513,62 @@ pub async fn run_loop_armed(
             continue;
         }
 
+        // Stand this round down while the loop's own admission hold is running.
+        //
+        // Deliberately here: after the watcher drain, so a held round still
+        // records lost and skipped events and still queues what it was told
+        // about, and before any lock, any batch and any status store, so the
+        // round itself costs one comparison. `pending_events` is left alone and
+        // no path is deferred, because a hold is not a failure and must not
+        // feed the per-path ladder a second time for the same refusal.
+        //
+        // The queue grows across a hold where today those paths would sit in the
+        // retry lane instead. That is the same set of paths either way, held as
+        // path buffers rather than admitted, and it is bounded by how much a
+        // person edits inside one hold; the existing backpressure warning covers
+        // a burst. Trading a few thousand paths of queue for a full store
+        // re-verification every thirty seconds is the whole point.
+        //
+        // This is NOT the "hold admission under memory pressure" idea the
+        // ambient tick refuses a few lines below, and the difference is the
+        // whole justification. That one would withhold an admission that WOULD
+        // have made a written file queryable, which is FIR-2606 arriving by a
+        // new route. This withholds nothing, because every attempt it stands
+        // down for has already failed at least
+        // `ADMISSION_FAILURE_STREAK_ATTENTION` times in a row and the next one
+        // fails for the same reason: the refusal belongs to the store, not to
+        // any path, so no attempt in the hold window could have admitted
+        // anything. The moment one succeeds the streak resets and the hold is
+        // gone.
+        if admission_is_held(
+            held_admission,
+            Instant::now(),
+            RepositoryMarks::read(&state),
+        ) {
+            // A held round is genuinely doing nothing, which is what this state
+            // means here and in the empty-queue branch below. Saying so is not
+            // bookkeeping: the supervisor parks a pass that spends a working
+            // stretch without advancing, and a hold read as a working stretch
+            // would have this change park the loop it exists to calm.
+            pass.idle();
+            tokio::select! {
+                _ = tokio::time::sleep(interval) => {}
+                _ = cancel.changed() => {
+                    state.reconciliation_status.store(RECON_IDLE, Ordering::Relaxed);
+                    info!("reconciliation loop shutting down");
+                    break;
+                }
+            }
+            continue;
+        }
+        if held_admission.is_some() {
+            // The hold elapsed, so this round attempts. Cleared before the
+            // attempt rather than after it, because a surface read mid-attempt
+            // should say the loop is trying, and a failure re-arms it below.
+            held_admission = None;
+            state.background_work.reconcile().clear_admission_hold();
+        }
+
         state
             .reconciliation_status
             .store(RECON_PROCESSING, Ordering::Relaxed);
@@ -3537,10 +3714,35 @@ pub async fn run_loop_armed(
                     "complete exact-tree admission failed; retaining graph truth and retrying watcher paths"
                 );
                 let deferred_at = Instant::now();
-                state
+                let streak = state
                     .background_work
                     .reconcile()
                     .record_admission_failure(&error, deferred_at);
+                // Widen the LOOP's own gap between attempts once the streak says
+                // these are no longer retries. The per-path ladder below still
+                // runs and still does its own job; it just cannot reach this
+                // failure, because a refusal the whole store shares is not a
+                // property of any of the paths it defers.
+                if let Some(held_for) = admission_hold(streak, ADMISSION_HOLD_CEILING) {
+                    held_admission = Some(AdmissionHoldState {
+                        until: deferred_at + held_for,
+                        // Read after the failure, so the hold is armed against
+                        // the store as it stands now rather than as it stood
+                        // before the attempt that just moved nothing.
+                        marks: RepositoryMarks::read(&state),
+                    });
+                    state
+                        .background_work
+                        .reconcile()
+                        .record_admission_hold(held_for, deferred_at);
+                    warn!(
+                        streak,
+                        held_for_secs = held_for.as_secs(),
+                        "holding the next complete exact-tree admission; every attempt since the \
+                         last success has failed for the same reason and each one costs a whole \
+                         admission"
+                    );
+                }
                 for event in &watcher_batch {
                     let (FileEvent::Changed(path) | FileEvent::Removed(path)) = event;
                     retry_lane.defer(path, deferred_at, retry_base);
@@ -7598,6 +7800,138 @@ mod tests {
             retry_backoff(u32::MAX, base),
             base * (1 << RETRY_BACKOFF_MAX_SHIFT),
             "an attempt count that cannot overflow the shift must still land on the ceiling"
+        );
+    }
+
+    /// The loop's own hold: nothing while the failures are still retries, then
+    /// a doubling gap to a ceiling.
+    ///
+    /// The first three assertions are the ones that matter. A hold that started
+    /// at or below the attention threshold would withhold admissions the retry
+    /// ladder is there to serve, which is the FIR-2606 class; a hold with no
+    /// ceiling would leave a store that healed unqueryable for as long as it had
+    /// been broken.
+    #[test]
+    fn admission_hold_starts_past_the_attention_streak_and_doubles_to_a_ceiling() {
+        let ceiling = ADMISSION_HOLD_CEILING;
+        assert_eq!(
+            admission_hold(0, ceiling),
+            None,
+            "a loop that has never failed must not be held"
+        );
+        assert_eq!(
+            admission_hold(
+                kin_cli::commands::resources::ADMISSION_FAILURE_STREAK_ATTENTION,
+                ceiling
+            ),
+            None,
+            "at the attention threshold the failures are still what the per-path ladder is for"
+        );
+        assert_eq!(
+            (kin_cli::commands::resources::ADMISSION_FAILURE_STREAK_ATTENTION + 1
+                ..=kin_cli::commands::resources::ADMISSION_FAILURE_STREAK_ATTENTION + 9)
+                .map(|streak| admission_hold(streak, ceiling).map(|held| held.as_secs()))
+                .collect::<Vec<_>>(),
+            vec![
+                Some(2),
+                Some(4),
+                Some(8),
+                Some(16),
+                Some(32),
+                Some(64),
+                Some(128),
+                Some(256),
+                Some(300),
+            ],
+            "the first hold past the threshold is the base, and each further failure doubles it \
+             to the ceiling"
+        );
+        assert_eq!(
+            admission_hold(u64::MAX, ceiling),
+            Some(ceiling),
+            "a streak that cannot overflow the shift must still land on the ceiling"
+        );
+    }
+
+    /// The boundary the held round turns on.
+    ///
+    /// Each case fails differently. No hold must always attempt, or a healthy
+    /// loop stops admitting. A live hold over an unchanged store must stand
+    /// down, or the whole change does nothing. An elapsed hold must attempt, or
+    /// a store that healed stays unqueryable because a deadline that passed is
+    /// still being obeyed.
+    #[test]
+    fn a_round_stands_down_only_while_its_hold_is_still_running() {
+        let now = Instant::now();
+        let marks = RepositoryMarks {
+            authority_generation: 17,
+            graph_version: 4_211,
+        };
+        let hold = |until| Some(AdmissionHoldState { until, marks });
+        assert!(
+            !admission_is_held(None, now, marks),
+            "a loop with no hold must attempt"
+        );
+        assert!(
+            admission_is_held(hold(now + Duration::from_secs(30)), now, marks),
+            "a hold that has not elapsed over an unchanged store must stand the round down"
+        );
+        assert!(
+            !admission_is_held(hold(now), now, marks),
+            "a deadline that has arrived is not a hold"
+        );
+        assert!(
+            !admission_is_held(hold(now - Duration::from_secs(1)), now, marks),
+            "a hold that elapsed must not keep standing rounds down"
+        );
+    }
+
+    /// A hold is interruptible: a store that moved is retried at once.
+    ///
+    /// This is the arm that keeps the fix from being a worse product than the
+    /// defect. The refusal belongs to the store, so the store changing
+    /// underneath is the one event that could clear it, and a hold that waited
+    /// out its full five minutes through a commit or a checkout would leave a
+    /// user staring at a daemon that had already been given what it needed.
+    /// Both marks are graded separately, because a commit that advances the
+    /// repository generation and an overlay update that advances only the graph
+    /// version are different events and either one is enough.
+    #[test]
+    fn a_hold_breaks_the_moment_the_store_it_was_armed_against_moves() {
+        let now = Instant::now();
+        let armed = RepositoryMarks {
+            authority_generation: 17,
+            graph_version: 4_211,
+        };
+        let held = Some(AdmissionHoldState {
+            until: now + Duration::from_secs(300),
+            marks: armed,
+        });
+        assert!(
+            admission_is_held(held, now, armed),
+            "an unchanged store is the case the hold exists for"
+        );
+        assert!(
+            !admission_is_held(
+                held,
+                now,
+                RepositoryMarks {
+                    authority_generation: 18,
+                    ..armed
+                }
+            ),
+            "an authority generation that moved must retry at once, not in five minutes"
+        );
+        assert!(
+            !admission_is_held(
+                held,
+                now,
+                RepositoryMarks {
+                    graph_version: 4_212,
+                    ..armed
+                }
+            ),
+            "a graph mutation must retry at once, not in five minutes"
         );
     }
 


### PR DESCRIPTION
## What

The reconcile loop now widens the gap between its own complete exact-tree
admission attempts once a run of them has failed, and says on every status
surface that it is doing so.

FIR-3504 (the daemon rests above its own 8 GiB allowance and each impact query
spikes it by gigabytes) and FIR-3506 (readiness: "alive but not ready" stalls and
a slow first query).

## Why

Measured on the founder's own daemon, read passively with no contact: pid 12538,
serving `--repo .../kin`, up five and a half hours, holding 11.25 GiB of
`phys_footprint` against a derived allowance of 8.00 GiB. Its whole tree is ten
processes and all nine children are node (one pyright, two
typescript-language-server, and their workers) totalling 0.81 GiB of resident
set against the daemon's own 12.86 GiB, so the overrun is inside the daemon's
own address space.

615 samples over 20.5 minutes say it is not leaking: the drift is 0.02 GiB down
on resident set and 0.04 GiB down on footprint. It cycles. Resident set moves
between 9.61 and 12.86 GiB and 36 percent of samples catch it in the trough.

The cycle is a wedge. Its log repeats roughly every 30 seconds: complete
exact-tree admission fails with "live exact tree does not match workspace
authority", the authority is reopened and re-verifies every persisted body, and
`publish_workspace_admission` is measured at 24.3 seconds. The arithmetic closes
on the observed cycle: the failure arm sleeps one poll interval and continues,
so the cadence is the per-path ladder's ceiling of 64 intervals,
`RETRY_BACKOFF_MAX_SHIFT = 6`, which is 6.4 s at the default 100 ms poll. 24.3
plus 6.4 is 30.7 seconds.

The per-path ladder is the right instrument for the failure it was built for and
the wrong one for this. Its own comment on `RetryLane` says every attempt costs
a complete exact-tree admission and that it exists for a path rewritten faster
than it reconciles. "Live exact tree does not match workspace authority at
repository generation 17", refused in `publish_local_workspace_enrichment`
(`crates/kin-daemon/src/state.rs:11418`), is a property of the store: no path can clear it, so every path retries on the same 6.4 second
ceiling forever.

The signal that should stop this already exists and is already computed.
`ADMISSION_FAILURE_STREAK_ATTENTION = 3` carries this rationale in the source:
"Three consecutive failures is no longer a retry: every attempt since the loop
last admitted anything has failed, and whatever is rejecting them is not
clearing on its own" (`crates/kin-cli/src/commands/resources.rs:297`). Searched
across `crates/kin-daemon/src`, `admission_failure_streak` appears only as the
field, the increment, the reset and the report, with `deferred_tree_wedge` as
the control that the search reaches the files a consumer would live in. So the
daemon decides "this is not clearing on its own", says so on three surfaces, and
then keeps paying the same full-store price every few seconds.

## How

`admission_hold(streak, ceiling)` in `crates/kin-daemon/src/loop_runner.rs` is
`None` up to and including `ADMISSION_FAILURE_STREAK_ATTENTION`, then doubles
from two seconds to a five minute ceiling. `admission_is_held(hold, now, marks)`
is the boundary a round turns on. Both are pure, so the ladder and the boundary
are gradeable without a daemon, a broken store or a clock.

The hold is interruptible. It is armed against two atomic loads,
`snapshot_generation` and `vfs_version`, and a round stands down only while the
clock has not elapsed AND those marks are unchanged. The refusal belongs to the
store, so the store moving underneath is the one event that could clear it: a
commit landing, a checkout completing, an operator repairing the working copy.
Without that half this would trade a hot loop for a daemon that ignores its user
for up to five minutes after every wedge.

Reading `publish_local_workspace_enrichment` (`crates/kin-daemon/src/state.rs:11418`),
the refusal is `live_tree != authority_snapshot.resolved_tree`, and the three
things that clear it, a commit whose transaction carries the tree, a complete
admission that publishes, and an explicit `kin admit`, each advance one of those
two marks. That is why they are the marks.

The check sits after the watcher drain, so a held round still records lost and
skipped events and still queues what it was told about, and before any lock, any
batch and any status store, so the round itself costs one comparison. It marks
the pass idle, because a held round is genuinely doing nothing and a hold read
as a working stretch would have the supervisor park the loop this change exists
to calm.

It withholds nothing. The ambient tick a few lines below deliberately refuses to
gate admission on memory pressure, and its comment says why: "Admission held
costs the thing itself: it is the path by which a written file becomes queryable
at all, and withholding it is the FIR-2606 failure class arriving by a new
route." That reasoning does not reach this hold. Every attempt it stands down
for has already failed at least three times in a row for a reason that belongs
to the store rather than to any path, so no attempt inside the hold window could
have admitted anything, and the existing guard on that decision,
`ambient_admission_is_measured_and_never_held`, is still green.

The hold is published rather than only logged. `AdmissionHold` carries
`next_attempt_in_seconds` and `held_for_seconds` into `ReconcileHealth`, and
`degraded_reasons` folds them into the sentence that already names the streak
rather than adding a second fault. Without that clause a held loop and a
hammering one are the same daemon from outside: the same streak, the same last
error, the same age, while one is spending a core on a 24 second attempt every
half minute and the other is not. That is the FIR-3506 half.

`record_admission_failure` now returns the streak it just incremented, so the
loop learns the one number it caused without building a whole report under the
lock on the path where it has least to spare.

One behavioural difference worth naming: events accumulate in `pending_events`
across a hold where today those paths sit in the retry lane instead. It is the
same set of paths either way, held as path buffers rather than admitted, bounded
by how much a person edits inside one hold, and the existing backpressure
warning covers a burst.

## Review delta

A strong-tier review of `c0bf41d46` returned LAND WITH CHANGES. Both blocking
items are fixed in `111b09316`, a new commit rather than a rewrite.

**The held path stopped publishing what the daemon was holding.** The loop has
two footprint-standing publishes, one in the empty-queue branch and one on the
working path, and the held branch `continue`d past both, so a held daemon with a
non-empty queue published no standing for the length of the hold. That is the
class the empty-queue branch already paid for on 2026-08-29, and the held case
is the worse one: it is the daemon a reader is actively trying to understand,
holding gigabytes and refusing to admit. Both stand-down paths now go through
one `stand_down_tick`, so neither can lose the publish on its own.

The arm is `a_round_that_stands_down_publishes_the_footprint_standing`, graded
against a real store rather than a predicate: it asserts no record exists, calls
the tick, then asserts `DaemonFootprint::read` returns one carrying this
process's pid and a non-zero budget. Falsified by dropping the publish:

```text
ARM stand-down-skips-the-publish: rc=101 RED (good)
thread 'loop_runner::tests::a_round_that_stands_down_publishes_the_footprint_standing' panicked at crates/kin-daemon/src/loop_runner.rs:7964:14:
a round that stood down must have published a standing
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1640 filtered out; finished in 0.41s
```

**The `admission_is_held` comment claimed a breaker the marks do not cover.** It
listed an operator repairing the working copy, and no mark sees that: those
edits arrive as watcher events and the admission that would move a mark is the
thing being held. The comment now names only what the marks cover, a commit, a
checkout and an explicit admission through the seam, and says plainly that the
ceiling is what picks up an unseen repair, which is the honest reason it is five
minutes rather than an hour.

Two non-blocking items from the same review, answered rather than machined. The
published hold and the loop-local one can disagree for one poll interval,
because a commit or explicit admit clears the published half through
`record_admission_success` while the local half survives to the next tick; both
of those paths publish a tree and so advance a mark, so the next tick reads the
hold as broken and clears locally, and the window falls safe. And the loop
wiring itself still has no test, because driving `run_loop` into four
consecutive whole-store refusals needs a store that refuses, which no fixture
here builds; the decision it carries is in two pure functions that are tested
and falsified.

The whole set after the delta:

```text
test loop_runner::tests::a_hold_breaks_the_moment_the_store_it_was_armed_against_moves ... ok
test loop_runner::tests::a_round_stands_down_only_while_its_hold_is_still_running ... ok
test background_work::tests::a_hold_is_cleared_by_a_success_and_by_the_attempt_it_gated ... ok
test background_work::tests::a_failure_returns_its_streak_and_a_hold_reaches_the_report ... ok
test loop_runner::tests::admission_hold_starts_past_the_attention_streak_and_doubles_to_a_ceiling ... ok
test daemon::memory_pressure_tests::ambient_admission_is_measured_and_never_held ... ok
test loop_runner::tests::a_round_that_stands_down_publishes_the_footprint_standing ... ok
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 1634 filtered out; finished in 0.53s
```

## Testing

Eight crate tests, run through the fleet's serialized build slot on the lane
worktree. Everything this change decides is expressible as a crate test, which
matters here: `Product Acceptance` carries
`if: ${{ github.event_name != 'pull_request' }}`, so a rule added under
`scripts/acceptance/` would not grade this pull request, while these run through
`ci.yml` on it.

```sh
cargo test -p kin-daemon --lib -- \
  admission_hold_starts_past_the_attention_streak_and_doubles_to_a_ceiling \
  a_round_stands_down_only_while_its_hold_is_still_running \
  a_hold_breaks_the_moment_the_store_it_was_armed_against_moves \
  a_failure_returns_its_streak_and_a_hold_reaches_the_report \
  a_hold_is_cleared_by_a_success_and_by_the_attempt_it_gated \
  ambient_admission_is_measured_and_never_held
cargo test -p kin-cli --lib -- \
  a_held_loop_says_so_and_a_hammering_one_does_not \
  status_names_a_held_admission_and_stays_quiet_otherwise
```

```text
test loop_runner::tests::a_round_stands_down_only_while_its_hold_is_still_running ... ok
test loop_runner::tests::a_hold_breaks_the_moment_the_store_it_was_armed_against_moves ... ok
test loop_runner::tests::admission_hold_starts_past_the_attention_streak_and_doubles_to_a_ceiling ... ok
test background_work::tests::a_hold_is_cleared_by_a_success_and_by_the_attempt_it_gated ... ok
test background_work::tests::a_failure_returns_its_streak_and_a_hold_reaches_the_report ... ok
test daemon::memory_pressure_tests::ambient_admission_is_measured_and_never_held ... ok
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 1634 filtered out; finished in 0.02s
```

```text
test commands::resources::tests::a_held_loop_says_so_and_a_hammering_one_does_not ... ok
test commands::status::tests::status_names_a_held_admission_and_stays_quiet_otherwise ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2299 filtered out; finished in 0.00s
```

`ambient_admission_is_measured_and_never_held` is in that list on purpose. It is
the existing guard on the decision this change sits next to, that the ambient
tick reads memory pressure and never gates admission on it, and it staying green
is what says the hold added here has not crossed that line.

## Falsification

Every new test was broken on purpose and had to go red. Each arm is one exact
string swap in the source, a run of that arm's test alone, then the exact
inverse swap with the file's sha256 asserted back to its pre-arm value. Nothing
here is restored with `git checkout --`, which would restore HEAD and destroy
the rest of the change; that is a trap this repository's own catalogue names.

The harness also refuses a vacuous arm. A `cargo test` filter that selects
nothing exits 0 with `0 passed; 0 failed`, which is a green that graded nothing,
and the first run of this harness hit exactly that shape because the filters
were bare test names under `--exact`. It was fixed and the arms rerun rather
than reported as red; the harness now requires the `test <full path> ...` line
to appear before it will call an arm anything at all.

Eight arms, eight reds, each in its own test.

```text
ARM ceiling-removed: rc=101 RED (good)
ARM starts-at-the-threshold: rc=101 RED (good)
ARM held-round-attempts-anyway: rc=101 RED (good)
ARM hold-ignores-a-moved-store: rc=101 RED (good)
ARM status-line-drops-the-streak: rc=101 RED (good)
ARM success-leaves-the-hold-standing: rc=101 RED (good)
ARM failure-hides-the-streak: rc=101 RED (good)
ARM hold-clause-dropped: rc=101 RED (good)
```

### ceiling-removed

Mutation: loop_runner.rs: `Some(held.min(ceiling))` -> `Some(held)`

```text
thread 'loop_runner::tests::admission_hold_starts_past_the_attention_streak_and_doubles_to_a_ceiling' panicked at crates/kin-daemon/src/loop_runner.rs:7830:9:
assertion `left == right` failed: the first hold past the threshold is the base, and each further failure doubles it to the ceiling
  left: [Some(2), Some(4), Some(8), Some(16), Some(32), Some(64), Some(128), Some(256), Some(512)]
 right: [Some(2), Some(4), Some(8), Some(16), Some(32), Some(64), Some(128), Some(256), Some(300)]
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1639 filtered out; finished in 0.02s
```

### failure-hides-the-streak

Mutation: background_work.rs: `record_admission_failure` returns `0`

```text
thread 'background_work::tests::a_failure_returns_its_streak_and_a_hold_reaches_the_report' panicked at crates/kin-daemon/src/background_work.rs:1667:9:
assertion `left == right` failed
  left: 0
 right: 1
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1639 filtered out; finished in 0.02s
```

### held-round-attempts-anyway

Mutation: loop_runner.rs: `admission_is_held` body -> `false`

```text
thread 'loop_runner::tests::a_round_stands_down_only_while_its_hold_is_still_running' panicked at crates/kin-daemon/src/loop_runner.rs:7876:9:
a hold that has not elapsed over an unchanged store must stand the round down
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1639 filtered out; finished in 0.02s
```

### hold-clause-dropped

Mutation: resources.rs: `match &self.admission_hold` -> `match &None::<AdmissionHold>`

```text
thread 'commands::resources::tests::a_held_loop_says_so_and_a_hammering_one_does_not' panicked at crates/kin-cli/src/commands/resources.rs:1287:9:
a held loop must name both when it will try again and how far the ladder climbed: complete exact-tree admission has failed 9 consecutive times (attention at 3); last succeeded 19800s ago; last error: live exact tree does not match workspace authority
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2300 filtered out; finished in 0.02s
```

### hold-ignores-a-moved-store

Mutation: loop_runner.rs: `admission_is_held` drops `&& hold.marks == marks`

```text
thread 'loop_runner::tests::a_hold_breaks_the_moment_the_store_it_was_armed_against_moves' panicked at crates/kin-daemon/src/loop_runner.rs:7915:9:
an authority generation that moved must retry at once, not in five minutes
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1639 filtered out; finished in 0.02s
```

### starts-at-the-threshold

Mutation: loop_runner.rs: `if over == 0` -> `if over == u64::MAX`

```text
thread 'loop_runner::tests::admission_hold_starts_past_the_attention_streak_and_doubles_to_a_ceiling' panicked at crates/kin-daemon/src/loop_runner.rs:7822:9:
assertion `left == right` failed: at the attention threshold the failures are still what the per-path ladder is for
  left: Some(2s)
 right: None
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1639 filtered out; finished in 0.02s
```

### status-line-drops-the-streak

Mutation: status.rs: the status line's streak argument -> `0`

```text
thread 'commands::status::tests::status_names_a_held_admission_and_stays_quiet_otherwise' panicked at crates/kin-cli/src/commands/status.rs:2560:13:
the line must carry "9 consecutive failures", got Admission held: this repository's daemon has stood down between complete admissions after 0 consecutive failures; it tries again in 240s (holding 300s). Refusal: live exact tree does not match workspace authority
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2300 filtered out; finished in 0.02s
```

### success-leaves-the-hold-standing

Mutation: background_work.rs: `record_admission_success` drops `inner.admission_hold = None;`

```text
thread 'background_work::tests::a_hold_is_cleared_by_a_success_and_by_the_attempt_it_gated' panicked at crates/kin-daemon/src/background_work.rs:1710:9:
an admission that landed proves the refusal cleared
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1639 filtered out; finished in 0.02s
```

## Precheck

```sh
.kin-coord/bin/heavy-slot.sh daemonlean kin -- \
  bin/kin-precheck kin --repo-dir kin=.kin-coord/worktrees/daemonlean-kin
```

```text
kin-precheck: repo=kin tree=.kin-coord/worktrees/daemonlean-kin sha=c8c53d2df964dcc25632cea65f4813e42ed944a9 branch=chore/lane-daemonlean-kin DIRTY
kin-precheck: behind origin/main 3 commit(s); the gate list below is the one on THIS tree, not the one on main
kin-precheck: 21 gates enumerated from the check job of .github/workflows/ci.yml
PASS     node-test                            node --test <16 file(s) named by the check job>
kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin c8c53d2df964dcc25632cea65f4813e42ed944a9 DIRTY

and again on the committed head after the review delta:

kin-precheck: 21 gates ran, 21 passed, 0 failed, on kin 111b093161187188234af3462cff1317552818f3
```

A run carrying any NOT RUN prints no tally at all and exits 2, so the tally is
itself the statement that every enumerated gate ran.
DIRTY is the point, not a caveat: the sha names the base commit and the tree the
gates graded is that commit plus exactly this change, uncommitted at the time.


## Measurement

All of it read passively from the process table with `ps` and
`proc_pid_rusage`; nothing was sent to the daemon and its store was not opened.
Two columns per subject on purpose: `ps -o rss` is the resident set, while
`ri_phys_footprint` is what `kin_daemon_spawn::process_footprint_bytes` reads on
macOS (`crates/kin-daemon-spawn/src/lib.rs:553`) and therefore the figure the
daemon grades itself against its budget with.

```text
$ ps -o pid,ppid,lstart,args= -p 12538
12538  1  Thu Sep 10 13:57:05 2026  .../kin-daemon --repo .../kin --port 0

$ python3 footprint.py 12538 6310 10767 66284       # 2026-09-10T23:30:04Z
12538 phys_footprint=12080606872 resident=13807452160
6310  phys_footprint=493626224  resident=448315392     # pyright-langserver
10767 phys_footprint=35689104   resident=51134464      # typescript-language-server
66284 phys_footprint=33788296   resident=41025536      # typescript-language-server
```

615 samples at two second intervals over 20.5 minutes:

```text
                    min     max   first30avg  last30avg    drift
root RSS           9.61   12.86       11.67      11.65      -0.02 GiB
tree RSS          10.41   13.66       12.47      12.45      -0.02 GiB
root footprint    10.92   13.04       11.28      11.25      -0.04 GiB
tree footprint    12.06   14.18       12.42      12.38      -0.04 GiB
resident under 10 GiB in 221/615 samples (36 percent)
```

The whole tree is ten processes and all nine children are node
(two typescript-language-server and one pyright, plus their workers) totalling
0.81 GiB of resident set. There is no rust-analyzer anywhere in it, on a
repository that is mostly Rust, so the overrun is inside the daemon's own
address space and a fix that stopped idle language servers would have moved it
by six percent.

Two numbers come out of that, and this change is honest about which one it
moves. There is a FLOOR of about 10.9 GiB that the daemon holds between
attempts, and about 3 GiB of CYCLING on top of it. This change removes the
cycling and the core it burns, taking the 24.3 second attempt from 79 percent of the
daemon's time (24.3 in a 30.7 second cycle) to 7.5 percent (24.3 in 324.3) once
the ladder settles, which takes twelve consecutive failures. It does not claim
to lower the floor. The report carries the full series, the
harness that took it, and a controlled arm on a freshly admitted copy of the
same repository.

Report: `.kin-coord/reports/daemonlean-20260910.md`.
Raw series and harness: `.kin-coord/measure/daemonlean-20260910/`.

## Not in this change

**The allowance.** It is not raised and it is not touched. It is Kin's own limit
on itself rather than a cap on the process, and the product already says exactly
that: `BUDGET_REMEDY` reads "This is Kin's own limit on itself, not the machine
running out. Restarting the daemon releases what it holds, and
KIN_DAEMON_MEMORY_BUDGET_BYTES raises the limit if this repository genuinely
needs more" (`crates/kin-core/src/memory_pressure.rs:1014`), and `kin doctor`
prints the derived number with the same framing
(`crates/kin-cli/src/commands/health.rs:4529`). The founder's daemon publishes
`level critical` against it, so the reading is working.

**The 10.9 GiB floor.** This change removes the repeating attempt and the core it
burns. It does not claim to lower the floor a daemon holds between attempts, and
the report says which of the two each number belongs to.

**`kin mcp start`.** It already attaches rather than spawning on the path read
here: `bind_daemon_when_asked` tries `AttachOnly` first and starts nothing
(`crates/kin-cli/src/commands/mcp.rs:883`), and a spawn happens only once a
`tools/call` has admitted one. If a second daemon still appears in practice the
cause is which repository the bind resolves to, which needs its own reproduction
rather than a speculative change here.

**The MCP envelope.** Stated plainly because an agent is the reader most likely
to be misled by its absence. Every surface a person types reaches the hold:
`/health` serializes the whole reconcile report
(`crates/kin-daemon/src/api.rs:4128`) and `AdmissionHold` is a field on it,
`kin graph status`, `kin doctor`, `kin admit` and `kin resources` render it
through `degraded_reasons`, and `kin status` prints its own line. The MCP
envelope does not. `Envelope::with_health` (`crates/kin-mcp/src/envelope.rs:2450`)
lifts named fields out of the health body rather than reading
`degraded_reasons`, so an agent reading `_kin` on a daemon that has stood down
sees nothing about it. Adding it means a new envelope observation and moves a
surface the `MCP surface contract` job grades, so it is a follow-up rather than
part of this change.

**A non-blocking readiness read in the CLI.** The daemon serves `GET /ready` with
`{ready, warming}` (`crates/kin-daemon/src/api.rs:2141`) and the CLI probes only
`GET /health`: across `crates/kin-cli`, `"/health"` appears twice in
`daemon_client.rs` and `/ready` appears nowhere, with `"/health"` as the control
that the search reaches that file. Wiring that in is a real improvement and a
separate change.
