### PR TITLE
Say why an entity has no history in blame and history (FIR-3547)

### DIFF
--- a/crates/kin-cli/src/commands/blame.rs
+++ b/crates/kin-cli/src/commands/blame.rs
@@ -123,7 +123,13 @@ pub fn execute_blame_request_with(
     lines.push(String::new());
 
     if revisions.is_empty() {
-        lines.push("  No history recorded for this entity.".to_string());
+        lines.extend(ref_lookup::empty_history_lines(
+            graph,
+            &target,
+            &pointer,
+            &head.change_id,
+            request.reference.as_deref(),
+        )?);
         let closing = ref_lookup::closing_notes(&lines, head.authority_open);
         lines.extend(closing);
         return Ok(BlameResponse { lines });

--- a/crates/kin-cli/src/commands/history.rs
+++ b/crates/kin-cli/src/commands/history.rs
@@ -177,7 +177,13 @@ pub fn execute_history_request_with(
     lines.extend(choice);
 
     if revisions.is_empty() {
-        lines.push("  No history recorded".to_string());
+        lines.extend(ref_lookup::empty_history_lines(
+            graph,
+            &target,
+            &pointer,
+            &head.change_id,
+            request.reference.as_deref(),
+        )?);
     } else {
         // Same rule as blame, from the same function, so the two surfaces cannot
         // disagree about which revisions are this entity's own.

--- a/crates/kin-cli/src/commands/ref_lookup.rs
+++ b/crates/kin-cli/src/commands/ref_lookup.rs
@@ -487,6 +487,121 @@ where
         .map_err(|error| projection_error(reference, head, error))
 }
 
+/// What an answer says when the entity it resolved has no revision on the line
+/// of history it read.
+///
+/// Never a bare "No history recorded". The answer names the entity it looked
+/// at, the ref, and which empty case this is, because each has a different next
+/// step. A function with sixteen callers answered "No history recorded for this
+/// entity." and nothing else, which reads like code that was never committed.
+pub(crate) fn empty_history_lines(
+    graph: &kin_db::InMemoryGraph,
+    target: &Entity,
+    pointer: &EntityPointer,
+    head: &SemanticChangeId,
+    reference: Option<&str>,
+) -> Result<Vec<String>> {
+    let kind = kin_review::StableEntityIdentity::from_entity(target).kind;
+    let line = reference.unwrap_or("HEAD");
+    let mut lines = vec![format!(
+        "  No history recorded for {kind} '{}'{} (entity {}) on the line of history reaching \
+         {line}.",
+        target.name,
+        pointer_suffix(pointer),
+        target.id
+    )];
+    if reference.is_some() {
+        // A `--ref` entity comes from the state replayed at that ref, and the
+        // replay mints a revision for every entity it adds, so an empty list
+        // there is a gap in that replay rather than one of the cases below.
+        lines.push(
+            "  The state replayed at that ref holds this entity without the revision that added \
+             it."
+            .to_string(),
+        );
+        return Ok(lines);
+    }
+    let case = if graph.latest_revision_id_for(&target.id).is_some() {
+        "  Changes in this store record this entity, but none is on the first-parent line \
+         reaching HEAD, so its history is on another line of history, such as a branch or the \
+         side of a merge."
+            .to_string()
+    } else if let Some(recorded) = committed_twin_on_line(graph, target, head)? {
+        format!(
+            "  Committed history on that line records {kind} '{}' in {} under entity {recorded}, \
+             a different id from the one the live graph holds, so the two share no history. This \
+             is a graph gap. `kin history {recorded} --ref HEAD` reads the committed one.",
+            target.name,
+            target
+                .file_origin
+                .as_ref()
+                .map(|file| file.0.as_str())
+                .unwrap_or("its file"),
+        )
+    } else {
+        "  No change in this store records this entity id. That is how an entity admitted from \
+         the working tree since the last commit looks, and `kin commit` records it."
+            .to_string()
+    };
+    lines.push(case);
+    Ok(lines)
+}
+
+/// The newest entity id that committed history on `head`'s first-parent line
+/// records under `target`'s file, kind and name, other than `target`'s own.
+///
+/// Walked newest first, so the answer is the version that line holds at
+/// `head`, and an id the walk has already seen removed is never reported as
+/// held. Only an answer that is already empty pays for the walk.
+fn committed_twin_on_line<G>(
+    graph: &G,
+    target: &Entity,
+    head: &SemanticChangeId,
+) -> Result<Option<EntityId>>
+where
+    G: GraphStore,
+    <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
+{
+    let Some(file) = target.file_origin.as_ref() else {
+        return Ok(None);
+    };
+    let mut removed = HashSet::new();
+    let mut walked = HashSet::new();
+    let mut current = Some(*head);
+    while let Some(change_id) = current {
+        if !walked.insert(change_id) {
+            break;
+        }
+        let Some(change) = graph
+            .get_change(&change_id)
+            .map_err(|error| anyhow!(error.to_string()))?
+        else {
+            break;
+        };
+        for delta in change.entity_deltas.iter().rev() {
+            let (entity, gone) = match delta {
+                kin_model::EntityDelta::Added { new }
+                | kin_model::EntityDelta::Modified { new, .. } => (new, false),
+                kin_model::EntityDelta::Removed { old } => (old, true),
+            };
+            if entity.id == target.id
+                || entity.name != target.name
+                || entity.kind != target.kind
+                || entity.file_origin.as_ref() != Some(file)
+            {
+                continue;
+            }
+            if gone {
+                removed.insert(entity.id);
+            } else if !removed.contains(&entity.id) {
+                return Ok(Some(entity.id));
+            }
+        }
+        current = change.parents.first().copied();
+    }
+    Ok(None)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -851,5 +966,72 @@ mod tests {
             alone.contains("58.2 s") && alone.contains("for this answer alone"),
             "{alone}"
         );
+    }
+
+    /// An empty history says which empty case it is. An entity recorded only
+    /// off HEAD's first-parent line, one committed history holds under another
+    /// id, and one no change records at all each get their own answer, and none
+    /// of them is the bare line.
+    #[test]
+    fn an_empty_history_says_which_empty_case_it_is() {
+        use kin_model::EntityStore;
+        let graph = kin_db::InMemoryGraph::new();
+        let side = named_entity("side_helper");
+        let fresh = named_entity("fresh_helper");
+        let committed = named_entity("gapped");
+        let mut regapped = committed.clone();
+        regapped.id = EntityId::new();
+
+        let root = change_with_deltas(Vec::new(), Vec::new());
+        let on_side = change_with_deltas(
+            vec![root.id],
+            vec![kin_model::EntityDelta::Added { new: side.clone() }],
+        );
+        let head = change_with_deltas(
+            vec![root.id],
+            vec![kin_model::EntityDelta::Added {
+                new: committed.clone(),
+            }],
+        );
+        for entry in [&root, &on_side, &head] {
+            graph.create_change(entry).unwrap();
+        }
+        for entity in [&side, &fresh, &regapped] {
+            graph.upsert_entity(entity).unwrap();
+        }
+        let answer = |entity: &Entity| {
+            let pointer = crate::entity_identity::entity_pointer(&graph, entity);
+            empty_history_lines(&graph, entity, &pointer, &head.id, None)
+                .unwrap()
+                .join("\n")
+        };
+
+        let elsewhere = answer(&side);
+        assert!(
+            elsewhere.contains(&side.id.to_string()) && elsewhere.contains("reaching HEAD"),
+            "the answer names the entity and the ref it read: {elsewhere}"
+        );
+        assert!(
+            elsewhere.contains("none is on the first-parent line"),
+            "an entity recorded only off HEAD's line must say so: {elsewhere}"
+        );
+
+        let gap = answer(&regapped);
+        assert!(
+            gap.contains(&format!("kin history {} --ref HEAD", committed.id)),
+            "a graph gap names the id committed history holds: {gap}"
+        );
+
+        let unrecorded = answer(&fresh);
+        assert!(
+            unrecorded.contains("No change in this store records this entity id"),
+            "an entity no change records must say so: {unrecorded}"
+        );
+        for text in [&elsewhere, &gap, &unrecorded] {
+            assert!(
+                !text.contains("No history recorded for this entity."),
+                "never the bare line: {text}"
+            );
+        }
     }
 }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -49138,12 +49138,26 @@ mod tests {
     /// status and the body, which carries the rendered lines on success and the
     /// refusal otherwise.
     async fn entity_read(app: &axum::Router, endpoint: &str, entity: &str) -> (StatusCode, String) {
+        entity_read_at(app, endpoint, entity, None).await
+    }
+
+    /// [`entity_read`] with an explicit ref.
+    async fn entity_read_at(
+        app: &axum::Router,
+        endpoint: &str,
+        entity: &str,
+        reference: Option<&str>,
+    ) -> (StatusCode, String) {
+        let request = match reference {
+            Some(reference) => json!({ "entity": entity, "reference": reference }),
+            None => json!({ "entity": entity }),
+        };
         let response = app
             .clone()
             .oneshot(
                 Request::post(endpoint)
                     .header("content-type", "application/json")
-                    .body(Body::from(json!({ "entity": entity }).to_string()))
+                    .body(Body::from(request.to_string()))
                     .unwrap(),
             )
             .await
@@ -49290,6 +49304,90 @@ mod tests {
             body.contains("src/a.py") && body.contains("src/b.py"),
             "a pin that excludes both twins names both: {body}"
         );
+    }
+
+    /// An entity no change records answers with what it is, at which ref and
+    /// why it has no history, never with the bare line.
+    #[tokio::test]
+    async fn blame_names_an_entity_no_commit_records_and_says_why() {
+        let state =
+            test_state_with_committed_sources(&[("src/lib.py", "def retained():\n    return 1\n")]);
+        let fresh = test_entity("fresh_helper", "src/new.py");
+        state.graph.upsert_entity(&fresh).unwrap();
+        let app = router(Arc::clone(&state));
+
+        let (status, body) = entity_read(&app, "/blame", "fresh_helper").await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        let lines = answer_lines(&body);
+        let answer = lines.join("\n");
+        assert!(
+            answer.contains(&fresh.id.to_string()) && answer.contains("reaching HEAD"),
+            "the answer names the entity and the ref it read: {answer}"
+        );
+        assert!(
+            answer.contains("No change in this store records this entity id"),
+            "{answer}"
+        );
+        assert!(
+            !lines
+                .iter()
+                .any(|line| line.trim() == "No history recorded for this entity."),
+            "never the bare line: {answer}"
+        );
+    }
+
+    /// The graph gap: the live graph holds an entity under an id committed
+    /// history does not record, while that history records the same file, kind
+    /// and name under another. The answer names the committed id, and the
+    /// command it suggests reads that id's history.
+    #[tokio::test]
+    async fn history_names_the_committed_id_behind_a_graph_gap() {
+        let state =
+            test_state_with_committed_sources(&[("src/lib.py", "def retained():\n    return 1\n")]);
+        let committed = state
+            .graph
+            .query_entities(&kin_model::EntityFilter {
+                name_pattern: Some("retained".to_string()),
+                ..Default::default()
+            })
+            .unwrap()
+            .into_iter()
+            .find(|entity| entity.name == "retained")
+            .expect("the fixture commits retained");
+        let mut regapped = committed.clone();
+        regapped.id = EntityId::new();
+        state.graph.remove_entity(&committed.id).unwrap();
+        state.graph.upsert_entity(&regapped).unwrap();
+        let app = router(Arc::clone(&state));
+
+        let (status, body) = entity_read(&app, "/history", "retained").await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        let answer = answer_lines(&body).join("\n");
+        assert!(answer.contains(&regapped.id.to_string()), "{answer}");
+        let suggested = format!("kin history {} --ref HEAD", committed.id);
+        assert!(
+            answer.contains(&suggested),
+            "the answer names the committed id and how to read it: {answer}"
+        );
+
+        // The suggested command answers from the state replayed at HEAD.
+        let (status, body) =
+            entity_read_at(&app, "/history", &committed.id.to_string(), Some("HEAD")).await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        let rows = answer_lines(&body)
+            .iter()
+            .filter(|line| {
+                line.starts_with("  ")
+                    && line
+                        .chars()
+                        .skip(2)
+                        .take(12)
+                        .filter(char::is_ascii_hexdigit)
+                        .count()
+                        == 12
+            })
+            .count();
+        assert_eq!(rows, 1, "the committed id carries its one revision: {body}");
     }
 
     #[tokio::test]

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -413,10 +413,13 @@ kin history <entity> [options]
 
 | Argument | Required | Description |
 | --- | --- | --- |
-| `<entity>` | yes | Entity name or ID |
+| `<entity>` | yes | Entity name or ID. A name with twins can carry its pin: `Name@file`, `Name@file:line`, `Name#kind` |
 
 | Flag | Default | Description |
 | --- | --- | --- |
+| `--file <file>` |  | Exact repo-relative file qualifier for stable identity resolution |
+| `--kind <kind>` |  | Exact entity-kind qualifier (for example: function or method) |
+| `--all-revisions` |  | List every file-level revision, including ones that did not change this entity |
 | `--ref <ref>` |  | Resolve history against a specific ref. Accepts `HEAD`, `HEAD~N`, branch names, `branch:&lt;name&gt;`, imported Git commits as `git:&lt;sha&gt;` or bare 40-hex SHAs, and semantic changes as `kin:&lt;id&gt;`, `change:&lt;id&gt;`, or bare change IDs. |
 
 ### `kin blame`
@@ -429,10 +432,13 @@ kin blame <entity> [options]
 
 | Argument | Required | Description |
 | --- | --- | --- |
-| `<entity>` | yes | Entity name or ID |
+| `<entity>` | yes | Entity name or ID. A name with twins can carry its pin: `Name@file`, `Name@file:line`, `Name#kind` |
 
 | Flag | Default | Description |
 | --- | --- | --- |
+| `--file <file>` |  | Exact repo-relative file qualifier for stable identity resolution |
+| `--kind <kind>` |  | Exact entity-kind qualifier (for example: function or method) |
+| `--all-revisions` |  | List every file-level revision, including ones that did not change this entity |
 | `--ref <ref>` |  | Resolve blame against a specific ref. Accepts `HEAD`, `HEAD~N`, branch names, `branch:&lt;name&gt;`, imported Git commits as `git:&lt;sha&gt;` or bare 40-hex SHAs, and semantic changes as `kin:&lt;id&gt;`, `change:&lt;id&gt;`, or bare change IDs. |
 
 ### `kin overview`


### PR DESCRIPTION
`kin blame` and `kin history` no longer answer an empty history with a bare "No history recorded". The answer now names the entity it looked at and the line of history it read, and says which of three empty cases it is, because each one has a different next step. This is the second half of FIR-3547, after #1713.

## Why

`kin blame` answered "No history recorded for this entity." and nothing else for a function with sixteen callers. That reads like code that was never committed. Usually it is one of three other things, and the answer can tell them apart from the graph alone.

## What the empty answer says now

The first line names the entity by kind, `path:line` (or `(span stale)` from #1702's shared pointer) and id, plus the ref it read, in the shape `No history recorded for <kind> '<name>' @ <path>:<line> (entity <id>) on the line of history reaching HEAD.` The second line says which case it is.

- Changes in this store record the entity, but none is on the first-parent line reaching HEAD. Its history is on another line, such as a branch or the side of a merge. The live graph's own revision chain answers this, so it costs nothing extra.
- Committed history on that line records the same file, kind and name under another id. The answer calls this a graph gap and names that id with `kin history <id> --ref HEAD`, the command that reads it. Only an answer that is already empty walks the line to find it.
- No change records the id at all. The answer says that is how an entity admitted from the working tree since the last commit looks, and that `kin commit` records it.

`docs/cli-reference.md` now lists `--file`, `--kind` and `--all-revisions` for both commands, with the pin spelling on `<entity>`. It is written by hand from the clap definitions and had missed `--all-revisions` before this.

## Tests

- `ref_lookup::tests::an_empty_history_says_which_empty_case_it_is` (kin-cli) builds all three cases on one graph. One entity is recorded only by a change off HEAD's first-parent line. Another is committed under one id and held live under a second. The third is recorded by no change. Each gets its own answer, and none is the bare line.
- `api::tests::blame_names_an_entity_no_commit_records_and_says_why` (kin-daemon, a real store through `init_from_git`): an entity upserted after the commit gets the "no change records this id" answer through the route.
- `api::tests::history_names_the_committed_id_behind_a_graph_gap` (kin-daemon): the committed `retained` is removed from the live graph and re-added under a new id. The answer names the committed id, and the command it suggests is run too and answers with the one revision.

## Falsification

R5 applies three mutations to `ref_lookup.rs` in one run, and each reddens a different test first, so none masks another. In M11 the recorded-elsewhere case is never chosen. In M12 the no-change-records-this-id case prints the bare line again. In M13 the graph-gap walk never finds the committed id. The run went red at the assertion each one targets, where `api.rs:49327` is the assertion that the answer says "No change in this store records this entity id":

```text
commands::ref_lookup::tests::an_empty_history_says_which_empty_case_it_is panicked at crates/kin-cli/src/commands/ref_lookup.rs:1014:9:
an entity recorded only off HEAD's line must say so:   No history recorded for function 'side_helper' @ src/lib.rs (entity 34e045c2-c999-4106-bd79-5956603d909f) on the line of history reaching HEAD.
api::tests::blame_names_an_entity_no_commit_records_and_says_why panicked at crates/kin-daemon/src/api.rs:49327:9:
Blame for 'fresh_helper' (Function, python) @ src/new.py:2 at 4bb0c4c27259200c8471216facaa8c1ea3435748a748608b30055a8c38957476:
api::tests::history_names_the_committed_id_behind_a_graph_gap panicked at crates/kin-daemon/src/api.rs:49368:9:
the answer names the committed id and how to read it: History for 'retained' (Function, python) @ src/lib.py:1 at 4bb0c4c27259:
targeted lib rc=101 integration rc=0 daemon rc=101
restored; porcelain now: []
```

## Local gates

`KIN_EMBED_BACKEND=cpu .kin-coord/bin/heavy-slot.sh clireadb kin -- bin/kin-precheck kin --repo-dir kin=<lane worktree>` (absolute paths in the run):

```text
kin-precheck: repo=kin tree=/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/clireadb-kin sha=8b78bac66183e6c4fc1cd9d3308102f6df721ca4 branch=chore/lane-clireadb-kin
kin-precheck: behind origin/main 1 commit(s); the gate list below is the one on THIS tree, not the one on main
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin 8b78bac66183e6c4fc1cd9d3308102f6df721ca4
```

Targeted tests on the same tree, through the same heavy slot: kin-cli lib slice 49 passed, `blame_projection_gap` 4, `declaration_resolution_e2e` 12, `entity_resolution_across_commands` 6, `entity_revision_history` 3, and the kin-daemon slice 8, which holds both new daemon tests and writepath's two attribution tests.

Refs FIR-3547.
