### PR TITLE
Serve blame and history from the daemon's held authority (FIR-3547)

### DIFF
--- a/crates/kin-cli/src/commands/blame.rs
+++ b/crates/kin-cli/src/commands/blame.rs
@@ -5,6 +5,9 @@ use anyhow::{Context, Result};
 use kin_model::ChangeStore;
 use serde::{Deserialize, Serialize};
 
+use super::ref_lookup;
+use super::repository_authority::RequestRepositoryAuthority;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BlameRequest {
     pub entity: String,
@@ -55,31 +58,43 @@ async fn run_daemon_blame(
     client.blame(request).await.context("daemon blame failed")
 }
 
+/// Blame with a binding this call opens for itself when its ref needs
+/// repository authority. A caller that already holds an authority, as the
+/// daemon does, uses [`execute_blame_request_with`].
 pub fn execute_blame_request(
     binding: &kin_core::LocalRepositoryAuthorityBinding,
     graph: &kin_db::InMemoryGraph,
     request: &BlameRequest,
 ) -> Result<BlameResponse> {
-    let head =
-        crate::commands::ref_lookup::resolve_ref(graph, binding, request.reference.as_deref())?;
-    let (target, revisions) = match request.reference.as_deref() {
-        Some(_) => crate::commands::ref_lookup::resolve_entity_with_revisions_at(
-            graph,
-            &request.entity,
-            &head,
-            request.reference.as_deref(),
-        )?,
-        None => {
-            let target = crate::commands::ref_lookup::resolve_entity_query(graph, &request.entity)?;
-            let revisions = crate::commands::ref_lookup::resolve_entity_revisions_at(
-                graph,
-                &target.id,
-                &head,
-                request.reference.as_deref(),
-            )?;
-            (target, revisions)
-        }
-    };
+    execute_blame_request_with(
+        &RequestRepositoryAuthority::pinned(binding.clone()),
+        graph,
+        request,
+    )
+}
+
+/// Blame an entity, resolving its ref through `authority`.
+///
+/// The daemon passes the authority it keeps for the current publication, so
+/// `HEAD` costs this answer nothing that grows with the store, and the answer
+/// names an open only when one happened on the thread that built it.
+pub fn execute_blame_request_with(
+    authority: &RequestRepositoryAuthority,
+    graph: &kin_db::InMemoryGraph,
+    request: &BlameRequest,
+) -> Result<BlameResponse> {
+    let head = ref_lookup::resolve_ref_through(graph, authority, request.reference.as_deref())?;
+    let ref_lookup::EntityTimeline {
+        target,
+        revisions,
+        pointer,
+        choice,
+    } = ref_lookup::resolve_entity_timeline(
+        graph,
+        &request.entity,
+        &head.change_id,
+        request.reference.as_deref(),
+    )?;
     // Trimmed by default: the revisions where THIS entity's own text moved.
     //
     // Blame's job is attribution, and the untrimmed list answers a different
@@ -93,17 +108,24 @@ pub fn execute_blame_request(
     let (revisions, withheld) = if request.all_revisions {
         (revisions, Vec::new())
     } else {
-        crate::commands::ref_lookup::split_own_revisions(&revisions)
+        ref_lookup::split_own_revisions(&revisions)
     };
     let mut lines = Vec::new();
     lines.push(format!(
-        "Blame for '{}' ({:?}, {}) at {}:",
-        target.name, target.kind, target.language, head
+        "Blame for '{}' ({:?}, {}){} at {}:",
+        target.name,
+        target.kind,
+        target.language,
+        ref_lookup::pointer_suffix(&pointer),
+        head.change_id
     ));
+    lines.extend(choice);
     lines.push(String::new());
 
     if revisions.is_empty() {
         lines.push("  No history recorded for this entity.".to_string());
+        let closing = ref_lookup::closing_notes(&lines, head.authority_open);
+        lines.extend(closing);
         return Ok(BlameResponse { lines });
     }
 
@@ -131,14 +153,21 @@ pub fn execute_blame_request(
             ));
             continue;
         };
+        // The subject line, the way `kin history` and `git log --oneline` print
+        // a change. The whole message put a pull request's entire body under one
+        // row and pushed every later revision off the screen.
         lines.push(format!(
             "{:<36}  {:<36}  {:<20}  {:<15}  {}",
-            revision.revision_id, change.id, change.timestamp, change.author, change.message,
+            revision.revision_id,
+            change.id,
+            change.timestamp,
+            change.author,
+            ref_lookup::subject_line(&change.message),
         ));
     }
 
     lines.push(format!("\n{} version(s) found.", revisions.len()));
-    if let Some(line) = crate::commands::ref_lookup::withheld_line(withheld.len()) {
+    if let Some(line) = ref_lookup::withheld_line(withheld.len()) {
         lines.push(line);
     }
     if unreadable > 0 {
@@ -148,7 +177,7 @@ pub fn execute_blame_request(
         ));
     }
 
-    lines.push(format!("\nState at {}:", head));
+    lines.push(format!("\nState at {}:", head.change_id));
     lines.push(format!("  Signature: {}", target.signature));
     lines.push(format!("  Visibility: {:?}", target.visibility));
     if let Some(ref file) = target.file_origin {
@@ -157,6 +186,8 @@ pub fn execute_blame_request(
     if let Some(ref doc) = target.doc_summary {
         lines.push(format!("  Doc: {}", doc));
     }
+    let closing = ref_lookup::closing_notes(&lines, head.authority_open);
+    lines.extend(closing);
 
     Ok(BlameResponse { lines })
 }

--- a/crates/kin-cli/src/commands/history.rs
+++ b/crates/kin-cli/src/commands/history.rs
@@ -5,6 +5,9 @@ use anyhow::{Context, Result};
 use kin_model::ChangeStore;
 use serde::{Deserialize, Serialize};
 
+use super::ref_lookup;
+use super::repository_authority::RequestRepositoryAuthority;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HistoryRequest {
     pub entity: String,
@@ -26,18 +29,6 @@ pub struct HistoryResponse {
 /// change range back to the operator.
 fn abbreviate_id(id: &str) -> String {
     id.chars().take(12).collect()
-}
-
-/// The first non-empty line of a commit message. Git calls this the subject and
-/// renders exactly this in `--oneline`; the body belongs in a detail view, not
-/// in a one-row-per-revision list.
-fn subject_line(message: &str) -> String {
-    message
-        .lines()
-        .map(str::trim)
-        .find(|line| !line.is_empty())
-        .unwrap_or("(no message)")
-        .to_string()
 }
 
 /// `YYYY-MM-DD` from an ISO-8601 timestamp. The clock time costs eleven columns
@@ -134,42 +125,56 @@ async fn run_daemon_history(
         .context("daemon history failed")
 }
 
+/// History with a binding this call opens for itself when its ref needs
+/// repository authority. A caller that already holds an authority, as the
+/// daemon does, uses [`execute_history_request_with`].
 pub fn execute_history_request(
     binding: &kin_core::LocalRepositoryAuthorityBinding,
     graph: &kin_db::InMemoryGraph,
     request: &HistoryRequest,
 ) -> Result<HistoryResponse> {
-    let head =
-        crate::commands::ref_lookup::resolve_ref(graph, binding, request.reference.as_deref())?;
-    let (target, revisions) = match request.reference.as_deref() {
-        Some(_) => crate::commands::ref_lookup::resolve_entity_with_revisions_at(
-            graph,
-            &request.entity,
-            &head,
-            request.reference.as_deref(),
-        )?,
-        None => {
-            let target = crate::commands::ref_lookup::resolve_entity_query(graph, &request.entity)?;
-            let revisions = crate::commands::ref_lookup::resolve_entity_revisions_at(
-                graph,
-                &target.id,
-                &head,
-                request.reference.as_deref(),
-            )?;
-            (target, revisions)
-        }
-    };
+    execute_history_request_with(
+        &RequestRepositoryAuthority::pinned(binding.clone()),
+        graph,
+        request,
+    )
+}
+
+/// An entity's history, resolving its ref through `authority`.
+///
+/// The same resolution and the same revisions blame reads, from the same
+/// functions, so the two surfaces cannot disagree about which entity a name
+/// means or which revisions are its own.
+pub fn execute_history_request_with(
+    authority: &RequestRepositoryAuthority,
+    graph: &kin_db::InMemoryGraph,
+    request: &HistoryRequest,
+) -> Result<HistoryResponse> {
+    let head = ref_lookup::resolve_ref_through(graph, authority, request.reference.as_deref())?;
+    let ref_lookup::EntityTimeline {
+        target,
+        revisions,
+        pointer,
+        choice,
+    } = ref_lookup::resolve_entity_timeline(
+        graph,
+        &request.entity,
+        &head.change_id,
+        request.reference.as_deref(),
+    )?;
     // Identifiers are abbreviated and messages are reduced to their subject
     // line, the way `git log --oneline` does. Printing two full 64-character
     // hashes per row plus a whole commit body pushed every readable field off
     // the right edge and turned a three-entry history into a wall of hex.
     let mut lines = vec![format!(
-        "History for '{}' ({:?}, {}) at {}:",
+        "History for '{}' ({:?}, {}){} at {}:",
         target.name,
         target.kind,
         target.language,
-        abbreviate_id(&head.to_string())
+        ref_lookup::pointer_suffix(&pointer),
+        abbreviate_id(&head.change_id.to_string())
     )];
+    lines.extend(choice);
 
     if revisions.is_empty() {
         lines.push("  No history recorded".to_string());
@@ -179,7 +184,7 @@ pub fn execute_history_request(
         let (revisions, withheld) = if request.all_revisions {
             (revisions, Vec::new())
         } else {
-            crate::commands::ref_lookup::split_own_revisions(&revisions)
+            ref_lookup::split_own_revisions(&revisions)
         };
         let mut rows = Vec::with_capacity(revisions.len());
         for revision in &revisions {
@@ -188,7 +193,7 @@ pub fn execute_history_request(
                 Some(entry) => (
                     calendar_date(&entry.timestamp.to_string()),
                     author_name(&entry.author.to_string()),
-                    subject_line(&entry.message),
+                    ref_lookup::subject_line(&entry.message),
                 ),
                 None => ("?".to_string(), "?".to_string(), "unknown".to_string()),
             };
@@ -200,10 +205,12 @@ pub fn execute_history_request(
             });
         }
         lines.extend(render_revision_rows(&rows));
-        if let Some(line) = crate::commands::ref_lookup::withheld_line(withheld.len()) {
+        if let Some(line) = ref_lookup::withheld_line(withheld.len()) {
             lines.push(line);
         }
     }
+    let closing = ref_lookup::closing_notes(&lines, head.authority_open);
+    lines.extend(closing);
 
     Ok(HistoryResponse { lines })
 }

--- a/crates/kin-cli/src/commands/ref_grammar.rs
+++ b/crates/kin-cli/src/commands/ref_grammar.rs
@@ -60,35 +60,60 @@ const AMBIGUITY_PREVIEW: usize = 4;
 pub(crate) const UNRESOLVABLE: &str =
     "is not a ref, a semantic change or its unique prefix, an imported Git object, or HEAD";
 
-/// Repository authority, opened only if an arm of the grammar asks for it.
+/// Repository authority, reached only if an arm of the grammar asks for it.
 ///
 /// The two callers arrive differently and the difference is load-bearing.
 /// `kin diff` already holds an open lease, so re-opening would be waste. `kin
-/// blame --ref` holds only a binding, and `explicit_semantic_change_and_parent_
-/// hops_need_no_file_or_git_fallback` pins the property that a `kin:<id>` or
-/// `change:<id>` selector resolves from the graph alone: an explicit semantic
-/// change is graph-owned truth and reaching for the authority envelope to
-/// confirm it would be a file-first fallback on a path that does not need one.
+/// blame` and `kin history` hold a [`RequestRepositoryAuthority`]: the daemon's
+/// shared arm, which hands over the authority it keeps for the current
+/// publication, or a binding a one-shot caller opens for itself.
+/// `explicit_semantic_change_and_parent_hops_need_no_file_or_git_fallback` pins
+/// the property that a `kin:<id>` or `change:<id>` selector resolves from the
+/// graph alone: an explicit semantic change is graph-owned truth and reaching
+/// for the authority envelope to confirm it would be a file-first fallback on a
+/// path that does not need one.
 ///
 /// Opening eagerly here is what broke that test, and the test was right.
+///
+/// [`RequestRepositoryAuthority`]: super::repository_authority::RequestRepositoryAuthority
 pub(crate) enum Authority<'a> {
     Held {
         lease: &'a kin_db::AuthorityReadLease<kin_db::RepositoryAuthorityState>,
         workspace_id: &'a WorkspaceId,
     },
     Deferred {
-        binding: &'a kin_core::LocalRepositoryAuthorityBinding,
+        source: &'a super::repository_authority::RequestRepositoryAuthority,
         opened: std::cell::OnceCell<OpenedAuthority>,
     },
 }
 
-/// An authority this module opened itself, kept alive beside its lease.
+/// An authority this module reached for, kept alive beside its lease.
 pub(crate) struct OpenedAuthority {
     lease: kin_db::AuthorityReadLease<kin_db::RepositoryAuthorityState>,
     workspace_id: WorkspaceId,
     // Held so the manager outlives the lease taken from it, rather than relying
     // on the lease's Arc alone.
-    _authority: super::repository_authority::ActiveRepositoryAuthority,
+    _authority: std::sync::Arc<super::repository_authority::ActiveRepositoryAuthority>,
+    cost: AuthorityOpen,
+}
+
+/// What reaching repository authority cost the thread that resolved a selector.
+///
+/// Measured where the authority is handed over rather than inferred afterwards,
+/// because the two ways of getting one differ by the size of the store: a server
+/// that already holds the current publication hands it over at once, and a
+/// whole-store open re-verifies every persisted body.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AuthorityOpen {
+    /// How long handing the authority over took.
+    pub(crate) waited: std::time::Duration,
+    /// Whether this thread performed a whole-store open to get it, read off the
+    /// per-thread counter the tests bound, rather than being handed one that was
+    /// already open.
+    pub(crate) opened_here: bool,
+    /// Whether the authority came from a server that keeps it for its current
+    /// publication, so an open paid for here is not paid again by the next read.
+    pub(crate) shared: bool,
 }
 
 impl<'a> Authority<'a> {
@@ -102,10 +127,23 @@ impl<'a> Authority<'a> {
         }
     }
 
-    pub(crate) fn deferred(binding: &'a kin_core::LocalRepositoryAuthorityBinding) -> Self {
+    pub(crate) fn deferred(
+        source: &'a super::repository_authority::RequestRepositoryAuthority,
+    ) -> Self {
         Self::Deferred {
-            binding,
+            source,
             opened: std::cell::OnceCell::new(),
+        }
+    }
+
+    /// What reaching the authority cost, when an arm of the grammar needed it.
+    ///
+    /// `None` for a lease the caller already held, and for a selector the graph
+    /// answered alone, since neither reached for anything.
+    pub(crate) fn open_cost(&self) -> Option<AuthorityOpen> {
+        match self {
+            Self::Held { .. } => None,
+            Self::Deferred { opened, .. } => opened.get().map(|held| held.cost),
         }
     }
 
@@ -121,22 +159,31 @@ impl<'a> Authority<'a> {
                 lease,
                 workspace_id,
             } => Ok((lease, workspace_id)),
-            Self::Deferred { binding, opened } => {
+            Self::Deferred { source, opened } => {
                 if opened.get().is_none() {
-                    let authority =
-                        super::repository_authority::ActiveRepositoryAuthority::open(binding)
-                            .map_err(|error| {
-                                ref_error(
+                    let opens_before =
+                        super::repository_authority::repository_authority_opens_on_this_thread();
+                    let started = std::time::Instant::now();
+                    let authority = source.open().map_err(|error| {
+                        ref_error(
                             original,
                             format!("this repository's authority could not be opened: {error:#}"),
                         )
-                            })?;
+                    })?;
+                    let cost = AuthorityOpen {
+                        waited: started.elapsed(),
+                        opened_here:
+                            super::repository_authority::repository_authority_opens_on_this_thread()
+                                > opens_before,
+                        shared: source.is_shared(),
+                    };
                     let lease = authority.manager().read_authority();
                     let workspace_id = authority.workspace_id.clone();
                     let _ = opened.set(OpenedAuthority {
                         lease,
                         workspace_id,
                         _authority: authority,
+                        cost,
                     });
                 }
                 let held = opened

--- a/crates/kin-cli/src/commands/ref_lookup.rs
+++ b/crates/kin-cli/src/commands/ref_lookup.rs
@@ -1,8 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-use anyhow::{anyhow, bail, Result};
-use kin_model::{Entity, EntityFilter, EntityId, EntityRevision, GraphStore, SemanticChangeId};
+use std::collections::HashSet;
+
+use anyhow::{anyhow, Result};
+use kin_model::{Entity, EntityId, EntityRevision, GraphStore, SemanticChangeId};
+
+use super::ref_grammar::AuthorityOpen;
+use super::repository_authority::RequestRepositoryAuthority;
+use crate::entity_identity::{EntityPointer, EntityResolution, IdentityQualifiers, PinSpelling};
 
 /// A reference did not resolve through repository-v6 authority.
 #[derive(Debug)]
@@ -83,6 +89,35 @@ fn projection_error(
         resolved: resolved.to_string(),
         reason: reason.to_string(),
     })
+}
+
+/// A query that named no one entity, and the answer that says why.
+///
+/// Typed so the daemon answers it as the caller's news rather than as an
+/// internal fault: the graph is sound, and the question needs a name the graph
+/// holds or a pin that picks one entity out of several.
+#[derive(Debug)]
+pub struct EntityQueryRefusal {
+    /// What the query reached and how to name one entity, ready to print.
+    pub lines: Vec<String>,
+    /// Whether the name reached nothing at all, rather than several entities or
+    /// entities every pin excluded.
+    pub absent: bool,
+}
+
+impl std::fmt::Display for EntityQueryRefusal {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.lines.join("\n"))
+    }
+}
+
+impl std::error::Error for EntityQueryRefusal {}
+
+/// The refusal inside an error, for a handler classifying it.
+pub fn entity_query_refusal(error: &anyhow::Error) -> Option<&EntityQueryRefusal> {
+    error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<EntityQueryRefusal>())
 }
 
 /// Split revisions into those that changed THIS entity and those that did not.
@@ -168,6 +203,14 @@ pub fn is_ref_resolution_error(error: &anyhow::Error) -> bool {
         .any(|cause| cause.downcast_ref::<RefResolutionError>().is_some())
 }
 
+/// A ref resolved for blame or history, and what reaching authority cost.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ResolvedHead {
+    pub(crate) change_id: SemanticChangeId,
+    /// Set when an arm of the grammar had to reach repository authority.
+    pub(crate) authority_open: Option<AuthorityOpen>,
+}
+
 /// Resolve a ref for `kin blame --ref` and `kin history --ref`.
 ///
 /// The grammar itself lives in [`super::ref_grammar`], which `kin diff` calls
@@ -187,14 +230,34 @@ where
     G: GraphStore,
     <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
 {
+    let authority = RequestRepositoryAuthority::pinned(binding.clone());
+    resolve_ref_through(graph, &authority, reference).map(|head| head.change_id)
+}
+
+/// [`resolve_ref`] through whatever authority the caller has.
+///
+/// The daemon's blame and history routes pass the authority it keeps for the
+/// current publication, so resolving `HEAD` costs a request nothing that grows
+/// with the store. Each request used to open the whole repository authority
+/// from disk for itself, decoding and re-verifying every persisted body to read
+/// one workspace pointer.
+pub(crate) fn resolve_ref_through<G>(
+    graph: &G,
+    authority: &RequestRepositoryAuthority,
+    reference: Option<&str>,
+) -> Result<ResolvedHead>
+where
+    G: GraphStore,
+    <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
+{
     let reference = reference.unwrap_or("HEAD");
     // Deferred rather than opened here. An explicit `kin:<id>` or `change:<id>`
     // is graph-owned truth and resolves without repository authority at all;
     // opening it eagerly turned that into a hard requirement and broke
     // `explicit_semantic_change_and_parent_hops_need_no_file_or_git_fallback`,
     // which is pinning exactly the right thing.
-    let authority = super::ref_grammar::Authority::deferred(binding);
-    let resolved = super::ref_grammar::resolve(&authority, graph, reference)
+    let deferred = super::ref_grammar::Authority::deferred(authority);
+    let resolved = super::ref_grammar::resolve(&deferred, graph, reference)
         .map_err(|error| ref_error(reference, format!("{error:#}")))?;
 
     if graph
@@ -211,88 +274,204 @@ where
             ),
         ));
     }
-    Ok(resolved.change_id)
-}
-
-pub(crate) fn resolve_entity_query<G>(graph: &G, entity_query: &str) -> Result<Entity>
-where
-    G: GraphStore,
-    <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
-{
-    let filter = EntityFilter {
-        name_pattern: Some(entity_query.to_string()),
-        ..Default::default()
-    };
-    let entities = graph
-        .query_entities(&filter)
-        .map_err(|error| anyhow!(error.to_string()))?;
-    choose_entity_match(entities, entity_query).or_else(|primary| {
-        // The store-side name_pattern filter and the local matcher do not agree
-        // on every query shape, so a whole-graph sweep is the backstop. It must
-        // still be narrowed to the query: handing choose_entity_match an
-        // unfiltered graph makes it report the first five entities
-        // alphabetically as "matches", which is how `kin history alwaysTrue`
-        // came back with "Multiple entities match 'alwaysTrue': AND_THEN,
-        // AND_WHEN, ANON_TEST_CASE, Approx". None of those contain the query.
-        let narrowed = graph
-            .list_all_entities()
-            .map_err(|error| anyhow!(error.to_string()))?
-            .into_iter()
-            .filter(|entity| entity_matches_query(entity, entity_query))
-            .collect::<Vec<_>>();
-        if narrowed.is_empty() {
-            // Nothing in the graph matches, so the first attempt's message is
-            // the accurate one. Surfacing a second, wider failure here would
-            // bury it.
-            return Err(primary);
-        }
-        choose_entity_match(narrowed, entity_query)
+    Ok(ResolvedHead {
+        change_id: resolved.change_id,
+        authority_open: deferred.open_cost(),
     })
 }
 
-/// The entity a query names at `head`, together with its revision timeline.
+/// The line an answer ends with when resolving its ref opened the whole store
+/// on the thread that built it, which is the one step whose cost follows the
+/// size of the store rather than the question.
 ///
-/// Both come out of one replay of committed state, which is also why the two
-/// are resolved together: the entity lookup already needs the state at `head`,
-/// and resolving revisions separately would replay the same history twice.
-pub(crate) fn resolve_entity_with_revisions_at<G>(
+/// Silent otherwise. A daemon handing over the authority it already holds for
+/// the current publication cost the answer nothing worth naming, and neither did
+/// a selector the graph answered alone.
+pub(crate) fn authority_open_line(open: Option<AuthorityOpen>) -> Option<String> {
+    let open = open.filter(|open| open.opened_here)?;
+    let seconds = open.waited.as_secs_f64();
+    Some(if open.shared {
+        format!(
+            "Answered by: this repository's daemon, which opened repository authority for its \
+             current publication to answer this ({seconds:.1} s, re-verifying every persisted \
+             body); later reads at this publication reuse that open."
+        )
+    } else {
+        format!(
+            "Answered by: a repository-authority open made for this answer alone ({seconds:.1} \
+             s, re-verifying every persisted body); the daemon serving this repository answers \
+             from one open per publication instead."
+        )
+    })
+}
+
+/// The notes a blame or history answer ends with: the stale-span note when a
+/// location it printed is marked, then the open line when resolving its ref
+/// opened the store on this thread.
+pub(crate) fn closing_notes(lines: &[String], open: Option<AuthorityOpen>) -> Vec<String> {
+    crate::entity_identity::stale_span_note(lines)
+        .into_iter()
+        .chain(authority_open_line(open))
+        .collect()
+}
+
+/// The first non-empty line of a commit message. Git calls this the subject and
+/// renders exactly this in `--oneline`; the body belongs in a detail view, not
+/// in a one-row-per-revision list. Blame and history both print it, from here,
+/// so the two cannot disagree about what a change is called.
+pub(crate) fn subject_line(message: &str) -> String {
+    message
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("(no message)")
+        .to_string()
+}
+
+/// ` @ path:line` for an answer's header, or nothing for an entity with no file.
+pub(crate) fn pointer_suffix(pointer: &EntityPointer) -> String {
+    if pointer.path.is_some() {
+        format!(" @ {}", pointer.render())
+    } else {
+        String::new()
+    }
+}
+
+/// The entity a blame or history answer is about, with what the answer prints
+/// before its rows.
+pub(crate) struct EntityTimeline {
+    pub(crate) target: Entity,
+    /// Every revision of `target` on the lineage reaching the head, oldest first.
+    pub(crate) revisions: Vec<EntityRevision>,
+    /// Where the entity starts, checked against the tree it was read from.
+    pub(crate) pointer: EntityPointer,
+    /// Every candidate and how to pin another, when the query reached several.
+    pub(crate) choice: Vec<String>,
+}
+
+/// Resolve `entity_query` at `head` and read its revisions there.
+///
+/// Without `--ref` the entity comes from the live graph, through the resolver
+/// every read command shares, so `kin blame` and `kin history` answer about the
+/// entity `kin refs` and `kin impact` answer about for the same name and pins.
+/// With `--ref` it comes from the state replayed at that ref, because a name can
+/// have meant a different entity then, or one since removed. The same pins,
+/// narrowing and ranking apply there, with dependents read from the replayed
+/// relations and locations checked against the replayed tree.
+pub(crate) fn resolve_entity_timeline<G>(
     graph: &G,
     entity_query: &str,
     head: &SemanticChangeId,
     reference: Option<&str>,
-) -> Result<(Entity, Vec<EntityRevision>)>
+) -> Result<EntityTimeline>
 where
     G: GraphStore,
     <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
 {
+    if reference.is_none() {
+        let resolution = crate::entity_identity::resolve_entity(
+            graph,
+            entity_query,
+            &IdentityQualifiers::default(),
+        )?;
+        let locate = |entity: &Entity| crate::entity_identity::entity_location(graph, entity);
+        let target = chosen_or_refused(&resolution, locate)?;
+        let revisions = resolve_entity_revisions_at(graph, &target.id, head, None)?;
+        return Ok(EntityTimeline {
+            pointer: crate::entity_identity::entity_pointer(graph, &target),
+            choice: crate::entity_identity::choice_note_by(
+                &resolution,
+                PinSpelling::FileKind,
+                locate,
+            ),
+            target,
+            revisions,
+        });
+    }
+
     let mut state = graph
         .resolve_graph_at(head)
         .map_err(|error| projection_error(reference, head, error))?;
-    let entities = state
-        .entities
+    let depended_on: HashSet<EntityId> = state
+        .relations
         .values()
-        .filter(|entity| entity_matches_query(entity, entity_query))
-        .cloned()
+        .filter_map(crate::entity_identity::depended_on_by)
         .collect();
-    let target = choose_entity_match(entities, entity_query)?;
+    let resolution = crate::entity_identity::resolve_entity_among(
+        state.entities.values(),
+        entity_query,
+        &IdentityQualifiers::default(),
+        |entity| Ok(depended_on.contains(&entity.id)),
+    )?;
+    let tree = &state.tree;
+    let locate =
+        |entity: &Entity| crate::entity_identity::entity_pointer_in_tree(tree, entity).render();
+    let target = chosen_or_refused(&resolution, locate)?;
+    let pointer = crate::entity_identity::entity_pointer_in_tree(tree, &target);
+    let choice = crate::entity_identity::choice_note_by(&resolution, PinSpelling::FileKind, locate);
     let revisions = state
         .entity_revisions
         .remove(&target.id)
         .unwrap_or_default();
-    Ok((target, revisions))
+    Ok(EntityTimeline {
+        target,
+        revisions,
+        pointer,
+        choice,
+    })
 }
 
-/// Every revision of `entity_id` visible at `head`, oldest first.
+/// The entity a resolution chose, or the refusal that says why it chose none.
 ///
-/// `ChangeStore::get_entity_revisions_at` is not usable here. It replays only
-/// the changes that mention this entity, yet validates every delta those
-/// changes carry. A change that touches this entity while also modifying or
-/// removing a second one is then checked against a state the second entity's
-/// own history was filtered out of, so a sound repository answers with a
-/// "stale old payload" conflict for an entity nobody asked about, and the
-/// command fails before printing a single revision. Replaying the complete
-/// first-parent state keeps every delta's precondition checkable, which is the
-/// same reason the MCP entity handlers resolve through `resolve_graph_at`.
+/// A partial name reaching several entities and a pin excluding every entity a
+/// name reaches are answered with the same lines `kin refs` and `kin impact`
+/// print, so an answer never guesses and never calls an entity absent that the
+/// graph holds.
+fn chosen_or_refused(
+    resolution: &EntityResolution,
+    locate: impl Fn(&Entity) -> String + Copy,
+) -> Result<Entity> {
+    let refusal = if resolution.name_matches.is_empty() {
+        EntityQueryRefusal {
+            lines: vec![format!(
+                "No entity matching '{}' found.",
+                resolution.reference.name
+            )],
+            absent: true,
+        }
+    } else if resolution.pin_excluded_all() {
+        EntityQueryRefusal {
+            lines: crate::entity_identity::pin_miss_lines_by(resolution, locate),
+            absent: false,
+        }
+    } else if resolution.needs_a_pin() {
+        EntityQueryRefusal {
+            lines: crate::entity_identity::pin_request_lines_by(resolution, locate),
+            absent: false,
+        }
+    } else {
+        return resolution.chosen().cloned().ok_or_else(|| {
+            anyhow!(
+                "resolving '{}' produced no candidate",
+                resolution.reference.name
+            )
+        });
+    };
+    Err(anyhow::Error::new(refusal))
+}
+
+/// Every revision of `entity_id` on the lineage reaching `head`, oldest first.
+///
+/// kin-model's `ChangeStore::get_entity_revisions_at` reads the complete
+/// first-parent history and applies only this entity's deltas, so every change
+/// is read against the state its parent published, and a change that also
+/// modifies or removes another entity is skipped for that entity rather than
+/// checked against a state its history was filtered out of. The whole-graph
+/// replay this used to run derived every entity and relation in the repository,
+/// swept every live relation after every change and replayed the tree, to keep
+/// one entity's list. The rows are the same, because a revision id is minted
+/// from the entity id and the change that introduced it; the replay's cost grew
+/// with the whole repository's history on every call.
 pub(crate) fn resolve_entity_revisions_at<G>(
     graph: &G,
     entity_id: &EntityId,
@@ -303,62 +482,9 @@ where
     G: GraphStore,
     <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
 {
-    let mut state = graph
-        .resolve_graph_at(head)
-        .map_err(|error| projection_error(reference, head, error))?;
-    Ok(state.entity_revisions.remove(entity_id).unwrap_or_default())
-}
-
-fn choose_entity_match(mut entities: Vec<Entity>, entity_query: &str) -> Result<Entity> {
-    if entities.is_empty() {
-        bail!("No entity matching '{entity_query}' found.");
-    }
-
-    entities.sort_by(|left, right| {
-        left.name
-            .cmp(&right.name)
-            .then_with(|| left.id.to_string().cmp(&right.id.to_string()))
-    });
-    if let Some(exact) = entities
-        .iter()
-        .find(|entity| entity.id.to_string() == entity_query || entity.name == entity_query)
-    {
-        return Ok(exact.clone());
-    }
-    if let Some(case_insensitive) = entities
-        .iter()
-        .find(|entity| entity.name.eq_ignore_ascii_case(entity_query))
-    {
-        return Ok(case_insensitive.clone());
-    }
-    match entities.as_slice() {
-        [entity] => Ok(entity.clone()),
-        many => {
-            let preview = many
-                .iter()
-                .take(5)
-                .map(|entity| entity.name.as_str())
-                .collect::<Vec<_>>()
-                .join(", ");
-            bail!("Multiple entities match '{entity_query}': {preview}. Use a more exact name.")
-        }
-    }
-}
-
-fn entity_matches_query(entity: &Entity, entity_query: &str) -> bool {
-    entity.id.to_string() == entity_query || name_matches_pattern(&entity.name, entity_query)
-}
-
-fn name_matches_pattern(name: &str, pattern: &str) -> bool {
-    let name = name.to_lowercase();
-    let pattern = pattern.to_lowercase();
-    if let Some(suffix) = pattern.strip_prefix('*') {
-        name.ends_with(suffix)
-    } else if let Some(prefix) = pattern.strip_suffix('*') {
-        name.starts_with(prefix)
-    } else {
-        name.contains(&pattern)
-    }
+    graph
+        .get_entity_revisions_at(entity_id, head)
+        .map_err(|error| projection_error(reference, head, error))
 }
 
 #[cfg(test)]
@@ -410,15 +536,13 @@ mod tests {
         }
     }
 
-    /// `resolve_entity_query` sweeps the whole graph when the store-side name
-    /// filter comes back unusable. That sweep must still be narrowed to the
-    /// query. It previously was not, so `choose_entity_match` received every
-    /// entity in the repo and reported the first five alphabetically as
-    /// "matches" — `kin history alwaysTrue` answered "Multiple entities match
-    /// 'alwaysTrue': AND_THEN, AND_WHEN, ANON_TEST_CASE, Approx", none of which
-    /// contain the query.
+    /// A name that reaches nothing is refused with its own name, never with a
+    /// list of unrelated entities. The whole-graph sweep this module used to run
+    /// handed its matcher an unfiltered graph, so `kin history alwaysTrue` once
+    /// answered "Multiple entities match 'alwaysTrue': AND_THEN, AND_WHEN,
+    /// ANON_TEST_CASE, Approx", none of which contain the query.
     #[test]
-    fn whole_graph_fallback_stays_narrowed_to_the_query() {
+    fn a_query_that_reaches_nothing_is_refused_with_its_own_name() {
         use kin_model::EntityStore;
         let graph = kin_db::InMemoryGraph::new();
         for name in [
@@ -431,17 +555,26 @@ mod tests {
         ] {
             graph.upsert_entity(&named_entity(name)).unwrap();
         }
+        let locate = |entity: &Entity| crate::entity_identity::entity_location(&graph, entity);
+        let resolve = |query: &str| {
+            crate::entity_identity::resolve_entity(&graph, query, &IdentityQualifiers::default())
+                .unwrap()
+        };
 
-        let resolved = resolve_entity_query(&graph, "alwaysTrue")
+        let chosen = chosen_or_refused(&resolve("alwaysTrue"), locate)
             .expect("an exact name present in the graph must resolve");
-        assert_eq!(resolved.name, "alwaysTrue");
+        assert_eq!(chosen.name, "alwaysTrue");
 
-        let err = resolve_entity_query(&graph, "definitely_not_here")
-            .expect_err("a query matching nothing must fail");
-        let message = err.to_string();
+        let error = chosen_or_refused(&resolve("definitely_not_here"), locate)
+            .expect_err("a query matching nothing must be refused");
+        let refusal =
+            entity_query_refusal(&error).expect("the refusal must be typed for the daemon");
+        assert!(refusal.absent, "nothing matched, so the entity is absent");
+        let message = error.to_string();
+        assert!(message.contains("definitely_not_here"), "{message}");
         assert!(
             !message.contains("AND_THEN") && !message.contains("Approx"),
-            "an unmatched query must not list unrelated entities as matches, got: {message}"
+            "an unmatched query must not list unrelated entities, got: {message}"
         );
     }
 
@@ -616,6 +749,107 @@ mod tests {
                 .to_string()
                 .contains("was never imported into this repository"),
             "{error:#}"
+        );
+    }
+
+    /// The shared arm is handed the authority its server already holds and
+    /// never opens the store on the resolving thread, the pinned arm opens for
+    /// itself, and a graph-only selector reaches for neither.
+    ///
+    /// The per-thread open counter is the bound, because an open's cost is a
+    /// property of the store rather than of the request: a timing assertion on
+    /// a fixture this small would pass with every request reopening.
+    #[test]
+    fn a_shared_authority_is_handed_over_rather_than_reopened() {
+        use crate::commands::repository_authority::{
+            repository_authority_opens_on_this_thread, ActiveRepositoryAuthority,
+            RequestRepositoryAuthority,
+        };
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let directory = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(directory.path()).unwrap();
+        let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&initialized.layout)
+            .expect("fixture must carry persisted empty repository authority");
+        let held = Arc::new(ActiveRepositoryAuthority::open(&binding).unwrap());
+        let handed_over = Arc::new(AtomicUsize::new(0));
+        let shared = RequestRepositoryAuthority::shared(binding.clone(), {
+            let held = Arc::clone(&held);
+            let handed_over = Arc::clone(&handed_over);
+            Arc::new(move || {
+                handed_over.fetch_add(1, Ordering::SeqCst);
+                Ok(Arc::clone(&held))
+            })
+        });
+        let graph = kin_db::InMemoryGraph::new();
+
+        // HEAD reads authority. This store has no commit, so HEAD names nothing
+        // and the answer is a refusal; what reaching authority cost is the
+        // property under test.
+        let opens = repository_authority_opens_on_this_thread();
+        let error = resolve_ref_through(&graph, &shared, None)
+            .expect_err("an unborn workspace has no HEAD");
+        assert!(is_ref_resolution_error(&error), "{error:#}");
+        assert_eq!(
+            handed_over.load(Ordering::SeqCst),
+            1,
+            "HEAD must ask the server for the authority it holds"
+        );
+        assert_eq!(
+            repository_authority_opens_on_this_thread(),
+            opens,
+            "the shared arm must not open the store on this thread"
+        );
+
+        // An explicit change is graph-owned truth and reaches for nothing.
+        let explicit = change(Vec::new());
+        graph.create_change(&explicit).unwrap();
+        let head = resolve_ref_through(&graph, &shared, Some(&format!("kin:{}", explicit.id)))
+            .expect("an explicit change the graph holds resolves");
+        assert_eq!(head.change_id, explicit.id);
+        assert_eq!(head.authority_open, None);
+        assert_eq!(
+            handed_over.load(Ordering::SeqCst),
+            1,
+            "a graph-only selector must not ask for authority"
+        );
+
+        // The control: the pinned arm opens for itself, so the bound above is
+        // one that could have moved.
+        let _ = resolve_ref_through(&graph, &RequestRepositoryAuthority::pinned(binding), None);
+        assert_eq!(
+            repository_authority_opens_on_this_thread(),
+            opens + 1,
+            "the pinned arm opens the store once"
+        );
+    }
+
+    /// An answer names an open only when its own thread paid for one, and says
+    /// whether a daemon now holds it for the next read.
+    #[test]
+    fn an_answer_names_an_open_only_when_its_thread_paid_for_one() {
+        let open = |opened_here, shared| {
+            Some(AuthorityOpen {
+                waited: std::time::Duration::from_millis(58_200),
+                opened_here,
+                shared,
+            })
+        };
+        assert_eq!(authority_open_line(None), None);
+        assert_eq!(
+            authority_open_line(open(false, true)),
+            None,
+            "an authority handed over costs the answer nothing worth naming"
+        );
+        let daemon = authority_open_line(open(true, true)).unwrap();
+        assert!(
+            daemon.contains("58.2 s") && daemon.contains("later reads at this publication reuse"),
+            "{daemon}"
+        );
+        let alone = authority_open_line(open(true, false)).unwrap();
+        assert!(
+            alone.contains("58.2 s") && alone.contains("for this answer alone"),
+            "{alone}"
         );
     }
 }

--- a/crates/kin-cli/src/commands/repository_authority.rs
+++ b/crates/kin-cli/src/commands/repository_authority.rs
@@ -240,6 +240,12 @@ impl RequestRepositoryAuthority {
         &self.binding
     }
 
+    /// Whether a server resolves this authority for the publication a request
+    /// reads at, so an open paid for here is kept for the requests after it.
+    pub fn is_shared(&self) -> bool {
+        self.shared.is_some()
+    }
+
     /// The open authority to read this command from.
     ///
     /// Reuses the caller's open when there is one, and otherwise performs the

--- a/crates/kin-cli/src/entity_identity.rs
+++ b/crates/kin-cli/src/entity_identity.rs
@@ -223,16 +223,25 @@ pub fn rank_candidates_by(
 
 /// Whether another entity calls, imports or references `entity`.
 fn has_dependents<G: GraphStore>(graph: &G, entity: &Entity) -> Result<bool> {
-    let own = GraphNodeId::Entity(entity.id);
     Ok(graph
         .get_all_relations_for_entity(&entity.id)?
         .iter()
-        .any(|relation| {
-            relation.dst == own
-                && relation.src != own
-                && relation.src.as_entity().is_some()
-                && DEPENDENT_RELATION_KINDS.contains(&relation.kind)
-        }))
+        .any(|relation| depended_on_by(relation) == Some(entity.id)))
+}
+
+/// The entity a relation makes something others depend on: the target of a
+/// call, import or reference from another entity, or `None`.
+///
+/// The one test behind [`rank_candidates`], so a ranking over a state replayed
+/// at a historical ref reads dependents exactly as a ranking over the live graph
+/// does.
+pub fn depended_on_by(relation: &kin_model::relation::Relation) -> Option<EntityId> {
+    let GraphNodeId::Entity(target) = relation.dst else {
+        return None;
+    };
+    (matches!(relation.src, GraphNodeId::Entity(source) if source != target)
+        && DEPENDENT_RELATION_KINDS.contains(&relation.kind))
+    .then_some(target)
 }
 
 /// How a query met the name of what it resolved to.
@@ -303,9 +312,21 @@ pub fn resolve_entity<G: GraphStore>(
     query: &str,
     flags: &IdentityQualifiers,
 ) -> Result<EntityResolution> {
-    let reference = merge_pins(parse_query(graph, query)?, flags)?;
+    let trimmed = query.trim();
+    let reference = merge_pins(
+        split_pins(trimmed, || {
+            Ok(graph
+                .query_entities(&EntityFilter {
+                    name_pattern: Some(trimmed.to_string()),
+                    ..Default::default()
+                })?
+                .iter()
+                .any(|entity| entity.name == trimmed))
+        })?,
+        flags,
+    )?;
     let name = reference.name.trim().to_string();
-    let (mut name_matches, name_match) = if let Ok(uuid) = uuid::Uuid::parse_str(&name) {
+    let (name_matches, name_match) = if let Ok(uuid) = uuid::Uuid::parse_str(&name) {
         (
             graph.get_entity(&EntityId(uuid))?.into_iter().collect(),
             NameMatch::Id,
@@ -313,14 +334,81 @@ pub fn resolve_entity<G: GraphStore>(
     } else {
         gather_by_name(graph, &name)?
     };
+    finish_resolution(reference, name_matches, name_match, |entity| {
+        has_dependents(graph, entity)
+    })
+}
+
+/// [`resolve_entity`] over entities that live outside a store, such as a state
+/// replayed at a historical ref: the same pins, the same narrowing and the same
+/// ranking, with the dependents test supplied by the caller.
+///
+/// A name reaches the entities whose names contain it, ignoring case, or the
+/// ones a leading or trailing `*` admits, which is what the store's name index
+/// answers with. The generics and qualified-leaf retries `kin trace` adds belong
+/// to the live graph's index and are not repeated over a replayed state.
+pub fn resolve_entity_among<'a>(
+    entities: impl IntoIterator<Item = &'a Entity>,
+    query: &str,
+    flags: &IdentityQualifiers,
+    has_dependents: impl FnMut(&Entity) -> Result<bool>,
+) -> Result<EntityResolution> {
+    let entities: Vec<&Entity> = entities.into_iter().collect();
+    let trimmed = query.trim();
+    let reference = merge_pins(
+        split_pins(trimmed, || {
+            Ok(entities.iter().any(|entity| entity.name == trimmed))
+        })?,
+        flags,
+    )?;
+    let name = reference.name.trim().to_string();
+    let (name_matches, name_match) = if let Ok(uuid) = uuid::Uuid::parse_str(&name) {
+        let id = EntityId(uuid);
+        (
+            entities
+                .iter()
+                .filter(|entity| entity.id == id)
+                .map(|entity| (*entity).clone())
+                .collect(),
+            NameMatch::Id,
+        )
+    } else if name.is_empty() {
+        (Vec::new(), NameMatch::Partial)
+    } else {
+        let folded = name.to_lowercase();
+        let glob = name.starts_with('*') || name.ends_with('*');
+        let reached = entities
+            .iter()
+            .filter(|entity| !kin_index::is_external_reference_target(entity))
+            .filter(|entity| {
+                if glob {
+                    glob_matches(&entity.name, &name)
+                } else {
+                    entity.name.to_lowercase().contains(&folded)
+                }
+            })
+            .map(|entity| (*entity).clone())
+            .collect();
+        narrow_by_name(reached, &name)
+    };
+    finish_resolution(reference, name_matches, name_match, has_dependents)
+}
+
+/// Pin, then rank, what a name reached: the tail every resolution shares.
+fn finish_resolution(
+    reference: EntityRef,
+    mut name_matches: Vec<Entity>,
+    name_match: NameMatch,
+    mut has_dependents: impl FnMut(&Entity) -> Result<bool>,
+) -> Result<EntityResolution> {
     let mut candidates = name_matches.clone();
     apply_qualifiers(&mut candidates, &reference.qualifiers);
     crate::entity_ref::apply_line(&mut candidates, reference.line);
-    rank_candidates(graph, &mut candidates)?;
+    rank_candidates_by(&mut candidates, &mut has_dependents)?;
     if candidates.is_empty() {
         // Only a miss lists these, and it lists them in the order the rule would
         // have chosen them.
-        rank_candidates(graph, &mut name_matches)?;
+        rank_candidates_by(&mut name_matches, &mut has_dependents)?;
     }
     Ok(EntityResolution {
         reference,
@@ -334,23 +422,13 @@ pub fn resolve_entity<G: GraphStore>(
 ///
 /// The raw token is tried as an entity name first, so a name that itself
 /// carries `@` or `#` resolves as that name rather than being split into a pin.
-fn parse_query<G: GraphStore>(graph: &G, query: &str) -> Result<EntityRef> {
-    let trimmed = query.trim();
+/// `raw_is_a_name` is asked only when the token carries one of them.
+fn split_pins(trimmed: &str, raw_is_a_name: impl FnOnce() -> Result<bool>) -> Result<EntityRef> {
     let bare = || EntityRef {
         name: trimmed.to_string(),
         ..EntityRef::default()
     };
-    if !(trimmed.contains('@') || trimmed.contains('#')) {
-        return Ok(bare());
-    }
-    let raw_is_a_name = graph
-        .query_entities(&EntityFilter {
-            name_pattern: Some(trimmed.to_string()),
-            ..Default::default()
-        })?
-        .iter()
-        .any(|entity| entity.name == trimmed);
-    if raw_is_a_name {
+    if !(trimmed.contains('@') || trimmed.contains('#')) || raw_is_a_name()? {
         return Ok(bare());
     }
     let parsed = crate::entity_ref::parse_entity_ref(trimmed);
@@ -405,13 +483,19 @@ fn gather_by_name<G: GraphStore>(graph: &G, name: &str) -> Result<(Vec<Entity>, 
             })
             .collect();
     }
+    Ok(narrow_by_name(matches, name))
+}
+
+/// Narrow what a name reached to its exact matches, then to its case-folded
+/// ones, when the name is some entity's whole name.
+fn narrow_by_name(matches: Vec<Entity>, name: &str) -> (Vec<Entity>, NameMatch) {
     let exact: Vec<Entity> = matches
         .iter()
         .filter(|entity| entity.name == name)
         .cloned()
         .collect();
     if !exact.is_empty() {
-        return Ok((exact, NameMatch::Exact));
+        return (exact, NameMatch::Exact);
     }
     let folded: Vec<Entity> = matches
         .iter()
@@ -419,9 +503,9 @@ fn gather_by_name<G: GraphStore>(graph: &G, name: &str) -> Result<(Vec<Entity>, 
         .cloned()
         .collect();
     if !folded.is_empty() {
-        return Ok((folded, NameMatch::CaseInsensitive));
+        return (folded, NameMatch::CaseInsensitive);
     }
-    Ok((matches, NameMatch::Partial))
+    (matches, NameMatch::Partial)
 }
 
 /// A leading `*` matches a suffix and a trailing one a prefix, ignoring case.
@@ -462,6 +546,12 @@ impl PinSpelling {
 /// One row per candidate: its kind, where it is, and its id, which pins it
 /// exactly in every command.
 pub fn candidate_rows<G: GraphStore>(graph: &G, candidates: &[Entity]) -> Vec<String> {
+    candidate_rows_by(candidates, |candidate| entity_location(graph, candidate))
+}
+
+/// [`candidate_rows`] with the location supplied by the caller, for candidates
+/// read from a replayed state whose tree is not the live graph's.
+pub fn candidate_rows_by(candidates: &[Entity], locate: impl Fn(&Entity) -> String) -> Vec<String> {
     let mut rows: Vec<String> = candidates
         .iter()
         .take(MAX_LISTED_CANDIDATES)
@@ -469,7 +559,7 @@ pub fn candidate_rows<G: GraphStore>(graph: &G, candidates: &[Entity]) -> Vec<St
             format!(
                 "  {:<9} {}  {}",
                 kin_review::StableEntityIdentity::from_entity(candidate).kind,
-                entity_location(graph, candidate),
+                locate(candidate),
                 candidate.id
             )
         })
@@ -494,6 +584,17 @@ pub fn choice_note<G: GraphStore>(
     resolution: &EntityResolution,
     spelling: PinSpelling,
 ) -> Vec<String> {
+    choice_note_by(resolution, spelling, |candidate| {
+        entity_location(graph, candidate)
+    })
+}
+
+/// [`choice_note`] with the location supplied by the caller.
+pub fn choice_note_by(
+    resolution: &EntityResolution,
+    spelling: PinSpelling,
+    locate: impl Fn(&Entity) -> String,
+) -> Vec<String> {
     if resolution.addressed_by_id() || resolution.candidates.len() < 2 {
         return Vec::new();
     }
@@ -502,7 +603,7 @@ pub fn choice_note<G: GraphStore>(
         resolution.reference.name,
         resolution.candidates.len()
     )];
-    lines.extend(candidate_rows(graph, &resolution.candidates));
+    lines.extend(candidate_rows_by(&resolution.candidates, locate));
     lines.push(format!("note: ranked {RANKING_RULE}."));
     let next = kin_review::StableEntityIdentity::from_entity(&resolution.candidates[1]);
     let file = if next.file.is_empty() {
@@ -519,13 +620,21 @@ pub fn choice_note<G: GraphStore>(
 
 /// The answer when a partial name reaches several entities.
 pub fn pin_request_lines<G: GraphStore>(graph: &G, resolution: &EntityResolution) -> Vec<String> {
+    pin_request_lines_by(resolution, |candidate| entity_location(graph, candidate))
+}
+
+/// [`pin_request_lines`] with the location supplied by the caller.
+pub fn pin_request_lines_by(
+    resolution: &EntityResolution,
+    locate: impl Fn(&Entity) -> String,
+) -> Vec<String> {
     let mut lines = vec![format!(
         "No entity is named '{}' exactly, and it is part of the names of {} entities, so there \
          is no one entity to answer about:",
         resolution.reference.name,
         resolution.candidates.len()
     )];
-    lines.extend(candidate_rows(graph, &resolution.candidates));
+    lines.extend(candidate_rows_by(&resolution.candidates, locate));
     lines.push(
         "hint: re-run with one of the names above, or pass its id. Pins narrow a name; they \
          cannot make a partial name exact."
@@ -537,6 +646,14 @@ pub fn pin_request_lines<G: GraphStore>(graph: &G, resolution: &EntityResolution
 /// The answer when the name resolves and the pins exclude every entity it
 /// reaches. The entity is in the graph, so saying it is absent would be false.
 pub fn pin_miss_lines<G: GraphStore>(graph: &G, resolution: &EntityResolution) -> Vec<String> {
+    pin_miss_lines_by(resolution, |candidate| entity_location(graph, candidate))
+}
+
+/// [`pin_miss_lines`] with the location supplied by the caller.
+pub fn pin_miss_lines_by(
+    resolution: &EntityResolution,
+    locate: impl Fn(&Entity) -> String,
+) -> Vec<String> {
     let name = &resolution.reference.name;
     let mut pins = resolution.reference.qualifiers.labels();
     if let Some(line) = resolution.reference.line {
@@ -550,7 +667,7 @@ pub fn pin_miss_lines<G: GraphStore>(graph: &G, resolution: &EntityResolution) -
             if count == 1 { "y" } else { "ies" }
         ),
     ];
-    lines.extend(candidate_rows(graph, &resolution.name_matches));
+    lines.extend(candidate_rows_by(&resolution.name_matches, locate));
     lines.push("hint: pin one of the entities above, or pass its id.".to_string());
     lines
 }
@@ -662,9 +779,33 @@ impl EntityPointer {
 /// Read an entity's pointer out of the graph. Graph reads only: the check
 /// compares two digests the graph already holds and never opens the file.
 pub fn entity_pointer<G: GraphStore>(graph: &G, entity: &Entity) -> EntityPointer {
+    pointer_against(entity, |file| {
+        graph
+            .get_tree_entry(file)
+            .ok()
+            .flatten()
+            .and_then(|entry| entry.blob_identity())
+    })
+}
+
+/// [`entity_pointer`] for an entity read from a state replayed at a historical
+/// ref, checked against that state's tree, so a line printed for the ref is
+/// vouched for by the bytes the ref holds rather than by today's.
+pub fn entity_pointer_in_tree(tree: &kin_model::ResolvedTree, entity: &Entity) -> EntityPointer {
+    pointer_against(entity, |file| {
+        let path = kin_model::RepoPath::from_utf8(file.0.clone()).ok()?;
+        tree.artifact_at_path(&path)
+            .and_then(|artifact| artifact.entry.blob_identity())
+    })
+}
+
+fn pointer_against(
+    entity: &Entity,
+    blob_at: impl FnOnce(&kin_model::FilePathId) -> Option<kin_model::Hash256>,
+) -> EntityPointer {
     let path = entity.file_origin.as_ref().map(|file| file.0.clone());
     let line = kin_mcp::handlers::common::entity_presentation_start_line(entity);
-    let stale = line.is_some() && span_is_stale(graph, entity);
+    let stale = line.is_some() && span_is_stale(entity, blob_at);
     EntityPointer {
         path,
         line: if stale { None } else { line },
@@ -681,14 +822,14 @@ pub fn entity_pointer<G: GraphStore>(graph: &G, entity: &Entity) -> EntityPointe
 /// a guess. The comparison is kin-mcp's `span_source_coherence`, the rule
 /// `get_entity_source` already refuses a stale span by, so the two surfaces
 /// cannot disagree about which spans are stale.
-fn span_is_stale<G: GraphStore>(graph: &G, entity: &Entity) -> bool {
+fn span_is_stale(
+    entity: &Entity,
+    blob_at: impl FnOnce(&kin_model::FilePathId) -> Option<kin_model::Hash256>,
+) -> bool {
     let Some(file) = entity.file_origin.as_ref() else {
         return false;
     };
-    let Ok(Some(entry)) = graph.get_tree_entry(file) else {
-        return false;
-    };
-    let Some(blob) = entry.blob_identity() else {
+    let Some(blob) = blob_at(file) else {
         return false;
     };
     kin_mcp::handlers::common::span_source_coherence(entity, &blob, &file.0).is_err()

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -618,8 +618,15 @@ enum Command {
     },
     /// Show entity history
     History {
-        /// Entity name or ID
+        /// Entity name or ID. A name with twins can carry its pin:
+        /// `Name@file`, `Name@file:line`, `Name#kind`
         entity: String,
+        /// Exact repo-relative file of the entity, when its name has twins
+        #[arg(long)]
+        file: Option<String>,
+        /// Exact entity kind (for example: function), when its name has twins
+        #[arg(long)]
+        kind: Option<String>,
         /// Resolve history against a specific ref.
         /// Accepts `HEAD`, `HEAD~N`, branch names, `branch:<name>`,
         /// imported Git commits as `git:<sha>` or bare 40-hex SHAs,
@@ -793,8 +800,15 @@ enum Command {
     },
     /// Show blame (version history) for an entity
     Blame {
-        /// Entity name or ID
+        /// Entity name or ID. A name with twins can carry its pin:
+        /// `Name@file`, `Name@file:line`, `Name#kind`
         entity: String,
+        /// Exact repo-relative file of the entity, when its name has twins
+        #[arg(long)]
+        file: Option<String>,
+        /// Exact entity kind (for example: function), when its name has twins
+        #[arg(long)]
+        kind: Option<String>,
         /// Resolve blame against a specific ref.
         /// Accepts `HEAD`, `HEAD~N`, branch names, `branch:<name>`,
         /// imported Git commits as `git:<sha>` or bare 40-hex SHAs,
@@ -3641,9 +3655,20 @@ fn run() -> Result<()> {
                 }
                 Command::History {
                     entity,
+                    file,
+                    kind,
                     reference,
                     all_revisions,
-                } => commands::history::run(entity, reference, all_revisions).await,
+                } => {
+                    // The flags are the `Name#kind@path` pin every resolver
+                    // reads, so the daemon sees one spelling.
+                    let entity = kin_cli::entity_ref::compose_entity_ref(
+                        &entity,
+                        file.as_deref(),
+                        kind.as_deref(),
+                    );
+                    commands::history::run(entity, reference, all_revisions).await
+                }
                 Command::HostedPublication { action } => {
                     // The exit status carries the outcome a caller branches on,
                     // the way `kin init` reports an unattested conversion: a
@@ -3782,9 +3807,20 @@ fn run() -> Result<()> {
                 },
                 Command::Blame {
                     entity,
+                    file,
+                    kind,
                     reference,
                     all_revisions,
-                } => commands::blame::run(entity, reference, all_revisions).await,
+                } => {
+                    // The flags are the `Name#kind@path` pin every resolver
+                    // reads, so the daemon sees one spelling.
+                    let entity = kin_cli::entity_ref::compose_entity_ref(
+                        &entity,
+                        file.as_deref(),
+                        kind.as_deref(),
+                    );
+                    commands::blame::run(entity, reference, all_revisions).await
+                }
                 Command::Agent { action } => {
                     // The agent loop is blocking, and a blocking HTTP client builds and
                     // drops its own runtime. Dropping one inside an async context panics,

--- a/crates/kin-cli/tests/entity_revision_history.rs
+++ b/crates/kin-cli/tests/entity_revision_history.rs
@@ -248,4 +248,158 @@ fn blame_reports_both_revisions_across_a_mixed_add_remove_change() {
         rendered.contains("Signature: fn alpha(v2)"),
         "blame reports the state at the requested head:\n{rendered}"
     );
+    assert!(
+        rendered.contains("Replace the beta helper with gamma")
+            && !rendered.contains("The body is not a subject line."),
+        "each blame row carries the subject line only, as history's does:\n{rendered}"
+    );
+}
+
+/// Two functions named `alpha` in two files, each with its own history.
+struct TwinHistory {
+    graph: kin_db::InMemoryGraph,
+    head: SemanticChangeId,
+    lib_alpha: EntityId,
+    other_alpha: EntityId,
+    lib_changes: [SemanticChangeId; 2],
+    other_change: SemanticChangeId,
+}
+
+fn twin_history() -> TwinHistory {
+    let graph = kin_db::InMemoryGraph::new();
+    let lib_alpha = EntityId::new();
+    let other_alpha = EntityId::new();
+    let mut other_v1 = entity(other_alpha, "alpha", 7);
+    other_v1.file_origin = Some(FilePathId::new("src/other.rs"));
+
+    let add_lib = change(
+        Vec::new(),
+        "Add alpha to lib",
+        vec![EntityDelta::Added {
+            new: entity(lib_alpha, "alpha", 1),
+        }],
+    );
+    let add_other = change(
+        vec![add_lib.id],
+        "Add alpha to other",
+        vec![EntityDelta::Added { new: other_v1 }],
+    );
+    let revise_lib = change(
+        vec![add_other.id],
+        "Revise lib alpha",
+        vec![EntityDelta::Modified {
+            old: entity(lib_alpha, "alpha", 1),
+            new: entity(lib_alpha, "alpha", 2),
+        }],
+    );
+    for entry in [&add_lib, &add_other, &revise_lib] {
+        graph.create_change(entry).expect("store change");
+    }
+
+    TwinHistory {
+        graph,
+        head: revise_lib.id,
+        lib_alpha,
+        other_alpha,
+        lib_changes: [add_lib.id, revise_lib.id],
+        other_change: add_other.id,
+    }
+}
+
+/// At a ref, blame and history resolve a name the way every read command does:
+/// twins answer about the first by the one ranking rule and list every candidate
+/// by id, a pin reaches the twin it names and only that twin's revisions, and a
+/// pin that excludes every twin is refused naming them, never called absent.
+#[test]
+fn blame_and_history_at_a_ref_pin_one_twin_and_list_the_others() {
+    let fixture = twin_history();
+    let head = format!("kin:{}", fixture.head);
+    let history = |entity: &str| {
+        execute_history_request(
+            &absent_binding(),
+            &fixture.graph,
+            &HistoryRequest {
+                entity: entity.to_string(),
+                reference: Some(head.clone()),
+                all_revisions: false,
+            },
+        )
+    };
+
+    let unpinned = history("alpha").expect("twins answer").lines;
+    assert!(
+        unpinned[0].contains("@ src/lib.rs"),
+        "an unpinned name answers about the first twin by path: {unpinned:#?}"
+    );
+    assert!(
+        unpinned
+            .iter()
+            .any(|line| line.contains("'alpha' names 2 entities")),
+        "the answer must say it chose: {unpinned:#?}"
+    );
+    for id in [fixture.lib_alpha, fixture.other_alpha] {
+        assert!(
+            unpinned.iter().any(|line| line.contains(&id.to_string())),
+            "every candidate is listed by id: {unpinned:#?}"
+        );
+    }
+
+    let pinned = history("alpha@src/other.rs")
+        .expect("a pinned twin answers")
+        .lines;
+    assert!(
+        pinned[0].contains("@ src/other.rs"),
+        "the pin reaches src/other.rs's twin: {pinned:#?}"
+    );
+    let rows = &pinned[1..];
+    assert!(
+        rows.iter()
+            .any(|line| line.contains(&abbreviated(&fixture.other_change))),
+        "the pinned twin's own revision is listed: {pinned:#?}"
+    );
+    for change_id in &fixture.lib_changes {
+        assert!(
+            !rows
+                .iter()
+                .any(|line| line.contains(&abbreviated(change_id))),
+            "only the pinned twin's revisions are listed: {pinned:#?}"
+        );
+    }
+    assert!(
+        !pinned.iter().any(|line| line.contains("names 2 entities")),
+        "a pinned answer made no choice: {pinned:#?}"
+    );
+
+    let blame = execute_blame_request(
+        &absent_binding(),
+        &fixture.graph,
+        &BlameRequest {
+            entity: "alpha#function@src/other.rs".to_string(),
+            reference: Some(head.clone()),
+            all_revisions: false,
+        },
+    )
+    .expect("a pinned twin answers blame")
+    .lines
+    .join("\n");
+    assert!(
+        blame
+            .lines()
+            .next()
+            .unwrap_or_default()
+            .contains("@ src/other.rs"),
+        "{blame}"
+    );
+    assert!(blame.contains("1 version(s) found."), "{blame}");
+
+    let error = history("alpha@src/nowhere.rs")
+        .expect_err("a pin that excludes every twin is refused, not answered");
+    let refusal = kin_cli::commands::ref_lookup::entity_query_refusal(&error)
+        .expect("the refusal is typed so the daemon answers it as the caller's news");
+    assert!(!refusal.absent, "the name reaches two entities: {error:#}");
+    let message = error.to_string();
+    assert!(
+        message.contains("src/lib.rs") && message.contains("src/other.rs"),
+        "the refusal names every twin the pin excluded: {message}"
+    );
 }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -9708,6 +9708,65 @@ fn persist_foreground_embed_batch(state: &DaemonState) -> Result<(), kin_db::Kin
     })
 }
 
+/// The authority `/blame` and `/history` resolve a ref through: this daemon's
+/// command slot, reached only when an arm of the ref grammar needs it.
+///
+/// These routes used to hand the ref grammar the bare binding, which opened the
+/// whole repository authority from disk to resolve `HEAD` on every request. On
+/// a full-history store of this repository that was about a minute per call,
+/// nearly all of it decoding and re-verifying the persisted snapshot, and each
+/// call held its own decoded copy while it ran. The slot is keyed on the durable
+/// publication read before the load it labels, so one open serves every read at
+/// that publication, as it already does for `/commands/log` and `/commands/diff`.
+///
+/// Lazy for the reason `/commands/graph` is lazy: an explicit `kin:<id>` or
+/// `change:<id>` is graph-owned truth, reads no authority, and must not start
+/// depending on a storage capability it never needed.
+fn entity_history_authority(
+    state: &Arc<DaemonState>,
+) -> Result<kin_cli::commands::repository_authority::RequestRepositoryAuthority, (StatusCode, String)>
+{
+    let binding = state
+        .local_repository_authority_binding()
+        .map_err(repository_authority_error)?;
+    let resolver_state = Arc::clone(state);
+    Ok(
+        kin_cli::commands::repository_authority::RequestRepositoryAuthority::shared(
+            binding,
+            Arc::new(move || {
+                command_repository_authority(&resolver_state)
+                    .map_err(|(_, message)| anyhow::anyhow!(message))
+            }),
+        ),
+    )
+}
+
+/// How a blame or history failure reaches the caller.
+///
+/// A live-graph replay miss is the CALLER'S news, not an internal fault. The ref
+/// was fine and the change is durable; this daemon's projection cannot replay to
+/// it. It reached `internal_error`, so the user got a 500 carrying the RESOLVED
+/// change id rather than the ref they typed, which is an internal invariant
+/// leaking. rc062j saw exactly that after a merge, on every ref form, always
+/// naming the same id. A query that named no one entity is the caller's news as
+/// well, and its body is the answer listing what the name reached.
+fn entity_history_error(error: anyhow::Error) -> (StatusCode, String) {
+    if kin_cli::commands::ref_lookup::is_graph_projection_error(&error) {
+        (StatusCode::CONFLICT, crate::error::cause_first(&error))
+    } else if kin_cli::commands::ref_lookup::is_ref_resolution_error(&error) {
+        (StatusCode::BAD_REQUEST, crate::error::cause_first(&error))
+    } else if let Some(refusal) = kin_cli::commands::ref_lookup::entity_query_refusal(&error) {
+        let status = if refusal.absent {
+            StatusCode::NOT_FOUND
+        } else {
+            StatusCode::BAD_REQUEST
+        };
+        (status, refusal.to_string())
+    } else {
+        internal_error(error)
+    }
+}
+
 /// POST /blame — render entity blame from daemon-owned graph state.
 async fn blame(
     headers: axum::http::HeaderMap,
@@ -9726,29 +9785,13 @@ async fn blame(
 
     let session_id = extract_session_id_from_headers(&headers)?;
     let graph = resolve_session_graph(&state, session_id.as_ref()).await;
-    let repository_authority = state
-        .local_repository_authority_binding()
-        .map_err(repository_authority_error)?;
-    let response = kin_cli::commands::blame::execute_blame_request(
+    let repository_authority = entity_history_authority(&state)?;
+    let response = kin_cli::commands::blame::execute_blame_request_with(
         &repository_authority,
         graph.as_ref(),
         &req,
     )
-    .map_err(|error| {
-        // A live-graph replay miss is the CALLER'S news, not an internal fault.
-        // The ref was fine and the change is durable; this daemon's projection
-        // cannot replay to it. It reached `internal_error` below, so the user
-        // got a 500 carrying the RESOLVED change id rather than the ref they
-        // typed, which is an internal invariant leaking. rc062j saw exactly
-        // that after a merge, on every ref form, always naming the same id.
-        if kin_cli::commands::ref_lookup::is_graph_projection_error(&error) {
-            (StatusCode::CONFLICT, crate::error::cause_first(&error))
-        } else if kin_cli::commands::ref_lookup::is_ref_resolution_error(&error) {
-            (StatusCode::BAD_REQUEST, crate::error::cause_first(&error))
-        } else {
-            internal_error(error)
-        }
-    })?;
+    .map_err(entity_history_error)?;
     Ok(Json(response))
 }
 
@@ -9770,29 +9813,13 @@ async fn history(
 
     let session_id = extract_session_id_from_headers(&headers)?;
     let graph = resolve_session_graph(&state, session_id.as_ref()).await;
-    let repository_authority = state
-        .local_repository_authority_binding()
-        .map_err(repository_authority_error)?;
-    let response = kin_cli::commands::history::execute_history_request(
+    let repository_authority = entity_history_authority(&state)?;
+    let response = kin_cli::commands::history::execute_history_request_with(
         &repository_authority,
         graph.as_ref(),
         &req,
     )
-    .map_err(|error| {
-        // A live-graph replay miss is the CALLER'S news, not an internal fault.
-        // The ref was fine and the change is durable; this daemon's projection
-        // cannot replay to it. It reached `internal_error` below, so the user
-        // got a 500 carrying the RESOLVED change id rather than the ref they
-        // typed, which is an internal invariant leaking. rc062j saw exactly
-        // that after a merge, on every ref form, always naming the same id.
-        if kin_cli::commands::ref_lookup::is_graph_projection_error(&error) {
-            (StatusCode::CONFLICT, crate::error::cause_first(&error))
-        } else if kin_cli::commands::ref_lookup::is_ref_resolution_error(&error) {
-            (StatusCode::BAD_REQUEST, crate::error::cause_first(&error))
-        } else {
-            internal_error(error)
-        }
-    })?;
+    .map_err(entity_history_error)?;
     Ok(Json(response))
 }
 /// state whose generation has not yet been persisted.
@@ -49068,6 +49095,201 @@ mod tests {
                 Err(_) => break,
             }
         }
+    }
+
+    /// A store whose repository authority holds one commit of `files`, so
+    /// `HEAD` names a change and blame and history resolve it through the
+    /// authority rather than through an explicit change id.
+    fn test_state_with_committed_sources(files: &[(&str, &str)]) -> Arc<DaemonState> {
+        install_test_registry_override();
+        let dir = std::env::temp_dir().join(format!("kin-daemon-history-state-{}", Uuid::new_v4()));
+        for (path, body) in files {
+            let path = dir.join(path);
+            std::fs::create_dir_all(path.parent().expect("a fixture file has a parent")).unwrap();
+            std::fs::write(&path, body).unwrap();
+        }
+        let steps: [&[&str]; 5] = [
+            &["init", "--initial-branch=main"],
+            &["config", "user.email", "kin@example.invalid"],
+            &["config", "user.name", "Kin Test"],
+            &["add", "--all"],
+            &["commit", "-s", "-m", "Seed the history fixture"],
+        ];
+        for args in steps {
+            let output = kin_git::test_support::fixture_git_in(&dir)
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        let layout = kin_core::init_from_git(&dir).unwrap().layout;
+        let state = Arc::new(DaemonState::open(layout).unwrap());
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        state
+    }
+
+    /// One `/blame` or `/history` request naming `entity`, with no ref: the
+    /// status and the body, which carries the rendered lines on success and the
+    /// refusal otherwise.
+    async fn entity_read(app: &axum::Router, endpoint: &str, entity: &str) -> (StatusCode, String) {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::post(endpoint)
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({ "entity": entity }).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 1 << 20)
+            .await
+            .unwrap();
+        (status, String::from_utf8_lossy(&body).into_owned())
+    }
+
+    fn answer_lines(body: &str) -> Vec<String> {
+        let answer: serde_json::Value =
+            serde_json::from_str(body).unwrap_or_else(|error| panic!("{error}: {body}"));
+        answer["lines"]
+            .as_array()
+            .expect("a blame or history answer carries its lines")
+            .iter()
+            .map(|line| line.as_str().unwrap_or_default().to_string())
+            .collect()
+    }
+
+    /// `/blame` and `/history` resolve `HEAD` from the authority this daemon
+    /// keeps for the current publication instead of opening the store per
+    /// request.
+    ///
+    /// Asserted on the answer, which names an open whenever one happened on the
+    /// thread that built it, and on the daemon's load counter. The counter alone
+    /// could not fail: a route handed the bare binding opens the store through
+    /// the ref grammar and never touches this daemon's cache, so the counter
+    /// stays flat while every request pays for a whole-store open.
+    #[tokio::test]
+    async fn blame_and_history_answer_head_from_the_authority_the_daemon_holds() {
+        let state =
+            test_state_with_committed_sources(&[("src/lib.py", "def retained():\n    return 1\n")]);
+        let loads_before = state.projection_authority.loads();
+        let app = router(Arc::clone(&state));
+
+        let (status, body) = entity_read(&app, "/blame", "retained").await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        let cold = answer_lines(&body);
+        assert!(
+            cold.iter()
+                .any(|line| line.starts_with("Blame for 'retained'")),
+            "{cold:#?}"
+        );
+        assert!(
+            cold.iter().any(|line| line.contains("1 version(s) found.")),
+            "HEAD must reach the committed revision: {cold:#?}"
+        );
+        assert!(
+            cold.iter().any(
+                |line| line.contains("opened repository authority for its current publication")
+            ),
+            "the first read at a publication pays for the open and says so: {cold:#?}"
+        );
+
+        for endpoint in ["/blame", "/history", "/history"] {
+            let (status, body) = entity_read(&app, endpoint, "retained").await;
+            assert_eq!(status, StatusCode::OK, "{endpoint}: {body}");
+            let lines = answer_lines(&body);
+            assert!(
+                !lines.iter().any(|line| line.starts_with("Answered by:")),
+                "{endpoint} at a publication this daemon already holds must not open the store: \
+                 {lines:#?}"
+            );
+        }
+        assert_eq!(
+            state.projection_authority.loads(),
+            loads_before + 1,
+            "one authority load serves every read at one publication"
+        );
+    }
+
+    /// Blame and history resolve a name through the resolver `kin refs` and
+    /// `kin impact` share: twins answer about the first by the one ranking rule,
+    /// say a choice was made and list every candidate by id, a pin reaches the
+    /// twin it names, and a pin that excludes both is refused naming both.
+    #[tokio::test]
+    async fn blame_and_history_pin_one_twin_and_list_the_others() {
+        let state = test_state_with_committed_sources(&[
+            ("src/a.py", "def helper():\n    return 1\n"),
+            ("src/b.py", "def helper():\n    return 2\n"),
+        ]);
+        let twins: Vec<Entity> = state
+            .graph
+            .query_entities(&kin_model::EntityFilter {
+                name_pattern: Some("helper".to_string()),
+                ..Default::default()
+            })
+            .unwrap()
+            .into_iter()
+            .filter(|entity| entity.name == "helper")
+            .collect();
+        assert_eq!(
+            twins.len(),
+            2,
+            "the fixture must hold two functions named helper: {twins:#?}"
+        );
+        let app = router(Arc::clone(&state));
+
+        let (status, body) = entity_read(&app, "/blame", "helper").await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        let unpinned = answer_lines(&body);
+        assert!(
+            unpinned[0].contains("@ src/a.py:1"),
+            "an unpinned name answers about the first twin by the ranking rule: {unpinned:#?}"
+        );
+        assert!(
+            unpinned
+                .iter()
+                .any(|line| line.contains("'helper' names 2 entities")),
+            "the answer must say it chose: {unpinned:#?}"
+        );
+        for twin in &twins {
+            assert!(
+                unpinned
+                    .iter()
+                    .any(|line| line.contains(&twin.id.to_string())),
+                "every candidate is listed by id: {unpinned:#?}"
+            );
+        }
+
+        for (endpoint, entity) in [
+            ("/history", "helper#function@src/b.py"),
+            ("/blame", "helper@src/b.py"),
+        ] {
+            let (status, body) = entity_read(&app, endpoint, entity).await;
+            assert_eq!(status, StatusCode::OK, "{endpoint} {entity}: {body}");
+            let pinned = answer_lines(&body);
+            assert!(
+                pinned[0].contains("@ src/b.py:1"),
+                "the pin reaches src/b.py's twin: {pinned:#?}"
+            );
+            assert!(
+                !pinned.iter().any(|line| line.contains("names 2 entities")),
+                "a pinned answer made no choice: {pinned:#?}"
+            );
+        }
+
+        let (status, body) = entity_read(&app, "/blame", "helper@src/nowhere.py").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+        assert!(
+            body.contains("src/a.py") && body.contains("src/b.py"),
+            "a pin that excludes both twins names both: {body}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
`kin blame` and `kin history` now answer from the authority the daemon already holds, instead of opening the whole store on every call. On a full-history store of this repository, `kin history` went from 60.3 s to 7.8 s and `kin blame` from 67.8 s to 9.3 s, same store, same commands. Memory is not better yet, and the last section says why.

## What was slow

Both daemon routes handed the ref grammar a bare binding, so resolving `HEAD` opened the whole repository authority from disk on every request. A 45 s `sample` of the daemon during `kin blame human_bytes` on the scratch store put 31,822 of the blame thread's 32,030 samples under `resolve_ref` -> `ActiveRepositoryAuthority::open` -> `recover_snapshot_from_state`. Every other command route that reads source already shares one open per publication (`/commands/log`, `/commands/diff`, `/commands/graph`, `/commands/status`).

## What changed

- `/blame` and `/history` resolve a ref through the daemon's command authority slot, reached lazily, so an explicit `kin:<id>` still reads no authority. The answer ends with an `Answered by:` line only when an open happened on the thread that built it, with the seconds it waited. Warm answers carry nothing new.
- Revisions without `--ref` come from kin-model's `get_entity_revisions_at`, which reads the first-parent history and applies only the queried entity's deltas. The replay it replaces rebuilt every entity and relation in the repository, sweeping every live relation after every change, to keep one entity's list. The rows are the same, because a revision id is minted from the entity id and the change that introduced it. `--ref` keeps the replay, since a name can mean a different or removed entity at that ref.
- Both commands resolve their entity through the resolver `kin refs` and `kin impact` have shared since #1702, so a name with twins gets the same ranking and the same choice note, which lists every candidate by id. Pins work as `Name#kind@path` or as `--file` with `--kind`. A partial name or a pin miss is refused with the candidates instead of guessed.
- The header carries the entity's `path:line`, and blame prints each change's subject line instead of the whole message.

## Measured on the same scratch store

Store: full history of kin at 47aa5172 (3012 commits, `--no-enrich`, 9.4 GB), warm daemon, same commands, same order after the same cold `graph status`. Before numbers are lane cliread's, on 47aa5172 bytes and on #1702's bytes (which did not touch blame or history).

| command | before (47aa5172) | before (#1702 bytes) | after |
|---|---|---|---|
| `kin history human_bytes` | 60.3 s | 91.5 s | 7.77 s |
| `kin blame human_bytes` | 67.8 s | 93.5 s | 9.29 s |
| `kin blame human_bytes` again | 64.3 s | 69.4 s | 7.82 s |
| `kin blame human_bytes --all-revisions` | 58.2 s | 62.9 s | 7.96 s |

After-run rows with no before counterpart, same daemon, same store, bytes of 2179a7fb7:

| command | after |
|---|---|
| `kin history human_bytes` again | 7.56 s |
| `kin blame human_bytes --file crates/kin-cli/src/commands/cache.rs --kind function` | 7.43 s |
| `kin history 'human_bytes#function@crates/kin-cli/src/commands/cache.rs'` | 7.52 s |
| `kin blame human_byte` (a partial name reaching several entities, refused with the list) | 0.06 s, exit 1 |
| `kin blame human_bytes --ref HEAD` (same held authority, whole-graph replay) | 14.35 s |
| `kin history human_bytes --ref HEAD` (same, replay) | 13.39 s |

The `--ref HEAD` pair is the A/B for the revision path: the same authority, the same ref, the same entity, and the replay costs about 6 s more per call than `get_entity_revisions_at`. The cold `graph status` that starts the daemon took 143.3 s here and 173.9 s in the before run. This PR does not touch that path, so read nothing into the difference.

Daemon memory footprint (from `top`, 5 s cadence): before, 7.5 to 16 GiB during `history` and 7.5 to 14 GiB during `blame`, against 3.7 to 8.5 GiB while loading. After, per step: 14 GiB during the first `history`, 12 to 20 GiB during the first `blame`, 9 to 13 GiB during the other blame and history calls, and 7.4 to 13 GiB during the `--ref HEAD` pair, against 3.7 to 7.9 GiB while loading. `top` rounds values above 10 GiB to whole GiB. Swap stayed at 8,052 MB used throughout.

## What this does not fix yet

The remaining 7 to 9 s and the footprint are the revision derivation itself. A 20 s `sample` during the unpinned `blame` on these bytes puts 5,690 of the handler's samples under `resolve_entity_timeline` -> `get_entity_revisions_at` -> `collect_changes_first_parent` -> `ChangeMap::read_change`, which decodes and validates every one of the 3,012 changes on the first-parent line to keep the handful that touch this entity. The authority open that dominated the before profile is gone from it. Reading only the entity's own changes needs kin-db to answer `get_entity_revisions_at` from the per-entity revision chain the live graph already keeps, walking parents through the change map's compact index instead of loading bodies. That is a kin-db change and is proposed as its own follow-up.

## Tests

- `api::tests::blame_and_history_answer_head_from_the_authority_the_daemon_holds` (kin-daemon, a real store with one commit through `init_from_git`). The first `/blame` pays the command slot's load and says so. One more `/blame` and two `/history` carry no open line, and `loads()` climbs by exactly one. The counter alone could not fail, because the old route opened the store through the ref grammar and never touched the daemon's cache.
- `api::tests::blame_and_history_pin_one_twin_and_list_the_others` (kin-daemon): two `def helper()` in two files. Unpinned, the header points at `src/a.py:1` and the note lists both ids. Pinned by suffix, the answer is about `src/b.py:1` with no note. A pin that excludes both is a 400 naming both files.
- `ref_lookup::tests::a_shared_authority_is_handed_over_rather_than_reopened` (kin-cli): the shared arm is handed the server's authority, and the per-thread open counter does not move. A `kin:<id>` asks for no authority at all. The pinned arm opens once, as the control.
- `ref_lookup::tests::an_answer_names_an_open_only_when_its_thread_paid_for_one` and `a_query_that_reaches_nothing_is_refused_with_its_own_name` (kin-cli). The second replaces `whole_graph_fallback_stays_narrowed_to_the_query`, and an unmatched name still never lists unrelated entities.
- `revisions_survive_a_change_that_also_removes_another_entity` now grades `get_entity_revisions_at`.
- `entity_revision_history::blame_and_history_at_a_ref_pin_one_twin_and_list_the_others` (kin-cli, `--ref` over the replayed state), plus a subject-line assertion on the existing blame test.

## Falsification

All ten mutations went red on the assertion each one targets, and every run left the tree clean.

Each run applies its mutations to the committed tree with `clireadb-falsify.py <run>` and runs the targeted tests above through the heavy slot. Afterwards `git checkout` restores the files, and porcelain was empty after every run. Runs are grouped so no mutation's target assertion is masked by another failing earlier in the same test.

R2 carries three mutations. In M2 the ref grammar ignores a server's shared authority and opens the store (`ref_grammar.rs`). In M8 a refusal loses its type (`ref_lookup.rs`). In M4 blame prints the whole commit message again (`blame.rs`).

```text
commands::ref_lookup::tests::a_shared_authority_is_handed_over_rather_than_reopened panicked at crates/kin-cli/src/commands/ref_lookup.rs:793:9:
assertion `left == right` failed: HEAD must ask the server for the authority it holds
  left: 0
api::tests::blame_and_history_answer_head_from_the_authority_the_daemon_holds panicked at crates/kin-daemon/src/api.rs:49208:13:
/blame at a publication this daemon already holds must not open the store: [
commands::ref_lookup::tests::a_query_that_reaches_nothing_is_refused_with_its_own_name panicked at crates/kin-cli/src/commands/ref_lookup.rs:571:42:
the refusal must be typed for the daemon
blame_and_history_at_a_ref_pin_one_twin_and_list_the_others panicked at crates/kin-cli/tests/entity_revision_history.rs:398:10:
the refusal is typed so the daemon answers it as the caller's news
api::tests::blame_and_history_pin_one_twin_and_list_the_others panicked at crates/kin-daemon/src/api.rs:49288:9:
assertion `left == right` failed: No entity named 'helper' matches --file src/nowhere.py.
blame_reports_both_revisions_across_a_mixed_add_remove_change panicked at crates/kin-cli/tests/entity_revision_history.rs:251:5:
each blame row carries the subject line only, as history's does:
targeted lib rc=101 integration rc=101 daemon rc=101
```

R3 carries two mutations. In M3 every answer names the authority it reached, whether or not it opened anything (`ref_lookup.rs`). In M5 the resolver reads the pins and then ignores them (`entity_identity.rs`), which also reddens three of #1702's pin tests in `entity_resolution_across_commands`, as it should, since every command shares the resolver.

```text
commands::ref_lookup::tests::an_answer_names_an_open_only_when_its_thread_paid_for_one panicked at crates/kin-cli/src/commands/ref_lookup.rs:839:9:
assertion `left == right` failed: an authority handed over costs the answer nothing worth naming
  left: Some("Answered by: this repository's daemon, which opened repository authority for its current publication to answer this (58.2 s, re-verifying every persisted body); later reads at this publication reuse that open.")
api::tests::blame_and_history_answer_head_from_the_authority_the_daemon_holds panicked at crates/kin-daemon/src/api.rs:49208:13:
/blame at a publication this daemon already holds must not open the store: [
blame_and_history_at_a_ref_pin_one_twin_and_list_the_others panicked at crates/kin-cli/tests/entity_revision_history.rs:350:5:
the pin reaches src/other.rs's twin: [
    "History for 'alpha' (Function, rust) @ src/lib.rs at 6011f077c0f5:",
api::tests::blame_and_history_pin_one_twin_and_list_the_others panicked at crates/kin-daemon/src/api.rs:49277:13:
the pin reaches src/b.py's twin: [
    "History for 'helper' (Function, python) @ src/a.py:1 at 7a61f54ab4f5:",
targeted lib rc=101 integration rc=101 daemon rc=101
```

R4 carries one mutation. In M9 the answer's header loses the entity's `path:line` pointer (`ref_lookup.rs`).

```text
blame_and_history_at_a_ref_pin_one_twin_and_list_the_others panicked at crates/kin-cli/tests/entity_revision_history.rs:330:5:
an unpinned name answers about the first twin by path: [
    "History for 'alpha' (Function, rust) at 8f42ec255999:",
api::tests::blame_and_history_pin_one_twin_and_list_the_others panicked at crates/kin-daemon/src/api.rs:49251:9:
an unpinned name answers about the first twin by the ranking rule: [
    "Blame for 'helper' (Function, python) at f644123141ca3f225b2cd2c69a2bcf06d573c4e9fd51bff2864eefb7b0f1cc22:",
targeted lib rc=0 integration rc=101 daemon rc=101
```

R1 carries three mutations and ran last, because its first attempt did not compile M7 and graded nothing. In M1 both routes hand the ref grammar the bare binding again (`api.rs`). In M7 revisions come from the entity-filtered history replayed with a whole-state validator (`ref_lookup.rs`), the class the doc comment names. In M10 the choice note is never printed (`entity_identity.rs`), which also reddens three of #1702's choice-note tests.

```text
api::tests::blame_and_history_answer_head_from_the_authority_the_daemon_holds panicked at crates/kin-daemon/src/api.rs:49197:9:
the first read at a publication pays for the open and says so: [
commands::ref_lookup::tests::revisions_survive_a_change_that_also_removes_another_entity panicked at crates/kin-cli/src/commands/ref_lookup.rs:673:14:
a sound history must not report a conflict for an unqueried entity: ref 'HEAD' resolves to semantic change 2bd6f6a35566d4e68e87a80161fe7a3bc0173a88150a026fdde1eaebfd99c67b, which this daemon's live graph projection does not hold, so its history cannot be replayed; durable history is intact and `kin log` and `kin diff` still read it. Restart the repository daemon with `kin daemon stop` and run the command again. Underlying cause: conflict: change 2bd6f6a35566d4e68e87a80161fe7a3bc0173a88150a026fdde1eaebfd99c67b has stale old payload for removed entity 40e8624c-caca-4316-b3bc-9874f695e8e1
blame_and_history_at_a_ref_pin_one_twin_and_list_the_others panicked at crates/kin-cli/tests/entity_revision_history.rs:334:5:
the answer must say it chose: [
api::tests::blame_and_history_pin_one_twin_and_list_the_others panicked at crates/kin-daemon/src/api.rs:49255:9:
the answer must say it chose: [
targeted lib rc=101 integration rc=101 daemon rc=101
```

## Local gates

`KIN_EMBED_BACKEND=cpu .kin-coord/bin/heavy-slot.sh clireadb kin -- bin/kin-precheck kin --repo-dir kin=<lane worktree>` (absolute paths in the run):

```text
kin-precheck: repo=kin tree=/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/clireadb-kin sha=2179a7fb7753aa78f03cee5760e98304ba79c955 branch=chore/lane-clireadb-kin
kin-precheck: behind origin/main 0 commit(s)
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin 2179a7fb7753aa78f03cee5760e98304ba79c955
```

Targeted tests on the same tree, through the same heavy slot: kin-cli lib slice `ref_lookup:: entity_identity:: entity_ref:: ref_grammar:: output_style::` 48 passed, `blame_projection_gap` 4, `declaration_resolution_e2e` 12, `entity_resolution_across_commands` 6, `entity_revision_history` 3, and the kin-daemon slice (`blame_and_history` plus writepath's two attribution tests, which call the binding-taking entry points) 6 passed.

Refs FIR-3547.
