### PR TITLE
Answer the file enumeration's pagination honestly on its last page and its cut ones

### DIFF
--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -1282,6 +1282,77 @@ pub(crate) fn collection_rows(payload: &Value, key: &str) -> usize {
         .map_or(0, Vec::len)
 }
 
+/// The budgeted tools whose responses carry a `next_cursor`, and so the tools
+/// whose withheld rows a caller can be handed a way back to.
+///
+/// Two producers mint one today: the daemon's locate route
+/// (`kin-daemon/src/api.rs`, a [`LocateCursor`]) and the file enumeration
+/// (`crate::handlers::file_entities`, a `PageCursor`). Every other budgeted tool
+/// answers one question in one response, so a cut there is recoverable only by
+/// asking a smaller question, which is what the remediation says.
+///
+/// [`repage_primary_after_cut`] must carry an arm for each name here, and
+/// `every_paged_tool_has_a_repage_arm` fails if it does not. A third paged tool
+/// added without an arm silently reintroduces FIR-3554: the rows go, the cursor
+/// does not move, and nothing in the response says the remainder became
+/// unreachable.
+const PAGED_TOOLS: [&str; 2] = ["semantic_locate", FILE_ENTITIES_TOOL];
+
+/// Re-point a paged tool's cursor after the ladder withheld a suffix of the
+/// primary collection, so the rows this response dropped stay reachable.
+///
+/// Returns whether the response now carries a cursor that reaches them. `false`
+/// means the caller has to be told so, which the remediation beside the call
+/// does, rather than being handed a token that skips past what it lost.
+///
+/// The two paged tools rebase differently because their cursors mean different
+/// things. A locate cursor names a held ranking and an absolute offset into it,
+/// so the recovery is to move that offset back by exactly the suffix withheld.
+/// A file-enumeration cursor names a path and an absolute offset into a stable
+/// ordered list, so the recovery is to recompute the offset from what this page
+/// actually served, which works identically whether the handler had minted a
+/// cursor or the page was the file's last one before the cut.
+fn repage_primary_after_cut(
+    payload: &mut Value,
+    tool: &str,
+    locate_cursor: Option<&mut LocateCursor>,
+    withheld: usize,
+    kept: usize,
+) -> bool {
+    if withheld == 0 || kept == 0 {
+        return false;
+    }
+    match tool {
+        "semantic_locate" => {
+            let Some(cursor) = locate_cursor else {
+                return false;
+            };
+            if !cursor.rebase_after_withheld(withheld, kept) {
+                return false;
+            }
+            payload["next_cursor"] = Value::String(cursor.encode());
+            true
+        }
+        FILE_ENTITIES_TOOL => {
+            let Some(token) =
+                crate::handlers::file_entities::PageCursor::after_withheld(payload, kept)
+            else {
+                return false;
+            };
+            payload["next_cursor"] = Value::String(token);
+            // The count beside the rows, which the handler decided before this
+            // cut existed. Left alone it reports the page the handler planned
+            // rather than the one that shipped, so a caller comparing
+            // `returned` against `total_in_file` reads a page as larger than
+            // the array it can see. The elision says how many went and why;
+            // this keeps the plain count honest.
+            payload["returned"] = json!(kept);
+            true
+        }
+        _ => false,
+    }
+}
+
 /// Run the ladder over one payload, recording what it cost in `accounting`.
 ///
 /// Split from [`enforce`] so the size the response ships at is measured on one
@@ -1499,12 +1570,8 @@ fn run_ladder(
             if Some(*key) == primary {
                 primary_withheld = withheld;
                 let kept = found.saturating_sub(withheld);
-                if let Some(cursor) = locate_cursor.as_mut() {
-                    if cursor.rebase_after_withheld(withheld, kept) {
-                        payload["next_cursor"] = Value::String(cursor.encode());
-                        cursor_rebased = true;
-                    }
-                }
+                cursor_rebased =
+                    repage_primary_after_cut(payload, tool, locate_cursor.as_mut(), withheld, kept);
             }
         }
         if measure(payload) <= target {
@@ -1533,10 +1600,18 @@ fn run_ladder(
             remediations.push(format!(
                 "re-issue with `page_size: {kept}` and follow `next_cursor`"
             ));
-        } else if tool == "semantic_locate" && primary_withheld > 0 && locate_cursor.is_none() {
-            // Naming a cursor here would be a recovery the response cannot
-            // provide. The two things that do reach the withheld rows are a
-            // larger ceiling and a narrower question, and the caller owns both.
+        } else if PAGED_TOOLS.contains(&tool) && primary_withheld > 0 {
+            // A paged tool whose cursor could not be re-pointed. Naming a cursor
+            // here would be a recovery the response cannot provide. The two
+            // things that do reach the withheld rows are a larger ceiling and a
+            // narrower question, and the caller owns both.
+            //
+            // Keyed on the paged set rather than on `semantic_locate` alone,
+            // because the sentence is about what a cursor can and cannot reach
+            // and every paged tool can arrive here. It used to name locate by
+            // hand, so the one other tool that mints a cursor fell through to
+            // the generic advice below and never said that the rows it dropped
+            // had become unreachable.
             //
             // The budget knob is named only while it can still move: a caller
             // already at the ceiling, or one whose answer does not fit under
@@ -3079,6 +3154,123 @@ mod tests {
             json!(40),
             "the full ranking size is still reported"
         );
+    }
+
+    /// One page of `crate::handlers::file_entities`, in the shape that handler
+    /// serves, with no `next_cursor`: the page the walk ends on.
+    ///
+    /// That is the page FIR-3554 is about. A cut here used to leave the caller
+    /// holding rows it could not finish, because there was no cursor to move and
+    /// nothing minted one.
+    fn file_entities_final_page(rows: usize, offset: usize, total: usize, body: usize) -> Value {
+        let entities: Vec<Value> = (0..rows)
+            .map(|index| {
+                json!({
+                    "id": format!("00000000-0000-4000-8000-{:012}", offset + index),
+                    "name": format!("entity{}", offset + index),
+                    "kind": "function",
+                    "language": "rust",
+                    "role": "source",
+                    "visibility": "public",
+                    "signature": "x".repeat(body),
+                    "start_line": 1,
+                    "end_line": 2,
+                })
+            })
+            .collect();
+        json!({
+            "path": "src/lib.rs",
+            "entities": entities,
+            "returned": rows,
+            "total_in_file": total,
+            "page_size": rows,
+            "offset": offset,
+            "next_cursor": Value::Null,
+            "truncated": false,
+        })
+    }
+
+    /// FIR-3554, the half the budget owns. A page cut by the character ceiling
+    /// must hand back a cursor that reaches what it dropped, even when the page
+    /// arrived with none because it was the file's last.
+    ///
+    /// Before this, `repage_primary_after_cut` ran for `semantic_locate` alone,
+    /// so a file enumeration lost its tail and was told to narrow `page_size`,
+    /// which asks a different question instead of finishing this one.
+    #[test]
+    fn a_budget_cut_on_a_file_enumeration_mints_a_reachable_cursor() {
+        let mut payload = file_entities_final_page(40, 200, 240, 600);
+        let budget = ResponseBudget {
+            max_chars: 6_000,
+            ..ResponseBudget::default()
+        };
+        enforce(&mut payload, FILE_ENTITIES_TOOL, &budget).expect("budgeted");
+        let kept = payload["entities"].as_array().expect("entities").len();
+        assert!(
+            kept < 40,
+            "the ceiling has to bite for this to test anything"
+        );
+        assert!(kept > 0, "a bound is not a refusal");
+        let token = payload["next_cursor"]
+            .as_str()
+            .expect("a cut page carries the cursor to its remainder");
+        let cursor = crate::handlers::file_entities::PageCursor::decode(token)
+            .expect("the minted token is this tool's own cursor");
+        assert_eq!(
+            cursor.offset,
+            200 + kept,
+            "the cursor must name the first row this response did not serve"
+        );
+        assert_eq!(cursor.path, "src/lib.rs");
+        assert_eq!(cursor.total, 240);
+        assert_eq!(
+            payload["returned"],
+            json!(kept),
+            "`returned` must count the rows that shipped, not the ones planned"
+        );
+        assert_eq!(payload["truncated"], json!(true));
+    }
+
+    /// Every name in [`PAGED_TOOLS`] reaches an arm that actually re-points a
+    /// cursor, and a tool outside the list reaches none.
+    ///
+    /// The list and the arms are two places one fact is written. A third paged
+    /// tool added to the list without an arm, or given an arm that cannot mint,
+    /// puts FIR-3554 back silently: the rows go and the cursor stays put.
+    #[test]
+    fn every_paged_tool_has_a_repage_arm() {
+        for tool in PAGED_TOOLS {
+            let (mut payload, mut locate) = match tool {
+                "semantic_locate" => (
+                    locate_payload(40, 300),
+                    Some(LocateCursor {
+                        key: "ranking".to_string(),
+                        page: 1,
+                        next_offset: Some(40),
+                        page_size: Some(40),
+                    }),
+                ),
+                FILE_ENTITIES_TOOL => (file_entities_final_page(40, 200, 240, 600), None),
+                other => panic!("{other} is in PAGED_TOOLS with no case here"),
+            };
+            assert!(
+                repage_primary_after_cut(&mut payload, tool, locate.as_mut(), 30, 10),
+                "{tool} is listed as paged but could not re-point its cursor"
+            );
+            assert!(
+                payload["next_cursor"]
+                    .as_str()
+                    .is_some_and(|t| !t.is_empty()),
+                "{tool} reported a re-point and left no cursor"
+            );
+        }
+
+        let mut unpaged = json!({"results": [1, 2, 3], "next_cursor": Value::Null});
+        assert!(
+            !repage_primary_after_cut(&mut unpaged, "semantic_search", None, 2, 1),
+            "an unpaged tool must not be handed a cursor it never mints"
+        );
+        assert_eq!(unpaged["next_cursor"], Value::Null);
     }
 
     fn cosine_locate_payload(hits: usize) -> Value {

--- a/crates/kin-mcp/src/handlers/file_entities.rs
+++ b/crates/kin-mcp/src/handlers/file_entities.rs
@@ -1284,7 +1284,6 @@ mod tests {
         let store = store_with(7, Some(ParseCompleteness::Full));
         let mut cursor: Option<String> = None;
         let mut pages = 0;
-        let mut last_truncated = true;
 
         loop {
             let mut args = vec![("page_size", serde_json::json!(3))];
@@ -1313,20 +1312,23 @@ mod tests {
                 payload["next_cursor"].as_str().is_some(),
                 "truncated and next_cursor must agree: page {pages}"
             );
-            last_truncated = truncated;
-
             match payload["next_cursor"].as_str() {
                 Some(token) => cursor = Some(token.to_string()),
-                None => break,
+                // Asserted where the final page is identified, rather than
+                // carried out of the loop in a variable whose initial value
+                // no path ever reads.
+                None => {
+                    assert!(
+                        !truncated,
+                        "the final page of a walk has nothing left to fetch"
+                    );
+                    break;
+                }
             }
             assert!(pages < 10, "cursor walk did not terminate");
         }
 
         assert_eq!(pages, 3, "7 entities at page_size 3 is three pages");
-        assert!(
-            !last_truncated,
-            "the final page of a walk has nothing left to fetch"
-        );
     }
 
     /// Pagination walks the whole set with no duplicates and no silent cap.

--- a/crates/kin-mcp/src/handlers/file_entities.rs
+++ b/crates/kin-mcp/src/handlers/file_entities.rs
@@ -446,6 +446,36 @@ impl PageCursor {
             total: value.get("t")?.as_u64()? as usize,
         })
     }
+
+    /// The cursor reaching the rows a response budget withheld from one page of
+    /// this tool, read off the served payload.
+    ///
+    /// The budget cuts a suffix of `entities` after the handler has already
+    /// decided this page's `next_cursor`, so the token the caller receives names
+    /// a row the response no longer carries, or is null on a page that was whole
+    /// before the cut. Either way the withheld rows become unreachable by
+    /// paging, and the caller is told to narrow `page_size`, which asks a
+    /// different question rather than finishing this one.
+    ///
+    /// Recomputing rather than adjusting the old token is what makes both cases
+    /// one case. This enumeration is a stable ordered list addressed by absolute
+    /// offset, so the first row not served is always `offset + kept`, whatever
+    /// the handler had planned. `None` means the cut left nothing beyond this
+    /// page, which is the only honest answer a cursor cannot give.
+    pub fn after_withheld(payload: &serde_json::Value, kept: usize) -> Option<String> {
+        let path = payload.get("path")?.as_str()?;
+        let offset = payload.get("offset")?.as_u64()? as usize;
+        let total = payload.get("total_in_file")?.as_u64()? as usize;
+        let reached = offset.checked_add(kept)?;
+        (reached < total).then(|| {
+            Self {
+                path: path.to_string(),
+                offset: reached,
+                total,
+            }
+            .encode()
+        })
+    }
 }
 
 /// Normalize a caller's path to the spelling the graph stores.
@@ -683,9 +713,19 @@ pub fn handle_list_file_entities<G: GraphStore>(
         "page_size": page_size,
         "offset": offset,
         "next_cursor": next_cursor,
-        // The same flag `kin_artifact_list` and `semantic_search` publish, in
-        // the same sense: this response does not hold everything it counted.
-        "truncated": next_cursor.is_some() || offset > 0,
+        // Whether rows remain past this response, which is the same sense
+        // `kin_artifact_list` publishes: `offset + returned < total`
+        // ([`crate::handlers::artifacts`]). This flag used to read
+        // `next_cursor.is_some() || offset > 0` under a comment claiming that
+        // parity, and the two disagreed on exactly the page a pager acts on:
+        // the last one. A walk's final page has `offset > 0` and no cursor, so
+        // it announced more to fetch over a response after which there is
+        // nothing, and an agent paging on the flag either loops or gives up
+        // holding a complete set it was told was partial. The count fields say
+        // how much of the file this page holds (`returned` against
+        // `total_in_file`); this says whether to ask again, and `next_cursor`
+        // is what answers it.
+        "truncated": next_cursor.is_some(),
         "enumeration_shifted": enumeration_shifted,
         FILE_COVERAGE_KEY: {
             "path": path,
@@ -1227,6 +1267,66 @@ mod tests {
             // answer it can still act on.
             assert_eq!(payload["total_in_file"], serde_json::json!(4));
         }
+    }
+
+    /// FIR-3554. `truncated` answers "ask again?", and on the page after which
+    /// there is nothing to ask for it answers no.
+    ///
+    /// The rule is `kin_artifact_list`'s, which this flag's own comment already
+    /// claimed parity with while disagreeing: that tool publishes
+    /// `offset + returned < total` ([`crate::handlers::artifacts`]), false on the
+    /// final page, and this one published `next_cursor.is_some() || offset > 0`,
+    /// true on it. The control is asserted on every page of the walk, not just
+    /// the last, so a change that fixes the final page by breaking an earlier
+    /// one cannot pass here.
+    #[test]
+    fn truncated_answers_whether_rows_remain_on_every_page() {
+        let store = store_with(7, Some(ParseCompleteness::Full));
+        let mut cursor: Option<String> = None;
+        let mut pages = 0;
+        let mut last_truncated = true;
+
+        loop {
+            let mut args = vec![("page_size", serde_json::json!(3))];
+            match &cursor {
+                Some(token) => args.push(("cursor", serde_json::json!(token))),
+                None => args.push(("path", serde_json::json!(FILE))),
+            }
+            let payload = call(&store, &args).unwrap();
+            pages += 1;
+
+            let offset = payload["offset"].as_u64().expect("offset") as usize;
+            let returned = payload["returned"].as_u64().expect("returned") as usize;
+            let total = payload["total_in_file"].as_u64().expect("total") as usize;
+            let truncated = payload["truncated"].as_bool().expect("truncated");
+            // kin_artifact_list's rule, spelled out rather than called, so this
+            // assertion states the contract instead of agreeing with whatever
+            // the other tool currently does.
+            assert_eq!(
+                truncated,
+                offset + returned < total,
+                "page {pages} at offset {offset} returned {returned} of {total} and said \
+                 truncated={truncated}"
+            );
+            assert_eq!(
+                truncated,
+                payload["next_cursor"].as_str().is_some(),
+                "truncated and next_cursor must agree: page {pages}"
+            );
+            last_truncated = truncated;
+
+            match payload["next_cursor"].as_str() {
+                Some(token) => cursor = Some(token.to_string()),
+                None => break,
+            }
+            assert!(pages < 10, "cursor walk did not terminate");
+        }
+
+        assert_eq!(pages, 3, "7 entities at page_size 3 is three pages");
+        assert!(
+            !last_truncated,
+            "the final page of a walk has nothing left to fetch"
+        );
     }
 
     /// Pagination walks the whole set with no duplicates and no silent cap.


### PR DESCRIPTION
Fixes FIR-3554. Part of FIR-3578, the audit of kin's file-shaped MCP and CLI surface.

## What this fixes

`list_file_entities` answered two pagination questions wrongly, and a caller acting on either
answer got the wrong number of pages.

**The final page announced more to fetch.** The handler computed
`"truncated": next_cursor.is_some() || offset > 0`, under a comment claiming parity with
`kin_artifact_list`. It is not parity. `kin_artifact_list` computes
`offset.saturating_add(returned) < total` (`crates/kin-mcp/src/handlers/artifacts.rs:390`), which
is false on the final page. The two tools answered the same question opposite ways, on exactly
the page a pager acts on, and one of them claimed to be the other. An agent paging on the flag
either loops or stops holding a complete set it was told was partial.

**A page the response budget cut lost its remainder.** `run_ladder` re-points a cursor for one
tool: `let mut locate_cursor = (tool == "semantic_locate").then(...)`. So when the character
ceiling withheld rows from a file enumeration, the cursor stayed where the handler left it, or
stayed null on a page that was whole before the cut, and the withheld rows became unreachable by
paging. The caller was told to narrow `page_size`, which asks a different question rather than
finishing this one. `returned` also kept counting the page the handler planned rather than the one
that shipped, so it disagreed with the array beside it.

## What changed

`truncated` on `list_file_entities` is now `next_cursor.is_some()`, which is the rule the comment
already asserted.

The budget's rebase moved behind `repage_primary_after_cut`, which carries an arm per paged tool.
`semantic_locate` keeps its existing behaviour, moving the held ranking's offset back by the
suffix withheld. `list_file_entities` gains one: `PageCursor::after_withheld` recomputes the token
from the page that actually shipped, so the first row not served is always `offset + kept`. That
works identically whether the handler had minted a cursor or the page was the file's last before
the cut, because this enumeration is a stable ordered list addressed by absolute offset. The arm
also sets `returned` to the rows that shipped.

The "this page has no `next_cursor`" remediation now keys on the paged set rather than on
`semantic_locate` by name, so a paged tool whose cursor could not be re-pointed says the rows
became unreachable instead of falling through to generic advice.

`PAGED_TOOLS` names the two tools whose responses carry a cursor, with the two producers named in
its doc comment, and `every_paged_tool_has_a_repage_arm` fails if a name there has no arm.

## Verification

Both new tests were falsified, and the falsification output is here rather than described, because
a claim hosted CI does not itself check belongs in the body as its command and its output.

Arm 1, restoring `|| offset > 0`, re-run against the test as it ships:

```
thread '...truncated_answers_whether_rows_remain_on_every_page' panicked at crates/kin-mcp/src/handlers/file_entities.rs:1304:13:
assertion `left == right` failed: page 3 at offset 6 returned 1 of 7 and said truncated=true
  left: true
 right: false
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1010 filtered out
```

That is the exact page the ticket is about: the last one. The per-page assertion catches it there,
and the break arm restates the same fact at the point the final page is identified.

Arm 2, making the `list_file_entities` rebase arm return `None`:

```
---- budget::tests::a_budget_cut_on_a_file_enumeration_mints_a_reachable_cursor stdout ----
thread '...' panicked at crates/kin-mcp/src/budget.rs:3213:14:
a cut page carries the cursor to its remainder

---- budget::tests::every_paged_tool_has_a_repage_arm stdout ----
thread '...' panicked at crates/kin-mcp/src/budget.rs:3253:13:
list_file_entities is listed as paged but could not re-point its cursor

test result: FAILED. 62 passed; 2 failed; 0 ignored; 0 measured; 947 filtered out
```

Both arms were restored by re-applying the line rather than by `git checkout`, and
`git status --porcelain` was read after each restoration.

The first push of this branch went red on all five fast-gate checks, and the cause was this PR's
own test, not the change it tests. The walk test declared `let mut last_truncated = true;` and
every path overwrote that value before reading it, which is `unused_assignments` and a hard error
under the `-D warnings` CI sets through `RUSTFLAGS`, so the kin-mcp test binary did not compile on
any shard; `Fast gate build and tests` is the aggregator whose only failing step is "Require every
fast-gate shard to have succeeded". A plain local `cargo test` does not set `-D warnings`, which is
why it passed here. The assertion now lives in the loop's break arm with no carried variable. Green
under the flags CI uses, clippy reproduced the way `ci.yml` assembles it:

```
$ allows="$(grep -Ev '^(#|$)' .github/clippy-allowed-lints.txt | tr '\n' ' ')"
$ RUSTFLAGS="-D warnings" cargo clippy -p kin-mcp --all-targets --all-features -- $allows
clippy debt allow-list: 45 lints
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.38s
clippy rc=0
$ RUSTFLAGS="-D warnings" cargo test -p kin-mcp --lib
test result: ok. 1011 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 23.37s
```

`cargo fmt --all -- --check` exits 0.

The budget test asserts the cut actually bit (`assert!(kept < 40, "the ceiling has to bite for
this to test anything")`) so a change that stops the ceiling biting fails the test rather than
passing it vacuously.

## Not in this PR

The `list_file_entities` key itself. The tool still resolves by path, and the entity-keyed
replacement waits on a logical namespace that does not exist in the graph yet: `kin_model::Entity`
carries `file_origin` and no namespace field, and `EntityFilter`'s only locational predicate is
`file_path`. That work is sequenced separately. This PR fixes the pagination contract on the tool
as it stands.
