### PR TITLE
Refuse a scope spelled in none of the documented forms instead of reading it as a path

### DIFF
--- a/crates/kin-cli/src/commands/note.rs
+++ b/crates/kin-cli/src/commands/note.rs
@@ -87,15 +87,8 @@ pub async fn todo_import(path: Option<String>) -> Result<()> {
 // -- Helpers --
 
 fn parse_annotation_target(target: &str) -> Result<AnnotationTarget> {
-    if let Some(rest) = target.strip_prefix("work:") {
-        let uuid = uuid::Uuid::parse_str(rest)
-            .map_err(|_| anyhow::anyhow!("invalid work item UUID: {}", rest))?;
-        Ok(AnnotationTarget::Work(WorkId(uuid)))
-    } else {
-        Ok(AnnotationTarget::Scope(
-            crate::commands::work::parse_work_scope(target)?,
-        ))
-    }
+    // One parser for the CLI and the MCP tools, as for `work::parse_work_scope`.
+    Ok(kin_mcp::handlers::common::parse_annotation_target(target)?)
 }
 
 #[cfg(test)]

--- a/crates/kin-cli/src/commands/session_run.rs
+++ b/crates/kin-cli/src/commands/session_run.rs
@@ -487,11 +487,13 @@ pub async fn exec(
     keep: bool,
     discard: bool,
     strategy: Option<String>,
-    scope: Option<String>,
 ) -> Result<()> {
     let invocation = ExecInvocation::parse(command_parts, shell)?;
     let layout = discover_layout()?;
-    let projection = materialize(layout, strategy, scope).await?;
+    // The whole session: a scoped session workspace is refused by the daemon
+    // until its selected artifact set can be authenticated outside the editable
+    // session.
+    let projection = materialize(layout, strategy, None).await?;
     eprintln!("Session workspace: {}", projection.root().display());
 
     let exit = run_in_session(&projection, invocation.command())?;

--- a/crates/kin-cli/src/commands/work.rs
+++ b/crates/kin-cli/src/commands/work.rs
@@ -360,30 +360,10 @@ fn parse_work_id(s: &str) -> Result<WorkId> {
 }
 
 pub(crate) fn parse_work_scope(s: &str) -> Result<WorkScope> {
-    if let Some(rest) = s.strip_prefix("entity:") {
-        let uuid = uuid::Uuid::parse_str(rest)
-            .map_err(|_| anyhow::anyhow!("invalid entity UUID: {}", rest))?;
-        Ok(WorkScope::Entity(EntityId(uuid)))
-    } else if let Some(rest) = s.strip_prefix("contract:") {
-        let uuid = uuid::Uuid::parse_str(rest)
-            .map_err(|_| anyhow::anyhow!("invalid contract UUID: {}", rest))?;
-        Ok(WorkScope::Contract(ContractId(uuid)))
-    } else if let Some(rest) = s.strip_prefix("artifact:") {
-        Ok(WorkScope::Artifact(FilePathId::new(rest)))
-    } else if let Some(rest) = s.strip_prefix("file:") {
-        Ok(WorkScope::Artifact(FilePathId::new(rest)))
-    } else if let Some(rest) = s.strip_prefix("change:") {
-        let hash = Hash256::from_hex(rest)
-            .map_err(|_| anyhow::anyhow!("invalid semantic change ID: {}", rest))?;
-        Ok(WorkScope::Change(SemanticChangeId::from_hash(hash)))
-    } else {
-        // Try as UUID (entity), then fall back to file path.
-        if let Ok(uuid) = uuid::Uuid::parse_str(s) {
-            Ok(WorkScope::Entity(EntityId(uuid)))
-        } else {
-            Ok(WorkScope::Artifact(FilePathId::new(s)))
-        }
-    }
+    // The CLI and the MCP tools read a scope through one parser, so the
+    // spellings it accepts, and the refusal an unrecognized one gets, are the
+    // same on both surfaces.
+    Ok(kin_mcp::handlers::common::parse_single_work_scope(s)?)
 }
 
 fn render_work_list(
@@ -977,6 +957,18 @@ mod tests {
     use super::*;
     use kin_model::WorkStore;
 
+    /// The CLI reads a scope through the same parser as the MCP tools, so a bare
+    /// path is refused here too rather than becoming a path scope.
+    #[test]
+    fn the_cli_scope_parser_refuses_a_bare_path() {
+        let error = parse_work_scope("src/main.rs").expect_err("a bare path is refused");
+        assert!(error.to_string().contains("artifact:<path>"), "{error}");
+        assert!(matches!(
+            parse_work_scope("artifact:src/main.rs"),
+            Ok(WorkScope::Artifact(_))
+        ));
+    }
+
     async fn create_in_layout_direct(
         layout: &kin_core::KinLayout,
         kind: String,
@@ -1157,7 +1149,7 @@ mod tests {
             "task".into(),
             "wire persistence".into(),
             Some("make work writes stick".into()),
-            Some("src/main.rs".into()),
+            Some("artifact:src/main.rs".into()),
             Some("high".into()),
         )
         .await
@@ -1220,7 +1212,7 @@ mod tests {
             "feature".into(),
             "ship semantic work graph".into(),
             None,
-            Some("src/main.rs".into()),
+            Some("artifact:src/main.rs".into()),
             None,
         )
         .await
@@ -1230,7 +1222,7 @@ mod tests {
             "task".into(),
             "wire graph queries".into(),
             None,
-            Some("src/lib.rs".into()),
+            Some("artifact:src/lib.rs".into()),
             None,
         )
         .await

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -933,9 +933,6 @@ enum Command {
         /// Materialization strategy
         #[arg(long)]
         strategy: Option<String>,
-        /// Scope filter
-        #[arg(long)]
-        scope: Option<String>,
     },
     /// Manage local telemetry consent and the spool
     Telemetry {
@@ -1904,7 +1901,7 @@ enum IntentAction {
     List,
     /// Register a new intent (lock a scope)
     Register {
-        /// Scope to lock (entity:<uuid>, file:<path>, or bare UUID/path)
+        /// Scope to lock (entity:<uuid>, contract:<uuid>, file:<path>, artifact:<path>, or an entity UUID)
         scope: String,
         /// Lock type: hard or soft
         #[arg(short, long, default_value = "soft")]
@@ -2046,7 +2043,7 @@ enum ReviewAction {
 enum TrafficAction {
     /// Show active traffic on a scope
     Show {
-        /// Scope to query (entity:<uuid>, file:<path>, or bare UUID/path)
+        /// Scope to query (entity:<uuid>, contract:<uuid>, file:<path>, artifact:<path>, or an entity UUID)
         scope: String,
     },
     /// List all active sessions
@@ -2316,7 +2313,7 @@ enum WorkAction {
         /// Optional description
         #[arg(short, long)]
         description: Option<String>,
-        /// Scope to link (entity:<uuid>, artifact:<path>, or bare path)
+        /// Scope to link (entity:<uuid>, contract:<uuid>, artifact:<path>, change:<id>, or an entity UUID)
         #[arg(short, long)]
         scope: Option<String>,
         /// Priority: critical, high, medium, low, none
@@ -2331,7 +2328,7 @@ enum WorkAction {
         /// Filter by kind
         #[arg(short, long)]
         kind: Option<String>,
-        /// Filter by scope (entity:<uuid>, contract:<uuid>, artifact:<path>, change:<id>, or bare path)
+        /// Filter by scope (entity:<uuid>, contract:<uuid>, artifact:<path>, change:<id>, or an entity UUID)
         #[arg(long)]
         scope: Option<String>,
     },
@@ -2391,7 +2388,7 @@ enum WorkAction {
 enum NoteAction {
     /// Add an annotation to a semantic scope or work item
     Add {
-        /// Target to annotate (entity:<uuid>, contract:<uuid>, artifact:<path>, change:<id>, work:<uuid>, or bare path)
+        /// Target to annotate (entity:<uuid>, contract:<uuid>, artifact:<path>, change:<id>, work:<uuid>, or an entity UUID)
         target: String,
         /// Annotation kind: comment, warning, instruction, reasoning
         #[arg(short, long)]
@@ -2402,7 +2399,7 @@ enum NoteAction {
     },
     /// List annotations for a semantic scope or work item
     List {
-        /// Target to query (entity:<uuid>, contract:<uuid>, artifact:<path>, change:<id>, work:<uuid>, or bare path)
+        /// Target to query (entity:<uuid>, contract:<uuid>, artifact:<path>, change:<id>, work:<uuid>, or an entity UUID)
         target: String,
     },
     /// Show stale annotations
@@ -4004,11 +4001,9 @@ fn run() -> Result<()> {
                     keep,
                     discard,
                     strategy,
-                    scope,
                 } => {
                     commands::capabilities::require_ready("exec")?;
-                    commands::session_run::exec(command, shell, keep, discard, strategy, scope)
-                        .await
+                    commands::session_run::exec(command, shell, keep, discard, strategy).await
                 }
                 Command::Telemetry { action } => match action {
                     TelemetryAction::Status => commands::telemetry::run_status().await,
@@ -4865,6 +4860,35 @@ fn default_filter_directives(command: &str) -> String {
 mod tests {
     use super::*;
     use clap::CommandFactory;
+
+    /// `kin exec` takes no scope. A scoped session workspace is refused by the
+    /// daemon until its selected artifact set can be authenticated outside the
+    /// editable session, so the command materializes the whole session. Read off
+    /// the clap definition rather than a parse, because `exec`'s command
+    /// positional accepts hyphen values and could swallow a stray flag into the
+    /// command it runs instead of rejecting it.
+    #[test]
+    fn exec_carries_no_scope_flag() {
+        std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| {
+                let cli = Cli::command();
+                let exec = cli
+                    .find_subcommand("exec")
+                    .expect("kin exec is a subcommand");
+                let ids: Vec<String> = exec
+                    .get_arguments()
+                    .map(|arg| arg.get_id().as_str().to_string())
+                    .collect();
+                // Positive control: the lookup sees exec's real flags, so the
+                // absence below is not a lookup that saw nothing.
+                assert!(ids.iter().any(|id| id == "strategy"), "{ids:?}");
+                assert!(!ids.iter().any(|id| id == "scope"), "{ids:?}");
+            })
+            .unwrap()
+            .join()
+            .unwrap();
+    }
 
     #[test]
     fn recovery_restore_requires_a_complete_fresh_target_pair() {

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -19269,13 +19269,69 @@ fn parse_scope(scope: &str) -> Result<IntentScope, (StatusCode, String)> {
             rest, "contract",
         )?)));
     }
-    if let Some(rest) = scope.strip_prefix("file:") {
+    // `artifact:` is how a work or annotation scope spells the same thing, so a
+    // caller who writes it here means a path too.
+    if let Some(rest) = scope
+        .strip_prefix("file:")
+        .or_else(|| scope.strip_prefix("artifact:"))
+    {
+        if rest.is_empty() {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!("scope {scope:?} names no path"),
+            ));
+        }
         return Ok(IntentScope::Artifact(FilePathId::new(rest)));
     }
     if let Ok(uuid) = Uuid::parse_str(scope) {
         return Ok(IntentScope::Entity(EntityId(uuid)));
     }
-    Ok(IntentScope::Artifact(FilePathId::new(scope)))
+    // Anything else is refused rather than read as a path. An intent's scope is
+    // its lock, and a path lock taken from a mistyped entity id would collide
+    // with every agent in that file for nothing anyone asked for.
+    Err((
+        StatusCode::BAD_REQUEST,
+        kin_mcp::handlers::common::unrecognized_scope_message(
+            scope,
+            kin_mcp::handlers::common::INTENT_SCOPE_FORMS,
+        ),
+    ))
+}
+
+#[cfg(test)]
+mod scope_grammar_tests {
+    use super::*;
+
+    /// An intent scope is written in one of the documented spellings, and
+    /// anything else is refused rather than read as a path.
+    #[test]
+    fn an_unspelled_scope_is_refused_and_every_spelling_resolves() {
+        let (status, message) =
+            parse_scope("src/main.rs").expect_err("a bare path is refused, not locked");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(message.contains("artifact:<path>"), "{message}");
+
+        for spelled in ["file:src/main.rs", "artifact:src/main.rs"] {
+            match parse_scope(spelled) {
+                Ok(IntentScope::Artifact(path)) => assert_eq!(path.0, "src/main.rs"),
+                other => panic!("{spelled} resolved to {other:?}"),
+            }
+        }
+        let id = Uuid::new_v4();
+        for spelled in [format!("entity:{id}"), id.to_string()] {
+            assert!(
+                matches!(
+                    parse_scope(&spelled),
+                    Ok(IntentScope::Entity(EntityId(found))) if found == id
+                ),
+                "{spelled}"
+            );
+        }
+        assert!(
+            parse_scope("file:").is_err(),
+            "a path scope must name a path"
+        );
+    }
 }
 
 fn parse_session_id(value: &str) -> Result<SessionId, (StatusCode, String)> {

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -1228,7 +1228,17 @@ fn parse_capabilities(args: &HashMap<String, serde_json::Value>) -> Option<Sessi
 
 fn scope_to_string(value: &serde_json::Value) -> Result<String, String> {
     if let Some(scope) = value.as_str() {
-        return Ok(scope.to_string());
+        // Forwarded verbatim to the daemon's intent parser, so it is checked
+        // here against the spellings that parser accepts, and this route gives
+        // the daemon's own MCP route's answer for the same input.
+        return if is_spelled_intent_scope(scope) {
+            Ok(scope.to_string())
+        } else {
+            Err(crate::handlers::common::unrecognized_scope_message(
+                scope,
+                crate::handlers::common::INTENT_SCOPE_FORMS,
+            ))
+        };
     }
     let Some(obj) = value.as_object() else {
         return Err(
@@ -1249,6 +1259,20 @@ fn scope_to_string(value: &serde_json::Value) -> Result<String, String> {
         "invalid scope: expected string, {\"Entity\":\"uuid\"}, {\"Contract\":\"uuid\"}, or {\"Artifact\":\"path\"}"
             .to_string(),
     )
+}
+
+/// Whether a string is written in one of the intent-scope spellings the
+/// daemon's parser accepts. The value after a prefix is not validated here: a
+/// malformed UUID after `entity:` is the daemon's to refuse, in its own words.
+fn is_spelled_intent_scope(scope: &str) -> bool {
+    ["entity:", "contract:", "file:", "artifact:"]
+        .iter()
+        .any(|prefix| {
+            scope
+                .strip_prefix(prefix)
+                .is_some_and(|rest| !rest.is_empty())
+        })
+        || uuid::Uuid::parse_str(scope).is_ok()
 }
 
 fn scope_strings(args: &HashMap<String, serde_json::Value>) -> Result<Vec<String>, String> {
@@ -4339,9 +4363,59 @@ mod tests {
     // ── Scope request-building (forwarded session/intent tools) ──────────────
 
     #[test]
-    fn scope_to_string_accepts_bare_string() {
-        let value = serde_json::json!("file:src/main.rs");
-        assert_eq!(scope_to_string(&value).unwrap(), "file:src/main.rs");
+    fn scope_to_string_passes_a_spelled_string_through() {
+        for spelled in [
+            "file:src/main.rs",
+            "artifact:src/main.rs",
+            "entity:00000000-0000-4000-8000-000000000001",
+            "00000000-0000-4000-8000-000000000001",
+        ] {
+            assert_eq!(
+                scope_to_string(&serde_json::json!(spelled)).unwrap(),
+                spelled
+            );
+        }
+    }
+
+    #[test]
+    fn scope_to_string_refuses_an_unspelled_string() {
+        for unspelled in ["src/main.rs", "main", "file:", "artifact:"] {
+            let error = scope_to_string(&serde_json::json!(unspelled)).unwrap_err();
+            assert!(error.contains("unrecognized scope"), "{unspelled}: {error}");
+        }
+    }
+
+    /// The stdio route to `kin_register_intent` and `kin_check_traffic` refuses a
+    /// scope in none of the documented spellings before anything is forwarded,
+    /// so it gives the answer the daemon's own MCP route gives for the same
+    /// input rather than taking a path lock.
+    #[tokio::test]
+    async fn the_stdio_intent_route_refuses_an_unspelled_scope_before_forwarding() {
+        let mut register = HashMap::new();
+        register.insert(
+            "session_id".to_string(),
+            serde_json::json!("00000000-0000-4000-8000-000000000001"),
+        );
+        register.insert(
+            "task_description".to_string(),
+            serde_json::json!("edit one function"),
+        );
+        register.insert("scopes".to_string(), serde_json::json!(["src/main.rs"]));
+        let mut traffic = HashMap::new();
+        traffic.insert("scopes".to_string(), serde_json::json!(["src/main.rs"]));
+
+        for (tool, args) in [
+            ("kin_register_intent", &register),
+            ("kin_check_traffic", &traffic),
+        ] {
+            match forward_tool_call(tool, args).await {
+                Err(message) => assert!(
+                    message.contains("unrecognized scope") && message.contains("artifact:<path>"),
+                    "{tool}: {message}"
+                ),
+                Ok(_) => panic!("{tool} forwarded a bare path instead of refusing it"),
+            }
+        }
     }
 
     #[test]

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -3709,20 +3709,49 @@ pub fn resolve_diff<G: GraphStore>(
 
 // ── Work/annotation helpers ──
 
+/// The spellings a work scope is written in, named once so every surface that
+/// refuses an unrecognized one lists the same forms.
+pub const WORK_SCOPE_FORMS: &str = "entity:<uuid>, contract:<uuid>, artifact:<path>, file:<path>, change:<id>, or a bare entity UUID";
+
+/// The spellings an annotation target is written in: every work scope, and a
+/// work item.
+pub const ANNOTATION_TARGET_FORMS: &str = "entity:<uuid>, contract:<uuid>, artifact:<path>, file:<path>, change:<id>, work:<uuid>, or a bare entity UUID";
+
+/// The spellings an intent or traffic scope is written in, which is what the
+/// daemon's intent parser accepts.
+pub const INTENT_SCOPE_FORMS: &str =
+    "entity:<uuid>, contract:<uuid>, file:<path>, artifact:<path>, or a bare entity UUID";
+
+/// The sentence every scope parser refuses an unrecognized spelling with.
+///
+/// A string is a scope only in one of the documented spellings. Reading any
+/// other string as a repository path would turn a mistyped entity id or a bare
+/// name into a durable file-path scope, a path lock or a path annotation, with
+/// nothing anywhere to say so, so a path is a scope only when it is spelled as
+/// one.
+pub fn unrecognized_scope_message(scope: &str, forms: &str) -> String {
+    format!(
+        "unrecognized scope {scope:?}: write it as {forms}. A repository path is a scope only \
+         when it is spelled as one, such as artifact:<path>; a bare string is not read as a path."
+    )
+}
+
 pub fn parse_work_scopes(val: Option<&serde_json::Value>) -> Result<Vec<kin_model::WorkScope>> {
     let arr = match val {
         Some(serde_json::Value::Array(a)) => a,
         _ => return Ok(vec![]),
     };
 
-    let mut scopes = Vec::new();
-    for item in arr {
-        if let Some(s) = item.as_str() {
-            let scope = parse_single_work_scope(s)?;
-            scopes.push(scope);
-        }
-    }
-    Ok(scopes)
+    // An entry that is not a string is refused rather than skipped, so a scope
+    // the caller named is never silently missing from the answer.
+    arr.iter()
+        .map(|item| {
+            let s = item.as_str().ok_or_else(|| {
+                McpError::InvalidParams(format!("scope entries must be strings, got {item}"))
+            })?;
+            parse_single_work_scope(s)
+        })
+        .collect()
 }
 
 pub fn parse_annotation_targets(
@@ -3733,59 +3762,147 @@ pub fn parse_annotation_targets(
         _ => return Ok(vec![]),
     };
 
-    let mut targets = Vec::new();
-    for item in raw_targets {
-        if let Some(s) = item.as_str() {
-            targets.push(parse_annotation_target(s)?);
-        }
-    }
-    Ok(targets)
+    raw_targets
+        .iter()
+        .map(|item| {
+            let s = item.as_str().ok_or_else(|| {
+                McpError::InvalidParams(format!("target entries must be strings, got {item}"))
+            })?;
+            parse_annotation_target(s)
+        })
+        .collect()
 }
 
 pub fn parse_annotation_target(s: &str) -> Result<kin_model::AnnotationTarget> {
     if let Some(rest) = s.strip_prefix("work:") {
         let uuid = uuid::Uuid::parse_str(rest)
             .map_err(|_| McpError::InvalidParams(format!("invalid work UUID: {}", rest)))?;
-        Ok(kin_model::AnnotationTarget::Work(kin_model::WorkId(uuid)))
-    } else {
-        Ok(kin_model::AnnotationTarget::Scope(parse_single_work_scope(
-            s,
-        )?))
+        return Ok(kin_model::AnnotationTarget::Work(kin_model::WorkId(uuid)));
     }
+    recognize_work_scope(s)?
+        .map(kin_model::AnnotationTarget::Scope)
+        .ok_or_else(|| {
+            McpError::InvalidParams(unrecognized_scope_message(s, ANNOTATION_TARGET_FORMS))
+        })
 }
 
 pub fn parse_single_work_scope(s: &str) -> Result<kin_model::WorkScope> {
+    recognize_work_scope(s)?
+        .ok_or_else(|| McpError::InvalidParams(unrecognized_scope_message(s, WORK_SCOPE_FORMS)))
+}
+
+/// A work scope in one of [`WORK_SCOPE_FORMS`], `Ok(None)` when the string is
+/// none of them, and an error when it names a form and then malforms it.
+///
+/// Unrecognized is its own answer so each caller refuses it with the forms that
+/// apply where it is called: an annotation target also accepts `work:<uuid>`.
+fn recognize_work_scope(s: &str) -> Result<Option<kin_model::WorkScope>> {
     if let Some(rest) = s.strip_prefix("entity:") {
         let uuid = uuid::Uuid::parse_str(rest)
             .map_err(|_| McpError::InvalidParams(format!("invalid entity UUID: {}", rest)))?;
-        Ok(kin_model::WorkScope::Entity(kin_model::EntityId(uuid)))
-    } else if let Some(rest) = s.strip_prefix("contract:") {
+        return Ok(Some(kin_model::WorkScope::Entity(kin_model::EntityId(
+            uuid,
+        ))));
+    }
+    if let Some(rest) = s.strip_prefix("contract:") {
         let uuid = uuid::Uuid::parse_str(rest)
             .map_err(|_| McpError::InvalidParams(format!("invalid contract UUID: {}", rest)))?;
-        Ok(kin_model::WorkScope::Contract(kin_model::ContractId(uuid)))
-    } else if let Some(rest) = s.strip_prefix("artifact:") {
-        Ok(kin_model::WorkScope::Artifact(kin_model::FilePathId::new(
-            rest,
-        )))
-    } else if let Some(rest) = s.strip_prefix("file:") {
-        Ok(kin_model::WorkScope::Artifact(kin_model::FilePathId::new(
-            rest,
-        )))
-    } else if let Some(rest) = s.strip_prefix("change:") {
+        return Ok(Some(kin_model::WorkScope::Contract(kin_model::ContractId(
+            uuid,
+        ))));
+    }
+    if let Some(rest) = s
+        .strip_prefix("artifact:")
+        .or_else(|| s.strip_prefix("file:"))
+    {
+        if rest.is_empty() {
+            return Err(McpError::InvalidParams(format!(
+                "scope {s:?} names no path"
+            )));
+        }
+        return Ok(Some(kin_model::WorkScope::Artifact(
+            kin_model::FilePathId::new(rest),
+        )));
+    }
+    if let Some(rest) = s.strip_prefix("change:") {
         let hash = kin_model::Hash256::from_hex(rest).map_err(|_| {
             McpError::InvalidParams(format!("invalid semantic change ID: {}", rest))
         })?;
-        Ok(kin_model::WorkScope::Change(
+        return Ok(Some(kin_model::WorkScope::Change(
             kin_model::SemanticChangeId::from_hash(hash),
-        ))
-    } else {
-        if let Ok(uuid) = uuid::Uuid::parse_str(s) {
-            Ok(kin_model::WorkScope::Entity(kin_model::EntityId(uuid)))
-        } else {
-            Ok(kin_model::WorkScope::Artifact(kin_model::FilePathId::new(
-                s,
-            )))
+        )));
+    }
+    Ok(uuid::Uuid::parse_str(s)
+        .ok()
+        .map(|uuid| kin_model::WorkScope::Entity(kin_model::EntityId(uuid))))
+}
+
+#[cfg(test)]
+mod scope_grammar_tests {
+    use super::*;
+
+    /// A scope is read only in one of the documented spellings. A bare string
+    /// is refused, and the refusal names the input and the forms, rather than
+    /// being read as a repository path.
+    #[test]
+    fn a_bare_string_is_refused_rather_than_read_as_a_path() {
+        match parse_single_work_scope("src/main.rs") {
+            Err(McpError::InvalidParams(message)) => {
+                assert!(message.contains("artifact:<path>"), "{message}");
+                assert!(message.contains("\"src/main.rs\""), "{message}");
+            }
+            other => panic!("a bare path must be refused, got {other:?}"),
         }
+        for spelled in ["artifact:src/main.rs", "file:src/main.rs"] {
+            match parse_single_work_scope(spelled) {
+                Ok(kin_model::WorkScope::Artifact(path)) => assert_eq!(path.0, "src/main.rs"),
+                other => panic!("{spelled} resolved to {other:?}"),
+            }
+        }
+        let id = uuid::Uuid::new_v4();
+        for spelled in [format!("entity:{id}"), id.to_string()] {
+            assert!(
+                matches!(
+                    parse_single_work_scope(&spelled),
+                    Ok(kin_model::WorkScope::Entity(kin_model::EntityId(found))) if found == id
+                ),
+                "{spelled}"
+            );
+        }
+        assert!(
+            parse_single_work_scope("artifact:").is_err(),
+            "a path scope must name a path"
+        );
+    }
+
+    /// An annotation target also takes a work item, and its refusal says so.
+    #[test]
+    fn an_annotation_target_refusal_names_the_work_form() {
+        match parse_annotation_target("src/main.rs") {
+            Err(McpError::InvalidParams(message)) => {
+                assert!(message.contains("work:<uuid>"), "{message}")
+            }
+            other => panic!("a bare path must be refused, got {other:?}"),
+        }
+        let id = uuid::Uuid::new_v4();
+        assert!(matches!(
+            parse_annotation_target(&format!("work:{id}")),
+            Ok(kin_model::AnnotationTarget::Work(kin_model::WorkId(found))) if found == id
+        ));
+    }
+
+    /// A scope entry that is not a string is refused rather than skipped, so a
+    /// scope the caller named is never silently missing.
+    #[test]
+    fn a_non_string_scope_entry_is_refused_rather_than_skipped() {
+        let entries = serde_json::json!(["artifact:src/main.rs", 7]);
+        assert!(parse_work_scopes(Some(&entries)).is_err());
+        let mut args = HashMap::new();
+        args.insert(
+            "targets".to_string(),
+            serde_json::json!([{ "Entity": "x" }]),
+        );
+        assert!(parse_annotation_targets(&args).is_err());
     }
 }
 

--- a/crates/kin-mcp/src/handlers/review.rs
+++ b/crates/kin-mcp/src/handlers/review.rs
@@ -1256,15 +1256,21 @@ fn parse_review_decision_state(s: &str) -> Result<kin_model::review::ReviewDecis
 }
 
 /// Parse an optional work scope from a JSON value (string like "entity:ID").
-fn parse_optional_work_scope(val: Option<&serde_json::Value>) -> Option<kin_model::WorkScope> {
+fn parse_optional_work_scope(
+    val: Option<&serde_json::Value>,
+) -> Result<Option<kin_model::WorkScope>> {
+    // A scope spelled in none of the documented forms is refused, not dropped:
+    // dropping it would fall through to `file_path`, or to no scope at all, and
+    // the note would anchor somewhere the caller did not ask for.
     val.and_then(|v| v.as_str())
-        .and_then(|s| parse_single_work_scope(s).ok())
+        .map(parse_single_work_scope)
+        .transpose()
 }
 
 fn parse_optional_scope_arg(
     args: &HashMap<String, serde_json::Value>,
 ) -> Result<Option<kin_model::WorkScope>> {
-    if let Some(scope) = parse_optional_work_scope(args.get("scope")) {
+    if let Some(scope) = parse_optional_work_scope(args.get("scope"))? {
         return Ok(Some(scope));
     }
 
@@ -1280,7 +1286,7 @@ fn parse_optional_scope_arg(
 fn parse_review_create_scopes(
     args: &HashMap<String, serde_json::Value>,
 ) -> Result<Vec<kin_model::WorkScope>> {
-    let scopes = parse_work_scopes(args.get("scopes")).unwrap_or_default();
+    let scopes = parse_work_scopes(args.get("scopes"))?;
     if !scopes.is_empty() {
         return Ok(scopes);
     }
@@ -1486,6 +1492,32 @@ mod tests {
             coverage[COVERING_TESTS_BOUND_KEY], COVERING_TESTS_BOUND,
             "a zero must say beside the number that missing local-variable property edges can \
              make it a false negative: {coverage}"
+        );
+    }
+
+    /// A review scope spelled in none of the documented forms is refused. Dropping
+    /// it instead would fall through to `file_path`, or to no scope, and the note
+    /// would anchor somewhere the caller did not ask for; a `scopes` entry would
+    /// fall through to `entity_ids`.
+    #[test]
+    fn a_misspelled_review_scope_is_refused_not_dropped() {
+        for args in [
+            serde_json::json!({ "scope": "src/a.rs" }),
+            serde_json::json!({ "scope": "src/a.rs", "file_path": "src/b.rs" }),
+        ] {
+            let args: HashMap<String, serde_json::Value> =
+                serde_json::from_value(args).expect("an argument object");
+            assert!(
+                parse_optional_scope_arg(&args).is_err(),
+                "a misspelled scope must refuse: {args:?}"
+            );
+        }
+
+        let mut args = HashMap::new();
+        args.insert("scopes".into(), serde_json::json!(["src/a.rs"]));
+        assert!(
+            parse_review_create_scopes(&args).is_err(),
+            "a misspelled scopes entry must refuse, not fall through to entity_ids"
         );
     }
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1421,7 +1421,6 @@ kin exec [options] -- <command>...
 | `--keep` |  | Keep the session workspace after the run and defer reconcile |
 | `--discard` |  | Discard all workspace changes after the run (no reconcile). Conflicts with `--keep`. |
 | `--strategy <strategy>` |  | Materialization strategy |
-| `--scope <scope>` |  | Scope filter |
 
 ### `kin shell`
 
@@ -1618,7 +1617,7 @@ kin intent register <scope> [options]
 
 | Argument | Required | Description |
 | --- | --- | --- |
-| `<scope>` | yes | Scope to lock (entity:&lt;uuid&gt;, file:&lt;path&gt;, or bare UUID/path) |
+| `<scope>` | yes | Scope to lock (entity:&lt;uuid&gt;, contract:&lt;uuid&gt;, file:&lt;path&gt;, artifact:&lt;path&gt;, or an entity UUID) |
 
 | Flag | Default | Description |
 | --- | --- | --- |
@@ -1670,7 +1669,7 @@ kin traffic show <scope>
 
 | Argument | Required | Description |
 | --- | --- | --- |
-| `<scope>` | yes | Scope to query (entity:&lt;uuid&gt;, file:&lt;path&gt;, or bare UUID/path) |
+| `<scope>` | yes | Scope to query (entity:&lt;uuid&gt;, contract:&lt;uuid&gt;, file:&lt;path&gt;, artifact:&lt;path&gt;, or an entity UUID) |
 
 #### `kin traffic sessions`
 
@@ -1703,7 +1702,7 @@ kin work create [options]
 | `-k, --kind <kind>` |  | Work kind: feature, task, issue, debt, todo, investigation |
 | `-t, --title <title>` |  | Work item title |
 | `-d, --description <description>` |  | Optional description |
-| `-s, --scope <scope>` |  | Scope to link (entity:&lt;uuid&gt;, artifact:&lt;path&gt;, or bare path) |
+| `-s, --scope <scope>` |  | Scope to link (entity:&lt;uuid&gt;, contract:&lt;uuid&gt;, artifact:&lt;path&gt;, change:&lt;id&gt;, or an entity UUID) |
 | `-p, --priority <priority>` |  | Priority: critical, high, medium, low, none |
 
 #### `kin work list`
@@ -1718,7 +1717,7 @@ kin work list [options]
 | --- | --- | --- |
 | `-s, --status <status>` |  | Filter by status |
 | `-k, --kind <kind>` |  | Filter by kind |
-| `--scope <scope>` |  | Filter by scope (entity:&lt;uuid&gt;, contract:&lt;uuid&gt;, artifact:&lt;path&gt;, change:&lt;id&gt;, or bare path) |
+| `--scope <scope>` |  | Filter by scope (entity:&lt;uuid&gt;, contract:&lt;uuid&gt;, artifact:&lt;path&gt;, change:&lt;id&gt;, or an entity UUID) |
 
 #### `kin work show`
 
@@ -1841,7 +1840,7 @@ kin note add <target> [options]
 
 | Argument | Required | Description |
 | --- | --- | --- |
-| `<target>` | yes | Target to annotate (entity:&lt;uuid&gt;, contract:&lt;uuid&gt;, artifact:&lt;path&gt;, change:&lt;id&gt;, work:&lt;uuid&gt;, or bare path) |
+| `<target>` | yes | Target to annotate (entity:&lt;uuid&gt;, contract:&lt;uuid&gt;, artifact:&lt;path&gt;, change:&lt;id&gt;, work:&lt;uuid&gt;, or an entity UUID) |
 
 | Flag | Default | Description |
 | --- | --- | --- |
@@ -1858,7 +1857,7 @@ kin note list <target>
 
 | Argument | Required | Description |
 | --- | --- | --- |
-| `<target>` | yes | Target to query (entity:&lt;uuid&gt;, contract:&lt;uuid&gt;, artifact:&lt;path&gt;, change:&lt;id&gt;, work:&lt;uuid&gt;, or bare path) |
+| `<target>` | yes | Target to query (entity:&lt;uuid&gt;, contract:&lt;uuid&gt;, artifact:&lt;path&gt;, change:&lt;id&gt;, work:&lt;uuid&gt;, or an entity UUID) |
 
 #### `kin note stale`
 


### PR DESCRIPTION
Part of FIR-3578, the audit of kin's file-shaped MCP and CLI surface.

## One call, two answers, by route

Through a stdio MCP server, `kin_register_intent` or `kin_check_traffic` with
`{"scopes": ["src/main.rs"]}` took a path lock on the daemon. The same call through the daemon's
own `/mcp/tools/call` route was refused. The schema for both tools documents typed scopes and
never a bare string.

The stdio server runs in `DaemonRequired` and sends every tool except `kin_tool_search` into
`daemon_delegate::forward_tool_call` before any handler runs. Its arms for these two tools built
their scopes with `scope_strings`, and `scope_to_string` passed any bare JSON string through
unchanged. The daemon's `parse_scope` then read anything that was not a UUID as a path. The daemon's
own MCP route runs the typed handler, which refused. The delegate's test for this was named
`scope_to_string_accepts_bare_string` and fed it `"file:src/main.rs"`, a string that is already
prefixed, so nothing tested a bare one.

## The same default, in five parsers

Every scope parser in the product ended in the same fallback: a string that was not a UUID became
a repository path. A mistyped entity id or a bare name turned into a durable file-path scope, a
path lock or a path annotation, with no error anywhere.

- kin-mcp `parse_single_work_scope` and `parse_annotation_target`, reached by `kin_work_create`,
  `kin_work_list`, `kin_work_link`, `kin_work_implement`, `kin_annotation_add` and
  `kin_annotation_list`, which fall through to the daemon's MCP route and run there.
- Two kin-mcp review sites that swallowed that parser's error: `parse_optional_work_scope` with
  `.ok()`, and `parse_review_create_scopes` with `unwrap_or_default()`. With the refusal in place,
  those would have silently turned a misspelled scope into no scope, so both now propagate.
- kin-cli `parse_work_scope` and `parse_annotation_target`, reached by `kin note`, `kin work` and
  `kin review note/discuss`. Their help promised "or bare path".
- The daemon's `parse_scope`, reached by `kin intent register` and `kin traffic show`.
- The stdio delegate's `scope_to_string`, above.

## What changed

Every parser now refuses an unrecognized string with a message naming the input and the accepted
forms, from one sentence and one set of forms defined in kin-mcp (`unrecognized_scope_message`,
`WORK_SCOPE_FORMS`, `ANNOTATION_TARGET_FORMS`, `INTENT_SCOPE_FORMS`). In kin-mcp the refusal is
`InvalidParams`, JSON-RPC -32602. In the daemon it is `400 Bad Request`.

A path is still a scope whenever it is spelled as one: `artifact:<path>` or `file:<path>`. A bare
UUID is still an entity. An empty path after either prefix is refused. A scope entry that is not a
string is refused rather than skipped.

kin-cli's two parsers now delegate to kin-mcp's, so the CLI and the tools cannot drift apart. The
daemon's intent parser learns `artifact:` as an alias of `file:`, because that is how the work and
annotation scopes spell the same thing. Before this change an intent on `artifact:src/x` silently
locked a path literally named `artifact:src/x`.

`kin exec --scope` is deleted. Every value it took was refused by
`create_session_workspace_from_authority` before a workspace existed, and it was the only caller
that ever set a session workspace scope. The wire field and the daemon-side refusal stay, as
defence against a mismatched client and daemon.

Every help and doc line that promised "or bare path" now lists the real forms: `main.rs` for
`kin intent register`, `kin traffic show`, `kin work create --scope`, `kin work list --scope`,
`kin note add` and `kin note list`, and the matching rows in `docs/cli-reference.md`, plus the
`kin exec` `--scope` row.

`kin_review_create`'s `entity_ids` is deliberately unchanged. Its schema documents "entity IDs or
artifact paths" as its contract, so it gets a dual-accept change of its own, not a refusal here.

## Who this can break

No recorded caller sends a bare scope, and every count below has a positive control that hits in
its repo. kinlab's 29 `artifact:` lines all spell the prefix, and kinlab never sends `kin_work_list`
a scope. Neither `kin_register_intent` nor `kin_check_traffic` has an external caller: kinlab's one
hit is a tool-roster line, and kin-editor has none. kin's seven `/intent/register` tests and two
`/traffic/` tests all spell `file:`. Three kin-cli fixtures passed bare paths through
`create_in_layout_direct` and now spell `artifact:`. The parsed scope is unchanged, so their
assertions are too.

## Verification

The claims below that hosted CI does not check are given as the command and its output, not
described.

Formatting and clippy ran the way `ci.yml` runs them (`ci.yml:1203-1214`): the debt allow-list
joined unquoted under bash, and `-D warnings` from `RUSTFLAGS`.

```
$ cargo fmt --all -- --check
fmt rc=0
$ allows="$(grep -Ev '^(#|$)' .github/clippy-allowed-lints.txt | tr '\n' ' ')"
$ RUSTFLAGS="-D warnings" cargo clippy -p kin-mcp -p kin-cli -p kin-daemon --all-targets --all-features -- $allows
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 04s
clippy rc=0
```

The only other line clippy printed is cargo's future-incompatibility note about the `block v0.1.6`
dependency, which is not a lint on this code.

Tests, under the same `RUSTFLAGS="-D warnings"`:

```
$ cargo test -p kin-mcp --lib
test result: ok. 1023 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 87.93s
$ cargo test -p kin-daemon --lib -- scope_grammar_tests intent traffic
test result: ok. 37 passed; 0 failed; 0 ignored; 0 measured; 1680 filtered out; finished in 2.11s
```

During that run, six kin-cli tests failed: the four `setup_git_authority_*` tests, which spawn host
git under timeouts, `merge_mcp_config_toml_preserves_existing_codex_config` and
`uninstall_whole_file_deletes_and_dry_run_does_not`. None of them is in a file this PR touches. The
run coincided with a fleet-wide compute quiet that held a 16 GB model resident. Rerun on the same
head with the same flags once the quiet lifted:

```
$ cargo test -p kin-cli --lib -- commands::setup::tests::merge_mcp_config_toml_preserves_existing_codex_config commands::setup::tests::setup_git_authority commands::setup::tests::setup_git_relative_host_path_cannot_rebind_under_repository_cwd commands::setup_ledger::tests::uninstall_whole_file_deletes_and_dry_run_does_not
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 2320 filtered out; finished in 0.81s
```

Main's CI push run for this PR's base commit (`c3bc1a5b6`, run 34647499862) passed every job that
runs them: the three fast-gate test shards, and both the macOS and ubuntu Check & Test shards. This
PR's own CI run grades the full suite.

Every new and touched test, run by name on the committed head after the falsification arms were
restored:

```
$ cargo test -p kin-mcp --lib -- scope_grammar_tests a_misspelled_review_scope scope_to_string parse_review_create_scopes parse_optional_scope_arg the_stdio_intent_route
test daemon_delegate::tests::scope_to_string_passes_a_spelled_string_through ... ok
test daemon_delegate::tests::scope_to_string_rejects_unknown_shape ... ok
test daemon_delegate::tests::scope_to_string_refuses_an_unspelled_string ... ok
test daemon_delegate::tests::scope_to_string_maps_tagged_variants ... ok
test handlers::common::scope_grammar_tests::an_annotation_target_refusal_names_the_work_form ... ok
test handlers::common::scope_grammar_tests::a_bare_string_is_refused_rather_than_read_as_a_path ... ok
test handlers::review::tests::a_misspelled_review_scope_is_refused_not_dropped ... ok
test handlers::common::scope_grammar_tests::a_non_string_scope_entry_is_refused_rather_than_skipped ... ok
test handlers::review::tests::parse_optional_scope_arg_uses_file_anchor_when_scope_missing ... ok
test handlers::review::tests::parse_review_create_scopes_accepts_uuid_and_paths ... ok
test daemon_delegate::tests::the_stdio_intent_route_refuses_an_unspelled_scope_before_forwarding ... ok
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 1012 filtered out; finished in 0.01s

$ cargo test -p kin-cli --lib -- commands::work::tests commands::note::tests
test commands::work::tests::the_cli_scope_parser_refuses_a_bare_path ... ok
test commands::work::tests::work_verification_report_uses_runs_and_work_tests ... ok
test commands::work::tests::todo_import_uses_snapshot_and_skips_duplicates ... ok
test commands::work::tests::todo_import_refuses_a_scan_root_outside_the_repository ... ok
test commands::work::tests::todo_import_accepts_a_scan_root_inside_the_repository ... ok
test commands::note::tests::add_annotation_persists_to_snapshot ... ok
test commands::work::tests::create_and_link_work_persist_to_snapshot ... ok
test commands::note::tests::add_annotation_to_work_item_persists_target_link ... ok
test commands::work::tests::close_work_updates_persisted_status ... ok
test commands::work::tests::work_relationships_persist_to_snapshot ... ok
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 2317 filtered out; finished in 2.44s

$ cargo test -p kin-cli --bin kin exec_carries_no_scope_flag
test tests::exec_carries_no_scope_flag ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 47 filtered out; finished in 0.01s

$ cargo test -p kin-daemon --lib an_unspelled_scope_is_refused_and_every_spelling_resolves
test api::scope_grammar_tests::an_unspelled_scope_is_refused_and_every_spelling_resolves ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1716 filtered out; finished in 0.01s
```

### Falsification

Each new test was falsified by putting back the behaviour it guards, one arm at a time, under plain
`cargo test`, so that the assertion fails and not a lint. Each arm was restored from the file's saved
pre-mutation bytes, checked by sha256, and the tree was confirmed identical to the committed head
after every arm.

A1, `recognize_work_scope` reads an unrecognized string as a path again:

```
thread 'handlers::common::scope_grammar_tests::an_annotation_target_refusal_names_the_work_form' panicked at crates/kin-mcp/src/handlers/common.rs:3883:22:
thread 'handlers::common::scope_grammar_tests::a_bare_string_is_refused_rather_than_read_as_a_path' panicked at crates/kin-mcp/src/handlers/common.rs:3852:22:
thread 'handlers::review::tests::a_misspelled_review_scope_is_refused_not_dropped' panicked at crates/kin-mcp/src/handlers/review.rs:1510:13:
test result: FAILED. 1 passed; 3 failed; 0 ignored; 0 measured; 1019 filtered out; finished in 0.09s
thread 'commands::work::tests::the_cli_scope_parser_refuses_a_bare_path' panicked at crates/kin-cli/src/commands/work.rs:964:53:
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2326 filtered out; finished in 0.04s
```

The one kin-mcp test that passed under A1 is the non-string-entry test, which does not depend on
that fallback and has its own arm, A6. The kin-cli failure shows the CLI reads through the shared
parser.

A2, `parse_optional_work_scope` swallows the parser's refusal with `.ok()` again:

```
thread 'handlers::review::tests::a_misspelled_review_scope_is_refused_not_dropped' panicked at crates/kin-mcp/src/handlers/review.rs:1508:13:
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1022 filtered out; finished in 0.02s
```

A3, the stdio delegate passes any non-empty string through to the daemon again:

```
thread 'daemon_delegate::tests::scope_to_string_refuses_an_unspelled_string' panicked at crates/kin-mcp/src/daemon_delegate.rs:4383:72:
thread 'daemon_delegate::tests::the_stdio_intent_route_refuses_an_unspelled_scope_before_forwarding' panicked at crates/kin-mcp/src/daemon_delegate.rs:4416:26:
test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 1021 filtered out; finished in 0.03s
```

A4, the daemon's `parse_scope` takes a path lock for an unrecognized string again:

```
thread 'api::scope_grammar_tests::an_unspelled_scope_is_refused_and_every_spelling_resolves' panicked at crates/kin-daemon/src/api.rs:19311:40:
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1716 filtered out; finished in 0.02s
```

A5, `kin exec` gets its `--scope` flag back, with the dispatch ignoring the field so the mutant
compiles and the assertion is what fails:

```
thread 'tests::exec_carries_no_scope_flag' panicked at crates/kin-cli/src/main.rs:4892:14:
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 47 filtered out; finished in 0.01s
```

A6, `parse_work_scopes` skips a non-string entry again:

```
thread 'handlers::common::scope_grammar_tests::a_non_string_scope_entry_is_refused_rather_than_skipped' panicked at crates/kin-mcp/src/handlers/common.rs:3899:9:
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1022 filtered out; finished in 0.01s
```

Every arm printed "restored by hash, tree matches the committed head", and the run ended
`ALL ARMS RUN` with no mutator state left behind.
