### PR TITLE
Give the Linux release build legs swap for the fat-LTO peak

### DIFF
--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -278,17 +278,46 @@ jobs:
           # the only leg that stripped it, and dropping that split is what puts
           # native vector search in the shipped Windows archive.
           #
-          # The Linux legs sample their own memory and disk into this step's own
-          # log while cargo runs, and the sampler stays here permanently. The
+          # The Linux legs are given swap and then sample their own memory and
+          # disk into this step's own log while cargo runs. Both halves stay
+          # here permanently, because the second is what proves the first is
+          # still enough.
+          #
+          # What this leg ran out of, measured rather than guessed. The
           # linux-aarch64 leg of v0.7.14 died at this step on all three attempts
           # of run 34579776198 with "The runner has received a shutdown signal"
-          # and exit code 143, roughly sixteen minutes in and always during
-          # kin-daemon's fat-LTO codegen, and the log carried no resource
-          # numbers at all. A post-mortem step cannot supply them: a runner
-          # being torn down runs no further step, so only output already
-          # streamed out of the step that is dying survives. The x86_64 leg
-          # samples too, as the control that says which numbers are normal for
-          # this build on a leg that finishes.
+          # and exit code 143, and the step log carried no resource numbers at
+          # all. Re-running the same build on main's head under the sampler
+          # (rc-build run 34642288259, job 103404693178) reproduced it exactly
+          # and said why. Free disk never moved: 108,661 MB on every one of the
+          # 55 samples, with the whole build consuming 1.9 GB. Memory went one
+          # way. The largest rustc climbed from 4,287 MB to 7,789 MB while
+          # available memory fell from 6,602 MB to 253 MB, the kernel then ate
+          # the image's own 3 GB swapfile to nothing by 20:18:51Z, and the
+          # runner was torn down thirteen seconds later, still climbing. The
+          # runner has 15,947 MB of RAM, so the peak needs more than the roughly
+          # 19 GB of RAM plus swap that the image ships with.
+          #
+          # Why the peak is that big: cargo links kin-cli and kin-daemon in one
+          # invocation, and the release profile is fat LTO with one codegen
+          # unit, so the peak is two whole-program links of a large Rust binary
+          # resident at once. The largest single process was 7.8 GB while total
+          # commitment was about 19 GB, which is that shape. Thin LTO on one
+          # architecture would change what ships and the release notes would
+          # have to say so, and the runner label is a cost decision rather than
+          # an engineering one, so the leg is given memory instead.
+          #
+          # Both Linux legs get it rather than the arm row alone, and the
+          # x86_64 leg's own samples from that same run are why the distinction
+          # is not worth a guard. It succeeded on an identically sized runner,
+          # 15,988 MB of RAM and the same 3 GB swapfile, with its largest rustc
+          # peaking at 4,193 MB, 5,006 MB still available and swap never
+          # touched. So the same fat-LTO build of the same crates costs roughly
+          # 1.9 times the peak resident set on aarch64 that it costs on x86_64,
+          # which is a property of the backend rather than of what is being
+          # built. The x86_64 leg has headroom today and its swap is insurance;
+          # keying the headroom to an architecture would record the accident of
+          # which leg crossed first rather than the reason either might.
           sampler=""
           if [ "$(uname -s)" = Linux ]; then
             echo "resources before the build"
@@ -296,6 +325,40 @@ jobs:
             free -m || true
             swapon --show || true
             df -h || true
+            # Raise total swap to the target, never taking more than half of
+            # what is free, and add to the image's swapfile rather than
+            # replacing it so nothing already paging is disturbed.
+            want_mb=24576
+            free_mb=$(df -m --output=avail / | tail -1 | tr -d ' ')
+            room_mb=$(( free_mb / 2 ))
+            [ "$want_mb" -le "$room_mb" ] || want_mb=$room_mb
+            have_mb=$(awk '/^SwapTotal:/{printf "%d", $2/1024}' /proc/meminfo)
+            add_mb=$(( want_mb - have_mb ))
+            if [ "$add_mb" -gt 512 ]; then
+              swapfile=/kin-release-swapfile
+              sudo rm -f "$swapfile"
+              if sudo fallocate -l "${add_mb}M" "$swapfile" \
+                && sudo chmod 600 "$swapfile" \
+                && sudo mkswap "$swapfile" > /dev/null \
+                && sudo swapon "$swapfile"
+              then
+                echo "added ${add_mb}MB of swap for a ${want_mb}MB total"
+              else
+                # A swapfile the kernel refuses is usually one fallocate left
+                # holding unwritten extents, which a written file cannot have.
+                sudo swapoff "$swapfile" 2> /dev/null || true
+                sudo rm -f "$swapfile"
+                sudo dd if=/dev/zero of="$swapfile" bs=1M count="$add_mb" status=none
+                sudo chmod 600 "$swapfile"
+                sudo mkswap "$swapfile" > /dev/null
+                sudo swapon "$swapfile"
+                echo "added ${add_mb}MB of swap for a ${want_mb}MB total, written rather than allocated"
+              fi
+            else
+              echo "existing ${have_mb}MB of swap already meets the ${want_mb}MB target"
+            fi
+            swapon --show || true
+            free -m || true
             (
               set +e
               set +o pipefail

--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -277,7 +277,50 @@ jobs:
           # Every platform now builds the same default feature set. Windows was
           # the only leg that stripped it, and dropping that split is what puts
           # native vector search in the shipped Windows archive.
-          cargo build --locked --release --target "$TARGET" -p kin-cli -p kin-daemon
+          #
+          # The Linux legs sample their own memory and disk into this step's own
+          # log while cargo runs, and the sampler stays here permanently. The
+          # linux-aarch64 leg of v0.7.14 died at this step on all three attempts
+          # of run 34579776198 with "The runner has received a shutdown signal"
+          # and exit code 143, roughly sixteen minutes in and always during
+          # kin-daemon's fat-LTO codegen, and the log carried no resource
+          # numbers at all. A post-mortem step cannot supply them: a runner
+          # being torn down runs no further step, so only output already
+          # streamed out of the step that is dying survives. The x86_64 leg
+          # samples too, as the control that says which numbers are normal for
+          # this build on a leg that finishes.
+          sampler=""
+          if [ "$(uname -s)" = Linux ]; then
+            echo "resources before the build"
+            nproc || true
+            free -m || true
+            swapon --show || true
+            df -h || true
+            (
+              set +e
+              set +o pipefail
+              while :; do
+                avail=$(awk '/^MemAvailable:/{printf "%d", $2/1024}' /proc/meminfo)
+                swap=$(awk '/^SwapFree:/{printf "%d", $2/1024}' /proc/meminfo)
+                root=$(df -m / | awk 'NR==2{print $4}')
+                top=$(ps -eo rss=,comm= --sort=-rss | head -1 | awk '{printf "%s/%dMB", $2, $1/1024}')
+                echo "resource-sample $(date -u +%H:%M:%SZ) mem_avail_mb=$avail swap_free_mb=$swap root_free_mb=$root top_rss=$top"
+                sleep 15
+              done
+            ) &
+            sampler=$!
+          fi
+          rc=0
+          cargo build --locked --release --target "$TARGET" -p kin-cli -p kin-daemon || rc=$?
+          if [ -n "$sampler" ]; then
+            kill "$sampler" 2>/dev/null || true
+          fi
+          if [ "$(uname -s)" = Linux ]; then
+            echo "resources after the build"
+            free -m || true
+            df -h || true
+          fi
+          exit "$rc"
         env:
           TARGET: ${{ matrix.target }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -669,7 +669,50 @@ jobs:
           # Every platform now builds the same default feature set. Windows was
           # the only leg that stripped it, and dropping that split is what puts
           # native vector search in the shipped Windows archive.
-          cargo build --locked --release --target "$TARGET" -p kin-cli -p kin-daemon
+          #
+          # The Linux legs sample their own memory and disk into this step's own
+          # log while cargo runs, and the sampler stays here permanently. The
+          # linux-aarch64 leg of v0.7.14 died at this step on all three attempts
+          # of run 34579776198 with "The runner has received a shutdown signal"
+          # and exit code 143, roughly sixteen minutes in and always during
+          # kin-daemon's fat-LTO codegen, and the log carried no resource
+          # numbers at all. A post-mortem step cannot supply them: a runner
+          # being torn down runs no further step, so only output already
+          # streamed out of the step that is dying survives. The x86_64 leg
+          # samples too, as the control that says which numbers are normal for
+          # this build on a leg that finishes.
+          sampler=""
+          if [ "$(uname -s)" = Linux ]; then
+            echo "resources before the build"
+            nproc || true
+            free -m || true
+            swapon --show || true
+            df -h || true
+            (
+              set +e
+              set +o pipefail
+              while :; do
+                avail=$(awk '/^MemAvailable:/{printf "%d", $2/1024}' /proc/meminfo)
+                swap=$(awk '/^SwapFree:/{printf "%d", $2/1024}' /proc/meminfo)
+                root=$(df -m / | awk 'NR==2{print $4}')
+                top=$(ps -eo rss=,comm= --sort=-rss | head -1 | awk '{printf "%s/%dMB", $2, $1/1024}')
+                echo "resource-sample $(date -u +%H:%M:%SZ) mem_avail_mb=$avail swap_free_mb=$swap root_free_mb=$root top_rss=$top"
+                sleep 15
+              done
+            ) &
+            sampler=$!
+          fi
+          rc=0
+          cargo build --locked --release --target "$TARGET" -p kin-cli -p kin-daemon || rc=$?
+          if [ -n "$sampler" ]; then
+            kill "$sampler" 2>/dev/null || true
+          fi
+          if [ "$(uname -s)" = Linux ]; then
+            echo "resources after the build"
+            free -m || true
+            df -h || true
+          fi
+          exit "$rc"
         env:
           TARGET: ${{ matrix.target }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -670,17 +670,46 @@ jobs:
           # the only leg that stripped it, and dropping that split is what puts
           # native vector search in the shipped Windows archive.
           #
-          # The Linux legs sample their own memory and disk into this step's own
-          # log while cargo runs, and the sampler stays here permanently. The
+          # The Linux legs are given swap and then sample their own memory and
+          # disk into this step's own log while cargo runs. Both halves stay
+          # here permanently, because the second is what proves the first is
+          # still enough.
+          #
+          # What this leg ran out of, measured rather than guessed. The
           # linux-aarch64 leg of v0.7.14 died at this step on all three attempts
           # of run 34579776198 with "The runner has received a shutdown signal"
-          # and exit code 143, roughly sixteen minutes in and always during
-          # kin-daemon's fat-LTO codegen, and the log carried no resource
-          # numbers at all. A post-mortem step cannot supply them: a runner
-          # being torn down runs no further step, so only output already
-          # streamed out of the step that is dying survives. The x86_64 leg
-          # samples too, as the control that says which numbers are normal for
-          # this build on a leg that finishes.
+          # and exit code 143, and the step log carried no resource numbers at
+          # all. Re-running the same build on main's head under the sampler
+          # (rc-build run 34642288259, job 103404693178) reproduced it exactly
+          # and said why. Free disk never moved: 108,661 MB on every one of the
+          # 55 samples, with the whole build consuming 1.9 GB. Memory went one
+          # way. The largest rustc climbed from 4,287 MB to 7,789 MB while
+          # available memory fell from 6,602 MB to 253 MB, the kernel then ate
+          # the image's own 3 GB swapfile to nothing by 20:18:51Z, and the
+          # runner was torn down thirteen seconds later, still climbing. The
+          # runner has 15,947 MB of RAM, so the peak needs more than the roughly
+          # 19 GB of RAM plus swap that the image ships with.
+          #
+          # Why the peak is that big: cargo links kin-cli and kin-daemon in one
+          # invocation, and the release profile is fat LTO with one codegen
+          # unit, so the peak is two whole-program links of a large Rust binary
+          # resident at once. The largest single process was 7.8 GB while total
+          # commitment was about 19 GB, which is that shape. Thin LTO on one
+          # architecture would change what ships and the release notes would
+          # have to say so, and the runner label is a cost decision rather than
+          # an engineering one, so the leg is given memory instead.
+          #
+          # Both Linux legs get it rather than the arm row alone, and the
+          # x86_64 leg's own samples from that same run are why the distinction
+          # is not worth a guard. It succeeded on an identically sized runner,
+          # 15,988 MB of RAM and the same 3 GB swapfile, with its largest rustc
+          # peaking at 4,193 MB, 5,006 MB still available and swap never
+          # touched. So the same fat-LTO build of the same crates costs roughly
+          # 1.9 times the peak resident set on aarch64 that it costs on x86_64,
+          # which is a property of the backend rather than of what is being
+          # built. The x86_64 leg has headroom today and its swap is insurance;
+          # keying the headroom to an architecture would record the accident of
+          # which leg crossed first rather than the reason either might.
           sampler=""
           if [ "$(uname -s)" = Linux ]; then
             echo "resources before the build"
@@ -688,6 +717,40 @@ jobs:
             free -m || true
             swapon --show || true
             df -h || true
+            # Raise total swap to the target, never taking more than half of
+            # what is free, and add to the image's swapfile rather than
+            # replacing it so nothing already paging is disturbed.
+            want_mb=24576
+            free_mb=$(df -m --output=avail / | tail -1 | tr -d ' ')
+            room_mb=$(( free_mb / 2 ))
+            [ "$want_mb" -le "$room_mb" ] || want_mb=$room_mb
+            have_mb=$(awk '/^SwapTotal:/{printf "%d", $2/1024}' /proc/meminfo)
+            add_mb=$(( want_mb - have_mb ))
+            if [ "$add_mb" -gt 512 ]; then
+              swapfile=/kin-release-swapfile
+              sudo rm -f "$swapfile"
+              if sudo fallocate -l "${add_mb}M" "$swapfile" \
+                && sudo chmod 600 "$swapfile" \
+                && sudo mkswap "$swapfile" > /dev/null \
+                && sudo swapon "$swapfile"
+              then
+                echo "added ${add_mb}MB of swap for a ${want_mb}MB total"
+              else
+                # A swapfile the kernel refuses is usually one fallocate left
+                # holding unwritten extents, which a written file cannot have.
+                sudo swapoff "$swapfile" 2> /dev/null || true
+                sudo rm -f "$swapfile"
+                sudo dd if=/dev/zero of="$swapfile" bs=1M count="$add_mb" status=none
+                sudo chmod 600 "$swapfile"
+                sudo mkswap "$swapfile" > /dev/null
+                sudo swapon "$swapfile"
+                echo "added ${add_mb}MB of swap for a ${want_mb}MB total, written rather than allocated"
+              fi
+            else
+              echo "existing ${have_mb}MB of swap already meets the ${want_mb}MB target"
+            fi
+            swapon --show || true
+            free -m || true
             (
               set +e
               set +o pipefail


### PR DESCRIPTION
## What this fixes

The `linux-aarch64` release leg runs out of memory. It killed the v0.7.14 release on all three attempts of run 34579776198, each time at `Build (kin-linux-aarch64)` / `Build kin-cli + kin-daemon (native)` with `The runner has received a shutdown signal` and exit code 143, and the step log carried no resource numbers at all, so nothing in it said what ran out. Every later tree does the same, so the rail stays shut until the leg gets headroom.

This is workflow only. No product code, no change to what ships.

## The measurement, before the fix

The first commit adds a sampler to the native build step. rc-build.yml dispatched on the lane branch at main's head reproduced the failure exactly and said why.

Run `34642288259`, arm job `103404693178`, step 20:05:34Z to 20:19:04Z, exit 143. The runner:

```
4
               total        used        free      shared  buff/cache   available
Mem:           15947        1332       12443          48        2471       14615
Swap:           3071           0        3071
NAME      TYPE SIZE USED PRIO
/swapfile file   3G   0B   -2
Filesystem      Size  Used Avail Use% Mounted on
/dev/root       145G   37G  108G  26% /
```

**Disk is not involved.** `root_free_mb` reads `108661` on every one of the 55 samples. The whole build consumed 1.9 GB out of 108 GB free.

**Memory is the whole story.** The last ten samples:

```
20:16:35Z mem_avail_mb=6602 swap_free_mb=3071 root_free_mb=108661 top_rss=rustc/4287MB
20:16:50Z mem_avail_mb=5679 swap_free_mb=3071 root_free_mb=108661 top_rss=rustc/4800MB
20:17:05Z mem_avail_mb=4520 swap_free_mb=3071 root_free_mb=108661 top_rss=rustc/5365MB
20:17:20Z mem_avail_mb=3370 swap_free_mb=3071 root_free_mb=108661 top_rss=rustc/5956MB
20:17:35Z mem_avail_mb=2202 swap_free_mb=3071 root_free_mb=108661 top_rss=rustc/6526MB
20:17:50Z mem_avail_mb=867  swap_free_mb=3071 root_free_mb=108661 top_rss=rustc/7165MB
20:18:05Z mem_avail_mb=468  swap_free_mb=2216 root_free_mb=108661 top_rss=rustc/7763MB
20:18:21Z mem_avail_mb=441  swap_free_mb=1279 root_free_mb=108661 top_rss=rustc/7789MB
20:18:36Z mem_avail_mb=356  swap_free_mb=542  root_free_mb=108661 top_rss=rustc/7436MB
20:18:51Z mem_avail_mb=253  swap_free_mb=0    root_free_mb=108661 top_rss=rustc/7711MB
20:19:04Z ##[error]Process completed with exit code 143.
20:19:04Z ##[error]The runner has received a shutdown signal.
```

Memory falls to 253 MB, the kernel drains the image's swapfile to zero, and the runner is torn down thirteen seconds later, still climbing. Preemption does not wait for swap to hit zero.

The largest single process peaks at 7,789 MB while total commitment is about 19 GB, so more than one multi-GB rustc is resident. That is the shape the timestamps already suggested: cargo links `kin-cli` and `kin-daemon` in one invocation and the release profile is fat LTO with one codegen unit, so the peak is two whole-program links of a large Rust binary at once.

## The x86_64 control, from the same run

The x86_64 leg of that same dispatch succeeded on an identically sized runner, 15,988 MB of RAM and the same 3 GB swapfile, four cores. Its largest rustc peaked at **4,193 MB**, its available memory never fell below **5,006 MB**, and `swap_free_mb` read `3071` on all sixty samples, so it never touched swap.

The same build of the same crates therefore costs roughly **1.9 times the peak resident set on aarch64 that it costs on x86_64**. That is a property of the backend, not of what is being built, and it is why one leg crossed and the other did not.

## The fix

Total swap is raised to 24 GB on the Linux legs, never taking more than half of what is free, added beside the image's own swapfile rather than replacing it.

- Fat LTO and `codegen-units = 1` are untouched on every leg. Thin LTO on one architecture would change what ships and the release notes would have to say so.
- The runner label stays `ubuntu-24.04-arm`. No paid runner is involved.
- The sampler stays permanently, because it is what will prove the headroom is still enough the next time this leg grows.

Both Linux legs get the headroom rather than the arm row alone. Swap nothing touches costs nothing on a leg that fits in RAM, the x86_64 numbers above show its half is insurance rather than a fix, and keying the headroom to an architecture would record the accident of which leg crossed first rather than the reason either might.

`rc-build.yml` carries the identical step because `scripts/check-rc-build-drift.mjs` requires it byte for byte.

## Proof

Three `rc-build.yml` dispatches at this PR's head sha `4dd82bbdfc1cd9ac35a7494e78233eae1e05929b`, run in parallel on three branches at that same sha. They cannot be three dispatches on one branch: `concurrency: kin-rc-build-${{ github.ref }}` with `cancel-in-progress: true` means a second dispatch on a ref cancels the first.

| proof | branch | run | arm job | native build step | peak rustc | lowest available | peak swap in use |
|---|---|---|---|---|---|---|---|
| 1 | `chore/lane-railfix2-kin-proof1` | `34644032861` | `103410494761` | 20:25:18Z to 20:39:29Z, 14m11s | 8,155 MB | 276 MB | 5,221 of 24,576 MB |
| 2 | `chore/lane-railfix2-kin-proof2` | `34644035434` | `103410491333` | 20:25:13Z to 20:39:11Z, 13m58s | 8,298 MB | 291 MB | 4,649 of 24,576 MB |
| 3 | `chore/lane-railfix2-kin-proof3` | `34644038521` | `103410515568` | 20:25:19Z to 20:38:33Z, 13m14s | 8,794 MB | 354 MB | 4,071 of 24,576 MB |

All three arm legs concluded `success`, and so did all three x86_64 legs.

Each arm leg logged `added 21505MB of swap for a 24576MB total`, the allocated path rather than the written fallback. Swap and memory right after setup, from proof 2:

```
added 21505MB of swap for a 24576MB total
NAME                  TYPE SIZE USED PRIO
/swapfile             file   3G   0B   -2
/kin-release-swapfile file  21G   0B   -3
               total        used        free      shared  buff/cache   available
Mem:           15947        1294       12474          47        2477       14652
Swap:          24576           0       24576
```

The tightest sample of each arm leg:

```
resource-sample 20:38:20Z mem_avail_mb=276 swap_free_mb=20405 root_free_mb=87156 top_rss=rustc/7715MB
resource-sample 20:38:14Z mem_avail_mb=291 swap_free_mb=19927 root_free_mb=87156 top_rss=rustc/7496MB
resource-sample 20:37:05Z mem_avail_mb=354 swap_free_mb=21881 root_free_mb=87156 top_rss=rustc/7583MB
```

And proof 2 after the build:

```
resources after the build
               total        used        free      shared  buff/cache   available
Mem:           15947         875       14609          27         746       15071
Swap:          24576         180       24396
Filesystem      Size  Used Avail Use% Mounted on
/dev/root       145G   60G   85G  42% /
```

**No thrash.** The arm build step took 13m14s to 14m11s, against 12m56s for v0.7.13's arm leg before it crossed the cliff and 11m36s for x86_64. Swap costs about a minute. Peak swap in use was 4.1 to 5.2 GB, so the build needs roughly 1.5 to 2.2 GB beyond what the image's 3 GB swapfile held, and 24 GB leaves about 19 GB spare. The two-invocation variant that would halve the peak was therefore not measured, and is not needed. It would also have been a change to what ships rather than a scheduling change, because cargo unifies features across the packages named in one invocation.

**The x86_64 half is insurance at zero cost.** In the same three runs the x86_64 legs peaked at 4,147, 4,189 and 4,345 MB of rustc, never had less than 4,819 MB available, and read `swap_free_mb=24576` on every sample. They never touched the new swap.

## Falsification

The step's diagnostics and headroom cannot mask a red build, and each swap path is observable in the log. Run in an `ubuntu:24.04` arm64 container with `sudo`, `fallocate`, `mkswap`, `swapon` and `dd` stubbed:

```
### A: happy path
STUB fallocate -l 22529M /kin-release-swapfile
added 22529MB of swap for a 24576MB total
FAKE-BUILD
FAKE-DONE
### A step rc=0
### B: build exits 101
STUB fallocate -l 22529M /kin-release-swapfile
added 22529MB of swap for a 24576MB total
FAKE-BUILD
### B step rc=101
### C: kernel refuses the allocated swapfile, dd fallback must run
STUB fallocate -l 22529M /kin-release-swapfile
STUB swapon REFUSED /kin-release-swapfile (has holes)
STUB dd if=/dev/zero of=/kin-release-swapfile bs=1M count=22529 status=none
STUB swapon accepted /kin-release-swapfile
added 22529MB of swap for a 24576MB total, written rather than allocated
### C step rc=0
```

Case B is the one that matters: a build exiting 101 still exits the step 101. Case C proves the log names which path ran rather than reporting both the same way.

The sizing rule was falsified separately across five cases:

```
free=108661 have=3071  -> add 21505MB for a 24576MB total
free=108661 have=30000 -> keep existing 30000MB against the 24576MB target
free=108661 have=24300 -> keep existing 24300MB against the 24576MB target
free=9000   have=3071  -> add 1429MB for a 4500MB total
free=2000   have=3071  -> keep existing 3071MB against the 1000MB target
```

## Local gates

`bin/kin-precheck kin --repo-dir kin=<this lane worktree>`, run through the fleet's builder slot against this PR's head sha:

```
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin 4dd82bbdfc1cd9ac35a7494e78233eae1e05929b
```

`guard:check-rc-build-drift.mjs` and `guard:test-release-workflow-authority.py` are both in that passing set, which are the two gates a change to this step could break. The authority guard asserts the build job's step order, and the new code sits inside an existing step rather than adding one, so that order is unchanged.

## What this does not do

It cannot reach `v0.7.14`. A tag run resolves its workflows from the tag, so the frozen copy of `release.yml` at `1a8e9494405bce2bfa45f95fa209a5f06d682e90` keeps dying however main changes. Recording that tag's abandonment is a separate pull request, and it lands after this one so the train's next cut builds on the fixed workflow.

Refs #1700.
