### PR TITLE
Grade the flake quarantine's clock on the UTC date (FIR-3531)

### DIFF
--- a/scripts/check-quarantine.py
+++ b/scripts/check-quarantine.py
@@ -92,7 +92,7 @@ import re
 import sys
 import tomllib
 import xml.etree.ElementTree as ElementTree
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 CONFIG = Path(".config") / "nextest.toml"
@@ -197,6 +197,18 @@ def parse_date(value):
         return date(int(match.group(1)), int(match.group(2)), int(match.group(3)))
     except ValueError:
         return None
+
+
+def grading_date(now):
+    """The date every clock here is graded on: the UTC date of `now`.
+
+    CI grades in UTC. A host west of Greenwich that graded on its own date
+    would call a row fresh for hours after the hosted runner calls it expired,
+    on a required context. A naive `now` is read as local time, which is what
+    `datetime.now()` returns, so it converts to the same date.
+    """
+
+    return now.astimezone(timezone.utc).date()
 
 
 def check_rows(rows, root, today):
@@ -441,7 +453,9 @@ def run_controls():
     with what it mutated.
     """
 
+    import os
     import tempfile
+    import time
 
     today = date(2026, 8, 27)
     fresh = (today - timedelta(days=1)).isoformat()
@@ -520,6 +534,60 @@ def run_controls():
             raise AssertionError(
                 "control failed: a row naming a missing source file was not "
                 "caught as stale-row"
+            )
+
+        # The clock is graded in UTC because CI is, whatever zone the host is
+        # in. The arm pins this process four hours west of Greenwich, where
+        # 23:30 on the 10th is already the 11th in UTC and a row dated the 27th
+        # of the month before is fifteen days old rather than the local date's
+        # fourteen. It grades that instant, aware and naive, then the finding
+        # the graded date produces, after proving the local date would not
+        # have produced it, so the arm can tell the two readings apart. The
+        # date is a past one so no reading of the wall clock can match it.
+        evening = datetime(2025, 9, 10, 23, 30)
+        instants = [evening.replace(tzinfo=timezone(timedelta(hours=-4)))]
+        pinned = hasattr(time, "tzset")
+        saved_tz = os.environ.get("TZ")
+        if pinned:
+            os.environ["TZ"] = "<-04>+4"
+            time.tzset()
+        try:
+            if pinned:
+                if time.timezone != 4 * 3600:
+                    raise AssertionError(
+                        "control failed: this process could not be pinned to "
+                        "UTC-4, so the arm would grade the host's own zone"
+                    )
+                instants.append(evening)
+            graded = {grading_date(instant) for instant in instants}
+        finally:
+            if pinned:
+                if saved_tz is None:
+                    os.environ.pop("TZ", None)
+                else:
+                    os.environ["TZ"] = saved_tz
+                time.tzset()
+        if graded != {date(2025, 9, 11)}:
+            shown = ", ".join(day.isoformat() for day in sorted(graded))
+            raise AssertionError(
+                f"control failed: 23:30 at UTC-4 on 2025-09-10 graded as {shown} "
+                "rather than 2025-09-11, so a host west of Greenwich reads a row "
+                "as fresh for hours after CI expires it"
+            )
+        boundary = CLEAN_FIXTURE.format(
+            since="2025-08-27", flake="2025-09-10", source="target.rs"
+        )
+        local, _ = check_rows(parse_rows(boundary), tmp, date(2025, 9, 10))
+        if any(finding.startswith("expired:") for finding in local):
+            raise AssertionError(
+                "control failed: the boundary row already expires on the local "
+                "date, so this arm cannot tell the two readings apart"
+            )
+        findings, _ = check_rows(parse_rows(boundary), tmp, date(2025, 9, 11))
+        if not any(finding.startswith("expired:") for finding in findings):
+            raise AssertionError(
+                "control failed: a row fifteen days old in UTC was not caught as "
+                "expired at 23:30 on a host four hours west of Greenwich"
             )
 
 
@@ -603,7 +671,8 @@ def main(argv):
                 quarantined.append(named.group(1).rsplit("::", 1)[-1])
         return report_junit(junit, quarantined)
 
-    findings, warnings = check_rows(rows, root, date.today())
+    today = grading_date(datetime.now(timezone.utc))
+    findings, warnings = check_rows(rows, root, today)
 
     for warning in warnings:
         print(f"::warning title=Quarantine promotion candidate::{warning}")


### PR DESCRIPTION
The flake quarantine guard now grades every row on the UTC date, the date the hosted runner grades on. Before this it read `date.today()`, the host's local date, so on a machine west of Greenwich a row CI had already expired read as fresh for as many hours a day as the offset. This is FIR-3531.

## What it cost

On a US Eastern host at 2026-09-11T00:04Z the guard printed "has not needed a retry in 14 days" and exited 0, while `Fast gate lint and policy`, a required context, printed 15 and exited 1 on kin#1686. Same bytes, same row, a different calendar. A lane that ran the guard locally before pushing got a green the hosted runner then refused.

## The change

`main()` grades on `grading_date(datetime.now(timezone.utc))`. `grading_date(now)` returns the UTC date of an instant and reads a naive instant as local time, which is what `datetime.now()` returns. `check_rows` is unchanged.

## The control, and what it covers

`run_controls()` runs on every invocation, CI's included, before any repository file is read. The new arm pins the process to UTC-4 with a POSIX zone string, so it needs no tz database, and asserts the pin took. It grades 23:30 on 2025-09-10 both aware and naive and requires 2025-09-11, then proves a row dated 2025-08-27 does not expire on the local date and does expire on the graded one. The date is in the past so no reading of the wall clock can match it.

The arm covers the conversion. It cannot see `main()`'s call site, which is the one line above, so the call site is graded on real bytes below instead.

## Falsification

Each arm is one mutation in a copy of the script, run against this tree, and counts as red only if the run fails with that arm's own message. A needle that did not occur exactly once would mark the arm vacuous.

```text
CLEAN unmutated: rc=0 GREEN (good)
  0 quarantine row(s), every one ticketed, dated, inside 14 days, and naming a test that still exists
ARM reads-the-instants-own-wall-clock: rc=1 RED (good)
  check-quarantine: control failed: 23:30 at UTC-4 on 2025-09-10 graded as 2025-09-10 rather than 2025-09-11, so a host west of Greenwich reads a row as fresh for hours after CI expires it
ARM reads-the-host-wall-clock: rc=1 RED (good)
  check-quarantine: control failed: 23:30 at UTC-4 on 2025-09-10 graded as 2026-09-11 rather than 2025-09-11, so a host west of Greenwich reads a row as fresh for hours after CI expires it
ARM converts-to-the-host-zone: rc=1 RED (good)
  check-quarantine: control failed: 23:30 at UTC-4 on 2025-09-10 graded as 2025-09-10 rather than 2025-09-11, so a host west of Greenwich reads a row as fresh for hours after CI expires it
ARM boundary-row-expires-on-both-readings: rc=1 RED (good)
  check-quarantine: control failed: the boundary row already expires on the local date, so this arm cannot tell the two readings apart
ARM zone-pin-does-not-take: rc=1 RED (good)
  check-quarantine: control failed: this process could not be pinned to UTC-4, so the arm would grade the host's own zone
```

## The call site, on real bytes

One row fifteen days old by the UTC date, graded by the script on main at `b010d4c25` and by this one, twelve hours west of Greenwich and in UTC:

```text
CALL SITE: row since=2026-08-27, UTC date 2026-09-11, UTC now 05:55Z
  main TZ=<-12>+12  rc=0 as expected
    1 quarantine row(s), every one ticketed, dated, inside 14 days, and naming a test that still exists
  main TZ=UTC       rc=1 as expected
    expired: row 0 (line 5) has been quarantined 15 days, the limit is 14. Fix the test and delete the row, naming the run where it passed without retries
  this TZ=<-12>+12  rc=1 as expected
    expired: row 0 (line 5) has been quarantined 15 days, the limit is 14. Fix the test and delete the row, naming the run where it passed without retries
  this TZ=UTC       rc=1 as expected
    expired: row 0 (line 5) has been quarantined 15 days, the limit is 14. Fix the test and delete the row, naming the run where it passed without retries
falsification: 0 problem(s)
```

The first line is the defect: the script on main passes a row the hosted runner expires. With this change both zones agree with CI.

## Local checks run

`python3 scripts/check-quarantine.py` on this tree exits 0 in the host zone and pinned to UTC-12, and the falsification run above reports 0 problems. No cargo was run: the change is one Python script, and the `Fast gate lint and policy` job grades it.
