### PR TITLE
Read a daemon's death off the record rather than off the sentence it rendered

### DIFF
--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -195,12 +195,20 @@ macro_rules! note {
 }
 
 /// Exit status for a conversion that produced a store whose semantic enrichment
-/// a killed daemon left unattested.
+/// a daemon's death left unattested.
 ///
 /// Distinct from success so a script can tell "converted" from "converted, and
 /// something died on the way", and distinct from 1 so it is never read as the
 /// conversion having failed. The store is real, publishable and answers
 /// questions; what nobody can attest is that its enrichment finished.
+///
+/// A death, not specifically a kill. The store's summary says which of the two
+/// its record supports, and on a host that publishes no memory accounting it
+/// says the weaker one, because an ending nothing waited on carries no exit
+/// status to attribute. Both leave the enrichment equally unattested, so both
+/// reach a script as this code; see
+/// [`EnrichmentCaveat`][crate::daemon_death::EnrichmentCaveat], which is the
+/// one reading this code and that summary are both derived from.
 pub const EXIT_ENRICHMENT_UNATTESTED: i32 = 7;
 
 /// Exit status for a verified init whose reopen-acceleration section did not
@@ -387,14 +395,24 @@ fn materialize_graph_section_after_init(
 /// So the degraded outcome gets its own code rather than an error. Exit 1 would
 /// say the conversion failed and invite a re-run, which at the repository size
 /// that causes this is a loop that cannot terminate.
+///
+/// Derived from the same reading the summary above is rendered from, rather
+/// than from the presence of a record. The two are the same set today and were
+/// still able to disagree about what they had said: the summary gained a second
+/// vocabulary for a death nothing observed, and everything that recognized a
+/// named death by matching the first vocabulary went stale without either
+/// surface changing its mind. One reading feeding both is what makes the
+/// agreement structural rather than a coincidence maintained by hand.
 fn exit_code_for(
     daemon_death: Option<&kin_daemon_spawn::DaemonKillRecord>,
     graph_section_failed: bool,
 ) -> i32 {
-    match daemon_death {
-        Some(_) => EXIT_ENRICHMENT_UNATTESTED,
-        None if graph_section_failed => EXIT_GRAPH_SECTION_UNMATERIALIZED,
-        None => 0,
+    if crate::daemon_death::enrichment_caveat(daemon_death).names_a_death() {
+        EXIT_ENRICHMENT_UNATTESTED
+    } else if graph_section_failed {
+        EXIT_GRAPH_SECTION_UNMATERIALIZED
+    } else {
+        0
     }
 }
 
@@ -3271,6 +3289,14 @@ mod tests {
     /// that are each correct can still jointly guarantee nothing: this walks the
     /// same reading into both surfaces and requires them to match, so a future
     /// change that fixes one and forgets the other goes red here.
+    ///
+    /// Every death class is walked, and that is the second defect this test
+    /// records. It used to feed one memory kill, so when a second class arrived
+    /// with a second sentence it stayed green while `kin init` exited 7 over a
+    /// summary whose wording no longer matched what this asserted about. The
+    /// agreement is now read off the caveat rather than off a sentence, and the
+    /// sentence is required to carry that caveat's own clause, so the surface
+    /// and the number cannot drift apart in either direction.
     #[test]
     fn the_exit_code_and_the_summary_agree_about_a_killed_daemon() {
         let status = enrichment(SemanticEnrichmentPresence::Present, 1058);
@@ -3286,19 +3312,53 @@ mod tests {
             limit_bytes: Some(8 * 1024 * 1024 * 1024),
             last_rss_bytes: Some(7 * 1024 * 1024 * 1024),
         };
+        // The ending nothing waited on: no signal and no memory attribution,
+        // which is what every macOS host and every uncapped Linux one records,
+        // and what both acceptance suites drive this path into.
+        let unobserved = kin_daemon_spawn::DaemonKillRecord {
+            memory_kills: 0,
+            last_cause: kin_daemon_spawn::DaemonKillCause::Unattributed { signal: 0 },
+            limit_bytes: None,
+            last_rss_bytes: None,
+            ..record
+        };
+        let signalled = kin_daemon_spawn::DaemonKillRecord {
+            last_cause: kin_daemon_spawn::DaemonKillCause::Unattributed { signal: 9 },
+            ..unobserved
+        };
 
-        for reading in [None, Some(&record)] {
+        for reading in [None, Some(&record), Some(&unobserved), Some(&signalled)] {
             let summary =
                 render_semantic_enrichment(&status, reading, &CrossFileEnrichment::Produced);
-            let names_a_kill = summary.contains("a daemon serving this store was killed");
+            let caveat = crate::daemon_death::enrichment_caveat(reading);
+            assert!(
+                summary.contains(caveat.clause()),
+                "the summary does not carry the caveat it was rendered from: wanted {:?} in \
+                 ({summary})",
+                caveat.clause()
+            );
+            let names_a_death = caveat.names_a_death();
             let code = exit_code_for(reading, false);
             assert_eq!(
-                names_a_kill,
+                names_a_death,
                 code != 0,
                 "the summary and the exit code disagree about one run: summary said \
-                 {names_a_kill}, exit code was {code} ({summary})"
+                 {names_a_death}, exit code was {code} ({summary})"
+            );
+            assert_eq!(
+                names_a_death,
+                summary.contains(crate::daemon_death::DEATH_CLAUSE_STEM),
+                "a reader recognizes a death by naming a daemon of this store, and this run \
+                 reads {names_a_death} to the caveat and the other way to the reader ({summary})"
             );
         }
+
+        assert_eq!(
+            exit_code_for(Some(&unobserved), false),
+            EXIT_ENRICHMENT_UNATTESTED,
+            "a daemon that ended without retiring left the enrichment just as unattested as \
+             one the kernel killed, and the code a script reads says so"
+        );
 
         assert_eq!(
             exit_code_for(None, false),

--- a/crates/kin-cli/src/daemon_death.rs
+++ b/crates/kin-cli/src/daemon_death.rs
@@ -125,33 +125,114 @@ pub fn kin_root_from_cwd() -> Option<std::path::PathBuf> {
     Some(kin_core::KinLayout::discover(&cwd)?.root().to_path_buf())
 }
 
+/// The half of the caveat every clause about a dead daemon carries, whatever
+/// vocabulary the record supports.
+///
+/// Named once because three separate surfaces have to recognize "this store's
+/// caveat names a daemon's death" across every death class, and each of them
+/// did it by matching whichever whole sentence existed the day it was written.
+/// [`EnrichmentCaveat`] records what that cost.
+pub const DEATH_CLAUSE_STEM: &str = "a daemon serving this store";
+
+/// What a store's own records let its enrichment caveat claim, as a value
+/// rather than as a sentence.
+///
+/// The reading is named because asking for it by matching the sentence is what
+/// broke. A second death class arrived with a second sentence, and every
+/// matcher written against the first went stale in that same commit while
+/// reading exactly like a product that had stopped reporting deaths at all:
+/// `kin init` kept exiting [`EXIT_ENRICHMENT_UNATTESTED`][exit] over a summary
+/// that no longer carried the phrase the exit code was being checked against,
+/// so the number a script reads and the sentence a person reads disagreed
+/// about one run. That is the FIR-2650 defect in the other direction, and both
+/// acceptance suites that grade this reported it as the product having
+/// regressed.
+///
+/// So the classification is a value every surface can ask for, the clause is
+/// derived from it, and [`Self::names_a_death`] is the one predicate the exit
+/// code is built on. A caller that wants to know whether a death was named
+/// asks the reading; nothing downstream matches a sentence.
+///
+/// [exit]: crate::commands::init::EXIT_ENRICHMENT_UNATTESTED
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnrichmentCaveat {
+    /// Nothing on record. The ordinary and unalarming case, true of a store
+    /// that never lost a daemon: its enrichment simply has not been certified.
+    Unattested,
+    /// A daemon serving this store ended without retiring its record, and
+    /// nothing on this host saw how. A kernel kill, a crash and a force exit
+    /// past the shutdown grace all leave exactly this, so the reading says how
+    /// it ended as far as anything saw it and stops there.
+    EndedWithoutRetiring,
+    /// A daemon serving this store was killed, and something observed it: the
+    /// kernel attributed the death to memory, or a signal was seen.
+    Killed,
+}
+
+impl EnrichmentCaveat {
+    /// Whether this caveat names a daemon's death at all, in either vocabulary.
+    ///
+    /// The predicate `kin init`'s exit code is derived from, so the number and
+    /// the sentence come from one reading of one record rather than from two
+    /// readings that are each correct and can still disagree about a run.
+    pub fn names_a_death(self) -> bool {
+        !matches!(self, Self::Unattested)
+    }
+
+    /// The clause this reading renders as, in place of a bare "completion not
+    /// attested".
+    ///
+    /// A store whose enrichment nobody attested and whose daemon died reads,
+    /// unchanged, exactly like a store whose enrichment simply has not been
+    /// certified yet. The counts are the same, the presence is the same, and
+    /// the parenthetical is the same. Naming the death is the only thing that
+    /// separates them.
+    ///
+    /// It stays a clause rather than becoming the whole line because the counts
+    /// beside it are still true: the entities were extracted and the relations
+    /// were derived. What is in doubt is whether anything more was coming.
+    pub fn clause(self) -> &'static str {
+        match self {
+            Self::Unattested => "completion not attested",
+            Self::EndedWithoutRetiring => {
+                "completion not attested, and a daemon serving this store ended without retiring"
+            }
+            Self::Killed => "completion not attested, and a daemon serving this store was killed",
+        }
+    }
+}
+
+/// How this store's records qualify its enrichment.
+///
+/// Exhaustive over the cause on purpose, so a third death class cannot be added
+/// without deciding here which vocabulary it belongs in. The arm this replaces
+/// was a `Some(_)` fallthrough, which is how the second class arrived already
+/// classified as the first.
+pub fn enrichment_caveat(record: Option<&DaemonKillRecord>) -> EnrichmentCaveat {
+    let Some(record) = record else {
+        return EnrichmentCaveat::Unattested;
+    };
+    match (record.attributed_to_memory(), record.last_cause) {
+        // The kernel's own accounting saw it, whatever the signal says.
+        (true, _) => EnrichmentCaveat::Killed,
+        (false, kin_daemon_spawn::DaemonKillCause::MemoryLimit { .. }) => EnrichmentCaveat::Killed,
+        // Signal zero is the record saying it has no signal, not a signal
+        // numbered zero: nobody waited on the process, so its exit status is
+        // gone. An ending nothing observed is not a kill anything saw.
+        (false, kin_daemon_spawn::DaemonKillCause::Unattributed { signal: 0 }) => {
+            EnrichmentCaveat::EndedWithoutRetiring
+        }
+        (false, kin_daemon_spawn::DaemonKillCause::Unattributed { .. }) => EnrichmentCaveat::Killed,
+    }
+}
+
 /// The clause that replaces a bare "completion not attested".
 ///
-/// A store whose enrichment nobody attested and whose daemon was killed reads,
-/// unchanged, exactly like a store whose enrichment simply has not been
-/// certified yet, which is the ordinary and unalarming case. The counts are the
-/// same, the presence is the same, and the parenthetical is the same. Naming
-/// the kill is the only thing that separates them.
-///
-/// It stays a clause rather than becoming the whole line because the counts
-/// beside it are still true: the entities were extracted and the relations were
-/// derived. What is in doubt is whether anything more was coming.
+/// Kept as a function because two rendering surfaces interpolate it directly.
+/// Any caller that needs to know what the clause SAYS asks
+/// [`enrichment_caveat`] instead.
 pub fn enrichment_clause(record: Option<&DaemonKillRecord>) -> &'static str {
-    match record {
-        // An ending nothing observed is not a kill anything saw. The record says
-        // the daemon did not retire, and that is all it says.
-        Some(record)
-            if !record.attributed_to_memory()
-                && matches!(
-                    record.last_cause,
-                    kin_daemon_spawn::DaemonKillCause::Unattributed { signal: 0 }
-                ) =>
-        {
-            "completion not attested, and a daemon serving this store ended without retiring"
-        }
-        Some(_) => "completion not attested, and a daemon serving this store was killed",
-        None => "completion not attested",
-    }
+    enrichment_caveat(record).clause()
 }
 
 /// The sentence a daemon request that went unanswered ends with, when the store
@@ -400,6 +481,97 @@ mod tests {
         let killed = enrichment_clause(Some(&memory_kill()));
         assert!(killed.starts_with("completion not attested"), "{killed}");
         assert!(killed.contains("killed"), "{killed}");
+    }
+
+    /// Every death this record can hold reaches a reader as a death.
+    ///
+    /// The class this guards is wording drift, and it has been paid for once.
+    /// A second death class arrived with a second sentence and every surface
+    /// that recognized "the caveat named a death" by matching the first
+    /// sentence went stale in that commit: two acceptance suites reported the
+    /// product as having stopped naming daemon deaths, on a build that had
+    /// started naming them more precisely. Those suites grade main after a
+    /// landing and no pull request sees them, so this stands in for them where
+    /// a pull request can go red.
+    ///
+    /// Written over every cause rather than over the two sentences, so a third
+    /// class is caught by this test and by the exhaustive match it exercises
+    /// rather than by a release. Both halves are required: a death clause has
+    /// to carry the stem, and the no-record control has to not carry it, or a
+    /// build that appended the stem to every caveat would pass a one-sided
+    /// check while telling a healthy reader their daemon died.
+    #[test]
+    fn every_death_class_names_a_daemon_of_this_store_in_its_caveat() {
+        let every_death = [
+            memory_kill(),
+            unattributed_kill(),
+            DaemonKillRecord {
+                last_cause: DaemonKillCause::Unattributed { signal: 9 },
+                ..unattributed_kill()
+            },
+            // A cause the kernel named without the tally agreeing, which is
+            // what a record written by an older build can carry.
+            DaemonKillRecord {
+                memory_kills: 0,
+                last_cause: DaemonKillCause::MemoryLimit {
+                    kernel_oom_kills: 1,
+                },
+                ..memory_kill()
+            },
+        ];
+        for record in &every_death {
+            let caveat = enrichment_caveat(Some(record));
+            assert!(
+                caveat.names_a_death(),
+                "{:?} is a death this store recorded and its caveat does not name one",
+                record.last_cause
+            );
+            let clause = caveat.clause();
+            assert!(
+                clause.contains(DEATH_CLAUSE_STEM),
+                "a reader and the suites that grade this recognize a death by {DEATH_CLAUSE_STEM:?}, \
+                 and {:?} renders {clause:?}",
+                record.last_cause
+            );
+            assert!(
+                clause.starts_with("completion not attested"),
+                "the counts beside it are still true: {clause}"
+            );
+        }
+
+        let control = enrichment_caveat(None);
+        assert!(
+            !control.names_a_death(),
+            "a store that lost no daemon must name none"
+        );
+        assert!(
+            !control.clause().contains(DEATH_CLAUSE_STEM),
+            "a reader who has never lost a daemon must not start seeing daemon deaths \
+             discussed: {}",
+            control.clause()
+        );
+    }
+
+    /// The two vocabularies stay apart, and each keeps its own class.
+    #[test]
+    fn an_observed_kill_and_an_unobserved_ending_read_as_different_things() {
+        assert_eq!(
+            enrichment_caveat(Some(&memory_kill())),
+            EnrichmentCaveat::Killed
+        );
+        assert_eq!(
+            enrichment_caveat(Some(&unattributed_kill())),
+            EnrichmentCaveat::EndedWithoutRetiring
+        );
+        assert_eq!(
+            enrichment_caveat(Some(&DaemonKillRecord {
+                last_cause: DaemonKillCause::Unattributed { signal: 9 },
+                ..unattributed_kill()
+            })),
+            EnrichmentCaveat::Killed,
+            "a signal something saw is a kill something saw"
+        );
+        assert_eq!(enrichment_caveat(None), EnrichmentCaveat::Unattested);
     }
 
     /// A store nothing has happened to says what it always said.

--- a/scripts/acceptance/init_budget_refusal.py
+++ b/scripts/acceptance/init_budget_refusal.py
@@ -601,6 +601,31 @@ def check_3(suite):
     return result
 
 
+# The half every clause about a dead daemon carries, in either vocabulary. It
+# matches `DEATH_CLAUSE_STEM` in `crates/kin-cli/src/daemon_death.rs`, which the
+# product renders every one of those clauses from.
+DEATH_CLAUSE_STEM = "a daemon serving this store"
+
+
+def summary_names_a_daemon_death(text):
+    """Whether `kin init`'s summary says a daemon of this store died.
+
+    Written over the stem both clauses share rather than over one of the
+    sentences, because matching a sentence is what broke. This check asked for
+    "a daemon serving this store was killed" verbatim; the product then gained
+    a second, more careful clause for an ending nothing observed, which is
+    exactly what this check's own kill produces on a host with no cgroup
+    accounting, and the check reported the product as having stopped naming
+    deaths on the build that had started naming them precisely.
+
+    Both halves are required. The caveat alone is true of every store and is
+    what the defect looked like, so a text carrying only "completion not
+    attested" names no death.
+    """
+    text = text or ""
+    return "completion not attested" in text and DEATH_CLAUSE_STEM in text
+
+
 def check_4(suite):
     """A daemon killed during a conversion makes `kin init` exit non-zero.
 
@@ -608,6 +633,13 @@ def check_4(suite):
     "completion not attested, and a daemon serving this store was killed". The
     words were already right; the exit code was the surface a scripted setup
     reads and it said the run was fine.
+
+    The summary is graded on what it names, not on which sentence it uses. A
+    daemon killed on a host that publishes no memory accounting, which is every
+    macOS host and every uncapped Linux one, leaves a record with no signal and
+    no attribution, and the product says that store's daemon "ended without
+    retiring" rather than claiming a kill nothing saw. Both readings are a
+    daemon death this store recorded, and both must carry the non-zero exit.
 
     Driven by killing the real daemon rather than by planting a record. The pid
     comes from the store's own `daemon.serving` file and the signal goes to that
@@ -694,23 +726,23 @@ def check_4(suite):
         result.unknown("the conversion wrote no store, so this is not the case under test")
         return result
 
-    says_killed = "a daemon serving this store was killed" in out
+    says_died = summary_names_a_daemon_death(out)
     if rc == 0:
         result.bad("`kin init` exited 0 after its daemon was killed, which is the zero a "
-                   "scripted setup reads as done (summary named the kill: %s)" % says_killed)
+                   "scripted setup reads as done (summary named the death: %s)" % says_died)
     else:
         result.ok("`kin init` exited %d" % rc)
 
     # The two surfaces have to agree. A non-zero exit whose summary says nothing,
-    # or a summary that names a kill beside a zero, is the same defect wearing
+    # or a summary that names a death beside a zero, is the same defect wearing
     # the other face.
-    if says_killed and rc == 0:
-        result.bad("the summary names the kill and the exit code says success")
-    elif rc != 0 and not says_killed:
-        result.bad("`kin init` exited %d but its summary never names a killed daemon: %s"
-                   % (rc, tail(out, 700)))
-    elif says_killed and rc != 0:
-        result.ok("the summary and the exit code agree that a daemon was killed")
+    if says_died and rc == 0:
+        result.bad("the summary names the death and the exit code says success")
+    elif rc != 0 and not says_died:
+        result.bad("`kin init` exited %d but its summary never names a daemon of this store "
+                   "that died: %s" % (rc, tail(out, 700)))
+    elif says_died and rc != 0:
+        result.ok("the summary and the exit code agree that a daemon of this store died")
     return result
 
 
@@ -907,6 +939,33 @@ def self_test():
     expect(passing.status == PASS, "two passes did not read PASS")
     expect("one" in passing.detail and "two" in passing.detail,
            "a passing detail dropped one of its assertions")
+
+    # The summary grader, over both vocabularies the product renders and over
+    # the two texts it must reject. The second accepted case is the one that
+    # went stale: a kill on a host with no memory accounting, which is what this
+    # suite's own check 4 produces.
+    death_summaries = [
+        (True, "Semantic enrichment: present (1058 entities, 2016 relations, 6731 changes in "
+               "durable authority generation 1; completion not attested, and a daemon serving "
+               "this store was killed)"),
+        (True, "Semantic enrichment: present (6 entities, 6 relations, 1 changes in durable "
+               "authority generation 2; completion not attested, and a daemon serving this "
+               "store ended without retiring)"),
+        # The measured line, which is the one this grader must reject: every
+        # word of it is true of a healthy store.
+        (False, "Semantic enrichment: present (1058 entities, 2016 relations, 6731 changes in "
+                "durable authority generation 1; completion not attested)"),
+        # A summary that named a daemon and dropped the caveat is not a fix
+        # either: the counts are still unattested and a reader loses that.
+        (False, "Semantic enrichment: present (1058 entities; a daemon serving this store was "
+                "killed)"),
+        (False, ""),
+        (False, None),
+    ]
+    for want, text in death_summaries:
+        expect(summary_names_a_daemon_death(text) == want,
+               "summary_names_a_daemon_death(%r) = %s, wanted %s"
+               % (text, summary_names_a_daemon_death(text), want))
 
     expect(len(CHECKS) == len({check_id for check_id, _ in CHECKS}),
            "two checks share an id, so one of them cannot be selected")

--- a/scripts/acceptance/memory_pressure_refusal.py
+++ b/scripts/acceptance/memory_pressure_refusal.py
@@ -624,11 +624,20 @@ def names_a_death(text):
     # `daemon_loss_explanation` and the kill record's own summary. Listed rather
     # than guessed at, because a grader matching a phrase nothing emits passes
     # every build.
+    #
+    # "without retiring" is the vocabulary for an ending nothing observed: no
+    # signal and no memory attribution, which is what every macOS host and every
+    # uncapped Linux one records. It is listed because this grader was passing
+    # such a sentence on the incidental "is gone" inside "its exit signal is
+    # gone", which is a phrase about the signal rather than about the daemon, so
+    # a reword of that sub-clause would have turned a real death into a silent
+    # miss.
     return any(phrase in text for phrase in (
         "is gone",
         "was terminated",
         "killed",
         "stopped beating",
+        "without retiring",
     ))
 
 
@@ -762,16 +771,31 @@ def enrichment_line(text):
     return None
 
 
-def enrichment_names_a_kill(line):
-    """Whether the enrichment line says a daemon serving this store was killed.
+# The half every clause about a dead daemon carries, in either vocabulary. It
+# matches `DEATH_CLAUSE_STEM` in `crates/kin-cli/src/daemon_death.rs`, which the
+# product renders every one of those clauses from.
+DEATH_CLAUSE_STEM = "a daemon serving this store"
+
+
+def enrichment_names_a_death(line):
+    """Whether the enrichment line says a daemon of this store died.
 
     "Completion not attested" is true of every store, which is exactly why it
     hid this one: the counts, the presence and the caveat were identical to a
     store whose enrichment simply had not been certified yet. Both halves are
     required, because the caveat alone is what the defect looked like.
+
+    The death half is read off the stem both clauses share rather than off the
+    word "killed". This grader asked for "killed" and the product then gained a
+    second, more careful clause for an ending nothing observed, which is what
+    this check's own SIGKILL produces on a host with no cgroup accounting: the
+    record carries no signal and no attribution, so the product says the daemon
+    "ended without retiring" rather than claiming a kill nothing saw. The check
+    then reported the product as having stopped naming deaths on the build that
+    had started naming them precisely.
     """
     line = line or ""
-    return "completion not attested" in line and "killed" in line
+    return "completion not attested" in line and DEATH_CLAUSE_STEM in line
 
 
 GRADERS = {
@@ -784,7 +808,7 @@ GRADERS = {
     "reason_names_the_budget": reason_names_the_budget,
     "status_publishes_the_standing": status_publishes_the_standing,
     "offers_the_idle_window": offers_the_idle_window,
-    "enrichment_names_a_kill": enrichment_names_a_kill,
+    "enrichment_names_a_death": enrichment_names_a_death,
     "row_reports_a_kill": row_reports_a_kill,
     "footprint_child_verdict": footprint_child_verdict,
     "contemporaneous_reading": contemporaneous_reading,
@@ -1864,9 +1888,16 @@ def check_9(suite):
     reader has no signal at all.
 
     The claim the fix may make is joint and not causal: this store's enrichment
-    is unattested AND a daemon serving it was killed. Whether that kill is what
+    is unattested AND a daemon serving it died. Whether that death is what
     stopped the enrichment is not something the record establishes, so the check
     does not ask for it.
+
+    Nor does it ask for one wording. The kill below is a SIGKILL this check
+    sends, and on a host that publishes no memory accounting the store's record
+    carries no signal and no attribution, so the product says that daemon
+    "ended without retiring" rather than claiming a kill nothing saw. Both are
+    this store naming a daemon of its own that died, which is what the reader
+    had no signal of at all, and the grader reads the stem they share.
 
     `kin status` is the surface probed because it is the durable one and it can
     be asked again. `kin init` renders the same clause from the same function
@@ -1875,7 +1906,7 @@ def check_9(suite):
     """
     result = Result(
         "9", TICKET_DEATH,
-        "an unattested enrichment names the daemon kill behind it, or names none",
+        "an unattested enrichment names the daemon death behind it, or names none",
     )
 
     # The control first, so a build that named a kill unconditionally fails here
@@ -1887,10 +1918,10 @@ def check_9(suite):
         result.unknown("this build's `kin status` carries no durable enrichment line: %s"
                        % tail(out, 700))
         return result
-    if enrichment_names_a_kill(line):
+    if enrichment_names_a_death(line):
         result.bad("a store that has lost no daemon reports one anyway: %s" % line)
     else:
-        result.ok("a store that has lost no daemon names no kill")
+        result.ok("a store that has lost no daemon names no death")
 
     repo = suite.fixture("killedenrich")
     rc, out = suite.restart_daemon(repo, pressure="nominal")
@@ -1917,8 +1948,8 @@ def check_9(suite):
         result.unknown("this build's `kin status` carries no durable enrichment line after "
                        "the kill: %s" % tail(out, 700))
         return result
-    if enrichment_names_a_kill(line):
-        result.ok("the enrichment line names the kill beside its counts")
+    if enrichment_names_a_death(line):
+        result.ok("the enrichment line names the daemon's death beside its counts")
     else:
         result.bad("the enrichment of a store whose daemon was killed reads exactly like one "
                    "that was merely never certified: %s" % line)
@@ -2805,6 +2836,12 @@ def self_test():
         (True, "the daemon serving this repository (pid 41) is gone; it was committing"),
         (True, "a daemon serving this store was killed 1 time(s)"),
         (True, "the daemon serving this repository was terminated while the request was in flight"),
+        # An ending nothing observed. It used to be accepted only by accident,
+        # on the "is gone" inside "its exit signal is gone", so the phrase about
+        # the daemon rather than about the signal is what carries it now.
+        (True, "a daemon serving this store ended 4 time(s) since 2026-09-11 20:42Z without "
+               "retiring its serving record, with nothing waiting on it, so how it ended is "
+               "not known"),
         # The measured sentence, which is the thing this grader must reject.
         (False, "the kin daemon at http://127.0.0.1:39767 stopped answering while the lsp "
                 "sweep status request was in flight; it exits after its idle window, so "
@@ -2857,21 +2894,28 @@ def self_test():
         (True, "Durable semantic enrichment: present (1058 entities, 2016 relations, 6731 "
                "changes at authority generation 1, workspace generation 1; completion not "
                "attested, and a daemon serving this store was killed)"),
+        # The second vocabulary, for an ending nothing observed. This is the
+        # line check 9's own SIGKILL produces on a host with no cgroup
+        # accounting, and the line this grader used to reject, reporting the
+        # product red for saying something more careful than "killed".
+        (True, "Durable semantic enrichment: present (6 entities, 6 relations, 1 changes at "
+               "authority generation 2, workspace generation 1; completion not attested, and "
+               "a daemon serving this store ended without retiring)"),
         # The measured line, which is the one this grader must reject.
         (False, "Durable semantic enrichment: present (1058 entities, 2016 relations, 6731 "
                 "changes at authority generation 1, workspace generation 1; completion not "
                 "attested)"),
         # A line that dropped the caveat is not a fix either: the counts are
-        # still unattested, and a reader told only about a kill loses that.
+        # still unattested, and a reader told only about a death loses that.
         (False, "Durable semantic enrichment: present (1058 entities; a daemon serving this "
                 "store was killed)"),
         (False, ""),
         (False, None),
     ]
     for want, line in enrichment_cases:
-        got = enrichment_names_a_kill(line)
+        got = enrichment_names_a_death(line)
         if got != want:
-            failures.append("enrichment_names_a_kill(%r) = %s, wanted %s" % (line, got, want))
+            failures.append("enrichment_names_a_death(%r) = %s, wanted %s" % (line, got, want))
 
     kill_row_cases = [
         (True, {"status": "degraded",


### PR DESCRIPTION
Main's acceptance has been red since 10:20Z on two findings, `init_budget:4` and
`memory_pressure:9`, both of them one class. Neither is visible to a pull request, because
`Product Acceptance` carries `if: ${{ github.event_name != 'pull_request' }}` and kin has no
merge_group, so main's own push run is the only grader.

## What the run said

Acceptance run 34626956116 on `c57d9c4e2`, verdict step:

```
init_budget: 1 FAIL, 5 PASS
memory_pressure: 1 FAIL, 13 PASS
init_budget:4 FAIL `kin init` exited 7 but its summary never names a killed daemon: ...
memory_pressure:9 FAIL the enrichment of a store whose daemon was killed reads exactly like
  one that was merely never certified: Durable semantic enrichment: present (6 entities,
  6 relations, 1 changes at authority generation 2, workspace generation 1; completion not
  attested, and a daemon serving this store ended without retiring)
acceptance gate FAILED on 2 finding(s)
```

Every other suite passed. Twenty-eight suites ran, so this is the whole of main's acceptance debt.

## Cause

#1716 gave `enrichment_clause` a second arm. A record whose last cause is
`DaemonKillCause::Unattributed { signal: 0 }` and which the kernel did not attribute to memory now
reads "ended without retiring" instead of "was killed". That reading is right and it stays: signal
zero is the record saying it has no signal, not a signal numbered zero, and a kernel kill, a crash
and a force exit past the shutdown grace all leave exactly that record, so "killed" states a fact
about the kernel no kernel reported.

What went stale beside it is every surface that asked "did this store name a death" by matching
the first sentence, and there were three of them:

- `init_budget_refusal.py` matched `"a daemon serving this store was killed"` verbatim. Its check
  4 SIGKILLs the real daemon on a runner with no readable cgroup accounting, which is exactly the
  record that now takes the second clause, so it read exit 7 beside a summary it could not
  recognize and reported the exit code and the prose as disagreeing.
- `memory_pressure_refusal.py`'s `enrichment_names_a_kill` required the word "killed", and its
  check 9 drives the same kill.
- The crate test `the_exit_code_and_the_summary_agree_about_a_killed_daemon` decided its own
  `names_a_kill` with `summary.contains("a daemon serving this store was killed")` and fed one
  `MemoryLimit` record, so it never saw the class and stayed green through all of it.

The exit code itself was never wrong: `exit_code_for` returned `EXIT_ENRICHMENT_UNATTESTED` for
any record. What was wrong is that three independent surfaces asked for a reading by matching a
sentence, so the day the product gained a second sentence they all reported a regression.

## The change

**The reading becomes a value.** `EnrichmentCaveat` in `daemon_death.rs` has three variants,
`Unattested`, `EndedWithoutRetiring` and `Killed`. `names_a_death()` is the one predicate,
`clause()` renders it, and `enrichment_clause` is derived from it rather than the other way round.
`enrichment_caveat` matches exhaustively over `(attributed_to_memory, last_cause)`, so a third
death class is a compile error in one place rather than a release-day surprise in three. The arm
it replaces was a `Some(_)` fallthrough, which is how the second class arrived already classified
as the first.

**`kin init`'s exit code is derived from that predicate** rather than from the presence of a
record. The two are the same set today and were still able to disagree about what they had said,
which is what shipped. One reading feeding both is what makes the agreement structural.

**Both acceptance graders read the stem the two clauses share**, `a daemon serving this store`,
beside the caveat, so either vocabulary counts as this store naming a daemon of its own that died.
Both halves stay required: the caveat alone is true of every store and is what the defect looked
like, and both suites keep a control arm that fails if a build starts naming deaths
unconditionally.

**`names_a_death` in `memory_pressure_refusal.py` gains `"without retiring"`**, which is worth its
own line. It was accepting the unobserved-ending sentence by accident, on the `"is gone"` inside
`"its exit signal is gone"`. That is a phrase about the signal, not about the daemon, so a reword
of that sub-clause would have turned a real death into a silent miss on the doctor row and the
warning line as well.

## What does not change

`enrichment_clause` returns the same three strings for the same three inputs, and
`exit_code_for` returns the same code for every input it could be given. A store's summary and
`kin init`'s exit code read exactly as they did on main. What changes is the shape of the contract,
so that the sentence and the number cannot drift apart again, and the three graders that were
matching a sentence.

## Where a pull request can see this

Acceptance grades main after a landing, so a rule added under `scripts/acceptance/` does not run on
the pull request that breaks it. The class is expressible as a crate test, so it is one, and
`ci.yml` grades it here:

- `every_death_class_names_a_daemon_of_this_store_in_its_caveat` walks every cause the record can
  hold, requires each caveat to name a death and to carry the stem, and requires the no-record
  control NOT to carry it. A build that appended the stem to every caveat passes the first half
  and fails the second.
- `the_exit_code_and_the_summary_agree_about_a_killed_daemon` now walks four readings instead of
  one, and additionally requires the rendered summary to contain the caveat's own clause.

## Falsification

Each grader was reverted to the matcher it replaced, its suite's own `--self-test` run, and then
restored. Full log in the lane report.

```
== BASELINE ==
SELFTEST PASS 26 assertions over 6 checks                    rc=0
kin-memory-pressure-repro: self-test 127/127 cases           rc=0

== ARM 1: init_budget summary grader back to the stale literal ==
SELFTEST FAIL summary_names_a_daemon_death('... completion not attested, and a daemon
  serving this store ended without retiring)') = False, wanted True
rc=1

== ARM 2: memory_pressure enrichment grader back to the stale literal ==
SELFTEST FAIL enrichment_names_a_death('... completion not attested, and a daemon serving
  this store ended without retiring)') = False, wanted True
kin-memory-pressure-repro: self-test 126/127 cases           rc=1

== ARM 3: names_a_death loses the unobserved-ending phrase ==
SELFTEST FAIL names_a_death('a daemon serving this store ended 4 time(s) since ... without
  retiring its serving record, ...') = False, wanted True
kin-memory-pressure-repro: self-test 126/127 cases           rc=1

== RESTORED ==
SELFTEST PASS 26 assertions over 6 checks                    rc=0
kin-memory-pressure-repro: self-test 127/127 cases           rc=0
```

The crate tests, falsified by breaking the predicate they guard:

```
`cargo test -p kin-cli --lib -- daemon_death the_exit_code_and_the_summary_agree_about_a_killed_daemon`

== BASELINE ==                                        13 passed; 0 failed   rc=0

== ARM A: an ending nothing observed is classified as no death at all ==
test daemon_death::tests::an_observed_kill_and_an_unobserved_ending_read_as_different_things ... FAILED
test daemon_death::tests::every_death_class_names_a_daemon_of_this_store_in_its_caveat ... FAILED
test commands::init::tests::the_exit_code_and_the_summary_agree_about_a_killed_daemon ... FAILED
test daemon_death::tests::an_ending_nothing_observed_is_not_called_a_kill ... FAILED
test result: FAILED. 9 passed; 4 failed                                     rc=101

== ARM B: the second vocabulary drops the stem a reader recognizes a death by ==
test daemon_death::tests::every_death_class_names_a_daemon_of_this_store_in_its_caveat ... FAILED
test commands::init::tests::the_exit_code_and_the_summary_agree_about_a_killed_daemon ... FAILED
test result: FAILED. 11 passed; 2 failed                                    rc=101

== ARM C: the exit code counts only an observed kill ==
test commands::init::tests::the_exit_code_and_the_summary_agree_about_a_killed_daemon ... FAILED
test result: FAILED. 12 passed; 1 failed                                    rc=101

== RESTORED ==                                        13 passed; 0 failed   rc=0
```

And both acceptance suites against binaries built from this branch, which is the pair that is red
on main:

```
Release build of kin and kin-daemon from this branch, each suite run as acceptance.yml runs it
(KIN_EMBED_BACKEND=cpu, KIN_DAEMON_AUTO_EMBED=0, KIN_VFS_DISABLE=1), on macOS.

CHECK 4 FIR-2650 PASS signalled the real daemon this store recorded (pid 25760); `kin init`
  exited 7; the summary and the exit code agree that a daemon of this store died
init_budget: 6 checks, 6 PASS

CHECK 9 FIR-2650 PASS a store that has lost no daemon names no death; the enrichment line names
  the daemon's death beside its counts; the warning line carries the cause and the remedy together
kin-memory-pressure-repro: 14 checks, 11 pass, 0 FAIL, 3 UNREADABLE
```

Check 4 took the real route, signalling the daemon the store itself recorded rather than planting
a record. The three UNREADABLE rows are memory_pressure 10, 11 and 12, which need `/proc` and read
that way on every macOS host; the Linux runner grades them.

`bin/kin-precheck kin`:

```
kin-precheck: repo=kin tree=.../maingreen-kin sha=d2eb09f71d0916923fbf6301e1c5f20bdd26612c branch=chore/lane-maingreen-kin
kin-precheck: behind origin/main 0 commit(s)
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows>
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:check-quarantine.py            python3 scripts/check-quarantine.py
...      (18 more guards, all PASS)
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin d2eb09f71d0916923fbf6301e1c5f20bdd26612c
```
