### PR TITLE
Record a reviewer's removal so it survives a push and a pull

### DIFF
--- a/crates/kin-cli/src/commands/review.rs
+++ b/crates/kin-cli/src/commands/review.rs
@@ -1035,17 +1035,26 @@ fn plan_assign(
     let rid = parse_review_id(&review_id)?;
     existing_review(graph, rid)?;
     let (actor_label, identity) = acting_as(actor);
+    // The stored set, which is an add log: it only grows, a removal is recorded
+    // as its own event, and a review's reviewers are derived from the two. So
+    // appending here never re-assigns anyone a removal took off, and it never
+    // drops an assignment this replica has not seen removed.
     let mut entries = graph.get_review_assignments(&rid)?;
-    entries.push(ReviewAssignment {
+    let assignment = ReviewAssignment {
         review_id: rid,
         reviewer: kin_model::IdentityRef::human(&reviewer),
         assigned_at: Timestamp::now(),
         assigned_by: identity,
-    });
+    };
+    let assigned = kin_review::assignments::AssignmentTag::of(&assignment);
+    entries.push(assignment);
     Ok(PlannedReviewEvent {
-        action: "review.assign",
+        action: kin_review::assignments::ASSIGN_ACTION,
         review_id: rid,
-        details: format!("review_id={review_id}; reviewer={reviewer}"),
+        details: format!(
+            "review_id={review_id}; reviewer={reviewer}; {}",
+            kin_review::assignments::tag_details(&[assigned])
+        ),
         actor_label,
         refs: None,
         answer: ReviewResponse {

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -49300,6 +49300,105 @@ mod tests {
         (sorted_lines(&list.text), sorted_lines(&show.text), record)
     }
 
+    /// A reviewer removed through MCP is still removed after a restart, and a
+    /// review's last reviewer can be removed at all.
+    ///
+    /// A removal is an audit event rather than a smaller assignment set: the set
+    /// is an add log, and a collaboration delta refuses an empty one. So this is
+    /// the test that the event is what a reopened daemon reads, and that the
+    /// reviewers it answers with are derived from the two.
+    ///
+    /// Falsify by dropping `review.unassign` from `records_audit_event`: nothing
+    /// records the removal, the reopened daemon answers with the reviewer again,
+    /// and the assertion after the restart goes red.
+    #[tokio::test]
+    async fn a_removed_reviewer_stays_removed_after_a_restart() {
+        use std::sync::atomic::Ordering;
+
+        let initial = test_state();
+        let layout = initial.layout.clone();
+        drop(initial);
+        let state = Arc::new(DaemonState::open(layout.clone()).unwrap());
+        state.is_initialized.store(true, Ordering::Relaxed);
+
+        let created = review_call(
+            &state,
+            serde_json::json!({
+                "op": "create",
+                "title": "Reviewers move",
+                "base": "main",
+                "head": "HEAD",
+                "description": "assigned, then one taken off",
+            }),
+        )
+        .await;
+        let review_id = created
+            .text
+            .lines()
+            .find_map(|line| line.strip_prefix("Created review "))
+            .expect("the create answer names the review")
+            .trim()
+            .to_string();
+        for reviewer in ["bob", "alice"] {
+            review_call(
+                &state,
+                serde_json::json!({ "op": "assign", "review_id": review_id, "reviewer": reviewer }),
+            )
+            .await;
+        }
+        let removed = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_review_unassign",
+            serde_json::json!({ "review_id": review_id, "reviewer": "bob" }),
+        )
+        .await;
+        assert_ne!(
+            removed.is_error,
+            Some(true),
+            "{}",
+            mcp_result_text(&removed)
+        );
+
+        let before = review_surfaces(&state, &review_id).await;
+        drop(state);
+        let reopened = Arc::new(DaemonState::open(layout).unwrap());
+        reopened.is_initialized.store(true, Ordering::Relaxed);
+        let after = review_surfaces(&reopened, &review_id).await;
+        assert_eq!(
+            after, before,
+            "every review surface must answer the same after a restart"
+        );
+        let reviewers = after.2.to_string();
+        assert!(
+            reviewers.contains("alice"),
+            "the reviewer who stayed is still one: {reviewers}"
+        );
+        assert!(
+            !reviewers.contains("bob"),
+            "a removed reviewer is not one after a restart: {reviewers}"
+        );
+
+        // And the last reviewer can go too, which a set that had to stay
+        // non-empty could never express.
+        let last = mcp_call(
+            router(Arc::clone(&reopened)),
+            "kin_review_unassign",
+            serde_json::json!({ "review_id": review_id, "reviewer": "alice" }),
+        )
+        .await;
+        assert_ne!(
+            last.is_error,
+            Some(true),
+            "removing a review's last reviewer must be allowed now: {}",
+            mcp_result_text(&last)
+        );
+        let emptied = review_surfaces(&reopened, &review_id).await.2.to_string();
+        assert!(
+            !emptied.contains("alice"),
+            "the last reviewer came off: {emptied}"
+        );
+    }
+
     /// A review, its decision, notes, discussion, reply, resolution and
     /// assignments answer the same on every surface after the daemon restarts on
     /// the same store, whether they were written through `POST /review` or MCP.

--- a/crates/kin-mcp/src/handlers/review.rs
+++ b/crates/kin-mcp/src/handlers/review.rs
@@ -941,17 +941,31 @@ fn plan_review_assign<G: GraphStore>(
     existing_review(store, &review_id)?;
     let assigned_at = Timestamp::now();
 
+    // The stored set, which is an add log: it only grows, a removal is recorded
+    // as its own event, and a review's reviewers are derived from the two.
     let mut entries = store
         .get_review_assignments(&review_id)
         .map_err(|e| McpError::Other(e.to_string()))?;
-    entries.extend(reviewers.iter().map(|reviewer| ReviewAssignment {
-        review_id,
-        reviewer: kin_model::IdentityRef::human(reviewer.clone()),
-        assigned_at: assigned_at.clone(),
-        assigned_by: assigner.clone(),
-    }));
+    let assigned: Vec<ReviewAssignment> = reviewers
+        .iter()
+        .map(|reviewer| ReviewAssignment {
+            review_id,
+            reviewer: kin_model::IdentityRef::human(reviewer.clone()),
+            assigned_at: assigned_at.clone(),
+            assigned_by: assigner.clone(),
+        })
+        .collect();
+    let tags: Vec<_> = assigned
+        .iter()
+        .map(kin_review::assignments::AssignmentTag::of)
+        .collect();
+    entries.extend(assigned);
 
-    let details = format!("review_id={review_id}; reviewers={}", reviewers.join(","));
+    let details = format!(
+        "review_id={review_id}; reviewers={}; {}",
+        reviewers.join(","),
+        kin_review::assignments::tag_details(&tags)
+    );
     let result = serde_json::json!({
         "review_id": review_id.to_string(),
         "reviewers": reviewers,
@@ -993,32 +1007,33 @@ fn plan_review_unassign<G: GraphStore>(
     let reviewer = get_string_param(args, "reviewer")?;
     existing_review(store, &review_id)?;
 
-    let live = store
-        .get_review_assignments(&review_id)
+    // The reviewers this review has, so removing someone already removed
+    // records nothing a second time.
+    let live = kin_review::assignments::current_assignments(store, &review_id)
         .map_err(|e| McpError::Other(e.to_string()))?;
-    let remaining: Vec<_> = live
-        .iter()
-        .filter(|assignment| assignment.reviewer.name != reviewer)
-        .cloned()
+    let removed: Vec<_> = live
+        .into_iter()
+        .filter(|assignment| assignment.reviewer.name == reviewer)
         .collect();
-    let write = if remaining.len() == live.len() {
-        // Not assigned, so there is nothing to remove.
+    let tags: Vec<_> = removed
+        .iter()
+        .map(kin_review::assignments::AssignmentTag::of)
+        .collect();
+    let write = if removed.is_empty() {
+        // Not assigned, so there is nothing to remove and nothing to record.
         ReviewWrite::default()
-    } else if remaining.is_empty() {
-        // A collaboration delta upserts a review's whole assignment set and
-        // refuses an empty one, so the last reviewer's removal has no durable
-        // form. Refused by name rather than applied to the live graph alone,
-        // where it would come back at the next restart.
-        return Err(McpError::InvalidParams(format!(
-            "cannot remove {reviewer}, the last reviewer of review {review_id}: repository \
-             authority cannot yet record a review with no reviewers, so assign another reviewer \
-             first"
-        )));
     } else {
+        // The removal is the audit event this write carries, which the review
+        // writer records for a write that carries records. It is not a smaller
+        // set: the set is an add log, a delta refuses an empty one, and shrinking
+        // it would leave a later re-assignment of the same reviewer unable to
+        // reach the live graph. So the set is written unchanged.
         ReviewWrite {
             assignments: Some(ReviewGroup {
                 review_id,
-                entries: remaining,
+                entries: store
+                    .get_review_assignments(&review_id)
+                    .map_err(|e| McpError::Other(e.to_string()))?,
             }),
             ..ReviewWrite::default()
         }
@@ -1031,9 +1046,12 @@ fn plan_review_unassign<G: GraphStore>(
     });
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
     Ok(PlannedReviewEvent {
-        action: "review.unassign",
+        action: kin_review::assignments::UNASSIGN_ACTION,
         review_id,
-        details: format!("review_id={review_id}; reviewer={reviewer}"),
+        details: format!(
+            "review_id={review_id}; reviewer={reviewer}; {}",
+            kin_review::assignments::tag_details(&tags)
+        ),
         actor_label: "mcp-client".to_string(),
         refs: None,
         write,
@@ -1088,11 +1106,29 @@ pub fn plan_review_mutation<G: GraphStore>(
 
 /// Apply a planned review write straight to `store`, for a caller with no
 /// repository authority behind it.
+///
+/// Nothing here records the audit event the daemon's review writer records, and
+/// a removal is proven by that event. Most removals are also expressed by the
+/// set they leave, so they land either way. The one that is not is a review's
+/// last reviewer, whose removal leaves a set a collaboration delta cannot carry:
+/// on this path it would leave no trace at all, so it is refused by name rather
+/// than answered as done.
 fn apply_planned<G: GraphStore>(planned: PlannedReviewTool, store: &G) -> Result<ToolCallResult> {
     planned
         .write
         .apply_to(store)
         .map_err(|error| McpError::Other(error.to_string()))?;
+    // A removal is an audit event, and this path records none, because nothing
+    // here holds repository authority. Its graph is its whole state, so the
+    // reviewer comes off that graph directly, which is what this surface did
+    // before removals were recorded at all.
+    if planned.action == kin_review::assignments::UNASSIGN_ACTION {
+        for tag in kin_review::assignments::tags_in_details(&planned.details) {
+            store
+                .remove_reviewer(&planned.review_id, &tag.reviewer)
+                .map_err(|error| McpError::Other(error.to_string()))?;
+        }
+    }
     Ok(planned.answer)
 }
 

--- a/crates/kin-remote/src/collaboration_transfer.rs
+++ b/crates/kin-remote/src/collaboration_transfer.rs
@@ -186,6 +186,9 @@ impl ReviewDomain {
     }
 
     /// Keep the review audit events and the actors they name.
+    ///
+    /// The `review.unassign` events among them are what records a reviewer's
+    /// removal, so carrying them is what carries removals between replicas.
     fn adopt_provenance(&mut self, events: &[AuditEvent], actors: &HashMap<ActorId, Actor>) {
         for event in events {
             if event.action.starts_with(REVIEW_AUDIT_PREFIX) {
@@ -285,6 +288,10 @@ impl ReviewDomain {
                 }
             }
         }
+        // A review's assignment set only ever grows: a removal is recorded as a
+        // `review.unassign` audit event, which travels with the events below,
+        // and each replica derives its reviewers from the set and those events.
+        // So merging the sets is appending, and no reviewer is taken off here.
         for (id, ours) in &self.assignments {
             let theirs = holder.assignments.get(id).cloned().unwrap_or_default();
             let merged = appended(&theirs, ours);
@@ -300,8 +307,9 @@ impl ReviewDomain {
                 gaps.push(CollaborationGap {
                     record: format!("assignments of review {id}"),
                     detail: format!(
-                        "{} holds {} that {} does not; if that was a removal, it cannot travel, \
-                         because a collaboration delta expresses no removal",
+                        "{} holds {} that {} does not; an assignment set only grows, and a removal \
+                         travels as its own record, so this is a set written before removals were \
+                         recorded and the difference cannot be read as either one",
                         sides.holder,
                         held_only.join(", "),
                         sides.sender

--- a/crates/kin-remote/src/repository_transfer_negotiation.rs
+++ b/crates/kin-remote/src/repository_transfer_negotiation.rs
@@ -1316,8 +1316,10 @@ mod tests {
     use crate::repository_transfer::{
         repository_ref_advertisement, RepositoryTransferApplyOutcome, FEATURE_COLLABORATION,
     };
+    use kin_model::provenance::{ActorId, AuditEvent, AuditEventId};
     use kin_model::review::{
-        Review, ReviewCompletionState, ReviewDecision, ReviewDecisionState, ReviewId,
+        Review, ReviewAssignment, ReviewCompletionState, ReviewDecision, ReviewDecisionState,
+        ReviewId,
     };
     use kin_model::{CollaborationDelta, IdentityRef, Keyed};
 
@@ -1771,6 +1773,152 @@ mod tests {
 
     fn reviews_of(manager: &TestManager) -> HashMap<ReviewId, Review> {
         manager.read_authority().snapshot().reviews.clone()
+    }
+
+    fn assignments_of(manager: &TestManager, review_id: &ReviewId) -> Vec<ReviewAssignment> {
+        manager
+            .read_authority()
+            .snapshot()
+            .review_assignments
+            .get(review_id)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    fn holds_event(manager: &TestManager, event_id: &AuditEventId) -> bool {
+        manager
+            .read_authority()
+            .snapshot()
+            .audit_events
+            .iter()
+            .any(|event| &event.event_id == event_id)
+    }
+
+    /// Commit `records` into `manager` as one collaboration-only transaction, in
+    /// the canonical order an export produces.
+    fn record_collaboration(
+        manager: &TestManager,
+        repository_id: &RepositoryId,
+        operation: u128,
+        records: CollaborationDelta,
+    ) {
+        let records = ReviewDomain::from_delta(&records)
+            .to_delta()
+            .expect("the fixture records something");
+        let lease = manager.read_authority();
+        let transaction = RepositoryTransaction {
+            schema_version: REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+            operation_id: OperationId::from_uuid(Uuid::from_u128(operation)),
+            repository_id: repository_id.clone(),
+            expected_generation: lease.roots().generation,
+            expected_roots: lease.roots().clone(),
+            actor: AuthorId::new("negotiation-fixture"),
+            reason: "record collaboration state".to_string(),
+            external_objects: Vec::new(),
+            git_authority_delta: None,
+            changes: Vec::new(),
+            aliases: Vec::new(),
+            ref_mutations: Vec::new(),
+            default_ref_mutation: None,
+            workspace_mutation: None,
+            local_overlay_delta: None,
+            merge_transaction_delta: None,
+            sealed_observation: None,
+            collaboration_delta: Some(records),
+        };
+        drop(lease);
+        manager.commit_repository_transaction(transaction).unwrap();
+    }
+
+    /// A replica that still holds an assignment never puts it back on a replica
+    /// that removed it, and the removal itself travels.
+    ///
+    /// A review's assignment set is an add log: it only grows, and what records a
+    /// removal is a `review.unassign` audit event. So a transfer has nothing to
+    /// undo, and carrying the event is what carries the removal. What the event
+    /// names, and how a replica derives its reviewers from the two, is
+    /// `kin_review::assignments` and is tested there.
+    ///
+    /// Falsify by dropping review audit events from the exported domain: the
+    /// removal never reaches the other replica and the last assertion goes red.
+    #[test]
+    fn a_removal_travels_and_a_replica_holding_the_assignment_does_not_undo_it() {
+        let fixture = fixture();
+        let peer = LocalPeer::new(&fixture.destination);
+        let review = review_record("assigned to two");
+        let id = review.review_id;
+        let assignment = |name: &str| ReviewAssignment {
+            review_id: id,
+            reviewer: IdentityRef::human(name),
+            assigned_at: Timestamp::now(),
+            assigned_by: IdentityRef::human("troy"),
+        };
+        let bob = assignment("bob");
+        let alice = assignment("alice");
+        record_collaboration(
+            &fixture.source,
+            &fixture.repository_id,
+            100,
+            CollaborationDelta {
+                reviews: vec![Keyed::new(id, review)],
+                review_assignments: vec![Keyed::new(id, vec![bob.clone(), alice.clone()])],
+                ..CollaborationDelta::default()
+            },
+        );
+        push(&fixture, &peer);
+        assert_eq!(
+            assignments_of(&fixture.destination, &id),
+            vec![bob.clone(), alice.clone()],
+            "the push carries both assignments"
+        );
+
+        // The remote takes bob off. The set it holds does not change; the event
+        // is what records it.
+        let removal = AuditEvent {
+            event_id: AuditEventId::new(),
+            actor_id: ActorId::new(),
+            action: "review.unassign".to_string(),
+            target_scope: None,
+            timestamp: Timestamp::now(),
+            details: Some(format!("review_id={id}; reviewer=bob")),
+        };
+        record_collaboration(
+            &fixture.destination,
+            &fixture.repository_id,
+            200,
+            CollaborationDelta {
+                audit_events: vec![removal.clone()],
+                ..CollaborationDelta::default()
+            },
+        );
+
+        // This replica still holds bob's assignment and pushes again.
+        push(&fixture, &peer);
+        assert_eq!(
+            assignments_of(&fixture.destination, &id),
+            vec![bob, alice],
+            "a push adds to the log and never re-assigns what a removal took off"
+        );
+        assert!(
+            holds_event(&fixture.destination, &removal.event_id),
+            "the remote still holds its removal"
+        );
+
+        // And a pull brings that removal home.
+        let remote = LocalPeer::new(&fixture.destination);
+        pull_from_remote(
+            &fixture.source,
+            &remote,
+            &fixture.repository_id,
+            &fixture.main,
+            &fixture.main,
+            AuthorId::new("review-puller"),
+        )
+        .unwrap();
+        assert!(
+            holds_event(&fixture.source, &removal.event_id),
+            "the removal travels to the replica that still held the assignment"
+        );
     }
 
     fn push(fixture: &Fixture, peer: &LocalPeer<'_>) -> RepositoryTransferOutcome {

--- a/crates/kin-review/src/assignments.rs
+++ b/crates/kin-review/src/assignments.rs
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Who a review's reviewers are, derived from its assignment records and the
+//! removals recorded against them.
+//!
+//! A collaboration delta upserts a review's whole assignment set and refuses an
+//! empty one, so a removal cannot be written as the set that is left. Removing a
+//! review's last reviewer would have no durable form at all, and a set compared
+//! by state cannot tell a removal from an addition, which is how a reviewer
+//! removed on one replica came back from a replica that still held the
+//! assignment.
+//!
+//! So a removal is recorded as history. A `review.unassign` audit event names
+//! each assignment it removes, by reviewer and the instant that assignment was
+//! made, and a review's reviewers are its stored assignments minus every pair a
+//! removal names. The events are the truth and the set is a view, so every
+//! surface that shows or plans reviewers reads them through this module rather
+//! than reading the stored set.
+
+use std::collections::HashSet;
+
+use kin_model::graph::{GraphStore, ProvenanceStore, ReviewStore};
+use kin_model::provenance::AuditEvent;
+use kin_model::review::{ReviewAssignment, ReviewId};
+use kin_model::Timestamp;
+use serde::{Deserialize, Serialize};
+
+/// The audit action that assigning a reviewer records.
+pub const ASSIGN_ACTION: &str = "review.assign";
+/// The audit action that removing a reviewer records, and the only durable
+/// record that the removal happened.
+pub const UNASSIGN_ACTION: &str = "review.unassign";
+
+/// The key an assign or unassign event carries its pairs under, inside the
+/// `key=value; key=value` details every review event already writes.
+const ASSIGNMENTS_KEY: &str = "assignments=";
+
+/// One assignment, as an event names it.
+///
+/// `assigned_at` is what separates one assignment of a reviewer from a later
+/// one, so a removal names the assignment it actually saw and never a
+/// re-assignment made after it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct AssignmentTag {
+    pub reviewer: String,
+    pub assigned_at: Timestamp,
+}
+
+impl AssignmentTag {
+    pub fn of(assignment: &ReviewAssignment) -> Self {
+        Self {
+            reviewer: assignment.reviewer.name.clone(),
+            assigned_at: assignment.assigned_at.clone(),
+        }
+    }
+}
+
+/// The `assignments=` fragment an event's details carry `tags` in.
+///
+/// JSON rather than the `key=value` spelling around it, because a reviewer name
+/// is free text: JSON escapes what a hand-rolled separator would not. The reader
+/// takes the one JSON value that follows the key, so the provenance the daemon's
+/// writer appends after it is untouched.
+pub fn tag_details(tags: &[AssignmentTag]) -> String {
+    let encoded = serde_json::to_string(tags).unwrap_or_else(|_| "[]".to_string());
+    format!("{ASSIGNMENTS_KEY}{encoded}")
+}
+
+/// The pairs `details` names, and none when it names none.
+pub fn tags_in_details(details: &str) -> Vec<AssignmentTag> {
+    let Some(start) = details.find(ASSIGNMENTS_KEY) else {
+        return Vec::new();
+    };
+    let rest = &details[start + ASSIGNMENTS_KEY.len()..];
+    serde_json::Deserializer::from_str(rest)
+        .into_iter::<Vec<AssignmentTag>>()
+        .next()
+        .and_then(Result::ok)
+        .unwrap_or_default()
+}
+
+/// Every assignment a removal in `events` names.
+pub fn removed_tags<'a>(
+    events: impl IntoIterator<Item = &'a AuditEvent>,
+) -> HashSet<AssignmentTag> {
+    events
+        .into_iter()
+        .filter(|event| event.action == UNASSIGN_ACTION)
+        .flat_map(|event| tags_in_details(event.details.as_deref().unwrap_or_default()))
+        .collect()
+}
+
+/// Every assignment a removal recorded in `store` names.
+///
+/// The whole audit log, because a removal is proven by an event of any age and
+/// the store's query filters on actor rather than on action. `usize::MAX` is
+/// how that query spells "all of it".
+pub fn removed_tags_in<S: GraphStore + ?Sized>(
+    store: &S,
+) -> Result<HashSet<AssignmentTag>, <S as GraphStore>::Error> {
+    let events = ProvenanceStore::query_audit_events(store, None, usize::MAX)?;
+    Ok(removed_tags(events.iter()))
+}
+
+/// The reviewers `review_id` has: its stored assignments, minus every pair a
+/// removal names.
+pub fn current_assignments<S: GraphStore + ?Sized>(
+    store: &S,
+    review_id: &ReviewId,
+) -> Result<Vec<ReviewAssignment>, <S as GraphStore>::Error> {
+    let removed = removed_tags_in(store)?;
+    let mut assignments = ReviewStore::get_review_assignments(store, review_id)?;
+    retain_current(&mut assignments, &removed);
+    Ok(assignments)
+}
+
+/// Drop from `assignments` every pair `removed` names.
+pub fn retain_current(assignments: &mut Vec<ReviewAssignment>, removed: &HashSet<AssignmentTag>) {
+    assignments.retain(|assignment| !removed.contains(&AssignmentTag::of(assignment)));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kin_model::provenance::{ActorId, AuditEventId};
+    use kin_model::review::ReviewId;
+    use kin_model::IdentityRef;
+
+    fn assignment(reviewer: &str, at: Timestamp) -> ReviewAssignment {
+        ReviewAssignment {
+            review_id: ReviewId::new(),
+            reviewer: IdentityRef::human(reviewer),
+            assigned_at: at,
+            assigned_by: IdentityRef::human("troy"),
+        }
+    }
+
+    fn event(action: &str, details: String) -> AuditEvent {
+        AuditEvent {
+            event_id: AuditEventId::new(),
+            actor_id: ActorId::new(),
+            action: action.to_string(),
+            target_scope: None,
+            timestamp: Timestamp::now(),
+            details: Some(details),
+        }
+    }
+
+    /// A removal names the assignment it saw, and the reader finds it whatever
+    /// the writer appended afterwards.
+    ///
+    /// Falsify by writing the pairs as bare text instead of JSON: the reviewer
+    /// holding a semicolon below comes back parsed as two names and the
+    /// round-trip assertion goes red.
+    #[test]
+    fn a_removal_names_the_assignment_it_removed() {
+        let at = Timestamp::now();
+        let awkward = assignment("ana; assigned_at=1970", at.clone());
+        let details = format!(
+            "review_id={}; reviewer={}; {}; authority_generation=7; session=abc",
+            awkward.review_id,
+            awkward.reviewer.name,
+            tag_details(&[AssignmentTag::of(&awkward)])
+        );
+
+        assert_eq!(tags_in_details(&details), vec![AssignmentTag::of(&awkward)]);
+        assert!(tags_in_details("review_id=1; reviewer=bob").is_empty());
+    }
+
+    /// The reviewers a review has are its assignments minus what removals name,
+    /// and a re-assignment after a removal is a different pair, so it stays.
+    ///
+    /// Falsify by matching a removal on the reviewer's name alone: the
+    /// re-assigned bob disappears and the last assertion goes red.
+    #[test]
+    fn a_removal_hides_the_assignment_it_names_and_no_later_one() {
+        let first = Timestamp::now();
+        let later = Timestamp::now();
+        let removed = assignment("bob", first);
+        let again = assignment("bob", later);
+        let kept = assignment("alice", Timestamp::now());
+        let removal = event(UNASSIGN_ACTION, tag_details(&[AssignmentTag::of(&removed)]));
+        let noise = event(ASSIGN_ACTION, tag_details(&[AssignmentTag::of(&again)]));
+
+        let removals = removed_tags([&removal, &noise]);
+        assert_eq!(removals.len(), 1, "only an unassign removes: {removals:?}");
+
+        let mut live = vec![removed.clone(), kept.clone(), again.clone()];
+        retain_current(&mut live, &removals);
+        assert_eq!(live, vec![kept, again]);
+    }
+}

--- a/crates/kin-review/src/lib.rs
+++ b/crates/kin-review/src/lib.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
+pub mod assignments;
 pub mod change_shape;
 pub mod diff;
 pub mod error;

--- a/crates/kin-review/src/records.rs
+++ b/crates/kin-review/src/records.rs
@@ -10,7 +10,7 @@
 //! surfaces that answer in JSON. A review is graph authority like any other
 //! record, so nothing here reads a file.
 
-use kin_model::graph::ReviewStore;
+use kin_model::graph::{GraphStore, ReviewStore};
 use kin_model::review::{
     Review, ReviewAssignment, ReviewDecision, ReviewDecisionState, ReviewDiscussion, ReviewFilter,
     ReviewId, ReviewNote,
@@ -68,18 +68,22 @@ pub fn list_stored_reviews<S: ReviewStore + ?Sized>(
 
 /// One review and its history, or `None` when the store holds no review under
 /// that id.
-pub fn read_review_record<S: ReviewStore + ?Sized>(
+/// The reviewers come from [`crate::assignments::current_assignments`] rather
+/// than from the stored set, because a removal is recorded as an event and the
+/// set it leaves behind cannot express one. Every surface that shows a review
+/// reads it here, so they all show the same reviewers.
+pub fn read_review_record<S: GraphStore + ?Sized>(
     store: &S,
     review_id: &ReviewId,
-) -> Result<Option<ReviewRecord>, S::Error> {
-    let Some(review) = store.get_review(review_id)? else {
+) -> Result<Option<ReviewRecord>, <S as GraphStore>::Error> {
+    let Some(review) = ReviewStore::get_review(store, review_id)? else {
         return Ok(None);
     };
     Ok(Some(ReviewRecord {
-        decisions: store.get_review_decisions(review_id)?,
-        notes: store.get_review_notes(review_id)?,
-        discussions: store.get_review_discussions(review_id)?,
-        assignments: store.get_review_assignments(review_id)?,
+        decisions: ReviewStore::get_review_decisions(store, review_id)?,
+        notes: ReviewStore::get_review_notes(store, review_id)?,
+        discussions: ReviewStore::get_review_discussions(store, review_id)?,
+        assignments: crate::assignments::current_assignments(store, review_id)?,
         review,
     }))
 }
@@ -333,6 +337,66 @@ mod tests {
                 .unwrap()
                 .is_none(),
             "an id the store does not hold is None, not an empty record"
+        );
+    }
+
+    /// A review shows the reviewers it has, which is its assignments minus
+    /// every one a removal names. Every surface reads a review here, so they
+    /// all show the same reviewers.
+    ///
+    /// Falsify by reading the stored set instead of deriving: the removed
+    /// reviewer comes back and the first assertion goes red.
+    #[test]
+    fn a_removed_reviewer_is_no_longer_a_reviewer() {
+        use crate::assignments::{tag_details, AssignmentTag, UNASSIGN_ACTION};
+        use kin_model::graph::ProvenanceStore;
+        use kin_model::provenance::{ActorId, AuditEvent, AuditEventId};
+        use kin_model::review::ReviewAssignment;
+
+        let graph = InMemoryGraph::new();
+        let review = review_at("assigned", 0, ReviewDecisionState::Pending);
+        graph.create_review(&review).unwrap();
+        let assignment = |name: &str| ReviewAssignment {
+            review_id: review.review_id,
+            reviewer: IdentityRef::human(name),
+            assigned_at: Timestamp::now(),
+            assigned_by: IdentityRef::human("troy"),
+        };
+        let bob = assignment("bob");
+        let alice = assignment("alice");
+        for entry in [&bob, &alice] {
+            graph.assign_reviewer(entry).unwrap();
+        }
+        graph
+            .record_audit_event(&AuditEvent {
+                event_id: AuditEventId::new(),
+                actor_id: ActorId::new(),
+                action: UNASSIGN_ACTION.to_string(),
+                target_scope: None,
+                timestamp: Timestamp::now(),
+                details: Some(format!(
+                    "review_id={}; reviewer=bob; {}",
+                    review.review_id,
+                    tag_details(&[AssignmentTag::of(&bob)])
+                )),
+            })
+            .unwrap();
+
+        let record = read_review_record(&graph, &review.review_id)
+            .unwrap()
+            .expect("the stored review reads back");
+        assert_eq!(
+            record.assignments,
+            vec![alice],
+            "a reviewer a removal names is not a reviewer any more"
+        );
+        assert_eq!(
+            graph
+                .get_review_assignments(&review.review_id)
+                .unwrap()
+                .len(),
+            2,
+            "and the stored set still holds both, because it is an add log"
         );
     }
 

--- a/crates/kin-review/src/write.rs
+++ b/crates/kin-review/src/write.rs
@@ -108,8 +108,20 @@ impl<A> PlannedReviewEvent<A> {
     /// Whether the writer records an audit event for this action. Creating a
     /// review and deciding one do; notes and comments carry their own author and
     /// time.
+    ///
+    /// Assigning and removing a reviewer do too, and for a second reason: a
+    /// removal has no other durable form. A delta upserts a review's whole
+    /// assignment set and refuses an empty one, so the event is what proves a
+    /// removal happened, and [`crate::assignments`] derives a review's reviewers
+    /// from the set and those events together.
     pub fn records_audit_event(&self) -> bool {
-        matches!(self.action, "review.create" | "review.decide")
+        matches!(
+            self.action,
+            "review.create"
+                | "review.decide"
+                | crate::assignments::ASSIGN_ACTION
+                | crate::assignments::UNASSIGN_ACTION
+        )
     }
 }
 

--- a/crates/kin-review/tests/derived_reviewers.rs
+++ b/crates/kin-review/tests/derived_reviewers.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Every surface that shows a review's reviewers derives them.
+//!
+//! A review's stored assignment set is an add log. A removal is recorded as a
+//! `review.unassign` audit event and never shrinks that set, because shrinking
+//! it cannot express removing a review's last reviewer and leaves a later
+//! re-assignment unable to reach the live graph. So a surface that reads the
+//! stored set shows reviewers who were removed, and
+//! `kin_review::assignments::current_assignments` is the one place that
+//! subtracts them.
+//!
+//! This is what fails when a new read surface skips it. It counts the raw reads
+//! per file rather than forbidding them outright, because the writers that keep
+//! the add log read it on purpose, and a new one has to be admitted here
+//! deliberately rather than by being overlooked.
+
+const REVIEW_RECORDS: &str = include_str!("../src/records.rs");
+const REVIEW_WRITE: &str = include_str!("../src/write.rs");
+const CLI_REVIEW: &str = include_str!("../../kin-cli/src/commands/review.rs");
+const MCP_REVIEW: &str = include_str!("../../kin-mcp/src/handlers/review.rs");
+const DAEMON_REVIEW: &str = include_str!("../../kin-daemon/src/repo_review.rs");
+
+const RAW_READ: &str = "get_review_assignments(";
+const DERIVED_READ: &str = "assignments::current_assignments(";
+
+/// What a file does, without what its tests do.
+///
+/// A test reads the stored set on purpose, to prove the add log still holds
+/// what a removal hid, and counting those would make this guard measure the
+/// tests rather than the surfaces.
+fn production(source: &str) -> &str {
+    source.split("\n#[cfg(test)]").next().unwrap_or(source)
+}
+
+fn occurrences(haystack: &str, needle: &str) -> usize {
+    production(haystack).matches(needle).count()
+}
+
+/// The scan can see a raw read at all, and the writers that keep the add log
+/// are where they are.
+///
+/// Without this, every count below could be zero because the needle is wrong
+/// rather than because nothing reads the stored set.
+#[test]
+fn the_writers_that_keep_the_add_log_read_the_stored_set() {
+    for (name, source, least) in [
+        (
+            "kin-review write.rs, which levels a written set",
+            REVIEW_WRITE,
+            2,
+        ),
+        (
+            "kin-cli review.rs, which appends an assignment",
+            CLI_REVIEW,
+            1,
+        ),
+        (
+            "kin-mcp review.rs, which appends and records a removal",
+            MCP_REVIEW,
+            2,
+        ),
+    ] {
+        let found = occurrences(source, RAW_READ);
+        assert!(
+            found >= least,
+            "{name} reads the stored set {found} time(s); this scan expected at least {least}, so \
+             either a writer stopped keeping the add log or the needle no longer matches"
+        );
+    }
+    assert_eq!(
+        occurrences(CLI_REVIEW, "get_review_assignments_no_crate_has("),
+        0,
+        "the must-miss control matched, so a count above proves nothing"
+    );
+}
+
+/// No surface that shows a review reads the stored set.
+#[test]
+fn no_review_read_surface_reads_the_stored_assignment_set() {
+    for (name, source) in [
+        (
+            "kin-review records.rs, where every surface reads a review",
+            REVIEW_RECORDS,
+        ),
+        ("kin-daemon repo_review.rs", DAEMON_REVIEW),
+    ] {
+        let found = occurrences(source, RAW_READ);
+        assert_eq!(
+            found, 0,
+            "{name} reads the stored assignment set {found} time(s), so it shows reviewers a \
+             removal already took off; read them through \
+             kin_review::assignments::current_assignments instead"
+        );
+    }
+    assert_eq!(
+        occurrences(REVIEW_RECORDS, DERIVED_READ),
+        1,
+        "records.rs must derive a review's reviewers exactly once, which is what every surface \
+         that shows a review reads"
+    );
+}
+
+/// The reviewers a review has come from one function, so two surfaces cannot
+/// disagree about who they are.
+#[test]
+fn one_function_answers_who_the_reviewers_are() {
+    let derivations = occurrences(REVIEW_RECORDS, DERIVED_READ)
+        + occurrences(CLI_REVIEW, DERIVED_READ)
+        + occurrences(MCP_REVIEW, DERIVED_READ)
+        + occurrences(DAEMON_REVIEW, DERIVED_READ);
+    assert!(
+        derivations >= 2,
+        "only {derivations} call site(s) derive the reviewers; the read path and the removal \
+         planner both have to, or a removal is decided against the wrong set"
+    );
+}


### PR DESCRIPTION
Removing a reviewer now sticks. Before this, a reviewer removed on one replica came back the moment a replica that still held the assignment pushed or pulled, because an assignment set compared by state cannot tell a removal from an addition. #1727 disclosed that under "What the rule leaves open"; this fixes it.

A review's stored assignment set is an add log now: it only grows. What records a removal is a `review.unassign` audit event naming the assignment it removed, by reviewer and the instant that assignment was made. A review's reviewers are the add log minus every pair a removal names, derived wherever a review is read. The events are the truth and the set is a view.

## Why this shape and not a smaller set

Three things follow from it, and the first two are why a removal does not just write a shorter set.

- Removing a review's last reviewer works. A collaboration delta refuses an empty assignment set, so a removal that emptied the set had no durable form at all, and the MCP tool refused it by name. An event has no such limit, so that refusal is gone.
- Re-assigning someone after removing them works. `ReviewWrite::apply_to` levels a live set by removing reviewers by name and then appending what the written set has past the live prefix. A set that had shrunk could not be leveled to one naming the same person again: the write lands in authority and the live graph cannot follow it, which is the `Diverged` refusal a review write must never take. An add log never shrinks, so a re-assignment is an append and the earlier pair stays, hidden.
- The transfer needs no new rule. A set that only grows merges by appending, so no transfer drops a reviewer, the receiver's prefix guard from #1727 stands exactly as written, and the removal travels as a review audit event, which #1727 already carries to any replica that lacks it.

## Where the reviewers are read

`kin_review::assignments::current_assignments` is the one function that subtracts removals, and `read_review_record` is the one place every surface reads a review: `kin review list` and `kin review show`, the `kin_review_list` and `kin_review_get` MCP tools, and the daemon's repo-scoped review routes. The removal planner derives too, so removing someone twice records nothing the second time. A source guard test counts the raw reads per file, so a new surface that reads the stored set fails it rather than quietly showing reviewers who were removed.

The pairs travel in the `assignments=` key of an event's details, holding a JSON array, inside the `key=value; key=value` details review events already write. JSON because a reviewer name is free text, and the reader takes the one JSON value after the key, so the provenance the daemon's writer appends afterwards is untouched.

## Tests, each falsified

Every test was run against a mutation that breaks the behaviour it guards, and all six went red on their own target test. Files were restored afterwards.

| Test | What the mutation broke |
|---|---|
| `a_removed_reviewer_stays_removed_after_a_restart` (kin-daemon) | `records_audit_event` stops recording `review.unassign`, so nothing proves the removal and the reopened daemon answers with the reviewer again. |
| `a_removed_reviewer_is_no_longer_a_reviewer` (kin-review) | `read_review_record` reads the stored set instead of deriving, so a removed reviewer is shown. |
| `a_removal_hides_the_assignment_it_names_and_no_later_one` | a removal matches on the reviewer's name instead of the pair, so re-assigning that person disappears too. |
| `a_removal_names_the_assignment_it_removed` | the pairs go into details as bare text instead of JSON, so a reviewer name holding a separator no longer round-trips. |
| `a_removal_travels_and_a_replica_holding_the_assignment_does_not_undo_it` (kin-remote) | the exported review domain drops audit events, so the removal never reaches the other replica. |
| `a_removed_reviewer_stays_removed_after_a_restart`, second arm | a removal shrinks the assignment set again, which cannot express removing a review's last reviewer. |

The sweep's output, verbatim, trimmed to the verdict and where each target test panicked. Its line numbers are from the tree it ran on, which carried a temporary measurement harness that is not in this PR.

```
F1-unassign-records-no-event: rc=101 RED, the mutant is killed by its target test | panicked at crates/kin-daemon/src/api.rs:49376:9
F2-read-the-stored-set: rc=101 RED, the mutant is killed by its target test | panicked at crates/kin-review/src/records.rs:388:9
F3-remove-by-name: rc=101 RED, the mutant is killed by its target test | panicked at crates/kin-review/src/assignments.rs:198:9
F4-pairs-as-bare-text: rc=101 RED, the mutant is killed by its target test | panicked at crates/kin-review/src/assignments.rs:171:9
F5-export-drops-review-events: rc=101 RED, the mutant is killed by its target test | panicked at crates/kin-remote/src/repository_transfer_negotiation.rs:1807:14
F6-removal-shrinks-the-set: rc=101 RED, the mutant is killed by its target test | panicked at crates/kin-daemon/src/api.rs:49389:9
FALSIFY_DONE restored=True at 20:39:00Z
```

Targeted tests, each with `KIN_EMBED_BACKEND=cpu`:

```
cargo test --locked -p kin-review                                277 passed + 3 guard tests, 0 failed
cargo test --locked -p kin-remote --lib                          140 passed, 0 failed
cargo test --locked -p kin-daemon --lib review                    23 passed, 0 failed
cargo test --locked -p kin-mcp --lib review                        7 passed, 0 failed
cargo test --locked -p kin-cli --lib commands::review               7 passed, 0 failed
```

`bin/kin-precheck kin` on the lane commit, every gate the check job in `ci.yml` names:

```
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin 4e1316c14a1e599f022a012a43ec0f966b44a111
```

## Numbers

Deriving a review's reviewers reads the audit log, and the store's audit query filters by actor rather than by action, so the cost is linear in the log. Measured in the crate on the test profile, which is an unoptimized build, on an Apple M5 Max: 200 reads of one review holding three assignments and one removal, through `read_review_record`, which is what every review surface calls.

| Audit events in the store | One `read_review_record` |
|---|---|
| 0 | 8.7 µs |
| 1,000 | 126.0 µs |
| 10,000 | 1,325.0 µs |

That is about 0.13 µs per recorded event. The surfaces that pay it are the ones that show a review: `kin review show` and `kin review list`, `kin_review_get` and `kin_review_list`, and the daemon's review routes. If a store ever holds enough events for that to matter, the answer is an audit query that filters on action, not a different record shape, because the events are what a removal is either way.

## Boundary

`records_audit_event` in the landed review write path gains `review.assign` and `review.unassign`, which is additive and is the change the captain approved; nothing else in that path moves. The standalone MCP server, the one with no repository authority behind it, records no audit event and never did, so it takes the reviewer off its own graph directly, as that surface always has. No root manifest and no `Cargo.lock` change.

## What is still open

A removal made before this landed recorded no event, so nothing proves it, and it behaves as it did: a replica that still holds the assignment can put it back. There is no history to backfill from. The durable end state is kin-model and kin-db accepting an explicit empty assignment set, after which a removal could shrink the set directly and this derivation would be a no-op for new stores; that is filed as a follow-up rather than started here.
