### PR TITLE
Record kin-vfs as parked in the ecosystem manifest and kin's own docs

### DIFF
--- a/docs/ecosystem-manifest.json
+++ b/docs/ecosystem-manifest.json
@@ -78,12 +78,13 @@
     },
     {
       "name": "kin-vfs",
-      "layer": "flagship",
+      "layer": "deprecated",
       "role": "filesystem-projection",
       "dependsOn": [
         "kin",
         "kin-db"
       ],
+      "note": "Defocused by the founder on 2026-09-11. Libc-interception filesystem projection via LD_PRELOAD and DYLD; the repository stays public and deprecated for reference, and its binaries leave the shipped release archives. kin-vfs-core is kept as a crate inside kin's own workspace for the projection engine. `kin run -- <cmd>` on fast ephemeral sandboxes (APFS copy-on-write on macOS, tmpfs or reflink on Linux) is the execution path being designed to replace it; localhost NFS is a secondary exploration, not a day-one dependency.",
       "quickChecks": [
         {
           "name": "cargo-tests",
@@ -99,8 +100,7 @@
       "layer": "flagship",
       "role": "editor-access-surface",
       "dependsOn": [
-        "kin",
-        "kin-vfs"
+        "kin"
       ],
       "quickChecks": [
         {
@@ -282,7 +282,7 @@
       "from": "kin",
       "to": "kin-vfs",
       "via": "filesystem-projection",
-      "purpose": "materializes graph-backed files through a transparent filesystem layer"
+      "purpose": "kin-vfs is defocused and kept public for reference since 2026-09-11, with kin run sandboxes replacing it as the execution path"
     },
     {
       "from": "kin",
@@ -301,12 +301,6 @@
       "to": "kin",
       "via": "control-plane-gateway",
       "purpose": "grounds hosted collaboration in real Kin workspace state"
-    },
-    {
-      "from": "kinlab",
-      "to": "kin-vfs",
-      "via": "native-adoption-wedge",
-      "purpose": "uses filesystem projection as part of the first-class adoption path"
     },
     {
       "from": "kin-mcp",

--- a/docs/readme-reference.md
+++ b/docs/readme-reference.md
@@ -272,7 +272,7 @@ Kin is one system with a few clear public surfaces:
 | Surface | What it does |
 | --- | --- |
 | **[kin](https://github.com/firelock-ai/kin)** | Semantic system of record: CLI, daemon, graph lifecycle, MCP, review, provenance, and Git coexistence. |
-| **[kin-vfs](https://github.com/firelock-ai/kin-vfs)** | Projects graph-owned files through normal filesystem calls so existing tools can keep using files. |
+| **[kin-vfs](https://github.com/firelock-ai/kin-vfs)** | Deprecated. Projected graph-owned files through normal filesystem calls; defocused 2026-09-11 in favor of `kin run -- <cmd>` sandboxes, kept public for reference. |
 | **[kin-editor](https://github.com/firelock-ai/kin-editor)** | VS Code access to the entity explorer, semantic search, trace, review, and rename surfaces. |
 | **[Kin MCP](mcp-tools.md)** | Typed graph tools for AI agents, bundled into `kin` and launched with `kin mcp start`. |
 | **[KinLab](https://kinlab.ai)** | Hosted collaboration and control plane. Public repository connection is not a first-run flow yet. |
@@ -283,10 +283,12 @@ The graph is the repository, and everything in the map below either reaches
 that authority or supports it. Humans and AI agents come in
 through the CLI, the bundled MCP server, or the VS Code extension. All
 three ask the same daemon, and the daemon answers from graph authority rather
-than by re-reading the tree. `kin-vfs` projects that same graph back through
-ordinary filesystem calls, so editors, compilers, and build systems keep seeing
-files. Git sits beside the graph as an import and export boundary rather than as
-an answer path, and KinLab is the hosted layer over the same authority.
+than by re-reading the tree. Filesystem projection (`kin-vfs`) used to project
+that same graph back through ordinary filesystem calls; it is defocused as of
+2026-09-11 and kept public for reference, with `kin run -- <cmd>` sandboxes as
+the adoption path being designed instead. Git sits beside the graph as an
+import and export boundary rather than as an answer path, and KinLab is the
+hosted layer over the same authority.
 
 ```mermaid
 flowchart TD
@@ -302,7 +304,7 @@ flowchart TD
     authority["Graph authority<br/>entities, relations, changes, provenance"]
     db["kin-db<br/>graph storage, snapshots,<br/>index, text and vector search"]
     prims["kin-model, kin-blobs, kin-search,<br/>kin-vector, kin-infer, kin-lsp"]
-    vfs["kin-vfs<br/>transparent file projection"]
+    vfs["kin-vfs (deprecated)<br/>parked, kept for reference"]
     tools["Editors, compilers, build systems"]
     git["Git<br/>import and export boundary"]
     kinlab["KinLab<br/>hosted collaboration and control plane"]
@@ -340,9 +342,9 @@ needs to assemble. None of them is installed separately.
 ## Open source and the Kin ecosystem
 
 The core of Kin is open source under Apache-2.0: [kin](https://github.com/firelock-ai/kin),
-[kin-db](https://github.com/firelock-ai/kin-db), [kin-vfs](https://github.com/firelock-ai/kin-vfs),
-and [kin-editor](https://github.com/firelock-ai/kin-editor), plus the supporting
-libraries kin-model, kin-blobs, kin-search, kin-vector, kin-infer, kin-lsp, and
+[kin-db](https://github.com/firelock-ai/kin-db), [kin-vfs](https://github.com/firelock-ai/kin-vfs)
+(deprecated, kept public for reference), and [kin-editor](https://github.com/firelock-ai/kin-editor),
+plus the supporting libraries kin-model, kin-blobs, kin-search, kin-vector, kin-infer, kin-lsp, and
 kin-actions.
 
 [KinLab](https://kinlab.ai) is a proprietary product built on this open core: the

--- a/docs/thesis.md
+++ b/docs/thesis.md
@@ -44,11 +44,13 @@ Kin can import an exact Git snapshot or complete reachable history, and can expo
 graph-owned state back to Git when interoperability is required. Git is an input/output
 boundary during migration, never a runtime answer authority or silent repair path.
 
-### 2. The virtual filesystem (`kin-vfs`)
-`kin-vfs` acts as a "Trojan horse" for graph-first adoption. By intercepting filesystem
-calls (via `LD_PRELOAD` / `DYLD_INSERT_LIBRARIES`), it serves graph-backed files as normal
-files to any compiler, linter, or legacy tool. To the host OS the codebase looks like
-ordinary files on disk, while the underlying data is served from the semantic graph.
+### 2. Filesystem projection (`kin-vfs`), parked
+Libc-interception filesystem projection (`kin-vfs`, via `LD_PRELOAD` / `DYLD_INSERT_LIBRARIES`)
+was the original adoption path. The founder defocused it on 2026-09-11: the repository stays
+public and deprecated for reference, and `kin-vfs-core` remains a crate in kin's own workspace
+for the projection engine. `kin run -- <cmd>` on fast ephemeral sandboxes (APFS copy-on-write on
+macOS, tmpfs or reflink on Linux) is the execution path being designed to replace it. Localhost
+NFS is a secondary exploration, not a day-one dependency.
 
 ### 3. Agent integration (MCP)
 Kin's built-in MCP server exposes semantic primitives directly to AI agents. Instead of


### PR DESCRIPTION
## What

Records the founder's parking of kin-vfs in kin's own canonical source of truth,
`docs/ecosystem-manifest.json`, and brings kin's in-repo docs into line. Companion to
kin-ecosystem#382 (lane vfspark), which already parked kin-vfs in the umbrella's `AGENTS.md`
and `docs/REPOS.md`.

The founder, 2026-09-11: "I think we are defocusing the VFS. seems easier to do NFS if we
want." Standing: the kin-vfs repository stays public and deprecated for reference; kin-vfs-core
stays as a crate in kin's workspace; the kin-vfs binaries leave the shipped release archives
(a separate change, not this PR).

## docs/ecosystem-manifest.json

- `kin-vfs` entry: `layer` changes from `flagship` to `deprecated`, with a `note` recording the
  parking, the kept crate, and the `kin run -- <cmd>` / localhost NFS successor path. Text is
  vfspark's proposed replacement, applied verbatim.
- `kin-editor`'s `dependsOn` drops `kin-vfs`. Verified read-only in the primary checkout: `git -C
  kin-editor grep -n "kin-vfs"` hits only `README.md:157` (an "Ecosystem" table row naming
  sibling repos) and `SECURITY.md:40` (a generic "other repos have their own policy" list).
  `git -C kin-editor grep -ln "kin-vfs" -- '*.json' '*.ts' '*.tsx' '*.js'` is empty: no build,
  config or runtime dependency.
- `kinlab`'s `dependsOn` keeps `kin-vfs`. Verified read-only in the primary checkout: kinlab's
  control-plane catalogs and imports kin-vfs as a tracked repo, for example
  `services/control-plane/src/repo-catalog.ts:69`: `{ name: "kin-vfs", layer: "flagship", role:
  "filesystem-projection" },`, plus `public-view.ts:61`, the import-orchestrator and
  import-supervisor tests, and `scripts/check-boundary-imports.mjs:45`. That is a real
  dependency, kept. (Side note for the captain: kinlab's own `repo-catalog.ts:69` still says
  `layer: "flagship"` for kin-vfs; that file is outside this lane's ownership and will read
  stale once this PR lands. Flagged, not fixed here.)
- `links`: the `kinlab` -> `kin-vfs` `native-adoption-wedge` entry is removed (`"purpose": "uses
  filesystem projection as part of the first-class adoption path"`); that framing is what the
  parking retires. The `kin` -> `kin-vfs` link stays, its `purpose` reworded to the parked state
  in one sentence.
- Layer taxonomy: `"deprecated"` is a new value with no documented taxonomy to extend.
  `git -C kin grep -n "flagship" -- '*.md'` returns zero hits anywhere in this repo, including
  `CONTRIBUTING.md`; the only "ecosystem-manifest" reference outside the file itself is
  `docs/README.md:61`, a plain doc link with no schema behind it. Nothing to add a line to;
  noted here and in the report rather than inventing documentation that doesn't exist.

## Docs

`docs/thesis.md`: rewrote the `kin-vfs` adoption-path section (previously "acts as a 'Trojan
horse' for graph-first adoption") to state the parked status and the `kin run` / NFS successor.

`docs/readme-reference.md`: reworded the "kin-vfs" row in "The stack" table, the "How the pieces
fit" paragraph, the mermaid diagram's `vfs` node label, and the "Open source and the Kin
ecosystem" paragraph, all of which presented kin-vfs as a current public-facing surface.

Left alone, per the brief's scope: `docs/env-vars.md`, `docs/projection.md`,
`docs/quickstart.md`, `docs/security/signing-and-update-trust.md`,
`docs/security/threat-model.md`, and `docs/windows-wsl2.md`. These document a feature that still
ships today (removal from release archives is a separate change) with no "current adoption
path" or "public lead" framing; they're factual/technical reference, not positioning. `README.md`
and `AGENTS.md` (kin's own) have zero kin-vfs mentions, confirmed by grep, so nothing to change
there.

## Verification

```
$ python3 -c 'import json,sys; json.load(open(sys.argv[1]))' docs/ecosystem-manifest.json
(rc 0, no output: valid JSON)

$ bin/check-precheck-coverage --manifest docs/ecosystem-manifest.json
check-precheck-coverage: 20 manifest repositories, 9 with a kin-precheck profile, 11 exempted with a reason
check-precheck-coverage: 1 exemption(s) name a repository not checked out here, so their claims were NOT verified on this run
(rc 0)

$ .kin-coord/bin/heavy-slot.sh vfsmanifest kin -- bin/kin-precheck kin --repo-dir kin=<worktree>
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows...>
PASS     guard:check_private_repo_coupling.sh bash scripts/check_private_repo_coupling.sh
PASS     guard:check_runtime_boundaries.sh    bash scripts/check_runtime_boundaries.sh
PASS     guard:test-release-policy-gate.sh    bash scripts/test-release-policy-gate.sh
PASS     guard:test-windows-authority-legs.sh bash scripts/test-windows-authority-legs.sh
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:check-kin-vfs-compat.mjs       node scripts/check-kin-vfs-compat.mjs
PASS     guard:check-rc-build-drift.mjs       node scripts/check-rc-build-drift.mjs
PASS     guard:check-required-contexts.py     python3 scripts/check-required-contexts.py
PASS     guard:test-assertion-reachability.py python3 scripts/test-assertion-reachability.py
PASS     guard:test-guard-duplicate-release-run.py python3 scripts/test-guard-duplicate-release-run.py
PASS     guard:test-homebrew-release-gate.py  python3 scripts/test-homebrew-release-gate.py
PASS     guard:test-install-checksum.py       python3 scripts/test-install-checksum.py
PASS     guard:test-private-repo-coupling.py  python3 scripts/test-private-repo-coupling.py
PASS     guard:test-release-tag-evaluate-dispatch.py python3 scripts/test-release-tag-evaluate-dispatch.py
PASS     guard:test-release-workflow-authority.py python3 scripts/test-release-workflow-authority.py
PASS     guard:test-select-release-candidate.py python3 scripts/test-select-release-candidate.py
PASS     guard:verify-hydration-semantics.py  python3 scripts/verify-hydration-semantics.py
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
PASS     node-test                            node --test <16 file(s) named by the check job>
PASS     guard:check-quarantine.py            python3 scripts/check-quarantine.py
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin 5503ce6eb57ac160412118c12832d7f99b681835 DIRTY
(rc 0; run before the rebase onto the v0.7.15 release commit below, which touched only
Cargo.lock/Cargo.toml/CHANGELOG.md/package.json files with no overlap with this PR's three docs
files)
```

Rebased cleanly onto `origin/main` (v0.7.15, `27a542c76`) with no conflicts; the pushed commit is
`cd5553415`.

Docs-only change: no Rust or JS touched, so this PR carries no falsification arm beyond the
commands above. The JSON schema has no validator for `layer`'s value set (confirmed above), so
"deprecated" cannot be mechanically checked either; it's a documentation convention, stated
honestly as one in this PR.
