### PR TITLE
Keep the agent's Kin session alive through a long model turn

### DIFF
--- a/crates/kin-agent/src/run.rs
+++ b/crates/kin-agent/src/run.rs
@@ -64,6 +64,10 @@ struct Server {
     client: McpClient,
     declared: Vec<McpTool>,
     session: Option<String>,
+    /// The session's idle window, as the reply that opened it named it in
+    /// `idle_timeout_secs`. `None` when the reply named none, and then nothing is
+    /// heartbeated on a guess.
+    session_ttl: Option<Duration>,
 }
 
 impl Server {
@@ -118,6 +122,8 @@ struct Counters {
     withheld_results: u32,
     /// Calls in a turn's batch that were never run because a budget was spent part way.
     skipped_calls: u32,
+    /// Heartbeats sent to keep a Kin session alive through a long wait on the endpoint.
+    session_heartbeats: u32,
     turns: u32,
     input_tokens: u64,
     output_tokens: u64,
@@ -140,6 +146,7 @@ impl Counters {
             clipped_results: 0,
             withheld_results: 0,
             skipped_calls: 0,
+            session_heartbeats: 0,
             turns: 0,
             input_tokens: 0,
             output_tokens: 0,
@@ -186,6 +193,7 @@ impl Counters {
             "clipped_results": self.clipped_results,
             "withheld_results": self.withheld_results,
             "skipped_calls": self.skipped_calls,
+            "session_heartbeats": self.session_heartbeats,
             "files_changed": self.edits,
         })
     }
@@ -338,6 +346,7 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
             client,
             declared,
             session: None,
+            session_ttl: None,
         });
     }
 
@@ -456,7 +465,15 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
             }
             meter.add(prompt.len() as u64);
             messages.push(json!({ "role": "user", "content": prompt }));
-            match complete_with_retry(&provider, &messages, &[], &mut counters, deadline_at) {
+            match wait_for_turn(
+                &provider,
+                &messages,
+                &[],
+                &mut counters,
+                deadline_at,
+                &mut servers,
+                &mut writer,
+            )? {
                 Ok(completion) => {
                     counters.absorb(&completion.usage);
                     let turn = parse::parse_choice(&completion.choice, belt.names());
@@ -488,26 +505,33 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
             break;
         }
 
-        let completion =
-            match complete_with_retry(&provider, &messages, &specs, &mut counters, deadline_at) {
-                Ok(completion) => completion,
-                Err(EndpointStop::Deadline { waited }) => {
-                    stop = Stop::deadline(
-                        &config,
-                        &format!("while waiting {} s on the endpoint", waited.as_secs()),
-                    );
-                    break;
-                }
-                Err(EndpointStop::Failed(err)) => {
-                    stop = Stop::new(
-                        ExitStatus::EndpointError,
-                        "endpoint_unreachable",
-                        Some(err.to_string()),
-                    );
-                    final_text = err.to_string();
-                    break;
-                }
-            };
+        let completion = match wait_for_turn(
+            &provider,
+            &messages,
+            &specs,
+            &mut counters,
+            deadline_at,
+            &mut servers,
+            &mut writer,
+        )? {
+            Ok(completion) => completion,
+            Err(EndpointStop::Deadline { waited }) => {
+                stop = Stop::deadline(
+                    &config,
+                    &format!("while waiting {} s on the endpoint", waited.as_secs()),
+                );
+                break;
+            }
+            Err(EndpointStop::Failed(err)) => {
+                stop = Stop::new(
+                    ExitStatus::EndpointError,
+                    "endpoint_unreachable",
+                    Some(err.to_string()),
+                );
+                final_text = err.to_string();
+                break;
+            }
+        };
         counters.absorb(&completion.usage);
         counters.turns += 1;
         meter.anchor(&completion.usage, message_bytes(&completion.choice));
@@ -1259,6 +1283,7 @@ fn complete_with_retry(
     tools: &[Value],
     counters: &mut Counters,
     deadline_at: Instant,
+    keepalive: &mut Keepalive<'_>,
 ) -> Result<Completion, EndpointStop> {
     let began = Instant::now();
     let mut last: Option<ProviderError> = None;
@@ -1271,7 +1296,7 @@ fn complete_with_retry(
         }
         let limit = remaining.min(provider.config().request_timeout);
         let asked = Instant::now();
-        let outcome = provider.complete_within(messages, tools, limit);
+        let outcome = keepalive.wait(provider, messages, tools, limit);
         // Time spent waiting is endpoint time whether or not an answer came back.
         counters.api_ms += asked.elapsed().as_millis();
         match outcome {
@@ -1298,6 +1323,167 @@ fn complete_with_retry(
     Err(EndpointStop::Failed(
         last.expect("at least one attempt was made"),
     ))
+}
+
+/// One turn's wait on the endpoint, with every attached Kin session kept alive through it
+/// and each heartbeat it sent written to the trace once the wait is over.
+fn wait_for_turn(
+    provider: &Provider,
+    messages: &[Value],
+    tools: &[Value],
+    counters: &mut Counters,
+    deadline_at: Instant,
+    servers: &mut [Server],
+    writer: &mut TranscriptWriter,
+) -> anyhow::Result<Result<Completion, EndpointStop>> {
+    let mut keepalive = Keepalive::new(servers);
+    let outcome = complete_with_retry(
+        provider,
+        messages,
+        tools,
+        counters,
+        deadline_at,
+        &mut keepalive,
+    );
+    counters.session_heartbeats += keepalive.beats;
+    for row in keepalive.rows {
+        writer.trace(row)?;
+    }
+    Ok(outcome)
+}
+
+/// Keeps every attached Kin session alive while the loop waits on the endpoint.
+///
+/// A session is reaped once it sits idle for the window the reply that opened it named, and
+/// every Kin call refreshes it, so the one long idle stretch in a run is a model turn. A
+/// turn can outlast the window: a deadline past it leaves room for three request timeouts on
+/// one turn, and a long prompt's prefill runs for minutes. So while a request is in flight
+/// each session is heartbeated at a third of its own window, and the heartbeats stop when
+/// the turn returns. A session whose reply named no window is not heartbeated, because its
+/// cadence would be a guess.
+struct Keepalive<'a> {
+    servers: &'a mut [Server],
+    /// When each server's session was last refreshed during this wait, by server index.
+    refreshed: Vec<Instant>,
+    /// A trace row per heartbeat, written by the caller once the wait returns.
+    rows: Vec<Value>,
+    beats: u32,
+}
+
+impl<'a> Keepalive<'a> {
+    fn new(servers: &'a mut [Server]) -> Self {
+        let refreshed = vec![Instant::now(); servers.len()];
+        Keepalive {
+            servers,
+            refreshed,
+            rows: Vec::new(),
+            beats: 0,
+        }
+    }
+
+    /// How often a server's session is heartbeated: a third of its window, and only for a
+    /// session that is open and named one.
+    fn cadence(server: &Server) -> Option<Duration> {
+        server.session.as_ref()?;
+        server.session_ttl.map(|ttl| ttl / 3)
+    }
+
+    /// The next instant any session is due a heartbeat.
+    fn next_due(&self) -> Option<Instant> {
+        self.servers
+            .iter()
+            .zip(&self.refreshed)
+            .filter_map(|(server, refreshed)| Self::cadence(server).map(|every| *refreshed + every))
+            .min()
+    }
+
+    /// Heartbeat every session that is due one.
+    fn beat_due(&mut self) {
+        let now = Instant::now();
+        for (index, server) in self.servers.iter_mut().enumerate() {
+            let Some(every) = Self::cadence(server) else {
+                continue;
+            };
+            if now < self.refreshed[index] + every {
+                continue;
+            }
+            let session = server.session.clone().unwrap_or_default();
+            let outcome = server
+                .client
+                .call_tool("kin_session_heartbeat", &json!({ "session_id": session }));
+            self.refreshed[index] = Instant::now();
+            self.beats += 1;
+            self.rows.push(json!({
+                "surface": "kin",
+                "server": server.name(),
+                "tool": "kin_session_heartbeat",
+                "policy": "allowed",
+                "event": "session_heartbeat",
+                "kin_session_id": session,
+                "wall_ms": outcome.as_ref().ok().map(|done| done.wall_ms as u64),
+                "is_error": outcome.as_ref().map(|done| done.is_error).unwrap_or(true),
+                "transport_error": outcome.as_ref().err().map(|err| err.to_string()),
+                "ts": now_iso(),
+            }));
+        }
+    }
+
+    /// One endpoint attempt. With a session to keep, the request runs on its own thread and
+    /// this one sends each heartbeat as it falls due, until the answer arrives.
+    fn wait(
+        &mut self,
+        provider: &Provider,
+        messages: &[Value],
+        tools: &[Value],
+        limit: Duration,
+    ) -> Result<Completion, ProviderError> {
+        if self.next_due().is_none() {
+            return provider.complete_within(messages, tools, limit);
+        }
+        std::thread::scope(|scope| {
+            let (answer, answered) = std::sync::mpsc::channel();
+            let request = scope.spawn(move || {
+                // The receiver lives until this scope ends, so the send cannot fail.
+                let _ = answer.send(provider.complete_within(messages, tools, limit));
+            });
+            loop {
+                let until = self
+                    .next_due()
+                    .map_or(limit, |due| due.saturating_duration_since(Instant::now()));
+                match answered.recv_timeout(until) {
+                    Ok(outcome) => return outcome,
+                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => self.beat_due(),
+                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                        // The request thread ends without answering only when it panics, and
+                        // the panic is carried here, as it would surface without the split.
+                        match request.join() {
+                            Err(panic) => std::panic::resume_unwind(panic),
+                            Ok(()) => unreachable!("the request thread always sends its answer"),
+                        }
+                    }
+                }
+            }
+        })
+    }
+}
+
+/// The idle window a session reply names in `idle_timeout_secs`, at its top level or one
+/// level down. `None` when it names none, or zero: an in-process session reports no window,
+/// and a heartbeat cadence is never guessed.
+pub(crate) fn session_idle_timeout(outcome: &ToolOutcome) -> Option<Duration> {
+    let payload: Value = serde_json::from_str(outcome.text.trim()).ok()?;
+    let object = payload.as_object()?;
+    let named =
+        |object: &Map<String, Value>| object.get("idle_timeout_secs").and_then(Value::as_u64);
+    let secs = named(object).or_else(|| {
+        ["session", "result"].iter().find_map(|nested| {
+            object
+                .get(*nested)
+                .and_then(Value::as_object)
+                .and_then(named)
+        })
+    })?;
+    (secs > 0).then_some(Duration::from_secs(secs))
 }
 
 fn start_kin_session(
@@ -1327,6 +1513,11 @@ fn start_kin_session(
     match server.client.call_tool("kin_session_start", &arguments) {
         Ok(outcome) => {
             let session = extract_id(&outcome, &["session_id", "id"]);
+            server.session_ttl = if outcome.is_error {
+                None
+            } else {
+                session_idle_timeout(&outcome)
+            };
             writer.trace(json!({
                 "surface": "kin",
                 "server": server_name,
@@ -1336,10 +1527,12 @@ fn start_kin_session(
                 "wall_ms": outcome.wall_ms as u64,
                 "is_error": outcome.is_error,
                 "kin_session_id": session.clone(),
+                "idle_timeout_secs": server.session_ttl.map(|ttl| ttl.as_secs()),
             }))?;
             Ok(if outcome.is_error { None } else { session })
         }
         Err(err) => {
+            server.session_ttl = None;
             writer.trace(json!({
                 "surface": "kin",
                 "server": server_name,

--- a/crates/kin-agent/src/tests.rs
+++ b/crates/kin-agent/src/tests.rs
@@ -683,3 +683,37 @@ fn a_named_api_key_variable_that_is_unset_fails_loudly() {
     assert!(ProviderConfig::api_key_from_env(Some("KIN_AGENT_KEY_THAT_IS_NOT_SET")).is_err());
     assert_eq!(ProviderConfig::api_key_from_env(None).unwrap(), None);
 }
+
+/// The heartbeat cadence comes from the window the session reply itself names, at its top
+/// level or one level down, and a reply that names none, or zero, gets no cadence at all.
+#[test]
+fn a_session_reply_names_its_idle_window_or_none() {
+    use crate::mcp::ToolOutcome;
+    use crate::run::session_idle_timeout;
+    use std::time::Duration;
+    let reply = |text: &str| ToolOutcome {
+        text: text.to_string(),
+        is_error: false,
+        envelope: None,
+        negative: None,
+        unreadable: false,
+        wall_ms: 0,
+    };
+    assert_eq!(
+        session_idle_timeout(&reply(r#"{"session_id": "s", "idle_timeout_secs": 1800}"#)),
+        Some(Duration::from_secs(1800))
+    );
+    assert_eq!(
+        session_idle_timeout(&reply(
+            r#"{"session": {"session_id": "s", "idle_timeout_secs": 90}}"#
+        )),
+        Some(Duration::from_secs(90))
+    );
+    // An in-process session reports no window, and a zero is not one.
+    assert_eq!(session_idle_timeout(&reply(r#"{"session_id": "s"}"#)), None);
+    assert_eq!(
+        session_idle_timeout(&reply(r#"{"session_id": "s", "idle_timeout_secs": 0}"#)),
+        None
+    );
+    assert_eq!(session_idle_timeout(&reply("not json")), None);
+}

--- a/crates/kin-agent/tests/loop_integration.rs
+++ b/crates/kin-agent/tests/loop_integration.rs
@@ -89,6 +89,40 @@ fn serve_one(mut stream: TcpStream, response: &Value) -> Option<Value> {
     Some(request)
 }
 
+/// A scripted endpoint that holds each answer for its own delay after the request arrives,
+/// the way a local model prefilling a long prompt does. It returns the base URL and a handle
+/// that yields, per request, the wall-clock seconds it arrived and was answered.
+fn start_paced_endpoint(
+    script: Vec<(Duration, Value)>,
+) -> (String, std::thread::JoinHandle<Vec<(f64, f64)>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+    let port = listener.local_addr().unwrap().port();
+    let handle = std::thread::spawn(move || {
+        let mut in_flight = Vec::new();
+        for (delay, response) in script {
+            let Ok((stream, _)) = listener.accept() else {
+                break;
+            };
+            let arrived = wall_now();
+            std::thread::sleep(delay);
+            if serve_one(stream, &response).is_none() {
+                break;
+            }
+            in_flight.push((arrived, wall_now()));
+        }
+        in_flight
+    });
+    (format!("http://127.0.0.1:{port}/v1"), handle)
+}
+
+/// Seconds since the Unix epoch, the clock the scripted MCP server stamps its calls with.
+fn wall_now() -> f64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs_f64()
+}
+
 fn completion(content: &str, tool_calls: Option<Value>) -> Value {
     let mut message = json!({ "role": "assistant", "content": content });
     let finish = if tool_calls.is_some() {
@@ -177,9 +211,15 @@ fn write_fake_mcp_server(dir: &Path) -> PathBuf {
 }
 
 const FAKE_SERVER: &str = r#"#!/usr/bin/env python3
-import json, os, sys
+import json, os, sys, time
 
 LOG = sys.argv[1]
+
+# An idle window in whole seconds, when a test names one. The session is then reaped once no
+# call has reached it for that long, the way the daemon reaps a PID-less session, every later
+# call is refused saying so, and each call is logged with the wall clock it arrived at.
+TTL = int(sys.argv[2]) if len(sys.argv) > 2 else None
+SESSION = {"last": None, "reaped": False}
 
 # Staged operations per transaction, so a commit publishes what was staged rather than
 # answering yes to anything. The server runs with the repository as its cwd.
@@ -198,6 +238,8 @@ TOOLS = [
      "inputSchema": {"type": "object", "properties": {}}},
     {"name": "kin_session_end", "description": "End a session.",
      "inputSchema": {"type": "object", "properties": {}}},
+    {"name": "kin_session_heartbeat", "description": "Keep a session alive.",
+     "inputSchema": {"type": "object", "properties": {"session_id": {"type": "string"}}}},
     {"name": "kin_transaction_begin", "description": "Begin a transaction.",
      "inputSchema": {"type": "object", "properties": {}}},
     {"name": "kin_transaction_stage", "description": "Stage transaction operations.",
@@ -239,9 +281,21 @@ def call(name, args):
     operations = args.get("operations", [])
     if name == "kin_transaction_commit":
         operations = STAGED.get(args.get("transaction_id"), [])
+    row = {"tool": name, "args": args, "disk": disk_snapshot(operations)}
+    if TTL is not None:
+        now = time.monotonic()
+        if SESSION["last"] is not None and now - SESSION["last"] > TTL:
+            SESSION["reaped"] = True
+        if not SESSION["reaped"]:
+            SESSION["last"] = now
+        row["wall"] = time.time()
+        row["reaped"] = SESSION["reaped"]
     with open(LOG, "a") as fh:
-        fh.write(json.dumps({"tool": name, "args": args,
-                             "disk": disk_snapshot(operations)}) + "\n")
+        fh.write(json.dumps(row) + "\n")
+    if TTL is not None and SESSION["reaped"]:
+        return payload({"error": "session sess-fixture-1 was reaped after %d s idle; call "
+                                 "kin_session_start for a new one" % TTL,
+                        "_kin": ENVELOPE}, is_error=True)
     if name == "kin_artifact_list":
         # Pretty-printed with one row per artifact, like the real server, so a listing
         # asked for a large limit is large for the same reason the real one is.
@@ -264,7 +318,13 @@ def call(name, args):
         # Numbered, so a harness that re-opens its session gets a new id, as it does from
         # a daemon that was started again.
         SESSIONS.append(len(SESSIONS) + 1)
-        return payload({"session_id": "sess-fixture-%d" % SESSIONS[-1], "_kin": ENVELOPE})
+        reply = {"session_id": "sess-fixture-%d" % SESSIONS[-1], "_kin": ENVELOPE}
+        if TTL is not None:
+            reply["idle_timeout_secs"] = TTL
+        return payload(reply)
+    if name == "kin_session_heartbeat":
+        return payload({"session_id": args.get("session_id"), "status": "alive",
+                        "_kin": ENVELOPE})
     if name == "kin_transaction_begin":
         # src/stale.py: the first session is gone, as after a daemon restart; a re-opened
         # session is accepted. src/nobegin.py: every begin is refused the same way.
@@ -2181,6 +2241,124 @@ fn a_slow_endpoint_is_abandoned_at_the_deadline_and_the_run_says_deadline() {
     assert!(
         detail.contains("2 s deadline") && detail.contains("on the endpoint"),
         "the stop must say the deadline cut an endpoint wait: {detail}"
+    );
+}
+
+/// A model turn longer than the session's idle window does not cost the run its session. The
+/// runner heartbeats at a third of the window the session reply named while the request is
+/// in flight, and only then, so the Kin call after the long turn is still served.
+#[test]
+fn a_model_turn_longer_than_the_idle_window_keeps_the_session_alive() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = fixture_repo(dir.path());
+    let out = dir.path().join("out");
+    let server = write_fake_mcp_server(dir.path());
+    let log = dir.path().join("mcp-calls.jsonl");
+
+    // The scripted session is reaped after two idle seconds, and the second turn takes five.
+    let window_secs = 2u64;
+    let (base_url, endpoint) = start_paced_endpoint(vec![
+        (
+            Duration::ZERO,
+            completion(
+                "Let me look.",
+                Some(tool_call(
+                    "c1",
+                    "mcp__kin__semantic_locate",
+                    json!({ "query": "greet" }),
+                )),
+            ),
+        ),
+        (
+            Duration::from_secs(5),
+            completion(
+                "Reading it.",
+                Some(tool_call(
+                    "c2",
+                    "mcp__kin__get_entity_source",
+                    json!({ "entity": "greet" }),
+                )),
+            ),
+        ),
+        (
+            Duration::ZERO,
+            completion("greet returns a greeting.", None),
+        ),
+    ]);
+    let mut command = mcp_command(&server, &log);
+    command.push(window_secs.to_string());
+    let outcome = kin_agent::run(config(&repo, &out, &base_url, command)).expect("the run returns");
+    let in_flight = endpoint.join().expect("endpoint thread");
+
+    assert_eq!(outcome.status, ExitStatus::Success);
+    let calls = mcp_log(&log);
+    let tools: Vec<&str> = calls
+        .iter()
+        .map(|call| call["tool"].as_str().unwrap())
+        .collect();
+    assert!(
+        calls.iter().all(|call| call["reaped"] == json!(false)),
+        "no call may find the session reaped: {tools:?}"
+    );
+    let view = analyze(&read_jsonl(&outcome.transcript_path));
+    let read_id = view
+        .tool_uses
+        .iter()
+        .find(|(_, name, _)| name == "mcp__kin__get_entity_source")
+        .map(|(id, _, _)| id.clone())
+        .expect("the model asked for the source after the long turn");
+    let (_, _, read_failed) = view
+        .tool_results
+        .iter()
+        .find(|(id, _, _)| *id == read_id)
+        .expect("the read has a result");
+    assert!(
+        !read_failed,
+        "the Kin call after the long turn must be served"
+    );
+
+    let locate = tools
+        .iter()
+        .position(|tool| *tool == "semantic_locate")
+        .unwrap();
+    let read = tools
+        .iter()
+        .position(|tool| *tool == "get_entity_source")
+        .unwrap();
+    let inside = calls[locate..read]
+        .iter()
+        .filter(|call| call["tool"] == "kin_session_heartbeat")
+        .count();
+    assert!(
+        inside >= 3,
+        "a five-second turn against a two-second window needs heartbeats inside it: {tools:?}"
+    );
+    let beats: Vec<&Value> = calls
+        .iter()
+        .filter(|call| call["tool"] == "kin_session_heartbeat")
+        .collect();
+    for beat in &beats {
+        assert_eq!(beat["args"]["session_id"], "sess-fixture-1");
+        let at = beat["wall"].as_f64().unwrap();
+        assert!(
+            in_flight
+                .iter()
+                .any(|(arrived, answered)| *arrived <= at && at <= answered + 0.25),
+            "a heartbeat at {at} was sent while no request was in flight: {in_flight:?}"
+        );
+    }
+    let gaps: Vec<f64> = calls
+        .windows(2)
+        .map(|pair| pair[1]["wall"].as_f64().unwrap() - pair[0]["wall"].as_f64().unwrap())
+        .collect();
+    assert!(
+        gaps.iter().all(|gap| *gap < window_secs as f64),
+        "no idle gap may reach the window: {gaps:?}"
+    );
+    assert_eq!(
+        view.result["kin_agent"]["session_heartbeats"].as_u64(),
+        Some(beats.len() as u64),
+        "the result record counts every heartbeat"
     );
 }
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1363,6 +1363,12 @@ result the conversation cannot hold is withheld with a note, and the agent is as
 final answer before the next request would overflow. The result record carries the reason
 in `stop_reason` and `stop_detail`, and the budget under `context`.
 
+The run's Kin session stays open through a long model turn. Every Kin call refreshes it, and
+while a request to the endpoint is in flight the runner sends `kin_session_heartbeat` at a
+third of the idle window the session reply named in `idle_timeout_secs`, so a turn longer
+than that window does not cost the run its session. A reply that names no window gets no
+heartbeat rather than a guessed one. The result record counts them in `session_heartbeats`.
+
 The exit code is the run's outcome: `0` a final answer, `1` a harness error, `2` the
 tool-call budget was spent, `3` the deadline expired, `4` the endpoint was unreachable or
 answered with nothing usable, `5` the MCP server failed, `6` the run changed files that


### PR DESCRIPTION
`kin agent run` now keeps its Kin session alive while it waits on the model, so a turn longer than the session's idle window no longer costs the run its session.

The daemon reaps a PID-less session once it has sat idle for `idle_timeout_secs`, 1800 s by default (`crates/kin-daemon/src/session_registry.rs:85`), and every Kin call refreshes it. So the idle stretch in a run is one model turn. The longest gaps between consecutive Kin calls in this morning's three local-model runs were 454.7 s, 224.8 s and 384.7 s, all under a quarter of the window. At the default `--deadline 900` a turn cannot reach it, because every endpoint attempt gets at most what is left of the deadline. Past a deadline of about 1800 s it can: three 600 s request timeouts on one turn come to 1801.5 s, and a model that loads a 262144-token window prefills a near-full prompt for far longer than the 128K prompt that took about 450 s.

While a request is in flight, the runner now heartbeats every attached session at a third of the window its `kin_session_start` reply named in `idle_timeout_secs`, and it stops when the turn returns. A reply that names no window gets no heartbeat, so the cadence is never a guess. The request runs on a scoped thread so the loop can send the heartbeats meanwhile, and a panic in it resurfaces on the loop's own thread. Each heartbeat is a trace row, and the result record counts them in `session_heartbeats`. `docs/cli-reference.md` says so.

The scripted MCP server can now reap a session that no call reached within its window and refuse every later call, the way the daemon does. `a_model_turn_longer_than_the_idle_window_keeps_the_session_alive` stalls the second model turn 5 s against a 2 s window. It asserts that no call found the session reaped, the read after the stall was served, at least three heartbeats landed inside the stall, each one while a request was in flight, no gap between calls reached the window, and the record counts every heartbeat. `a_session_reply_names_its_idle_window_or_none` covers reading the window.

## Local verification

Hosted CI runs the suites. It does not run the falsification below, so here are the command and its output, at 7bcd10489, this branch rebased onto #1708 (which also edits `run.rs`; the one conflict was the scripted server's `kin_session_start` branch, now numbering sessions as #1708 does and naming the idle window as this change needs). The script applies one mutation at a time, runs the test written for it, and restores the file from HEAD.

```
$ .kin-coord/bin/heavy-slot.sh agentloopb kin -- bash falsify-heartbeat.sh
HEAD 7bcd10489602b1d7845fe8f67a201b11c355c931 on chore/lane-agentloopb-kin at 2026-09-11T11:10:56Z
STEP kin-agent: rc=0
test result: ok. 45 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
test result: ok. 25 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 5.09s
```

Each new test, with the behaviour it guards broken. The `#` lines name the mutation; the rest is output.

```
# never_beat: no session ever has a cadence
CASE never_beat: rc=101 (a falsified test must exit nonzero)
test a_model_turn_longer_than_the_idle_window_keeps_the_session_alive ... FAILED
no call may find the session reaped: ["kin_session_start", "semantic_locate", "get_entity_source", "kin_session_end"]
# constant_window: the window is a constant 1800 s instead of the reply's
CASE constant_window: rc=101 (a falsified test must exit nonzero)
test a_model_turn_longer_than_the_idle_window_keeps_the_session_alive ... FAILED
no call may find the session reaped: ["kin_session_start", "semantic_locate", "get_entity_source", "kin_session_end"]
# cadence_is_the_window: heartbeat once per window instead of a third of it
CASE cadence_is_the_window: rc=101 (a falsified test must exit nonzero)
test a_model_turn_longer_than_the_idle_window_keeps_the_session_alive ... FAILED
no call may find the session reaped: ["kin_session_start", "semantic_locate", "kin_session_heartbeat", "kin_session_heartbeat", "get_entity_source", "kin_session_end"]
# no_nested_window: the window is read only at the reply's top level
CASE no_nested_window: rc=101 (a falsified test must exit nonzero)
test tests::a_session_reply_names_its_idle_window_or_none ... FAILED
# zero_is_a_window: a zero window is taken as one
CASE zero_is_a_window: rc=101 (a falsified test must exit nonzero)
test tests::a_session_reply_names_its_idle_window_or_none ... FAILED
```

The third case is worth reading twice: heartbeating once per window still lets the session lapse, which is why the cadence is a third of it.

On the rebased head, `cargo fmt --all -- --check` exits 0, and the npm launcher job's policy step, extracted verbatim from ci.yml and run from this branch's root, ends `STEP OK`. Before the rebase, at 49db4059e, `bin/kin-precheck` ran the gates of ci.yml's check job, and hosted CI concluded all 48 checks on that head with none failed:

```
kin-precheck: repo=kin tree=.../agentloopb-kin sha=49db4059eed96bbbc59d3d89e166fcd7f4cbe7f3 branch=chore/lane-agentloopb-kin
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin 49db4059eed96bbbc59d3d89e166fcd7f4cbe7f3
```
