### PR TITLE
Serve repo-scoped review reads and semantic diff on the multi-repo daemon surface

### DIFF
--- a/crates/kin-cli/src/commands/review.rs
+++ b/crates/kin-cli/src/commands/review.rs
@@ -67,6 +67,21 @@ pub enum ReviewRequest {
     },
 }
 
+/// A review id the store holds no review under.
+///
+/// Typed so the daemon can answer 404 for it rather than the 500 an untyped
+/// error gets: a missing record is the caller's answer, not a daemon fault.
+#[derive(Debug)]
+pub struct ReviewNotFound(pub String);
+
+impl std::fmt::Display for ReviewNotFound {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "review not found: {}", self.0)
+    }
+}
+
+impl std::error::Error for ReviewNotFound {}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReviewResponse {
     #[serde(default)]
@@ -950,28 +965,21 @@ fn list_reviews_with_graph(
     graph: &kin_db::InMemoryGraph,
     state: Option<String>,
 ) -> Result<ReviewExecution> {
-    use kin_model::review::{ReviewDecisionState, ReviewFilter};
-
     let state_filter = state
         .as_deref()
-        .map(|s| match s.to_lowercase().as_str() {
-            "pending" => Ok(ReviewDecisionState::Pending),
-            "approved" => Ok(ReviewDecisionState::Approved),
-            "needs_work" | "needs-work" => Ok(ReviewDecisionState::NeedsWork),
-            "blocked" => Ok(ReviewDecisionState::Blocked),
-            _ => Err(anyhow::anyhow!(
-                "invalid state: {}. Use: pending, approved, needs_work, blocked",
-                s
-            )),
+        .map(|s| {
+            kin_review::records::parse_review_decision_state(s).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "invalid state: {}. Use: pending, approved, needs_work, blocked",
+                    s
+                )
+            })
         })
         .transpose()?;
 
-    let filter = ReviewFilter {
-        states: state_filter.map(|value| vec![value]),
-        reviewer: None,
-    };
-
-    let reviews = graph.list_reviews(&filter)?;
+    // The shared read the MCP tools and the daemon's repo-scoped routes use,
+    // which also fixes the order: newest first, not the store's map order.
+    let reviews = kin_review::records::list_stored_reviews(graph, state_filter)?;
 
     if reviews.is_empty() {
         return Ok(ReviewExecution {
@@ -1014,9 +1022,15 @@ fn show_review_with_graph(
     use kin_model::review::ReviewId;
 
     let rid = ReviewId(uuid::Uuid::parse_str(&review_id)?);
-    let review = graph
-        .get_review(&rid)?
-        .ok_or_else(|| anyhow::anyhow!("review not found: {}", review_id))?;
+    // The shared read the MCP tools and the daemon's repo-scoped routes use.
+    let kin_review::records::ReviewRecord {
+        review,
+        decisions,
+        notes,
+        discussions,
+        assignments,
+    } = kin_review::records::read_review_record(graph, &rid)?
+        .ok_or_else(|| anyhow::Error::new(ReviewNotFound(review_id.clone())))?;
 
     let mut text = String::new();
     writeln!(text, "Review: {}", review.review_id)?;
@@ -1028,7 +1042,6 @@ fn show_review_with_graph(
         review.base_ref, review.head_ref
     )?;
 
-    let decisions = graph.get_review_decisions(&rid)?;
     if !decisions.is_empty() {
         writeln!(text, "\nDecisions:")?;
         for d in &decisions {
@@ -1045,7 +1058,6 @@ fn show_review_with_graph(
         }
     }
 
-    let notes = graph.get_review_notes(&rid)?;
     if !notes.is_empty() {
         writeln!(text, "\nNotes:")?;
         for n in &notes {
@@ -1058,7 +1070,6 @@ fn show_review_with_graph(
         }
     }
 
-    let discussions = graph.get_review_discussions(&rid)?;
     if !discussions.is_empty() {
         writeln!(text, "\nDiscussions:")?;
         for d in &discussions {
@@ -1080,7 +1091,6 @@ fn show_review_with_graph(
         }
     }
 
-    let assignments = graph.get_review_assignments(&rid)?;
     if !assignments.is_empty() {
         writeln!(text, "\nAssigned reviewers:")?;
         for a in &assignments {

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -1249,6 +1249,20 @@ const REPO_SCOPED_BLOB_CAPABILITY: &str = "repo_scoped_blob_v1";
 /// is a comparison of zero files, which is indistinguishable from two refs that
 /// really are identical. A caller reading this string never has to guess.
 const REPO_SCOPED_COMPARE_CAPABILITY: &str = "repo_scoped_compare_v1";
+/// This daemon lists a repository's stored reviews and reads one in full.
+///
+/// A control plane asking an older daemon for a review gets an unmatched-route
+/// 404, which reads exactly like a review this repository does not hold. The
+/// capability is how that caller keeps "no such review" and "this daemon
+/// cannot say" apart.
+const REPO_SCOPED_REVIEWS_CAPABILITY: &str = "repo_reviews_v1";
+/// This daemon answers what changed between two refs, entity by entity.
+///
+/// Advertised for the compare capability's reason: a caller that cannot tell
+/// a daemon without this route from one with it has to decide what an
+/// unanswered diff means, and zero changed entities is the tempting wrong
+/// answer.
+const REPO_SCOPED_SEMANTIC_DIFF_CAPABILITY: &str = "repo_semantic_diff_v1";
 /// Retained continuations per repository, not per daemon.
 ///
 /// A per-daemon cap is a shared resource across tenants, and the eviction that
@@ -2266,6 +2280,18 @@ fn api_routes() -> Router<Arc<DaemonState>> {
         )
         .route("/repos/{repo_id}/refs", get(repo_refs))
         .route("/repos/{repo_id}/history", get(repo_history))
+        .route(
+            "/repos/{repo_id}/reviews",
+            get(crate::repo_review::repo_reviews),
+        )
+        .route(
+            "/repos/{repo_id}/reviews/{review_id}",
+            get(crate::repo_review::repo_review_detail),
+        )
+        .route(
+            "/repos/{repo_id}/semantic-diff",
+            get(crate::repo_review::repo_semantic_diff),
+        )
         .route(
             "/repos/{repo_id}/transfer/advertise",
             get(repo_transfer_advertise),
@@ -9442,6 +9468,11 @@ async fn review(
     .map_err(|error| {
         if kin_cli::commands::ref_lookup::is_ref_resolution_error(&error) {
             (StatusCode::BAD_REQUEST, crate::error::cause_first(&error))
+        } else if error
+            .downcast_ref::<kin_cli::commands::review::ReviewNotFound>()
+            .is_some()
+        {
+            (StatusCode::NOT_FOUND, error.to_string())
         } else {
             internal_error(error)
         }
@@ -15737,7 +15768,7 @@ async fn mcp_tools_call_dispatch(
 /// [`DaemonError::RepoAbsentFromStorage`] so it survives the trip here. Reading
 /// it back out of a flattened storage error's wording would be the same
 /// infer-from-the-failure mistake the served key space exists to avoid.
-async fn repo_scoped_graph(
+pub(crate) async fn repo_scoped_graph(
     state: &DaemonState,
     repo_id: &str,
 ) -> Result<Arc<kin_db::InMemoryGraph>, (StatusCode, String)> {
@@ -15873,7 +15904,7 @@ fn repository_metadata(
 /// graph in one entry, probes its publication cursor, and replaces both as one
 /// unit when authority moves, so this is both cheaper and stricter about
 /// generation consistency.
-async fn repository_ref_metadata(
+pub(crate) async fn repository_ref_metadata(
     state: &DaemonState,
     repo_id: &str,
 ) -> Result<Arc<kin_db::PersistedRepositoryAuthority>, (StatusCode, String)> {
@@ -17016,6 +17047,8 @@ async fn repo_health(
                     REPO_SCOPED_SEMANTIC_CAPABILITY.to_string(),
                     REPO_SCOPED_BLOB_CAPABILITY.to_string(),
                     REPO_SCOPED_COMPARE_CAPABILITY.to_string(),
+                    REPO_SCOPED_REVIEWS_CAPABILITY.to_string(),
+                    REPO_SCOPED_SEMANTIC_DIFF_CAPABILITY.to_string(),
                 ]
             })
             .unwrap_or_default(),
@@ -20228,6 +20261,7 @@ fn bind_std_listener(
 #[cfg(test)]
 mod tests {
     mod outside_graph_disclosure;
+    mod repo_review_routes;
     mod session_identity;
     mod session_move_identity;
     /// THE WIRING SPINE (FIR-2524, captain's rider). The envelope the impact

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -26392,6 +26392,8 @@ mod tests {
                 REPO_SCOPED_SEMANTIC_CAPABILITY.to_string(),
                 REPO_SCOPED_BLOB_CAPABILITY.to_string(),
                 REPO_SCOPED_COMPARE_CAPABILITY.to_string(),
+                REPO_SCOPED_REVIEWS_CAPABILITY.to_string(),
+                REPO_SCOPED_SEMANTIC_DIFF_CAPABILITY.to_string(),
             ]
         );
 

--- a/crates/kin-daemon/src/api/tests/repo_review_routes.rs
+++ b/crates/kin-daemon/src/api/tests/repo_review_routes.rs
@@ -1,0 +1,524 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! The repo-scoped review reads and semantic diff, over the router.
+//!
+//! The hosted fixture is the store the routes exist for: two generations on
+//! `main`, a second ref `legacy` at the first, and one review record of
+//! `legacy..main` committed into graph authority the way a transfer carries
+//! one. Every arm reads it through the router, so the route table, the
+//! extractors and the refusal header are under test with the logic.
+
+use super::*;
+use crate::repo_review::{
+    RepoReviewDetailResponse, RepoReviewsResponse, RepoSemanticDiffResponse,
+    REPO_REVIEW_REFUSAL_HEADER, RISK_NOT_ASSESSED,
+};
+use kin_model::review::{
+    Review, ReviewCompletionState, ReviewDecisionState, ReviewId as StoredReviewId,
+};
+
+/// GET one path: the status, the refusal header, and the body.
+async fn read(state: Arc<DaemonState>, path: &str) -> (StatusCode, Option<String>, Vec<u8>) {
+    let response = router(state)
+        .oneshot(Request::get(path).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let status = response.status();
+    let refusal = response
+        .headers()
+        .get(REPO_REVIEW_REFUSAL_HEADER)
+        .map(|value| value.to_str().unwrap().to_string());
+    let body = axum::body::to_bytes(response.into_body(), 4 * 1024 * 1024)
+        .await
+        .unwrap();
+    (status, refusal, body.to_vec())
+}
+
+/// Commit one review record into hosted authority, alone, the way a transfer
+/// pack carries collaboration: a transaction whose only mutation is the record.
+fn publish_hosted_review(
+    storage: &FsPath,
+    repository_id: &RepositoryId,
+    operation: u128,
+    review: &Review,
+) {
+    use kin_model::{RepositoryTransaction, REPOSITORY_TRANSACTION_SCHEMA_VERSION};
+
+    let manager = RepositoryAuthorityManager::open(
+        repository_id.clone(),
+        Arc::new(kin_db::LocalFileBackend::new(storage.to_path_buf())),
+    )
+    .unwrap();
+    let lease = manager.read_authority();
+    let transaction = RepositoryTransaction {
+        schema_version: REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+        operation_id: kin_model::OperationId::from_uuid(Uuid::from_u128(operation)),
+        repository_id: repository_id.clone(),
+        expected_generation: lease.roots().generation,
+        expected_roots: lease.roots().clone(),
+        actor: AuthorId::new("repo-review-test"),
+        reason: format!("record review {}", review.review_id),
+        external_objects: Vec::new(),
+        git_authority_delta: None,
+        changes: Vec::new(),
+        aliases: Vec::new(),
+        ref_mutations: Vec::new(),
+        default_ref_mutation: None,
+        workspace_mutation: None,
+        local_overlay_delta: None,
+        merge_transaction_delta: None,
+        sealed_observation: None,
+        collaboration_delta: Some(kin_model::CollaborationDelta {
+            reviews: vec![kin_model::Keyed::new(review.review_id, review.clone())],
+            ..kin_model::CollaborationDelta::default()
+        }),
+    };
+    drop(lease);
+    manager.commit_repository_transaction(transaction).unwrap();
+}
+
+struct ReviewFixture {
+    state: Arc<DaemonState>,
+    repo_id: String,
+    first: SemanticChangeId,
+    second: SemanticChangeId,
+    review: Review,
+    _working: tempfile::TempDir,
+    _storage: tempfile::TempDir,
+}
+
+/// One review record and two refs: `main` at the second generation, `legacy`
+/// at the first, and the review asks what `legacy..main` changed.
+async fn review_fixture() -> ReviewFixture {
+    let repo_id = format!("hostedreview-{}", Uuid::new_v4());
+    let (state, working, storage) = replica_state(&repo_id);
+    let repository_id = RepositoryId::new(&repo_id).unwrap();
+    let (first, _entities) = publish_hosted_semantic_change(
+        storage.path(),
+        &repository_id,
+        None,
+        0x5245_5601,
+        "publish the first generation",
+        &[(
+            "only_in_first",
+            "src/only_in_first.rs",
+            "fn only_in_first() {}\n",
+        )],
+    );
+    let (second, _entities) = publish_hosted_semantic_change(
+        storage.path(),
+        &repository_id,
+        Some(first),
+        0x5245_5602,
+        "publish the second generation",
+        &[(
+            "only_in_second",
+            "src/only_in_second.rs",
+            "fn only_in_second() {}\n",
+        )],
+    );
+    add_hosted_ref(
+        storage.path(),
+        &repository_id,
+        0x5245_5603,
+        kin_model::RefName::branch(b"legacy").unwrap(),
+        first,
+    );
+    let now = kin_model::Timestamp::now();
+    let review = Review {
+        review_id: StoredReviewId::new(),
+        title: "Review the second generation".to_string(),
+        base_ref: "legacy".to_string(),
+        head_ref: "main".to_string(),
+        state: ReviewDecisionState::Pending,
+        completion: ReviewCompletionState::InReview,
+        created_by: kin_model::IdentityRef::human("reviewer"),
+        created_at: now.clone(),
+        updated_at: now,
+        scopes: Vec::new(),
+    };
+    publish_hosted_review(storage.path(), &repository_id, 0x5245_5604, &review);
+    state.evict_repo_cache_for_test(&repo_id).await;
+    ReviewFixture {
+        state,
+        repo_id,
+        first,
+        second,
+        review,
+        _working: working,
+        _storage: storage,
+    }
+}
+
+/// A record read resolves the review's refs and computes nothing from them.
+fn assert_not_computed(summary: &crate::repo_review::ReviewChangeSummary, fixture: &ReviewFixture) {
+    assert_eq!(summary.state, "not_computed", "{summary:?}");
+    assert_eq!(
+        summary.base_change_id.as_deref(),
+        Some(fixture.first.to_string().as_str())
+    );
+    assert_eq!(
+        summary.head_change_id.as_deref(),
+        Some(fixture.second.to_string().as_str())
+    );
+    assert_eq!(summary.merge_base_change_id, None);
+    assert_eq!(
+        summary.changed_entity_count, None,
+        "a count nobody computed is null, never zero"
+    );
+    assert_eq!(summary.risk, RISK_NOT_ASSESSED);
+    let gap = summary.gap.as_ref().expect("not_computed says why");
+    assert_eq!(gap.kind, "not_computed");
+    assert!(gap.message.contains("semantic-diff"), "{gap:?}");
+}
+
+/// The listing serves the stored record, with its refs resolved and its range
+/// left to the semantic diff.
+#[tokio::test]
+async fn the_review_listing_serves_the_stored_record_with_its_refs_resolved() {
+    let fixture = review_fixture().await;
+    let (status, refusal, body) = read(
+        Arc::clone(&fixture.state),
+        &format!("/repos/{}/reviews", fixture.repo_id),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+    assert_eq!(refusal, None);
+    let listing: RepoReviewsResponse = serde_json::from_slice(&body).unwrap();
+    assert_eq!(listing.repo_id, fixture.repo_id);
+    assert_eq!(listing.evidence.review_records, 1);
+    assert_eq!(listing.reviews.len(), 1, "one stored review, one row");
+
+    let row = &listing.reviews[0];
+    assert_eq!(row.summary.review_id, fixture.review.review_id.to_string());
+    assert_eq!(row.summary.title, fixture.review.title);
+    assert_eq!(row.summary.state, "pending");
+    assert_eq!(row.summary.base_ref, "legacy");
+    assert_eq!(row.summary.head_ref, "main");
+    assert_eq!(row.completion, "in-review");
+    assert_not_computed(&row.change_summary, &fixture);
+
+    // A filter that excludes the one record answers an empty list beside the
+    // count that proves the store was read and holds a review.
+    let (status, _, body) = read(
+        Arc::clone(&fixture.state),
+        &format!("/repos/{}/reviews?state=approved", fixture.repo_id),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let narrowed: RepoReviewsResponse = serde_json::from_slice(&body).unwrap();
+    assert!(narrowed.reviews.is_empty());
+    assert_eq!(narrowed.evidence.review_records, 1);
+    assert_eq!(narrowed.evidence.state_filter.as_deref(), Some("approved"));
+
+    let (status, refusal, body) = read(
+        Arc::clone(&fixture.state),
+        &format!("/repos/{}/reviews?state=merged", fixture.repo_id),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(refusal.as_deref(), Some("bad-request"));
+    assert!(String::from_utf8_lossy(&body).contains("merged"));
+}
+
+/// The detail is the stored record, and each way of not naming one refuses
+/// in its own words.
+#[tokio::test]
+async fn the_review_detail_serves_the_record_and_refuses_what_names_no_review() {
+    let fixture = review_fixture().await;
+    let review_id = fixture.review.review_id;
+    let (status, refusal, body) = read(
+        Arc::clone(&fixture.state),
+        &format!("/repos/{}/reviews/{review_id}", fixture.repo_id),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+    assert_eq!(refusal, None);
+    let detail: RepoReviewDetailResponse = serde_json::from_slice(&body).unwrap();
+    assert_eq!(detail.review.review_id, review_id.to_string());
+    assert_eq!(detail.review.title, fixture.review.title);
+    assert_eq!(detail.review.base_ref, "legacy");
+    assert_eq!(detail.review.head_ref, "main");
+    assert!(detail.review.decisions.is_empty());
+    assert_not_computed(&detail.change_summary, &fixture);
+
+    // The detail is kin_review_get's object at the top level, so a client
+    // mapping the MCP tool's answer maps this one.
+    let raw: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    for key in [
+        "review_id",
+        "title",
+        "state",
+        "base_ref",
+        "head_ref",
+        "scopes",
+        "decisions",
+        "notes",
+        "discussions",
+        "assignments",
+    ] {
+        assert!(
+            raw.get(key).is_some(),
+            "the detail must carry {key} at the top level"
+        );
+    }
+
+    let absent = StoredReviewId::new();
+    let (status, refusal, body) = read(
+        Arc::clone(&fixture.state),
+        &format!("/repos/{}/reviews/{absent}", fixture.repo_id),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(refusal.as_deref(), Some("unknown-review"));
+    assert!(
+        String::from_utf8_lossy(&body).contains(&absent.to_string()),
+        "the refusal must name the review it could not find"
+    );
+
+    let (status, refusal, _) = read(
+        Arc::clone(&fixture.state),
+        &format!("/repos/{}/reviews/not-a-review", fixture.repo_id),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(refusal.as_deref(), Some("invalid-review-id"));
+
+    let (status, refusal, _) = read(
+        Arc::clone(&fixture.state),
+        &format!("/repos/{}-elsewhere/reviews/{review_id}", fixture.repo_id),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(refusal.as_deref(), Some("unknown-repository"));
+}
+
+/// The semantic diff answers the range with risk not assessed, adds risk only
+/// under risk=assess, and refuses a side that names nothing.
+///
+/// Forward, `legacy..main` adds one function. Reversed, the head adds nothing
+/// the base lacks, which is the empty answer, and it has to arrive with the
+/// zero in its evidence and the distance beside it rather than as a bare empty
+/// list a failed computation could also produce.
+#[tokio::test]
+async fn the_semantic_diff_answers_the_range_and_assesses_risk_only_when_asked() {
+    let fixture = review_fixture().await;
+    let (status, refusal, body) = read(
+        Arc::clone(&fixture.state),
+        &format!(
+            "/repos/{}/semantic-diff?base=legacy&head=main",
+            fixture.repo_id
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+    assert_eq!(refusal, None);
+    let diff: RepoSemanticDiffResponse = serde_json::from_slice(&body).unwrap();
+    assert_eq!(diff.base_ref, "legacy");
+    assert_eq!(diff.head_ref, "main");
+    assert_eq!(diff.base_change_id, fixture.first.to_string());
+    assert_eq!(diff.head_change_id, fixture.second.to_string());
+    assert_eq!(diff.merge_base_change_id, fixture.first.to_string());
+    assert_eq!((diff.ahead, diff.behind), (1, 0));
+    assert_eq!(diff.evidence.changes_in_range, 1);
+    assert_eq!(diff.evidence.entity_changes, 1);
+    assert_eq!(diff.evidence.unresolved_removals, 0);
+    assert_eq!(diff.evidence.merge_base_path, "closed_walks");
+    assert_eq!(diff.overall_risk, RISK_NOT_ASSESSED);
+    assert_eq!(diff.evidence.risk, RISK_NOT_ASSESSED);
+    assert_eq!(diff.risk_findings, None);
+    assert_eq!(diff.entities.len(), 1, "{:?}", diff.entities);
+    let entity = &diff.entities[0];
+    assert_eq!(entity.name.as_deref(), Some("only_in_second"));
+    assert_eq!(entity.kind.as_deref(), Some("Function"));
+    assert_eq!(entity.change_type, "added");
+    assert_eq!(entity.risk_level, RISK_NOT_ASSESSED);
+    assert_eq!(entity.before_signature, None);
+    assert_eq!(
+        entity.after_signature.as_deref(),
+        Some("fn only_in_second() {}")
+    );
+    assert_eq!(entity.file.as_deref(), Some("src/only_in_second.rs"));
+    assert_eq!(
+        entity.start_line,
+        Some(1),
+        "the 1-based line an editor shows"
+    );
+    assert!(entity.changes.is_empty());
+
+    let (status, _, body) = read(
+        Arc::clone(&fixture.state),
+        &format!(
+            "/repos/{}/semantic-diff?base=legacy&head=main&risk=assess",
+            fixture.repo_id
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+    let assessed: RepoSemanticDiffResponse = serde_json::from_slice(&body).unwrap();
+    assert_eq!(assessed.overall_risk, "low");
+    assert_eq!(assessed.evidence.risk, "assessed");
+    assert!(assessed.risk_findings.is_some());
+    assert_eq!(assessed.entities.len(), 1);
+    assert_eq!(assessed.entities[0].risk_level, "low");
+
+    let (status, _, body) = read(
+        Arc::clone(&fixture.state),
+        &format!(
+            "/repos/{}/semantic-diff?base=main&head=legacy",
+            fixture.repo_id
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+    let reversed: RepoSemanticDiffResponse = serde_json::from_slice(&body).unwrap();
+    assert!(reversed.entities.is_empty());
+    assert_eq!((reversed.ahead, reversed.behind), (0, 1));
+    assert_eq!(reversed.evidence.changes_in_range, 0);
+    assert_eq!(reversed.merge_base_change_id, fixture.first.to_string());
+    assert_eq!(reversed.overall_risk, RISK_NOT_ASSESSED);
+
+    let (status, refusal, body) = read(
+        Arc::clone(&fixture.state),
+        &format!(
+            "/repos/{}/semantic-diff?base=no-such-branch&head=main",
+            fixture.repo_id
+        ),
+    )
+    .await;
+    let message = String::from_utf8_lossy(&body);
+    assert_eq!(status, StatusCode::NOT_FOUND, "{message}");
+    assert_eq!(refusal.as_deref(), Some("unknown-ref"));
+    assert!(
+        message.starts_with("base:") && message.contains("no-such-branch"),
+        "the refusal must name the side and the ref: {message}"
+    );
+
+    for query in [
+        "base=&head=main",
+        "head=main",
+        "base=legacy&head=main&risk=maybe",
+    ] {
+        let (status, refusal, _) = read(
+            Arc::clone(&fixture.state),
+            &format!("/repos/{}/semantic-diff?{query}", fixture.repo_id),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{query}");
+        assert_eq!(refusal.as_deref(), Some("bad-request"), "{query}");
+    }
+}
+
+/// A caller probes the capability list before it calls the routes.
+#[tokio::test]
+async fn repo_health_advertises_the_review_and_semantic_diff_reads() {
+    let fixture = review_fixture().await;
+    let (status, _, body) = read(
+        Arc::clone(&fixture.state),
+        &format!("/repos/{}/health", fixture.repo_id),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let health: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let capabilities: Vec<&str> = health["semantic_capabilities"]
+        .as_array()
+        .expect("semantic_capabilities is a list")
+        .iter()
+        .filter_map(serde_json::Value::as_str)
+        .collect();
+    for capability in ["repo_reviews_v1", "repo_semantic_diff_v1"] {
+        assert!(
+            capabilities.contains(&capability),
+            "{capability} must be advertised: {capabilities:?}"
+        );
+    }
+}
+
+/// On a local daemon the repo-scoped listing reads the graph `POST /review`
+/// writes, and a stored ref that resolves to nothing is an explicit gap.
+///
+/// The review is created through the single-repo route and read back through
+/// the repo-scoped one, so the two cannot be reading different stores. Its
+/// refs name nothing in a fresh store, and the row says so under a refusal
+/// kind rather than reporting zero changed entities.
+#[tokio::test]
+async fn a_local_listing_reads_what_post_review_wrote_and_names_an_unresolved_ref() {
+    let state = test_state();
+    state
+        .is_initialized
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    let response = router(Arc::clone(&state))
+        .oneshot(
+            Request::post("/review")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "op": "create",
+                        "title": "Local review",
+                        "base": "main",
+                        "head": "feature/nowhere",
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let repo_id = state.cached_repo_id.clone();
+    let (status, _, body) = read(Arc::clone(&state), &format!("/repos/{repo_id}/reviews")).await;
+    assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+    let listing: RepoReviewsResponse = serde_json::from_slice(&body).unwrap();
+    assert_eq!(listing.reviews.len(), 1);
+    assert_eq!(listing.reviews[0].summary.title, "Local review");
+    let summary = &listing.reviews[0].change_summary;
+    assert_eq!(summary.state, "unresolved", "{summary:?}");
+    assert_eq!(
+        summary.changed_entity_count, None,
+        "an unresolved range is never reported as zero changed entities"
+    );
+    assert_eq!(summary.risk, RISK_NOT_ASSESSED);
+    let gap = summary
+        .gap
+        .as_ref()
+        .expect("an unresolved summary names its gap");
+    assert_eq!(gap.kind, "unknown-ref", "{gap:?}");
+    assert!(gap.message.starts_with("base:"), "{gap:?}");
+}
+
+/// `POST /review` show of an id the store holds no review under answers 404.
+///
+/// It answered 500, which a caller reads as a daemon fault and retries. The
+/// missing record is the caller's answer, and the status now says so.
+#[tokio::test]
+async fn post_review_show_of_a_missing_review_answers_404() {
+    let state = test_state();
+    state
+        .is_initialized
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    let absent = StoredReviewId::new();
+    let response = router(Arc::clone(&state))
+        .oneshot(
+            Request::post("/review")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "op": "show", "review_id": absent.to_string() })
+                        .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let message = String::from_utf8_lossy(&body);
+    assert_eq!(status, StatusCode::NOT_FOUND, "{message}");
+    assert!(
+        message.contains(&absent.to_string()),
+        "the refusal must name the review: {message}"
+    );
+}

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -139,6 +139,7 @@ pub mod publication_lease;
 pub mod replica_adoption;
 pub mod repo_blob;
 pub mod repo_compare;
+pub mod repo_review;
 mod repository_admit;
 mod repository_branch;
 mod repository_checkout;

--- a/crates/kin-daemon/src/repo_blob.rs
+++ b/crates/kin-daemon/src/repo_blob.rs
@@ -348,10 +348,25 @@ pub(crate) fn resolve_read_point(
     let authority = view
         .authority()
         .map_err(|parts| RepoBlobError::from_parts(RepoBlobRefusal::RepositoryUnreadable, parts))?;
+    resolve_read_point_in(authority, reference, repo_id)
+}
+
+/// [`resolve_read_point`] against an authority envelope the caller already
+/// holds, for a route that reads the envelope without a whole read view.
+///
+/// The rule is the same one rather than a copy of it, which is why the view
+/// form above only unwraps its envelope and delegates here.
+pub(crate) fn resolve_read_point_in(
+    authority: &kin_db::PersistedRepositoryAuthority,
+    reference: Option<&str>,
+    repo_id: &str,
+) -> Result<(kin_model::SemanticChangeId, Option<String>), RepoBlobError> {
     let resolve = |target: &kin_model::RefTarget| {
-        view.resolve_target(target).map_err(|parts| {
-            RepoBlobError::from_parts(RepoBlobRefusal::RepositoryUnreadable, parts)
-        })
+        crate::state::resolve_repository_target(authority, target)
+            .map_err(crate::api::repository_authority_error)
+            .map_err(|parts| {
+                RepoBlobError::from_parts(RepoBlobRefusal::RepositoryUnreadable, parts)
+            })
     };
     let Some(reference) = reference.map(str::trim).filter(|value| !value.is_empty()) else {
         let default_ref = default_repository_ref(authority)

--- a/crates/kin-daemon/src/repo_review.rs
+++ b/crates/kin-daemon/src/repo_review.rs
@@ -1,0 +1,1451 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Repo-scoped review reads, and the entity-level diff between two refs.
+//!
+//! A hosted repository could list its entities, files, refs and history and
+//! compare two refs file by file, but it could not answer the two questions a
+//! review screen asks first: which reviews exist, and what changed at the level
+//! of functions and types. `GET /repos/{repo_id}/reviews`,
+//! `GET /repos/{repo_id}/reviews/{review_id}` and
+//! `GET /repos/{repo_id}/semantic-diff?base=&head=` answer them from the same
+//! graph authority `GET /repos/{repo_id}/entities` reads. Nothing on these paths
+//! reads a file: a review is a graph record, and a diff is a fold over the
+//! changes graph authority holds.
+//!
+//! One read serves every surface. The rows and the full record come from
+//! `kin_review::records`, which `kin review list`, `kin review show` and the
+//! `kin_review_list` and `kin_review_get` MCP tools read through too, so a
+//! caller maps one shape whether it asked a local tool or a hosted daemon.
+//!
+//! Refs resolve exactly as `/compare` and `/blob` resolve them, and the range is
+//! the one `/compare` measures: everything the head reaches that the base does
+//! not, reviewed from their merge base. That is the range a review of a branch
+//! means. It is not what `kin_review::compute_diff` walks, because the store's
+//! backward walk stops only at the literal base node and crosses a merge into
+//! the base's own history.
+//!
+//! Risk is asked for, not assumed. Measured on a 3,014-change store, the diff
+//! answers in milliseconds while risk, which needs impact read at the head's own
+//! graph state, replays the whole history and took over a minute. So the diff is
+//! the default, `risk=assess` is the one way to a risk level, and an unassessed
+//! risk says `not_assessed` wherever a level would otherwise show, never a blank
+//! and never a default level. The record reads never compute a range at all.
+//!
+//! Refusals are the design. A ref that does not resolve names its side, an id
+//! that is not a review id or names no review says which, and a head whose
+//! history the graph cannot replay refuses rather than answering a diff without
+//! its risk. An empty answer is a real zero with its evidence beside it: how
+//! many reviews the store holds, how many changes the range holds.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use axum::extract::rejection::QueryRejection;
+use axum::extract::{Path, Query, State};
+use axum::http::{HeaderName, HeaderValue, StatusCode};
+use axum::response::IntoResponse;
+use axum::Json;
+use kin_model::review::{Review, ReviewId, RiskLevel};
+use kin_model::{ChangeStore, Entity, SemanticChangeId};
+use kin_review::records::{ReviewRecordView, ReviewSummaryView};
+use kin_review::{EntityChange, EntityChangeKind, RangeReview, ReviewError, SemanticDiff};
+use serde::{Deserialize, Serialize};
+
+use crate::api::RepositoryReadView;
+use crate::repo_blob::{RepoBlobError, RepoBlobRefusal};
+use crate::repo_compare::{Distance, RepoCompareError, RepoCompareRefusal};
+use crate::state::DaemonState;
+
+/// The header every refusal from these routes carries, naming which refusal.
+pub const REPO_REVIEW_REFUSAL_HEADER: &str = "x-kin-review-refusal";
+
+/// What a risk field says when risk was not assessed.
+///
+/// A word rather than a null or a default level: a reader told nothing and a
+/// reader told "low" look the same on a page, and only one of them is true.
+pub const RISK_NOT_ASSESSED: &str = "not_assessed";
+
+/// Which refusal, in a closed set a caller can branch on without reading English.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepoReviewRefusal {
+    /// The request itself could not be understood, so nothing was resolved.
+    BadRequest,
+    /// This daemon does not serve a repository by that id.
+    UnknownRepository,
+    /// It serves the id and could not read it as a repository.
+    RepositoryUnreadable,
+    /// A side named neither a ref this repository carries nor a change id.
+    UnknownRef,
+    /// A side is a short alias more than one ref answers to.
+    AmbiguousRef,
+    /// The two histories share no ancestor, so there is no range between them.
+    NoCommonAncestor,
+    /// A side's history ran past the walk's bound before an ancestor was found.
+    HistoryTooDeep,
+    /// Several best common ancestors exist and none descends from another.
+    AmbiguousMergeBase,
+    /// The review id is not an id at all.
+    InvalidReviewId,
+    /// The review id is well formed and this repository holds no such review.
+    UnknownReview,
+    /// The graph cannot replay the history a side names, so neither the diff
+    /// nor its risk can be established.
+    RefStateUnavailable,
+}
+
+impl RepoReviewRefusal {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::BadRequest => "bad-request",
+            Self::UnknownRepository => "unknown-repository",
+            Self::RepositoryUnreadable => "repository-unreadable",
+            Self::UnknownRef => "unknown-ref",
+            Self::AmbiguousRef => "ambiguous-ref",
+            Self::NoCommonAncestor => "no-common-ancestor",
+            Self::HistoryTooDeep => "history-too-deep",
+            Self::AmbiguousMergeBase => "ambiguous-merge-base",
+            Self::InvalidReviewId => "invalid-review-id",
+            Self::UnknownReview => "unknown-review",
+            Self::RefStateUnavailable => "ref-state-unavailable",
+        }
+    }
+}
+
+/// A refusal from these routes: a status, a kind, and a sentence for a person.
+#[derive(Debug, Clone)]
+pub struct RepoReviewError {
+    pub status: StatusCode,
+    pub kind: RepoReviewRefusal,
+    pub message: String,
+}
+
+impl RepoReviewError {
+    fn new(status: StatusCode, kind: RepoReviewRefusal, message: impl Into<String>) -> Self {
+        Self {
+            status,
+            kind,
+            message: message.into(),
+        }
+    }
+
+    /// A repository-addressed failure from the shared `/repos` helpers, which
+    /// already decided between "not served here" (404) and "served and broken".
+    fn from_repository(parts: (StatusCode, String)) -> Self {
+        let kind = if parts.0 == StatusCode::NOT_FOUND {
+            RepoReviewRefusal::UnknownRepository
+        } else {
+            RepoReviewRefusal::RepositoryUnreadable
+        };
+        Self::new(parts.0, kind, parts.1)
+    }
+
+    /// A side that did not resolve, under the blob route's own rule. The side
+    /// leads the sentence because the status cannot say which one it was.
+    fn from_read_point(side: &str, error: RepoBlobError) -> Self {
+        let kind = match error.kind {
+            RepoBlobRefusal::UnknownRef => RepoReviewRefusal::UnknownRef,
+            RepoBlobRefusal::AmbiguousRef => RepoReviewRefusal::AmbiguousRef,
+            RepoBlobRefusal::UnknownRepository => RepoReviewRefusal::UnknownRepository,
+            _ => RepoReviewRefusal::RepositoryUnreadable,
+        };
+        Self::new(error.status, kind, format!("{side}: {}", error.message))
+    }
+
+    /// A merge-base refusal from `/compare`'s own measurement.
+    fn from_distance(error: RepoCompareError) -> Self {
+        let kind = match error.kind {
+            RepoCompareRefusal::BadRequest => RepoReviewRefusal::BadRequest,
+            RepoCompareRefusal::UnknownRepository => RepoReviewRefusal::UnknownRepository,
+            RepoCompareRefusal::UnknownRef => RepoReviewRefusal::UnknownRef,
+            RepoCompareRefusal::AmbiguousRef => RepoReviewRefusal::AmbiguousRef,
+            RepoCompareRefusal::NoCommonAncestor => RepoReviewRefusal::NoCommonAncestor,
+            RepoCompareRefusal::HistoryTooDeep => RepoReviewRefusal::HistoryTooDeep,
+            RepoCompareRefusal::AmbiguousMergeBase => RepoReviewRefusal::AmbiguousMergeBase,
+            RepoCompareRefusal::RepositoryUnreadable | RepoCompareRefusal::PathNotRepresentable => {
+                RepoReviewRefusal::RepositoryUnreadable
+            }
+        };
+        Self::new(error.status, kind, error.message)
+    }
+
+    fn from_review(error: ReviewError) -> Self {
+        match error {
+            ReviewError::RefStateUnavailable { at, missing } => Self::new(
+                StatusCode::FAILED_DEPENDENCY,
+                RepoReviewRefusal::RefStateUnavailable,
+                format!(
+                    "the graph cannot replay the history of {at}: change {missing} in its \
+                     ancestry is not in this repository's graph, so no diff and no risk were \
+                     computed"
+                ),
+            ),
+            other => Self::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                RepoReviewRefusal::RepositoryUnreadable,
+                format!("the review of this range failed: {other}"),
+            ),
+        }
+    }
+
+    fn unreadable(context: impl std::fmt::Display, error: impl std::fmt::Display) -> Self {
+        Self::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            RepoReviewRefusal::RepositoryUnreadable,
+            format!("{context}: {error}"),
+        )
+    }
+}
+
+impl IntoResponse for RepoReviewError {
+    fn into_response(self) -> axum::response::Response {
+        let mut response = (self.status, self.message).into_response();
+        response.headers_mut().insert(
+            HeaderName::from_static(REPO_REVIEW_REFUSAL_HEADER),
+            HeaderValue::from_static(self.kind.as_str()),
+        );
+        response
+    }
+}
+
+/// A risk level as these routes and the boundary contract spell it.
+pub fn risk_label(level: RiskLevel) -> &'static str {
+    match level {
+        RiskLevel::Low => "low",
+        RiskLevel::Medium => "medium",
+        RiskLevel::High => "high",
+        RiskLevel::Critical => "critical",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Response shapes
+// ---------------------------------------------------------------------------
+
+/// What a stored review's refs resolve to, and why nothing more is here.
+///
+/// The record reads never compute a range: that is the semantic diff's job and
+/// its cost. `state` is `not_computed` when both stored refs resolved, and
+/// `unresolved` when `gap` names the refusal one of them met. The count and the
+/// merge base are then null, and `risk` is `not_assessed`, never a level.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReviewChangeSummary {
+    pub state: String,
+    pub base_change_id: Option<String>,
+    pub head_change_id: Option<String>,
+    pub merge_base_change_id: Option<String>,
+    pub changed_entity_count: Option<usize>,
+    pub risk: String,
+    pub gap: Option<ReviewSummaryGap>,
+}
+
+/// Why a review's change summary holds what it holds.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReviewSummaryGap {
+    /// `not_computed`, or one of the refusal kinds [`REPO_REVIEW_REFUSAL_HEADER`]
+    /// carries.
+    pub kind: String,
+    pub message: String,
+}
+
+/// One row of `GET /repos/{repo_id}/reviews`.
+///
+/// The first five fields are `kin_review_list`'s row, unchanged.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RepoReviewRow {
+    #[serde(flatten)]
+    pub summary: ReviewSummaryView,
+    pub completion: String,
+    pub scopes: Vec<String>,
+    pub created_at: kin_model::Timestamp,
+    pub updated_at: kin_model::Timestamp,
+    pub change_summary: ReviewChangeSummary,
+}
+
+/// The evidence beside a review listing, so an empty one is a real zero.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RepoReviewsEvidence {
+    /// Every review record this repository's graph holds, before any filter.
+    pub review_records: usize,
+    /// The decision state the listing was narrowed to, if any.
+    pub state_filter: Option<String>,
+}
+
+/// `GET /repos/{repo_id}/reviews`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RepoReviewsResponse {
+    pub repo_id: String,
+    pub reviews: Vec<RepoReviewRow>,
+    pub evidence: RepoReviewsEvidence,
+}
+
+/// `GET /repos/{repo_id}/reviews/{review_id}`.
+///
+/// The flattened fields are `kin_review_get`'s object, unchanged.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RepoReviewDetailResponse {
+    #[serde(flatten)]
+    pub review: ReviewRecordView,
+    pub repo_id: String,
+    pub completion: String,
+    pub created_at: kin_model::Timestamp,
+    pub updated_at: kin_model::Timestamp,
+    pub change_summary: ReviewChangeSummary,
+}
+
+/// One field that moved between an entity's base and head records.
+///
+/// `old` and `new` are both null for `body` and `fingerprint`: the graph holds
+/// a fingerprint for them rather than text, so the row says the field changed
+/// and claims no values.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SemanticDiffFieldChange {
+    pub field: String,
+    pub old: Option<String>,
+    pub new: Option<String>,
+}
+
+/// One changed entity.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SemanticDiffEntityRow {
+    pub id: String,
+    /// Null only for a removal whose base-side record is unrecoverable, which
+    /// `evidence.unresolved_removals` counts; a bare id is never offered as a
+    /// name.
+    pub name: Option<String>,
+    pub kind: Option<String>,
+    /// `added`, `modified` or `removed`.
+    pub change_type: String,
+    /// `low`, `medium`, `high` or `critical` from this entity's own findings
+    /// under `risk=assess`, never above `overall_risk`; otherwise
+    /// [`RISK_NOT_ASSESSED`].
+    pub risk_level: String,
+    pub changes: Vec<SemanticDiffFieldChange>,
+    pub before_signature: Option<String>,
+    pub after_signature: Option<String>,
+    pub file: Option<String>,
+    /// The 1-based line an editor shows, not the graph's 0-based row.
+    pub start_line: Option<u32>,
+}
+
+/// The review engine's findings for the range, as `kin review` reports them.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct SemanticDiffRiskFindings {
+    pub breaking_changes: Vec<String>,
+    pub test_coverage_gaps: Vec<String>,
+    pub contract_violations: Vec<String>,
+    pub work_risks: Vec<String>,
+    pub notes: Vec<String>,
+}
+
+/// What the diff was computed from, so an empty entity list is a real zero.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SemanticDiffEvidence {
+    /// Changes the head reaches that the base does not.
+    pub changes_in_range: usize,
+    pub entity_changes: usize,
+    pub relation_changes: usize,
+    /// Recorded modifications that moved only span or source-blob provenance,
+    /// counted rather than listed.
+    pub provenance_only_entity_changes: usize,
+    pub unresolved_removals: usize,
+    /// `assessed` or [`RISK_NOT_ASSESSED`].
+    pub risk: String,
+    /// How the merge base was established: `closed_walks` or `full_walk`.
+    pub merge_base_path: String,
+}
+
+/// `GET /repos/{repo_id}/semantic-diff`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RepoSemanticDiffResponse {
+    pub repo_id: String,
+    /// Each side as the caller sent it.
+    pub base_ref: String,
+    pub head_ref: String,
+    /// Each side as it resolved.
+    pub base_change_id: String,
+    pub head_change_id: String,
+    pub merge_base_change_id: String,
+    pub ahead: usize,
+    pub behind: usize,
+    /// A level under `risk=assess`, otherwise [`RISK_NOT_ASSESSED`].
+    pub overall_risk: String,
+    pub entities: Vec<SemanticDiffEntityRow>,
+    /// Present only when risk was assessed.
+    pub risk_findings: Option<SemanticDiffRiskFindings>,
+    pub evidence: SemanticDiffEvidence,
+}
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct RepoReviewsQuery {
+    #[serde(default)]
+    state: Option<String>,
+}
+
+/// GET /repos/{repo_id}/reviews: every review record, newest first.
+pub async fn repo_reviews(
+    Path(repo_id): Path<String>,
+    State(state): State<Arc<DaemonState>>,
+    // Fallible so a malformed query still carries the refusal header.
+    query: Result<Query<RepoReviewsQuery>, QueryRejection>,
+) -> Result<Json<RepoReviewsResponse>, RepoReviewError> {
+    let Query(query) = query.map_err(|rejection| {
+        RepoReviewError::new(
+            rejection.status(),
+            RepoReviewRefusal::BadRequest,
+            rejection.body_text(),
+        )
+    })?;
+    let state_filter = query
+        .state
+        .as_deref()
+        .map(|value| {
+            kin_review::records::parse_review_decision_state(value.trim()).ok_or_else(|| {
+                RepoReviewError::new(
+                    StatusCode::BAD_REQUEST,
+                    RepoReviewRefusal::BadRequest,
+                    format!(
+                        "state {value:?} is not a review decision state; this listing filters \
+                         on pending, approved, needs_work or blocked"
+                    ),
+                )
+            })
+        })
+        .transpose()?;
+
+    let pair = open_pair(&state, &repo_id).await?;
+    let response = blocking(move || {
+        let graph = pair.graph.as_ref();
+        // One read of the whole set, narrowed here, so the count beside the
+        // rows describes the same read the rows came from.
+        let held = kin_review::records::list_stored_reviews(graph, None)
+            .map_err(|error| RepoReviewError::unreadable("listing review records", error))?;
+        let reviews = held
+            .iter()
+            .filter(|review| state_filter.is_none_or(|wanted| review.state == wanted))
+            .map(|review| RepoReviewRow {
+                summary: ReviewSummaryView::from(review),
+                completion: review.completion.to_string(),
+                scopes: review.scopes.iter().map(ToString::to_string).collect(),
+                created_at: review.created_at.clone(),
+                updated_at: review.updated_at.clone(),
+                change_summary: change_summary(&pair.authority, &repo_id, review),
+            })
+            .collect();
+        Ok(RepoReviewsResponse {
+            evidence: RepoReviewsEvidence {
+                review_records: held.len(),
+                state_filter: state_filter.map(kin_review::records::review_state_label),
+            },
+            repo_id,
+            reviews,
+        })
+    })
+    .await?;
+    Ok(Json(response))
+}
+
+/// GET /repos/{repo_id}/reviews/{review_id}: one stored review in full.
+pub async fn repo_review_detail(
+    Path((repo_id, review_id)): Path<(String, String)>,
+    State(state): State<Arc<DaemonState>>,
+) -> Result<Json<RepoReviewDetailResponse>, RepoReviewError> {
+    // Checked before anything is opened: an id that cannot name a review is
+    // the caller's to fix, and no repository state changes that.
+    let parsed = uuid::Uuid::parse_str(review_id.trim())
+        .map(ReviewId)
+        .map_err(|_| {
+            RepoReviewError::new(
+                StatusCode::BAD_REQUEST,
+                RepoReviewRefusal::InvalidReviewId,
+                format!(
+                    "{review_id:?} is not a review id; a review id is the UUID \
+                     GET /repos/{repo_id}/reviews lists as review_id"
+                ),
+            )
+        })?;
+
+    let pair = open_pair(&state, &repo_id).await?;
+    let response = blocking(move || {
+        let graph = pair.graph.as_ref();
+        let record = kin_review::records::read_review_record(graph, &parsed)
+            .map_err(|error| {
+                RepoReviewError::unreadable(format!("reading review {parsed}"), error)
+            })?
+            .ok_or_else(|| {
+                RepoReviewError::new(
+                    StatusCode::NOT_FOUND,
+                    RepoReviewRefusal::UnknownReview,
+                    format!(
+                        "repository {repo_id} holds no review {parsed}; \
+                         GET /repos/{repo_id}/reviews lists the reviews it holds"
+                    ),
+                )
+            })?;
+        Ok(RepoReviewDetailResponse {
+            review: ReviewRecordView::from(&record),
+            completion: record.review.completion.to_string(),
+            created_at: record.review.created_at.clone(),
+            updated_at: record.review.updated_at.clone(),
+            change_summary: change_summary(&pair.authority, &repo_id, &record.review),
+            repo_id,
+        })
+    })
+    .await?;
+    Ok(Json(response))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RepoSemanticDiffQuery {
+    /// A ref name or a canonical change id. Required: this route has no default.
+    base: String,
+    head: String,
+    /// `assess` to add risk; absent for the diff alone.
+    #[serde(default)]
+    risk: Option<String>,
+}
+
+/// GET /repos/{repo_id}/semantic-diff: what the head changes, entity by entity.
+pub async fn repo_semantic_diff(
+    Path(repo_id): Path<String>,
+    State(state): State<Arc<DaemonState>>,
+    query: Result<Query<RepoSemanticDiffQuery>, QueryRejection>,
+) -> Result<Json<RepoSemanticDiffResponse>, RepoReviewError> {
+    let Query(query) = query.map_err(|rejection| {
+        RepoReviewError::new(
+            rejection.status(),
+            RepoReviewRefusal::BadRequest,
+            rejection.body_text(),
+        )
+    })?;
+    // Both sides are required and neither may be blank, checked before
+    // anything is opened; see `nonblank_ref`.
+    let base_ref = nonblank_ref("base", &query.base)?.to_string();
+    let head_ref = nonblank_ref("head", &query.head)?.to_string();
+    let assess = match query.risk.as_deref() {
+        None => false,
+        Some("assess") => true,
+        Some(other) => {
+            return Err(RepoReviewError::new(
+                StatusCode::BAD_REQUEST,
+                RepoReviewRefusal::BadRequest,
+                format!(
+                    "risk={other:?} is not a mode of this read; send risk=assess to assess \
+                     risk, or leave risk out for the diff alone"
+                ),
+            ));
+        }
+    };
+
+    let pair = open_pair(&state, &repo_id).await?;
+    let base = resolve_side("base", &pair.authority, &base_ref, &repo_id)?;
+    let head = resolve_side("head", &pair.authority, &head_ref, &repo_id)?;
+    let graph = Arc::clone(&pair.graph);
+    let (shape, answer) = blocking(move || review_range(&graph, base, head, assess)).await?;
+    Ok(Json(semantic_diff_response(
+        repo_id,
+        base_ref,
+        head_ref,
+        (base, head),
+        &shape,
+        &answer,
+        assess,
+    )?))
+}
+
+// ---------------------------------------------------------------------------
+// Shared reads
+// ---------------------------------------------------------------------------
+
+/// One repository generation's graph and the authority envelope naming its refs.
+///
+/// A hosted daemon takes both out of one cached generation, so a publication
+/// landing mid-request cannot pair one generation's refs with another's graph
+/// (FIR-2924). A local daemon serves its own repository: its live graph and
+/// the publication-keyed ref envelope, without the whole-snapshot clone the
+/// local read view makes to resolve trees, since nothing here resolves one.
+/// That clone is not a small thing: one local `/compare` call on a 9.4 GiB
+/// store grew its daemon past 19 GB while it ran.
+struct RepoReadPair {
+    graph: Arc<kin_db::InMemoryGraph>,
+    authority: Arc<kin_db::PersistedRepositoryAuthority>,
+}
+
+async fn open_pair(state: &DaemonState, repo_id: &str) -> Result<RepoReadPair, RepoReviewError> {
+    if state.storage_backend.is_some() {
+        return match crate::api::repository_read_view(state, repo_id)
+            .await
+            .map_err(RepoReviewError::from_repository)?
+        {
+            RepositoryReadView::Hosted {
+                generation,
+                metadata,
+            } => Ok(RepoReadPair {
+                graph: Arc::clone(generation.graph()),
+                authority: metadata,
+            }),
+            RepositoryReadView::Local { .. } => Err(RepoReviewError::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                RepoReviewRefusal::RepositoryUnreadable,
+                "a daemon with a storage backend answered with a local read view",
+            )),
+        };
+    }
+    let graph = crate::api::repo_scoped_graph(state, repo_id)
+        .await
+        .map_err(RepoReviewError::from_repository)?;
+    let authority = crate::api::repository_ref_metadata(state, repo_id)
+        .await
+        .map_err(RepoReviewError::from_repository)?;
+    Ok(RepoReadPair { graph, authority })
+}
+
+/// Run graph work off the async runtime, keeping a worker failure a refusal.
+async fn blocking<T: Send + 'static>(
+    work: impl FnOnce() -> Result<T, RepoReviewError> + Send + 'static,
+) -> Result<T, RepoReviewError> {
+    tokio::task::spawn_blocking(work)
+        .await
+        .map_err(|error| RepoReviewError::unreadable("the review worker failed", error))?
+}
+
+/// One side of a range, refused when it names nothing.
+///
+/// The shared resolver reads a blank reference as no reference and answers
+/// the repository's default ref. A route with no default must not inherit
+/// that: a blank base would quietly become the default branch, and a stored
+/// review whose ref was saved blank would be summarized against a range its
+/// author never named.
+fn nonblank_ref<'a>(side: &str, value: &'a str) -> Result<&'a str, RepoReviewError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(RepoReviewError::new(
+            StatusCode::BAD_REQUEST,
+            RepoReviewRefusal::BadRequest,
+            format!(
+                "{side} must name a ref or a change id, and it is blank. A range read has no \
+                 default for either side."
+            ),
+        ));
+    }
+    Ok(trimmed)
+}
+
+fn resolve_side(
+    side: &str,
+    authority: &kin_db::PersistedRepositoryAuthority,
+    reference: &str,
+    repo_id: &str,
+) -> Result<SemanticChangeId, RepoReviewError> {
+    let reference = nonblank_ref(side, reference)?;
+    crate::repo_blob::resolve_read_point_in(authority, Some(reference), repo_id)
+        .map(|(change_id, _)| change_id)
+        .map_err(|error| RepoReviewError::from_read_point(side, error))
+}
+
+/// A stored review's refs, resolved, and nothing computed from them.
+fn change_summary(
+    authority: &kin_db::PersistedRepositoryAuthority,
+    repo_id: &str,
+    review: &Review,
+) -> ReviewChangeSummary {
+    let unresolved = |base: Option<SemanticChangeId>, error: RepoReviewError| ReviewChangeSummary {
+        state: "unresolved".to_string(),
+        base_change_id: base.map(|id| id.to_string()),
+        head_change_id: None,
+        merge_base_change_id: None,
+        changed_entity_count: None,
+        risk: RISK_NOT_ASSESSED.to_string(),
+        gap: Some(ReviewSummaryGap {
+            kind: error.kind.as_str().to_string(),
+            message: error.message,
+        }),
+    };
+    let base = match resolve_side("base", authority, &review.base_ref, repo_id) {
+        Ok(change_id) => change_id,
+        Err(error) => return unresolved(None, error),
+    };
+    let head = match resolve_side("head", authority, &review.head_ref, repo_id) {
+        Ok(change_id) => change_id,
+        Err(error) => return unresolved(Some(base), error),
+    };
+    ReviewChangeSummary {
+        state: "not_computed".to_string(),
+        base_change_id: Some(base.to_string()),
+        head_change_id: Some(head.to_string()),
+        merge_base_change_id: None,
+        changed_entity_count: None,
+        risk: RISK_NOT_ASSESSED.to_string(),
+        gap: Some(ReviewSummaryGap {
+            kind: "not_computed".to_string(),
+            message: format!(
+                "the review reads do not compute a range; GET /repos/{repo_id}/semantic-diff \
+                 with base={} and head={} answers its changed entities, and adds their risk with \
+                 risk=assess",
+                review.base_ref, review.head_ref
+            ),
+        }),
+    }
+}
+
+/// How a range's merge base was established.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MergeBasePath {
+    /// kin-db's parents-only candidate, proven by two closed, disjoint walks.
+    ClosedWalks,
+    /// The exact walk over both full ancestries.
+    FullWalk,
+}
+
+impl MergeBasePath {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ClosedWalks => "closed_walks",
+            Self::FullWalk => "full_walk",
+        }
+    }
+}
+
+/// Where a range starts, how far apart its tips are, and the head's own side.
+#[derive(Debug)]
+struct RangeShape {
+    merge_base: SemanticChangeId,
+    ahead: usize,
+    behind: usize,
+    /// Every change the head reaches that the base does not, when the closed
+    /// walks already hold it; `None` after the full walk, which keeps no set.
+    head_side: Option<HashSet<SemanticChangeId>>,
+    path: MergeBasePath,
+}
+
+/// The merge base, the distance, and the head's side, as cheaply as is exact.
+///
+/// kin-db answers merge base candidates from parents alone, so it never decodes
+/// a change body, but it keeps the common ancestors nearest the head by depth,
+/// which in a history with merges can be an ancestor of the best one. So its
+/// answer is used only when [`closed_sides`] proves it, and anything else takes
+/// the exact walk `/compare` uses, which decodes every change on both full
+/// ancestries and refuses what it cannot settle.
+fn range_shape(
+    graph: &kin_db::InMemoryGraph,
+    base: SemanticChangeId,
+    head: SemanticChangeId,
+) -> Result<RangeShape, RepoReviewError> {
+    let candidates = graph
+        .find_merge_bases(&base, &head)
+        .map_err(|error| RepoReviewError::unreadable("finding the merge base", error))?;
+    if candidates.is_empty() {
+        // kin-db walks one side's whole ancestry and the other's until each
+        // path meets it, so an empty answer is exact.
+        return Err(RepoReviewError::new(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            RepoReviewRefusal::NoCommonAncestor,
+            format!("{base} and {head} share no ancestor, so there is no range between them"),
+        ));
+    }
+    if let [merge_base] = candidates.as_slice() {
+        if let Some((head_side, base_side)) = closed_sides(graph, *merge_base, base, head)? {
+            return Ok(RangeShape {
+                merge_base: *merge_base,
+                ahead: head_side.len(),
+                behind: base_side.len(),
+                head_side: Some(head_side),
+                path: MergeBasePath::ClosedWalks,
+            });
+        }
+    }
+    let exact = distance(graph, &base, &head)?;
+    Ok(RangeShape {
+        merge_base: exact.merge_base,
+        ahead: exact.ahead,
+        behind: exact.behind,
+        head_side: None,
+        path: MergeBasePath::FullWalk,
+    })
+}
+
+/// Each tip's walk down to `merge_base`, when both close on it and share nothing.
+///
+/// A walk closes when every path from its tip ends at `merge_base`. Two closed
+/// walks that share no change prove `merge_base` is the one best common
+/// ancestor, and each walk is then exactly what its tip reaches that the other
+/// tip does not, so the distance and the head's side come from them. The proof:
+/// a change in a closed walk descends from `merge_base`, so the other tip could
+/// reach it only without passing `merge_base`, which would put it in the other
+/// walk too; and any other common ancestor either descends from `merge_base`,
+/// and so sits in both walks, or is an ancestor of it. Disjointness rules out
+/// the first case, and the second is not better.
+///
+/// Cost is the walks' length, the range rather than the history. A walk that
+/// does not close reaches past `merge_base` to a root, and the caller then pays
+/// for the exact walk.
+fn closed_sides(
+    graph: &kin_db::InMemoryGraph,
+    merge_base: SemanticChangeId,
+    base: SemanticChangeId,
+    head: SemanticChangeId,
+) -> Result<Option<(HashSet<SemanticChangeId>, HashSet<SemanticChangeId>)>, RepoReviewError> {
+    let Some(head_side) = closed_walk(graph, merge_base, head)? else {
+        return Ok(None);
+    };
+    let Some(base_side) = closed_walk(graph, merge_base, base)? else {
+        return Ok(None);
+    };
+    if head_side.intersection(&base_side).next().is_some() {
+        return Ok(None);
+    }
+    Ok(Some((head_side, base_side)))
+}
+
+/// The changes `tip` reaches without passing `merge_base`, if every one of
+/// those paths ends at `merge_base`.
+///
+/// The store's walk stops only at `merge_base` itself, so a path around it runs
+/// on to a root. A root in the walk, or a parent the walk could not read, means
+/// the walk did not close.
+fn closed_walk(
+    graph: &kin_db::InMemoryGraph,
+    merge_base: SemanticChangeId,
+    tip: SemanticChangeId,
+) -> Result<Option<HashSet<SemanticChangeId>>, RepoReviewError> {
+    let changes = graph
+        .get_changes_since(&merge_base, &tip)
+        .map_err(|error| RepoReviewError::unreadable("walking the range", error))?;
+    let ids: HashSet<SemanticChangeId> = changes.iter().map(|change| change.id).collect();
+    let closed = changes.iter().all(|change| {
+        !change.parents.is_empty()
+            && change
+                .parents
+                .iter()
+                .all(|parent| *parent == merge_base || ids.contains(parent))
+    });
+    Ok(closed.then_some(ids))
+}
+
+/// The merge base and the distance by `/compare`'s own exact walk over the
+/// graph's full change history.
+fn distance(
+    graph: &kin_db::InMemoryGraph,
+    base: &SemanticChangeId,
+    head: &SemanticChangeId,
+) -> Result<Distance, RepoReviewError> {
+    let mut cache: HashMap<SemanticChangeId, Vec<SemanticChangeId>> = HashMap::new();
+    let mut parents_of =
+        |change_id: &SemanticChangeId| -> Result<Vec<SemanticChangeId>, RepoCompareError> {
+            if let Some(parents) = cache.get(change_id) {
+                return Ok(parents.clone());
+            }
+            let change = graph
+                .get_change(change_id)
+                .map_err(|error| RepoCompareError {
+                    status: StatusCode::INTERNAL_SERVER_ERROR,
+                    kind: RepoCompareRefusal::RepositoryUnreadable,
+                    message: format!("reading change {change_id}: {error}"),
+                })?
+                .ok_or_else(|| RepoCompareError {
+                    status: StatusCode::FAILED_DEPENDENCY,
+                    kind: RepoCompareRefusal::RepositoryUnreadable,
+                    message: format!("history references missing change {change_id}"),
+                })?;
+            let parents = change.parents.clone();
+            cache.insert(*change_id, parents.clone());
+            Ok(parents)
+        };
+    crate::repo_compare::measure_distance_with(base, head, &mut parents_of)
+        .map_err(RepoReviewError::from_distance)
+}
+
+/// The head's side of a range by two exact ancestry walks, for a range the
+/// closed walks could not answer.
+fn exact_head_side(
+    graph: &kin_db::InMemoryGraph,
+    base: &SemanticChangeId,
+    head: &SemanticChangeId,
+) -> Result<HashSet<SemanticChangeId>, RepoReviewError> {
+    let head_ancestry = kin_review::ref_graph::collect_ancestry(graph, head)
+        .map_err(RepoReviewError::from_review)?;
+    let base_ancestry = kin_review::ref_graph::collect_ancestry(graph, base)
+        .map_err(RepoReviewError::from_review)?;
+    Ok(head_ancestry.difference(&base_ancestry).copied().collect())
+}
+
+/// What a range read answered.
+#[derive(Debug)]
+enum RangeAnswer {
+    /// The head adds nothing the base lacks.
+    Empty,
+    /// The diff alone.
+    Diff(SemanticDiff),
+    /// The diff and its risk, from the review engine.
+    Assessed(Box<RangeReview>),
+}
+
+/// Read everything `head` reaches that `base` does not: the diff always, its
+/// risk only when asked.
+fn review_range(
+    graph: &kin_db::InMemoryGraph,
+    base: SemanticChangeId,
+    head: SemanticChangeId,
+    assess: bool,
+) -> Result<(RangeShape, RangeAnswer), RepoReviewError> {
+    let mut shape = range_shape(graph, base, head)?;
+    if shape.ahead == 0 {
+        return Ok((shape, RangeAnswer::Empty));
+    }
+    if assess {
+        let range =
+            kin_review::SemanticReview::create_range_review(graph, &shape.merge_base, &head)
+                .map_err(RepoReviewError::from_review)?;
+        return Ok((shape, RangeAnswer::Assessed(Box::new(range))));
+    }
+    let head_side = match shape.head_side.take() {
+        Some(side) => side,
+        None => exact_head_side(graph, &base, &head)?,
+    };
+    let diff = kin_review::diff::compute_diff_scoped(graph, &shape.merge_base, &head, |id| {
+        head_side.contains(id)
+    })
+    .map_err(RepoReviewError::from_review)?;
+    Ok((shape, RangeAnswer::Diff(diff)))
+}
+
+/// The response for one range read.
+///
+/// `assess` is the request's own mode, carried in because an empty range holds
+/// no review to say it: an empty range read under `risk=assess` is assessed,
+/// nothing changed, and nothing is what the engine ranks low.
+fn semantic_diff_response(
+    repo_id: String,
+    base_ref: String,
+    head_ref: String,
+    (base, head): (SemanticChangeId, SemanticChangeId),
+    shape: &RangeShape,
+    answer: &RangeAnswer,
+    assess: bool,
+) -> Result<RepoSemanticDiffResponse, RepoReviewError> {
+    let empty_diff = SemanticDiff::default();
+    let (diff, changes_in_range, assessed): (&SemanticDiff, usize, Option<&RangeReview>) =
+        match answer {
+            RangeAnswer::Empty => (&empty_diff, 0, None),
+            RangeAnswer::Diff(diff) => (diff, shape.ahead, None),
+            RangeAnswer::Assessed(range) => (
+                &range.review.diff,
+                range.changes_in_range,
+                Some(range.as_ref()),
+            ),
+        };
+
+    let mut entities = Vec::with_capacity(diff.entity_changes.len());
+    let mut unresolved_removals = 0;
+    for change in &diff.entity_changes {
+        let level = match assessed {
+            // Every changed entity has a level by construction. A missing one
+            // is a defect to report, not a gap to fill with a default.
+            Some(range) => Some(
+                range
+                    .entity_risk
+                    .get(&change.entity_id)
+                    .copied()
+                    .ok_or_else(|| {
+                        RepoReviewError::unreadable(
+                            "assembling the semantic diff",
+                            format!(
+                                "no risk level was computed for changed entity {}",
+                                change.entity_id
+                            ),
+                        )
+                    })?,
+            ),
+            None => None,
+        };
+        if matches!(change.kind, EntityChangeKind::Removed { old: None }) {
+            unresolved_removals += 1;
+        }
+        entities.push(entity_row(change, level));
+    }
+
+    let (overall_risk, risk_findings) = match (assessed, assess) {
+        (Some(range), _) => (
+            risk_label(range.review.risk.overall_risk).to_string(),
+            Some(SemanticDiffRiskFindings {
+                breaking_changes: range.review.risk.breaking_changes.clone(),
+                test_coverage_gaps: range.review.risk.test_coverage_gaps.clone(),
+                contract_violations: range.review.risk.contract_violations.clone(),
+                work_risks: range.review.risk.work_risks.clone(),
+                notes: range.review.risk.notes.clone(),
+            }),
+        ),
+        (None, true) => (
+            risk_label(RiskLevel::Low).to_string(),
+            Some(SemanticDiffRiskFindings::default()),
+        ),
+        (None, false) => (RISK_NOT_ASSESSED.to_string(), None),
+    };
+
+    Ok(RepoSemanticDiffResponse {
+        repo_id,
+        base_ref,
+        head_ref,
+        base_change_id: base.to_string(),
+        head_change_id: head.to_string(),
+        merge_base_change_id: shape.merge_base.to_string(),
+        ahead: shape.ahead,
+        behind: shape.behind,
+        overall_risk,
+        entities,
+        risk_findings,
+        evidence: SemanticDiffEvidence {
+            changes_in_range,
+            entity_changes: diff.entity_changes.len(),
+            relation_changes: diff.relation_changes.len(),
+            provenance_only_entity_changes: diff.provenance_only_entity_changes,
+            unresolved_removals,
+            risk: if assess {
+                "assessed".to_string()
+            } else {
+                RISK_NOT_ASSESSED.to_string()
+            },
+            merge_base_path: shape.path.as_str().to_string(),
+        },
+    })
+}
+
+fn entity_row(change: &EntityChange, level: Option<RiskLevel>) -> SemanticDiffEntityRow {
+    let (change_type, subject, changes, before_signature, after_signature) = match &change.kind {
+        EntityChangeKind::Added(entity) => (
+            "added",
+            Some(entity),
+            Vec::new(),
+            None,
+            Some(entity.signature.clone()),
+        ),
+        EntityChangeKind::Modified { old, new } => (
+            "modified",
+            Some(new),
+            field_changes(old, new),
+            Some(old.signature.clone()),
+            Some(new.signature.clone()),
+        ),
+        EntityChangeKind::Removed { old } => (
+            "removed",
+            old.as_ref(),
+            Vec::new(),
+            old.as_ref().map(|entity| entity.signature.clone()),
+            None,
+        ),
+    };
+    let (file, start_line) = subject.map_or((None, None), location);
+    SemanticDiffEntityRow {
+        id: change.entity_id.to_string(),
+        name: subject.map(|entity| entity.name.clone()),
+        kind: subject.map(|entity| format!("{:?}", entity.kind)),
+        change_type: change_type.to_string(),
+        risk_level: level.map_or(RISK_NOT_ASSESSED, risk_label).to_string(),
+        changes,
+        before_signature,
+        after_signature,
+        file,
+        start_line,
+    }
+}
+
+fn location(entity: &Entity) -> (Option<String>, Option<u32>) {
+    match &entity.span {
+        Some(span) => (
+            Some(span.file.to_string()),
+            Some(span.start_line.saturating_add(1)),
+        ),
+        None => (entity.file_origin.as_ref().map(ToString::to_string), None),
+    }
+}
+
+/// The fields that moved between a modified entity's base and head records.
+///
+/// Never empty. kin-review keeps a modification only when the entity changed
+/// beyond its span and provenance, so when none of the named fields moved,
+/// what moved is the fingerprint itself, and saying so beats an empty list a
+/// reader would take for "nothing changed".
+fn field_changes(old: &Entity, new: &Entity) -> Vec<SemanticDiffFieldChange> {
+    let mut changes = Vec::new();
+    let mut compare = |field: &str, before: Option<String>, after: Option<String>| {
+        if before != after {
+            changes.push(SemanticDiffFieldChange {
+                field: field.to_string(),
+                old: before,
+                new: after,
+            });
+        }
+    };
+    compare("name", Some(old.name.clone()), Some(new.name.clone()));
+    compare(
+        "kind",
+        Some(format!("{:?}", old.kind)),
+        Some(format!("{:?}", new.kind)),
+    );
+    compare(
+        "signature",
+        Some(old.signature.clone()),
+        Some(new.signature.clone()),
+    );
+    compare(
+        "visibility",
+        Some(format!("{:?}", old.visibility)),
+        Some(format!("{:?}", new.visibility)),
+    );
+    compare(
+        "role",
+        Some(format!("{:?}", old.role)),
+        Some(format!("{:?}", new.role)),
+    );
+    compare(
+        "file",
+        old.file_origin.as_ref().map(ToString::to_string),
+        new.file_origin.as_ref().map(ToString::to_string),
+    );
+    compare(
+        "doc_summary",
+        old.doc_summary.clone(),
+        new.doc_summary.clone(),
+    );
+    // The graph holds the body's behavior hash rather than its text, so the
+    // row names the field and claims no values.
+    if old.fingerprint.behavior_hash != new.fingerprint.behavior_hash {
+        changes.push(SemanticDiffFieldChange {
+            field: "body".to_string(),
+            old: None,
+            new: None,
+        });
+    }
+    if changes.is_empty() {
+        changes.push(SemanticDiffFieldChange {
+            field: "fingerprint".to_string(),
+            old: None,
+            new: None,
+        });
+    }
+    changes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kin_model::entity::{
+        EntityKind, EntityMetadata, EntityRole, FingerprintAlgorithm, SemanticFingerprint,
+        SourceSpan, Visibility,
+    };
+    use kin_model::ids::{EntityId, FilePathId, LanguageId};
+    use kin_model::Hash256;
+
+    fn entity(name: &str) -> Entity {
+        Entity {
+            id: EntityId::new(),
+            kind: EntityKind::Function,
+            name: name.to_string(),
+            language: LanguageId::Rust,
+            fingerprint: SemanticFingerprint {
+                algorithm: FingerprintAlgorithm::V1TreeSitter,
+                ast_hash: Hash256::from_bytes([1; 32]),
+                signature_hash: Hash256::from_bytes([2; 32]),
+                behavior_hash: Hash256::from_bytes([3; 32]),
+                equivalence_hash: Hash256::from_bytes([4; 32]),
+                stability_score: 1.0,
+            },
+            file_origin: None,
+            span: None,
+            signature: format!("fn {name}()"),
+            visibility: Visibility::Public,
+            role: EntityRole::Source,
+            doc_summary: None,
+            metadata: EntityMetadata::default(),
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        }
+    }
+
+    /// One committed change adding `added`, with its id computed from its
+    /// content, so every change in a fixture DAG is distinct.
+    fn change(parents: Vec<SemanticChangeId>, added: &[&Entity]) -> kin_model::SemanticChange {
+        let mut change = kin_model::SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([0; 32])),
+            parents,
+            timestamp: kin_model::Timestamp::now(),
+            author: kin_model::AuthorId::new("repo-review-test"),
+            message: "range fixture".to_string(),
+            entity_deltas: added
+                .iter()
+                .map(|entity| kin_model::EntityDelta::Added {
+                    new: (*entity).clone(),
+                })
+                .collect(),
+            relation_deltas: vec![],
+            tree_deltas: vec![],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            origin: kin_model::ChangeOrigin::Native,
+            admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
+        };
+        change.id = kin_model::compute_semantic_change_id(&change).unwrap();
+        change
+    }
+
+    fn graph_of(changes: &[&kin_model::SemanticChange]) -> kin_db::InMemoryGraph {
+        let graph = kin_db::InMemoryGraph::new();
+        for change in changes {
+            graph.create_change(change).unwrap();
+        }
+        graph
+    }
+
+    fn field(name: &str, old: Option<&str>, new: Option<&str>) -> SemanticDiffFieldChange {
+        SemanticDiffFieldChange {
+            field: name.to_string(),
+            old: old.map(str::to_string),
+            new: new.map(str::to_string),
+        }
+    }
+
+    /// root, then the base on one side and two changes on the head's side.
+    #[test]
+    fn a_linear_range_answers_from_two_closed_walks() {
+        let root = change(vec![], &[&entity("root_fn")]);
+        let base = change(vec![root.id], &[&entity("only_on_base")]);
+        let head_one = change(vec![root.id], &[&entity("head_one")]);
+        let head_two = change(vec![head_one.id], &[&entity("head_two")]);
+        let graph = graph_of(&[&root, &base, &head_one, &head_two]);
+
+        let shape = range_shape(&graph, base.id, head_two.id).unwrap();
+        assert_eq!(shape.path, MergeBasePath::ClosedWalks);
+        assert_eq!(shape.merge_base, root.id);
+        assert_eq!((shape.ahead, shape.behind), (2, 1));
+        assert_eq!(
+            shape.head_side,
+            Some([head_one.id, head_two.id].into_iter().collect())
+        );
+    }
+
+    /// The head merges a side branch and the base, so its walk runs around the
+    /// base down to the root: the closed walks cannot answer, the exact one can.
+    #[test]
+    fn a_merge_that_reaches_past_the_base_takes_the_exact_walk() {
+        let root = change(vec![], &[&entity("root_fn")]);
+        let base = change(vec![root.id], &[&entity("on_base")]);
+        let side = change(vec![root.id], &[&entity("on_side")]);
+        let head = change(vec![side.id, base.id], &[&entity("merge_fn")]);
+        let graph = graph_of(&[&root, &base, &side, &head]);
+
+        let shape = range_shape(&graph, base.id, head.id).unwrap();
+        assert_eq!(shape.path, MergeBasePath::FullWalk);
+        assert_eq!(shape.merge_base, base.id);
+        assert_eq!((shape.ahead, shape.behind), (2, 0));
+    }
+
+    /// kin-db's nearest-by-depth candidate here is the root, one hop from the
+    /// head through its second parent, while the best common ancestor is the
+    /// change the base and the head's first line both grew from. Both walks
+    /// down to the root close; they share that change, and only the
+    /// disjointness check refuses the near candidate.
+    #[test]
+    fn a_nearer_but_older_candidate_is_refused_by_the_change_both_walks_share() {
+        let root = change(vec![], &[&entity("root_fn")]);
+        let shared = change(vec![root.id], &[&entity("shared_fn")]);
+        let base = change(vec![shared.id], &[&entity("on_base")]);
+        let line = change(vec![shared.id], &[&entity("on_head")]);
+        let head = change(vec![line.id, root.id], &[&entity("merge_fn")]);
+        let graph = graph_of(&[&root, &shared, &base, &line, &head]);
+        assert_eq!(
+            graph.find_merge_bases(&base.id, &head.id).unwrap(),
+            vec![root.id],
+            "the fixture must present the near, older candidate"
+        );
+
+        let shape = range_shape(&graph, base.id, head.id).unwrap();
+        assert_eq!(shape.path, MergeBasePath::FullWalk);
+        assert_eq!(shape.merge_base, shared.id);
+        assert_eq!((shape.ahead, shape.behind), (2, 1));
+    }
+
+    /// The diff alone says not_assessed everywhere a level would show, and
+    /// risk=assess is what turns the same range into levels.
+    #[test]
+    fn risk_is_not_assessed_unless_asked_and_a_level_only_when_asked() {
+        let root = change(vec![], &[&entity("root_fn")]);
+        let base = change(vec![root.id], &[&entity("only_on_base")]);
+        let head_one = change(vec![root.id], &[&entity("head_one")]);
+        let head_two = change(vec![head_one.id], &[&entity("head_two")]);
+        let graph = graph_of(&[&root, &base, &head_one, &head_two]);
+        let respond = |assess: bool| {
+            let (shape, answer) = review_range(&graph, base.id, head_two.id, assess).unwrap();
+            semantic_diff_response(
+                "repo".to_string(),
+                "base".to_string(),
+                "head".to_string(),
+                (base.id, head_two.id),
+                &shape,
+                &answer,
+                assess,
+            )
+            .unwrap()
+        };
+
+        let plain = respond(false);
+        let names: HashSet<String> = plain
+            .entities
+            .iter()
+            .filter_map(|row| row.name.clone())
+            .collect();
+        assert_eq!(
+            names,
+            ["head_one", "head_two"]
+                .map(String::from)
+                .into_iter()
+                .collect(),
+            "the base's own change is outside the range"
+        );
+        assert_eq!(plain.overall_risk, RISK_NOT_ASSESSED);
+        assert!(plain
+            .entities
+            .iter()
+            .all(|row| row.risk_level == RISK_NOT_ASSESSED));
+        assert_eq!(plain.risk_findings, None);
+        assert_eq!(plain.evidence.risk, RISK_NOT_ASSESSED);
+        assert_eq!(plain.evidence.merge_base_path, "closed_walks");
+        assert_eq!(plain.evidence.changes_in_range, 2);
+
+        let assessed = respond(true);
+        assert_eq!(assessed.overall_risk, "low");
+        assert!(assessed.entities.iter().all(|row| row.risk_level == "low"));
+        assert!(assessed.risk_findings.is_some());
+        assert_eq!(assessed.evidence.risk, "assessed");
+        assert_eq!(assessed.entities.len(), plain.entities.len());
+
+        // An empty range: a real zero either way, and only the asked-for one
+        // carries a level.
+        let (shape, answer) = review_range(&graph, head_two.id, head_two.id, false).unwrap();
+        assert!(matches!(answer, RangeAnswer::Empty));
+        let empty = semantic_diff_response(
+            "repo".to_string(),
+            "head".to_string(),
+            "head".to_string(),
+            (head_two.id, head_two.id),
+            &shape,
+            &answer,
+            false,
+        )
+        .unwrap();
+        assert!(empty.entities.is_empty());
+        assert_eq!(empty.overall_risk, RISK_NOT_ASSESSED);
+        assert_eq!(empty.evidence.changes_in_range, 0);
+    }
+
+    #[test]
+    fn a_signature_change_names_the_signature_and_nothing_it_did_not_change() {
+        let old = entity("parse");
+        let mut new = old.clone();
+        new.signature = "fn parse(strict: bool)".to_string();
+        assert_eq!(
+            field_changes(&old, &new),
+            vec![field(
+                "signature",
+                Some("fn parse()"),
+                Some("fn parse(strict: bool)")
+            )]
+        );
+    }
+
+    #[test]
+    fn a_body_change_is_named_without_inventing_its_text() {
+        let old = entity("render");
+        let mut new = old.clone();
+        new.fingerprint.behavior_hash = Hash256::from_bytes([9; 32]);
+        assert_eq!(field_changes(&old, &new), vec![field("body", None, None)]);
+    }
+
+    #[test]
+    fn a_modification_no_named_field_explains_still_names_what_moved() {
+        // An empty list would read as "nothing changed" on a row that says
+        // modified, which is the one reading the row exists to rule out.
+        let old = entity("stable");
+        let mut new = old.clone();
+        new.fingerprint.stability_score = 0.5;
+        assert_eq!(
+            field_changes(&old, &new),
+            vec![field("fingerprint", None, None)]
+        );
+    }
+
+    #[test]
+    fn a_removal_with_no_base_record_offers_no_name() {
+        let change = EntityChange {
+            entity_id: EntityId::new(),
+            kind: EntityChangeKind::Removed { old: None },
+        };
+        let row = entity_row(&change, None);
+        assert_eq!(row.id, change.entity_id.to_string());
+        assert_eq!(row.name, None, "a bare id is never offered as a name");
+        assert_eq!(row.kind, None);
+        assert_eq!(row.change_type, "removed");
+        assert_eq!(row.risk_level, RISK_NOT_ASSESSED);
+        assert_eq!(row.before_signature, None);
+        assert_eq!(row.file, None);
+    }
+
+    #[test]
+    fn a_placed_entity_reports_the_line_an_editor_shows() {
+        let mut added = entity("placed");
+        added.span = Some(SourceSpan {
+            file: FilePathId::new("src/lib.rs"),
+            start_byte: 0,
+            end_byte: 1,
+            start_line: 41,
+            start_col: 0,
+            end_line: 42,
+            end_col: 0,
+        });
+        let row = entity_row(
+            &EntityChange {
+                entity_id: added.id,
+                kind: EntityChangeKind::Added(added.clone()),
+            },
+            Some(RiskLevel::Critical),
+        );
+        assert_eq!(row.file.as_deref(), Some("src/lib.rs"));
+        assert_eq!(row.start_line, Some(42), "graph row 41 is editor line 42");
+        assert_eq!(row.risk_level, "critical");
+        assert_eq!(row.after_signature.as_deref(), Some("fn placed()"));
+        assert_eq!(row.before_signature, None);
+    }
+
+    #[test]
+    fn every_refusal_kind_has_a_distinct_stable_spelling() {
+        let kinds = [
+            RepoReviewRefusal::BadRequest,
+            RepoReviewRefusal::UnknownRepository,
+            RepoReviewRefusal::RepositoryUnreadable,
+            RepoReviewRefusal::UnknownRef,
+            RepoReviewRefusal::AmbiguousRef,
+            RepoReviewRefusal::NoCommonAncestor,
+            RepoReviewRefusal::HistoryTooDeep,
+            RepoReviewRefusal::AmbiguousMergeBase,
+            RepoReviewRefusal::InvalidReviewId,
+            RepoReviewRefusal::UnknownReview,
+            RepoReviewRefusal::RefStateUnavailable,
+        ];
+        let spellings: std::collections::BTreeSet<&str> =
+            kinds.iter().map(|kind| kind.as_str()).collect();
+        assert_eq!(spellings.len(), kinds.len(), "two kinds share a spelling");
+        assert!(
+            spellings
+                .iter()
+                .all(|spelling| HeaderValue::from_str(spelling).is_ok()),
+            "every spelling has to survive the header it travels in"
+        );
+    }
+}

--- a/crates/kin-mcp/src/handlers/review.rs
+++ b/crates/kin-mcp/src/handlers/review.rs
@@ -871,37 +871,26 @@ pub fn handle_review_list<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
 ) -> Result<ToolCallResult> {
-    use kin_model::review::ReviewFilter;
-
     let state = get_optional_string_param(args, "state");
     let state_filter = state
         .as_deref()
         .map(parse_review_decision_state)
         .transpose()?;
 
-    let filter = ReviewFilter {
-        states: state_filter.map(|s| vec![s]),
-        reviewer: None,
-    };
-
-    let reviews = store
-        .list_reviews(&filter)
+    // The shared read, so this tool, `kin review list` and the daemon's
+    // repo-scoped listing cannot drift apart on what a review row is.
+    let reviews = kin_review::records::list_stored_reviews(store, state_filter)
         .map_err(|e| McpError::Other(e.to_string()))?;
-
-    let result: Vec<_> = reviews
+    let result: Vec<kin_review::records::ReviewSummaryView> = reviews
         .iter()
-        .map(|r| {
-            serde_json::json!({
-                "review_id": r.review_id.to_string(),
-                "title": r.title,
-                "state": format!("{:?}", r.state).to_lowercase(),
-                "base_ref": r.base_ref,
-                "head_ref": r.head_ref,
-            })
-        })
+        .map(kin_review::records::ReviewSummaryView::from)
         .collect();
 
-    let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
+    // Printed through a `Value`, as the `json!` rows this replaced were, so
+    // the key order is the one serde_json's `preserve_order` feature gives
+    // `json!` in whichever build this is, and the text stays what it was.
+    let value = serde_json::to_value(&result).map_err(McpError::Json)?;
+    let json = serde_json::to_string_pretty(&value).map_err(McpError::Json)?;
     Ok(ToolCallResult::text(json))
 }
 
@@ -917,60 +906,16 @@ pub fn handle_review_get<G: GraphStore>(
 ) -> Result<ToolCallResult> {
     let review_id = parse_review_id(args, "review_id")?;
 
-    let review = store
-        .get_review(&review_id)
+    // The shared read and its JSON view, the same object the daemon's
+    // repo-scoped review route answers, so a client maps one shape.
+    let record = kin_review::records::read_review_record(store, &review_id)
         .map_err(|e| McpError::Other(e.to_string()))?
         .ok_or_else(|| McpError::InvalidParams(format!("review not found: {}", review_id)))?;
+    let result = kin_review::records::ReviewRecordView::from(&record);
 
-    let decisions = store
-        .get_review_decisions(&review_id)
-        .map_err(|e| McpError::Other(e.to_string()))?;
-
-    let notes = store
-        .get_review_notes(&review_id)
-        .map_err(|e| McpError::Other(e.to_string()))?;
-
-    let discussions = store
-        .get_review_discussions(&review_id)
-        .map_err(|e| McpError::Other(e.to_string()))?;
-
-    let assignments = store
-        .get_review_assignments(&review_id)
-        .map_err(|e| McpError::Other(e.to_string()))?;
-
-    let result = serde_json::json!({
-        "review_id": review.review_id.to_string(),
-        "title": review.title,
-        "state": format!("{:?}", review.state).to_lowercase(),
-        "base_ref": review.base_ref,
-        "head_ref": review.head_ref,
-        "scopes": review.scopes.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
-        "decisions": decisions.iter().map(|d| serde_json::json!({
-            "state": format!("{:?}", d.state).to_lowercase(),
-            "comment": d.comment,
-            "reviewer": d.reviewer.name,
-        })).collect::<Vec<_>>(),
-        "notes": notes.iter().map(|n| serde_json::json!({
-            "note_id": n.note_id.to_string(),
-            "body": n.body,
-            "scope": n.scope.as_ref().map(|s| s.to_string()),
-            "author": n.authored_by.name,
-        })).collect::<Vec<_>>(),
-        "discussions": discussions.iter().map(|d| serde_json::json!({
-            "discussion_id": d.discussion_id.to_string(),
-            "state": format!("{:?}", d.state).to_lowercase(),
-            "scope": d.scope.as_ref().map(|s| s.to_string()),
-            "comments": d.comments.iter().map(|c| serde_json::json!({
-                "body": c.body,
-                "author": c.authored_by.name,
-            })).collect::<Vec<_>>(),
-        })).collect::<Vec<_>>(),
-        "assignments": assignments.iter().map(|a| serde_json::json!({
-            "reviewer": a.reviewer.name,
-        })).collect::<Vec<_>>(),
-    });
-
-    let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
+    // Through a `Value` for the reason `handle_review_list` gives.
+    let value = serde_json::to_value(&result).map_err(McpError::Json)?;
+    let json = serde_json::to_string_pretty(&value).map_err(McpError::Json)?;
     Ok(ToolCallResult::text(json))
 }
 
@@ -997,17 +942,12 @@ fn parse_discussion_id(
 }
 
 fn parse_review_decision_state(s: &str) -> Result<kin_model::review::ReviewDecisionState> {
-    use kin_model::review::ReviewDecisionState;
-    match s.to_lowercase().as_str() {
-        "pending" => Ok(ReviewDecisionState::Pending),
-        "approved" | "approve" => Ok(ReviewDecisionState::Approved),
-        "needs_work" | "needs-work" | "needswork" => Ok(ReviewDecisionState::NeedsWork),
-        "blocked" | "block" => Ok(ReviewDecisionState::Blocked),
-        _ => Err(McpError::InvalidParams(format!(
+    kin_review::records::parse_review_decision_state(s).ok_or_else(|| {
+        McpError::InvalidParams(format!(
             "invalid review state: {}. Valid values: pending, approved, needs_work, blocked",
             s
-        ))),
-    }
+        ))
+    })
 }
 
 /// Parse an optional work scope from a JSON value (string like "entity:ID").

--- a/crates/kin-review/src/lib.rs
+++ b/crates/kin-review/src/lib.rs
@@ -9,6 +9,7 @@ pub mod gate;
 pub mod impact;
 pub mod inline;
 pub mod ranked_impact;
+pub mod records;
 pub mod ref_graph;
 pub mod release_gate;
 pub mod revert_history;
@@ -47,8 +48,8 @@ pub use release_gate::{
     source_bound_release_proof_coverage_for_entities, unapproved_changes, CoverageProvenance,
     SecurityFinding, SecurityFindingCounts, SecuritySeverity, UnapprovedChange,
 };
-pub use review::{Review, SemanticReview};
-pub use risk::assess_risk;
+pub use review::{RangeReview, Review, SemanticReview};
+pub use risk::{assess_risk, entity_risk_levels};
 pub use shadow::{
     build_shadow_report, build_shadow_report_at, build_shadow_report_base_off_ancestry,
     derive_shadow_policy, format_shadow_report, ShadowArtifactActivity, ShadowArtifactAspect,

--- a/crates/kin-review/src/records.rs
+++ b/crates/kin-review/src/records.rs
@@ -1,0 +1,477 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Stored review records, read once for every surface that shows them.
+//!
+//! Three surfaces read a stored review: `kin review list` and `kin review show`
+//! on the CLI, the `kin_review_list` and `kin_review_get` MCP tools, and the
+//! daemon's repo-scoped review routes. They read the same records, so they read
+//! them here: one set of store calls, one ordering, and one JSON shape for the
+//! surfaces that answer in JSON. A review is graph authority like any other
+//! record, so nothing here reads a file.
+
+use kin_model::graph::ReviewStore;
+use kin_model::review::{
+    Review, ReviewAssignment, ReviewDecision, ReviewDecisionState, ReviewDiscussion, ReviewFilter,
+    ReviewId, ReviewNote,
+};
+use serde::{Deserialize, Serialize};
+
+/// One stored review and everything recorded against it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReviewRecord {
+    pub review: Review,
+    pub decisions: Vec<ReviewDecision>,
+    pub notes: Vec<ReviewNote>,
+    pub discussions: Vec<ReviewDiscussion>,
+    pub assignments: Vec<ReviewAssignment>,
+}
+
+/// Parse a decision-state filter in any spelling a review read accepts.
+///
+/// `None` for anything else, so each surface refuses in its own words: the
+/// caller knows whether it was a flag, a tool argument or a query parameter.
+pub fn parse_review_decision_state(value: &str) -> Option<ReviewDecisionState> {
+    match value.to_lowercase().as_str() {
+        "pending" => Some(ReviewDecisionState::Pending),
+        "approved" | "approve" => Some(ReviewDecisionState::Approved),
+        "needs_work" | "needs-work" | "needswork" => Some(ReviewDecisionState::NeedsWork),
+        "blocked" | "block" => Some(ReviewDecisionState::Blocked),
+        _ => None,
+    }
+}
+
+/// Every review the store holds, narrowed to one decision state when asked,
+/// newest first.
+///
+/// The store answers in its own map order, which is not stable from one
+/// process to the next. A listing that reorders itself between two reads looks
+/// like a listing that changed, so the order is fixed here: creation time,
+/// newest first, then the review id to separate two created in one instant.
+pub fn list_stored_reviews<S: ReviewStore + ?Sized>(
+    store: &S,
+    state: Option<ReviewDecisionState>,
+) -> Result<Vec<Review>, S::Error> {
+    let filter = ReviewFilter {
+        states: state.map(|state| vec![state]),
+        reviewer: None,
+    };
+    let mut reviews = store.list_reviews(&filter)?;
+    reviews.sort_by(|left, right| {
+        right
+            .created_at
+            .cmp(&left.created_at)
+            .then_with(|| left.review_id.0.cmp(&right.review_id.0))
+    });
+    Ok(reviews)
+}
+
+/// One review and its history, or `None` when the store holds no review under
+/// that id.
+pub fn read_review_record<S: ReviewStore + ?Sized>(
+    store: &S,
+    review_id: &ReviewId,
+) -> Result<Option<ReviewRecord>, S::Error> {
+    let Some(review) = store.get_review(review_id)? else {
+        return Ok(None);
+    };
+    Ok(Some(ReviewRecord {
+        decisions: store.get_review_decisions(review_id)?,
+        notes: store.get_review_notes(review_id)?,
+        discussions: store.get_review_discussions(review_id)?,
+        assignments: store.get_review_assignments(review_id)?,
+        review,
+    }))
+}
+
+/// A decision state as the JSON review reads spell it.
+///
+/// This is the lowercased variant name, so `NeedsWork` reads `needswork`,
+/// which is what `kin_review_list` has always answered. It is not the model's
+/// `Display` spelling (`needs-work`), and moving to that here would change a
+/// published tool answer under every caller that already parses it.
+pub fn review_state_label(state: ReviewDecisionState) -> String {
+    format!("{state:?}").to_lowercase()
+}
+
+/// One row of a review listing.
+///
+/// Field order is the key order `kin_review_list` has always printed wherever
+/// serde_json keeps key order, and a test pins it, so a reordering here is a
+/// visible change to a published tool answer rather than a silent one.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReviewSummaryView {
+    pub review_id: String,
+    pub title: String,
+    pub state: String,
+    pub base_ref: String,
+    pub head_ref: String,
+}
+
+impl From<&Review> for ReviewSummaryView {
+    fn from(review: &Review) -> Self {
+        Self {
+            review_id: review.review_id.to_string(),
+            title: review.title.clone(),
+            state: review_state_label(review.state),
+            base_ref: review.base_ref.clone(),
+            head_ref: review.head_ref.clone(),
+        }
+    }
+}
+
+/// One decision in a review's history.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReviewDecisionView {
+    pub state: String,
+    pub comment: Option<String>,
+    pub reviewer: String,
+}
+
+/// One note on a review.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReviewNoteView {
+    pub note_id: String,
+    pub body: String,
+    pub scope: Option<String>,
+    pub author: String,
+}
+
+/// One comment in a discussion thread.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReviewCommentView {
+    pub body: String,
+    pub author: String,
+}
+
+/// One discussion thread on a review.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReviewDiscussionView {
+    pub discussion_id: String,
+    pub state: String,
+    pub scope: Option<String>,
+    pub comments: Vec<ReviewCommentView>,
+}
+
+/// One reviewer assignment.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReviewAssignmentView {
+    pub reviewer: String,
+}
+
+/// One review in full, as the JSON review reads answer it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReviewRecordView {
+    pub review_id: String,
+    pub title: String,
+    pub state: String,
+    pub base_ref: String,
+    pub head_ref: String,
+    pub scopes: Vec<String>,
+    pub decisions: Vec<ReviewDecisionView>,
+    pub notes: Vec<ReviewNoteView>,
+    pub discussions: Vec<ReviewDiscussionView>,
+    pub assignments: Vec<ReviewAssignmentView>,
+}
+
+impl From<&ReviewRecord> for ReviewRecordView {
+    fn from(record: &ReviewRecord) -> Self {
+        let review = &record.review;
+        Self {
+            review_id: review.review_id.to_string(),
+            title: review.title.clone(),
+            state: review_state_label(review.state),
+            base_ref: review.base_ref.clone(),
+            head_ref: review.head_ref.clone(),
+            scopes: review.scopes.iter().map(ToString::to_string).collect(),
+            decisions: record
+                .decisions
+                .iter()
+                .map(|decision| ReviewDecisionView {
+                    state: review_state_label(decision.state),
+                    comment: decision.comment.clone(),
+                    reviewer: decision.reviewer.name.clone(),
+                })
+                .collect(),
+            notes: record
+                .notes
+                .iter()
+                .map(|note| ReviewNoteView {
+                    note_id: note.note_id.to_string(),
+                    body: note.body.clone(),
+                    scope: note.scope.as_ref().map(ToString::to_string),
+                    author: note.authored_by.name.clone(),
+                })
+                .collect(),
+            discussions: record
+                .discussions
+                .iter()
+                .map(|discussion| ReviewDiscussionView {
+                    discussion_id: discussion.discussion_id.to_string(),
+                    state: format!("{:?}", discussion.state).to_lowercase(),
+                    scope: discussion.scope.as_ref().map(ToString::to_string),
+                    comments: discussion
+                        .comments
+                        .iter()
+                        .map(|comment| ReviewCommentView {
+                            body: comment.body.clone(),
+                            author: comment.authored_by.name.clone(),
+                        })
+                        .collect(),
+                })
+                .collect(),
+            assignments: record
+                .assignments
+                .iter()
+                .map(|assignment| ReviewAssignmentView {
+                    reviewer: assignment.reviewer.name.clone(),
+                })
+                .collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kin_db::InMemoryGraph;
+    use kin_model::review::{
+        ReviewComment, ReviewCompletionState, ReviewDiscussionId, ReviewDiscussionState,
+        ReviewNoteId,
+    };
+    use kin_model::timestamp::Timestamp;
+    use kin_model::IdentityRef;
+
+    fn review_at(title: &str, seconds: u32, state: ReviewDecisionState) -> Review {
+        // Built from its wire form so the test needs no clock crate of its own.
+        let at: Timestamp = serde_json::from_value(serde_json::json!(format!(
+            "2026-09-11T00:{:02}:{:02}Z",
+            seconds / 60,
+            seconds % 60
+        )))
+        .expect("an RFC 3339 instant");
+        Review {
+            review_id: ReviewId::new(),
+            title: title.to_string(),
+            base_ref: "main".to_string(),
+            head_ref: format!("feature/{title}"),
+            state,
+            completion: ReviewCompletionState::InReview,
+            created_by: IdentityRef::human("reviewer"),
+            created_at: at.clone(),
+            updated_at: at,
+            scopes: vec![],
+        }
+    }
+
+    #[test]
+    fn a_listing_is_newest_first_whatever_order_the_store_holds() {
+        let graph = InMemoryGraph::new();
+        // Inserted oldest, newest, middle: neither insertion order nor its
+        // reverse is the answer, so a sort that is missing or backwards fails.
+        let oldest = review_at("oldest", 0, ReviewDecisionState::Pending);
+        let newest = review_at("newest", 200, ReviewDecisionState::Pending);
+        let middle = review_at("middle", 100, ReviewDecisionState::Approved);
+        for review in [&oldest, &newest, &middle] {
+            graph.create_review(review).unwrap();
+        }
+
+        let titles: Vec<String> = list_stored_reviews(&graph, None)
+            .unwrap()
+            .into_iter()
+            .map(|review| review.title)
+            .collect();
+        assert_eq!(titles, vec!["newest", "middle", "oldest"]);
+
+        let approved: Vec<String> =
+            list_stored_reviews(&graph, Some(ReviewDecisionState::Approved))
+                .unwrap()
+                .into_iter()
+                .map(|review| review.title)
+                .collect();
+        assert_eq!(approved, vec!["middle"], "the state filter must narrow");
+    }
+
+    #[test]
+    fn a_record_carries_its_history_and_an_absent_id_reads_none() {
+        let graph = InMemoryGraph::new();
+        let review = review_at("record", 0, ReviewDecisionState::Pending);
+        graph.create_review(&review).unwrap();
+        graph
+            .add_review_decision(
+                &review.review_id,
+                &ReviewDecision {
+                    reviewer: IdentityRef::human("ada"),
+                    state: ReviewDecisionState::NeedsWork,
+                    comment: Some("split the parser change".to_string()),
+                    decided_at: Timestamp::now(),
+                },
+            )
+            .unwrap();
+        graph
+            .add_review_note(&ReviewNote {
+                note_id: ReviewNoteId::new(),
+                review_id: review.review_id,
+                body: "checked the call sites".to_string(),
+                scope: None,
+                authored_by: IdentityRef::human("ada"),
+                created_at: Timestamp::now(),
+            })
+            .unwrap();
+
+        let record = read_review_record(&graph, &review.review_id)
+            .unwrap()
+            .expect("the stored review reads back");
+        assert_eq!(record.review, review);
+        assert_eq!(record.decisions.len(), 1);
+        assert_eq!(record.notes.len(), 1);
+        assert!(record.discussions.is_empty());
+        assert!(record.assignments.is_empty());
+
+        assert!(
+            read_review_record(&graph, &ReviewId::new())
+                .unwrap()
+                .is_none(),
+            "an id the store does not hold is None, not an empty record"
+        );
+    }
+
+    /// The views are the JSON the MCP tools have always printed, byte for byte.
+    ///
+    /// The expected text is built the way `kin_review_get` built it before the
+    /// read moved here: a `json!` object per row. Key order is part of what an
+    /// MCP client sees, so the comparison is on the printed text, not on the
+    /// parsed value, which would pass with the keys in any order.
+    #[test]
+    fn the_record_view_prints_exactly_what_kin_review_get_printed() {
+        let review = review_at("record", 0, ReviewDecisionState::NeedsWork);
+        let discussion_id = ReviewDiscussionId::new();
+        let record = ReviewRecord {
+            decisions: vec![ReviewDecision {
+                reviewer: IdentityRef::human("ada"),
+                state: ReviewDecisionState::NeedsWork,
+                comment: None,
+                decided_at: Timestamp::now(),
+            }],
+            notes: vec![],
+            discussions: vec![ReviewDiscussion {
+                discussion_id,
+                review_id: review.review_id,
+                scope: None,
+                state: ReviewDiscussionState::Open,
+                comments: vec![ReviewComment {
+                    authored_by: IdentityRef::human("lin"),
+                    body: "why here".to_string(),
+                    created_at: Timestamp::now(),
+                }],
+                created_at: Timestamp::now(),
+            }],
+            assignments: vec![],
+            review: review.clone(),
+        };
+
+        let legacy = serde_json::json!({
+            "review_id": review.review_id.to_string(),
+            "title": review.title,
+            "state": "needswork",
+            "base_ref": review.base_ref,
+            "head_ref": review.head_ref,
+            "scopes": Vec::<String>::new(),
+            "decisions": [{
+                "state": "needswork",
+                "comment": serde_json::Value::Null,
+                "reviewer": "ada",
+            }],
+            "notes": Vec::<serde_json::Value>::new(),
+            "discussions": [{
+                "discussion_id": discussion_id.to_string(),
+                "state": "open",
+                "scope": serde_json::Value::Null,
+                "comments": [{ "body": "why here", "author": "lin" }],
+            }],
+            "assignments": Vec::<serde_json::Value>::new(),
+        });
+        let view = serde_json::to_value(ReviewRecordView::from(&record)).unwrap();
+        assert_eq!(
+            serde_json::to_string_pretty(&view).unwrap(),
+            serde_json::to_string_pretty(&legacy).unwrap()
+        );
+
+        let legacy_row = serde_json::json!({
+            "review_id": review.review_id.to_string(),
+            "title": review.title,
+            "state": "needswork",
+            "base_ref": review.base_ref,
+            "head_ref": review.head_ref,
+        });
+        let row = serde_json::to_value(ReviewSummaryView::from(&review)).unwrap();
+        assert_eq!(
+            serde_json::to_string_pretty(&row).unwrap(),
+            serde_json::to_string_pretty(&legacy_row).unwrap()
+        );
+
+        // The comparison above goes through a `serde_json::Value`, whose key
+        // order is serde_json's `preserve_order` feature: sorted without it,
+        // insertion order with it. A build with the feature off prints both
+        // sides sorted and cannot see the fields reordered, which is how a
+        // swapped pair survived here once. Printing the view directly always
+        // follows declaration order, so the order `kin_review_get` has printed
+        // wherever key order is kept is pinned in every build.
+        assert_keys_in_order(
+            &serde_json::to_string(&ReviewSummaryView::from(&review)).unwrap(),
+            &["review_id", "title", "state", "base_ref", "head_ref"],
+        );
+        assert_keys_in_order(
+            &serde_json::to_string(&ReviewRecordView::from(&record)).unwrap(),
+            &[
+                "review_id",
+                "title",
+                "state",
+                "base_ref",
+                "head_ref",
+                "scopes",
+                "decisions",
+                "notes",
+                "discussions",
+                "assignments",
+            ],
+        );
+    }
+
+    /// Each key's first appearance comes after the one before it.
+    fn assert_keys_in_order(printed: &str, keys: &[&str]) {
+        let positions: Vec<usize> = keys
+            .iter()
+            .map(|key| {
+                printed
+                    .find(&format!("\"{key}\":"))
+                    .unwrap_or_else(|| panic!("{key} missing from {printed}"))
+            })
+            .collect();
+        assert!(
+            positions.windows(2).all(|pair| pair[0] < pair[1]),
+            "keys out of order, expected {keys:?} in {printed}"
+        );
+    }
+
+    #[test]
+    fn every_spelling_a_review_read_accepted_still_parses() {
+        for (spelling, state) in [
+            ("pending", ReviewDecisionState::Pending),
+            ("approved", ReviewDecisionState::Approved),
+            ("approve", ReviewDecisionState::Approved),
+            ("needs_work", ReviewDecisionState::NeedsWork),
+            ("needs-work", ReviewDecisionState::NeedsWork),
+            ("needswork", ReviewDecisionState::NeedsWork),
+            ("BLOCKED", ReviewDecisionState::Blocked),
+            ("block", ReviewDecisionState::Blocked),
+        ] {
+            assert_eq!(
+                parse_review_decision_state(spelling),
+                Some(state),
+                "{spelling}"
+            );
+        }
+        assert_eq!(parse_review_decision_state("merged"), None);
+    }
+}

--- a/crates/kin-review/src/review.rs
+++ b/crates/kin-review/src/review.rs
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
+use std::collections::BTreeMap;
+
 use kin_model::graph::GraphStore;
 use kin_model::ids::SemanticChangeId;
-use kin_model::review::RiskSummary;
+use kin_model::review::{RiskLevel, RiskSummary};
 use serde::{Deserialize, Serialize};
 
 use kin_model::change::SemanticChange as SemanticChangeModel;
 use kin_model::ids::EntityId;
 
-use crate::diff::{self, SemanticDiff};
+use crate::diff::{self, EntityChangeKind, SemanticDiff};
 use crate::error::ReviewError;
 use crate::impact::{self, ImpactReport};
 use crate::inline::{self, InlineComment};
@@ -25,6 +27,21 @@ pub struct Review {
     pub impact: ImpactReport,
     pub risk: RiskSummary,
     pub inline_comments: Vec<InlineComment>,
+}
+
+/// A review of a DAG-true range: every change `head` reaches that `base` does
+/// not. See [`SemanticReview::create_range_review`].
+#[derive(Debug, Clone)]
+pub struct RangeReview {
+    pub review: Review,
+    /// How many changes the range holds: the head's ancestry less the base's.
+    /// Zero means the head adds nothing the base lacks, and the review is
+    /// empty because the range is, not because anything was skipped.
+    pub changes_in_range: usize,
+    /// Each changed entity's own risk level, read by
+    /// [`crate::risk::entity_risk_levels`] from the same findings the review's
+    /// overall risk is read from. One entry per changed entity.
+    pub entity_risk: BTreeMap<EntityId, RiskLevel>,
 }
 
 /// The main entry point for creating a semantic review.
@@ -87,6 +104,79 @@ impl SemanticReview {
             impact: impact_report,
             risk: risk_summary,
             inline_comments,
+        })
+    }
+
+    /// Review the DAG-true range `base..head`: every change `head` reaches
+    /// that `base` does not, with impact read at head and a removed entity's
+    /// consumers read at base.
+    ///
+    /// This is the range shadow review evaluates, packaged for a caller that
+    /// wants the review rather than the gate. The membership test answers the
+    /// same set whether or not `base` is an ancestor of `head`, but a caller
+    /// comparing two branches should pass their merge base: the store's range
+    /// walk stops only at the literal base node, so any other base makes it
+    /// visit everything `head` reaches before the filter drops it.
+    ///
+    /// Risk is assessed after the base-side overlay, so the breaking-removal
+    /// rule reads the consumers a removed entity had where it still existed.
+    /// Fails with [`ReviewError::RefStateUnavailable`] when either side's
+    /// ancestry is not fully present in the store.
+    pub fn create_range_review<G: GraphStore>(
+        store: &G,
+        base: &SemanticChangeId,
+        head: &SemanticChangeId,
+    ) -> Result<RangeReview, ReviewError> {
+        let at_head = GraphAtRef::materialize(store, head)?;
+        let base_ancestry = crate::ref_graph::collect_ancestry(store, base)?;
+        let changes_in_range = at_head
+            .ancestry()
+            .iter()
+            .filter(|id| !base_ancestry.contains(id))
+            .count();
+        if changes_in_range == 0 {
+            // The head adds nothing the base lacks. That is a real, empty
+            // review, and it answers as one rather than as the diff's
+            // `NoChanges` error, which a caller would read as a failure.
+            let diff = SemanticDiff {
+                base: Some(*base),
+                head: Some(*head),
+                ..Default::default()
+            };
+            let impact = ImpactReport::default();
+            let risk = risk::assess_risk(&diff, &impact);
+            return Ok(RangeReview {
+                review: Review {
+                    base: Some(*base),
+                    head: Some(*head),
+                    diff,
+                    impact,
+                    risk,
+                    inline_comments: Vec::new(),
+                },
+                changes_in_range,
+                entity_risk: BTreeMap::new(),
+            });
+        }
+        let in_range =
+            |id: &SemanticChangeId| at_head.ancestry_contains(id) && !base_ancestry.contains(id);
+        let mut review = Self::create_review_scoped(base, head, store, &at_head, in_range)?;
+        let removes_an_entity = review
+            .diff
+            .entity_changes
+            .iter()
+            .any(|change| matches!(change.kind, EntityChangeKind::Removed { .. }));
+        if removes_an_entity {
+            let at_base = GraphAtRef::materialize(store, base)?;
+            crate::shadow::overlay_removed_entity_impact_from_base(&mut review, &at_base)?;
+            review.risk = risk::assess_risk(&review.diff, &review.impact);
+            review.inline_comments = inline::collect_inline_comments(&review.diff, &review.impact);
+        }
+        let entity_risk = risk::entity_risk_levels(&review.diff, &review.impact);
+        Ok(RangeReview {
+            review,
+            changes_in_range,
+            entity_risk,
         })
     }
 
@@ -191,6 +281,154 @@ mod tests {
 
     fn test_change_id(byte: u8) -> SemanticChangeId {
         SemanticChangeId::from_hash(Hash256::from_bytes([byte; 32]))
+    }
+
+    fn calls(src: &Entity, dst: &Entity) -> kin_model::relation::Relation {
+        kin_model::relation::Relation {
+            id: RelationId::new(),
+            kind: kin_model::relation::RelationKind::Calls,
+            src: kin_model::relation::GraphNodeId::Entity(src.id),
+            dst: kin_model::relation::GraphNodeId::Entity(dst.id),
+            confidence: 1.0,
+            origin: kin_model::relation::RelationOrigin::Parsed,
+            created_in: None,
+            import_source: None,
+            evidence: vec![],
+        }
+    }
+
+    fn committed(
+        parents: Vec<SemanticChangeId>,
+        entity_deltas: Vec<EntityDelta>,
+        relation_deltas: Vec<kin_model::change::RelationDelta>,
+    ) -> SemanticChange {
+        let mut change = SemanticChange {
+            id: test_change_id(0),
+            parents,
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("test"),
+            message: "range review fixture".into(),
+            entity_deltas,
+            relation_deltas,
+            tree_deltas: vec![],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            origin: kin_model::ChangeOrigin::Native,
+            admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
+        };
+        change.id = kin_model::compute_semantic_change_id(&change).unwrap();
+        change
+    }
+
+    /// A review of a branch is the branch's own changes, from the merge base.
+    ///
+    /// Root adds three functions, `caller` calling `doomed`. The base line adds
+    /// `only_on_main`; the branch widens `shared`'s signature and deletes
+    /// `doomed` while `caller` still calls it. The range is the branch alone,
+    /// so `only_on_main` must not appear, and the deletion is breaking because
+    /// its caller survives. A base off the head's ancestry must answer the same
+    /// range, and the range from the head to itself is empty, not an error.
+    #[test]
+    fn a_range_review_covers_the_head_side_only_and_ranks_each_entity() {
+        use kin_model::change::RelationDelta;
+        use kin_model::ChangeStore;
+        use std::collections::BTreeSet;
+
+        let graph = InMemoryGraph::new();
+        let shared = test_entity("shared");
+        let doomed = test_entity("doomed");
+        let caller = test_entity("caller");
+        let only_on_main = test_entity("only_on_main");
+        let edge = calls(&caller, &doomed);
+        let root = committed(
+            vec![],
+            vec![
+                EntityDelta::Added {
+                    new: shared.clone(),
+                },
+                EntityDelta::Added {
+                    new: doomed.clone(),
+                },
+                EntityDelta::Added {
+                    new: caller.clone(),
+                },
+            ],
+            vec![RelationDelta::Added { new: edge.clone() }],
+        );
+        let main = committed(
+            vec![root.id],
+            vec![EntityDelta::Added {
+                new: only_on_main.clone(),
+            }],
+            vec![],
+        );
+        let mut widened = shared.clone();
+        widened.signature = "fn shared(flag: bool)".to_string();
+        let branch = committed(
+            vec![root.id],
+            vec![
+                EntityDelta::Modified {
+                    old: shared.clone(),
+                    new: widened,
+                },
+                EntityDelta::Removed {
+                    old: doomed.clone(),
+                },
+            ],
+            vec![RelationDelta::Removed { old: edge }],
+        );
+        for change in [&root, &main, &branch] {
+            graph.create_change(change).unwrap();
+        }
+        let changed_in = |range: &RangeReview| -> BTreeSet<EntityId> {
+            range
+                .review
+                .diff
+                .entity_changes
+                .iter()
+                .map(|change| change.entity_id)
+                .collect()
+        };
+
+        let range = SemanticReview::create_range_review(&graph, &root.id, &branch.id).unwrap();
+        assert_eq!(range.changes_in_range, 1);
+        assert_eq!(
+            changed_in(&range),
+            [shared.id, doomed.id].into_iter().collect::<BTreeSet<_>>(),
+            "the base line's own change is outside the range"
+        );
+        assert_eq!(range.entity_risk.len(), 2);
+        assert_eq!(
+            range.entity_risk[&doomed.id],
+            RiskLevel::High,
+            "deleting what a surviving caller calls is breaking: {:?}",
+            range.review.risk
+        );
+        assert_eq!(
+            range.entity_risk[&shared.id],
+            RiskLevel::Medium,
+            "a widened signature with no consumers and no tests is a coverage gap: {:?}",
+            range.review.risk
+        );
+        assert_eq!(range.review.risk.overall_risk, RiskLevel::High);
+
+        let from_sibling =
+            SemanticReview::create_range_review(&graph, &main.id, &branch.id).unwrap();
+        assert_eq!(from_sibling.changes_in_range, 1);
+        assert_eq!(
+            changed_in(&from_sibling),
+            changed_in(&range),
+            "the membership test must not depend on the base being an ancestor"
+        );
+
+        let empty = SemanticReview::create_range_review(&graph, &branch.id, &branch.id).unwrap();
+        assert_eq!(empty.changes_in_range, 0);
+        assert!(empty.review.diff.is_empty());
+        assert!(empty.entity_risk.is_empty());
+        assert_eq!(empty.review.risk.overall_risk, RiskLevel::Low);
     }
 
     #[test]

--- a/crates/kin-review/src/risk.rs
+++ b/crates/kin-review/src/risk.rs
@@ -174,21 +174,41 @@ fn removed_entity_dependents(
     (listed, total)
 }
 
-/// Assess risk given a diff and its impact report.
+/// Which list of a [`RiskSummary`] one per-change finding belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FindingClass {
+    Breaking,
+    CoverageGap,
+    ContractViolation,
+    Note,
+}
+
+/// One finding the per-change rules raised, with the entity it was raised on.
 ///
-/// Returns a `RiskSummary` (from kin-model) with:
-/// - breaking changes (contract/signature changes with consumers)
-/// - test coverage gaps (modified entities with no test coverage)
-/// - contract violations
-/// - overall risk level
-pub fn assess_risk(diff: &SemanticDiff, impact: &ImpactReport) -> RiskSummary {
-    let mut breaking_changes = Vec::new();
-    let mut test_coverage_gaps = Vec::new();
-    let mut contract_violations = Vec::new();
-    let mut notes = Vec::new();
+/// The entity travels with the finding so one rule pass feeds both the
+/// diff-wide summary and each entity's own level. Two passes, one per
+/// consumer, would be two copies of every rule, and the day one copy moved
+/// the other would go on reporting the old rule with nothing to notice.
+struct ChangeFinding {
+    entity_id: EntityId,
+    class: FindingClass,
+    message: String,
+}
+
+/// Run the per-change rules over every entity change, in diff order.
+///
+/// Within each class the findings keep the order the rules emit them in,
+/// which is the order [`assess_risk`] has always reported, so splitting them
+/// back out by class reproduces its lists exactly.
+fn change_findings(diff: &SemanticDiff, impact: &ImpactReport) -> Vec<ChangeFinding> {
+    let mut findings = Vec::new();
 
     // Check for signature changes on entities with consumers/callers
     for change in &diff.entity_changes {
+        let mut breaking_changes = Vec::new();
+        let mut test_coverage_gaps = Vec::new();
+        let mut contract_violations = Vec::new();
+        let mut notes = Vec::new();
         match &change.kind {
             EntityChangeKind::Modified { old, new } => {
                 // Signature changed?
@@ -301,6 +321,41 @@ pub fn assess_risk(diff: &SemanticDiff, impact: &ImpactReport) -> RiskSummary {
                 }
             }
         }
+        for (class, messages) in [
+            (FindingClass::Breaking, breaking_changes),
+            (FindingClass::CoverageGap, test_coverage_gaps),
+            (FindingClass::ContractViolation, contract_violations),
+            (FindingClass::Note, notes),
+        ] {
+            findings.extend(messages.into_iter().map(|message| ChangeFinding {
+                entity_id: change.entity_id,
+                class,
+                message,
+            }));
+        }
+    }
+    findings
+}
+
+/// Assess risk given a diff and its impact report.
+///
+/// Returns a `RiskSummary` (from kin-model) with:
+/// - breaking changes (contract/signature changes with consumers)
+/// - test coverage gaps (modified entities with no test coverage)
+/// - contract violations
+/// - overall risk level
+pub fn assess_risk(diff: &SemanticDiff, impact: &ImpactReport) -> RiskSummary {
+    let mut breaking_changes = Vec::new();
+    let mut test_coverage_gaps = Vec::new();
+    let mut contract_violations = Vec::new();
+    let mut notes = Vec::new();
+    for finding in change_findings(diff, impact) {
+        match finding.class {
+            FindingClass::Breaking => breaking_changes.push(finding.message),
+            FindingClass::CoverageGap => test_coverage_gaps.push(finding.message),
+            FindingClass::ContractViolation => contract_violations.push(finding.message),
+            FindingClass::Note => notes.push(finding.message),
+        }
     }
 
     // Removed relations that break contracts
@@ -358,13 +413,14 @@ pub fn assess_risk(diff: &SemanticDiff, impact: &ImpactReport) -> RiskSummary {
         }
     }
 
-    let overall_risk = compute_risk_level(
-        &breaking_changes,
-        &test_coverage_gaps,
-        &contract_violations,
-        &work_risks,
-        impact,
-    );
+    let overall_risk = level_for(&RiskEvidence {
+        contract_violation: !contract_violations.is_empty(),
+        breaking: !breaking_changes.is_empty(),
+        coverage_gap: !test_coverage_gaps.is_empty(),
+        blast_radius: impact.total_affected(),
+        work_risk: !work_risks.is_empty(),
+        unreviewed_agent_change: !impact.unreviewed_agent_changes.is_empty(),
+    });
 
     RiskSummary {
         overall_risk,
@@ -376,40 +432,90 @@ pub fn assess_risk(diff: &SemanticDiff, impact: &ImpactReport) -> RiskSummary {
     }
 }
 
-fn compute_risk_level(
-    breaking_changes: &[String],
-    test_coverage_gaps: &[String],
-    contract_violations: &[String],
-    work_risks: &[String],
-    impact: &ImpactReport,
-) -> RiskLevel {
-    if !contract_violations.is_empty() {
+/// The evidence a risk level is read from, for the whole diff or one entity.
+#[derive(Debug, Clone, Copy, Default)]
+struct RiskEvidence {
+    contract_violation: bool,
+    breaking: bool,
+    coverage_gap: bool,
+    /// Entities the change reaches. Diff-wide only: no single entity owns it.
+    blast_radius: usize,
+    /// In-progress work on changed code. Diff-wide only, for the same reason.
+    work_risk: bool,
+    unreviewed_agent_change: bool,
+}
+
+/// The one precedence every risk level is read through.
+fn level_for(evidence: &RiskEvidence) -> RiskLevel {
+    if evidence.contract_violation {
         return RiskLevel::Critical;
     }
 
-    if !breaking_changes.is_empty() {
+    if evidence.breaking {
         return RiskLevel::High;
     }
 
-    if !test_coverage_gaps.is_empty() && impact.total_affected() > 5 {
+    if evidence.coverage_gap && evidence.blast_radius > 5 {
         return RiskLevel::High;
     }
 
-    if !test_coverage_gaps.is_empty() || impact.total_affected() > 3 {
+    if evidence.coverage_gap || evidence.blast_radius > 3 {
         return RiskLevel::Medium;
     }
 
     // In-progress work items on changed code is at least Medium risk.
-    if !work_risks.is_empty() {
+    if evidence.work_risk {
         return RiskLevel::Medium;
     }
 
     // Unreviewed agent changes bump risk to at least Medium.
-    if !impact.unreviewed_agent_changes.is_empty() {
+    if evidence.unreviewed_agent_change {
         return RiskLevel::Medium;
     }
 
     RiskLevel::Low
+}
+
+/// Each changed entity's risk level, read from that entity's own findings.
+///
+/// The findings are the ones [`assess_risk`] reports, from the same rule pass,
+/// and the level comes through the same precedence, so the two cannot disagree
+/// about what a finding is worth. What is left out is what no single entity
+/// owns: the diff's total blast radius and the work items it touches describe
+/// the whole range and stay in [`RiskSummary::overall_risk`]. Every input here
+/// is at most its diff-wide counterpart and the precedence only rises with its
+/// inputs, so no entity's level can exceed the overall level. An unreviewed
+/// agent change is attributed, because the impact report names the entity.
+///
+/// Every entity the diff changes has an entry, a `Low` one included, so an
+/// absent entry means an entity this diff never changed.
+pub fn entity_risk_levels(
+    diff: &SemanticDiff,
+    impact: &ImpactReport,
+) -> BTreeMap<EntityId, RiskLevel> {
+    let mut evidence: BTreeMap<EntityId, RiskEvidence> = diff
+        .entity_changes
+        .iter()
+        .map(|change| (change.entity_id, RiskEvidence::default()))
+        .collect();
+    for finding in change_findings(diff, impact) {
+        let entry = evidence.entry(finding.entity_id).or_default();
+        match finding.class {
+            FindingClass::ContractViolation => entry.contract_violation = true,
+            FindingClass::Breaking => entry.breaking = true,
+            FindingClass::CoverageGap => entry.coverage_gap = true,
+            FindingClass::Note => {}
+        }
+    }
+    for entity_id in &impact.unreviewed_agent_changes {
+        if let Some(entry) = evidence.get_mut(entity_id) {
+            entry.unreviewed_agent_change = true;
+        }
+    }
+    evidence
+        .into_iter()
+        .map(|(entity_id, evidence)| (entity_id, level_for(&evidence)))
+        .collect()
 }
 
 #[cfg(test)]
@@ -601,6 +707,147 @@ mod tests {
                 .any(|finding| finding.contains("json")),
             "one stranded external consumer is still a breaking removal: {:?}",
             summary.breaking_changes
+        );
+    }
+
+    fn ranked(level: RiskLevel) -> u8 {
+        match level {
+            RiskLevel::Low => 0,
+            RiskLevel::Medium => 1,
+            RiskLevel::High => 2,
+            RiskLevel::Critical => 3,
+        }
+    }
+
+    fn modification_of(old: &Entity, new: &Entity) -> EntityChange {
+        EntityChange {
+            entity_id: old.id,
+            kind: EntityChangeKind::Modified {
+                old: old.clone(),
+                new: new.clone(),
+            },
+        }
+    }
+
+    /// Each entity's level reads its own findings, and none outranks the diff.
+    ///
+    /// Five entities, one per outcome, in one diff. A level read off the
+    /// diff-wide lists would rank all five critical, because one of them is a
+    /// contract violation; a level that ignored findings would rank all five
+    /// low. Only per-entity attribution gets every one right.
+    #[test]
+    fn each_entity_is_ranked_on_its_own_findings_and_none_outranks_the_diff() {
+        let mut contract_old = test_entity("create_order");
+        contract_old.kind = EntityKind::ApiEndpoint;
+        let mut contract_new = contract_old.clone();
+        contract_new.doc_summary = Some("now paginated".to_string());
+        let signature_old = test_entity("parse_config");
+        let mut signature_new = signature_old.clone();
+        signature_new.signature = "fn parse_config(strict: bool)".to_string();
+        let gap_old = test_entity("render_row");
+        let mut gap_new = gap_old.clone();
+        gap_new.doc_summary = Some("renders one row".to_string());
+        let covered_old = test_entity("format_date");
+        let mut covered_new = covered_old.clone();
+        covered_new.doc_summary = Some("formats a date".to_string());
+        let mut added = test_entity("helper");
+        added.visibility = Visibility::Private;
+
+        let diff = SemanticDiff {
+            entity_changes: vec![
+                modification_of(&contract_old, &contract_new),
+                modification_of(&signature_old, &signature_new),
+                modification_of(&gap_old, &gap_new),
+                modification_of(&covered_old, &covered_new),
+                EntityChange {
+                    entity_id: added.id,
+                    kind: EntityChangeKind::Added(added.clone()),
+                },
+            ],
+            ..Default::default()
+        };
+        let impact = ImpactReport {
+            entity_impacts: vec![
+                entity_impact_counts(contract_old.id, 0, 2, 1),
+                entity_impact_counts(signature_old.id, 3, 0, 1),
+                entity_impact_counts(gap_old.id, 0, 0, 0),
+                entity_impact_counts(covered_old.id, 0, 0, 2),
+                entity_impact_counts(added.id, 0, 0, 0),
+            ],
+            ..Default::default()
+        };
+
+        let levels = entity_risk_levels(&diff, &impact);
+        let overall = assess_risk(&diff, &impact).overall_risk;
+        assert_eq!(levels[&contract_old.id], RiskLevel::Critical);
+        assert_eq!(levels[&signature_old.id], RiskLevel::High);
+        assert_eq!(levels[&gap_old.id], RiskLevel::Medium);
+        assert_eq!(levels[&covered_old.id], RiskLevel::Low);
+        assert_eq!(levels[&added.id], RiskLevel::Low);
+        assert_eq!(
+            levels.len(),
+            diff.entity_changes.len(),
+            "every changed entity is ranked, a low one included"
+        );
+        assert_eq!(overall, RiskLevel::Critical);
+        for (entity_id, level) in &levels {
+            assert!(
+                ranked(*level) <= ranked(overall),
+                "{entity_id} ranked {level:?} above the diff's {overall:?}"
+            );
+        }
+    }
+
+    /// The diff-wide terms raise the overall level and no single entity.
+    ///
+    /// One entity with a coverage gap, in a diff whose total blast radius is
+    /// six. The overall level escalates to high on that total; the entity keeps
+    /// the medium its own finding earns, because six affected entities describe
+    /// the range and not this one. An unreviewed agent change is the other
+    /// case: the impact report names the entity, so it is attributed.
+    #[test]
+    fn diff_wide_terms_raise_the_overall_level_without_raising_an_entity() {
+        let gap_old = test_entity("render_row");
+        let mut gap_new = gap_old.clone();
+        gap_new.doc_summary = Some("renders one row".to_string());
+        let quiet_old = test_entity("format_date");
+        let mut quiet_new = quiet_old.clone();
+        quiet_new.doc_summary = Some("formats a date".to_string());
+        let diff = SemanticDiff {
+            entity_changes: vec![
+                modification_of(&gap_old, &gap_new),
+                modification_of(&quiet_old, &quiet_new),
+            ],
+            ..Default::default()
+        };
+        let impact = ImpactReport {
+            affected_callers: (0..6)
+                .map(|n| test_entity(&format!("caller_{n}")))
+                .collect(),
+            entity_impacts: vec![
+                entity_impact_counts(gap_old.id, 0, 0, 0),
+                entity_impact_counts(quiet_old.id, 0, 0, 3),
+            ],
+            unreviewed_agent_changes: vec![quiet_old.id],
+            ..Default::default()
+        };
+        assert!(
+            impact.total_affected() > 5,
+            "the fixture must cross the diff-wide escalation"
+        );
+
+        let overall = assess_risk(&diff, &impact).overall_risk;
+        let levels = entity_risk_levels(&diff, &impact);
+        assert_eq!(overall, RiskLevel::High);
+        assert_eq!(
+            levels[&gap_old.id],
+            RiskLevel::Medium,
+            "six affected entities belong to the range, not to this entity"
+        );
+        assert_eq!(
+            levels[&quiet_old.id],
+            RiskLevel::Medium,
+            "an unreviewed agent change names its entity, so it is attributed"
         );
     }
 

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -465,7 +465,7 @@ pub fn build_shadow_report_at<G: GraphStore>(
 /// a consumer that let go of the removed surface in the same change is not a
 /// broken contract. Removed ids are iterated in sorted order and the impacts
 /// are re-sorted by id, so the overlay is replay-deterministic.
-fn overlay_removed_entity_impact_from_base<G: GraphStore>(
+pub(crate) fn overlay_removed_entity_impact_from_base<G: GraphStore>(
     review: &mut Review,
     at_base: &GraphAtRef<'_, G>,
 ) -> Result<(), ReviewError> {

--- a/packages/boundary-contracts/src/index.d.ts
+++ b/packages/boundary-contracts/src/index.d.ts
@@ -127,7 +127,7 @@ export interface RepoScopedSemanticToolError {
 
 export type ActorKind = "human" | "agent" | "system";
 export type EvidenceStatus = "complete" | "partial" | "missing";
-export type ReviewRisk = "low" | "medium" | "high";
+export type ReviewRisk = "low" | "medium" | "high" | "not_assessed";
 export type ReviewAuthority = "graph" | "overlay";
 export type ReviewPlane = "repo-local" | "hosted-managed";
 export type ReviewProvenance = "graph" | "overlay" | "system-generated";
@@ -222,7 +222,7 @@ export interface ReviewQueueItem {
   domain: string;
   scope: string;
   summary: string;
-  changedEntities: number;
+  changedEntities: number | null;
   activeAgents: number;
   evidenceStatus: EvidenceStatus;
   risk: ReviewRisk;
@@ -356,7 +356,7 @@ export interface SemanticDiffEntity {
   name: string;
   kind: string;
   changeType: "added" | "modified" | "removed";
-  riskLevel: "low" | "medium" | "high";
+  riskLevel: "low" | "medium" | "high" | "critical" | "not_assessed";
   changes: SemanticDiffEntityChange[];
 }
 
@@ -367,7 +367,7 @@ export interface SemanticDiffResponse {
 export interface EntityChange {
   name: string;
   kind: string;
-  riskLevel: "low" | "medium" | "high";
+  riskLevel: "low" | "medium" | "high" | "critical" | "not_assessed";
   beforeSignature?: string;
   afterSignature?: string;
 }

--- a/packages/boundary-contracts/src/index.d.ts
+++ b/packages/boundary-contracts/src/index.d.ts
@@ -127,7 +127,7 @@ export interface RepoScopedSemanticToolError {
 
 export type ActorKind = "human" | "agent" | "system";
 export type EvidenceStatus = "complete" | "partial" | "missing";
-export type ReviewRisk = "low" | "medium" | "high" | "not_assessed";
+export type ReviewRisk = "low" | "medium" | "high" | "critical" | "not_assessed";
 export type ReviewAuthority = "graph" | "overlay";
 export type ReviewPlane = "repo-local" | "hosted-managed";
 export type ReviewProvenance = "graph" | "overlay" | "system-generated";

--- a/packages/boundary-contracts/test/contracts.test.js
+++ b/packages/boundary-contracts/test/contracts.test.js
@@ -1016,6 +1016,61 @@ test('the graph feed shape is one contract the Rust, the schema and the declarat
   }
 });
 
+test('a semantic diff risk level is one the daemon emits, critical and not_assessed included', async () => {
+  const [declarations, reviewSource] = await Promise.all([
+    fs.readFile(path.join(packageRoot, 'src/index.d.ts'), 'utf8'),
+    fs.readFile(path.join(repositoryRoot, 'crates/kin-daemon/src/repo_review.rs'), 'utf8')
+  ]);
+
+  // The daemon's spelling of every level, read from the one function that
+  // writes it onto the wire, so a level added there cannot go undeclared here.
+  const labelFunction = reviewSource.match(
+    /pub fn risk_label\(level: RiskLevel\) -> &'static str \{([\s\S]*?)\n\}/
+  );
+  assert.ok(labelFunction, 'the Rust risk label authority must remain readable');
+  const levels = [...labelFunction[1].matchAll(/RiskLevel::\w+ => "([a-z]+)"/g)].map(
+    (match) => match[1]
+  );
+  assert.deepEqual([...levels].sort(), ['critical', 'high', 'low', 'medium']);
+  // And the one word a field carries instead of a level when risk was not
+  // assessed, so a page says so rather than showing a default.
+  const notAssessed = reviewSource.match(/pub const RISK_NOT_ASSESSED: &str = "([a-z_]+)";/);
+  assert.ok(notAssessed, 'the Rust not-assessed spelling must remain readable');
+  const emitted = [...levels, notAssessed[1]].sort();
+  assert.deepEqual(emitted, ['critical', 'high', 'low', 'medium', 'not_assessed']);
+
+  // A union that drops a level makes a renderer flatten it into a neighbour,
+  // and the one it would lose first is the most severe.
+  for (const name of ['SemanticDiffEntity', 'EntityChange']) {
+    const body = declarations.match(new RegExp(`export interface ${name} \\{([\\s\\S]*?)\\n\\}`));
+    assert.ok(body, `${name} must be declared in index.d.ts`);
+    const union = body[1].match(/riskLevel: ([^;]+);/);
+    assert.ok(union, `${name} must declare riskLevel`);
+    const declared = [...union[1].matchAll(/"([a-z_]+)"/g)].map((match) => match[1]).sort();
+    assert.deepEqual(
+      declared,
+      emitted,
+      `${name}.riskLevel must carry every level the daemon emits`
+    );
+  }
+
+  // A hosted list row carries no assessed risk and no computed count, so the
+  // queue item's risk can say not_assessed and its count can be null.
+  const reviewRisk = declarations.match(/export type ReviewRisk = ([^;]+);/);
+  assert.ok(reviewRisk, 'ReviewRisk must be declared in index.d.ts');
+  assert.ok(
+    [...reviewRisk[1].matchAll(/"([a-z_]+)"/g)].map((match) => match[1]).includes(notAssessed[1]),
+    `ReviewRisk must carry ${notAssessed[1]}`
+  );
+  const queueItem = declarations.match(/export interface ReviewQueueItem \{([\s\S]*?)\n\}/);
+  assert.ok(queueItem, 'ReviewQueueItem must be declared in index.d.ts');
+  assert.match(
+    queueItem[1],
+    /\n {2}changedEntities: number \| null;/,
+    'a list row that computed no count must be able to say so'
+  );
+});
+
 test('the pass boundary says what the whole reconcile did', async () => {
   // A renderer lays out on this frame, not on each of the 26 entity events one
   // appended function produces, so it has to say how much to apply.

--- a/packages/boundary-contracts/test/contracts.test.js
+++ b/packages/boundary-contracts/test/contracts.test.js
@@ -1055,12 +1055,15 @@ test('a semantic diff risk level is one the daemon emits, critical and not_asses
   }
 
   // A hosted list row carries no assessed risk and no computed count, so the
-  // queue item's risk can say not_assessed and its count can be null.
+  // queue item's risk can say not_assessed and its count can be null. A client
+  // takes an assessed review's risk from the semantic diff, whose overall_risk
+  // can be critical, so the queue item carries every level the daemon emits.
   const reviewRisk = declarations.match(/export type ReviewRisk = ([^;]+);/);
   assert.ok(reviewRisk, 'ReviewRisk must be declared in index.d.ts');
-  assert.ok(
-    [...reviewRisk[1].matchAll(/"([a-z_]+)"/g)].map((match) => match[1]).includes(notAssessed[1]),
-    `ReviewRisk must carry ${notAssessed[1]}`
+  assert.deepEqual(
+    [...reviewRisk[1].matchAll(/"([a-z_]+)"/g)].map((match) => match[1]).sort(),
+    emitted,
+    'ReviewRisk must carry every level the daemon emits, critical and not_assessed included'
   );
   const queueItem = declarations.match(/export interface ReviewQueueItem \{([\s\S]*?)\n\}/);
   assert.ok(queueItem, 'ReviewQueueItem must be declared in index.d.ts');


### PR DESCRIPTION
kin-daemon now answers the three reads kinlab's cloud gateway needs to show a review of a hosted
repository, from the same graph authority `GET /repos/{repo_id}/entities` reads. On a scratch store of
kin itself the semantic diff of a branch now answers in 230 ms where the first cut of these
routes took over 100 s, because risk is assessed only when a caller asks for it.

- `GET /repos/{repo_id}/reviews` lists every stored review, newest first. Each row is
  `kin_review_list`'s row plus completion, scopes, timestamps and a change summary. The summary
  resolves the review's stored refs and computes nothing from them: `state: not_computed` names the
  semantic diff as the read that computes the range, and `state: unresolved` names the refusal a ref
  met. Its `risk` is `not_assessed` and its count is null, never zero.
- `GET /repos/{repo_id}/reviews/{review_id}` answers the stored record exactly as `kin_review_get`
  prints it, plus the same change summary.
- `GET /repos/{repo_id}/semantic-diff?base=&head=[&risk=assess]` answers what the head changes,
  entity by entity: id, name, kind, change type, field changes, signatures and location, reviewed
  from the merge base, with the evidence behind an empty answer. Without `risk=assess`,
  `overall_risk`, every entity's `risk_level` and `evidence.risk` say `not_assessed` and
  `risk_findings` is null. With it, the review engine ranks the range and each entity on its own
  findings. Any other `risk` value is a 400.
- `GET /repos/{repo_id}/health` on a hosted daemon advertises `repo_reviews_v1` and
  `repo_semantic_diff_v1` beside the three repo-scoped capabilities already there. The list is
  built only when the daemon has a storage backend, so a local daemon still answers an empty one.
- `POST /review` with `op: show` for an id the store holds no review under answers 404, not 500.

A ref or review id that does not resolve answers non-2xx, names it, and carries
`x-kin-review-refusal`. Nothing on these paths reads a file. Creating or deciding a review in cloud
mode is untouched.

## Why risk is opt-in

Risk needs impact read at the head's own graph state, and the engine gets that by replaying the
whole history, twice when anything was removed. On the scratch store that took 63 to 113 s per read,
past both kinlab's 12 s default daemon request timeout and its 30 s review tool timeout, while the
diff itself took milliseconds. So the diff is the
default. The rule that keeps the fast answer honest: a risk that was not assessed says
`not_assessed` wherever a level would otherwise show, never blank and never a default level, and
`risk=assess` is the only way to a level. Making risk itself fast is a separate change.

## Measurement

Measured on a scratch clone of kin (main at 47aa5172 and a second ref pr-1616 at 48b03771, 3,014
changes, a 9.4 GiB store), initialised with this branch's own release bytes, one local daemon at a
time, stopped by its pid. The first cut is this branch before the fast default, three tries per read.
This PR is one request per read on the same store.

| Read | First cut, 3 tries | This PR, 1 request | Bytes, first cut / this PR | This PR's answer |
|---|---|---|---|---|
| `GET /repos/{id}/reviews`, first read after the review create | not separated | 43.8 s, 200 | 733 / 918 | summary_states ['not_computed'] |
| `GET /repos/{id}/reviews` | 83.4, 78.1, 63.3 s | 0.99 ms, 200 | 733 / 918 | summary_states ['not_computed'] |
| `GET /repos/{id}/reviews/{review_id}` | 85.2, 90.9, 112.8 s | 0.79 ms, 200 | 874 / 1,057 | summary_state not_computed |
| semantic-diff `base=main&head=pr-1616` | 107.0, 103.8, 107.7 s, risk always assessed | 0.230 s, 200 | 30,369 / 26,033 | entities 67; overall_risk not_assessed; merge_base_path closed_walks |
| semantic-diff `base=pr-1616&head=main` | 100.8, 95.2, 73.7 s, risk always assessed | 0.504 s, 200 | 590,406 / 526,330 | entities 718; overall_risk not_assessed; merge_base_path closed_walks |
| the branch range with `risk=assess` | the same read as above | 53.0 s, 200 | 30,369 / 30,420 | entities 67; overall_risk high; merge_base_path closed_walks |
| the main range with `risk=assess` | the same read as above | 53.9 s, 200 | 590,406 / 590,457 | entities 718; overall_risk high; merge_base_path closed_walks |
| semantic-diff, unknown base ref | 0.001 s, 404 | 0.004 s, 404 | n/a / 162 |  |
| semantic-diff, `risk=maybe` | no such parameter | 0.72 ms, 400 | n/a / 110 |  |
| `POST /review` show, absent review id | answered 500 | 0.72 ms, 404 | n/a / n/a |  |

The surfaces the routes replace or sit beside, measured on the first cut's store (3 tries, unchanged by this PR):

| Read | Time | Bytes |
|---|---|---|
| MCP `semantic_diff` from the merge base to pr-1616 | 0.009, 0.006, 0.026 s | 33,756 |
| MCP `semantic_diff` from the merge base to main | 0.271, 0.276, 0.277 s | 832,887 |
| `POST /review` shadow, merge base to pr-1616 | 64.4, 63.6, 63.9 s | 249,831 |
| `POST /review` shadow, merge base to main | 65.2, 73.8, 67.2 s | 74,674,437 |

Merge base path: `closed_walks` on 4 of 4 range reads, `full_walk` (the fallback) on 0. Peak daemon footprint across this PR's run: 16,384 MB; swap alarms: 0.

The first repo-scoped read after a publication on a local daemon pays one full open of the persisted
repository authority, which re-verifies every persisted body, plus a clone of its envelope. Here that
took 43.8 s, right after the fixture review was created, while the daemon's own persistence flush for
that same create ran beside it. Every local `/repos` read shares that cost (it is
`local_repository_ref_metadata` missing its cache after the publication moved), so it has its own row
rather than being charged to a route. A hosted daemon reads the graph and the refs from its cached
generation instead. Swap stayed flat at 8,052 MB throughout, and the daemon's footprint peaked at
16,384 MB during that cold read and flush. Language servers started on every daemon in both runs
even with `KIN_DAEMON_DISABLE_LSP=1` set, so both columns share that condition.

## How

- One read of stored reviews, `kin_review::records`, now serves `kin review list`, `kin review show`,
  the `kin_review_list` and `kin_review_get` MCP tools, and these routes. The MCP tools print the
  same JSON as before, and a test pins both the text and the key order.
- `assess_risk`'s per-change rules run once and tag each finding with its entity.
  `entity_risk_levels` ranks each entity through the same precedence. The diff-wide terms, total
  blast radius and work items, stay in the overall level, so no entity outranks its review.
- The merge base comes from kin-db's parents-only `find_merge_bases`, and it is trusted only when the
  walks from both tips close on it and share no change. That proves it is the one best common
  ancestor, and the walks are then exactly the two sides of the range, so the cost follows the range
  rather than the history. Anything else, a merge that reaches past the base or several candidates,
  takes `/compare`'s exact full-ancestry walk. `evidence.merge_base_path` says which answered:
  `closed_walks` or `full_walk`. A unit test builds a history where kin-db's nearest-by-depth
  candidate is an older ancestor and proves the disjointness check refuses it.
- The diff is `compute_diff_scoped` over the head's side of the range. Under `risk=assess` it is
  `SemanticReview::create_range_review`, the range shadow review already evaluates, with a removed
  entity's consumers read at base. The MCP `semantic_diff` tool's `compute_diff` walk crosses merges
  into the base's own history, so these routes don't use it.
- Refs resolve through the blob route's own rule (`resolve_read_point_in`, which
  `resolve_read_point` now delegates to). A hosted daemon takes the graph and the refs from one
  cached generation. A local daemon reads its live graph and ref envelope without the whole-snapshot
  clone the local read view makes; one local `/compare` call on this store grew its daemon past
  19 GB.
- `@kin/boundary-contracts`: both `riskLevel` unions carry `critical` and `not_assessed`,
  `ReviewRisk` gains `critical` and `not_assessed` so it carries the same five values (a client
  takes a review's risk from the semantic diff, whose `overall_risk` can be `critical`), and
  `ReviewQueueItem.changedEntities` becomes `number | null`.
  A test binds the unions to the daemon's `risk_label` and `RISK_NOT_ASSESSED`, so a hosted page can
  neither flatten a critical change to high nor show a level nobody assessed.

Sequencing: kinlab's gateway as merged answers 502 on a `risk_level` it does not know, so the kinlab
change that maps `not_assessed` lands before any hosted daemon running this code is promoted.

## A review made on a local daemon does not survive a restart

Found while measuring. A review created through `POST /review` on a local daemon was gone after a
same-bytes restart: the new detail route answered 404, the list was empty, `POST /review show`
answered 500 (404 after this PR) and the MCP tool said not found. Review records travel into graph
authority only inside a `CollaborationDelta`. At 47aa5172, all 29 transaction sites in
`crates/kin-daemon/src` set `collaboration_delta: None` and none sets `Some`, so the record lived in
the live graph alone. The commit, merge and state paths are `repository_commit.rs` lines 428, 1160,
2107 and 3754, `repository_merge.rs` lines 749, 1010, 1435 and 2862, and `state.rs` lines 11533,
12589 and 19902.
These routes read what graph authority holds, which is what a hosted repository carries. Making a
local review durable is a separate change.

## Ticket

For the captain to file in Linear project "Kin":

"kin-daemon: serve repo-scoped review reads and semantic diff on the hosted multi-repo surface.
kinlab's cloud gateway cannot show a review because the hosted daemon has no repo-scoped review or
entity-diff read. Add, under the same graph authority `GET /repos/{repo_id}/entities` reads,
`GET /repos/{repo_id}/reviews`, `GET /repos/{repo_id}/reviews/{review_id}` and
`GET /repos/{repo_id}/semantic-diff?base=&head=`. A ref that does not resolve answers non-2xx and
names the ref; nothing falls back to file search. Done when kinlab's cloud gateway renders one real
review for firelock-ai/kin."

## Local verification

None of this is checked by hosted CI before merge, so here is each command and its output tail.

Crate tests on the first commit's tree, through the fleet's heavy-slot wrapper, and the contracts test:

```text
$ cargo test --locked -p kin-review --lib
kin-review rc=0 passed=268
$ cargo test --locked -p kin-mcp --lib review
kin-mcp-review rc=0 passed=7
$ cargo test --locked -p kin-cli --lib review
kin-cli-review rc=0 passed=8
$ cargo test --locked -p kin-daemon --lib -- repo_review compare_route blob_route
test result: ok. 21 passed; 0 failed; 0 ignored; 0 measured; 1650 filtered out
$ node --test packages/boundary-contracts/test/contracts.test.js
# tests 20
# pass 20
# fail 0
```

Falsification on the first commit's tree, one mutation per behaviour, each applied as a literal substitution
(refused if the file did not change), the file restored from a copy and touched after each arm, and
`git diff` hashed before and after the run:

```text
START 11:06:15Z diff=da39a3ee5e6b
closed-walk-always-closed  rc=101  a_merge_that_reaches_past_the_base_takes_the_exact_walk FAILED (15 passed; 1 failed)
disjointness-dropped       rc=101  a_nearer_but_older_candidate_is_refused_by_the_change_both_walks_share FAILED (15 passed; 1 failed)
assess-ignored             rc=101  the_semantic_diff_answers_the_range_and_assesses_risk_only_when_asked FAILED (15 passed; 1 failed)
default-entity-level-low   rc=101  risk_is_not_assessed_unless_asked_and_a_level_only_when_asked FAILED (13 passed; 3 failed)
default-overall-low        rc=101  risk_is_not_assessed_unless_asked_and_a_level_only_when_asked FAILED (14 passed; 2 failed)
summary-claims-computed    rc=101  the_review_listing_serves_the_stored_record_with_its_refs_resolved FAILED (14 passed; 2 failed)
missing-review-500         rc=101  post_review_show_of_a_missing_review_answers_404 FAILED (15 passed; 1 failed)
RESTORED rc=0 diff=da39a3ee5e6b test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 1642 filtered out; finished in 2.97s
END 11:10:00Z
contracts review-risk-narrowed               rc=1  not ok 17, error: 'ReviewRisk must carry not_assessed'
contracts changed-entities-not-nullable      rc=1  not ok 17, error: 'a list row that computed no count must be able to say so'
contracts entity-risk-without-not-assessed   rc=1  not ok 17, SemanticDiffEntity.riskLevel must carry every level the daemon emits
contracts RESTORED rc=0 # pass 20 # fail 0
START 11:36:14Z diff=da39a3ee5e6b
unknown-ref-takes-default  rc=101  the_semantic_diff_answers_the_range_and_assesses_risk_only_when_asked FAILED (13 passed; 3 failed)
absent-review-misnamed     rc=101  the_review_detail_serves_the_record_and_refuses_what_names_no_review FAILED (15 passed; 1 failed)
listing-drops-rows         rc=101  the_review_listing_serves_the_stored_record_with_its_refs_resolved FAILED (14 passed; 2 failed)
RESTORED rc=0 diff=da39a3ee5e6b test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 1642 filtered out; finished in 2.39s
END 11:37:20Z
```

`da39a3ee5e6b` is the hash of an empty diff: the run started and ended on the committed tree.

Falsification of the shared review read and per-entity risk, run on the first cut of this branch.
kin-review has not changed since, so these still stand; the route tests the B arms broke were
rewritten for the fast default and are covered by the arms above.

```text
A1 attribute every finding to one entity        rc=101  both per-entity risk tests FAILED
A2 give each entity the diff-wide blast radius  rc=101  diff_wide_terms_raise_the_overall_level_without_raising_an_entity FAILED
A3 drop the base ancestry from the range        rc=101  a_range_review_covers_the_head_side_only_and_ranks_each_entity FAILED
A4 list oldest first                            rc=101  a_listing_is_newest_first_whatever_order_the_store_holds FAILED
B1 listing drops rows, detail reads a fresh id,
   health drops repo_reviews_v1                 rc=101  listing, detail, health and local route tests FAILED
B2 resolve both sides to the default ref        rc=101  the semantic diff route test FAILED
B3 answer a one-change range as empty           rc=101  the semantic diff route test FAILED
B4 local listing reads a fresh empty graph      rc=101  a_local_listing_reads_what_post_review_wrote_and_names_an_unresolved_ref FAILED
```

A5 (swap two fields of the MCP row view) first survived: the text comparison goes through a
`serde_json::Value`, whose key order follows serde_json's `preserve_order` feature, and that feature
is off in the `-p kin-review` test build. The test now also asserts the declaration order directly,
and the MCP handlers print through a `Value` as the `json!` rows they replaced did. Re-run on the
strengthened test:

```text
ARM A5-rerun rc=101
test records::tests::the_record_view_prints_exactly_what_kin_review_get_printed ... FAILED
keys out of order, expected ["review_id", "title", "state", "base_ref", "head_ref"] in {"review_id":"02c746cb-...","state":"needswork","title":"record",...}
```

Gates on the tree rebased onto current main, each cargo command through the fleet's heavy-slot wrapper:

```text
REBASE 91fb68a0d1c32d2446ae7683c25ad83597a19972 onto origin/main 691ab34664eb9b1a97ec8c51ac6589ff5f90217a at 11:37:44Z
REBASED head=c377aef38aafcf402557a2ce9de3fe45870c1900 parent=691ab34664eb9b1a97ec8c51ac6589ff5f90217a (want 691ab34664eb9b1a97ec8c51ac6589ff5f90217a)
patch-id before=a575df06395f34d2be73076e12ddbeb78ea91fed after=a575df06395f34d2be73076e12ddbeb78ea91fed SAME
TESTS rc=0
kin-review rc=0 passed=268 failed_lines=0
kin-mcp-review rc=0 passed=7 failed_lines=0
kin-cli-review rc=0 passed=8 failed_lines=0
kin-daemon-routes rc=0 passed=21 failed_lines=0
ALL_DONE failed=0
PRECHECK rc=0
kin-precheck: repo=kin tree=/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/hostedreview-kin sha=c377aef38aafcf402557a2ce9de3fe45870c1900 branch=chore/lane-hostedreview-kin
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin c377aef38aafcf402557a2ce9de3fe45870c1900
VERIFY_DONE failed=0 head=c377aef38aafcf402557a2ce9de3fe45870c1900
REBASE_VERIFY_EXIT=0
$ node --test packages/boundary-contracts/test/contracts.test.js
# tests 20
# pass 20
# fail 0
```

## Fix round after the first CI run

The first run of this PR failed `Fast gate test shard (2)` on
`api::tests::repo_scoped_hosted_auth_rejects_missing_and_wrong_tokens`, which pins the hosted
health's `semantic_capabilities` to an exact list. The local runs had filtered on this change's own
tests and precheck does not run the full suite, so nothing ran that test before the push. The second
commit names all five capabilities in that pin, in the order the health builder emits them.

The same commit gives `ReviewRisk` `critical`, so it carries the same five values as the two
`riskLevel` unions: kinlab's typecheck of the change that consumes these routes failed only on that,
because a client takes an assessed review's risk from the semantic diff, whose `overall_risk` can be
`critical`. The contracts test binds `ReviewRisk` to the daemon's spellings. Dropping `critical`
again turned it red (`not ok 17 ... ReviewRisk must carry every level the daemon emits, critical and
not_assessed included`), and the restored file ran 20 of 20.

Before that commit was pushed, the test that failed and the whole lib suites of the two crates this
change touches most ran on its tree, through the fleet's heavy-slot wrapper:

```text
$ cargo test --locked -p kin-daemon --lib -- repo_scoped_hosted_auth_rejects_missing_and_wrong_tokens
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1670 filtered out; finished in 0.85s
$ cargo test --locked -p kin-daemon --lib
test result: ok. 1667 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 296.56s
$ cargo test --locked -p kin-mcp --lib
test result: ok. 1006 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 23.37s
$ node --test packages/boundary-contracts/test/contracts.test.js
# tests 20
# pass 20
# fail 0
```
