### PR TITLE
Retire the FIR-2809 quarantine row after 15 days without a retry

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -84,35 +84,3 @@ path = "junit.xml"
 # the guard says so. `source` is the file the test lives in, and the guard joins
 # it against the filter so a renamed or deleted test cannot leave a row behind
 # that applies to nothing.
-
-# quarantine: ticket=FIR-2809 since=2026-08-27 last-flake=2026-08-27 source=crates/kin-core/tests/init_phase_ladder_contiguous.rs
-#
-# The dates above are correct and deliberately unchanged. On 2026-08-30 lane
-# daemonmem reproduced this guard red three times, at 3141, 3423 and 3442 ms
-# uncovered against a 2.0 percent bar, but those were LOCAL `cargo test` runs
-# under the full workspace suite, not nextest retries. The field above means the
-# most recent run in which this test needed a RETRY, read off nextest's own
-# summary, and CI has recorded none: runs 33292963787, 33293674768 and
-# 33293776932 on 2026-08-30 each report "test(s) recorded, none needed a retry"
-# with the junit-reporting invocation present. Writing a CI date that no CI run
-# produced would put local evidence into a field defined by the hosted summary.
-#
-# So expect the promotion arm to advise deletion from 2026-09-03, and read that
-# advice against this paragraph rather than acting on the date alone. The cause
-# was found and fixed under FIR-2980: the uncovered stretch was init's own
-# capture-staging teardown, `GitCaptureStaging::drop` calling `remove_dir_all`
-# over the whole Git capture, now inside a `kin.init.release_capture_staging`
-# span. That work measured 141 ms unloaded and 1140 ms under IO contention, and
-# CPU contention does not move it. If this row is still quiet after that fix has
-# had a week on main, the promotion is the right call rather than a premature one.
-#
-# Day-one intake, and the only row. It ejected pull request 1141 for a measured
-# 34 minutes on 2026-08-26. It has the evidence quarantine demands: the guard was
-# confirmed LOAD-SENSITIVE by the control that counts, same bytes, round one red
-# at 2.6% against a 2.0% bar and round two green. Note what that entry did and
-# copy it: the bar was NOT loosened, and the breached-ladder control that must
-# stay red was re-run to prove the guard still catches a real breach. Parking a
-# test here is never a licence to weaken the assertion it makes.
-[[profile.default.overrides]]
-filter = 'binary_id(=kin-core::init_phase_ladder_contiguous) & test(=the_admission_ladder_accounts_for_the_whole_of_init)'
-retries = 2


### PR DESCRIPTION
## What

Delete the FIR-2809 quarantine row from `.config/nextest.toml`. One row, 32
lines, nothing else.

## Why now

Its clock ran out and it is refusing every kin pull request. `check-quarantine.py`
refuses a row older than `QUARANTINE_MAX_DAYS = 14`, and at 2026-09-11T00:01:42Z
the required `Fast gate lint and policy` context went red on kin#1686 with:

```text
##[warning]promotion: row 0 (line 116) has not needed a retry in 15 days. Delete the row and let the test stand on its own, or record a newer flake
expired: row 0 (line 116) has been quarantined 15 days, the limit is 14. Fix the test and delete the row, naming the run where it passed without retries
1 quarantine finding(s). A quarantine row is a promise to fix a test, with a clock on it. Fix the test and delete the row, or correct the row.
##[error]Process completed with exit code 1.
```

It is a calendar expiry rather than any diff's fault, and the timestamps prove
it: the same gate concluded `success` on main head `4ea6adf8f` at
2026-09-10T23:39:36Z and on kin#1684 at 2026-09-10T23:16:31Z, and `failure` at
2026-09-11T00:01:42Z. From `since=2026-08-27` to the 10th is 14 days, which
passes; to the 11th is 15, which does not.

## The evidence the guard demands

"Fix the test and delete the row, naming the run where it passed without
retries." From the repository's own reporter, on main run
[34541446699](https://github.com/firelock-ai/kin/actions/runs/34541446699) at
`c8c53d2df964dcc25632cea65f4813e42ed944a9`, job
[103084826630](https://github.com/firelock-ai/kin/actions/runs/34541446699/job/103084826630)
"Fast gate test shard (1)":

```text
PASS [  68.996s] (1650/3229) kin-core::init_phase_ladder_contiguous the_admission_ladder_accounts_for_the_whole_of_init
```

and that same job's `check-quarantine.py --report-junit` step, which reads the
JUnit record for what `--flaky-result fail` would have said:

```text
3229 test(s) recorded, none needed a retry
```

So the test passed on its first try in a named run. The guard's promotion arm
has been advising deletion on the same basis for days.

The row's own comment block asked for this outcome. It records that the cause
was found and fixed under FIR-2980, init's capture-staging teardown now inside a
`kin.init.release_capture_staging` span, and says: "If this row is still quiet
after that fix has had a week on main, the promotion is the right call rather
than a premature one." It has been quiet.

## What this does not claim

FIR-2809 stays open. Its acceptance, a load-robust measurement, has not landed,
and the deleted comment block itself records lane daemonmem reproducing the
guard red three times on 2026-08-30, at 3141, 3423 and 3442 ms uncovered against
a 2.0 percent bar, under LOCAL `cargo test` in the full workspace suite rather
than as nextest retries. This retires the row on the CI evidence the guard
demands, not on a claim that the measurement is now load-proof. A return of the
flake in CI re-quarantines under the same ticket.

The `since` date is not renewed. A renewed clock is the graveyard the guard
exists to refuse.

## Testing

The guard, on this tree:

```sh
python3 scripts/check-quarantine.py
```

```text
0 quarantine row(s), every one ticketed, dated, inside 14 days, and naming a test that still exists
```
rc=0.

The red control is the CI output quoted above, on the tree that still carries
the row.

## One thing found while doing this, reported and not fixed here

`check-quarantine.py:606` calls `check_rows(rows, root, date.today())`, and
`date.today()` is LOCAL time. On a US Eastern host at 2026-09-11T00:04Z the same
bytes read:

```text
local today: 2026-09-10
utc today:   2026-09-11
```

so the guard printed "has not needed a retry in 14 days" and exited 0 locally
while CI, in UTC, printed 15 and exited 1. A lane can get a green the hosted
runner refuses, for as many hours a day as its offset. That is a separate
one-line change and a separate ticket.
