### PR TITLE
Grade an agent edit made after its daemon restarts (FIR-3550)

### DIFF
--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -469,7 +469,15 @@ drives an edit the planner refuses (an unterminated comment that hides a
 declaration) and requires the file untouched and the model told. `create_lands` and
 `refused_create_is_clean` do the same for `write_file`, the second one requiring the
 refused content to come back to the model rather than as a file the graph does not
-hold.
+hold. `edit_survives_a_daemon_restart` stops the fixture's daemon with
+`kin daemon stop` after the agent's session opens and before its first edit, which
+is what an unattended update did to the demo's real-model run. Sessions live in the
+daemon, so the next begin names a session that no longer exists. The check requires
+the edit to commit through Kin anyway: the harness has to open a new session, and
+the file, `get_entity_source`, the durability block and the edit's own provenance
+must agree. It is the one place where kin-mcp's refusal wording meets kin-agent's
+reading of it. The suite sets `KIN_REGISTRY_PATH` under its scratch home, because
+`KIN_HOME` does not move the supervisor.
 
 `eject_journal_repro.py` covers the eject archive round trip the rc0552n green
 stranger lost on 0.5.52 (FIR-2664). A finished `kin eject` left its journal in

--- a/scripts/acceptance/agent_write_publish_repro.py
+++ b/scripts/acceptance/agent_write_publish_repro.py
@@ -16,7 +16,7 @@ without writing first, so neither could see the composition. This suite runs the
 binaries end to end: `kin init`, `kin agent run` against a scripted chat endpoint, and a
 direct `kin mcp start` session to read the result back.
 
-Four checks, one repository, run in order:
+Five checks, one repository, run in order:
 
   edit_lands            an `edit_file` on a tracked function commits: the run exits 0,
                         the file holds the new text, `get_entity_source` answers with the
@@ -29,6 +29,14 @@ Four checks, one repository, run in order:
   refused_create_is_clean
                         a `write_file` over a tracked path is refused, the tracked file
                         keeps its text, and the refused content comes back to the model
+  edit_survives_a_daemon_restart
+                        the repository's daemon is stopped after the agent's session opens
+                        and before its first edit, as an unattended update did in the
+                        demo's real-model run. Sessions live in the daemon, so begin is
+                        refused for a session that no longer exists; the harness must open
+                        a new one and commit through it. The run exits 0, the file and
+                        `get_entity_source` carry the edit, durability reads `recorded`,
+                        and no edit is written outside a transaction
 
 What it is blind to: it drives one agent, one repository and one scripted conversation. It
 does not grade the cost of a commit, the delegate's retry on a slow one, or a real model.
@@ -48,10 +56,12 @@ import functools
 import json
 import os
 import shutil
+import socket
 import subprocess
 import sys
 import tempfile
 import threading
+import time
 
 try:
     from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -83,6 +93,11 @@ REFUSED_REPLACE = "/* pub fn kept() -> u8 {"
 CREATED_PATH = "src/added.rs"
 CREATED_BODY = "pub fn added() -> u8 {\n    3\n}\n"
 OVERWRITE_BODY = "# replaced wholesale\n"
+
+# The edit made after the daemon is restarted, on a function no earlier check changes.
+RESTART_FIND = "pub fn other() -> u8 {\n    4\n}"
+RESTART_REPLACE = "/// The other value.\npub fn other() -> u8 {\n    0x2b\n}"
+RESTART_MARKER = "0x2b"
 
 
 def run(cmd, cwd=None, env=None, timeout=600):
@@ -187,6 +202,44 @@ def grade_refused_create_is_clean(rc, disk_before, disk_after, tool_result):
     return PASS, "the refused write left the tracked file alone and handed the content back"
 
 
+def grade_edit_survives_a_daemon_restart(stop, rc, disk, source_payload, status_payload, trace):
+    """`stop` is the restart's (rc, detail); `trace` is the run's kin-trace rows."""
+    if not stop or stop[0] != 0:
+        return UNREADABLE, "no restart was exercised: %s" % (
+            stop[1] if stop else "the model endpoint was never asked for its first answer")
+    if rc is None or disk is None or source_payload is None or status_payload is None \
+            or trace is None:
+        return UNREADABLE, "the run or its read-back produced nothing to grade"
+    problems = []
+    if rc != 0:
+        problems.append("kin agent run exited %s, not 0" % rc)
+    if RESTART_MARKER not in disk:
+        problems.append("the file on disk does not carry the edit")
+    if not mentions(source_payload, RESTART_MARKER):
+        problems.append("get_entity_source still answers with the old body")
+    state = durability_state(status_payload)
+    if state != "recorded":
+        problems.append("durability reads %r, not 'recorded'" % state)
+    edits = [row for row in trace if row.get("surface") == "local"
+             and row.get("tool") in ("edit_file", "write_file")]
+    if not edits:
+        problems.append("the trace records no edit")
+    for row in edits:
+        provenance = row.get("provenance") or {}
+        if provenance.get("closed_with") != "kin_transaction_commit" \
+                or provenance.get("closed_cleanly") is not True:
+            problems.append("the edit did not commit through a transaction (%s)" % (
+                provenance.get("reason") or provenance.get("detail") or "no reason recorded"))
+    if problems:
+        return FAIL, "; ".join(problems)
+    refused = any(row.get("tool") == "kin_transaction_begin" and row.get("is_error")
+                  and "Session not found" in str(row.get("detail") or "") for row in trace)
+    sessions = sum(1 for row in trace if row.get("tool") == "kin_session_start")
+    how = ("begin was refused for the gone session and the harness opened a new one"
+           if refused and sessions >= 2 else "no begin was refused after the restart")
+    return PASS, "the edit committed through Kin after a daemon restart; %s" % how
+
+
 # ── the scripted chat endpoint ─────────────────────────────────────────────
 
 
@@ -204,10 +257,15 @@ def completion(text, tool=None, arguments=None):
 
 
 class Endpoint(object):
-    """One scripted conversation: each request pops the next answer."""
+    """One scripted conversation: each request pops the next answer.
 
-    def __init__(self, script):
+    `before_first`, when given, runs once before the first answer goes back, while the
+    agent waits on its model, which is where a real model spends its long turns.
+    """
+
+    def __init__(self, script, before_first=None):
         answers = list(script)
+        pending = [before_first] if before_first else []
         lock = threading.Lock()
 
         class Handler(BaseHTTPRequestHandler):
@@ -228,6 +286,8 @@ class Endpoint(object):
             def do_POST(self):
                 self.rfile.read(int(self.headers.get("Content-Length", "0")))
                 with lock:
+                    while pending:
+                        pending.pop(0)()
                     answer = answers.pop(0) if answers else completion("Done.")
                 self._send(answer)
 
@@ -299,12 +359,17 @@ class Suite(object):
         self.verbose = verbose
         self.env = dict(os.environ)
         self.env["KIN_HOME"] = os.path.join(workdir, "home")
+        # KIN_HOME does not move the supervisor. It lives beside an explicit
+        # KIN_REGISTRY_PATH, or else in the real home's `.kin`, where a daemon started
+        # here would take the machine-wide supervisor with the build under test.
+        self.env["KIN_REGISTRY_PATH"] = os.path.join(workdir, "home", "registry.toml")
         self.env.pop("KIN_MCP_REPO", None)
         if daemon:
             self.env["KIN_DAEMON_BIN"] = daemon
         self._repo = None
         self._setup_error = None
         self._runs = 0
+        self.last_trace = None
 
     def git(self, cwd, args):
         # The caller's global and system git config stay out of the fixture: a hooks
@@ -356,11 +421,15 @@ class Suite(object):
         with open(path) as handle:
             return handle.read()
 
-    def agent(self, script):
-        """Run `kin agent run` through one scripted conversation; return rc and its trace."""
+    def agent(self, script, before_first=None):
+        """Run `kin agent run` through one scripted conversation.
+
+        Returns the exit code and the last tool result the model was sent, and keeps the
+        run's kin-trace rows on `last_trace`.
+        """
         self._runs += 1
         out = os.path.join(self.workdir, "run-%d" % self._runs)
-        endpoint = Endpoint(script)
+        endpoint = Endpoint(script, before_first=before_first)
         try:
             rc, stdout, stderr = run([self.kin, "agent", "run", "--task",
                                       "Make the change the conversation asks for.",
@@ -381,10 +450,46 @@ class Suite(object):
                     for block in (record.get("message") or {}).get("content") or []:
                         if isinstance(block, dict) and block.get("type") == "tool_result":
                             tool_result = block.get("content")
+        self.last_trace = None
+        trace = os.path.join(out, "kin-trace.jsonl")
+        if os.path.exists(trace):
+            with open(trace) as handle:
+                self.last_trace = [json.loads(line) for line in handle if line.strip()]
         return rc, tool_result
 
     def mcp(self):
         return Mcp([self.kin, "mcp", "start", "--repo", self.repo()], self.env, self.workdir)
+
+    def stop_daemon(self):
+        """Stop this fixture's daemon with `kin daemon stop` and wait for its port to close.
+
+        Returns (rc, detail). The port is read first, because a stopped daemon removes its
+        endpoint files.
+        """
+        port = None
+        port_file = os.path.join(self.repo(), ".kin", "daemon.port")
+        if os.path.exists(port_file):
+            with open(port_file) as handle:
+                text = handle.read().strip()
+            port = int(text) if text.isdigit() else None
+        if port is None:
+            return 1, "no daemon was serving the fixture when the restart was due"
+        rc, _, err = run([self.kin, "daemon", "stop"], cwd=self.repo(), env=self.env,
+                         timeout=180)
+        if rc != 0:
+            return rc, "kin daemon stop exited %s: %s" % (rc, err.strip()[-300:])
+        deadline = time.time() + 60
+        while time.time() < deadline:
+            probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            probe.settimeout(1)
+            try:
+                probe.connect(("127.0.0.1", port))
+            except OSError:
+                return 0, "the daemon on port %d stopped" % port
+            finally:
+                probe.close()
+            time.sleep(0.5)
+        return 1, "the daemon on port %d still answered 60 s after kin daemon stop" % port
 
 
 class Result(object):
@@ -458,11 +563,34 @@ def check_refused_create_is_clean(suite):
     return Result("refused_create_is_clean", verdict, "%s %s" % (TICKET, detail))
 
 
+def check_edit_survives_a_daemon_restart(suite):
+    stop = []
+    rc, _ = suite.agent([completion("Documenting other.", "edit_file",
+                                    {"path": "src/other.rs", "find": RESTART_FIND,
+                                     "replace": RESTART_REPLACE}),
+                         completion("other is documented.")],
+                        before_first=lambda: stop.append(suite.stop_daemon()))
+    session = suite.mcp()
+    try:
+        listed = session.call("list_file_entities", {"path": "src/other.rs", "limit": 50})
+        focal = entity_id(listed, "other")
+        source = session.call("get_entity_source", {"entity_id": focal}) if focal else None
+        status = session.call("kin_graph_status", {})
+    finally:
+        session.close()
+    verdict, detail = grade_edit_survives_a_daemon_restart(
+        stop[0] if stop else None, rc, suite.read("src/other.rs"), source, status,
+        suite.last_trace)
+    return Result("edit_survives_a_daemon_restart", verdict, "%s %s" % (TICKET, detail))
+
+
 CHECKS = [
     ("edit_lands", check_edit_lands),
     ("refused_edit_is_clean", check_refused_edit_is_clean),
     ("create_lands", check_create_lands),
     ("refused_create_is_clean", check_refused_create_is_clean),
+    # Last, because it stops the daemon every earlier check ran against.
+    ("edit_survives_a_daemon_restart", check_edit_survives_a_daemon_restart),
 ]
 
 
@@ -480,8 +608,10 @@ def absolute_binary(path):
 
 def self_test():
     failures = []
+    checked = []
 
     def expect(what, got, want):
+        checked.append(what)
         if got != want:
             failures.append("%s: got %s, want %s" % (what, got, want))
 
@@ -524,13 +654,49 @@ def self_test():
     expect("refused create without its content",
            grade_refused_create_is_clean(6, README, README, "did not publish it")[0], FAIL)
 
+    stopped = (0, "the daemon on port 1 stopped")
+    other_edited = OTHER_RS.replace(RESTART_FIND, RESTART_REPLACE)
+    new_other = {"source": RESTART_REPLACE, "_kin": {}}
+    old_other = {"source": RESTART_FIND, "_kin": {}}
+    committed = {"surface": "local", "tool": "edit_file",
+                 "provenance": {"bracketed": True, "closed_with": "kin_transaction_commit",
+                                "closed_cleanly": True}}
+    reopened = [{"tool": "kin_session_start"},
+                {"tool": "kin_transaction_begin", "is_error": True,
+                 "detail": "Session not found: s1. It was ended or expired after its idle "
+                           "timeout."},
+                {"tool": "kin_session_start"}, {"tool": "kin_transaction_begin"},
+                {"tool": "kin_transaction_stage"}, {"tool": "kin_transaction_commit"},
+                committed]
+    written_locally = [{"tool": "kin_session_start"},
+                       {"tool": "kin_transaction_begin", "is_error": True,
+                        "detail": "Session not found: s1."},
+                       {"surface": "local", "tool": "edit_file",
+                        "provenance": {"bracketed": False, "reason": "Session not found: s1."}}]
+    expect("edit survives a restart",
+           grade_edit_survives_a_daemon_restart(stopped, 0, other_edited, new_other, recorded,
+                                                reopened)[0], PASS)
+    expect("restart ends in a local write",
+           grade_edit_survives_a_daemon_restart(stopped, 0, other_edited, old_other,
+                                                uncommitted, written_locally)[0], FAIL)
+    expect("restart ends in a refusal",
+           grade_edit_survives_a_daemon_restart(stopped, 6, OTHER_RS, old_other, recorded,
+                                                written_locally)[0], FAIL)
+    expect("restart's local write picked up only by the reconcile loop",
+           grade_edit_survives_a_daemon_restart(stopped, 0, other_edited, new_other, recorded,
+                                                written_locally)[0], FAIL)
+    expect("restart never happened",
+           grade_edit_survives_a_daemon_restart((1, "kin daemon stop exited 1"), 0,
+                                                other_edited, new_other, recorded,
+                                                reopened)[0], UNREADABLE)
+
     report = report_payload([Result("edit_lands", PASS, "x")])
     expect("report keyed results", sorted(report), ["results", "suite", "ticket"])
     expect("report row id", report["results"][0]["id"], "edit_lands")
 
     for failure in failures:
         print("SELF-TEST FAIL %s" % failure)
-    print("SELF-TEST %s (%d expectations)" % ("FAIL" if failures else "PASS", 17))
+    print("SELF-TEST %s (%d expectations)" % ("FAIL" if failures else "PASS", len(checked)))
     return 1 if failures else 0
 
 


### PR DESCRIPTION
An agent edit made after its daemon restarts now has an end-to-end check, so a regression in the session re-open shows up on main's acceptance run.

## What this grades

In the local-model run on the FIR-3550 fix, an unattended update stopped the daemon while the model was still reading. Sessions live in the daemon, so its replacement didn't know the agent's session and `kin_transaction_begin` was refused. #1708 made the harness re-open its session once and retry, and write nothing when it still can't open a transaction. Its crate tests drive a scripted MCP server, though, so they can't see whether kin-mcp's real refusal still reads the way kin-agent's matcher expects.

`edit_survives_a_daemon_restart` is the fifth check in `scripts/acceptance/agent_write_publish_repro.py`. The scripted model endpoint runs `kin daemon stop` on the fixture after the agent's session opens and before its first answer, then waits for the port to close. The check requires the edit to commit through Kin anyway: `kin agent run` exits 0, the file and `get_entity_source` carry the edit, the durability block reads `recorded`, and the edit's own provenance says it closed with `kin_transaction_commit`. That last requirement is what catches a local write the reconcile loop picks up afterwards. If the stop itself fails, the check reads UNREADABLE, since no restart was exercised.

The suite also sets `KIN_REGISTRY_PATH` under its scratch home, because `KIN_HOME` does not move the supervisor, so a run could otherwise take the machine-wide one with the build under test. The self-test now counts its expectations. It used to print a fixed 17 while 15 ran, and it runs 20 now.

## Evidence (local; acceptance does not run on pull requests)

On PR 4's release bytes (`kin 0.7.14 (6008e323bd9e...)`, the head #1708 squashed onto main as 1b075cbc7; the two other PRs main carries since then don't touch the agent write path), all five checks pass. The new one shows the class it exists for, with the real kin-mcp refusal text:

```
$ python3 scripts/acceptance/agent_write_publish_repro.py --kin <release>/kin \
    --daemon <release>/kin-daemon --json agent_write.json --keep --verbose
CHECK edit_lands FIR-3550 PASS FIR-3550 the edit committed: disk, get_entity_source and durability agree
CHECK refused_edit_is_clean FIR-3550 PASS FIR-3550 the refused edit left the file untouched and the model was told
CHECK create_lands FIR-3550 PASS FIR-3550 the created module committed and the graph lists its function
CHECK refused_create_is_clean FIR-3550 PASS FIR-3550 the refused write left the tracked file alone and handed the content back
CHECK edit_survives_a_daemon_restart FIR-3550 PASS FIR-3550 the edit committed through Kin after a daemon restart; begin was refused for the gone session and the harness opened a new one
```

Exit 0.

Falsified by building `kin` with the session re-open turned off (`reopened` starts true in `begin_transaction`, so a gone session is never re-opened), with `kin-daemon` and everything else unchanged. The new check goes red for the reason it exists, and the other four stay green:

```
CHECK edit_lands FIR-3550 PASS FIR-3550 the edit committed: disk, get_entity_source and durability agree
CHECK refused_edit_is_clean FIR-3550 PASS FIR-3550 the refused edit left the file untouched and the model was told
CHECK create_lands FIR-3550 PASS FIR-3550 the created module committed and the graph lists its function
CHECK refused_create_is_clean FIR-3550 PASS FIR-3550 the refused write left the tracked file alone and handed the content back
CHECK edit_survives_a_daemon_restart FIR-3550 FAIL FIR-3550 kin agent run exited 6, not 0; the file on disk does not carry the edit; get_entity_source still answers with the old body; the edit did not commit through a transaction ({"message":"Session not found: 7c50aff9-721a-4119-a2e2-12eb92d4b7a6. It was ended or expired after its idle timeout. Call kin_session_start for a new session id and begin the transaction on that one; kin_session_heartbeat keeps a session alive through a long read phase."})
```

Exit 1. The source was restored from the commit afterwards.

```
$ python3 scripts/acceptance/agent_write_publish_repro.py --self-test
SELF-TEST PASS (20 expectations)
```

## Local gates

`bin/kin-precheck kin --repo-dir kin=<this branch's worktree>`, with the gate list read from ci.yml's check job:

```
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:check_private_repo_coupling.sh bash scripts/check_private_repo_coupling.sh
PASS     guard:check_runtime_boundaries.sh    bash scripts/check_runtime_boundaries.sh
PASS     guard:test-release-policy-gate.sh    bash scripts/test-release-policy-gate.sh
PASS     guard:test-windows-authority-legs.sh bash scripts/test-windows-authority-legs.sh
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:check-kin-vfs-compat.mjs       node scripts/check-kin-vfs-compat.mjs
PASS     guard:check-rc-build-drift.mjs       node scripts/check-rc-build-drift.mjs
PASS     guard:check-required-contexts.py     python3 scripts/check-required-contexts.py
PASS     guard:test-assertion-reachability.py python3 scripts/test-assertion-reachability.py
PASS     guard:test-guard-duplicate-release-run.py python3 scripts/test-guard-duplicate-release-run.py
PASS     guard:test-homebrew-release-gate.py  python3 scripts/test-homebrew-release-gate.py
PASS     guard:test-install-checksum.py       python3 scripts/test-install-checksum.py
PASS     guard:test-private-repo-coupling.py  python3 scripts/test-private-repo-coupling.py
PASS     guard:test-release-tag-evaluate-dispatch.py python3 scripts/test-release-tag-evaluate-dispatch.py
PASS     guard:test-release-workflow-authority.py python3 scripts/test-release-workflow-authority.py
PASS     guard:test-select-release-candidate.py python3 scripts/test-select-release-candidate.py
PASS     guard:verify-hydration-semantics.py  python3 scripts/verify-hydration-semantics.py
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
PASS     node-test                            node --test <16 file(s) named by the check job>
PASS     guard:check-quarantine.py            python3 scripts/check-quarantine.py
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin c97563e5a614de189cbc31ea22bff132b3573881
```

FIR-3550
