### PR TITLE
Answer a hosted context pack on the most-called entity instead of a retryable 503

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -13629,6 +13629,15 @@ fn repo_scoped_handler_failure(error: kin_mcp::McpError) -> RepoScopedMcpFailure
             "invalid_semantic_tool_call",
             false,
         ),
+        // This request's own source allowance is spent, or a body is larger than
+        // its per-blob ceiling. The repository is fine and the same request
+        // cannot succeed on a retry, so it is neither retryable nor a 503; a
+        // narrower request can succeed, which makes it the caller's lever.
+        kin_mcp::McpError::SourceBudgetExhausted(_) => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "source_budget_exhausted",
+            false,
+        ),
         kin_mcp::McpError::GraphStore(_)
         | kin_mcp::McpError::Io(_)
         | kin_mcp::McpError::Json(_)
@@ -24169,6 +24178,30 @@ mod tests {
         message: &str,
         symbols: &[(&str, &str, &str)],
     ) -> (SemanticChangeId, Vec<EntityId>) {
+        let chain: Vec<(usize, usize)> = (1..symbols.len()).map(|i| (i - 1, i)).collect();
+        publish_hosted_semantic_change_with_calls(
+            storage,
+            repository_id,
+            previous,
+            operation,
+            message,
+            symbols,
+            &chain,
+        )
+    }
+
+    /// [`publish_hosted_semantic_change`] with its `Calls` edges named by
+    /// symbol index instead of chained, for a fixture whose graph shape is the
+    /// point of the test.
+    fn publish_hosted_semantic_change_with_calls(
+        storage: &FsPath,
+        repository_id: &RepositoryId,
+        previous: Option<SemanticChangeId>,
+        operation: u128,
+        message: &str,
+        symbols: &[(&str, &str, &str)],
+        calls: &[(usize, usize)],
+    ) -> (SemanticChangeId, Vec<EntityId>) {
         use kin_model::{
             compute_resolved_tree_hash, compute_semantic_change_id, AdmissionCase,
             AdmissionPolicyDelta, ChangeOrigin, DefaultRefExpectation, DefaultRefMutation,
@@ -24217,14 +24250,14 @@ mod tests {
                 ),
             });
         }
-        let relation_deltas = entities
-            .windows(2)
-            .map(|pair| kin_model::RelationDelta::Added {
+        let relation_deltas = calls
+            .iter()
+            .map(|&(src, dst)| kin_model::RelationDelta::Added {
                 new: kin_model::Relation {
                     id: kin_model::RelationId::new(),
                     kind: RelationKind::Calls,
-                    src: GraphNodeId::Entity(pair[0]),
-                    dst: GraphNodeId::Entity(pair[1]),
+                    src: GraphNodeId::Entity(entities[src]),
+                    dst: GraphNodeId::Entity(entities[dst]),
                     confidence: 1.0,
                     origin: kin_model::RelationOrigin::Parsed,
                     created_in: None,
@@ -27804,6 +27837,203 @@ mod tests {
             "{failed}"
         );
         assert_eq!(failed["error"]["retryable"], true, "{failed}");
+    }
+
+    /// P1: a context pack on the focal the most code calls must answer, and must
+    /// not spend the request's source allowance on caller bodies it never ships.
+    ///
+    /// Forty callers in forty files, with the arguments the hosted inspector
+    /// sends. The pack used to read one body per caller to decide who its
+    /// dependents were, so the 33rd caller file spent the 32-read allowance and
+    /// the whole pack answered 503 retryable: the most-called entity in a
+    /// repository was the one entity whose context could never be read.
+    #[tokio::test]
+    async fn a_hosted_context_pack_names_every_caller_without_reading_their_bodies() {
+        const CALLERS: usize = 40;
+        let repo_id = format!("repo-scoped-pack-fanin-{}", Uuid::new_v4());
+        let repository_id = RepositoryId::new(repo_id.clone()).unwrap();
+        let (state, faults, backend_dir) =
+            hosted_state_with_backend_dir("repo-mcp-pack-fanin", &repo_id, &[]);
+        let names: Vec<String> = std::iter::once("fanin_target".to_string())
+            .chain((0..CALLERS).map(|index| format!("fanin_caller_{index}")))
+            .collect();
+        let paths: Vec<String> = std::iter::once("src/target.rs".to_string())
+            .chain((0..CALLERS).map(|index| format!("src/callers/c{index}.rs")))
+            .collect();
+        let bodies: Vec<String> = names
+            .iter()
+            .map(|name| format!("fn {name}() {{}}\n"))
+            .collect();
+        let symbols: Vec<(&str, &str, &str)> = (0..names.len())
+            .map(|index| {
+                (
+                    names[index].as_str(),
+                    paths[index].as_str(),
+                    bodies[index].as_str(),
+                )
+            })
+            .collect();
+        let calls: Vec<(usize, usize)> = (1..=CALLERS).map(|caller| (caller, 0)).collect();
+        let (_, entities) = publish_hosted_semantic_change_with_calls(
+            &backend_dir,
+            &repository_id,
+            None,
+            0xb301,
+            "publish fan-in fixture",
+            &symbols,
+            &calls,
+        );
+        let target = entities[0];
+        let app = router(Arc::clone(&state));
+
+        // Warm the view first, so the authority open's own reads are not
+        // counted against the pack.
+        let (status, _, warm) = call_repo_mcp_tool(
+            app.clone(),
+            &repo_id,
+            "semantic_locate",
+            json!({ "query": "fanin_target", "include_snippet": false }),
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{warm}");
+        let baseline_reads = faults.blob_read_ceilings().len();
+
+        let (status, _, body) = call_repo_mcp_tool(
+            app,
+            &repo_id,
+            "get_context_pack",
+            json!({
+                "entity_id": target.to_string(),
+                "compact": true,
+                "max_response_chars": 60_000
+            }),
+            None,
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "the most-called entity's pack must answer: {body}"
+        );
+        let pack = successful_repo_mcp_payload(body);
+        assert_eq!(
+            pack["dependency_selection"]["certified_dependents"], CALLERS,
+            "{pack}"
+        );
+        let returned = pack["dependents"].as_array().map_or(0, Vec::len);
+        let withheld = pack["dependents_withheld"].as_u64().unwrap_or(0) as usize;
+        assert_eq!(
+            returned + withheld,
+            CALLERS,
+            "every caller is returned or counted as withheld: {pack}"
+        );
+        let reads = faults.blob_read_ceilings().len() - baseline_reads;
+        assert!(
+            reads <= 1,
+            "a pack names its dependents from edges and the tree, so it reads at most the \
+             focal's own body; it read {reads}"
+        );
+    }
+
+    /// P1: a focal whose file is larger than the request's per-blob allowance
+    /// answers with its body withheld and says so, never a bare 503.
+    #[tokio::test]
+    async fn a_hosted_context_pack_on_an_oversized_file_withholds_the_body_and_says_so() {
+        let repo_id = format!("repo-scoped-pack-oversize-{}", Uuid::new_v4());
+        let repository_id = RepositoryId::new(repo_id.clone()).unwrap();
+        let (state, _faults, backend_dir) =
+            hosted_state_with_backend_dir("repo-mcp-pack-oversize", &repo_id, &[]);
+        // The file is sized from the allowance this request will actually get,
+        // so it is over the per-blob ceiling whatever the constants say, while a
+        // 10,000-character budget still leaves the response room for a pack.
+        let request_budget = kin_mcp::budget::ResponseBudget::from_arguments(&HashMap::from([(
+            "max_chars".to_string(),
+            json!(10_000),
+        )]))
+        .less_envelope_reserve();
+        let (per_blob, _total, _reads) = repo_scoped_source_projection_limits(&request_budget);
+        let mut oversized = String::from("fn oversized_focal() {}\n");
+        while (oversized.len() as u64) <= per_blob + 64 * 1024 {
+            oversized.push_str("// padding that takes this file past the per-blob allowance\n");
+        }
+        let (_, entities) = publish_hosted_semantic_change(
+            &backend_dir,
+            &repository_id,
+            None,
+            0xb302,
+            "publish oversize fixture",
+            &[
+                ("oversized_focal", "src/oversized.rs", oversized.as_str()),
+                (
+                    "oversized_callee",
+                    "src/callee.rs",
+                    "fn oversized_callee() {}\n",
+                ),
+            ],
+        );
+        let focal = entities[0];
+        let app = router(Arc::clone(&state));
+
+        let (status, _, body) = call_repo_mcp_tool(
+            app,
+            &repo_id,
+            "get_context_pack",
+            json!({
+                "entity_id": focal.to_string(),
+                "compact": true,
+                "max_chars": 10_000
+            }),
+            None,
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "a file over the per-blob allowance is the request's bound, not an outage: {body}"
+        );
+        let result: kin_mcp::ToolCallResult =
+            serde_json::from_value(body["result"].clone()).unwrap();
+        let kin_mcp::ContentBlock::Text { text } = result.content.first().unwrap();
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "the pack answered with a tool error: {text}"
+        );
+        let pack: serde_json::Value = serde_json::from_str(text).unwrap();
+        let degradations = pack["degradations"].as_array().cloned().unwrap_or_default();
+        assert!(
+            degradations.iter().any(|degradation| {
+                degradation["component"] == "entity_source"
+                    && degradation["reason"] == "hosted_source_read_cap"
+            }),
+            "the withheld body is disclosed where the verdict reads it: {pack}"
+        );
+        assert_eq!(
+            pack["focal_entity"]["body_withheld"], "hosted_source_read_cap",
+            "the row says what it lacks: {pack}"
+        );
+    }
+
+    /// A spent source allowance is the request's bound, which a narrower request
+    /// can meet and no retry of the same one can, so it is never a retryable 503.
+    #[test]
+    fn a_spent_source_allowance_is_the_requests_bound_not_a_retryable_outage() {
+        let spent = repo_scoped_handler_failure(kin_mcp::McpError::SourceBudgetExhausted(
+            "blob abc is 300000 bytes, over the 262144-byte per-blob allowance".into(),
+        ));
+        assert_eq!(spent.status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(spent.code, "source_budget_exhausted");
+        assert!(
+            !spent.retryable,
+            "no retry of the same request can clear a spent allowance"
+        );
+        // The control: a real authority gap keeps its retryable 503.
+        let gap = repo_scoped_handler_failure(kin_mcp::McpError::Context(
+            "graph authority gap: cannot load immutable source blob abc".into(),
+        ));
+        assert_eq!(gap.status, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(gap.retryable);
     }
 
     /// The classifier the route above depends on, and the control that must

--- a/crates/kin-mcp/src/error.rs
+++ b/crates/kin-mcp/src/error.rs
@@ -34,6 +34,14 @@ pub enum McpError {
     #[error("entity absent at workspace generation: {0}")]
     WorkspaceAbsent(String),
 
+    /// This request's hosted source allowance (its reads, its bytes, or one
+    /// blob's size against the per-blob ceiling) ran out before the read.
+    /// Deterministic for the request as made: a retry cannot clear it, a
+    /// narrower request can, and a surface that can answer without the body
+    /// should say what it withheld instead of failing.
+    #[error("hosted source projection budget exhausted: {0}")]
+    SourceBudgetExhausted(String),
+
     #[error("review error: {0}")]
     Review(String),
 

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -1316,6 +1316,162 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
     relation_kinds: &[RelationKind],
     repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<Vec<ReferenceRow>> {
+    collect_reference_rows(
+        store,
+        entity_id,
+        relation_kinds,
+        repository_authority,
+        ReferenceBodies::Project,
+    )
+}
+
+/// The same rows as [`collect_graph_reference_rows`], without the bodies.
+///
+/// For a surface that uses the rows for who reaches `entity_id` and never
+/// serializes a caller's body. Membership is decided exactly as the projecting
+/// form decides it, including the skip of a caller the current workspace no
+/// longer carries, but from the held tree alone, so the answer costs no source
+/// read however many callers there are. A hosted request's source allowance
+/// would otherwise be spent on bodies nobody ships, and the entity the most
+/// code calls is the one that runs out first.
+pub fn collect_graph_reference_members<G: GraphStore>(
+    store: &G,
+    entity_id: &EntityId,
+    relation_kinds: &[RelationKind],
+    repository_authority: Option<&RequestRepositoryAuthority>,
+) -> Result<Vec<ReferenceRow>> {
+    collect_reference_rows(
+        store,
+        entity_id,
+        relation_kinds,
+        repository_authority,
+        ReferenceBodies::Omit,
+    )
+}
+
+/// Whether a reference row projects its caller's body.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ReferenceBodies {
+    Project,
+    Omit,
+}
+
+/// The snippet a reference row carries, or `None` when the caller is absent
+/// from the current workspace and the row is skipped.
+fn reference_row_snippet<G: GraphStore>(
+    held: &HeldSourceAuthority<'_, G>,
+    entity: &Entity,
+    bodies: ReferenceBodies,
+) -> Result<Option<Option<String>>> {
+    match bodies {
+        ReferenceBodies::Project => {
+            match read_bounded_entity_snippet_held(held, entity, EntitySourceScope::WorkspaceHead) {
+                Ok(snippet) => Ok(Some(snippet)),
+                Err(error) if is_absent_at_generation(&error) => Ok(None),
+                Err(error) => Err(error),
+            }
+        }
+        ReferenceBodies::Omit => {
+            Ok(entity_present_at_workspace_head_held(held, entity)?.then_some(None))
+        }
+    }
+}
+
+/// Whether the workspace this request reads at still carries `entity`'s file,
+/// answered from the held tree without reading any body.
+///
+/// The membership half of the head read [`read_entity_source_excerpt_detailed_held`]
+/// performs: the same origin and span checks and the same tree lookup, so a
+/// caller that read would skip as absent is skipped here too, and one it would
+/// refuse as a gap is refused here too. What it leaves out is everything after
+/// the lookup, which exists to vouch for bytes, and nothing here serves bytes.
+/// An entity with no span or no file origin has nothing to look up and counts
+/// as present, the same reading the projection gives it.
+pub fn entity_present_at_workspace_head_held<G: GraphStore>(
+    held: &HeldSourceAuthority<'_, G>,
+    entity: &Entity,
+) -> Result<bool> {
+    let (Some(recorded_span), Some(recorded_origin)) =
+        (entity.span.as_ref(), entity.file_origin.as_ref())
+    else {
+        return Ok(true);
+    };
+    if &recorded_span.file != recorded_origin {
+        return Err(graph_source_gap(format!(
+            "entity {} has divergent file_origin '{}' and span file '{}'",
+            entity.id, recorded_origin.0, recorded_span.file.0
+        )));
+    }
+    let path = RepoPath::from_utf8(recorded_origin.0.clone()).map_err(|error| {
+        graph_source_gap(format!(
+            "entity {} has an invalid repository path '{}': {error}",
+            entity.id, recorded_origin.0
+        ))
+    })?;
+    Ok(held
+        .workspace_sample()?
+        .tree
+        .artifact_at_path(&path)
+        .is_some())
+}
+
+/// The row field that says a body was withheld at the hosted source allowance.
+pub const BODY_WITHHELD_FIELD: &str = "body_withheld";
+
+/// The degradation reason hosted surfaces publish for a read the request's
+/// source allowance refused.
+pub const HOSTED_SOURCE_READ_CAP_REASON: &str = "hosted_source_read_cap";
+
+/// Publish in `degradations` that this answer withheld bodies at the hosted
+/// source allowance, when any row it rendered says so.
+///
+/// The row already names what it lacks; this is the one aggregate the verdict
+/// reads, so a pack that shipped a signature where a body was asked for says so
+/// in `_kin.verdict` rather than reading as complete. It derives from the rows,
+/// the one producer of that fact, instead of keeping a second count.
+pub fn disclose_withheld_source_reads(
+    result: &mut serde_json::Value,
+    fields: &ContextSourceFields,
+) {
+    let withheld = fields
+        .borrow()
+        .values()
+        .filter(|row| {
+            row.get(BODY_WITHHELD_FIELD)
+                .and_then(serde_json::Value::as_str)
+                == Some(HOSTED_SOURCE_READ_CAP_REASON)
+        })
+        .count();
+    if withheld == 0 {
+        return;
+    }
+    let entry = serde_json::json!({
+        "component": "entity_source",
+        "reason": HOSTED_SOURCE_READ_CAP_REASON,
+        "detail": format!(
+            "{withheld} body read(s) refused at this request's hosted source allowance: the \
+             allowance was spent, or the file is larger than its per-blob ceiling; those rows \
+             carry a signature and say what they withheld"
+        ),
+        "remediation": "ask for a narrower pack, or read the withheld body directly where a \
+                        surface serves it",
+    });
+    match result
+        .get_mut("degradations")
+        .and_then(serde_json::Value::as_array_mut)
+    {
+        Some(list) => list.push(entry),
+        None => result["degradations"] = serde_json::json!([entry]),
+    }
+}
+
+fn collect_reference_rows<G: GraphStore>(
+    store: &G,
+    entity_id: &EntityId,
+    relation_kinds: &[RelationKind],
+    repository_authority: Option<&RequestRepositoryAuthority>,
+    bodies: ReferenceBodies,
+) -> Result<Vec<ReferenceRow>> {
     let allowed: std::collections::HashSet<_> = relation_kinds.iter().copied().collect();
     let mut grouped: HashMap<EntityId, ReferenceRow> = HashMap::new();
     // Spans a row's edges carried that named some other file, counted so an
@@ -1360,14 +1516,8 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
         // reported as one. Failing the whole reference set over it -- the shape
         // this had -- made `find_references` unusable on any repository that
         // ever deleted a file.
-        let snippet = match read_bounded_entity_snippet_held(
-            &held,
-            &entity,
-            EntitySourceScope::WorkspaceHead,
-        ) {
-            Ok(snippet) => snippet,
-            Err(error) if is_absent_at_generation(&error) => continue,
-            Err(error) => return Err(error),
+        let Some(snippet) = reference_row_snippet(&held, &entity, bodies)? else {
+            continue;
         };
         let entry = grouped
             .entry(source_entity_id)
@@ -1474,14 +1624,8 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
             else {
                 continue;
             };
-            let snippet = match read_bounded_entity_snippet_held(
-                &held,
-                &entity,
-                EntitySourceScope::WorkspaceHead,
-            ) {
-                Ok(snippet) => snippet,
-                Err(error) if is_absent_at_generation(&error) => continue,
-                Err(error) => return Err(error),
+            let Some(snippet) = reference_row_snippet(&held, &entity, bodies)? else {
+                continue;
             };
             let file_path = entity.file_origin.as_ref().map(|path| path.0.clone());
             let entry = grouped
@@ -2517,12 +2661,21 @@ fn resolve_entity_source_authority<G: GraphStore>(
             span_source_coherence(entity, &hash, &recorded_origin.0)?
         }
     };
-    let bytes = held.load_source_blob(authority, hash).map_err(|error| {
-        graph_source_gap(format!(
-            "blob {hash} for entity {} artifact {:?} is unavailable or corrupt: {error}",
-            entity.id, current_artifact.artifact_id
-        ))
-    })?;
+    let bytes = held
+        .load_source_blob(authority, hash)
+        .map_err(|error| match error {
+            // The request's allowance refused this read. That is a bound, so it
+            // stays typed and a surface can withhold this one body instead of
+            // failing the whole answer as if the repository were unreadable.
+            McpError::SourceBudgetExhausted(detail) => McpError::SourceBudgetExhausted(format!(
+                "entity {} artifact {:?}: {detail}",
+                entity.id, current_artifact.artifact_id
+            )),
+            error => graph_source_gap(format!(
+                "blob {hash} for entity {} artifact {:?} is unavailable or corrupt: {error}",
+                entity.id, current_artifact.artifact_id
+            )),
+        })?;
     if span.start_byte >= span.end_byte || span.end_byte > bytes.len() {
         return Err(graph_source_gap(format!(
             "entity {} span {}..{} is invalid for artifact {:?} ({} bytes)",
@@ -2657,6 +2810,22 @@ impl<G: GraphStore> kin_context::ContextProjectionProvider for ContextSourceProv
                 return Ok(kin_context::BodyCandidate::Unavailable {
                     reason: error.to_string(),
                 })
+            }
+            // The request's source allowance refused this read. The body is
+            // withheld rather than missing: the row keeps its signature and says
+            // so, and `disclose_withheld_source_reads` publishes the aggregate.
+            Err(McpError::SourceBudgetExhausted(detail)) => {
+                self.fields
+                    .borrow_mut()
+                    .entry(entity.id)
+                    .or_default()
+                    .insert(
+                        BODY_WITHHELD_FIELD.into(),
+                        serde_json::json!(HOSTED_SOURCE_READ_CAP_REASON),
+                    );
+                return Ok(kin_context::BodyCandidate::Unavailable {
+                    reason: format!("body withheld at the hosted source allowance: {detail}"),
+                });
             }
             Err(error) => return Err(kin_context::ContextError::Other(error.to_string())),
         };

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -1082,7 +1082,11 @@ impl<G: GraphStore> SingleContextRender<'_, G> {
                     // -- is that function's, so the two cannot drift apart by being edited
                     // separately.
                     let reference_kinds = default_reference_kinds();
-                    let reference_rows = collect_graph_reference_rows(
+                    // Membership only: the pack ships ids and edges for its
+                    // dependents and never a caller's body, so reading one per
+                    // caller spent a hosted request's whole source allowance on
+                    // bytes nobody receives.
+                    let reference_rows = collect_graph_reference_members(
                         store,
                         &entity_id,
                         &reference_kinds,
@@ -1401,6 +1405,7 @@ impl<G: GraphStore> SingleContextRender<'_, G> {
             );
         }
 
+        disclose_withheld_source_reads(&mut result, fields);
         disclose_projection_bodies(&mut result);
         loop {
             let rendered = serialize_with_measured_tokens(&mut result)?;
@@ -1712,6 +1717,7 @@ fn render_multi_context<G: GraphStore>(
         );
     }
 
+    disclose_withheld_source_reads(&mut result, fields);
     disclose_projection_bodies(&mut result);
     Ok(result)
 }

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -7893,6 +7893,94 @@ mod tests {
     /// The assertion that matters is that the LIVE callers come back. A test
     /// that only asserted the call no longer errors would also pass if the fix
     /// dropped every row.
+    /// The membership form names the same callers the projecting form does,
+    /// skips the same caller history deleted, and carries no body for any of
+    /// them. The context pack reads its dependents this way because it never
+    /// ships a caller's body.
+    #[test]
+    fn a_membership_read_names_the_same_callers_without_their_bodies() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        reset_trace_source_registry();
+        let dir = tempdir().unwrap();
+        let kin_dir = dir.path().join(".kin");
+        fs::create_dir_all(&kin_dir).unwrap();
+        let _guard = EnvVarGuard::set("KIN_SOURCE_ROOT", dir.path());
+        let blob_store = kin_blobs::BlobStore::new(kin_dir.join("objects")).unwrap();
+
+        const LIVE_CALLERS: usize = 3;
+        let mut store = EmptyStore::default();
+        let install = |store: &mut EmptyStore, name: &str| -> Entity {
+            let content = format!("export function {name}() {{ return \"{name}\"; }}\n");
+            let hash = blob_store.write(content.as_bytes()).unwrap();
+            let file_id = FilePathId::new(format!("src/{name}.ts"));
+            store.file_hashes.insert(file_id.clone(), hash);
+            let entity = whole_file_entity(&file_id, &content, Some(hash));
+            store.insert_test_entity(entity.clone());
+            entity
+        };
+        let target = install(&mut store, "target");
+        for index in 0..LIVE_CALLERS {
+            let caller = install(&mut store, &format!("caller{index}"));
+            store.insert_test_calls_relation(&caller, &target);
+        }
+        install_empty_store_exact_tree(&mut store, dir.path());
+        let deleted_content = "export function deleted_caller() { return 0; }\n";
+        let deleted_hash = blob_store.write(deleted_content.as_bytes()).unwrap();
+        let deleted = whole_file_entity(
+            &FilePathId::new("src/deleted_caller.ts"),
+            deleted_content,
+            Some(deleted_hash),
+        );
+        store.insert_test_entity(deleted.clone());
+        store.insert_test_calls_relation(&deleted, &target);
+
+        let authority = test_repository_authority(dir.path());
+        let projected = collect_graph_reference_rows(
+            &store,
+            &target.id,
+            &[RelationKind::Calls],
+            Some(&authority),
+        )
+        .unwrap();
+        let members = collect_graph_reference_members(
+            &store,
+            &target.id,
+            &[RelationKind::Calls],
+            Some(&authority),
+        )
+        .unwrap();
+
+        let ids = |rows: &[ReferenceRow]| {
+            let mut ids: Vec<Option<String>> =
+                rows.iter().map(|row| row.entity_id.clone()).collect();
+            ids.sort();
+            ids
+        };
+        assert_eq!(members.len(), LIVE_CALLERS, "{members:?}");
+        assert_eq!(
+            ids(&members),
+            ids(&projected),
+            "the two forms must agree on who reaches the target"
+        );
+        assert!(
+            members.iter().all(|row| row.snippet.is_none()),
+            "the membership form reads no body: {members:?}"
+        );
+        assert!(
+            projected.iter().all(|row| row.snippet.is_some()),
+            "the control: the projecting form still carries every body"
+        );
+        assert!(
+            !members
+                .iter()
+                .any(|row| row.file_path.as_deref() == Some("src/deleted_caller.ts")),
+            "a caller the current workspace does not contain is skipped here too: {members:?}"
+        );
+    }
+
     #[test]
     fn a_reference_set_survives_a_caller_whose_file_history_deleted() {
         let _lock = ENV_MUTEX

--- a/crates/kin-mcp/src/handlers/repository_authority.rs
+++ b/crates/kin-mcp/src/handlers/repository_authority.rs
@@ -284,8 +284,10 @@ impl RequestRepositoryAuthority {
             return Ok(Arc::clone(bytes));
         }
         if state.remaining_reads == 0 || state.remaining_bytes == 0 {
-            return Err(McpError::Context(format!(
-                "graph authority gap: hosted source projection budget was exhausted before blob {digest}"
+            // Typed rather than spelled as an authority gap: the repository is
+            // fine and this request's allowance is spent, which no retry clears.
+            return Err(McpError::SourceBudgetExhausted(format!(
+                "this request's source allowance was spent before blob {digest}"
             )));
         }
         let max_bytes = budget.max_blob_bytes.min(state.remaining_bytes);
@@ -671,10 +673,20 @@ impl ActiveRepositoryAuthority {
     ) -> Result<Vec<u8>> {
         self.manager
             .load_source_blob_bounded(&self.repository_id, digest, max_bytes)
-            .map_err(|error| {
-                McpError::Context(format!(
+            .map_err(|error| match error {
+                // A body larger than this request may read is the request's
+                // bound answering, not the repository failing.
+                kin_db::KinDbError::SourceBlobReadLimitExceeded {
+                    actual_bytes,
+                    max_bytes,
+                    ..
+                } => McpError::SourceBudgetExhausted(format!(
+                    "blob {digest} is {actual_bytes} bytes, over the {max_bytes}-byte per-blob \
+                     allowance this request reads under"
+                )),
+                error => McpError::Context(format!(
                     "graph authority gap: cannot load immutable source blob {digest}: {error}"
-                ))
+                )),
             })?
             .ok_or_else(|| {
                 McpError::Context(format!(


### PR DESCRIPTION
A hosted context pack on the entity the most code calls now answers. Before this, the pack read a source body for every caller just to decide who its dependents were, so once a focal's callers spanned more than 32 files the request's source allowance ran out and the whole pack came back `503 repo_authority_unavailable, retryable: true`. No retry could clear it. That is why the biggest node on the hosted kin graph, the most clickable one in the picture, answered 503 three times in a row while random entities answered 200.

## The two paths, both deterministic

The hosted route gives each call one source allowance: 32 blob reads and, for the 60,000-character budget the hosted inspector sends, 1,856,000 bytes, with the same number as the per-blob ceiling.

1. Read count. `handle_get_context_pack` built its dependents through `collect_graph_reference_rows`, which reads a bounded snippet for every caller, compact or not. The pack never ships those snippets. The 33rd distinct caller file hit `RequestRepositoryAuthority::load_source_blob`'s refusal, spelled as a `graph authority gap`, and `repo_scoped_handler_failure` maps that prefix to a retryable 503.
2. One big file. A blob larger than the per-blob ceiling comes back from kin-db as `SourceBlobReadLimitExceeded`, which `ActiveRepositoryAuthority::load_source_blob_bounded` wrapped as the same authority gap. kin's own `crates/kin-daemon/src/api.rs` is 2,576,656 bytes, so on the hosted kin store any pack that had to read it failed the same way, however few callers it had.

Neither reproduces through the binary on a local store: the repo-scoped route needs hosted storage, and local reads carry no allowance. Both reproduce on the hosted fixture over `kin_db::LocalFileBackend`, the same code path production runs minus GCS.

## What changed

- The pack reads its dependents through a new `collect_graph_reference_members`: the same rows, the same membership (including the skip of a caller the current workspace no longer carries), decided from graph edges and the held tree with no body read. `find_references` keeps the projecting form it serializes.
- A spent allowance and an over-ceiling blob are typed as `McpError::SourceBudgetExhausted` instead of an authority gap.
- When a pack's own projection still runs into the allowance, the row keeps its signature, says `body_withheld: hosted_source_read_cap`, and the payload carries a `degradations` entry `entity_source:hosted_source_read_cap`, which is what `_kin.verdict` reads. The route answers 200.
- `repo_scoped_handler_failure` maps `SourceBudgetExhausted` to `422 source_budget_exhausted, retryable: false` for any other surface that still meets it. A narrower request can succeed; the same request retried cannot.

## Tests

Three hosted tests in `crates/kin-daemon/src/api.rs`, on the existing hosted fixture over `kin_db::LocalFileBackend` (its publish helper now takes explicit `Calls` pairs so a fixture can be star-shaped):

- `a_hosted_context_pack_names_every_caller_without_reading_their_bodies`: one focal, forty callers in forty files, the hosted inspector's exact arguments (`compact: true`, `max_response_chars: 60000`). 200, `certified_dependents` 40, every caller returned or counted as withheld, and the backend was asked for at most one body, the focal's own. Before this change it answered 503.
- `a_hosted_context_pack_on_an_oversized_file_withholds_the_body_and_says_so`: a focal in a file over the per-blob allowance. 200, the focal row says `body_withheld: hosted_source_read_cap`, and `degradations` carries `entity_source:hosted_source_read_cap`. Before this change it answered 503.
- `a_spent_source_allowance_is_the_requests_bound_not_a_retryable_outage`: the handler maps `SourceBudgetExhausted` to 422 `source_budget_exhausted`, not retryable; a real authority gap stays a retryable 503 as the control.

One kin-mcp test in `handlers/mod.rs`, `a_membership_read_names_the_same_callers_without_their_bodies`: the membership form names exactly the callers the projecting form does, skips the one history deleted, and carries no body, with the projecting form's bodies as the control.

Each guard falsified on its own (mutate one spot, run the test written for it, restore the committed file):

Pack back on the projecting collector (`collect_graph_reference_rows` in the pack's references snapshot):

```
test api::tests::a_hosted_context_pack_names_every_caller_without_reading_their_bodies ... FAILED
assertion `left == right` failed: the most-called entity's pack must answer: {"capability":"repo_scoped_semantic_tools_v1","error":{"code":"invalid_semantic_tool_call","message":"context error: context error: hosted source projection budget exhausted: entity ...
  left: 422
 right: 200
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1703 filtered out
```

The withheld-body arm removed from `ContextSourceProvider::full_body`:

```
test api::tests::a_hosted_context_pack_on_an_oversized_file_withholds_the_body_and_says_so ... FAILED
assertion `left == right` failed: a file over the per-blob allowance is the request's bound, not an outage: {"capability":"repo_scoped_semantic_tools_v1","error":{"code":"invalid_semantic_tool_call","message":"context error: hosted source projection budget exh...
  left: 422
 right: 200
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1703 filtered out
```

The handler mapping flipped back to a retryable 503:

```
test api::tests::a_spent_source_allowance_is_the_requests_bound_not_a_retryable_outage ... FAILED
assertion `left == right` failed
  left: 503
 right: 422
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1703 filtered out
```

The membership form made to read bodies:

```
test handlers::tests::a_membership_read_names_the_same_callers_without_their_bodies ... FAILED
the membership form reads no body: [ReferenceRow { entity_id: Some("6c481792-..."), name: "alpha", kind: Some("Function"), file_path: Some("src/caller0.ts"), ...
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1007 filtered out
```

The driver (`falsify-b3.py`) restored the committed file after every arm, checked its blob against HEAD, and ended `restored: 8eddc8372 clean`. Under the two mutations that break the fix, the typed error surfaces as a 422 rather than main's 503, because it no longer carries the authority-gap prefix; either way the pack does not answer.

## Local verification

- `cargo test --locked -p kin-daemon --lib -- a_hosted_context_pack a_spent_source_allowance repo_scoped_source`: 5 passed, 0 failed (the three new tests and the two existing hosted source-read tests).
- `cargo test --locked -p kin-mcp --lib -- every_producer_spells a_membership_read a_reference_set_survives context_pack`: 17 passed, 0 failed.
- `cargo clippy --locked -p kin-mcp -p kin-daemon --all-targets --all-features -- -D warnings` with the allow list from `.github/clippy-allowed-lints.txt`: rc 0.
- `rustfmt --check --edition 2021` on every changed file: clean.
- `bin/kin-precheck kin --repo-dir kin=<lane worktree>` on this head: `kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml` then `kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin 8eddc837293040df1dba1d10a93b1e709104a077`.
