### PR TITLE
Add the agent-write suite to the acceptance inventory and run the visibility rule on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1042,6 +1042,14 @@ jobs:
       - name: Test bounded brownfield trace witnesses
         run: python3 scripts/acceptance/test_brownfield_trace_witness.py
 
+      # acceptance.yml runs the step visibility rule only on a push to main, so a
+      # pull request that adds a report-producing suite without its inventory entry
+      # lands green and turns every acceptance run on main red (kin#1703, 2026-09-11).
+      - name: Falsify and enforce the workflow step visibility rule
+        run: |
+          python3 scripts/acceptance/test_workflow_step_visibility.py --self-test
+          python3 scripts/acceptance/test_workflow_step_visibility.py
+
       # magic-repro case 16 reads two surfaces and decides whether they agree,
       # and acceptance.yml never grades that reading on a pull request. kin#1642
       # added the arm and the daemon route it exercises in one commit, and the

--- a/scripts/acceptance/test_workflow_step_visibility.py
+++ b/scripts/acceptance/test_workflow_step_visibility.py
@@ -128,6 +128,11 @@ EXPECTED_SUITES = (
         "acceptance/working_copy_freshness.json",
     ),
     ExpectedSuite(
+        "scripts/acceptance/agent_write_publish_repro.py",
+        "agent_write",
+        "acceptance/agent_write.json",
+    ),
+    ExpectedSuite(
         "scripts/acceptance/vcs_read_surfaces_repro.py",
         "vcs_read_surfaces",
         "acceptance/vcs_read_surfaces.json",


### PR DESCRIPTION
Product Acceptance has been red on every push to main since 10:20Z on 2026-09-11 (issue #1712). #1703 added the agent-write acceptance suite to acceptance.yml without adding it to the reviewed inventory in scripts/acceptance/test_workflow_step_visibility.py, so the step "Falsify and enforce the workflow step visibility rule" fails with `VIOLATION: report-producing suite inventory or order changed` (29 suites in the workflow, 28 expected), every step behind it without `if: always()` is skipped, the release build never runs, `target/release/kin` does not exist, and all 28 suites report nothing (68 findings per run). Nothing on a pull request runs that rule, because Product Acceptance carries `if: github.event_name != 'pull_request'`, which is how #1703 landed green.

Two changes:

1. `scripts/acceptance/test_workflow_step_visibility.py`: the agent-write suite joins `EXPECTED_SUITES` between the working-copy freshness suite and the VCS read-surface suite, where the workflow runs it.
2. `.github/workflows/ci.yml`: the `fast-gate-lint` job runs the rule's self-test and the rule on every pull request, beside the other acceptance-side checks that acceptance.yml cannot grade on a pull request. The `check` job is untouched, since `bin/kin-precheck` enumerates that job's steps by name.

Verification, run on this head from the worktree root:

```
$ python3 scripts/acceptance/test_workflow_step_visibility.py --self-test
self-test: all 2 controls clean, all 24 adversarial mutants caught
$ python3 scripts/acceptance/test_workflow_step_visibility.py
workflow authority holds: 29 suite reports reach one always-running verdict in order
$ ruby -ryaml -e 'YAML.load_file(ARGV[0]); puts "yaml ok"' .github/workflows/ci.yml
yaml ok
```

On the merged sha the next Product Acceptance run on main should build the binaries and grade all 29 suites again.
