### PR TITLE
Bound an answer only by the degraded flags that describe what it reads (FIR-3541)

### DIFF
--- a/crates/kin-cli/src/commands/dead_code.rs
+++ b/crates/kin-cli/src/commands/dead_code.rs
@@ -985,13 +985,21 @@ mod tests {
             .upsert_relation(&make_call_relation_with(&live, &caller, 0.9))
             .unwrap();
 
-        let degraded = kin_mcp::Envelope::daemon().with_health(&serde_json::json!({
-            "initialized": true,
-            "graph_loaded": true,
-            "graph_entity_count": 2,
-            "graph_generation": 1,
-            "embed_worker_failed": true,
-        }));
+        // A held language-server sweep: a flag that describes the relations the
+        // scan reads, so it still puts the clean line in doubt.
+        let degraded = kin_mcp::Envelope::daemon()
+            .with_health(&serde_json::json!({
+                "initialized": true,
+                "graph_loaded": true,
+                "graph_entity_count": 2,
+                "graph_generation": 1,
+            }))
+            .with_memory_pressure(Some(&kin_core::memory_pressure::PressureRefusal {
+                work: "lsp-sweep".to_string(),
+                level: "critical".to_string(),
+                reason: "host memory pressure is critical".to_string(),
+                at_unix: 0,
+            }));
         let coverage =
             kin_core::reference_coverage::collect_reference_edge_coverage(&graph).unwrap();
         let response =
@@ -1006,6 +1014,24 @@ mod tests {
             output.contains("Kin cannot rule out unreachable entities it did not see"),
             "a clean scan off a degraded daemon must say the substrate was in doubt, and must \
              use ITS OWN noun rather than impact's 'dependents': {output}"
+        );
+
+        // The other direction. A stopped embedding worker describes vectors,
+        // which the scan never reads, so the clean line stands unqualified.
+        let vectors_only = kin_mcp::Envelope::daemon().with_health(&serde_json::json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "graph_entity_count": 2,
+            "graph_generation": 1,
+            "embed_worker_failed": true,
+        }));
+        let response =
+            build_dead_code_report(&vectors_only, &graph, &Default::default(), &coverage).unwrap();
+        let output = response.lines.join("\n");
+        assert!(output.contains("No dead code found."), "{output}");
+        assert!(
+            !output.contains("Kin cannot rule out unreachable entities it did not see"),
+            "a flag that describes vectors must not put a relation scan in doubt: {output}"
         );
     }
 

--- a/crates/kin-cli/src/commands/impact.rs
+++ b/crates/kin-cli/src/commands/impact.rs
@@ -2453,13 +2453,21 @@ mod tests {
             healthy.lines
         );
 
-        let degraded = kin_mcp::Envelope::daemon().with_health(&serde_json::json!({
-            "initialized": true,
-            "graph_loaded": true,
-            "graph_entity_count": 3,
-            "graph_generation": 1,
-            "embed_worker_failed": true,
-        }));
+        // A held language-server sweep: a flag that describes the relations
+        // impact reads, so it still refuses.
+        let degraded = kin_mcp::Envelope::daemon()
+            .with_health(&serde_json::json!({
+                "initialized": true,
+                "graph_loaded": true,
+                "graph_entity_count": 3,
+                "graph_generation": 1,
+            }))
+            .with_memory_pressure(Some(&kin_core::memory_pressure::PressureRefusal {
+                work: "lsp-sweep".to_string(),
+                level: "critical".to_string(),
+                reason: "host memory pressure is critical".to_string(),
+                at_unix: 0,
+            }));
         let refused = build_impact_response(&layout, &graph, &request, &degraded)
             .await
             .unwrap();
@@ -2492,6 +2500,41 @@ mod tests {
             refused.negative,
             kin_mcp::negative::negative_for("impact_analysis", &payload, &degraded, &[]),
             "the field is the verdict `impact_analysis` publishes, byte for byte"
+        );
+
+        // A stopped embedding worker describes vectors, which impact never
+        // reads, so the same empty answer certifies in prose and payload alike
+        // while the flag stays disclosed.
+        let vectors_only = kin_mcp::Envelope::daemon().with_health(&serde_json::json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "graph_entity_count": 3,
+            "graph_generation": 1,
+            "embed_worker_failed": true,
+        }));
+        let certified = build_impact_response(&layout, &graph, &request, &vectors_only)
+            .await
+            .unwrap();
+        let certified_verdict = certified
+            .negative
+            .as_ref()
+            .expect("an empty impact answer publishes its verdict");
+        assert_eq!(
+            certified_verdict["safe_to_conclude_absent"],
+            serde_json::json!(true),
+            "a flag that describes vectors must not bound an answer read off relations: \
+             {certified_verdict}"
+        );
+        assert!(
+            certified_verdict["degraded_signals"]
+                .as_array()
+                .is_some_and(|signals| signals.contains(&serde_json::json!("embed_worker_failed"))),
+            "the flag stays disclosed: {certified_verdict}"
+        );
+        assert!(
+            !certified.lines.join("\n").contains("cannot rule out"),
+            "a certified absence prints no refusal: {:?}",
+            certified.lines
         );
     }
 

--- a/crates/kin-cli/src/commands/impact.rs
+++ b/crates/kin-cli/src/commands/impact.rs
@@ -760,13 +760,21 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
 
-        let degraded = kin_mcp::Envelope::daemon().with_health(&serde_json::json!({
-            "initialized": true,
-            "graph_loaded": true,
-            "graph_entity_count": 1,
-            "graph_generation": 1,
-            "embed_worker_failed": true,
-        }));
+        // A held language-server sweep: a flag that describes the relations
+        // impact reads, so it still bounds this answer.
+        let degraded = kin_mcp::Envelope::daemon()
+            .with_health(&serde_json::json!({
+                "initialized": true,
+                "graph_loaded": true,
+                "graph_entity_count": 1,
+                "graph_generation": 1,
+            }))
+            .with_memory_pressure(Some(&kin_core::memory_pressure::PressureRefusal {
+                work: "lsp-sweep".to_string(),
+                level: "critical".to_string(),
+                reason: "host memory pressure is critical".to_string(),
+                at_unix: 0,
+            }));
 
         let response = build_impact_response(
             &layout,
@@ -809,7 +817,7 @@ mod tests {
             "the CLI must inherit the refusal the MCP surface reached: {rendered}"
         );
         assert!(
-            rendered.contains("embed_worker_failed"),
+            rendered.contains("memory_pressure"),
             "the line names the signal the verdict disclosed rather than inventing a cause: \
              {rendered}"
         );
@@ -818,6 +826,51 @@ mod tests {
         assert!(
             !rendered.contains("holds no cross-file"),
             "no absent class was observed, so none may be claimed: {rendered}"
+        );
+
+        // The other direction. A stopped embedding worker describes vectors,
+        // which impact never reads, so the same empty answer is no longer
+        // bounded by it on either surface, and the flag stays disclosed.
+        let vectors_only = kin_mcp::Envelope::daemon().with_health(&serde_json::json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "graph_entity_count": 1,
+            "graph_generation": 1,
+            "embed_worker_failed": true,
+        }));
+        let response = build_impact_response(
+            &layout,
+            &graph,
+            &ImpactRequest {
+                entity: "orphan".to_string(),
+                depth: 3,
+                file: None,
+                kind: None,
+                signature: None,
+                require_unique: false,
+            },
+            &vectors_only,
+        )
+        .await
+        .expect("impact response");
+        let rendered = response.lines.join("\n");
+        let mcp = kin_mcp::negative::negative_for("impact_analysis", &payload, &vectors_only, &[])
+            .expect("impact_analysis always qualifies");
+        assert_eq!(
+            mcp["safe_to_conclude_absent"],
+            serde_json::json!(true),
+            "a flag that describes vectors must not bound an answer read off relations: {mcp}"
+        );
+        assert!(
+            mcp["degraded_signals"]
+                .as_array()
+                .is_some_and(|signals| signals.contains(&serde_json::json!("embed_worker_failed"))),
+            "the flag stays disclosed: {mcp}"
+        );
+        assert!(
+            !rendered.contains("Kin cannot rule out dependents"),
+            "the CLI inherits the certified verdict, not a refusal the MCP surface no longer \
+             reaches: {rendered}"
         );
     }
 

--- a/crates/kin-cli/src/commands/refs.rs
+++ b/crates/kin-cli/src/commands/refs.rs
@@ -1616,24 +1616,36 @@ mod tests {
                 .unwrap();
         }
 
-        let degraded = kin_mcp::Envelope::daemon().with_health(&serde_json::json!({
-            "initialized": true,
-            "graph_loaded": true,
-            "graph_entity_count": 3,
-            "graph_generation": 1,
-            "embed_worker_failed": true,
-        }));
-        let response = build_refs_response(
-            &layout,
-            &graph,
-            &RefsRequest {
-                entity: "orphan".to_string(),
-                kind: "all".to_string(),
-            },
-            &degraded,
-        )
-        .expect("refs response");
-        let rendered = response.lines.join("\n");
+        // A held language-server sweep: a flag that describes the relations
+        // refs reads, so it still bounds this answer.
+        let degraded = kin_mcp::Envelope::daemon()
+            .with_health(&serde_json::json!({
+                "initialized": true,
+                "graph_loaded": true,
+                "graph_entity_count": 3,
+                "graph_generation": 1,
+            }))
+            .with_memory_pressure(Some(&kin_core::memory_pressure::PressureRefusal {
+                work: "lsp-sweep".to_string(),
+                level: "critical".to_string(),
+                reason: "host memory pressure is critical".to_string(),
+                at_unix: 0,
+            }));
+        let answer = |envelope: &kin_mcp::Envelope| {
+            build_refs_response(
+                &layout,
+                &graph,
+                &RefsRequest {
+                    entity: "orphan".to_string(),
+                    kind: "all".to_string(),
+                },
+                envelope,
+            )
+            .expect("refs response")
+            .lines
+            .join("\n")
+        };
+        let rendered = answer(&degraded);
 
         assert!(
             !rendered.contains("holds no cross-file"),
@@ -1645,8 +1657,24 @@ mod tests {
             "a degraded daemon is a real gap and must still be spoken: {rendered}"
         );
         assert!(
-            rendered.contains("embed_worker_failed"),
+            rendered.contains("memory_pressure"),
             "and it must name the signal the verdict disclosed: {rendered}"
+        );
+
+        // The other direction. A stopped embedding worker describes vectors,
+        // which refs never reads, so it no longer puts this answer in doubt.
+        let vectors_only = kin_mcp::Envelope::daemon().with_health(&serde_json::json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "graph_entity_count": 3,
+            "graph_generation": 1,
+            "embed_worker_failed": true,
+        }));
+        let rendered = answer(&vectors_only);
+        assert!(!rendered.contains("holds no cross-file"), "{rendered}");
+        assert!(
+            !rendered.contains("Kin cannot rule out references it did not see"),
+            "a flag that describes vectors must not bound an answer read off relations: {rendered}"
         );
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -20385,13 +20385,15 @@ mod tests {
 
     #[test]
     fn the_impact_envelope_carries_the_daemons_degraded_signals() {
+        // A withheld mass deletion: a flag this build does not scope, so it
+        // bounds every answer, including one read off relations.
         let health = serde_json::json!({
             "initialized": true,
             "graph_loaded": true,
             "graph_entity_count": 3,
             "graph_generation": 7,
-            "embed_worker_failed": true,
-            "mass_deletion_blocked": false,
+            "embed_worker_failed": false,
+            "mass_deletion_blocked": true,
         });
         let envelope = kin_mcp::Envelope::daemon().with_health(&health);
 
@@ -20428,7 +20430,7 @@ mod tests {
                 .as_array()
                 .is_some_and(|signals| signals
                     .iter()
-                    .any(|signal| signal.as_str() == Some("embed_worker_failed"))),
+                    .any(|signal| signal.as_str() == Some("mass_deletion_blocked"))),
             "the signal must reach the verdict the CLI renders: {negative}"
         );
 
@@ -20448,6 +20450,34 @@ mod tests {
             negative["safe_to_conclude_absent"],
             serde_json::json!(true),
             "an undegraded daemon must still certify: {negative}"
+        );
+
+        // The other direction, and the disclosure with it. A stopped embedding
+        // worker describes vectors, which impact never reads, so the same
+        // answer certifies while the signal still reaches the verdict.
+        let vectors_only = kin_mcp::Envelope::daemon().with_health(&serde_json::json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "graph_entity_count": 3,
+            "graph_generation": 7,
+            "embed_worker_failed": true,
+            "mass_deletion_blocked": false,
+        }));
+        let negative =
+            kin_mcp::negative::negative_for("impact_analysis", &payload, &vectors_only, &[])
+                .expect("impact_analysis always qualifies");
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            serde_json::json!(true),
+            "a flag that describes vectors must not bound an answer read off relations: {negative}"
+        );
+        assert!(
+            negative["degraded_signals"]
+                .as_array()
+                .is_some_and(|signals| signals
+                    .iter()
+                    .any(|signal| signal.as_str() == Some("embed_worker_failed"))),
+            "the signal still reaches the verdict where it does not bound it: {negative}"
         );
     }
 
@@ -48757,8 +48787,12 @@ mod tests {
         state
             .is_initialized
             .store(true, std::sync::atomic::Ordering::Relaxed);
+        // A withheld mass deletion: a flag this build does not scope, so it
+        // bounds every answer this route serves, including one read off
+        // relations. The health snapshot carries it and the embedding flag and
+        // nothing else, which is why the arm below uses the other one.
         state
-            .embed_worker_failed
+            .mass_deletion_blocked
             .store(true, std::sync::atomic::Ordering::Relaxed);
 
         let response = router(Arc::clone(&state))
@@ -48790,9 +48824,55 @@ mod tests {
              thinner snapshot leaves this line out entirely: {rendered}"
         );
         assert!(
-            rendered.contains("embed_worker_failed"),
+            rendered.contains("mass_deletion_blocked"),
             "the line names the signal the verdict disclosed rather than inventing a cause: \
              {rendered}"
+        );
+
+        // The other direction, through the same route. A stopped embedding
+        // worker describes vectors, which impact never reads, so the rendered
+        // verdict no longer refuses and the payload still discloses the flag.
+        state
+            .mass_deletion_blocked
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+        state
+            .embed_worker_failed
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/impact")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "entity": "orphan", "depth": 3 }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let result: kin_cli::commands::impact::ImpactResponse =
+            serde_json::from_slice(&body).unwrap();
+        let rendered = result.lines.join("\n");
+        assert!(
+            rendered.contains("No local downstream impact found."),
+            "the orphan still reports no impact: {rendered}"
+        );
+        assert!(
+            !rendered.contains("Kin cannot rule out dependents"),
+            "a flag that describes vectors must not bound an answer read off relations: {rendered}"
+        );
+        let verdict = result
+            .negative
+            .as_ref()
+            .expect("an empty impact answer publishes its verdict");
+        assert!(
+            verdict["degraded_signals"]
+                .as_array()
+                .is_some_and(|signals| signals.contains(&serde_json::json!("embed_worker_failed"))),
+            "the flag stays disclosed where it does not bound: {verdict}"
         );
     }
 

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -361,6 +361,13 @@ pub struct Degraded {
     /// clears itself rather than needing a second event to retract it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub memory_pressure: Option<bool>,
+    /// Which heavy work the standing memory-pressure refusal declined, by its
+    /// stable id (`embed-batch`, `lsp-sweep`), kept beside the flag so the
+    /// verdict can bound only the answers that work feeds. Never on the wire:
+    /// the wire keeps `memory_pressure: true` alone, and an envelope read back
+    /// from the wire carries no work id, which bounds every answer.
+    #[serde(skip)]
+    pub memory_pressure_work: Option<String>,
     /// This store's graph currently holds fewer relations than its own last
     /// verified-good census did, over an entity count that did not fall. The
     /// relation census is the only surface that could see it, and on the rc0550
@@ -415,6 +422,38 @@ impl Degraded {
         ]
         .into_iter()
         .any(|flag| flag == Some(true))
+    }
+
+    /// Whether a standing flag bounds an answer drawn from `substrate`.
+    ///
+    /// A flag describes one producer, and it bounds the answers whose substrate
+    /// that producer feeds. Scoping is opt-in per flag: this clears, from a
+    /// copy, exactly the flags whose producer cannot touch `substrate`, and asks
+    /// [`Self::any`] about what is left. A flag not named here, and a
+    /// memory-pressure refusal of any work other than the two named here or of
+    /// work nobody recorded, is never cleared, so it keeps bounding every
+    /// answer.
+    pub fn bounds(&self, substrate: AbsenceSubstrate) -> bool {
+        use kin_core::memory_pressure::HeavyWork;
+        let mut rest = self.clone();
+        // A stopped embedding worker freezes the vector index, and a store with
+        // no durable vector sidecar runs no embedding at all. Only an answer
+        // ranked over vectors reads either.
+        if substrate != AbsenceSubstrate::Vectors {
+            rest.embed_worker_failed = None;
+            rest.embed_persistence_unavailable = None;
+        }
+        // A held embedding batch leaves vectors where they are; a held sweep
+        // leaves cross-file relations at what is durable.
+        let work = rest.memory_pressure_work.as_deref();
+        let embed_batch_out_of_scope =
+            work == Some(HeavyWork::EmbedBatch.id()) && substrate != AbsenceSubstrate::Vectors;
+        let lsp_sweep_out_of_scope =
+            work == Some(HeavyWork::LspSweep.id()) && substrate != AbsenceSubstrate::Relations;
+        if embed_batch_out_of_scope || lsp_sweep_out_of_scope {
+            rest.memory_pressure = None;
+        }
+        rest.any()
     }
 
     /// The names of the degraded signals that are affirmatively set, in a stable
@@ -1211,6 +1250,25 @@ pub enum NegativeClass {
     /// absence-trust depends on the *graph* being initialized and loaded, not on
     /// embedding coverage.
     Structural,
+}
+
+/// What an absence answer reads, which decides the degraded flags that bound
+/// it.
+///
+/// Finer than [`NegativeClass`], which only separates vectors from the graph:
+/// a held language-server sweep leaves relations stale and changes nothing the
+/// entity index or history holds, so the graph is split where the flags split
+/// it. See [`Degraded::bounds`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AbsenceSubstrate {
+    /// Embeddings, ranked by `semantic_locate`.
+    Vectors,
+    /// Which entities exist under a name, kind, role or file.
+    EntityIndex,
+    /// Typed relations between entities.
+    Relations,
+    /// Change history.
+    History,
 }
 
 /// Which substrate an answer was drawn from, and therefore what "complete"
@@ -2272,6 +2330,7 @@ impl Envelope {
             },
             sweep_suspended: self.degraded.sweep_suspended,
             memory_pressure: self.degraded.memory_pressure,
+            memory_pressure_work: self.degraded.memory_pressure_work.clone(),
             relation_census_loss: self.degraded.relation_census_loss,
             hydration_semantics_stale: self.degraded.hydration_semantics_stale,
             enrichment_shortfall: self.degraded.enrichment_shortfall,
@@ -2359,8 +2418,9 @@ impl Envelope {
         mut self,
         refusal: Option<&kin_core::memory_pressure::PressureRefusal>,
     ) -> Self {
-        if refusal.is_some() {
+        if let Some(refusal) = refusal {
             self.degraded.memory_pressure = Some(true);
+            self.degraded.memory_pressure_work = Some(refusal.work.clone());
         }
         self
     }
@@ -2710,9 +2770,11 @@ impl Envelope {
     ///
     /// This is the epistemic core of the confidence-qualified-negative contract:
     /// a "not found" is only distinguishable from "not indexed" when the answer
-    /// came from daemon-owned truth (`RepoDaemon`) with no degraded signals **and**
-    /// the substrate the tool actually reads is complete. The two runtime/degraded
-    /// gates are shared; the completeness gate is class-specific:
+    /// came from daemon-owned truth (`RepoDaemon`) with no degraded signal
+    /// bounding `substrate`, the thing the answer reads ([`Degraded::bounds`]),
+    /// **and** that substrate is complete. The runtime gate is shared, the
+    /// degraded gate is scoped to the substrate, and the completeness gate is
+    /// class-specific:
     ///
     /// - [`NegativeClass::Semantic`] tools read embeddings, so absence is
     ///   authoritative only with **complete embedding coverage**.
@@ -2730,14 +2792,18 @@ impl Envelope {
     /// and finishes the sentence there. Claiming the wider silence from here
     /// shipped in v0.5.43 as `trust_reason` ending "with no degraded signals"
     /// one field away from a two-element `degraded_signals` array (FIR-2505).
-    pub fn negative_trust(&self, class: NegativeClass) -> (bool, &'static str) {
+    pub fn negative_trust(
+        &self,
+        class: NegativeClass,
+        substrate: AbsenceSubstrate,
+    ) -> (bool, &'static str) {
         if self.runtime != Runtime::RepoDaemon {
             return (
                 false,
                 "offline_fallback: answered by the in-process graph, a fallback surface — not authoritative graph truth",
             );
         }
-        if self.degraded.any() {
+        if self.degraded.bounds(substrate) {
             return (
                 false,
                 "degraded: the daemon reported a degraded signal, so the index may not reflect current truth",
@@ -6377,6 +6443,56 @@ mod tests {
         );
     }
 
+    /// The refused work is what lets the verdict bound only the answers that
+    /// work feeds, and it never reaches the wire. The wire keeps
+    /// `memory_pressure: true` exactly as before, and an envelope read back
+    /// from the wire has no work id, so it bounds every answer. Selected-graph
+    /// qualification, which rebuilds the flags for graph status, keeps the work
+    /// beside the flag it belongs to.
+    #[test]
+    fn the_wire_keeps_memory_pressure_and_never_the_refused_work() {
+        let refusal = kin_core::memory_pressure::PressureRefusal {
+            work: "embed-batch".to_string(),
+            level: "critical".to_string(),
+            reason: "host memory pressure is critical".to_string(),
+            at_unix: 4_800,
+        };
+        let held = Envelope::daemon().with_memory_pressure(Some(&refusal));
+        assert_eq!(
+            held.degraded.memory_pressure_work.as_deref(),
+            Some("embed-batch")
+        );
+        assert!(!held.degraded.bounds(AbsenceSubstrate::Relations));
+
+        let json = serde_json::to_string(&held.degraded).expect("serialize degraded");
+        assert!(json.contains("\"memory_pressure\":true"), "{json}");
+        assert!(
+            !json.contains("embed-batch") && !json.contains("memory_pressure_work"),
+            "the refused work stays off the wire: {json}"
+        );
+
+        let read_back: Degraded = serde_json::from_str(&json).expect("degraded reads back");
+        assert_eq!(read_back.memory_pressure, Some(true));
+        for substrate in [
+            AbsenceSubstrate::Vectors,
+            AbsenceSubstrate::EntityIndex,
+            AbsenceSubstrate::Relations,
+            AbsenceSubstrate::History,
+        ] {
+            assert!(
+                read_back.bounds(substrate),
+                "a refusal with no recorded work bounds every answer: {substrate:?}"
+            );
+        }
+
+        let selected = held.with_selected_graph_observation(level_counts(4, 4), 4, 0, 4);
+        assert_eq!(selected.degraded.memory_pressure, Some(true));
+        assert!(
+            !selected.degraded.bounds(AbsenceSubstrate::Relations),
+            "selected-graph qualification keeps the refused work beside its flag"
+        );
+    }
+
     /// Absent rather than `false` on the wire, for the reason every flag in
     /// this struct is absent when unobserved: a client cannot tell a
     /// serialized `false` from an answer that looked and found nothing wrong.
@@ -6502,9 +6618,22 @@ mod tests {
                 .degraded
                 .active_labels()
                 .contains(&"hydration_semantics_stale"));
-            let (trusted, reason) = flagged.negative_trust(NegativeClass::Semantic);
+            let (trusted, reason) =
+                flagged.negative_trust(NegativeClass::Semantic, AbsenceSubstrate::Vectors);
             assert!(!trusted);
             assert!(reason.contains("degraded"), "{reason}");
+            for substrate in [
+                AbsenceSubstrate::Vectors,
+                AbsenceSubstrate::EntityIndex,
+                AbsenceSubstrate::Relations,
+                AbsenceSubstrate::History,
+            ] {
+                assert!(
+                    flagged.degraded.bounds(substrate),
+                    "a hydration gap keeps bounding every answer until HEAD is verified: \
+                     {substrate:?}"
+                );
+            }
 
             let selected = flagged.with_selected_graph_observation(level_counts(4, 4), 4, 0, 4);
             assert_eq!(

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -53,7 +53,7 @@
 
 use serde_json::{json, Map, Value};
 
-use crate::envelope::{Envelope, NegativeClass};
+use crate::envelope::{AbsenceSubstrate, Envelope, NegativeClass};
 
 /// Reserved, additive top-level key under which a retrieval tool's
 /// confidence-qualified negative is attached, beside the `_kin` envelope.
@@ -373,6 +373,23 @@ fn spec_for(tool: &str) -> Option<RetrievalSpec> {
 /// completeness signal follow from that declaration.
 pub(crate) fn negative_class_for(tool: &str) -> Option<NegativeClass> {
     spec_for(tool).map(|spec| spec.class)
+}
+
+/// What `tool`'s absence reads, which decides the degraded flags that bound it.
+///
+/// Only the tools that read something other than relations are named, because
+/// relations is the substrate the most flags describe: a structural tool left
+/// off this list is bounded by every flag a relation answer is, which is the
+/// safe way for a new tool to start.
+fn absence_substrate(tool: &str, class: NegativeClass) -> AbsenceSubstrate {
+    match (class, tool) {
+        (NegativeClass::Semantic, _) => AbsenceSubstrate::Vectors,
+        (NegativeClass::Structural, FILE_ENTITIES_TOOL | "semantic_search") => {
+            AbsenceSubstrate::EntityIndex
+        }
+        (NegativeClass::Structural, "entity_history") => AbsenceSubstrate::History,
+        (NegativeClass::Structural, _) => AbsenceSubstrate::Relations,
+    }
 }
 
 /// The cross-file edge classes each tool's ABSENCE claim depends on: the
@@ -2496,7 +2513,8 @@ pub fn negative_for(
         return None;
     }
 
-    let (mut trustworthy, trust_reason) = envelope.negative_trust(spec.class);
+    let (mut trustworthy, trust_reason) =
+        envelope.negative_trust(spec.class, absence_substrate(tool, spec.class));
     let mut trust_reason = trust_reason.to_string();
 
     // The coverage gate leads every other gap because it is the one that can
@@ -3030,7 +3048,10 @@ pub fn resolution_miss_for(tool: &str, message: &str, envelope: &Envelope) -> Op
         return None;
     }
 
-    let (mut trustworthy, trust_reason) = envelope.negative_trust(NegativeClass::Structural);
+    // A name that resolves to nothing is a claim about the entity index, so
+    // only a flag that bounds the entity index bounds it.
+    let (mut trustworthy, trust_reason) =
+        envelope.negative_trust(NegativeClass::Structural, AbsenceSubstrate::EntityIndex);
     let mut trust_reason = trust_reason.to_string();
 
     // A graph holding no entities answers every name identically, so a miss
@@ -5558,11 +5579,12 @@ mod tests {
 
     #[test]
     fn find_references_degraded_is_inconclusive() {
-        // The degraded gate is class-independent: it short-circuits before the
-        // structural graph check.
+        // A flag that bounds every substrate short-circuits before the
+        // structural graph check. A withheld mass deletion is one: the graph
+        // itself may not hold what the working copy does.
         let mut env = structural_ready_envelope();
         env.degraded = Degraded {
-            embed_worker_failed: Some(true),
+            mass_deletion_blocked: Some(true),
             ..Degraded::default()
         };
         // One coverage shortfall on purpose, so the second half of the
@@ -5578,9 +5600,368 @@ mod tests {
             .contains("degraded"));
         assert_eq!(
             negative["degraded_signals"],
-            json!(["embed_worker_failed", "edge_coverage:imports_absent"]),
+            json!(["mass_deletion_blocked", "edge_coverage:imports_absent"]),
             "the daemon's flag leads, and the answer's own coverage shortfalls follow \
              it rather than being dropped"
+        );
+    }
+
+    /// A memory-pressure refusal of `work`, the record a daemon writes when it
+    /// holds that work back.
+    fn pressure_refusal(work: &str) -> kin_core::memory_pressure::PressureRefusal {
+        kin_core::memory_pressure::PressureRefusal {
+            work: work.to_string(),
+            level: "critical".to_string(),
+            reason: "host memory pressure is critical".to_string(),
+            at_unix: 4_800,
+        }
+    }
+
+    /// How a certified answer names a flag it considered that does not bound
+    /// it. The certified reason is the only one a scoped-out flag may appear
+    /// in, because an inconclusive reason lists only what limits the answer.
+    fn considered(label: &str) -> String {
+        format!(
+            "; the disclosed signals [{label}] were considered and are not load-bearing for this \
+             claim"
+        )
+    }
+
+    fn empty_ranking() -> Value {
+        json!({ "query": "auth", "results": [], "total_ranked": 0 })
+    }
+
+    /// An embed-batch refusal holds background embedding back, which leaves
+    /// vectors where they are and changes nothing a relation walk or the entity
+    /// index reads. Measured on a kin-db scratch store, that refusal alone made
+    /// two exact caller sets and a file enumeration inconclusive. It bounds the
+    /// vector answer, and the others certify while naming it.
+    #[test]
+    fn an_embed_batch_refusal_bounds_vector_answers_and_no_other() {
+        let refusal = pressure_refusal("embed-batch");
+
+        let references = negative_for(
+            "find_references",
+            &authoritative_empty_references("function"),
+            &structural_ready_envelope().with_memory_pressure(Some(&refusal)),
+        )
+        .expect("empty references yields a negative");
+        assert_eq!(
+            references["safe_to_conclude_absent"],
+            json!(true),
+            "{references}"
+        );
+        assert!(
+            references["trust_reason"]
+                .as_str()
+                .unwrap()
+                .ends_with(&considered("memory_pressure")),
+            "{references}"
+        );
+
+        let search = negative_for(
+            "semantic_search",
+            &empty_search_page(scope_with_a_measured_class(Some(12))),
+            &structural_ready_envelope().with_memory_pressure(Some(&refusal)),
+        )
+        .expect("an empty search yields a negative");
+        assert_eq!(search["safe_to_conclude_absent"], json!(true), "{search}");
+        assert!(
+            search["trust_reason"]
+                .as_str()
+                .unwrap()
+                .ends_with(&considered("memory_pressure")),
+            "{search}"
+        );
+
+        let locate = negative_for(
+            "semantic_locate",
+            &empty_ranking(),
+            &semantic_authoritative_envelope().with_memory_pressure(Some(&refusal)),
+        )
+        .expect("an empty ranking yields a negative");
+        assert_eq!(locate["safe_to_conclude_absent"], json!(false), "{locate}");
+        assert!(
+            locate["trust_reason"]
+                .as_str()
+                .unwrap()
+                .starts_with("degraded:"),
+            "{locate}"
+        );
+
+        let degraded = Envelope::daemon()
+            .with_memory_pressure(Some(&refusal))
+            .degraded;
+        assert!(!degraded.bounds(AbsenceSubstrate::History));
+    }
+
+    /// An lsp-sweep refusal holds the language-server sweep back, which leaves
+    /// cross-file relations at what is durable. It keeps bounding relation
+    /// answers, for a reason that is about them, and no longer bounds the
+    /// entity index or the vector ranking.
+    #[test]
+    fn an_lsp_sweep_refusal_bounds_relation_answers_and_no_other() {
+        let refusal = pressure_refusal("lsp-sweep");
+
+        let references = negative_for(
+            "find_references",
+            &authoritative_empty_references("function"),
+            &structural_ready_envelope().with_memory_pressure(Some(&refusal)),
+        )
+        .expect("empty references yields a negative");
+        assert_eq!(
+            references["safe_to_conclude_absent"],
+            json!(false),
+            "{references}"
+        );
+        assert!(
+            references["trust_reason"]
+                .as_str()
+                .unwrap()
+                .starts_with("degraded:"),
+            "{references}"
+        );
+
+        let search = negative_for(
+            "semantic_search",
+            &empty_search_page(scope_with_a_measured_class(Some(12))),
+            &structural_ready_envelope().with_memory_pressure(Some(&refusal)),
+        )
+        .expect("an empty search yields a negative");
+        assert_eq!(search["safe_to_conclude_absent"], json!(true), "{search}");
+        assert!(
+            search["trust_reason"]
+                .as_str()
+                .unwrap()
+                .ends_with(&considered("memory_pressure")),
+            "{search}"
+        );
+
+        let locate = negative_for(
+            "semantic_locate",
+            &empty_ranking(),
+            &semantic_authoritative_envelope().with_memory_pressure(Some(&refusal)),
+        )
+        .expect("an empty ranking yields a negative");
+        assert_eq!(locate["safe_to_conclude_absent"], json!(true), "{locate}");
+        assert!(
+            locate["trust_reason"]
+                .as_str()
+                .unwrap()
+                .ends_with(&considered("memory_pressure")),
+            "{locate}"
+        );
+
+        let degraded = Envelope::daemon()
+            .with_memory_pressure(Some(&refusal))
+            .degraded;
+        assert!(!degraded.bounds(AbsenceSubstrate::History));
+    }
+
+    /// A stopped embedding worker and a store with no vector sidecar both
+    /// describe vectors, and bound the vector answer alone.
+    #[test]
+    fn the_embedding_flags_bound_vector_answers_and_no_other() {
+        for degraded in [
+            Degraded {
+                embed_worker_failed: Some(true),
+                ..Degraded::default()
+            },
+            Degraded {
+                embed_persistence_unavailable: Some(true),
+                ..Degraded::default()
+            },
+        ] {
+            let label = degraded.active_labels()[0];
+
+            let mut structural = structural_ready_envelope();
+            structural.degraded = degraded.clone();
+            let references = negative_for(
+                "find_references",
+                &authoritative_empty_references("function"),
+                &structural,
+            )
+            .expect("empty references yields a negative");
+            assert_eq!(
+                references["safe_to_conclude_absent"],
+                json!(true),
+                "{label}: {references}"
+            );
+            assert!(
+                references["trust_reason"]
+                    .as_str()
+                    .unwrap()
+                    .ends_with(&considered(label)),
+                "{label}: {references}"
+            );
+
+            let mut semantic = semantic_authoritative_envelope();
+            semantic.degraded = degraded.clone();
+            let locate = negative_for("semantic_locate", &empty_ranking(), &semantic)
+                .expect("an empty ranking yields a negative");
+            assert_eq!(
+                locate["safe_to_conclude_absent"],
+                json!(false),
+                "{label}: {locate}"
+            );
+            assert!(
+                locate["trust_reason"]
+                    .as_str()
+                    .unwrap()
+                    .starts_with("degraded:"),
+                "{label}: {locate}"
+            );
+
+            assert!(!degraded.bounds(AbsenceSubstrate::EntityIndex), "{label}");
+            assert!(!degraded.bounds(AbsenceSubstrate::History), "{label}");
+        }
+    }
+
+    /// Scoping is opt-in per flag, never the fallback. A refusal of work this
+    /// build does not scope, a refusal read back from the wire with no work
+    /// recorded, and a flag with no scope of its own each keep bounding every
+    /// answer.
+    #[test]
+    fn a_refusal_of_unnamed_work_or_an_unlisted_flag_bounds_every_answer() {
+        let mut standing: Vec<(String, Degraded)> = ["ambient-admission", "future-heavy-work"]
+            .into_iter()
+            .map(|work| {
+                (
+                    format!("a refusal of {work}"),
+                    Envelope::daemon()
+                        .with_memory_pressure(Some(&pressure_refusal(work)))
+                        .degraded,
+                )
+            })
+            .collect();
+        standing.push((
+            "a refusal with no recorded work".to_string(),
+            Degraded {
+                memory_pressure: Some(true),
+                ..Degraded::default()
+            },
+        ));
+        standing.push((
+            "a suspended sweep".to_string(),
+            Degraded {
+                sweep_suspended: Some(true),
+                ..Degraded::default()
+            },
+        ));
+        standing.push((
+            "a hydration gap".to_string(),
+            Degraded {
+                hydration_semantics_stale: Some(true),
+                ..Degraded::default()
+            },
+        ));
+
+        for (what, degraded) in standing {
+            for substrate in [
+                AbsenceSubstrate::Vectors,
+                AbsenceSubstrate::EntityIndex,
+                AbsenceSubstrate::Relations,
+                AbsenceSubstrate::History,
+            ] {
+                assert!(
+                    degraded.bounds(substrate),
+                    "{what} must bound {substrate:?}"
+                );
+            }
+
+            let mut structural = structural_ready_envelope();
+            structural.degraded = degraded.clone();
+            for (tool, payload) in [
+                (
+                    "find_references",
+                    authoritative_empty_references("function"),
+                ),
+                (
+                    "semantic_search",
+                    empty_search_page(scope_with_a_measured_class(Some(12))),
+                ),
+            ] {
+                let negative = negative_for(tool, &payload, &structural)
+                    .expect("an empty answer yields a negative");
+                assert_eq!(
+                    negative["safe_to_conclude_absent"],
+                    json!(false),
+                    "{what} on {tool}: {negative}"
+                );
+                assert!(
+                    negative["trust_reason"]
+                        .as_str()
+                        .unwrap()
+                        .starts_with("degraded:"),
+                    "{what} on {tool}: {negative}"
+                );
+            }
+
+            let mut semantic = semantic_authoritative_envelope();
+            semantic.degraded = degraded;
+            let locate = negative_for("semantic_locate", &empty_ranking(), &semantic)
+                .expect("an empty ranking yields a negative");
+            assert_eq!(
+                locate["safe_to_conclude_absent"],
+                json!(false),
+                "{what}: {locate}"
+            );
+        }
+    }
+
+    /// A flag scoped out of an answer that something else limits stays in every
+    /// place a reader looks for disclosure, and out of the one place that lists
+    /// what limits the answer: `trust_reason` on an inconclusive answer is that
+    /// list, and the one verdict's limiting factor is built from it.
+    #[test]
+    fn a_scoped_out_flag_stays_disclosed_where_something_else_limits_the_answer() {
+        let envelope = Envelope::daemon()
+            .with_health(&json!({
+                "reconciliation_status": "reconciling",
+                "graph_loaded": true,
+            }))
+            .with_memory_pressure(Some(&pressure_refusal("embed-batch")));
+        let payload = authoritative_empty_references("function");
+        let negative = negative_for("find_references", &payload, &envelope)
+            .expect("empty references yields a negative");
+        assert_eq!(negative["trust"], json!("inconclusive"), "{negative}");
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            reason.starts_with("graph_uninitialized"),
+            "the graph gate is what limits this answer: {reason}"
+        );
+        assert!(
+            !reason.contains("memory_pressure") && !reason.contains("degraded:"),
+            "an inconclusive reason lists only what limits the answer: {reason}"
+        );
+        assert!(
+            negative["degraded_signals"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("memory_pressure")),
+            "{negative}"
+        );
+        assert!(
+            negative["advice"]
+                .as_str()
+                .unwrap()
+                .contains("memory_pressure"),
+            "{negative}"
+        );
+
+        let verdict = crate::verdict::Verdict::compute(
+            "find_references",
+            &payload,
+            &envelope,
+            Some(&negative),
+        )
+        .expect("a qualified answer carries a verdict")
+        .to_value();
+        let factor = verdict["limiting_factor"].as_str().unwrap_or_default();
+        assert!(factor.contains("graph_uninitialized"), "{verdict}");
+        assert!(
+            !factor.contains("memory_pressure") && !factor.contains("degraded:"),
+            "a flag that does not bound the answer never reads as its limit: {verdict}"
         );
     }
 
@@ -6096,7 +6477,7 @@ mod tests {
     fn neighborhood_gap_keeps_the_substrate_reason_beside_it() {
         let mut env = structural_ready_envelope();
         env.degraded = Degraded {
-            embed_worker_failed: Some(true),
+            mass_deletion_blocked: Some(true),
             ..Degraded::default()
         };
         let mut payload = neighborhood_payload("both", 0);

--- a/crates/kin-mcp/src/server.rs
+++ b/crates/kin-mcp/src/server.rs
@@ -2218,11 +2218,45 @@ mod tests {
             "certified"
         );
 
+        // An outstanding sweep stays visible on every answer and bounds only
+        // the relation answers it feeds. This one ranks vectors over whole
+        // embeddings, so it certifies and names the refusal it considered.
+        let held_sweep = finalized_empty_locate_with_pressure("lsp-sweep", Some(coverage(0, 9, 9)));
+        assert_eq!(
+            held_sweep[ENVELOPE_KEY]["degraded"]["memory_pressure"], true,
+            "a held sweep stays visible: {held_sweep}"
+        );
+        assert!(
+            held_sweep["negative"]["degraded_signals"]
+                .as_array()
+                .expect("negative degradation labels")
+                .iter()
+                .any(|label| label.as_str() == Some("memory_pressure")),
+            "a held sweep reaches the response-level negative: {held_sweep}"
+        );
+        assert_eq!(
+            held_sweep["negative"]["trust"], "authoritative",
+            "a held sweep does not bound a vector ranking: {held_sweep}"
+        );
+        assert!(
+            held_sweep["negative"]["trust_reason"]
+                .as_str()
+                .unwrap_or_default()
+                .contains(
+                    "the disclosed signals [memory_pressure] were considered and are not \
+                     load-bearing for this claim"
+                ),
+            "{held_sweep}"
+        );
+        assert_eq!(
+            held_sweep[ENVELOPE_KEY]["verdict"]["inputs"]["absence_gate"],
+            "certified"
+        );
+
         for (work, observed) in [
             ("embed-batch", Some(coverage(1, 9, 9))),
             ("embed-batch", Some(coverage(0, 8, 9))),
             ("embed-batch", None),
-            ("lsp-sweep", Some(coverage(0, 9, 9))),
             ("future-heavy-work", Some(coverage(0, 9, 9))),
         ] {
             let response = finalized_empty_locate_with_pressure(work, observed);


### PR DESCRIPTION
A standing degraded flag now bounds only the answers whose substrate it describes, so a background embedding
batch held back for memory no longer turns an exact caller set or a file enumeration into a lower bound.

## What was wrong

`Envelope::negative_trust` refused every absence with "degraded: the daemon reported a degraded signal"
whenever any flag stood, before it looked at what the answer reads. Measured this morning on release bytes of
main at `1a8078794` against a kin-db scratch store (5,088 entities, 72 Rust files): the two one-caller sets asked
for callers only certified with nothing standing, and went inconclusive with that clause as their only limiting
factor under an `embed-batch` refusal, which costs vectors and nothing a relation walk or the entity index reads.
The before and after below are on today's bytes and the same store.

## What changes

`crates/kin-mcp/src/envelope.rs` and `crates/kin-mcp/src/negative.rs`:

- `Degraded::bounds(substrate)` decides whether any standing flag bounds an answer drawn from one substrate.
  It clears, from a copy, exactly the flags whose producer cannot touch that substrate and asks `any()` about
  what is left, so a flag it does not name keeps bounding every answer:

  | flag | bounds |
  |---|---|
  | `memory_pressure`, refused work `embed-batch` | vectors |
  | `memory_pressure`, refused work `lsp-sweep` | relations |
  | `memory_pressure`, any other work or none recorded | every answer |
  | `embed_worker_failed`, `embed_persistence_unavailable` | vectors |
  | every other flag, `hydration_semantics_stale` included | every answer |

- `AbsenceSubstrate` names what an answer reads: vectors (`semantic_locate`), the entity index
  (`list_file_entities`, `semantic_search`, and a name that resolves to nothing), history (`entity_history`),
  and relations for every other structural tool. Relations is the default, so a new tool starts bounded by
  every flag a relation answer is.
- `negative_trust` takes the substrate and refuses only when a flag bounds it. The refusal reads exactly as it
  did.
- `with_memory_pressure` keeps the refused work's id beside the flag under `#[serde(skip)]`, so the wire still
  carries `memory_pressure: true` alone, and an envelope read back from the wire has no work id and bounds
  every answer. Selected-graph qualification, which rebuilds the flags for graph status, carries the id with
  its flag.
- A flag that does not bound an answer stays in `_kin.degraded` and in the answer's `degraded_signals`. On a
  certified answer the existing qualifier names it: "the disclosed signals [memory_pressure] were considered
  and are not load-bearing for this claim". On an answer something else limits, `trust_reason` lists only what
  limits it, because the one verdict builds `limiting_factor` from it, and the flag stays in `degraded_signals`
  and the advice sentence.
- Two existing tests used `embed_worker_failed` to stand for any flag on a structural answer. They now use
  `mass_deletion_blocked`, which still bounds every answer, so they keep testing what they were written for.

What stays: one verdict, the most pessimistic input still wins, no threshold, cap or refusal bar moves, and
`hydration_semantics_stale` keeps bounding every answer until the HEAD verification exists (its own PR).
`sweep_suspended`, `enrichment_shortfall` and `relation_census_loss` keep bounding every answer here; scoping
them to relations is the next PR.

## Measurement

Same store and same questions on both sides: before on release bytes of `b18011c76` (the head #1722 merged
from), after on release bytes of this change over that same tree, one scratch daemon at a time, each stopped by
its pid. The kin-db scratch store holds 5,088 entities in 72 Rust files. Each arm stands one condition:

- v4, nothing standing: the control;
- v6, the hydration record moved aside, so `hydration_semantics_stale` stands;
- v7, `KIN_MEMORY_PRESSURE=critical` with embedding on and the sweep off, which records an `embed-batch` refusal;
- v8, `KIN_MEMORY_PRESSURE=critical` with the sweep on and embedding off, which records an `lsp-sweep` refusal.

v4 and v6 run with the language-server sweep off. On these bytes rust-analyzer resolves, so the sweep starts with
the daemon, and the first v4 run's calls-only answers came back as errors: "no settled graph authority for
find_references: a language-server enrichment sweep was installing relations while this read ran". That run
measured the install window rather than the verdict, so both sides reran v4 and v6 with the sweep off.

| arm | question | before (wording bytes) | after (this change) |
|---|---|---|---|
| v4, nothing standing | callers of `is_control_directory_component`, calls only | certified, 1 row | certified, 1 row |
| v4, nothing standing | callers of `is_program_source_path`, calls only | certified, 1 row | certified, 1 row |
| v4, nothing standing | `list_file_entities` on `admission.rs` | certified, 97 rows | certified, 97 rows |
| v4, nothing standing | `semantic_locate` | inconclusive, 5 rows; limited by `relevance_floor_unmeasured`, `substrate_partial` | inconclusive, 5 rows; limited by `relevance_floor_unmeasured`, `substrate_partial` |
| v6, hydration record moved aside | callers of `is_control_directory_component`, calls only | inconclusive, 1 row; limited by `degraded` | inconclusive, 1 row; limited by `degraded` |
| v6, hydration record moved aside | callers of `is_program_source_path`, calls only | inconclusive, 1 row; limited by `degraded` | inconclusive, 1 row; limited by `degraded` |
| v6, hydration record moved aside | `list_file_entities` on `admission.rs` | inconclusive, 97 rows; limited by `degraded` | inconclusive, 97 rows; limited by `degraded` |
| v6, hydration record moved aside | `semantic_locate` | inconclusive, 5 rows; limited by `relevance_floor_unmeasured`, `substrate_partial` | inconclusive, 5 rows; limited by `relevance_floor_unmeasured`, `substrate_partial` |
| v7, embed-batch refusal | callers of `is_control_directory_component`, calls only | inconclusive, 1 row; limited by `degraded` | certified, 1 row |
| v7, embed-batch refusal | callers of `is_program_source_path`, calls only | inconclusive, 1 row; limited by `degraded` | certified, 1 row |
| v7, embed-batch refusal | `list_file_entities` on `admission.rs` | inconclusive, 97 rows; limited by `degraded` | certified, 97 rows |
| v7, embed-batch refusal | `semantic_locate` | inconclusive, 5 rows; limited by `relevance_floor_unmeasured`, `substrate_partial` | inconclusive, 5 rows; limited by `relevance_floor_unmeasured`, `substrate_partial` |
| v8, lsp-sweep refusal | callers of `is_control_directory_component`, calls only | inconclusive, 1 row; limited by `degraded` | inconclusive, 1 row; limited by `degraded` |
| v8, lsp-sweep refusal | callers of `is_program_source_path`, calls only | inconclusive, 1 row; limited by `degraded` | inconclusive, 1 row; limited by `degraded` |
| v8, lsp-sweep refusal | `list_file_entities` on `admission.rs` | inconclusive, 97 rows; limited by `degraded` | certified, 97 rows |
| v8, lsp-sweep refusal | `semantic_locate` | inconclusive, 5 rows; limited by `relevance_floor_unmeasured`, `substrate_partial` | inconclusive, 5 rows; limited by `relevance_floor_unmeasured`, `substrate_partial` |

v7 is the demo's shape, and it now certifies what the graph holds while the flag stands. Every answer in the arm
carried `memory_pressure: true`, and the certified ones name it in their reason:

```text
trust_reason=structural_authoritative: daemon graph initialized and loaded; the disclosed signals [memory_pressure] were considered and are not load-bearing for this claim
```

v8 shows the other direction. A held sweep describes relations, so the two caller sets stay bounded, now for a
reason that is about them, while the file enumeration, which reads the entity index, certifies and names the flag:

```text
id 15 list_file_entities admission.rs   trust=authoritative  trust_reason=structural_authoritative: daemon graph initialized and loaded; the disclosed signals [memory_pressure] were considered and are not load-bearing for this claim
id 22 callers, calls only               trust=inconclusive   trust_reason=degraded: the daemon reported a degraded signal, so the index may not reflect current truth
```

v6 is unchanged on purpose: a hydration gap keeps bounding every answer until the HEAD verification exists. The
`semantic_locate` question returned five rows in every arm, so its verdict rests on its own relevance and
coverage readings rather than on the absence gate; TA covers the empty ranking an embed-batch refusal does bound.
Every daemon stayed under 8 GiB: the before arms peaked between 5,967 and 7,743 MB, the after arms between 5,927
and 6,527 MB, and no sample crossed the alarm line.

## Tests and falsification

Seven tests in kin-mcp, six new and one existing test updated:

- TA `an_embed_batch_refusal_bounds_vector_answers_and_no_other`: under an embed-batch refusal, `find_references`
  and `semantic_search` certify and end their reason with "the disclosed signals [memory_pressure] were considered
  and are not load-bearing for this claim"; `semantic_locate` stays inconclusive on `degraded:`; history is not
  bounded.
- TB `an_lsp_sweep_refusal_bounds_relation_answers_and_no_other`: under an lsp-sweep refusal, `find_references`
  stays inconclusive on `degraded:`, and `semantic_search` and `semantic_locate` certify naming the flag.
- TC `the_embedding_flags_bound_vector_answers_and_no_other`: `embed_worker_failed` and
  `embed_persistence_unavailable` each bound `semantic_locate` and nothing else.
- TD `a_refusal_of_unnamed_work_or_an_unlisted_flag_bounds_every_answer`: a refusal of `ambient-admission`, a
  refusal of work this build has never heard of, a refusal read back from the wire with no work recorded, a
  suspended sweep and a hydration gap each bound all four substrates and every answer asked.
- TE `a_scoped_out_flag_stays_disclosed_where_something_else_limits_the_answer`: an embed-batch refusal on an
  answer the graph gate limits. `trust_reason` and the one verdict's `limiting_factor` name `graph_uninitialized`
  and never the flag; `degraded_signals` and the advice name it.
- TF `the_wire_keeps_memory_pressure_and_never_the_refused_work` (envelope.rs): the wire carries
  `memory_pressure: true` and no work id; read back, it bounds every substrate; selected-graph qualification keeps
  the work id with its flag.
- TG `memory_pressure_qualifies_verdicts_only_for_outstanding_work` (server.rs, existing): it expected a held
  sweep to make an empty `semantic_locate` inconclusive, which is the old any-flag rule, and the first run of the
  suite failed on exactly that. It now pins the new rule through `finalize`: the held sweep stays visible and the
  vector ranking certifies naming it, while the embed-batch and unknown-work cases stay inconclusive.

Three kin-cli tests, second commit. `impact::a_degraded_daemon_makes_the_cli_inherit_the_mcp_verdict`,
`dead_code::a_degraded_daemon_makes_the_clean_dead_code_scan_say_so` and
`refs::a_degraded_daemon_still_speaks_when_coverage_is_complete` stood a stopped embedding worker as the degraded
daemon behind a relation answer, and CI caught them on the first head: they asserted the old any-flag rule. Each
now keeps its original assertions on a held language-server sweep, which describes the relations those commands
read (the signal the rendered line names moves from `embed_worker_failed` to `memory_pressure`), and adds the other
direction: with only the embedding flag standing, the same answer is no longer bounded on either surface, and the
flag stays disclosed.

```text
$ heavy-slot.sh enrichverdict kin -- cargo test -p kin-cli --lib -- <these three>      (the tree committed as d262e93f6)
test commands::dead_code::tests::a_degraded_daemon_makes_the_clean_dead_code_scan_say_so ... ok
test commands::refs::tests::a_degraded_daemon_still_speaks_when_coverage_is_complete ... ok
test commands::impact::tests::a_degraded_daemon_makes_the_cli_inherit_the_mcp_verdict ... ok
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 2321 filtered out; finished in 0.03s
```

The whole kin-cli suite on `d262e93f6` is graded by CI's Fast gate test shards. Falsification of these three
tests, on the same head: each arm swaps one exact string in `envelope.rs`, runs the three tests, restores the
file and checks its sha256. R1 makes every standing flag bound every answer again, which must fail the three
negative arms; R2 makes a held sweep bound nothing, which must fail the three positive arms.

```text
$ heavy-slot.sh enrichverdict kin -- python3 falsify-cli.py
R1 RED (every standing flag bounds every answer again, so a stopped embedding worker bounds a relation answer); failed 3 of 3; restored sha256 e0a633fec81b; at crates/kin-cli/src/commands/dead_code.rs:1032:9, crates/kin-cli/src/commands/impact.rs:859:9, crates/kin-cli/src/commands/refs.rs:1675:9
R2 RED (a held sweep bounds no answer, so it no longer bounds a relation answer); failed 3 of 3; restored sha256 e0a633fec81b; at crates/kin-cli/src/commands/dead_code.rs:1013:9, crates/kin-cli/src/commands/impact.rs:809:9, crates/kin-cli/src/commands/refs.rs:1655:9
```

```text
$ heavy-slot.sh enrichverdict kin -- bin/kin-precheck kin --repo-dir kin=<worktree>
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin d262e93f689a9c41c357b2389eb167d41940bec1
```

Three more tests, third commit. CI's next run named them: kin-cli
`impact::an_empty_answer_carries_the_same_verdict_in_prose_and_in_the_payload`, and kin-daemon
`api::the_impact_envelope_carries_the_daemons_degraded_signals` and
`api::a_degraded_daemon_reaches_the_impact_cli_through_the_route`. Same class again, and the full suites on
`d262e93f6` (kin-cli 2321 passed, kin-daemon lib 1695 passed) confirmed these three and no others. Each keeps its
original assertions on a flag that still bounds an answer read off relations: a held language-server sweep where
the test builds its own envelope, and a withheld mass deletion where the daemon's health snapshot is the only
source, since `daemon_health_snapshot` publishes `embed_worker_failed` and `mass_deletion_blocked` and nothing
else. Each adds the other direction, where the embedding flag alone certifies and stays in `degraded_signals`;
the route's arm reads that back out of the HTTP response, so the disclosure is proven through serialization too.

```text
$ heavy-slot.sh enrichverdict kin -- cargo test -p kin-cli --lib -- <the impact verdict test>      (376d47ff7)
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2323 filtered out; finished in 0.09s
$ heavy-slot.sh enrichverdict kin -- cargo test -p kin-daemon --lib -- <the two daemon tests>
test api::tests::the_impact_envelope_carries_the_daemons_degraded_signals ... ok
test api::tests::a_degraded_daemon_reaches_the_impact_cli_through_the_route ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 1699 filtered out; finished in 0.87s
```

Falsification of all six degraded-daemon tests, across both crates, on `376d47ff7`: each arm swaps one exact
string in `envelope.rs`, runs the six, restores the file and checks its sha256. R1 restores the old rule, so
every arm that must no longer bound fails; R2 scopes a held sweep to nothing, so the four kin-cli bounding
arms fail; R3 collapses the conservative default, so every bounding arm fails, including the two that stand
an unlisted flag through the daemon's health snapshot.

```text
$ heavy-slot.sh enrichverdict kin -- python3 falsify-round2.py
R1 RED (every standing flag bounds every answer again); failed 6 of 6 expected; restored sha256 e0a633fec81b
R2 RED (a held sweep bounds no answer); failed 4 of 4 expected; restored sha256 e0a633fec81b
R3 RED (nothing left after the scoped flags bounds anything, so the conservative default is gone); failed 6 of 6 expected; restored sha256 e0a633fec81b
```

```text
$ heavy-slot.sh enrichverdict kin -- bin/kin-precheck kin --repo-dir kin=<worktree>
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin 376d47ff76547fe408444a73bbd66cbfdbdf2daf
```


```text
$ heavy-slot.sh enrichverdict kin -- bash tests-scoping.sh      (head f448fc25c on main cbd15e0a6)
fmt rc=0
test result: ok. 1013 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 93.81s   (kin-mcp --lib)
```

Falsification, on the same head: each arm swaps one exact string, runs TA to TG, requires exactly the named
tests to fail, restores the file and checks its sha256 (`envelope.rs` `e0a633fec81b` and a clean worktree before and
after every arm).

```text
$ heavy-slot.sh enrichverdict kin -- python3 falsify-scoping.py
S1 RED  every standing flag bounds every answer again                                          TA, TB, TC, TE, TG negative.rs:5649:9, negative.rs:5731:9, negative.rs:5785:13, negative.rs:5929:9, server.rs:2237:9
S2 RED  an embed-batch refusal bounds no answer                                                TA, TG           negative.rs:5683:9, server.rs:2275:13
S3 RED  an lsp-sweep refusal bounds no answer                                                  TB               negative.rs:5712:9
S4 RED  the embedding flags bound no answer                                                    TC               negative.rs:5802:13
S5 RED  a refusal of unnamed or unrecorded work is scoped out instead of bounding everything   TD, TF, TG       envelope.rs:6482:13, negative.rs:5866:17, server.rs:2275:13
S6 RED  the refused work reaches the wire                                                      TF               envelope.rs:6469:9
S7 RED  a scoped-out flag drops out of the disclosed signals                                   TA, TB, TE, TG   negative.rs:5655:9, negative.rs:5733:9, negative.rs:5938:9, server.rs:2229:9
S8 RED  selected-graph qualification drops the refused work                                    TF               envelope.rs:6489:9
```

## Local gates

On the current head. The runs on the two earlier heads are above, beside the tests each of them
fixed.

```text
$ heavy-slot.sh enrichverdict kin -- bin/kin-precheck kin --repo-dir kin=<worktree>
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin 376d47ff76547fe408444a73bbd66cbfdbdf2daf
```

Ticket: FIR-3541.
