### PR TITLE
Grade an agent's write end to end in product acceptance (FIR-3550)

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -307,6 +307,13 @@ jobs:
       - name: Falsify the working-copy freshness graders
         run: python3 scripts/acceptance/working_copy_freshness_repro.py --self-test
 
+      # FIR-3550. Kin's own agent could not land an edit: its edit_file wrote the file
+      # first, and the commit held every tracked path to the prior tree, so the agent's
+      # own bytes read as drift. Each grader is driven against the outcome that broke and
+      # the one the product owes, with no binary.
+      - name: Falsify the agent write graders
+        run: python3 scripts/acceptance/agent_write_publish_repro.py --self-test
+
       # The graders here separate a true sentence from a misleading one, and the
       # two look identical from outside: every verdict this suite grades was
       # right about the graph. So each grader is driven against the literal
@@ -1025,6 +1032,31 @@ jobs:
             echo "::warning title=Working-copy freshness acceptance suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
           fi
 
+      - name: Agent write acceptance suite (verdict comes from the gate step)
+        id: agentwrite
+        if: always()
+        run: |
+          set -uo pipefail
+          mkdir -p acceptance
+          rc=0
+          python3 scripts/acceptance/agent_write_publish_repro.py \
+            --kin target/release/kin \
+            --daemon target/release/kin-daemon \
+            --json acceptance/agent_write.json \
+            --verbose >acceptance/agent_write.log 2>&1 || rc=$?
+          cat acceptance/agent_write.log
+          {
+            echo "### Agent write acceptance suite (exit $rc)"
+            echo ''
+            echo '```'
+            grep -E '^CHECK ' acceptance/agent_write.log || echo '(no CHECK line was printed)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning title=Agent write acceptance suite returned nonzero::suite process exit $rc; verdict deferred to the Acceptance verdict step"
+          fi
+
       - name: VCS read-surface acceptance suite (verdict comes from the gate step)
         id: vcsreadsurfaces
         if: always()
@@ -1360,6 +1392,7 @@ jobs:
             --report mcp_spawn=acceptance/mcp_spawn.json \
             --report verdict_limits=acceptance/verdict_limits.json \
             --report working_copy_freshness=acceptance/working_copy_freshness.json \
+            --report agent_write=acceptance/agent_write.json \
             --report vcs_read_surfaces=acceptance/vcs_read_surfaces.json \
             --report ref_grammar=acceptance/ref_grammar.json \
             --report diff_content=acceptance/diff_content.json \

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -453,6 +453,24 @@ alone. Every assertion now has an input only it can catch, so deleting a
 defence turns the suite red and nothing else does. Adding inputs is the fix for
 that class; deleting the second assertion never is.
 
+`agent_write_publish_repro.py` covers what Kin's own agent can write (FIR-3550).
+In run 3 of the 2026-09-11 local-model demo a model under `kin agent run` called
+`edit_file` to put a doc comment above a function, and the commit refused the
+agent's own bytes as drift: "tracked working-copy path ... differs from prior
+workspace source (the file content changed)". The harness wrote the file before it
+staged and committed, and the commit held every tracked path to the prior tree.
+Both hermetic suites stayed green, because kin-agent's scripted MCP server
+projected whatever it was sent and kin-daemon's commit tests staged without writing
+first, so only the real binaries together could show it. The suite runs `kin init`,
+`kin agent run` against a scripted chat endpoint, and a direct `kin mcp start`
+session to read the result back. `edit_lands` requires an edit to commit, with the
+file, `get_entity_source` and the durability block agreeing. `refused_edit_is_clean`
+drives an edit the planner refuses (an unterminated comment that hides a
+declaration) and requires the file untouched and the model told. `create_lands` and
+`refused_create_is_clean` do the same for `write_file`, the second one requiring the
+refused content to come back to the model rather than as a file the graph does not
+hold.
+
 `eject_journal_repro.py` covers the eject archive round trip the rc0552n green
 stranger lost on 0.5.52 (FIR-2664). A finished `kin eject` left its journal in
 the archived `kin/` at the detach phase, `cp -r` of that archive back to `.kin`
@@ -655,6 +673,10 @@ python3 scripts/acceptance/verdict_limits_repro.py \
 python3 scripts/acceptance/working_copy_freshness_repro.py \
   --kin target/release/kin --daemon target/release/kin-daemon \
   --json acceptance/working_copy_freshness.json --verbose
+
+python3 scripts/acceptance/agent_write_publish_repro.py \
+  --kin target/release/kin --daemon target/release/kin-daemon \
+  --json acceptance/agent_write.json --verbose
 
 python3 scripts/acceptance/bridge_reach_repro.py \
   --kin target/release/kin \

--- a/scripts/acceptance/agent_write_publish_repro.py
+++ b/scripts/acceptance/agent_write_publish_repro.py
@@ -1,0 +1,594 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+"""Prove an agent's write reaches graph authority, and a refused one leaves nothing behind.
+
+FIR-3550. In run 3 of the local-model demo a 27B model under `kin agent run` read a
+function, called the agent's own `edit_file` to put a doc comment above it, and Kin
+refused the commit: "tracked working-copy path ... differs from prior workspace source
+(the file content changed)". The harness had written the file before it staged and
+committed, and the commit held every tracked path to the prior tree, so the agent's own
+bytes read as drift. The edit stayed on disk and the graph kept the old text.
+
+Two hermetic test suites were green the whole time. kin-agent's runs against a scripted
+MCP server that projected whatever it was sent, and kin-daemon's commit tests staged
+without writing first, so neither could see the composition. This suite runs the real
+binaries end to end: `kin init`, `kin agent run` against a scripted chat endpoint, and a
+direct `kin mcp start` session to read the result back.
+
+Four checks, one repository, run in order:
+
+  edit_lands            an `edit_file` on a tracked function commits: the run exits 0,
+                        the file holds the new text, `get_entity_source` answers with the
+                        new body, and the durability block reads `recorded`
+  refused_edit_is_clean an edit authority refuses (an unterminated comment that hides a
+                        declaration, which the planner rejects) leaves the file exactly as
+                        it was, the run exits 6, and the model is told it did not land
+  create_lands          a `write_file` of a new module commits, the file exists with the
+                        body, and the graph lists its function
+  refused_create_is_clean
+                        a `write_file` over a tracked path is refused, the tracked file
+                        keeps its text, and the refused content comes back to the model
+
+What it is blind to: it drives one agent, one repository and one scripted conversation. It
+does not grade the cost of a commit, the delegate's retry on a slow one, or a real model.
+
+Each check prints one line:
+
+    CHECK <id> <ticket> PASS|FAIL|UNREADABLE <detail>
+
+Exit status is 0 when every check passed, 1 when one failed, 2 when one could not be
+read, and 3 when the run could not be set up. `--self-test` drives every grader against
+an input that must pass and one that must fail, and needs no binary.
+"""
+from __future__ import print_function
+
+import argparse
+import functools
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+
+try:
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+except ImportError:  # pragma: no cover - python 2 is not supported by this suite
+    raise SystemExit("python 3 is required")
+
+PASS = "PASS"
+FAIL = "FAIL"
+UNREADABLE = "UNREADABLE"
+
+TICKET = "FIR-3550"
+
+print = functools.partial(print, flush=True)
+
+LIB_RS = "pub fn value() -> u8 {\n    1\n}\n"
+OTHER_RS = "pub fn other() -> u8 {\n    4\n}\n\npub fn kept() -> u8 {\n    5\n}\n"
+README = "# agent write fixture\n"
+
+EDIT_FIND = "pub fn value() -> u8 {\n    1\n}"
+EDIT_REPLACE = "/// The value this module reports.\npub fn value() -> u8 {\n    0x2a\n}"
+EDIT_MARKER = "0x2a"
+
+# An unterminated block comment swallows `kept`, so the new text parses incomplete and the
+# planner refuses to publish a deletion it cannot verify. Deterministic, and independent
+# of the daemon's reconcile timing, which a drift-based refusal would race.
+REFUSED_FIND = "pub fn kept() -> u8 {"
+REFUSED_REPLACE = "/* pub fn kept() -> u8 {"
+
+CREATED_PATH = "src/added.rs"
+CREATED_BODY = "pub fn added() -> u8 {\n    3\n}\n"
+OVERWRITE_BODY = "# replaced wholesale\n"
+
+
+def run(cmd, cwd=None, env=None, timeout=600):
+    proc = subprocess.Popen(cmd, cwd=cwd, env=env, stdin=subprocess.DEVNULL,
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                            universal_newlines=True)
+    try:
+        out, err = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        out, err = proc.communicate()
+        return 124, out, err
+    return proc.returncode, out, err
+
+
+# ── graders ────────────────────────────────────────────────────────────────
+#
+# Every grader takes what a run produced and returns (status, detail). Kept apart from
+# the run so `--self-test` can hand each one an input that must pass and one that must
+# fail, with no binary anywhere.
+
+
+def durability_state(payload):
+    if not isinstance(payload, dict):
+        return None
+    block = (payload.get("_kin") or {}).get("durability")
+    if isinstance(block, dict):
+        return block.get("state")
+    return None
+
+
+def mentions(payload, needle):
+    if isinstance(payload, str):
+        return needle in payload
+    if isinstance(payload, list):
+        return any(mentions(item, needle) for item in payload)
+    if isinstance(payload, dict):
+        return any(mentions(value, needle) for value in payload.values())
+    return False
+
+
+def grade_edit_lands(rc, disk, source_payload, status_payload):
+    if rc is None or disk is None or source_payload is None or status_payload is None:
+        return UNREADABLE, "the run or its read-back produced nothing to grade"
+    problems = []
+    if rc != 0:
+        problems.append("kin agent run exited %s, not 0" % rc)
+    if EDIT_MARKER not in disk:
+        problems.append("the file on disk does not carry the edit")
+    if not mentions(source_payload, EDIT_MARKER):
+        problems.append("get_entity_source still answers with the old body")
+    state = durability_state(status_payload)
+    if state != "recorded":
+        problems.append("durability reads %r, not 'recorded'" % state)
+    if problems:
+        return FAIL, "; ".join(problems)
+    return PASS, "the edit committed: disk, get_entity_source and durability agree"
+
+
+def grade_refused_edit_is_clean(rc, disk_before, disk_after, tool_result):
+    if rc is None or disk_after is None or tool_result is None:
+        return UNREADABLE, "the run produced nothing to grade"
+    problems = []
+    if rc != 6:
+        problems.append("kin agent run exited %s, not 6 (changes_unpublished)" % rc)
+    if disk_after != disk_before:
+        problems.append("the refused edit changed the file on disk")
+    if "did not land" not in tool_result or "unchanged" not in tool_result:
+        problems.append("the model was not told the edit did not land and the file is unchanged")
+    if problems:
+        return FAIL, "; ".join(problems)
+    return PASS, "the refused edit left the file untouched and the model was told"
+
+
+def grade_create_lands(rc, disk, listed_payload):
+    if rc is None or listed_payload is None:
+        return UNREADABLE, "the run or its read-back produced nothing to grade"
+    problems = []
+    if rc != 0:
+        problems.append("kin agent run exited %s, not 0" % rc)
+    if disk != CREATED_BODY:
+        problems.append("the created file is missing or holds other bytes")
+    if not mentions(listed_payload, "added"):
+        problems.append("the graph does not list the created function")
+    if problems:
+        return FAIL, "; ".join(problems)
+    return PASS, "the created module committed and the graph lists its function"
+
+
+def grade_refused_create_is_clean(rc, disk_before, disk_after, tool_result):
+    if rc is None or disk_after is None or tool_result is None:
+        return UNREADABLE, "the run produced nothing to grade"
+    problems = []
+    if rc != 6:
+        problems.append("kin agent run exited %s, not 6 (changes_unpublished)" % rc)
+    if disk_after != disk_before:
+        problems.append("the refused write changed the tracked file")
+    if OVERWRITE_BODY.strip() not in tool_result:
+        problems.append("the refused content did not come back to the model")
+    if problems:
+        return FAIL, "; ".join(problems)
+    return PASS, "the refused write left the tracked file alone and handed the content back"
+
+
+# ── the scripted chat endpoint ─────────────────────────────────────────────
+
+
+def completion(text, tool=None, arguments=None):
+    message = {"role": "assistant", "content": text}
+    finish = "stop"
+    if tool:
+        message["tool_calls"] = [{"id": "call_1", "type": "function",
+                                  "function": {"name": tool,
+                                               "arguments": json.dumps(arguments)}}]
+        finish = "tool_calls"
+    return {"id": "chatcmpl-acceptance", "object": "chat.completion",
+            "choices": [{"index": 0, "message": message, "finish_reason": finish}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5}}
+
+
+class Endpoint(object):
+    """One scripted conversation: each request pops the next answer."""
+
+    def __init__(self, script):
+        answers = list(script)
+        lock = threading.Lock()
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *_):
+                pass
+
+            def _send(self, payload):
+                body = json.dumps(payload).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def do_GET(self):
+                self._send({"object": "list", "data": [{"id": "scripted", "object": "model"}]})
+
+            def do_POST(self):
+                self.rfile.read(int(self.headers.get("Content-Length", "0")))
+                with lock:
+                    answer = answers.pop(0) if answers else completion("Done.")
+                self._send(answer)
+
+        self.server = HTTPServer(("127.0.0.1", 0), Handler)
+        self.thread = threading.Thread(target=self.server.serve_forever)
+        self.thread.daemon = True
+        self.thread.start()
+        self.base_url = "http://127.0.0.1:%d/v1" % self.server.server_address[1]
+
+    def close(self):
+        self.server.shutdown()
+        self.server.server_close()
+
+
+# ── the product under test ─────────────────────────────────────────────────
+
+
+class Mcp(object):
+    """A minimal newline-delimited JSON-RPC client over `kin mcp start`."""
+
+    def __init__(self, argv, env, cwd):
+        self.proc = subprocess.Popen(argv, env=env, cwd=cwd, stdin=subprocess.PIPE,
+                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                     universal_newlines=True)
+        self.next_id = 1
+        self.request("initialize", {"protocolVersion": "2025-06-18", "capabilities": {},
+                                    "clientInfo": {"name": "agent-write-acceptance",
+                                                   "version": "0"}})
+        self.proc.stdin.write(json.dumps({"jsonrpc": "2.0",
+                                          "method": "notifications/initialized",
+                                          "params": {}}) + "\n")
+        self.proc.stdin.flush()
+
+    def request(self, method, params):
+        rid = self.next_id
+        self.next_id += 1
+        self.proc.stdin.write(json.dumps({"jsonrpc": "2.0", "id": rid, "method": method,
+                                          "params": params}) + "\n")
+        self.proc.stdin.flush()
+        while True:
+            line = self.proc.stdout.readline()
+            if not line:
+                raise RuntimeError("kin mcp start closed during %s" % method)
+            message = json.loads(line)
+            if message.get("id") == rid:
+                return message
+
+    def call(self, name, arguments):
+        result = self.request("tools/call", {"name": name, "arguments": arguments})
+        blocks = (result.get("result") or {}).get("content") or []
+        text = "".join(block.get("text", "") for block in blocks)
+        try:
+            return json.loads(text)
+        except ValueError:
+            return None
+
+    def close(self):
+        try:
+            self.proc.stdin.close()
+            self.proc.wait(timeout=30)
+        except Exception:  # noqa: BLE001 - teardown only
+            self.proc.kill()
+
+
+class Suite(object):
+    def __init__(self, kin, workdir, daemon=None, verbose=False):
+        self.kin = kin
+        self.workdir = workdir
+        self.verbose = verbose
+        self.env = dict(os.environ)
+        self.env["KIN_HOME"] = os.path.join(workdir, "home")
+        self.env.pop("KIN_MCP_REPO", None)
+        if daemon:
+            self.env["KIN_DAEMON_BIN"] = daemon
+        self._repo = None
+        self._setup_error = None
+        self._runs = 0
+
+    def git(self, cwd, args):
+        # The caller's global and system git config stay out of the fixture: a hooks
+        # path or a commit-message policy there is the machine's, not the product's.
+        env = dict(self.env, GIT_AUTHOR_NAME="Acceptance", GIT_AUTHOR_EMAIL="acceptance@example.invalid",
+                   GIT_COMMITTER_NAME="Acceptance", GIT_COMMITTER_EMAIL="acceptance@example.invalid",
+                   GIT_CONFIG_NOSYSTEM="1", GIT_CONFIG_GLOBAL=os.devnull)
+        rc, out, err = run(["git"] + args, cwd=cwd, env=env, timeout=120)
+        if rc != 0:
+            raise RuntimeError("git %s failed: %s" % (" ".join(args), err.strip()))
+        return out
+
+    def repo(self):
+        """The initialised fixture, built once.
+
+        A fixture that failed to build is never handed out half made: every later check
+        gets the same setup error, so it reads UNREADABLE rather than grading an agent
+        run against a directory Kin was never initialised in.
+        """
+        if self._repo:
+            return self._repo
+        if self._setup_error:
+            raise RuntimeError(self._setup_error)
+        path = os.path.join(self.workdir, "repo")
+        try:
+            os.makedirs(os.path.join(path, "src"))
+            for relative, body in (("src/lib.rs", LIB_RS), ("src/other.rs", OTHER_RS),
+                                   ("README.md", README),
+                                   ("Cargo.toml", '[package]\nname = "agentwrite"\n'
+                                                  'version = "0.1.0"\nedition = "2021"\n')):
+                with open(os.path.join(path, relative), "w") as handle:
+                    handle.write(body)
+            self.git(path, ["init", "-q", "-b", "main"])
+            self.git(path, ["add", "."])
+            self.git(path, ["commit", "-q", "-m", "Add the agent write fixture"])
+            rc, out, err = run([self.kin, "init"], cwd=path, env=self.env, timeout=900)
+            if rc not in (0, 7, 8):
+                raise RuntimeError("kin init exited %s: %s" % (rc, err.strip()[-600:]))
+        except Exception as error:  # noqa: BLE001 - recorded once, raised for every check
+            self._setup_error = "fixture setup failed: %s" % error
+            raise RuntimeError(self._setup_error)
+        self._repo = path
+        return path
+
+    def read(self, relative):
+        path = os.path.join(self.repo(), relative)
+        if not os.path.exists(path):
+            return None
+        with open(path) as handle:
+            return handle.read()
+
+    def agent(self, script):
+        """Run `kin agent run` through one scripted conversation; return rc and its trace."""
+        self._runs += 1
+        out = os.path.join(self.workdir, "run-%d" % self._runs)
+        endpoint = Endpoint(script)
+        try:
+            rc, stdout, stderr = run([self.kin, "agent", "run", "--task",
+                                      "Make the change the conversation asks for.",
+                                      "--model", "scripted", "--base-url", endpoint.base_url,
+                                      "--repo", self.repo(), "--out", out,
+                                      "--max-tool-calls", "4", "--deadline", "600"],
+                                     cwd=self.workdir, env=self.env, timeout=900)
+        finally:
+            endpoint.close()
+        if self.verbose:
+            print("kin agent run rc=%s\n%s" % (rc, stderr[-2000:]))
+        tool_result = None
+        transcript = os.path.join(out, "transcript.jsonl")
+        if os.path.exists(transcript):
+            with open(transcript) as handle:
+                for line in handle:
+                    record = json.loads(line)
+                    for block in (record.get("message") or {}).get("content") or []:
+                        if isinstance(block, dict) and block.get("type") == "tool_result":
+                            tool_result = block.get("content")
+        return rc, tool_result
+
+    def mcp(self):
+        return Mcp([self.kin, "mcp", "start", "--repo", self.repo()], self.env, self.workdir)
+
+
+class Result(object):
+    def __init__(self, ident, status, detail):
+        self.ident = ident
+        self.status = status
+        self.detail = detail
+
+
+def entity_id(listed, name):
+    stack = [listed]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, dict):
+            if node.get("name") == name and (node.get("id") or node.get("entity_id")):
+                return node.get("id") or node.get("entity_id")
+            stack.extend(node.values())
+        elif isinstance(node, list):
+            stack.extend(node)
+    return None
+
+
+def check_edit_lands(suite):
+    rc, _ = suite.agent([completion("Documenting value.", "edit_file",
+                                    {"path": "src/lib.rs", "find": EDIT_FIND,
+                                     "replace": EDIT_REPLACE}),
+                         completion("value is documented.")])
+    session = suite.mcp()
+    try:
+        listed = session.call("list_file_entities", {"path": "src/lib.rs", "limit": 50})
+        focal = entity_id(listed, "value")
+        source = session.call("get_entity_source", {"entity_id": focal}) if focal else None
+        status = session.call("kin_graph_status", {})
+    finally:
+        session.close()
+    verdict, detail = grade_edit_lands(rc, suite.read("src/lib.rs"), source, status)
+    return Result("edit_lands", verdict, "%s %s" % (TICKET, detail))
+
+
+def check_refused_edit_is_clean(suite):
+    before = suite.read("src/other.rs")
+    rc, tool_result = suite.agent([completion("Commenting out kept.", "edit_file",
+                                              {"path": "src/other.rs", "find": REFUSED_FIND,
+                                               "replace": REFUSED_REPLACE}),
+                                   completion("kept is commented out.")])
+    verdict, detail = grade_refused_edit_is_clean(rc, before, suite.read("src/other.rs"),
+                                                  tool_result)
+    return Result("refused_edit_is_clean", verdict, "%s %s" % (TICKET, detail))
+
+
+def check_create_lands(suite):
+    rc, _ = suite.agent([completion("Adding a module.", "write_file",
+                                    {"path": CREATED_PATH, "content": CREATED_BODY}),
+                         completion("src/added.rs holds added.")])
+    session = suite.mcp()
+    try:
+        listed = session.call("list_file_entities", {"path": CREATED_PATH, "limit": 50})
+    finally:
+        session.close()
+    verdict, detail = grade_create_lands(rc, suite.read(CREATED_PATH), listed)
+    return Result("create_lands", verdict, "%s %s" % (TICKET, detail))
+
+
+def check_refused_create_is_clean(suite):
+    before = suite.read("README.md")
+    rc, tool_result = suite.agent([completion("Rewriting the readme.", "write_file",
+                                              {"path": "README.md", "content": OVERWRITE_BODY}),
+                                   completion("README.md rewritten.")])
+    verdict, detail = grade_refused_create_is_clean(rc, before, suite.read("README.md"),
+                                                    tool_result)
+    return Result("refused_create_is_clean", verdict, "%s %s" % (TICKET, detail))
+
+
+CHECKS = [
+    ("edit_lands", check_edit_lands),
+    ("refused_edit_is_clean", check_refused_edit_is_clean),
+    ("create_lands", check_create_lands),
+    ("refused_create_is_clean", check_refused_create_is_clean),
+]
+
+
+def report_payload(results):
+    """The report shape `scripts/acceptance/gate.py` reads: keyed `results`, not `checks`."""
+    return {"suite": "agent_write_publish", "ticket": TICKET,
+            "results": [{"id": r.ident, "ticket": TICKET, "status": r.status,
+                         "detail": r.detail} for r in results]}
+
+
+def absolute_binary(path):
+    """A binary path the fixtures can still find after they change directory."""
+    return path and os.path.abspath(os.path.expanduser(path))
+
+
+def self_test():
+    failures = []
+
+    def expect(what, got, want):
+        if got != want:
+            failures.append("%s: got %s, want %s" % (what, got, want))
+
+    recorded = {"_kin": {"durability": {"state": "recorded"}}}
+    uncommitted = {"_kin": {"durability": {"state": "live_uncommitted"}}}
+    new_source = {"source": "pub fn value() -> u8 {\n    0x2a\n}", "_kin": {}}
+    old_source = {"source": "pub fn value() -> u8 {\n    1\n}", "_kin": {}}
+    edited = EDIT_REPLACE + "\n"
+
+    expect("edit lands",
+           grade_edit_lands(0, edited, new_source, recorded)[0], PASS)
+    expect("edit refused by the commit",
+           grade_edit_lands(6, edited, old_source, uncommitted)[0], FAIL)
+    expect("edit lands on disk only",
+           grade_edit_lands(0, edited, old_source, recorded)[0], FAIL)
+    expect("edit with no read-back",
+           grade_edit_lands(0, edited, None, recorded)[0], UNREADABLE)
+
+    told = ("The edit of `src/other.rs` did not land: repository authority did not publish "
+            "it: ... Nothing was written, so `src/other.rs` is unchanged on disk and in the graph.")
+    expect("refused edit, clean",
+           grade_refused_edit_is_clean(6, OTHER_RS, OTHER_RS, told)[0], PASS)
+    expect("refused edit left on disk",
+           grade_refused_edit_is_clean(6, OTHER_RS, OTHER_RS.replace("pub fn kept", "/* pub fn kept"),
+                                       told)[0], FAIL)
+    expect("refused edit reported as a success",
+           grade_refused_edit_is_clean(0, OTHER_RS, OTHER_RS, "Edited `src/other.rs`.")[0], FAIL)
+
+    listed = {"entities": [{"name": "added", "id": "e1"}]}
+    expect("create lands", grade_create_lands(0, CREATED_BODY, listed)[0], PASS)
+    expect("create left no file", grade_create_lands(0, None, listed)[0], FAIL)
+    expect("create not in the graph", grade_create_lands(0, CREATED_BODY, {"entities": []})[0],
+           FAIL)
+
+    handed_back = "`README.md` was not created: ... The 21 bytes you sent follow ...\n" + OVERWRITE_BODY
+    expect("refused create, clean",
+           grade_refused_create_is_clean(6, README, README, handed_back)[0], PASS)
+    expect("refused create written anyway",
+           grade_refused_create_is_clean(6, README, OVERWRITE_BODY, handed_back)[0], FAIL)
+    expect("refused create without its content",
+           grade_refused_create_is_clean(6, README, README, "did not publish it")[0], FAIL)
+
+    report = report_payload([Result("edit_lands", PASS, "x")])
+    expect("report keyed results", sorted(report), ["results", "suite", "ticket"])
+    expect("report row id", report["results"][0]["id"], "edit_lands")
+
+    for failure in failures:
+        print("SELF-TEST FAIL %s" % failure)
+    print("SELF-TEST %s (%d expectations)" % ("FAIL" if failures else "PASS", 17))
+    return 1 if failures else 0
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kin", default=os.environ.get("KIN_BIN") or shutil.which("kin"))
+    parser.add_argument("--daemon", default=os.environ.get("KIN_DAEMON_BIN"))
+    parser.add_argument("--json", dest="json_path")
+    parser.add_argument("--keep", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    opts = parser.parse_args(argv)
+
+    if opts.self_test:
+        return self_test()
+
+    if not opts.kin:
+        print("SETUP no kin binary: pass --kin or set KIN_BIN")
+        return 3
+    opts.kin = absolute_binary(opts.kin)
+    opts.daemon = absolute_binary(opts.daemon)
+
+    workdir = tempfile.mkdtemp(prefix="agent-write-publish-")
+    suite = Suite(opts.kin, workdir, daemon=opts.daemon, verbose=opts.verbose)
+    try:
+        results = []
+        for ident, check in CHECKS:
+            try:
+                results.append(check(suite))
+            except Exception as error:  # noqa: BLE001 - a setup failure is not a verdict
+                results.append(Result(ident, UNREADABLE, "%s check raised: %s" % (TICKET, error)))
+        for result in results:
+            print("CHECK %s %s %s %s" % (result.ident, TICKET, result.status, result.detail))
+        if opts.json_path:
+            directory = os.path.dirname(os.path.abspath(opts.json_path))
+            if directory and not os.path.isdir(directory):
+                os.makedirs(directory)
+            with open(opts.json_path, "w") as handle:
+                json.dump(report_payload(results), handle, indent=2)
+        if [r.ident for r in results] != [ident for ident, _ in CHECKS]:
+            print("SETUP the checks asked and the checks answered differ")
+            return 3
+        if any(result.status == FAIL for result in results):
+            return 1
+        if any(result.status == UNREADABLE for result in results):
+            return 2
+        return 0
+    finally:
+        try:
+            if suite._repo:
+                run([opts.kin, "daemon", "stop"], cwd=suite._repo, env=suite.env, timeout=180)
+        except Exception:  # noqa: BLE001 - teardown must not change the verdict
+            pass
+        if not opts.keep:
+            shutil.rmtree(workdir, ignore_errors=True)
+        else:
+            print("kept fixtures under %s" % workdir)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Kin's own agent writing through Kin now has an end-to-end acceptance suite. The FIR-3550 failure was a composition that both halves' hermetic tests missed, so this suite runs the real binaries together.

## Why it needs real binaries

In run 3 of the local-model demo, `kin agent run`'s `edit_file` wrote the file before it staged and committed, and the commit held every tracked path to the prior tree, so Kin refused the agent's own edit. kin-agent's tests ran against a scripted MCP server that projected whatever it was sent, and kin-daemon's commit tests staged without writing first. Each half was green and the product was broken, the same shape FIR-2624 found for creates. The write-path PR keeps crate tests for both halves so a pull request catches each of them. This suite is the one place the halves meet.

## What it runs

`scripts/acceptance/agent_write_publish_repro.py` builds a small Rust repository, runs `kin init`, then drives `kin agent run` against a scripted chat endpoint and reads the result back over a direct `kin mcp start` session.

- `edit_lands` requires an `edit_file` on a tracked function to commit, with the run exiting 0 and the file, `get_entity_source` and the durability block agreeing on the new body.
- `refused_edit_is_clean` drives an edit the planner refuses (an unterminated comment that hides a declaration). The file must stay exactly as it was, and the model must be told the edit did not land.
- `create_lands` requires a `write_file` of a new module to commit and the graph to list its function.
- `refused_create_is_clean` writes over a tracked path. The tracked file must keep its text, and the refused content must come back to the model rather than as a stray file.

`--self-test` drives every grader against an input that must pass and one that must fail, with no binary. The workflow runs the self-test and then the suite, writes `acceptance/agent_write.json`, and the gate reads that report beside the others.

## When it grades

Nothing here runs on this pull request. kin's `Product Acceptance` job carries `if: ${{ github.event_name != 'pull_request' }}` and holds every acceptance step, the self-tests included, so the graders and the suite first run on main's push once this merges. Main's run is the grader.

## Local runs

Against release binaries built from main plus this suite's companion fixes (`cargo build --release --locked --bin kin --bin kin-daemon`):

```
SELF-TEST PASS (17 expectations)
CHECK edit_lands FIR-3550 PASS FIR-3550 the edit committed: disk, get_entity_source and durability agree
CHECK refused_edit_is_clean FIR-3550 PASS FIR-3550 the refused edit left the file untouched and the model was told
CHECK create_lands FIR-3550 PASS FIR-3550 the created module committed and the graph lists its function
CHECK refused_create_is_clean FIR-3550 PASS FIR-3550 the refused write left the tracked file alone and handed the content back
suite_rc=0
```

The same suite against the v0.7.12 release bytes, which predate the write-path fix, fails every check:

```
CHECK edit_lands FIR-3550 FAIL FIR-3550 kin agent run exited 6, not 0
CHECK refused_edit_is_clean FIR-3550 FAIL FIR-3550 the refused edit changed the file on disk; the model was not told the edit did not land and the file is unchanged
CHECK create_lands FIR-3550 FAIL FIR-3550 kin agent run exited 6, not 0
CHECK refused_create_is_clean FIR-3550 FAIL FIR-3550 the refused write changed the tracked file; the refused content did not come back to the model
suite_rc=1
```

On the old bytes the create fails too, because the refused edit from the first check stays on disk as drift and blocks every later commit, which is the stranded-edit state this suite exists to catch.

The first local run found a fixture bug, now fixed: the suite's git calls inherited the machine's global git config, and a failed setup handed later checks a half-built fixture. Git now runs with `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_NOSYSTEM` isolated, and a failed setup is raised for every later check so they read UNREADABLE instead of grading a directory Kin was never initialised in.

`bin/kin-precheck` passed all 22 enumerated gates on the suite's previous head. The one change since is the suite file itself, which no check-job gate reads.

FIR-3550
