### PR TITLE
Run one exact MCP commit per transaction and let a re-sent request join it (FIR-3550)

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -14590,6 +14590,63 @@ async fn mcp_tools_call_inner(
     State(state): State<Arc<DaemonState>>,
     Json(request): Json<McpToolCallRequest>,
 ) -> Result<Json<kin_mcp::ToolCallResult>, (StatusCode, String)> {
+    let Some((transaction_id, fingerprint)) = mcp_commit_identity(&headers, &request) else {
+        return mcp_tools_call_dispatch(headers, State(state), Json(request)).await;
+    };
+    let outcome =
+        match crate::mcp_commit::InflightMcpCommits::claim(&state, &transaction_id, fingerprint) {
+            crate::mcp_commit::McpCommitRole::Alone => {
+                return mcp_tools_call_dispatch(headers, State(state), Json(request)).await;
+            }
+            crate::mcp_commit::McpCommitRole::Join(outcome) => outcome,
+            crate::mcp_commit::McpCommitRole::Lead(lease) => {
+                let outcome = lease.subscribe();
+                // On its own task, so the commit runs to its end even when the request
+                // that started it stops listening. The lease drops after the publish and
+                // takes the in-flight entry with it.
+                tokio::spawn(async move {
+                    let published = mcp_tools_call_dispatch(headers, State(state), Json(request))
+                        .await
+                        .map(|Json(result)| result);
+                    lease.publish(published);
+                });
+                outcome
+            }
+        };
+    crate::mcp_commit::await_mcp_commit_outcome(outcome, &transaction_id)
+        .await
+        .map(Json)
+}
+
+/// The transaction a commit request names, and what makes two requests the same request:
+/// every argument in a stable order, and the caller the `X-Kin-Session` header names.
+fn mcp_commit_identity(
+    headers: &axum::http::HeaderMap,
+    request: &McpToolCallRequest,
+) -> Option<(String, String)> {
+    if request.name != "kin_transaction_commit" {
+        return None;
+    }
+    let transaction_id = request
+        .arguments
+        .get("transaction_id")?
+        .as_str()?
+        .to_string();
+    let arguments: std::collections::BTreeMap<&String, &serde_json::Value> =
+        request.arguments.iter().collect();
+    let caller = headers
+        .get("X-Kin-Session")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("");
+    let fingerprint = serde_json::to_string(&(caller, arguments)).ok()?;
+    Some((transaction_id, fingerprint))
+}
+
+async fn mcp_tools_call_dispatch(
+    headers: axum::http::HeaderMap,
+    State(state): State<Arc<DaemonState>>,
+    Json(request): Json<McpToolCallRequest>,
+) -> Result<Json<kin_mcp::ToolCallResult>, (StatusCode, String)> {
     // The same budget the wrapper will enforce, so an arm that bounds its own
     // walk bounds it to the number this call is actually served under.
     let response_budget =
@@ -44195,6 +44252,114 @@ mod tests {
             !block.note.contains("everything"),
             "no sentence over one axis may claim the whole graph: {}",
             block.note
+        );
+    }
+
+    /// Poll `ready` until it holds, failing the test with `what` after twenty seconds.
+    async fn wait_until(ready: impl Fn() -> bool, what: &str) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+        while !ready() {
+            assert!(std::time::Instant::now() < deadline, "{what}");
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    }
+
+    /// A commit sent again while it is still running joins it instead of running twice.
+    ///
+    /// `kin mcp start` re-sends a tool call once when its first 60 s run out, and a commit
+    /// on a large store runs longer than that. In run 3 of the local-model demo the daemon
+    /// then ran one commit twice back to back, about 135 s each, to the same answer. Here
+    /// the first commit is held at its first step, the identical request is sent again, and
+    /// only once that request has joined is the first released. Without the join the second
+    /// request queues on the coordination gate, never joins, and the wait fails loudly.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_commit_re_sent_while_it_runs_joins_it_instead_of_running_again() {
+        let state = test_state();
+        crate::mcp_commit::tests::install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 {\n    1\n}\n",
+            "value",
+        );
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let session_id = mcp_test_session(&state);
+        let begin = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_transaction_begin",
+            serde_json::json!({ "session_id": session_id, "scope": "src/lib.rs" }),
+        )
+        .await;
+        let begin_json: serde_json::Value = serde_json::from_str(&mcp_result_text(&begin)).unwrap();
+        let tx_id = begin_json["transaction_id"].as_str().unwrap().to_string();
+        let stage = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_transaction_stage",
+            serde_json::json!({
+                "transaction_id": tx_id,
+                "session_id": session_id,
+                "operations": [{
+                    "verb": "replace",
+                    "target": "src/lib.rs",
+                    "body": "pub fn value() -> u8 {\n    2\n}\n",
+                    "description": "change what value returns"
+                }]
+            }),
+        )
+        .await;
+        assert_ne!(stage.is_error, Some(true), "{}", mcp_result_text(&stage));
+
+        let (release, hold) = std::sync::mpsc::channel::<()>();
+        *state.mcp_commit_hold.lock().unwrap() = Some(hold);
+        let commit = serde_json::json!({ "transaction_id": tx_id });
+        let first = tokio::spawn(mcp_call(
+            router(Arc::clone(&state)),
+            "kin_transaction_commit",
+            commit.clone(),
+        ));
+        wait_until(
+            || {
+                state
+                    .mcp_commit_attempts
+                    .load(std::sync::atomic::Ordering::SeqCst)
+                    == 1
+            },
+            "the first commit never started",
+        )
+        .await;
+        let second = tokio::spawn(mcp_call(
+            router(Arc::clone(&state)),
+            "kin_transaction_commit",
+            commit,
+        ));
+        wait_until(
+            || {
+                state
+                    .inflight_mcp_commits
+                    .joined
+                    .load(std::sync::atomic::Ordering::SeqCst)
+                    == 1
+            },
+            "the re-sent commit never joined the one in flight",
+        )
+        .await;
+        release.send(()).unwrap();
+
+        let first = first.await.unwrap();
+        let second = second.await.unwrap();
+        assert_ne!(first.is_error, Some(true), "{}", mcp_result_text(&first));
+        assert_eq!(
+            mcp_result_text(&first),
+            mcp_result_text(&second),
+            "both requests must get the one commit's answer"
+        );
+        assert_eq!(
+            state
+                .mcp_commit_attempts
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the commit must run once"
         );
     }
 

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -46,6 +46,151 @@ struct ExactMcpPlan {
     authored_files: BTreeSet<RepoPath>,
 }
 
+/// Exact MCP commits in flight, keyed by transaction id.
+///
+/// `kin mcp start` gives a forwarded call 60 s (`KIN_MCP_DAEMON_TIMEOUT_SECS`) and then
+/// sends it once more on the rest of its patience, and a commit on a large store runs past
+/// that: on a 5,088-entity store each attempt took about 135 s, and the second request
+/// waited on the coordination gate and then ran the whole commit again to the same answer.
+/// A commit is one daemon-owned job per transaction. The first request runs it on its own
+/// task, so a client that stops listening cannot cancel it half way, and an identical
+/// request that arrives while it runs is answered with the same outcome instead of starting
+/// another.
+#[derive(Default)]
+pub(crate) struct InflightMcpCommits {
+    running: std::sync::Mutex<HashMap<String, InflightMcpCommit>>,
+    /// How many requests joined a commit already in flight.
+    #[cfg(test)]
+    pub(crate) joined: std::sync::atomic::AtomicUsize,
+}
+
+struct InflightMcpCommit {
+    fingerprint: String,
+    outcome: tokio::sync::watch::Receiver<Option<McpCommitOutcome>>,
+}
+
+/// What the daemon's MCP route answers for one commit request.
+pub(crate) type McpCommitOutcome =
+    std::result::Result<kin_mcp::ToolCallResult, (axum::http::StatusCode, String)>;
+
+/// Whether a commit request runs the commit, joins one already running, or runs alone.
+pub(crate) enum McpCommitRole {
+    /// No commit for this transaction is running, so this request runs it and publishes
+    /// the outcome for every request that joins.
+    Lead(InflightMcpCommitLease),
+    /// An identical request is already running this commit; its outcome is this one's.
+    Join(tokio::sync::watch::Receiver<Option<McpCommitOutcome>>),
+    /// A commit for this transaction is running under different arguments or for a
+    /// different caller. Nothing is shared: the request runs as it always has, and the
+    /// coordination gate and the transaction's own state decide what it may do.
+    Alone,
+}
+
+/// The leading request's hold on one in-flight entry.
+///
+/// Publishing wakes every joined request. Dropping the lease removes the entry, on every
+/// exit a panic included, so no request can wait on a commit nobody is running, and a
+/// request that arrives after the entry is gone starts afresh: a commit that landed
+/// replays its receipt, and one that failed plans again.
+pub(crate) struct InflightMcpCommitLease {
+    state: Arc<DaemonState>,
+    transaction_id: String,
+    publish: tokio::sync::watch::Sender<Option<McpCommitOutcome>>,
+}
+
+impl InflightMcpCommitLease {
+    /// Where the leading request, like any joined one, waits for the outcome.
+    pub(crate) fn subscribe(&self) -> tokio::sync::watch::Receiver<Option<McpCommitOutcome>> {
+        self.publish.subscribe()
+    }
+
+    /// Hand the commit's outcome to every request waiting on it.
+    pub(crate) fn publish(&self, outcome: McpCommitOutcome) {
+        let _ = self.publish.send(Some(outcome));
+    }
+}
+
+impl Drop for InflightMcpCommitLease {
+    fn drop(&mut self) {
+        self.state
+            .inflight_mcp_commits
+            .running
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(&self.transaction_id);
+    }
+}
+
+impl InflightMcpCommits {
+    /// Decide this request's role for the commit of `transaction_id`.
+    ///
+    /// `fingerprint` is what makes two requests the same request. A re-sent request
+    /// carries the same one; a different caller or different arguments do not, and those
+    /// never share an outcome.
+    pub(crate) fn claim(
+        state: &Arc<DaemonState>,
+        transaction_id: &str,
+        fingerprint: String,
+    ) -> McpCommitRole {
+        let mut running = state
+            .inflight_mcp_commits
+            .running
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        match running.get(transaction_id) {
+            Some(commit) if commit.fingerprint == fingerprint => {
+                #[cfg(test)]
+                state
+                    .inflight_mcp_commits
+                    .joined
+                    .fetch_add(1, Ordering::SeqCst);
+                McpCommitRole::Join(commit.outcome.clone())
+            }
+            Some(_) => McpCommitRole::Alone,
+            None => {
+                let (publish, outcome) = tokio::sync::watch::channel(None);
+                running.insert(
+                    transaction_id.to_string(),
+                    InflightMcpCommit {
+                        fingerprint,
+                        outcome,
+                    },
+                );
+                McpCommitRole::Lead(InflightMcpCommitLease {
+                    state: Arc::clone(state),
+                    transaction_id: transaction_id.to_string(),
+                    publish,
+                })
+            }
+        }
+    }
+}
+
+/// Wait for the outcome of a commit in flight.
+pub(crate) async fn await_mcp_commit_outcome(
+    mut outcome: tokio::sync::watch::Receiver<Option<McpCommitOutcome>>,
+    transaction_id: &str,
+) -> McpCommitOutcome {
+    loop {
+        if let Some(published) = outcome.borrow_and_update().clone() {
+            return published;
+        }
+        if outcome.changed().await.is_err() {
+            // The leading task ended. It publishes before it lets go, so an empty slot here
+            // means it ended without an outcome, which only a panic does.
+            return outcome.borrow().clone().unwrap_or_else(|| {
+                Err((
+                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                    format!(
+                        "the commit of transaction {transaction_id} ended without an answer; \
+                         send the commit again, which resumes or replays it"
+                    ),
+                ))
+            });
+        }
+    }
+}
+
 /// What this process knows about a commit beyond the change it published.
 ///
 /// Present when the commit was planned here and absent when it was recovered by
@@ -239,6 +384,19 @@ fn commit_exact_transaction_inner(
     arguments: &HashMap<String, serde_json::Value>,
     coordination: Option<&kin_mcp::CoordinationWritePreflight>,
 ) -> Result<kin_mcp::ToolCallResult, String> {
+    #[cfg(test)]
+    {
+        state.mcp_commit_attempts.fetch_add(1, Ordering::SeqCst);
+        let hold = state
+            .mcp_commit_hold
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        if let Some(hold) = hold {
+            // Released by the test, or by its sender dropping when the test panics.
+            let _ = hold.recv();
+        }
+    }
     if state.storage_backend.is_some() {
         return Err(
             "exact MCP repository commits are not yet available for hosted snapshot backends"

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -3103,6 +3103,16 @@ pub struct DaemonState {
     /// but before the derived graph and terminal transaction state install.
     #[cfg(test)]
     pub(crate) mcp_fail_after_authority_once: AtomicBool,
+    /// Exact MCP commits in flight, keyed by transaction id, so a re-sent commit joins
+    /// the one already running instead of running the whole commit a second time.
+    pub(crate) inflight_mcp_commits: crate::mcp_commit::InflightMcpCommits,
+    /// How many exact MCP commits started, for the tests that prove a re-sent commit
+    /// does not start a second one.
+    #[cfg(test)]
+    pub(crate) mcp_commit_attempts: std::sync::atomic::AtomicUsize,
+    /// Holds the next exact MCP commit at its first step until the test releases it.
+    #[cfg(test)]
+    pub(crate) mcp_commit_hold: std::sync::Mutex<Option<std::sync::mpsc::Receiver<()>>>,
     /// Deterministic crash seam after a branch repository CAS but before the
     /// daemon installs its derived graph/generation cursor.
     #[cfg(test)]
@@ -5564,6 +5574,11 @@ impl DaemonState {
             finalization_fail_once: AtomicBool::new(false),
             #[cfg(test)]
             mcp_fail_after_authority_once: AtomicBool::new(false),
+            inflight_mcp_commits: Default::default(),
+            #[cfg(test)]
+            mcp_commit_attempts: std::sync::atomic::AtomicUsize::new(0),
+            #[cfg(test)]
+            mcp_commit_hold: std::sync::Mutex::new(None),
             #[cfg(test)]
             repository_command_fail_after_authority_once: AtomicBool::new(false),
             #[cfg(test)]
@@ -5948,6 +5963,11 @@ impl DaemonState {
             finalization_fail_once: AtomicBool::new(false),
             #[cfg(test)]
             mcp_fail_after_authority_once: AtomicBool::new(false),
+            inflight_mcp_commits: Default::default(),
+            #[cfg(test)]
+            mcp_commit_attempts: std::sync::atomic::AtomicUsize::new(0),
+            #[cfg(test)]
+            mcp_commit_hold: std::sync::Mutex::new(None),
             #[cfg(test)]
             repository_command_fail_after_authority_once: AtomicBool::new(false),
             #[cfg(test)]


### PR DESCRIPTION
A commit that is re-sent while it is still running now joins the one in flight instead of running again. In the local-model demo's run 3 the daemon ran one agent commit twice back to back, about 135 s each on a 5,088-entity store, both to the same answer.

## Why it ran twice

`kin mcp start` forwards a tool call to the daemon with a 60 s budget (`KIN_MCP_DAEMON_TIMEOUT_SECS`). When that runs out it sends the call once more on the rest of its 300 s patience. A commit on a large store takes longer than 60 s, the daemon does not stop the first attempt when its client leaves, and the second request waited on the coordination gate and then ran the whole commit again. From the demo daemon's log: `load_commit_base` 21,982 ms and 19,019 ms, `plan_transaction` 20,239 ms and 19,721 ms, `reconcile_workspace_and_commit_authority` 84,917 ms and 84,020 ms, one attempt after the other. Reproduced on an APFS clone of that store with the v0.7.12 release bytes, 06:37Z to 06:43Z.

## The fix

The daemon keeps its exact MCP commits in flight, keyed by transaction id. The first request for a transaction leads. It runs the commit on its own task, so a client that stops listening can no longer cancel it half way, and publishes the outcome on a watch channel. An identical request, meaning the same arguments from the same `X-Kin-Session` caller, that arrives while the commit runs joins and returns the same outcome, while different arguments or a different caller run as they always have. Once the outcome is published a drop guard removes the entry, on every exit including a panic, so nothing can wait on a commit nobody is running. After that, the same request starts afresh, which replays a landed commit's receipt or plans a failed one again.

## Test

`api::tests::a_commit_re_sent_while_it_runs_joins_it_instead_of_running_again` holds the first commit at its first step and sends the identical request again. Only once that request has joined is the first released, and the test asserts one commit attempt and the same answer for both requests. Without the join the second request queues on the coordination gate and never joins, so the test fails on its own wait rather than on timing luck.

## Falsification (local)

With coalescing disabled (the commit identity check renamed so it never matches), the test fails on its own wait:

```
test api::tests::a_commit_re_sent_while_it_runs_joins_it_instead_of_running_again ... FAILED
panicked at crates/kin-daemon/src/api.rs:44262:13:
the re-sent commit never joined the one in flight
test result: FAILED. 0 passed; 1 failed; ... finished in 21.54s
```

Restored, the same filtered run passed 90 of 90. At full scale on the 5,088-entity store with release bytes of main plus this change, the daemon ran exactly one commit attempt (one `load_commit_base` in its log) although the delegate's 60 s budget ran out mid-commit, where v0.7.12 ran two.

## Local gates

`bin/kin-precheck kin --repo-dir kin=<this worktree>` on this head:

```
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin 50504b836decb27add08c3e5951df77a9a18325c
```

Tests on the same head, rebased onto main 1a8078794:

```
cargo test -p kin-daemon --lib -- a_commit_re_sent_while_it_runs_joins mcp_commit::tests an_agent_edit_staged_after_it_reached_disk
test api::tests::a_commit_re_sent_while_it_runs_joins_it_instead_of_running_again ... ok
test result: ok. 79 passed; 0 failed; 0 ignored; 0 measured; 1571 filtered out; finished in 34.13s
```

Builds on the FIR-3550 write-path change (kin #1697, merged), which added the route test fixture this test reuses.

FIR-3550
