### PR TITLE
Resolve a name one way in refs, impact and graph source, and mark stale pointers

### DIFF
--- a/crates/kin-cli/src/commands/context.rs
+++ b/crates/kin-cli/src/commands/context.rs
@@ -792,7 +792,7 @@ fn resolve_context_target(
         crate::entity_identity::resolve_identity(graph, &reference.name, &reference.qualifiers)?;
     let mut matches = resolved.matches;
     crate::entity_ref::apply_line(&mut matches, reference.line);
-    Ok(crate::entity_identity::choose_definition(&matches).cloned())
+    crate::entity_identity::choose_definition(graph, &matches)
 }
 
 fn parse_budget(s: &str) -> Result<TokenBudget> {
@@ -957,7 +957,7 @@ fn resolve_focal(
 
     let mut matches = resolved.matches.clone();
     crate::entity_ref::apply_line(&mut matches, reference.line);
-    let Some(chosen) = crate::entity_identity::choose_definition(&matches) else {
+    let Some(chosen) = crate::entity_identity::choose_definition(graph, &matches)? else {
         // The name is in the graph and the pin excluded every entity carrying
         // it. Naming the twins that do exist is what turns this from a dead end
         // into a correctable one.
@@ -969,7 +969,7 @@ fn resolve_focal(
         for candidate in resolved.name_matches.iter().take(8) {
             lines.push(format!(
                 "  {} ({})",
-                crate::entity_identity::entity_location(candidate),
+                crate::entity_identity::entity_location(graph, candidate),
                 kin_review::StableEntityIdentity::from_entity(candidate).kind
             ));
         }
@@ -984,7 +984,7 @@ fn resolve_focal(
             .with_twins(twins, reference.pin_note())
     };
     Ok(Ok(ResolvedFocal {
-        entity: chosen.clone(),
+        entity: chosen,
         resolution,
     }))
 }

--- a/crates/kin-cli/src/commands/declaration_neighbors.rs
+++ b/crates/kin-cli/src/commands/declaration_neighbors.rs
@@ -80,7 +80,9 @@ impl DeclarationNeighbors {
     }
 }
 
-/// `path:line` for an entity, or just the path when the graph carries no span.
+/// `path:line` for an entity, just the path when the graph carries no span, or
+/// `path (span stale)` when the span describes an older version of the file
+/// than the graph holds; `None` when the entity has no file at all.
 ///
 /// Location is projection metadata for the human reading the listing; the
 /// analysis itself is keyed on graph identity, never on paths.
@@ -88,14 +90,11 @@ impl DeclarationNeighbors {
 /// The line is 1-based, through the same seam every other presentation surface
 /// converts at. A `path:line` string is read straight into an editor, so the
 /// raw graph row this used to emit put the reader one line above the entity.
-pub fn entity_location(entity: &Entity) -> Option<String> {
-    let path = entity.file_origin.as_ref().map(|f| f.0.clone())?;
-    Some(
-        match kin_mcp::handlers::common::entity_presentation_start_line(entity) {
-            Some(line) => format!("{path}:{line}"),
-            None => path,
-        },
-    )
+/// One implementation, [`crate::entity_identity::entity_pointer`], so no two
+/// listings can disagree about where an entity is.
+pub fn entity_location(graph: &impl GraphStore, entity: &Entity) -> Option<String> {
+    entity.file_origin.as_ref()?;
+    Some(crate::entity_identity::entity_pointer(graph, entity).render())
 }
 
 fn entity_kind_label(entity: &Entity) -> String {
@@ -148,7 +147,7 @@ fn collect_members(
                 relation_kinds,
             )?,
             kind: entity_kind_label(&entity),
-            location: entity_location(&entity).unwrap_or_else(|| "unknown".to_string()),
+            location: entity_location(graph, &entity).unwrap_or_else(|| "unknown".to_string()),
             name: entity.name,
         });
     }
@@ -177,7 +176,7 @@ fn collect_siblings(graph: &impl GraphStore, target: &Entity) -> Result<Vec<Sibl
         })
         .map(|entity| SiblingSummary {
             kind: entity_kind_label(&entity),
-            location: entity_location(&entity).unwrap_or_else(|| "unknown".to_string()),
+            location: entity_location(graph, &entity).unwrap_or_else(|| "unknown".to_string()),
             name: entity.name,
         })
         .collect();

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -1511,19 +1511,59 @@ fn build_graph_inspect_response(
     name: &str,
 ) -> Result<GraphCommandResponse> {
     let entities = graph.list_all_entities()?;
-    let matches: Vec<_> = if let Ok(uuid) = uuid::Uuid::parse_str(name.trim()) {
+    // Inspect lists every entity a name reaches, so it keeps its own gather (an
+    // exact name, or a `.name` suffix). A `#kind@path:line` suffix narrows that
+    // list with the pins every read command applies, and the list is ordered by
+    // the rule every read command chooses with. The raw token is tried as a name
+    // first, so a name carrying `@` or `#` is never split into a pin.
+    let trimmed = name.trim();
+    let reference = if entities.iter().any(|entity| entity.name == trimmed)
+        || !(trimmed.contains('@') || trimmed.contains('#'))
+    {
+        crate::entity_ref::EntityRef {
+            name: trimmed.to_string(),
+            ..Default::default()
+        }
+    } else {
+        crate::entity_ref::parse_entity_ref(trimmed)
+    };
+    let lookup = reference.name.as_str();
+    let mut matches: Vec<_> = if let Ok(uuid) = uuid::Uuid::parse_str(lookup) {
         graph.get_entity(&EntityId(uuid))?.into_iter().collect()
     } else {
         entities
             .into_iter()
-            .filter(|e| e.name == name || e.name.ends_with(&format!(".{}", name)))
+            .filter(|e| e.name == lookup || e.name.ends_with(&format!(".{}", lookup)))
             .collect()
     };
+    let name_reached_something = !matches.is_empty();
+    crate::entity_identity::apply_qualifiers(&mut matches, &reference.qualifiers);
+    crate::entity_ref::apply_line(&mut matches, reference.line);
+    crate::entity_identity::rank_candidates(graph, &mut matches)?;
 
     if matches.is_empty() {
+        // A pin that excluded every entity the name reaches is a filter miss,
+        // never an absent entity.
+        let (lines, error) = if name_reached_something {
+            let pin = reference.pin_note().unwrap_or_default();
+            (
+                vec![
+                    format!("No entity named '{lookup}' matches the pin {pin}."),
+                    format!(
+                        "hint: `kin graph inspect {lookup}` lists every entity with that name."
+                    ),
+                ],
+                format!("no entity named '{lookup}' matches the pin {pin}"),
+            )
+        } else {
+            (
+                graph_entity_not_found_lines(name),
+                format!("no entity found matching '{}'", name),
+            )
+        };
         return Ok(GraphCommandResponse {
-            lines: graph_entity_not_found_lines(name),
-            error: Some(format!("no entity found matching '{}'", name)),
+            lines,
+            error: Some(error),
             source: None,
             reference_edge_coverage: None,
             relation_census: None,
@@ -1541,8 +1581,16 @@ fn build_graph_inspect_response(
             lines.push(format!("  File: {}", fo.0));
         }
         if let Some(ref span) = entity.span {
-            let (start_line, end_line) = presentation_span_lines(span);
-            lines.push(format!("  Span: lines {start_line}-{end_line}"));
+            if crate::entity_identity::entity_pointer(graph, &entity).stale {
+                lines.push(format!(
+                    "  Span: {} (recorded against an older version of this file than the graph \
+                     holds, so its lines are not printed)",
+                    crate::entity_identity::STALE_SPAN_MARK
+                ));
+            } else {
+                let (start_line, end_line) = presentation_span_lines(span);
+                lines.push(format!("  Span: lines {start_line}-{end_line}"));
+            }
         }
         lines.push(format!("  Signature: {}", entity.signature));
         if let Some(ref doc) = entity.doc_summary {
@@ -1694,24 +1742,32 @@ pub fn build_entity_source_outcome(
             ));
         }
     };
+    entity_source_outcome(repository_authority, graph, &entity)
+}
 
+/// The source outcome for an entity the caller already resolved.
+fn entity_source_outcome(
+    repository_authority: &super::repository_authority::RequestRepositoryAuthority,
+    graph: &kin_db::InMemoryGraph,
+    entity: &Entity,
+) -> Result<EntitySourceOutcome> {
     // A structurally sourceless entity (no file origin or no span) is a valid ID
-    // with nothing to return — reported as `NoSource`, not as the genuine
-    // extraction error below (which signals corrupt spans or unavailable blobs).
+    // with nothing to return, reported as `NoSource` rather than as the genuine
+    // extraction error below, which signals corrupt spans or unavailable blobs.
     if entity.file_origin.is_none() {
         return Ok(EntitySourceOutcome::NoSource(entity_no_source_message(
-            &entity,
+            entity,
             "the entity has no file origin",
         )));
     }
     if entity.span.is_none() {
         return Ok(EntitySourceOutcome::NoSource(entity_no_source_message(
-            &entity,
+            entity,
             "the entity has no source span",
         )));
     }
 
-    let record = graph_source_record(repository_authority, graph, &entity)?;
+    let record = graph_source_record(repository_authority, graph, entity)?;
     Ok(EntitySourceOutcome::Found(record))
 }
 
@@ -1720,17 +1776,55 @@ pub fn build_graph_source_response(
     graph: &kin_db::InMemoryGraph,
     entity_query: &str,
 ) -> Result<GraphCommandResponse> {
-    match build_entity_source_outcome(repository_authority, graph, entity_query)? {
+    // `kin graph source` resolves through the resolver every read command
+    // shares, so it answers about the entity `kin refs` and `kin impact` answer
+    // about. The daemon's MCP source tool keeps `build_entity_source_outcome`.
+    let resolution = crate::entity_identity::resolve_entity(
+        graph,
+        entity_query,
+        &crate::entity_identity::IdentityQualifiers::default(),
+    )?;
+    let refusal = if resolution.pin_excluded_all() {
+        Some(crate::entity_identity::pin_miss_lines(graph, &resolution))
+    } else if resolution.needs_a_pin() {
+        Some(crate::entity_identity::pin_request_lines(
+            graph,
+            &resolution,
+        ))
+    } else {
+        None
+    };
+    if let Some(lines) = refusal {
+        return Ok(GraphCommandResponse {
+            error: Some(lines.join("\n")),
+            lines,
+            source: None,
+            reference_edge_coverage: None,
+            relation_census: None,
+            graph_section: None,
+        });
+    }
+    let outcome = match resolution.chosen() {
+        Some(entity) => entity_source_outcome(repository_authority, graph, entity)?,
+        None => EntitySourceOutcome::NotFound(entity_source_not_found_message(entity_query)),
+    };
+    let choice = crate::entity_identity::choice_note(
+        graph,
+        &resolution,
+        crate::entity_identity::PinSpelling::FileKind,
+    );
+    match outcome {
         EntitySourceOutcome::Found(record) => {
             let mut lines = vec![
                 format!(
                     "Entity source for '{}' -> {} ({})",
-                    entity_query, record.name, record.kind
+                    resolution.reference.name, record.name, record.kind
                 ),
                 format!("ID: {}", record.id),
                 format!("File: {}", record.file_path),
                 format!("Lines: {}-{}", record.start_line, record.end_line),
             ];
+            lines.extend(choice);
             if !record.signature.is_empty() {
                 lines.push(format!("Signature: {}", record.signature));
             }

--- a/crates/kin-cli/src/commands/impact.rs
+++ b/crates/kin-cli/src/commands/impact.rs
@@ -74,14 +74,19 @@ pub struct CandidateIdentity {
     pub name: String,
     pub kind: String,
     pub location: String,
+    /// The id that pins this candidate exactly in every command. Defaulted so
+    /// an answer from an older daemon, which sends none, still parses.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub entity_id: String,
 }
 
 impl CandidateIdentity {
-    fn from_entity(entity: &kin_model::Entity) -> Self {
+    fn from_entity(graph: &kin_db::InMemoryGraph, entity: &kin_model::Entity) -> Self {
         Self {
             name: entity.name.clone(),
             kind: format!("{:?}", entity.kind),
-            location: entity_location(entity).unwrap_or_else(|| "unknown".to_string()),
+            location: entity_location(graph, entity).unwrap_or_else(|| "unknown".to_string()),
+            entity_id: entity.id.to_string(),
         }
     }
 }
@@ -156,18 +161,30 @@ pub async fn build_impact_response(
     request: &ImpactRequest,
     envelope: &kin_mcp::Envelope,
 ) -> Result<ImpactResponse> {
-    let ResolvedEntities {
-        mut matches,
-        mut name_matches,
-        exact_name,
-    } = resolve_entities(graph, request)?;
-    let stable_order = |left: &kin_model::Entity, right: &kin_model::Entity| {
+    // One resolver for every read command (FIR-3505): the typed qualifiers and
+    // any `Name#kind@path:line` suffix merge into one pin, and the answer is the
+    // entity the shared ranking puts first.
+    let resolution = crate::entity_identity::resolve_entity(
+        graph,
+        &request.entity,
+        &crate::entity_identity::IdentityQualifiers {
+            file: request.file.clone(),
+            kind: request.kind.clone(),
+            signature: request.signature.clone(),
+        },
+    )?;
+    // An id names one entity as surely as an exact name does, so a structured
+    // caller that passed one is not refused as ambiguous.
+    let exact_name = resolution.exact_name() || resolution.addressed_by_id();
+    let matches = &resolution.candidates;
+    // The structured listing keeps its identity order, which is what a caller
+    // comparing two answers diffs; the answer itself is chosen by the ranking.
+    let mut name_matches = resolution.name_matches.clone();
+    name_matches.sort_by(|left, right| {
         kin_review::StableEntityIdentity::from_entity(left)
             .cmp(&kin_review::StableEntityIdentity::from_entity(right))
             .then_with(|| left.id.cmp(&right.id))
-    };
-    matches.sort_by(stable_order);
-    name_matches.sort_by(stable_order);
+    });
 
     let mut query = ImpactQuery {
         entity: request.entity.clone(),
@@ -180,19 +197,23 @@ pub async fn build_impact_response(
     if name_matches.len() > 1 || matches.is_empty() {
         query.name_candidates = name_matches
             .iter()
-            .map(CandidateIdentity::from_entity)
+            .map(|entity| CandidateIdentity::from_entity(graph, entity))
             .collect();
     }
 
     if matches.is_empty() {
-        let qualifiers = active_qualifiers(request);
+        let name = resolution.reference.name.as_str();
+        let mut qualifiers = resolution.reference.qualifiers.labels();
+        if let Some(line) = resolution.reference.line {
+            qualifiers.push(format!("line {line}"));
+        }
         // A name that resolves to nothing at all is a genuine miss. A name that
         // resolves and is then filtered out by the qualifiers is not, and must
         // not be reported as one.
         let lines = if name_matches.is_empty() || qualifiers.is_empty() {
-            impact_not_found_guidance(&request.entity)
+            impact_not_found_guidance(name)
         } else {
-            let members_in_scope = match request.file.as_deref() {
+            let members_in_scope = match resolution.reference.qualifiers.file.as_deref() {
                 Some(file) => crate::commands::declaration_neighbors::collect(
                     graph,
                     &name_matches[0],
@@ -203,12 +224,7 @@ pub async fn build_impact_response(
                 .collect(),
                 None => Vec::new(),
             };
-            qualifier_miss_guidance(
-                &request.entity,
-                &qualifiers,
-                &name_matches,
-                &members_in_scope,
-            )
+            qualifier_miss_guidance(graph, name, &qualifiers, &name_matches, &members_in_scope)
         };
         return Ok(ImpactResponse {
             lines,
@@ -227,7 +243,7 @@ pub async fn build_impact_response(
     // next instead of being told the graph holds nothing (FIR-2478).
     if request.require_unique && (matches.len() != 1 || !exact_name) {
         return Ok(ImpactResponse {
-            lines: ambiguous_resolution_guidance(&request.entity, exact_name, &matches),
+            lines: ambiguous_resolution_guidance(graph, &request.entity, exact_name, matches),
             schema_version: IMPACT_RESPONSE_SCHEMA_VERSION.to_string(),
             resolution: "ambiguous".to_string(),
             query,
@@ -236,44 +252,36 @@ pub async fn build_impact_response(
         });
     }
 
-    prefer_entities_owning_incoming_relations(graph, &mut matches)?;
+    // A partial name reaching several entities names none of them, so the
+    // person at a terminal is asked which one, the way a structured caller is,
+    // rather than handed an analysis of whichever sorted first.
+    if resolution.needs_a_pin() {
+        return Ok(ImpactResponse {
+            lines: crate::entity_identity::pin_request_lines(graph, &resolution),
+            schema_version: IMPACT_RESPONSE_SCHEMA_VERSION.to_string(),
+            resolution: "ambiguous".to_string(),
+            query,
+            ranked: None,
+            negative: None,
+        });
+    }
 
     let target = &matches[0];
-    let target_at = entity_location(target)
+    let target_at = entity_location(graph, target)
         .map(|loc| format!(" @ {loc}"))
         .unwrap_or_default();
     let mut lines = vec![format!(
         "Impact analysis for '{}' ({:?}){}:",
         target.name, target.kind, target_at
     )];
-    if matches.len() > 1 {
-        lines.push(format!(
-            "  Note: {} matches; showing the deterministic first match. Use --json with --file/--kind/--signature for fail-closed resolution.",
-            matches.len()
-        ));
-        // Naming the identities that were passed over is what lets a reader tell
-        // an answer about the wrong node from an answer about a node with
-        // nothing to report.
-        lines.push("  Other matches:".to_string());
-        for other in matches
-            .iter()
-            .skip(1)
-            .take(crate::commands::declaration_neighbors::MAX_LISTED)
-        {
-            lines.push(format!(
-                "    - {} ({:?}) @ {}",
-                other.name,
-                other.kind,
-                entity_location(other).unwrap_or_else(|| "unknown".to_string())
-            ));
-        }
-        if let Some(more) = crate::commands::declaration_neighbors::and_more_suffix(
-            crate::commands::declaration_neighbors::MAX_LISTED,
-            matches.len() - 1,
-        ) {
-            lines.push(format!("    {more}"));
-        }
-    }
+    // Naming the identities that were passed over, and the rule that passed
+    // over them, is what lets a reader tell an answer about the wrong node from
+    // an answer about a node with nothing to report.
+    lines.extend(crate::entity_identity::choice_note(
+        graph,
+        &resolution,
+        crate::entity_identity::PinSpelling::FileKind,
+    ));
 
     // One depth for both walks. `rank_impact` bounds itself at
     // `IMPACT_MAX_DEPTH` and says nothing about it, so a deeper request used to
@@ -314,11 +322,15 @@ pub async fn build_impact_response(
                     format!("  {hop} hops:")
                 });
             }
-            let at = entity_location(entity)
+            let at = entity_location(graph, entity)
                 .map(|loc| format!(" @ {loc}"))
                 .unwrap_or_default();
             lines.push(format!("    - {} ({:?}){}", entity.name, entity.kind, at));
         }
+    }
+
+    if let Some(note) = crate::entity_identity::stale_span_note(&lines) {
+        lines.push(note);
     }
 
     let ranked = if request.require_unique {
@@ -334,43 +346,6 @@ pub async fn build_impact_response(
         ranked,
         negative,
     })
-}
-
-/// Move the identities that own incoming relations to the front, preserving the
-/// deterministic order within each group.
-///
-/// When one name covers several graph identities, only some of them are what
-/// impact analysis is about. A re-export, a forward declaration, or a test
-/// fixture sharing the name carries no dependents, and answering for it prints
-/// an empty result that is indistinguishable from a subject nothing depends on.
-/// The identity that owns incoming edges is the one the question was about.
-///
-/// A tie leaves the order untouched, so a set where nothing carries edges still
-/// resolves to the same deterministic first match it always did. That is what
-/// keeps this from being a reshuffle dressed as a preference.
-fn prefer_entities_owning_incoming_relations(
-    graph: &kin_db::InMemoryGraph,
-    matches: &mut [kin_model::Entity],
-) -> Result<()> {
-    if matches.len() < 2 {
-        return Ok(());
-    }
-    let mut owns_incoming = std::collections::HashSet::new();
-    for entity in matches.iter() {
-        if !graph
-            .get_all_relations_for_entity(&entity.id)?
-            .into_iter()
-            .any(|relation| {
-                relation.dst == GraphNodeId::Entity(entity.id)
-                    && relation.src != GraphNodeId::Entity(entity.id)
-            })
-        {
-            continue;
-        }
-        owns_incoming.insert(entity.id);
-    }
-    matches.sort_by_key(|entity| !owns_incoming.contains(&entity.id));
-    Ok(())
 }
 
 /// The relation kinds a member's dependent count is read over.
@@ -594,61 +569,6 @@ fn downstream_impact_by_hop<G: ImpactWalkGraph>(
     Ok(reached)
 }
 
-/// What a query resolved to, at both stages of resolution.
-///
-/// The two are kept apart so a qualifier that narrows the set to nothing can be
-/// reported as the filter miss it is. Collapsing them is what let
-/// `kin impact Error --file src/error.rs` answer "Entity 'Error' not found in
-/// this repo's graph" about an entity the unfiltered lookup had just found.
-struct ResolvedEntities {
-    /// After `--file`, `--kind`, and `--signature`.
-    matches: Vec<kin_model::Entity>,
-    /// Before them: what the name alone resolves to.
-    name_matches: Vec<kin_model::Entity>,
-    /// Whether the query is some entity's name exactly, rather than a fragment
-    /// of it. A structured caller resolves only on an exact name, so this is
-    /// what separates "the graph holds nothing by that name" from "the name you
-    /// gave is part of several entities' names".
-    exact_name: bool,
-}
-
-/// Resolve this request's entity through the one resolver every read command
-/// shares.
-///
-/// The rules here used to live in this function alone, which is why `kin trace`
-/// and `kin xref` could not read an id and no command but this one could take
-/// `--file` (FIR-3071). They now live in [`crate::entity_identity`]; this stays
-/// as the thin adapter between `ImpactRequest` and that resolver.
-fn resolve_entities(
-    graph: &kin_db::InMemoryGraph,
-    request: &ImpactRequest,
-) -> Result<ResolvedEntities> {
-    let resolved = crate::entity_identity::resolve_identity(
-        graph,
-        &request.entity,
-        &crate::entity_identity::IdentityQualifiers {
-            file: request.file.clone(),
-            kind: request.kind.clone(),
-            signature: request.signature.clone(),
-        },
-    )?;
-    Ok(ResolvedEntities {
-        matches: resolved.matches,
-        name_matches: resolved.name_matches,
-        exact_name: resolved.exact_name,
-    })
-}
-
-/// The qualifiers a request carried, spelled the way the user passed them.
-fn active_qualifiers(request: &ImpactRequest) -> Vec<String> {
-    crate::entity_identity::IdentityQualifiers {
-        file: request.file.clone(),
-        kind: request.kind.clone(),
-        signature: request.signature.clone(),
-    }
-    .labels()
-}
-
 /// The answer when a name resolves but the identity qualifiers exclude every
 /// match.
 ///
@@ -657,6 +577,7 @@ fn active_qualifiers(request: &ImpactRequest) -> Vec<String> {
 /// Report the miss as a miss and name what the name alone does resolve to, so
 /// the next command is a copy of one of these lines.
 fn qualifier_miss_guidance(
+    graph: &kin_db::InMemoryGraph,
     entity: &str,
     qualifiers: &[String],
     candidates: &[kin_model::Entity],
@@ -681,7 +602,7 @@ fn qualifier_miss_guidance(
             "  {} ({:?}) @ {}",
             candidate.name,
             candidate.kind,
-            entity_location(candidate).unwrap_or_else(|| "unknown".to_string())
+            entity_location(graph, candidate).unwrap_or_else(|| "unknown".to_string())
         ));
     }
     if let Some(more) = crate::commands::declaration_neighbors::and_more_suffix(
@@ -715,12 +636,13 @@ fn qualifier_miss_guidance(
     lines
 }
 
-/// `path:line` for an entity, or just the path when the graph carries no span.
+/// `path:line` for an entity, just the path when the graph carries no span, or
+/// the path marked stale when the span describes an older version of the file.
 ///
 /// Location is projection metadata for the human reading the listing; the
 /// analysis itself is keyed on graph identity, never on paths.
-fn entity_location(entity: &kin_model::Entity) -> Option<String> {
-    crate::commands::declaration_neighbors::entity_location(entity)
+fn entity_location(graph: &kin_db::InMemoryGraph, entity: &kin_model::Entity) -> Option<String> {
+    crate::commands::declaration_neighbors::entity_location(graph, entity)
 }
 
 /// The answer when a structured caller's query does not name exactly one
@@ -736,6 +658,7 @@ fn entity_location(entity: &kin_model::Entity) -> Option<String> {
 /// contract as absent (FIR-2478). That case is answered by naming the
 /// identities, because the next command is a copy of one of these lines.
 fn ambiguous_resolution_guidance(
+    graph: &kin_db::InMemoryGraph,
     entity: &str,
     exact_name: bool,
     matches: &[kin_model::Entity],
@@ -762,7 +685,7 @@ fn ambiguous_resolution_guidance(
             "  {} ({:?}) @ {}",
             candidate.name,
             candidate.kind,
-            entity_location(candidate).unwrap_or_else(|| "unknown".to_string())
+            entity_location(graph, candidate).unwrap_or_else(|| "unknown".to_string())
         ));
     }
     if let Some(more) = crate::commands::declaration_neighbors::and_more_suffix(

--- a/crates/kin-cli/src/commands/refs.rs
+++ b/crates/kin-cli/src/commands/refs.rs
@@ -192,56 +192,68 @@ pub fn build_refs_response(
     envelope: &kin_mcp::Envelope,
 ) -> Result<RefsResponse> {
     let relation_kinds = parse_relation_kinds(&request.kind)?;
-    let addressed_by_id = uuid::Uuid::parse_str(request.entity.trim()).ok();
-    let target = if let Some(uuid) = addressed_by_id {
-        graph.get_entity(&EntityId(uuid))?
-    } else {
-        // `select_best_entity` scores name quality, export status, kind and
-        // reference counts, all of which tie for a prototype and its definition,
-        // so on a C repository it answered about the header (FIR-3071). The
-        // ranked answer stands unless it is a declaration whose definition the
-        // same name also reaches, which is the one case its key cannot decide.
-        entity_ranking::select_best_entity(graph, &request.entity)?.map(|entity| {
-            let filter = kin_model::EntityFilter {
-                name_pattern: Some(entity.name.clone()),
-                ..Default::default()
-            };
-            let pool = graph.query_entities(&filter).unwrap_or_default();
-            kin_core::prefer_definition_among_same_name(entity, &pool)
-        })
-    };
-    // `None` means the focal was pinned by id, which is the rule the shared
-    // producer switches on. Kept beside the resolution so the two cannot drift.
-    let resolved_by_name = if addressed_by_id.is_some() {
-        None
-    } else {
-        Some(request.entity.trim())
-    };
-    let Some(target) = target else {
+    // The one resolver every read command shares (FIR-3505). The ranker this
+    // replaced tied every twin on name, kind and callers, so it answered about
+    // whichever one the store listed first, and nothing said a choice was made.
+    let resolution = crate::entity_identity::resolve_entity(
+        graph,
+        &request.entity,
+        &crate::entity_identity::IdentityQualifiers::default(),
+    )?;
+    let refusal = if resolution.name_matches.is_empty() {
         // Not an absence claim about references: the focal never resolved, so
         // nothing was walked and there is no coverage question to answer. A
         // verdict here would qualify a lookup failure as if it were a finding.
-        let lines = refs_not_found_guidance(&request.entity);
+        Some(refs_not_found_guidance(&resolution.reference.name))
+    } else if resolution.pin_excluded_all() {
+        Some(crate::entity_identity::pin_miss_lines(graph, &resolution))
+    } else if resolution.needs_a_pin() {
+        Some(crate::entity_identity::pin_request_lines(
+            graph,
+            &resolution,
+        ))
+    } else {
+        None
+    };
+    if let Some(lines) = refusal {
         return Ok(RefsResponse {
             error: Some(lines.join("\n")),
             lines,
             negative: None,
         });
+    }
+    let target = resolution.chosen().cloned().ok_or_else(|| {
+        anyhow::anyhow!(
+            "resolving '{}' produced no candidate",
+            resolution.reference.name
+        )
+    })?;
+    // `None` means the focal was pinned by id, which is the rule the shared
+    // producer switches on. Kept beside the resolution so the two cannot drift.
+    let resolved_by_name = if resolution.addressed_by_id() {
+        None
+    } else {
+        Some(resolution.reference.name.as_str())
     };
     let target = &target;
 
     let refs = collect_references(graph, target, &relation_kinds)?;
-    let target_path = target
-        .file_origin
-        .as_ref()
-        .map(|f| display_read_path(layout, &f.0))
+    let target_path = declaration_neighbors::entity_location(graph, target)
+        .map(|location| display_read_path(layout, &location))
         .unwrap_or_else(|| "unknown".to_string());
 
     let mut lines = Vec::new();
     lines.push(format!(
         "References to '{}' -> {} ({:?}) @ {}",
-        request.entity, target.name, target.kind, target_path
+        resolution.reference.name, target.name, target.kind, target_path
     ));
+    let choice = crate::entity_identity::choice_note(
+        graph,
+        &resolution,
+        crate::entity_identity::PinSpelling::FileEntityKind,
+    );
+    let listed_candidates = !choice.is_empty();
+    lines.extend(choice);
 
     if refs.is_empty() {
         lines.push(format!(
@@ -261,7 +273,12 @@ pub fn build_refs_response(
             envelope,
         ));
         let neighbors = declaration_neighbors::collect(graph, target, &relation_kinds)?;
-        lines.extend(empty_result_context(target, &neighbors));
+        // The candidate note above already named every same-name identity, so
+        // the sibling listing would only repeat it.
+        lines.extend(empty_result_context(target, &neighbors, !listed_candidates));
+        if let Some(note) = crate::entity_identity::stale_span_note(&lines) {
+            lines.push(note);
+        }
         return Ok(RefsResponse {
             lines,
             negative,
@@ -285,9 +302,10 @@ pub fn build_refs_response(
             .as_deref()
             .map(|path| display_read_path(layout, path))
             .unwrap_or_else(|| "unknown".to_string());
-        let location = match entry.start_line {
-            Some(line) => format!("{file_path}:{line}"),
-            None => file_path,
+        let location = match (entry.start_line, entry.span_stale) {
+            (_, true) => format!("{file_path} {}", crate::entity_identity::STALE_SPAN_MARK),
+            (Some(line), false) => format!("{file_path}:{line}"),
+            (None, false) => file_path,
         };
         lines.push(format!(
             "  {} @ {} [{}] ({}) {}",
@@ -349,6 +367,9 @@ pub fn build_refs_response(
     // bill. Stamping a coverage verdict on a non-empty answer is the FIR-2404
     // failure in its opposite costume, which this rollout's positive control
     // exists to catch.
+    if let Some(note) = crate::entity_identity::stale_span_note(&lines) {
+        lines.push(note);
+    }
     Ok(RefsResponse {
         lines,
         negative: None,
@@ -501,6 +522,7 @@ fn reference_sites_label(entry: &ReferenceEntry) -> String {
 fn empty_result_context(
     target: &Entity,
     neighbors: &declaration_neighbors::DeclarationNeighbors,
+    list_siblings: bool,
 ) -> Vec<String> {
     let mut lines = Vec::new();
 
@@ -535,7 +557,7 @@ fn empty_result_context(
         lines.push(format!("  try: kin refs {}", first.name));
     }
 
-    if !neighbors.siblings.is_empty() {
+    if list_siblings && !neighbors.siblings.is_empty() {
         lines.push(format!(
             "{} other graph identit{} the name '{}':",
             neighbors.siblings.len(),
@@ -826,8 +848,12 @@ pub(crate) struct ReferenceEntry {
     pub(crate) file_path: Option<String>,
     /// 1-based, as every `file:line` an agent pastes into an editor is.
     /// `None` for an entity the graph carries no span for, because reporting a
-    /// line for one would be a fabricated position.
+    /// line for one would be a fabricated position, and `None` when the span
+    /// is stale, for the same reason.
     start_line: Option<u32>,
+    /// The caller's span was measured against an older version of its file
+    /// than the graph holds, so the row prints the path marked stale.
+    span_stale: bool,
     /// 1-based lines of the reference sites inside this caller, ascending and
     /// deduplicated. Read from the same relation evidence and through the same
     /// helper `find_references` uses, because two surfaces answering "where"
@@ -975,11 +1001,13 @@ pub(crate) fn collect_graph_references(
         } else {
             Some(ReferenceLinesAbsent::NoEvidenceSpan)
         };
+        let pointer = crate::entity_identity::entity_pointer(graph, &entity);
         references.push(ReferenceEntry {
             entity_id: source_id,
             name: entity.name.clone(),
             file_path: entity.file_origin.as_ref().map(|f| f.0.clone()),
-            start_line: kin_mcp::handlers::common::entity_presentation_start_line(&entity),
+            start_line: pointer.line,
+            span_stale: pointer.stale,
             reference_lines,
             reference_lines_absent,
             relation_kinds: source_kinds,

--- a/crates/kin-cli/src/commands/trace.rs
+++ b/crates/kin-cli/src/commands/trace.rs
@@ -465,6 +465,7 @@ fn build_trace_lines_with_graph(
     // single prompt with nothing marking the difference (FIR-3071).
     if !resolution.addressed_by_id {
         lines.extend(crate::entity_identity::twin_note(
+            graph,
             entity,
             target,
             &resolution.candidates,
@@ -997,7 +998,12 @@ fn resolve_trace_target(
     crate::entity_identity::apply_qualifiers(&mut candidates, &qualifiers);
     if candidates.is_empty() {
         return Err(anyhow::Error::new(TraceMiss {
-            lines: trace_qualifier_miss_guidance(entity, &qualifiers.labels(), &name_candidates),
+            lines: trace_qualifier_miss_guidance(
+                graph,
+                entity,
+                &qualifiers.labels(),
+                &name_candidates,
+            ),
         }));
     }
 
@@ -1034,6 +1040,7 @@ fn trace_id_not_found_guidance(entity: &str) -> Vec<String> {
 /// so the next command is a copy of one of these lines. Same shape `kin impact`
 /// already uses for the same case.
 fn trace_qualifier_miss_guidance(
+    graph: &impl GraphStore,
     entity: &str,
     qualifiers: &[String],
     candidates: &[Entity],
@@ -1057,7 +1064,7 @@ fn trace_qualifier_miss_guidance(
             "  {} ({}) @ {}",
             candidate.name,
             kin_review::StableEntityIdentity::from_entity(candidate).kind,
-            crate::entity_identity::entity_location(candidate)
+            crate::entity_identity::entity_location(graph, candidate)
         ));
     }
     if let Some(more) = crate::commands::declaration_neighbors::and_more_suffix(

--- a/crates/kin-cli/src/entity_identity.rs
+++ b/crates/kin-cli/src/entity_identity.rs
@@ -25,8 +25,10 @@
 //! this module prints suggests, so a `--file`/`--kind` pair copied out of that
 //! note is the pair the filter compares.
 
-use anyhow::Result;
-use kin_model::{Entity, EntityFilter, EntityId, GraphStore};
+use anyhow::{bail, Result};
+use kin_model::{Entity, EntityFilter, EntityId, GraphNodeId, GraphStore, RelationKind};
+
+use crate::entity_ref::EntityRef;
 
 /// The qualifiers that pin one entity when a name reaches several.
 #[derive(Debug, Clone, Default)]
@@ -159,15 +161,398 @@ pub fn apply_qualifiers(matches: &mut Vec<Entity>, qualifiers: &IdentityQualifie
 
 /// The entity to answer about when several share a name and nothing pins one.
 ///
-/// Ordered by [`kin_core::definition_identity_key`]: a body beats a declaration,
-/// then the file path, then the start line, then the id. Every term is read off
-/// the entity record, so the choice is a property of the candidates and not of
-/// the order the store listed them in, which is what made the same question
-/// answer two ways across six stores built from one tree (FIR-3071).
-pub fn choose_definition(matches: &[Entity]) -> Option<&Entity> {
-    matches.iter().min_by(|a, b| {
-        kin_core::definition_identity_key(a).cmp(&kin_core::definition_identity_key(b))
+/// The first entity [`rank_candidates`] puts forward, so `kin context` chooses
+/// by the same rule as every other read command. Every term of that rule is read
+/// off the graph, so the choice is a property of the candidates and not of the
+/// order the store listed them in, which is what made the same question answer
+/// two ways across six stores built from one tree (FIR-3071).
+pub fn choose_definition<G: GraphStore>(graph: &G, matches: &[Entity]) -> Result<Option<Entity>> {
+    let mut ranked = matches.to_vec();
+    rank_candidates(graph, &mut ranked)?;
+    Ok(ranked.into_iter().next())
+}
+
+/// The relation kinds that make an entity something others depend on, for
+/// [`rank_candidates`]. The set `kin refs` answers on by default, so "has
+/// dependents" means `kin refs` would list someone.
+const DEPENDENT_RELATION_KINDS: [RelationKind; 3] = [
+    RelationKind::Calls,
+    RelationKind::Imports,
+    RelationKind::References,
+];
+
+/// The rule [`rank_candidates`] orders same-named entities by, as the sentence an
+/// answer prints when it had to choose.
+pub const RANKING_RULE: &str = "a definition before a declaration, then an entity something \
+     calls, imports or references before one nothing does, then by file path and line";
+
+/// Order `candidates` by the one rule every read command chooses with.
+///
+/// Lower sorts first: a definition before a declaration ([`kin_core::carries_body`]
+/// reads the stored signature), then an entity another entity calls, imports or
+/// references before one nothing does, then file path, then start line, then id.
+/// A re-export, a forward declaration or a fixture sharing a name carries no
+/// dependents, and answering for it prints an empty result indistinguishable
+/// from a subject nothing depends on, which is why the second term exists.
+/// Every term is read off the graph, so `kin refs`, `kin impact`, `kin blame`
+/// and the graph commands choose the same entity for the same name.
+pub fn rank_candidates<G: GraphStore>(graph: &G, candidates: &mut Vec<Entity>) -> Result<()> {
+    rank_candidates_by(candidates, |entity| has_dependents(graph, entity))
+}
+
+/// [`rank_candidates`] with the dependents test supplied by the caller, for a
+/// candidate set that lives outside a store, such as a state replayed at a
+/// historical ref.
+pub fn rank_candidates_by(
+    candidates: &mut Vec<Entity>,
+    mut has_dependents: impl FnMut(&Entity) -> Result<bool>,
+) -> Result<()> {
+    if candidates.len() < 2 {
+        return Ok(());
+    }
+    let mut keyed = Vec::with_capacity(candidates.len());
+    for entity in candidates.drain(..) {
+        let dependents = has_dependents(&entity)?;
+        let (declaration, path, line, id) = kin_core::definition_identity_key(&entity);
+        keyed.push(((declaration, !dependents, path, line, id), entity));
+    }
+    keyed.sort_by(|left, right| left.0.cmp(&right.0));
+    candidates.extend(keyed.into_iter().map(|(_, entity)| entity));
+    Ok(())
+}
+
+/// Whether another entity calls, imports or references `entity`.
+fn has_dependents<G: GraphStore>(graph: &G, entity: &Entity) -> Result<bool> {
+    let own = GraphNodeId::Entity(entity.id);
+    Ok(graph
+        .get_all_relations_for_entity(&entity.id)?
+        .iter()
+        .any(|relation| {
+            relation.dst == own
+                && relation.src != own
+                && relation.src.as_entity().is_some()
+                && DEPENDENT_RELATION_KINDS.contains(&relation.kind)
+        }))
+}
+
+/// How a query met the name of what it resolved to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NameMatch {
+    /// The query was an entity id, which names one entity.
+    Id,
+    /// Some entity's name is the query exactly.
+    Exact,
+    /// Some entity's name is the query once ASCII case is ignored.
+    CaseInsensitive,
+    /// The query is only part of the names it reached.
+    Partial,
+}
+
+/// Everything one query resolved to, at every stage, so a command can answer
+/// and also say how it chose.
+pub struct EntityResolution {
+    /// The query with its `#kind@path:line` suffix read out and merged with the
+    /// caller's flags.
+    pub reference: EntityRef,
+    /// What the name or id alone reaches, before any pin.
+    pub name_matches: Vec<Entity>,
+    /// What survives the pins, ranked by [`rank_candidates`]; the first is the
+    /// answer.
+    pub candidates: Vec<Entity>,
+    pub name_match: NameMatch,
+}
+
+impl EntityResolution {
+    /// The entity the answer is about.
+    pub fn chosen(&self) -> Option<&Entity> {
+        self.candidates.first()
+    }
+
+    pub fn addressed_by_id(&self) -> bool {
+        self.name_match == NameMatch::Id
+    }
+
+    pub fn exact_name(&self) -> bool {
+        self.name_match == NameMatch::Exact
+    }
+
+    /// A partial name that reaches several entities names none of them, so the
+    /// caller is asked which it meant instead of being handed a guess.
+    pub fn needs_a_pin(&self) -> bool {
+        self.name_match == NameMatch::Partial && self.candidates.len() > 1
+    }
+
+    /// The name reaches entities and the pins exclude every one of them, which
+    /// is a filter miss and never an absent entity.
+    pub fn pin_excluded_all(&self) -> bool {
+        !self.name_matches.is_empty() && self.candidates.is_empty()
+    }
+}
+
+/// Resolve `query` the one way every read command resolves a name.
+///
+/// The query is an entity id, a name, or a name carrying the
+/// `Name#kind@path:line` suffix `kin context` already reads; `flags` are the
+/// same pins spelled as command-line flags, and a pin given both ways with two
+/// values is refused. Names go through the graph's name index with the generics
+/// and qualified-leaf retries `kin trace` has always used, drop external
+/// reference targets, and narrow to exact, then case-folded, matches when any
+/// exist. What survives the pins is ranked by [`rank_candidates`].
+pub fn resolve_entity<G: GraphStore>(
+    graph: &G,
+    query: &str,
+    flags: &IdentityQualifiers,
+) -> Result<EntityResolution> {
+    let reference = merge_pins(parse_query(graph, query)?, flags)?;
+    let name = reference.name.trim().to_string();
+    let (mut name_matches, name_match) = if let Ok(uuid) = uuid::Uuid::parse_str(&name) {
+        (
+            graph.get_entity(&EntityId(uuid))?.into_iter().collect(),
+            NameMatch::Id,
+        )
+    } else {
+        gather_by_name(graph, &name)?
+    };
+    let mut candidates = name_matches.clone();
+    apply_qualifiers(&mut candidates, &reference.qualifiers);
+    crate::entity_ref::apply_line(&mut candidates, reference.line);
+    rank_candidates(graph, &mut candidates)?;
+    if candidates.is_empty() {
+        // Only a miss lists these, and it lists them in the order the rule would
+        // have chosen them.
+        rank_candidates(graph, &mut name_matches)?;
+    }
+    Ok(EntityResolution {
+        reference,
+        name_matches,
+        candidates,
+        name_match,
     })
+}
+
+/// Read the pins out of a query's suffix.
+///
+/// The raw token is tried as an entity name first, so a name that itself
+/// carries `@` or `#` resolves as that name rather than being split into a pin.
+fn parse_query<G: GraphStore>(graph: &G, query: &str) -> Result<EntityRef> {
+    let trimmed = query.trim();
+    let bare = || EntityRef {
+        name: trimmed.to_string(),
+        ..EntityRef::default()
+    };
+    if !(trimmed.contains('@') || trimmed.contains('#')) {
+        return Ok(bare());
+    }
+    let raw_is_a_name = graph
+        .query_entities(&EntityFilter {
+            name_pattern: Some(trimmed.to_string()),
+            ..Default::default()
+        })?
+        .iter()
+        .any(|entity| entity.name == trimmed);
+    if raw_is_a_name {
+        return Ok(bare());
+    }
+    let parsed = crate::entity_ref::parse_entity_ref(trimmed);
+    if parsed.name.trim().is_empty() {
+        return Ok(bare());
+    }
+    Ok(parsed)
+}
+
+/// Merge the pins a query's suffix carried with the ones its flags carried.
+fn merge_pins(mut reference: EntityRef, flags: &IdentityQualifiers) -> Result<EntityRef> {
+    let pairs = [
+        ("file", &mut reference.qualifiers.file, &flags.file),
+        ("kind", &mut reference.qualifiers.kind, &flags.kind),
+        (
+            "signature",
+            &mut reference.qualifiers.signature,
+            &flags.signature,
+        ),
+    ];
+    for (label, from_query, from_flag) in pairs {
+        match (from_query.as_deref(), from_flag.as_deref()) {
+            (Some(spelled), Some(flagged)) if spelled != flagged => bail!(
+                "the {label} pin was given twice with two values: '{spelled}' in the entity \
+                 name and '{flagged}' as a flag; give it once"
+            ),
+            (None, Some(flagged)) => *from_query = Some(flagged.to_string()),
+            _ => {}
+        }
+    }
+    Ok(reference)
+}
+
+/// Every entity a name reaches, narrowed to exact or case-folded matches when
+/// the name is some entity's whole name.
+fn gather_by_name<G: GraphStore>(graph: &G, name: &str) -> Result<(Vec<Entity>, NameMatch)> {
+    if name.is_empty() {
+        return Ok((Vec::new(), NameMatch::Partial));
+    }
+    let mut matches = kin_core::query_trace_matches(graph, name)?;
+    matches.retain(|entity| !kin_index::is_external_reference_target(entity));
+    if matches.is_empty() && (name.starts_with('*') || name.ends_with('*')) {
+        // The name index is a substring test and reads `*` literally, so a glob
+        // is answered by a sweep. It stays narrowed to the query: an unfiltered
+        // sweep is how `kin history alwaysTrue` once listed four unrelated names
+        // as its matches.
+        matches = graph
+            .list_all_entities()?
+            .into_iter()
+            .filter(|entity| {
+                !kin_index::is_external_reference_target(entity) && glob_matches(&entity.name, name)
+            })
+            .collect();
+    }
+    let exact: Vec<Entity> = matches
+        .iter()
+        .filter(|entity| entity.name == name)
+        .cloned()
+        .collect();
+    if !exact.is_empty() {
+        return Ok((exact, NameMatch::Exact));
+    }
+    let folded: Vec<Entity> = matches
+        .iter()
+        .filter(|entity| entity.name.eq_ignore_ascii_case(name))
+        .cloned()
+        .collect();
+    if !folded.is_empty() {
+        return Ok((folded, NameMatch::CaseInsensitive));
+    }
+    Ok((matches, NameMatch::Partial))
+}
+
+/// A leading `*` matches a suffix and a trailing one a prefix, ignoring case.
+fn glob_matches(name: &str, pattern: &str) -> bool {
+    let name = name.to_lowercase();
+    let pattern = pattern.to_lowercase();
+    if let Some(suffix) = pattern.strip_prefix('*') {
+        name.ends_with(suffix.trim_end_matches('*'))
+    } else if let Some(prefix) = pattern.strip_suffix('*') {
+        name.starts_with(prefix)
+    } else {
+        name == pattern
+    }
+}
+
+/// How many candidates a note lists before it points at `kin graph inspect`.
+const MAX_LISTED_CANDIDATES: usize = 8;
+
+/// How a command spells its pins, for the line that tells a reader how to reach
+/// another candidate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PinSpelling {
+    /// `--file <path> --kind <kind>`.
+    FileKind,
+    /// `kin refs`, whose `--kind` already filters relation kinds.
+    FileEntityKind,
+}
+
+impl PinSpelling {
+    fn flags(self, file: &str, kind: &str) -> String {
+        match self {
+            Self::FileKind => format!("--file {file} --kind {kind}"),
+            Self::FileEntityKind => format!("--file {file} --entity-kind {kind}"),
+        }
+    }
+}
+
+/// One row per candidate: its kind, where it is, and its id, which pins it
+/// exactly in every command.
+pub fn candidate_rows<G: GraphStore>(graph: &G, candidates: &[Entity]) -> Vec<String> {
+    let mut rows: Vec<String> = candidates
+        .iter()
+        .take(MAX_LISTED_CANDIDATES)
+        .map(|candidate| {
+            format!(
+                "  {:<9} {}  {}",
+                kin_review::StableEntityIdentity::from_entity(candidate).kind,
+                entity_location(graph, candidate),
+                candidate.id
+            )
+        })
+        .collect();
+    if candidates.len() > MAX_LISTED_CANDIDATES {
+        rows.push(format!(
+            "  ... and {} more; `kin graph inspect {}` lists every one",
+            candidates.len() - MAX_LISTED_CANDIDATES,
+            candidates[0].name
+        ));
+    }
+    rows
+}
+
+/// What an answer says when its query reached more than one entity: every
+/// candidate, the rule that picked the first, and how to pin another.
+///
+/// Silent for an id and for a query that reached one entity, because nothing
+/// was chosen.
+pub fn choice_note<G: GraphStore>(
+    graph: &G,
+    resolution: &EntityResolution,
+    spelling: PinSpelling,
+) -> Vec<String> {
+    if resolution.addressed_by_id() || resolution.candidates.len() < 2 {
+        return Vec::new();
+    }
+    let mut lines = vec![format!(
+        "note: '{}' names {} entities in this graph; this answer is about the first one listed.",
+        resolution.reference.name,
+        resolution.candidates.len()
+    )];
+    lines.extend(candidate_rows(graph, &resolution.candidates));
+    lines.push(format!("note: ranked {RANKING_RULE}."));
+    let next = kin_review::StableEntityIdentity::from_entity(&resolution.candidates[1]);
+    let file = if next.file.is_empty() {
+        "<path>"
+    } else {
+        next.file.as_str()
+    };
+    lines.push(format!(
+        "note: to answer about another, pin it, for example {}, or pass its id.",
+        spelling.flags(file, &next.kind)
+    ));
+    lines
+}
+
+/// The answer when a partial name reaches several entities.
+pub fn pin_request_lines<G: GraphStore>(graph: &G, resolution: &EntityResolution) -> Vec<String> {
+    let mut lines = vec![format!(
+        "No entity is named '{}' exactly, and it is part of the names of {} entities, so there \
+         is no one entity to answer about:",
+        resolution.reference.name,
+        resolution.candidates.len()
+    )];
+    lines.extend(candidate_rows(graph, &resolution.candidates));
+    lines.push(
+        "hint: re-run with one of the names above, or pass its id. Pins narrow a name; they \
+         cannot make a partial name exact."
+            .to_string(),
+    );
+    lines
+}
+
+/// The answer when the name resolves and the pins exclude every entity it
+/// reaches. The entity is in the graph, so saying it is absent would be false.
+pub fn pin_miss_lines<G: GraphStore>(graph: &G, resolution: &EntityResolution) -> Vec<String> {
+    let name = &resolution.reference.name;
+    let mut pins = resolution.reference.qualifiers.labels();
+    if let Some(line) = resolution.reference.line {
+        pins.push(format!("line {line}"));
+    }
+    let count = resolution.name_matches.len();
+    let mut lines = vec![
+        format!("No entity named '{name}' matches {}.", pins.join(" ")),
+        format!(
+            "'{name}' resolves in this repo's graph to {count} entit{}:",
+            if count == 1 { "y" } else { "ies" }
+        ),
+    ];
+    lines.extend(candidate_rows(graph, &resolution.name_matches));
+    lines.push("hint: pin one of the entities above, or pass its id.".to_string());
+    lines
 }
 
 /// How many candidates a note lists before it stops.
@@ -183,7 +568,12 @@ const MAX_LISTED_TWINS: usize = 4;
 ///
 /// Silent when the caller passed an id or when the name reached one entity,
 /// because there was nothing to choose.
-pub fn twin_note(query: &str, chosen: &Entity, matches: &[Entity]) -> Vec<String> {
+pub fn twin_note<G: GraphStore>(
+    graph: &G,
+    query: &str,
+    chosen: &Entity,
+    matches: &[Entity],
+) -> Vec<String> {
     if matches.len() < 2 {
         return Vec::new();
     }
@@ -197,7 +587,7 @@ pub fn twin_note(query: &str, chosen: &Entity, matches: &[Entity]) -> Vec<String
         } else {
             "declaration"
         },
-        entity_location(chosen),
+        entity_location(graph, chosen),
     )];
     let others: Vec<&Entity> = matches
         .iter()
@@ -207,7 +597,7 @@ pub fn twin_note(query: &str, chosen: &Entity, matches: &[Entity]) -> Vec<String
         let identity = kin_review::StableEntityIdentity::from_entity(candidate);
         lines.push(format!(
             "note: also {} ({}).",
-            entity_location(candidate),
+            entity_location(graph, candidate),
             identity.kind
         ));
     }
@@ -229,11 +619,94 @@ pub fn twin_note(query: &str, chosen: &Entity, matches: &[Entity]) -> Vec<String
     lines
 }
 
-/// `path:line` for an entity, or `unknown` when the graph carries no file for
-/// it. Presentation only; resolution is keyed on graph identity, never on paths.
-pub fn entity_location(entity: &Entity) -> String {
-    crate::commands::declaration_neighbors::entity_location(entity)
-        .unwrap_or_else(|| "unknown".to_string())
+/// `path:line` for an entity, `path (span stale)` when its span describes an
+/// older version of the file than the graph holds, or `unknown` when the graph
+/// carries no file for it. Presentation only; resolution is keyed on graph
+/// identity, never on paths.
+pub fn entity_location<G: GraphStore>(graph: &G, entity: &Entity) -> String {
+    entity_pointer(graph, entity).render()
+}
+
+/// The mark a location carries when the graph cannot vouch for its line.
+pub const STALE_SPAN_MARK: &str = "(span stale)";
+
+/// Where an entity starts, as far as the graph can vouch for it.
+///
+/// The line comes from the entity's own span, converted to 1-based at the seam
+/// every surface converts at. It is withheld, and the pointer marked stale,
+/// when the span was measured against different bytes than the graph's tree now
+/// holds at that path: the reconciler stamps every entity with the digest of the
+/// source its span was derived from, and a digest that disagrees with the tree
+/// means the line lands wherever that code used to be. A store that stopped
+/// re-deriving entities printed `cache.rs:35` for a function that has sat at
+/// line 41 since August, which is the class this names.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntityPointer {
+    pub path: Option<String>,
+    /// 1-based start line; `None` without a span, or when the span is stale.
+    pub line: Option<u32>,
+    pub stale: bool,
+}
+
+impl EntityPointer {
+    pub fn render(&self) -> String {
+        match (&self.path, self.line) {
+            (Some(path), _) if self.stale => format!("{path} {STALE_SPAN_MARK}"),
+            (Some(path), Some(line)) => format!("{path}:{line}"),
+            (Some(path), None) => path.clone(),
+            (None, _) => "unknown".to_string(),
+        }
+    }
+}
+
+/// Read an entity's pointer out of the graph. Graph reads only: the check
+/// compares two digests the graph already holds and never opens the file.
+pub fn entity_pointer<G: GraphStore>(graph: &G, entity: &Entity) -> EntityPointer {
+    let path = entity.file_origin.as_ref().map(|file| file.0.clone());
+    let line = kin_mcp::handlers::common::entity_presentation_start_line(entity);
+    let stale = line.is_some() && span_is_stale(graph, entity);
+    EntityPointer {
+        path,
+        line: if stale { None } else { line },
+        stale,
+    }
+}
+
+/// Whether the entity's recorded span digest provably disagrees with the blob
+/// the graph's tree holds at its path.
+///
+/// Only a provable disagreement counts. An entity that records no digest, a path
+/// the tree does not carry, or a tree entry that cannot be read is unverifiable,
+/// and an unverifiable line prints as it always did rather than being withheld on
+/// a guess. The comparison is kin-mcp's `span_source_coherence`, the rule
+/// `get_entity_source` already refuses a stale span by, so the two surfaces
+/// cannot disagree about which spans are stale.
+fn span_is_stale<G: GraphStore>(graph: &G, entity: &Entity) -> bool {
+    let Some(file) = entity.file_origin.as_ref() else {
+        return false;
+    };
+    let Ok(Some(entry)) = graph.get_tree_entry(file) else {
+        return false;
+    };
+    let Some(blob) = entry.blob_identity() else {
+        return false;
+    };
+    kin_mcp::handlers::common::span_source_coherence(entity, &blob, &file.0).is_err()
+}
+
+/// The sentence an answer carries once when any location it printed is stale.
+pub fn stale_span_note(lines: &[String]) -> Option<String> {
+    lines
+        .iter()
+        .any(|line| line.contains(STALE_SPAN_MARK))
+        .then(|| {
+            format!(
+                "note: a location marked {STALE_SPAN_MARK} belongs to an entity record measured \
+                 against an older version of that file than the graph now holds, so its line is \
+                 left out rather than printed wrong; `kin graph status` reports whether \
+                 admission is keeping up."
+            )
+        })
 }
 
 #[cfg(test)]
@@ -309,11 +782,16 @@ mod tests {
     /// whichever order the store lists the twins in.
     #[test]
     fn choose_definition_ignores_the_order_the_store_listed_the_twins_in() {
+        let graph = InMemoryGraph::new();
         let forward = vec![definition(), declaration()];
         let reversed = vec![declaration(), definition()];
 
-        let first = choose_definition(&forward).expect("a candidate");
-        let second = choose_definition(&reversed).expect("a candidate");
+        let first = choose_definition(&graph, &forward)
+            .unwrap()
+            .expect("a candidate");
+        let second = choose_definition(&graph, &reversed)
+            .unwrap()
+            .expect("a candidate");
 
         assert_eq!(
             first.id, second.id,
@@ -328,9 +806,12 @@ mod tests {
 
     #[test]
     fn twin_note_names_the_choice_and_the_flags_that_pin_the_other() {
+        let graph = InMemoryGraph::new();
         let matches = vec![definition(), declaration()];
-        let chosen = choose_definition(&matches).expect("a candidate");
-        let note = twin_note("buffer_grow", chosen, &matches).join("\n");
+        let chosen = choose_definition(&graph, &matches)
+            .unwrap()
+            .expect("a candidate");
+        let note = twin_note(&graph, "buffer_grow", &chosen, &matches).join("\n");
 
         assert!(note.contains("names 2 entities"), "{note}");
         assert!(note.contains("traced the definition"), "{note}");
@@ -340,9 +821,12 @@ mod tests {
 
     #[test]
     fn twin_note_is_silent_when_the_name_reaches_one_entity() {
+        let graph = InMemoryGraph::new();
         let matches = vec![definition()];
-        let chosen = choose_definition(&matches).expect("a candidate");
-        assert!(twin_note("buffer_grow", chosen, &matches).is_empty());
+        let chosen = choose_definition(&graph, &matches)
+            .unwrap()
+            .expect("a candidate");
+        assert!(twin_note(&graph, "buffer_grow", &chosen, &matches).is_empty());
     }
 
     #[test]
@@ -415,5 +899,170 @@ mod tests {
         assert!(resolved.matches.is_empty());
         assert_eq!(resolved.name_matches.len(), 1);
         assert!(resolved.exact_name);
+    }
+
+    fn calls(graph: &InMemoryGraph, caller: &Entity, callee: &Entity) {
+        use kin_model::relation::{Relation, RelationOrigin};
+        graph
+            .upsert_relation(&Relation {
+                id: kin_model::RelationId::from_content(
+                    &caller.id.to_string(),
+                    &callee.id.to_string(),
+                    "calls",
+                ),
+                kind: RelationKind::Calls,
+                src: GraphNodeId::Entity(caller.id),
+                dst: GraphNodeId::Entity(callee.id),
+                confidence: 1.0,
+                origin: RelationOrigin::Parsed,
+                created_in: None,
+                import_source: None,
+                evidence: Vec::new(),
+            })
+            .unwrap();
+    }
+
+    /// Among definitions, one something calls outranks one nothing does, even
+    /// when the uncalled one sorts first by path.
+    #[test]
+    fn a_called_definition_outranks_an_uncalled_one() {
+        let graph = InMemoryGraph::new();
+        let uncalled = twin("grow", "src/a.c", 1, "int grow(void)", 20);
+        let called = twin("grow", "src/z.c", 1, "int grow(void)", 20);
+        let caller = twin("user", "src/user.c", 1, "int user(void)", 20);
+        for entity in [&uncalled, &called, &caller] {
+            graph.upsert_entity(entity).unwrap();
+        }
+        calls(&graph, &caller, &called);
+
+        let resolution = resolve_entity(&graph, "grow", &IdentityQualifiers::default()).unwrap();
+        assert_eq!(resolution.chosen().map(|e| e.id), Some(called.id));
+    }
+
+    /// A definition outranks a declaration even when only the declaration is
+    /// called, because the declaration is not where the code is.
+    #[test]
+    fn a_definition_outranks_a_called_declaration() {
+        let graph = InMemoryGraph::new();
+        let caller = twin("user", "src/user.c", 1, "int user(void)", 20);
+        for entity in [&definition(), &declaration(), &caller] {
+            graph.upsert_entity(entity).unwrap();
+        }
+        calls(&graph, &caller, &declaration());
+
+        let resolution =
+            resolve_entity(&graph, "buffer_grow", &IdentityQualifiers::default()).unwrap();
+        assert_eq!(resolution.chosen().map(|e| e.id), Some(definition().id));
+    }
+
+    /// The note names every candidate by id, states the rule, and shows the pin
+    /// that reaches the next one, in the command's own flag spelling.
+    #[test]
+    fn the_choice_note_lists_every_candidate_and_how_to_pin_the_next() {
+        let graph = InMemoryGraph::new();
+        graph.upsert_entity(&definition()).unwrap();
+        graph.upsert_entity(&declaration()).unwrap();
+
+        let resolution =
+            resolve_entity(&graph, "buffer_grow", &IdentityQualifiers::default()).unwrap();
+        let note = choice_note(&graph, &resolution, PinSpelling::FileEntityKind).join("\n");
+
+        assert!(note.contains("names 2 entities"), "{note}");
+        assert!(note.contains(&definition().id.to_string()), "{note}");
+        assert!(note.contains(&declaration().id.to_string()), "{note}");
+        assert!(note.contains(RANKING_RULE), "{note}");
+        assert!(
+            note.contains("--file src/buffer.h --entity-kind function"),
+            "{note}"
+        );
+    }
+
+    /// An id names one entity, so nothing was chosen and nothing is noted.
+    #[test]
+    fn an_id_carries_no_choice_note() {
+        let graph = InMemoryGraph::new();
+        graph.upsert_entity(&definition()).unwrap();
+        graph.upsert_entity(&declaration()).unwrap();
+
+        let resolution = resolve_entity(
+            &graph,
+            &declaration().id.to_string(),
+            &IdentityQualifiers::default(),
+        )
+        .unwrap();
+        assert!(resolution.addressed_by_id());
+        assert_eq!(resolution.chosen().map(|e| e.id), Some(declaration().id));
+        assert!(choice_note(&graph, &resolution, PinSpelling::FileKind).is_empty());
+    }
+
+    /// A name that itself carries `@` resolves as that name, not as a pin.
+    #[test]
+    fn a_name_carrying_an_at_sign_is_not_split_into_a_pin() {
+        let graph = InMemoryGraph::new();
+        let odd = twin("user@host", "src/odd.c", 3, "int user_at_host(void)", 30);
+        graph.upsert_entity(&odd).unwrap();
+
+        let resolution =
+            resolve_entity(&graph, "user@host", &IdentityQualifiers::default()).unwrap();
+        assert_eq!(resolution.chosen().map(|e| e.id), Some(odd.id));
+        assert!(resolution.reference.qualifiers.file.is_none());
+    }
+
+    /// A glob reaches by prefix and stays narrowed to the query, and a partial
+    /// reach of several names asks for a pin.
+    #[test]
+    fn a_glob_query_reaches_by_prefix_and_stays_narrowed() {
+        let graph = InMemoryGraph::new();
+        for name in ["buffer_grow", "buffer_shrink", "grow_buffer"] {
+            graph
+                .upsert_entity(&twin(name, &format!("src/{name}.c"), 1, "int f(void)", 10))
+                .unwrap();
+        }
+
+        let resolution =
+            resolve_entity(&graph, "buffer_*", &IdentityQualifiers::default()).unwrap();
+        let names: Vec<&str> = resolution
+            .candidates
+            .iter()
+            .map(|entity| entity.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["buffer_grow", "buffer_shrink"]);
+        assert!(resolution.needs_a_pin());
+    }
+
+    /// Case alone does not make a name partial.
+    #[test]
+    fn a_name_that_differs_only_in_case_resolves_without_a_pin() {
+        let graph = InMemoryGraph::new();
+        graph
+            .upsert_entity(&twin("BufferGrow", "src/a.c", 1, "int f(void)", 10))
+            .unwrap();
+        graph
+            .upsert_entity(&twin("BufferGrowLater", "src/b.c", 1, "int g(void)", 10))
+            .unwrap();
+
+        let resolution =
+            resolve_entity(&graph, "buffergrow", &IdentityQualifiers::default()).unwrap();
+        assert_eq!(resolution.name_match, NameMatch::CaseInsensitive);
+        assert_eq!(resolution.candidates.len(), 1);
+        assert!(!resolution.needs_a_pin());
+    }
+
+    /// A digest the graph cannot compare against, because its tree carries no
+    /// entry for the path, leaves the line in place rather than withholding it
+    /// on a guess.
+    #[test]
+    fn a_path_the_tree_does_not_carry_leaves_the_line_in_place() {
+        let graph = InMemoryGraph::new();
+        let mut entity = definition();
+        entity.metadata.extra.insert(
+            "blob_hash".to_string(),
+            serde_json::Value::String("aa".repeat(32)),
+        );
+        graph.upsert_entity(&entity).unwrap();
+
+        let pointer = entity_pointer(&graph, &entity);
+        assert!(!pointer.stale);
+        assert_eq!(pointer.render(), "src/buffer.c:6");
     }
 }

--- a/crates/kin-cli/src/entity_ref.rs
+++ b/crates/kin-cli/src/entity_ref.rs
@@ -103,6 +103,26 @@ pub fn parse_entity_ref(token: &str) -> EntityRef {
     }
 }
 
+/// Spell a name and its pins as the one token every command's resolver reads.
+///
+/// The flags a command takes (`--file`, `--kind`) and the suffix a caller can
+/// type (`Name#kind@path`) are the same pin, so a command turns its flags into
+/// the suffix and the daemon reads one spelling. A pin already in the name and
+/// the same pin as a flag with a different value is refused by the resolver,
+/// not silently overridden here.
+pub fn compose_entity_ref(name: &str, file: Option<&str>, kind: Option<&str>) -> String {
+    let mut token = name.trim().to_string();
+    if let Some(kind) = kind.map(str::trim).filter(|kind| !kind.is_empty()) {
+        token.push('#');
+        token.push_str(kind);
+    }
+    if let Some(file) = file.map(str::trim).filter(|file| !file.is_empty()) {
+        token.push('@');
+        token.push_str(file);
+    }
+    token
+}
+
 /// Narrow `matches` to the entity whose span contains `line`.
 ///
 /// A no-op when nothing contains it. A line is a convenience for pointing at a

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -556,11 +556,21 @@ enum Command {
     /// Show upstream callers/importers/references for an entity
     Refs {
         /// Entity name or ID. Required unless --bulk-json + --entities is provided.
+        /// A name with twins can carry its pin: `Name@file`, `Name@file:line`,
+        /// `Name#kind`
         #[arg(required_unless_present = "bulk_json")]
         entity: Option<String>,
         /// Filter relation kinds: all, calls, imports, or references (or Any for bulk mode)
         #[arg(long, default_value = "all")]
         kind: String,
+        /// Exact repo-relative file of the entity, when its name has twins
+        #[arg(long, conflicts_with = "bulk_json")]
+        file: Option<String>,
+        /// Exact entity kind (for example: function or method), when its name
+        /// has twins. `--kind` filters relation kinds here, so the entity's own
+        /// kind takes this flag
+        #[arg(long, conflicts_with = "bulk_json")]
+        entity_kind: Option<String>,
         /// Bulk mode: classify many entities by reachability in one daemon call.
         /// Outputs JSON to stdout. Requires --entities.
         #[arg(long, default_value_t = false, requires = "entities")]
@@ -1674,24 +1684,45 @@ enum GraphAction {
     },
     /// Look up an entity by name and show its relations
     Inspect {
-        /// Entity name or UUID to inspect
+        /// Entity name or UUID to inspect. A name can carry its pin:
+        /// `Name@file`, `Name@file:line`, `Name#kind`
         name: String,
+        /// Keep only the entities in this exact repo-relative file
+        #[arg(long)]
+        file: Option<String>,
+        /// Keep only entities of this exact kind (for example: function)
+        #[arg(long)]
+        kind: Option<String>,
         /// Output machine-readable JSON ({lines, error}); missing entities exit 0 with structured error.
         #[arg(long, default_value_t = false)]
         json: bool,
     },
     /// Print the exact implementation body for an entity
     Source {
-        /// Entity name or ID
+        /// Entity name or ID. A name with twins can carry its pin:
+        /// `Name@file`, `Name@file:line`, `Name#kind`
         entity: String,
+        /// Exact repo-relative file of the entity, when its name has twins
+        #[arg(long)]
+        file: Option<String>,
+        /// Exact entity kind (for example: function), when its name has twins
+        #[arg(long)]
+        kind: Option<String>,
         /// Output machine-readable JSON
         #[arg(long, default_value_t = false)]
         json: bool,
     },
     /// Alias for source: print the exact implementation body for an entity
     Body {
-        /// Entity name or ID
+        /// Entity name or ID. A name with twins can carry its pin:
+        /// `Name@file`, `Name@file:line`, `Name#kind`
         entity: String,
+        /// Exact repo-relative file of the entity, when its name has twins
+        #[arg(long)]
+        file: Option<String>,
+        /// Exact entity kind (for example: function), when its name has twins
+        #[arg(long)]
+        kind: Option<String>,
         /// Output machine-readable JSON
         #[arg(long, default_value_t = false)]
         json: bool,
@@ -3486,6 +3517,8 @@ fn run() -> Result<()> {
                 Command::Refs {
                     entity,
                     kind,
+                    file,
+                    entity_kind,
                     bulk_json,
                     entities,
                     compact,
@@ -3501,6 +3534,13 @@ fn run() -> Result<()> {
                         commands::refs::run_bulk(entities, kind, effective_compact).await
                     } else {
                         let entity = entity.expect("clap requires an entity without --bulk-json");
+                        // The flags are the `Name#kind@path` pin every resolver
+                        // reads, so the daemon sees one spelling.
+                        let entity = kin_cli::entity_ref::compose_entity_ref(
+                            &entity,
+                            file.as_deref(),
+                            entity_kind.as_deref(),
+                        );
                         commands::refs::run(entity, kind).await
                     }
                 }
@@ -4054,13 +4094,47 @@ fn run() -> Result<()> {
                     GraphAction::Status => commands::graph::status().await,
                     GraphAction::Validate => commands::graph::validate().await,
                     GraphAction::Materialize { json } => commands::graph::materialize(json).await,
-                    GraphAction::Inspect { name, json } => {
+                    // The flags are the `Name#kind@path` pin every resolver
+                    // reads, so the daemon sees one spelling.
+                    GraphAction::Inspect {
+                        name,
+                        file,
+                        kind,
+                        json,
+                    } => {
+                        let name = kin_cli::entity_ref::compose_entity_ref(
+                            &name,
+                            file.as_deref(),
+                            kind.as_deref(),
+                        );
                         commands::graph::inspect(name, json).await
                     }
-                    GraphAction::Source { entity, json } => {
+                    GraphAction::Source {
+                        entity,
+                        file,
+                        kind,
+                        json,
+                    } => {
+                        let entity = kin_cli::entity_ref::compose_entity_ref(
+                            &entity,
+                            file.as_deref(),
+                            kind.as_deref(),
+                        );
                         commands::graph::source(entity, json).await
                     }
-                    GraphAction::Body { entity, json } => commands::graph::body(entity, json).await,
+                    GraphAction::Body {
+                        entity,
+                        file,
+                        kind,
+                        json,
+                    } => {
+                        let entity = kin_cli::entity_ref::compose_entity_ref(
+                            &entity,
+                            file.as_deref(),
+                            kind.as_deref(),
+                        );
+                        commands::graph::body(entity, json).await
+                    }
                     GraphAction::Export {
                         limit,
                         kinds,

--- a/crates/kin-cli/src/output_style.rs
+++ b/crates/kin-cli/src/output_style.rs
@@ -114,10 +114,17 @@ fn paint_refs(line: &str) -> String {
     // resolution marker trails the relation bracket, and the reference sites
     // trail that. Anchoring on any one shape loses the color silently, because
     // an unmatched line prints as plain text.
+    // A location the graph cannot vouch for carries `(span stale)` after the
+    // path, and stays part of the painted location.
     let entry = compiled(
         &ENTRY,
-        r"^  (.+) @ (\S+) \[([^\]]*)\](?: \(([^)]*)\))?(?: (sites .*))?$",
+        r"^  (.+) @ (\S+(?: \(span stale\))?) \[([^\]]*)\](?: \(([^)]*)\))?(?: (sites .*))?$",
     );
+    // The candidate note every resolving command shares (FIR-3505).
+    if let Some(rest) = line.strip_prefix("note: ") {
+        return format!("{DIM}note:{RESET} {rest}");
+    }
+
     if let Some(caps) = entry.captures(line) {
         let resolution = caps
             .get(4)
@@ -143,9 +150,11 @@ fn paint_impact(line: &str) -> String {
     static ENTITY: OnceLock<Regex> = OnceLock::new();
     static NOTE: OnceLock<Regex> = OnceLock::new();
 
+    // `(span stale)` after the path is part of the location when the graph
+    // cannot vouch for the line, so it stays inside the painted span.
     let header = compiled(
         &HEADER,
-        r"^Impact analysis for '(.*)' \(([^)]+)\)(?: @ (\S+))?:$",
+        r"^Impact analysis for '(.*)' \(([^)]+)\)(?: @ (\S+(?: \(span stale\))?))?:$",
     );
     if let Some(caps) = header.captures(line) {
         let at = caps
@@ -178,7 +187,10 @@ fn paint_impact(line: &str) -> String {
         return format!("{BOLD_WHITE}{line}{RESET}");
     }
 
-    let entity = compiled(&ENTITY, r"^    - (.+) \(([^)]+)\)(?: @ (\S+))?$");
+    let entity = compiled(
+        &ENTITY,
+        r"^    - (.+) \(([^)]+)\)(?: @ (\S+(?: \(span stale\))?))?$",
+    );
     if let Some(caps) = entity.captures(line) {
         let at = caps
             .get(3)
@@ -193,6 +205,10 @@ fn paint_impact(line: &str) -> String {
     let note = compiled(&NOTE, r"^  Note: (.*)$");
     if let Some(caps) = note.captures(line) {
         return format!("  {DIM}Note:{RESET} {}", &caps[1]);
+    }
+    // The candidate note every resolving command shares (FIR-3505).
+    if let Some(rest) = line.strip_prefix("note: ") {
+        return format!("{DIM}note:{RESET} {rest}");
     }
 
     line.to_string()
@@ -411,8 +427,10 @@ mod tests {
         let header = lines.first().expect("a response opens with its header");
         let painted = paint_refs(header);
         assert_painted(&painted, header, &format!("{BOLD_WHITE}probe_symbol"));
+        // The header points at the definition's own line (FIR-3548), and the
+        // line stays inside the painted location.
         assert!(
-            painted.contains(&format!("{ACCENT}target_mod.rs{RESET}")),
+            painted.contains(&format!("{ACCENT}target_mod.rs:1{RESET}")),
             "target location must be painted whole: {painted:?}"
         );
         assert!(painted.contains(&format!("{DIM}(Function)")));

--- a/crates/kin-cli/tests/entity_resolution_across_commands.rs
+++ b/crates/kin-cli/tests/entity_resolution_across_commands.rs
@@ -1,0 +1,427 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! One name, five definitions: every read command has to answer about the same
+//! one, say that it chose and how, and point at the line the function is on.
+//!
+//! The fixture is the shape a recorded demo hit on this repository:
+//! `human_bytes` is defined in five files, and in `src/cache.rs` it sits under
+//! a gated `use` block, a `#[cfg]` attribute and a doc comment. `kin refs` and
+//! `kin impact` used to choose among the five by two different rules and say
+//! nothing about it (FIR-3505), and a store whose `cache.rs` records were never
+//! re-derived pointed six lines above the function, at its imports (FIR-3548).
+//! Everything runs through the real Rust parser and the real cross-file linker.
+
+use kin_cli::commands::impact::{build_impact_response, ImpactRequest};
+use kin_cli::commands::refs::{build_refs_response, RefsRequest};
+use kin_db::InMemoryGraph;
+use kin_index::{link_cross_file, FileParseData};
+use kin_model::{
+    ArtifactId, Entity, EntityStore, FilePathId, Hash256, LocatedEntry, RepoPath, TransactionDelta,
+    TreeDelta, TreeEntry,
+};
+use kin_parser::{LanguageAdapter, RustAdapter};
+
+/// The function sits under imports, an attribute and a doc comment, the way
+/// `crates/kin-cli/src/commands/cache.rs` holds its `human_bytes`.
+const CACHE_RS: &str = r#"//! Inspect and bound the embedding cache.
+
+#[cfg(feature = "embeddings")]
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+
+#[cfg(feature = "embeddings")]
+use kin_db::embed::cache_admin::{
+    self, AgeBucket, CacheStats,
+};
+
+/// Render a binary byte count with IEC unit labels.
+#[cfg(feature = "embeddings")]
+fn human_bytes(bytes: u64) -> String {
+    format!("{bytes} B")
+}
+
+pub fn print_status(bytes: u64) -> String {
+    human_bytes(bytes)
+}
+"#;
+
+const BYTE_FMT_RS: &str = r#"pub(super) fn human_bytes(bytes: u64) -> String {
+    format!("{bytes} MiB")
+}
+
+pub fn memory_line(bytes: u64) -> String {
+    human_bytes(bytes)
+}
+"#;
+
+const INIT_ATTEMPT_RS: &str = r#"pub fn human_bytes(bytes: u64) -> String {
+    format!("{bytes} bytes")
+}
+
+pub fn doctor_row(bytes: u64) -> String {
+    human_bytes(bytes)
+}
+"#;
+
+const MEMORY_PRESSURE_RS: &str = r#"fn human_bytes(bytes: u64) -> String {
+    format!("{bytes}")
+}
+
+pub fn describe(bytes: u64) -> String {
+    human_bytes(bytes)
+}
+"#;
+
+const SPAWN_RS: &str = r#"fn human_bytes(bytes: u64) -> String {
+    format!("{bytes} b")
+}
+
+pub fn cause_sentence(bytes: u64) -> String {
+    human_bytes(bytes)
+}
+"#;
+
+const FILES: [(&str, &str); 5] = [
+    ("src/byte_fmt.rs", BYTE_FMT_RS),
+    ("src/cache.rs", CACHE_RS),
+    ("src/init_attempt.rs", INIT_ATTEMPT_RS),
+    ("src/memory_pressure.rs", MEMORY_PRESSURE_RS),
+    ("src/spawn.rs", SPAWN_RS),
+];
+
+fn parse_rs(file_path: &str, source: &str) -> FileParseData {
+    let adapter = RustAdapter;
+    let file_id = FilePathId::new(file_path);
+    let bytes = source.as_bytes();
+    let tree = adapter.parse(bytes).expect("parse fixture");
+    let output = adapter.extract(&tree, bytes, &file_id).expect("extract");
+    let entities: Vec<Entity> = output
+        .entities
+        .into_iter()
+        .map(|entity| entity.into_entity_with_source(adapter.language_id(), &file_id, Some(bytes)))
+        .collect();
+    FileParseData {
+        file_path: file_path.to_string(),
+        entities,
+        relations: output.relations,
+        imports: output.imports,
+    }
+}
+
+/// The fixture repository, ingested in the given file order.
+fn twins_graph(order: &[(&str, &str)]) -> InMemoryGraph {
+    let files: Vec<FileParseData> = order
+        .iter()
+        .map(|(path, source)| parse_rs(path, source))
+        .collect();
+    let artifact_ids = files
+        .iter()
+        .map(|file| (file.file_path.clone(), ArtifactId::new()))
+        .collect();
+    let relations = link_cross_file(&files, &artifact_ids).expect("link fixture");
+    let graph = InMemoryGraph::new();
+    for entity in files.iter().flat_map(|file| file.entities.iter()) {
+        graph.upsert_entity(entity).expect("upsert entity");
+    }
+    for relation in &relations {
+        graph.upsert_relation(relation).expect("upsert relation");
+    }
+    graph
+}
+
+/// The 1-based line of the first line in `source` containing `needle`.
+fn line_of(source: &str, needle: &str) -> u32 {
+    let index = source
+        .lines()
+        .position(|line| line.contains(needle))
+        .unwrap_or_else(|| panic!("{needle:?} is not in the fixture"));
+    u32::try_from(index + 1).unwrap()
+}
+
+fn human_bytes_twins(graph: &InMemoryGraph) -> Vec<Entity> {
+    graph
+        .query_entities(&kin_model::EntityFilter {
+            name_pattern: Some("human_bytes".to_string()),
+            ..Default::default()
+        })
+        .unwrap()
+        .into_iter()
+        .filter(|entity| entity.name == "human_bytes" && entity.file_origin.is_some())
+        .collect()
+}
+
+fn healthy_envelope() -> kin_mcp::Envelope {
+    kin_mcp::Envelope::daemon().with_health(&serde_json::json!({
+        "initialized": true,
+        "graph_loaded": true,
+        "graph_entity_count": 10,
+        "graph_generation": 1,
+    }))
+}
+
+fn refs_response(graph: &InMemoryGraph, entity: &str) -> kin_cli::commands::refs::RefsResponse {
+    let dir = tempfile::tempdir().unwrap();
+    let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+    build_refs_response(
+        &layout,
+        graph,
+        &RefsRequest {
+            entity: entity.to_string(),
+            kind: "all".to_string(),
+        },
+        &healthy_envelope(),
+    )
+    .expect("refs response")
+}
+
+async fn impact_result(
+    graph: &InMemoryGraph,
+    entity: &str,
+    file: Option<&str>,
+) -> anyhow::Result<kin_cli::commands::impact::ImpactResponse> {
+    let dir = tempfile::tempdir().unwrap();
+    let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+    build_impact_response(
+        &layout,
+        graph,
+        &ImpactRequest {
+            entity: entity.to_string(),
+            depth: 1,
+            file: file.map(ToOwned::to_owned),
+            kind: None,
+            signature: None,
+            require_unique: false,
+        },
+        &healthy_envelope(),
+    )
+    .await
+}
+
+/// The file an answer's first line points at, read off `@ <path>[:line]`.
+fn header_file(first_line: &str) -> String {
+    let location = first_line
+        .rsplit(" @ ")
+        .next()
+        .unwrap_or_else(|| panic!("no location in {first_line:?}"));
+    location
+        .trim_end_matches(':')
+        .split([':', ' '])
+        .next()
+        .unwrap()
+        .to_string()
+}
+
+/// FIR-3548. The pointer is the function's own line, read from its span, and
+/// never the gated `use` block six lines above it.
+#[tokio::test]
+async fn a_function_under_imports_is_pointed_at_on_its_own_line() {
+    let graph = twins_graph(&FILES);
+    let fn_line = line_of(CACHE_RS, "fn human_bytes(");
+    let use_line = line_of(CACHE_RS, "use kin_db::embed::cache_admin");
+    assert!(use_line < fn_line, "the fixture must put the imports first");
+
+    let impact = impact_result(&graph, "human_bytes", Some("src/cache.rs"))
+        .await
+        .expect("impact");
+    let header = &impact.lines[0];
+    assert!(
+        header.ends_with(&format!("@ src/cache.rs:{fn_line}:")),
+        "impact must point at the function's line {fn_line}: {header}"
+    );
+    assert!(
+        !header.contains(&format!("src/cache.rs:{use_line}")),
+        "impact must never point at the import block: {header}"
+    );
+
+    let refs = refs_response(&graph, "human_bytes@src/cache.rs");
+    assert!(
+        refs.lines[0].ends_with(&format!("@ src/cache.rs:{fn_line}")),
+        "refs must point at the same line: {:?}",
+        refs.lines[0]
+    );
+}
+
+/// Give the `cache.rs` twin a recorded source digest and put `tree_blob` in the
+/// graph's tree at its path.
+fn record_digest_and_tree(graph: &InMemoryGraph, span_blob: [u8; 32], tree_blob: [u8; 32]) {
+    let mut entity = human_bytes_twins(graph)
+        .into_iter()
+        .find(|entity| entity.file_origin.as_ref().map(|f| f.0.as_str()) == Some("src/cache.rs"))
+        .expect("the cache.rs twin");
+    let hex: String = span_blob.iter().map(|byte| format!("{byte:02x}")).collect();
+    entity
+        .metadata
+        .extra
+        .insert("blob_hash".to_string(), serde_json::Value::String(hex));
+    graph.upsert_entity(&entity).expect("re-record the entity");
+    graph
+        .apply_transaction_delta(&TransactionDelta {
+            tree_deltas: vec![TreeDelta::Added {
+                artifact_id: ArtifactId::new(),
+                new: LocatedEntry::new(
+                    RepoPath::from_utf8("src/cache.rs").unwrap(),
+                    TreeEntry::blob(Hash256::from_bytes(tree_blob), false),
+                ),
+            }],
+            ..TransactionDelta::default()
+        })
+        .expect("admit the tree entry");
+}
+
+/// FIR-3548, the store the demo ran against. The entity's span was measured
+/// against one version of the file and the graph's tree now holds another, so
+/// the line would land wherever the function used to be. The answer marks the
+/// pointer stale and says why instead of printing that line.
+#[tokio::test]
+async fn a_span_from_an_older_version_of_the_file_is_marked_stale() {
+    let fn_line = line_of(CACHE_RS, "fn human_bytes(");
+
+    let current = twins_graph(&FILES);
+    record_digest_and_tree(&current, [0xaa; 32], [0xaa; 32]);
+    let agreeing = impact_result(&current, "human_bytes", Some("src/cache.rs"))
+        .await
+        .expect("impact");
+    assert!(
+        agreeing.lines[0].ends_with(&format!("@ src/cache.rs:{fn_line}:")),
+        "a span measured against the blob the tree holds keeps its line: {}",
+        agreeing.lines[0]
+    );
+
+    let stale = twins_graph(&FILES);
+    record_digest_and_tree(&stale, [0xaa; 32], [0xbb; 32]);
+    let impact = impact_result(&stale, "human_bytes", Some("src/cache.rs"))
+        .await
+        .expect("impact");
+    let header = &impact.lines[0];
+    assert!(
+        header.ends_with("@ src/cache.rs (span stale):"),
+        "a span from another version of the file must be marked, not printed: {header}"
+    );
+    assert!(
+        !header.contains(&format!("src/cache.rs:{fn_line}")),
+        "no line may be printed for a stale span: {header}"
+    );
+    let joined = impact.lines.join("\n");
+    assert!(
+        joined.contains("older version of that file than the graph now holds"),
+        "the answer must say why the line is missing: {joined}"
+    );
+
+    let refs = refs_response(&stale, "human_bytes@src/cache.rs");
+    assert!(
+        refs.lines[0].ends_with("@ src/cache.rs (span stale)"),
+        "refs reads the same pointer: {:?}",
+        refs.lines[0]
+    );
+}
+
+/// FIR-3505. A bare name reaching five definitions: `kin refs` and `kin impact`
+/// answer about the same one, whatever order the store ingested them in, and
+/// both list every candidate with its id and the rule that chose.
+#[tokio::test]
+async fn refs_and_impact_choose_the_same_twin_and_name_every_candidate() {
+    let forward = twins_graph(&FILES);
+    let mut reversed_files = FILES;
+    reversed_files.reverse();
+    let reversed = twins_graph(&reversed_files);
+
+    let mut chosen = Vec::new();
+    for graph in [&forward, &reversed] {
+        let twins = human_bytes_twins(graph);
+        assert_eq!(twins.len(), 5, "the fixture defines five twins");
+
+        let refs = refs_response(graph, "human_bytes");
+        assert!(refs.error.is_none(), "{:?}", refs.lines);
+        let impact = impact_result(graph, "human_bytes", None)
+            .await
+            .expect("impact");
+        let refs_file = header_file(&refs.lines[0]);
+        let impact_file = header_file(&impact.lines[0]);
+        assert_eq!(
+            refs_file, impact_file,
+            "refs and impact must answer about the same twin"
+        );
+
+        for answer in [refs.lines.join("\n"), impact.lines.join("\n")] {
+            assert!(
+                answer.contains("'human_bytes' names 5 entities"),
+                "the answer must say it chose: {answer}"
+            );
+            for twin in &twins {
+                assert!(
+                    answer.contains(&twin.id.to_string()),
+                    "every candidate's id must be listed: {answer}"
+                );
+            }
+            assert!(
+                answer.contains("a definition before a declaration"),
+                "the rule must be stated: {answer}"
+            );
+        }
+        chosen.push(refs_file);
+    }
+    assert_eq!(
+        chosen[0], chosen[1],
+        "the choice must not move with the order the store listed the twins in"
+    );
+}
+
+/// The same pin reaches the same entity whether it is spelled as a suffix on
+/// the name or as a flag, and in either command.
+#[tokio::test]
+async fn one_pin_reaches_one_entity_in_every_spelling_and_command() {
+    let graph = twins_graph(&FILES);
+    let fn_line = line_of(INIT_ATTEMPT_RS, "fn human_bytes(");
+    let expected = format!("src/init_attempt.rs:{fn_line}");
+
+    let by_flag = impact_result(&graph, "human_bytes", Some("src/init_attempt.rs"))
+        .await
+        .expect("impact");
+    let by_suffix = impact_result(&graph, "human_bytes#function@src/init_attempt.rs", None)
+        .await
+        .expect("impact");
+    let refs = refs_response(&graph, "human_bytes@src/init_attempt.rs");
+    for first in [&by_flag.lines[0], &by_suffix.lines[0], &refs.lines[0]] {
+        assert!(first.contains(&expected), "{first}");
+    }
+    for answer in [&by_flag.lines, &by_suffix.lines, &refs.lines] {
+        assert!(
+            !answer.join("\n").contains("names 5 entities"),
+            "a pinned query chose nothing, so it carries no candidate note: {answer:?}"
+        );
+    }
+}
+
+/// A pin spelled twice with two values is refused rather than resolved one way
+/// or the other.
+#[tokio::test]
+async fn a_pin_given_twice_with_two_values_is_refused() {
+    let graph = twins_graph(&FILES);
+    let error = impact_result(&graph, "human_bytes@src/cache.rs", Some("src/spawn.rs"))
+        .await
+        .expect_err("two values for one pin must be refused");
+    assert!(
+        format!("{error:#}").contains("given twice"),
+        "the refusal must say what was wrong: {error:#}"
+    );
+}
+
+/// A name that is only part of the names it reaches names none of them, so
+/// `kin refs` asks which one rather than answering about a guess.
+#[test]
+fn a_partial_name_reaching_several_entities_is_asked_about_not_guessed() {
+    let graph = twins_graph(&FILES);
+    let refs = refs_response(&graph, "human_byte");
+    let error = refs
+        .error
+        .expect("a partial name with twins must be refused");
+    assert!(
+        error.contains("No entity is named 'human_byte' exactly"),
+        "{error}"
+    );
+    for twin in human_bytes_twins(&graph) {
+        assert!(error.contains(&twin.id.to_string()), "{error}");
+    }
+}


### PR DESCRIPTION
`kin refs`, `kin impact` and `kin graph source` now resolve a name the same way, say when they had to choose, and never print a line number the graph cannot vouch for.

## What was wrong

A name with twins was resolved by four different rules. On a fresh full-history store of this repository, `human_bytes` names five functions. `kin refs` ranked them with `select_best_entity`, where all five tie on name, kind and callers, so the store's listing order decided. `kin impact` sorted by path and preferred identities with incoming edges. `kin blame` and `kin history` took the smallest id string. `kin graph source` used the ranker with a first-match fallback. None of them listed the candidates with ids, and `kin refs` could not be pinned at all, because its `--kind` filters relation kinds. In the recorded demo, the unpinned `kin refs human_bytes --kind calls` answered about `crates/kin-core/src/init_attempt.rs` while the pinned `kin impact` in the same run answered about `crates/kin-cli/src/commands/cache.rs`, with nothing saying so (FIR-3505).

The same demo printed `cache.rs:35` for a function on line 41 (FIR-3548). The formatter was not at fault. The demo's store served entity records whose spans date from `cache.rs` as it stood on 2026-07-10, and four functions in that file sit exactly at their July lines. On a fresh store the pinned `kin impact` prints `cache.rs:41`. What was missing was any check that a span still describes the file the graph holds.

## What changed

One resolver, `entity_identity::resolve_entity`, now serves `refs`, `impact`, `graph source` and `graph inspect`. It reads an id or a name. A name may carry the `Name#kind@path:line` suffix `kin context` already reads, and the command's flags merge into that suffix. A pin given twice with two values is refused.

One ranking decides among twins, and the answer prints it. A definition wins over a declaration. Among definitions, one that other code depends on wins over one nothing depends on. File path and then line settle any tie left. `kin context` ranks the same way.

When a name matches several entities, the answer lists every candidate with its kind, location and entity id, followed by the rule and the pin that reaches the next candidate. A partial name that reaches several entities gets that list as a refusal rather than an answer about a guess.

`kin refs` gains `--file` and `--entity-kind`, and `kin graph inspect`, `source` and `body` gain `--file` and `--kind`. The flags travel as the same suffix, so no daemon wire shape changes.

Every `@ path:line` now comes from one pointer, `entity_identity::entity_pointer`. The line is the span's own. If the entity's recorded `blob_hash` disagrees with the blob the graph's tree holds at that path, the pointer prints `path (span stale)` in place of a line, and a note explains why. The check goes through kin-mcp's `span_source_coherence` and reads the graph only.

`kin refs` also puts the line in its header, and the `kin impact --json` candidates carry `entity_id`.

`blame` and `history` move onto this resolver in the follow-up PR for FIR-3547, together with their latency fix. The MCP tools keep their own resolution. That surface belongs to another lane, and the lane report names the call sites.

## Measured before

Fresh full-history store of this repository at 47aa5172, 3012 commits, release bytes, warm daemon:

| command | wall | answered about |
|---|---|---|
| `kin refs human_bytes --kind calls` | 0.047 s | `byte_fmt.rs`, header `@ crates/kin-cli/src/commands/byte_fmt.rs` with no line and no candidates |
| `kin impact human_bytes --depth 1` | 0.035 s | `byte_fmt.rs:8`, "Note: 5 matches; showing the deterministic first match", four others without ids |
| `kin impact human_bytes --file crates/kin-cli/src/commands/cache.rs --kind function --depth 1` | 0.042 s | `cache.rs:41` |
| `kin graph source human_bytes` | 0.058 s | `byte_fmt.rs` lines 8-16, no candidates |

The same commands on this branch's release bytes follow in a comment once that run finishes.

## Verified locally

`cargo test -p kin-cli --locked --no-fail-fast` through the lane's heavy slot, on the commit before the rebase onto 1a8078794:

```
84 test binaries: 3301 passed, 1 failed, 3 ignored
failed: commands::setup::tests::setup_registers_the_managed_launcher_when_it_exists
  called `Result::unwrap()` on an `Err` value: failed to read managed config ACL
  Caused by: Invalid argument (os error 22)
```

That test lives in `setup.rs`, which this change does not touch, and alone it passes:

```
cargo test -p kin-cli --locked --lib setup_registers_the_managed_launcher_when_it_exists
test commands::setup::tests::setup_registers_the_managed_launcher_when_it_exists ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2306 filtered out; finished in 0.17s
```

`rustfmt --check --edition 2021` on every touched file is clean. The falsification runs for the new tests and the precheck run follow in a comment.

FIR-3505, FIR-3548.
