### PR TITLE
Decide a flush publication from the live graph before materializing authority

### DIFF
--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -3787,6 +3787,14 @@ pub(crate) fn graph_collapse_is_wipe(current: u64, baseline: u64) -> bool {
     current.saturating_mul(4) < baseline
 }
 
+// Workspace graphs the flush has materialized out of authority on this thread.
+// Read through `DaemonState::flush_workspace_graph_builds`, which carries the
+// reason it exists.
+#[cfg(test)]
+thread_local! {
+    static FLUSH_WORKSPACE_GRAPH_BUILDS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
 impl DaemonState {
     /// Workspace identity pinned when this local daemon opened repository
     /// authority. Mutation routes must use this instead of reparsing a mutable
@@ -11449,6 +11457,20 @@ impl DaemonState {
         Ok(index_path)
     }
 
+    /// Workspace graphs this thread's flushes have materialized out of
+    /// authority.
+    ///
+    /// A flush that publishes nothing must not build one. The build is
+    /// O(graph), and on a store whose workspace carries a semantic overlay it
+    /// is also what rewrites the prepared workspace artifact, 1,752,126,377
+    /// bytes on the store lane daemonlifeb measured. Per thread for the reason
+    /// the authority-open counters are: a test owns its thread, so a concurrent
+    /// test can neither inflate nor deflate another's reading.
+    #[cfg(test)]
+    fn flush_workspace_graph_builds() -> usize {
+        FLUSH_WORKSPACE_GRAPH_BUILDS.with(std::cell::Cell::get)
+    }
+
     /// The daemon's one held repository authority for the current publication.
     ///
     /// Borrowed rather than opened: an open decodes the complete persisted
@@ -11468,6 +11490,11 @@ impl DaemonState {
     /// Prove the derived graph still matches workspace authority at this
     /// generation, publish the language-server relations authority does not
     /// hold yet, and report the generation the workspace ends at.
+    ///
+    /// The order is load-bearing. The tree proof reads the workspace's exact
+    /// persisted tree out of the authority envelope, the decision to publish is
+    /// taken from the live graph, and authority's workspace graph is
+    /// materialized only when there is a relation to publish.
     ///
     /// Language-server relations are the one part of this derived graph that
     /// nothing rebuilds. Parser reconciliation re-derives its own output from
@@ -11524,6 +11551,38 @@ impl DaemonState {
                     self.cached_repo_id
                 )))
             })?;
+        let roots = lease.roots().clone();
+
+        // The live tree is proved against the workspace's own persisted tree
+        // rather than against a materialized workspace graph. Materialization
+        // asserts the two are equal on its way out, so this is the same proof,
+        // and it costs nothing: a flush with nothing to publish no longer
+        // builds the workspace graph at all, which on a store whose workspace
+        // carries a semantic overlay is where the prepared artifact gets
+        // rewritten whole.
+        let live_tree = self.graph.resolved_tree();
+        if live_tree != workspace.tree {
+            return Err(DaemonError::Graph(kin_db::KinDbError::StorageError(
+                format!(
+                    "refusing to acknowledge derived graph state at repository generation {expected_generation}: live exact tree does not match workspace authority"
+                ),
+            )));
+        }
+
+        let live_snapshot = self.graph.to_snapshot();
+        // Whether there is anything to publish is decided from the live graph
+        // alone. This publication carries language-server relations and nothing
+        // else, so a live graph holding none cannot produce a delta, and asking
+        // authority to materialize its workspace graph to learn that was the
+        // whole cost of an idle flush.
+        if !live_snapshot
+            .relations
+            .values()
+            .any(|relation| relation.origin == kin_model::RelationOrigin::Lsp)
+        {
+            return Ok(expected_generation);
+        }
+
         let authority_snapshot = lease
             .workspace_graph_snapshot(&workspace_id)
             .map_err(DaemonError::from)?
@@ -11533,22 +11592,13 @@ impl DaemonState {
                     self.cached_repo_id
                 )))
             })?;
-        let roots = lease.roots().clone();
+        #[cfg(test)]
+        FLUSH_WORKSPACE_GRAPH_BUILDS.with(|builds| builds.set(builds.get() + 1));
         // The lease is a read of this authority and the commit below goes
         // through the authority itself, so the read ends here and the open
         // does not.
         drop(lease);
 
-        let live_tree = self.graph.resolved_tree();
-        if live_tree != authority_snapshot.resolved_tree {
-            return Err(DaemonError::Graph(kin_db::KinDbError::StorageError(
-                format!(
-                    "refusing to acknowledge derived graph state at repository generation {expected_generation}: live exact tree does not match workspace authority"
-                ),
-            )));
-        }
-
-        let live_snapshot = self.graph.to_snapshot();
         let (semantic_delta, unpublishable) =
             Self::language_server_enrichment_delta(&live_snapshot, &authority_snapshot)?;
         if unpublishable > 0 {
@@ -20156,6 +20206,55 @@ mod tests {
             1,
             "one publication is one whole-store open: the flush loads it, and its finalize and \
              the readers after it borrow that load"
+        );
+    }
+
+    /// A flush with nothing to publish does not materialize authority's
+    /// workspace graph.
+    ///
+    /// The build is O(graph), and on a store whose workspace carries a semantic
+    /// overlay it is also what rewrites the prepared workspace artifact, so an
+    /// idle flush used to pay the largest thing in the pass to discover it had
+    /// nothing to do.
+    #[test]
+    fn a_flush_with_nothing_to_publish_does_not_build_the_workspace_graph() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let state = test_state(init.layout, repo_dir.path());
+        let caller = test_entity("send", "src/sessions.rs");
+        let callee = test_entity("adapter_send", "src/adapters.rs");
+        publish_authority_entities(&state, &[caller.clone(), callee.clone()]);
+
+        let before = DaemonState::flush_workspace_graph_builds();
+        state
+            .save_snapshot()
+            .expect("a flush with nothing to publish succeeds");
+        assert_eq!(
+            DaemonState::flush_workspace_graph_builds(),
+            before,
+            "a flush with no language-server relation to publish must not build authority's \
+             workspace graph to find that out"
+        );
+
+        // Non-vacuity: with one relation to publish, the same flush does build
+        // it, so the count above is not a counter that cannot move.
+        state.graph.upsert_entity(&caller).unwrap();
+        state.graph.upsert_entity(&callee).unwrap();
+        state
+            .graph
+            .upsert_relation(&language_server_relation(
+                &caller,
+                &callee,
+                kin_model::RelationOrigin::Lsp,
+            ))
+            .unwrap();
+        state
+            .save_snapshot()
+            .expect("the flush publishes the language-server relation");
+        assert_eq!(
+            DaemonState::flush_workspace_graph_builds(),
+            before + 1,
+            "a flush that publishes must build the workspace graph it diffs against"
         );
     }
 


### PR DESCRIPTION
A flush with nothing to publish no longer materializes authority's workspace graph. It proves its tree from the workspace's exact persisted tree and decides from the live graph whether there is a language-server relation to publish.

## Why

The flush's pass used to build authority's workspace graph first and prove the live tree against it. Only then did it ask whether anything needed publishing. The build is O(graph), and on a store whose workspace carries a semantic overlay it is also what rewrites the prepared workspace artifact whole: 1,752,126,377 bytes on the store lane daemonlifeb measured. So an idle flush paid the largest thing in the pass to discover it had nothing to do, and with language servers off it had nothing to do every time.

## How

- The tree proof reads `workspace.tree` out of the authority envelope the flush already holds. Materialization asserts that tree equal to the graph it resolves (kin-db `repository.rs:6605`), so this is the same proof at no cost.
- Whether to publish is decided from the live graph. This publication carries `RelationOrigin::Lsp` relations and nothing else, so a live graph holding none cannot produce a delta.
- Authority's workspace graph is materialized only when a relation is there to publish, and the diff and the commit run against it exactly as before.

Nothing else about the pass changes. The generation check, the refusal when the live tree does not match authority, the endpoint rule and the no-retraction rule all stay where they were, and a flush that cannot publish still refuses to acknowledge its batch.

## Numbers

Same store (fresh APFS clones of one kin-db store: 607 changes, a 1,418,328,932-byte snapshot, 5,710
bodies), same driver and settings, one standalone daemon each. Before is run 5 on kin #1729's bytes.
After is run 6 on this change's bytes, so the after run also carries whatever else merged to main
between the two.

This removes a workspace-graph materialization from every flush pass. Each pass used to build
authority's workspace graph twice, once to prove the live tree against it and once to diff. It now
builds it only when a language-server relation is there to publish, and this store has none.

| flush pass | before builds | after builds | before elapsed | after elapsed |
|---|---|---|---|---|
| startup | 2 | 1 | 203 ms | 101 ms |
| after the pack read | 2 | 1 | 2,160 ms | 1,856 ms |
| during the 8-file edit | 2 and 2, over two passes | 1, over one pass | 8,655 and 8,253 ms | 8,487 ms |
| at shutdown | 2 | 1, and a second pass built none | 7,962 ms | 11,777 ms, and 6 ms |
| flush passes outside the commit | 10 builds | 4 builds | | |

One build per pass remains and this change leaves it alone. The flush's snapshot write reads
committed authority through `load_committed_authority_graph` (`state.rs:11728`, materializing at
`11776`), which builds the workspace graph once. Run 6's log shows that read under a second before
each `saved snapshot` line.

Each skipped build took 0.52, 0.58, 0.79 and 1.53 s in run 5, read as the gap between the pair of
`served the workspace base from a materialized graph section` lines inside one flush pass. On this
store that build is served from a prepared section rather than rebuilt, because the workspace carries
no semantic overlay and no `.kpqg` artifact is rewritten. On a store whose workspace does carry one,
the same build is what rewrites the prepared artifact whole, 1,752,126,377 bytes on the store lane
daemonlifeb measured.

Whole-store opens stay as they were: 12 in run 5 and 10 in run 6, where the difference is the
driver's 8-file edit admitting in two rounds there and one here. The box carried six builders during
run 6, so `mcp_commit` reads 184.2 s against 158.6 s with its open count identical at 1, and the
shutdown flush reads longer after than before.

## Tests

`a_flush_with_nothing_to_publish_does_not_build_the_workspace_graph` in `crates/kin-daemon/src/state.rs` counts the flush's materializations on a `#[cfg(test)]` thread-local. An idle flush must build none, and the non-vacuity arm adds one language-server relation and requires the same flush to build one.

```text
$ cargo test -p kin-daemon --lib
test result: ok. 1706 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 404.51s
```

The suite ran twice. The first full run of this crate's library tests reported one failure,
`daemon::memory_pressure_tests::a_real_child_process_is_counted_by_the_real_walk`, which spawns a real
child process and retries the process-table walk for up to two seconds to see it; its own doc calls
that wait the test's whole flake surface. This change touches `state.rs` alone. That test then passed
three times out of three alone on the same head, and the whole library suite reran green at 1,706
passed and 0 failed. The box was carrying six builders at the time, load average 20.13, 23.86 and
20.47.

## Falsification

```text
$ bash falsify-c.sh
arm eager_build applied
arm eager_build rc=101
test state::tests::a_flush_with_nothing_to_publish_does_not_build_the_workspace_graph ... FAILED
thread 'state::tests::a_flush_with_nothing_to_publish_does_not_build_the_workspace_graph' (84644238) panicked at crates/kin-daemon/src/state.rs:20224:9:
  left: 1
 right: 0
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1709 filtered out; finished in 1.63s
restored to d48a83c54
chain done 20:13:38Z
```

## Local gates

```text
$ bin/kin-precheck kin --repo-dir kin=<this worktree>
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin d48a83c54a03b582997e8f5fc0aa65a52f431fd6
```

kin's Product Acceptance job grades main after landing, not this pull request.
