### PR TITLE
Configure LM Studio and the Grok CLI in kin setup, and read an artifact by its label (FIR-3544)

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -2610,6 +2610,17 @@ pub(crate) fn mcp_client_config_paths() -> Vec<(&'static str, &'static str, Path
             "Google Antigravity",
             home.join(".gemini").join("config").join("mcp_config.json"),
         ),
+        (
+            "lmstudio",
+            "LM Studio",
+            home.join(".lmstudio").join("mcp.json"),
+        ),
+        (
+            "grok",
+            "Grok CLI",
+            // Grok reads the TOML `[mcp_servers.<name>]` tables Codex reads.
+            home.join(".grok").join("config.toml"),
+        ),
     ];
     if let Some(repo_root) = current_health_repo() {
         paths.push((
@@ -2679,7 +2690,10 @@ fn mcp_argument_vector_matches(
         McpLauncherTopology::Native => &["mcp", "start"],
         McpLauncherTopology::CanonicalNpm => &["-y", CANONICAL_NPM_MCP_PACKAGE, "mcp", "start"],
     };
-    if matches!(client_id, "codex" | "antigravity" | "antigravity_workspace") {
+    if matches!(
+        client_id,
+        "codex" | "grok" | "antigravity" | "antigravity_workspace"
+    ) {
         args.len() == prefix.len() + 2
             && values_match_strings(&args[..prefix.len()], prefix)
             && args[prefix.len()].as_str() == Some("--repo")
@@ -5573,6 +5587,43 @@ mod tests {
     use super::*;
     use kin_core::test_env::EnvVarGuard;
     use serial_test::serial;
+
+    /// Grok's Kin entry names one repository, as Codex's does, and LM Studio's
+    /// follows the session's working directory, as Cursor's does. Both are
+    /// checked clients.
+    #[test]
+    fn grok_is_bound_to_one_repository_and_lm_studio_is_not() {
+        let bound = serde_json::json!({ "args": ["mcp", "start", "--repo", "/work/umbrella"] });
+        let unbound = serde_json::json!({ "args": ["mcp", "start"] });
+        assert!(mcp_argument_vector_matches(
+            &bound,
+            "grok",
+            McpLauncherTopology::Native
+        ));
+        assert!(!mcp_argument_vector_matches(
+            &unbound,
+            "grok",
+            McpLauncherTopology::Native
+        ));
+        assert!(mcp_argument_vector_matches(
+            &unbound,
+            "lmstudio",
+            McpLauncherTopology::Native
+        ));
+        assert!(!mcp_argument_vector_matches(
+            &bound,
+            "lmstudio",
+            McpLauncherTopology::Native
+        ));
+        let ids: Vec<&str> = mcp_client_config_paths()
+            .iter()
+            .map(|(id, _, _)| *id)
+            .collect();
+        assert!(
+            ids.contains(&"lmstudio") && ids.contains(&"grok"),
+            "both clients are health-checked: {ids:?}"
+        );
+    }
 
     /// No em dash reaches a reader through this file.
     ///

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -1654,6 +1654,8 @@ const IDX_CODEX: usize = 2;
 const IDX_GEMINI: usize = 3;
 const IDX_WINDSURF: usize = 4;
 const IDX_ANTIGRAVITY: usize = 5;
+const IDX_LMSTUDIO: usize = 6;
+const IDX_GROK: usize = 7;
 
 /// The Claude Code CLI filename, by platform.
 fn claude_cli_filename() -> &'static str {
@@ -1702,6 +1704,8 @@ fn claude_code_install_evidence(home: &Path) -> bool {
 /// - Codex CLI: `codex` binary on PATH
 /// - Gemini CLI: `gemini` binary on PATH, or `~/.gemini` directory
 /// - Windsurf: `windsurf` binary on PATH, or `/Applications/Windsurf.app`
+/// - LM Studio: `lms` binary on PATH, `~/.lmstudio`, or `/Applications/LM Studio.app`
+/// - Grok CLI: `grok` binary on PATH, or `~/.grok`
 fn detect_ai_assistants() -> Vec<AiAssistant> {
     let claude_detected = check_binary_in_path("claude").is_some()
         || home_dir()
@@ -1722,6 +1726,15 @@ fn detect_ai_assistants() -> Vec<AiAssistant> {
         || PathBuf::from("/Applications/Antigravity IDE.app").exists()
         || home_dir()
             .map(|home| home.join(".gemini").join("antigravity").exists())
+            .unwrap_or(false);
+    let lmstudio_detected = check_binary_in_path("lms").is_some()
+        || PathBuf::from("/Applications/LM Studio.app").exists()
+        || home_dir()
+            .map(|home| home.join(".lmstudio").exists())
+            .unwrap_or(false);
+    let grok_detected = check_binary_in_path("grok").is_some()
+        || home_dir()
+            .map(|home| home.join(".grok").exists())
             .unwrap_or(false);
 
     vec![
@@ -1754,6 +1767,16 @@ fn detect_ai_assistants() -> Vec<AiAssistant> {
             name: "Google Antigravity",
             detected: antigravity_detected,
             install_hint: "install Google Antigravity",
+        },
+        AiAssistant {
+            name: "LM Studio",
+            detected: lmstudio_detected,
+            install_hint: "install from lmstudio.ai",
+        },
+        AiAssistant {
+            name: "Grok CLI",
+            detected: grok_detected,
+            install_hint: "install the Grok CLI from x.ai",
         },
     ]
 }
@@ -1996,6 +2019,18 @@ fn configure_cursor() -> Result<PathBuf> {
     Ok(target)
 }
 
+/// Configure MCP for LM Studio.
+///
+/// LM Studio reads its MCP servers from `~/.lmstudio/mcp.json`, a top-level
+/// `mcpServers` object whose stdio entries take `command`, `args` and `env`: the
+/// shape Cursor reads, so the same merge writes it.
+fn configure_lmstudio() -> Result<PathBuf> {
+    let home = home_dir()?;
+    let target = home.join(".lmstudio").join("mcp.json");
+    merge_mcp_config(&target, "lmstudio")?;
+    Ok(target)
+}
+
 /// Merge the "kin" MCP server entry into a TOML MCP config (Codex CLI's
 /// `~/.codex/config.toml`). Creates the file if it doesn't exist.
 ///
@@ -2004,13 +2039,21 @@ fn configure_cursor() -> Result<PathBuf> {
 /// TOML edit so unrelated keys, tables, and comments in the user's config are
 /// left untouched.
 fn merge_mcp_config_toml(path: &PathBuf, repo_root: &Path) -> Result<()> {
+    merge_mcp_config_toml_for(path, repo_root, "codex")
+}
+
+/// [`merge_mcp_config_toml`] for any client whose Kin entry is a repository-bound
+/// `[mcp_servers.kin]` table, recorded in the install ledger under that client's id.
+/// The Grok CLI reads the same table from `~/.grok/config.toml`.
+fn merge_mcp_config_toml_for(path: &PathBuf, repo_root: &Path, target_id: &str) -> Result<()> {
     let topology = McpTopologyLock::acquire()?;
-    merge_mcp_config_toml_with_topology(path, repo_root, &topology)
+    merge_mcp_config_toml_with_topology(path, repo_root, target_id, &topology)
 }
 
 fn merge_mcp_config_toml_with_topology(
     path: &PathBuf,
     repo_root: &Path,
+    target_id: &str,
     _topology: &McpTopologyLock,
 ) -> Result<()> {
     let lock = ConfigLock::acquire(path)?;
@@ -2019,7 +2062,7 @@ fn merge_mcp_config_toml_with_topology(
         .get("command")
         .and_then(serde_json::Value::as_str)
         .unwrap_or("kin");
-    merge_mcp_config_toml_locked(path, repo_root, &lock, "codex", command)
+    merge_mcp_config_toml_locked(path, repo_root, &lock, target_id, command)
 }
 
 fn merge_mcp_config_toml_locked(
@@ -2033,7 +2076,8 @@ fn merge_mcp_config_toml_locked(
 
     let repo_root = canonical_initialized_repo(repo_root).with_context(|| {
         format!(
-            "Codex MCP binding requires an initialized Kin repository: {}",
+            "{} MCP binding requires an initialized Kin repository: {}",
+            toml_client_label(target_id),
             repo_root.display()
         )
     })?;
@@ -2126,8 +2170,13 @@ fn merge_mcp_config_toml_locked(
 
     let formatted = doc.to_string();
     lock.write_guarded(path, formatted.as_bytes(), original.as_deref())?;
-    let owned_entry = read_kin_mcp_entry_from_bytes(path, formatted.as_bytes())
-        .context("generated Codex MCP entry is missing")?;
+    let owned_entry =
+        read_kin_mcp_entry_from_bytes(path, formatted.as_bytes()).with_context(|| {
+            format!(
+                "generated {} MCP entry is missing",
+                toml_client_label(target_id)
+            )
+        })?;
     record_mcp_entry_in_ledger(target_id, path, &owned_entry)
 }
 
@@ -2140,6 +2189,20 @@ fn configure_codex() -> Result<PathBuf> {
     let target = home.join(".codex").join("config.toml");
     let repo_root = current_initialized_setup_repo("Codex CLI")?;
     merge_mcp_config_toml(&target, &repo_root)?;
+    Ok(target)
+}
+
+/// Configure MCP for the Grok CLI.
+///
+/// Grok reads MCP servers from `~/.grok/config.toml`, the `[mcp_servers.<name>]`
+/// tables Codex reads, and applies that user-scope file to every project. So its
+/// Kin entry names one repository with `--repo`, as Codex's does, rather than
+/// trusting a session's working directory, which is often not a Kin repository.
+fn configure_grok() -> Result<PathBuf> {
+    let home = home_dir()?;
+    let target = home.join(".grok").join("config.toml");
+    let repo_root = current_initialized_setup_repo("Grok CLI")?;
+    merge_mcp_config_toml_for(&target, &repo_root, "grok")?;
     Ok(target)
 }
 
@@ -2935,7 +2998,29 @@ fn mcp_target_supported(id: &str) -> bool {
             | "antigravity_workspace"
             | "gemini"
             | "windsurf"
+            | "lmstudio"
+            | "grok"
     )
+}
+
+/// Clients whose Kin entry is a `[mcp_servers.kin]` table in a TOML config, which
+/// only the TOML writer may touch: a JSON merge refuses the file, and a repair
+/// routed there would leave the entry unrepaired.
+fn mcp_target_is_toml(id: &str) -> bool {
+    matches!(id, "codex" | "grok")
+}
+
+/// Clients whose Kin entry names one repository with `--repo`.
+fn mcp_target_is_repo_bound(id: &str) -> bool {
+    matches!(id, "codex" | "grok" | "antigravity")
+}
+
+/// How a TOML client is named in a message.
+fn toml_client_label(id: &str) -> &'static str {
+    match id {
+        "grok" => "Grok CLI",
+        _ => "Codex",
+    }
 }
 
 fn workspace_root_for_mcp_path(path: &Path) -> Option<PathBuf> {
@@ -3515,6 +3600,8 @@ fn allowed_static_mcp_target_paths(id: &str) -> Result<Vec<PathBuf>> {
                 .join("antigravity-ide")
                 .join("mcp_config.json"),
         ],
+        "lmstudio" => vec![home.join(".lmstudio").join("mcp.json")],
+        "grok" => vec![home.join(".grok").join("config.toml")],
         "antigravity_workspace" => Vec::new(),
         _ => anyhow::bail!("unsupported managed MCP target '{id}'"),
     };
@@ -3601,7 +3688,7 @@ pub(crate) fn normalize_mcp_repair_targets(
             target.repo_root = Some(root);
         } else {
             validate_static_mcp_target_path(&target.id, &target.path)?;
-            if target.id == "codex" || target.id == "antigravity" {
+            if mcp_target_is_repo_bound(&target.id) {
                 let repo_root = target
                     .repo_root
                     .as_deref()
@@ -3935,7 +4022,7 @@ fn capture_mcp_repair_target_excluding(
     let repo_root = match id {
         "antigravity_workspace" => workspace_root_for_mcp_path(&path),
         "antigravity" => json_mcp_repo_from_entry_bytes(&bytes, "Antigravity")?,
-        "codex" => codex_repo_from_entry_bytes(&bytes)?,
+        "codex" | "grok" => codex_repo_from_entry_bytes(&bytes)?,
         _ => None,
     };
     Ok(Some(McpRepairTarget {
@@ -11885,10 +11972,12 @@ fn merge_codex_mcp_target_locked(
     command: &str,
     lock: &ConfigLock,
 ) -> Result<()> {
-    let repo_root = target
-        .repo_root
-        .as_deref()
-        .context("cannot determine an initialized Kin repository for the Codex MCP binding")?;
+    let repo_root = target.repo_root.as_deref().with_context(|| {
+        format!(
+            "cannot determine an initialized Kin repository for the {} MCP binding",
+            toml_client_label(&target.id)
+        )
+    })?;
     merge_mcp_config_toml_locked(&target.path, repo_root, lock, &target.id, command)
 }
 
@@ -11973,7 +12062,7 @@ fn remerge_mcp_targets_with_launcher(
 
     let mut outcome = McpRemergeOutcome::default();
     for (target, lock) in targets.into_iter().zip(&mut locks) {
-        let result = if target.id == "codex" {
+        let result = if mcp_target_is_toml(&target.id) {
             merge_codex_mcp_target_locked(&target, &command, lock)
         } else {
             merge_json_mcp_target_locked(&target, &command, lock)
@@ -12057,7 +12146,7 @@ pub(crate) fn remerge_mcp_targets_exact_with_topology_and_finalizer(
     }
     let mut repaired = Vec::with_capacity(targets.len());
     for (target, lock) in targets.iter().zip(&mut locks) {
-        if target.id == "codex" {
+        if mcp_target_is_toml(&target.id) {
             merge_codex_mcp_target_locked(target, &command, lock)?;
         } else {
             merge_json_mcp_target_locked(target, &command, lock)?;
@@ -13044,6 +13133,8 @@ fn mcp_config_path_for_index(idx: usize) -> Option<PathBuf> {
                 .join("mcp_config.json"),
         ),
         IDX_ANTIGRAVITY => Some(home.join(".gemini").join("config").join("mcp_config.json")),
+        IDX_LMSTUDIO => Some(home.join(".lmstudio").join("mcp.json")),
+        IDX_GROK => Some(home.join(".grok").join("config.toml")),
         _ => None,
     }
 }
@@ -13057,6 +13148,8 @@ fn configure_assistant_by_index(idx: usize) -> Option<Result<PathBuf>> {
         IDX_GEMINI => Some(configure_gemini_cli()),
         IDX_WINDSURF => Some(configure_windsurf()),
         IDX_ANTIGRAVITY => Some(configure_antigravity()),
+        IDX_LMSTUDIO => Some(configure_lmstudio()),
+        IDX_GROK => Some(configure_grok()),
         _ => None,
     }
 }
@@ -17802,6 +17895,7 @@ wait
         for (name, configure) in [
             ("Codex CLI", configure_codex as fn() -> Result<PathBuf>),
             ("Google Antigravity", configure_antigravity),
+            ("Grok CLI", configure_grok),
         ] {
             let error = configure()
                 .expect_err("a client whose entry names a repository cannot bind without one");
@@ -21435,6 +21529,51 @@ $value = if ($env:KIN_TEST_PATH_PRESENT -eq '1') { $env:KIN_TEST_PATH_VALUE } el
         );
     }
 
+    /// LM Studio reads `~/.lmstudio/mcp.json` in the shape Cursor reads, so setup
+    /// writes the same entry there, leaves every other server alone, and offers it
+    /// at the index it dispatches on.
+    #[test]
+    #[serial]
+    fn setup_registers_kin_with_lm_studio_beside_its_other_servers() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("home");
+        let kin_home = dir.path().join("kin-home");
+        fs::create_dir_all(home.join(".lmstudio")).unwrap();
+        fs::create_dir_all(kin_home.join("bin")).unwrap();
+        fs::copy(
+            env::current_exe().unwrap(),
+            kin_home.join("bin").join("kin"),
+        )
+        .unwrap();
+        fs::write(
+            home.join(".lmstudio").join("mcp.json"),
+            r#"{"mcpServers":{"other":{"command":"other-server"}}}"#,
+        )
+        .unwrap();
+        let _home = EnvVarGuard::set("HOME", &home);
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
+
+        let config = configure_lmstudio().unwrap();
+        assert_eq!(config, home.join(".lmstudio").join("mcp.json"));
+        let root: serde_json::Value = serde_json::from_slice(&fs::read(&config).unwrap()).unwrap();
+        let kin = &root["mcpServers"]["kin"];
+        assert_eq!(kin["args"], serde_json::json!(["mcp", "start"]));
+        assert_eq!(kin["env"]["KIN_MCP_TOOL_PROFILE"], "agent-default");
+        assert!(Path::new(kin["command"].as_str().unwrap()).is_absolute());
+        assert_eq!(
+            root["mcpServers"]["other"]["command"], "other-server",
+            "every other server is left alone"
+        );
+        let assistants = detect_ai_assistants();
+        assert_eq!(assistants[IDX_LMSTUDIO].name, "LM Studio");
+        assert!(
+            assistants[IDX_LMSTUDIO].detected,
+            "~/.lmstudio is evidence of an install"
+        );
+        assert_eq!(mcp_config_path_for_index(IDX_LMSTUDIO), Some(config));
+        assert_eq!(assistants[IDX_GROK].name, "Grok CLI");
+    }
+
     /// Without a managed binary, setup falls back to the running executable
     /// and says so: nothing manages that path, and `kin update` will not
     /// repair a client config that points at it.
@@ -21484,6 +21623,50 @@ $value = if ($env:KIN_TEST_PATH_PRESENT -eq '1') { $env:KIN_TEST_PATH_VALUE } el
         ] {
             assert!(!text.contains('\u{2014}'), "{name} carries an em dash");
         }
+    }
+
+    /// Grok reads the `[mcp_servers.kin]` table Codex reads, from its own
+    /// `config.toml`, bound to one repository, and the rest of the file survives.
+    #[test]
+    #[serial]
+    fn grok_gets_a_repository_bound_mcp_table_beside_its_other_servers() {
+        let dir = tempfile::tempdir().unwrap();
+        let _kin_home = EnvVarGuard::set("KIN_HOME", dir.path().join("kin-home"));
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(repo.join(".kin")).unwrap();
+        let repo = repo.canonicalize().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(
+            &path,
+            "# grok settings\n[mcp_servers.linear]\nurl = \"https://mcp.linear.app/mcp\"\n",
+        )
+        .unwrap();
+
+        merge_mcp_config_toml_for(&path, &repo, "grok").unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(
+            content.contains("# grok settings"),
+            "comments survive: {content}"
+        );
+        let root: toml::Value = toml::from_str(&content).unwrap();
+        assert_eq!(
+            root["mcp_servers"]["linear"]["url"].as_str(),
+            Some("https://mcp.linear.app/mcp"),
+            "every other server is left alone"
+        );
+        let kin = &root["mcp_servers"]["kin"];
+        let args: Vec<&str> = kin["args"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|arg| arg.as_str().unwrap())
+            .collect();
+        assert_eq!(args, vec!["mcp", "start", "--repo", repo.to_str().unwrap()]);
+        assert_eq!(
+            kin["env"]["KIN_MCP_TOOL_PROFILE"].as_str(),
+            Some("agent-default")
+        );
     }
 
     #[test]
@@ -23895,6 +24078,60 @@ $value = if ($env:KIN_TEST_PATH_PRESENT -eq '1') { $env:KIN_TEST_PATH_VALUE } el
             assert!(format!("{error:#}").contains("not an allowed canonical config path"));
             assert_eq!(fs::read(victim).unwrap(), bytes);
         }
+    }
+
+    /// A Grok entry is repaired as the TOML table it is, keeping its repository
+    /// binding and every key Kin does not own, never handed to the JSON writer.
+    #[test]
+    #[serial]
+    fn a_grok_entry_is_repaired_as_toml_and_keeps_its_repository() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("home");
+        let kin_home = dir.path().join("kin-home");
+        fs::create_dir_all(kin_home.join("bin")).unwrap();
+        fs::copy(std::env::current_exe().unwrap(), kin_home.join("bin/kin")).unwrap();
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(repo.join(".kin")).unwrap();
+        let repo = repo.canonicalize().unwrap();
+        let config = home.join(".grok/config.toml");
+        fs::create_dir_all(config.parent().unwrap()).unwrap();
+        fs::write(
+            &config,
+            format!(
+                "[mcp_servers.kin]\ncommand = \"/stale/kin\"\nargs = [\"mcp\", \"start\", \"--repo\", {:?}]\n\n[mcp_servers.kin.env]\nKIN_MCP_TOOL_PROFILE = \"agent-default\"\nKIN_EMBED_BACKEND = \"cpu\"\n",
+                repo.to_string_lossy()
+            ),
+        )
+        .unwrap();
+        let _home = EnvVarGuard::set("HOME", &home);
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
+
+        let grok = current_mcp_repair_targets()
+            .unwrap()
+            .into_iter()
+            .find(|target| target.id == "grok")
+            .expect("a Grok entry is captured for repair");
+        assert_eq!(grok.repo_root.as_deref(), Some(repo.as_path()));
+        remerge_mcp_targets_exact_with_finalizer(&[grok], || Ok(()))
+            .expect("a Grok entry repairs as TOML");
+
+        let root: toml::Value = toml::from_str(&fs::read_to_string(&config).unwrap()).unwrap();
+        let kin = &root["mcp_servers"]["kin"];
+        assert_ne!(
+            kin["command"].as_str(),
+            Some("/stale/kin"),
+            "the launcher is repaired"
+        );
+        assert_eq!(
+            kin["args"][3].as_str(),
+            repo.to_str(),
+            "the repository binding is kept"
+        );
+        assert_eq!(
+            kin["env"]["KIN_EMBED_BACKEND"].as_str(),
+            Some("cpu"),
+            "a key Kin does not own is kept"
+        );
     }
 
     #[test]

--- a/crates/kin-mcp/src/handlers/artifacts.rs
+++ b/crates/kin-mcp/src/handlers/artifacts.rs
@@ -37,8 +37,10 @@ carries the printable form beside it. Omit `source_change_id` to read the exact 
 workspace tree.";
 
 pub const ARTIFACT_READ_DESC: &str = "\
-Read one exact graph-owned repository artifact by stable `artifact_id` or canonical \
-byte-exact `path`. Blob and symlink bytes are returned losslessly as base64 and, only when \
+Read one exact graph-owned repository artifact by stable `artifact_id` or by `path`: the \
+repository-relative string `kin_artifact_list` prints as `path_label` (a leading `/` is \
+tolerated), or the byte-exact `{\"bytes_hex\": ...}` object for a path whose bytes are not \
+valid UTF-8. Blob and symlink bytes are returned losslessly as base64 and, only when \
 valid UTF-8, as `text_utf8`. Gitlinks return their external object identity, as the \
 algorithm-tagged `git_object_id` plus a printable `git_object_id_hex`, and have no \
 repository-owned body. Content-addressed hashes are lowercase hex strings, including the \
@@ -243,12 +245,74 @@ fn parse_artifact_id(value: &serde_json::Value) -> Result<ArtifactId> {
         .map_err(|error| McpError::InvalidParams(format!("invalid artifact_id: {error}")))
 }
 
+/// The spellings of a repository path this surface accepts, named in every refusal.
+const ACCEPTED_PATH_SHAPES: &str = "a repository-relative path string as kin_artifact_list \
+     prints it in path_label, such as \"src/lib.rs\" (a leading \"/\" is tolerated), or \
+     {\"bytes_hex\": \"...\"} for a path whose bytes are not valid UTF-8";
+
+/// Read a caller's `path` into a repository path.
+///
+/// Two spellings are accepted: the plain repository-relative string
+/// `kin_artifact_list` prints as `path_label`, and the byte-exact
+/// `{"bytes_hex": ...}` object for a path the label cannot spell. A repository
+/// path never begins with `/` or `./`, so either prefix is dropped before the
+/// path is checked: a caller that writes the path it was shown as if it were
+/// rooted means that same file, and refusing it left an agent holding the right
+/// path with no way to read it.
 fn parse_repo_path(value: &serde_json::Value) -> Result<RepoPath> {
-    serde_json::from_value(value.clone()).map_err(|error| {
-        McpError::InvalidParams(format!(
-            "invalid byte-exact path; expected {{\"bytes_hex\":\"...\"}}: {error}"
-        ))
-    })
+    let refuse = |why: String| {
+        McpError::InvalidParams(format!("invalid path: {why}; pass {ACCEPTED_PATH_SHAPES}"))
+    };
+    let bytes = match value {
+        serde_json::Value::String(text) => text.as_bytes().to_vec(),
+        serde_json::Value::Object(fields) => match (fields.len(), fields.get("bytes_hex")) {
+            (1, Some(serde_json::Value::String(hex))) => decode_lowercase_hex(hex)
+                .ok_or_else(|| refuse(format!("{hex:?} is not canonical lowercase hex")))?,
+            _ => {
+                return Err(refuse(
+                    "an object path carries exactly one key, bytes_hex".to_string(),
+                ))
+            }
+        },
+        other => {
+            return Err(refuse(format!(
+                "{} is neither a string nor an object",
+                json_kind(other)
+            )))
+        }
+    };
+    let mut rest: &[u8] = &bytes;
+    while let Some(stripped) = rest.strip_prefix(b"/").or_else(|| rest.strip_prefix(b"./")) {
+        rest = stripped;
+    }
+    RepoPath::from_bytes(rest.to_vec()).map_err(|error| refuse(error.to_string()))
+}
+
+/// Bytes from canonical lowercase hex, or `None` for anything else.
+fn decode_lowercase_hex(hex: &str) -> Option<Vec<u8>> {
+    if hex.is_empty() || !hex.len().is_multiple_of(2) {
+        return None;
+    }
+    let digit = |byte: u8| match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        _ => None,
+    };
+    hex.as_bytes()
+        .chunks(2)
+        .map(|pair| Some((digit(pair[0])? << 4) | digit(pair[1])?))
+        .collect()
+}
+
+fn json_kind(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "a boolean",
+        serde_json::Value::Number(_) => "a number",
+        serde_json::Value::String(_) => "a string",
+        serde_json::Value::Array(_) => "an array",
+        serde_json::Value::Object(_) => "an object",
+    }
 }
 
 fn select_artifact<'a>(
@@ -274,7 +338,11 @@ fn select_artifact<'a>(
             McpError::Context("graph authority gap: artifact_id is absent from this tree".into())
         }),
         (false, true) => by_path.ok_or_else(|| {
-            McpError::Context("graph authority gap: exact path is absent from this tree".into())
+            McpError::Context(
+                "graph authority gap: exact path is absent from this tree; a path is \
+                 repository-relative, spelled as kin_artifact_list prints it in path_label"
+                    .into(),
+            )
         }),
         (true, true) => match (by_id, by_path) {
             (Some(left), Some(right)) if left.artifact_id == right.artifact_id => Ok(left),
@@ -530,6 +598,48 @@ mod tests {
             assert_eq!(
                 model["type"], wire["type"],
                 "the variant tag must be unchanged: {model} vs {wire}"
+            );
+        }
+    }
+
+    /// A path reads from either spelling, with or without the leading slash a
+    /// model writes when it treats the path it was shown as rooted.
+    #[test]
+    fn a_path_is_read_from_either_spelling_with_or_without_a_leading_slash() {
+        let expected = RepoPath::from_utf8("crates/kin-db/src/admission.rs").unwrap();
+        let hex = |text: &str| {
+            text.bytes()
+                .map(|byte| format!("{byte:02x}"))
+                .collect::<String>()
+        };
+        for value in [
+            serde_json::json!("crates/kin-db/src/admission.rs"),
+            serde_json::json!("/crates/kin-db/src/admission.rs"),
+            serde_json::json!("./crates/kin-db/src/admission.rs"),
+            serde_json::json!({ "bytes_hex": hex("crates/kin-db/src/admission.rs") }),
+            serde_json::json!({ "bytes_hex": hex("/crates/kin-db/src/admission.rs") }),
+        ] {
+            assert_eq!(parse_repo_path(&value).unwrap(), expected, "{value}");
+        }
+        // The control: a path the label cannot spell still reads byte-exact.
+        let raw = RepoPath::from_bytes(b"assets/\xffpayload.bin".to_vec()).unwrap();
+        assert_eq!(
+            parse_repo_path(&serde_json::to_value(&raw).unwrap()).unwrap(),
+            raw
+        );
+        // Every refusal names the shapes that are accepted.
+        for bad in [
+            serde_json::json!(""),
+            serde_json::json!("/"),
+            serde_json::json!(42),
+            serde_json::json!({ "bytes_hex": "ZZ" }),
+            serde_json::json!({ "hex": "61" }),
+            serde_json::json!("a/../b"),
+        ] {
+            let error = parse_repo_path(&bad).unwrap_err().to_string();
+            assert!(
+                error.contains("repository-relative path string") && error.contains("bytes_hex"),
+                "{bad}: {error}"
             );
         }
     }

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -6562,6 +6562,23 @@ mod tests {
             std::str::from_utf8(compose_bytes).unwrap()
         );
         assert_ne!(compose["text_utf8"], "filesystem fallback must never win\n");
+        // The spelling an agent reads off the listing, with the leading slash a
+        // model tends to add, reads the same artifact.
+        let by_label = tool_result_json(
+            artifacts::handle_artifact_read(
+                &HashMap::from([
+                    ("path".into(), serde_json::json!("/compose.yaml")),
+                    (
+                        "source_change_id".into(),
+                        serde_json::json!(change.id.to_string()),
+                    ),
+                ]),
+                &store,
+                Some(&authority),
+            )
+            .unwrap(),
+        );
+        assert_eq!(by_label["text_utf8"], compose["text_utf8"]);
 
         let binary = tool_result_json(
             artifacts::handle_artifact_read(

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -510,15 +510,21 @@ fn registered_tools() -> ToolsListResult {
                     "properties": {
                         "artifact_id": { "type": "string", "format": "uuid" },
                         "path": {
-                            "type": "object",
-                            "properties": {
-                                "bytes_hex": {
-                                    "type": "string",
-                                    "pattern": "^(?:[0-9a-f]{2})+$"
+                            "description": "Repository-relative path as kin_artifact_list prints it in path_label (a leading / is tolerated), or {\"bytes_hex\": ...} for a path whose bytes are not valid UTF-8.",
+                            "anyOf": [
+                                { "type": "string", "minLength": 1 },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "bytes_hex": {
+                                            "type": "string",
+                                            "pattern": "^(?:[0-9a-f]{2})+$"
+                                        }
+                                    },
+                                    "required": ["bytes_hex"],
+                                    "additionalProperties": false
                                 }
-                            },
-                            "required": ["bytes_hex"],
-                            "additionalProperties": false
+                            ]
                         },
                         "source_change_id": {
                             "type": "string",

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -510,7 +510,7 @@ fn registered_tools() -> ToolsListResult {
                     "properties": {
                         "artifact_id": { "type": "string", "format": "uuid" },
                         "path": {
-                            "description": "Repository-relative path as kin_artifact_list prints it in path_label (a leading / is tolerated), or {\"bytes_hex\": ...} for a path whose bytes are not valid UTF-8.",
+                            "description": "Repo-relative path as in path_label (a leading / is fine), or {bytes_hex} for non-UTF-8",
                             "anyOf": [
                                 { "type": "string", "minLength": 1 },
                                 {

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -80,7 +80,8 @@ root, route and uptime, the same fields `kin daemon status` prints for it.
 
 The recommended way to expose these tools is the guided wizard: run `kin setup` and choose
 the **AI agents** intent. It writes Kin's MCP server entry into every detected client
-(Claude Code, Cursor, Codex CLI, Gemini CLI, Windsurf) with the curated tool profile, and
+(Claude Code, Cursor, Codex CLI, Gemini CLI, Windsurf, Google Antigravity, LM Studio, Grok
+CLI) with the curated tool profile, and
 adds a Kin-first discovery reminder to your agent instruction files. `kin setup status`
 then verifies each client config.
 
@@ -395,4 +396,4 @@ Both tools ship in the `agent-default` profile, so an agent configured with
 `kin setup --intent agent` already has them.
 
 - **`kin_artifact_list`**: List the exact graph-owned repository artifacts at one semantic change. This is the repository-membership surface, so it covers code and every non-code tracked object, including Docker Compose files, Dockerfiles, lockfiles, configuration, binary assets, unsupported languages, symlinks, executable files, and gitlinks. Identity comes from `artifact_id` and never from a path, and a listed artifact is read by passing its `artifact_id` to `kin_artifact_read`. Each row names its path once: `path_label` is the exact path whenever `path_label_lossy` is false, and only a path whose bytes are not valid UTF-8 also carries the byte-exact `path` as a lowercase `bytes_hex` object. Omit `source_change_id` to read the exact current workspace tree.
-- **`kin_artifact_read`**: Read one exact graph-owned repository artifact by stable `artifact_id` or canonical byte-exact `path`. Blob and symlink bytes come back losslessly as base64, and as `text_utf8` only when they are valid UTF-8. Gitlinks return their external object identity and have no repository-owned body. The read is bound to the resolved tree entry and fails loudly when the tree, identity, or content-addressed blob is missing. It never reads the working directory.
+- **`kin_artifact_read`**: Read one exact graph-owned repository artifact by stable `artifact_id` or by `path`: the repository-relative string `kin_artifact_list` prints as `path_label` (a leading `/` is tolerated), or the byte-exact `{"bytes_hex": ...}` object for a path whose bytes are not valid UTF-8. Blob and symlink bytes come back losslessly as base64, and as `text_utf8` only when they are valid UTF-8. Gitlinks return their external object identity and have no repository-owned body. The read is bound to the resolved tree entry and fails loudly when the tree, identity, or content-addressed blob is missing. It never reads the working directory.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -552,7 +552,7 @@ after both commits exist so the exact SHAs are part of Kin's imported graph.
 
 If you chose the **AI agents** intent in step 2, `kin setup` already wrote Kin's MCP
 server entry into every detected AI client (Claude Code, Cursor, Codex CLI, Gemini CLI,
-Windsurf, Google Antigravity) and added a Kin-first discovery reminder to your agent
+Windsurf, Google Antigravity, LM Studio, Grok CLI) and added a Kin-first discovery reminder to your agent
 instruction files. There
 is **nothing else to configure**. Open your agent in a Kin repository and ask it to use
 the semantic tools:
@@ -724,6 +724,8 @@ Config file locations the wizard targets (and `kin setup status` inspects):
 | Gemini CLI | `~/.gemini/settings.json` |
 | Windsurf | `~/.codeium/windsurf/mcp_config.json` |
 | Google Antigravity | `~/.gemini/config/mcp_config.json` (global) and `<repo>/.agents/mcp_config.json` (workspace) |
+| LM Studio | `~/.lmstudio/mcp.json` |
+| Grok CLI | `~/.grok/config.toml` (TOML, bound to one repository like Codex) |
 
 Codex is the exception: it reads TOML (`[mcp_servers.<name>]` tables), not JSON. The wizard
 merges this table into `~/.codex/config.toml`, leaving the rest of the file untouched:

--- a/docs/session-runtime.md
+++ b/docs/session-runtime.md
@@ -19,7 +19,7 @@ Four surfaces share this contract:
 
 `kin setup` is **not** part of this contract: it is one-time configuration that
 installs Kin's MCP server entry into your AI clients (Claude Code, Cursor,
-Codex, Gemini, Windsurf) and your shell hook. In short:
+Codex, Gemini, Windsurf, Google Antigravity, LM Studio, Grok CLI) and your shell hook. In short:
 
 - **`kin setup`**: configure clients once (MCP install, shell hook).
 - **`kin exec` / `kin shell`**: run ordinary commands through a session workspace.

--- a/llms-install.md
+++ b/llms-install.md
@@ -143,6 +143,8 @@ It writes Kin's MCP server entry into the clients it finds:
 | Gemini CLI | `~/.gemini/settings.json` |
 | Windsurf | `~/.codeium/windsurf/mcp_config.json` |
 | Google Antigravity | `~/.gemini/config/mcp_config.json` |
+| LM Studio | `~/.lmstudio/mcp.json` |
+| Grok CLI | `~/.grok/config.toml` |
 
 The merge is defensive. It refuses to write to a file that is not valid JSON, only touches
 the `command`, `args`, and `env` keys under its own entry, and records every write to a

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -13957,7 +13957,7 @@ def main() -> None:
         "CANONICAL_NPM_MCP_COMMAND",
         "CANONICAL_NPM_MCP_PACKAGE",
         "mcp_argument_vector_matches(entry, client_id, topology)",
-        '"codex" | "antigravity" | "antigravity_workspace"',
+        '"codex" | "grok" | "antigravity" | "antigravity_workspace"',
         "configured_mcp_launcher()",
     ):
         require(health, policy, "product-owned exact MCP entry health validation")


### PR DESCRIPTION
`kin setup` now wires Kin into LM Studio and the Grok CLI, and `kin_artifact_read` reads a file by the path `kin_artifact_list` prints for it.

A local-model user had to wire Kin by hand: setup knew Claude Code, Cursor, Codex, Gemini, Windsurf and Antigravity, and LM Studio's `~/.lmstudio/mcp.json` sat at `{"mcpServers": {}}`.

LM Studio reads `~/.lmstudio/mcp.json` in the shape Cursor reads (a top-level `mcpServers` object whose stdio entries take `command`, `args` and `env`, per the schema LM Studio bundles), so setup merges the same Kin entry there. It is detected by `lms` on PATH, `~/.lmstudio`, or `/Applications/LM Studio.app`.

The Grok CLI documents `~/.grok/config.toml` with the `[mcp_servers.<name>]` tables Codex reads, and applies that user-scope file to every project. So its Kin entry names one repository with `--repo`, as Codex's does, and setup defers it until a repository exists rather than writing an entry that points nowhere. It is detected by `grok` on PATH or `~/.grok`. Health requires an absolute `--repo` for Grok without comparing it to the repository `kin doctor` happens to run in, so an entry deliberately bound to one repository stays healthy everywhere.

Both clients are health-checked (`mcp_client_lmstudio`, `mcp_client_grok`), captured and repaired by `kin update` through the right writer (repair now routes TOML clients to the TOML writer by kind instead of by the literal `codex`, so a Grok table is never handed to the JSON merge), recorded in the install ledger, and removed on uninstall by the extension-keyed path that already covers Codex. On a fresh host with neither client, their health rows read `unsupported`, which the release proof does not count as needing attention.

`kin_artifact_read` refused the path a local model derived from the listing, `/crates/kin-db/src/admission.rs` as hex, because of its leading slash, and it took only the byte-exact `{"bytes_hex": ...}` form. It now also takes the repository-relative string `kin_artifact_list` prints as `path_label`. A leading `/` or `./` is dropped from either spelling, since a repository path never has one, and every refusal names both accepted shapes. The tool's `path` description stays inside the 90-character budget the agent tool profile holds every property description to.

Resolves FIR-3544.

## Local verification

Hosted CI runs the suites and the gates. It does not run the falsification below, so here are the command and its output, at 29310f209 on this branch. The script applies one mutation at a time, runs the tests written for it, and restores the file from HEAD.

```
$ .kin-coord/bin/heavy-slot.sh agentloopb kin -- bash falsify-3544.sh
HEAD 29310f209bc85fc31b5dbc23c8dd621c0ccf09f0 on chore/lane-agentloopb-kin at 2026-09-11T10:05:25Z
STEP kin-mcp-lib: rc=0
test result: ok. 1006 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 26.64s
STEP kin-cli-targeted: rc=0
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 2295 filtered out; finished in 1.23s
STEP kin-cli-check: rc=0
STEP zero-file-search: rc=0
Verification PASSED: Zero File-Search Invariant holds.
```

Each new test, with the behaviour it guards broken. The `#` lines name the mutation; the rest is output.

```
# leading_slash: artifacts.rs .strip_prefix(b"/") becomes .strip_prefix(b"//")
CASE leading_slash: rc=101 (a falsified test must exit nonzero)
test handlers::artifacts::tests::a_path_is_read_from_either_spelling_with_or_without_a_leading_slash ... FAILED
test handlers::tests::exact_artifact_tools_preserve_every_repository_leaf_without_entities ... FAILED
test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 1004 filtered out; finished in 0.96s
# plain_string: artifacts.rs reads a string path as no bytes at all
CASE plain_string: rc=101 (a falsified test must exit nonzero)
test handlers::artifacts::tests::a_path_is_read_from_either_spelling_with_or_without_a_leading_slash ... FAILED
test handlers::tests::exact_artifact_tools_preserve_every_repository_leaf_without_entities ... FAILED
test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 1004 filtered out; finished in 0.43s
# lmstudio_path: setup.rs writes ~/.lmstudio/kin-mcp.json instead of ~/.lmstudio/mcp.json
CASE lmstudio_path: rc=101 (a falsified test must exit nonzero)
test commands::setup::tests::setup_registers_kin_with_lm_studio_beside_its_other_servers ... FAILED
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2304 filtered out; finished in 0.22s
# grok_repo_bound: setup.rs binds Grok to env::current_dir() instead of an initialized repository
CASE grok_repo_bound: rc=101 (a falsified test must exit nonzero)
test commands::setup::tests::configuring_a_repo_bound_client_with_no_repository_defers ... FAILED
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2304 filtered out; finished in 0.10s
# grok_toml_repair: setup.rs matches!(id, "codex" | "grok") becomes matches!(id, "codex")
CASE grok_toml_repair: rc=101 (a falsified test must exit nonzero)
test commands::setup::tests::a_grok_entry_is_repaired_as_toml_and_keeps_its_repository ... FAILED
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2304 filtered out; finished in 0.16s
# health_grok: health.rs drops "grok" from the repository-bound client ids
CASE health_grok: rc=101 (a falsified test must exit nonzero)
test commands::health::tests::grok_is_bound_to_one_repository_and_lm_studio_is_not ... FAILED
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2304 filtered out; finished in 0.02s
```

The description budget has its own red run. At d93b17ede, the first commit before this branch was rebased onto main, `cargo test -p kin-mcp --lib` failed one test:

```
test agent_belt::tests::no_agent_default_property_description_exceeds_its_budget ... FAILED
over the 90-character property budget: [("kin_artifact_read", "path", 163)]; give each one a single clause in shared_property_descriptions or tool_property_descriptions
test result: FAILED. 999 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 20.58s
```

The second commit shortens that description to 87 characters, and the 1006-passed run above is its green.

## The health policy guard

`scripts/test-release-workflow-authority.py` pins the health.rs match arm that marks the repository-bound MCP clients as a substring needle. Adding Grok to that arm changed its text, so the `npm launcher tests` job refused the file although the policy only grew. The needle now names all four clients, so the guard also protects Grok's binding. No Rust changed for this.

The whole CI step that runs it ("Test release ordering and npm provenance policy", extracted verbatim from ci.yml and run from this branch's root) passes:

```
$ bash npm-launcher-step.sh
...
STEP OK
rc=0
```

Falsified on an export of 6da051077, so nothing else was mutated. The unmutated export is the control:

```
CONTROL unmutated export: rc=0
release workflow authority is reviewed-PR to App-tag automatic, protected, pinned, GCP-free on release writes, cross-platform byte-canonical, with dev-only Artifact Registry OIDC and npm automatic through short-lived OIDC with post-public proof
MUTATION drop_grok_from_arm applied: rc=0
CASE drop_grok_from_arm: rc=1 (the guard must exit nonzero)
AssertionError: product-owned exact MCP entry health validation is missing required policy: "codex" | "grok" | "antigravity" | "antigravity_workspace"
```
