### PR TITLE
Level the live graph with repository authority instead of refusing every later admission (FIR-3546)

### DIFF
--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -445,6 +445,15 @@ pub struct ReconcileHealth {
     /// admission has covered that loss yet. Absent on every other daemon.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub watcher_loss: Option<WatcherLossState>,
+    /// The live graph's tree fell behind repository authority's and levelling
+    /// it has failed. Absent on every daemon whose graph and authority agree,
+    /// and cleared by the first levelling or admission that lands.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authority_split: Option<AuthoritySplit>,
+    /// The most recent levelling of the live graph with repository authority,
+    /// and what it dropped. Absent until one has happened in this daemon's life.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authority_levelled: Option<AuthorityLevelled>,
 }
 
 /// The background-work supervisor's account of a parked reconciliation loop.
@@ -566,6 +575,66 @@ pub struct WatcherLossState {
     pub disclosure: String,
 }
 
+/// Consecutive failed attempts to level the live graph with repository
+/// authority before the daemon says a restart is what clears it.
+///
+/// Not one. A levelling reads authority's tree, plans the transition and
+/// applies it, and an enrichment write landing between the plan and the apply
+/// can refuse one attempt that the next attempt, planned a moment later, gets
+/// through. Three in a row is no longer that race.
+pub const AUTHORITY_SPLIT_WEDGE_ATTEMPTS: u64 = 3;
+
+/// The live graph's tree is behind repository authority's, and levelling it
+/// has failed.
+///
+/// Every complete admission plans from the live graph's tree, and publication
+/// refuses a plan taken from a tree authority does not hold, so while the two
+/// disagree every admission is refused. The reconcile loop levels the graph on
+/// the first such refusal; this is what is left when that levelling fails.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthoritySplit {
+    /// The last levelling attempt's error, verbatim.
+    pub error: String,
+    /// Consecutive levelling attempts that have failed.
+    #[serde(default)]
+    pub attempts: u64,
+    /// Seconds since the last failed attempt. Monotonic.
+    #[serde(default)]
+    pub age_seconds: u64,
+    /// Wall-clock time of the last failed attempt, RFC 3339.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub at: Option<String>,
+}
+
+/// A levelling of the live graph with repository authority that landed.
+///
+/// Reported although it healed, because it changed what the graph holds with
+/// nobody asking: the paths it moved are re-derived from their bytes, and a
+/// relation whose endpoint the levelled graph no longer carries was dropped
+/// rather than left to refuse every later transaction.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthorityLevelled {
+    /// The repository authority generation the graph was levelled to.
+    #[serde(default)]
+    pub generation: u64,
+    /// Paths the levelling moved in the live graph's tree.
+    #[serde(default)]
+    pub paths: u64,
+    /// Relations dropped because the levelled graph no longer carries one of
+    /// their endpoints.
+    #[serde(default)]
+    pub dropped_relations: u64,
+    /// A bounded sample of the dropped relation ids.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dropped_relations_sample: Vec<String>,
+    /// Seconds since the levelling landed. Monotonic.
+    #[serde(default)]
+    pub age_seconds: u64,
+    /// Wall-clock time of the levelling, RFC 3339.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub at: Option<String>,
+}
+
 impl ReconcileHealth {
     /// Every reason this reconcile state is degraded, worst first, empty when
     /// it is not.
@@ -593,6 +662,33 @@ impl ReconcileHealth {
                  publication error: {}",
                 wedge.age_seconds, wedge.error
             ));
+        }
+        // Beside the wedge, and for the same reason: while the graph's tree is
+        // behind authority's, every admission is refused against the newer tree,
+        // so the streak and the backlog below are this fault's consequences
+        // rather than faults of their own. It names the restart only once the
+        // levelling has failed often enough that it is no longer a race.
+        if let Some(split) = &self.authority_split {
+            if split.attempts >= AUTHORITY_SPLIT_WEDGE_ATTEMPTS {
+                reasons.push(format!(
+                    "restart required, the live graph cannot be levelled with repository \
+                     authority: levelling has failed {} consecutive times (restart required at \
+                     {AUTHORITY_SPLIT_WEDGE_ATTEMPTS}), so every complete admission is refused \
+                     against authority's newer tree; `kin daemon stop` in this repository ends \
+                     this daemon and the next kin command starts one that loads its graph from \
+                     repository authority; last levelling error {}s ago: {}",
+                    split.attempts, split.age_seconds, split.error
+                ));
+            } else {
+                reasons.push(format!(
+                    "the live graph's tree is behind repository authority's and levelling it has \
+                     failed {} consecutive time(s) (restart required at \
+                     {AUTHORITY_SPLIT_WEDGE_ATTEMPTS}), so complete admissions are refused against \
+                     authority's newer tree until a levelling lands, which the reconcile loop \
+                     tries again on its next admission; last levelling error {}s ago: {}",
+                    split.attempts, split.age_seconds, split.error
+                ));
+            }
         }
         // Next, because it outranks every other reading here: a parked loop is
         // not admitting anything at all, so whatever the counters below say
@@ -694,6 +790,28 @@ impl ReconcileHealth {
     /// rules instead of waiting.
     pub fn notices(&self) -> Vec<String> {
         let mut notices = Vec::new();
+        // A levelling that landed is not a fault, and it still has to be said:
+        // it changed what the graph holds and may have dropped relations, and a
+        // reader who finds an edge missing needs to know one was dropped rather
+        // than never written.
+        if let Some(levelled) = &self.authority_levelled {
+            let dropped = if levelled.dropped_relations == 0 {
+                String::new()
+            } else {
+                format!(
+                    ", and dropped {} relation(s) whose endpoints the levelled graph no longer \
+                     carries ({})",
+                    levelled.dropped_relations,
+                    levelled.dropped_relations_sample.join(", ")
+                )
+            };
+            notices.push(format!(
+                "This daemon levelled its live graph with repository authority {}s ago: the \
+                 graph's tree had fallen behind authority's at generation {}, so it brought {} \
+                 path(s) level and re-derived them{dropped}.",
+                levelled.age_seconds, levelled.generation, levelled.paths
+            ));
+        }
         if self.untracked_path_count > 0 {
             let sample = if self.untracked_paths_sample.is_empty() {
                 String::new()
@@ -1487,6 +1605,96 @@ mod tests {
         };
         assert!(!healthy.degraded(), "{:?}", healthy.degraded_reasons());
         assert!(serde_json::to_value(&healthy).unwrap()["deferred_tree_wedge"].is_null());
+    }
+
+    /// A graph behind authority names how many levellings failed, and says a
+    /// restart is required only once they are no longer a race.
+    ///
+    /// Both halves matter. A first failed levelling is one an enrichment write
+    /// landing between plan and apply can cause, and the next attempt gets
+    /// through, so calling that a wedge would send a reader to restart a daemon
+    /// that was about to recover. Past the ceiling nothing recovers on its own,
+    /// and the reason has to lead with the restart and name the command.
+    #[test]
+    fn a_split_says_restart_only_once_levelling_has_failed_past_its_ceiling() {
+        let split = |attempts| ReconcileHealth {
+            authority_split: Some(AuthoritySplit {
+                error: "transaction relation r1 has unadmitted source endpoint entity:e1"
+                    .to_string(),
+                attempts,
+                age_seconds: 12,
+                at: Some("2026-09-11T07:00:00+00:00".to_string()),
+            }),
+            ..Default::default()
+        };
+
+        let first = split(1).degraded_reasons();
+        assert_eq!(first.len(), 1, "one fault, one reason: {first:?}");
+        assert!(
+            first[0].contains("failed 1 consecutive time(s)"),
+            "the count is the news: {first:?}"
+        );
+        assert!(
+            first[0].contains("unadmitted source endpoint"),
+            "the levelling's own error, not a summary invented here: {first:?}"
+        );
+        assert!(
+            !first[0].contains("restart required,"),
+            "one failed levelling is a race the next attempt gets through: {first:?}"
+        );
+
+        let wedged = split(AUTHORITY_SPLIT_WEDGE_ATTEMPTS).degraded_reasons();
+        assert!(
+            wedged[0].starts_with("restart required"),
+            "past the ceiling the recovery is the headline: {wedged:?}"
+        );
+        assert!(
+            wedged[0].contains("kin daemon stop"),
+            "and it names the command that performs it: {wedged:?}"
+        );
+
+        let healthy = ReconcileHealth {
+            authority_split: None,
+            ..split(AUTHORITY_SPLIT_WEDGE_ATTEMPTS)
+        };
+        assert!(!healthy.degraded(), "{:?}", healthy.degraded_reasons());
+        assert!(serde_json::to_value(&healthy).unwrap()["authority_split"].is_null());
+    }
+
+    /// A levelling that landed is a notice, not a fault, and it names what it
+    /// dropped, so a reader who finds an edge missing learns it was dropped
+    /// rather than never written.
+    #[test]
+    fn a_levelling_that_landed_is_a_notice_naming_what_it_dropped() {
+        let levelled = ReconcileHealth {
+            authority_levelled: Some(AuthorityLevelled {
+                generation: 17,
+                paths: 8,
+                dropped_relations: 1,
+                dropped_relations_sample: vec!["1426e6a7-3bcb-080b-fa61-b04267f3bb1f".to_string()],
+                age_seconds: 30,
+                at: Some("2026-09-11T07:00:00+00:00".to_string()),
+            }),
+            ..Default::default()
+        };
+        assert!(
+            levelled.degraded_reasons().is_empty(),
+            "a levelling that landed healed the store: {:?}",
+            levelled.degraded_reasons()
+        );
+        let notices = levelled.notices();
+        assert_eq!(notices.len(), 1, "{notices:?}");
+        for fact in [
+            "generation 17",
+            "8 path(s)",
+            "dropped 1 relation(s)",
+            "1426e6a7",
+        ] {
+            assert!(notices[0].contains(fact), "missing {fact:?}: {notices:?}");
+        }
+        let encoded = serde_json::to_value(&levelled).unwrap();
+        let decoded: ReconcileHealth = serde_json::from_value(encoded).unwrap();
+        assert_eq!(decoded, levelled);
     }
 
     /// The wedge crosses the wire intact. Every surface but the daemon's own

--- a/crates/kin-daemon/src/background_work.rs
+++ b/crates/kin-daemon/src/background_work.rs
@@ -650,6 +650,19 @@ impl RecordedFault {
     }
 }
 
+/// How many dropped relation ids a levelling record names outright.
+const LEVELLED_DROPPED_SAMPLE_LIMIT: usize = 5;
+
+/// A levelling of the live graph with repository authority that landed.
+#[derive(Debug)]
+struct LevelledRecord {
+    generation: u64,
+    paths: u64,
+    dropped_relations: u64,
+    dropped_relations_sample: Vec<String>,
+    at: RecordedFault,
+}
+
 /// Persist the durable last-admission marker after a complete pass succeeded.
 ///
 /// Called beside [`ReconcileProbes::record_admission_success`] rather than from
@@ -829,6 +842,11 @@ struct ReconcileProbesInner {
     /// know nothing about the store's layout. So the loop and the explicit
     /// admission path push what they read, and this is what the surfaces see.
     watcher_loss: Option<WatcherLossState>,
+    /// The last failed attempt to level the live graph with repository
+    /// authority, and how many have failed in a row.
+    authority_split: Option<(RecordedFault, u64)>,
+    /// The most recent levelling that landed.
+    authority_levelled: Option<LevelledRecord>,
 }
 
 /// Host content one complete walk declined to observe at all.
@@ -951,6 +969,9 @@ impl ReconcileProbes {
         // Clearing it here rather than on a timer means the state can only leave
         // the surfaces by being resolved.
         inner.deferred_tree_wedge = None;
+        // The same proof ends a split: an admission that landed was planned
+        // from a tree repository authority accepted.
+        inner.authority_split = None;
     }
 
     /// A commit's deferred tree was left unpublished because the publication
@@ -974,6 +995,50 @@ impl ReconcileProbes {
     /// own transaction carries the tree across.
     pub fn clear_deferred_tree_wedge(&self) {
         self.lock().deferred_tree_wedge = None;
+    }
+
+    /// One attempt to level the live graph with repository authority failed.
+    ///
+    /// Returns the consecutive count including this one, which the surfaces
+    /// compare with `AUTHORITY_SPLIT_WEDGE_ATTEMPTS` to decide whether a
+    /// restart is what clears it.
+    pub fn record_authority_split(&self, error: impl std::fmt::Display, now: Instant) -> u64 {
+        let mut inner = self.lock();
+        let attempts = inner
+            .authority_split
+            .as_ref()
+            .map_or(0, |(_, attempts)| *attempts)
+            .saturating_add(1);
+        inner.authority_split = Some((RecordedFault::new(error.to_string(), now), attempts));
+        attempts
+    }
+
+    /// A levelling landed: the live graph's tree is repository authority's
+    /// again.
+    ///
+    /// Ends the split and records what the levelling did, every dropped
+    /// relation included, because a reader who finds an edge missing needs to
+    /// know it was dropped rather than never written.
+    pub fn record_authority_levelled(
+        &self,
+        generation: u64,
+        paths: u64,
+        dropped_relations: &[String],
+        now: Instant,
+    ) {
+        let mut inner = self.lock();
+        inner.authority_split = None;
+        inner.authority_levelled = Some(LevelledRecord {
+            generation,
+            paths,
+            dropped_relations: dropped_relations.len() as u64,
+            dropped_relations_sample: dropped_relations
+                .iter()
+                .take(LEVELLED_DROPPED_SAMPLE_LIMIT)
+                .cloned()
+                .collect(),
+            at: RecordedFault::new(String::new(), now),
+        });
     }
 
     /// Whether the loop finished a tick still holding work.
@@ -1155,6 +1220,24 @@ impl ReconcileProbes {
                 }
             }),
             watcher_loss: inner.watcher_loss.clone(),
+            authority_split: inner.authority_split.as_ref().map(|(fault, attempts)| {
+                kin_cli::commands::resources::AuthoritySplit {
+                    error: fault.message.clone(),
+                    attempts: *attempts,
+                    age_seconds: age(fault),
+                    at: Some(fault.wall_clock.to_rfc3339()),
+                }
+            }),
+            authority_levelled: inner.authority_levelled.as_ref().map(|record| {
+                kin_cli::commands::resources::AuthorityLevelled {
+                    generation: record.generation,
+                    paths: record.paths,
+                    dropped_relations: record.dropped_relations,
+                    dropped_relations_sample: record.dropped_relations_sample.clone(),
+                    age_seconds: age(&record.at),
+                    at: Some(record.at.wall_clock.to_rfc3339()),
+                }
+            }),
         }
     }
 }

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -257,6 +257,22 @@ impl ExactTreeAdmission {
             yielded_authority: true,
         }
     }
+
+    /// Fold a levelling that ran before this pass into what the pass reports,
+    /// so the caller re-derives the paths the levelling moved exactly as it
+    /// re-derives its own.
+    fn absorb_levelling(&mut self, working_dir: &Path, levelling: AuthorityLevelling) {
+        note_transition_paths(
+            working_dir,
+            &levelling.deltas,
+            &mut self.changed_paths,
+            &mut self.semantic_events,
+        );
+        self.semantic_events = dedup_file_events(std::mem::take(&mut self.semantic_events));
+        let mut deltas = levelling.deltas;
+        deltas.append(&mut self.deltas);
+        self.deltas = deltas;
+    }
 }
 
 /// Where an admitted exact tree crosses repository authority.
@@ -812,7 +828,7 @@ fn unobserved_move_destinations(
 /// The scan itself stays complete either way, so a rename keeps one stable
 /// artifact identity even when its two halves arrive in different notification
 /// batches. Only the planned transition is bounded.
-fn exact_tree_admission(
+fn exact_tree_admission_once(
     state: &DaemonState,
     observation: Option<&BTreeSet<RepoPath>>,
     publication: TreePublication,
@@ -994,22 +1010,12 @@ fn exact_tree_admission(
 
     let mut changed_paths = BTreeSet::new();
     let mut semantic_events = Vec::new();
-    for delta in &deltas {
-        if let Some(old) = delta.old_state() {
-            changed_paths.insert(old.path.clone());
-            if delta.new_state().is_none_or(|new| new.path != old.path) {
-                if let Ok(path) = kin_index::host_path_from_repo_path(working_dir, &old.path) {
-                    semantic_events.push(FileEvent::Removed(path));
-                }
-            }
-        }
-        if let Some(new) = delta.new_state() {
-            changed_paths.insert(new.path.clone());
-            if let Ok(path) = kin_index::host_path_from_repo_path(working_dir, &new.path) {
-                semantic_events.push(FileEvent::Changed(path));
-            }
-        }
-    }
+    note_transition_paths(
+        working_dir,
+        &deltas,
+        &mut changed_paths,
+        &mut semantic_events,
+    );
 
     let mut deferred_tree = None;
     if !deltas.is_empty() {
@@ -1099,33 +1105,8 @@ fn exact_tree_admission(
         // it: the old identity is dropped and every reference to it with it. The
         // binder is what keeps one id across that rename.
         let relocations = path_relocations_in(&deltas);
-        let mut relocated_entities = Vec::new();
-        if !relocations.is_empty() {
-            let authority_context =
-                crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(
-                    state,
-                )?;
-            let authority = authority_context.open().map_err(DaemonError::Graph)?;
-            let module_relocations = crate::repository_commit::plan_session_module_relocations(
-                state.blobs.as_ref(),
-                &authority,
-                &deltas,
-            )?;
-            for (from_id, to_id) in &relocations {
-                relocated_entities.extend(
-                    crate::repository_commit::plan_session_entity_relocations(
-                        state.graph.as_ref(),
-                        from_id,
-                        to_id,
-                    )?,
-                );
-            }
-            crate::repository_commit::bind_session_module_relocations(
-                &mut relocated_entities,
-                &module_relocations,
-            )?;
-        }
-        state
+        let relocated_entities = plan_relocated_entities(state, &deltas, &relocations)?;
+        let applied = state
             .graph
             .apply_transaction_delta(&TransactionDelta {
                 entity_deltas: relocated_entities,
@@ -1133,19 +1114,17 @@ fn exact_tree_admission(
                 tree_deltas: deltas.clone(),
                 ..TransactionDelta::default()
             })
-            .map_err(|error| name_stranded_endpoint_refusal(DaemonError::Graph(error), &deltas))?;
-        // After the transaction, in the order the MCP seam has always used.
-        // These records are not part of a TransactionDelta, so they were never
-        // inside one.
-        let mut moved_layouts = Vec::new();
-        for (from_id, to_id) in &relocations {
-            crate::mcp_commit::relocate_file_records(
-                state.graph.as_ref(),
-                from_id,
-                to_id,
-                &mut moved_layouts,
-            )
-            .map_err(DaemonError::Graph)?;
+            .map_err(|error| name_stranded_endpoint_refusal(DaemonError::Graph(error), &deltas));
+        match applied {
+            Ok(()) => relocate_file_records_for(state, &relocations)?,
+            // A deferred tree has not crossed authority, so a refusal here
+            // splits nothing: the caller's transaction never runs and authority
+            // keeps the tree this graph still holds.
+            Err(refusal) if defer => return Err(refusal),
+            // Authority has already accepted `desired_tree`. Handing the refusal
+            // back from here is how a graph falls behind authority for good, so
+            // the graph is levelled with authority in this same round instead.
+            Err(refusal) => level_after_refused_apply(state, refusal)?,
         }
     }
 
@@ -1185,6 +1164,323 @@ fn exact_tree_admission(
         deferred_tree,
         yielded_authority: false,
     })
+}
+
+/// Derive and publish one complete exact-tree transition, levelling the live
+/// graph with repository authority first when authority refuses the plan.
+///
+/// [`exact_tree_admission_once`] is the transition itself. A stale-plan refusal
+/// is the one answer from it that a retry cannot change: the plan is taken from
+/// the live graph's tree, the refusal says authority holds another, and the next
+/// plan would be taken from the same tree. So the graph is levelled with
+/// authority and the observation is planned once more, against the tree
+/// authority actually holds. Once, not in a loop: a second refusal goes back to
+/// the caller and its retry ladder like any other.
+fn exact_tree_admission(
+    state: &DaemonState,
+    observation: Option<&BTreeSet<RepoPath>>,
+    publication: TreePublication,
+) -> Result<ExactTreeAdmission> {
+    let refusal = match exact_tree_admission_once(state, observation, publication) {
+        Err(error) if crate::repository_commit::is_stale_plan_refusal(&error) => error,
+        answered => return answered,
+    };
+    let levelling = match settle_levelling(state, level_graph_with_authority(state)) {
+        Ok(Some(levelling)) => levelling,
+        // Already level, so authority moved between this plan and its
+        // publication rather than the graph falling behind it: the refusal
+        // stands and the caller's ladder retries it. A levelling that failed was
+        // recorded where the surfaces read it, and the refusal it could not
+        // clear is still the answer.
+        Ok(None) | Err(_) => return Err(refusal),
+    };
+    let mut admission = exact_tree_admission_once(state, observation, publication)?;
+    admission.absorb_levelling(state.layout.working_dir(), levelling);
+    Ok(admission)
+}
+
+/// The paths one tree transition moved, and the host events that re-derive
+/// them.
+fn note_transition_paths(
+    working_dir: &Path,
+    deltas: &[TreeDelta],
+    changed_paths: &mut BTreeSet<RepoPath>,
+    semantic_events: &mut Vec<FileEvent>,
+) {
+    for delta in deltas {
+        if let Some(old) = delta.old_state() {
+            changed_paths.insert(old.path.clone());
+            if delta.new_state().is_none_or(|new| new.path != old.path) {
+                if let Ok(path) = kin_index::host_path_from_repo_path(working_dir, &old.path) {
+                    semantic_events.push(FileEvent::Removed(path));
+                }
+            }
+        }
+        if let Some(new) = delta.new_state() {
+            changed_paths.insert(new.path.clone());
+            if let Ok(path) = kin_index::host_path_from_repo_path(working_dir, &new.path) {
+                semantic_events.push(FileEvent::Changed(path));
+            }
+        }
+    }
+}
+
+/// The entity moves a transition's path relocations owe, planned through the
+/// same planner and binder the session admission uses rather than a shorter
+/// local rule.
+///
+/// Opens repository authority only when there is a relocation to plan: the
+/// module relocation reads bodies authority owns, and no other transition
+/// needs anything from it.
+fn plan_relocated_entities(
+    state: &DaemonState,
+    deltas: &[TreeDelta],
+    relocations: &[(FilePathId, FilePathId)],
+) -> Result<Vec<kin_model::EntityDelta>> {
+    let mut relocated_entities = Vec::new();
+    if relocations.is_empty() {
+        return Ok(relocated_entities);
+    }
+    let authority_context =
+        crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(state)?;
+    let authority = authority_context.open().map_err(DaemonError::Graph)?;
+    let module_relocations = crate::repository_commit::plan_session_module_relocations(
+        state.blobs.as_ref(),
+        &authority,
+        deltas,
+    )?;
+    for (from_id, to_id) in relocations {
+        relocated_entities.extend(crate::repository_commit::plan_session_entity_relocations(
+            state.graph.as_ref(),
+            from_id,
+            to_id,
+        )?);
+    }
+    crate::repository_commit::bind_session_module_relocations(
+        &mut relocated_entities,
+        &module_relocations,
+    )?;
+    Ok(relocated_entities)
+}
+
+/// Move the per-file records a relocation owes, after the transaction that
+/// moved the tree, in the order the MCP seam has always used. These records
+/// are not part of a TransactionDelta, so they were never inside one.
+fn relocate_file_records_for(
+    state: &DaemonState,
+    relocations: &[(FilePathId, FilePathId)],
+) -> Result<()> {
+    let mut moved_layouts = Vec::new();
+    for (from_id, to_id) in relocations {
+        crate::mcp_commit::relocate_file_records(
+            state.graph.as_ref(),
+            from_id,
+            to_id,
+            &mut moved_layouts,
+        )
+        .map_err(DaemonError::Graph)?;
+    }
+    Ok(())
+}
+
+/// What levelling the live graph with repository authority did.
+#[derive(Debug)]
+struct AuthorityLevelling {
+    /// The tree transition the live graph took to reach authority's tree.
+    deltas: Vec<TreeDelta>,
+    /// Relations dropped in the same transaction because the levelled graph no
+    /// longer carries one of their endpoints.
+    dropped_relations: Vec<kin_model::RelationId>,
+    /// The repository authority generation the graph was levelled to.
+    generation: u64,
+}
+
+/// Bring the live graph's exact tree level with repository authority's
+/// workspace tree.
+///
+/// Every complete admission plans from the live graph's tree, and publication
+/// refuses a plan taken from a tree authority does not hold, so a graph that
+/// falls behind authority refuses every later admission, and until this nothing
+/// in the daemon brought it level short of a restart. Measured on a long-lived
+/// store: one admission's tree crossed authority, the graph refused the same
+/// transition over a relation it could not carry, and every admission for the
+/// next eleven hours, 981 of them, was refused against the tree the graph never
+/// took.
+///
+/// It moves the TREE and the enrichment that goes with removed and moved paths,
+/// nothing more. The caller re-derives the paths it moves from their bytes,
+/// exactly as the round that fell behind would have. Authority's entity overlay
+/// is deliberately not imported: an ambient admission publishes no re-parsed
+/// entities, so that overlay can be older than the parse the live graph holds,
+/// and importing it would replace a fresh parse with a stale one.
+///
+/// A relation whose endpoint the levelled graph will not carry is dropped in the
+/// same transaction and returned so the caller can say so. kin-db checks every
+/// relation on every transaction and refuses the whole transaction over one
+/// such edge, which is how the round that fell behind was refused.
+///
+/// `None` when the graph is already level.
+fn level_graph_with_authority(state: &DaemonState) -> Result<Option<AuthorityLevelling>> {
+    let authority_context =
+        crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(state)?;
+    let authority_tree = crate::repository_commit::authority_workspace_tree(&authority_context)?;
+    let live_tree = state.graph.resolved_tree();
+    if live_tree == authority_tree {
+        return Ok(None);
+    }
+    let deltas = kin_core::exact_tree_correction(&live_tree, &authority_tree)?;
+    evict_enrichment_for_removed_paths(state, &deltas)?;
+    let relocations = path_relocations_in(&deltas);
+    let relocated_entities = plan_relocated_entities(state, &deltas, &relocations)?;
+    // The census walks the relations without copying the graph, so the copy
+    // the scan needs is paid only when there is a strand to find.
+    let stranded = if state.graph.stranded_relation_count() == 0 {
+        Vec::new()
+    } else {
+        relations_stranded_by(state.graph.as_ref(), &authority_tree, &relocated_entities)
+    };
+    let dropped_relations = stranded
+        .iter()
+        .map(|relation| relation.id)
+        .collect::<Vec<_>>();
+    state
+        .graph
+        .apply_transaction_delta(&TransactionDelta {
+            entity_deltas: relocated_entities,
+            relation_deltas: stranded
+                .into_iter()
+                .map(|old| kin_model::RelationDelta::Removed { old })
+                .collect(),
+            tree_deltas: deltas.clone(),
+            ..TransactionDelta::default()
+        })
+        .map_err(|error| name_stranded_endpoint_refusal(DaemonError::Graph(error), &deltas))?;
+    relocate_file_records_for(state, &relocations)?;
+    // A writer outside this daemon can move authority without this process
+    // hearing of it, and every later derived-index step compares against this
+    // cursor, so it follows the tree the graph was just levelled to.
+    let (roots, _) = current_authority_admission(state)?;
+    if roots.generation > state.snapshot_generation.load(Ordering::SeqCst) {
+        state.record_repository_authority_commit(roots.generation)?;
+    }
+    state.bump_version();
+    Ok(Some(AuthorityLevelling {
+        deltas,
+        dropped_relations,
+        generation: roots.generation,
+    }))
+}
+
+/// Relations the live graph holds that the levelled graph could not carry.
+///
+/// The test kin-db's transaction gate applies, for the two node kinds a tree
+/// transition moves: an entity endpoint has to be an entity the graph holds
+/// once `relocated` is applied, and an artifact endpoint has to be an artifact
+/// of `target_tree`. Every other kind is left to kin-db's own check, because a
+/// tree transition cannot strand it.
+fn relations_stranded_by(
+    graph: &kin_db::InMemoryGraph,
+    target_tree: &kin_model::ResolvedTree,
+    relocated: &[kin_model::EntityDelta],
+) -> Vec<kin_model::Relation> {
+    let snapshot = graph.to_snapshot();
+    let mut entities = snapshot
+        .entities
+        .keys()
+        .copied()
+        .collect::<std::collections::HashSet<_>>();
+    for delta in relocated {
+        match delta {
+            kin_model::EntityDelta::Added { new } => {
+                entities.insert(new.id);
+            }
+            kin_model::EntityDelta::Removed { old } => {
+                entities.remove(&old.id);
+            }
+            kin_model::EntityDelta::Modified { .. } => {}
+        }
+    }
+    let artifacts = target_tree
+        .artifacts_by_path()
+        .map(|artifact| artifact.artifact_id)
+        .collect::<std::collections::HashSet<_>>();
+    let carried = |node: kin_model::GraphNodeId| match node {
+        kin_model::GraphNodeId::Entity(id) => entities.contains(&id),
+        kin_model::GraphNodeId::Artifact(id) => artifacts.contains(&id),
+        _ => true,
+    };
+    snapshot
+        .relations
+        .into_values()
+        .filter(|relation| !carried(relation.src) || !carried(relation.dst))
+        .collect()
+}
+
+/// Record one levelling attempt where the surfaces read it, and hand it back.
+///
+/// A levelling that landed is published although it healed, because it changed
+/// what the graph holds and may have dropped relations, and a log line is gone
+/// by the time anyone reads a status surface. A failed one extends the count
+/// the surfaces turn into a restart-required wedge.
+fn settle_levelling(
+    state: &DaemonState,
+    attempt: Result<Option<AuthorityLevelling>>,
+) -> Result<Option<AuthorityLevelling>> {
+    let probes = state.background_work.reconcile();
+    match &attempt {
+        Ok(Some(levelling)) => {
+            let dropped = levelling
+                .dropped_relations
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>();
+            warn!(
+                generation = levelling.generation,
+                paths = levelling.deltas.len(),
+                dropped_relations = ?dropped,
+                "the live graph had fallen behind repository authority; levelled its tree with \
+                 authority, dropped the relations it could no longer carry, and re-deriving the \
+                 paths it moved"
+            );
+            probes.record_authority_levelled(
+                levelling.generation,
+                levelling.deltas.len() as u64,
+                &dropped,
+                Instant::now(),
+            );
+        }
+        Ok(None) => {}
+        Err(error) => {
+            let attempts = probes.record_authority_split(error, Instant::now());
+            warn!(
+                attempts,
+                error = %error,
+                "could not level the live graph with repository authority; complete admissions \
+                 are refused against authority's newer tree until a levelling lands"
+            );
+        }
+    }
+    attempt
+}
+
+/// Finish a round whose tree repository authority accepted and whose graph
+/// apply was refused.
+///
+/// Handing the refusal back is how a graph falls behind authority: the
+/// publication is durable, the graph keeps the tree authority just replaced,
+/// and every later plan is taken from that older tree. Levelling the graph now
+/// applies the transition the round owed and drops the relation that refused
+/// it, in the same round.
+fn level_after_refused_apply(state: &DaemonState, refusal: DaemonError) -> Result<()> {
+    warn!(
+        error = %refusal,
+        "repository authority accepted this admission's tree and the live graph refused the same \
+         transition; levelling the graph with authority"
+    );
+    match settle_levelling(state, level_graph_with_authority(state)) {
+        Ok(Some(_)) => Ok(()),
+        Ok(None) | Err(_) => Err(refusal),
+    }
 }
 
 /// Run one ambient reconcile round's admission the way the loop runs it, and
@@ -4496,6 +4792,7 @@ mod tests {
 
     include!("loop_runner/tests/startup_recovery.rs");
     include!("loop_runner/tests/enrichment_churn.rs");
+    include!("loop_runner/tests/authority_split.rs");
 
     #[test]
     fn partial_c_disclosure_persists_and_only_clean_outcomes_settle() {

--- a/crates/kin-daemon/src/loop_runner/tests/authority_split.rs
+++ b/crates/kin-daemon/src/loop_runner/tests/authority_split.rs
@@ -1,0 +1,281 @@
+// The live graph falling behind repository authority, and the levelling that
+// brings it back level. Included into `loop_runner::tests`.
+
+/// Plant the edge a late enrichment write can leave: a relation whose source
+/// entity the graph does not hold.
+///
+/// `upsert_relation` does not judge entity endpoints, while kin-db's
+/// transaction gate refuses every later transaction as long as one stands.
+/// Returns the relation and the endpoint it is filed under.
+#[cfg(unix)]
+fn split_plant_relation_from_a_missing_entity(
+    state: &Arc<DaemonState>,
+    target_file: &str,
+) -> (kin_model::RelationId, kin_model::GraphNodeId) {
+    let target = state
+        .graph
+        .query_entities(&EntityFilter {
+            file_path: Some(FilePathId::new(target_file)),
+            ..Default::default()
+        })
+        .unwrap()
+        .into_iter()
+        .find(|entity| entity.kind == kin_model::EntityKind::Function)
+        .expect("the fixture file derives a function");
+    let endpoint = kin_model::GraphNodeId::Entity(target.id);
+    let relation = kin_model::Relation {
+        id: kin_model::RelationId::new(),
+        kind: kin_model::RelationKind::Calls,
+        src: kin_model::GraphNodeId::Entity(EntityId::new()),
+        dst: endpoint,
+        confidence: 0.95,
+        origin: kin_model::RelationOrigin::Lsp,
+        created_in: None,
+        import_source: None,
+        evidence: Vec::new(),
+    };
+    state.graph.upsert_relation(&relation).unwrap();
+    (relation.id, endpoint)
+}
+
+#[cfg(unix)]
+fn split_relation_is_held(
+    state: &DaemonState,
+    relation: kin_model::RelationId,
+    endpoint: kin_model::GraphNodeId,
+) -> bool {
+    state
+        .graph
+        .get_all_relations_for_node(&endpoint)
+        .unwrap()
+        .iter()
+        .any(|held| held.id == relation)
+}
+
+#[cfg(unix)]
+fn split_function_start_line(state: &DaemonState, name: &str) -> u32 {
+    state
+        .graph
+        .query_entities(&EntityFilter::default())
+        .unwrap()
+        .into_iter()
+        .find(|entity| entity.name == name && entity.kind == kin_model::EntityKind::Function)
+        .and_then(|entity| entity.span)
+        .map(|span| span.start_line)
+        .expect("the function is in the graph with a span")
+}
+
+/// Move repository authority to new bytes at `rel_path` without the live graph
+/// hearing of it, which is the state a split leaves: authority one generation
+/// ahead of the graph.
+#[cfg(unix)]
+fn split_publish_behind_the_graphs_back(state: &Arc<DaemonState>, rel_path: &str, content: &[u8]) {
+    std::fs::write(state.layout.working_dir().join(rel_path), content).unwrap();
+    let digest = state.blobs.write(content).unwrap();
+    let previous = state.graph.resolved_tree();
+    let path = test_repo_path(rel_path);
+    let desired = kin_model::ResolvedTree::from_artifacts(previous.artifacts_by_path().map(
+        |artifact| {
+            if artifact.path == path {
+                kin_model::ResolvedArtifact::new(
+                    artifact.artifact_id,
+                    artifact.path.clone(),
+                    TreeEntry::blob(Hash256::from_bytes(digest.0), false),
+                )
+            } else {
+                artifact.clone()
+            }
+        },
+    ))
+    .unwrap();
+    let (roots, _) = current_authority_admission(state).unwrap();
+    let admitted = crate::repository_commit::admitted_workspace_tree_for_test(
+        state.layout.working_dir(),
+        roots,
+        previous,
+        desired,
+    );
+    let context =
+        crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(state)
+            .unwrap();
+    crate::repository_commit::publish_workspace_tree(
+        state.blobs.as_ref(),
+        &context,
+        &admitted,
+        kin_model::OperationId::new(),
+        kin_model::AuthorId::new("a writer this daemon never heard from"),
+    )
+    .unwrap()
+    .expect("authority moves to the new bytes");
+}
+
+/// An admission whose tree authority accepts and whose graph apply is refused is
+/// finished in the same round: the graph is levelled with authority, the relation
+/// that refused it is dropped with a record, and the next admission plans from
+/// the tree authority holds.
+///
+/// This is the split reproduced through its real trigger, a relation whose
+/// source entity the graph does not hold. Without the levelling the round hands
+/// back the refusal with authority one generation ahead of the graph, and every
+/// later round is refused as a stale plan, one full authority open each.
+#[cfg(unix)]
+#[test]
+#[serial_test::serial(commit_phase_capture)]
+fn a_graph_apply_refused_after_authority_moved_is_levelled_in_the_same_round() {
+    let repo = tempfile::tempdir().unwrap();
+    let state = open_test_state(&repo);
+    admit_and_derive(&state, "a.py", "def a():\n    return 1\n");
+    admit_and_derive(&state, "b.py", "def b():\n    return 2\n");
+    let (dangling, endpoint) = split_plant_relation_from_a_missing_entity(&state, "a.py");
+    let generation = authority_generation(&state);
+
+    std::fs::write(repo.path().join("b.py"), "def b():\n    return 3\n").unwrap();
+    let observation = BTreeSet::from([test_repo_path("b.py")]);
+    let admission = exact_tree_admission(&state, Some(&observation), TreePublication::Standalone)
+        .expect("a round whose tree authority accepted must finish, not leave the graph behind");
+
+    assert_eq!(
+        authority_generation(&state),
+        generation + 1,
+        "the round published its tree"
+    );
+    assert_eq!(
+        state.graph.resolved_tree(),
+        authority_tree(&state),
+        "the live graph must be level with authority when the round returns"
+    );
+    assert!(
+        !split_relation_is_held(&state, dangling, endpoint),
+        "the relation that refused the transition is dropped"
+    );
+    let levelled = state
+        .background_work
+        .reconcile()
+        .report(Instant::now())
+        .authority_levelled
+        .expect("a levelling that dropped a relation is recorded, not only logged");
+    assert_eq!(levelled.dropped_relations, 1);
+    assert_eq!(levelled.dropped_relations_sample, vec![dangling.to_string()]);
+    assert!(
+        admission
+            .semantic_events
+            .iter()
+            .any(|event| matches!(event, FileEvent::Changed(path) if path.ends_with("b.py"))),
+        "the path the round moved is still re-derived: {:?}",
+        admission.semantic_events
+    );
+
+    std::fs::write(repo.path().join("a.py"), "def a():\n    return 4\n").unwrap();
+    let next = BTreeSet::from([test_repo_path("a.py")]);
+    exact_tree_admission(&state, Some(&next), TreePublication::Standalone)
+        .expect("the next admission plans from authority's tree and is not refused as stale");
+    assert_eq!(authority_generation(&state), generation + 2);
+}
+
+/// A graph already behind authority is levelled on the first stale-plan refusal
+/// and the observation is planned again, so the file it names is admitted and
+/// re-derived at its new position.
+///
+/// The shape of a store left split: authority holds a newer tree the graph never
+/// took, and a file whose function has moved down its file waits in the startup
+/// catch-up. Before the levelling every round was refused and the graph kept
+/// answering at the function's old line.
+#[cfg(unix)]
+#[test]
+#[serial_test::serial(commit_phase_capture)]
+fn a_plan_from_a_graph_behind_authority_is_levelled_and_planned_again() {
+    let repo = tempfile::tempdir().unwrap();
+    let state = open_test_state(&repo);
+    let original = "def human_bytes(n):\n    return n\n";
+    admit_and_derive(&state, "cache.py", original);
+    admit_and_derive(&state, "other.py", "def other():\n    return 1\n");
+    let before = split_function_start_line(&state, "human_bytes");
+
+    split_publish_behind_the_graphs_back(&state, "other.py", b"def other():\n    return 2\n");
+    assert_ne!(
+        state.graph.resolved_tree(),
+        authority_tree(&state),
+        "the fixture must leave the graph behind authority or nothing below is tested"
+    );
+
+    let moved = format!("{}{original}", "# moved down\n".repeat(6));
+    std::fs::write(repo.path().join("cache.py"), &moved).unwrap();
+    let observation = BTreeSet::from([test_repo_path("cache.py")]);
+    let admission = exact_tree_admission(&state, Some(&observation), TreePublication::Standalone)
+        .expect("a plan from a graph behind authority is levelled and planned again, not refused");
+
+    assert_eq!(
+        state.graph.resolved_tree(),
+        authority_tree(&state),
+        "graph and authority agree after the round"
+    );
+    assert!(
+        admission
+            .semantic_events
+            .iter()
+            .any(|event| matches!(event, FileEvent::Changed(path) if path.ends_with("other.py"))),
+        "the path the levelling moved is re-derived with the round's own: {:?}",
+        admission.semantic_events
+    );
+    derive_semantics(&state, "cache.py");
+    assert_eq!(
+        split_function_start_line(&state, "human_bytes"),
+        before + 6,
+        "the admission observed the file at its new position"
+    );
+    let levelled = state
+        .background_work
+        .reconcile()
+        .report(Instant::now())
+        .authority_levelled
+        .expect("the levelling is recorded");
+    assert_eq!(levelled.paths, 1, "one path was behind: {levelled:?}");
+    assert_eq!(levelled.dropped_relations, 0);
+}
+
+/// A levelling that fails is published with its count, reaches the restart
+/// ceiling the surfaces name, and is cleared by the first levelling that lands.
+#[test]
+fn a_failed_levelling_counts_toward_the_restart_ceiling_and_one_that_lands_clears_it() {
+    let repo = tempfile::tempdir().unwrap();
+    let state = open_test_state(&repo);
+    let refused = || -> Result<Option<AuthorityLevelling>> {
+        Err(DaemonError::IncompatibleRepo(
+            "transaction relation r1 has unadmitted source endpoint entity:e1".to_string(),
+        ))
+    };
+    for attempt in 1..=kin_cli::commands::resources::AUTHORITY_SPLIT_WEDGE_ATTEMPTS {
+        assert!(settle_levelling(&state, refused()).is_err());
+        let split = state
+            .background_work
+            .reconcile()
+            .report(Instant::now())
+            .authority_split
+            .expect("a failed levelling is published, not only logged");
+        assert_eq!(split.attempts, attempt);
+        assert!(split.error.contains("unadmitted source endpoint"), "{split:?}");
+    }
+    let wedged = state.background_work.reconcile().report(Instant::now());
+    assert!(
+        wedged.degraded_reasons()[0].starts_with("restart required"),
+        "{:?}",
+        wedged.degraded_reasons()
+    );
+
+    let landed = settle_levelling(
+        &state,
+        Ok(Some(AuthorityLevelling {
+            deltas: Vec::new(),
+            dropped_relations: Vec::new(),
+            generation: 9,
+        })),
+    )
+    .unwrap();
+    assert!(landed.is_some());
+    let report = state.background_work.reconcile().report(Instant::now());
+    assert!(
+        report.authority_split.is_none(),
+        "a levelling that landed ends the split"
+    );
+    assert_eq!(report.authority_levelled.unwrap().generation, 9);
+}

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -958,6 +958,27 @@ pub(crate) fn commit_session_workspace_admission(
     })
 }
 
+/// The clause both stale-plan refusals in [`publish_workspace_tree`] end on.
+///
+/// One constant for the refusal and for [`is_stale_plan_refusal`], because the
+/// reconcile loop answers this refusal differently from every other one. It does
+/// not describe the transition; it says the tree the plan was taken from is not
+/// the tree authority holds, so the answer is to bring the graph level with
+/// authority and plan again, never to retry the same plan. A classifier holding
+/// its own copy of this text would stop matching the first time the wording
+/// moved; one reading the constant the refusal is built from cannot.
+pub(crate) const STALE_PLAN_REFUSAL: &str =
+    "exact admission does not replan a stale desired tree against newer authority";
+
+/// Whether `error` is one of [`publish_workspace_tree`]'s stale-plan refusals.
+pub(crate) fn is_stale_plan_refusal(error: &DaemonError) -> bool {
+    matches!(
+        error,
+        DaemonError::Core(kin_core::KinError::Model(ModelError::InvalidOperation(message)))
+            if message.contains(STALE_PLAN_REFUSAL)
+    )
+}
+
 /// Atomically publish one exact graph-owned workspace tree.
 ///
 /// The caller has already performed the explicit filesystem-ingestion scan and
@@ -990,10 +1011,10 @@ pub(crate) fn publish_workspace_tree(
     let authority = authority_context.open().map_err(DaemonError::Graph)?;
     let lease = authority.read_authority();
     if lease.roots() != &admitted.expected_roots {
-        return Err(invalid(
+        return Err(invalid(format!(
             "repository authority moved after the complete workspace observation was planned; \
-             exact admission does not replan a stale desired tree against newer authority",
-        ));
+             {STALE_PLAN_REFUSAL}"
+        )));
     }
     let workspace = lease
         .metadata()
@@ -1013,11 +1034,10 @@ pub(crate) fn publish_workspace_tree(
         )));
     }
     if workspace.tree != admitted.previous_tree {
-        return Err(invalid(
+        return Err(invalid(format!(
             "the complete workspace observation was planned against a tree that is not this \
-             workspace's authority tree; exact admission does not replan a stale desired tree \
-             against newer authority",
-        ));
+             workspace's authority tree; {STALE_PLAN_REFUSAL}"
+        )));
     }
     if workspace.tree == *desired_tree {
         return Ok(None);
@@ -2997,6 +3017,15 @@ mod tests {
                 .contains("does not replan a stale desired tree against newer authority"),
             "{error}"
         );
+        assert!(
+            super::is_stale_plan_refusal(&error),
+            "the reconcile loop levels the graph on exactly this refusal, so it has to recognize \
+             it: {error}"
+        );
+        assert!(
+            !super::is_stale_plan_refusal(&super::invalid("an unrelated refusal")),
+            "and only it"
+        );
 
         let lease = context.open().unwrap().read_authority();
         let workspace = lease
@@ -3060,6 +3089,7 @@ mod tests {
                 .contains("does not replan a stale desired tree against newer authority"),
             "{error}"
         );
+        assert!(super::is_stale_plan_refusal(&error), "{error}");
     }
 
     #[test]


### PR DESCRIPTION
## What

A daemon whose live graph falls behind repository authority now levels the graph with authority and keeps admitting, instead of refusing every admission until someone restarts it.

Two places do it. When an ambient admission's tree has already crossed authority and the live graph then refuses the same transition, the round levels the graph in place before it returns. When a plan is refused because it was taken from a tree authority does not hold, the loop levels the graph and plans the observation once more, against the tree authority actually holds. A relation the levelled graph cannot carry is dropped in the same transaction and recorded. A levelling that fails is counted, and after three in a row every status surface says a restart is required and names `kin daemon stop`.

FIR-3546. FIR-3540's settle fallback for `find_references` is the next pull request.

## Why

The founder's own daemon (kin 0.7.9, pid 12538) has refused every complete admission since 2026-09-10T18:17:42Z. Read from its log, with the daemon untouched and the store unopened:

```text
98728: 2026-09-10T18:17:41.974661Z  INFO admitted exact workspace tree into repository authority ... generation=17 ... file_deltas=8
98730: 2026-09-10T18:17:42.019103Z  WARN complete exact-tree admission failed ... error=refusing to drop this transition: the graph still holds a relation whose endpoint is the artifact being removed, and kin-db refuses a transition that strands one (Graph error: storage error: transaction relation 1426e6a7-3bcb-080b-fa61-b04267f3bb1f has unadmitted source endpoint entity:bd1bd80c-e4a7-4a6c-84b2-a91a7f58f70e) ...
98736: 2026-09-10T18:19:06.992154Z  WARN complete exact-tree admission failed ... error=... the complete workspace observation was planned against a tree that is not this workspace's authority tree; exact admission does not replan a stale desired tree against newer authority
```

The standalone admission publishes to authority first and applies the same tree delta to the live graph second. At generation 17 the publication landed and the graph apply was refused over one relation whose source entity the graph no longer held. `upsert_relation` does not judge entity endpoints, so an enrichment write can leave exactly that edge, and kin-db's transaction gate refuses the whole transaction while it stands. From then on authority held generation 17's tree and the graph held generation 16's. Every later plan was taken from the graph's tree and `publish_workspace_tree` refused it. The persistence flush refused on the same divergence and logged it as "daemon persistence unhealthy: check disk space and permissions", which is not the cause. Nothing in the daemon brought the graph level short of a restart.

What that cost, 2026-09-11T05:20:24Z to 06:27:54Z (4,050 s):

```text
refused admissions                              76, one every 53 s
publish_workspace_admission time                1,856,878 ms, 21,413 to 31,963 ms each (45.8% of wall time)
full-store authority opens (every body re-verified)  139
  from the refused publish                      75
  from the refused persistence flush            64
```

The loop holds the graph-authority mutation guard across the refused publish, so for 45.8% of that hour every stable reader found no settled epoch. That is FIR-3540's `find_references` failure on this store.

Across the log (it starts 2026-08-10) the split happened exactly once, and only 16 ambient admissions succeeded in a month. It mattered this much because of what it froze. A file changed while no daemon was running is seen by nobody: the watcher only reports what it was alive for, so the next daemon's startup catch-up re-observes the paths modified since the last successful admission and nothing older. The founder's `crates/kin-cli/src/commands/cache.rs` changed on disk at 2026-09-10T00:12:17Z, inside that daemon's catch-up window, and the split stopped the catch-up after 160 paths, so the graph still answers for `human_bytes` at its July line. Once a split stands, even the files a daemon was about to take stay behind.

Restarts are not the gap here. Every ambient publication records semantic debt and the first round after a start re-parses it; the existing reopen tests are green on this base (`startup_diagnostic_standalone_admission_retains_exact_body_debt`, `startup_diagnostic_refused_commit_retains_fallback_debt_and_recovers_after_reopen` with `{"before":0,"after":17,"expected":17}`, `startup_diagnostic_purge_records_changed_body_for_reopen`; 3 passed, 0 failed).

### Reproduced on main before the change

A scratch harness (not in this change) on `47aa5172c`: admit and derive two files, plant one relation whose source entity the graph does not hold, edit one file, run one ambient admission, then keep editing.

```text
SPLIT_MEASURE round=split ok=false elapsed_ms=99 authority_opens=1 generation_before=3 generation_after=4 graph_tree_is_authority_tree=false error=Some("refusing to drop this transition: ...")
SPLIT_MEASURE round=1 ok=false elapsed_ms=17 authority_opens=1 generation=4 graph_tree_is_authority_tree=false error=Some("... planned against a tree that is not this workspace's authority tree; exact adm")
SPLIT_MEASURE rounds 2 to 5: the same refusal, one authority open each, generation stays 4
```

The real reconcile loop over the same split, with kin#1686's hold in place, attempted at 0.16, 0.27, 0.53, 0.95, 3.1, 7.1, 15.2 and 31.3 seconds and was still split at 45 seconds. The hold spaces the refusals out; nothing levels the graph, so they never end.

The same harness on this change:

```text
SPLIT_MEASURE round=split ok=true elapsed_ms=107 authority_opens=3 generation_before=3 generation_after=4 graph_tree_is_authority_tree=true error=None
SPLIT_MEASURE round=1 ok=true elapsed_ms=99 authority_opens=1 generation=5 graph_tree_is_authority_tree=true error=None
SPLIT_MEASURE rounds 2 to 5: ok, one authority open each, generation 6 to 9, level every time
SPLIT_CADENCE end t_ms=45040 failures=0 streak=0 graph_tree_is_authority_tree=true
```

The round that used to split levels in place and every later round admits.

## How

`crates/kin-daemon/src/loop_runner.rs`:

- `level_graph_with_authority` reads authority's workspace tree, applies `exact_tree_correction` from the live tree to it with the same eviction and relocation planning an ambient admission uses, and drops in the same transaction every relation kin-db's gate would refuse: an entity endpoint the graph will not hold, or an artifact endpoint the target tree does not carry. The whole-graph scan runs only when kin-db's `stranded_relation_count` finds a strand. It moves the tree and the enrichment that goes with removed and moved paths, and it does not import authority's entity overlay, because an ambient admission publishes no re-parsed entities and that overlay can be older than the parse the graph holds. If authority moved without this daemon, the generation cursor follows it.
- After a standalone publication, a refused graph apply now calls `level_after_refused_apply`, so the round that would have split finishes level. A deferred tree has not crossed authority, so its refusal is returned unchanged.
- `exact_tree_admission` answers a stale-plan refusal by levelling and planning once more. Once, not in a loop.
- `settle_levelling` publishes every attempt: a landed levelling with what it moved and dropped, a failed one with its count.

`crates/kin-daemon/src/repository_commit.rs`: both stale-plan refusals are built from one constant, `STALE_PLAN_REFUSAL`, and `is_stale_plan_refusal` reads that constant and the error's variant rather than a copy of the text.

`crates/kin-daemon/src/background_work.rs` and `crates/kin-cli/src/commands/resources.rs`: `ReconcileHealth` gains `authority_split` and `authority_levelled`, both absent unless set. A split is a degraded reason naming its count and last error, and from `AUTHORITY_SPLIT_WEDGE_ATTEMPTS` (3) on it leads with "restart required" and names `kin daemon stop`. A landed levelling is a notice naming the generation, the paths and the dropped relation ids. A successful admission or levelling clears the split.

## Tests

Three crate tests in `crates/kin-daemon/src/loop_runner/tests/authority_split.rs`, the split reproduced through its real trigger:

- `a_graph_apply_refused_after_authority_moved_is_levelled_in_the_same_round`: the planted relation, one edited file, one admission. The round returns level with authority, the relation is gone and recorded, the moved path is still re-derived, and the next admission is not refused.
- `a_plan_from_a_graph_behind_authority_is_levelled_and_planned_again`: authority moved behind the graph's back, then a file whose function moved down six lines is observed. The round levels, plans again, and the function is re-derived six lines down. That is the cache.rs shape.
- `a_failed_levelling_counts_toward_the_restart_ceiling_and_one_that_lands_clears_it`.

Plus two rendering tests in `resources.rs` and the stale-plan classifier asserted in the two existing `repository_commit` refusal tests.

The changed modules, run through the fleet's build slot on this worktree:

```sh
cargo test -p kin-daemon -p kin-cli --lib -- loop_runner:: repository_commit:: background_work:: commands::resources::
```

```text
test loop_runner::tests::a_plan_from_a_graph_behind_authority_is_levelled_and_planned_again ... ok
test repository_commit::tests::desired_tree_planned_against_a_foreign_prior_tree_is_refused ... ok
test repository_commit::tests::stale_desired_tree_is_refused_against_newer_authority ... ok
test loop_runner::tests::a_graph_apply_refused_after_authority_moved_is_levelled_in_the_same_round ... ok
test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 2269 filtered out; finished in 0.01s    (kin-cli)
test result: ok. 231 passed; 0 failed; 2 ignored; 0 measured; 1414 filtered out; finished in 80.93s  (kin-daemon)
```

The two ignored tests were the measurement harness, which is not part of this change.

## Falsification

Every arm is one exact string swap, a run of that arm's test alone by its full path with `--exact` (the harness refuses an arm whose test line never appears), then the inverse swap with the file's sha256 asserted back to its pre-arm value.

```text
ARM A1 in-round levelling removed (Err(refusal) => return Err(refusal)): rc=101 RED (good)
thread 'loop_runner::tests::a_graph_apply_refused_after_authority_moved_is_levelled_in_the_same_round' panicked at crates/kin-daemon/src/loop_runner/tests/authority_split.rs:135:10:
a round whose tree authority accepted must finish, not leave the graph behind: IncompatibleRepo("refusing to drop this transition: the graph still holds a relation whose endpoint is the artifact being removed, and kin-db refuses a transition that strands one (Graph error: storage error: transaction relation d1fcff49-... has unadmitted source endpoint entity:f36330f3-...). ...")

ARM A2 replan removed (the stale-plan guard made unreachable): rc=101 RED (good)
thread 'loop_runner::tests::a_plan_from_a_graph_behind_authority_is_levelled_and_planned_again' panicked at crates/kin-daemon/src/loop_runner/tests/authority_split.rs:205:10:
a plan from a graph behind authority is levelled and planned again, not refused: Core(Model(InvalidOperation("the complete workspace observation was planned against a tree that is not this workspace's authority tree; exact admission does not replan a stale desired tree against newer authority")))

ARM A3 stranded relations kept (the scan never runs): rc=101 RED (good)
thread 'loop_runner::tests::a_graph_apply_refused_after_authority_moved_is_levelled_in_the_same_round' panicked at crates/kin-daemon/src/loop_runner/tests/authority_split.rs:135:10:
a round whose tree authority accepted must finish, not leave the graph behind: IncompatibleRepo("refusing to drop this transition: ... transaction relation ad5a4afe-... has unadmitted source endpoint entity:a4faf1e6-... ...")

ARM A4 a failed levelling not counted: rc=101 RED (good)
thread 'loop_runner::tests::a_failed_levelling_counts_toward_the_restart_ceiling_and_one_that_lands_clears_it' panicked at crates/kin-daemon/src/loop_runner/tests/authority_split.rs:254:14:
a failed levelling is published, not only logged

ARM A5 a landed levelling not recorded: rc=101 RED (good)
thread 'loop_runner::tests::a_graph_apply_refused_after_authority_moved_is_levelled_in_the_same_round' panicked at crates/kin-daemon/src/loop_runner/tests/authority_split.rs:156:10:
a levelling that dropped a relation is recorded, not only logged

ARM A6 a landed levelling leaves the split standing: rc=101 RED (good)
thread 'loop_runner::tests::a_failed_levelling_counts_toward_the_restart_ceiling_and_one_that_lands_clears_it' panicked at crates/kin-daemon/src/loop_runner/tests/authority_split.rs:276:5:
a levelling that landed ends the split

ARM A7 the stale-plan classifier blind: rc=101 RED (good)
thread 'repository_commit::tests::stale_desired_tree_is_refused_against_newer_authority' panicked at crates/kin-daemon/src/repository_commit.rs:3020:9:
the reconcile loop levels the graph on exactly this refusal, so it has to recognize it: Core error: model error: invalid operation: repository authority moved after the complete workspace observation was planned; exact admission does not replan a stale desired tree against newer authority
```

```text
ARM A8 the restart ceiling ignored (restart named from the first failure): rc=101 RED (good)
thread 'commands::resources::tests::a_split_says_restart_only_once_levelling_has_failed_past_its_ceiling' panicked at crates/kin-cli/src/commands/resources.rs:1633:9:
the count is the news: ["restart required, the live graph cannot be levelled with repository authority: levelling has failed 1 consecutive times (restart required at 3), ..."]

ARM A9 the levelled notice dropped: rc=101 RED (good)
thread 'commands::resources::tests::a_levelling_that_landed_is_a_notice_naming_what_it_dropped' panicked at crates/kin-cli/src/commands/resources.rs:1686:9:
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2300 filtered out; finished in 0.02s
```

Nine arms, nine reds, and after the last one all five files compared byte-identical to a copy taken before the first.

## Precheck

```sh
.kin-coord/bin/heavy-slot.sh daemonlife kin -- \
  bin/kin-precheck kin --repo-dir kin=.kin-coord/worktrees/daemonlife-kin
```

```text
kin-precheck: repo=kin tree=.kin-coord/worktrees/daemonlife-kin sha=47aa5172cae3b5342652aaaa6795c3731b6304dd branch=chore/lane-daemonlife-kin DIRTY
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin 47aa5172cae3b5342652aaaa6795c3731b6304dd DIRTY
```

DIRTY is the point: the sha names the base, and the tree graded was that base plus exactly this change. The branch was then rebased onto `3c2da55b0`, whose two new commits touch none of these files.

## Not in this change

FIR-3540's settle fallback, so `find_references` answers from the last certified graph state with a disclosure when a writer holds the epoch through every attempt. It is the next pull request.

The late enrichment write that leaves a relation with no source entity. kin-db's `upsert_relation` deliberately does not judge entity endpoints, so the write that created the edge on the founder's store is still possible; what changes here is that it no longer wedges the store.

The persistence flush's "check disk space and permissions" line for a tree mismatch. With the split levelled in the round it arises, the flush recovers on its own, so the line no longer stands for hours.
