### PR TITLE
Move to kin-db 0.7.112 and keep a tracked nested control directory through projection (FIR-3527)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3295,9 +3295,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.110"
+version = "0.7.112"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "8dec6290998b6f6f76fa86e3ac944cea5c37593aadc13a9146093aabaf71b021"
+checksum = "a9b48e0fb7b023ce7997c3878b9a56a6e0b387ad4e97053852e6fbc9cd70da38"
 dependencies = [
  "bincode",
  "bstr",
@@ -6684,7 +6684,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ kin-lsp = { version = "=0.7.19", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.110", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.112", registry = "kin", default-features = false }
 # Pinned to the exact version kin-db builds its name-token index with. A
 # per-token name query hits that index only when the token came out of the same
 # tokenizer, so a version skew here would be a silent recall loss rather than a

--- a/crates/kin-core/src/tree.rs
+++ b/crates/kin-core/src/tree.rs
@@ -12137,16 +12137,43 @@ fn projection_control_names_match(left: &std::ffi::OsStr, right: &std::ffi::OsSt
     }
 }
 
-fn is_reserved_source_component(component: &str) -> bool {
+/// A component whose materialization would write into repository control.
+///
+/// Position decides for a control DIRECTORY and does not for a run marker,
+/// which is the split kin-db's admission authority makes in
+/// `intrinsic_repository_control`. `.git` and `.kin` at `index == 0` are this
+/// repository's own, so projecting into one would write over the store that
+/// owns the projection. Deeper, the same name is a directory somebody
+/// committed on purpose, and materializing it is the entire point of a
+/// startup-recovery or migration fixture. `.kin-session` is transient run state
+/// wherever it sits, so it stays reserved at every depth.
+///
+/// Authority is what keeps the deeper case honest rather than trusting the
+/// path: kin-db admits a nested control directory only where the tree tracks
+/// it, so one that reaches here below the root was admitted deliberately. Until
+/// that kin-db lands, no such path can be in a graph this reads, and this is
+/// inert.
+fn is_control_plane_component(component: &str) -> bool {
     if component.eq_ignore_ascii_case(".git")
         || component.eq_ignore_ascii_case(".kin")
         || component.eq_ignore_ascii_case(".kin-session")
     {
         return true;
     }
-
     let key = projection_component_comparison_key(component);
     matches!(key.as_str(), ".git" | ".kin" | ".kin-session")
+}
+
+fn is_run_marker_component(component: &str) -> bool {
+    component.eq_ignore_ascii_case(".kin-session")
+        || projection_component_comparison_key(component) == ".kin-session"
+}
+
+fn is_reserved_source_component(index: usize, component: &str) -> bool {
+    if !is_control_plane_component(component) {
+        return false;
+    }
+    is_run_marker_component(component) || index == 0
 }
 
 fn validate_portable_source_path(path: &str) -> Result<Vec<&str>> {
@@ -12161,11 +12188,11 @@ fn validate_portable_source_path(path: &str) -> Result<Vec<&str>> {
         )));
     }
     let components: Vec<_> = path.split('/').collect();
-    if components.iter().any(|component| {
+    if components.iter().enumerate().any(|(index, component)| {
         component.is_empty()
             || component.len() > 255
             || matches!(*component, "." | "..")
-            || is_reserved_source_component(component)
+            || is_reserved_source_component(index, component)
             || !is_safe_windows_source_component(component)
     }) {
         return Err(KinError::Other(format!(
@@ -12187,11 +12214,11 @@ fn validate_source_path(path: &str) -> Result<Vec<&str>> {
         )));
     }
     let components: Vec<_> = path.split('/').collect();
-    if components.iter().any(|component| {
+    if components.iter().enumerate().any(|(index, component)| {
         component.is_empty()
             || component.len() > 255
             || matches!(*component, "." | "..")
-            || is_reserved_source_component(component)
+            || is_reserved_source_component(index, component)
             || cfg!(windows) && !is_safe_windows_source_component(component)
     }) {
         return Err(KinError::Other(format!(
@@ -12295,7 +12322,7 @@ fn validate_source_symlink_target_with_windows_rules(
                     )));
                 }
             }
-            component if is_reserved_source_component(component) => {
+            component if is_control_plane_component(component) => {
                 return Err(KinError::Other(format!(
                     "source symlink targets reserved control-plane path {target:?}"
                 )))
@@ -12314,7 +12341,7 @@ fn validate_source_symlink_target_with_windows_rules(
     }
     if resolved
         .iter()
-        .any(|component| is_reserved_source_component(component))
+        .any(|component| is_control_plane_component(component))
     {
         return Err(KinError::Other(format!(
             "source symlink targets reserved control-plane path {target:?}"
@@ -13349,12 +13376,33 @@ mod tests {
         );
     }
 
+    /// A Unicode case alias cannot reach a reserved name, and position decides
+    /// which names are reserved where.
+    ///
+    /// The alias half is the original guard: `.g\u{131}t` is a dotless i and
+    /// `.\u{212a}in` a Kelvin sign, and both fold onto a reserved name through
+    /// `projection_component_comparison_key`. The position half is FIR-3527: a
+    /// control directory is the repository's own only at component zero, a run
+    /// marker is reserved wherever it sits, and both must stay true of the
+    /// aliases too or the alias path becomes the way around the new boundary.
     #[test]
     fn unicode_case_aliases_cannot_target_reserved_control_plane_paths() {
-        for component in [".g\u{131}t", ".\u{212a}in", ".\u{212a}in-session"] {
+        for component in [".g\u{131}t", ".\u{212a}in"] {
             assert!(
-                is_reserved_source_component(component),
-                "Unicode alias of a reserved component was accepted: {component:?}"
+                is_reserved_source_component(0, component),
+                "Unicode alias of the repository's own control directory was accepted: \
+                 {component:?}"
+            );
+            assert!(
+                !is_reserved_source_component(1, component),
+                "a control directory below the repository root is content, alias or not: \
+                 {component:?}"
+            );
+        }
+        for index in [0, 1, 7] {
+            assert!(
+                is_reserved_source_component(index, ".\u{212a}in-session"),
+                "Unicode alias of a run marker was accepted at index {index}"
             );
         }
     }
@@ -17039,5 +17087,160 @@ mod tests {
             std::fs::read(outside.join("delete.txt")).unwrap(),
             b"outside sentinel"
         );
+    }
+
+    /// FIR-3527. A control directory a tree TRACKS is content, so projection
+    /// must be able to materialize it, and the repository's own must stay
+    /// unwritable.
+    ///
+    /// kin's own repository tracks two of these as startup-recovery fixtures,
+    /// and a fixture whose whole purpose is to be opened as a store is useless
+    /// if `kin checkout` cannot write it. The reason this is safe to relax is
+    /// upstream and not here: kin-db admits a nested control directory only
+    /// where the tree tracks it, so a graph path reaching this validator below
+    /// the root was admitted deliberately.
+    ///
+    /// Both halves matter. Without the refusing arm this reads as "stop
+    /// reserving `.kin`", which would let a projection write over the store
+    /// that owns it.
+    #[test]
+    fn projection_materializes_a_nested_control_directory_and_never_the_repositorys_own() {
+        for path in [
+            "scripts/release-proof/startup-recovery/fixtures/legacy-fixed/.kin/config.toml",
+            "scripts/release-proof/startup-recovery/fixtures/recorded-fixed/.kin/manifest.json",
+            "fixtures/nested/.KIN/config.toml",
+            "fixtures/nested/.git/config",
+        ] {
+            validate_source_paths([&repo_path(path)])
+                .unwrap_or_else(|error| panic!("{path} must be projectable: {error}"));
+        }
+
+        for path in [
+            ".kin/config.toml",
+            ".KIN/config.toml",
+            ".git/config",
+            ".kin-session/state.json",
+            "nested/.kin-session/state.json",
+        ] {
+            let error = validate_source_paths([&repo_path(path)])
+                .expect_err(&format!("{path} must stay unprojectable"));
+            assert!(
+                error.to_string().contains("unsafe graph-owned source path"),
+                "{path} must be refused as an unsafe source path, got: {error}"
+            );
+        }
+    }
+
+    /// The same boundary on the portable validator, which grades an archive
+    /// that will be extracted on a host this one is not.
+    #[test]
+    fn the_portable_validator_draws_the_same_line() {
+        validate_portable_source_paths(["fixtures/legacy-fixed/.kin/config.toml"])
+            .expect("a nested control directory must survive a portable archive");
+        for path in [
+            ".kin/config.toml",
+            ".git/config",
+            "nested/.kin-session/state.json",
+        ] {
+            assert!(
+                validate_portable_source_paths([path]).is_err(),
+                "{path} must stay out of a portable archive"
+            );
+        }
+    }
+
+    /// A SYMLINK TARGET STAYS OUT OF EVERY CONTROL DIRECTORY, including one a
+    /// file path may now be materialized into. The asymmetry is deliberate.
+    ///
+    /// A file path is bounded by the tree: it is in the graph because authority
+    /// admitted it, and authority admits a nested control directory only where
+    /// the tree TRACKS it, so materializing one writes bytes the repository
+    /// owns. A symlink target is bounded by nothing. It is validated for shape
+    /// and never against the tree, so a tracked link may name any path at all,
+    /// including one inside a live nested store that nothing tracks. Following
+    /// it on the host then reaches that store's internals.
+    ///
+    /// So the file rule moved and the link rule did not. The first pair below
+    /// is the whole point: the same path, admitted as a file and refused as a
+    /// link target.
+    ///
+    /// This was found by running the full kin-core suite rather than the six
+    /// tests this change added. A position-aware link rule passed all six and
+    /// failed `materialization_rejects_escaping_or_reserved_symlink_targets`,
+    /// which has guarded `dir/link -> .kin/config` since before this change.
+    #[test]
+    fn a_symlink_target_stays_out_of_every_control_directory_a_file_may_reach() {
+        let fixture = "fixtures/legacy-fixed/.kin/config.toml";
+        validate_source_paths([&repo_path(fixture)])
+            .expect("as a file path, a tracked nested control directory is content");
+        let error = validate_source_entry(
+            &repo_path("fixtures/link"),
+            symlink(),
+            b"legacy-fixed/.kin/config.toml",
+        )
+        .expect_err("as a link target, the same path is still refused");
+        assert!(
+            error.to_string().contains("reserved control-plane path"),
+            "the refusal must name the control plane: {error}"
+        );
+
+        for (path, target) in [
+            // The repository's own, directly and by walking back with `..`.
+            ("link", ".kin/config.toml".as_bytes()),
+            ("fixtures/nested/link", "../../.kin/config.toml".as_bytes()),
+            (
+                "fixtures/nested/deeper/link",
+                "../../../.git/config".as_bytes(),
+            ),
+            // Entering the repository's own control directory and leaving
+            // again, which resolves to something innocent.
+            ("link", ".kin/../compose.yaml".as_bytes()),
+            // A run marker, wherever it sits.
+            ("fixtures/link", "nested/.kin-session/state.json".as_bytes()),
+            // Entering a NESTED control directory and leaving again. Only the
+            // per-component check in the loop can see this one: the resolved
+            // target is `fixtures/compose.yaml`, which is innocent, so the
+            // check on the fully resolved path finds nothing. It is refused
+            // because a symlink traversing a control directory follows it on
+            // the host, whatever the tree thinks of the directory.
+            (
+                "fixtures/link",
+                "legacy-fixed/.kin/../compose.yaml".as_bytes(),
+            ),
+        ] {
+            assert!(
+                validate_source_entry(&repo_path(path), symlink(), target).is_err(),
+                "link {path} -> {} must be refused",
+                String::from_utf8_lossy(target)
+            );
+        }
+
+        // A link that LIVES inside a nested control directory, with a target
+        // that is innocent on its own. The loop never sees those components,
+        // because they are inherited from the link's own path rather than
+        // pushed by the target, and that path now validates as a file path. So
+        // only the check on the fully resolved target catches this one, which
+        // is why that check is still here.
+        assert!(
+            validate_source_entry(
+                &repo_path("fixtures/legacy-fixed/.kin/link"),
+                symlink(),
+                b"config.toml"
+            )
+            .is_err(),
+            "a symlink inside a nested control directory must be refused"
+        );
+        validate_source_paths([&repo_path("fixtures/legacy-fixed/.kin/link")])
+            .expect("and the same path as a file is content, which is what makes it reachable");
+
+        // The control for all of it: an ordinary relative target still works,
+        // so this is a rule about control paths and not a validator that
+        // refuses every symlink.
+        validate_source_entry(
+            &repo_path("fixtures/link"),
+            symlink(),
+            b"legacy-fixed/sentinel.py",
+        )
+        .expect("an ordinary relative target must stay valid");
     }
 }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -20886,8 +20886,6 @@ mod tests {
             ".GiT/config",
             ".kin/config.toml",
             ".KIN/config.toml",
-            "nested/.kin/graph.kndb",
-            "nested/.KiN/graph.kndb",
             ".kin-session/base.json",
             ".KIN-SESSION/base.json",
             "nested/.kin-session/base.json",
@@ -20903,10 +20901,31 @@ mod tests {
                 "accepted {path:?}"
             );
         }
+
+        // FIR-3527. `nested/.kin/graph.kndb` moved off the list above, and the
+        // reason is a change in what can reach here rather than a relaxation.
+        // These entries come from the graph, which is what the error text on
+        // the validator says, and admission takes a control directory into the
+        // graph only where the tree TRACKS it. kin's own repository tracks two
+        // as startup-recovery fixtures. Refusing them here refused the archive
+        // for carrying a file the repository committed on purpose. The
+        // repository's own control directory at the root and every run marker
+        // stay on the list, because neither is ever content.
+        for path in ["nested/.kin/graph.kndb", "nested/.KiN/graph.kndb"] {
+            validate_exact_source_path(path)
+                .unwrap_or_else(|error| panic!("refused tracked content {path:?}: {error:?}"));
+        }
+
         assert!(validate_exact_source_symlink("dir/link", "../../secret").is_err());
         assert!(validate_exact_source_symlink("link", "/etc/passwd").is_err());
         assert!(validate_exact_source_symlink("dir/link", "../.kin-session/base.json").is_err());
         assert!(validate_exact_source_symlink("dir/link", "../.KiN-SeSsIoN/base.json").is_err());
+        // A LINK target does not move with the path rule, and this is the pair
+        // that pins the difference. A path is in the graph because authority
+        // admitted it; a link target is validated for shape and never against
+        // the tree, so it may name anything at all, including a live nested
+        // store nothing tracks.
+        assert!(validate_exact_source_symlink("dir/link", "../nested/.kin/graph.kndb").is_err());
         assert!(validate_exact_source_symlink("dir/link", "../README.md").is_ok());
     }
 

--- a/crates/kin-daemon/src/commit_deltas.rs
+++ b/crates/kin-daemon/src/commit_deltas.rs
@@ -661,6 +661,16 @@ impl CompleteWorkspaceObservation {
 /// Graph-only entries (currently Gitlinks) are copied from the parent tree:
 /// their host checkout is neither membership evidence nor an identity source.
 ///
+/// So is a member whose path names repository control. The walk drops those as
+/// the first decision it makes about any entry, before it reads the entry's
+/// type and whatever the tracked set says (`kin_index::Scanner::walk`), so it
+/// holds no evidence about one and never will. A member like that is a control
+/// directory a tree TRACKS, which authority admits only deliberately (kin-db
+/// `intrinsic_repository_control`), and kin's own repository carries two as
+/// startup-recovery fixtures. Omitting them here would plan their removal on
+/// the first ambient pass after admission, which is a silent deletion of
+/// committed files and not an observation.
+///
 /// So are the tracked paths the walk declined to observe because ignore rules
 /// cover them. The walk holds no evidence about those paths, and an observation
 /// that omitted them would plan their removal, which would turn a rule into a
@@ -674,7 +684,10 @@ pub(crate) fn observed_tree_from_complete_scan(
 ) -> Result<CompleteWorkspaceObservation> {
     let mut observed = previous
         .artifacts_by_path()
-        .filter(|artifact| matches!(artifact.entry, TreeEntry::Gitlink { .. }))
+        .filter(|artifact| {
+            matches!(artifact.entry, TreeEntry::Gitlink { .. })
+                || kin_index::is_repository_control_path(&artifact.path)
+        })
         .map(|artifact| (artifact.path.clone(), artifact.entry))
         .collect::<BTreeMap<_, _>>();
     for path in scan.unverified_ignored_paths() {
@@ -2777,6 +2790,126 @@ mod tests {
             resolved.entities.len(),
             folded.entities.len(),
             "the marker proves the refused section did not answer"
+        );
+    }
+
+    /// FIR-3527. The walk cannot see a tracked control path, so the observation
+    /// carries it forward rather than reading "unobserved" as "deleted".
+    ///
+    /// `Scanner::walk` drops a control path as the first decision it makes
+    /// about any entry, before it reads the entry's type and whatever the
+    /// tracked set says. So a member like that is permanently unobservable
+    /// here, exactly as an ignored tracked path is, and for the same reason the
+    /// ignored case is carried forward. The member exists at all because
+    /// authority admits a control directory a tree TRACKS (kin-db
+    /// `intrinsic_repository_control`), which is what kin's own two
+    /// startup-recovery fixtures are.
+    ///
+    /// Without this, the first ambient pass after admitting such a repository
+    /// plans `Removed` for every one of those committed files.
+    ///
+    /// The falsification arm is in the test: the same fixture removes a tracked
+    /// ORDINARY path from the host and requires its `Removed`, so the absence
+    /// above is this rule and not a planner that never removes anything.
+    #[test]
+    fn an_ambient_pass_keeps_a_tracked_control_path_the_walk_cannot_see() {
+        let tmp = tempfile::tempdir().unwrap();
+        let init = kin_core::init(tmp.path()).unwrap();
+        let layout = init.layout;
+        let blobs = BlobStore::new(layout.ingest_cas_dir()).unwrap();
+
+        let working = layout.working_dir();
+        std::fs::create_dir_all(working.join("fixtures/legacy-fixed/.kin")).unwrap();
+        let fixture_bytes = b"[repository]\n";
+        std::fs::write(
+            working.join("fixtures/legacy-fixed/.kin/config.toml"),
+            fixture_bytes,
+        )
+        .unwrap();
+        let kept_bytes = b"pub fn kept() {}";
+        std::fs::write(working.join("kept.rs"), kept_bytes).unwrap();
+
+        let control = RepoPath::from_utf8("fixtures/legacy-fixed/.kin/config.toml").unwrap();
+        let control_entry = TreeEntry::blob(
+            Hash256::from_bytes(blobs.write(fixture_bytes).unwrap().0),
+            false,
+        );
+        let kept = RepoPath::from_utf8("kept.rs").unwrap();
+        let kept_entry = TreeEntry::blob(
+            Hash256::from_bytes(blobs.write(kept_bytes).unwrap().0),
+            false,
+        );
+        let previous = resolved_tree(vec![
+            (ArtifactId::new(), control.clone(), control_entry),
+            (ArtifactId::new(), kept.clone(), kept_entry),
+        ]);
+
+        let ignore = kin_index::RepositoryIgnore::load(working).unwrap();
+        let scan = kin_index::scan_repository(
+            working,
+            &ignore,
+            previous.artifacts_by_path().map(|artifact| &artifact.path),
+        )
+        .unwrap();
+        assert!(
+            !scan.entries().any(|entry| entry.repo_path == control),
+            "the premise of this test is that the walk cannot observe the control path; if it \
+             can, this test is guarding nothing"
+        );
+        assert!(
+            !scan.unverified_ignored_paths().any(|path| *path == control),
+            "and no ignore rule covers it either, so the existing carry-forward does not reach it"
+        );
+
+        let observed = observed_tree_from_complete_scan(&blobs, &scan, &previous).unwrap();
+        assert_eq!(
+            observed.entries().get(&control),
+            Some(&control_entry),
+            "an unobservable control path must keep the exact entry graph truth holds"
+        );
+
+        let deltas =
+            kin_core::plan_observed_tree_deltas(&previous, observed.entries().clone()).unwrap();
+        assert!(
+            !deltas
+                .iter()
+                .any(|delta| matches!(delta, TreeDelta::Removed { .. })),
+            "an ambient pass must not delete a committed file it was never able to read: \
+             {deltas:?}"
+        );
+
+        // Falsification, in the fixture rather than in prose: a tracked
+        // ordinary path that really is gone from the host must still be
+        // removed, or the assertion above is a planner that removes nothing.
+        let gone = RepoPath::from_utf8("gone.rs").unwrap();
+        let previous_with_gone = resolved_tree(vec![
+            (ArtifactId::new(), control.clone(), control_entry),
+            (ArtifactId::new(), kept, kept_entry),
+            (ArtifactId::new(), gone.clone(), control_entry),
+        ]);
+        let scan = kin_index::scan_repository(
+            working,
+            &ignore,
+            previous_with_gone
+                .artifacts_by_path()
+                .map(|artifact| &artifact.path),
+        )
+        .unwrap();
+        let observed =
+            observed_tree_from_complete_scan(&blobs, &scan, &previous_with_gone).unwrap();
+        let deltas =
+            kin_core::plan_observed_tree_deltas(&previous_with_gone, observed.entries().clone())
+                .unwrap();
+        assert!(
+            deltas.iter().any(|delta| matches!(
+                delta,
+                TreeDelta::Removed { old, .. } if old.path == gone
+            )),
+            "a tracked ordinary path absent from the host must still be removed: {deltas:?}"
+        );
+        assert!(
+            observed.entries().contains_key(&control),
+            "and the control path survives the same pass that removed it"
         );
     }
 }

--- a/crates/kin-daemon/src/storage_delegate.rs
+++ b/crates/kin-daemon/src/storage_delegate.rs
@@ -62,7 +62,7 @@ use kin_db::{
 /// `storage_backend_surface_is_audited_against_the_pinned_kin_db` fails when
 /// the workspace pin moves past it, which is the only moment a method can have
 /// appeared.
-pub const AUDITED_KIN_DB_VERSION: &str = "0.7.110";
+pub const AUDITED_KIN_DB_VERSION: &str = "0.7.112";
 
 /// Wraps a [`StorageBackendDelegate`] so it can be handed anywhere a
 /// `Box<dyn StorageBackend>` is expected.


### PR DESCRIPTION
Closes the kin half of FIR-3527 and moves kin onto kin-db 0.7.112, which carries
the admission fix. kin could not admit its own repository: `kin init` on a
full-history clone ran 28 minutes and refused on a startup-recovery fixture the
repository tracks. kin-db#314 fixed admission and landed as 0.7.112. This PR is
the kin side, and it has to be one PR because the pin move alone cannot land.

## Why one PR carries three things

The registry wave, kin#1665, moves the pin to `=0.7.112` and is red on
`storage_delegate::tests::storage_backend_surface_is_audited_against_the_pinned_kin_db`.
That test is right to refuse: it requires a person to re-read kin-db's
`StorageBackend` surface whenever the pin moves. A version bump that needs a
same-tree source edit cannot land through the wave, which is the FIR-3468 shape,
so the pin, the audit and the filters that make 0.7.112 safe to consume travel
together here.

**The pin.** `Cargo.toml` moves `kin-db` from `=0.7.110` to `=0.7.112`, and
`Cargo.lock` is regenerated from the registry with
`cargo update -p kin-db --precise 0.7.112`, never from a path patch. The kin-db
entry keeps its `sparse+https://kinlab.ai/registry/cargo/` source and takes
checksum `a9b48e0f...`, which is the registry's and matches the bot's lock.

That update also moved one transitive edge, `winapi-util 0.1.11` from
`windows-sys 0.48.0` to the `0.61.2` already in the lock. kin-db's manifest
changed nothing but its version between the two tags
(`git diff v0.7.110 v0.7.112 -- Cargo.toml crates/kin-db/Cargo.toml`), so that
hunk is cargo re-resolving kin-db's subgraph, and it is byte-identical to the
bot's. `fuzz/Cargo.lock` is untouched: it has no kin-db entry, and the bot's
`bitflags` bump there is unrelated drift the next wave can carry.

**The audit.** `AUDITED_KIN_DB_VERSION` moves to `0.7.112` after a re-read, not
before one. `StorageBackend` declares the same 33 methods at v0.7.110, v0.7.111
and v0.7.112, with nothing added and nothing removed across either step, and no
commit between v0.7.110 and v0.7.112 touches
`crates/kin-db/src/storage/backend.rs`, so no signature moved either. The table
needs no new row, and the roster count stays at 33.

The re-read, as run against kin-db's own release tags rather than from memory:

```console
$ python3 trait-methods.py   # extracts top-level fn names from `pub trait StorageBackend`
v0.7.110: 33  v0.7.111: 33  v0.7.112: 33
added 110->111: []
removed 110->111: []
added 111->112: []
removed 111->112: []
$ git -C kin-db log --oneline v0.7.110..v0.7.112 -- crates/kin-db/src/storage/backend.rs
$
```

The empty `git log` is the part that rules out a changed signature under an
unchanged name, which a name comparison alone could not.

**The filters.** Two places in kin would disagree with graph truth once 0.7.112
admits a nested control directory the tree tracks.

The projection guard refused `.git`, `.kin` and `.kin-session` at any component
of any graph path, so `kin checkout`, branch switch, merge, rollback, stash,
clone and eject would all fail with `unsafe graph-owned source path`, and the
transition ladder validates the whole tree before any mutation, so checking out
one unrelated file fails too. The predicate now splits three ways.
`is_control_plane_component` is the any-depth spelling question with the
Unicode-alias key folded in. `is_reserved_source_component(index, component)`
is position-aware and used only by the two file-path validators: a control
directory is the repository's own at index zero and content below it, and a run
marker is reserved at every depth. The symlink-target validator keeps the
any-depth rule, unchanged from today.

**A file path is bounded by the tracked tree and a symlink target is bounded by
nothing, and a pre-existing test proved it.** A path is in the graph because
authority admitted it, and authority admits a nested control directory only
where the tree TRACKS it. A symlink target is checked for shape and never
against the tree, so a tracked link may name any path at all, including one
inside a live nested store nothing tracks. A position-aware symlink rule passed
all six tests this change first added and failed
`materialization_rejects_escaping_or_reserved_symlink_targets`, which has guarded
`dir/link -> .kin/config` since before any of this. Running the full 893-test
kin-core suite found it; six filtered runs never could.

The ambient observation, `observed_tree_from_complete_scan`, carried only
Gitlinks and ignored tracked paths forward. The walk drops a control path as the
first decision it makes about any entry, before it reads the entry's type and
before anything consults the tracked set, so a tracked control path is
permanently unobservable there, exactly as an ignored tracked path is. kin's own
`.gitignore` is root-anchored `/.kin/`, kin has no `.kinignore`, and the default
ignored names carry no control name, so the first ambient pass after admission
would have planned `Removed` for every fixture file. They are carried forward
now, on the walk's own predicate so the two answer the same question by
construction.

## Two pre-existing tests, one unchanged and one moved

`materialization_rejects_escaping_or_reserved_symlink_targets` (kin-core) is
untouched, because the symlink rule is untouched.

`exact_source_paths_and_symlinks_fail_closed` (kin-daemon) had
`nested/.kin/graph.kndb` and `nested/.KiN/graph.kndb` on its refused list. Those
two move to an accepted assertion, and a new arm requires the same path refused
as a link target. That test was written when nothing could put a nested control
path in a graph. Its entries come from the graph, which its validator's own
error text says, so it carries the same bound the file rule relies on.

## Gates

Full lib suites on this tree, the one CI grades, with the 0.7.112 pin from the
registry:

```console
$ .kin-coord/bin/heavy-slot.sh admitfold kin -- bash -c 'set -o pipefail; \
    HF_HUB_OFFLINE=1 cargo test -p kin-core -p kin-daemon --lib 2>&1 \
    | grep -E "^test result:|FAILED|panicked"; echo "TEST_RC=${pipestatus[1]:-$?}"'
test result: ok. 892 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 19.87s
test result: ok. 1638 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 279.94s
TEST_RC=0
```

Precheck on the same tree, full output kept so the enumeration line survives:

```console
$ .kin-coord/bin/heavy-slot.sh admitfold kin -- \
    bin/kin-precheck kin --repo-dir kin=.kin-coord/worktrees/admitfold-kin
kin-precheck: repo=kin tree=.../worktrees/admitfold-kin sha=cab3af80e56d3da6f76118c5303a3e3c48b04337 branch=chore/lane-admitfold-kin DIRTY
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin cab3af80e56d3da6f76118c5303a3e3c48b04337 DIRTY
PRECHECK_RC=0
```

The DIRTY tree was exactly this PR's second commit and nothing else:
`Cargo.lock`, `Cargo.toml` and `crates/kin-daemon/src/storage_delegate.rs`,
5 insertions and 5 deletions, with no `[patch.kin]` in `.cargo/config.toml` and
no `path =` line in `Cargo.lock`.

## Falsification

Eight arms on the exact tree above. Each mutates behaviour, never an assertion,
runs the six new tests plus the two pre-existing ones that caught an earlier
version of the symlink rule plus the storage audit, then restores the file byte
for byte and proves it with a sha256.

```text
root-anchoring-removed             rc=101
session-marker-root-only           rc=101
unicode-alias-key-dropped          rc=101
symlink-rule-follows-the-file-rule rc=101
symlink-final-check-removed        rc=101
carry-forward-removed              rc=101
carry-forward-takes-everything     rc=101
audit-left-at-the-old-pin          rc=101
restore verified byte-exact for all three files
```

Four are worth naming. `symlink-rule-follows-the-file-rule` makes the loop check
position-aware and reds on `fixtures/link -> legacy-fixed/.kin/../compose.yaml`,
a target that passes through a nested control directory and resolves to
something innocent, which only the loop can see. `symlink-final-check-removed`
reds on a link that LIVES inside a nested control directory, whose components
come from its own path and never pass through the loop. An earlier draft of this
PR concluded that final check was dead and removed it; the full kin-core suite
said otherwise, and each check now has a case only it catches.
`carry-forward-takes-everything` reds the falsification arm inside
`an_ambient_pass_keeps_a_tracked_control_path_the_walk_cannot_see`, so the
absence of `Removed` there is this rule and not a planner that removes nothing.
`audit-left-at-the-old-pin` leaves `AUDITED_KIN_DB_VERSION` at `0.7.110` beside
the `0.7.112` pin, which is exactly the state kin#1665 is in, and the audit reds
exactly as it does there.

## End-to-end

Two witnesses, one already in and one running.

**Admission, already witnessed.** Lane daemonlean ran `kin init` on an untouched
full-history clone of kin, both fixture directories tracked and in place, with
this lane's earlier DEV-LOCAL build: kin-db path-patched to #314's head plus the
first version of these filters. It printed "Initialized Kin repository authority
... Authority generation: 1 ... Imported: exact reachable Git history, refs, raw
objects, workspace, and admission policy", and then all ten `kin impact` queries
it ran returned 0. Its exit code was 7, which is `EXIT_ENRICHMENT_UNATTESTED`
(`crates/kin-cli/src/commands/init.rs:204`), and whose doc comment says it is
"distinct from 1 so it is never read as the conversion having failed. The store
is real, publishable and answers questions." A daemon serving the store was
killed during semantic enrichment; admission itself succeeded. That subject
carries no symlinks, so the symlink rule that changed since that build cannot
have reached it.

**This PR's own bytes, running now.** `kin` and `kin-daemon` built release from
this branch's head against registry kin-db 0.7.112, on a fresh single-branch
clone at `b010d4c25` (3010 commits, 1105 files, 35 tracked `.kin` paths, no
symlinks): `kin init`, one `kin checkout` of an unrelated file, one commit of an
unrelated edit, then both fixture subtrees deleted from disk and restored by
`kin checkout` from graph history and compared byte for byte against Git. Its
numbers are added here when it finishes. Until then this section is a plan, not
a result.

## Landing order

kin-db#314 has landed (squash `488ca5e7`, kin-db 0.7.112 on the registry). This
PR carries the same pin and the same kin-db lock entry as the registry wave
kin#1665, plus the audit re-read that wave cannot make on its own. Once this
lands, kin#1665 should regenerate green on its next tick, carrying only the
unrelated `fuzz/Cargo.lock` drift, or be closed as superseded.

## What this does NOT change

The walk itself. `Scanner::walk` still skips every control path, so a tracked one
is carried forward rather than re-observed: an edit to a fixture file is
invisible to Kin and `kin doctor --drift` will not see it. Teaching the walk to
descend into a control directory that holds tracked paths, the way it already
descends into an ignored directory that does, is the complete fix and a bigger
change in the hottest loop.

`kin-cli/src/commands/reconcile.rs:766` refuses a session projection carrying a
reserved control path and is untouched; a session workspace is a derived scratch
projection, and whether the same argument applies there is a separate decision.

kin-index's control list is case-SENSITIVE and carries `.kin-git-capture-` and
`.kin.init-`, which kin-db lacks, so a tracked `.kin.init-*` path is admitted by
kin-db today and invisible to the walk. That predates this change.

FIR-3527. Lane report: `.kin-coord/reports/admitfold-20260910.md`.
