### PR TITLE
Commit review state to repository authority so reviews survive a restart

### DIFF
--- a/crates/kin-cli/src/commands/review.rs
+++ b/crates/kin-cli/src/commands/review.rs
@@ -4,6 +4,7 @@
 use anyhow::{Context, Result};
 use kin_model::provenance::ApprovalDecision;
 use kin_model::{ChangeStore, ProvenanceStore, ReviewStore};
+use kin_review::write::{PlannedReviewEvent, ReviewGroup, ReviewTargetMissing, ReviewWrite};
 use serde::{Deserialize, Serialize};
 use std::fmt::Write as _;
 
@@ -32,32 +33,50 @@ pub enum ReviewRequest {
         base: String,
         head: String,
         description: Option<String>,
+        /// The actor label the caller acts as. The CLI sends its own, so the
+        /// daemon records who asked rather than who started the daemon; a
+        /// caller that sends none is recorded under the daemon's label. The
+        /// same field on every mutation below means the same thing.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        actor: Option<String>,
     },
     Decide {
         review_id: String,
         state: String,
         comment: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        actor: Option<String>,
     },
     Note {
         review_id: String,
         body: String,
         scope: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        actor: Option<String>,
     },
     Discuss {
         review_id: String,
         body: String,
         scope: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        actor: Option<String>,
     },
     Reply {
         discussion_id: String,
         body: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        actor: Option<String>,
     },
     Resolve {
         discussion_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        actor: Option<String>,
     },
     Assign {
         review_id: String,
         reviewer: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        actor: Option<String>,
     },
     List {
         state: Option<String>,
@@ -81,6 +100,23 @@ impl std::fmt::Display for ReviewNotFound {
 }
 
 impl std::error::Error for ReviewNotFound {}
+
+impl ReviewRequest {
+    /// Whether this request writes review state, which only the daemon's
+    /// review writer may do.
+    pub fn is_mutation(&self) -> bool {
+        matches!(
+            self,
+            Self::Create { .. }
+                | Self::Decide { .. }
+                | Self::Note { .. }
+                | Self::Discuss { .. }
+                | Self::Reply { .. }
+                | Self::Resolve { .. }
+                | Self::Assign { .. }
+        )
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReviewResponse {
@@ -206,38 +242,16 @@ pub async fn execute_review_request(
             )?,
             mutated: false,
         }),
-        ReviewRequest::Create {
-            title,
-            base,
-            head,
-            description,
-        } => create_review_with_graph(graph, title, base, head, description),
-        ReviewRequest::Decide {
-            review_id,
-            state,
-            comment,
-        } => decide_review_with_graph(graph, review_id, state, comment),
-        ReviewRequest::Note {
-            review_id,
-            body,
-            scope,
-        } => add_note_with_graph(graph, review_id, body, scope),
-        ReviewRequest::Discuss {
-            review_id,
-            body,
-            scope,
-        } => start_discussion_with_graph(graph, review_id, body, scope),
-        ReviewRequest::Reply {
-            discussion_id,
-            body,
-        } => reply_discussion_with_graph(graph, discussion_id, body),
-        ReviewRequest::Resolve { discussion_id } => {
-            resolve_discussion_with_graph(graph, discussion_id)
-        }
-        ReviewRequest::Assign {
-            review_id,
-            reviewer,
-        } => assign_reviewer_with_graph(graph, review_id, reviewer),
+        ReviewRequest::Create { .. }
+        | ReviewRequest::Decide { .. }
+        | ReviewRequest::Note { .. }
+        | ReviewRequest::Discuss { .. }
+        | ReviewRequest::Reply { .. }
+        | ReviewRequest::Resolve { .. }
+        | ReviewRequest::Assign { .. } => anyhow::bail!(
+            "review mutations are repository writes: plan them with plan_review_mutation and \
+             commit them through the daemon's review writer"
+        ),
         ReviewRequest::List { state } => list_reviews_with_graph(graph, state),
         ReviewRequest::Show { review_id } => show_review_with_graph(graph, review_id),
     }
@@ -593,9 +607,9 @@ fn parse_change_ids(change_csv: &str) -> Result<Vec<kin_model::SemanticChangeId>
         .collect()
 }
 
-// ── Review mutation subcommands (Phase 11) ──
-// These depend on kin_model::review types being added by a teammate.
-// Structurally complete; will compile once kin-model review types land.
+// ── Review mutation subcommands ──
+// Each asks the daemon, which plans the event against its live graph, commits
+// the records to repository authority, and only then answers.
 
 pub async fn shadow_report(
     base: String,
@@ -631,68 +645,70 @@ pub async fn create_review(
             base,
             head,
             description,
+            actor: Some(crate::provenance::current_actor_label()),
         })
         .await?,
     );
     Ok(())
 }
 
-fn create_review_with_graph(
-    graph: &kin_db::InMemoryGraph,
+fn plan_create(
     title: String,
     base: String,
     head: String,
     description: Option<String>,
-) -> Result<ReviewExecution> {
+    actor: Option<String>,
+) -> Result<PlannedReviewEvent<ReviewResponse>> {
     use kin_model::review::{
         Review, ReviewCompletionState, ReviewDecisionState, ReviewId, ReviewNote, ReviewNoteId,
     };
     use kin_model::timestamp::Timestamp;
 
+    let (actor_label, identity) = acting_as(actor);
     let now = Timestamp::now();
+    let review_id = ReviewId::new();
+    let notes = description
+        .filter(|body| !body.trim().is_empty())
+        .map(|body| ReviewNote {
+            note_id: ReviewNoteId::new(),
+            review_id,
+            body,
+            scope: None,
+            authored_by: identity.clone(),
+            created_at: now.clone(),
+        })
+        .into_iter()
+        .collect();
     let review = Review {
-        review_id: ReviewId::new(),
+        review_id,
         title: title.clone(),
         base_ref: base.clone(),
         head_ref: head.clone(),
         state: ReviewDecisionState::Pending,
         completion: ReviewCompletionState::InReview,
         scopes: vec![],
-        created_by: kin_model::IdentityRef::human("cli-user"),
+        created_by: identity,
         created_at: now.clone(),
-        updated_at: now.clone(),
+        updated_at: now,
     };
-
-    graph.create_review(&review)?;
-    if let Some(body) = description.filter(|body| !body.trim().is_empty()) {
-        let note = ReviewNote {
-            note_id: ReviewNoteId::new(),
-            review_id: review.review_id,
-            body,
-            scope: None,
-            authored_by: kin_model::IdentityRef::human("cli-user"),
-            created_at: now,
-        };
-        graph.add_review_note(&note)?;
-    }
-    crate::provenance::record_cli_audit_event(
-        graph,
-        "review.create",
-        None,
-        Some(format!(
-            "review_id={}; title={}; base={}; head={}",
-            review.review_id, title, base, head
-        )),
-    )?;
-    Ok(ReviewExecution {
-        response: ReviewResponse {
+    Ok(PlannedReviewEvent {
+        action: "review.create",
+        review_id,
+        details: format!("review_id={review_id}; title={title}; base={base}; head={head}"),
+        actor_label,
+        answer: ReviewResponse {
             text: format!(
                 "Created review {}\n  Title: {}\n  Base: {} -> Head: {}\n",
-                review.review_id, title, base, head
+                review_id, title, base, head
             ),
             json: None,
         },
-        mutated: true,
+        refs: Some((base, head)),
+        write: ReviewWrite {
+            review: Some(review),
+            notes,
+            ..ReviewWrite::default()
+        },
     })
 }
 
@@ -706,22 +722,24 @@ pub async fn decide_review(
             review_id,
             state,
             comment,
+            actor: Some(crate::provenance::current_actor_label()),
         })
         .await?,
     );
     Ok(())
 }
 
-fn decide_review_with_graph(
+fn plan_decide(
     graph: &kin_db::InMemoryGraph,
     review_id: String,
     state: String,
     comment: Option<String>,
-) -> Result<ReviewExecution> {
-    use kin_model::review::{ReviewDecision, ReviewDecisionState, ReviewId};
+    actor: Option<String>,
+) -> Result<PlannedReviewEvent<ReviewResponse>> {
+    use kin_model::review::{ReviewDecision, ReviewDecisionState};
     use kin_model::timestamp::Timestamp;
 
-    let rid = ReviewId(uuid::Uuid::parse_str(&review_id)?);
+    let rid = parse_review_id(&review_id)?;
     let decision_state = match state.to_lowercase().as_str() {
         "approved" | "approve" => ReviewDecisionState::Approved,
         "needs_work" | "needs-work" => ReviewDecisionState::NeedsWork,
@@ -731,27 +749,40 @@ fn decide_review_with_graph(
             state
         ),
     };
+    let mut review = existing_review(graph, rid)?;
+    let (actor_label, identity) = acting_as(actor);
 
     let decision = ReviewDecision {
         state: decision_state,
         comment: comment.filter(|value| !value.trim().is_empty()),
-        reviewer: kin_model::IdentityRef::human("cli-user"),
+        reviewer: identity,
         decided_at: Timestamp::now(),
     };
-
-    graph.add_review_decision(&rid, &decision)?;
-    crate::provenance::record_cli_audit_event(
-        graph,
-        "review.decide",
-        None,
-        Some(format!("review_id={}; decision={}", review_id, state)),
-    )?;
-    Ok(ReviewExecution {
-        response: ReviewResponse {
+    // The decision is history and the review's state is where it stands now, so
+    // one event moves both. Without this an approved review reads pending on
+    // every surface that prints its state.
+    review.state = decision_state;
+    review.updated_at = decision.decided_at.clone();
+    let mut history = graph.get_review_decisions(&rid)?;
+    history.push(decision);
+    Ok(PlannedReviewEvent {
+        action: "review.decide",
+        review_id: rid,
+        details: format!("review_id={review_id}; decision={state}"),
+        actor_label,
+        refs: None,
+        answer: ReviewResponse {
             text: format!("Recorded decision '{}' on review {}\n", state, review_id),
             json: None,
         },
-        mutated: true,
+        write: ReviewWrite {
+            review: Some(review),
+            decisions: Some(ReviewGroup {
+                review_id: rid,
+                entries: history,
+            }),
+            ..ReviewWrite::default()
+        },
     })
 }
 
@@ -761,43 +792,54 @@ pub async fn add_note(review_id: String, body: String, scope: Option<String>) ->
             review_id,
             body,
             scope,
+            actor: Some(crate::provenance::current_actor_label()),
         })
         .await?,
     );
     Ok(())
 }
 
-fn add_note_with_graph(
+fn plan_note(
     graph: &kin_db::InMemoryGraph,
     review_id: String,
     body: String,
     scope: Option<String>,
-) -> Result<ReviewExecution> {
-    use kin_model::review::{ReviewId, ReviewNote, ReviewNoteId};
+    actor: Option<String>,
+) -> Result<PlannedReviewEvent<ReviewResponse>> {
+    use kin_model::review::{ReviewNote, ReviewNoteId};
     use kin_model::timestamp::Timestamp;
 
     let scope = scope
         .as_deref()
         .map(crate::commands::work::parse_work_scope)
         .transpose()?;
-    let rid = ReviewId(uuid::Uuid::parse_str(&review_id)?);
+    let rid = parse_review_id(&review_id)?;
+    existing_review(graph, rid)?;
+    let (actor_label, identity) = acting_as(actor);
     let note = ReviewNote {
         note_id: ReviewNoteId::new(),
         review_id: rid,
-        body: body.clone(),
+        body,
         scope: scope.clone(),
-        authored_by: kin_model::IdentityRef::human("cli-user"),
+        authored_by: identity,
         created_at: Timestamp::now(),
     };
 
-    graph.add_review_note(&note)?;
     let mut text = format!("Added note {} to review {}\n", note.note_id, review_id);
     if let Some(s) = scope {
         writeln!(text, "  Scope: {}", s)?;
     }
-    Ok(ReviewExecution {
-        response: ReviewResponse { text, json: None },
-        mutated: true,
+    Ok(PlannedReviewEvent {
+        action: "review.note",
+        review_id: rid,
+        details: format!("review_id={review_id}; note_id={}", note.note_id),
+        actor_label,
+        refs: None,
+        answer: ReviewResponse { text, json: None },
+        write: ReviewWrite {
+            notes: vec![note],
+            ..ReviewWrite::default()
+        },
     })
 }
 
@@ -811,20 +853,22 @@ pub async fn start_discussion(
             review_id,
             body,
             scope,
+            actor: Some(crate::provenance::current_actor_label()),
         })
         .await?,
     );
     Ok(())
 }
 
-fn start_discussion_with_graph(
+fn plan_discuss(
     graph: &kin_db::InMemoryGraph,
     review_id: String,
     body: String,
     scope: Option<String>,
-) -> Result<ReviewExecution> {
+    actor: Option<String>,
+) -> Result<PlannedReviewEvent<ReviewResponse>> {
     use kin_model::review::{
-        ReviewComment, ReviewDiscussion, ReviewDiscussionId, ReviewDiscussionState, ReviewId,
+        ReviewComment, ReviewDiscussion, ReviewDiscussionId, ReviewDiscussionState,
     };
     use kin_model::timestamp::Timestamp;
 
@@ -832,21 +876,23 @@ fn start_discussion_with_graph(
         .as_deref()
         .map(crate::commands::work::parse_work_scope)
         .transpose()?;
-    let rid = ReviewId(uuid::Uuid::parse_str(&review_id)?);
+    let rid = parse_review_id(&review_id)?;
+    existing_review(graph, rid)?;
+    let (actor_label, identity) = acting_as(actor);
+    let now = Timestamp::now();
     let discussion = ReviewDiscussion {
         discussion_id: ReviewDiscussionId::new(),
         review_id: rid,
         scope: scope.clone(),
         state: ReviewDiscussionState::Open,
         comments: vec![ReviewComment {
-            body: body.clone(),
-            authored_by: kin_model::IdentityRef::human("cli-user"),
-            created_at: Timestamp::now(),
+            body,
+            authored_by: identity,
+            created_at: now.clone(),
         }],
-        created_at: Timestamp::now(),
+        created_at: now,
     };
 
-    graph.create_review_discussion(&discussion)?;
     let mut text = format!(
         "Started discussion {} on review {}",
         discussion.discussion_id, review_id
@@ -855,9 +901,20 @@ fn start_discussion_with_graph(
     if let Some(s) = scope {
         writeln!(text, "  Scope: {}", s)?;
     }
-    Ok(ReviewExecution {
-        response: ReviewResponse { text, json: None },
-        mutated: true,
+    Ok(PlannedReviewEvent {
+        action: "review.discuss",
+        review_id: rid,
+        details: format!(
+            "review_id={review_id}; discussion_id={}",
+            discussion.discussion_id
+        ),
+        actor_label,
+        refs: None,
+        answer: ReviewResponse { text, json: None },
+        write: ReviewWrite {
+            discussions: vec![discussion],
+            ..ReviewWrite::default()
+        },
     })
 }
 
@@ -866,56 +923,91 @@ pub async fn reply_discussion(discussion_id: String, body: String) -> Result<()>
         run_daemon_review(&ReviewRequest::Reply {
             discussion_id,
             body,
+            actor: Some(crate::provenance::current_actor_label()),
         })
         .await?,
     );
     Ok(())
 }
 
-fn reply_discussion_with_graph(
+fn plan_reply(
     graph: &kin_db::InMemoryGraph,
     discussion_id: String,
     body: String,
-) -> Result<ReviewExecution> {
+    actor: Option<String>,
+) -> Result<PlannedReviewEvent<ReviewResponse>> {
     use kin_model::review::{ReviewComment, ReviewDiscussionId};
     use kin_model::timestamp::Timestamp;
 
     let did = ReviewDiscussionId(uuid::Uuid::parse_str(&discussion_id)?);
-    let comment = ReviewComment {
-        body: body.clone(),
-        authored_by: kin_model::IdentityRef::human("cli-user"),
+    let mut discussion = existing_discussion(graph, did)?;
+    let (actor_label, identity) = acting_as(actor);
+    discussion.comments.push(ReviewComment {
+        body,
+        authored_by: identity,
         created_at: Timestamp::now(),
-    };
-
-    graph.add_discussion_comment(&did, &comment)?;
-    Ok(ReviewExecution {
-        response: ReviewResponse {
+    });
+    Ok(PlannedReviewEvent {
+        action: "review.reply",
+        review_id: discussion.review_id,
+        details: format!("discussion_id={discussion_id}"),
+        actor_label,
+        refs: None,
+        answer: ReviewResponse {
             text: format!("Replied to discussion {}\n", discussion_id),
             json: None,
         },
-        mutated: true,
+        write: ReviewWrite {
+            discussions: vec![discussion],
+            ..ReviewWrite::default()
+        },
     })
 }
 
 pub async fn resolve_discussion(discussion_id: String) -> Result<()> {
-    print_review_response(run_daemon_review(&ReviewRequest::Resolve { discussion_id }).await?);
+    print_review_response(
+        run_daemon_review(&ReviewRequest::Resolve {
+            discussion_id,
+            actor: Some(crate::provenance::current_actor_label()),
+        })
+        .await?,
+    );
     Ok(())
 }
 
-fn resolve_discussion_with_graph(
+fn plan_resolve(
     graph: &kin_db::InMemoryGraph,
     discussion_id: String,
-) -> Result<ReviewExecution> {
+    actor: Option<String>,
+) -> Result<PlannedReviewEvent<ReviewResponse>> {
     use kin_model::review::{ReviewDiscussionId, ReviewDiscussionState};
 
     let did = ReviewDiscussionId(uuid::Uuid::parse_str(&discussion_id)?);
-    graph.set_discussion_state(&did, ReviewDiscussionState::Resolved)?;
-    Ok(ReviewExecution {
-        response: ReviewResponse {
+    let mut discussion = existing_discussion(graph, did)?;
+    let (actor_label, _identity) = acting_as(actor);
+    let review_id = discussion.review_id;
+    // A thread that is already resolved changes nothing, so nothing is written
+    // and no transaction is spent on it.
+    let write = if discussion.state == ReviewDiscussionState::Resolved {
+        ReviewWrite::default()
+    } else {
+        discussion.state = ReviewDiscussionState::Resolved;
+        ReviewWrite {
+            discussions: vec![discussion],
+            ..ReviewWrite::default()
+        }
+    };
+    Ok(PlannedReviewEvent {
+        action: "review.resolve",
+        review_id,
+        details: format!("discussion_id={discussion_id}"),
+        actor_label,
+        refs: None,
+        answer: ReviewResponse {
             text: format!("Resolved discussion {}\n", discussion_id),
             json: None,
         },
-        mutated: true,
+        write,
     })
 }
 
@@ -924,36 +1016,187 @@ pub async fn assign_reviewer(review_id: String, reviewer: String) -> Result<()> 
         run_daemon_review(&ReviewRequest::Assign {
             review_id,
             reviewer,
+            actor: Some(crate::provenance::current_actor_label()),
         })
         .await?,
     );
     Ok(())
 }
 
-fn assign_reviewer_with_graph(
+fn plan_assign(
     graph: &kin_db::InMemoryGraph,
     review_id: String,
     reviewer: String,
-) -> Result<ReviewExecution> {
-    use kin_model::review::{ReviewAssignment, ReviewId};
+    actor: Option<String>,
+) -> Result<PlannedReviewEvent<ReviewResponse>> {
+    use kin_model::review::ReviewAssignment;
     use kin_model::timestamp::Timestamp;
 
-    let rid = ReviewId(uuid::Uuid::parse_str(&review_id)?);
-    let assignment = ReviewAssignment {
+    let rid = parse_review_id(&review_id)?;
+    existing_review(graph, rid)?;
+    let (actor_label, identity) = acting_as(actor);
+    let mut entries = graph.get_review_assignments(&rid)?;
+    entries.push(ReviewAssignment {
         review_id: rid,
         reviewer: kin_model::IdentityRef::human(&reviewer),
         assigned_at: Timestamp::now(),
-        assigned_by: kin_model::IdentityRef::human("cli-user"),
-    };
-
-    graph.assign_reviewer(&assignment)?;
-    Ok(ReviewExecution {
-        response: ReviewResponse {
+        assigned_by: identity,
+    });
+    Ok(PlannedReviewEvent {
+        action: "review.assign",
+        review_id: rid,
+        details: format!("review_id={review_id}; reviewer={reviewer}"),
+        actor_label,
+        refs: None,
+        answer: ReviewResponse {
             text: format!("Assigned {} to review {}\n", reviewer, review_id),
             json: None,
         },
-        mutated: true,
+        write: ReviewWrite {
+            assignments: Some(ReviewGroup {
+                review_id: rid,
+                entries,
+            }),
+            ..ReviewWrite::default()
+        },
     })
+}
+
+/// Plan one review mutation against `graph` without writing anything.
+///
+/// Review state is repository authority. The daemon's review writer commits the
+/// planned records as one collaboration-only transaction and only then applies
+/// them to its live graph, so a review answers after a restart exactly as it
+/// did before one. This is the half that needs only the request and the graph.
+pub fn plan_review_mutation(
+    graph: &kin_db::InMemoryGraph,
+    request: ReviewRequest,
+) -> Result<PlannedReviewEvent<ReviewResponse>> {
+    match request {
+        ReviewRequest::Create {
+            title,
+            base,
+            head,
+            description,
+            actor,
+        } => plan_create(title, base, head, description, actor),
+        ReviewRequest::Decide {
+            review_id,
+            state,
+            comment,
+            actor,
+        } => plan_decide(graph, review_id, state, comment, actor),
+        ReviewRequest::Note {
+            review_id,
+            body,
+            scope,
+            actor,
+        } => plan_note(graph, review_id, body, scope, actor),
+        ReviewRequest::Discuss {
+            review_id,
+            body,
+            scope,
+            actor,
+        } => plan_discuss(graph, review_id, body, scope, actor),
+        ReviewRequest::Reply {
+            discussion_id,
+            body,
+            actor,
+        } => plan_reply(graph, discussion_id, body, actor),
+        ReviewRequest::Resolve {
+            discussion_id,
+            actor,
+        } => plan_resolve(graph, discussion_id, actor),
+        ReviewRequest::Assign {
+            review_id,
+            reviewer,
+            actor,
+        } => plan_assign(graph, review_id, reviewer, actor),
+        ReviewRequest::Run { .. }
+        | ReviewRequest::Shadow { .. }
+        | ReviewRequest::List { .. }
+        | ReviewRequest::Show { .. } => {
+            anyhow::bail!("this review request reads review state and writes nothing")
+        }
+    }
+}
+
+/// The changes a review's base and head refs resolve to under `lease`, as audit
+/// detail.
+///
+/// Recorded when a review is created, so its provenance still names the exact
+/// changes it was opened against after either ref moves. A ref that resolves to
+/// nothing, such as the `working-tree` an MCP caller may name, is recorded as
+/// unresolved rather than failing the write. Read from the lease the writer
+/// already holds, so it costs no second authority open.
+pub fn review_ref_provenance(
+    lease: &kin_db::AuthorityReadLease<kin_db::RepositoryAuthorityState>,
+    workspace_id: &kin_model::WorkspaceId,
+    graph: &kin_db::InMemoryGraph,
+    base: &str,
+    head: &str,
+) -> String {
+    let authority = crate::commands::ref_grammar::Authority::held(lease, workspace_id);
+    let resolve = |reference: &str| {
+        crate::commands::ref_grammar::resolve(&authority, graph, reference)
+            .map(|resolved| resolved.change_id.to_string())
+            .unwrap_or_else(|_| "unresolved".to_string())
+    };
+    format!(
+        "base_change={}; head_change={}",
+        resolve(base),
+        resolve(head)
+    )
+}
+
+/// The label and identity a review event acts as: the caller's own when it sent
+/// one, this process's otherwise.
+fn acting_as(actor: Option<String>) -> (String, kin_model::IdentityRef) {
+    let label = actor
+        .map(|label| label.trim().to_string())
+        .filter(|label| !label.is_empty())
+        .unwrap_or_else(crate::provenance::current_actor_label);
+    let identity = crate::provenance::identity_for_label(&label);
+    (label, identity)
+}
+
+fn parse_review_id(review_id: &str) -> Result<kin_model::review::ReviewId> {
+    Ok(kin_model::review::ReviewId(uuid::Uuid::parse_str(
+        review_id,
+    )?))
+}
+
+fn existing_review(
+    graph: &kin_db::InMemoryGraph,
+    review_id: kin_model::review::ReviewId,
+) -> Result<kin_model::review::Review> {
+    graph
+        .get_review(&review_id)?
+        .ok_or_else(|| anyhow::Error::new(ReviewNotFound(review_id.to_string())))
+}
+
+/// The discussion with `discussion_id`, found through the reviews that hold
+/// discussions, since the store answers discussions by review.
+fn existing_discussion(
+    graph: &kin_db::InMemoryGraph,
+    discussion_id: kin_model::review::ReviewDiscussionId,
+) -> Result<kin_model::review::ReviewDiscussion> {
+    let every_review = kin_model::review::ReviewFilter {
+        states: None,
+        reviewer: None,
+    };
+    for review in graph.list_reviews(&every_review)? {
+        let found = graph
+            .get_review_discussions(&review.review_id)?
+            .into_iter()
+            .find(|discussion| discussion.discussion_id == discussion_id);
+        if let Some(discussion) = found {
+            return Ok(discussion);
+        }
+    }
+    Err(anyhow::Error::new(ReviewTargetMissing(format!(
+        "review discussion not found: {discussion_id}"
+    ))))
 }
 
 pub async fn list_reviews(state: Option<String>) -> Result<()> {
@@ -1130,7 +1373,6 @@ fn inline_comment_severity(kind: kin_review::InlineCommentKind) -> &'static str 
 mod tests {
     use super::*;
     use kin_db::LocalFileBackend;
-    use kin_model::ProvenanceStore;
     use kin_model::{RepositoryId, WorkspaceId};
     use std::sync::Arc;
 
@@ -1150,61 +1392,178 @@ mod tests {
         );
     }
 
-    #[test]
-    fn create_review_records_audit_event() {
-        let graph = kin_db::InMemoryGraph::new();
+    fn create_request(actor: &str) -> ReviewRequest {
+        ReviewRequest::Create {
+            title: "Fix login".into(),
+            base: "main".into(),
+            head: "feature/login".into(),
+            description: Some("body edit".into()),
+            actor: Some(actor.into()),
+        }
+    }
 
-        create_review_with_graph(
+    /// Planning a review writes nothing and states everything the writer needs:
+    /// the records, the audit action and its details, the refs to resolve, and
+    /// who is acting.
+    #[test]
+    fn planning_a_review_writes_nothing_and_names_its_refs() {
+        let graph = kin_db::InMemoryGraph::new();
+        let planned = plan_review_mutation(&graph, create_request("troy")).unwrap();
+
+        assert_eq!(planned.action, "review.create");
+        assert!(planned.records_audit_event());
+        assert!(
+            planned.details.contains("base=main") && planned.details.contains("head=feature/login"),
+            "audit details should carry review refs: {}",
+            planned.details
+        );
+        assert_eq!(
+            planned.refs,
+            Some(("main".to_string(), "feature/login".to_string()))
+        );
+        assert_eq!(planned.actor_label, "troy");
+        let review = planned
+            .write
+            .review
+            .as_ref()
+            .expect("a create writes the review");
+        assert_eq!(review.created_by, kin_model::IdentityRef::human("troy"));
+        assert_eq!(
+            planned.write.notes.len(),
+            1,
+            "the description is the review's first note"
+        );
+        planned
+            .write
+            .to_delta()
+            .expect("a planned create is a valid collaboration delta");
+        assert!(
+            graph
+                .list_reviews(&kin_model::review::ReviewFilter::default())
+                .unwrap()
+                .is_empty(),
+            "planning must not write"
+        );
+        assert!(planned
+            .answer
+            .text
+            .starts_with(&format!("Created review {}", planned.review_id)));
+    }
+
+    /// A decision moves the review's state and carries the whole history.
+    ///
+    /// Falsify by dropping the state assignment in `plan_decide`: the review then
+    /// reads pending after an approval, which is what every read printed before.
+    #[test]
+    fn a_planned_decision_moves_the_review_and_carries_its_history() {
+        use kin_model::review::ReviewDecisionState;
+
+        let graph = kin_db::InMemoryGraph::new();
+        let created = plan_review_mutation(&graph, create_request("troy")).unwrap();
+        created.write.apply_to(&graph).unwrap();
+        let review_id = created.review_id.to_string();
+
+        let first = plan_review_mutation(
             &graph,
-            "Fix login".into(),
-            "main".into(),
-            "feature/login".into(),
-            Some("body edit".into()),
+            ReviewRequest::Decide {
+                review_id: review_id.clone(),
+                state: "needs_work".into(),
+                comment: None,
+                actor: Some("alice".into()),
+            },
+        )
+        .unwrap();
+        first.write.apply_to(&graph).unwrap();
+        let second = plan_review_mutation(
+            &graph,
+            ReviewRequest::Decide {
+                review_id,
+                state: "approved".into(),
+                comment: Some("ship it".into()),
+                actor: Some("bob".into()),
+            },
         )
         .unwrap();
 
-        let events = graph.query_audit_events(None, 10).unwrap();
-        assert_eq!(events.len(), 1, "review create must record one audit event");
-        assert_eq!(events[0].action, "review.create");
-        let details = events[0].details.as_deref().unwrap_or_default();
-        assert!(
-            details.contains("base=main") && details.contains("head=feature/login"),
-            "audit details should carry review refs: {details}"
+        assert_eq!(second.action, "review.decide");
+        assert_eq!(
+            second.write.review.as_ref().unwrap().state,
+            ReviewDecisionState::Approved
+        );
+        let history = &second.write.decisions.as_ref().unwrap().entries;
+        assert_eq!(
+            history
+                .iter()
+                .map(|decision| decision.state)
+                .collect::<Vec<_>>(),
+            vec![
+                ReviewDecisionState::NeedsWork,
+                ReviewDecisionState::Approved
+            ]
+        );
+        second.write.apply_to(&graph).unwrap();
+        assert_eq!(
+            graph.get_review(&created.review_id).unwrap().unwrap().state,
+            ReviewDecisionState::Approved
         );
     }
 
+    /// Resolving a resolved thread plans an empty write, so the writer spends no
+    /// transaction on it.
     #[test]
-    fn decide_review_records_audit_event() {
+    fn resolving_a_resolved_discussion_writes_nothing() {
         let graph = kin_db::InMemoryGraph::new();
-
-        let execution = create_review_with_graph(
+        let created = plan_review_mutation(&graph, create_request("troy")).unwrap();
+        created.write.apply_to(&graph).unwrap();
+        let discuss = plan_review_mutation(
             &graph,
-            "Fix login".into(),
-            "main".into(),
-            "feature/login".into(),
-            None,
+            ReviewRequest::Discuss {
+                review_id: created.review_id.to_string(),
+                body: "why this shape?".into(),
+                scope: None,
+                actor: None,
+            },
         )
         .unwrap();
-        // Recover the review id from the create response text.
-        let review_id = execution
-            .response
-            .text
-            .lines()
-            .find_map(|line| line.strip_prefix("Created review "))
-            .map(|s| s.trim().to_string())
-            .expect("review id in create response");
+        discuss.write.apply_to(&graph).unwrap();
+        let discussion_id = discuss.write.discussions[0].discussion_id.to_string();
 
-        decide_review_with_graph(&graph, review_id, "approved".into(), None).unwrap();
-
-        let events = graph.query_audit_events(None, 10).unwrap();
-        assert_eq!(
-            events.len(),
-            2,
-            "create + decide must each record an audit event"
+        let resolve = || {
+            plan_review_mutation(
+                &graph,
+                ReviewRequest::Resolve {
+                    discussion_id: discussion_id.clone(),
+                    actor: None,
+                },
+            )
+            .unwrap()
+        };
+        let first = resolve();
+        assert!(!first.write.is_empty());
+        first.write.apply_to(&graph).unwrap();
+        assert!(
+            resolve().write.is_empty(),
+            "a resolved thread has nothing left to resolve"
         );
-        // query_audit_events returns most-recent first.
-        assert_eq!(events[0].action, "review.decide");
-        assert_eq!(events[1].action, "review.create");
+    }
+
+    /// A mutation never runs through the read executor, which has no repository
+    /// authority to commit it to.
+    #[tokio::test]
+    async fn the_read_executor_refuses_a_mutation() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+        let graph = kin_db::InMemoryGraph::new();
+
+        let error =
+            execute_review_request(&absent_binding(&layout), &graph, create_request("troy"))
+                .await
+                .expect_err("a mutation must not execute without the review writer");
+        assert!(error.to_string().contains("review writer"), "{error}");
+        assert!(graph
+            .list_reviews(&kin_model::review::ReviewFilter::default())
+            .unwrap()
+            .is_empty());
     }
 
     /// A query for raw Git commits that were never imported must fail from

--- a/crates/kin-cli/src/provenance.rs
+++ b/crates/kin-cli/src/provenance.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Result;
 use kin_model::provenance::{Actor, ActorId, ActorKind, AuditEvent, AuditEventId};
-use kin_model::{ExternalRef, GraphStore, Hash256, Timestamp, WorkScope};
+use kin_model::{ExternalRef, GraphStore, Hash256, IdentityRef, Timestamp, WorkScope};
 use sha2::{Digest, Sha256};
 
 pub fn ensure_cli_actor<G>(graph: &G) -> Result<ActorId>
@@ -45,7 +45,55 @@ where
     G: GraphStore,
     <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
 {
-    let actor_id = ensure_cli_actor(graph)?;
+    let (actor, event) =
+        plan_audit_event(graph, &current_actor_label(), action, target_scope, details)?;
+    if let Some(actor) = actor {
+        graph
+            .create_actor(&actor)
+            .map_err(|err| anyhow::anyhow!(err.to_string()))?;
+    }
+    graph
+        .record_audit_event(&event)
+        .map_err(|err| anyhow::anyhow!(err.to_string()))?;
+    Ok(event.event_id)
+}
+
+/// The actor and audit event [`record_cli_audit_event`] writes, for `label`,
+/// without writing either.
+///
+/// A durable write commits these records to repository authority before any
+/// graph sees them, so it needs the records rather than the side effect. The
+/// actor is `Some` only when `graph` does not hold it yet.
+pub fn plan_audit_event<G>(
+    graph: &G,
+    label: &str,
+    action: &str,
+    target_scope: Option<WorkScope>,
+    details: Option<String>,
+) -> Result<(Option<Actor>, AuditEvent)>
+where
+    G: GraphStore,
+    <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
+{
+    let actor_id = actor_id_from_label(label);
+    let actor = if graph
+        .get_actor(&actor_id)
+        .map_err(|err| anyhow::anyhow!(err.to_string()))?
+        .is_none()
+    {
+        Some(Actor {
+            actor_id,
+            kind: actor_kind_from_label(label),
+            display_name: label.to_string(),
+            external_refs: vec![ExternalRef {
+                system: "local".into(),
+                identifier: label.to_string(),
+                url: None,
+            }],
+        })
+    } else {
+        None
+    };
     let event = AuditEvent {
         event_id: AuditEventId::new(),
         actor_id,
@@ -54,13 +102,19 @@ where
         timestamp: Timestamp::now(),
         details,
     };
-    graph
-        .record_audit_event(&event)
-        .map_err(|err| anyhow::anyhow!(err.to_string()))?;
-    Ok(event.event_id)
+    Ok((actor, event))
 }
 
-pub(crate) fn current_actor_label() -> String {
+/// The identity a record names for `label`: a human when the label reads as
+/// one, an assistant otherwise.
+pub fn identity_for_label(label: &str) -> IdentityRef {
+    match actor_kind_from_label(label) {
+        ActorKind::Human => IdentityRef::human(label),
+        _ => IdentityRef::assistant(label),
+    }
+}
+
+pub fn current_actor_label() -> String {
     std::env::var("KIN_ACTOR")
         .ok()
         .filter(|value| !value.trim().is_empty())

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -9441,21 +9441,21 @@ async fn review(
     }
 
     let session_id = extract_session_id_from_headers(&headers)?;
-    let mutates = matches!(
-        req,
-        kin_cli::commands::review::ReviewRequest::Create { .. }
-            | kin_cli::commands::review::ReviewRequest::Decide { .. }
-            | kin_cli::commands::review::ReviewRequest::Note { .. }
-            | kin_cli::commands::review::ReviewRequest::Discuss { .. }
-            | kin_cli::commands::review::ReviewRequest::Reply { .. }
-            | kin_cli::commands::review::ReviewRequest::Resolve { .. }
-            | kin_cli::commands::review::ReviewRequest::Assign { .. }
-    );
-    let graph = if mutates {
-        Arc::clone(&state.graph)
-    } else {
-        resolve_session_graph(&state, session_id.as_ref()).await
-    };
+    if req.is_mutation() {
+        // Review state is repository authority, so a mutation answers only once
+        // the review writer has committed it. The two gates are the pair every
+        // authority writer in this daemon holds; the writer takes the persistence
+        // lock itself.
+        let _coordination = state.coordination_gate.lock().await;
+        let _graph_mutation = state.begin_graph_authority_mutation();
+        let answer =
+            crate::review_write::commit_review_event(&state, session_id.as_ref(), |graph| {
+                kin_cli::commands::review::plan_review_mutation(graph, req)
+            })
+            .map_err(review_write_refusal)?;
+        return Ok(Json(answer));
+    }
+    let graph = resolve_session_graph(&state, session_id.as_ref()).await;
     let repository_authority = state
         .local_repository_authority_binding()
         .map_err(repository_authority_error)?;
@@ -9477,14 +9477,41 @@ async fn review(
             internal_error(error)
         }
     })?;
-    if execution.mutated {
-        state.bump_version();
-        state.emit_event(DaemonEvent::GraphRootChanged {
-            old_root_hash: None,
-            new_root_hash: "review-state".to_string(),
-        });
-    }
     Ok(Json(execution.response))
+}
+
+/// Answer a refused review write with the status its cause earns: a request that
+/// names nothing the store holds is not found, one the planner refused is a bad
+/// request, and a write authority kept moving under is a conflict.
+fn review_write_refusal(
+    refusal: crate::review_write::ReviewWriteRefusal<anyhow::Error>,
+) -> (StatusCode, String) {
+    use crate::review_write::ReviewWriteRefusal;
+    let status = match &refusal {
+        ReviewWriteRefusal::Plan(error)
+            if error.chain().any(|cause| {
+                cause
+                    .downcast_ref::<kin_cli::commands::review::ReviewNotFound>()
+                    .is_some()
+                    || cause
+                        .downcast_ref::<kin_review::write::ReviewTargetMissing>()
+                        .is_some()
+            }) =>
+        {
+            StatusCode::NOT_FOUND
+        }
+        ReviewWriteRefusal::Plan(_) => StatusCode::BAD_REQUEST,
+        ReviewWriteRefusal::Hosted => StatusCode::CONFLICT,
+        ReviewWriteRefusal::Commit { conflict: true, .. } => StatusCode::CONFLICT,
+        ReviewWriteRefusal::Authority(_)
+        | ReviewWriteRefusal::Commit { .. }
+        | ReviewWriteRefusal::Diverged { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+    };
+    let message = match &refusal {
+        ReviewWriteRefusal::Plan(error) => crate::error::cause_first(error),
+        other => other.to_string(),
+    };
+    (status, message)
 }
 
 /// POST /work — run work item reads and mutations in the repo daemon.
@@ -15628,6 +15655,18 @@ async fn mcp_tools_call_dispatch(
                 scope,
             )
             .await
+        } else if kin_mcp::handlers::review::is_review_mutation(&request.name) {
+            // Review writes are repository authority: planned against the live
+            // graph and committed by the daemon's one review writer before the
+            // tool answers, exactly as `POST /review` does. Every name here is a
+            // graph-mutating tool, so this dispatch already holds the
+            // coordination gate and a graph-authority guard.
+            crate::review_write::commit_mcp_review_tool(
+                &state,
+                session_id.as_ref(),
+                &request.name,
+                &request.arguments,
+            )
         } else if request.name == "kin_transaction_commit" {
             // Synchronous authority work on a runtime worker, exactly like the
             // CLI commit path, so it publishes the same mid-transaction proof.
@@ -48845,48 +48884,288 @@ mod tests {
     #[tokio::test]
     async fn review_endpoint_lists_live_review_state() {
         let state = test_state();
-        let repository_authority = state.local_repository_authority_binding().unwrap();
-        let execution = kin_cli::commands::review::execute_review_request(
-            &repository_authority,
-            state.graph.as_ref(),
-            kin_cli::commands::review::ReviewRequest::Create {
-                title: "Listed review".to_string(),
-                base: "main".to_string(),
-                head: "HEAD".to_string(),
-                description: None,
-            },
-        )
-        .await
-        .unwrap();
-        assert!(execution.mutated);
         state
             .is_initialized
             .store(true, std::sync::atomic::Ordering::Relaxed);
-        let app = router(state);
-        let response = app
+        review_call(
+            &state,
+            serde_json::json!({
+                "op": "create",
+                "title": "Listed review",
+                "base": "main",
+                "head": "HEAD",
+            }),
+        )
+        .await;
+
+        let result = review_call(&state, serde_json::json!({ "op": "list", "state": null })).await;
+        assert!(result.text.contains("Listed review"));
+        assert!(result.text.contains("1 review(s)"));
+    }
+
+    /// POST one review request and return the daemon's answer, asserting 200.
+    async fn review_call(
+        state: &Arc<DaemonState>,
+        request: serde_json::Value,
+    ) -> kin_cli::commands::review::ReviewResponse {
+        let response = router(Arc::clone(state))
             .oneshot(
                 Request::post("/review")
                     .header("content-type", "application/json")
-                    .body(Body::from(
-                        serde_json::json!({
-                            "op": "list",
-                            "state": null,
-                        })
-                        .to_string(),
-                    ))
+                    .body(Body::from(request.to_string()))
                     .unwrap(),
             )
             .await
             .unwrap();
-
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(response.into_body(), 16 * 1024)
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
             .await
             .unwrap();
-        let result: kin_cli::commands::review::ReviewResponse =
-            serde_json::from_slice(&body).unwrap();
-        assert!(result.text.contains("Listed review"));
-        assert!(result.text.contains("1 review(s)"));
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        serde_json::from_slice(&body).unwrap()
+    }
+
+    /// What every review surface answers about one review, in a form that does
+    /// not depend on the store's map order, which differs between processes:
+    /// the list's lines, the show text's lines, and the MCP record with its
+    /// notes and discussions ordered by id.
+    async fn review_surfaces(
+        state: &Arc<DaemonState>,
+        review_id: &str,
+    ) -> (Vec<String>, Vec<String>, serde_json::Value) {
+        fn sorted_lines(text: &str) -> Vec<String> {
+            let mut lines: Vec<String> = text.lines().map(str::to_owned).collect();
+            lines.sort();
+            lines
+        }
+        let list = review_call(state, serde_json::json!({ "op": "list", "state": null })).await;
+        let show = review_call(
+            state,
+            serde_json::json!({ "op": "show", "review_id": review_id }),
+        )
+        .await;
+        let get = mcp_call(
+            router(Arc::clone(state)),
+            "kin_review_get",
+            serde_json::json!({ "review_id": review_id }),
+        )
+        .await;
+        assert_ne!(get.is_error, Some(true), "{}", mcp_result_text(&get));
+        let mut record: serde_json::Value = serde_json::from_str(&mcp_result_text(&get)).unwrap();
+        for (collection, id) in [("notes", "note_id"), ("discussions", "discussion_id")] {
+            if let Some(entries) = record
+                .get_mut(collection)
+                .and_then(serde_json::Value::as_array_mut)
+            {
+                entries.sort_by(|left, right| left[id].as_str().cmp(&right[id].as_str()));
+            }
+        }
+        (sorted_lines(&list.text), sorted_lines(&show.text), record)
+    }
+
+    /// A review, its decision, notes, discussion, reply, resolution and
+    /// assignments answer the same on every surface after the daemon restarts on
+    /// the same store, whether they were written through `POST /review` or MCP.
+    ///
+    /// This is the measurement that found the defect, run in the crate. Before the
+    /// review writer existed, the reopened daemon answered "No reviews found." on
+    /// the list, "review not found" on show and an MCP error on get. Falsify by
+    /// skipping the commit in `review_write::commit_review_event` while keeping the
+    /// live apply: every read before the restart still passes and every read after
+    /// it fails.
+    #[tokio::test]
+    async fn review_state_survives_a_daemon_restart_on_every_surface() {
+        use std::sync::atomic::Ordering;
+
+        let initial = test_state();
+        let layout = initial.layout.clone();
+        drop(initial);
+        let state = Arc::new(DaemonState::open(layout.clone()).unwrap());
+        state.is_initialized.store(true, Ordering::Relaxed);
+        let generation_at_open = state.snapshot_generation.load(Ordering::SeqCst);
+
+        let created = review_call(
+            &state,
+            serde_json::json!({
+                "op": "create",
+                "title": "Durable review",
+                "base": "main",
+                "head": "HEAD",
+                "description": "opened before a restart",
+            }),
+        )
+        .await;
+        let review_id = created
+            .text
+            .lines()
+            .find_map(|line| line.strip_prefix("Created review "))
+            .expect("the create answer names the review")
+            .trim()
+            .to_string();
+        review_call(
+            &state,
+            serde_json::json!({
+                "op": "decide",
+                "review_id": review_id,
+                "state": "approved",
+                "comment": "ship it",
+            }),
+        )
+        .await;
+        review_call(
+            &state,
+            serde_json::json!({
+                "op": "note",
+                "review_id": review_id,
+                "body": "a standalone note",
+                "scope": null,
+            }),
+        )
+        .await;
+        let discussed = review_call(
+            &state,
+            serde_json::json!({
+                "op": "discuss",
+                "review_id": review_id,
+                "body": "why this shape?",
+                "scope": null,
+            }),
+        )
+        .await;
+        let discussion_id = discussed
+            .text
+            .split_whitespace()
+            .nth(2)
+            .expect("the discuss answer names the discussion")
+            .to_string();
+        review_call(
+            &state,
+            serde_json::json!({
+                "op": "reply",
+                "discussion_id": discussion_id,
+                "body": "one writer, one transaction",
+            }),
+        )
+        .await;
+        review_call(
+            &state,
+            serde_json::json!({ "op": "resolve", "discussion_id": discussion_id }),
+        )
+        .await;
+        review_call(
+            &state,
+            serde_json::json!({ "op": "assign", "review_id": review_id, "reviewer": "carol" }),
+        )
+        .await;
+
+        // The MCP writers go through the same writer.
+        let assigned = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_review_assign",
+            serde_json::json!({ "review_id": review_id, "reviewer": "dave" }),
+        )
+        .await;
+        assert_ne!(
+            assigned.is_error,
+            Some(true),
+            "{}",
+            mcp_result_text(&assigned)
+        );
+        let agent_review = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_review_create",
+            serde_json::json!({ "title": "Agent review", "base": "main", "head": "HEAD" }),
+        )
+        .await;
+        assert_ne!(
+            agent_review.is_error,
+            Some(true),
+            "a create naming no reviewer must succeed, as the tool's schema says: {}",
+            mcp_result_text(&agent_review)
+        );
+        let agent_review_id =
+            serde_json::from_str::<serde_json::Value>(&mcp_result_text(&agent_review)).unwrap()
+                ["review_id"]
+                .as_str()
+                .unwrap()
+                .to_string();
+
+        let before = review_surfaces(&state, &review_id).await;
+        let agent_before = review_surfaces(&state, &agent_review_id).await;
+        let generation_before_restart = state.snapshot_generation.load(Ordering::SeqCst);
+        drop(state);
+
+        let reopened = Arc::new(DaemonState::open(layout).unwrap());
+        reopened.is_initialized.store(true, Ordering::Relaxed);
+        let after = review_surfaces(&reopened, &review_id).await;
+        assert_eq!(
+            after, before,
+            "every review surface must answer the same after a restart"
+        );
+        assert_eq!(
+            review_surfaces(&reopened, &agent_review_id).await,
+            agent_before
+        );
+        // Checked after the reads, so a write that skipped authority fails on the
+        // read-back itself, which is what a person restarting the daemon sees.
+        assert_eq!(
+            generation_before_restart,
+            generation_at_open + 9,
+            "each of the nine review writes commits exactly one authority transaction"
+        );
+        assert_eq!(
+            reopened.snapshot_generation.load(Ordering::SeqCst),
+            generation_before_restart
+        );
+
+        let (list, show, record) = after;
+        let list = list.join("\n");
+        let show = show.join("\n");
+        assert!(list.contains("[approved] Durable review"), "{list}");
+        assert!(list.contains("2 review(s)"), "{list}");
+        assert!(
+            show.contains("one writer, one transaction") && show.contains("resolved"),
+            "{show}"
+        );
+        assert!(
+            show.contains("a standalone note") && show.contains("opened before a restart"),
+            "{show}"
+        );
+        assert_eq!(record["state"], "approved");
+        let reviewers: Vec<&str> = record["assignments"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|assignment| assignment["reviewer"].as_str().unwrap())
+            .collect();
+        assert_eq!(reviewers, vec!["carol", "dave"]);
+
+        // Provenance survives with the records: who acted, the changes the refs
+        // resolved to, and the authority generation the review was written at.
+        let events =
+            kin_model::ProvenanceStore::query_audit_events(reopened.graph.as_ref(), None, 20)
+                .unwrap();
+        let created_event = events
+            .iter()
+            .find(|event| {
+                event.action == "review.create"
+                    && event
+                        .details
+                        .as_deref()
+                        .is_some_and(|details| details.contains(&review_id))
+            })
+            .expect("the create's audit event survives the restart");
+        let details = created_event.details.as_deref().unwrap();
+        assert!(
+            details.contains("base_change=")
+                && details.contains("head_change=")
+                && details.contains("authority_generation="),
+            "{details}"
+        );
+        assert!(
+            events.iter().any(|event| event.action == "review.decide"),
+            "the decision's audit event survives the restart"
+        );
     }
 
     #[cfg(feature = "embeddings")]

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -153,6 +153,7 @@ mod repository_rename;
 mod repository_rollback;
 mod repository_stash;
 mod repository_tag;
+mod review_write;
 mod semantic_debt;
 pub mod session_registry;
 pub mod source_body_memo;

--- a/crates/kin-daemon/src/review_write.rs
+++ b/crates/kin-daemon/src/review_write.rs
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! The one writer for review state.
+//!
+//! Every review mutation, whether it arrives through `POST /review` or one of the
+//! MCP review tools, is planned against the live graph and committed here as one
+//! collaboration-only repository transaction before the caller is answered. Only
+//! once authority holds the records are they applied to the live graph, so the
+//! graph never shows a review authority does not hold, and a daemon that reopens
+//! the store serves exactly the reviews it answered with: the workspace graph a
+//! daemon opens carries the collaboration maps authority holds.
+//!
+//! The writer takes `persist_lock` itself. Its caller holds the coordination gate
+//! and a graph-authority mutation guard, the pair every authority writer in this
+//! daemon holds, because the MCP dispatch already takes both for each tool that
+//! mutates the graph and neither lock is reentrant.
+
+use std::collections::HashMap;
+
+use kin_model::{
+    AuthorId, CollaborationDelta, OperationId, RepositoryCommitReceipt, RepositoryTransaction,
+    SessionId, REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+};
+use kin_review::write::PlannedReviewEvent;
+
+use crate::local_repository_authority::ActiveLocalRepositoryAuthority;
+use crate::state::{DaemonEvent, DaemonState};
+
+/// Why a review write did not complete.
+#[derive(Debug)]
+pub(crate) enum ReviewWriteRefusal<E> {
+    /// The planner refused the request. Nothing was written.
+    Plan(E),
+    /// A hosted daemon's review state arrives through the transfer seam.
+    Hosted,
+    /// The daemon could not bind or open its repository authority. Nothing was
+    /// written.
+    Authority(String),
+    /// The transaction was not committed. Nothing was written. `conflict` is set
+    /// when authority kept moving under the write.
+    Commit { conflict: bool, detail: String },
+    /// The transaction committed and the live graph could not follow it.
+    Diverged { generation: u64, detail: String },
+}
+
+impl<E: std::fmt::Display> std::fmt::Display for ReviewWriteRefusal<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Plan(error) => write!(f, "{error}"),
+            Self::Hosted => f.write_str(
+                "a hosted daemon takes review state through the repository transfer seam, not \
+                 through review writes",
+            ),
+            Self::Authority(detail) => write!(f, "review state is repository authority: {detail}"),
+            Self::Commit { detail, .. } => {
+                write!(
+                    f,
+                    "review write was not committed to repository authority: {detail}"
+                )
+            }
+            Self::Diverged { generation, detail } => write!(
+                f,
+                "review write committed to repository authority at generation {generation}, but \
+                 the daemon's live graph could not follow it: {detail}; restart the daemon to \
+                 serve review state from authority again"
+            ),
+        }
+    }
+}
+
+/// Plan, commit and apply one review event, and return the planner's answer once
+/// the records are durable. An event that changes nothing commits nothing.
+///
+/// The caller holds `coordination_gate` and a graph-authority mutation guard for
+/// the whole call. `plan` runs against the live graph under those locks, so the
+/// records it reads are the ones authority holds.
+pub(crate) fn commit_review_event<A, E>(
+    state: &DaemonState,
+    session: Option<&SessionId>,
+    plan: impl FnOnce(&kin_db::InMemoryGraph) -> Result<PlannedReviewEvent<A>, E>,
+) -> Result<A, ReviewWriteRefusal<E>> {
+    if state.storage_backend.is_some() {
+        return Err(ReviewWriteRefusal::Hosted);
+    }
+    let _persistence = state
+        .persist_lock
+        .lock()
+        .map_err(|_| ReviewWriteRefusal::Authority("daemon persistence lock poisoned".into()))?;
+    let authority = ActiveLocalRepositoryAuthority::open_bound(state)
+        .map_err(|refusal| ReviewWriteRefusal::Authority(format!("{:#}", refusal.into_error())))?;
+    let mut planned = plan(state.graph.as_ref()).map_err(ReviewWriteRefusal::Plan)?;
+    if planned.write.is_empty() {
+        return Ok(planned.answer);
+    }
+
+    if planned.records_audit_event() {
+        record_provenance(state, &authority, session, &mut planned)?;
+    }
+    let delta = planned
+        .write
+        .to_delta()
+        .map_err(|error| ReviewWriteRefusal::Commit {
+            conflict: false,
+            detail: error.to_string(),
+        })?;
+    let reason = match session {
+        Some(session) => format!(
+            "{} {} (session {session})",
+            planned.action, planned.review_id
+        ),
+        None => format!("{} {}", planned.action, planned.review_id),
+    };
+    let receipt = commit_collaboration(
+        &authority,
+        delta,
+        &reason,
+        &AuthorId::new(planned.actor_label.clone()),
+    )?;
+
+    // Durable from here. The two steps below make this process agree with what
+    // authority now holds, and a failure in either is reported as exactly that.
+    state
+        .record_repository_authority_commit(receipt.generation)
+        .map_err(|error| ReviewWriteRefusal::Diverged {
+            generation: receipt.generation,
+            detail: error.to_string(),
+        })?;
+    planned
+        .write
+        .apply_to(state.graph.as_ref())
+        .map_err(|error| ReviewWriteRefusal::Diverged {
+            generation: receipt.generation,
+            detail: error.to_string(),
+        })?;
+
+    state.bump_version();
+    state.mark_dirty();
+    state.emit_event(DaemonEvent::GraphRootChanged {
+        old_root_hash: None,
+        new_root_hash: "review-state".to_string(),
+    });
+    state.emit_event(DaemonEvent::RepositoryAuthorityChanged {
+        repository_id: receipt.repository_id.to_string(),
+        operation_id: receipt.operation_id,
+        previous_generation: receipt.roots_before.generation,
+        new_generation: receipt.generation,
+    });
+    Ok(planned.answer)
+}
+
+/// Commit one MCP review write tool through [`commit_review_event`].
+///
+/// The dispatch that calls this already holds the coordination gate and a
+/// graph-authority mutation guard, as it does for every tool that mutates the
+/// graph.
+pub(crate) fn commit_mcp_review_tool(
+    state: &DaemonState,
+    session: Option<&SessionId>,
+    tool: &str,
+    arguments: &HashMap<String, serde_json::Value>,
+) -> Result<kin_mcp::ToolCallResult, kin_mcp::McpError> {
+    let outcome = commit_review_event(state, session, |graph| {
+        kin_mcp::handlers::review::plan_review_mutation(tool, arguments, graph)
+            .unwrap_or_else(|| Err(kin_mcp::McpError::ToolNotFound(tool.to_string())))
+    });
+    match outcome {
+        Ok(answer) => Ok(answer),
+        Err(ReviewWriteRefusal::Plan(error)) => Err(error),
+        Err(refusal) => Err(kin_mcp::McpError::Other(refusal.to_string())),
+    }
+}
+
+/// Add the audit event for a create or a decision, carrying what only the
+/// writer knows: the changes the review's refs resolve to under the lease it
+/// commits against, the session that asked, and the authority generation.
+fn record_provenance<A, E>(
+    state: &DaemonState,
+    authority: &ActiveLocalRepositoryAuthority,
+    session: Option<&SessionId>,
+    planned: &mut PlannedReviewEvent<A>,
+) -> Result<(), ReviewWriteRefusal<E>> {
+    let mut details = planned.details.clone();
+    {
+        let lease = authority.manager.read_authority();
+        if let Some((base, head)) = &planned.refs {
+            details.push_str("; ");
+            details.push_str(&kin_cli::commands::review::review_ref_provenance(
+                &lease,
+                &authority.workspace_id,
+                state.graph.as_ref(),
+                base,
+                head,
+            ));
+        }
+        details.push_str(&format!(
+            "; authority_generation={}",
+            lease.roots().generation
+        ));
+    }
+    if let Some(session) = session {
+        details.push_str(&format!("; session={session}"));
+    }
+    let (actor, event) = kin_cli::provenance::plan_audit_event(
+        state.graph.as_ref(),
+        &planned.actor_label,
+        planned.action,
+        None,
+        Some(details),
+    )
+    .map_err(|error| ReviewWriteRefusal::Commit {
+        conflict: false,
+        detail: format!("{error:#}"),
+    })?;
+    planned.write.actors.extend(actor);
+    planned.write.audit_events.push(event);
+    Ok(())
+}
+
+/// Commit `delta` as a transaction whose only mutation it is.
+///
+/// A roots conflict means another process moved authority between the read and
+/// the compare-and-swap. The records do not depend on the roots they commit
+/// against, so one fresh attempt is safe; a second conflict is reported.
+fn commit_collaboration<E>(
+    authority: &ActiveLocalRepositoryAuthority,
+    delta: CollaborationDelta,
+    reason: &str,
+    actor: &AuthorId,
+) -> Result<RepositoryCommitReceipt, ReviewWriteRefusal<E>> {
+    let mut attempts = 0;
+    loop {
+        attempts += 1;
+        let roots = authority.manager.read_authority().roots().clone();
+        let transaction = RepositoryTransaction {
+            schema_version: REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+            operation_id: OperationId::new(),
+            repository_id: authority.repository_id.clone(),
+            expected_generation: roots.generation,
+            expected_roots: roots,
+            actor: actor.clone(),
+            reason: reason.to_string(),
+            external_objects: Vec::new(),
+            git_authority_delta: None,
+            changes: Vec::new(),
+            aliases: Vec::new(),
+            ref_mutations: Vec::new(),
+            default_ref_mutation: None,
+            workspace_mutation: None,
+            local_overlay_delta: None,
+            merge_transaction_delta: None,
+            sealed_observation: None,
+            collaboration_delta: Some(delta.clone()),
+        };
+        match authority.manager.commit_repository_transaction(transaction) {
+            Ok(receipt) => return Ok(receipt),
+            Err(kin_db::KinDbError::Model(kin_model::ModelError::Conflict(_))) if attempts == 1 => {
+                continue
+            }
+            Err(error) => {
+                let conflict = matches!(
+                    error,
+                    kin_db::KinDbError::Model(kin_model::ModelError::Conflict(_))
+                );
+                return Err(ReviewWriteRefusal::Commit {
+                    conflict,
+                    detail: error.to_string(),
+                });
+            }
+        }
+    }
+}

--- a/crates/kin-mcp/src/handlers/review.rs
+++ b/crates/kin-mcp/src/handlers/review.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use super::repository_authority::RequestRepositoryAuthority;
 use kin_model::graph::GraphStore;
 use kin_model::ids::SemanticChangeId;
+use kin_review::write::{PlannedReviewEvent, ReviewGroup, ReviewWrite};
 use kin_review::{format_review, SemanticReview};
 
 use crate::error::{McpError, Result};
@@ -524,6 +525,13 @@ pub fn handle_review_create<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
 ) -> Result<ToolCallResult> {
+    apply_planned(plan_review_create(args, store)?, store)
+}
+
+fn plan_review_create<G: GraphStore>(
+    args: &HashMap<String, serde_json::Value>,
+    _store: &G,
+) -> Result<PlannedReviewTool> {
     use kin_model::review::{
         Review, ReviewAssignment, ReviewCompletionState, ReviewDecisionState, ReviewId,
     };
@@ -534,6 +542,8 @@ pub fn handle_review_create<G: GraphStore>(
     let head = get_optional_string_param(args, "head").unwrap_or_else(|| "working-tree".into());
     let scopes = parse_review_create_scopes(args)?;
     let created_by = parse_identity_arg(args, "created_by", "created_by_kind", "mcp-client");
+    // Optional, as the tool's schema says: a review may open with no reviewer.
+    let reviewers = parse_optional_reviewer_list(args)?;
     let now = Timestamp::now();
 
     let review = Review {
@@ -548,30 +558,42 @@ pub fn handle_review_create<G: GraphStore>(
         created_at: now.clone(),
         updated_at: now.clone(),
     };
-
-    store
-        .create_review(&review)
-        .map_err(|e| McpError::Other(e.to_string()))?;
-
-    for reviewer in parse_reviewer_list(args)? {
-        let assignment = ReviewAssignment {
-            review_id: review.review_id,
-            reviewer: kin_model::IdentityRef::human(reviewer),
-            assigned_at: now.clone(),
-            assigned_by: created_by.clone(),
-        };
-        store
-            .assign_reviewer(&assignment)
-            .map_err(|e| McpError::Other(e.to_string()))?;
-    }
+    let review_id = review.review_id;
+    let assignments = (!reviewers.is_empty()).then(|| ReviewGroup {
+        review_id,
+        entries: reviewers
+            .into_iter()
+            .map(|reviewer| ReviewAssignment {
+                review_id,
+                reviewer: kin_model::IdentityRef::human(reviewer),
+                assigned_at: now.clone(),
+                assigned_by: created_by.clone(),
+            })
+            .collect(),
+    });
 
     let result = serde_json::json!({
-        "review_id": review.review_id.to_string(),
+        "review_id": review_id.to_string(),
         "title": review.title,
         "state": "pending",
     });
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
-    Ok(ToolCallResult::text(json))
+    Ok(PlannedReviewEvent {
+        action: "review.create",
+        review_id,
+        details: format!(
+            "review_id={}; title={}; base={}; head={}",
+            review_id, review.title, review.base_ref, review.head_ref
+        ),
+        actor_label: created_by.name.clone(),
+        refs: Some((review.base_ref.clone(), review.head_ref.clone())),
+        write: ReviewWrite {
+            review: Some(review),
+            assignments,
+            ..ReviewWrite::default()
+        },
+        answer: ToolCallResult::text(json),
+    })
 }
 
 pub const REVIEW_DECIDE_DESC: &str = "\
@@ -585,6 +607,13 @@ pub fn handle_review_decide<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
 ) -> Result<ToolCallResult> {
+    apply_planned(plan_review_decide(args, store)?, store)
+}
+
+fn plan_review_decide<G: GraphStore>(
+    args: &HashMap<String, serde_json::Value>,
+    store: &G,
+) -> Result<PlannedReviewTool> {
     use kin_model::review::ReviewDecision;
     use kin_model::timestamp::Timestamp;
 
@@ -596,6 +625,7 @@ pub fn handle_review_decide<G: GraphStore>(
     let reviewer = parse_identity_arg(args, "reviewer", "reviewer_kind", "mcp-client");
 
     let state = parse_review_decision_state(&state_str)?;
+    let mut review = existing_review(store, &review_id)?;
 
     let decision = ReviewDecision {
         state,
@@ -607,10 +637,15 @@ pub fn handle_review_decide<G: GraphStore>(
         reviewer: reviewer.clone(),
         decided_at: Timestamp::now(),
     };
-
-    store
-        .add_review_decision(&review_id, &decision)
+    // The decision is history and the review's state is where it stands now, so
+    // one event moves both: without this an approved review reads pending on
+    // every surface that prints its state.
+    review.state = state;
+    review.updated_at = decision.decided_at.clone();
+    let mut history = store
+        .get_review_decisions(&review_id)
         .map_err(|e| McpError::Other(e.to_string()))?;
+    history.push(decision);
 
     let result = serde_json::json!({
         "review_id": review_id.to_string(),
@@ -618,7 +653,22 @@ pub fn handle_review_decide<G: GraphStore>(
         "reviewer": reviewer.name,
     });
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
-    Ok(ToolCallResult::text(json))
+    Ok(PlannedReviewEvent {
+        action: "review.decide",
+        review_id,
+        details: format!("review_id={review_id}; decision={state_str}"),
+        actor_label: reviewer.name,
+        refs: None,
+        write: ReviewWrite {
+            review: Some(review),
+            decisions: Some(ReviewGroup {
+                review_id,
+                entries: history,
+            }),
+            ..ReviewWrite::default()
+        },
+        answer: ToolCallResult::text(json),
+    })
 }
 
 pub const REVIEW_NOTE_ADD_DESC: &str = "\
@@ -633,6 +683,13 @@ pub fn handle_review_note_add<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
 ) -> Result<ToolCallResult> {
+    apply_planned(plan_review_note_add(args, store)?, store)
+}
+
+fn plan_review_note_add<G: GraphStore>(
+    args: &HashMap<String, serde_json::Value>,
+    store: &G,
+) -> Result<PlannedReviewTool> {
     use kin_model::review::{ReviewNote, ReviewNoteId};
     use kin_model::timestamp::Timestamp;
 
@@ -640,6 +697,7 @@ pub fn handle_review_note_add<G: GraphStore>(
     let body = get_string_param(args, "body")?;
     let scope = parse_optional_scope_arg(args)?;
     let author = parse_identity_arg(args, "author", "author_kind", "mcp-client");
+    existing_review(store, &review_id)?;
 
     let note = ReviewNote {
         note_id: ReviewNoteId::new(),
@@ -650,10 +708,6 @@ pub fn handle_review_note_add<G: GraphStore>(
         created_at: Timestamp::now(),
     };
 
-    store
-        .add_review_note(&note)
-        .map_err(|e| McpError::Other(e.to_string()))?;
-
     let result = serde_json::json!({
         "note_id": note.note_id.to_string(),
         "review_id": review_id.to_string(),
@@ -661,7 +715,18 @@ pub fn handle_review_note_add<G: GraphStore>(
         "author": author.name,
     });
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
-    Ok(ToolCallResult::text(json))
+    Ok(PlannedReviewEvent {
+        action: "review.note",
+        review_id,
+        details: format!("review_id={review_id}; note_id={}", note.note_id),
+        actor_label: author.name,
+        refs: None,
+        write: ReviewWrite {
+            notes: vec![note],
+            ..ReviewWrite::default()
+        },
+        answer: ToolCallResult::text(json),
+    })
 }
 
 pub const REVIEW_DISCUSS_DESC: &str = "\
@@ -676,6 +741,13 @@ pub fn handle_review_discuss<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
 ) -> Result<ToolCallResult> {
+    apply_planned(plan_review_discuss(args, store)?, store)
+}
+
+fn plan_review_discuss<G: GraphStore>(
+    args: &HashMap<String, serde_json::Value>,
+    store: &G,
+) -> Result<PlannedReviewTool> {
     use kin_model::review::{
         ReviewComment, ReviewDiscussion, ReviewDiscussionId, ReviewDiscussionState,
     };
@@ -685,7 +757,9 @@ pub fn handle_review_discuss<G: GraphStore>(
     let body = get_string_param(args, "body")?;
     let scope = parse_optional_scope_arg(args)?;
     let author = parse_identity_arg(args, "author", "author_kind", "mcp-client");
+    existing_review(store, &review_id)?;
 
+    let now = Timestamp::now();
     let discussion_id = ReviewDiscussionId::new();
     let discussion = ReviewDiscussion {
         discussion_id,
@@ -695,14 +769,10 @@ pub fn handle_review_discuss<G: GraphStore>(
         comments: vec![ReviewComment {
             body: body.clone(),
             authored_by: author.clone(),
-            created_at: Timestamp::now(),
+            created_at: now.clone(),
         }],
-        created_at: Timestamp::now(),
+        created_at: now,
     };
-
-    store
-        .create_review_discussion(&discussion)
-        .map_err(|e| McpError::Other(e.to_string()))?;
 
     let result = serde_json::json!({
         "discussion_id": discussion_id.to_string(),
@@ -712,7 +782,18 @@ pub fn handle_review_discuss<G: GraphStore>(
         "author": author.name,
     });
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
-    Ok(ToolCallResult::text(json))
+    Ok(PlannedReviewEvent {
+        action: "review.discuss",
+        review_id,
+        details: format!("review_id={review_id}; discussion_id={discussion_id}"),
+        actor_label: author.name,
+        refs: None,
+        write: ReviewWrite {
+            discussions: vec![discussion],
+            ..ReviewWrite::default()
+        },
+        answer: ToolCallResult::text(json),
+    })
 }
 
 pub const REVIEW_DISCUSS_REPLY_DESC: &str = "\
@@ -726,22 +807,25 @@ pub fn handle_review_discuss_reply<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
 ) -> Result<ToolCallResult> {
+    apply_planned(plan_review_discuss_reply(args, store)?, store)
+}
+
+fn plan_review_discuss_reply<G: GraphStore>(
+    args: &HashMap<String, serde_json::Value>,
+    store: &G,
+) -> Result<PlannedReviewTool> {
     use kin_model::review::ReviewComment;
     use kin_model::timestamp::Timestamp;
 
     let discussion_id = parse_discussion_id(args, "discussion_id")?;
     let body = get_string_param(args, "body")?;
     let author = parse_identity_arg(args, "author", "author_kind", "mcp-client");
-
-    let comment = ReviewComment {
+    let mut discussion = existing_discussion(store, &discussion_id)?;
+    discussion.comments.push(ReviewComment {
         body: body.clone(),
         authored_by: author.clone(),
         created_at: Timestamp::now(),
-    };
-
-    store
-        .add_discussion_comment(&discussion_id, &comment)
-        .map_err(|e| McpError::Other(e.to_string()))?;
+    });
 
     let result = serde_json::json!({
         "discussion_id": discussion_id.to_string(),
@@ -749,7 +833,18 @@ pub fn handle_review_discuss_reply<G: GraphStore>(
         "author": author.name,
     });
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
-    Ok(ToolCallResult::text(json))
+    Ok(PlannedReviewEvent {
+        action: "review.reply",
+        review_id: discussion.review_id,
+        details: format!("discussion_id={discussion_id}"),
+        actor_label: author.name,
+        refs: None,
+        write: ReviewWrite {
+            discussions: vec![discussion],
+            ..ReviewWrite::default()
+        },
+        answer: ToolCallResult::text(json),
+    })
 }
 
 pub const REVIEW_DISCUSS_RESOLVE_DESC: &str = "\
@@ -762,6 +857,13 @@ pub fn handle_review_discuss_resolve<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
 ) -> Result<ToolCallResult> {
+    apply_planned(plan_review_discuss_resolve(args, store)?, store)
+}
+
+fn plan_review_discuss_resolve<G: GraphStore>(
+    args: &HashMap<String, serde_json::Value>,
+    store: &G,
+) -> Result<PlannedReviewTool> {
     use kin_model::review::ReviewDiscussionState;
 
     let discussion_id = parse_discussion_id(args, "discussion_id")?;
@@ -782,17 +884,35 @@ pub fn handle_review_discuss_resolve<G: GraphStore>(
     } else {
         ReviewDiscussionState::Open
     };
+    let mut discussion = existing_discussion(store, &discussion_id)?;
+    let review_id = discussion.review_id;
+    // A thread already in the asked-for state changes nothing, so nothing is
+    // written and no transaction is spent on it.
+    let write = if discussion.state == new_state {
+        ReviewWrite::default()
+    } else {
+        discussion.state = new_state;
+        ReviewWrite {
+            discussions: vec![discussion],
+            ..ReviewWrite::default()
+        }
+    };
 
-    store
-        .set_discussion_state(&discussion_id, new_state)
-        .map_err(|e| McpError::Other(e.to_string()))?;
-
+    let label = if resolved { "resolved" } else { "open" };
     let result = serde_json::json!({
         "discussion_id": discussion_id.to_string(),
-        "state": if resolved { "resolved" } else { "open" },
+        "state": label,
     });
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
-    Ok(ToolCallResult::text(json))
+    Ok(PlannedReviewEvent {
+        action: "review.resolve",
+        review_id,
+        details: format!("discussion_id={discussion_id}; state={label}"),
+        actor_label: "mcp-client".to_string(),
+        refs: None,
+        write,
+        answer: ToolCallResult::text(json),
+    })
 }
 
 pub const REVIEW_ASSIGN_DESC: &str = "\
@@ -805,27 +925,33 @@ pub fn handle_review_assign<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
 ) -> Result<ToolCallResult> {
+    apply_planned(plan_review_assign(args, store)?, store)
+}
+
+fn plan_review_assign<G: GraphStore>(
+    args: &HashMap<String, serde_json::Value>,
+    store: &G,
+) -> Result<PlannedReviewTool> {
     use kin_model::review::ReviewAssignment;
     use kin_model::timestamp::Timestamp;
 
     let review_id = parse_review_id(args, "review_id")?;
     let reviewers = parse_reviewer_list(args)?;
     let assigner = parse_identity_arg(args, "assigned_by", "assigned_by_kind", "mcp-client");
+    existing_review(store, &review_id)?;
     let assigned_at = Timestamp::now();
 
-    for reviewer in &reviewers {
-        let assignment = ReviewAssignment {
-            review_id,
-            reviewer: kin_model::IdentityRef::human(reviewer.clone()),
-            assigned_at: assigned_at.clone(),
-            assigned_by: assigner.clone(),
-        };
+    let mut entries = store
+        .get_review_assignments(&review_id)
+        .map_err(|e| McpError::Other(e.to_string()))?;
+    entries.extend(reviewers.iter().map(|reviewer| ReviewAssignment {
+        review_id,
+        reviewer: kin_model::IdentityRef::human(reviewer.clone()),
+        assigned_at: assigned_at.clone(),
+        assigned_by: assigner.clone(),
+    }));
 
-        store
-            .assign_reviewer(&assignment)
-            .map_err(|e| McpError::Other(e.to_string()))?;
-    }
-
+    let details = format!("review_id={review_id}; reviewers={}", reviewers.join(","));
     let result = serde_json::json!({
         "review_id": review_id.to_string(),
         "reviewers": reviewers,
@@ -833,7 +959,18 @@ pub fn handle_review_assign<G: GraphStore>(
         "assigned": true,
     });
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
-    Ok(ToolCallResult::text(json))
+    Ok(PlannedReviewEvent {
+        action: "review.assign",
+        review_id,
+        details,
+        actor_label: assigner.name,
+        refs: None,
+        write: ReviewWrite {
+            assignments: Some(ReviewGroup { review_id, entries }),
+            ..ReviewWrite::default()
+        },
+        answer: ToolCallResult::text(json),
+    })
 }
 
 pub const REVIEW_UNASSIGN_DESC: &str = "\
@@ -845,12 +982,47 @@ pub fn handle_review_unassign<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
 ) -> Result<ToolCallResult> {
+    apply_planned(plan_review_unassign(args, store)?, store)
+}
+
+fn plan_review_unassign<G: GraphStore>(
+    args: &HashMap<String, serde_json::Value>,
+    store: &G,
+) -> Result<PlannedReviewTool> {
     let review_id = parse_review_id(args, "review_id")?;
     let reviewer = get_string_param(args, "reviewer")?;
+    existing_review(store, &review_id)?;
 
-    store
-        .remove_reviewer(&review_id, &reviewer)
+    let live = store
+        .get_review_assignments(&review_id)
         .map_err(|e| McpError::Other(e.to_string()))?;
+    let remaining: Vec<_> = live
+        .iter()
+        .filter(|assignment| assignment.reviewer.name != reviewer)
+        .cloned()
+        .collect();
+    let write = if remaining.len() == live.len() {
+        // Not assigned, so there is nothing to remove.
+        ReviewWrite::default()
+    } else if remaining.is_empty() {
+        // A collaboration delta upserts a review's whole assignment set and
+        // refuses an empty one, so the last reviewer's removal has no durable
+        // form. Refused by name rather than applied to the live graph alone,
+        // where it would come back at the next restart.
+        return Err(McpError::InvalidParams(format!(
+            "cannot remove {reviewer}, the last reviewer of review {review_id}: repository \
+             authority cannot yet record a review with no reviewers, so assign another reviewer \
+             first"
+        )));
+    } else {
+        ReviewWrite {
+            assignments: Some(ReviewGroup {
+                review_id,
+                entries: remaining,
+            }),
+            ..ReviewWrite::default()
+        }
+    };
 
     let result = serde_json::json!({
         "review_id": review_id.to_string(),
@@ -858,7 +1030,104 @@ pub fn handle_review_unassign<G: GraphStore>(
         "unassigned": true,
     });
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
-    Ok(ToolCallResult::text(json))
+    Ok(PlannedReviewEvent {
+        action: "review.unassign",
+        review_id,
+        details: format!("review_id={review_id}; reviewer={reviewer}"),
+        actor_label: "mcp-client".to_string(),
+        refs: None,
+        write,
+        answer: ToolCallResult::text(json),
+    })
+}
+
+/// A review write tool planned as the records it writes and the answer it gives
+/// once they are written.
+pub type PlannedReviewTool = PlannedReviewEvent<ToolCallResult>;
+
+/// The review tools that write review state.
+pub const REVIEW_MUTATION_TOOLS: [&str; 8] = [
+    "kin_review_create",
+    "kin_review_decide",
+    "kin_review_note_add",
+    "kin_review_discuss",
+    "kin_review_discuss_reply",
+    "kin_review_discuss_resolve",
+    "kin_review_assign",
+    "kin_review_unassign",
+];
+
+/// Whether `tool` writes review state.
+pub fn is_review_mutation(tool: &str) -> bool {
+    REVIEW_MUTATION_TOOLS.contains(&tool)
+}
+
+/// Plan one review write tool against `store` without writing anything, or
+/// `None` when `tool` writes no review state.
+///
+/// A daemon commits the planned records to repository authority before its live
+/// graph sees them, so its dispatch calls this rather than the
+/// `handle_review_*` functions, which apply the same plan straight to a store.
+pub fn plan_review_mutation<G: GraphStore>(
+    tool: &str,
+    args: &HashMap<String, serde_json::Value>,
+    store: &G,
+) -> Option<Result<PlannedReviewTool>> {
+    Some(match tool {
+        "kin_review_create" => plan_review_create(args, store),
+        "kin_review_decide" => plan_review_decide(args, store),
+        "kin_review_note_add" => plan_review_note_add(args, store),
+        "kin_review_discuss" => plan_review_discuss(args, store),
+        "kin_review_discuss_reply" => plan_review_discuss_reply(args, store),
+        "kin_review_discuss_resolve" => plan_review_discuss_resolve(args, store),
+        "kin_review_assign" => plan_review_assign(args, store),
+        "kin_review_unassign" => plan_review_unassign(args, store),
+        _ => return None,
+    })
+}
+
+/// Apply a planned review write straight to `store`, for a caller with no
+/// repository authority behind it.
+fn apply_planned<G: GraphStore>(planned: PlannedReviewTool, store: &G) -> Result<ToolCallResult> {
+    planned
+        .write
+        .apply_to(store)
+        .map_err(|error| McpError::Other(error.to_string()))?;
+    Ok(planned.answer)
+}
+
+fn existing_review<G: GraphStore>(
+    store: &G,
+    review_id: &kin_model::review::ReviewId,
+) -> Result<kin_model::review::Review> {
+    store
+        .get_review(review_id)
+        .map_err(|e| McpError::Other(e.to_string()))?
+        .ok_or_else(|| McpError::InvalidParams(format!("review not found: {review_id}")))
+}
+
+/// The discussion with `discussion_id`, found through the reviews that hold
+/// discussions, since the store answers discussions by review.
+fn existing_discussion<G: GraphStore>(
+    store: &G,
+    discussion_id: &kin_model::review::ReviewDiscussionId,
+) -> Result<kin_model::review::ReviewDiscussion> {
+    let reviews = store
+        .list_reviews(&kin_model::review::ReviewFilter::default())
+        .map_err(|e| McpError::Other(e.to_string()))?;
+    for review in reviews {
+        let found = store
+            .get_review_discussions(&review.review_id)
+            .map_err(|e| McpError::Other(e.to_string()))?
+            .into_iter()
+            .find(|discussion| discussion.discussion_id == *discussion_id);
+        if let Some(discussion) = found {
+            return Ok(discussion);
+        }
+    }
+    Err(McpError::InvalidParams(format!(
+        "review discussion not found: {discussion_id}"
+    )))
 }
 
 pub const REVIEW_LIST_DESC: &str = "\
@@ -1008,7 +1277,12 @@ fn parse_review_create_scopes(
         .collect()
 }
 
-fn parse_reviewer_list(args: &HashMap<String, serde_json::Value>) -> Result<Vec<String>> {
+/// Every reviewer the call names, deduplicated, possibly none.
+///
+/// `requested_reviewers` is the name the create tool's schema documents and
+/// `reviewers` the assign tool's; both are read so a caller following either
+/// schema is heard.
+fn parse_optional_reviewer_list(args: &HashMap<String, serde_json::Value>) -> Result<Vec<String>> {
     let mut reviewers = Vec::new();
 
     if let Some(reviewer) = get_optional_string_param(args, "reviewer") {
@@ -1018,21 +1292,27 @@ fn parse_reviewer_list(args: &HashMap<String, serde_json::Value>) -> Result<Vec<
         }
     }
 
-    if let Some(values) = args.get("reviewers").and_then(|value| value.as_array()) {
-        for value in values {
-            let reviewer = value.as_str().ok_or_else(|| {
-                McpError::InvalidParams("reviewers entries must be strings".into())
-            })?;
-            let trimmed = reviewer.trim();
-            if !trimmed.is_empty() {
-                reviewers.push(trimmed.to_string());
+    for key in ["reviewers", "requested_reviewers"] {
+        if let Some(values) = args.get(key).and_then(|value| value.as_array()) {
+            for value in values {
+                let reviewer = value.as_str().ok_or_else(|| {
+                    McpError::InvalidParams(format!("{key} entries must be strings"))
+                })?;
+                let trimmed = reviewer.trim();
+                if !trimmed.is_empty() {
+                    reviewers.push(trimmed.to_string());
+                }
             }
         }
     }
 
     reviewers.sort();
     reviewers.dedup();
+    Ok(reviewers)
+}
 
+fn parse_reviewer_list(args: &HashMap<String, serde_json::Value>) -> Result<Vec<String>> {
+    let reviewers = parse_optional_reviewer_list(args)?;
     if reviewers.is_empty() {
         return Err(McpError::InvalidParams(
             "missing reviewer assignment: provide reviewer or reviewers".into(),

--- a/crates/kin-review/src/lib.rs
+++ b/crates/kin-review/src/lib.rs
@@ -16,6 +16,7 @@ pub mod revert_history;
 pub mod review;
 pub mod risk;
 pub mod shadow;
+pub mod write;
 
 pub use change_shape::{
     classify_change_shape, evidence_note, gate_action_for, BodyShape, Branch, ChangeShape,

--- a/crates/kin-review/src/write.rs
+++ b/crates/kin-review/src/write.rs
@@ -1,0 +1,574 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! One review event as the exact records it writes into repository authority.
+//!
+//! A review mutation is planned against the live graph, committed to repository
+//! authority as one collaboration-only transaction, and only then applied to the
+//! live graph. [`ReviewWrite`] is what passes between those steps: the records the
+//! event leaves behind, each one whole, so one value builds the transaction's
+//! [`CollaborationDelta`] and levels the live graph to exactly what authority
+//! holds after the commit.
+//!
+//! Whole records rather than operations, because that is what the delta carries.
+//! kin-model's collaboration delta upserts a review, its decision history and its
+//! assignment set by key, and admits notes and discussions by value, so a decision
+//! is written as the review's whole history after the append and a reply as the
+//! discussion's whole new copy. The live graph offers only appends and removals
+//! by name for the two grouped collections, which is why [`ReviewWrite::apply_to`]
+//! levels a group by appending what it lacks and reports a live group it cannot
+//! reach that way instead of guessing.
+
+use std::cmp::Ordering;
+use std::collections::BTreeSet;
+
+use kin_model::provenance::{Actor, AuditEvent};
+use kin_model::review::{
+    Review, ReviewAssignment, ReviewDecision, ReviewDiscussion, ReviewId, ReviewNote,
+};
+use kin_model::{CollaborationDelta, GraphStore, Keyed};
+
+/// A review's decision history or assignment set as it stands after one event.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReviewGroup<T> {
+    pub review_id: ReviewId,
+    pub entries: Vec<T>,
+}
+
+/// Every record one review event writes, as authority holds it afterwards.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ReviewWrite {
+    /// The review after the event: newly created, or with its state moved by a
+    /// decision.
+    pub review: Option<Review>,
+    /// The review's whole decision history after the event.
+    pub decisions: Option<ReviewGroup<ReviewDecision>>,
+    pub notes: Vec<ReviewNote>,
+    /// Each discussion the event touched, as its whole new copy.
+    pub discussions: Vec<ReviewDiscussion>,
+    /// The review's whole assignment set after the event.
+    pub assignments: Option<ReviewGroup<ReviewAssignment>>,
+    /// Actors an audit event below names that the store does not hold yet.
+    pub actors: Vec<Actor>,
+    pub audit_events: Vec<AuditEvent>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ReviewWriteError {
+    /// kin-model refused the collaboration delta this write builds.
+    #[error("review write is not a valid collaboration delta: {0}")]
+    Invalid(String),
+    /// The store refused one of the records.
+    #[error("review store refused the write: {0}")]
+    Store(String),
+    /// The live group holds entries the written group does not start with, so
+    /// appending cannot make the two equal.
+    #[error(
+        "the live {collection} of review {review_id} is not a prefix of the one this write \
+         holds, so the live graph cannot be leveled to it by appending"
+    )]
+    Diverged {
+        collection: &'static str,
+        review_id: ReviewId,
+    },
+}
+
+/// A review, discussion or other target an event names that the store does not
+/// hold.
+///
+/// Its own type so a caller can answer it as a missing resource rather than as a
+/// failure of the store.
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+pub struct ReviewTargetMissing(pub String);
+
+/// One review event planned against the live graph and not yet written anywhere.
+///
+/// The planner states what it can from the request and the graph alone. The
+/// writer that commits it adds what only it holds, such as the session and the
+/// changes the review's refs resolve to at commit time, to the audit event it
+/// records for the actions that carry one.
+#[derive(Debug, Clone)]
+pub struct PlannedReviewEvent<A> {
+    pub write: ReviewWrite,
+    /// The audit action this event is, such as `review.create`.
+    pub action: &'static str,
+    pub review_id: ReviewId,
+    /// Audit details the planner can state from the request alone.
+    pub details: String,
+    /// The identity this event acts as, by label.
+    pub actor_label: String,
+    /// The base and head refs a created review names.
+    pub refs: Option<(String, String)>,
+    /// What the caller answers once the write is durable.
+    pub answer: A,
+}
+
+impl<A> PlannedReviewEvent<A> {
+    /// Whether the writer records an audit event for this action. Creating a
+    /// review and deciding one do; notes and comments carry their own author and
+    /// time.
+    pub fn records_audit_event(&self) -> bool {
+        matches!(self.action, "review.create" | "review.decide")
+    }
+}
+
+impl ReviewWrite {
+    /// Whether this write records nothing, which is what an event that changes
+    /// nothing plans, such as resolving a discussion that is already resolved.
+    pub fn is_empty(&self) -> bool {
+        self.review.is_none()
+            && self.decisions.is_none()
+            && self.notes.is_empty()
+            && self.discussions.is_empty()
+            && self.assignments.is_none()
+            && self.actors.is_empty()
+            && self.audit_events.is_empty()
+    }
+
+    /// The collaboration delta that admits these records into repository
+    /// authority, in the one order kin-model accepts.
+    pub fn to_delta(&self) -> Result<CollaborationDelta, ReviewWriteError> {
+        let mut delta = CollaborationDelta {
+            reviews: self
+                .review
+                .iter()
+                .map(|review| Keyed::new(review.review_id, review.clone()))
+                .collect(),
+            review_decisions: self
+                .decisions
+                .iter()
+                .map(|group| Keyed::new(group.review_id, group.entries.clone()))
+                .collect(),
+            review_notes: self.notes.clone(),
+            review_discussions: self.discussions.clone(),
+            review_assignments: self
+                .assignments
+                .iter()
+                .map(|group| Keyed::new(group.review_id, group.entries.clone()))
+                .collect(),
+            actors: self
+                .actors
+                .iter()
+                .map(|actor| Keyed::new(actor.actor_id, actor.clone()))
+                .collect(),
+            audit_events: self.audit_events.clone(),
+            ..CollaborationDelta::default()
+        };
+        canonicalize(&mut delta);
+        delta
+            .validate()
+            .map_err(|error| ReviewWriteError::Invalid(error.to_string()))?;
+        Ok(delta)
+    }
+
+    /// Level `store` to hold exactly these records.
+    ///
+    /// Keyed records and whole copies replace what the store holds under the same
+    /// id; a group gains the entries the store lacks. Actors are created only when
+    /// absent, and audit events are appended.
+    pub fn apply_to<G: GraphStore>(&self, store: &G) -> Result<(), ReviewWriteError> {
+        fn refused(error: impl std::fmt::Display) -> ReviewWriteError {
+            ReviewWriteError::Store(error.to_string())
+        }
+
+        for actor in &self.actors {
+            if store.get_actor(&actor.actor_id).map_err(refused)?.is_none() {
+                store.create_actor(actor).map_err(refused)?;
+            }
+        }
+        if let Some(review) = &self.review {
+            store.create_review(review).map_err(refused)?;
+        }
+        if let Some(group) = &self.decisions {
+            let live = store
+                .get_review_decisions(&group.review_id)
+                .map_err(refused)?;
+            for decision in missing_suffix(&live, group, "decision history")? {
+                store
+                    .add_review_decision(&group.review_id, decision)
+                    .map_err(refused)?;
+            }
+        }
+        for note in &self.notes {
+            store.add_review_note(note).map_err(refused)?;
+        }
+        for discussion in &self.discussions {
+            store
+                .create_review_discussion(discussion)
+                .map_err(refused)?;
+        }
+        if let Some(group) = &self.assignments {
+            let mut live = store
+                .get_review_assignments(&group.review_id)
+                .map_err(refused)?;
+            // A removal leaves reviewers live that the group no longer names, and
+            // the store removes by reviewer name.
+            let kept: BTreeSet<&str> = group
+                .entries
+                .iter()
+                .map(|assignment| assignment.reviewer.name.as_str())
+                .collect();
+            let removed: BTreeSet<String> = live
+                .iter()
+                .filter(|assignment| !kept.contains(assignment.reviewer.name.as_str()))
+                .map(|assignment| assignment.reviewer.name.clone())
+                .collect();
+            if !removed.is_empty() {
+                for name in &removed {
+                    store
+                        .remove_reviewer(&group.review_id, name)
+                        .map_err(refused)?;
+                }
+                live = store
+                    .get_review_assignments(&group.review_id)
+                    .map_err(refused)?;
+            }
+            for assignment in missing_suffix(&live, group, "assignment set")? {
+                store.assign_reviewer(assignment).map_err(refused)?;
+            }
+        }
+        for event in &self.audit_events {
+            store.record_audit_event(event).map_err(refused)?;
+        }
+        Ok(())
+    }
+}
+
+/// The entries of `written` after the prefix `live` already holds.
+fn missing_suffix<'a, T: PartialEq>(
+    live: &[T],
+    written: &'a ReviewGroup<T>,
+    collection: &'static str,
+) -> Result<&'a [T], ReviewWriteError> {
+    let entries = &written.entries;
+    if entries.len() >= live.len() && entries[..live.len()] == *live {
+        Ok(&entries[live.len()..])
+    } else {
+        Err(ReviewWriteError::Diverged {
+            collection,
+            review_id: written.review_id,
+        })
+    }
+}
+
+/// Put every collection the review domain writes into kin-model's canonical
+/// order.
+fn canonicalize(delta: &mut CollaborationDelta) {
+    canonical_sort(&mut delta.reviews, |reviews| CollaborationDelta {
+        reviews,
+        ..CollaborationDelta::default()
+    });
+    canonical_sort(&mut delta.review_decisions, |review_decisions| {
+        CollaborationDelta {
+            review_decisions,
+            ..CollaborationDelta::default()
+        }
+    });
+    canonical_sort(&mut delta.review_notes, |review_notes| CollaborationDelta {
+        review_notes,
+        ..CollaborationDelta::default()
+    });
+    canonical_sort(&mut delta.review_discussions, |review_discussions| {
+        CollaborationDelta {
+            review_discussions,
+            ..CollaborationDelta::default()
+        }
+    });
+    canonical_sort(&mut delta.review_assignments, |review_assignments| {
+        CollaborationDelta {
+            review_assignments,
+            ..CollaborationDelta::default()
+        }
+    });
+    canonical_sort(&mut delta.actors, |actors| CollaborationDelta {
+        actors,
+        ..CollaborationDelta::default()
+    });
+    canonical_sort(&mut delta.audit_events, |audit_events| CollaborationDelta {
+        audit_events,
+        ..CollaborationDelta::default()
+    });
+}
+
+/// Sort `records` into the one order kin-model's delta validation accepts, and
+/// drop exact duplicates.
+///
+/// kin-model refuses a collection that is not strictly increasing by the
+/// canonical encoding of each entry's key, or of the entry itself when the
+/// collection is unkeyed, and keeps that encoder private. So the comparator asks
+/// kin-model directly: two entries are in order exactly when a delta holding just
+/// those two, in that order, validates. Anything this sorts is therefore in the
+/// order the same crate will check, with no second copy of the encoding here to
+/// drift from it.
+fn canonical_sort<T: Clone + PartialEq>(
+    records: &mut Vec<T>,
+    place: impl Fn(Vec<T>) -> CollaborationDelta,
+) {
+    if records.len() < 2 {
+        return;
+    }
+    let in_order = |first: &T, second: &T| {
+        place(vec![first.clone(), second.clone()])
+            .validate()
+            .is_ok()
+    };
+    records.sort_by(|first, second| {
+        if in_order(first, second) {
+            Ordering::Less
+        } else if in_order(second, first) {
+            Ordering::Greater
+        } else {
+            Ordering::Equal
+        }
+    });
+    records.dedup();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kin_model::review::{
+        ReviewCompletionState, ReviewDecisionState, ReviewDiscussionId, ReviewDiscussionState,
+        ReviewNoteId,
+    };
+    use kin_model::{IdentityRef, ReviewStore, Timestamp};
+
+    /// A fixed instant, so records built twice compare equal.
+    fn at(seconds: u32) -> Timestamp {
+        serde_json::from_value(serde_json::Value::String(format!(
+            "2023-11-14T22:13:{seconds:02}Z"
+        )))
+        .unwrap()
+    }
+
+    fn review(id: ReviewId, state: ReviewDecisionState, updated: u32) -> Review {
+        Review {
+            review_id: id,
+            title: "Fix login".to_string(),
+            base_ref: "main".to_string(),
+            head_ref: "feature/login".to_string(),
+            state,
+            completion: ReviewCompletionState::InReview,
+            created_by: IdentityRef::human("troy"),
+            created_at: at(0),
+            updated_at: at(updated),
+            scopes: vec![],
+        }
+    }
+
+    fn decision(state: ReviewDecisionState, seconds: u32) -> ReviewDecision {
+        ReviewDecision {
+            reviewer: IdentityRef::human("reviewer"),
+            state,
+            comment: None,
+            decided_at: at(seconds),
+        }
+    }
+
+    fn assignment(id: ReviewId, name: &str) -> ReviewAssignment {
+        ReviewAssignment {
+            review_id: id,
+            reviewer: IdentityRef::human(name),
+            assigned_at: at(1),
+            assigned_by: IdentityRef::human("troy"),
+        }
+    }
+
+    fn note(id: ReviewId, body: &str) -> ReviewNote {
+        ReviewNote {
+            note_id: ReviewNoteId::new(),
+            review_id: id,
+            body: body.to_string(),
+            scope: None,
+            authored_by: IdentityRef::human("troy"),
+            created_at: at(2),
+        }
+    }
+
+    /// A decision is the review's whole history after the append plus the review
+    /// with its state moved, and applying it to a store holding the history before
+    /// the append leaves the store equal to both.
+    #[test]
+    fn a_decision_writes_the_whole_history_and_moves_the_review() {
+        let id = ReviewId::new();
+        let store = kin_db::InMemoryGraph::new();
+        store
+            .create_review(&review(id, ReviewDecisionState::Pending, 0))
+            .unwrap();
+        let first = decision(ReviewDecisionState::NeedsWork, 5);
+        store.add_review_decision(&id, &first).unwrap();
+
+        let second = decision(ReviewDecisionState::Approved, 9);
+        let write = ReviewWrite {
+            review: Some(review(id, ReviewDecisionState::Approved, 9)),
+            decisions: Some(ReviewGroup {
+                review_id: id,
+                entries: vec![first.clone(), second.clone()],
+            }),
+            ..ReviewWrite::default()
+        };
+
+        let delta = write.to_delta().unwrap();
+        assert_eq!(delta.reviews.len(), 1);
+        assert_eq!(delta.review_decisions.len(), 1);
+        assert_eq!(
+            delta.review_decisions[0].value,
+            vec![first.clone(), second.clone()]
+        );
+
+        write.apply_to(&store).unwrap();
+        assert_eq!(
+            store.get_review_decisions(&id).unwrap(),
+            vec![first, second]
+        );
+        assert_eq!(
+            store.get_review(&id).unwrap().unwrap().state,
+            ReviewDecisionState::Approved
+        );
+    }
+
+    /// Records assembled in any order build the one delta kin-model accepts.
+    ///
+    /// Falsify by returning early from `canonical_sort`: the reversed input then
+    /// fails validation, because kin-model refuses a collection out of its
+    /// canonical order rather than sorting it.
+    #[test]
+    fn records_in_any_order_build_one_valid_delta() {
+        let id = ReviewId::new();
+        let notes = vec![note(id, "a"), note(id, "b"), note(id, "c"), note(id, "d")];
+        let forward = ReviewWrite {
+            notes: notes.clone(),
+            ..ReviewWrite::default()
+        };
+        let mut reversed_notes = notes;
+        reversed_notes.reverse();
+        let reversed = ReviewWrite {
+            notes: reversed_notes,
+            ..ReviewWrite::default()
+        };
+
+        let first = forward.to_delta().expect("forward order must validate");
+        let second = reversed.to_delta().expect("reversed order must validate");
+        assert_eq!(first, second, "assembly order must not change the delta");
+    }
+
+    /// A live group the write does not extend is reported, not overwritten.
+    #[test]
+    fn a_live_history_the_write_does_not_extend_is_reported() {
+        let id = ReviewId::new();
+        let store = kin_db::InMemoryGraph::new();
+        store
+            .create_review(&review(id, ReviewDecisionState::Pending, 0))
+            .unwrap();
+        store
+            .add_review_decision(&id, &decision(ReviewDecisionState::Blocked, 3))
+            .unwrap();
+
+        let write = ReviewWrite {
+            decisions: Some(ReviewGroup {
+                review_id: id,
+                entries: vec![decision(ReviewDecisionState::Approved, 4)],
+            }),
+            ..ReviewWrite::default()
+        };
+        let error = write.apply_to(&store).unwrap_err();
+        assert!(
+            matches!(
+                error,
+                ReviewWriteError::Diverged {
+                    collection: "decision history",
+                    ..
+                }
+            ),
+            "{error}"
+        );
+    }
+
+    /// An assignment set that lost a reviewer levels the store by removing that
+    /// reviewer, and one that gained a reviewer by appending.
+    #[test]
+    fn an_assignment_set_levels_removals_and_additions() {
+        let id = ReviewId::new();
+        let store = kin_db::InMemoryGraph::new();
+        store
+            .create_review(&review(id, ReviewDecisionState::Pending, 0))
+            .unwrap();
+        store.assign_reviewer(&assignment(id, "alice")).unwrap();
+        store.assign_reviewer(&assignment(id, "bob")).unwrap();
+
+        ReviewWrite {
+            assignments: Some(ReviewGroup {
+                review_id: id,
+                entries: vec![assignment(id, "alice")],
+            }),
+            ..ReviewWrite::default()
+        }
+        .apply_to(&store)
+        .unwrap();
+        assert_eq!(
+            store.get_review_assignments(&id).unwrap(),
+            vec![assignment(id, "alice")]
+        );
+
+        ReviewWrite {
+            assignments: Some(ReviewGroup {
+                review_id: id,
+                entries: vec![assignment(id, "alice"), assignment(id, "carol")],
+            }),
+            ..ReviewWrite::default()
+        }
+        .apply_to(&store)
+        .unwrap();
+        assert_eq!(
+            store.get_review_assignments(&id).unwrap(),
+            vec![assignment(id, "alice"), assignment(id, "carol")]
+        );
+    }
+
+    /// A reply is the discussion's whole new copy, and applying it replaces the
+    /// copy the store held.
+    #[test]
+    fn a_reply_replaces_the_discussion_copy() {
+        let id = ReviewId::new();
+        let store = kin_db::InMemoryGraph::new();
+        store
+            .create_review(&review(id, ReviewDecisionState::Pending, 0))
+            .unwrap();
+        let mut discussion = ReviewDiscussion {
+            discussion_id: ReviewDiscussionId::new(),
+            review_id: id,
+            scope: None,
+            state: ReviewDiscussionState::Open,
+            comments: vec![],
+            created_at: at(1),
+        };
+        store.create_review_discussion(&discussion).unwrap();
+
+        discussion.comments.push(kin_model::review::ReviewComment {
+            authored_by: IdentityRef::human("reviewer"),
+            body: "why this shape?".to_string(),
+            created_at: at(2),
+        });
+        discussion.state = ReviewDiscussionState::Resolved;
+        let write = ReviewWrite {
+            discussions: vec![discussion.clone()],
+            ..ReviewWrite::default()
+        };
+        write.to_delta().unwrap();
+        write.apply_to(&store).unwrap();
+        assert_eq!(store.get_review_discussions(&id).unwrap(), vec![discussion]);
+    }
+
+    /// An empty write is refused as a delta, which is why a planner that changes
+    /// nothing must not reach a commit.
+    #[test]
+    fn an_empty_write_is_not_a_delta() {
+        let write = ReviewWrite::default();
+        assert!(write.is_empty());
+        assert!(matches!(
+            write.to_delta().unwrap_err(),
+            ReviewWriteError::Invalid(_)
+        ));
+    }
+}


### PR DESCRIPTION
Reviews now survive a daemon restart. Every review write, from `POST /review`, `kin review` or the eight MCP review tools, commits one collaboration-only repository transaction before it answers, and only then updates the daemon's live graph. A daemon that restarts on the same store serves the same reviews, decisions, notes, discussions, replies and assignments it answered with before.

## Why

Until now a review lived only in one daemon's memory. Measured on kin bytes 74bed151 with the restart as the only variable: a review created through `POST /review` at 10:15:00Z answered on every surface, the daemon was stopped by pid at 10:34:32Z and the same binary started, and after that the list said "No reviews found.", show said "review not found" and MCP `kin_review_get` returned an error.

kin-model 0.7.28 and kin-db 0.7.112 already carry reviews in authority through `RepositoryTransaction::collaboration_delta`, and a daemon already rebuilds its reviews from authority when it opens. Nothing in kin wrote that seam: every production transaction set it to `None`.

## What changed

- `kin_review::write` holds one event's records whole (`ReviewWrite`) and builds the collaboration delta from them. It orders each collection by asking kin-model's own `validate` about pairs of entries, so its order cannot drift from the one kin-model checks.
- Review mutations are planned rather than written: `kin_cli::commands::review::plan_review_mutation` for the HTTP and CLI path, `kin_mcp::handlers::review::plan_review_mutation` for MCP. `execute_review_request` now refuses a mutation, so nothing writes review state around the writer.
- `kin_daemon::review_write` is the one writer. Under the coordination gate, the graph-authority guard and the persistence lock, it opens the bound authority, commits the delta as a transaction with no other mutation, records the new generation, then applies the records to the live graph. It adds the `review.create` and `review.decide` audit events itself, with the changes the review's base and head resolve to under the lease it commits against, the session that asked, and the authority generation.
- `POST /review` and the MCP tools-call dispatch both route review writes through it. A missing review now answers 404 and a malformed request 400, where both were 500.

## Fixed on the way

- A decision now moves the review's `state` and `updated_at`. Nothing called `update_review_state`, so an approved review read pending on every surface that prints its state.
- `kin_review_create` no longer returns an error after writing the review when no reviewer is named, and it reads `requested_reviewers`, the name its schema documents.
- Review records name the caller's actor label (`KIN_ACTOR`, then `USER`) instead of a fixed `cli-user`. The CLI sends its own label with each write, so the daemon records who asked rather than who started it.

## Boundaries

- Unassigning a review's last reviewer is refused by name, because a collaboration delta cannot express an empty assignment set.
- A reply or a resolve adds a new copy of the discussion to authority, and the graph serves the newest. Keyed discussions in kin-model and kin-db would drop the old copies; nothing here needs them.
- `kin push` and `kin pull` do not carry reviews yet. That is the next PR.

## Migration

No store format changes. A store with no durable reviews needs nothing. Reviews that a daemon running an earlier build holds in memory are lost at its next restart, as they always were. This build never holds a review that authority does not.

## Authority open per review event

Each review write is one repository transaction, so it pays what every authority transaction in this daemon pays today: open the bound authority, then prepare the successor. Measured on release bytes of `992b66d1b` against a scratch store converted from the kin-db repository (832 commits, 204 files), one `kin review create`, from the daemon log:

```text
slow repository authority successor preparation elapsed_ms=40968 clone_ms=2 admit_ms=11078
  refs_overlay_ms=0 collaboration_ms=0 workspace_ms=0 merge_ms=0 admission_verify_ms=0
  change_bodies_ms=0 history_replay_ms=13248 replay_decode_ms=7242 roots_ms=112
  storage_admission_ms=16525 successor_index_ms=0
```

The collaboration lap is 0 ms. The 41 s is admission, history replay, replay decode and storage admission over the whole store, which is the O(store) cost class already ticketed separately; the second review create measured the same (40882 ms). End to end through the CLI, `kin review create` took 63.438 s and 63.682 s; through `POST /review` with the daemon's token, a create answered 200 in 68.3 s.

## Cost on kin-db 0.7.112: a review write persists a full snapshot

Every review write is persisted as a full authority snapshot rather than an incremental frame, on generation 2 and again on generation 3:

```text
ERROR kindb.commit.persist_successor: authority frame encoding refused; persisting this publication as
  a full snapshot generation=2 error=storage error: authority frame for generation 2 does not
  reproduce the successor: reviews differ; refusing to persist it
INFO  kindb.commit.persist_successor: slow repository authority snapshot persistence write_ms=14953
  snapshot_bytes=1621252636
```

That is 1.62 GB and about 15 s per review create on this store. The cause is in kin-db, not here: `AuthorityFrame::drain` (`storage/authority_frame.rs:337`) carries new changes, admission policies, external objects, aliases, the Git authority patch and changed workspaces, and no collaboration collection. `prove_reproduces` rebuilds the base plus the frame, which keeps the base's reviews, and its comparison names "reviews". The refusal is the safety net doing its job, so the write is correct and durable. The fix is a frame that carries the collaboration collections a transaction changed, and it is being filed as its own kin-db lane.

## Local evidence

Hosted CI is the gate of record for the full workspace. These are the checks it does not run for this PR, as the commands and their output.

Crate tests on this head (`7b082fbd1`, rebased on `54c360d57`, which is #1718's repo-scoped review reads), each through the fleet's builder slot. The daemon set is 21 because #1718's `repo_review` route tests match the filter too, including the one that reads what `POST /review` wrote:

```text
kin-review rc=0 passed=6 failed_lines=0          cargo test --locked -p kin-review --lib write
kin-cli-review rc=0 passed=7 failed_lines=0      cargo test --locked -p kin-cli --lib commands::review
kin-mcp-review rc=0 passed=7 failed_lines=0      cargo test --locked -p kin-mcp --lib review
kin-daemon-review rc=0 passed=21 failed_lines=0  cargo test --locked -p kin-daemon --lib review
ALL_DONE failed=0 at 15:14:30Z
```

`review_state_survives_a_daemon_restart_on_every_surface` is the measurement above, run in the crate: create, decide, note, discuss, reply, resolve and assign through `POST /review`, assign and create through MCP, drop the daemon state, open a new one on the same store, and require the list, show and `kin_review_get` to answer the same, the decision's state to read approved, both assignments to be there, and the `review.create` audit event to carry `base_change`, `head_change` and `authority_generation`.

Falsification, one mutation per behaviour, each file restored from a copy and proven by sha after every arm (`falsify.sh`, baseline `eb41da94024b0c02`):

```text
F1 skip the authority commit, keep the live apply     rc=101
  review_state_survives_a_daemon_restart_on_every_surface ... FAILED
  assertion `left == right` failed: review not found: 39914ec2-6bba-47d3-a911-e0b7be2c7908
    left: 500
   right: 200
  restored sha=eb41da94024b0c02
F2 send MCP review writes back to the live-only handlers   rc=101
  review_state_survives_a_daemon_restart_on_every_surface ... FAILED
  every review surface must answer the same after a restart
    after restart: "1 review(s)", assignments [carol]
    before:        "2 review(s)", assignments [carol, dave]
  restored sha=eb41da94024b0c02
```

F1 is hostedreview's measurement failing the way it failed before this change: the reopened daemon answers show with "review not found". F2 shows the MCP arm is load-bearing on its own: with it bypassed, the HTTP writes survive and the MCP-created review and the MCP assignment do not.

```text
F3 a decision no longer moves the review's state           rc=101
  a_planned_decision_moves_the_review_and_carries_its_history ... FAILED
  assertion `left == right` failed
    left: Pending
   right: Approved
  restored sha=eb41da94024b0c02
F4 no canonical ordering of the delta                      rc=101
  records_in_any_order_build_one_valid_delta ... FAILED
  reversed order must validate: Invalid("invalid operation: collaboration delta `review_notes`
  is not strictly increasing, so either it repeats a record or two senders holding the same
  records would produce two transaction identities")
  restored sha=eb41da94024b0c02
FALSIFY_END 11:41:28Z sha=eb41da94024b0c02 baseline=eb41da94024b0c02
```

F4's refusal comes from kin-model's own validation, which is the point: the writer orders records by asking kin-model, so an order it would refuse never reaches a commit.

The check job's gates, read out of this repository's own `ci.yml` and run against the rebased tree:

```text
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt       cargo fmt -- --check
PASS     clippy    cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:zero_file_search_guard.sh, guard:verify-zero-file-search.py, guard:check-quarantine.py,
         node-test and the 16 other guards the check job names
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin 7b082fbd11d0cb4f878e37b299338169b860c7eb
```

The same 22 passed on the pre-rebase head `992b66d1b`, where the falsification above ran; the rebase over #1718 changed only a conflict at the top of `review.rs` and the not-found mapping of the write path.

## Measured after landing

Same release bytes and store, with the daemon's token. Every review write through `POST /review` and MCP answered 200 in 64.0 to 85.1 s (12 writes), and `kin review create` took 65.7 s. `kin branch list`, which opens the authority and commits nothing, took 7.4 s. `kin tag` was refused by release policy (412, before any commit); `kin tag --force` committed in 67.2 s and 68.2 s, the same cost as a review write, because every transaction pays the preparation above.

Then the daemon was stopped by its pid and the same bytes started again. The list, show, and `kin_review_get` for a review and for an MCP-created review answered the same after the restart (`SURVIVAL list: same`, `show: same`, `get: same`, `agent-get: same`), 7 reviews in all, and the review decided through MCP still read `needswork`.
