### PR TITLE
Write nothing when an agent edit cannot open a transaction, and re-open a gone session (FIR-3550)

### DIFF
--- a/crates/kin-agent/src/belt.rs
+++ b/crates/kin-agent/src/belt.rs
@@ -632,6 +632,19 @@ pub fn unpublished_create(arguments: &Value, reason: &str) -> LocalOutcome {
     ))
 }
 
+/// The outcome of an `edit_file` or `write_file` for which Kin could not open a transaction.
+///
+/// Kin is attached, so the change belongs in the graph, and without a transaction it cannot
+/// get there. Nothing is written: a local write here would be a change on disk the graph
+/// never hears about. The model is told why, in the server's words.
+pub fn unbracketed_refusal(arguments: &Value, reason: &str) -> LocalOutcome {
+    let raw_path = arguments.get("path").and_then(Value::as_str).unwrap_or("");
+    LocalOutcome::error(format!(
+        "`{raw_path}` was not changed: Kin could not open a transaction for this change: \
+         {reason}. Nothing was written, so `{raw_path}` is unchanged on disk and in the graph."
+    ))
+}
+
 impl LocalOutcome {
     /// A refusal the model is handed instead of a run, in the shape a run would have
     /// produced, so a routing failure reads to the caller exactly like a tool failure.

--- a/crates/kin-agent/src/run.rs
+++ b/crates/kin-agent/src/run.rs
@@ -822,11 +822,16 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
                                             let plan = plan_stage(&repo, tool, &call.arguments);
                                             let mut bracket = begin_transaction(
                                                 &mut servers[index],
+                                                &config,
                                                 session.as_deref(),
                                                 &call.arguments,
                                                 &plan,
                                                 &mut writer,
                                             )?;
+                                            // A gone session is re-opened inside the
+                                            // bracket, so the stage below names the
+                                            // session the transaction was begun under.
+                                            let session = servers[index].session.clone();
                                             // Repository authority writes a created file
                                             // itself as part of publishing the change, so
                                             // a create is published FIRST and is never
@@ -903,6 +908,32 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
                                                         provenance,
                                                     )
                                                 }
+                                            } else if servers[index]
+                                                .declares("kin_transaction_begin")
+                                                && servers[index].declares("kin_transaction_stage")
+                                            {
+                                                // Kin is attached and no transaction opened,
+                                                // so nothing is written: a local write here is
+                                                // a change on disk the graph never hears about,
+                                                // the state a refused commit used to leave.
+                                                counters.unpublished_changes += 1;
+                                                let reason =
+                                                    bracket.reason.clone().unwrap_or_else(|| {
+                                                        "no reason was given".to_string()
+                                                    });
+                                                let provenance = close_transaction(
+                                                    &mut servers[index],
+                                                    bracket,
+                                                    false,
+                                                    &mut writer,
+                                                )?;
+                                                (
+                                                    belt::unbracketed_refusal(
+                                                        &call.arguments,
+                                                        &reason,
+                                                    ),
+                                                    provenance,
+                                                )
                                             } else {
                                                 let mut outcome = match tool {
                                                     LocalTool::Edit => {
@@ -1453,8 +1484,19 @@ impl Bracket {
     }
 }
 
+/// Whether a refused `kin_transaction_begin` says the session it named no longer exists.
+///
+/// A session lives in the daemon that registered it, so a daemon that stops and is started
+/// again for the same repository answers every later call with "session not found" while
+/// the harness still holds the old id. Both the daemon and the MCP session registry word
+/// the refusal this way.
+fn session_is_gone(refusal: &str) -> bool {
+    refusal.to_ascii_lowercase().contains("session not found")
+}
+
 fn begin_transaction(
     server: &mut Server,
+    config: &AgentConfig,
     session: Option<&str>,
     arguments: &Value,
     plan: &StagePlan,
@@ -1481,45 +1523,62 @@ fn begin_transaction(
         .and_then(Value::as_str)
         .unwrap_or("repository")
         .to_string();
-    match server.client.call_tool(
-        "kin_transaction_begin",
-        &json!({ "session_id": session, "scope": scope }),
-    ) {
-        Ok(outcome) if !outcome.is_error => {
-            let transaction_id = extract_id(&outcome, &["transaction_id", "id"]);
-            writer.trace(json!({
-                "surface": "kin",
-                "server": server_name,
-                "tool": "kin_transaction_begin",
-                "policy": "allowed",
-                "event": "transaction_begin",
-                "scope": scope,
-                "wall_ms": outcome.wall_ms as u64,
-                "is_error": false,
-                "transaction_id": transaction_id.clone(),
-            }))?;
-            Ok(Bracket {
-                reason: transaction_id
-                    .is_none()
-                    .then(|| "the server returned no transaction id".to_string()),
-                transaction_id,
-                staged: None,
-            })
+    let mut session = session.to_string();
+    let mut reopened = false;
+    loop {
+        match server.client.call_tool(
+            "kin_transaction_begin",
+            &json!({ "session_id": session, "scope": scope }),
+        ) {
+            Ok(outcome) if !outcome.is_error => {
+                let transaction_id = extract_id(&outcome, &["transaction_id", "id"]);
+                writer.trace(json!({
+                    "surface": "kin",
+                    "server": server_name,
+                    "tool": "kin_transaction_begin",
+                    "policy": "allowed",
+                    "event": "transaction_begin",
+                    "scope": scope,
+                    "wall_ms": outcome.wall_ms as u64,
+                    "is_error": false,
+                    "transaction_id": transaction_id.clone(),
+                }))?;
+                return Ok(Bracket {
+                    reason: transaction_id
+                        .is_none()
+                        .then(|| "the server returned no transaction id".to_string()),
+                    transaction_id,
+                    staged: None,
+                });
+            }
+            Ok(outcome) => {
+                // The envelope comes first in every answer and is longer than the budget, so
+                // it is stripped, or the refusal's own words never reach the trace.
+                let detail = close_detail(&outcome.text);
+                writer.trace(json!({
+                    "surface": "kin",
+                    "server": server_name,
+                    "tool": "kin_transaction_begin",
+                    "policy": "allowed",
+                    "event": "transaction_begin",
+                    "scope": scope,
+                    "is_error": true,
+                    "detail": detail.clone(),
+                }))?;
+                // When the session is gone, re-open once and retry begin, so an edit made
+                // after the daemon was restarted still goes through a transaction.
+                if !reopened && session_is_gone(&outcome.text) {
+                    reopened = true;
+                    if let Some(fresh) = start_kin_session(server, config, writer)? {
+                        server.session = Some(fresh.clone());
+                        session = fresh;
+                        continue;
+                    }
+                }
+                return Ok(Bracket::unopened(detail));
+            }
+            Err(err) => return Ok(Bracket::unopened(err.to_string())),
         }
-        Ok(outcome) => {
-            writer.trace(json!({
-                "surface": "kin",
-                "server": server_name,
-                "tool": "kin_transaction_begin",
-                "policy": "allowed",
-                "event": "transaction_begin",
-                "scope": scope,
-                "is_error": true,
-                "detail": truncate(&outcome.text, 300),
-            }))?;
-            Ok(Bracket::unopened(truncate(&outcome.text, 200)))
-        }
-        Err(err) => Ok(Bracket::unopened(err.to_string())),
     }
 }
 

--- a/crates/kin-agent/tests/loop_integration.rs
+++ b/crates/kin-agent/tests/loop_integration.rs
@@ -184,6 +184,8 @@ LOG = sys.argv[1]
 # Staged operations per transaction, so a commit publishes what was staged rather than
 # answering yes to anything. The server runs with the repository as its cwd.
 STAGED = {}
+# Every session this server has opened, in order.
+SESSIONS = []
 
 TOOLS = [
     {"name": "semantic_locate", "description": "Find entities by meaning.",
@@ -259,7 +261,18 @@ def call(name, args):
     if name == "get_entity_source":
         return payload({"source": "def greet(name):\n    return name\n", "_kin": ENVELOPE})
     if name == "kin_session_start":
-        return payload({"session_id": "sess-fixture-1", "_kin": ENVELOPE})
+        # Numbered, so a harness that re-opens its session gets a new id, as it does from
+        # a daemon that was started again.
+        SESSIONS.append(len(SESSIONS) + 1)
+        return payload({"session_id": "sess-fixture-%d" % SESSIONS[-1], "_kin": ENVELOPE})
+    if name == "kin_transaction_begin":
+        # src/stale.py: the first session is gone, as after a daemon restart; a re-opened
+        # session is accepted. src/nobegin.py: every begin is refused the same way.
+        scope, session = args.get("scope"), args.get("session_id")
+        gone = {"error": "Session not found: " + str(session) + ". It was ended or expired "
+                         "after its idle timeout.", "_kin": ENVELOPE}
+        if scope == "src/nobegin.py" or (scope == "src/stale.py" and session == "sess-fixture-1"):
+            return payload(gone, is_error=True)
     if name == "kin_session_end":
         return payload({"ended": True, "_kin": ENVELOPE})
     if name == "kin_transaction_begin":
@@ -269,7 +282,7 @@ def call(name, args):
         # the mirror of it: a replace whose path authority does not track. TRACKED stands
         # for the fixture graph's contents, so both refusals are the graph's answer rather
         # than a look at the working tree.
-        TRACKED = ("src/greet.py", "README.md", "src/dirty.py")
+        TRACKED = ("src/greet.py", "README.md", "src/dirty.py", "src/stale.py")
         for op in args.get("operations", []):
             verb = op.get("verb")
             target = op.get("target")
@@ -367,6 +380,18 @@ fn fixture_repo(dir: &Path) -> PathBuf {
     std::fs::write(
         repo.join("src/dirty.py"),
         "def stale(name):\n    return name\n",
+    )
+    .unwrap();
+    // The scripted server refuses begin for these two by path: src/stale.py only under the
+    // first session, as after a daemon restart, and src/nobegin.py under every session.
+    std::fs::write(
+        repo.join("src/stale.py"),
+        "def later(name):\n    return name\n",
+    )
+    .unwrap();
+    std::fs::write(
+        repo.join("src/nobegin.py"),
+        "def never(name):\n    return name\n",
     )
     .unwrap();
     repo
@@ -1222,6 +1247,141 @@ fn a_create_authority_refuses_leaves_no_file_and_hands_the_content_back() {
     assert!(
         observation.contains(body),
         "the refused content must come back to the model: {observation}"
+    );
+}
+
+/// When the session is gone, as after the daemon that held it was stopped and started again,
+/// the edit re-opens the session once, begins again under the new one, and lands.
+#[test]
+fn an_edit_after_the_session_is_gone_reopens_it_and_publishes() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = fixture_repo(dir.path());
+    let out = dir.path().join("out");
+    let server = write_fake_mcp_server(dir.path());
+    let log = dir.path().join("mcp-calls.jsonl");
+    let endpoint = FakeEndpoint::start(vec![
+        completion(
+            "Fixing it.",
+            Some(tool_call(
+                "c1",
+                "edit_file",
+                json!({ "path": "src/stale.py", "find": "return name", "replace": "return name.strip()" }),
+            )),
+        ),
+        completion("Fixed.", None),
+    ]);
+    let base_url = endpoint.base_url.clone();
+
+    let outcome = kin_agent::run(config(&repo, &out, &base_url, mcp_command(&server, &log)))
+        .expect("the run completes");
+    assert_eq!(outcome.status, ExitStatus::Success, "{:?}", outcome.result);
+    assert_eq!(outcome.result["kin_agent"]["unpublished_changes"], 0);
+
+    let calls = mcp_log(&log);
+    let names: Vec<&str> = calls
+        .iter()
+        .map(|call| call["tool"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        names,
+        vec![
+            "kin_session_start",
+            "kin_transaction_begin",
+            "kin_session_start",
+            "kin_transaction_begin",
+            "kin_transaction_stage",
+            "kin_transaction_commit",
+            "kin_session_end"
+        ],
+        "a gone session is re-opened once and the begin retried: {names:?}"
+    );
+    let stage = calls
+        .iter()
+        .find(|call| call["tool"] == "kin_transaction_stage")
+        .expect("the edit is staged");
+    assert_eq!(
+        stage["args"]["session_id"], "sess-fixture-2",
+        "the stage names the re-opened session"
+    );
+    assert_eq!(
+        std::fs::read_to_string(repo.join("src/stale.py")).unwrap(),
+        "def later(name):\n    return name.strip()\n"
+    );
+}
+
+/// When Kin is attached but no transaction opens, the edit writes nothing and the model is
+/// told why, in the server's own words with the envelope stripped.
+///
+/// The harness used to fall back to a local write and report "Edited", which is how a real
+/// run left ten lines on disk that repository authority never saw.
+#[test]
+fn an_edit_kin_cannot_open_a_transaction_for_writes_nothing_and_says_why() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = fixture_repo(dir.path());
+    let out = dir.path().join("out");
+    let server = write_fake_mcp_server(dir.path());
+    let log = dir.path().join("mcp-calls.jsonl");
+    let endpoint = FakeEndpoint::start(vec![
+        completion(
+            "Fixing it.",
+            Some(tool_call(
+                "c1",
+                "edit_file",
+                json!({ "path": "src/nobegin.py", "find": "return name", "replace": "return name.strip()" }),
+            )),
+        ),
+        completion("Fixed.", None),
+    ]);
+    let base_url = endpoint.base_url.clone();
+
+    let outcome = kin_agent::run(config(&repo, &out, &base_url, mcp_command(&server, &log)))
+        .expect("the run completes");
+    assert_eq!(outcome.status, ExitStatus::ChangesUnpublished);
+    assert_eq!(outcome.result["kin_agent"]["unpublished_changes"], 1);
+    assert_eq!(
+        std::fs::read_to_string(repo.join("src/nobegin.py")).unwrap(),
+        "def never(name):\n    return name\n",
+        "nothing may be written without a transaction"
+    );
+
+    let calls = mcp_log(&log);
+    let names: Vec<&str> = calls
+        .iter()
+        .map(|call| call["tool"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        names,
+        vec![
+            "kin_session_start",
+            "kin_transaction_begin",
+            "kin_session_start",
+            "kin_transaction_begin",
+            "kin_session_end"
+        ],
+        "begin is retried once and nothing is staged: {names:?}"
+    );
+
+    // The refusal's own words reach the trace, not the envelope that comes first.
+    let trace = read_jsonl(&outcome.trace_path);
+    let begin = trace
+        .iter()
+        .rev()
+        .find(|row| row["tool"] == "kin_transaction_begin")
+        .expect("the refused begin is traced");
+    let detail = begin["detail"].as_str().unwrap();
+    assert!(detail.contains("Session not found"), "{detail}");
+    assert!(!detail.contains("envelope_version"), "{detail}");
+
+    let requests = endpoint.requests();
+    let observation = requests[1]["messages"].as_array().unwrap().last().unwrap()["content"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert!(
+        observation.contains("was not changed")
+            && observation.contains("Session not found")
+            && observation.contains("unchanged on disk and in the graph"),
+        "the model must be told nothing changed and why: {observation}"
     );
 }
 


### PR DESCRIPTION
An agent edit that cannot open a Kin transaction now writes nothing and says why, and a session lost to a daemon restart is re-opened once so the edit still goes through Kin.

## What happened

In the real local-model run on the FIR-3550 write-path fix, qwen/qwen3.8-27b read for about ten minutes and then called `edit_file`. By then the daemon that held the agent's session had been stopped and started again (the unattended updater's cooperative stop at 10:10:12Z reached this scratch daemon too). The replacement did not know the session, so `kin_transaction_begin` was refused. The runner then fell back to its unbracketed path. It wrote the file locally in 15 ms and told the model "Edited", which left ten lines on disk that repository authority never saw. The trace could not even show why, because the `_kin` envelope spent the 300-character budget before the refusal's own words.

## The fix

With Kin attached and no transaction open, `edit_file` and `write_file` write nothing. The change is counted as unpublished, and the model is told the file was not changed and why, in the server's words. A server that exposes no transaction tools keeps the old local write, since there is no Kin write path to use.

When begin's refusal says the session is not found, the harness re-opens its session once and retries begin under the new id, and the stage names that session. It retries once only, so a server that keeps refusing ends in the refusal above.

The refused begin's detail goes through `close_detail`, which strips the envelope as the stage and commit details already do.

## Tests

- `an_edit_after_the_session_is_gone_reopens_it_and_publishes`: begin is refused under the first session, and the edit lands under a second one the harness opened.
- `an_edit_kin_cannot_open_a_transaction_for_writes_nothing_and_says_why`: every begin is refused. The file stays untouched and the run ends `ChangesUnpublished`, while the trace and the model both carry "Session not found" without the envelope.

## Falsification (local, on the fix commit, restored from it after each)

Without the re-open (`reopened` starts true), both tests go red:

```
test an_edit_after_the_session_is_gone_reopens_it_and_publishes ... FAILED
test an_edit_kin_cannot_open_a_transaction_for_writes_nothing_and_says_why ... FAILED
  left: ChangesUnpublished
```

With the refusal detail truncated with its envelope again, the no-transaction test goes red on the trace:

```
test an_edit_kin_cannot_open_a_transaction_for_writes_nothing_and_says_why ... FAILED
{"error": "Session not found: sess-fixture-2. It was ended or expired after its idle timeout.", "_kin": {"envelope_version": "1", ...
```

With the no-local-write branch switched off (`&& false &&` added to its condition), the no-transaction test goes red, because the edit was written locally and the run called it a success. The re-open test stays green, as it should, since it never reaches that branch:

```
test an_edit_kin_cannot_open_a_transaction_for_writes_nothing_and_says_why ... FAILED
test an_edit_after_the_session_is_gone_reopens_it_and_publishes ... ok
thread 'an_edit_kin_cannot_open_a_transaction_for_writes_nothing_and_says_why' panicked at crates/kin-agent/tests/loop_integration.rs:1339:5:
assertion `left == right` failed
  left: Success
 right: ChangesUnpublished
test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 23 filtered out; finished in 0.05s
```

The same mutation with that test's status and counter assertions taken out, so the disk assertion is the first one reached, shows the file itself changing:

```
thread 'an_edit_kin_cannot_open_a_transaction_for_writes_nothing_and_says_why' panicked at crates/kin-agent/tests/loop_integration.rs:1339:5:
assertion `left == right` failed: nothing may be written without a transaction
  left: "def never(name):\n    return name.strip()\n"
 right: "def never(name):\n    return name\n"
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 24 filtered out; finished in 0.02s
```

## Local gates

`bin/kin-precheck kin --repo-dir kin=<this branch's worktree>`, with the gate list read from ci.yml's check job:

```
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:check_private_repo_coupling.sh bash scripts/check_private_repo_coupling.sh
PASS     guard:check_runtime_boundaries.sh    bash scripts/check_runtime_boundaries.sh
PASS     guard:test-release-policy-gate.sh    bash scripts/test-release-policy-gate.sh
PASS     guard:test-windows-authority-legs.sh bash scripts/test-windows-authority-legs.sh
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:check-kin-vfs-compat.mjs       node scripts/check-kin-vfs-compat.mjs
PASS     guard:check-rc-build-drift.mjs       node scripts/check-rc-build-drift.mjs
PASS     guard:check-required-contexts.py     python3 scripts/check-required-contexts.py
PASS     guard:test-assertion-reachability.py python3 scripts/test-assertion-reachability.py
PASS     guard:test-guard-duplicate-release-run.py python3 scripts/test-guard-duplicate-release-run.py
PASS     guard:test-homebrew-release-gate.py  python3 scripts/test-homebrew-release-gate.py
PASS     guard:test-install-checksum.py       python3 scripts/test-install-checksum.py
PASS     guard:test-private-repo-coupling.py  python3 scripts/test-private-repo-coupling.py
PASS     guard:test-release-tag-evaluate-dispatch.py python3 scripts/test-release-tag-evaluate-dispatch.py
PASS     guard:test-release-workflow-authority.py python3 scripts/test-release-workflow-authority.py
PASS     guard:test-select-release-candidate.py python3 scripts/test-select-release-candidate.py
PASS     guard:verify-hydration-semantics.py  python3 scripts/verify-hydration-semantics.py
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
PASS     node-test                            node --test <16 file(s) named by the check job>
PASS     guard:check-quarantine.py            python3 scripts/check-quarantine.py
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin 6008e323bd9e6fdf04e79aa7ffa5c7cbba7935dc
```

The loop's own gap, that nothing heartbeats the session while the model thinks, is separate work in the agent loop. This change is the belt under it.

FIR-3550
