### PR TITLE
Start the same language server from every daemon and name what a daemon cannot serve (FIR-3551)

### DIFF
--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -2729,6 +2729,40 @@ mod tests {
             assert!(matches!(outcome, CrossFileEnrichment::Withheld { .. }));
         }
 
+        /// The second daemon on one store, which is what FIR-3551 measured.
+        ///
+        /// Every Rust file already carries edges an earlier pass made durable,
+        /// this daemon cannot start rust-analyzer, and its sweep now reports
+        /// those files under the language it cannot serve rather than as done.
+        /// This is the status that sweep publishes, read the way `kin init` and
+        /// `kin daemon sweep` read it: the line names the language and its file
+        /// count, says the earlier edges remain, and never says complete.
+        #[test]
+        fn a_daemon_that_cannot_serve_already_enriched_files_never_reads_complete() {
+            let status = serde_json::json!({
+                "files_done": 0,
+                "files_total": 72,
+                "files_blocked": 72,
+                "languages_skipped": [{
+                    "language": "rust",
+                    "files": 72,
+                    "reason": "this daemon cannot start a rust language server (server \
+                               initialization failed: Unknown binary 'rust-analyzer' in official \
+                               toolchain '1.96.0-aarch64-apple-darwin'), and these files keep the \
+                               language-server edges an earlier pass made durable but get no new \
+                               ones until it starts"
+                }]
+            });
+            let skipped = skipped_languages_from_status(&status);
+            assert_eq!(skipped.len(), 1, "the row survives parsing: {skipped:?}");
+
+            let (line, outcome) = cross_file_enrichment_outcome(0, 72, 72, &skipped);
+            assert!(!line.contains("complete"), "{line}");
+            assert!(line.contains("rust: 72 files not enriched"), "{line}");
+            assert!(line.contains("an earlier pass made durable"), "{line}");
+            assert!(matches!(outcome, CrossFileEnrichment::Withheld { .. }));
+        }
+
         /// The sentence accounts for every file the daemon says was blocked.
         ///
         /// Measured, at the sha this test lands on, on three rust, three

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -56,6 +56,34 @@ fn should_enable_lsp_enrichment(config_enabled: bool, filesystem_reconcile_disab
     config_enabled && !filesystem_reconcile_disabled
 }
 
+/// Start the language-server readiness probe only on a daemon that enriches.
+///
+/// The probe starts every enrichable language's server to see whether it
+/// completes a handshake. It used to run before the enrichment decision and
+/// regardless of it, so a daemon started with `KIN_DAEMON_DISABLE_LSP=1` still
+/// launched typescript-language-server, rust-analyzer and pyright at startup,
+/// and its answer described a host this daemon was never going to use. Now the
+/// same decision that opens the sweep's channel decides, and a daemon that does
+/// not enrich leaves readiness unpublished, which every observation already
+/// reads as unknown: the honest state for a daemon that did not look.
+///
+/// The spawner is a parameter so the gate is testable without a server.
+fn start_readiness_probe_if_enabled(
+    enrichment_enabled: bool,
+    workspace_root: std::path::PathBuf,
+    spawn: impl FnOnce(std::path::PathBuf),
+) -> bool {
+    if !enrichment_enabled {
+        info!(
+            "language-server enrichment is switched off for this daemon, so the readiness probe \
+             starts no language server"
+        );
+        return false;
+    }
+    spawn(workspace_root);
+    true
+}
+
 /// Whether the daemon opens its enrichment channel at startup.
 ///
 /// Taken ONCE, during startup, and that is the whole reason a language server
@@ -348,7 +376,6 @@ fn spawn_language_server_readiness_probe(workspace_root: std::path::PathBuf) {
     use kin_core::reference_coverage::{
         LanguageServerReadiness, LanguageServerReadinessMap, ENRICHABLE_LANGUAGES,
     };
-    use kin_lsp::registry::{ProviderGapReason, ProviderRegistry};
 
     tokio::spawn(async move {
         // One task per language so the probes overlap: the worst case is one
@@ -359,25 +386,7 @@ fn spawn_language_server_readiness_probe(workspace_root: std::path::PathBuf) {
             .map(|language| {
                 let workspace_root = workspace_root.clone();
                 tokio::spawn(async move {
-                    let registry = ProviderRegistry::with_defaults();
-                    let initialization_options = lsp_adapter_for(language, &workspace_root)
-                        .and_then(|(_, _, init_opts)| init_opts);
-                    let readiness = match kin_lsp::lifecycle::probe_readiness(
-                        &registry,
-                        language,
-                        &workspace_root,
-                        initialization_options,
-                    )
-                    .await
-                    {
-                        Ok(_) => LanguageServerReadiness::Usable,
-                        Err(gap) => match gap.reason {
-                            ProviderGapReason::ServerUnusable { message } => {
-                                LanguageServerReadiness::Unusable { reason: message }
-                            }
-                            _ => LanguageServerReadiness::Absent,
-                        },
-                    };
+                    let readiness = probe_language_server(language, &workspace_root).await;
                     (language, readiness)
                 })
             })
@@ -407,6 +416,133 @@ fn spawn_language_server_readiness_probe(workspace_root: std::path::PathBuf) {
 
         kin_mcp::edge_coverage::publish_language_server_readiness(readiness);
     });
+}
+
+/// Whether this daemon can start `language`'s server right now, asked the way
+/// the sweep and the incremental path start one.
+///
+/// The command is resolved by [`crate::language_server_command`], so the probe
+/// starts the binary the sweep will start, with the adapter's own arguments.
+/// It used to resolve kin-lsp's registry list instead (`pylsp` behind
+/// `pyright-langserver`, `vtsls` behind `typescript-language-server`) through
+/// the daemon's inherited working directory, so it could read a language as
+/// served that no sweep could serve, and the other way round.
+pub(crate) async fn probe_language_server(
+    language: kin_model::LanguageId,
+    workspace_root: &std::path::Path,
+) -> kin_core::reference_coverage::LanguageServerReadiness {
+    let Some((command, _, _)) = lsp_adapter_for(language, workspace_root) else {
+        return kin_core::reference_coverage::LanguageServerReadiness::Absent;
+    };
+    let resolved =
+        crate::language_server_command::resolve_on_this_host(command, workspace_root.to_path_buf())
+            .await;
+    probe_resolved_language_server(language, workspace_root, resolved).await
+}
+
+/// The probe's second half, from a resolution already made, so a test can hand
+/// it any resolution without the host's toolchains.
+async fn probe_resolved_language_server(
+    language: kin_model::LanguageId,
+    workspace_root: &std::path::Path,
+    resolved: crate::language_server_command::ServerCommand,
+) -> kin_core::reference_coverage::LanguageServerReadiness {
+    use crate::language_server_command::ServerCommand;
+    use kin_core::reference_coverage::LanguageServerReadiness;
+
+    let program = match resolved {
+        ServerCommand::NotInstalled => return LanguageServerReadiness::Absent,
+        ServerCommand::Unresolvable { reason } => {
+            return LanguageServerReadiness::Unusable { reason };
+        }
+        ServerCommand::Resolved { program, chosen } => {
+            info!(
+                %language,
+                program = %program.display(),
+                %chosen,
+                "resolved the language server this daemon starts"
+            );
+            program
+        }
+    };
+    let (args, initialization_options) = lsp_adapter_for(language, workspace_root)
+        .map(|(_, args, init_opts)| (args, init_opts))
+        .unwrap_or_default();
+    let args_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    match tokio::time::timeout(
+        kin_lsp::lifecycle::READINESS_PROBE_TIMEOUT,
+        kin_lsp::lifecycle::LspServer::start(
+            &program.to_string_lossy(),
+            &args_refs,
+            workspace_root,
+            initialization_options,
+        ),
+    )
+    .await
+    {
+        Err(_) => LanguageServerReadiness::Unusable {
+            reason: format!(
+                "{} did not complete the initialize handshake within {}s",
+                program.display(),
+                kin_lsp::lifecycle::READINESS_PROBE_TIMEOUT.as_secs()
+            ),
+        },
+        Ok(Err(error)) => LanguageServerReadiness::Unusable {
+            reason: error.to_string(),
+        },
+        // Dropped rather than shut down: `kill_on_drop` ends the process at
+        // once, and a probe has no session worth closing.
+        Ok(Ok(server)) => {
+            drop(server);
+            LanguageServerReadiness::Usable
+        }
+    }
+}
+
+/// Resolve `command` and start it: the one way this daemon starts a language
+/// server for the cold sweep and the incremental path.
+///
+/// The error is a sentence a skip reason can carry as it is: the resolver's
+/// own when nothing it found can serve, and the server's when it started and
+/// refused the handshake.
+async fn start_resolved_language_server(
+    language: kin_model::LanguageId,
+    command: &str,
+    args: &[String],
+    workspace_root: &std::path::Path,
+    initialization_options: Option<serde_json::Value>,
+) -> std::result::Result<kin_lsp::lifecycle::LspServer, String> {
+    use crate::language_server_command::ServerCommand;
+
+    let program = match crate::language_server_command::resolve_on_this_host(
+        command.to_string(),
+        workspace_root.to_path_buf(),
+    )
+    .await
+    {
+        ServerCommand::Resolved { program, chosen } => {
+            info!(
+                %language,
+                program = %program.display(),
+                %chosen,
+                "starting the language server this daemon resolved"
+            );
+            program
+        }
+        ServerCommand::NotInstalled => {
+            return Err(format!("no `{command}` is on this daemon's PATH"));
+        }
+        ServerCommand::Unresolvable { reason } => return Err(reason),
+    };
+    let args_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    kin_lsp::lifecycle::LspServer::start(
+        &program.to_string_lossy(),
+        &args_refs,
+        workspace_root,
+        initialization_options,
+    )
+    .await
+    .map_err(|error| error.to_string())
 }
 
 pub fn lsp_adapter_for(
@@ -3774,6 +3910,60 @@ fn sweep_work_succeeded(
         && (relations.published == 0 || published)
 }
 
+/// Report files this pass skipped as already enriched, in a language this
+/// daemon cannot serve, under that language instead of as done.
+///
+/// `readiness_now` holds, for each language that had no running server when the
+/// pass ended, either the probe's answer or, for a language whose server already
+/// refused in this pass, that refusal. A language it does not mention was served
+/// in this pass and keeps its counts. The
+/// files stay marked, because their edges are durable; what changes is that the
+/// pass no longer claims a server stands behind them, so `files_done` counts
+/// only files a server this daemon can run has processed, and the summary names
+/// the language and its file count the way `kin graph status` does.
+fn attribute_unserved_already_enriched(
+    tally: &mut SweepTally,
+    already_enriched_by_language: &std::collections::HashMap<kin_model::LanguageId, u64>,
+    readiness_now: &std::collections::HashMap<
+        kin_model::LanguageId,
+        kin_core::reference_coverage::LanguageServerReadiness,
+    >,
+    skip_files: &mut std::collections::HashMap<kin_model::LanguageId, u64>,
+    skip_reason: &mut std::collections::HashMap<kin_model::LanguageId, String>,
+) {
+    use kin_core::reference_coverage::LanguageServerReadiness;
+
+    for (language, readiness) in readiness_now {
+        let cause = match readiness {
+            LanguageServerReadiness::Usable => continue,
+            LanguageServerReadiness::Unusable { reason } => reason.clone(),
+            LanguageServerReadiness::Absent => {
+                "no server for it is on this daemon's PATH".to_string()
+            }
+        };
+        let files = already_enriched_by_language
+            .get(language)
+            .copied()
+            .unwrap_or(0);
+        let moved = usize::try_from(files)
+            .unwrap_or(usize::MAX)
+            .min(tally.already_enriched);
+        if moved == 0 {
+            continue;
+        }
+        tally.already_enriched -= moved;
+        tally.server_unavailable += moved;
+        *skip_files.entry(*language).or_insert(0) += moved as u64;
+        skip_reason.entry(*language).or_insert_with(|| {
+            format!(
+                "this daemon cannot start a {language} language server ({cause}), and these \
+                 files keep the language-server edges an earlier pass made durable but get no \
+                 new ones until it starts"
+            )
+        });
+    }
+}
+
 /// How long the file-level definitions pass may take for one file.
 ///
 /// The pass had no bound of any kind. It is called at its sweep site as
@@ -4291,16 +4481,20 @@ pub async fn run_with_authority_on(
     // than re-sweeping a converged graph.
     load_lsp_enriched_marker(&state);
 
+    // Set up LSP enrichment channel before wrapping state in Arc.
+    let enrichment_enabled =
+        should_enable_lsp_enrichment(config.lsp_enabled, state.filesystem_reconcile_disabled());
+
     // The working directory as the layout already holds it. Deliberately not
     // canonicalized: a readiness probe asks whether a server starts and
     // completes a handshake, never resolving a file through this path, so the
     // filesystem round trip would buy nothing and this is an authority-path
     // crate where every such call has to earn itself.
-    spawn_language_server_readiness_probe(state.layout.working_dir().to_path_buf());
-
-    // Set up LSP enrichment channel before wrapping state in Arc.
-    let enrichment_enabled =
-        should_enable_lsp_enrichment(config.lsp_enabled, state.filesystem_reconcile_disabled());
+    start_readiness_probe_if_enabled(
+        enrichment_enabled,
+        state.layout.working_dir().to_path_buf(),
+        spawn_language_server_readiness_probe,
+    );
     // Recorded so a caller can tell a deliberately disabled daemon from one that
     // simply found no server. Those need opposite answers and the channel alone
     // cannot separate them.
@@ -5108,10 +5302,8 @@ pub async fn run_with_authority_on(
                         // Lazily start LSP server for this language.
                         if !servers.contains_key(&lang) {
                             if let Some((cmd, args, init_opts)) = lsp_adapter_for(lang, &lsp_root) {
-                                let args_refs: Vec<&str> =
-                                    args.iter().map(|s| s.as_str()).collect();
-                                match kin_lsp::lifecycle::LspServer::start(
-                                    &cmd, &args_refs, &lsp_root, init_opts,
+                                match start_resolved_language_server(
+                                    lang, &cmd, &args, &lsp_root, init_opts,
                                 )
                                 .await
                                 {
@@ -5395,6 +5587,15 @@ pub async fn run_with_authority_on(
                         > = std::collections::HashMap::new();
                         let mut skip_files: std::collections::HashMap<kin_model::LanguageId, u64> =
                             std::collections::HashMap::new();
+                        // Files skipped as already enriched, per language. A
+                        // language whose every file was already enriched never
+                        // reaches a server start in this pass, so without this
+                        // the pass has no evidence the daemon can still serve
+                        // it, and a daemon that cannot would read complete.
+                        let mut already_enriched_by_language: std::collections::HashMap<
+                            kin_model::LanguageId,
+                            u64,
+                        > = std::collections::HashMap::new();
 
                         // Build entity index for the whole graph (used for target matching).
                         let entity_refs: Vec<kin_lsp::EntityRef> = entities
@@ -5452,6 +5653,7 @@ pub async fn run_with_authority_on(
                             // dares run is a sweep that never runs.
                             if file_already_enriched(&lsp_state, &file_id.0) {
                                 tally.already_enriched += 1;
+                                *already_enriched_by_language.entry(lang).or_insert(0) += 1;
                                 // Published here as well as on the enriching
                                 // arm, because `files_done` means a file the
                                 // sweep is done with and a skip is one. Stored
@@ -5498,10 +5700,8 @@ pub async fn run_with_authority_on(
                                 if let Some((cmd, args, init_opts)) =
                                     lsp_adapter_for(lang, &lsp_root)
                                 {
-                                    let args_refs: Vec<&str> =
-                                        args.iter().map(|s| s.as_str()).collect();
-                                    match kin_lsp::lifecycle::LspServer::start(
-                                        &cmd, &args_refs, &lsp_root, init_opts,
+                                    match start_resolved_language_server(
+                                        lang, &cmd, &args, &lsp_root, init_opts,
                                     )
                                     .await
                                     {
@@ -5842,6 +6042,52 @@ pub async fn run_with_authority_on(
                                 relations = total_relations.published,
                                 "not recording these files as enriched: their relations were \
                                  not published, so the next sweep must redo them"
+                            );
+                        }
+
+                        // A language whose every file this pass skipped as
+                        // already enriched never reached a server start, so the
+                        // pass holds no evidence this daemon can still serve it.
+                        // Ask now, the way the readiness probe asks. One it
+                        // cannot serve is reported with its files instead of
+                        // counted as done, which is what let a second daemon on
+                        // an enriched store read complete while it could not
+                        // start the server at all. Published before the counters
+                        // below, so every waiter reads the corrected numbers.
+                        //
+                        // Not on a pass that is stopping. A probe can take its
+                        // whole handshake budget per language, and a daemon on
+                        // its way out has a shutdown grace to keep; the files it
+                        // did not settle are reported as not visited instead.
+                        if !tally.ended_early {
+                            let mut readiness_now = std::collections::HashMap::new();
+                            for language in already_enriched_by_language.keys() {
+                                if servers.contains_key(language) {
+                                    continue;
+                                }
+                                // A language whose server already refused in
+                                // this pass needs no second start to know it.
+                                let readiness = if server_start_failed.contains(language) {
+                                    kin_core::reference_coverage::LanguageServerReadiness::Unusable {
+                                        reason: skip_reason.get(language).cloned().unwrap_or_else(
+                                            || "its server did not start in this pass".to_string(),
+                                        ),
+                                    }
+                                } else {
+                                    probe_language_server(*language, &lsp_root).await
+                                };
+                                readiness_now.insert(*language, readiness);
+                            }
+                            attribute_unserved_already_enriched(
+                                &mut tally,
+                                &already_enriched_by_language,
+                                &readiness_now,
+                                &mut skip_files,
+                                &mut skip_reason,
+                            );
+                            lsp_state.lsp_sweep_files_done.store(
+                                tally.files_processed() as u64,
+                                std::sync::atomic::Ordering::SeqCst,
                             );
                         }
 
@@ -10677,6 +10923,284 @@ mod lsp_query_column_tests {
     #[test]
     fn a_name_absent_from_the_signature_keeps_the_declaration_column() {
         assert_eq!(lsp_query_column("const x = 1", "handle", 3), 3);
+    }
+}
+
+#[cfg(test)]
+mod language_server_resolution_tests {
+    use super::{
+        attribute_unserved_already_enriched, probe_resolved_language_server,
+        start_readiness_probe_if_enabled, SweepTally,
+    };
+    use crate::language_server_command::ServerCommand;
+    use kin_core::reference_coverage::LanguageServerReadiness;
+    use kin_model::LanguageId;
+    use std::collections::HashMap;
+    use std::path::{Path, PathBuf};
+
+    const UNKNOWN_BINARY: &str = "server initialization failed: server shutdown unexpectedly \
+        (server stderr: error: Unknown binary 'rust-analyzer' in official toolchain \
+        '1.96.0-aarch64-apple-darwin'.)";
+
+    /// The second daemon on one store, exactly as measured: every Rust file was
+    /// enriched by an earlier pass, so this pass skipped all of them before any
+    /// server start, and this daemon cannot start rust-analyzer. Counted as done
+    /// they made `files_done` 72 of 72 with nothing skipped, and `kin init` and
+    /// `kin daemon sweep` print "complete" off exactly that.
+    #[test]
+    fn already_enriched_files_in_a_language_this_daemon_cannot_serve_are_not_done() {
+        let mut tally = SweepTally {
+            already_enriched: 72,
+            ..SweepTally::default()
+        };
+        let by_language = HashMap::from([(LanguageId::Rust, 72u64)]);
+        let readiness = HashMap::from([(
+            LanguageId::Rust,
+            LanguageServerReadiness::Unusable {
+                reason: UNKNOWN_BINARY.to_string(),
+            },
+        )]);
+        let mut skip_files = HashMap::new();
+        let mut skip_reason = HashMap::new();
+
+        attribute_unserved_already_enriched(
+            &mut tally,
+            &by_language,
+            &readiness,
+            &mut skip_files,
+            &mut skip_reason,
+        );
+
+        assert_eq!(
+            tally.files_processed(),
+            0,
+            "no server this daemon can run processed any of them"
+        );
+        assert_eq!(tally.blocked(), 72);
+        assert_eq!(
+            tally.unaccounted(72),
+            0,
+            "every file is still accounted for"
+        );
+        assert_eq!(skip_files.get(&LanguageId::Rust), Some(&72));
+        let reason = skip_reason
+            .get(&LanguageId::Rust)
+            .expect("the language is named with a reason");
+        assert!(
+            reason.contains("Unknown binary 'rust-analyzer'"),
+            "{reason}"
+        );
+        assert!(reason.contains("an earlier pass made durable"), "{reason}");
+        assert!(
+            !reason.contains("; "),
+            "`; ` divides verdict clauses and must not appear inside one: {reason}"
+        );
+    }
+
+    /// The control. A language this daemon can serve keeps its already-enriched
+    /// files as done, so a converged store with a working server still reads
+    /// complete. Without this, reporting every skip as blocked would pass the
+    /// test above.
+    #[test]
+    fn already_enriched_files_in_a_language_this_daemon_serves_stay_done() {
+        let mut tally = SweepTally {
+            already_enriched: 72,
+            ..SweepTally::default()
+        };
+        let by_language = HashMap::from([(LanguageId::Rust, 72u64)]);
+        let readiness = HashMap::from([(LanguageId::Rust, LanguageServerReadiness::Usable)]);
+        let mut skip_files = HashMap::new();
+        let mut skip_reason = HashMap::new();
+
+        attribute_unserved_already_enriched(
+            &mut tally,
+            &by_language,
+            &readiness,
+            &mut skip_files,
+            &mut skip_reason,
+        );
+
+        assert_eq!(tally.files_processed(), 72);
+        assert_eq!(tally.blocked(), 0);
+        assert!(skip_files.is_empty() && skip_reason.is_empty());
+    }
+
+    /// A language the readiness map does not mention was served in this pass or
+    /// already failed to start in it, and its counts are left exactly as the
+    /// loop recorded them.
+    #[test]
+    fn a_language_the_pass_already_settled_is_left_alone() {
+        let mut tally = SweepTally {
+            already_enriched: 10,
+            enriched: 5,
+            ..SweepTally::default()
+        };
+        let by_language = HashMap::from([(LanguageId::Python, 10u64)]);
+        let mut skip_files = HashMap::new();
+        let mut skip_reason = HashMap::new();
+
+        attribute_unserved_already_enriched(
+            &mut tally,
+            &by_language,
+            &HashMap::new(),
+            &mut skip_files,
+            &mut skip_reason,
+        );
+
+        assert_eq!(tally.files_processed(), 15);
+        assert!(skip_files.is_empty());
+    }
+
+    /// A language whose server refused to start in this pass: two edited files
+    /// hit the refusal and seventy were already enriched. All seventy-two are
+    /// unserved by this daemon, so all seventy-two are reported under the
+    /// language, and the reason the start failure recorded is kept rather than
+    /// replaced, because it names what this process actually saw.
+    #[test]
+    fn a_refused_server_takes_its_already_enriched_files_with_it() {
+        let mut tally = SweepTally {
+            already_enriched: 70,
+            server_unavailable: 2,
+            ..SweepTally::default()
+        };
+        let by_language = HashMap::from([(LanguageId::Rust, 70u64)]);
+        let recorded =
+            "the `rust-analyzer` language server did not start (no toolchain ships it), \
+                        so nothing in this language was enriched"
+                .to_string();
+        let readiness = HashMap::from([(
+            LanguageId::Rust,
+            LanguageServerReadiness::Unusable {
+                reason: recorded.clone(),
+            },
+        )]);
+        let mut skip_files = HashMap::from([(LanguageId::Rust, 2u64)]);
+        let mut skip_reason = HashMap::from([(LanguageId::Rust, recorded.clone())]);
+
+        attribute_unserved_already_enriched(
+            &mut tally,
+            &by_language,
+            &readiness,
+            &mut skip_files,
+            &mut skip_reason,
+        );
+
+        assert_eq!(tally.files_processed(), 0);
+        assert_eq!(tally.blocked(), 72);
+        assert_eq!(skip_files.get(&LanguageId::Rust), Some(&72));
+        assert_eq!(skip_reason.get(&LanguageId::Rust), Some(&recorded));
+    }
+
+    /// `KIN_DAEMON_DISABLE_LSP=1` starts no language server at all. The probe
+    /// used to run before the enrichment decision and launched every
+    /// enrichable language's server on such a daemon anyway.
+    #[test]
+    fn a_daemon_that_does_not_enrich_starts_no_readiness_probe() {
+        let mut spawned: Option<PathBuf> = None;
+        assert!(!start_readiness_probe_if_enabled(
+            false,
+            PathBuf::from("/work"),
+            |root| spawned = Some(root),
+        ));
+        assert_eq!(spawned, None, "a disabled daemon must not probe");
+
+        assert!(start_readiness_probe_if_enabled(
+            true,
+            PathBuf::from("/work"),
+            |root| spawned = Some(root),
+        ));
+        assert_eq!(
+            spawned,
+            Some(PathBuf::from("/work")),
+            "an enabled daemon probes"
+        );
+    }
+
+    /// The probe reports the resolver's answer in the resolver's words. A
+    /// registry lookup could never produce this reason, so a probe that went
+    /// back to resolving its own list fails here.
+    #[tokio::test]
+    async fn the_probe_reports_what_the_resolver_found() {
+        let root = Path::new("/nonexistent-workspace");
+        assert_eq!(
+            probe_resolved_language_server(LanguageId::Rust, root, ServerCommand::NotInstalled)
+                .await,
+            LanguageServerReadiness::Absent
+        );
+        let reason = "`rust-analyzer` on this daemon's PATH is rustup's proxy, and no installed \
+                      toolchain ships it"
+            .to_string();
+        assert_eq!(
+            probe_resolved_language_server(
+                LanguageId::Rust,
+                root,
+                ServerCommand::Unresolvable {
+                    reason: reason.clone()
+                },
+            )
+            .await,
+            LanguageServerReadiness::Unusable { reason }
+        );
+    }
+
+    /// The program the resolver names is the program the probe starts. A
+    /// fixture that completes the handshake reads usable and one that exits
+    /// reads unusable with its own last words, so neither answer can come from
+    /// whatever the host has installed.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn the_probe_starts_the_program_the_resolver_named() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let write_fixture = |name: &str, body: &str| {
+            let path = dir.path().join(name);
+            std::fs::write(&path, body).expect("fixture body");
+            let mut permissions = std::fs::metadata(&path).expect("metadata").permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&path, permissions).expect("executable");
+            path
+        };
+        let usable = write_fixture(
+            "usable-server",
+            "#!/bin/sh\nread -r _ 2>/dev/null\n\
+             BODY='{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"capabilities\":{\"definitionProvider\":true,\"referencesProvider\":true}}}'\n\
+             printf 'Content-Length: %d\\r\\n\\r\\n%s' \"${#BODY}\" \"$BODY\"\n\
+             sleep 30\n",
+        );
+        let refusing = write_fixture(
+            "refusing-server",
+            "#!/bin/sh\necho \"error: fixture toolchain has no such binary\" >&2\nexit 1\n",
+        );
+
+        assert_eq!(
+            probe_resolved_language_server(
+                LanguageId::Rust,
+                dir.path(),
+                ServerCommand::Resolved {
+                    program: usable,
+                    chosen: "a fixture".to_string()
+                },
+            )
+            .await,
+            LanguageServerReadiness::Usable
+        );
+        match probe_resolved_language_server(
+            LanguageId::Rust,
+            dir.path(),
+            ServerCommand::Resolved {
+                program: refusing,
+                chosen: "a fixture".to_string(),
+            },
+        )
+        .await
+        {
+            LanguageServerReadiness::Unusable { reason } => assert!(
+                reason.contains("fixture toolchain has no such binary"),
+                "the server's own last words are the reason: {reason}"
+            ),
+            other => panic!("a server that exits must read unusable, got {other:?}"),
+        }
     }
 }
 

--- a/crates/kin-daemon/src/language_server_command.rs
+++ b/crates/kin-daemon/src/language_server_command.rs
@@ -1,0 +1,647 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Which executable this daemon starts for a language server.
+//!
+//! One answer, decided here and used by every path that starts a server: the
+//! readiness probe, the cold sweep and the incremental path. Each of them used
+//! to hand a bare command name to `LspServer::start`, which resolved it through
+//! `PATH` from whatever working directory the daemon inherited, and the probe
+//! resolved a list of its own through kin-lsp's registry. For `rust-analyzer`
+//! that name is usually rustup's proxy, and the proxy picks a toolchain from the
+//! working directory it runs in.
+//!
+//! Measured on a kin-db clone that pins `channel = "1.96.0"`, a toolchain
+//! installed without the rust-analyzer component: the daemon `kin init` started
+//! from outside the clone ran stable's rust-analyzer and enriched 72 of 72
+//! files, and the daemon `kin mcp start --repo` started inside the clone could
+//! not start one at all. Two daemons on one store disagreed about whether Rust
+//! could be enriched, and which one a user got depended on the directory they
+//! launched from.
+//!
+//! So the proxy is asked, from the workspace root, which binary it would run
+//! there, and when the toolchain the workspace selects does not ship one, every
+//! other installed toolchain is asked in turn. The first that answers is started
+//! by absolute path, which the daemon's working directory can no longer change.
+//! When none answers, the failure names every toolchain tried and the command
+//! that repairs it, rather than a bare "did not start".
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// What one language server's command resolves to on this host.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ServerCommand {
+    /// Start this program. `chosen` says how it was picked, which is what the
+    /// daemon logs so a reader can tell which binary ran.
+    Resolved { program: PathBuf, chosen: String },
+    /// Nothing by the adapter's command name is on this daemon's `PATH`.
+    NotInstalled,
+    /// Something by that name is on `PATH` and nothing it leads to can serve.
+    /// `reason` names what was tried and what would repair it.
+    Unresolvable { reason: String },
+}
+
+/// What the resolver asks of the host, so every branch is testable without
+/// the toolchains a test machine happens to have.
+pub(crate) trait ToolchainHost {
+    /// Where `binary` resolves on this process's `PATH`.
+    fn find_on_path(&self, binary: &str) -> Option<PathBuf>;
+
+    /// The rustup executable behind `program` when `program` is one of
+    /// rustup's proxies, and `None` when it is a server binary of its own.
+    fn rustup_behind(&self, program: &Path) -> Option<PathBuf>;
+
+    /// The toolchain rustup selects in `dir`, by name.
+    fn active_toolchain(&self, rustup: &Path, dir: &Path) -> Option<String>;
+
+    /// Every installed toolchain, the default first.
+    fn installed_toolchains(&self, rustup: &Path, dir: &Path) -> Vec<String>;
+
+    /// `rustup which <binary>` run in `dir`, or for `toolchain` when one is
+    /// named. The error is rustup's own words.
+    fn rustup_which(
+        &self,
+        rustup: &Path,
+        dir: &Path,
+        toolchain: Option<&str>,
+        binary: &str,
+    ) -> Result<PathBuf, String>;
+}
+
+/// Resolve `binary`, the command an adapter names, for the workspace rooted at
+/// `workspace_root`.
+///
+/// A binary that is not rustup's proxy is started from where `PATH` found it,
+/// which is every server but rust-analyzer on a rustup host and is the behaviour
+/// the daemon always had for them. Only the proxy is resolved further, because
+/// only the proxy's answer depends on the directory it is asked from.
+pub(crate) fn resolve_server_command(
+    binary: &str,
+    workspace_root: &Path,
+    host: &dyn ToolchainHost,
+) -> ServerCommand {
+    let Some(found) = host.find_on_path(binary) else {
+        return ServerCommand::NotInstalled;
+    };
+    let Some(rustup) = host.rustup_behind(&found) else {
+        return ServerCommand::Resolved {
+            chosen: format!("{} on this daemon's PATH", found.display()),
+            program: found,
+        };
+    };
+
+    let selected = host.active_toolchain(&rustup, workspace_root);
+    let selected_name = selected
+        .clone()
+        .unwrap_or_else(|| "the toolchain this workspace selects".to_string());
+    let mut tried: Vec<String> = Vec::new();
+    match host.rustup_which(&rustup, workspace_root, None, binary) {
+        Ok(program) => {
+            return ServerCommand::Resolved {
+                chosen: format!(
+                    "rustup toolchain {selected_name}, which {} selects",
+                    workspace_root.display()
+                ),
+                program,
+            };
+        }
+        Err(error) => tried.push(format!("{selected_name} ({error})")),
+    }
+    for toolchain in host.installed_toolchains(&rustup, workspace_root) {
+        if selected.as_deref() == Some(toolchain.as_str()) {
+            continue;
+        }
+        match host.rustup_which(&rustup, workspace_root, Some(&toolchain), binary) {
+            Ok(program) => {
+                return ServerCommand::Resolved {
+                    chosen: format!(
+                        "rustup toolchain {toolchain}, because {selected_name}, which {} \
+                         selects, does not ship {binary}",
+                        workspace_root.display()
+                    ),
+                    program,
+                };
+            }
+            Err(error) => tried.push(format!("{toolchain} ({error})")),
+        }
+    }
+    let repair_for_selected = selected
+        .as_deref()
+        .map(|name| {
+            format!(
+                ", or `rustup component add {binary} --toolchain {name}` for the toolchain this \
+                 workspace selects"
+            )
+        })
+        .unwrap_or_default();
+    ServerCommand::Unresolvable {
+        reason: format!(
+            "`{binary}` on this daemon's PATH is rustup's proxy ({}), and no installed toolchain \
+             ships it. Tried {}. Install it with `rustup component add {binary}`{repair_for_selected}",
+            found.display(),
+            tried.join(", "),
+        ),
+    }
+}
+
+/// [`resolve_server_command`] against this host, off the async runtime,
+/// because a rustup query is a process to wait for.
+pub(crate) async fn resolve_on_this_host(binary: String, workspace_root: PathBuf) -> ServerCommand {
+    tokio::task::spawn_blocking(move || {
+        resolve_server_command(&binary, &workspace_root, &SystemToolchainHost)
+    })
+    .await
+    .unwrap_or_else(|error| ServerCommand::Unresolvable {
+        reason: format!("the language-server resolver did not finish ({error})"),
+    })
+}
+
+/// The host this daemon runs on.
+pub(crate) struct SystemToolchainHost;
+
+/// How long one rustup query may take.
+///
+/// rustup answers these from local state in milliseconds. The bound exists so a
+/// rustup that decides to do something slower cannot hold a sweep, and it is
+/// paid only when a query hangs.
+const RUSTUP_QUERY_BUDGET: Duration = Duration::from_secs(10);
+
+impl ToolchainHost for SystemToolchainHost {
+    fn find_on_path(&self, binary: &str) -> Option<PathBuf> {
+        which::which(binary).ok()
+    }
+
+    fn rustup_behind(&self, program: &Path) -> Option<PathBuf> {
+        proxy_rustup_for(program)
+    }
+
+    fn active_toolchain(&self, rustup: &Path, dir: &Path) -> Option<String> {
+        run_rustup(rustup, dir, &["show", "active-toolchain"])
+            .ok()
+            .and_then(|stdout| first_token(&stdout))
+    }
+
+    fn installed_toolchains(&self, rustup: &Path, dir: &Path) -> Vec<String> {
+        run_rustup(rustup, dir, &["toolchain", "list"])
+            .map(|stdout| parse_toolchain_list(&stdout))
+            .unwrap_or_default()
+    }
+
+    fn rustup_which(
+        &self,
+        rustup: &Path,
+        dir: &Path,
+        toolchain: Option<&str>,
+        binary: &str,
+    ) -> Result<PathBuf, String> {
+        let mut args = vec!["which"];
+        if let Some(toolchain) = toolchain {
+            args.push("--toolchain");
+            args.push(toolchain);
+        }
+        args.push(binary);
+        let stdout = run_rustup(rustup, dir, &args)?;
+        first_line(&stdout)
+            .map(PathBuf::from)
+            .filter(|path| path.is_absolute())
+            .ok_or_else(|| format!("rustup named no absolute path for {binary}"))
+    }
+}
+
+/// The rustup executable behind `program`, when `program` is one of its
+/// proxies.
+///
+/// rustup installs a proxy for every tool it manages beside itself in
+/// `$CARGO_HOME/bin`, as a symbolic link to `rustup` on some hosts and as a hard
+/// link on others. A program that is neither, including a rust-analyzer
+/// installed into the same directory by its own installer, is a server binary
+/// and is started as found.
+fn proxy_rustup_for(program: &Path) -> Option<PathBuf> {
+    let rustup = program
+        .parent()?
+        .join(format!("rustup{}", std::env::consts::EXE_SUFFIX));
+    if program.file_name() == rustup.file_name() {
+        return None;
+    }
+    let rustup_identity = std::fs::metadata(&rustup).ok()?;
+    if let (Ok(target), Ok(rustup_target)) = (
+        std::fs::canonicalize(program),
+        std::fs::canonicalize(&rustup),
+    ) {
+        if target == rustup_target {
+            return Some(rustup);
+        }
+    }
+    let identity = std::fs::metadata(program).ok()?;
+    #[cfg(unix)]
+    let same_file = {
+        use std::os::unix::fs::MetadataExt;
+        identity.dev() == rustup_identity.dev() && identity.ino() == rustup_identity.ino()
+    };
+    // Windows exposes no stable file identity through std, and rustup installs
+    // its proxies there as hard links to, or copies of, the rustup.exe beside
+    // them, so the same length beside it is the proxy.
+    #[cfg(not(unix))]
+    let same_file = identity.len() == rustup_identity.len();
+    same_file.then_some(rustup)
+}
+
+/// Run one local rustup query in `dir` and return its standard output.
+///
+/// `RUSTUP_AUTO_INSTALL=0` because a query must never install a toolchain a
+/// `rust-toolchain.toml` names: this runs inside a daemon nobody is watching,
+/// and a download it started would be a side effect nobody asked for. The
+/// error carries rustup's first line of standard error, which is the sentence
+/// that names the toolchain and what it lacks.
+fn run_rustup(rustup: &Path, dir: &Path, args: &[&str]) -> Result<String, String> {
+    use std::process::{Command, Stdio};
+
+    let mut child = Command::new(rustup)
+        .args(args)
+        .current_dir(dir)
+        .env("RUSTUP_AUTO_INSTALL", "0")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| format!("could not run {}: {error}", rustup.display()))?;
+    let deadline = std::time::Instant::now() + RUSTUP_QUERY_BUDGET;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) if std::time::Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Ok(None) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!(
+                    "`rustup {}` did not answer within {}s",
+                    args.join(" "),
+                    RUSTUP_QUERY_BUDGET.as_secs()
+                ));
+            }
+            Err(error) => return Err(format!("could not wait for rustup: {error}")),
+        }
+    }
+    let output = child
+        .wait_with_output()
+        .map_err(|error| format!("could not read rustup's answer: {error}"))?;
+    if output.status.success() {
+        return Ok(String::from_utf8_lossy(&output.stdout).into_owned());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    Err(first_line(&stderr).unwrap_or_else(|| format!("rustup exited with {}", output.status)))
+}
+
+/// The first non-empty line, trimmed.
+fn first_line(text: &str) -> Option<String> {
+    text.lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(str::to_string)
+}
+
+/// The first word of the first non-empty line: the toolchain name in
+/// `rustup show active-toolchain`'s answer, which follows it with why it was
+/// chosen.
+fn first_token(text: &str) -> Option<String> {
+    first_line(text)?
+        .split_whitespace()
+        .next()
+        .map(str::to_string)
+}
+
+/// Toolchain names from `rustup toolchain list`, the default first and the
+/// rest in the order rustup printed them.
+///
+/// Each line is a name optionally followed by markers such as `(default)`,
+/// `(active)` or `(active, default)`. A line that does not start with a name,
+/// such as rustup's "no installed toolchains", names nothing.
+fn parse_toolchain_list(stdout: &str) -> Vec<String> {
+    let mut default = Vec::new();
+    let mut rest = Vec::new();
+    for line in stdout
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+    {
+        if line.starts_with("no installed toolchains") {
+            continue;
+        }
+        let Some(name) = line.split_whitespace().next() else {
+            continue;
+        };
+        let markers = &line[name.len()..];
+        if markers.contains("default") {
+            default.push(name.to_string());
+        } else {
+            rest.push(name.to_string());
+        }
+    }
+    default.extend(rest);
+    default
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    const WORKSPACE: &str = "/work/kin-db";
+    const PROXY: &str = "/home/u/.cargo/bin/rust-analyzer";
+    const RUSTUP: &str = "/home/u/.cargo/bin/rustup";
+    const STABLE_RA: &str = "/home/u/.rustup/toolchains/stable/bin/rust-analyzer";
+    const PINNED_RA: &str = "/home/u/.rustup/toolchains/1.96.0/bin/rust-analyzer";
+
+    /// A host whose PATH, proxies and toolchains are whatever a test says.
+    #[derive(Default)]
+    struct FakeHost {
+        on_path: HashMap<String, PathBuf>,
+        proxies: HashMap<PathBuf, PathBuf>,
+        active: Option<String>,
+        installed: Vec<String>,
+        /// What `rustup which` answers in the workspace directory.
+        workspace_answer: Option<Result<PathBuf, String>>,
+        /// What `rustup which --toolchain <name>` answers, per toolchain.
+        toolchain_answers: HashMap<String, Result<PathBuf, String>>,
+        asked: RefCell<Vec<String>>,
+    }
+
+    impl ToolchainHost for FakeHost {
+        fn find_on_path(&self, binary: &str) -> Option<PathBuf> {
+            self.on_path.get(binary).cloned()
+        }
+
+        fn rustup_behind(&self, program: &Path) -> Option<PathBuf> {
+            self.proxies.get(program).cloned()
+        }
+
+        fn active_toolchain(&self, _rustup: &Path, _dir: &Path) -> Option<String> {
+            self.active.clone()
+        }
+
+        fn installed_toolchains(&self, _rustup: &Path, _dir: &Path) -> Vec<String> {
+            self.installed.clone()
+        }
+
+        fn rustup_which(
+            &self,
+            _rustup: &Path,
+            dir: &Path,
+            toolchain: Option<&str>,
+            binary: &str,
+        ) -> Result<PathBuf, String> {
+            self.asked.borrow_mut().push(format!(
+                "{}:{}",
+                toolchain.unwrap_or("<workspace>"),
+                binary
+            ));
+            assert_eq!(
+                dir,
+                Path::new(WORKSPACE),
+                "rustup is asked from the workspace root"
+            );
+            match toolchain {
+                None => self
+                    .workspace_answer
+                    .clone()
+                    .unwrap_or_else(|| Err("no answer configured".to_string())),
+                Some(name) => self
+                    .toolchain_answers
+                    .get(name)
+                    .cloned()
+                    .unwrap_or_else(|| Err(format!("unknown toolchain {name}"))),
+            }
+        }
+    }
+
+    fn unknown_binary(toolchain: &str) -> Result<PathBuf, String> {
+        Err(format!(
+            "error: unknown binary 'rust-analyzer' in toolchain '{toolchain}'"
+        ))
+    }
+
+    /// The kin-db host, exactly: rustup's proxy on PATH, a workspace pinned to
+    /// 1.96.0 installed without the component, and stable carrying it.
+    fn pinned_workspace_host() -> FakeHost {
+        FakeHost {
+            on_path: HashMap::from([("rust-analyzer".to_string(), PathBuf::from(PROXY))]),
+            proxies: HashMap::from([(PathBuf::from(PROXY), PathBuf::from(RUSTUP))]),
+            active: Some("1.96.0-aarch64-apple-darwin".to_string()),
+            installed: vec![
+                "stable-aarch64-apple-darwin".to_string(),
+                "nightly-2026-06-17-aarch64-apple-darwin".to_string(),
+                "1.96.0-aarch64-apple-darwin".to_string(),
+            ],
+            workspace_answer: Some(unknown_binary("1.96.0-aarch64-apple-darwin")),
+            toolchain_answers: HashMap::from([
+                (
+                    "stable-aarch64-apple-darwin".to_string(),
+                    Ok(PathBuf::from(STABLE_RA)),
+                ),
+                (
+                    "nightly-2026-06-17-aarch64-apple-darwin".to_string(),
+                    unknown_binary("nightly-2026-06-17-aarch64-apple-darwin"),
+                ),
+                (
+                    "1.96.0-aarch64-apple-darwin".to_string(),
+                    unknown_binary("1.96.0-aarch64-apple-darwin"),
+                ),
+            ]),
+            ..FakeHost::default()
+        }
+    }
+
+    /// The measured failure. A workspace whose pinned toolchain has no
+    /// rust-analyzer still gets one, from a toolchain that ships it, by
+    /// absolute path, and the log line says why that toolchain was chosen.
+    #[test]
+    fn a_pinned_toolchain_without_the_server_falls_back_to_one_that_ships_it() {
+        let host = pinned_workspace_host();
+        match resolve_server_command("rust-analyzer", Path::new(WORKSPACE), &host) {
+            ServerCommand::Resolved { program, chosen } => {
+                assert_eq!(program, PathBuf::from(STABLE_RA));
+                assert!(
+                    chosen.contains("stable-aarch64-apple-darwin")
+                        && chosen.contains("1.96.0-aarch64-apple-darwin")
+                        && chosen.contains("does not ship rust-analyzer"),
+                    "the log line must name the toolchain used and the one it replaced: {chosen}"
+                );
+            }
+            other => panic!("expected stable's rust-analyzer, got {other:?}"),
+        }
+        let asked = host.asked.borrow();
+        assert_eq!(
+            asked.first().map(String::as_str),
+            Some("<workspace>:rust-analyzer"),
+            "the workspace's own selection is asked first, so a pin that does ship it wins: \
+             {asked:?}"
+        );
+    }
+
+    /// A workspace whose selected toolchain ships the server uses that one and
+    /// asks nothing else.
+    #[test]
+    fn the_workspace_toolchain_is_used_when_it_ships_the_server() {
+        let mut host = pinned_workspace_host();
+        host.workspace_answer = Some(Ok(PathBuf::from(PINNED_RA)));
+        match resolve_server_command("rust-analyzer", Path::new(WORKSPACE), &host) {
+            ServerCommand::Resolved { program, chosen } => {
+                assert_eq!(program, PathBuf::from(PINNED_RA));
+                assert!(chosen.contains("1.96.0-aarch64-apple-darwin"), "{chosen}");
+            }
+            other => panic!("expected the pinned toolchain's rust-analyzer, got {other:?}"),
+        }
+        assert_eq!(
+            host.asked.borrow().len(),
+            1,
+            "no fallback when the pin answers"
+        );
+    }
+
+    /// No toolchain ships it: the failure is loud, names every toolchain it
+    /// tried with rustup's own words, and says how to repair it.
+    #[test]
+    fn no_toolchain_that_ships_the_server_fails_loud_naming_every_one_tried() {
+        let mut host = pinned_workspace_host();
+        host.toolchain_answers.insert(
+            "stable-aarch64-apple-darwin".to_string(),
+            unknown_binary("stable-aarch64-apple-darwin"),
+        );
+        match resolve_server_command("rust-analyzer", Path::new(WORKSPACE), &host) {
+            ServerCommand::Unresolvable { reason } => {
+                for toolchain in [
+                    "1.96.0-aarch64-apple-darwin",
+                    "stable-aarch64-apple-darwin",
+                    "nightly-2026-06-17-aarch64-apple-darwin",
+                ] {
+                    assert!(reason.contains(toolchain), "{toolchain} missing: {reason}");
+                }
+                assert!(
+                    reason.contains("unknown binary 'rust-analyzer'"),
+                    "{reason}"
+                );
+                assert!(
+                    reason.contains("rustup component add rust-analyzer"),
+                    "{reason}"
+                );
+                assert!(
+                    !reason.contains("; "),
+                    "a reason can reach a verdict clause, where `; ` divides clauses: {reason}"
+                );
+            }
+            other => panic!("expected a loud failure, got {other:?}"),
+        }
+        let asked = host.asked.borrow();
+        assert_eq!(
+            asked
+                .iter()
+                .filter(|question| question.starts_with("1.96.0"))
+                .count(),
+            0,
+            "the workspace's own toolchain is not asked twice: {asked:?}"
+        );
+    }
+
+    /// A server that is not rustup's proxy is started from where PATH found
+    /// it, and rustup is never asked about it.
+    #[test]
+    fn a_binary_that_is_not_a_proxy_starts_as_found() {
+        let host = FakeHost {
+            on_path: HashMap::from([(
+                "rust-analyzer".to_string(),
+                PathBuf::from("/opt/homebrew/bin/rust-analyzer"),
+            )]),
+            ..FakeHost::default()
+        };
+        assert_eq!(
+            resolve_server_command("rust-analyzer", Path::new(WORKSPACE), &host),
+            ServerCommand::Resolved {
+                program: PathBuf::from("/opt/homebrew/bin/rust-analyzer"),
+                chosen: "/opt/homebrew/bin/rust-analyzer on this daemon's PATH".to_string(),
+            }
+        );
+        assert!(host.asked.borrow().is_empty());
+    }
+
+    /// Nothing on PATH is `NotInstalled`, which the probe reports as absent
+    /// and the sweep as a skip, exactly as a missing binary always was.
+    #[test]
+    fn nothing_on_path_is_not_installed() {
+        assert_eq!(
+            resolve_server_command("gopls", Path::new(WORKSPACE), &FakeHost::default()),
+            ServerCommand::NotInstalled
+        );
+    }
+
+    #[test]
+    fn the_toolchain_list_puts_the_default_first_and_keeps_rustups_order() {
+        let listed = "stable-aarch64-apple-darwin\n\
+                      nightly-aarch64-apple-darwin (default)\n\
+                      1.96.0-aarch64-apple-darwin (active)\n\
+                      1.91.0-aarch64-apple-darwin\n";
+        assert_eq!(
+            parse_toolchain_list(listed),
+            vec![
+                "nightly-aarch64-apple-darwin",
+                "stable-aarch64-apple-darwin",
+                "1.96.0-aarch64-apple-darwin",
+                "1.91.0-aarch64-apple-darwin",
+            ]
+        );
+        assert_eq!(
+            parse_toolchain_list("1.96.0-aarch64-apple-darwin (active, default)\n"),
+            vec!["1.96.0-aarch64-apple-darwin"]
+        );
+        assert!(parse_toolchain_list("no installed toolchains\n").is_empty());
+    }
+
+    #[test]
+    fn the_active_toolchain_is_the_first_word_of_rustups_answer() {
+        assert_eq!(
+            first_token(
+                "1.96.0-aarch64-apple-darwin (overridden by '/work/kin-db/rust-toolchain.toml')\n"
+            )
+            .as_deref(),
+            Some("1.96.0-aarch64-apple-darwin")
+        );
+        assert_eq!(first_token("\n\n"), None);
+    }
+
+    /// The proxy check against real files: a symbolic link and a hard link to
+    /// `rustup` are proxies, and a server binary installed beside rustup by its
+    /// own installer is not.
+    #[cfg(unix)]
+    #[test]
+    fn a_proxy_is_recognised_by_file_identity_and_a_real_binary_is_not() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let rustup = dir.path().join("rustup");
+        std::fs::write(&rustup, b"#!/bin/sh\n").expect("rustup stand-in");
+
+        let symlinked = dir.path().join("rust-analyzer");
+        std::os::unix::fs::symlink("rustup", &symlinked).expect("symlink proxy");
+        assert_eq!(proxy_rustup_for(&symlinked), Some(rustup.clone()));
+
+        let hard_linked = dir.path().join("cargo");
+        std::fs::hard_link(&rustup, &hard_linked).expect("hard-link proxy");
+        assert_eq!(proxy_rustup_for(&hard_linked), Some(rustup.clone()));
+
+        let standalone = dir.path().join("gopls");
+        std::fs::write(&standalone, b"#!/bin/sh\necho a real server\n").expect("server");
+        assert_eq!(proxy_rustup_for(&standalone), None);
+
+        assert_eq!(
+            proxy_rustup_for(&rustup),
+            None,
+            "rustup itself is not a proxy"
+        );
+
+        let elsewhere = tempfile::tempdir().expect("second temp dir");
+        let lonely = elsewhere.path().join("rust-analyzer");
+        std::fs::write(&lonely, b"#!/bin/sh\n").expect("server without rustup beside it");
+        assert_eq!(proxy_rustup_for(&lonely), None);
+    }
+}

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -130,6 +130,7 @@ pub mod graph_only_members;
 #[cfg(test)]
 mod graph_status_first_contact;
 pub mod hosted_start;
+mod language_server_command;
 pub mod lifecycle;
 mod local_repository_authority;
 pub mod loop_runner;

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -690,6 +690,16 @@
       ]
     },
     {
+      "file": "crates/kin-daemon/src/language_server_command.rs",
+      "reason": "Language-server command resolution boundary. proxy_rustup_for asks whether the program PATH names is rustup's proxy by comparing its file identity with the rustup executable beside it, and run_rustup runs rustup's own local queries (which toolchain a directory selects, which toolchains are installed, which binary one of them ships) with auto-install switched off and a bounded wait. Both decide which executable the daemon starts for a language server, and neither reads repository content or derives a query answer. Function-scoped so the resolver's logic and any filesystem access added beside these two bodies stay scanned.",
+      "owner": "kin-daemon",
+      "expiration": "2026-12-31",
+      "allow_fn": [
+        "proxy_rustup_for",
+        "run_rustup"
+      ]
+    },
+    {
       "file": "crates/kin-daemon/src/bin/kin-daemon.rs",
       "reason": "Daemon process entry point. Every pin is either a process exit with a status or the directory probe that recognizes a .kin layout when deciding which repository to bind, which precedes any graph consult. Neither class reads repository content nor answers a query. Pinned by expression with exact counts rather than by function, because the four functions involved are most of this binary and exempting their bodies would leave more unscanned than the primitives justify.",
       "owner": "kin-daemon",


### PR DESCRIPTION
Every daemon on one store now starts the same rust-analyzer, whichever directory launched it, and a daemon
that cannot serve a language says so instead of reading complete.

## What was wrong

The daemon started language servers by bare command name, so `PATH` and the working directory the daemon
inherited from whoever launched it decided what ran. For `rust-analyzer` that name is rustup's proxy, which
picks a toolchain from its working directory. On a kin-db clone pinning `channel = "1.96.0"` (installed
without the rust-analyzer component) on a host where stable ships it, `kin init` run from outside the clone
got stable's server and enriched 72 of 72 files, and the daemon `kin mcp start --repo` spawned inside the
clone got the pinned toolchain and could not start one. `kin init` run from inside the clone, the way a user
runs it, got no Rust enrichment at all. The readiness probe resolved kin-lsp's registry list instead of the
command the sweep starts, and it ran even with `KIN_DAEMON_DISABLE_LSP=1`.

Init's `complete (72/72 files)` was true for its own daemon, and the sweep already counted a server that
failed its handshake as skipped. The remaining attestation gap: a sweep skips already-enriched files before
it starts any server, so a daemon that cannot serve a language whose files an earlier pass enriched would
count them done and read complete.

## What changes

- `crates/kin-daemon/src/language_server_command.rs` (new): one resolver for every path that starts a
  server. A binary that is not rustup's proxy starts as `PATH` found it, as before. The proxy is asked, from
  the workspace root, which binary it would run; when the workspace's toolchain does not ship it, every
  other installed toolchain is asked, default first, and the first answer is started by absolute path. When
  none ships it, the failure names every toolchain tried with rustup's own words and the
  `rustup component add` command. rustup queries run with auto-install off and a bounded wait.
- `crates/kin-daemon/src/daemon.rs`: the readiness probe, the cold sweep and the incremental path all start
  what the resolver returns, and each logs the program and why it was chosen. The probe runs only on a
  daemon that enriches. A language whose files this pass found already enriched and that this daemon cannot
  serve is reported under that language with its file count, and those files leave `files_done`.
- `crates/kin-cli/src/commands/init.rs`: a test that the second daemon's status never reads complete.
- `scripts/zero-file-search-allowlist.json`: the resolver's two host boundaries, function-scoped. The entry is
  config IO only: resolving which binary to start is not a semantic answer, and neither body reads repository
  content.
- The graph-status wording (`missing_language_server_warning` saying edges are absent while the same screen
  counts them) is left for a third PR. Its sentences are asserted by
  `scripts/acceptance/language_server_warning.py` and `scripts/acceptance/first_contact_honesty.py`, which
  grade main rather than this PR, so the rewording belongs in a change that moves those arms with it. With
  this PR the second daemon starts rust-analyzer, so the measured instance of that contradiction is gone.

## Measurement

Before, on release bytes from `main` at `1a8078794`, against a fresh single-branch clone of kin-db at
`488ca5e7c` under a scratch `KIN_HOME`, with rustup's proxies on PATH and the clone pinning
`channel = "1.96.0"` (a toolchain installed without the rust-analyzer component). This host has seven
toolchains and only stable ships rust-analyzer:

```text
$ (cd kin-db && rustup which rust-analyzer)
error: unknown binary 'rust-analyzer' in toolchain '1.96.0-aarch64-apple-darwin'
$ (cd ~ && rustup which rust-analyzer)
/Users/troyfortinjr/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rust-analyzer
```

Daemon one, started by `kin init` run from a directory outside the clone. The process sampler saw its
rust-analyzer child exec stable's binary with the daemon's inherited working directory:

```text
daemon pid=93138 cwd=/Users/troyfortinjr/kin-scratch-enrichverdict
rust-analyzer pid=95099 ppid=93138 exe=/Users/troyfortinjr/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rust-analyzer cwd=/Users/troyfortinjr/kin-scratch-enrichverdict RUSTUP_TOOLCHAIN=stable-aarch64-apple-darwin
LSP cold sweep complete files=72 total_files=72 relations=51703 enriched=72 already_enriched=0 ... server_unavailable=0 ... published=true
  cross-file enrichment complete (72/72 files)
```

Daemon two, the one `kin mcp start --repo <clone>` spawns, which makes the clone its working directory:

```text
daemon pid=36426 cwd=/Users/troyfortinjr/kin-scratch-enrichverdict/kin-db
WARN a language server is installed but cannot start ... language=rust reason=server initialization failed: server shutdown unexpectedly (server stderr: error: Unknown binary 'rust-analyzer' in official toolchain '1.96.0-aarch64-apple-darwin'.)
LSP cold sweep complete files=0 total_files=72 relations=0 enriched=0 already_enriched=0 ... server_unavailable=72 ... published=false
$ kin graph status
  rust: 72 files, calls 23725/56539 (41%), ... cross-file 18125, intra-file 26849 [partial]
⚠ no language server for rust (72 files); cross-file reference and override edges are absent for those files, so this graph is incomplete rather than clean
```

And a two-file crate pinning the same toolchain, initialised from inside itself the way a user runs it:

```text
note: cross-file enrichment finished without enriching any of the 3 files it walked (3 blocked); ...
    rust: 3 files not enriched, because the `rust-analyzer` language server did not start (... Unknown binary 'rust-analyzer' in official toolchain '1.96.0-aarch64-apple-darwin'.)), so nothing in this language was enriched
```

After, on release bytes of this change (built from the tree committed as `97a67685b` on `1a8078794`, rebased to `ed296dc54` on main at `691ab3466` with no upstream change to its files), the same two daemons on a fresh clone of the same commit:

Daemon one, `kin init` run from outside the clone again. It now picks rust-analyzer the same way wherever it
runs: the toolchain the workspace selects first, then the next that ships it, started by absolute path, so
no proxy runs and `RUSTUP_TOOLCHAIN` is never exported:

```text
resolved the language server this daemon starts language=rust program=/Users/troyfortinjr/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rust-analyzer chosen=rustup toolchain stable-aarch64-apple-darwin, because 1.96.0-aarch64-apple-darwin, which /Users/troyfortinjr/kin-scratch-enrichverdict/kin-db-after selects, does not ship rust-analyzer
rust-analyzer pid=56560 ppid=46358 exe=/Users/troyfortinjr/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rust-analyzer cwd=/Users/troyfortinjr/kin-scratch-enrichverdict RUSTUP_TOOLCHAIN=unset
LSP cold sweep complete files=72 total_files=72 relations=49708 enriched=72 already_enriched=0 ... server_unavailable=0 ... published=true
  cross-file enrichment complete (72/72 files)
```

Daemon two, the one `kin mcp start --repo <clone>` spawns with the clone as its working directory, which is
the daemon that could not start a server before:

```text
daemon pid=4873 exe=.../bin-fix/kin-daemon cwd=/Users/troyfortinjr/kin-scratch-enrichverdict/kin-db-after
resolved the language server this daemon starts language=rust program=/Users/troyfortinjr/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rust-analyzer chosen=rustup toolchain stable-aarch64-apple-darwin, because 1.96.0-aarch64-apple-darwin, which /Users/troyfortinjr/kin-scratch-enrichverdict/kin-db-after selects, does not ship rust-analyzer
starting the language server this daemon resolved language=rust program=/Users/troyfortinjr/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rust-analyzer chosen=(the same)
rust-analyzer pid=5898 ppid=4873 exe=/Users/troyfortinjr/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rust-analyzer cwd=/Users/troyfortinjr/kin-scratch-enrichverdict/kin-db-after RUSTUP_TOOLCHAIN=unset
LSP cold sweep complete files=72 total_files=72 relations=20683 enriched=72 already_enriched=0 ... server_unavailable=0 ... published=true
$ kin daemon sweep        (cwd = the clone)
cross-file enrichment complete (72/72 files)
$ kin graph status
  rust: 72 files, calls 23725/56539 (41%), imports 0/441 (0%), 441 name a module outside this repository, cross-file 18138, intra-file 26849 [partial]
  (no "no language server for rust" warning: the daemon serving the graph can serve Rust)
```

## Tests and falsification

New crate tests: seven in `language_server_command.rs` (the pinned toolchain falls back to one that ships the
server and the log line says why; a workspace toolchain that ships it is used and nothing else is asked; no
toolchain ships it and the failure names every one tried with rustup's words and the repair, with no `; ` in
it; a non-proxy binary starts as found; nothing on PATH is `NotInstalled`; the toolchain list and the active
toolchain parse; and, against real files, a symlink and a hard link to `rustup` are proxies while a server
binary beside it is not), six in `daemon.rs` (unservable already-enriched files leave `files_done`; servable
ones stay; a language the pass already served is untouched; a refused server takes its already-enriched files
with it and keeps the reason it recorded; a disabled daemon starts no readiness probe; the probe reports the
resolver's own answer, and starts the program the resolver named, against fixture servers), and one in
`init.rs` (the second daemon's status never reads complete).

```text
$ heavy-slot.sh enrichverdict kin -- bash tests-1.sh      (round 2, 11:19Z, the tree this PR carries before its rebase)
test result: ok. 40 passed; 0 failed; 0 ignored; 0 measured; 1624 filtered out; finished in 1.40s
kin-daemon tests rc=0
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 2294 filtered out; finished in 0.00s
kin-cli tests rc=0
```

Falsification: each arm swaps one exact string, runs the one test that guards it with `--exact`, restores
the file and checks its sha256; the worktree's diff hash was the same before and after all eight
(`cf8d578feefc9c26`).

```text
$ heavy-slot.sh enrichverdict kin -- python3 falsify.py
F1 RED (the resolver stops falling back to other toolchains)          a_pinned_toolchain_without_the_server_falls_back_to_one_that_ships_it ... FAILED
F2 RED (a proxy is no longer recognised)                              a_proxy_is_recognised_by_file_identity_and_a_real_binary_is_not ... FAILED
F3 RED (the loud failure drops the toolchains it tried)               no_toolchain_that_ships_the_server_fails_loud_naming_every_one_tried ... FAILED
F4 RED (the readiness probe ignores the enrichment decision)          a_daemon_that_does_not_enrich_starts_no_readiness_probe ... FAILED
F5 RED (unservable already-enriched files are counted done again)     already_enriched_files_in_a_language_this_daemon_cannot_serve_are_not_done ... FAILED
F6 RED (the probe starts a bare command, not the resolved program)    the_probe_starts_the_program_the_resolver_named ... FAILED
F7 RED (the probe reads an unresolvable server as absent)             the_probe_reports_what_the_resolver_found ... FAILED
F8 RED (init's summary stops naming the language it could not serve)  a_daemon_that_cannot_serve_already_enriched_files_never_reads_complete ... FAILED
```

## Local gates

```text
$ heavy-slot.sh enrichverdict kin -- bin/kin-precheck kin --repo-dir kin=<worktree>
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
PASS     guard:check-quarantine.py            python3 scripts/check-quarantine.py
... (17 further guards, all PASS)
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin 1a8078794859f3c57b04512a009a7b39614acc11 DIRTY
```

The falsification, precheck and the release bytes measured below were all taken on this change applied to
`1a8078794`, before the rebase onto current main, whose seven intervening commits touch none of these files;
the targeted tests were rerun on the rebased head:

```text
$ heavy-slot.sh enrichverdict kin -- bash tests-1.sh      (the rebased head ed296dc54, 11:35Z)
tree: .../enrichverdict-kin ed296dc54 chore/lane-enrichverdict-kin
test result: ok. 40 passed; 0 failed; 0 ignored; 0 measured; 1630 filtered out; finished in 1.02s
kin-daemon tests rc=0
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 2310 filtered out; finished in 0.00s
kin-cli tests rc=0
```

Ticket: FIR-3551.
