### PR TITLE
Mark the files a sweep finished even when another file's query failed

### DIFF
--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -3910,19 +3910,39 @@ impl SweepTally {
     }
 }
 
+/// Whether one file's language-server passes in this sweep completed with no
+/// failed and no over-budget query.
+///
+/// Decided per file, from the tally's two failure counters as they stood before
+/// and after that file's passes. A file whose definitions pass ran over its
+/// budget, or whose per-entity queries failed, may hold incomplete relations, so
+/// it is not marked and the next sweep retries it.
+fn file_passes_completed(
+    tally: &SweepTally,
+    query_failures_before: usize,
+    definitions_over_budget_before: usize,
+) -> bool {
+    tally.query_failures == query_failures_before
+        && tally.definitions_over_budget == definitions_over_budget_before
+}
+
+/// Record `files` as durably enriched, when this sweep's write was durable.
+///
+/// `files` holds only the files whose passes completed ([`file_passes_completed`]).
+/// A failed query used to refuse the marker for the whole pass, so one failed
+/// call in one file sent every later daemon back over every file: on a 72-file
+/// store the pass published its relations, refused the marker, and the next
+/// daemon walked all 72 files again for about four minutes. The caller holds the
+/// files that failed back instead, and a pass whose write did not reach disk
+/// still marks nothing.
 fn mark_completed_sweep_files(
     state: &DaemonState,
     files: &[String],
     epoch: u64,
-    tally: &SweepTally,
     relations: EnrichmentWrite,
     published: bool,
 ) -> bool {
-    // A published subset cannot certify query arms that failed or timed out.
-    if tally.query_failures > 0
-        || tally.definitions_over_budget > 0
-        || !sweep_marker_is_durable(relations, published)
-    {
+    if !sweep_marker_is_durable(relations, published) {
         return false;
     }
     mark_files_enriched(state, files, epoch);
@@ -5598,6 +5618,9 @@ pub async fn run_with_authority_on(
                             .store(total_files as u64, std::sync::atomic::Ordering::SeqCst);
                         let mut tally = SweepTally::default();
                         let mut enriched_this_sweep: Vec<String> = Vec::new();
+                        // Files the sweep finished whose queries failed or ran over
+                        // budget: counted enriched, never marked, retried next pass.
+                        let mut held_back_this_sweep: Vec<String> = Vec::new();
                         let file_definitions_budget = lsp_file_definitions_budget();
                         let mut total_relations = EnrichmentWrite::default();
                         // Languages whose server refused to start, remembered for
@@ -5856,6 +5879,8 @@ pub async fn run_with_authority_on(
 
                             // File-level enrichment: query definition at every identifier
                             // to capture ALL relationships (40-50x more than per-entity).
+                            let query_failures_before = tally.query_failures;
+                            let definitions_over_budget_before = tally.definitions_over_budget;
                             let file_result = file_definitions_within_budget(
                                 kin_lsp::file_enrichment::enrich_file_definitions(
                                     server,
@@ -5911,7 +5936,15 @@ pub async fn run_with_authority_on(
                                 .await;
 
                             tally.enriched += 1;
-                            enriched_this_sweep.push(file_id.0.clone());
+                            if file_passes_completed(
+                                &tally,
+                                query_failures_before,
+                                definitions_over_budget_before,
+                            ) {
+                                enriched_this_sweep.push(file_id.0.clone());
+                            } else {
+                                held_back_this_sweep.push(file_id.0.clone());
+                            }
                             lsp_state.lsp_sweep_files_done.store(
                                 tally.files_processed() as u64,
                                 std::sync::atomic::Ordering::SeqCst,
@@ -6058,19 +6091,28 @@ pub async fn run_with_authority_on(
                         // divergence means a file was counted enriched without
                         // being recorded, or recorded without being counted.
                         // Either way the marker would stop describing the sweep.
-                        if enriched_this_sweep.len() != tally.enriched {
+                        if enriched_this_sweep.len() + held_back_this_sweep.len() != tally.enriched
+                        {
                             warn!(
                                 recorded = enriched_this_sweep.len(),
+                                held_back = held_back_this_sweep.len(),
                                 counted = tally.enriched,
-                                "the enriched-file set and the enriched count disagree; the \
+                                "the enriched-file sets and the enriched count disagree; the \
                                  marker no longer describes this sweep"
+                            );
+                        }
+                        if let Some(first) = held_back_this_sweep.first() {
+                            warn!(
+                                files = held_back_this_sweep.len(),
+                                first = %first,
+                                "not recording these files as enriched: a language-server query \
+                                 failed or ran over its budget for them, so the next sweep retries them"
                             );
                         }
                         if !mark_completed_sweep_files(
                             &lsp_state,
                             &enriched_this_sweep,
                             marker_epoch,
-                            &tally,
                             total_relations,
                             published,
                         ) {
@@ -7283,44 +7325,68 @@ mod tests {
         assert!(kin_daemon_spawn::read_daemon_kill_record(root.path()).is_none());
     }
 
+    /// A file whose queries partly failed is still never marked, and it no
+    /// longer takes the rest of the pass down with it.
+    ///
+    /// Three files through one pass: one completes, one has a per-entity query
+    /// fail, one's definitions pass runs over its budget. Only the first is
+    /// marked, so the next daemon skips it and retries the other two. A write
+    /// that did not reach disk marks nothing, the completed file included.
     #[test]
-    fn partial_query_success_does_not_persist_a_skip_marker() {
+    fn a_file_whose_query_failed_is_held_back_and_the_rest_are_marked() {
         let root = tempfile::tempdir().unwrap();
         let init = kin_core::init(root.path()).unwrap();
         let state = super::DaemonState::open(init.layout.clone()).unwrap();
-        let files = vec!["pkg/sessions.py".to_string()];
-        let published = super::EnrichmentWrite {
-            published: 1,
-            offered: 1,
+        let written = super::EnrichmentWrite {
+            published: 2,
+            offered: 2,
             vector_stale: 0,
         };
         let epoch = super::current_marker_epoch(&state);
-        let mut tally = super::SweepTally {
-            enriched: 1,
-            query_failures: 1,
-            ..Default::default()
-        };
+
+        let mut tally = super::SweepTally::default();
+        let mut completed = Vec::new();
+        let mut held_back = Vec::new();
+        for (file, failed_queries, over_budget) in [
+            ("pkg/models.py", 0, 0),
+            ("pkg/sessions.py", 1, 0),
+            ("pkg/adapters.py", 0, 1),
+        ] {
+            let before = (tally.query_failures, tally.definitions_over_budget);
+            tally.query_failures += failed_queries;
+            tally.definitions_over_budget += over_budget;
+            tally.enriched += 1;
+            if super::file_passes_completed(&tally, before.0, before.1) {
+                completed.push(file.to_string());
+            } else {
+                held_back.push(file.to_string());
+            }
+        }
+        assert_eq!(completed, vec!["pkg/models.py".to_string()]);
+        assert_eq!(
+            held_back,
+            vec!["pkg/sessions.py".to_string(), "pkg/adapters.py".to_string()]
+        );
+
         assert!(!super::mark_completed_sweep_files(
-            &state, &files, epoch, &tally, published, true
-        ));
-        assert!(!state.lsp_enriched_files.lock().unwrap().contains(&files[0]));
-        assert!(!super::lsp_enriched_marker_path(&state).exists());
-        tally.query_failures = 0;
-        tally.definitions_over_budget = 1;
-        assert!(!super::mark_completed_sweep_files(
-            &state, &files, epoch, &tally, published, true
+            &state, &completed, epoch, written, false
         ));
         assert!(!super::lsp_enriched_marker_path(&state).exists());
-        tally.definitions_over_budget = 0;
+
         assert!(super::mark_completed_sweep_files(
-            &state, &files, epoch, &tally, published, true
+            &state, &completed, epoch, written, true
         ));
-        assert!(state.lsp_enriched_files.lock().unwrap().contains(&files[0]));
+        let marked = state.lsp_enriched_files.lock().unwrap().clone();
+        assert!(marked.contains("pkg/models.py"), "{marked:?}");
+        assert!(
+            !marked.contains("pkg/sessions.py") && !marked.contains("pkg/adapters.py"),
+            "{marked:?}"
+        );
         let saved: Vec<String> = serde_json::from_slice(
             &std::fs::read(super::lsp_enriched_marker_path(&state)).unwrap(),
         )
         .unwrap();
-        assert_eq!(saved, files);
+        assert_eq!(saved, completed);
     }
 
     #[test]


### PR DESCRIPTION
A sweep that published its work now records the files it finished, so the next daemon resumes instead of
re-sweeping the whole repository, and the warning names the reason it held a file back.

## What was wrong

`mark_completed_sweep_files` refused the whole durable marker whenever any language-server query in the pass
failed or timed out (`tally.query_failures > 0`), even after the pass had published its relations. On a fresh
kin-db store the pass enriched 72 of 72 files and published 39,081 relations, and then logged:

```text
published language-server enrichment into workspace authority ... published=39081 generation=2
WARN not recording these files as enriched: their relations were not published, so the next sweep must redo them files=72 relations=51703
```

No `lsp-enriched-files.json` was written, so every later daemon on the store re-swept all 72 files
(about 4.5 minutes on that store, the whole repository on a large one), and the warning named a cause that
had not happened: the relations had been published.

## What changes

`crates/kin-daemon/src/daemon.rs` only:

- `file_passes_completed` decides, per file, whether that file's passes completed: the tally's two failure
  counters (`query_failures`, `definitions_over_budget`) must not have moved during its definitions pass and
  its per-entity queries.
- The sweep keeps files that completed in `enriched_this_sweep` and the rest in a new `held_back_this_sweep`.
  Both are still counted as enriched for the pass; only the first is marked.
- `mark_completed_sweep_files` no longer takes the tally. It marks the files it is given when the write was
  durable and marks nothing when it was not, which is the only case left for its existing warning.
- A new warning names the files held back ("a language-server query failed or ran over its budget for them,
  so the next sweep retries them") with their count and the first one.
- `sweep_work_succeeded` is unchanged: a pass with a failed query still does not count as a succeeded pass.

## Measurement

Before, on release bytes of main with #1717 (the marker code unchanged), against a fresh single-branch kin-db
clone: `kin init`'s daemon swept, published and refused the marker, and the next daemon (`kin mcp start
--repo`) found nothing marked and walked all 72 files again:

```text
11:32:10.73  LSP cold sweep started, enriching all entities                         (init's daemon)
11:35:58.25  published language-server enrichment into workspace authority ... published=38418 generation=2
11:36:13.40  WARN not recording these files as enriched: their relations were not published, so the next sweep must redo them files=72 relations=49708
11:36:13.40  LSP cold sweep complete files=72 ... enriched=72 already_enriched=0 ... published=true
11:36:44.21  LSP cold sweep started, enriching all entities                         (the next daemon)
11:40:19.39  published language-server enrichment into workspace authority ... published=4133 generation=3
11:40:37.17  WARN not recording these files as enriched: their relations were not published, so the next sweep must redo them files=72 relations=20683
11:40:37.17  LSP cold sweep complete files=72 ... enriched=72 already_enriched=0 ... published=true
```

So every daemon start on this store re-walks all 72 files, 3 minutes 53 seconds for the second one, and both
warnings name a cause that did not happen: both passes published.

After, on release bytes of this change over main `2e6faae16`, the same two daemons on a fresh clone of the
same commit:

```text
12:14:35.03  LSP cold sweep started, enriching all entities                         (init's daemon)
12:17:47.55  published language-server enrichment into workspace authority ... published=39077 generation=2
12:18:02.67  WARN not recording these files as enriched: a language-server query failed or ran over its budget for them, so the next sweep retries them files=4 first=crates/kin-db/src/engine/traverse.rs
12:18:02.67  LSP cold sweep complete files=72 ... relations=51752 enriched=72 already_enriched=0 ... published=true
12:18:43.84  LSP cold sweep started, enriching all entities                         (the next daemon)
12:20:49.02  published language-server enrichment into workspace authority ... published=942 generation=3
12:21:04.04  WARN not recording these files as enriched: a language-server query failed or ran over its budget for them, so the next sweep retries them files=1 first=crates/kin-db/src/storage/repository.rs
12:21:04.04  LSP cold sweep complete files=72 ... relations=6702 enriched=4 already_enriched=68 ... published=true
lsp-enriched-files.json: 71 files marked
```

The next daemon skipped the 68 files the first pass finished and walked only the 4 it held back, and each
warning now names the cause that held. `kin init` and `kin daemon sweep` both printed
`cross-file enrichment complete (72/72 files)`.

## Tests and falsification

`a_file_whose_query_failed_is_held_back_and_the_rest_are_marked` replaces the whole-pass test it supersedes
(`partial_query_success_does_not_persist_a_skip_marker`, whose intent it keeps per file). It runs three files
through one pass: one completes, one has a per-entity query fail, one's definitions pass runs over budget.
Only the first is marked and saved to `lsp-enriched-files.json`, and a write that did not reach disk marks
nothing, the completed file included.

```text
$ heavy-slot.sh enrichverdict kin -- bash tests-marker.sh      (head 82a269702 on main b04ea0da0)
fmt rc=0
test result: ok. 41 passed; 0 failed; 0 ignored; 0 measured; 1651 filtered out; finished in 1.66s
kin-daemon tests rc=0
```

Falsification, on the same head: each arm swaps one exact string in `daemon.rs`, runs the test with `--exact`,
restores the file and checks its sha256. `daemon.rs` hashed `ff7f1ee6fb236324` and the worktree was clean
before and after all three.

```text
$ heavy-slot.sh enrichverdict kin -- python3 falsify-marker.py
K1 RED (a file whose query failed is marked anyway)          daemon.rs:7365 panicked
K2 RED (a file that completed is held back)                  daemon.rs:7365 panicked
K3 RED (a write that did not reach disk marks its files)     daemon.rs:7369 panicked
```

## Local gates

```text
$ heavy-slot.sh enrichverdict kin -- bin/kin-precheck kin --repo-dir kin=<worktree>
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin 82a2697028faeff2a2b2fe1252e5fe2372976f19
```

Ticket: follow-up to FIR-3551 (the refused marker is what sent the second daemon into its re-sweep).
