### PR TITLE
Name the cross-file edges a graph still holds when no language server can run

### DIFF
--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -1101,12 +1101,11 @@ fn build_graph_status_response_for_store(
     // kind absent. So it belongs on the warning line, carrying the affected file
     // count the coverage line already computes rather than any estimate of what
     // a server would have found (FIR-2777).
-    if let Some(missing) = health
-        .reference_edge_coverage
-        .missing_language_server_warning()
-    {
-        warnings.push(missing);
-    }
+    warnings.extend(
+        health
+            .reference_edge_coverage
+            .missing_language_server_warnings(),
+    );
     let criticals = health.critical_issues.clone();
     let all_relation_count = health
         .semantic_relation_count

--- a/crates/kin-core/src/reference_coverage.rs
+++ b/crates/kin-core/src/reference_coverage.rs
@@ -315,6 +315,46 @@ pub struct LanguageReferenceCoverage {
 }
 
 impl LanguageReferenceCoverage {
+    /// The warning line for one language no language server can enrich, in a
+    /// sentence the output prints verbatim.
+    ///
+    /// Two things in the row decide what it may claim. First, whether the graph
+    /// holds any cross-file reference edge for the language. With none, those
+    /// edges are absent and the sentence says so. With some, resolved from
+    /// source or left by an earlier daemon whose server did run, it names the
+    /// count instead: on a 72-file Rust store an earlier daemon had enriched,
+    /// the coverage row counted 18125 cross-file edges and the warning under it
+    /// called them absent. Second, whether a server is installed at all. One
+    /// that is installed and did not start is not "no language server", so the
+    /// sentence says none can run rather than sending a reader to install what
+    /// they already have. Every form keeps the prefix `no language server for`
+    /// and the file count, which a reader's search and the acceptance grader
+    /// key on.
+    fn language_server_gap_warning(&self) -> String {
+        let files = format!(
+            "{} file{}",
+            self.files,
+            if self.files == 1 { "" } else { "s" }
+        );
+        let gap = match self.reference_enrichment {
+            ReferenceEnrichment::LanguageServerUnusable => {
+                format!("no language server for {} can run ({files})", self.language)
+            }
+            _ => format!("no language server for {} ({files})", self.language),
+        };
+        match self.cross_file_reference_edges {
+            0 => format!(
+                "{gap}; cross-file reference and override edges are absent for those files, so \
+                 this graph is incomplete rather than clean"
+            ),
+            held => format!(
+                "{gap}; the graph holds {held} cross-file reference edge{} for those files, and \
+                 no edge from a language server can be added or refreshed for them until one runs",
+                if held == 1 { "" } else { "s" }
+            ),
+        }
+    }
+
     /// Percent of parsed call sites that produced an edge, capped at 100.
     ///
     /// A call site can fan out to several same-named targets, so the raw ratio
@@ -552,8 +592,8 @@ impl ReferenceEdgeCoverage {
             .collect()
     }
 
-    /// The missing-language-server condition as a WARNING, carrying the count
-    /// of files it affects.
+    /// The missing-language-server condition as WARNINGS, one per language,
+    /// each carrying the count of files it affects.
     ///
     /// The same condition already appears as an indented detail under the
     /// coverage section, where a reader looking for whether the graph is
@@ -569,31 +609,24 @@ impl ReferenceEdgeCoverage {
     /// running one, and a warning that guessed would be wrong by an unknown
     /// amount on any repository unlike the one measured. `files` is a number the
     /// graph already holds.
-    pub fn missing_language_server_warning(&self) -> Option<String> {
-        let missing: Vec<&LanguageReferenceCoverage> = self
-            .languages
+    ///
+    /// One warning per language, because what each may claim depends on that
+    /// language's own row; `language_server_gap_warning` says how.
+    pub fn missing_language_server_warnings(&self) -> Vec<String> {
+        self.languages
             .iter()
             .filter(|language| language.reference_enrichment.is_actionable_gap())
-            .collect();
-        if missing.is_empty() {
-            return None;
-        }
-        let named: Vec<String> = missing
+            .map(LanguageReferenceCoverage::language_server_gap_warning)
+            .collect()
+    }
+
+    /// Languages in one language-server state, in row order.
+    fn languages_in_state(&self, state: ReferenceEnrichment) -> Vec<&str> {
+        self.languages
             .iter()
-            .map(|language| {
-                format!(
-                    "{} ({} file{})",
-                    language.language,
-                    language.files,
-                    if language.files == 1 { "" } else { "s" }
-                )
-            })
-            .collect();
-        Some(format!(
-            "no language server for {}; cross-file reference and override edges are absent for \
-             those files, so this graph is incomplete rather than clean",
-            named.join(", ")
-        ))
+            .filter(|language| language.reference_enrichment == state)
+            .map(|language| language.language.as_str())
+            .collect()
     }
 
     /// Whether any surface should present this as needing attention.
@@ -648,12 +681,23 @@ impl ReferenceEdgeCoverage {
             lines.push(format!("  {}", language_summary(language)));
         }
 
-        let missing = self.languages_missing_a_language_server();
-        if !missing.is_empty() {
+        // Split by state, because the repairs differ: an install for one, a
+        // broken install for the other. A server that was installed and did not
+        // start used to be reported here as "no language server found".
+        let not_installed = self.languages_in_state(ReferenceEnrichment::NoLanguageServer);
+        if !not_installed.is_empty() {
             lines.push(format!(
                 "  cross-file reference and override edges unavailable for {}: no language server \
                  found",
-                missing.join(", ")
+                not_installed.join(", ")
+            ));
+        }
+        let cannot_start = self.languages_in_state(ReferenceEnrichment::LanguageServerUnusable);
+        if !cannot_start.is_empty() {
+            lines.push(format!(
+                "  cross-file reference and override edges cannot be produced for {}: a language \
+                 server is installed but it did not start",
+                cannot_start.join(", ")
             ));
         }
         let unsupported: Vec<&str> = self
@@ -2229,6 +2273,120 @@ mod tests {
             resolution: ReferenceResolution::FullyResolved,
             reference_enrichment: enrichment,
         }
+    }
+
+    /// A server that is installed and did not start, over a graph that still
+    /// holds cross-file edges, is reported as exactly that.
+    ///
+    /// The measured case: a 72-file Rust store an earlier daemon had enriched,
+    /// and a later daemon that could not start rust-analyzer. The coverage row
+    /// counted 18125 cross-file edges, and the two lines under it said no
+    /// language server was found and that those edges were absent.
+    #[test]
+    fn a_server_that_did_not_start_over_held_edges_is_not_called_missing() {
+        let mut rust = language_row("rust", ReferenceEnrichment::LanguageServerUnusable);
+        rust.files = 72;
+        rust.cross_file_reference_edges = 18125;
+        let coverage = ReferenceEdgeCoverage {
+            parse: None,
+            languages: vec![language_row("python", ReferenceEnrichment::Available), rust],
+            totals: None,
+        };
+
+        let warnings = coverage.missing_language_server_warnings();
+        assert_eq!(
+            warnings.len(),
+            1,
+            "only the language no server can serve warns: {warnings:?}"
+        );
+        assert!(
+            warnings[0].starts_with("no language server for rust can run (72 files); "),
+            "an installed server that did not start is not a missing one: {}",
+            warnings[0]
+        );
+        assert!(
+            warnings[0].contains("the graph holds 18125 cross-file reference edges"),
+            "{}",
+            warnings[0]
+        );
+        assert!(!warnings[0].contains("are absent"), "{}", warnings[0]);
+
+        let rendered = coverage.summary_lines().join("\n");
+        assert!(
+            rendered.contains(
+                "cross-file reference and override edges cannot be produced for rust: a \
+                 language server is installed but it did not start"
+            ),
+            "{rendered}"
+        );
+        assert!(!rendered.contains("no language server found"), "{rendered}");
+    }
+
+    /// No server and no cross-file edge keeps the sentence it always had, word
+    /// for word, because there it is true.
+    #[test]
+    fn a_missing_server_over_no_cross_file_edge_keeps_its_sentence() {
+        let mut python = language_row("python", ReferenceEnrichment::NoLanguageServer);
+        python.files = 5;
+        python.cross_file_reference_edges = 0;
+        let coverage = ReferenceEdgeCoverage {
+            parse: None,
+            languages: vec![python],
+            totals: None,
+        };
+
+        assert_eq!(
+            coverage.missing_language_server_warnings(),
+            vec![
+                "no language server for python (5 files); cross-file reference and override \
+                 edges are absent for those files, so this graph is incomplete rather than clean"
+                    .to_string()
+            ]
+        );
+        assert!(
+            coverage
+                .summary_lines()
+                .join("\n")
+                .contains("unavailable for python: no language server found"),
+            "the line that identifies a graph with no server stays"
+        );
+    }
+
+    /// No server, and cross-file edges resolved from source: the shape of the
+    /// acceptance grader's no-server sample, which carries 11. The warning keeps
+    /// what that grader keys on, the prefix and the file count, and names the
+    /// edges rather than calling them absent.
+    #[test]
+    fn a_missing_server_over_source_resolved_edges_names_them() {
+        let mut python = language_row("python", ReferenceEnrichment::NoLanguageServer);
+        python.files = 5;
+        python.cross_file_reference_edges = 11;
+        let coverage = ReferenceEdgeCoverage {
+            parse: None,
+            languages: vec![python],
+            totals: None,
+        };
+
+        let warnings = coverage.missing_language_server_warnings();
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(
+            warnings[0].starts_with("no language server for python (5 files); "),
+            "{}",
+            warnings[0]
+        );
+        assert!(
+            warnings[0].contains("the graph holds 11 cross-file reference edges"),
+            "{}",
+            warnings[0]
+        );
+        assert!(!warnings[0].contains("are absent"), "{}", warnings[0]);
+        assert!(
+            coverage
+                .summary_lines()
+                .join("\n")
+                .contains("unavailable for python: no language server found"),
+            "the no-server arm keeps the line that identifies it"
+        );
     }
 
     /// Fan-out can put more edges on the numerator than the denominator ever


### PR DESCRIPTION
When no language server can run for a language, `kin graph status` now names the cross-file edges the graph still
holds for it instead of calling them absent, and a server that is installed but did not start no longer reads as
"no language server found".

## What was wrong

On a kin-db store (72 Rust files) that an earlier daemon had enriched, served by a daemon that could not start
rust-analyzer, `kin graph status` printed:

```text
  rust: 72 files, calls 23725/56539 (41%), imports 0/441 (0%), 441 name a module outside this repository, cross-file 18125, intra-file 26849 [partial]
  cross-file reference and override edges unavailable for rust: no language server found
⚠ no language server for rust (72 files); cross-file reference and override edges are absent for those files, so this graph is incomplete rather than clean
```

The row counts 18,125 cross-file edges and the warning under it calls them absent. And the page has one sentence
for two states that need different repairs: no server installed, and a server that is installed and did not start,
which `kin doctor` already tells apart ("installed but it did not start").

## What changes

`crates/kin-core/src/reference_coverage.rs`:

- `missing_language_server_warning`, one sentence naming every language, becomes `missing_language_server_warnings`,
  one line per language, built by `LanguageReferenceCoverage::language_server_gap_warning`. Each language's own
  edge count and server state decide its sentence, and one sentence over several languages cannot say "absent" for
  one and "18125 held" for another.
- A language with no cross-file reference edge keeps its sentence word for word. A language that holds some names
  the count: "the graph holds 18125 cross-file reference edges for those files, and no edge from a language server
  can be added or refreshed for them until one runs".
- A server that is installed and did not start reads "no language server for rust can run (72 files)", and the
  coverage line splits by state: not installed keeps "unavailable for rust: no language server found", did not
  start reads "cannot be produced for rust: a language server is installed but it did not start".

`crates/kin-cli/src/commands/graph.rs`: the one caller takes every line (`extend` in place of `push`), the way it
already takes `census_comparison.loss_lines()`.

## Measurement

Measured on the kin-db store (72 Rust files) that the sweep-marker PR's two daemons had enriched, served by a
daemon started with a stub `rust-analyzer` first on its PATH that exits at once. The daemon resolved the stub,
tried it and logged what it found:

```text
WARN kin_daemon::daemon: a language server is installed but cannot start, so this language's cross-file reference edges cannot be produced on this host language=rust reason=server initialization failed: server shutdown unexpectedly (server stderr: stub rust-analyzer: this server does not start)
```

Before, release bytes of main 2e6faae16 with the sweep-marker change, `kin graph status` against that daemon:

```text
  rust: 72 files, calls 23725/56539 (41%), imports 0/441 (0%), 441 name a module outside this repository, cross-file 18138, intra-file 26849 [partial]
  cross-file reference and override edges unavailable for rust: no language server found
⚠ no language server for rust (72 files); cross-file reference and override edges are absent for those files, so this graph is incomplete rather than clean
```

After, release bytes of this branch at b18011c76, the same store and the same stub:

```text
  rust: 72 files, calls 23725/56539 (41%), imports 0/441 (0%), 441 name a module outside this repository, cross-file 18138, intra-file 26849 [partial]
  cross-file reference and override edges cannot be produced for rust: a language server is installed but it did not start
⚠ no language server for rust can run (72 files); the graph holds 18138 cross-file reference edges for those files, and no edge from a language server can be added or refreshed for them until one runs
```

Same store, same row, same 18,138 edges. The two lines under the row now say what the daemon logged: a server
that is installed and did not start, and edges the graph holds rather than edges that are absent.

## Acceptance

`scripts/acceptance/language_server_warning.py` is untouched. For the no-server arm it keys on a warning line
carrying `no language server for` and a `(N files)` count, and on the page carrying `no language server found`;
for the pyright arm, on no such warning line. Every form keeps the prefix and the count, and the not-installed
coverage line is unchanged. Its own no-server sample carries `cross-file 11`, so the held-edges sentence can reach
that arm, which is why the grader's own functions ran on real bytes before and after:

```text
$ python3 wording-measure-corpus.py
  (the grader's own five-file corpus and its own grading functions; arm A runs with PATH=/usr/bin:/bin,
   arm B with pyright's directory in front; every daemon stopped by pid after its arm)

before: release bytes of main 2e6faae16 with the sweep-marker change (main's wording), arm A, no server
  python: 5 files, calls 5/6 (83%), imports 3/3 (100%), cross-file 11, intra-file 0 [partial]
  cross-file reference and override edges unavailable for python: no language server found
⚠ no language server for python (5 files); cross-file reference and override edges are absent for those files, so this graph is incomplete rather than clean
  arm_is_the_no_server_arm=True gap_reaches_warning_line=PASS gap_names_affected_count=PASS
before, arm B, pyright: cross-file 15, no gap warning; arm_is_the_server_arm=True line_is_quiet=PASS

after: release bytes of this branch at b18011c76, arm A, no server
  python: 5 files, calls 5/6 (83%), imports 3/3 (100%), cross-file 11, intra-file 0 [partial]
  cross-file reference and override edges unavailable for python: no language server found
⚠ no language server for python (5 files); the graph holds 11 cross-file reference edges for those files, and no edge from a language server can be added or refreshed for them until one runs
  arm_is_the_no_server_arm=True gap_reaches_warning_line=PASS gap_names_affected_count=PASS
after, arm B, pyright: cross-file 15, no gap warning; arm_is_the_server_arm=True line_is_quiet=PASS
```

So the acceptance corpus's own no-server arm was already the case this fixes: its row counts 11 cross-file edges
and the old warning called them absent.

## Tests and falsification

Three kin-core tests beside the one that pins the not-installed coverage line:

- T1 `a_server_that_did_not_start_over_held_edges_is_not_called_missing`: rust, 72 files, 18125 cross-file
  edges, a server installed and not started, beside a python row with a working server. One warning, for rust
  only, reading `no language server for rust can run (72 files); ` and naming the 18125 edges, never "are
  absent"; the coverage line says the server is installed but did not start and never "no language server
  found".
- T2 `a_missing_server_over_no_cross_file_edge_keeps_its_sentence`: python, 5 files, no cross-file edge, no
  server. The warning equals today's sentence word for word, and the not-installed coverage line stays.
- T3 `a_missing_server_over_source_resolved_edges_names_them`: python, 5 files, 11 cross-file edges, no server,
  the shape of the grader's no-server sample. The warning keeps `no language server for python (5 files); `,
  names the 11 edges and never says "are absent", and the not-installed coverage line stays.

```text
$ heavy-slot.sh enrichverdict kin -- bash tests-wording.sh      (head b18011c76 on main 427eb6e9e)
fmt rc=0
test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 864 filtered out; finished in 0.01s     (kin-core reference_coverage)
test result: ok. 96 passed; 0 failed; 0 ignored; 0 measured; 2228 filtered out; finished in 13.08s   (kin-cli commands::graph)
```

Falsification, on the same head: each arm swaps one exact string in `reference_coverage.rs`, runs the three
tests, requires exactly the named ones to fail, restores the file and checks its sha256 (`a2a13780775d` and a
clean worktree before and after every arm).

```text
$ heavy-slot.sh enrichverdict kin -- python3 falsify-wording.py
W1 RED (every row takes the zero-edge sentence)                            T1, T3 failed   reference_coverage.rs:2307, :2377
W2 RED (a server that did not start gets the not-installed wording)        T1 failed       reference_coverage.rs:2302
W3 RED (the coverage line calls a server that did not start not found)     T1 failed       reference_coverage.rs:2322
W4 RED (the zero-edge sentence drifts)                                     T2 failed       reference_coverage.rs:2338
W5 RED (the file count leaves the not-installed sentence)                  T2, T3 failed   reference_coverage.rs:2338, :2372
```

## Local gates

```text
$ heavy-slot.sh enrichverdict kin -- bin/kin-precheck kin --repo-dir kin=<worktree>
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin b18011c76a1300bac192c39e74e418e9483c954b
```

Ticket: follow-up to FIR-3551 (measured on its second run).
