### PR TITLE
Carry review records through kin push and kin pull

### DIFF
--- a/crates/kin-cli/src/commands/transfer.rs
+++ b/crates/kin-cli/src/commands/transfer.rs
@@ -16,6 +16,7 @@
 use anyhow::{bail, Context, Result};
 use kin_core::{KinConfig, KinLayout, RemoteHostKind, RemoteTransportKind};
 use kin_model::RefName;
+use kin_remote::collaboration_transfer::CollaborationTransfer;
 use kin_remote::repository_transfer_negotiation::{
     RepositoryPushPlan, RepositoryTransferDirection, RepositoryTransferOutcome,
     RepositoryTransferPlan,
@@ -458,7 +459,8 @@ fn render_outcome(response: &CommandTransferResponse, json: bool) -> Result<()> 
         // is the mode a caller chains work from, so it is the mode where an
         // exit status that ignored a working tree left behind would do the most
         // damage. The body still carries the state; this decides the status.
-        return workspace_follow_outcome(&response.workspace);
+        workspace_follow_outcome(&response.workspace)?;
+        return review_records_outcome(&response.outcome);
     }
     let outcome = &response.outcome;
     let verb = match outcome.direction {
@@ -495,7 +497,80 @@ fn render_outcome(response: &CommandTransferResponse, json: bool) -> Result<()> 
             "Search and retrieval answer from behind the admitted head until those views are rebuilt. Restart the daemon to rebuild them."
         );
     }
-    render_workspace_follow(&response.workspace)
+    render_review_records(outcome);
+    render_workspace_follow(&response.workspace)?;
+    review_records_outcome(outcome)
+}
+
+/// Report what the review phase did.
+///
+/// It runs after the ref phase, so whatever it reports, any history the
+/// transfer moved is already durable.
+fn render_review_records(outcome: &RepositoryTransferOutcome) {
+    let Some(reviews) = &outcome.collaboration else {
+        return;
+    };
+    let push = outcome.direction == RepositoryTransferDirection::Push;
+    match reviews {
+        CollaborationTransfer::InSync => {
+            println!("Reviews:   both replicas already hold the same review records.")
+        }
+        CollaborationTransfer::PeerUnsupported {
+            local_records: Some(count),
+        } => println!(
+            "Reviews:   not carried. The remote does not exchange review records (collaboration-v1), so the {count} held here stayed here."
+        ),
+        CollaborationTransfer::PeerUnsupported {
+            local_records: None,
+        } => println!(
+            "Reviews:   not pulled. The remote does not exchange review records (collaboration-v1), so any it holds stayed there."
+        ),
+        CollaborationTransfer::Skipped { reason } => {
+            println!("Reviews:   not exchanged: {reason}")
+        }
+        CollaborationTransfer::Exchanged {
+            carried,
+            gaps,
+            receipt,
+        } => {
+            match (receipt, push) {
+                (Some(receipt), true) => println!(
+                    "Reviews:   carried {carried} review record(s) to the remote (its authority generation {}).",
+                    receipt.authority_receipt.generation
+                ),
+                (Some(receipt), false) => println!(
+                    "Reviews:   pulled {carried} review record(s) (authority generation {}).",
+                    receipt.authority_receipt.generation
+                ),
+                (None, true) => {
+                    println!("Reviews:   the remote already holds every review record this replica has.")
+                }
+                (None, false) => {
+                    println!("Reviews:   this replica already holds every review record the remote has.")
+                }
+            }
+            for gap in gaps {
+                println!("Review gap: {}: {}", gap.record, gap.detail);
+            }
+        }
+        CollaborationTransfer::Refused { reason } => {
+            println!("Reviews:   not exchanged: {reason}")
+        }
+    }
+}
+
+/// Fail the command when its review phase could not complete, in every output
+/// mode, for the reason the working-tree check does: a caller chaining work
+/// onto a transfer reads the exit status. A peer that does not exchange review
+/// records, and a record the merge names instead of overwriting, are reported
+/// and are not failures.
+fn review_records_outcome(outcome: &RepositoryTransferOutcome) -> Result<()> {
+    if let Some(CollaborationTransfer::Refused { reason }) = &outcome.collaboration {
+        bail!(
+            "review records were not exchanged: {reason}. Any history this transfer moved is durable; re-running it retries the review records."
+        );
+    }
+    Ok(())
 }
 
 /// Report what the working tree did, and fail the command when it did not
@@ -682,6 +757,7 @@ mod tests {
                 destination_ref: main,
                 plan: RepositoryTransferPlan::UpToDate { head: None },
                 receipts: Vec::new(),
+                collaboration: None,
             },
             derived_views: DerivedViewRefresh::Current,
             workspace,

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -16289,7 +16289,7 @@ fn configured_transfer_limits() -> kin_remote::repository_transfer::RepositoryTr
 /// A hosted daemon runs no policy. Its storage backend is not a local `.kin`
 /// layout, and the scaffolding directory beside it belongs to no repository
 /// whose provenance this transfer touched.
-fn apply_received_repository_transfer_pack(
+pub(crate) fn apply_received_repository_transfer_pack(
     state: &DaemonState,
     authority: &RepositoryAuthorityManager<dyn StorageBackend>,
     repository_id: &RepositoryId,
@@ -16544,6 +16544,28 @@ async fn repo_transfer_receive(
     Json(request): Json<RepositoryTransferReceiveRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     let (repository_id, authority) = repository_transfer_authority(&state, &repo_id)?;
+    if request.pack.collaboration.is_some() && state.storage_backend.is_none() {
+        // Review records land the way a review write does, under the two gates
+        // every authority writer here holds, so the live graph a review write
+        // plans against follows them before anything else can plan.
+        let _coordination = state.coordination_gate.lock().await;
+        let admitted = {
+            let _graph_mutation = state.begin_graph_authority_mutation();
+            crate::review_transfer::admit_review_records(
+                &state,
+                &authority,
+                &repository_id,
+                &request.destination_ref,
+                kin_model::AuthorId::new("kin-daemon:repository-transfer-receiver"),
+                &request.pack,
+            )
+        };
+        let (receipt, stale) = admitted.map_err(repository_transfer_error)?;
+        if let Some(detail) = stale {
+            record_derived_view_staleness(&state, &DerivedViewRefresh::Stale { detail }).await;
+        }
+        return Ok(Json(receipt));
+    }
     let receipt = apply_received_repository_transfer_pack(
         &state,
         &authority,
@@ -16810,6 +16832,27 @@ pub(crate) async fn pull_into_replica(
                 &source_ref,
                 &destination_ref,
                 |pack| {
+                    if pack.collaboration.is_some() && local_derived_views {
+                        // Review records land the way a review write does; see
+                        // `review_transfer`. This runs on a blocking thread, so
+                        // the coordination gate is taken without an await.
+                        let _coordination = blocking_state.coordination_gate.blocking_lock();
+                        let _graph_mutation = blocking_state.begin_graph_authority_mutation();
+                        let (receipt, stale) = crate::review_transfer::admit_review_records(
+                            &blocking_state,
+                            &authority,
+                            &repository_id,
+                            &destination_ref,
+                            kin_model::AuthorId::new("kin-daemon:repository-transfer-puller"),
+                            pack,
+                        )?;
+                        if let Some(detail) = stale {
+                            if !refresh.is_stale() {
+                                refresh = DerivedViewRefresh::Stale { detail };
+                            }
+                        }
+                        return Ok(receipt);
+                    }
                     let receipt = apply_received_repository_transfer_pack(
                         &blocking_state,
                         &authority,
@@ -16857,7 +16900,7 @@ pub(crate) async fn pull_into_replica(
     // Hosted cache freshness is cursor-driven. Do not put a durable pull
     // receipt behind an in-flight full reload, and do not evict a successor a
     // concurrent reader may already have installed.
-    if !outcome.moved_history() {
+    if !outcome.moved_history() && !outcome.carried_review_records() {
         derived_views = DerivedViewRefresh::Current;
     }
     record_derived_view_staleness(&state, &derived_views).await;

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -153,6 +153,7 @@ mod repository_rename;
 mod repository_rollback;
 mod repository_stash;
 mod repository_tag;
+mod review_transfer;
 mod review_write;
 mod semantic_debt;
 pub mod session_registry;

--- a/crates/kin-daemon/src/review_transfer.rs
+++ b/crates/kin-daemon/src/review_transfer.rs
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Review records a repository transfer admits into this daemon's replica.
+//!
+//! A collaboration pack lands in repository authority like any other pack. What
+//! is particular to it is the live graph. Review writes are planned against the
+//! live graph, so records that reached authority without reaching the graph
+//! under the locks a review write holds could be overwritten by the next write
+//! planned from it. A received review record therefore lands the way a review
+//! write does: the caller holds the coordination gate and a graph-authority
+//! mutation guard, this takes the persistence lock, and the live graph follows
+//! authority before any of them is released.
+
+use std::collections::HashMap;
+
+use kin_db::{RepositoryAuthorityManager, StorageBackend};
+use kin_model::review::ReviewId;
+use kin_model::{AuthorId, CollaborationDelta, RefName, RepositoryId};
+use kin_remote::repository_transfer::{
+    RepositoryTransferApplyOutcome, RepositoryTransferError, RepositoryTransferPack,
+    RepositoryTransferReceipt,
+};
+use kin_review::write::{ReviewGroup, ReviewWrite};
+
+use crate::state::{DaemonEvent, DaemonState};
+
+/// Admit one collaboration pack and bring the live graph to what authority now
+/// holds.
+///
+/// The caller holds `coordination_gate` and a graph-authority mutation guard.
+/// Returns the receipt and, when authority moved but the live graph could not
+/// follow it, what went wrong. The records are durable either way, and a caller
+/// told the admission failed would retry a publication that already happened.
+pub(crate) fn admit_review_records(
+    state: &DaemonState,
+    authority: &RepositoryAuthorityManager<dyn StorageBackend>,
+    repository_id: &RepositoryId,
+    destination_ref: &RefName,
+    actor: AuthorId,
+    pack: &RepositoryTransferPack,
+) -> Result<(RepositoryTransferReceipt, Option<String>), RepositoryTransferError> {
+    let _persistence = state.persist_lock.lock().map_err(|_| {
+        RepositoryTransferError::Storage("daemon persistence lock poisoned".to_string())
+    })?;
+    let receipt = crate::api::apply_received_repository_transfer_pack(
+        state,
+        authority,
+        repository_id,
+        destination_ref,
+        actor,
+        pack,
+    )?;
+    // A replay was followed when it first landed.
+    if receipt.outcome != RepositoryTransferApplyOutcome::Committed {
+        return Ok((receipt, None));
+    }
+    let stale = follow_review_records(state, &receipt, pack.collaboration.as_ref()).err();
+    Ok((receipt, stale))
+}
+
+fn follow_review_records(
+    state: &DaemonState,
+    receipt: &RepositoryTransferReceipt,
+    records: Option<&CollaborationDelta>,
+) -> Result<(), String> {
+    let committed = &receipt.authority_receipt;
+    state
+        .record_repository_authority_commit(committed.generation)
+        .map_err(|error| format!("record repository authority generation: {error}"))?;
+    for write in records.map(review_writes).unwrap_or_default() {
+        write
+            .apply_to(state.graph.as_ref())
+            .map_err(|error| format!("bring the daemon's review state to authority: {error}"))?;
+    }
+    state.bump_version();
+    state.mark_dirty();
+    state.emit_event(DaemonEvent::GraphRootChanged {
+        old_root_hash: None,
+        new_root_hash: "review-state".to_string(),
+    });
+    state.emit_event(DaemonEvent::RepositoryAuthorityChanged {
+        repository_id: committed.repository_id.to_string(),
+        operation_id: committed.operation_id,
+        previous_generation: committed.roots_before.generation,
+        new_generation: committed.generation,
+    });
+    Ok(())
+}
+
+/// `records` as the review writes the live graph applies: the provenance they
+/// carry first, so every actor an audit event names exists before any review
+/// does, then one write per review.
+fn review_writes(records: &CollaborationDelta) -> Vec<ReviewWrite> {
+    let mut by_review: HashMap<ReviewId, ReviewWrite> = HashMap::new();
+    for entry in &records.reviews {
+        by_review.entry(entry.key).or_default().review = Some(entry.value.clone());
+    }
+    for entry in &records.review_decisions {
+        by_review.entry(entry.key).or_default().decisions = Some(ReviewGroup {
+            review_id: entry.key,
+            entries: entry.value.clone(),
+        });
+    }
+    for note in &records.review_notes {
+        by_review
+            .entry(note.review_id)
+            .or_default()
+            .notes
+            .push(note.clone());
+    }
+    for discussion in &records.review_discussions {
+        by_review
+            .entry(discussion.review_id)
+            .or_default()
+            .discussions
+            .push(discussion.clone());
+    }
+    for entry in &records.review_assignments {
+        by_review.entry(entry.key).or_default().assignments = Some(ReviewGroup {
+            review_id: entry.key,
+            entries: entry.value.clone(),
+        });
+    }
+    let provenance = ReviewWrite {
+        actors: records
+            .actors
+            .iter()
+            .map(|entry| entry.value.clone())
+            .collect(),
+        audit_events: records.audit_events.clone(),
+        ..ReviewWrite::default()
+    };
+    std::iter::once(provenance)
+        .chain(by_review.into_values())
+        .filter(|write| !write.is_empty())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kin_model::review::{
+        Review, ReviewCompletionState, ReviewDecision, ReviewDecisionState, ReviewNote,
+        ReviewNoteId,
+    };
+    use kin_model::{IdentityRef, Keyed, ReviewStore, Timestamp};
+
+    fn review(id: ReviewId, state: ReviewDecisionState) -> Review {
+        Review {
+            review_id: id,
+            title: "Carry reviews through a pull".to_string(),
+            base_ref: "main".to_string(),
+            head_ref: "feature/reviews".to_string(),
+            state,
+            completion: ReviewCompletionState::InReview,
+            created_by: IdentityRef::human("troy"),
+            created_at: Timestamp::now(),
+            updated_at: Timestamp::now(),
+            scopes: vec![],
+        }
+    }
+
+    /// Records a pull admits reach the live graph whole: a new review with its
+    /// note, and a decision appended to a review the graph already held, which
+    /// is how the holder's history arrives in a pack, as its prefix.
+    ///
+    /// Falsify by dropping the decisions arm of `review_writes`: the held
+    /// review keeps one decision and the assertion on two goes red.
+    #[test]
+    fn admitted_records_bring_the_live_graph_to_authority() {
+        let graph = kin_db::InMemoryGraph::new();
+        let held = ReviewId::new();
+        let first = ReviewDecision {
+            reviewer: IdentityRef::human("alice"),
+            state: ReviewDecisionState::NeedsWork,
+            comment: None,
+            decided_at: Timestamp::now(),
+        };
+        graph
+            .create_review(&review(held, ReviewDecisionState::NeedsWork))
+            .unwrap();
+        graph.add_review_decision(&held, &first).unwrap();
+
+        let arrived = ReviewId::new();
+        let second = ReviewDecision {
+            reviewer: IdentityRef::human("bob"),
+            state: ReviewDecisionState::Approved,
+            comment: None,
+            decided_at: Timestamp::now(),
+        };
+        let note = ReviewNote {
+            note_id: ReviewNoteId::new(),
+            review_id: arrived,
+            body: "looks right".to_string(),
+            scope: None,
+            authored_by: IdentityRef::human("bob"),
+            created_at: Timestamp::now(),
+        };
+        let records = CollaborationDelta {
+            reviews: vec![
+                Keyed::new(held, review(held, ReviewDecisionState::Approved)),
+                Keyed::new(arrived, review(arrived, ReviewDecisionState::Pending)),
+            ],
+            review_decisions: vec![Keyed::new(held, vec![first, second])],
+            review_notes: vec![note.clone()],
+            ..CollaborationDelta::default()
+        };
+
+        for write in review_writes(&records) {
+            write.apply_to(&graph).unwrap();
+        }
+
+        assert_eq!(
+            graph.get_review(&held).unwrap().unwrap().state,
+            ReviewDecisionState::Approved
+        );
+        assert_eq!(graph.get_review_decisions(&held).unwrap().len(), 2);
+        assert!(graph.get_review(&arrived).unwrap().is_some());
+        assert_eq!(graph.get_review_notes(&arrived).unwrap(), vec![note]);
+    }
+}

--- a/crates/kin-remote/src/collaboration_transfer.rs
+++ b/crates/kin-remote/src/collaboration_transfer.rs
@@ -1,0 +1,996 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Review records on the repository transfer seam.
+//!
+//! Review state is replicated collaboration authority, so a push and a pull carry
+//! it after the ref phase, in a pack that moves no history. The exporting side
+//! offers its review domain: every review, its decision and assignment histories,
+//! its notes, the copy of each discussion it serves, and the actors and review
+//! audit events those writes recorded. The side that sends to a holder sends only
+//! what the holder lacks, merged so the holder never loses a record, and names
+//! every record it cannot settle instead of overwriting it.
+//!
+//! What decides a conflict is always a history one side can prove, never a clock
+//! alone. A review's state moves only when a decision is recorded, and authority
+//! keeps each review's decisions, so the review whose decisions contain the
+//! other's is the newer one. A discussion's copies are kept in authority in the
+//! order they were admitted, so a copy that appears in a replica's own history is
+//! older than that replica's current copy. Where neither holds, the record is a
+//! named gap.
+
+use std::cmp::Ordering;
+use std::collections::HashMap;
+
+use kin_db::GraphSnapshot;
+use kin_model::provenance::{Actor, ActorId, AuditEvent, AuditEventId};
+use kin_model::review::{
+    Review, ReviewAssignment, ReviewComment, ReviewDecision, ReviewDiscussion, ReviewDiscussionId,
+    ReviewId, ReviewNote, ReviewNoteId,
+};
+use kin_model::{CollaborationDelta, Keyed};
+use serde::{Deserialize, Serialize};
+
+use crate::repository_transfer::RepositoryTransferReceipt;
+use crate::repository_transfer_negotiation::RepositoryTransferDirection;
+
+/// The most review-domain records one collaboration pack carries.
+///
+/// A count, not a byte size: review records are small and bounded by what a
+/// person or an agent writes, so the count is what grows with a repository's
+/// review history. Past it a transfer refuses by name rather than sending a
+/// partial set.
+pub const MAX_COLLABORATION_RECORDS: usize = 20_000;
+
+/// The audit actions a review write records, and so the audit events that travel
+/// with review state.
+const REVIEW_AUDIT_PREFIX: &str = "review.";
+
+/// A record two replicas hold differently that the merge cannot settle, named
+/// rather than overwritten.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CollaborationGap {
+    /// What the record is, such as `review 1f0c...`.
+    pub record: String,
+    /// Both versions, and why neither can be preferred.
+    pub detail: String,
+}
+
+/// What the review phase of a push or a pull did.
+///
+/// The review phase runs after the ref phase, so by the time it reports, the
+/// history the transfer moved is already durable. That is why a review phase
+/// that cannot complete is an outcome rather than an error: failing the
+/// transfer would tell the caller a publication that happened did not.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CollaborationTransfer {
+    /// Both replicas' collaboration roots already agree, so nothing was compared
+    /// and nothing was sent.
+    InSync,
+    /// The peer does not advertise `collaboration-v1`, so no review record
+    /// travelled. `local_records` is how many this replica holds that stayed
+    /// here on a push; a pull cannot count what the peer holds.
+    PeerUnsupported { local_records: Option<usize> },
+    /// There was nothing to anchor review records to, such as a ref neither
+    /// replica publishes yet.
+    Skipped { reason: String },
+    /// The two replicas' review records were compared. `carried` records were
+    /// published on the receiving replica, none when it already held them all,
+    /// and `gaps` names every record the merge could not settle.
+    Exchanged {
+        carried: usize,
+        gaps: Vec<CollaborationGap>,
+        receipt: Option<RepositoryTransferReceipt>,
+    },
+    /// The review phase did not complete and published nothing.
+    Refused { reason: String },
+}
+
+/// What one side of a transfer sends to a holder, and what it names instead.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct CollaborationMerge {
+    /// The records the holder lacks, in the order kin-model accepts, or `None`
+    /// when there is nothing to send.
+    pub delta: Option<CollaborationDelta>,
+    /// Records the merge could not settle.
+    pub gaps: Vec<CollaborationGap>,
+}
+
+/// One replica's review domain, as the transfer seam exchanges it.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ReviewDomain {
+    reviews: HashMap<ReviewId, Review>,
+    decisions: HashMap<ReviewId, Vec<ReviewDecision>>,
+    notes: HashMap<ReviewNoteId, ReviewNote>,
+    /// The copy of each discussion this replica serves.
+    discussions: HashMap<ReviewDiscussionId, ReviewDiscussion>,
+    /// Every copy of each discussion this replica holds, in admission order.
+    /// Present for a replica's own domain; a peer's export carries only the copy
+    /// it serves, which is all a canonically ordered delta can say.
+    discussion_history: HashMap<ReviewDiscussionId, Vec<ReviewDiscussion>>,
+    assignments: HashMap<ReviewId, Vec<ReviewAssignment>>,
+    actors: HashMap<ActorId, Actor>,
+    audit_events: HashMap<AuditEventId, AuditEvent>,
+}
+
+impl ReviewDomain {
+    /// This replica's own review domain, read from its authority snapshot.
+    ///
+    /// The snapshot keeps discussion copies in the order they were admitted, and
+    /// the graph serves the last one, so the last copy per discussion is the
+    /// current one and the rest are its history.
+    pub fn from_snapshot(snapshot: &GraphSnapshot) -> Self {
+        let mut domain = Self {
+            reviews: snapshot.reviews.clone(),
+            decisions: snapshot.review_decisions.clone(),
+            notes: snapshot
+                .review_notes
+                .iter()
+                .map(|note| (note.note_id, note.clone()))
+                .collect(),
+            assignments: snapshot.review_assignments.clone(),
+            ..Self::default()
+        };
+        for discussion in &snapshot.review_discussions {
+            domain
+                .discussion_history
+                .entry(discussion.discussion_id)
+                .or_default()
+                .push(discussion.clone());
+            domain
+                .discussions
+                .insert(discussion.discussion_id, discussion.clone());
+        }
+        domain.adopt_provenance(&snapshot.audit_events, &snapshot.actors);
+        domain
+    }
+
+    /// A peer's review domain, from the collaboration records it exported.
+    pub fn from_delta(delta: &CollaborationDelta) -> Self {
+        let mut domain = Self {
+            reviews: delta
+                .reviews
+                .iter()
+                .map(|entry| (entry.key, entry.value.clone()))
+                .collect(),
+            decisions: delta
+                .review_decisions
+                .iter()
+                .map(|entry| (entry.key, entry.value.clone()))
+                .collect(),
+            notes: delta
+                .review_notes
+                .iter()
+                .map(|note| (note.note_id, note.clone()))
+                .collect(),
+            discussions: delta
+                .review_discussions
+                .iter()
+                .map(|discussion| (discussion.discussion_id, discussion.clone()))
+                .collect(),
+            assignments: delta
+                .review_assignments
+                .iter()
+                .map(|entry| (entry.key, entry.value.clone()))
+                .collect(),
+            ..Self::default()
+        };
+        let actors: HashMap<ActorId, Actor> = delta
+            .actors
+            .iter()
+            .map(|entry| (entry.key, entry.value.clone()))
+            .collect();
+        domain.adopt_provenance(&delta.audit_events, &actors);
+        domain
+    }
+
+    /// Keep the review audit events and the actors they name.
+    fn adopt_provenance(&mut self, events: &[AuditEvent], actors: &HashMap<ActorId, Actor>) {
+        for event in events {
+            if event.action.starts_with(REVIEW_AUDIT_PREFIX) {
+                if let Some(actor) = actors.get(&event.actor_id) {
+                    self.actors.insert(event.actor_id, actor.clone());
+                }
+                self.audit_events.insert(event.event_id, event.clone());
+            }
+        }
+    }
+
+    /// How many records this domain holds, counting a history as one record.
+    pub fn record_count(&self) -> usize {
+        self.reviews.len()
+            + self.decisions.len()
+            + self.notes.len()
+            + self.discussions.len()
+            + self.assignments.len()
+            + self.actors.len()
+            + self.audit_events.len()
+    }
+
+    /// The whole domain as a delta, one current copy per discussion: what an
+    /// exporter offers. `None` when the domain is empty.
+    pub fn to_delta(&self) -> Option<CollaborationDelta> {
+        let mut delta = CollaborationDelta {
+            reviews: keyed(&self.reviews),
+            review_decisions: keyed(&self.decisions),
+            review_notes: self.notes.values().cloned().collect(),
+            review_discussions: self.discussions.values().cloned().collect(),
+            review_assignments: keyed(&self.assignments),
+            actors: keyed(&self.actors),
+            audit_events: self.audit_events.values().cloned().collect(),
+            ..CollaborationDelta::default()
+        };
+        finish(&mut delta)
+    }
+
+    /// What `self` sends to `holder` so the holder ends up with both sides'
+    /// records, and the records it names instead of sending.
+    ///
+    /// `direction` is the transfer this merge serves, which is only how its
+    /// gaps name the two replicas: on a push this replica sends, on a pull the
+    /// remote does.
+    pub fn merge_into(
+        &self,
+        holder: &ReviewDomain,
+        direction: RepositoryTransferDirection,
+    ) -> CollaborationMerge {
+        let sides = Sides::of(direction);
+        let mut delta = CollaborationDelta::default();
+        let mut gaps = Vec::new();
+
+        for (id, review) in &self.reviews {
+            match holder.reviews.get(id) {
+                None => delta.reviews.push(Keyed::new(*id, review.clone())),
+                Some(held) if held == review => {}
+                Some(held) => {
+                    if let Some(gap) =
+                        self.settle_review(holder, sides, id, review, held, &mut delta)
+                    {
+                        gaps.push(gap);
+                    }
+                }
+            }
+        }
+        for (id, ours) in &self.decisions {
+            let theirs = holder.decisions.get(id).cloned().unwrap_or_default();
+            let merged = appended(&theirs, ours);
+            if merged != theirs {
+                delta.review_decisions.push(Keyed::new(*id, merged));
+            }
+        }
+        for (id, note) in &self.notes {
+            match holder.notes.get(id) {
+                None => delta.review_notes.push(note.clone()),
+                Some(held) if held == note => {}
+                Some(_) => gaps.push(CollaborationGap {
+                    record: format!("review note {id}"),
+                    detail:
+                        "the two replicas hold different contents under one note id, and notes \
+                             are never edited, so neither copy can be preferred"
+                            .to_string(),
+                }),
+            }
+        }
+        for (id, ours) in &self.discussions {
+            match holder.discussions.get(id) {
+                None => delta.review_discussions.push(ours.clone()),
+                Some(theirs) if theirs == ours => {}
+                Some(theirs) => {
+                    if let Some(gap) =
+                        self.settle_discussion(holder, sides, id, ours, theirs, &mut delta)
+                    {
+                        gaps.push(gap);
+                    }
+                }
+            }
+        }
+        for (id, ours) in &self.assignments {
+            let theirs = holder.assignments.get(id).cloned().unwrap_or_default();
+            let merged = appended(&theirs, ours);
+            if merged != theirs {
+                delta.review_assignments.push(Keyed::new(*id, merged));
+            }
+            let held_only: Vec<&str> = theirs
+                .iter()
+                .filter(|assignment| !ours.contains(assignment))
+                .map(|assignment| assignment.reviewer.name.as_str())
+                .collect();
+            if !held_only.is_empty() {
+                gaps.push(CollaborationGap {
+                    record: format!("assignments of review {id}"),
+                    detail: format!(
+                        "{} holds {} that {} does not; if that was a removal, it cannot travel, \
+                         because a collaboration delta expresses no removal",
+                        sides.holder,
+                        held_only.join(", "),
+                        sides.sender
+                    ),
+                });
+            }
+        }
+        for (id, actor) in &self.actors {
+            match holder.actors.get(id) {
+                None => delta.actors.push(Keyed::new(*id, actor.clone())),
+                Some(held) if held == actor => {}
+                Some(_) => gaps.push(CollaborationGap {
+                    record: format!("actor {id}"),
+                    detail: "the two replicas describe one actor id differently".to_string(),
+                }),
+            }
+        }
+        for (id, event) in &self.audit_events {
+            if !holder.audit_events.contains_key(id) {
+                delta.audit_events.push(event.clone());
+            }
+        }
+
+        CollaborationMerge {
+            delta: finish(&mut delta),
+            gaps,
+        }
+    }
+
+    /// A review both sides hold with different contents.
+    ///
+    /// Its decisions are the causal record: a review's state moves only when a
+    /// decision is recorded, so the side whose decisions contain the other's
+    /// holds the newer review. `updated_at` decides only where neither side holds
+    /// a decision, and that choice is disclosed, because two machines' clocks can
+    /// disagree.
+    fn settle_review(
+        &self,
+        holder: &ReviewDomain,
+        sides: Sides,
+        id: &ReviewId,
+        ours: &Review,
+        held: &Review,
+        delta: &mut CollaborationDelta,
+    ) -> Option<CollaborationGap> {
+        let our_decisions = self.decisions.get(id).map(Vec::as_slice).unwrap_or(&[]);
+        let their_decisions = holder.decisions.get(id).map(Vec::as_slice).unwrap_or(&[]);
+        let we_contain = their_decisions.iter().all(|d| our_decisions.contains(d));
+        let they_contain = our_decisions.iter().all(|d| their_decisions.contains(d));
+        let record = format!("review {id}");
+        if our_decisions.is_empty() && their_decisions.is_empty() {
+            return match ours.updated_at.0.cmp(&held.updated_at.0) {
+                Ordering::Greater => {
+                    delta.reviews.push(Keyed::new(*id, ours.clone()));
+                    Some(CollaborationGap {
+                        record,
+                        detail: format!(
+                            "neither replica holds a decision for it, so the later updated_at \
+                             decided: {} {} over {} {}; clocks on two machines can disagree",
+                            sides.sender, ours.updated_at, sides.holder, held.updated_at
+                        ),
+                    })
+                }
+                Ordering::Less => None,
+                Ordering::Equal => Some(CollaborationGap {
+                    record,
+                    detail:
+                        "the two replicas hold different contents with the same updated_at and \
+                             no decision to order them"
+                            .to_string(),
+                }),
+            };
+        }
+        if we_contain && our_decisions.len() > their_decisions.len() {
+            delta.reviews.push(Keyed::new(*id, ours.clone()));
+            return None;
+        }
+        if they_contain && their_decisions.len() > our_decisions.len() {
+            return None;
+        }
+        Some(CollaborationGap {
+            record,
+            detail: format!(
+                "both replicas decided it independently: {} holds it {} after {} decision(s), {} \
+                 holds it {} after {}; the decisions merge, and it stays {} on {} until a new \
+                 decision settles it",
+                sides.sender,
+                ours.state,
+                our_decisions.len(),
+                sides.holder,
+                held.state,
+                their_decisions.len(),
+                held.state,
+                sides.holder
+            ),
+        })
+    }
+
+    /// A discussion both sides serve with different copies.
+    ///
+    /// A copy in a replica's own admission history is older than that
+    /// replica's current copy. Failing that, a copy whose comments strictly
+    /// extend the other's, in the same state, is the newer one. Anything else is
+    /// a named gap.
+    fn settle_discussion(
+        &self,
+        holder: &ReviewDomain,
+        sides: Sides,
+        id: &ReviewDiscussionId,
+        ours: &ReviewDiscussion,
+        theirs: &ReviewDiscussion,
+        delta: &mut CollaborationDelta,
+    ) -> Option<CollaborationGap> {
+        let theirs_is_our_past = self
+            .discussion_history
+            .get(id)
+            .is_some_and(|history| history.contains(theirs));
+        let ours_is_their_past = holder
+            .discussion_history
+            .get(id)
+            .is_some_and(|history| history.contains(ours));
+        if theirs_is_our_past && !ours_is_their_past {
+            delta.review_discussions.push(ours.clone());
+            return None;
+        }
+        if ours_is_their_past && !theirs_is_our_past {
+            return None;
+        }
+        if ours.state == theirs.state && extends(&ours.comments, &theirs.comments) {
+            delta.review_discussions.push(ours.clone());
+            return None;
+        }
+        if ours.state == theirs.state && extends(&theirs.comments, &ours.comments) {
+            return None;
+        }
+        Some(CollaborationGap {
+            record: format!("review discussion {id}"),
+            detail: format!(
+                "{} serves it {} with {} comment(s), {} serves it {} with {}, and neither copy is \
+                 in the other's history",
+                sides.sender,
+                ours.state,
+                ours.comments.len(),
+                sides.holder,
+                theirs.state,
+                theirs.comments.len()
+            ),
+        })
+    }
+}
+
+/// How a merge's gaps name its two replicas, which depends on which one sends.
+#[derive(Debug, Clone, Copy)]
+struct Sides {
+    sender: &'static str,
+    holder: &'static str,
+}
+
+impl Sides {
+    fn of(direction: RepositoryTransferDirection) -> Self {
+        match direction {
+            RepositoryTransferDirection::Push => Self {
+                sender: "this replica",
+                holder: "the remote",
+            },
+            RepositoryTransferDirection::Pull => Self {
+                sender: "the remote",
+                holder: "this replica",
+            },
+        }
+    }
+}
+
+/// Why `delta` carries something other than review records, or `None` when it
+/// carries only those.
+///
+/// Review records are all a transfer exchanges, so a pack carrying anything else
+/// is refused whole rather than admitted in part.
+pub fn outside_review_domain(delta: &CollaborationDelta) -> Option<String> {
+    let others = [
+        ("work items", delta.work_items.len()),
+        ("annotations", delta.annotations.len()),
+        ("work links", delta.work_links.len()),
+        ("test cases", delta.test_cases.len()),
+        ("assertions", delta.assertions.len()),
+        ("verification runs", delta.verification_runs.len()),
+        ("mock hints", delta.mock_hints.len()),
+        ("contracts", delta.contracts.len()),
+        ("delegations", delta.delegations.len()),
+        ("approvals", delta.approvals.len()),
+    ];
+    if let Some((name, count)) = others.iter().find(|(_, count)| *count > 0) {
+        return Some(format!(
+            "it carries {count} {name}, and a transfer exchanges review records only"
+        ));
+    }
+    delta
+        .audit_events
+        .iter()
+        .find(|event| !event.action.starts_with(REVIEW_AUDIT_PREFIX))
+        .map(|event| {
+            format!(
+                "it carries audit event {} for {}, which no review write records",
+                event.event_id, event.action
+            )
+        })
+}
+
+/// The records in `incoming` that would overwrite or drop something `held`
+/// holds, which a receiver refuses rather than admits.
+///
+/// This is the merge rule enforced where the records land. A sender that merged
+/// against this replica's records sends nothing this names. A pack built
+/// without that merge, or against records this replica has since moved past, is
+/// refused here record by record instead of overwriting them. Actors and audit
+/// events are checked against everything `held` holds, not only the review
+/// domain, because an id is one record whichever write recorded it.
+pub fn admission_refusals(
+    held: &GraphSnapshot,
+    incoming: &CollaborationDelta,
+) -> Vec<CollaborationGap> {
+    let domain = ReviewDomain::from_snapshot(held);
+    let mut refusals = Vec::new();
+    let arriving_decisions: HashMap<ReviewId, &[ReviewDecision]> = incoming
+        .review_decisions
+        .iter()
+        .map(|entry| (entry.key, entry.value.as_slice()))
+        .collect();
+
+    for entry in &incoming.reviews {
+        let Some(current) = domain.reviews.get(&entry.key) else {
+            continue;
+        };
+        if current == &entry.value {
+            continue;
+        }
+        let decided = domain
+            .decisions
+            .get(&entry.key)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        let arriving = arriving_decisions
+            .get(&entry.key)
+            .copied()
+            .unwrap_or(decided);
+        let supersedes = if decided.is_empty() && arriving.is_empty() {
+            entry.value.updated_at.0 > current.updated_at.0
+        } else {
+            arriving.len() > decided.len() && decided.iter().all(|d| arriving.contains(d))
+        };
+        if !supersedes {
+            refusals.push(CollaborationGap {
+                record: format!("review {}", entry.key),
+                detail: format!(
+                    "this replica holds it {} after {} decision(s) and the pack carries it {} after \
+                     {}; the pack's decisions do not extend this replica's, so admitting it would \
+                     overwrite a state decided here",
+                    current.state,
+                    decided.len(),
+                    entry.value.state,
+                    arriving.len()
+                ),
+            });
+        }
+    }
+    for entry in &incoming.review_decisions {
+        let current = domain
+            .decisions
+            .get(&entry.key)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        if !entry.value.starts_with(current) {
+            refusals.push(CollaborationGap {
+                record: format!("decision history of review {}", entry.key),
+                detail: format!(
+                    "this replica holds {} decision(s) the pack's {} do not begin with, so admitting \
+                     it would drop or reorder decisions",
+                    current.len(),
+                    entry.value.len()
+                ),
+            });
+        }
+    }
+    for entry in &incoming.review_assignments {
+        let current = domain
+            .assignments
+            .get(&entry.key)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        if !entry.value.starts_with(current) {
+            refusals.push(CollaborationGap {
+                record: format!("assignments of review {}", entry.key),
+                detail: format!(
+                    "this replica holds {} assignment(s) the pack's {} do not begin with, so admitting \
+                     it would remove a reviewer",
+                    current.len(),
+                    entry.value.len()
+                ),
+            });
+        }
+    }
+    for note in &incoming.review_notes {
+        if domain
+            .notes
+            .get(&note.note_id)
+            .is_some_and(|current| current != note)
+        {
+            refusals.push(CollaborationGap {
+                record: format!("review note {}", note.note_id),
+                detail: "this replica holds different contents under the same note id".to_string(),
+            });
+        }
+    }
+    for discussion in &incoming.review_discussions {
+        let id = discussion.discussion_id;
+        let Some(current) = domain.discussions.get(&id) else {
+            continue;
+        };
+        if current == discussion {
+            continue;
+        }
+        let is_past = domain
+            .discussion_history
+            .get(&id)
+            .is_some_and(|history| history.contains(discussion));
+        let is_behind =
+            current.state == discussion.state && extends(&current.comments, &discussion.comments);
+        if is_past || is_behind {
+            refusals.push(CollaborationGap {
+                record: format!("review discussion {id}"),
+                detail: format!(
+                    "this replica serves a newer copy, {} with {} comment(s), than the pack's {} \
+                     with {}",
+                    current.state,
+                    current.comments.len(),
+                    discussion.state,
+                    discussion.comments.len()
+                ),
+            });
+        }
+    }
+    for entry in &incoming.actors {
+        if held
+            .actors
+            .get(&entry.key)
+            .is_some_and(|current| current != &entry.value)
+        {
+            refusals.push(CollaborationGap {
+                record: format!("actor {}", entry.key),
+                detail: "this replica describes the same actor id differently".to_string(),
+            });
+        }
+    }
+    for event in &incoming.audit_events {
+        if held
+            .audit_events
+            .iter()
+            .any(|current| current.event_id == event.event_id && current != event)
+        {
+            refusals.push(CollaborationGap {
+                record: format!("audit event {}", event.event_id),
+                detail: "this replica holds a different event under the same id".to_string(),
+            });
+        }
+    }
+    refusals
+}
+
+/// `base` followed by every entry of `extra` it lacks, in `extra`'s order.
+fn appended<T: Clone + PartialEq>(base: &[T], extra: &[T]) -> Vec<T> {
+    let mut merged = base.to_vec();
+    for entry in extra {
+        if !merged.contains(entry) {
+            merged.push(entry.clone());
+        }
+    }
+    merged
+}
+
+/// Whether `longer` is `shorter` with at least one more comment after it.
+fn extends(longer: &[ReviewComment], shorter: &[ReviewComment]) -> bool {
+    longer.len() > shorter.len() && longer[..shorter.len()] == *shorter
+}
+
+fn keyed<K: Copy + Eq + std::hash::Hash, V: Clone>(map: &HashMap<K, V>) -> Vec<Keyed<K, V>> {
+    map.iter()
+        .map(|(key, value)| Keyed::new(*key, value.clone()))
+        .collect()
+}
+
+/// Order `delta` the one way kin-model accepts, and answer `None` for an empty
+/// one, which kin-model refuses as a delta.
+fn finish(delta: &mut CollaborationDelta) -> Option<CollaborationDelta> {
+    if delta.is_empty() {
+        return None;
+    }
+    canonical_sort(&mut delta.reviews, |reviews| CollaborationDelta {
+        reviews,
+        ..CollaborationDelta::default()
+    });
+    canonical_sort(&mut delta.review_decisions, |review_decisions| {
+        CollaborationDelta {
+            review_decisions,
+            ..CollaborationDelta::default()
+        }
+    });
+    canonical_sort(&mut delta.review_notes, |review_notes| CollaborationDelta {
+        review_notes,
+        ..CollaborationDelta::default()
+    });
+    canonical_sort(&mut delta.review_discussions, |review_discussions| {
+        CollaborationDelta {
+            review_discussions,
+            ..CollaborationDelta::default()
+        }
+    });
+    canonical_sort(&mut delta.review_assignments, |review_assignments| {
+        CollaborationDelta {
+            review_assignments,
+            ..CollaborationDelta::default()
+        }
+    });
+    canonical_sort(&mut delta.actors, |actors| CollaborationDelta {
+        actors,
+        ..CollaborationDelta::default()
+    });
+    canonical_sort(&mut delta.audit_events, |audit_events| CollaborationDelta {
+        audit_events,
+        ..CollaborationDelta::default()
+    });
+    Some(delta.clone())
+}
+
+/// Sort into the order kin-model's delta validation accepts by asking it: two
+/// entries are in order exactly when a delta holding just those two, in that
+/// order, validates. kin-model keeps its canonical encoder private, and this is
+/// the same comparator `kin_review::write` uses for a single event.
+fn canonical_sort<T: Clone + PartialEq>(
+    records: &mut Vec<T>,
+    place: impl Fn(Vec<T>) -> CollaborationDelta,
+) {
+    if records.len() < 2 {
+        return;
+    }
+    let in_order = |first: &T, second: &T| {
+        place(vec![first.clone(), second.clone()])
+            .validate()
+            .is_ok()
+    };
+    records.sort_by(|first, second| {
+        if in_order(first, second) {
+            Ordering::Less
+        } else if in_order(second, first) {
+            Ordering::Greater
+        } else {
+            Ordering::Equal
+        }
+    });
+    records.dedup();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kin_model::review::{ReviewCompletionState, ReviewDecisionState, ReviewDiscussionState};
+    use kin_model::{IdentityRef, Timestamp};
+
+    const PUSH: RepositoryTransferDirection = RepositoryTransferDirection::Push;
+
+    fn at(seconds: u32) -> Timestamp {
+        serde_json::from_value(serde_json::Value::String(format!(
+            "2023-11-14T22:13:{seconds:02}Z"
+        )))
+        .unwrap()
+    }
+
+    fn review(id: ReviewId, state: ReviewDecisionState, updated: u32) -> Review {
+        Review {
+            review_id: id,
+            title: "Fix login".to_string(),
+            base_ref: "main".to_string(),
+            head_ref: "feature/login".to_string(),
+            state,
+            completion: ReviewCompletionState::InReview,
+            created_by: IdentityRef::human("troy"),
+            created_at: at(0),
+            updated_at: at(updated),
+            scopes: vec![],
+        }
+    }
+
+    fn decision(name: &str, state: ReviewDecisionState, seconds: u32) -> ReviewDecision {
+        ReviewDecision {
+            reviewer: IdentityRef::human(name),
+            state,
+            comment: None,
+            decided_at: at(seconds),
+        }
+    }
+
+    fn comment(body: &str, seconds: u32) -> ReviewComment {
+        ReviewComment {
+            authored_by: IdentityRef::human("troy"),
+            body: body.to_string(),
+            created_at: at(seconds),
+        }
+    }
+
+    fn domain(reviews: Vec<(Review, Vec<ReviewDecision>)>) -> ReviewDomain {
+        let mut domain = ReviewDomain::default();
+        for (review, decisions) in reviews {
+            if !decisions.is_empty() {
+                domain.decisions.insert(review.review_id, decisions);
+            }
+            domain.reviews.insert(review.review_id, review);
+        }
+        domain
+    }
+
+    /// A holder missing exactly one record receives exactly that record, and a
+    /// holder that already has everything receives nothing.
+    #[test]
+    fn a_holder_missing_one_record_gets_exactly_that_record() {
+        let shared = review(ReviewId::new(), ReviewDecisionState::Pending, 1);
+        let missing = review(ReviewId::new(), ReviewDecisionState::Pending, 2);
+        let ours = domain(vec![(shared.clone(), vec![]), (missing.clone(), vec![])]);
+        let holder = domain(vec![(shared, vec![])]);
+
+        let merge = ours.merge_into(&holder, PUSH);
+        let delta = merge.delta.expect("the missing review must travel");
+        assert_eq!(delta.record_count(), 1, "exactly one record: {delta:?}");
+        assert_eq!(delta.reviews[0].key, missing.review_id);
+        assert!(merge.gaps.is_empty(), "{:?}", merge.gaps);
+
+        assert_eq!(
+            ours.merge_into(&ours.clone(), PUSH),
+            CollaborationMerge::default()
+        );
+    }
+
+    /// The review whose decisions contain the other's is the newer one; a review
+    /// both sides decided independently is a named gap and its decisions merge.
+    ///
+    /// Falsify by deciding on `updated_at` instead: the stale holder copy below
+    /// carries the later timestamp and would win.
+    #[test]
+    fn decision_history_decides_a_review_and_divergence_is_named() {
+        let id = ReviewId::new();
+        let first = decision("alice", ReviewDecisionState::NeedsWork, 5);
+        let second = decision("bob", ReviewDecisionState::Approved, 9);
+        let ours = domain(vec![(
+            review(id, ReviewDecisionState::Approved, 9),
+            vec![first.clone(), second.clone()],
+        )]);
+        // A skewed clock: the holder's copy is older by history but newer by time.
+        let behind = domain(vec![(
+            review(id, ReviewDecisionState::NeedsWork, 50),
+            vec![first.clone()],
+        )]);
+        let merge = ours.merge_into(&behind, PUSH);
+        let delta = merge.delta.expect("the newer review must travel");
+        assert_eq!(delta.reviews[0].value.state, ReviewDecisionState::Approved);
+        assert_eq!(
+            delta.review_decisions[0].value,
+            vec![first.clone(), second.clone()]
+        );
+        assert!(merge.gaps.is_empty(), "{:?}", merge.gaps);
+
+        let diverged = domain(vec![(
+            review(id, ReviewDecisionState::Blocked, 7),
+            vec![
+                first.clone(),
+                decision("carol", ReviewDecisionState::Blocked, 7),
+            ],
+        )]);
+        let merge = ours.merge_into(&diverged, PUSH);
+        let delta = merge.delta.expect("the decisions still merge");
+        assert!(
+            delta.reviews.is_empty(),
+            "a divergent review must not be sent"
+        );
+        assert_eq!(delta.review_decisions[0].value.len(), 3);
+        assert_eq!(merge.gaps.len(), 1);
+        assert!(merge.gaps[0].detail.contains("decided it independently"));
+    }
+
+    /// A discussion copy in our own history is superseded by our current copy;
+    /// copies neither side can order are a named gap.
+    #[test]
+    fn discussion_history_decides_a_copy_and_the_rest_is_named() {
+        let review_id = ReviewId::new();
+        let discussion_id = ReviewDiscussionId::new();
+        let open = ReviewDiscussion {
+            discussion_id,
+            review_id,
+            scope: None,
+            state: ReviewDiscussionState::Open,
+            comments: vec![comment("why?", 1)],
+            created_at: at(1),
+        };
+        let mut resolved = open.clone();
+        resolved.state = ReviewDiscussionState::Resolved;
+
+        let mut ours = ReviewDomain::default();
+        ours.discussion_history
+            .insert(discussion_id, vec![open.clone(), resolved.clone()]);
+        ours.discussions.insert(discussion_id, resolved.clone());
+        let mut holder = ReviewDomain::default();
+        holder.discussions.insert(discussion_id, open.clone());
+
+        let merge = ours.merge_into(&holder, PUSH);
+        assert_eq!(
+            merge.delta.unwrap().review_discussions,
+            vec![resolved.clone()]
+        );
+        assert!(merge.gaps.is_empty());
+
+        // With no history on either side, a copy that extends the other's
+        // comments in the same state is the newer one: the holder is ahead, so
+        // nothing travels and nothing is named.
+        let mut extended = resolved.clone();
+        extended.comments.push(comment("a reply made elsewhere", 3));
+        let mut ahead = ReviewDomain::default();
+        ahead.discussions.insert(discussion_id, extended.clone());
+        let mut behind = ReviewDomain::default();
+        behind.discussions.insert(discussion_id, resolved);
+        assert_eq!(
+            behind.merge_into(&ahead, PUSH),
+            CollaborationMerge::default()
+        );
+
+        // Each side holds a reply the other lacks: neither copy can be preferred.
+        let mut ours_diverged = open.clone();
+        ours_diverged.comments.push(comment("a reply made here", 3));
+        let mut theirs_diverged = open;
+        theirs_diverged
+            .comments
+            .push(comment("a reply made elsewhere", 3));
+        let mut mine = ReviewDomain::default();
+        mine.discussions.insert(discussion_id, ours_diverged);
+        let mut stranger = ReviewDomain::default();
+        stranger.discussions.insert(discussion_id, theirs_diverged);
+        let merge = mine.merge_into(&stranger, PUSH);
+        assert!(merge.delta.is_none(), "a divergent copy must not travel");
+        assert_eq!(merge.gaps.len(), 1, "{:?}", merge.gaps);
+        assert!(merge.gaps[0].detail.contains("neither copy"));
+    }
+
+    /// An assignment only the holder has is disclosed, not silently kept or
+    /// dropped.
+    #[test]
+    fn a_holder_only_assignment_is_disclosed() {
+        let id = ReviewId::new();
+        let assignment = |name: &str| ReviewAssignment {
+            review_id: id,
+            reviewer: IdentityRef::human(name),
+            assigned_at: at(1),
+            assigned_by: IdentityRef::human("troy"),
+        };
+        let mut ours = ReviewDomain::default();
+        ours.assignments.insert(id, vec![assignment("alice")]);
+        let mut holder = ReviewDomain::default();
+        holder
+            .assignments
+            .insert(id, vec![assignment("alice"), assignment("bob")]);
+
+        let merge = ours.merge_into(&holder, PUSH);
+        assert!(merge.delta.is_none());
+        assert_eq!(merge.gaps.len(), 1);
+        assert!(merge.gaps[0].detail.contains("bob"));
+    }
+
+    /// The exported delta is one kin-model accepts, whatever order the maps
+    /// yielded.
+    #[test]
+    fn an_export_is_a_valid_delta() {
+        let ours = domain(
+            (0..12)
+                .map(|n| {
+                    (
+                        review(ReviewId::new(), ReviewDecisionState::Pending, n),
+                        vec![],
+                    )
+                })
+                .collect(),
+        );
+        let delta = ours.to_delta().expect("twelve reviews export");
+        delta.validate().expect("an export must validate");
+        assert_eq!(delta.reviews.len(), 12);
+        assert!(ReviewDomain::default().to_delta().is_none());
+    }
+}

--- a/crates/kin-remote/src/lib.rs
+++ b/crates/kin-remote/src/lib.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
+pub mod collaboration_transfer;
 pub mod connection;
 pub mod delta_bridge;
 pub mod delta_pull;

--- a/crates/kin-remote/src/repository_transfer.rs
+++ b/crates/kin-remote/src/repository_transfer.rs
@@ -20,12 +20,16 @@ use kin_db::{
 };
 use kin_model::{
     compute_resolved_tree_hash, validate_semantic_change_id, AdmissionCase, AuthorId, ChangeOrigin,
-    ChangeStore, DefaultRefExpectation, DefaultRefMutation, ExternalChangeAlias, ExternalObjectId,
-    ExternalObjectKind, ExternalObjectRecord, GitExternalAuthority, GitExternalAuthorityDelta,
-    Hash256, ModelError, OperationId, RefExpectation, RefMutation, RefName, RefTarget,
-    RefUpdatePolicy, RepositoryCommitOutcome, RepositoryCommitReceipt, RepositoryId,
-    RepositoryTransaction, RootBundle, SemanticChange, SemanticChangeId, TreeEntry, WorkspaceId,
-    REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+    ChangeStore, CollaborationDelta, DefaultRefExpectation, DefaultRefMutation,
+    ExternalChangeAlias, ExternalObjectId, ExternalObjectKind, ExternalObjectRecord,
+    GitExternalAuthority, GitExternalAuthorityDelta, Hash256, ModelError, OperationId,
+    RefExpectation, RefMutation, RefName, RefTarget, RefUpdatePolicy, RepositoryCommitOutcome,
+    RepositoryCommitReceipt, RepositoryId, RepositoryTransaction, RootBundle, SemanticChange,
+    SemanticChangeId, TreeEntry, WorkspaceId, REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+};
+
+use crate::collaboration_transfer::{
+    admission_refusals, outside_review_domain, ReviewDomain, MAX_COLLABORATION_RECORDS,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -130,6 +134,14 @@ pub const FEATURE_EXACT_TREES: &str = "exact-trees-v1";
 pub const FEATURE_IMMUTABLE_SOURCE_CAS: &str = "immutable-source-cas-v1";
 pub const FEATURE_REF_CAS: &str = "ref-cas-v1";
 pub const FEATURE_RAW_REPOSITORY_PATHS: &str = "raw-repository-paths-v1";
+/// This peer exchanges review records in a collaboration-only pack after the
+/// ref phase.
+///
+/// Advertised, never required: a peer without it gets exactly the transfer it
+/// always got, and the sender says which records it did not carry. So it is
+/// deliberately absent from [`REQUIRED_FEATURES`], whose list a pack must
+/// repeat exactly.
+pub const FEATURE_COLLABORATION: &str = "collaboration-v1";
 
 pub const MAX_TRANSFER_CHANGES: usize = 512;
 pub const MAX_TRANSFER_TREES: usize = MAX_TRANSFER_CHANGES;
@@ -772,6 +784,14 @@ pub struct RepositoryTransferPack {
     /// declared one is caught as a transfer-identity mismatch.
     #[serde(default)]
     pub source_hydration_semantics: Option<u32>,
+    /// Review records this pack carries.
+    ///
+    /// Present only on a pack that moves no history, sent after the ref phase to
+    /// a peer that advertises [`FEATURE_COLLABORATION`], and absent from every
+    /// other pack. Not serialized when absent, so a pack that carries none keeps
+    /// its bytes and its transfer identity exactly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub collaboration: Option<CollaborationDelta>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -841,7 +861,7 @@ pub fn repository_transfer_status<B: StorageBackend + ?Sized + 'static>(
         roots: lease.roots().clone(),
         default_ref: lease.authority_metadata().ref_state.default_ref.clone(),
         git_authority_hash,
-        supported_features: required_features(),
+        supported_features: advertised_features(),
         limits: RepositoryTransferLimits::default(),
         push_apply_ready: true,
         bounded_envelope_export_ready: true,
@@ -925,9 +945,26 @@ pub fn repository_ref_advertisement<B: StorageBackend + ?Sized + 'static>(
         refs,
         default_ref: lease.authority_metadata().ref_state.default_ref.clone(),
         roots: lease.roots().clone(),
-        supported_features: required_features(),
+        supported_features: advertised_features(),
         limits: RepositoryTransferLimits::default(),
     })
+}
+
+/// What this build advertises: every required feature, then the optional ones.
+///
+/// A peer checks only that the required ones are present, so an optional
+/// feature here is invisible to a peer that does not know it.
+fn advertised_features() -> Vec<String> {
+    let mut features = required_features();
+    features.push(FEATURE_COLLABORATION.to_string());
+    features
+}
+
+/// Whether a peer advertising `supported` exchanges review records.
+pub fn peer_exchanges_collaboration(supported: &[String]) -> bool {
+    supported
+        .iter()
+        .any(|feature| feature == FEATURE_COLLABORATION)
 }
 
 /// One pack of a transfer that may need more than one, and what is left after
@@ -1037,6 +1074,25 @@ pub fn build_repository_transfer_segment<B: StorageBackend + ?Sized + 'static>(
         expectation.destination_head,
     )?;
     if closure.is_empty() {
+        // Nothing left to fast-forward. A peer that exchanges review records
+        // asks this way for this replica's, once the ref phase has brought both
+        // replicas to one head; a peer that does not is told there is no
+        // segment, exactly as before.
+        if peer_exchanges_collaboration(&expectation.supported_features) {
+            let records =
+                ReviewDomain::from_snapshot(authority.read_authority().snapshot()).to_delta();
+            let pack = collaboration_pack(
+                &context,
+                &expectation,
+                source_ref,
+                source_hydration_semantics,
+                records,
+            )?;
+            return Ok(RepositoryTransferSegment {
+                pack,
+                remaining_changes: 0,
+            });
+        }
         return Err(invalid(format!(
             "source head {} is already the destination head; there is no segment to build",
             context.source_head
@@ -1100,6 +1156,113 @@ pub fn build_repository_transfer_segment<B: StorageBackend + ?Sized + 'static>(
             }
         }
     }
+}
+
+/// A pack carrying `collaboration` from this replica and moving no history.
+///
+/// Built against `expectation`, the destination's lease, once the ref phase has
+/// brought both replicas to one head. The envelope names that head as source,
+/// target and expected destination alike, which is what `validate_pack`
+/// requires of a pack carrying records, and the destination's compare-and-swap
+/// on its lease still decides whether the records land.
+pub fn build_collaboration_transfer_pack<B: StorageBackend + ?Sized + 'static>(
+    authority: &RepositoryAuthorityManager<B>,
+    source_ref: &RefName,
+    expectation: &RepositoryTransferExpectation,
+    source_hydration_semantics: Option<u32>,
+    collaboration: CollaborationDelta,
+) -> Result<RepositoryTransferPack> {
+    let expectation = locally_bounded_expectation(expectation)?;
+    let context = TransferSourceContext::read(authority, source_ref, &expectation)?;
+    collaboration_pack(
+        &context,
+        &expectation,
+        source_ref,
+        source_hydration_semantics,
+        Some(collaboration),
+    )
+}
+
+/// `exported`, a review export's answer, carrying `collaboration` in place of
+/// the records it was exported with, under an operation of its own.
+///
+/// A pull merges the remote's records against this replica's before admitting
+/// any, so what it admits is the merge rather than the export. The rest of the
+/// envelope is the export's, built against this replica's own lease, and
+/// admission checks it against that lease like any other pack.
+pub fn with_collaboration(
+    mut exported: RepositoryTransferPack,
+    collaboration: CollaborationDelta,
+    limits: &RepositoryTransferLimits,
+) -> Result<RepositoryTransferPack> {
+    if pack_moves_history(&exported) {
+        return Err(invalid(
+            "only a pack that moves no history can carry review records",
+        ));
+    }
+    exported.collaboration = Some(collaboration);
+    exported.operation_id = OperationId::new();
+    exported.transfer_id = compute_transfer_id(&exported)?;
+    validate_pack(&exported, limits)?;
+    Ok(exported)
+}
+
+/// The history-less pack a review export answers with.
+///
+/// It carries `collaboration` when this replica holds review records, and no
+/// records at all when it holds none, which is how a peer with nothing to offer
+/// says so. Admission refuses that second kind, because it publishes nothing.
+fn collaboration_pack(
+    context: &TransferSourceContext,
+    expectation: &RepositoryTransferExpectation,
+    source_ref: &RefName,
+    source_hydration_semantics: Option<u32>,
+    collaboration: Option<CollaborationDelta>,
+) -> Result<RepositoryTransferPack> {
+    let head = context.source_head;
+    if expectation.destination_head != Some(head) {
+        return Err(RepositoryTransferError::Conflict(format!(
+            "review records travel only between replicas at one head: this replica is at {head} and \
+             the destination at {}",
+            expectation
+                .destination_head
+                .map(|head| head.to_string())
+                .unwrap_or_else(|| "an unborn ref".to_string())
+        )));
+    }
+    let tree = TransferChangeStore::new(context.all_changes.values().cloned())
+        .resolve_tree_at(&head)
+        .map_err(model)?;
+    let mut pack = RepositoryTransferPack {
+        schema_version: REPOSITORY_TRANSFER_SCHEMA_VERSION,
+        protocol: REPOSITORY_TRANSFER_PROTOCOL.to_string(),
+        transfer_id: Hash256::from_bytes([0; 32]),
+        operation_id: OperationId::new(),
+        repository_id: expectation.repository_id.clone(),
+        source_ref: source_ref.clone(),
+        destination_ref: expectation.destination_ref.clone(),
+        source_head: head,
+        transfer_target_head: head,
+        source_tree_hash: compute_resolved_tree_hash(&tree).map_err(model)?,
+        expected_destination_target: expectation.destination_target.clone(),
+        expected_destination_head: expectation.destination_head,
+        expected_destination_roots: expectation.roots.clone(),
+        expected_destination_default_ref: expectation.default_ref.clone(),
+        source_git_authority_hash: context.source_git_authority_hash,
+        expected_destination_git_authority_hash: expectation.git_authority_hash,
+        git_authority_bootstrap: None,
+        required_features: required_features(),
+        changes: Vec::new(),
+        trees: Vec::new(),
+        external_objects: Vec::new(),
+        aliases: Vec::new(),
+        bodies: Vec::new(),
+        source_hydration_semantics,
+        collaboration,
+    };
+    pack.transfer_id = compute_transfer_id(&pack)?;
+    validate_pack(&pack, &expectation.limits)?;
+    Ok(pack)
 }
 
 /// Check everything a publication decides before it assembles a pack.
@@ -1522,6 +1685,7 @@ fn assemble_segment_pack<B: StorageBackend + ?Sized + 'static>(
         aliases,
         bodies,
         source_hydration_semantics,
+        collaboration: None,
     };
     pack.transfer_id = compute_transfer_id(&pack)?;
     // The sender checks its own work against the ceilings it ASSEMBLED under,
@@ -1659,6 +1823,13 @@ where
             pack.destination_ref, expected_destination_ref
         )));
     }
+    // A review export's answer from a peer that holds no records moves no
+    // history and carries nothing. It is an answer, never a publication.
+    if pack.collaboration.is_none() && !pack_moves_history(pack) {
+        return Err(invalid(
+            "pack publishes nothing: it moves no history and carries no review records",
+        ));
+    }
 
     let transaction = transfer_transaction(pack, actor)?;
     let transaction_hash = transaction.transaction_hash().map_err(model)?;
@@ -1733,6 +1904,23 @@ where
         return Err(RepositoryTransferError::Conflict(
             "destination semantic head moved from the pack lease".to_string(),
         ));
+    }
+    // The merge rule, enforced by the replica the records land on rather than
+    // trusted to the sender: a record this replica holds is only ever extended,
+    // never replaced by one its own history does not lead to.
+    if let Some(collaboration) = &pack.collaboration {
+        let refusals = admission_refusals(lease.snapshot(), collaboration);
+        if !refusals.is_empty() {
+            return Err(RepositoryTransferError::Conflict(format!(
+                "the pack would overwrite review records this replica holds, so none were \
+                 admitted: {}",
+                refusals
+                    .iter()
+                    .map(|gap| format!("{}: {}", gap.record, gap.detail))
+                    .collect::<Vec<_>>()
+                    .join("; ")
+            )));
+        }
     }
     let current_git_hash =
         hash_git_authority(lease.authority_metadata().git_external_authority.as_ref())?;
@@ -1851,6 +2039,33 @@ pub fn validate_pack(
         limits.max_external_objects,
     )?;
     enforce_count("aliases", pack.aliases.len(), MAX_TRANSFER_ALIASES as u32)?;
+    if let Some(collaboration) = &pack.collaboration {
+        // Review records travel after the ref phase in a pack of their own, so a
+        // pack that publishes history carrying them is malformed, not merely
+        // unusual: its records would land under a lease the ref move is
+        // changing.
+        if pack_moves_history(pack) {
+            return Err(invalid(
+                "a pack carries review records only when it moves no history; review records \
+                 follow the ref phase in a pack of their own",
+            ));
+        }
+        if let Some(reason) = outside_review_domain(collaboration) {
+            return Err(invalid(format!(
+                "pack's collaboration records are not all review records: {reason}"
+            )));
+        }
+        collaboration
+            .validate()
+            .map_err(|error| invalid(format!("collaboration records are not valid: {error}")))?;
+        let records = collaboration.record_count();
+        if records > MAX_COLLABORATION_RECORDS {
+            return Err(invalid(format!(
+                "pack carries {records} review records, over the {MAX_COLLABORATION_RECORDS} one \
+                 pack may carry"
+            )));
+        }
+    }
 
     let expected_id = compute_transfer_id(pack)?;
     if expected_id != pack.transfer_id {
@@ -2404,10 +2619,27 @@ fn published_ref_target(pack: &RepositoryTransferPack) -> RefTarget {
     }
 }
 
+/// Whether `pack` publishes anything but review records: a change, a tree, a
+/// body, an external object, an alias, a bootstrap, or a head other than the
+/// one the destination already holds.
+pub(crate) fn pack_moves_history(pack: &RepositoryTransferPack) -> bool {
+    !pack.changes.is_empty()
+        || !pack.trees.is_empty()
+        || !pack.bodies.is_empty()
+        || !pack.external_objects.is_empty()
+        || !pack.aliases.is_empty()
+        || pack.git_authority_bootstrap.is_some()
+        || pack.transfer_target_head != pack.source_head
+        || pack.expected_destination_head != Some(pack.source_head)
+}
+
 fn transfer_transaction(
     pack: &RepositoryTransferPack,
     actor: AuthorId,
 ) -> Result<RepositoryTransaction> {
+    // `validate_pack` has already refused records on a pack that moves history,
+    // so a pack carrying them moves no ref: its only mutation is the records.
+    let collaboration_only = pack.collaboration.is_some();
     let expected = pack
         .expected_destination_target
         .clone()
@@ -2445,18 +2677,22 @@ fn transfer_transaction(
             .map(GitExternalAuthorityDelta::initialize),
         changes: pack.changes.clone(),
         aliases: pack.aliases.clone(),
-        ref_mutations: vec![RefMutation {
-            name: pack.destination_ref.clone(),
-            expected,
-            new_target: Some(published_ref_target(pack)),
-            policy: RefUpdatePolicy::FastForwardOnly,
-        }],
-        default_ref_mutation,
+        ref_mutations: if collaboration_only {
+            Vec::new()
+        } else {
+            vec![RefMutation {
+                name: pack.destination_ref.clone(),
+                expected,
+                new_target: Some(published_ref_target(pack)),
+                policy: RefUpdatePolicy::FastForwardOnly,
+            }]
+        },
+        default_ref_mutation: default_ref_mutation.filter(|_| !collaboration_only),
         workspace_mutation: None,
         local_overlay_delta: None,
         merge_transaction_delta: None,
         sealed_observation: None,
-        collaboration_delta: None,
+        collaboration_delta: pack.collaboration.clone(),
     };
     transaction.validate().map_err(model)?;
     Ok(transaction)
@@ -2504,6 +2740,10 @@ struct RepositoryTransferIdentity<'a> {
     aliases: &'a [ExternalChangeAlias],
     bodies: Vec<RepositoryTransferBodyIdentity>,
     source_hydration_semantics: Option<u32>,
+    /// Skipped when absent, so every pack that carries no review records keeps
+    /// the identity it always had.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    collaboration: Option<Hash256>,
 }
 
 #[derive(Serialize)]
@@ -2549,6 +2789,15 @@ fn compute_transfer_id(pack: &RepositoryTransferPack) -> Result<Hash256> {
             })
             .collect(),
         source_hydration_semantics: pack.source_hydration_semantics,
+        collaboration: pack
+            .collaboration
+            .as_ref()
+            .map(|delta| {
+                serde_json::to_vec(delta)
+                    .map(|bytes| domain_hash(b"kin-repository-transfer-collaboration-v1\0", &bytes))
+                    .map_err(|error| invalid(format!("serialize collaboration records: {error}")))
+            })
+            .transpose()?,
     };
     let payload = serde_json::to_vec(&identity)
         .map_err(|error| invalid(format!("serialize transfer identity: {error}")))?;
@@ -3291,6 +3540,60 @@ mod tests {
         }
     }
 
+    /// Review records ride only in a pack that moves no history. A ref pack
+    /// carrying them, with its transfer identity recomputed so the identity
+    /// check cannot be what refuses it, is refused by name.
+    ///
+    /// Falsify by removing the `pack_moves_history` refusal from
+    /// `validate_pack`: the pack is no longer refused for this reason and the
+    /// message assertion goes red.
+    #[test]
+    fn review_records_inside_a_ref_pack_are_refused() {
+        let fixture = fixture();
+        let review_id = kin_model::review::ReviewId::new();
+        let mut pack = fixture.pack.clone();
+        assert!(!pack.changes.is_empty(), "the fixture pack moves history");
+        pack.collaboration = Some(CollaborationDelta {
+            reviews: vec![kin_model::Keyed::new(
+                review_id,
+                kin_model::review::Review {
+                    review_id,
+                    title: "rides along".to_string(),
+                    base_ref: "main".to_string(),
+                    head_ref: "feature".to_string(),
+                    state: kin_model::review::ReviewDecisionState::Pending,
+                    completion: kin_model::review::ReviewCompletionState::InReview,
+                    created_by: kin_model::IdentityRef::human("troy"),
+                    created_at: kin_model::Timestamp::now(),
+                    updated_at: kin_model::Timestamp::now(),
+                    scopes: vec![],
+                },
+            )],
+            ..CollaborationDelta::default()
+        });
+        pack.transfer_id = compute_transfer_id(&pack).unwrap();
+
+        let error = apply_repository_transfer_pack(
+            &fixture.destination,
+            &fixture.repository_id,
+            &fixture.main,
+            AuthorId::new("mixed-sender"),
+            &pack,
+            &RepositoryTransferLimits::default(),
+        )
+        .expect_err("a ref pack carrying review records must be refused");
+        assert!(
+            error.to_string().contains("only when it moves no history"),
+            "{error}"
+        );
+        assert!(fixture
+            .destination
+            .read_authority()
+            .snapshot()
+            .reviews
+            .is_empty());
+    }
+
     /// Build the bootstrap pack a Git-admitted publisher would send into a
     /// replica that has never held anything.
     ///
@@ -3398,6 +3701,7 @@ mod tests {
             // A Git-admitted bootstrap fixture speaks for no local store, so it
             // declares nothing, which is the same thing a hosted sender does.
             source_hydration_semantics: None,
+            collaboration: None,
         };
         pack.transfer_id = compute_transfer_id(&pack).unwrap();
         pack

--- a/crates/kin-remote/src/repository_transfer_negotiation.rs
+++ b/crates/kin-remote/src/repository_transfer_negotiation.rs
@@ -27,10 +27,12 @@ use kin_db::{RepositoryAuthorityManager, StorageBackend};
 use kin_model::{AuthorId, RefName, RepositoryId, RootBundle, SemanticChange, SemanticChangeId};
 use serde::{Deserialize, Serialize};
 
+use crate::collaboration_transfer::{CollaborationTransfer, ReviewDomain};
 use crate::repository_transfer::{
-    apply_repository_transfer_pack_with_pre_commit, build_repository_transfer_segment,
-    count_repository_transfer_packs, model, repository_transfer_status,
-    require_negotiated_features, validate_limits, verify_transfer_source_readiness,
+    apply_repository_transfer_pack_with_pre_commit, build_collaboration_transfer_pack,
+    build_repository_transfer_segment, count_repository_transfer_packs, model, pack_moves_history,
+    peer_exchanges_collaboration, repository_transfer_status, require_negotiated_features,
+    validate_limits, validate_pack, verify_transfer_source_readiness, with_collaboration,
     RepositoryAuthorityMetadata, RepositoryRefAdvertisement, RepositoryTransferError,
     RepositoryTransferExpectation, RepositoryTransferLimits, RepositoryTransferPack,
     RepositoryTransferReceipt, RepositoryTransferStatus, Result, REPOSITORY_TRANSFER_PROTOCOL,
@@ -113,13 +115,32 @@ pub struct RepositoryTransferOutcome {
     /// One receipt per published pack, in publication order. Empty exactly
     /// when the plan was [`RepositoryTransferPlan::UpToDate`].
     pub receipts: Vec<RepositoryTransferReceipt>,
+    /// What the review phase did once the ref phase above was done. Its
+    /// receipt, when it published one, is here rather than in `receipts`,
+    /// because it moved no history.
+    ///
+    /// Absent in an outcome from a daemon that predates the review phase.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub collaboration: Option<CollaborationTransfer>,
 }
 
 impl RepositoryTransferOutcome {
     /// True when this negotiation published at least one repository
-    /// transaction.
+    /// transaction that moved history.
     pub fn moved_history(&self) -> bool {
         !self.receipts.is_empty()
+    }
+
+    /// True when the review phase published review records on the receiving
+    /// replica.
+    pub fn carried_review_records(&self) -> bool {
+        matches!(
+            self.collaboration,
+            Some(CollaborationTransfer::Exchanged {
+                receipt: Some(_),
+                ..
+            })
+        )
     }
 
     /// The receipt for the pack that landed the transfer's final head.
@@ -709,6 +730,15 @@ where
             &expectation,
             source_hydration_semantics,
         )?;
+        // A segment with no changes is the answer to a review export, which the
+        // ref phase never asks for: this replica's ref moved back under the
+        // negotiation until it no longer leads the remote's.
+        if segment.pack.changes.is_empty() {
+            return Err(conflict(format!(
+                "local authority moved during negotiation: {source_ref} no longer leads the \
+                 remote's {destination_ref}"
+            )));
+        }
         if segment.pack.transfer_target_head != source_head {
             return Err(conflict(format!(
                 "local authority moved during negotiation: planned head {source_head}, packed transfer toward {}",
@@ -743,6 +773,14 @@ where
         },
         (_, plan) => plan,
     };
+    let collaboration = push_review_records(
+        local,
+        transport,
+        repository_id,
+        source_ref,
+        destination_ref,
+        source_hydration_semantics,
+    );
     Ok(RepositoryTransferOutcome {
         direction: RepositoryTransferDirection::Push,
         repository_id: repository_id.clone(),
@@ -750,7 +788,262 @@ where
         destination_ref: destination_ref.clone(),
         plan,
         receipts,
+        collaboration: Some(collaboration),
     })
+}
+
+/// Carry this replica's review records to the remote once the ref phase has
+/// brought both replicas to one head.
+///
+/// The remote's records are read first and merged against this replica's, so
+/// the pack carries only what the remote lacks and never a record that would
+/// replace one the remote decided; the remote's admission enforces the same
+/// rule against its own lease. A lease that moves between the export and the
+/// publication is retried once, from a fresh export. The ref phase has already
+/// published by now, so a review phase that cannot complete is reported in the
+/// outcome rather than raised.
+fn push_review_records<B, T>(
+    local: &RepositoryAuthorityManager<B>,
+    transport: &T,
+    repository_id: &RepositoryId,
+    source_ref: &RefName,
+    destination_ref: &RefName,
+    source_hydration_semantics: Option<u32>,
+) -> CollaborationTransfer
+where
+    B: StorageBackend + ?Sized + 'static,
+    T: RepositoryTransferTransport + ?Sized,
+{
+    let mut attempts = 0;
+    loop {
+        attempts += 1;
+        match try_push_review_records(
+            local,
+            transport,
+            repository_id,
+            source_ref,
+            destination_ref,
+            source_hydration_semantics,
+        ) {
+            Ok(transfer) => return transfer,
+            Err(RepositoryTransferError::Conflict(_)) if attempts == 1 => {}
+            Err(error) => {
+                return CollaborationTransfer::Refused {
+                    reason: error.to_string(),
+                }
+            }
+        }
+    }
+}
+
+fn try_push_review_records<B, T>(
+    local: &RepositoryAuthorityManager<B>,
+    transport: &T,
+    repository_id: &RepositoryId,
+    source_ref: &RefName,
+    destination_ref: &RefName,
+    source_hydration_semantics: Option<u32>,
+) -> Result<CollaborationTransfer>
+where
+    B: StorageBackend + ?Sized + 'static,
+    T: RepositoryTransferTransport + ?Sized,
+{
+    // The remote's lease comes first, so a record it admits after this read
+    // moves the roots the publication below is checked against.
+    let remote = negotiated_destination_lease(transport, repository_id, destination_ref)?;
+    if !peer_exchanges_collaboration(&remote.supported_features) {
+        let held = ReviewDomain::from_snapshot(local.read_authority().snapshot());
+        return Ok(CollaborationTransfer::PeerUnsupported {
+            local_records: Some(held.record_count()),
+        });
+    }
+    let own = RepositoryTransferExpectation::try_from(repository_transfer_status(
+        local,
+        repository_id,
+        source_ref,
+    )?)?;
+    if own.roots.collaboration == remote.roots.collaboration {
+        return Ok(CollaborationTransfer::InSync);
+    }
+    let exported = transport.export_pack(repository_id, destination_ref, &own)?;
+    let theirs = exported_review_domain(&exported, &own)?;
+    let merge = ReviewDomain::from_snapshot(local.read_authority().snapshot())
+        .merge_into(&theirs, RepositoryTransferDirection::Push);
+    let Some(records) = merge.delta else {
+        return Ok(CollaborationTransfer::Exchanged {
+            carried: 0,
+            gaps: merge.gaps,
+            receipt: None,
+        });
+    };
+    let carried = records.record_count();
+    let pack = build_collaboration_transfer_pack(
+        local,
+        source_ref,
+        &remote,
+        source_hydration_semantics,
+        records,
+    )?;
+    let receipt = transport.receive_pack(repository_id, destination_ref, &pack)?;
+    verify_receipt_binds_pack(&pack, &receipt).map_err(|error| {
+        invalid(format!(
+            "the remote answered its review records with a receipt that does not bind them: {error}"
+        ))
+    })?;
+    Ok(CollaborationTransfer::Exchanged {
+        carried,
+        gaps: merge.gaps,
+        receipt: Some(receipt),
+    })
+}
+
+/// Pull the remote's review records into this replica once the ref phase has
+/// brought both replicas to one head.
+///
+/// This replica is the holder here, so the remote's export is merged against
+/// this replica's own records and only the merge is admitted, through the
+/// caller's `admit` like every other pack of the pull. Admission checks it
+/// against this replica's lease, which is read before the merge, and a lease
+/// that moves in between is retried once from a fresh export.
+fn pull_review_records<B, T, A>(
+    local: &RepositoryAuthorityManager<B>,
+    transport: &T,
+    repository_id: &RepositoryId,
+    source_ref: &RefName,
+    destination_ref: &RefName,
+    admit: &mut A,
+) -> CollaborationTransfer
+where
+    B: StorageBackend + ?Sized + 'static,
+    T: RepositoryTransferTransport + ?Sized,
+    A: FnMut(&RepositoryTransferPack) -> Result<RepositoryTransferReceipt>,
+{
+    let mut attempts = 0;
+    loop {
+        attempts += 1;
+        match try_pull_review_records(
+            local,
+            transport,
+            repository_id,
+            source_ref,
+            destination_ref,
+            admit,
+        ) {
+            Ok(transfer) => return transfer,
+            Err(RepositoryTransferError::Conflict(_)) if attempts == 1 => {}
+            Err(error) => {
+                return CollaborationTransfer::Refused {
+                    reason: error.to_string(),
+                }
+            }
+        }
+    }
+}
+
+fn try_pull_review_records<B, T, A>(
+    local: &RepositoryAuthorityManager<B>,
+    transport: &T,
+    repository_id: &RepositoryId,
+    source_ref: &RefName,
+    destination_ref: &RefName,
+    admit: &mut A,
+) -> Result<CollaborationTransfer>
+where
+    B: StorageBackend + ?Sized + 'static,
+    T: RepositoryTransferTransport + ?Sized,
+    A: FnMut(&RepositoryTransferPack) -> Result<RepositoryTransferReceipt>,
+{
+    let advertisement = read_ref_advertisement(transport, repository_id)?;
+    if !peer_exchanges_collaboration(&advertisement.supported_features) {
+        return Ok(CollaborationTransfer::PeerUnsupported {
+            local_records: None,
+        });
+    }
+    // This replica's lease comes first, so a record admitted here after this
+    // read moves the roots the admission below is checked against, rather than
+    // being overwritten by a merge that never saw it.
+    let status = repository_transfer_status(local, repository_id, destination_ref)?;
+    if status.destination_head.is_none() {
+        return Ok(CollaborationTransfer::Skipped {
+            reason: format!(
+                "this replica publishes no {destination_ref} yet, and review records travel only \
+                 between replicas at one published head"
+            ),
+        });
+    }
+    if status.roots.collaboration == advertisement.roots.collaboration {
+        return Ok(CollaborationTransfer::InSync);
+    }
+    let lease = RepositoryTransferExpectation::try_from(status)?;
+    let exported = transport.export_pack(repository_id, source_ref, &lease)?;
+    let theirs = exported_review_domain(&exported, &lease)?;
+    let merge = theirs.merge_into(
+        &ReviewDomain::from_snapshot(local.read_authority().snapshot()),
+        RepositoryTransferDirection::Pull,
+    );
+    let Some(records) = merge.delta else {
+        return Ok(CollaborationTransfer::Exchanged {
+            carried: 0,
+            gaps: merge.gaps,
+            receipt: None,
+        });
+    };
+    let carried = records.record_count();
+    let pack = with_collaboration(exported, records, &lease.limits)?;
+    let receipt = admit(&pack)?;
+    verify_receipt_binds_pack(&pack, &receipt).map_err(|error| {
+        invalid(format!(
+            "admitting the remote's review records returned a receipt that does not bind them: \
+             {error}"
+        ))
+    })?;
+    Ok(CollaborationTransfer::Exchanged {
+        carried,
+        gaps: merge.gaps,
+        receipt: Some(receipt),
+    })
+}
+
+/// The peer's review domain, from the pack its export answered a review request
+/// with.
+///
+/// The answer has to move no history. An export that found history to send
+/// means the peer's ref moved after the ref phase, and review records travel
+/// only between replicas at one head.
+fn exported_review_domain(
+    pack: &RepositoryTransferPack,
+    requested: &RepositoryTransferExpectation,
+) -> Result<ReviewDomain> {
+    require_protocol(pack.schema_version, &pack.protocol, "review export")?;
+    require_same_repository(
+        &requested.repository_id,
+        &pack.repository_id,
+        "review export",
+    )?;
+    if pack.destination_ref != requested.destination_ref {
+        return Err(invalid(format!(
+            "remote answered a review export for ref {} but this replica asked about {}",
+            pack.destination_ref, requested.destination_ref
+        )));
+    }
+    if pack_moves_history(pack) {
+        return Err(conflict(format!(
+            "the remote's {} moved after the ref phase, so its review export carries history \
+             instead of review records",
+            pack.source_ref
+        )));
+    }
+    if pack.expected_destination_roots != requested.roots {
+        return Err(conflict(
+            "the remote answered a review export against a lease this replica did not send",
+        ));
+    }
+    validate_pack(pack, &requested.limits)?;
+    Ok(pack
+        .collaboration
+        .as_ref()
+        .map(ReviewDomain::from_delta)
+        .unwrap_or_default())
 }
 
 /// What a pull negotiation produced, before anything is admitted locally.
@@ -914,7 +1207,9 @@ where
 /// packs itself, so that publication and the refresh of everything derived from
 /// it stay on one path. `admit` is that step. It is called once per pack, in
 /// order, and this function verifies each returned receipt binds the pack it
-/// was given before asking for the next one.
+/// was given before asking for the next one. After the ref phase it is called
+/// once more when the remote holds review records this replica lacks, with a
+/// pack that carries them and moves no history.
 ///
 /// A remote gap larger than one negotiated envelope arrives as several packs.
 /// Each is admitted and receipted on its own; see [`RepositoryTransferOutcome`]
@@ -935,6 +1230,7 @@ where
     let mut receipts = Vec::new();
     let mut originally_at = None;
     let mut admitted_changes = 0usize;
+    let mut up_to_date = None;
 
     loop {
         let negotiation =
@@ -942,14 +1238,7 @@ where
         let pack = match negotiation {
             PullNegotiation::UpToDate { head: current } => {
                 if receipts.is_empty() {
-                    return Ok(RepositoryTransferOutcome {
-                        direction: RepositoryTransferDirection::Pull,
-                        repository_id: repository_id.clone(),
-                        source_ref: source_ref.clone(),
-                        destination_ref: destination_ref.clone(),
-                        plan: RepositoryTransferPlan::UpToDate { head: current },
-                        receipts,
-                    });
+                    up_to_date = Some(current);
                 }
                 break;
             }
@@ -971,23 +1260,40 @@ where
         }
     }
 
-    // The head this pull admitted is the one the last receipt was verified to
-    // bind, not a head tracked alongside it.
-    let source_head = receipts
-        .last()
-        .map(|receipt| receipt.destination_head)
-        .ok_or_else(|| invalid("a pull that moved history produces at least one receipt"))?;
+    let plan = match up_to_date {
+        Some(head) => RepositoryTransferPlan::UpToDate { head },
+        None => {
+            // The head this pull admitted is the one the last receipt was
+            // verified to bind, not a head tracked alongside it.
+            let source_head = receipts
+                .last()
+                .map(|receipt| receipt.destination_head)
+                .ok_or_else(|| {
+                    invalid("a pull that moved history produces at least one receipt")
+                })?;
+            RepositoryTransferPlan::FastForward {
+                source_head,
+                destination_head: originally_at,
+                change_count: Some(admitted_changes),
+            }
+        }
+    };
+    let collaboration = pull_review_records(
+        local,
+        transport,
+        repository_id,
+        source_ref,
+        destination_ref,
+        &mut admit,
+    );
     Ok(RepositoryTransferOutcome {
         direction: RepositoryTransferDirection::Pull,
         repository_id: repository_id.clone(),
         source_ref: source_ref.clone(),
         destination_ref: destination_ref.clone(),
-        plan: RepositoryTransferPlan::FastForward {
-            source_head,
-            destination_head: originally_at,
-            change_count: Some(admitted_changes),
-        },
+        plan,
         receipts,
+        collaboration: Some(collaboration),
     })
 }
 
@@ -1008,8 +1314,12 @@ mod tests {
     use uuid::Uuid;
 
     use crate::repository_transfer::{
-        repository_ref_advertisement, RepositoryTransferApplyOutcome,
+        repository_ref_advertisement, RepositoryTransferApplyOutcome, FEATURE_COLLABORATION,
     };
+    use kin_model::review::{
+        Review, ReviewCompletionState, ReviewDecision, ReviewDecisionState, ReviewId,
+    };
+    use kin_model::{CollaborationDelta, IdentityRef, Keyed};
 
     use super::*;
 
@@ -1168,8 +1478,13 @@ mod tests {
         /// Publish no default ref, to prove a clone refuses rather than
         /// synthesizing a ref the remote does not publish.
         strip_default_ref: bool,
+        /// Advertise no `collaboration-v1`, as every peer that predates the
+        /// review phase does.
+        strip_collaboration: bool,
         exported: RefCell<usize>,
         received: RefCell<usize>,
+        /// Every pack this peer was asked to publish, in order.
+        received_packs: RefCell<Vec<RepositoryTransferPack>>,
     }
 
     impl<'a> LocalPeer<'a> {
@@ -1183,8 +1498,10 @@ mod tests {
                 advertised_max_changes: None,
                 advertised_max_trees: None,
                 strip_default_ref: false,
+                strip_collaboration: false,
                 exported: RefCell::new(0),
                 received: RefCell::new(0),
+                received_packs: RefCell::new(Vec::new()),
             }
         }
 
@@ -1229,6 +1546,13 @@ mod tests {
                 ..Self::new(authority)
             }
         }
+
+        fn without_collaboration(authority: &'a TestManager) -> Self {
+            Self {
+                strip_collaboration: true,
+                ..Self::new(authority)
+            }
+        }
     }
 
     impl RepositoryTransferTransport for LocalPeer<'_> {
@@ -1242,6 +1566,11 @@ mod tests {
             }
             if self.strip_default_ref {
                 advertisement.default_ref = None;
+            }
+            if self.strip_collaboration {
+                advertisement
+                    .supported_features
+                    .retain(|feature| feature != FEATURE_COLLABORATION);
             }
             Ok(advertisement)
         }
@@ -1264,6 +1593,11 @@ mod tests {
             }
             if let Some(max_trees) = self.advertised_max_trees {
                 status.limits.max_trees = max_trees;
+            }
+            if self.strip_collaboration {
+                status
+                    .supported_features
+                    .retain(|feature| feature != FEATURE_COLLABORATION);
             }
             Ok(status)
         }
@@ -1295,6 +1629,7 @@ mod tests {
             pack: &RepositoryTransferPack,
         ) -> Result<RepositoryTransferReceipt> {
             *self.received.borrow_mut() += 1;
+            self.received_packs.borrow_mut().push(pack.clone());
             let mut receipt = apply_repository_transfer_pack(
                 self.authority,
                 repository_id,
@@ -1361,6 +1696,381 @@ mod tests {
         let lease = manager.read_authority();
         let target = lease.resolve_ref_target(ref_name).unwrap()?;
         Some(lease.resolve_target_change_id(&target).unwrap())
+    }
+
+    fn review_record(title: &str) -> Review {
+        Review {
+            review_id: ReviewId::new(),
+            title: title.to_string(),
+            base_ref: "main".to_string(),
+            head_ref: "feature/reviews".to_string(),
+            state: ReviewDecisionState::Pending,
+            completion: ReviewCompletionState::InReview,
+            created_by: IdentityRef::human("troy"),
+            created_at: Timestamp::now(),
+            updated_at: Timestamp::now(),
+            scopes: vec![],
+        }
+    }
+
+    fn decision(reviewer: &str, state: ReviewDecisionState) -> ReviewDecision {
+        ReviewDecision {
+            reviewer: IdentityRef::human(reviewer),
+            state,
+            comment: None,
+            decided_at: Timestamp::now(),
+        }
+    }
+
+    /// Commit review records into `manager` the way the daemon's review writer
+    /// does: one transaction whose only mutation they are.
+    fn record_reviews(
+        manager: &TestManager,
+        repository_id: &RepositoryId,
+        operation: u128,
+        reviews: Vec<(Review, Vec<ReviewDecision>)>,
+    ) {
+        let records = CollaborationDelta {
+            review_decisions: reviews
+                .iter()
+                .filter(|(_, decisions)| !decisions.is_empty())
+                .map(|(review, decisions)| Keyed::new(review.review_id, decisions.clone()))
+                .collect(),
+            reviews: reviews
+                .into_iter()
+                .map(|(review, _)| Keyed::new(review.review_id, review))
+                .collect(),
+            ..CollaborationDelta::default()
+        };
+        // The one canonical order kin-model admits, as an export produces it.
+        let records = ReviewDomain::from_delta(&records).to_delta().unwrap();
+        let lease = manager.read_authority();
+        let transaction = RepositoryTransaction {
+            schema_version: REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+            operation_id: OperationId::from_uuid(Uuid::from_u128(operation)),
+            repository_id: repository_id.clone(),
+            expected_generation: lease.roots().generation,
+            expected_roots: lease.roots().clone(),
+            actor: AuthorId::new("negotiation-fixture"),
+            reason: "record review state".to_string(),
+            external_objects: Vec::new(),
+            git_authority_delta: None,
+            changes: Vec::new(),
+            aliases: Vec::new(),
+            ref_mutations: Vec::new(),
+            default_ref_mutation: None,
+            workspace_mutation: None,
+            local_overlay_delta: None,
+            merge_transaction_delta: None,
+            sealed_observation: None,
+            collaboration_delta: Some(records),
+        };
+        drop(lease);
+        manager.commit_repository_transaction(transaction).unwrap();
+    }
+
+    fn reviews_of(manager: &TestManager) -> HashMap<ReviewId, Review> {
+        manager.read_authority().snapshot().reviews.clone()
+    }
+
+    fn push(fixture: &Fixture, peer: &LocalPeer<'_>) -> RepositoryTransferOutcome {
+        push_to_remote(
+            &fixture.source,
+            peer,
+            &fixture.repository_id,
+            &fixture.main,
+            &fixture.main,
+            None,
+        )
+        .unwrap()
+    }
+
+    /// Review records follow the history a push publishes, and a second push
+    /// finds the two replicas' collaboration roots equal and sends nothing.
+    ///
+    /// Falsify by dropping the roots comparison from the push's review phase:
+    /// the second push then exports and merges, and the `InSync` assertion
+    /// goes red.
+    #[test]
+    fn a_push_carries_review_records_and_a_repush_carries_nothing() {
+        let fixture = fixture();
+        let peer = LocalPeer::new(&fixture.destination);
+        record_reviews(
+            &fixture.source,
+            &fixture.repository_id,
+            100,
+            vec![
+                (review_record("carry me"), vec![]),
+                (
+                    review_record("and my decision"),
+                    vec![decision("alice", ReviewDecisionState::Approved)],
+                ),
+            ],
+        );
+
+        let outcome = push(&fixture, &peer);
+        assert!(outcome.moved_history(), "the history moves first");
+        match &outcome.collaboration {
+            Some(CollaborationTransfer::Exchanged {
+                carried,
+                gaps,
+                receipt: Some(_),
+            }) => {
+                assert_eq!(*carried, 3, "two reviews and one decision history");
+                assert!(gaps.is_empty(), "{gaps:?}");
+            }
+            other => panic!("review records must travel with the push: {other:?}"),
+        }
+        assert_eq!(
+            reviews_of(&fixture.destination),
+            reviews_of(&fixture.source)
+        );
+
+        let sent = peer.received_packs.borrow().len();
+        let again = push(&fixture, &peer);
+        assert_eq!(again.collaboration, Some(CollaborationTransfer::InSync));
+        assert_eq!(
+            peer.received_packs.borrow().len(),
+            sent,
+            "a re-push whose collaboration roots agree sends no pack"
+        );
+    }
+
+    /// A receiver that holds every review record but one is sent exactly that
+    /// record, in a pack that moves no history.
+    ///
+    /// Falsify by sending the whole domain instead of the merge: the pack then
+    /// carries both reviews and the count assertion goes red.
+    #[test]
+    fn a_receiver_missing_one_record_is_sent_exactly_that_record() {
+        let fixture = fixture();
+        let peer = LocalPeer::new(&fixture.destination);
+        record_reviews(
+            &fixture.source,
+            &fixture.repository_id,
+            100,
+            vec![(review_record("both replicas hold me"), vec![])],
+        );
+        push(&fixture, &peer);
+
+        let missing = review_record("only the source holds me");
+        record_reviews(
+            &fixture.source,
+            &fixture.repository_id,
+            101,
+            vec![(missing.clone(), vec![])],
+        );
+        let outcome = push(&fixture, &peer);
+        assert!(!outcome.moved_history());
+        assert!(
+            matches!(
+                outcome.collaboration,
+                Some(CollaborationTransfer::Exchanged {
+                    carried: 1,
+                    receipt: Some(_),
+                    ..
+                })
+            ),
+            "{:?}",
+            outcome.collaboration
+        );
+        let packs = peer.received_packs.borrow();
+        let last = packs.last().expect("the review phase sent a pack");
+        assert!(last.changes.is_empty(), "a records pack moves no history");
+        let carried = last
+            .collaboration
+            .as_ref()
+            .expect("the last pack carries review records");
+        assert_eq!(carried.record_count(), 1, "{carried:?}");
+        assert_eq!(carried.reviews[0].key, missing.review_id);
+        assert_eq!(reviews_of(&fixture.destination).len(), 2);
+    }
+
+    /// A peer that does not advertise collaboration-v1 gets exactly the
+    /// transfer it always got, and the sender says how many records stayed.
+    ///
+    /// Falsify by skipping the feature check in the push's review phase: it
+    /// then asks the peer for a review export and publishes records to it, and
+    /// the assertions on both go red.
+    #[test]
+    fn a_peer_without_collaboration_gets_a_plain_transfer_and_is_told_what_stayed() {
+        let fixture = fixture();
+        let peer = LocalPeer::without_collaboration(&fixture.destination);
+        record_reviews(
+            &fixture.source,
+            &fixture.repository_id,
+            100,
+            vec![(review_record("stays here"), vec![])],
+        );
+
+        let outcome = push(&fixture, &peer);
+        assert!(outcome.moved_history(), "the history still moves");
+        assert_eq!(
+            outcome.collaboration,
+            Some(CollaborationTransfer::PeerUnsupported {
+                local_records: Some(1)
+            })
+        );
+        assert_eq!(*peer.exported.borrow(), 0, "no review export was asked for");
+        assert!(peer
+            .received_packs
+            .borrow()
+            .iter()
+            .all(|pack| pack.collaboration.is_none()));
+        assert!(reviews_of(&fixture.destination).is_empty());
+    }
+
+    /// A pull brings the remote's review records in after its history, and a
+    /// second pull finds nothing to carry.
+    ///
+    /// Falsify by dropping the review phase from the pull: the first
+    /// collaboration assertion goes red.
+    #[test]
+    fn a_pull_brings_review_records_in_and_a_repull_carries_nothing() {
+        let fixture = fixture();
+        let remote = LocalPeer::new(&fixture.source);
+        let decided = review_record("decided on the remote");
+        record_reviews(
+            &fixture.source,
+            &fixture.repository_id,
+            100,
+            vec![(
+                decided.clone(),
+                vec![decision("bob", ReviewDecisionState::NeedsWork)],
+            )],
+        );
+        let pull = || {
+            pull_from_remote(
+                &fixture.destination,
+                &remote,
+                &fixture.repository_id,
+                &fixture.main,
+                &fixture.main,
+                AuthorId::new("review-puller"),
+            )
+            .unwrap()
+        };
+
+        let outcome = pull();
+        assert!(outcome.moved_history());
+        assert!(
+            matches!(
+                outcome.collaboration,
+                Some(CollaborationTransfer::Exchanged {
+                    carried: 2,
+                    receipt: Some(_),
+                    ..
+                })
+            ),
+            "{:?}",
+            outcome.collaboration
+        );
+        assert_eq!(
+            reviews_of(&fixture.destination),
+            reviews_of(&fixture.source)
+        );
+        assert_eq!(
+            fixture
+                .destination
+                .read_authority()
+                .snapshot()
+                .review_decisions
+                .get(&decided.review_id)
+                .map(Vec::len),
+            Some(1)
+        );
+
+        let again = pull();
+        assert_eq!(again.collaboration, Some(CollaborationTransfer::InSync));
+    }
+
+    /// The merge never builds a pack that overwrites a review the receiver
+    /// decided further, and a pack built without the merge is refused where it
+    /// lands, naming the record.
+    ///
+    /// Falsify by removing `admission_refusals` from the receive path: the
+    /// stale review is admitted over the newer one and the refusal assertion
+    /// goes red.
+    #[test]
+    fn a_receiver_refuses_review_records_that_would_overwrite_a_newer_decision() {
+        let fixture = fixture();
+        let peer = LocalPeer::new(&fixture.destination);
+        let first = decision("alice", ReviewDecisionState::NeedsWork);
+        let mut review = review_record("decided twice on the remote");
+        review.state = ReviewDecisionState::NeedsWork;
+        record_reviews(
+            &fixture.source,
+            &fixture.repository_id,
+            100,
+            vec![(review.clone(), vec![first.clone()])],
+        );
+        push(&fixture, &peer);
+
+        // The remote decides again, and this replica never hears of it.
+        let mut newer = review.clone();
+        newer.state = ReviewDecisionState::Approved;
+        record_reviews(
+            &fixture.destination,
+            &fixture.repository_id,
+            200,
+            vec![(
+                newer,
+                vec![first, decision("bob", ReviewDecisionState::Approved)],
+            )],
+        );
+
+        let outcome = push(&fixture, &peer);
+        assert!(
+            matches!(
+                outcome.collaboration,
+                Some(CollaborationTransfer::Exchanged {
+                    carried: 0,
+                    receipt: None,
+                    ..
+                })
+            ),
+            "the remote's history contains this replica's, so nothing travels: {:?}",
+            outcome.collaboration
+        );
+
+        let lease = RepositoryTransferExpectation::try_from(
+            repository_transfer_status(&fixture.destination, &fixture.repository_id, &fixture.main)
+                .unwrap(),
+        )
+        .unwrap();
+        let unmerged = ReviewDomain::from_snapshot(fixture.source.read_authority().snapshot())
+            .to_delta()
+            .unwrap();
+        let pack = build_collaboration_transfer_pack(
+            &fixture.source,
+            &fixture.main,
+            &lease,
+            None,
+            unmerged,
+        )
+        .unwrap();
+        let message = apply_repository_transfer_pack(
+            &fixture.destination,
+            &fixture.repository_id,
+            &fixture.main,
+            AuthorId::new("stale-sender"),
+            &pack,
+            &RepositoryTransferLimits::default(),
+        )
+        .expect_err("a pack that would overwrite a newer decision must be refused")
+        .to_string();
+        assert!(
+            message.contains("would overwrite review records"),
+            "{message}"
+        );
+        assert!(
+            message.contains(&review.review_id.to_string()),
+            "the refusal names the record: {message}"
+        );
+        assert_eq!(
+            reviews_of(&fixture.destination)[&review.review_id].state,
+            ReviewDecisionState::Approved
+        );
     }
 
     #[test]
@@ -2851,6 +3561,7 @@ mod tests {
             destination_ref: ref_name.clone(),
             plan: RepositoryTransferPlan::UpToDate { head },
             receipts: Vec::new(),
+            collaboration: None,
         }
     }
 }

--- a/packages/boundary-contracts/schemas/hosted-repository-transfer.schema.json
+++ b/packages/boundary-contracts/schemas/hosted-repository-transfer.schema.json
@@ -78,7 +78,8 @@
               "external_objects",
               "aliases",
               "bodies",
-              "source_hydration_semantics"
+              "source_hydration_semantics",
+              "collaboration"
             ]
           },
           {

--- a/packages/boundary-contracts/src/index.d.ts
+++ b/packages/boundary-contracts/src/index.d.ts
@@ -729,6 +729,13 @@ export interface RepositoryTransferPack {
    * record and sends `null`.
    */
   source_hydration_semantics: number | null;
+  /**
+   * Review records this pack carries. Present only on a pack that moves no
+   * history, sent after the ref phase to a peer that advertises the
+   * `collaboration-v1` feature; absent from every other pack, so a pack that
+   * carries none serializes exactly as it did before.
+   */
+  collaboration?: Record<string, unknown>;
 }
 
 export interface RepositoryTransferReceipt {


### PR DESCRIPTION
`kin push` and `kin pull` now carry review records. After the ref phase, the two replicas compare collaboration roots. If they differ, the sending side reads the other side's review records, merges, and sends only what the other side lacks, in a pack that moves no history. A push or pull whose roots already agree sends nothing. A peer that doesn't advertise `collaboration-v1` gets exactly the transfer it got before, and the sender says how many records it didn't carry.

This is the second half of making review state repository authority. #1720 made every review, decision and comment durable in the local store. This makes it travel.

## The merge rule

A keyed record both sides hold with different contents is never silently overwritten, with one exception named under "What the rule leaves open" below: an assignment removal. Either a history the pack can prove decides it, or it's reported as a named gap carrying both versions.

- A review is decided by its decision history. Its state only moves when a decision is recorded, and authority keeps every decision, so the side whose decisions contain the other's holds the newer review. When each side has decisions the other lacks, the decisions merge by append, the review is reported as a gap with both states and both decision counts, and it stays as the receiver holds it until a new decision settles it.
- `updated_at` decides a review only when neither side holds any decision for it, and that choice is always reported as a gap naming both timestamps, because clocks on two machines can disagree. Equal timestamps with different contents is a gap.
- A decision history or an assignment set travels whole. The receiver's entries stay as the prefix and the sender's missing entries are appended. An assignment only the receiver holds is reported, because a collaboration delta can't express a removal.
- A discussion copy that appears in a replica's own admission history is older than that replica's current copy. Failing that, a copy whose comments strictly extend the other's, in the same state, is newer. Anything else is a gap.
- Notes, actors and review audit events travel when the receiver lacks the id. The same id with different contents is a gap. Unkeyed records append.

The receiver enforces the same rule, so it doesn't rest on the sender being careful. Admission refuses a pack that would replace or drop anything the receiver holds (a review the pack's decisions don't extend, a decision or assignment group that doesn't begin with the held one, a changed note, actor or audit event, a discussion copy older than the one it serves) and names every record. The pack is built against the receiver's lease, so a record the receiver admits after the export fails the roots check, and the sender retries once from a fresh export.

## What the rule leaves open

Four things, each for a follow-up rather than this PR.

- An assignment set is compared by state, and state can't tell a removal from an addition. A reviewer removed on one replica comes back when a replica that still holds the assignment pushes or pulls, because the merge reads the missing entry as new, and the receiver admits it because nothing it holds is dropped. The reverse case, a reviewer only the receiver holds, is reported. The fix is to record removals so the merge can decide from history, the way it does for decisions.
- A review whose decision histories match on both sides but whose record differs, meaning an edit that records no decision, can't be ordered by history. It's reported as a gap and stays as the receiver holds it, and the receiver refuses it too. The gap's text says both replicas decided it independently, which overstates what happened.
- The receiver refuses only the discussion regressions it can prove from its own history. A pack from a sender that skipped the merge can still make a divergent copy the one the receiver serves. The older copy stays in authority, so nothing is lost, but which copy is current changes.
- When neither side holds a decision, the later `updated_at` wins at the sender and again at the receiver, so a skewed clock can win. That's always reported as a gap, never silent.

## The pack

`RepositoryTransferPack` gains `collaboration`, serialized only when present and bound into the transfer identity only then, so a pack without records keeps its bytes and its transfer id. `validate_pack` refuses records on a pack that moves history, anything outside the review domain, and more than 20,000 records. A records pack's transaction mutates no ref. `collaboration-v1` is advertised and never required, so an older peer sees nothing new. An export whose closure is empty answers a peer that asked for review records with a history-less pack carrying them, or carrying nothing when it holds none, and admission refuses a pack that publishes nothing.

In the daemon, a received records pack lands the way a review write does: under the coordination gate and a graph-authority mutation guard, with the persistence lock, and the live graph follows authority before those are released. That matters because review writes plan against the live graph. The CLI prints a `Reviews:` line and a `Review gap:` line per gap. It exits nonzero only when the review phase was refused, and says that any history the transfer moved is durable, so a caller retrying knows what already landed.

## Tests, each falsified

The captain's four arms, the pull round trip, the receiver's refusal and the live graph each have a crate test, and each test was run against a mutation that breaks the behaviour it guards. All eight went red on their own target test, and every file was restored afterwards.

| Test | What the mutation broke |
|---|---|
| `review_records_inside_a_ref_pack_are_refused` | `validate_pack` no longer refuses records on a pack that moves history. The test recomputes the transfer identity first, so the identity check can't be what refuses it. |
| `a_peer_without_collaboration_gets_a_plain_transfer_and_is_told_what_stayed` | The push's review phase skips the feature check, asks the old peer for a review export and publishes records to it. |
| `a_push_carries_review_records_and_a_repush_carries_nothing` | The push no longer compares collaboration roots, so a re-push exports and merges instead of answering in sync. |
| `a_receiver_missing_one_record_is_sent_exactly_that_record` | The push sends its whole review domain instead of the merge, so the pack carries two records. |
| `a_pull_brings_review_records_in_and_a_repull_carries_nothing` | The pull's review phase always answers in sync, so nothing is pulled. |
| `a_receiver_refuses_review_records_that_would_overwrite_a_newer_decision` | Admission no longer runs the receiver's merge-rule check, so a stale review overwrites a newer decision. |
| `decision_history_decides_a_review_and_divergence_is_named` | A review is decided on `updated_at` instead of its decision history, so a skewed clock wins. |
| `admitted_records_bring_the_live_graph_to_authority` | Received decision histories no longer reach the daemon's live graph. |

The sweep's output tail, verbatim, trimmed to the verdict and where each target test panicked:

```
F1-roots-compare: rc=101 RED, the mutant is killed by its target test | ... panicked at crates/kin-remote/src/repository_transfer_negotiation.rs:1832:9
F2-whole-domain-not-merge: rc=101 RED, the mutant is killed by its target test | ... panicked at crates/kin-remote/src/repository_transfer_negotiation.rs:1885:9
F3-feature-check: rc=101 RED, the mutant is killed by its target test | ... panicked at crates/kin-remote/src/repository_transfer_negotiation.rs:1909:9
F4-pull-review-phase: rc=101 RED, the mutant is killed by its target test | ... panicked at crates/kin-remote/src/repository_transfer_negotiation.rs:1957:9
F5-receiver-guard: rc=101 RED, the mutant is killed by its target test | ... panicked at crates/kin-remote/src/repository_transfer_negotiation.rs:2060:10
F6-ref-pack-refusal: rc=101 RED, the mutant is killed by its target test | ... panicked at crates/kin-remote/src/repository_transfer.rs:3583:10
F7-decision-history-rule: rc=101 RED, the mutant is killed by its target test | ... panicked at crates/kin-remote/src/collaboration_transfer.rs:864:33
F8-daemon-live-decisions: rc=101 RED, the mutant is killed by its target test | ... panicked at crates/kin-daemon/src/review_transfer.rs:218:9
FALSIFY_DONE restored=True at 16:23:37Z
```

## Numbers

Measured in-process over two real on-disk authorities (`LocalFileBackend`), running the kin-remote push the daemon runs inside its blocking task. The HTTP hop between two daemons is not in these numbers. Test profile, which is an unoptimized build, because the release profile is fat LTO. Apple M5 Max, macOS 26.4. Each cell is the median of five pushes, each onto a fresh pair of replicas holding a two-change history, with every review carrying one decision.

| Reviews (records) | Push, peer without collaboration-v1 | Push with the review phase | Review pack, JSON bytes |
|---|---|---|---|
| 1 (2) | 90.85 ms | 175.91 ms | 3,372 |
| 10 (20) | 92.69 ms | 175.61 ms | 8,199 |
| 100 (200) | 91.89 ms | 186.36 ms | 56,660 |

The left column is the transfer every earlier build performs, so before and after differ by the review phase alone. That phase costs about 85 to 95 ms here and barely moves with the record count, because it's a status read, an export, a merge and one collaboration-only commit on the receiver. The pack grows about 540 bytes per decided review on top of a fixed envelope of about 2.8 KB. A push whose collaboration roots already agree skips all of it.

Beside the kin-db per-event numbers from #1720: on a scratch store converted from the kin-db repository (832 commits, 204 files), one collaboration-only commit prepared its successor in 40,968 ms, all of it admission, history replay, replay decode and storage admission over the whole store, and then persisted a full 1.62 GB snapshot in about 15 s, because kin-db 0.7.112's authority frame carries no collaboration collection. The receiver's commit here is a repository transaction through the same kin-db commit path, so on a store that size I'd expect a push that carries records to pay about that once on the receiver, and a push whose roots agree to pay nothing. I haven't measured a transfer receive on that store. The frame fix is its own kin-db lane.

## Boundary

This PR owns kin-remote and the pack schema in `packages/boundary-contracts`: the export leaf's response keys and the TS interface, `node --test` 20 of 20. The landed review write path doesn't change. `crates/kin-review/src/write.rs` and `crates/kin-daemon/src/review_write.rs` are untouched, and the new `crates/kin-daemon/src/review_transfer.rs` calls the existing `ReviewWrite::apply_to`. The hosted side needs kinlab main at or after 644c4cae1, where `REPOSITORY_TRANSFER_PACK_FIELDS` admits `collaboration` (#581).

## Migration

No store migration. Review records have lived in repository authority since #1720; this adds a pack field and a feature string. A pack without records is byte for byte what it was. An older peer never receives a records pack because it doesn't advertise the feature, and a newer client talking to an older daemon reports the review phase as not carried.

## Gates run

Targeted tests on the lane tree, each with `KIN_EMBED_BACKEND=cpu`. These and the falsification sweep ran before a rustfmt pass, which changed formatting only in three files; the line numbers in the sweep's output are from that tree.

```
cargo test --locked -p kin-remote --lib                                     139 passed, 0 failed
cargo test --locked -p kin-cli --lib commands::transfer                      13 passed, 0 failed
cargo test --locked -p kin-daemon --lib review_transfer                       1 passed, 0 failed
cargo test --locked -p kin-daemon --test transfer_admission_policy            4 passed, 0 failed
cargo test --locked -p kin-daemon --lib -- transfer pull push clone          38 passed, 0 failed
node --test packages/boundary-contracts/test/contracts.test.js               20 passed, 0 failed
```

`bin/kin-precheck kin` on the lane commit cb5f0a727, every gate the check job in `ci.yml` names:

```
kin-precheck: repo=kin tree=/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/reviewdurable-kin sha=cb5f0a72794c2b4d5bae4b2423b254838bca0885 branch=chore/lane-reviewdurable-transfer-kin
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin cb5f0a72794c2b4d5bae4b2423b254838bca0885
```
