### PR TITLE
Publish agent writes through authority and accept a working copy at the staged bytes (FIR-3550)

### DIFF
--- a/crates/kin-agent/src/belt.rs
+++ b/crates/kin-agent/src/belt.rs
@@ -430,8 +430,91 @@ pub fn resolve_across_repos(repos: &[PathBuf], raw: &str) -> Result<(usize, Path
     }
 }
 
-/// Run `edit_file`.
+/// An `edit_file` call resolved against the file's current text, before anything is written.
+///
+/// The harness publishes an edit through repository authority, and authority's projection is
+/// what writes the file, so the edit is computed here and handed to the stage as the file's
+/// complete new text instead of being applied to the working copy first.
+#[derive(Debug, Clone)]
+pub struct PlannedEdit {
+    /// The path as the model wrote it, for the messages the model reads.
+    pub raw_path: String,
+    /// The resolved path inside the repository.
+    pub path: PathBuf,
+    /// How many occurrences the edit replaces.
+    pub replaced: usize,
+    /// The file's length before the edit, in bytes.
+    pub before_len: usize,
+    /// The file's complete new text.
+    pub updated: String,
+}
+
+impl PlannedEdit {
+    /// What the edit does, without saying whether it landed.
+    fn summary(&self) -> String {
+        format!(
+            "Edited `{}`: replaced {} occurrence{} ({} bytes before, {} after)",
+            self.raw_path,
+            self.replaced,
+            if self.replaced == 1 { "" } else { "s" },
+            self.before_len,
+            self.updated.len()
+        )
+    }
+}
+
+/// Run `edit_file` on the working copy directly.
+///
+/// This is the path for an edit no transaction brackets. A bracketed edit is planned with
+/// [`plan_edit`] and published through repository authority, which writes the file itself.
 pub fn run_edit(repo: &Path, arguments: &Value) -> LocalOutcome {
+    let planned = match plan_edit(repo, arguments) {
+        Ok(planned) => planned,
+        Err(refusal) => return refusal,
+    };
+    if let Err(err) = std::fs::write(&planned.path, &planned.updated) {
+        return LocalOutcome::error(format!("could not write `{}`: {err}", planned.raw_path));
+    }
+    LocalOutcome {
+        text: format!("{}.", planned.summary()),
+        is_error: false,
+        changed: Some(planned.raw_path.clone()),
+        body: Some(planned.updated),
+    }
+}
+
+/// The outcome of an `edit_file` whose change repository authority published for us.
+///
+/// The new text reached the working copy through the commit rather than through this
+/// process, so nothing is written here; the model is told what landed and who wrote it.
+pub fn published_edit(planned: PlannedEdit) -> LocalOutcome {
+    LocalOutcome {
+        text: format!(
+            "{} and published it through repository authority, which wrote the file.",
+            planned.summary()
+        ),
+        is_error: false,
+        changed: Some(planned.raw_path.clone()),
+        body: Some(planned.updated),
+    }
+}
+
+/// The outcome of an `edit_file` repository authority did not publish.
+///
+/// Nothing was written. The edit exists only in the model's own call, the working copy and
+/// the graph both still hold the file as it was, and the model is told so, with the server's
+/// reason, so it can correct the cause and send the edit again.
+pub fn unpublished_edit(planned: &PlannedEdit, reason: &str) -> LocalOutcome {
+    LocalOutcome::error(format!(
+        "The edit of `{path}` did not land: repository authority did not publish it: {reason}. \
+         Nothing was written, so `{path}` is unchanged on disk and in the graph. Correct the \
+         cause and send the edit again.",
+        path = planned.raw_path,
+    ))
+}
+
+/// Resolve an `edit_file` call against the file's current text without writing anything.
+pub fn plan_edit(repo: &Path, arguments: &Value) -> Result<PlannedEdit, LocalOutcome> {
     let raw_path = arguments.get("path").and_then(Value::as_str).unwrap_or("");
     let find = arguments.get("find").and_then(Value::as_str).unwrap_or("");
     let replace = arguments
@@ -443,55 +526,37 @@ pub fn run_edit(repo: &Path, arguments: &Value) -> LocalOutcome {
         .and_then(Value::as_bool)
         .unwrap_or(false);
 
-    let path = match resolve_in_repo(repo, raw_path) {
-        Ok(path) => path,
-        Err(message) => return LocalOutcome::error(message),
-    };
-    let original = match std::fs::read_to_string(&path) {
-        Ok(text) => text,
-        Err(err) => {
-            return LocalOutcome::error(format!(
-                "could not read `{raw_path}`: {err}. Use Kin to find the file before editing it."
-            ))
-        }
-    };
+    let path = resolve_in_repo(repo, raw_path).map_err(LocalOutcome::error)?;
+    let original = std::fs::read_to_string(&path).map_err(|err| {
+        LocalOutcome::error(format!(
+            "could not read `{raw_path}`: {err}. Use Kin to find the file before editing it."
+        ))
+    })?;
     let occurrences = original.matches(find).count();
     if occurrences == 0 {
-        return LocalOutcome::error(format!(
+        return Err(LocalOutcome::error(format!(
             "the `find` text does not appear in `{raw_path}`. Read the exact current text with \
              {KIN_TOOL_PREFIX}get_entity_source before editing, and match it byte for byte."
-        ));
+        )));
     }
     if occurrences > 1 && !replace_all {
-        return LocalOutcome::error(format!(
+        return Err(LocalOutcome::error(format!(
             "the `find` text appears {occurrences} times in `{raw_path}`. Give a longer, unique \
              snippet, or set replace_all to true if every occurrence should change."
-        ));
+        )));
     }
     let updated = if replace_all {
         original.replace(find, replace)
     } else {
         original.replacen(find, replace, 1)
     };
-    if let Err(err) = std::fs::write(&path, &updated) {
-        return LocalOutcome::error(format!("could not write `{raw_path}`: {err}"));
-    }
-    LocalOutcome {
-        text: format!(
-            "Edited `{raw_path}`: replaced {} occurrence{} ({} bytes before, {} after).",
-            if replace_all { occurrences } else { 1 },
-            if replace_all && occurrences != 1 {
-                "s"
-            } else {
-                ""
-            },
-            original.len(),
-            updated.len()
-        ),
-        is_error: false,
-        changed: Some(raw_path.to_string()),
-        body: Some(updated),
-    }
+    Ok(PlannedEdit {
+        raw_path: raw_path.to_string(),
+        path,
+        replaced: if replace_all { occurrences } else { 1 },
+        before_len: original.len(),
+        updated,
+    })
 }
 
 /// Run `write_file`.
@@ -546,6 +611,25 @@ pub fn published_create(arguments: &Value) -> LocalOutcome {
         changed: Some(raw_path.to_string()),
         body: Some(content.to_string()),
     }
+}
+
+/// The outcome of a `write_file` repository authority did not publish.
+///
+/// Nothing is written, so the path stays exactly as it was on disk and in the graph. The
+/// refused content comes back in the result, which is where the model keeps its work: a
+/// copy left on disk was a file the graph did not hold, the same split a refused edit left.
+pub fn unpublished_create(arguments: &Value, reason: &str) -> LocalOutcome {
+    let raw_path = arguments.get("path").and_then(Value::as_str).unwrap_or("");
+    let content = arguments
+        .get("content")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    LocalOutcome::error(format!(
+        "`{raw_path}` was not created: repository authority did not publish it: {reason}. \
+         Nothing was written, so `{raw_path}` is unchanged on disk and in the graph. The {} \
+         bytes you sent follow, so you can correct the cause and send them again:\n{content}",
+        content.len()
+    ))
 }
 
 impl LocalOutcome {

--- a/crates/kin-agent/src/run.rs
+++ b/crates/kin-agent/src/run.rs
@@ -105,8 +105,9 @@ struct Counters {
     kin_calls: u32,
     local_calls: u32,
     refused_calls: u32,
-    /// Local edits whose transaction the daemon refused to publish. A run holding one of
-    /// these wrote files and landed nothing, which must not read as a success.
+    /// Changes the model asked for that repository authority did not publish. A run holding
+    /// one of these landed nothing for that change, whatever its closing paragraph says,
+    /// which must not read as a success.
     unpublished_changes: u32,
     repairs: u32,
     unsafe_absence_events: u32,
@@ -827,17 +828,39 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
                                                 &mut writer,
                                             )?;
                                             // Repository authority writes a created file
-                                            // itself as part of publishing the change. So
-                                            // a create is published FIRST and the local
-                                            // write is the fallback: writing it here
-                                            // first leaves an untracked path sitting on
-                                            // the exact workspace target, which
+                                            // itself as part of publishing the change, so
+                                            // a create is published FIRST and is never
+                                            // written locally: writing it here first
+                                            // leaves an untracked path sitting on the
+                                            // exact workspace target, which
                                             // `validate_reconciliation_targets` refuses,
                                             // and every commit fails on the harness's own
                                             // file.
                                             let publish_first = bracket.transaction_id.is_some()
                                                 && matches!(plan, StagePlan::Create { .. });
-                                            let (outcome, provenance) = if publish_first {
+                                            // An edit is published first too, with no local
+                                            // fallback: its new text is computed from the
+                                            // file's current text and staged whole, and the
+                                            // commit's projection writes the file. Written to
+                                            // the working copy ahead of the commit, the edit
+                                            // read to the daemon as drift from the prior tree
+                                            // and was refused over its own bytes, and every
+                                            // refusal left it on disk with the graph still
+                                            // holding the old text.
+                                            let publish_edit = bracket.transaction_id.is_some()
+                                                && matches!(plan, StagePlan::Replace { .. });
+                                            let (outcome, provenance) = if publish_edit {
+                                                publish_planned_edit(
+                                                    &mut servers[index],
+                                                    bracket,
+                                                    session.as_deref(),
+                                                    &plan,
+                                                    &repo,
+                                                    &call.arguments,
+                                                    &mut counters,
+                                                    &mut writer,
+                                                )?
+                                            } else if publish_first {
                                                 let staged = stage_planned_operation(
                                                     &mut servers[index],
                                                     &mut bracket,
@@ -858,24 +881,27 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
                                                         provenance,
                                                     )
                                                 } else {
-                                                    // Nothing was published, so the file
-                                                    // does not exist yet. Write it, so the
-                                                    // model keeps its work, and tell the
-                                                    // model the change did not land rather
-                                                    // than reporting a bare success.
+                                                    // Nothing was published and nothing is
+                                                    // written: the path stays as it was on
+                                                    // disk and in the graph. The refused
+                                                    // content goes back to the model in the
+                                                    // tool result, which is where the model
+                                                    // keeps its work; a local copy was a
+                                                    // file the graph did not hold.
                                                     counters.unpublished_changes += 1;
-                                                    let mut outcome =
-                                                        belt::run_write(&repo, &call.arguments);
-                                                    if !outcome.is_error {
-                                                        outcome.text = format!(
-                                                            "{} Repository authority did \
-                                                             not publish it: {}. The file \
-                                                             is on disk and uncommitted.",
-                                                            outcome.text,
-                                                            unpublished_reason(&provenance),
-                                                        );
-                                                    }
-                                                    (outcome, provenance)
+                                                    let reason = unpublished_reason(&provenance);
+                                                    let provenance = abort_refused_commit(
+                                                        &mut servers[index],
+                                                        provenance,
+                                                        &mut writer,
+                                                    )?;
+                                                    (
+                                                        belt::unpublished_create(
+                                                            &call.arguments,
+                                                            &reason,
+                                                        ),
+                                                        provenance,
+                                                    )
                                                 }
                                             } else {
                                                 let mut outcome = match tool {
@@ -1642,6 +1668,96 @@ fn close_transaction(
         "response": detail.clone(),
         "detail": if is_error { Value::String(detail) } else { Value::Null },
     }))
+}
+
+/// Publish one `edit_file` call through repository authority before anything touches the
+/// working copy.
+///
+/// The edit is resolved against the file's current text, its complete new text is staged as
+/// the `replace` operation, and the commit publishes it; repository authority's projection is
+/// what writes the file. When authority does not publish, nothing was written: the transaction
+/// is aborted so the model's retry opens a clean one, and the model is told the edit did not
+/// land and why. An edit that cannot be applied to the current text stages nothing and aborts
+/// the bracket, because an empty transaction is refused by design.
+#[allow(clippy::too_many_arguments)]
+fn publish_planned_edit(
+    server: &mut Server,
+    mut bracket: Bracket,
+    session: Option<&str>,
+    plan: &StagePlan,
+    repo: &Path,
+    arguments: &Value,
+    counters: &mut Counters,
+    writer: &mut TranscriptWriter,
+) -> anyhow::Result<(belt::LocalOutcome, Value)> {
+    let planned = match belt::plan_edit(repo, arguments) {
+        Ok(planned) => planned,
+        Err(refusal) => {
+            let provenance = close_transaction(server, bracket, false, writer)?;
+            return Ok((refusal, provenance));
+        }
+    };
+    let staged = stage_planned_operation(
+        server,
+        &mut bracket,
+        session,
+        plan,
+        Some(&planned.updated),
+        writer,
+    )?;
+    let provenance = close_transaction(server, bracket, staged, writer)?;
+    if published_by_authority(&provenance) {
+        return Ok((belt::published_edit(planned), provenance));
+    }
+    counters.unpublished_changes += 1;
+    let reason = unpublished_reason(&provenance);
+    let provenance = abort_refused_commit(server, provenance, writer)?;
+    Ok((belt::unpublished_edit(&planned, &reason), provenance))
+}
+
+/// Abort a transaction whose commit repository authority refused.
+///
+/// A refused commit leaves the transaction open on the server, its staged set cleared or its
+/// commit fence reset, and nothing here can reuse it: the model's retry is a new call that
+/// opens a new bracket. Left open, every refusal holds one of the session's unfinished
+/// transaction slots until the session ends, so a model that keeps correcting and retrying is
+/// eventually refused a bracket at all. A bracket that closed by aborting has nothing left to
+/// release.
+fn abort_refused_commit(
+    server: &mut Server,
+    mut provenance: Value,
+    writer: &mut TranscriptWriter,
+) -> anyhow::Result<Value> {
+    if provenance["closed_with"] != json!("kin_transaction_commit") {
+        return Ok(provenance);
+    }
+    let Some(transaction_id) = provenance["transaction_id"].as_str().map(str::to_string) else {
+        return Ok(provenance);
+    };
+    let server_name = server.name();
+    let outcome = server.client.call_tool(
+        "kin_transaction_abort",
+        &json!({ "transaction_id": transaction_id }),
+    );
+    let (is_error, detail) = match &outcome {
+        Ok(outcome) => (outcome.is_error, close_detail(&outcome.text)),
+        Err(err) => (true, err.to_string()),
+    };
+    writer.trace(json!({
+        "surface": "kin",
+        "server": server_name,
+        "tool": "kin_transaction_abort",
+        "policy": "allowed",
+        "event": "transaction_abort",
+        "transaction_id": transaction_id,
+        "is_error": is_error,
+        "detail": detail,
+    }))?;
+    provenance["aborted_after_refusal"] = json!({
+        "closed_cleanly": !is_error,
+        "detail": if is_error { Value::String(detail) } else { Value::Null },
+    });
+    Ok(provenance)
 }
 
 /// Whether repository authority actually published this bracket.

--- a/crates/kin-agent/tests/loop_integration.rs
+++ b/crates/kin-agent/tests/loop_integration.rs
@@ -219,9 +219,27 @@ def payload(obj, is_error=False, indent=None):
             "isError": is_error}
 
 
+def disk_snapshot(operations):
+    # What the working copy holds, at the moment of this call, at every path the call's
+    # operations name. The real daemon reads the working copy at commit to decide whether it
+    # may project over it, so the order a harness writes in is part of the contract, and a
+    # test has to be able to see it.
+    seen = {}
+    for op in operations:
+        target = op.get("target")
+        if target and os.path.isfile(target):
+            with open(target) as fh:
+                seen[target] = fh.read()
+    return seen
+
+
 def call(name, args):
+    operations = args.get("operations", [])
+    if name == "kin_transaction_commit":
+        operations = STAGED.get(args.get("transaction_id"), [])
     with open(LOG, "a") as fh:
-        fh.write(json.dumps({"tool": name, "args": args}) + "\n")
+        fh.write(json.dumps({"tool": name, "args": args,
+                             "disk": disk_snapshot(operations)}) + "\n")
     if name == "kin_artifact_list":
         # Pretty-printed with one row per artifact, like the real server, so a listing
         # asked for a large limit is large for the same reason the real one is.
@@ -281,6 +299,13 @@ def call(name, args):
             if op.get("verb") in ("replace", "overwrite") and op.get("target") == "src/dirty.py":
                 return payload({"message": "repository authority refused the rewrite of "
                                            "src/dirty.py: the working copy is not clean",
+                                "_kin": ENVELOPE}, is_error=True)
+        # A create that stages cleanly and is refused when it commits, the create twin of the
+        # rewrite above, so a harness's behaviour after a refused commit is observable.
+        for op in operations:
+            if op.get("verb") in ("create", "add", "insert") and op.get("target") == "src/refused.py":
+                return payload({"message": "repository authority refused the create of "
+                                           "src/refused.py: its directory is not admitted",
                                 "_kin": ENVELOPE}, is_error=True)
         for op in operations:
             target = op.get("target")
@@ -726,16 +751,52 @@ fn a_staged_edit_the_daemon_refuses_tells_the_model_it_did_not_land() {
         .expect("the edit is staged");
     assert_eq!(staged["args"]["operations"][0]["verb"], "replace");
 
+    // Authority is the only writer, so a refusal leaves the working copy exactly as it was.
+    // A harness that wrote first stranded the edit on disk here while the graph kept the old
+    // text, which is the split FIR-3550 found on a real store.
+    assert_eq!(
+        std::fs::read_to_string(repo.join("src/dirty.py")).unwrap(),
+        "def stale(name):\n    return name\n",
+        "a refused edit must leave the file untouched"
+    );
+
+    // The refused transaction is released rather than left open. Each refusal would
+    // otherwise hold one of the session's unfinished-transaction slots until the session
+    // ends, and a model that keeps retrying would be refused a bracket altogether.
+    let names: Vec<&str> = calls
+        .iter()
+        .map(|call| call["tool"].as_str().unwrap())
+        .collect();
+    let commit_at = names
+        .iter()
+        .position(|name| *name == "kin_transaction_commit")
+        .expect("the edit reached the commit");
+    assert_eq!(
+        names.get(commit_at + 1),
+        Some(&"kin_transaction_abort"),
+        "a refused commit must be followed by an abort: {names:?}"
+    );
+    let trace = read_jsonl(&outcome.trace_path);
+    let edit = trace
+        .iter()
+        .find(|row| row["surface"] == "local" && row["tool"] == "edit_file")
+        .expect("the local edit is traced");
+    assert_eq!(edit["provenance"]["closed_with"], "kin_transaction_commit");
+    assert_eq!(edit["provenance"]["closed_cleanly"], false);
+    assert_eq!(
+        edit["provenance"]["aborted_after_refusal"]["closed_cleanly"],
+        true
+    );
+
     // The assertion this test exists for. The model's own tool result, which is the only
     // thing it reads, has to say the change did not land.
     let records = read_jsonl(&outcome.transcript_path);
     let view = analyze(&records);
-    let result = &view
+    let (_, result, is_error) = view
         .tool_results
         .iter()
         .find(|(id, _, _)| id == &view.tool_uses[0].0)
-        .expect("the edit has a result")
-        .1;
+        .expect("the edit has a result");
     assert!(
         result.contains("did not publish it"),
         "the model must be told its edit did not land, got: {result}"
@@ -745,8 +806,87 @@ fn a_staged_edit_the_daemon_refuses_tells_the_model_it_did_not_land() {
         "the model must be told WHY, in the server's own words, got: {result}"
     );
     assert!(
-        result.contains("uncommitted"),
-        "the model must be told where its work is, got: {result}"
+        result.contains("unchanged on disk and in the graph"),
+        "the model must be told where things stand, got: {result}"
+    );
+    assert!(*is_error, "an edit that did not land is a failed call");
+}
+
+/// FIR-3550: an in-place edit is published through repository authority before the working
+/// copy changes, and the commit is what writes the file.
+///
+/// Staged after a local write, the edit reached the real daemon holding a working copy that
+/// already carried the new bytes, and the commit refused it as drift from the prior tree. So
+/// the order is asserted directly, from what the server saw on disk when each call arrived:
+/// the old text at the stage, and the old text still at the commit.
+#[test]
+fn an_in_place_edit_is_published_by_authority_before_the_file_changes() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = fixture_repo(dir.path());
+    let out = dir.path().join("out");
+    let server = write_fake_mcp_server(dir.path());
+    let log = dir.path().join("mcp-calls.jsonl");
+    let original = std::fs::read_to_string(repo.join("src/greet.py")).unwrap();
+
+    let endpoint = FakeEndpoint::start(vec![
+        completion(
+            "Documenting greet.",
+            Some(tool_call(
+                "c1",
+                "edit_file",
+                json!({
+                    "path": "src/greet.py",
+                    "find": "def greet(name):",
+                    "replace": "def greet(name):\n    \"\"\"Return a greeting for name.\"\"\""
+                }),
+            )),
+        ),
+        completion("greet carries a docstring.", None),
+    ]);
+    let base_url = endpoint.base_url.clone();
+
+    let outcome = kin_agent::run(config(&repo, &out, &base_url, mcp_command(&server, &log)))
+        .expect("the run completes");
+    assert_eq!(outcome.status, ExitStatus::Success, "{:?}", outcome.result);
+    assert_eq!(outcome.result["kin_agent"]["unpublished_changes"], 0);
+
+    let calls = mcp_log(&log);
+    let stage = calls
+        .iter()
+        .find(|call| call["tool"] == "kin_transaction_stage")
+        .expect("the edit is staged");
+    assert_eq!(
+        stage["disk"]["src/greet.py"], original,
+        "the working copy must still hold the old text when the edit is staged"
+    );
+    let commit = calls
+        .iter()
+        .find(|call| call["tool"] == "kin_transaction_commit")
+        .expect("the edit is committed");
+    assert_eq!(
+        commit["disk"]["src/greet.py"], original,
+        "the working copy must still hold the old text when the commit arrives, because the \
+         commit is what writes it"
+    );
+    let staged_body = stage["args"]["operations"][0]["body"].as_str().unwrap();
+    assert!(
+        staged_body.contains("\"\"\"Return a greeting for name.\"\"\""),
+        "the staged body carries the edit: {staged_body}"
+    );
+
+    // The file holds what the commit published, and the model is told authority wrote it.
+    assert_eq!(
+        std::fs::read_to_string(repo.join("src/greet.py")).unwrap(),
+        staged_body
+    );
+    let requests = endpoint.requests();
+    let observation = requests[1]["messages"].as_array().unwrap().last().unwrap()["content"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert!(
+        observation.contains("published it through repository authority"),
+        "the model must be told the edit landed: {observation}"
     );
 }
 
@@ -988,10 +1128,12 @@ fn a_refused_commit_downgrades_the_run_and_keeps_its_reason_in_the_trace() {
         "the envelope must not be what the budget was spent on: {detail}"
     );
 
-    // The model's work is not lost, and the model is told it did not land.
+    // Nothing was written, so the tracked file keeps its text. The model's work comes back
+    // in its own tool result rather than as a file the graph does not hold, and the model
+    // is told it did not land.
     assert_eq!(
         std::fs::read_to_string(repo.join("README.md")).unwrap(),
-        "# again\n"
+        "# fixture\n"
     );
     let requests = endpoint.requests();
     let observation = requests[1]["messages"].as_array().unwrap().last().unwrap()["content"]
@@ -1001,6 +1143,85 @@ fn a_refused_commit_downgrades_the_run_and_keeps_its_reason_in_the_trace() {
     assert!(
         observation.contains("did not publish it"),
         "the model must be told the change did not land: {observation}"
+    );
+    assert!(
+        observation.contains("# again"),
+        "the refused content must come back to the model: {observation}"
+    );
+}
+
+/// FIR-3550, the create half: a `write_file` repository authority refuses at commit leaves
+/// no file behind.
+///
+/// The harness used to write the file locally after the refusal so the model kept its
+/// work, which left a file on disk the graph did not hold, the same split a refused edit
+/// left. The work now travels back in the tool result, the refused transaction is
+/// released, and the path stays absent.
+#[test]
+fn a_create_authority_refuses_leaves_no_file_and_hands_the_content_back() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = fixture_repo(dir.path());
+    let out = dir.path().join("out");
+    let server = write_fake_mcp_server(dir.path());
+    let log = dir.path().join("mcp-calls.jsonl");
+    let body = "def refused(name):\n    return name\n";
+
+    let endpoint = FakeEndpoint::start(vec![
+        completion(
+            "Adding the module.",
+            Some(tool_call(
+                "c1",
+                "write_file",
+                json!({ "path": "src/refused.py", "content": body }),
+            )),
+        ),
+        completion("src/refused.py is in place.", None),
+    ]);
+    let base_url = endpoint.base_url.clone();
+
+    let outcome = kin_agent::run(config(&repo, &out, &base_url, mcp_command(&server, &log)))
+        .expect("the run completes");
+    assert_eq!(outcome.status, ExitStatus::ChangesUnpublished);
+    assert_eq!(outcome.result["kin_agent"]["unpublished_changes"], 1);
+    assert!(
+        !repo.join("src/refused.py").exists(),
+        "a refused create must leave no file behind"
+    );
+
+    let calls = mcp_log(&log);
+    let names: Vec<&str> = calls
+        .iter()
+        .map(|call| call["tool"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        names,
+        vec![
+            "kin_session_start",
+            "kin_transaction_begin",
+            "kin_transaction_stage",
+            "kin_transaction_commit",
+            "kin_transaction_abort",
+            "kin_session_end"
+        ],
+        "a create refused at commit must be released with an abort"
+    );
+
+    let requests = endpoint.requests();
+    let observation = requests[1]["messages"].as_array().unwrap().last().unwrap()["content"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert!(
+        observation.contains("did not publish it"),
+        "the model must be told the create did not land: {observation}"
+    );
+    assert!(
+        observation.contains("its directory is not admitted"),
+        "the model must be told WHY, in the server's own words: {observation}"
+    );
+    assert!(
+        observation.contains(body),
+        "the refused content must come back to the model: {observation}"
     );
 }
 
@@ -1029,14 +1250,14 @@ fn a_write_over_a_tracked_path_is_refused_by_the_graph_and_aborts() {
 
     let outcome = kin_agent::run(config(&repo, &out, &base_url, mcp_command(&server, &log)))
         .expect("the run completes");
-    // Nothing was published, so the run does not get to call itself a success. The model
-    // still keeps its work: the harness falls back to the local write when the bracket
-    // could not publish, which is the only reason the file below exists.
+    // Nothing was published, so the run does not get to call itself a success, and nothing
+    // was written: the tracked file keeps its text and the model's content comes back in
+    // its tool result.
     assert_eq!(outcome.status, ExitStatus::ChangesUnpublished);
     assert_eq!(outcome.result["kin_agent"]["unpublished_changes"], 1);
     assert_eq!(
         std::fs::read_to_string(repo.join("README.md")).unwrap(),
-        "# rewritten\n"
+        "# fixture\n"
     );
 
     // Repository authority refuses the create by name, so the transaction aborts rather

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -101,6 +101,7 @@ pub use resolver::{ImportResolver, PythonResolver, SymbolTable, TypeScriptResolv
 pub use sync_state::SyncStateStore;
 pub use tree::{
     materialize_source_entry, materialize_source_tree, prepare_source_tree, reconcile_source_tree,
+    reconcile_source_tree_and_commit_authored_repository_transaction,
     reconcile_source_tree_and_commit_repository_transaction, replace_source_tree,
     report_repository_workspace_projection_drift, resolve_change_tree,
     should_preserve_checkout_path, source_projection_disposition, validate_portable_source_paths,

--- a/crates/kin-core/src/tree.rs
+++ b/crates/kin-core/src/tree.rs
@@ -436,6 +436,71 @@ pub fn reconcile_source_tree_and_commit_repository_transaction<'a, 'b>(
     authority: &RepositoryAuthorityManager<LocalFileBackend>,
     transaction: RepositoryTransaction,
 ) -> Result<(usize, RepositoryCommitReceipt)> {
+    reconcile_source_tree_and_commit_accepting_targets(
+        root,
+        previous_tree,
+        target_tree,
+        previous_entries,
+        entries,
+        authority,
+        transaction,
+        None,
+    )
+}
+
+/// Reconcile a graph-derived working tree and publish its repository
+/// transaction, accepting paths the transaction itself authored whose working
+/// copy already holds their exact target bytes.
+///
+/// A writer that authored a path's new content and put those bytes on disk
+/// before committing is publishing a change the working copy already shows.
+/// [`reconcile_source_tree_and_commit_repository_transaction`] calls that path
+/// drift, because it holds every tracked path to the previous tree. Here an
+/// authored path is held to its previous body or to its exact target body,
+/// read through the same no-follow capability and identity revalidation as
+/// every other path. A path already at its target is neither written nor
+/// journaled, so a failure before the authority commit leaves the author's
+/// bytes where the author put them. Every path the transaction did not author
+/// is still held to the previous tree byte for byte, and an authored path
+/// holding any third body is refused exactly as before. Authority itself still
+/// compares against the original previous tree; only the filesystem baseline
+/// moves.
+///
+/// Each authored path must name a regular-file entry of the target tree.
+#[allow(clippy::too_many_arguments)]
+pub fn reconcile_source_tree_and_commit_authored_repository_transaction<'a, 'b>(
+    root: &Path,
+    previous_tree: &ResolvedTree,
+    target_tree: &ResolvedTree,
+    previous_entries: impl IntoIterator<Item = (&'b RepoPath, TreeEntry, &'b [u8])>,
+    entries: impl IntoIterator<Item = (&'a RepoPath, TreeEntry, &'a [u8])>,
+    authority: &RepositoryAuthorityManager<LocalFileBackend>,
+    transaction: RepositoryTransaction,
+    authored_paths: &BTreeSet<RepoPath>,
+) -> Result<(usize, RepositoryCommitReceipt)> {
+    reconcile_source_tree_and_commit_accepting_targets(
+        root,
+        previous_tree,
+        target_tree,
+        previous_entries,
+        entries,
+        authority,
+        transaction,
+        Some(authored_paths),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn reconcile_source_tree_and_commit_accepting_targets<'a, 'b>(
+    root: &Path,
+    previous_tree: &ResolvedTree,
+    target_tree: &ResolvedTree,
+    previous_entries: impl IntoIterator<Item = (&'b RepoPath, TreeEntry, &'b [u8])>,
+    entries: impl IntoIterator<Item = (&'a RepoPath, TreeEntry, &'a [u8])>,
+    authority: &RepositoryAuthorityManager<LocalFileBackend>,
+    transaction: RepositoryTransaction,
+    accepted_target_paths: Option<&BTreeSet<RepoPath>>,
+) -> Result<(usize, RepositoryCommitReceipt)> {
     let entries = validated_source_entries(entries)?;
     let previous_entries = validated_source_entries(previous_entries)?;
     validate_repository_projection_transaction(
@@ -461,6 +526,7 @@ pub fn reconcile_source_tree_and_commit_repository_transaction<'a, 'b>(
         &should_preserve_checkout_path,
         ReconciledProjectionOptions {
             open_mode: ProjectionOpenMode::ExistingRepositoryFrozen(authority),
+            accepted_target_paths,
             ..ReconciledProjectionOptions::default()
         },
         || {},

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -44198,6 +44198,134 @@ mod tests {
         );
     }
 
+    /// Any string anywhere in a tool payload containing `needle`.
+    fn payload_mentions(payload: &serde_json::Value, needle: &str) -> bool {
+        match payload {
+            serde_json::Value::String(text) => text.contains(needle),
+            serde_json::Value::Array(items) => {
+                items.iter().any(|item| payload_mentions(item, needle))
+            }
+            serde_json::Value::Object(fields) => {
+                fields.values().any(|value| payload_mentions(value, needle))
+            }
+            _ => false,
+        }
+    }
+
+    /// FIR-3550 through the route every agent call reaches the daemon by. The writer edits
+    /// the file first, then stages its complete new text and commits: the order `kin agent`'s
+    /// `edit_file` ran in during run 3 of the local-model demo, and the order of any agent
+    /// that edits with its own file tools. The commit used to refuse the writer's own bytes as
+    /// drift from the prior tree. It now publishes them, `get_entity_source` answers with the
+    /// new body, durability reads level, and the working copy matches what authority holds.
+    #[tokio::test]
+    async fn an_agent_edit_staged_after_it_reached_disk_commits_and_reads_back() {
+        let state = test_state();
+        let (entity, _) = crate::mcp_commit::tests::install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 {\n    1\n}\n",
+            "value",
+        );
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let session_id = mcp_test_session(&state);
+        let edited = "/// The value this module reports.\npub fn value() -> u8 {\n    0x2a\n}\n";
+
+        let begin = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_transaction_begin",
+            serde_json::json!({ "session_id": session_id, "scope": "src/lib.rs" }),
+        )
+        .await;
+        assert_ne!(begin.is_error, Some(true), "{}", mcp_result_text(&begin));
+        let begin_json: serde_json::Value = serde_json::from_str(&mcp_result_text(&begin)).unwrap();
+        let tx_id = begin_json["transaction_id"].as_str().unwrap().to_string();
+
+        let working = state.layout.working_dir().join("src/lib.rs");
+        std::fs::write(&working, edited).unwrap();
+
+        let stage = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_transaction_stage",
+            serde_json::json!({
+                "transaction_id": tx_id,
+                "session_id": session_id,
+                "operations": [{
+                    "verb": "replace",
+                    "target": "src/lib.rs",
+                    "body": edited,
+                    "description": "document value and change what it returns"
+                }]
+            }),
+        )
+        .await;
+        assert_ne!(stage.is_error, Some(true), "{}", mcp_result_text(&stage));
+
+        let commit = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_transaction_commit",
+            serde_json::json!({ "transaction_id": tx_id }),
+        )
+        .await;
+        assert_ne!(
+            commit.is_error,
+            Some(true),
+            "the agent's own edit was refused: {}",
+            mcp_result_text(&commit)
+        );
+
+        let source = mcp_call(
+            router(Arc::clone(&state)),
+            "get_entity_source",
+            serde_json::json!({ "entity_id": entity.id.to_string() }),
+        )
+        .await;
+        let source_text = mcp_result_text(&source);
+        assert_ne!(source.is_error, Some(true), "{source_text}");
+        let source_payload: serde_json::Value = serde_json::from_str(&source_text).unwrap();
+        assert!(
+            payload_mentions(&source_payload, "0x2a"),
+            "get_entity_source must answer with the committed body: {source_text}"
+        );
+
+        let status = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_graph_status",
+            serde_json::json!({}),
+        )
+        .await;
+        assert_ne!(status.is_error, Some(true), "{}", mcp_result_text(&status));
+        let block = durability_block(&state).await;
+        assert_eq!(block.state, "recorded", "{}", block.note);
+        assert_eq!(block.live_only_entities, Some(0), "{}", block.note);
+        assert_eq!(block.live_only_relations, Some(0), "{}", block.note);
+
+        let context =
+            crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(&state)
+                .unwrap();
+        let base = crate::repository_commit::load_native_commit_base(&context).unwrap();
+        let artifact = base
+            .tree
+            .artifact_at_path(&RepoPath::from_utf8("src/lib.rs").unwrap())
+            .expect("the edited file stays tracked");
+        let published = crate::repository_commit::load_native_source_blob(
+            &context,
+            artifact
+                .entry
+                .blob_identity()
+                .expect("a tracked source file has a body"),
+        )
+        .unwrap();
+        assert_eq!(published, edited.as_bytes(), "authority holds the edit");
+        assert_eq!(
+            std::fs::read(&working).unwrap(),
+            published,
+            "the working copy must match what authority published"
+        );
+    }
+
     /// The control. Right after a commit that captured every live relation, the
     /// same block reads level on both axes, so the disclosure above is a
     /// reading and not a fixture that always fires.

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -29,7 +29,7 @@ use crate::local_repository_authority::{
     require_fresh_daemon_workspace, LocalRepositoryAuthorityContext,
 };
 use crate::repository_commit::{
-    commit_native_plan_with_projection, load_native_commit_base, load_native_source_blob,
+    commit_native_plan_with_authored_projection, load_native_commit_base, load_native_source_blob,
     plan_native_commit_from_base_declaring_carry, recover_native_commit, NativeCommitBase,
     NativeCommitResult,
 };
@@ -39,6 +39,11 @@ struct ExactMcpPlan {
     native: crate::repository_commit::NativeCommitPlan,
     layouts: Vec<FileLayout>,
     carried_pending_files: Vec<RepoPath>,
+    /// The paths this transaction's own operations write. Publication accepts
+    /// one of them when the working copy already holds its exact target bytes,
+    /// because a writer that edited the file and then staged its new text is
+    /// publishing the change the working copy already shows.
+    authored_files: BTreeSet<RepoPath>,
 }
 
 /// What this process knows about a commit beyond the change it published.
@@ -413,11 +418,12 @@ fn commit_exact_transaction_inner(
     }
 
     let committed = match timed_commit_phase("publish_authority_and_projection", || {
-        commit_native_plan_with_projection(
+        commit_native_plan_with_authored_projection(
             &state.layout,
             state.blobs.as_ref(),
             &authority_context,
             plan.native,
+            &plan.authored_files,
         )
     }) {
         Ok(committed) => committed,
@@ -1392,6 +1398,7 @@ fn plan_exact_transaction(
         native,
         layouts,
         carried_pending_files,
+        authored_files,
     })
 }
 
@@ -3036,7 +3043,7 @@ fn stabilize_layout_ids(
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use std::path::Path;
     use std::sync::OnceLock;
@@ -3117,7 +3124,10 @@ mod tests {
         String::from_utf8(output.stdout).unwrap().trim().to_string()
     }
 
-    fn install_exact_source(
+    /// Install `content` at `file` as committed, projected source and return the named
+    /// entity with the change that installed it. Shared with the route tests in `api`, which
+    /// need tracked source on disk to drive a commit through `/mcp/tools/call`.
+    pub(crate) fn install_exact_source(
         state: &Arc<DaemonState>,
         file: &str,
         content: &[u8],
@@ -3787,6 +3797,181 @@ mod tests {
             named("doomed").is_empty(),
             "an entity the new text drops must leave the graph"
         );
+    }
+
+    const DOCUMENTED_RS: &str = "/// The value this module reports.\npub fn value() -> u8 {\n    1\n}\n\npub fn doomed() -> u8 {\n    9\n}\n";
+    const OTHER_RS: &str = "pub fn other() -> u8 {\n    4\n}\n";
+
+    fn commit_arguments(transaction_id: &str) -> HashMap<String, serde_json::Value> {
+        HashMap::from([(
+            "transaction_id".to_string(),
+            serde_json::json!(transaction_id),
+        )])
+    }
+
+    /// Stage `body` as the complete new text of `path` in a fresh transaction and commit it.
+    fn replace_and_commit(
+        state: &Arc<DaemonState>,
+        sessions: &kin_mcp::SessionRegistry,
+        path: &str,
+        body: &str,
+    ) -> kin_mcp::ToolCallResult {
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, &format!("file:{path}"))
+            .unwrap();
+        sessions
+            .stage_transaction(
+                &transaction.transaction_id,
+                vec![replaced_source_file(path, body)],
+            )
+            .unwrap();
+        commit_exact_transaction(
+            state,
+            sessions,
+            &commit_arguments(&transaction.transaction_id),
+            None,
+        )
+    }
+
+    /// The shape run 3 of the local-model demo hit: the writer edits the file, then stages
+    /// the file's complete new text and commits. By then the working copy holds exactly the
+    /// bytes the transaction publishes, and the commit held every tracked path to the
+    /// previous tree, so it refused the writer's own edit as drift ("tracked working-copy
+    /// path ... differs from prior workspace source (the file content changed)") and left
+    /// the edit on disk with authority still on the old text. A working-copy change that is
+    /// the staged change is not a conflict: the commit publishes it, the file keeps the
+    /// published bytes, and authority holds the same bytes.
+    #[test]
+    fn an_edit_the_writer_already_put_on_disk_is_published_rather_than_refused() {
+        let (_dir, state) = test_state();
+        let (value, installed) =
+            install_exact_source(&state, "src/lib.rs", TRACKED_RS.as_bytes(), "value");
+        let working = state.layout.working_dir().join("src/lib.rs");
+        std::fs::write(&working, DOCUMENTED_RS).unwrap();
+
+        let sessions = test_sessions();
+        let result = replace_and_commit(&state, &sessions, "src/lib.rs", DOCUMENTED_RS);
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "the writer's own edit was refused: {}",
+            result_text(&result)
+        );
+
+        assert_eq!(std::fs::read_to_string(&working).unwrap(), DOCUMENTED_RS);
+        let after = load_native_commit_base(&state.layout).unwrap();
+        let published = after
+            .tree
+            .artifact_at_path(&RepoPath::from_utf8("src/lib.rs").unwrap())
+            .expect("the edited file stays tracked");
+        let hash = published
+            .entry
+            .blob_identity()
+            .expect("a tracked source file has a body");
+        assert_eq!(
+            load_native_source_blob(&state.layout, hash).unwrap(),
+            DOCUMENTED_RS.as_bytes(),
+            "authority must hold the bytes the working copy holds"
+        );
+        let committed = SemanticChangeId::from_hash(
+            Hash256::from_hex(
+                commit_reply(&result)["change_id"]
+                    .as_str()
+                    .expect("a successful commit names its change"),
+            )
+            .expect("the change id is a content hash"),
+        );
+        assert_eq!(
+            state
+                .graph
+                .get_changes_since(&installed, &committed)
+                .unwrap()
+                .iter()
+                .map(|change| change.id)
+                .collect::<Vec<_>>(),
+            vec![committed],
+            "the edit must publish exactly one change on top of the fixture"
+        );
+        assert!(
+            after.graph.get_entity(&value.id).unwrap().is_some(),
+            "the documented entity keeps its identity"
+        );
+    }
+
+    /// The rule above is exact. An authored path whose working copy holds a third body,
+    /// neither its previous text nor the text staged, is a real conflict: publishing would
+    /// overwrite bytes nobody staged, or declare a tree the disk does not hold. It is refused
+    /// as before, authority does not move, and the bytes on disk are left alone.
+    #[test]
+    fn an_authored_path_holding_a_third_body_is_still_refused() {
+        let (_dir, state) = test_state();
+        install_exact_source(&state, "src/lib.rs", TRACKED_RS.as_bytes(), "value");
+        let before = load_native_commit_base(&state.layout).unwrap();
+        let working = state.layout.working_dir().join("src/lib.rs");
+        let foreign = "pub fn value() -> u8 {\n    7\n}\n";
+        std::fs::write(&working, foreign).unwrap();
+
+        let sessions = test_sessions();
+        let result = replace_and_commit(&state, &sessions, "src/lib.rs", DOCUMENTED_RS);
+        assert_eq!(
+            result.is_error,
+            Some(true),
+            "a third body on disk was published over: {}",
+            result_text(&result)
+        );
+        assert!(
+            result_text(&result).contains("differs from prior workspace source"),
+            "the refusal must name the drift: {}",
+            result_text(&result)
+        );
+        assert_eq!(
+            load_native_commit_base(&state.layout).unwrap().roots,
+            before.roots,
+            "a refused commit must not move authority"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&working).unwrap(),
+            foreign,
+            "the refusal must leave the bytes on disk alone"
+        );
+    }
+
+    /// Accepting an authored path loosens no other path. With the authored file already at
+    /// its target and a second tracked file carrying an edit no operation staged, the commit
+    /// is refused over the second file, authority does not move, and neither file is
+    /// touched: the unstaged edit is not overwritten and the authored bytes are not rolled
+    /// back.
+    #[test]
+    fn accepting_an_authored_path_still_holds_every_other_path_to_the_prior_tree() {
+        let (_dir, state) = test_state();
+        install_exact_source(&state, "src/lib.rs", TRACKED_RS.as_bytes(), "value");
+        install_exact_source(&state, "src/other.rs", OTHER_RS.as_bytes(), "other");
+        let before = load_native_commit_base(&state.layout).unwrap();
+        let lib = state.layout.working_dir().join("src/lib.rs");
+        let other = state.layout.working_dir().join("src/other.rs");
+        std::fs::write(&lib, DOCUMENTED_RS).unwrap();
+        let unstaged = "pub fn other() -> u8 {\n    5\n}\n";
+        std::fs::write(&other, unstaged).unwrap();
+
+        let sessions = test_sessions();
+        let result = replace_and_commit(&state, &sessions, "src/lib.rs", DOCUMENTED_RS);
+        let text = result_text(&result);
+        assert_eq!(
+            result.is_error,
+            Some(true),
+            "an unstaged edit rode along: {text}"
+        );
+        assert!(
+            text.contains("src/other.rs") && text.contains("differs from prior workspace source"),
+            "the refusal must name the file nobody staged: {text}"
+        );
+        assert_eq!(
+            load_native_commit_base(&state.layout).unwrap().roots,
+            before.roots,
+            "a refused commit must not move authority"
+        );
+        assert_eq!(std::fs::read_to_string(&lib).unwrap(), DOCUMENTED_RS);
+        assert_eq!(std::fs::read_to_string(&other).unwrap(), unstaged);
     }
 
     #[test]

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -2421,6 +2421,35 @@ pub(crate) fn commit_native_plan_with_projection(
         authority_context,
         plan,
         WorkingCopyProof::MatchesPreviousTree,
+        None,
+    )
+}
+
+/// Publish one native repository transaction whose own operations authored
+/// some of the paths it moves, accepting each such path when the working copy
+/// already holds its exact target bytes.
+///
+/// A writer that edits a file and then stages that file's complete new text
+/// has, by the time it commits, already put the target bytes on disk. Held to
+/// the previous tree, as [`commit_native_plan_with_projection`] holds every
+/// path, the writer's own edit reads as drift and the commit is refused over
+/// the very change it carries. Every path the transaction did not author is
+/// still held to the previous tree, and an authored path holding any other
+/// body is refused exactly as before.
+pub(crate) fn commit_native_plan_with_authored_projection(
+    layout: &kin_core::KinLayout,
+    blobs: &kin_blobs::BlobStore,
+    authority_context: &LocalRepositoryAuthorityContext,
+    plan: NativeCommitPlan,
+    authored: &BTreeSet<RepoPath>,
+) -> Result<NativeCommitResult> {
+    commit_native_plan_with_working_copy_proof(
+        layout,
+        blobs,
+        authority_context,
+        plan,
+        WorkingCopyProof::MatchesPreviousTree,
+        Some(authored),
     )
 }
 
@@ -2483,6 +2512,7 @@ pub(crate) fn commit_native_plan_with_observed_target_tree(
         authority_context,
         plan,
         WorkingCopyProof::ObservedTargetTree,
+        None,
     )
 }
 
@@ -2503,6 +2533,7 @@ fn commit_native_plan_with_working_copy_proof(
     authority_context: &LocalRepositoryAuthorityContext,
     plan: NativeCommitPlan,
     working_copy: WorkingCopyProof,
+    authored: Option<&BTreeSet<RepoPath>>,
 ) -> Result<NativeCommitResult> {
     let repository_id = authority_context.repository_id().clone();
     if plan.transaction.repository_id != repository_id {
@@ -2569,24 +2600,45 @@ fn commit_native_plan_with_working_copy_proof(
                     )
                 },
             )?,
-            WorkingCopyProof::MatchesPreviousTree => crate::mcp_commit::timed_commit_phase(
-                "reconcile_workspace_and_commit_authority",
-                || {
-                    kin_core::reconcile_source_tree_and_commit_repository_transaction(
-                        layout.working_dir(),
-                        &plan.previous_tree,
-                        &plan.target_tree,
-                        previous_entries
+            WorkingCopyProof::MatchesPreviousTree => {
+                let accepted = authored
+                    .map(|authored| accepted_authored_paths(authored, &target_entries))
+                    .filter(|accepted| !accepted.is_empty());
+                crate::mcp_commit::timed_commit_phase(
+                    "reconcile_workspace_and_commit_authority",
+                    || {
+                        let previous = previous_entries
                             .iter()
-                            .map(|(path, entry, body)| (path, *entry, body.as_ref())),
-                        target_entries
+                            .map(|(path, entry, body)| (path, *entry, body.as_ref()));
+                        let target = target_entries
                             .iter()
-                            .map(|(path, entry, body)| (path, *entry, body.as_ref())),
-                        &authority,
-                        plan.transaction,
-                    )
-                },
-            )?,
+                            .map(|(path, entry, body)| (path, *entry, body.as_ref()));
+                        match &accepted {
+                            Some(accepted) => {
+                                kin_core::reconcile_source_tree_and_commit_authored_repository_transaction(
+                                    layout.working_dir(),
+                                    &plan.previous_tree,
+                                    &plan.target_tree,
+                                    previous,
+                                    target,
+                                    &authority,
+                                    plan.transaction,
+                                    accepted,
+                                )
+                            }
+                            None => kin_core::reconcile_source_tree_and_commit_repository_transaction(
+                                layout.working_dir(),
+                                &plan.previous_tree,
+                                &plan.target_tree,
+                                previous,
+                                target,
+                                &authority,
+                                plan.transaction,
+                            ),
+                        }
+                    },
+                )?
+            }
         }
     };
     let materializable = materializable_artifact_count(&plan.target_tree)?;
@@ -2611,6 +2663,23 @@ fn commit_native_plan_with_working_copy_proof(
         relation_count: plan.relation_count,
         file_count: plan.file_count,
     })
+}
+
+/// The authored paths a commit may find already holding their target bytes:
+/// each one the target tree materializes as a regular file. A retired path has
+/// no target entry, and a symbolic link is not a body a writer puts on disk
+/// ahead of a commit, so both stay held to the previous tree.
+fn accepted_authored_paths(
+    authored: &BTreeSet<RepoPath>,
+    target_entries: &[ProjectionEntry],
+) -> BTreeSet<RepoPath> {
+    target_entries
+        .iter()
+        .filter(|(path, entry, _)| {
+            authored.contains(path) && matches!(entry, kin_model::TreeEntry::Blob { .. })
+        })
+        .map(|(path, _, _)| path.clone())
+        .collect()
 }
 
 fn load_projection_entries(

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -827,12 +827,12 @@
     },
     {
       "file": "crates/kin-agent/src/belt.rs",
-      "reason": "kin-agent is a CLIENT of graph authority, never a source of it. It reaches Kin only through the MCP server over stdio, so every tool result it hands a model comes from the graph, and it deliberately ships no file-read, file-search or shell tool for a model to call. The filesystem and subprocess touches here are the two explicit boundaries the zero-file-search rule allows: materializing an edit the model asked for, and writing the run's own transcript. This module is the write boundary. `edit_file` reads the one file it is about to change so a find-and-replace can be exact and can refuse an ambiguous match, and `write_file` writes the one file it was given; both resolve the path inside the repository first and refuse any escape. Neither answers a question: the model has already been told where the code is by `mcp__kin__semantic_locate` and what it says by `mcp__kin__get_entity_source`, and nothing derived from these reads reaches a tool result. Pinned rather than whole-file so a newly added filesystem primitive in this module fails the guard, which is exactly what should happen if anyone ever adds a read or search tool to the belt.",
+      "reason": "kin-agent is a CLIENT of graph authority, never a source of it. It reaches Kin only through the MCP server over stdio, so every tool result it hands a model comes from the graph, and it deliberately ships no file-read, file-search or shell tool for a model to call. The filesystem and subprocess touches here are the two explicit boundaries the zero-file-search rule allows: materializing an edit the model asked for, and writing the run's own transcript. This module is the write boundary. `edit_file` reads the one file it is about to change so a find-and-replace can be exact and can refuse an ambiguous match. When a Kin transaction brackets the call, the edit's complete new text is staged and repository authority's commit writes the file; the harness writes it itself, as `write_file` writes the one file it was given, only when no transaction could be opened. Both resolve the path inside the repository first and refuse any escape. Neither answers a question: the model has already been told where the code is by `mcp__kin__semantic_locate` and what it says by `mcp__kin__get_entity_source`, and nothing derived from these reads reaches a tool result. Pinned rather than whole-file so a newly added filesystem primitive in this module fails the guard, which is exactly what should happen if anyone ever adds a read or search tool to the belt.",
       "owner": "kin-agent",
       "expiration": "2026-12-31",
       "allow_match": [
         "std::fs::read_to_string(&path)",
-        "std::fs::write(&path, &updated)",
+        "std::fs::write(&planned.path, &planned.updated)",
         "std::fs::create_dir_all(parent)",
         "path.exists()",
         "std::fs::write(&path, content)"


### PR DESCRIPTION
An agent's edit now lands. Before this, `kin_transaction_commit` refused an edit that was already on disk as drift from its own prior tree, so every `kin agent` edit failed and stayed on disk while the graph kept the old text. FIR-3550 found it in run 3 of the local-model demo: the model did everything right and Kin refused its own write path.

## What was wrong

`kin agent`'s `edit_file` wrote the new bytes to the working copy, then staged the file's complete new text and committed. The exact MCP commit publishes through `commit_native_plan_with_projection`, which asserts the working copy still holds the plan's previous tree. So kin-core's preflight compared the edited file with the previous blob and refused: `tracked working-copy path .../admission.rs differs from prior workspace source (the file content changed)`. The working copy held exactly the bytes the transaction was publishing.

Reproduced on the v0.7.12 release bytes before any change: 122 ms to the refusal on a 3-entity store, and 291 s on an APFS clone of the demo's 5,088-entity kin-db store, where the commit ran twice (see the follow-up below).

## The fix

On the daemon side, a working-copy change that is the staged change is no longer a conflict. The exact MCP commit now names the paths its own operations author, and kin-core accepts one of them when, and only when, its live bytes already equal the target entry, read through the same no-follow capability and identity revalidation as every other path. This is the `accepted_target_paths` rule merge resolution already uses (`transition_repository_workspace_tree_and_commit_authored_transaction`), exposed for source reconciliation as `reconcile_source_tree_and_commit_authored_repository_transaction`. Every path the transaction did not author is still held to the prior tree byte for byte, and an authored path holding any third body is refused exactly as before. Authority still compares against the original previous tree. `kin commit` and every other caller pass no authored set and behave as they did.

In the runner, `edit_file` and `write_file` publish through repository authority before the working copy changes, and the commit's projection writes the file. When authority refuses, nothing is written. The runner then aborts the transaction, because a session holds at most eight unfinished ones and a leaked refusal would eventually cost the model its bracket. The model is told the change did not land, why, and that the path is unchanged on disk and in the graph. A refused create used to be written locally "so the model keeps its work". That is now served by the tool result carrying the refused content back to the model, rather than by a stray file the graph does not hold.

## Tests

kin-daemon, on a real store through `commit_exact_transaction`:
- `an_edit_the_writer_already_put_on_disk_is_published_rather_than_refused` commits the run 3 shape, and disk, authority and the change log agree afterwards.
- `an_authored_path_holding_a_third_body_is_still_refused` keeps the rule to exact bytes. Authority does not move and the foreign bytes stay.
- `accepting_an_authored_path_still_holds_every_other_path_to_the_prior_tree` shows an unstaged edit in a second file still blocking the commit, with neither file touched.

kin-daemon, through `/mcp/tools/call`: `an_agent_edit_staged_after_it_reached_disk_commits_and_reads_back` drives begin, stage and commit the way the agent does. Then `get_entity_source` answers with the new body, the durability block reads `recorded` with nothing live-only, and the working copy matches the blob authority holds.

kin-agent, against the scripted server, which now records what the disk held when each call arrived and refuses `src/refused.py` at commit:
- `an_in_place_edit_is_published_by_authority_before_the_file_changes` sees the old text on disk at the stage and still at the commit.
- `a_staged_edit_the_daemon_refuses_tells_the_model_it_did_not_land` leaves the file untouched after a refused commit and follows the refusal with an abort. The model's tool result is an error that says so.
- `a_create_authority_refuses_leaves_no_file_and_hands_the_content_back` covers the create half.
- `a_refused_commit_downgrades_the_run_and_keeps_its_reason_in_the_trace` and `a_write_over_a_tracked_path_is_refused_by_the_graph_and_aborts` now assert the tracked file keeps its text.

## Falsification (local, run on the fix commit and restored from it after each set, then repeated on the tree rebased onto #1694 with the same seven tests red)

The daemon rule removed (the accepted set forced empty), the runner writing an edit before its commit, and the create's local write restored, all at once:

```
test mcp_commit::tests::an_edit_the_writer_already_put_on_disk_is_published_rather_than_refused ... FAILED
test api::tests::an_agent_edit_staged_after_it_reached_disk_commits_and_reads_back ... FAILED
test mcp_commit::tests::accepting_an_authored_path_still_holds_every_other_path_to_the_prior_tree ... FAILED
test mcp_commit::tests::an_authored_path_holding_a_third_body_is_still_refused ... ok
  the writer's own edit was refused: exact MCP repository commit failed before authority moved:
  Core error: repository projection conflict: tracked working-copy path .../src/lib.rs differs
  from prior workspace source (the file content changed); exact workspace reconciliation refused

test a_staged_edit_the_daemon_refuses_tells_the_model_it_did_not_land ... FAILED
  a refused edit must leave the file untouched
    left: "def stale(name):\n    return name.strip()\n"
test an_in_place_edit_is_published_by_authority_before_the_file_changes ... FAILED
  the working copy must still hold the old text when the edit is staged
test a_create_authority_refuses_leaves_no_file_and_hands_the_content_back ... FAILED
  a refused create must leave no file behind
test a_refused_commit_downgrades_the_run_and_keeps_its_reason_in_the_trace ... FAILED
  left: "# again\n"  right: "# fixture\n"
test a_write_over_a_tracked_path_is_refused_by_the_graph_and_aborts ... FAILED
  left: "# rewritten\n"  right: "# fixture\n"
test result: FAILED. 11 passed; 5 failed; 1 ignored
```

The third-body test stays green there because it encodes the strict behavior the mutation restores. Two kin-core weakenings aimed at the narrowness tests (a preflight that skips untouched paths, and an acceptance that ignores the bytes) turned those tests red only on wording. The commit was still refused, by kin-core's later identity revalidation (`exact workspace target src/other.rs has no retained publication identity`), so both properties are enforced twice in kin-core and a single weakening cannot break them.

## Local gates

`bin/kin-precheck kin --repo-dir kin=<this worktree>` on the rebased tree:

```
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
FAIL     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py  (exit 1)
kin-precheck: 22 gates ran, 21 passed, 1 failed, on kin dcacb2d2b49aac04c0a0f7d5fdc6f4ace386ece2
```

The one failure was the allowlist pinning `belt.rs`'s old write line (`std::fs::write(&path, &updated)`), which the `plan_edit` split renamed. The entry now pins the new line, and its reason says a bracketed edit is written by authority's commit, not by the harness. Rerun on the amended commit:

```
Deny-set self-test passed: 30 matcher cases (6 negative controls) and 6 binding-learner cases (2 negative controls).
Verification PASSED: Zero File-Search Invariant holds.
```

Tests on the same tree: `cargo test -p kin-agent --tests` 44 unit and 22 integration passed, 1 ignored. `cargo test -p kin-daemon --lib -- mcp_commit::tests an_agent_edit_staged_after_it_reached_disk` 78 passed. `cargo test -p kin-core --lib -- authored_projection post_preflight_editor` 5 passed.

## Follow-ups, not in this PR

The commit ran twice in the demo. `kin mcp start`'s delegate gives a tool call 60 s, then re-POSTs it once, and the daemon runs the second request after the first. A second PR makes the daemon join an in-flight commit by transaction id. The commit's cost on the 5,088-entity store (about 21 s to load the base, 21 s to plan and 93 s to reconcile and publish, with the daemon at 14.4 to 16.4 GiB resident) is profiled in the lane report and goes to its own ticket.

FIR-3550
