### PR TITLE
Isolate the stand-down footprint publish from the suite clock

### DIFF
--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -2461,12 +2461,17 @@ const FOOTPRINT_SAMPLE_INTERVAL: Duration = Duration::from_secs(2);
 /// `None` when the process table could not be read at all, which keeps the
 /// P1 rule on this axis too: a daemon that cannot measure itself decides
 /// exactly as it did before the budget existed.
-fn sample_tree_footprint() -> Option<kin_core::memory_pressure::TreeFootprint> {
+fn footprint_sample_cell(
+) -> &'static std::sync::Mutex<Option<(Instant, Option<kin_core::memory_pressure::TreeFootprint>)>>
+{
     static LAST: std::sync::OnceLock<
         std::sync::Mutex<Option<(Instant, Option<kin_core::memory_pressure::TreeFootprint>)>>,
     > = std::sync::OnceLock::new();
-    let cell = LAST.get_or_init(|| std::sync::Mutex::new(None));
-    let mut guard = cell.lock().ok()?;
+    LAST.get_or_init(|| std::sync::Mutex::new(None))
+}
+
+fn sample_tree_footprint() -> Option<kin_core::memory_pressure::TreeFootprint> {
+    let mut guard = footprint_sample_cell().lock().ok()?;
     if let Some((taken, footprint)) = guard.as_ref() {
         if taken.elapsed() < FOOTPRINT_SAMPLE_INTERVAL {
             return *footprint;
@@ -2475,6 +2480,15 @@ fn sample_tree_footprint() -> Option<kin_core::memory_pressure::TreeFootprint> {
     let sampled = walk_process_table();
     *guard = Some((Instant::now(), sampled));
     sampled
+}
+
+/// Put a known tree standing in the sample cache so a test can grade a publish
+/// without sharing the host process table with a thousand parallel siblings.
+#[cfg(test)]
+pub(crate) fn seed_tree_footprint_for_test(footprint: kin_core::memory_pressure::TreeFootprint) {
+    if let Ok(mut guard) = footprint_sample_cell().lock() {
+        *guard = Some((Instant::now(), Some(footprint)));
+    }
 }
 
 /// Walk the host's process table and fold this process's tree out of it.
@@ -2692,6 +2706,20 @@ static FOOTPRINT_LAST_PUBLISH: std::sync::OnceLock<
 fn footprint_last_publish(
 ) -> &'static std::sync::Mutex<Option<(Instant, kin_core::memory_pressure::PressureLevel)>> {
     FOOTPRINT_LAST_PUBLISH.get_or_init(|| std::sync::Mutex::new(None))
+}
+
+/// Forget the process-wide publish clock.
+///
+/// The idle publisher checks this clock before it writes, and the clock is one
+/// cell for the whole test process. A sibling that published in the last thirty
+/// seconds makes `stand_down_tick` a no-op for every other store, which is how
+/// `a_round_that_stands_down_publishes_the_footprint_standing` went red on the
+/// featureless main job: 1561 tests in one process, one shared cadence.
+#[cfg(test)]
+pub(crate) fn reset_footprint_publish_clock_for_test() {
+    if let Ok(mut guard) = footprint_last_publish().lock() {
+        *guard = None;
+    }
 }
 
 /// Whether the interval alone owes a publish.

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -7945,8 +7945,24 @@ mod tests {
     /// Graded against a real store rather than a predicate, because the property
     /// is that a record reaches disk. Breaking `stand_down_tick` by dropping its
     /// publish reds this and nothing else.
+    ///
+    /// The idle publisher's cadence and tree sample are process-wide. A suite
+    /// that already published in the last thirty seconds, or that pinned
+    /// `KIN_MEMORY_PRESSURE` with no figures, makes the tick a no-op for this
+    /// store. Seed both so the arm grades the tick, not the neighbours.
     #[test]
     fn a_round_that_stands_down_publishes_the_footprint_standing() {
+        let _budget = kin_core::test_env::EnvVarGuard::set(
+            kin_core::memory_pressure::FOOTPRINT_BUDGET_ENV,
+            (8u64 * 1024 * 1024 * 1024).to_string(),
+        );
+        crate::daemon::reset_footprint_publish_clock_for_test();
+        crate::daemon::seed_tree_footprint_for_test(kin_core::memory_pressure::TreeFootprint {
+            own_bytes: 64 * 1024 * 1024,
+            children_bytes: 0,
+            child_count: 0,
+            kernel_capped: false,
+        });
         let repo = tempfile::TempDir::new().unwrap();
         let state = open_test_state(&repo);
         let pass = state


### PR DESCRIPTION
Main's feature-permutation job has been red since #1686 because `a_round_that_stands_down_publishes_the_footprint_standing` shares the idle publisher's process-wide 30-second clock and tree-sample cache with the rest of the suite. A sibling that already published makes `stand_down_tick` a no-op for this store, so the test panics with no record on disk. That is a suite isolation defect, not a missing publish in the hold path.

This seeds a known standing and clears the publish clock so the arm grades the tick. The featureless lib test is green locally. Dropping the publish from `stand_down_tick` reds it:

```
thread 'loop_runner::tests::a_round_that_stands_down_publishes_the_footprint_standing' panicked at crates/kin-daemon/src/loop_runner.rs:7979:14:
a round that stood down must have published a standing
test result: FAILED. 0 passed; 1 failed
```

Local: `cargo test -p kin-daemon --no-default-features --lib --locked loop_runner::tests::a_round_that_stands_down_publishes_the_footprint_standing -- --exact` and `cargo fmt -p kin-daemon -- --check`.

Does not close FIR-3504 or FIR-3506. Those landed in #1686. This keeps their test from lying on the featureless main job.
