### PR TITLE
Run the admission off the runtime worker and answer /health without an authority load (FIR-3542)

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -798,6 +798,29 @@ pub(crate) fn cached_authority_admission(
     Ok((admission.roots, admission.policy))
 }
 
+/// The admission pair for the current publication when it is already held, and
+/// `None` when holding it would take a load.
+///
+/// For a caller that must answer now. A load is a whole-store open, and behind
+/// the load gate it also waits out any other caller's open: `/health` took
+/// 11,332.9 ms and 10,134.4 ms on a 3.5 GiB scratch store doing exactly that,
+/// past every client's health budget. The publication record it reads is one
+/// small file, so this costs what a cache hit costs.
+pub(crate) fn held_authority_admission(
+    state: &DaemonState,
+) -> Option<(
+    kin_model::RootBundle,
+    Option<kin_index::ResolvedAdmissionMatcher>,
+)> {
+    let backend = state.local_repository_backend()?;
+    let binding = state.local_repository_authority_binding().ok()?;
+    let published = read_local_publication_identity(&backend, binding.repository_id()).ok()?;
+    state
+        .projection_authority
+        .reuse_admission(&published)
+        .map(|admission| (admission.roots, admission.policy))
+}
+
 pub(crate) fn cached_authority_has_open_merge(
     state: &DaemonState,
 ) -> Result<bool, (StatusCode, String)> {
@@ -4161,6 +4184,27 @@ async fn raise_idle_timeout(
     .into_response()
 }
 
+/// [`measure_untracked_host_content`] for `/health`, which answers every
+/// client's liveness probe and must do so inside its budget. It never pays for
+/// or waits out an admission-pair load, and leaves the previous reading with its
+/// age when the pair for the current publication is not already held.
+async fn measure_untracked_host_content_now(state: &Arc<DaemonState>) {
+    let probing = Arc::clone(state);
+    match tokio::task::spawn_blocking(move || {
+        crate::loop_runner::refresh_untracked_reading_without_waiting(&probing)
+    })
+    .await
+    {
+        Ok(Ok(_)) => {}
+        Ok(Err(error)) => {
+            tracing::debug!(%error, "could not measure untracked host content")
+        }
+        Err(error) => {
+            tracing::debug!(%error, "the untracked host-content measurement did not run")
+        }
+    }
+}
+
 async fn health(
     Query(repo_query): Query<RepoQuery>,
     State(state): State<Arc<DaemonState>>,
@@ -4208,7 +4252,7 @@ async fn health(
     let coordination_event_persist_failures = state
         .coordination_event_persist_failures
         .load(std::sync::atomic::Ordering::Relaxed);
-    measure_untracked_host_content(&state).await;
+    measure_untracked_host_content_now(&state).await;
     let sampled_at = std::time::Instant::now();
     let background_passes = state.background_work.reports(sampled_at);
     let background_pass_stopped = state.background_work.any_stopped();
@@ -35150,6 +35194,55 @@ mod tests {
             .unwrap();
         let repeated_digest: [u8; 32] = Sha256::digest(&repeated).into();
         assert_eq!(repeated_digest, first_digest);
+    }
+
+    /// `/health` answers while another caller holds the admission-pair load.
+    ///
+    /// Measured on a 3.5 GiB scratch store: `/health` took 11,332.9 ms and
+    /// 10,134.4 ms waiting on that load, past the client's 2 s health budget, so
+    /// a daemon that was only busy read as one that did not answer. The load
+    /// gate is held on another thread here, as an open in flight holds it, with
+    /// the pair cold, which is the state a moved publication leaves.
+    ///
+    /// Breaking it: measure through the waiting refresh again, and this waits
+    /// for the gate.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn health_answers_while_the_admission_pair_is_loading() {
+        let state = test_state();
+        let (held_tx, held_rx) = std::sync::mpsc::channel::<()>();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let gate_state = Arc::clone(&state);
+        let holder = std::thread::spawn(move || {
+            let _gate = lock_recover(&gate_state.projection_authority.load_gate);
+            held_tx.send(()).unwrap();
+            let _ = release_rx.recv_timeout(Duration::from_secs(4));
+        });
+        held_rx.recv().unwrap();
+
+        let started = std::time::Instant::now();
+        let response = router(Arc::clone(&state))
+            .oneshot(Request::get("/health").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let waited = started.elapsed();
+        let _ = release_tx.send(());
+        holder.join().unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(
+            waited < Duration::from_secs(2),
+            "/health waited {waited:?} on another caller's admission-pair load"
+        );
+
+        // Non-vacuity: this state does reach the pair. With the gate free, the
+        // waiting refresh loads it, so the answer above was fast because
+        // `/health` did not wait, not because it had nothing to wait for.
+        let loads = state.projection_authority.loads();
+        crate::loop_runner::refresh_untracked_reading(&state).unwrap();
+        assert!(
+            state.projection_authority.loads() > loads,
+            "the waiting refresh must load the admission pair on this state"
+        );
     }
 
     #[tokio::test]

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -632,6 +632,24 @@ pub(crate) fn current_authority_admission(
 /// reading still being current enough, or a daemon whose graph is its own write
 /// authority and whose checkout is therefore not evidence about anything.
 pub(crate) fn refresh_untracked_reading(state: &DaemonState) -> Result<bool> {
+    refresh_untracked_reading_with(state, true)
+}
+
+/// [`refresh_untracked_reading`] for a caller that must answer now.
+///
+/// When the admission pair for the current publication is not already held,
+/// the reading keeps the age it has rather than this call paying for, or
+/// waiting out, a whole-store open to refresh it. Every surface judges the
+/// count by that age, so an older reading is disclosed rather than hidden.
+/// `/health` is the caller: a client's probe budget there is two seconds.
+pub(crate) fn refresh_untracked_reading_without_waiting(state: &DaemonState) -> Result<bool> {
+    refresh_untracked_reading_with(state, false)
+}
+
+fn refresh_untracked_reading_with(
+    state: &DaemonState,
+    wait_for_admission_pair: bool,
+) -> Result<bool> {
     // A graph-authority daemon does not scan a projected checkout in the first
     // place, so host paths there are not content anything failed to admit and
     // counting them would manufacture a disclosure out of the projection.
@@ -651,7 +669,14 @@ pub(crate) fn refresh_untracked_reading(state: &DaemonState) -> Result<bool> {
         return Ok(false);
     }
     let working_dir = state.layout.working_dir();
-    let (_roots, policy) = current_authority_admission(state)?;
+    let policy = if wait_for_admission_pair {
+        current_authority_admission(state)?.1
+    } else {
+        match crate::api::held_authority_admission(state) {
+            Some((_roots, policy)) => policy,
+            None => return Ok(false),
+        }
+    };
     let previous = state.graph.resolved_tree();
     let tracked_paths = previous
         .artifacts_by_path()
@@ -1176,7 +1201,66 @@ fn exact_tree_admission_once(
 /// authority and the observation is planned once more, against the tree
 /// authority actually holds. Once, not in a loop: a second refusal goes back to
 /// the caller and its retry ladder like any other.
+///
+/// The whole of it runs through [`off_the_runtime_worker`]: a publication opens
+/// repository authority end to end, and holding a runtime worker for that long
+/// is how a daemon in the middle of an admission stopped answering `/readiness`.
 fn exact_tree_admission(
+    state: &DaemonState,
+    observation: Option<&BTreeSet<RepoPath>>,
+    publication: TreePublication,
+) -> Result<ExactTreeAdmission> {
+    off_the_runtime_worker(|| {
+        #[cfg(test)]
+        pause_admission_for_test(state);
+        exact_tree_admission_on_this_thread(state, observation, publication)
+    })
+}
+
+/// Run synchronous work that can hold this thread for seconds or minutes
+/// without holding the runtime worker it was called on.
+///
+/// A complete exact-tree admission publishes to repository authority, and the
+/// publication opens the whole store: 78.5 s and 121.9 s on a 3.5 GiB scratch
+/// store, 21 to 32 s a round on the founder's. Inline on a runtime worker it
+/// keeps whatever the scheduler queued on that worker for the whole time, and a
+/// worker's LIFO slot is not stealable, so a daemon in an admission could leave
+/// its listener unpolled: measured, every new connection to `/readiness` waited
+/// out the admission, two 60 s timeouts and then an answer as the publication
+/// finished. `block_in_place` hands the worker's queue to a replacement thread
+/// before the work starts. On a current-thread runtime, where it would refuse
+/// and every task shares the one thread anyway, and off any runtime, including
+/// a blocking-pool thread, the work runs directly.
+pub(crate) fn off_the_runtime_worker<R>(work: impl FnOnce() -> R) -> R {
+    match tokio::runtime::Handle::try_current().map(|handle| handle.runtime_flavor()) {
+        Ok(tokio::runtime::RuntimeFlavor::MultiThread) => tokio::task::block_in_place(work),
+        _ => work(),
+    }
+}
+
+/// A pause an admission takes before it starts, for the one daemon state a
+/// test names, so a test can hold an admission open without a store large
+/// enough to make it slow. Keyed by the state's address, so no other test's
+/// admission waits on it.
+#[cfg(test)]
+static ADMISSION_PAUSE_FOR_TEST: std::sync::Mutex<Option<(usize, Duration)>> =
+    std::sync::Mutex::new(None);
+
+#[cfg(test)]
+fn pause_admission_for_test(state: &DaemonState) {
+    let owner = state as *const DaemonState as usize;
+    let named = *ADMISSION_PAUSE_FOR_TEST
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some((named_state, pause)) = named {
+        if named_state == owner {
+            std::thread::sleep(pause);
+        }
+    }
+}
+
+/// [`exact_tree_admission`] on whichever thread it was handed.
+fn exact_tree_admission_on_this_thread(
     state: &DaemonState,
     observation: Option<&BTreeSet<RepoPath>>,
     publication: TreePublication,
@@ -4793,6 +4877,7 @@ mod tests {
     include!("loop_runner/tests/startup_recovery.rs");
     include!("loop_runner/tests/enrichment_churn.rs");
     include!("loop_runner/tests/authority_split.rs");
+    include!("loop_runner/tests/admission_worker.rs");
 
     #[test]
     fn partial_c_disclosure_persists_and_only_clean_outcomes_settle() {

--- a/crates/kin-daemon/src/loop_runner/tests/admission_worker.rs
+++ b/crates/kin-daemon/src/loop_runner/tests/admission_worker.rs
@@ -1,0 +1,72 @@
+// An admission and the runtime worker it runs on. Included into
+// `loop_runner::tests`.
+
+/// Clears the admission pause however the case ends, so a failing assertion
+/// cannot leave a pause armed for an address a later allocation might reuse.
+struct AdmissionPauseGuard;
+
+impl Drop for AdmissionPauseGuard {
+    fn drop(&mut self) {
+        *ADMISSION_PAUSE_FOR_TEST
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+    }
+}
+
+/// An admission does not hold the runtime worker it runs on.
+///
+/// A multi-thread runtime with one worker, an admission held open for two
+/// seconds through the test pause, and a task spawned while it is held. That
+/// task can only run on a worker: if the admission kept its worker, the task
+/// waits the pause out; handed off, it runs at once. Measured before this on a
+/// real daemon over a 3.5 GiB store, a worker held by the reconcile loop's
+/// admission for 121.9 s left every new connection to `/readiness` unanswered
+/// until the publication finished.
+///
+/// Breaking it: run the admission inline on its worker again, and the spawned
+/// task waits for the whole pause.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn an_admission_does_not_hold_the_runtime_worker_it_runs_on() {
+    let parent = tempfile::tempdir().unwrap();
+    let repo = tempfile::tempdir_in(parent.path()).unwrap();
+    let state = open_test_state(&repo);
+    state.is_initialized.store(true, Ordering::Relaxed);
+    std::fs::write(
+        state.layout.working_dir().join("held.py"),
+        "def held():\n    return 1\n",
+    )
+    .unwrap();
+
+    let _guard = AdmissionPauseGuard;
+    *ADMISSION_PAUSE_FOR_TEST
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) =
+        Some((Arc::as_ptr(&state) as usize, Duration::from_secs(2)));
+    let admitting = {
+        let state = Arc::clone(&state);
+        tokio::spawn(async move {
+            exact_tree_admission(&state, None, TreePublication::Standalone)
+                .map(|admission| admission.changed_paths.len())
+        })
+    };
+
+    // The test's own thread is blocked on purpose: it is not a runtime worker,
+    // and a runtime timer would need the very worker this case is about.
+    std::thread::sleep(Duration::from_millis(400));
+    let spawned = std::time::Instant::now();
+    let answered = tokio::spawn(async { std::time::Instant::now() })
+        .await
+        .unwrap();
+    let waited = answered.saturating_duration_since(spawned);
+    let admitted = admitting.await.unwrap();
+
+    assert!(
+        admitted.is_ok(),
+        "the admission itself must succeed, or this case measures a failure: {admitted:?}"
+    );
+    assert!(
+        waited < Duration::from_millis(1000),
+        "a task spawned while an admission ran waited {waited:?} for a worker, so the admission \
+         is holding the runtime worker it runs on"
+    );
+}


### PR DESCRIPTION
## What

The daemon now answers `/readiness` and `/health` while it runs an admission. The reconcile loop's admission no longer holds the runtime worker it runs on, and `/health` no longer waits on a whole-store authority load to refresh its untracked-content reading.

FIR-3542, the second of two changes. The first (the `kin status` client) is kin#1710.

## Why

A daemon in the middle of a long admission stopped answering its liveness probes, so every client read it as not answering. Measured on an APFS clone of a 3.5 GiB kin-db store with a standalone 0.7.12 daemon, polling `/readiness` and `/health` with a 60 s timeout:

```text
run 1, 64 files edited at 10:22:45Z; the loop's publication ran 10:22:46Z to 10:24:48Z (publish_workspace_admission elapsed_ms=121932)
  /readiness 10:22:45Z  TimeoutError at 60,001.6 ms   (TCP connect answered in 0.5 ms)
  /readiness 10:23:45Z  TimeoutError at 60,003.0 ms
  /readiness 10:24:46Z  200 in 5,802.3 ms, then 115 answers under a millisecond
run 2, the same edit; publication 78,528 ms
  /readiness stalled once, 6,448.5 ms; /health stalled once, 10,134.4 ms (run 1's first /health: 11,332.9 ms)
```

A thread sample 8 s into run 2's admission names the hold. A runtime worker (`multi_thread::worker::run -> Context::run_task`) spent all 2,178 samples of a 3 s window inside:

```text
kin_daemon::loop_runner::run_loop_armed::{closure}
kin_daemon::loop_runner::exact_tree_admission
kin_daemon::mcp_commit::timed_commit_phase
kin_daemon::loop_runner::publish_exact_workspace_tree
kin_core::repository_authority::open_persisted_local_repository_authority
kin_db::storage::repository::RepositoryAuthorityManager::open_with_payload_stats
```

The loop holds `coordination_gate` and `reconciler.write()` across that call. A worker blocked in synchronous code keeps whatever the scheduler queued on it, and its LIFO slot is not stealable, so whether the listener's task is stranded is scheduling luck: run 1 lost every new connection for two minutes, run 2 lost six seconds. `/health` is a second, separate wait: it refreshes its untracked-content reading through the admission-pair cache, and on a cold pair that is a whole-store open behind the cache's load gate.

## How

`crates/kin-daemon/src/loop_runner.rs`:

- `exact_tree_admission` runs its body, now `exact_tree_admission_on_this_thread`, through `off_the_runtime_worker`. On a multi-thread runtime that is `tokio::task::block_in_place`, which hands the worker's queue to a replacement thread before the work starts. On a current-thread runtime, where `block_in_place` refuses and every task shares the one thread anyway, and off any runtime, including a blocking-pool thread, the work runs directly (checked in tokio 1.53.1's `block_in_place`: a blocking-pool thread is not entered, so it runs the closure). Every caller of `exact_tree_admission` gets this: the ambient loop, the explicit seam behind `/admit` and commit, and the startup paths.
- `refresh_untracked_reading_without_waiting`: the same measurement, except that when the admission pair for the current publication is not already held it keeps the previous reading and its age.
- A `#[cfg(test)]` pause, keyed by the daemon state's address, so a test can hold an admission open.

`crates/kin-daemon/src/api.rs`: `held_authority_admission` reads the pair only from the cache (the publication record it checks is one small file), and `/health` calls `measure_untracked_host_content_now`, which uses it. `daemon_health_snapshot`, the MCP envelope's health, keeps the refresh that waits, because it certifies absences from that reading.

## Tests

- `loop_runner::tests::an_admission_does_not_hold_the_runtime_worker_it_runs_on`: a multi-thread runtime with one worker, an admission held open for 2 s by the test pause, and a task spawned while it is held. The task has to run within 1 s. If the admission kept its worker, the task waits the pause out.
- `api::tests::health_answers_while_the_admission_pair_is_loading`: the load gate held on another thread, the pair cold, and `/health` has to answer within 2 s. Then, with the gate free, the waiting refresh loads the pair on the same state, so the fast answer is not a path that had nothing to wait for.

On this head, `ca30563b8` (rebased onto main at `a2e742ad7`): the two new tests with the existing `/health` test, then the whole `loop_runner::tests` module one test at a time.

```text
$ KIN_EMBED_BACKEND=cpu .kin-coord/bin/heavy-slot.sh daemonlifeb2 kin -- bash -c 'cargo test -p kin-daemon --lib -- loop_runner::tests::an_admission_does_not_hold api::tests::health_answers_while api::tests::health_returns_ok && cargo test -p kin-daemon --lib -- loop_runner::tests --test-threads 1'
test api::tests::health_answers_while_the_admission_pair_is_loading ... ok
test api::tests::health_returns_ok_with_extended_fields ... ok
test loop_runner::tests::an_admission_does_not_hold_the_runtime_worker_it_runs_on ... ok
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 1652 filtered out; finished in 2.86s
test result: ok. 154 passed; 0 failed; 0 ignored; 0 measured; 1501 filtered out; finished in 102.49s
```

One test at a time because `a_round_that_stands_down_publishes_the_footprint_standing` shares a process-wide publish clock, by its own doc comment, and failed once when the module ran on parallel threads ("a round that stood down must have published a standing"); alone on the same head it passed three times of three. CI runs the unit suites under nextest, one process per test, so it does not share that state there.

## Falsification

```text
$ bash falsify-arm2.sh <label> <file> kin-daemon <test path> <arm dir>
  (one exact swap, then heavy-slot.sh daemonlifeb2 kin -- cargo test -p kin-daemon --lib -- <test path> --exact, then swap back and check the sha256)

G1  off_the_runtime_worker runs the work inline on a multi-thread runtime
    `Ok(tokio::runtime::RuntimeFlavor::MultiThread) => work(),`
    RED  loop_runner::tests::an_admission_does_not_hold_the_runtime_worker_it_runs_on
    panicked at crates/kin-daemon/src/loop_runner/tests/admission_worker.rs:67:5:
    a task spawned while an admission ran waited 1.788461792s for a worker, so the admission is holding the runtime worker it runs on
G2  /health measures through the waiting refresh again
    `measure_untracked_host_content(&state).await;`
    RED  api::tests::health_answers_while_the_admission_pair_is_loading
    panicked at crates/kin-daemon/src/api.rs:35232:9:
    /health waited 4.023118875s on another caller's admission-pair load
```

## Precheck

```text
$ KIN_EMBED_BACKEND=cpu .kin-coord/bin/heavy-slot.sh daemonlifeb2 kin -- bin/kin-precheck kin --repo-dir kin=<lane worktree>
kin-precheck: repo=kin tree=<lane worktree> sha=ca30563b8f1ff2981960db4ca3ed4d4086124f31 branch=chore/lane-daemonlifeb2-kin
kin-precheck: behind origin/main 1 commit(s); the gate list below is the one on THIS tree, not the one on main
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:check-quarantine.py            python3 scripts/check-quarantine.py
         (and 18 more guard and node gates, all PASS)
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin ca30563b8f1ff2981960db4ca3ed4d4086124f31
```

The one commit behind is kin#1708, which touches none of this change's files.

## Not in this change

- The cached admission pair still loads under a synchronous lock from other async handlers; those loads are one per publication and are not on the liveness path this measured.
- The kill wording and the shutdown that force-exits at its 25 s grace are FIR-3549, next.
