### PR TITLE
Read and commit an exact MCP commit through the daemon's held authority

### DIFF
--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -29,9 +29,9 @@ use crate::local_repository_authority::{
     require_fresh_daemon_workspace, LocalRepositoryAuthorityContext,
 };
 use crate::repository_commit::{
-    commit_native_plan_with_authored_projection, load_native_commit_base, load_native_source_blob,
-    plan_native_commit_from_base_declaring_carry, recover_native_commit, NativeCommitBase,
-    NativeCommitResult,
+    commit_native_plan_with_authored_projection, load_native_commit_base_from,
+    load_native_source_blob, plan_native_commit_from_base_declaring_carry, recover_native_commit,
+    NativeCommitBase, NativeCommitResult,
 };
 use crate::state::DaemonState;
 
@@ -537,8 +537,18 @@ fn commit_exact_transaction_inner(
             .map_err(|error| format!("persist receipt-less committing reset: {error}"))?;
     }
 
-    let base = timed_commit_phase("load_commit_base", || {
-        load_native_commit_base(&authority_context)
+    // The base, the plan and the publication all read and commit through the
+    // authority the daemon holds for the current publication, so a commit pays
+    // no whole-store open of its own when the daemon already holds one, and one
+    // when the record has moved since.
+    let (held_authority, base) = timed_commit_phase("load_commit_base", || {
+        crate::api::held_repository_authority(state)
+            .map_err(|(_, message)| message)
+            .and_then(|authority| {
+                load_native_commit_base_from(&authority, authority_context.workspace_id())
+                    .map(|base| (authority, base))
+                    .map_err(|error| error.to_string())
+            })
     })
     .map_err(|error| format!("load exact MCP commit base: {error}"))?;
     require_bound_authority_revision(state, &base, &transaction_id)?;
@@ -546,6 +556,7 @@ fn commit_exact_transaction_inner(
         plan_exact_transaction(
             state,
             &authority_context,
+            &held_authority,
             &transaction,
             &actor,
             operation_id,
@@ -1144,6 +1155,7 @@ fn semantic_workspace_matches(left: &kin_db::InMemoryGraph, right: &kin_db::InMe
 fn plan_exact_transaction(
     state: &DaemonState,
     authority_context: &LocalRepositoryAuthorityContext,
+    held_authority: &Arc<kin_db::RepositoryAuthorityManager<kin_db::LocalFileBackend>>,
     transaction: &kin_mcp::McpTransaction,
     actor: &CommitActor,
     operation_id: OperationId,
@@ -1522,6 +1534,7 @@ fn plan_exact_transaction(
             &authored_files,
             &|carried| commit_message(&transaction.transaction_id, carried),
             base,
+            Some(Arc::clone(held_authority)),
         )
         .map_err(|error| format!("plan exact MCP repository commit: {error}"))
     };
@@ -2874,8 +2887,16 @@ fn finalize_committed_transaction(
         None => (Vec::new(), None),
     };
     let authority_context = authority_context(state)?;
+    // Through the held resolver: the commit moved the record, so this is the
+    // one fresh open the publication costs, and it is installed under the new
+    // label for every reader after it rather than paid and dropped here.
     let authority = timed_finalize_step("reload_repository_authority", || {
-        load_native_commit_base(&authority_context)
+        crate::api::held_repository_authority(state)
+            .map_err(|(_, message)| message)
+            .and_then(|held| {
+                load_native_commit_base_from(&held, authority_context.workspace_id())
+                    .map_err(|error| error.to_string())
+            })
     })
     .map_err(|error| format!("reload committed MCP repository authority: {error}"))?;
     // A resume has no plan and still owes the same answer, so it recovers the
@@ -4053,6 +4074,46 @@ pub(crate) mod tests {
         assert!(
             after.graph.get_entity(&value.id).unwrap().is_some(),
             "the documented entity keeps its identity"
+        );
+    }
+
+    /// One exact MCP commit pays no whole-store open of its own when the daemon already
+    /// holds the authority for the current publication.
+    ///
+    /// Its base, its plan and its publication read and commit through that one held
+    /// authority. The only open is the finalize's, because the commit moved
+    /// `authority.json`: it is the one fresh load the new publication costs, and the
+    /// readers after the commit borrow it. Before, the base and the plan each opened
+    /// the whole store and the finalize opened it a third time without keeping it.
+    #[test]
+    fn an_exact_commit_reads_and_commits_through_the_held_authority() {
+        let (_dir, state) = test_state();
+        install_exact_source(&state, "src/lib.rs", TRACKED_RS.as_bytes(), "value");
+        // Hold the current publication first, so the count below is the commit's.
+        crate::api::held_repository_authority(&state).unwrap();
+        let before = kin_core::authority_opens();
+
+        let sessions = test_sessions();
+        let result = replace_and_commit(&state, &sessions, "src/lib.rs", DOCUMENTED_RS);
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "the commit must land for its open count to mean anything: {}",
+            result_text(&result)
+        );
+        assert_eq!(
+            kin_core::authority_opens() - before,
+            1,
+            "an exact commit must read its base and plan through the held authority and pay \
+             only the finalize's one fresh load for the publication it made"
+        );
+
+        crate::api::cached_authority_admission(&state).unwrap();
+        crate::api::held_repository_authority(&state).unwrap();
+        assert_eq!(
+            kin_core::authority_opens() - before,
+            1,
+            "the readers after the commit must borrow the finalize's load, not pay their own"
         );
     }
 

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -94,7 +94,11 @@ pub struct NativeCommitPlan {
     previous_tree: kin_model::ResolvedTree,
     target_tree: kin_model::ResolvedTree,
     source_hashes: Vec<Hash256>,
-    authority: RepositoryAuthorityManager<LocalFileBackend>,
+    /// The authority this plan read, still open, which the publication then
+    /// commits through. Shared rather than owned, so a daemon can plan against
+    /// the authority it already holds for the current publication instead of
+    /// opening the whole store again.
+    authority: Arc<RepositoryAuthorityManager<LocalFileBackend>>,
 }
 
 #[derive(Debug)]
@@ -1271,6 +1275,7 @@ pub(crate) fn plan_native_amend(
         None,
         Some(amend),
         SemanticCurrency::DaemonMaintained,
+        None,
     )
 }
 
@@ -1298,6 +1303,7 @@ pub(crate) fn plan_native_commit(
         None,
         None,
         SemanticCurrency::DaemonMaintained,
+        None,
     )
 }
 
@@ -1331,6 +1337,7 @@ pub(crate) fn plan_native_commit_from_base(
         Some(&base.roots),
         None,
         SemanticCurrency::AuthoritySnapshot,
+        None,
     )
 }
 
@@ -1362,6 +1369,7 @@ pub(crate) fn plan_native_commit_from_base_declaring_carry(
     authored_files: &BTreeSet<RepoPath>,
     message: &dyn Fn(&[RepoPath]) -> String,
     base: &NativeCommitBase,
+    held: Option<Arc<RepositoryAuthorityManager<LocalFileBackend>>>,
 ) -> Result<NativeCommitPlan> {
     plan_native_commit_inner(
         graph,
@@ -1375,6 +1383,7 @@ pub(crate) fn plan_native_commit_from_base_declaring_carry(
         Some(&base.roots),
         None,
         SemanticCurrency::AuthoritySnapshot,
+        held,
     )
 }
 
@@ -1787,6 +1796,7 @@ fn plan_native_commit_inner(
     expected_roots: Option<&RootBundle>,
     amend: Option<&NativeAmend>,
     currency: SemanticCurrency,
+    held: Option<Arc<RepositoryAuthorityManager<LocalFileBackend>>>,
 ) -> Result<NativeCommitPlan> {
     let repository_id = authority_context.repository_id().clone();
     let workspace_id = authority_context.workspace_id();
@@ -1810,8 +1820,14 @@ fn plan_native_commit_inner(
     // That shape is shared with every phase already named in this function and
     // is not changed here; it is written down so a reader of a live trace does
     // not read the label as tightly as the durations.
-    let authority = crate::mcp_commit::timed_commit_phase("plan_open_authority", || {
-        authority_context.open().map_err(DaemonError::Graph)
+    // A caller that already holds the authority for the current publication
+    // hands it in and this phase costs nothing; otherwise it is one open.
+    let authority = crate::mcp_commit::timed_commit_phase("plan_open_authority", || match held {
+        Some(held) => Ok(held),
+        None => authority_context
+            .open()
+            .map(Arc::new)
+            .map_err(DaemonError::Graph),
     })?;
     let lease = authority.read_authority();
     if expected_roots.is_some_and(|expected| expected != lease.roots()) {
@@ -2198,8 +2214,17 @@ fn plan_native_commit_inner(
 pub(crate) fn load_native_commit_base(
     authority_context: &LocalRepositoryAuthorityContext,
 ) -> Result<NativeCommitBase> {
-    let workspace_id = authority_context.workspace_id();
     let authority = authority_context.open().map_err(DaemonError::Graph)?;
+    load_native_commit_base_from(&authority, authority_context.workspace_id())
+}
+
+/// [`load_native_commit_base`] against an authority the caller already holds,
+/// so a daemon reads its commit base from the authority it holds for the
+/// current publication instead of opening the whole store for it.
+pub(crate) fn load_native_commit_base_from(
+    authority: &RepositoryAuthorityManager<LocalFileBackend>,
+    workspace_id: WorkspaceId,
+) -> Result<NativeCommitBase> {
     let lease = authority.read_authority();
     let workspace = lease
         .metadata()


### PR DESCRIPTION
An exact MCP commit now reads its base and its plan through the daemon's held authority and commits through it, so the commit path pays at most one whole-store open where it paid three.

## Why

On a scratch clone of kin-db (a 1,418,328,932-byte snapshot, 5,710 bodies) one MCP commit opened the whole store for its base (6.4 s), again for its plan (6.4 s), and a third time in the finalize's reload (7.5 s), each open decoding the snapshot and re-verifying every body. The first two read the publication the daemon already held. The third was dropped as soon as the finalize had read it, so every reader after the commit paid again. Numbers, logs and method are in the lane report `authoritycost-20260911.md` (run 3, 3303c1d55 release bytes).

## How

- `load_native_commit_base_from` reads a commit base from an authority the caller holds, and `load_native_commit_base` keeps its open for callers without one.
- `plan_native_commit_inner` and `plan_native_commit_from_base_declaring_carry` take the held authority, and `NativeCommitPlan.authority` is an `Arc`, so the publication commits through the authority the plan read. The other planners pass `None` and open as before.
- In `commit_exact_transaction_inner` the base comes from `held_repository_authority` and the plan borrows the same authority. The finalize's reload goes through the held resolver. The commit moved `authority.json`, so that reload is the one fresh load the new publication costs, and it is installed for the readers after the commit.

kin-db's compare-and-swap still refuses a commit whose base another writer moved, so sharing one authority across base, plan and publication gives up no guard. The daemon's flush cannot commit through the shared authority between them, because the MCP commit holds the coordination gate and the flush only ever tries it.

This builds on #1725 (the daemon's held authority) and lands after it.

## Numbers

Same store (fresh APFS clones of one kin-db store), same driver and settings, one standalone daemon each, both on the same main (427eb6e9e). Before is run 4 on #1725's bytes. After is run 5 on #1725 plus this change. Whole-store opens that started in each phase, with their summed milliseconds:

| phase | before opens (ms) | after opens (ms) | before wall s | after wall s |
|---|---|---|---|---|
| MCP commit | 3 (22,614) | 1 (7,134) | 168.2 | 158.6 |
| refs read right after the commit | 1 (7,186) | 0 | 7.30 | 0.035 |
| get_entity_source after it | 1 (7,133) | 1 (7,127) | 7.2 | 7.2 |
| get_context_pack after it | 1 (7,174) | 1 (6,942) | 13.0 | 12.7 |
| dirty stop | 2 (14,442) | 2 (13,318) | 63.6 | 61.9 |
| whole run | 13 | 12 | | |

Inside the commit, `plan_transaction` fell from 7,453 ms to 745 ms, because the base and the plan no longer open the store. The one open left is the finalize's reload (7,595 ms), and the refs read after the commit now borrows it instead of paying 7.3 s of its own. The rest of the commit is kin-db's projection freeze and successor preparation (`reconcile_workspace_and_commit_authority` 126.6 s) and the section rewrite (21.8 s), which this change does not touch. The `get_entity_source` and `get_context_pack` rows are the command and query wrappers, which still hold their own copies until the next PR. The 8-file edit is left out of the table because run 5 admitted it in two rounds where run 4 admitted it in one, and the extra round's two opens belong to admission and the flush, which this change leaves alone.

## Tests

`an_exact_commit_reads_and_commits_through_the_held_authority` in `crates/kin-daemon/src/mcp_commit.rs` commits one staged replace while the daemon holds the current publication. On the kin-core funnel's thread-local count, the commit must pay exactly one open and the readers after it none.

```text
$ cargo test -p kin-daemon --lib
test result: ok. 1701 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 307.93s
```

## Falsification

Each arm went on top of the committed fix, and its replacement had to match exactly once. After each arm both files came back from the commit, with the tree checked clean. Both arms went red.

```text
arm plan_opens (the plan opens its own authority again instead of borrowing the held one)
test mcp_commit::tests::an_exact_commit_reads_and_commits_through_the_held_authority ... FAILED
panicked at crates/kin-daemon/src/mcp_commit.rs:4104:9
  left: 2
 right: 1
test result: FAILED. 0 passed; 1 failed

arm finalize_opens (the finalize reloads through a private open instead of the held resolver)
test mcp_commit::tests::an_exact_commit_reads_and_commits_through_the_held_authority ... FAILED
panicked at crates/kin-daemon/src/mcp_commit.rs:4109:9
  left: 2
 right: 1
test result: FAILED. 0 passed; 1 failed
```

Under `finalize_opens` the commit itself still pays one open, and the second assertion catches the readers after it paying another, because the private reload was never installed.

## Local gates

```text
$ bin/kin-precheck kin --repo-dir kin=<this worktree>
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin c4fdbb19cc748deb0c7ec91bcc18f685408cdfa8
```

kin's Product Acceptance job grades main after landing, not this pull request.
