### PR TITLE
Rank, page and describe the hosted entity list

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -1618,6 +1618,11 @@ fn default_true() -> bool {
 pub struct RepoEntitiesResponse {
     pub repo_id: String,
     pub entities: Vec<RepoEntityEntry>,
+    /// Entities the filter matched before the window, present only when the
+    /// caller asked for a window. Without it a paging reader cannot tell a last
+    /// page from a full one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total: Option<usize>,
 }
 
 /// Repo file listing response.
@@ -1678,12 +1683,30 @@ pub struct RepoHistoryEntry {
 }
 
 /// A single entity entry returned from the multi-repo search.
+///
+/// Everything past `file_path` is optional and absent unless the caller asked
+/// for it, so a reader of this row keeps reading it unchanged.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RepoEntityEntry {
     pub id: String,
     pub name: String,
     pub kind: String,
     pub file_path: Option<String>,
+    /// Distinct undirected (neighbour, kind) pairs, the graph export's own
+    /// definition of degree, so a list and a picture of one repository agree.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub degree: Option<usize>,
+    /// Distinct entities that reach this one over a call, an import or a
+    /// reference, self excluded and receiver-name guesses excluded: the set the
+    /// reference surface certifies, and the number importance orders by.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dependents: Option<usize>,
+    /// The declaration as the graph recorded it, collapsed to one line.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature: Option<String>,
+    /// The first line of the entity's doc summary, when it has one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
 }
 
 /// Provenance hash chain step — one level in the Merkle DAG proof lineage.
@@ -1740,10 +1763,26 @@ pub struct ProvenanceBrokenChain {
 }
 
 /// Query parameters for multi-repo entity search.
+///
+/// A request that names none of the optional ones gets the response this route
+/// has always served, in the order it has always served it.
 #[derive(Debug, Deserialize)]
 struct RepoEntitiesQuery {
     #[serde(default)]
     query: Option<String>,
+    /// `importance` puts what most of the repository depends on first. Absent
+    /// keeps the graph's own order.
+    #[serde(default)]
+    order: Option<String>,
+    /// Rows to return, from `offset`. Absent returns every matching row.
+    #[serde(default)]
+    limit: Option<usize>,
+    /// Rows to skip before the window. Absent starts at the first row.
+    #[serde(default)]
+    offset: Option<usize>,
+    /// Comma-separated optional row fields: `ranking`, `signature`, `summary`.
+    #[serde(default)]
+    include: Option<String>,
 }
 
 /// The current API version number, returned in the `X-Kin-API-Version` header.
@@ -17241,35 +17280,253 @@ async fn repo_health(
     }))
 }
 
-/// GET /repos/{repo_id}/entities?query=X — search entities in a specific repo's graph.
+/// GET /repos/{repo_id}/entities: the entities of one repository's graph.
+///
+/// `query` narrows by name as it always has. `order=importance` puts what the
+/// rest of the repository most depends on first, `limit` and `offset` window the
+/// result, and `include` adds the ranking numbers, the signature and the doc
+/// summary to each row. A request that names none of those is answered exactly
+/// as before: every matching entity, in the graph's own order, four fields to a
+/// row, which is what keeps a reader of today's shape reading it unchanged.
 async fn repo_entities(
     Path(repo_id): Path<String>,
     Query(params): Query<RepoEntitiesQuery>,
     State(state): State<Arc<DaemonState>>,
 ) -> std::result::Result<impl IntoResponse, (StatusCode, String)> {
     let graph = repo_scoped_graph(&state, &repo_id).await?;
+    let order = RepoEntityOrder::parse(params.order.as_deref())?;
+    let fields = RepoEntityFields::parse(params.include.as_deref())?;
+    let window = repo_entity_window(params.limit, params.offset)?;
+    let query = params.query.clone();
+    let repo = repo_id.clone();
 
-    let filter = kin_model::EntityFilter {
-        name_pattern: params.query.clone(),
-        ..Default::default()
-    };
-
-    let entities = graph.query_entities(&filter).map_err(internal_error)?;
-
-    let entries: Vec<RepoEntityEntry> = entities
-        .into_iter()
-        .map(|e| RepoEntityEntry {
-            id: e.id.to_string(),
-            name: e.name.clone(),
-            kind: format!("{:?}", e.kind),
-            file_path: e.file_origin.as_ref().map(|f| f.0.clone()),
+    // Ranking reads every entity's relations, which is real CPU work at
+    // repository scale, so it runs off the request thread for the reason the
+    // graph export's projection does: one caller's ranking must not stall every
+    // other request this runtime is serving.
+    tokio::task::spawn_blocking(move || {
+        let filter = kin_model::EntityFilter {
+            name_pattern: query,
+            ..Default::default()
+        };
+        let mut matched = graph.query_entities(&filter)?;
+        let ranks = if order == RepoEntityOrder::Importance || fields.ranking {
+            Some(repo_entity_ranks(graph.as_ref())?)
+        } else {
+            None
+        };
+        if let (RepoEntityOrder::Importance, Some(ranks)) = (order, ranks.as_ref()) {
+            matched.sort_by(|left, right| {
+                let (left_rank, right_rank) = (entity_rank(ranks, left), entity_rank(ranks, right));
+                right_rank
+                    .dependents
+                    .cmp(&left_rank.dependents)
+                    .then_with(|| right_rank.degree.cmp(&left_rank.degree))
+                    .then_with(|| left.name.cmp(&right.name))
+                    .then_with(|| left.id.cmp(&right.id))
+            });
+        }
+        // The population this window was cut from, so a reader of one page can
+        // tell a last page from a full one. Absent when no window was asked for,
+        // where the rows are the population.
+        let total = window.map(|_| matched.len());
+        let rows: Vec<kin_model::Entity> = match window {
+            Some((offset, limit)) => matched.into_iter().skip(offset).take(limit).collect(),
+            None => matched,
+        };
+        let entries = rows
+            .into_iter()
+            .map(|entity| {
+                let rank = ranks.as_ref().map(|ranks| entity_rank(ranks, &entity));
+                RepoEntityEntry {
+                    id: entity.id.to_string(),
+                    name: entity.name.clone(),
+                    kind: format!("{:?}", entity.kind),
+                    file_path: entity.file_origin.as_ref().map(|f| f.0.clone()),
+                    degree: rank.map(|rank| rank.degree),
+                    dependents: rank.map(|rank| rank.dependents),
+                    signature: fields
+                        .signature
+                        .then(|| one_line(&entity.signature))
+                        .flatten(),
+                    summary: fields
+                        .summary
+                        .then(|| entity.doc_summary.as_deref().and_then(one_line))
+                        .flatten(),
+                }
+            })
+            .collect();
+        Ok::<_, anyhow::Error>(RepoEntitiesResponse {
+            repo_id: repo,
+            entities: entries,
+            total,
         })
-        .collect();
+    })
+    .await
+    .map_err(internal_error)?
+    .map(Json)
+    .map_err(internal_error)
+}
 
-    Ok(Json(RepoEntitiesResponse {
-        repo_id,
-        entities: entries,
-    }))
+/// How a caller asked the entity list to be ordered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RepoEntityOrder {
+    /// The graph's own order: entity id, or name rank when `query` narrowed it.
+    Graph,
+    /// What the repository most depends on first.
+    Importance,
+}
+
+impl RepoEntityOrder {
+    /// Refuse an order this route cannot serve rather than quietly answering in
+    /// another one. A caller that asked to be ranked and was not would publish
+    /// the unranked list as ranked.
+    fn parse(raw: Option<&str>) -> std::result::Result<Self, (StatusCode, String)> {
+        match raw.map(str::trim) {
+            None | Some("") => Ok(Self::Graph),
+            Some("importance") => Ok(Self::Importance),
+            Some(other) => Err((
+                StatusCode::BAD_REQUEST,
+                format!("order must be 'importance' when given; got '{other}'"),
+            )),
+        }
+    }
+}
+
+/// The optional row fields a caller asked for.
+#[derive(Debug, Clone, Copy, Default)]
+struct RepoEntityFields {
+    ranking: bool,
+    signature: bool,
+    summary: bool,
+}
+
+impl RepoEntityFields {
+    fn parse(raw: Option<&str>) -> std::result::Result<Self, (StatusCode, String)> {
+        let mut fields = Self::default();
+        for name in raw
+            .unwrap_or_default()
+            .split(',')
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+        {
+            match name {
+                "ranking" => fields.ranking = true,
+                "signature" => fields.signature = true,
+                "summary" => fields.summary = true,
+                other => {
+                    return Err((
+                        StatusCode::BAD_REQUEST,
+                        format!(
+                            "include accepts 'ranking', 'signature' and 'summary'; got '{other}'"
+                        ),
+                    ))
+                }
+            }
+        }
+        Ok(fields)
+    }
+}
+
+/// The `(offset, limit)` a caller asked for, and `None` for the whole list.
+///
+/// A zero limit is refused rather than clamped, for the reason every other
+/// bounded read on these routes refuses it: clamping answers a request for
+/// nothing with a page, and the caller cannot tell the cap from its own request.
+fn repo_entity_window(
+    limit: Option<usize>,
+    offset: Option<usize>,
+) -> std::result::Result<Option<(usize, usize)>, (StatusCode, String)> {
+    match (limit, offset) {
+        (None, None) => Ok(None),
+        (Some(0), _) => Err((
+            StatusCode::BAD_REQUEST,
+            "limit must be at least 1; leave it out to read the whole list".to_string(),
+        )),
+        (limit, offset) => Ok(Some((offset.unwrap_or(0), limit.unwrap_or(usize::MAX)))),
+    }
+}
+
+/// One entity's place in its graph.
+#[derive(Debug, Clone, Copy, Default)]
+struct RepoEntityRank {
+    degree: usize,
+    dependents: usize,
+}
+
+fn entity_rank(
+    ranks: &HashMap<EntityId, RepoEntityRank>,
+    entity: &kin_model::Entity,
+) -> RepoEntityRank {
+    ranks.get(&entity.id).copied().unwrap_or_default()
+}
+
+/// Degree and certified dependents for every entity of one graph, in one pass.
+///
+/// `degree` is the graph export's own definition, distinct undirected
+/// (neighbour, kind) pairs among entity-to-entity edges, so the list and the
+/// picture of one repository cannot disagree about how connected a thing is.
+///
+/// `dependents` is the other half, and the one importance orders by, because
+/// degree alone ranks a long test function that calls fifty things above the
+/// function fifty things call. It counts distinct entities that reach this one
+/// over a call, an import or a reference, excluding the entity itself and
+/// excluding receiver-name guesses, which is exactly the set the reference
+/// surface certifies: those guesses bind `x.clone()` to every method named
+/// `clone` in the repository, and counting them would rank the guess.
+fn repo_entity_ranks(
+    graph: &kin_db::InMemoryGraph,
+) -> anyhow::Result<HashMap<EntityId, RepoEntityRank>> {
+    let entities = graph.list_all_entities()?;
+    let known: HashSet<EntityId> = entities.iter().map(|entity| entity.id).collect();
+    let reference_kinds = kin_mcp::handlers::common::default_reference_kinds();
+    let mut edges: HashSet<(EntityId, EntityId, kin_model::RelationKind)> = HashSet::new();
+    let mut dependents: HashMap<EntityId, HashSet<EntityId>> = HashMap::new();
+    for entity in &entities {
+        for relation in graph.get_all_relations_for_entity(&entity.id)? {
+            let (Some(source), Some(destination)) =
+                (relation.src.as_entity(), relation.dst.as_entity())
+            else {
+                continue;
+            };
+            if !known.contains(&source) || !known.contains(&destination) {
+                continue;
+            }
+            let pair = if source <= destination {
+                (source, destination)
+            } else {
+                (destination, source)
+            };
+            edges.insert((pair.0, pair.1, relation.kind));
+            // Counted from the destination's own walk, so each edge is read
+            // once however many entities report it.
+            if destination == entity.id
+                && source != destination
+                && reference_kinds.contains(&relation.kind)
+                && !kin_index::resolution::is_receiver_name_guess(&relation)
+            {
+                dependents.entry(destination).or_default().insert(source);
+            }
+        }
+    }
+    let mut ranks: HashMap<EntityId, RepoEntityRank> = HashMap::new();
+    for (source, destination, _kind) in &edges {
+        ranks.entry(*source).or_default().degree += 1;
+        ranks.entry(*destination).or_default().degree += 1;
+    }
+    for (entity_id, reaching) in dependents {
+        ranks.entry(entity_id).or_default().dependents = reaching.len();
+    }
+    Ok(ranks)
+}
+
+/// One line of text, whitespace collapsed, or `None` when there is none.
+///
+/// A signature the parser recorded across several lines is still one
+/// declaration, and a row that carries it as such is what a list can render.
+fn one_line(text: &str) -> Option<String> {
+    let collapsed = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    (!collapsed.is_empty()).then_some(collapsed)
 }
 
 /// GET /repos/{repo_id}/files — list the default ref's exact repository tree.
@@ -43993,6 +44250,244 @@ mod tests {
     /// is `/repos/{repo_id}/entities`, which carries no relations at all, so a
     /// renderer has nothing to draw an edge from except the file each entity
     /// happens to sit in.
+    /// A graph with the shape ranking exists for: one entity the repository
+    /// depends on, one that depends on plenty and that nothing needs, and one
+    /// that only a receiver-name guess reaches.
+    ///
+    /// `noisy` carries the higher degree of the two, which is exactly why degree
+    /// alone cannot order this list: it is the long test function that calls
+    /// five things, and nothing calls it.
+    async fn ranked_entities_state() -> (Arc<DaemonState>, String) {
+        let state = test_state();
+        let repo_id = advertised_repo_id(Arc::clone(&state)).await;
+        let hub = test_entity("hub", "src/hub.py");
+        state.graph.upsert_entity(&hub).unwrap();
+        for index in 0..3 {
+            let caller = test_entity(&format!("caller_{index}"), &format!("src/c{index}.py"));
+            state.graph.upsert_entity(&caller).unwrap();
+            link(&state, &caller, &hub, kin_model::RelationKind::Calls);
+        }
+        let noisy = test_entity("noisy", "src/noisy.py");
+        state.graph.upsert_entity(&noisy).unwrap();
+        for index in 0..5 {
+            let callee = test_entity(&format!("callee_{index}"), &format!("src/t{index}.py"));
+            state.graph.upsert_entity(&callee).unwrap();
+            link(&state, &noisy, &callee, kin_model::RelationKind::Calls);
+        }
+        let guessed = test_entity("guessed", "src/guessed.py");
+        let guesser = test_entity("guesser", "src/guesser.py");
+        state.graph.upsert_entity(&guessed).unwrap();
+        state.graph.upsert_entity(&guesser).unwrap();
+        // A receiver-name guess, at the confidence the linker's fan-out tier
+        // stamps, which is what `is_receiver_name_guess` reads.
+        state
+            .graph
+            .upsert_relation(&kin_model::Relation {
+                id: kin_model::RelationId::new(),
+                kind: kin_model::RelationKind::Calls,
+                src: GraphNodeId::Entity(guesser.id),
+                dst: GraphNodeId::Entity(guessed.id),
+                confidence: kin_index::resolution::RECEIVER_NAME_FANOUT_CONFIDENCE,
+                origin: kin_model::RelationOrigin::Inferred,
+                created_in: None,
+                import_source: None,
+                evidence: Vec::new(),
+            })
+            .unwrap();
+        (state, repo_id)
+    }
+
+    async fn ranked_entities(
+        state: Arc<DaemonState>,
+        repo_id: &str,
+        query: &str,
+    ) -> (StatusCode, RepoEntitiesResponse) {
+        let (status, body) = repo_route(state, &format!("/repos/{repo_id}/entities?{query}")).await;
+        if status != StatusCode::OK {
+            return (
+                status,
+                RepoEntitiesResponse {
+                    repo_id: repo_id.to_string(),
+                    entities: Vec::new(),
+                    total: None,
+                },
+            );
+        }
+        (status, serde_json::from_slice(&body).unwrap())
+    }
+
+    /// P1: a request that asks for nothing new gets the response this route has
+    /// always served, field for field. Everything ranking added is opt-in, and a
+    /// consumer reading today's four fields must keep reading them.
+    #[tokio::test]
+    async fn a_repo_entity_list_answers_exactly_as_before_when_nothing_is_asked_of_it() {
+        let (state, repo_id) = ranked_entities_state().await;
+        let (status, body) = repo_route(state, &format!("/repos/{repo_id}/entities")).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let mut top: Vec<&str> = payload
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        top.sort_unstable();
+        assert_eq!(
+            top,
+            ["entities", "repo_id"],
+            "a default answer carries no window and no ranking: {payload}"
+        );
+        for row in payload["entities"].as_array().unwrap() {
+            let mut keys: Vec<&str> = row
+                .as_object()
+                .unwrap()
+                .keys()
+                .map(String::as_str)
+                .collect();
+            keys.sort_unstable();
+            assert_eq!(keys, ["file_path", "id", "kind", "name"], "{row}");
+        }
+    }
+
+    /// P1: importance leads with what the repository depends on, not with what
+    /// is merely busy.
+    #[tokio::test]
+    async fn a_repo_entity_list_ordered_by_importance_leads_with_what_the_repository_depends_on() {
+        let (state, repo_id) = ranked_entities_state().await;
+        let (status, payload) =
+            ranked_entities(state, &repo_id, "order=importance&include=ranking").await;
+        assert_eq!(status, StatusCode::OK);
+        let first = &payload.entities[0];
+        assert_eq!(first.name, "hub", "the entity three others call leads");
+        assert_eq!(first.dependents, Some(3));
+        assert_eq!(first.degree, Some(3));
+        let noisy = payload
+            .entities
+            .iter()
+            .find(|entity| entity.name == "noisy")
+            .expect("the busy entity is still in the list");
+        assert_eq!(
+            noisy.dependents,
+            Some(0),
+            "nothing depends on it however much it calls"
+        );
+        assert_eq!(
+            noisy.degree,
+            Some(5),
+            "and its degree is the higher of the two"
+        );
+    }
+
+    /// P1: a name-only receiver guess is a candidate, not a dependent. Counting
+    /// one would rank the guess: it binds `x.clone()` to every method named
+    /// `clone` in the repository.
+    #[tokio::test]
+    async fn a_repo_entity_list_does_not_count_a_receiver_name_guess_as_a_dependent() {
+        let (state, repo_id) = ranked_entities_state().await;
+        let (status, payload) =
+            ranked_entities(state, &repo_id, "include=ranking&query=guessed").await;
+        assert_eq!(status, StatusCode::OK);
+        let guessed = payload
+            .entities
+            .iter()
+            .find(|entity| entity.name == "guessed")
+            .expect("the guessed entity is in the list");
+        assert_eq!(
+            guessed.dependents,
+            Some(0),
+            "the guess does not certify a dependent"
+        );
+        assert_eq!(
+            guessed.degree,
+            Some(1),
+            "the control: the edge is still there and still counts toward degree"
+        );
+    }
+
+    /// The list and the picture of one repository must not disagree about how
+    /// connected a thing is, so the list's degree is the export's degree for
+    /// every entity of a fixture, not just for one.
+    #[tokio::test]
+    async fn a_repo_entity_lists_degree_is_the_graph_exports_degree() {
+        let (state, repo_id) = ranked_entities_state().await;
+        let export = repo_export_payload(Arc::clone(&state), &repo_id, "limit=0").await;
+        let (status, payload) = ranked_entities(state, &repo_id, "include=ranking").await;
+        assert_eq!(status, StatusCode::OK);
+        let listed: HashMap<String, Option<usize>> = payload
+            .entities
+            .iter()
+            .map(|entity| (entity.id.clone(), entity.degree))
+            .collect();
+        assert_eq!(
+            listed.len(),
+            export.nodes.len(),
+            "both surfaces answer for the same entities"
+        );
+        assert!(
+            export.nodes.iter().any(|node| node.degree > 0),
+            "a fixture where every degree is zero would compare nothing"
+        );
+        for node in &export.nodes {
+            assert_eq!(
+                listed.get(&node.id).copied().flatten(),
+                Some(node.degree),
+                "degree disagrees for {}",
+                node.name
+            );
+        }
+    }
+
+    /// An order this route cannot serve, and a window of nothing, are refused
+    /// rather than answered in some other way: a caller that asked to be ranked
+    /// and was not would publish the unranked list as ranked.
+    #[tokio::test]
+    async fn a_repo_entity_list_refuses_an_order_it_cannot_serve_and_a_zero_limit() {
+        let (state, repo_id) = ranked_entities_state().await;
+        for query in ["order=alphabetical", "limit=0", "include=colour"] {
+            let (status, _) = repo_route(
+                Arc::clone(&state),
+                &format!("/repos/{repo_id}/entities?{query}"),
+            )
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::BAD_REQUEST,
+                "'{query}' must be refused, not quietly ignored"
+            );
+        }
+        // The control: the same route without those answers as before.
+        let (status, _) = repo_route(state, &format!("/repos/{repo_id}/entities")).await;
+        assert_eq!(status, StatusCode::OK);
+    }
+
+    /// A window says what it was cut from, or a reader of one page cannot tell a
+    /// last page from a full one.
+    #[tokio::test]
+    async fn a_repo_entity_window_says_what_it_was_cut_from() {
+        let (state, repo_id) = ranked_entities_state().await;
+        let (_, whole) = ranked_entities(Arc::clone(&state), &repo_id, "order=importance").await;
+        let (status, window) =
+            ranked_entities(state, &repo_id, "order=importance&limit=2&offset=1").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(window.entities.len(), 2);
+        assert_eq!(
+            window.total,
+            Some(whole.entities.len()),
+            "the window reports the population it was cut from"
+        );
+        assert_eq!(whole.total, None, "and the whole list carries no window");
+        let names: Vec<&str> = window
+            .entities
+            .iter()
+            .map(|entity| entity.name.as_str())
+            .collect();
+        let expected: Vec<&str> = whole.entities[1..3]
+            .iter()
+            .map(|entity| entity.name.as_str())
+            .collect();
+        assert_eq!(names, expected, "the window is that slice of the order");
+    }
+
     #[tokio::test]
     async fn a_repo_scoped_export_draws_the_named_repositorys_relations() {
         let state = test_state();

--- a/packages/boundary-contracts/schemas/repo-entities.schema.json
+++ b/packages/boundary-contracts/schemas/repo-entities.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kin://contracts/repo-entities",
+  "description": "The entities of one repository's graph, as served by GET /repos/{repo_id}/entities on the daemon. Identity is always present on a row; the ranking numbers and the text ride along only when the request asked for them with include, and total appears only when the request asked for a window with limit or offset. A reader of the identity fields alone keeps reading every response this route has ever served.",
+  "type": "object",
+  "required": ["repo_id", "entities"],
+  "additionalProperties": false,
+  "properties": {
+    "repo_id": {
+      "type": "string",
+      "description": "The repository this list was read from."
+    },
+    "entities": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/entity" }
+    },
+    "total": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Entities the filter matched before the window was applied. Present only when the request asked for a window, where it is what separates a last page from a full one."
+    }
+  },
+  "$defs": {
+    "entity": {
+      "type": "object",
+      "required": ["id", "name", "kind", "file_path"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Entity UUID."
+        },
+        "name": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string",
+          "description": "Entity kind in the graph's own spelling, e.g. Function, Method, EnumVariant."
+        },
+        "file_path": {
+          "type": ["string", "null"],
+          "description": "Repository-relative path, or null for an entity the graph placed in no file."
+        },
+        "degree": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Distinct undirected (neighbour, kind) pairs, the same definition the graph export publishes, so a list and a picture of one repository agree. Present only when the request asked for include=ranking or order=importance."
+        },
+        "dependents": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Distinct entities that reach this one over a call, an import or a reference, the entity itself excluded and receiver-name guesses excluded: the set the reference surface certifies, and what order=importance ranks by. Present under the same conditions as degree."
+        },
+        "signature": {
+          "type": "string",
+          "description": "The declaration as the graph recorded it, collapsed to one line. Present only when the request asked for include=signature and the entity has one."
+        },
+        "summary": {
+          "type": "string",
+          "description": "The first line of the entity's doc summary. Present only when the request asked for include=summary and the entity has one."
+        }
+      }
+    }
+  }
+}

--- a/packages/boundary-contracts/src/index.d.ts
+++ b/packages/boundary-contracts/src/index.d.ts
@@ -999,6 +999,50 @@ export interface RepoImportedWorkSummary {
 }
 
 /**
+ * One entity of a repository's graph, as `GET /repos/{repo_id}/entities` serves
+ * it.
+ *
+ * Identity is always present. The ranking numbers and the text ride along only
+ * when the request asked for them, so a consumer reading the identity fields
+ * alone reads every response this route has ever served.
+ */
+export interface RepoEntityEntry {
+  /** Entity UUID. */
+  id: string;
+  name: string;
+  /** Entity kind in the graph's own spelling, e.g. Function, Method, EnumVariant. */
+  kind: string;
+  /** Repository-relative path, or null for an entity the graph placed in no file. */
+  file_path: string | null;
+  /**
+   * Distinct undirected (neighbour, kind) pairs, the same definition the graph
+   * export publishes. Present only under include=ranking or order=importance.
+   */
+  degree?: number;
+  /**
+   * Distinct entities that reach this one over a call, an import or a
+   * reference, the entity itself and receiver-name guesses excluded. This is
+   * what order=importance ranks by. Present under the same conditions as degree.
+   */
+  dependents?: number;
+  /** The declaration as the graph recorded it, collapsed to one line. */
+  signature?: string;
+  /** The first line of the entity's doc summary. */
+  summary?: string;
+}
+
+/** The entities of one repository's graph. */
+export interface RepoEntitiesResponse {
+  repo_id: string;
+  entities: RepoEntityEntry[];
+  /**
+   * Entities the filter matched before the window. Present only when the
+   * request asked for one with limit or offset.
+   */
+  total?: number;
+}
+
+/**
  * The drawable projection of a Kin repository graph.
  *
  * Served by `GET /graph/export` and `GET /repos/{repo_id}/graph/export` on the

--- a/packages/boundary-contracts/src/index.js
+++ b/packages/boundary-contracts/src/index.js
@@ -31,7 +31,8 @@ const schemaFiles = {
   shadowGateReport: 'shadow-gate-report.schema.json',
   hostedRepositoryTransfer: 'hosted-repository-transfer.schema.json',
   graphExport: 'graph-export.schema.json',
-  graphEvent: 'graph-event.schema.json'
+  graphEvent: 'graph-event.schema.json',
+  repoEntities: 'repo-entities.schema.json'
 };
 
 const schemaIdMap = {

--- a/packages/boundary-contracts/test/contracts.test.js
+++ b/packages/boundary-contracts/test/contracts.test.js
@@ -32,6 +32,7 @@ test('all schemas load', async () => {
   assert.ok(schemas.repoScopedSemanticToolError);
   assert.ok(schemas.shadowGateReport);
   assert.ok(schemas.daemonError);
+  assert.ok(schemas.repoEntities);
 });
 
 test('a daemon refusal body carries its marker only when the daemon set it', async () => {
@@ -998,6 +999,90 @@ test('the graph feed shape is one contract the Rust, the schema and the declarat
     ['GraphExportLink', rustStructFields(exportSource, 'GraphExportLink').fields, Object.keys(exportSchema.$defs.link.properties)],
     ['GraphExport', rustStructFields(exportSource, 'GraphExportPayload').fields, Object.keys(exportSchema.properties)],
     ['GraphNodeSummary', rustStructFields(stateSource, 'GraphNodeSummary').fields, Object.keys(eventSchema.$defs.nodeSummary.properties)]
+  ];
+
+  for (const [name, rustFields, schemaFields] of pairs) {
+    assert.deepEqual(
+      [...rustFields].sort(),
+      [...schemaFields].sort(),
+      `${name}: the Rust struct and the JSON Schema must carry the same fields`
+    );
+    const declared = declaredInterfaceFields(declarations, name);
+    assert.ok(declared, `${name} must be declared in index.d.ts`);
+    assert.deepEqual(
+      [...declared].sort(),
+      [...rustFields].sort(),
+      `${name}: the TypeScript declaration and the Rust struct must carry the same fields`
+    );
+  }
+});
+
+const minimalEntities = {
+  repo_id: 'kin',
+  entities: [
+    { id: 'e1', name: 'alpha', kind: 'Function', file_path: 'src/a.rs' },
+    { id: 'e2', name: 'Beta::make', kind: 'Method', file_path: null }
+  ]
+};
+
+test('an entity list is identity first, and everything ranked rides along', async () => {
+  // The identity shape is what this route has always served, and it stays
+  // valid on its own: a consumer reading it does not have to learn the rest.
+  assert.equal((await validateContract('repoEntities', minimalEntities)).ok, true);
+
+  const ranked = structuredClone(minimalEntities);
+  ranked.total = 2;
+  ranked.entities[0].degree = 12;
+  ranked.entities[0].dependents = 4;
+  ranked.entities[0].signature = 'fn alpha() -> usize';
+  ranked.entities[0].summary = 'Counts what alpha counts.';
+  assert.equal(
+    (await validateContract('repoEntities', ranked)).ok,
+    true,
+    'the ranked answer is the same contract with more of it filled in'
+  );
+
+  const { file_path: _dropped, ...noPath } = minimalEntities.entities[0];
+  assert.equal(
+    (await validateContract('repoEntities', { ...minimalEntities, entities: [noPath] })).ok,
+    false,
+    'null is how a row says the graph placed this entity in no file, so the field cannot be absent'
+  );
+
+  const unknown = structuredClone(minimalEntities);
+  unknown.entities[0].rank = 3;
+  assert.equal(
+    (await validateContract('repoEntities', unknown)).ok,
+    false,
+    'a field nobody agreed on is how the three copies of this shape drift apart'
+  );
+});
+
+test('the entity list shape is one contract the Rust, the schema and the declarations agree on', async () => {
+  const [declarations, apiSource, schema] = await Promise.all([
+    fs.readFile(path.join(packageRoot, 'src/index.d.ts'), 'utf8'),
+    fs.readFile(path.join(repositoryRoot, 'crates/kin-daemon/src/api.rs'), 'utf8'),
+    loadSchema('repoEntities')
+  ]);
+
+  // The extractor must be shown to work before an empty result reads as agreement.
+  assert.equal(rustStructFields(apiSource, 'RepoEntityNotAStruct'), null);
+  assert.ok(
+    rustStructFields(apiSource, 'RepoEntityEntry').fields.includes('dependents'),
+    'the Rust extractor must find a field the struct is known to declare'
+  );
+
+  const pairs = [
+    [
+      'RepoEntityEntry',
+      rustStructFields(apiSource, 'RepoEntityEntry').fields,
+      Object.keys(schema.$defs.entity.properties)
+    ],
+    [
+      'RepoEntitiesResponse',
+      rustStructFields(apiSource, 'RepoEntitiesResponse').fields,
+      Object.keys(schema.properties)
+    ]
   ];
 
   for (const [name, rustFields, schemaFields] of pairs) {


### PR DESCRIPTION
The hosted entity list can now be ranked, paged and read at a glance, and a caller that asks for none of that gets exactly the response this route has always served.

`GET /repos/{repo_id}/entities` returned every entity of a repository in one response, in the graph's own order, with four fields to a row: id, name, kind, file path. On kin that is 27,987 rows and 4.26 MB, ordered by entity id, which is content-derived and so arbitrary with respect to importance. The hosted page shows the first fifty of them, and they are whichever fifty happen to sort first.

## What changed

- `order=importance` leads with what the rest of the repository depends on: certified dependents first, then degree, then name, then id.
- `limit` and `offset` window the result, and the response carries `total`, the population the window was cut from, so a reader can tell a last page from a full one. A zero limit is refused rather than clamped.
- `include=ranking,signature,summary` adds the two numbers, the declaration collapsed to one line, and the first line of the doc summary.
- `degree` is the graph export's own definition, distinct undirected (neighbour, kind) pairs, so a list and a picture of one repository cannot disagree. A test pins the two together over a whole fixture graph.
- `dependents` is the number importance ranks by: distinct entities that reach this one over a call, an import or a reference, the entity itself excluded and receiver-name guesses excluded. That exclusion is the point. A name-only receiver guess binds `x.clone()` to every method named `clone` in the repository, so counting those would rank the guess: on a kin-db store `ChangeMap::clone` carries 205 such edges.
- The row is typed in `packages/boundary-contracts`: a new `repo-entities` schema, `RepoEntityEntry` and `RepoEntitiesResponse` declarations, and a test binding the Rust struct, the JSON Schema and the TypeScript declaration to the same field set.

Everything added is optional and absent unless asked for, and the default response is unchanged, so a consumer reading today's four fields keeps reading them. That is what lets this land without the hosted page changing in the same breath.

## Page cost on one store

One scratch store, one daemon, this branch's own release bytes (`kin-daemon 0.7.14 (768eee4b4)`), `KIN_EMBED_BACKEND=cpu`: a fresh kin-db clone holding 5,088 entities and 13,394 relations. Before and after are the same binary on the same store, so the only difference is what the caller asked for.

| call | rows | bytes | time |
|---|---|---|---|
| `/entities`, as today | 5,088 | 801,381 | 13.7 to 19.6 ms |
| `?order=importance&limit=50&include=ranking,signature,summary` | 50, `total` 5,088 | 13,858 | 23.3 to 23.8 ms |
| `?order=importance&include=ranking` | 5,088 | 934,453 | 31.3 ms |

The three samples behind each row, as curl reported them. Default: 801,381 bytes at 0.019584 s, 0.013720 s and 0.014355 s. Ranked page of fifty: 13,858 bytes at 0.023292 s, 0.023583 s and 0.023831 s. Every call answered 200.

The fifty rows a page shows cost 1.7% of the bytes the route moves today, 801 KB down to 13.9 KB. Ranking is one pass over the relations whether or not the result is windowed, which is the 9 ms and the 133 KB in the third row, and the point of the window is that nobody has to pay for the whole list to fill one page. On the hosted kin repo the audit measured that same default call at 27,987 rows and 4.26 MB, with the page showing the first fifty in entity-id order.

The ranked page leads with `KinDbError::StorageError` at 352 dependents and degree 353, then `GraphSnapshot::empty` at 245, `InMemoryGraph::new` at 235 and `LocalFileBackend::new` at 185. Twelve of the fifty are test helpers, which is honest for kin-db: `test_entity` at 130 dependents really is called by 130 entities.

## Tests

Six route tests in `crates/kin-daemon/src/api.rs`, on a fixture built for the shape ranking exists for: `hub`, which three entities call; `noisy`, which calls five and that nothing calls, so it carries the higher degree of the two; and `guessed`, which only a receiver-name guess reaches.

- `a_repo_entity_list_answers_exactly_as_before_when_nothing_is_asked_of_it`: the default answer's top-level keys are `entities` and `repo_id`, and every row's keys are exactly `file_path`, `id`, `kind`, `name`.
- `a_repo_entity_list_ordered_by_importance_leads_with_what_the_repository_depends_on`: `hub` leads with 3 dependents and degree 3, while `noisy` sits lower with 0 dependents and degree 5.
- `a_repo_entity_list_does_not_count_a_receiver_name_guess_as_a_dependent`: `guessed` reports 0 dependents, and degree 1 as the control that the edge is there.
- `a_repo_entity_lists_degree_is_the_graph_exports_degree`: both surfaces are asked for the same fixture and every entity's degree matches, with a guard that the fixture is not all zeros.
- `a_repo_entity_list_refuses_an_order_it_cannot_serve_and_a_zero_limit`: `order=alphabetical`, `limit=0` and `include=colour` each get a 400, and the bare route still answers 200.
- `a_repo_entity_window_says_what_it_was_cut_from`: a window of two at offset one returns that slice of the order and reports the population, while the whole list carries no `total`.

Two contract tests in `packages/boundary-contracts/test/contracts.test.js`: the identity shape validates on its own and the ranked shape is the same contract with more of it filled in, an absent `file_path` and an unknown field are both refused, and the Rust struct, the JSON Schema and the TypeScript declaration are bound to one field set.

Each guard falsified on its own (mutate one spot, run the test written for it, restore the committed file):

Each arm is one exact mutation in `crates/kin-daemon/src/api.rs`, then `cargo test --locked -p kin-daemon --lib -- <that one test>`, so 1,714 other tests are filtered out and only the guard under test is graded. After every arm the file is restored with `git checkout --` and the driver refuses to continue unless the restored blob hashes to HEAD's, ending at `restored: 768eee4b4 clean`. The arms were run at `768eee4b4`, the head before the rebase described under Local verification; the mutations are what prove these tests are sensitive, and a clean rebase does not change that.

**Order by degree instead of dependents.** `noisy` has the higher degree and nothing calls it, so it takes the lead.

```
== arm importance-ignores-dependents: rc=101
   test api::tests::a_repo_entity_list_ordered_by_importance_leads_with_what_the_repository_depends_on ... FAILED
   test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1714 filtered out; finished in 1.85s
   panicked at crates/kin-daemon/src/api.rs:44331:9:
   assertion `left == right` failed: the entity three others call leads
     left: "noisy"
```

**Drop the receiver-name-guess filter.** The guessed entity starts certifying a dependent it never had.

```
== arm guesses-count-as-dependents: rc=101
   test api::tests::a_repo_entity_list_does_not_count_a_receiver_name_guess_as_a_dependent ... FAILED
   test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1714 filtered out; finished in 1.99s
   panicked at crates/kin-daemon/src/api.rs:44364:9:
   assertion `left == right` failed: the guess does not certify a dependent
     left: Some(1)
```

**Count each edge in both directions.** Degree doubles and stops matching the graph export.

```
== arm degree-counts-both-directions: rc=101
   test api::tests::a_repo_entity_lists_degree_is_the_graph_exports_degree ... FAILED
   test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1714 filtered out; finished in 0.90s
   panicked at crates/kin-daemon/src/api.rs:44402:13:
   assertion `left == right` failed: degree disagrees for caller_2
     left: Some(2)
```

**Clamp `limit=0` to the whole list instead of refusing it.** The route answers 200 to a request it cannot honestly serve.

```
== arm zero-limit-clamped: rc=101
   test api::tests::a_repo_entity_list_refuses_an_order_it_cannot_serve_and_a_zero_limit ... FAILED
   test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1714 filtered out; finished in 0.60s
   panicked at crates/kin-daemon/src/api.rs:44419:13:
   assertion `left == right` failed: 'limit=0' must be refused, not quietly ignored
     left: 200
```

## Local verification

This branch was rebased after it was opened. Main had moved one commit ahead with #1726, which edits `crates/kin-daemon/src/api.rs`, the same file this change edits, so it was rebased rather than left to squash onto a main that had moved under it. The rebase was clean, `git diff --name-only origin/main...HEAD` is still exactly the five files, and the tests and gates below were re-run on the rebased head.

- `cargo test --locked -p kin-daemon --lib -- a_repo_entity a_repo_scoped_export`: 8 passed, 0 failed at `768eee4b4`, and 8 passed, 0 failed again at the rebased `bfdac6ee2`.
- `node --test` on `packages/boundary-contracts`: 18 of 18 pass.
- `cargo clippy --locked -p kin-daemon --all-targets --all-features -- -D warnings` with the allow list from `.github/clippy-allowed-lints.txt`: rc 0.
- `rustfmt --check --edition 2021 crates/kin-daemon/src/api.rs`: clean.
- `bin/kin-precheck kin --repo-dir kin=<this worktree>`: `22 gates enumerated from the check job of .github/workflows/ci.yml`, then `22 gates ran, 22 passed, 0 failed, on kin 768eee4b4a1a632d5ea85fab2c35e0fdb7d15b32`, and after the rebase `22 gates ran, 22 passed, 0 failed, on kin bfdac6ee2759f95a6a8e1d3c2065f9effe6782d2`. That tally covers fmt, clippy and every guard script the check job names, `node --test` over its 16 files included.
