### PR TITLE
Hold one repository authority per publication for the daemon's own readers

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -144,7 +144,7 @@ const MAX_AUTHORITY_PUBLICATION_RECORD_BYTES: u64 = 1024 * 1024;
 /// whether an already-loaded authority may be reused, and every answer served
 /// still comes from repository-v6 graph truth.
 #[derive(Clone, PartialEq, Eq)]
-enum LocalPublicationIdentity {
+pub(crate) enum LocalPublicationIdentity {
     /// The repository has persisted no authority yet, so its authority is the
     /// unpublished generation-zero state.
     Unpublished,
@@ -158,7 +158,7 @@ enum LocalPublicationIdentity {
 /// request and pay the full load only when the publication has actually moved
 /// — including when it moved under a separate process such as a CLI ingest or
 /// commit running beside the daemon.
-fn read_local_publication_identity(
+pub(crate) fn read_local_publication_identity(
     backend: &LocalFileBackend,
     repository_id: &RepositoryId,
 ) -> Result<LocalPublicationIdentity, (StatusCode, String)> {
@@ -341,6 +341,37 @@ impl ProjectionAuthorityCache {
         });
     }
 
+    /// Hold the authority the daemon's own startup open already paid for.
+    ///
+    /// Opening the daemon decodes the whole persisted authority and re-verifies
+    /// every body in repository CAS, and the admission pair, the first flush and
+    /// the first projection read each used to pay that again within seconds of
+    /// startup, for the same publication. `published` must be the identity read
+    /// BEFORE that open, exactly as every other slot's label is, so a reader
+    /// reuses it only while the record still reads the same and loads fresh the
+    /// moment another writer moves it.
+    ///
+    /// Not counted in [`Self::loads`]. That counter has always counted the
+    /// loads this cache's resolvers paid, and the startup open was never one of
+    /// them; counting it now would change what a daemon reports as its
+    /// `Authority loads` without changing anything it pays.
+    pub(crate) fn install_opened(
+        &self,
+        published: LocalPublicationIdentity,
+        manager: Arc<RepositoryAuthorityManager<LocalFileBackend>>,
+        repository_id: RepositoryId,
+        workspace_id: WorkspaceId,
+    ) {
+        self.install(
+            published,
+            ActiveApiRepositoryAuthority {
+                manager,
+                repository_id,
+                workspace_id,
+            },
+        );
+    }
+
     fn reuse_query(
         &self,
         published: &LocalPublicationIdentity,
@@ -443,13 +474,28 @@ fn confirm_pinned_projection_namespace(
     }
 }
 
-/// Resolve the repository-v6 authority the projection routes answer from.
+/// The daemon's one held repository-v6 authority and the publication label it
+/// was loaded under.
+///
+/// Every local reader in this daemon that needs the authority itself borrows
+/// this one: the projection routes, the refs envelope, the admission pair, the
+/// persistence flush and its read-index finalize, search bodies, the blob
+/// loader and scope builds. An open decodes the complete persisted authority
+/// and re-verifies every body in repository CAS, so each reader that opened its
+/// own paid the whole store again for a publication the daemon already held.
+///
+/// The label is the rule that makes borrowing safe. It is the digest of
+/// `authority.json` read strictly before the load it labels, and the held
+/// authority is handed out only while the record still reads the same. A
+/// publication by anyone else, the CLI or a second daemon included, changes
+/// those bytes, and the next reader loads fresh under the new label instead of
+/// being served what this daemon held before it.
 ///
 /// Blocking: reads storage metadata and, on a publication change, loads the
 /// complete durable authority. Callers run it on a blocking thread.
-fn projection_repository_authority(
+fn held_projection_authority(
     state: &DaemonState,
-) -> Result<ActiveApiRepositoryAuthority, (StatusCode, String)> {
+) -> Result<(LocalPublicationIdentity, ActiveApiRepositoryAuthority), (StatusCode, String)> {
     let backend = state.local_repository_backend().ok_or_else(|| {
         repository_authority_error("local daemon is missing its startup storage capability")
     })?;
@@ -466,7 +512,7 @@ fn projection_repository_authority(
 
     let published = read_local_publication_identity(&backend, &repository_id)?;
     if let Some(authority) = state.projection_authority.reuse(&published) {
-        return Ok(authority);
+        return Ok((published, authority));
     }
 
     let _load = lock_recover(&state.projection_authority.load_gate);
@@ -475,12 +521,12 @@ fn projection_repository_authority(
     // before the load it describes.
     let published = read_local_publication_identity(&backend, &repository_id)?;
     if let Some(authority) = state.projection_authority.reuse(&published) {
-        return Ok(authority);
+        return Ok((published, authority));
     }
     let authority = ActiveApiRepositoryAuthority::open(state)?;
     state
         .projection_authority
-        .install(published, authority.clone());
+        .install(published.clone(), authority.clone());
     // Whether reuse is actually holding is not visible from request latency
     // alone, and a count that climbs with request volume rather than with
     // publications is the signal that it is not.
@@ -489,7 +535,26 @@ fn projection_repository_authority(
         loads = state.projection_authority.loads(),
         "projection repository authority loaded"
     );
-    Ok(authority)
+    Ok((published, authority))
+}
+
+/// Resolve the repository-v6 authority the projection routes answer from: the
+/// daemon's held one (see [`held_projection_authority`]).
+fn projection_repository_authority(
+    state: &DaemonState,
+) -> Result<ActiveApiRepositoryAuthority, (StatusCode, String)> {
+    held_projection_authority(state).map(|(_, authority)| authority)
+}
+
+/// The daemon's held authority manager, for readers outside this module.
+///
+/// The same label rule as [`held_projection_authority`]: reused only while
+/// `authority.json` reads as it did before the authority was loaded, loaded
+/// fresh otherwise. Blocking.
+pub(crate) fn held_repository_authority(
+    state: &DaemonState,
+) -> Result<Arc<RepositoryAuthorityManager<LocalFileBackend>>, (StatusCode, String)> {
+    projection_repository_authority(state).map(|authority| authority.manager)
 }
 
 /// The repository authority envelope a local daemon's refs routes answer from.
@@ -743,29 +808,24 @@ fn cached_authority_admission_entry(
         return Ok(admission);
     }
 
-    let _load = lock_recover(&state.projection_authority.load_gate);
-    // Re-read under the gate: the publication may have moved while this request
-    // waited, and the label installed below must be the one taken before the
-    // open it describes.
-    let published = read_local_publication_identity(&backend, &repository_id)?;
+    // The values come out of the daemon's one held authority rather than an
+    // open of their own. `held_projection_authority` applies the same label rule
+    // under the same load gate, so a burst of cold callers still pays one load
+    // between them, and the label installed below is the one that authority was
+    // loaded under, never a later reading.
+    let (published, authority) = held_projection_authority(state)?;
     if let Some(admission) = state.projection_authority.reuse_admission(&published) {
         return Ok(admission);
     }
 
-    let context =
-        crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(state)
-            .map_err(|error| repository_authority_error(error.to_string()))?;
-    let authority = context
-        .open()
-        .map_err(|error| repository_authority_error(error.to_string()))?;
-    state.projection_authority.record_load();
-    let lease = authority.read_authority();
+    let workspace_id = binding.workspace_id();
+    let lease = authority.manager.read_authority();
     let roots = lease.roots().clone();
-    let open_merge =
-        crate::repository_merge_state::open_merge_summary(&lease, context.workspace_id());
+    let open_merge = crate::repository_merge_state::open_merge_summary(&lease, workspace_id);
     drop(lease);
     let policy = authority
-        .workspace_admission_snapshot(context.repository_id(), &context.workspace_id())
+        .manager
+        .workspace_admission_snapshot(&repository_id, &workspace_id)
         .map_err(|error| repository_authority_error(error.to_string()))?
         .map(|snapshot| snapshot.matcher);
     let admission = HeldAdmission {
@@ -4818,7 +4878,7 @@ async fn set_scope(
                 Some(&ref_string),
             )
             .map_err(|err| (StatusCode::BAD_REQUEST, format!("{:#}", err)))?;
-            let authority = ActiveApiRepositoryAuthority::open(&state_clone)?;
+            let authority = projection_repository_authority(&state_clone)?;
             let historical =
                 kin_core::build_graph_at_ref(&authority.manager, &head).map_err(internal_error)?;
 
@@ -9967,7 +10027,7 @@ fn attach_search_bodies(
     response: &mut kin_cli::commands::search::DaemonSearchResponse,
     max_lines: usize,
 ) {
-    let Ok(authority) = ActiveApiRepositoryAuthority::open(state) else {
+    let Ok(authority) = projection_repository_authority(state) else {
         return;
     };
     let lease = authority.manager.read_authority();
@@ -19591,7 +19651,7 @@ pub(crate) fn repository_source_blob_loader(
     repo_id: &str,
 ) -> Result<RepositorySourceBlobLoader, (StatusCode, String)> {
     let Some(backend) = state.storage_backend.as_ref().map(Arc::clone) else {
-        let authority = ActiveApiRepositoryAuthority::open(state)?;
+        let authority = projection_repository_authority(state)?;
         return Ok(Box::new(
             move |path: &RepoPath, digest: kin_model::Hash256, _remaining_bytes: u64| {
                 authority.manager.load_source_blob(digest).map_err(|error| {
@@ -35311,6 +35371,10 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn health_answers_while_the_admission_pair_is_loading() {
         let state = test_state();
+        // Cold the way a moved publication leaves it. The daemon holds the
+        // authority it opened at startup, and a publication elsewhere retires
+        // that, so every reader after it has to take the load gate.
+        state.projection_authority.invalidate();
         let (held_tx, held_rx) = std::sync::mpsc::channel::<()>();
         let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
         let gate_state = Arc::clone(&state);

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -5307,6 +5307,15 @@ impl DaemonState {
         } else {
             Self::pin_registered_local_repository_authorities(&layout)
         };
+        // The publication this open is about to load, read BEFORE it for the
+        // reason every held authority's label is read first: a label taken
+        // afterwards could name a publication that landed during the load and
+        // mark older bytes as current. An unreadable record only means the
+        // daemon does not hold this open afterwards; the open itself decides
+        // whether the store is usable.
+        let startup_publication =
+            crate::api::read_local_publication_identity(&local_repository_backend, &repository_id)
+                .ok();
         // Startup is a reopen of an initialized repository, never construction
         // of an unpersisted generation-zero authority. Use the receipt from
         // this same recovery to refuse an intact namespace whose authority
@@ -5486,7 +5495,8 @@ impl DaemonState {
             "loaded daemon query graph from workspace-scoped repository-v6 authority"
         );
         drop(lease);
-        drop(authority);
+        // `authority` stays alive: the daemon keeps the manager this open paid
+        // for as its held authority, installed once the state exists below.
 
         // The repository snapshot above is authoritative. Vector/text
         // structures built from it are derived query surfaces only.
@@ -5725,6 +5735,18 @@ impl DaemonState {
                     state.finalize_loaded_generation(generation)
                 })?;
             }
+        }
+        // Hold the startup open instead of dropping it. It carries the label read
+        // before it, so the admission pair, the first flush and the first
+        // projection read reuse it while the record still reads the same, and
+        // load fresh the moment another writer moves it.
+        if let Some(published) = startup_publication {
+            state.projection_authority.install_opened(
+                published,
+                Arc::new(authority),
+                repository_id,
+                workspace_id,
+            );
         }
         state.register_daemon_system_session();
         // The first settled status reading, taken here because this is the last
@@ -11333,7 +11355,9 @@ impl DaemonState {
 
     /// Finish local artifacts for one already-committed authority generation.
     ///
-    /// The read index is rebuilt from reopened durable authority, not the live
+    /// The read index is rebuilt from durable authority at that generation
+    /// (the daemon's held authority while the record still reads as it did
+    /// when that authority was loaded, a fresh open otherwise), not the live
     /// graph, which may already contain mutations that arrived after the
     /// committed batch. It is staged off-path, the old canonical index is
     /// removed, the generation marker is durably published, and only then is
@@ -11414,6 +11438,22 @@ impl DaemonState {
         Ok(index_path)
     }
 
+    /// The daemon's one held repository authority for the current publication.
+    ///
+    /// Borrowed rather than opened: an open decodes the complete persisted
+    /// authority and re-verifies every body in repository CAS, and the flush and
+    /// its finalize each used to pay that for a publication the daemon already
+    /// held. The held authority is handed out only while `authority.json` still
+    /// reads as it did before that authority was loaded, so a publication by
+    /// another process is loaded fresh, never served from what this daemon held
+    /// before it.
+    fn held_local_repository_authority(
+        &self,
+    ) -> Result<Arc<RepositoryAuthorityManager<LocalFileBackend>>> {
+        crate::api::held_repository_authority(self)
+            .map_err(|(_, message)| DaemonError::Graph(kin_db::KinDbError::StorageError(message)))
+    }
+
     /// Prove the derived graph still matches workspace authority at this
     /// generation, publish the language-server relations authority does not
     /// hold yet, and report the generation the workspace ends at.
@@ -11436,14 +11476,16 @@ impl DaemonState {
     /// whatever an earlier attempt failed to land, and it does not care which
     /// batch an edge arrived in.
     ///
-    /// One authority open serves the whole pass. An open is O(store) rather
-    /// than a cheap handle, because kin-db decodes the complete persisted
-    /// authority and then re-verifies every body in repository CAS against its
-    /// content address, so the tree proof, the diff, and the commit all run
-    /// against this one lease.
+    /// One authority serves the whole pass, and it is the daemon's held one,
+    /// not an open of its own. An open is O(store) rather than a cheap handle,
+    /// because kin-db decodes the complete persisted authority and then
+    /// re-verifies every body in repository CAS against its content address,
+    /// and a flush that opened its own paid that for a publication the daemon
+    /// already held. The tree proof, the diff and the commit all run against
+    /// this one authority.
     fn publish_local_workspace_enrichment(&self, expected_generation: u64) -> Result<u64> {
         let binding = self.local_repository_authority_binding()?;
-        let authority = binding.open_manager().map_err(DaemonError::from)?;
+        let authority = self.held_local_repository_authority()?;
         let workspace_id = binding.workspace_id();
         let lease = authority.read_authority();
         let observed_generation = lease.roots().generation;
@@ -11658,7 +11700,7 @@ impl DaemonState {
             }
         } else {
             let binding = self.local_repository_authority_binding()?;
-            let authority = binding.open_manager().map_err(DaemonError::from)?;
+            let authority = self.held_local_repository_authority()?;
             let lease = authority.read_authority();
             let observed_generation = lease.roots().generation;
             if observed_generation != generation {
@@ -19982,6 +20024,127 @@ mod tests {
                 .contains_key(&enriched.id),
             "a language-server relation must be graph-owned durable truth, not runtime state \
              the next process does not inherit"
+        );
+    }
+
+    /// One publication costs the daemon one whole-store open, however many of
+    /// its own readers ask for authority at it.
+    ///
+    /// An open decodes the complete persisted authority and re-verifies every
+    /// body in repository CAS. The startup open used to be dropped, and the
+    /// admission pair and the persistence flush then opened the store again for
+    /// the publication the daemon had just loaded.
+    #[test]
+    fn the_startup_open_serves_the_admission_pair_and_the_flush() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        // The positive control: opening the daemon genuinely opens authority,
+        // so a counter that cannot move is caught here rather than read below
+        // as a pass.
+        let before_open = kin_core::authority_opens();
+        let state = test_state(init.layout, repo_dir.path());
+        assert!(
+            kin_core::authority_opens() > before_open,
+            "the authority-open counter did not move across a daemon open, so it cannot report \
+             an open at all and the assertion below would pass on any tree"
+        );
+
+        let before = kin_core::authority_opens();
+        crate::api::cached_authority_admission(&state)
+            .expect("the admission pair must resolve at the startup publication");
+        state
+            .save_snapshot()
+            .expect("a flush with nothing to publish succeeds");
+        crate::api::held_repository_authority(&state)
+            .expect("the held authority must answer at the startup publication");
+        assert_eq!(
+            kin_core::authority_opens(),
+            before,
+            "the admission pair, the flush and a projection read at the startup publication \
+             must borrow the authority the daemon opened at startup, not open the store again"
+        );
+    }
+
+    /// A publication the held authority did not make is loaded fresh, never
+    /// served from what the daemon held before it.
+    ///
+    /// The commit below goes through a manager of its own, the way the CLI or a
+    /// second daemon writes beside this one, so the held authority never sees
+    /// it. What the commit changes is `authority.json`, and the held authority's
+    /// label is the digest of that record as it read before the held load.
+    #[test]
+    fn a_record_another_writer_moved_is_loaded_fresh_not_served_from_the_held_authority() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let state = test_state(init.layout, repo_dir.path());
+        let held = crate::api::held_repository_authority(&state).unwrap();
+        let held_generation = held.read_authority().roots().generation;
+
+        publish_authority_entities(&state, &[test_entity("send", "src/sessions.rs")]);
+
+        let before = kin_core::authority_opens();
+        let fresh = crate::api::held_repository_authority(&state).unwrap();
+        let fresh_generation = fresh.read_authority().roots().generation;
+        assert!(
+            fresh_generation > held_generation,
+            "a reader after another writer's publication must get that publication (generation \
+             {fresh_generation}), never the held authority at generation {held_generation}"
+        );
+        assert_eq!(
+            kin_core::authority_opens() - before,
+            1,
+            "a moved record must cost exactly one fresh load"
+        );
+        let (roots, _) = crate::api::cached_authority_admission(&state).unwrap();
+        assert_eq!(
+            roots.generation, fresh_generation,
+            "the admission pair must follow the moved record too"
+        );
+        assert_eq!(
+            kin_core::authority_opens() - before,
+            1,
+            "and share that fresh load rather than paying one of its own"
+        );
+    }
+
+    /// The flush after a publication pays one open for it, and its finalize and
+    /// the readers after it borrow that one.
+    #[test]
+    fn the_flush_after_a_publication_opens_once_and_its_finalize_borrows_it() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let state = test_state(init.layout, repo_dir.path());
+        publish_authority_entities(
+            &state,
+            &[
+                test_entity("send", "src/sessions.rs"),
+                test_entity("adapter_send", "src/adapters.rs"),
+            ],
+        );
+        assert!(
+            state
+                .post_commit_finalization_pending
+                .load(Ordering::SeqCst),
+            "the fixture publication must leave a finalize for the flush to run"
+        );
+
+        let before = kin_core::authority_opens();
+        state
+            .save_snapshot()
+            .expect("the flush after a publication succeeds");
+        assert!(
+            !state
+                .post_commit_finalization_pending
+                .load(Ordering::SeqCst),
+            "the flush must have run its read-index finalize"
+        );
+        crate::api::cached_authority_admission(&state).unwrap();
+        crate::api::held_repository_authority(&state).unwrap();
+        assert_eq!(
+            kin_core::authority_opens() - before,
+            1,
+            "one publication is one whole-store open: the flush loads it, and its finalize and \
+             the readers after it borrow that load"
         );
     }
 


### PR DESCRIPTION
The daemon now opens the whole store once per publication instead of once per reader. It keeps its startup open rather than dropping it, and its own readers borrow that one held authority for as long as `authority.json` reads the same as it did before the load.

## Why

Every whole-store open decodes the persisted snapshot and re-verifies every body in repository CAS. On a scratch clone of kin-db (607 changes, a 1,418,328,932-byte snapshot, 5,710 bodies of 184,236,518 bytes) each one took 6.3 to 7.6 s and 0.5 to 1.1 GiB of footprint while it ran. The daemon paid them over and over for the same publication.

- At start it paid three in the first 25 s. Beside the startup open, the admission pair and the startup flush each opened the store again, and the flush then published nothing.
- After each publication, every reader paid one on its first read, and every flush paid two: one to publish before it knew its delta and one to rebuild the read index.
- One MCP commit cost nine opens. Its base and plan opened the store before it, and seven more opens followed in the 22 s after it for the one publication it made.
- A dirty stop took 17.4 s, and all of it was the in-flight flush's two opens for one publication.

The full tables, logs and method are in the lane report `authoritycost-20260911.md` (runs 1 to 3, 3303c1d55 release bytes, LSP and auto-embed off, one standalone daemon on one scratch store).

## How

`api.rs` already held authority for the projection routes under the right rule. The label is the SHA-256 of `authority.json` read strictly before the load it labels, and the held authority is reused only while the record still reads the same. This change makes that one held authority the daemon's, and moves the readers that paid the most onto it.

- `held_projection_authority` is the projection slot's resolver, now returning the label with the authority. `projection_repository_authority` and a crate-visible `held_repository_authority` sit on it.
- `open_with_repo_id` reads the label before its open and installs the manager it paid for (`ProjectionAuthorityCache::install_opened`) instead of dropping it.
- `cached_authority_admission_entry` reads roots, the open-merge summary and the admission snapshot from the held authority instead of opening its own. A burst of cold callers still pays one load between them, under the same load gate.
- `publish_local_workspace_enrichment` and `load_committed_authority_graph` borrow the held authority through `held_local_repository_authority`.
- `attach_search_bodies`, `set_scope` and `repository_source_blob_loader` borrow it too. Each of them opened the store per request.

The label check is what keeps this safe. A held authority whose label differs from the record is never served, so a publication by the CLI or a second daemon is loaded fresh. Every held authority came from a full kin-db open, the pinned-namespace probe stays ahead of every reuse, and opens still verify every body.

## What remains, until kin-db's K3

The daemon still pays one open per publication it makes itself, shared by every reader after it. Relabelling its own commit is not race-free today, because a label read after the commit could name another writer's publication. kin-db lane freezetrust is adding K3 (the manager reports its durable head and the digest of the record that names it), and the relabel follows its release. The MCP commit path's own opens are the next PR, and the query and command wrappers' separate opens come after that.

## Numbers

Same store (fresh APFS clones of one kin-db store), same driver and settings, one standalone daemon each. Before is run 3 on 3303c1d55 release bytes. After is run 4 on this commit's release bytes (main 427eb6e9e plus this change). Whole-store opens that started in each phase, with their summed milliseconds:

| phase | before opens (ms) | after opens (ms) | before wall s | after wall s |
|---|---|---|---|---|
| startup | 3 (21,964) | 1 (8,261) | 86.7 | 73.4 |
| first refs read | 1 (6,364) | 0 | 6.37 | 0.01 |
| first get_entity_source | 1 (6,408) | 1 (6,560) | 6.4 | 6.6 |
| first get_context_pack | 1 (6,388) | 1 (6,495) | 11.7 | 12.1 |
| MCP commit | 3 (20,185) | 3 (22,614) | 149.2 | 168.2 |
| refs read after the commit | 2 (14,556) | 1 (7,186) | 7.0 | 7.3 |
| get_entity_source after it | 3 (21,715) | 1 (7,133) | 7.5 | 7.2 |
| get_context_pack after it | 1 (6,681) | 1 (7,174) | 19.7 | 13.0 |
| 8-file edit, admission and flush | 3 (22,294) | 2 (13,554) | 140.9 | 123.7 |
| dirty stop | 4 (25,821) | 2 (14,442) | 72.7 | 63.6 |
| whole run | 22 | 13 | | |

The startup flush fell from 7,138 ms to 256 ms, because it borrows the startup open instead of paying its own. A dirty stop went from 13.71 s to 7.63 s from SIGTERM to exit, with the flush in flight at the signal both times: after this change its finalize borrows the open its publish paid for. The commit's own three opens are the next PR's, and the `get_entity_source` and `get_context_pack` rows are the command and query wrappers, which still hold their own copies until the PR after that. Other builds were running on the box during run 4's commit, and this change leaves the commit path alone, so that row reads as unchanged rather than slower.

## Tests

New in `crates/kin-daemon/src/state.rs`, each on the kin-core funnel's thread-local open count with its positive control:

- `the_startup_open_serves_the_admission_pair_and_the_flush` holds the admission pair, a flush and a projection read at the startup publication to zero opens.
- `a_record_another_writer_moved_is_loaded_fresh_not_served_from_the_held_authority` commits through another manager beside the daemon. The next reader must get that publication's generation for exactly one load, and the admission pair must follow it without another.
- `the_flush_after_a_publication_opens_once_and_its_finalize_borrows_it` holds the flush after a publication, its finalize and the readers after it to one open between them.

```text
$ cargo test -p kin-daemon --lib
test result: ok. 1692 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 298.71s

$ cargo test -p kin-daemon --lib -- <the three new tests and the flush, admission and finalize guards>
[ 4/16] plan semantic import 0.2stest state::tests::a_record_another_writer_moved_is_loaded_fresh_not_served_from_the_held_authority ... ok
test state::tests::the_startup_open_serves_the_admission_pair_and_the_flush ... ok
test state::tests::the_flush_after_a_publication_opens_once_and_its_finalize_borrows_it ... ok
test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 1664 filtered out; finished in 6.82s
```

## Falsification

Each arm went on top of the committed fix through `falsify.py`, which refuses unless its replacement matches exactly once. After each arm the file came back from the commit, with the tree checked clean. Every arm went red on the test written for it.

```text
arm flush_opens (the flush opens its own authority again)
test state::tests::the_startup_open_serves_the_admission_pair_and_the_flush ... FAILED
test state::tests::the_flush_after_a_publication_opens_once_and_its_finalize_borrows_it ... FAILED
assertion `left == right` failed: the admission pair, the flush and a projection read at the startup publication must borrow the authority the daemon opened at startup, not open the store again
test result: FAILED. 1 passed; 2 failed

arm finalize_opens (the read-index finalize opens its own again)
test state::tests::the_flush_after_a_publication_opens_once_and_its_finalize_borrows_it ... FAILED
assertion `left == right` failed: one publication is one whole-store open: the flush loads it, and its finalize and the readers after it borrow that load
test result: FAILED. 2 passed; 1 failed

arm startup_drops (startup drops its manager)
test state::tests::the_startup_open_serves_the_admission_pair_and_the_flush ... FAILED
test result: FAILED. 2 passed; 1 failed

arm label_ignored (the held authority is handed out whatever the record reads)
test state::tests::a_record_another_writer_moved_is_loaded_fresh_not_served_from_the_held_authority ... FAILED
test state::tests::the_flush_after_a_publication_opens_once_and_its_finalize_borrows_it ... FAILED
test result: FAILED. 1 passed; 2 failed
```

Under `label_ignored` the flush test fails on the flush itself: it borrowed the stale manager, and the flush's own generation check refused it ("post-commit authority moved ... reopen before finalizing derived indexes") rather than acknowledging stale state. Logs: `prA-falsify-<arm>.log` in the lane's scratch.

## Local gates

```text
$ bin/kin-precheck kin --repo-dir kin=<this worktree>
kin-precheck: behind origin/main 3 commit(s); the gate list below is the one on THIS tree, not the one on main
kin-precheck: target=/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/cargo-target/authoritycost-kin (caller) sccache=/opt/homebrew/bin/sccache (caller) RUSTFLAGS=-D warnings
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 6 step(s) the check job runs that this gate deliberately does not:
kin-precheck: 16 file(s) the check job hands to node --test, classified by rule and run here as one gate:
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin 4f2c2af01e3a517a29f91e208097fddc04d0a2e8
```

kin's Product Acceptance job grades main after landing, not this pull request.
