### PR TITLE
Key the footprint publish cadence by store root

### DIFF
--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -3083,40 +3083,35 @@ pub(crate) struct PressureCall {
 /// window every reader judges it by, at one small write per half minute.
 const FOOTPRINT_PUBLISH_INTERVAL: Duration = Duration::from_secs(30);
 
-/// Publish this daemon's standing against its budget, on a cadence.
-///
-/// Called from every point that already took a pressure call, so the standing
-/// keeps up with the daemon's own work without a task of its own to schedule,
-/// idle-shutdown against, or leak. A level change publishes at once: the rung
-/// is the part a reader acts on, and delaying it by up to half a minute would
-/// be the one field worth having promptly.
-/// When this daemon last published a standing, and at what level.
+/// When each store this process serves last had a standing published, and at
+/// what rung.
 ///
 /// Hoisted out of [`publish_footprint_standing`] so the idle path can ask
 /// whether the interval alone owes a publish WITHOUT paying for a pressure
 /// read first. That question has to be cheap: it is asked on a tick that found
 /// nothing to do, at the loop's poll cadence.
-static FOOTPRINT_LAST_PUBLISH: std::sync::OnceLock<
-    std::sync::Mutex<Option<(Instant, kin_core::memory_pressure::PressureLevel)>>,
-> = std::sync::OnceLock::new();
-
-fn footprint_last_publish(
-) -> &'static std::sync::Mutex<Option<(Instant, kin_core::memory_pressure::PressureLevel)>> {
-    FOOTPRINT_LAST_PUBLISH.get_or_init(|| std::sync::Mutex::new(None))
-}
-
-/// Forget the process-wide publish clock.
 ///
-/// The idle publisher checks this clock before it writes, and the clock is one
-/// cell for the whole test process. A sibling that published in the last thirty
-/// seconds makes `stand_down_tick` a no-op for every other store, which is how
-/// `a_round_that_stands_down_publishes_the_footprint_standing` went red on the
-/// featureless main job: 1561 tests in one process, one shared cadence.
-#[cfg(test)]
-pub(crate) fn reset_footprint_publish_clock_for_test() {
-    if let Ok(mut guard) = footprint_last_publish().lock() {
-        *guard = None;
-    }
+/// Keyed by store root because the record it paces is. A standing is written
+/// to one store's `footprint_record_path`, and "never published" is a fact
+/// about that store, while one cell for the whole process read it as a fact
+/// about the process. A daemon process opens exactly one `DaemonState`
+/// (`create_state` in the binary, hosted mode included, whose other
+/// repositories are cached graphs inside that one state), so in production
+/// this holds one entry and decides exactly what the single cell decided.
+/// Where one process holds many stores, which is this crate's own test binary,
+/// the single cell let one store's publish tell a store that had never
+/// published anything that it was not owed one.
+static FOOTPRINT_LAST_PUBLISH: std::sync::OnceLock<std::sync::Mutex<FootprintPublishClock>> =
+    std::sync::OnceLock::new();
+
+/// The last publish per store root, and the rung it published at.
+type FootprintPublishClock = std::collections::HashMap<
+    std::path::PathBuf,
+    (Instant, kin_core::memory_pressure::PressureLevel),
+>;
+
+fn footprint_last_publish() -> &'static std::sync::Mutex<FootprintPublishClock> {
+    FOOTPRINT_LAST_PUBLISH.get_or_init(|| std::sync::Mutex::new(FootprintPublishClock::new()))
 }
 
 /// Whether the interval alone owes a publish.
@@ -3161,7 +3156,9 @@ fn publish_is_owed(since_last: Option<Duration>, level_changed: bool) -> bool {
 /// twenty-nine of every thirty seconds.
 pub(crate) fn publish_footprint_standing_on_idle_tick(state: &DaemonState) {
     let since_last = match footprint_last_publish().lock() {
-        Ok(guard) => guard.as_ref().map(|(published, _)| published.elapsed()),
+        Ok(guard) => guard
+            .get(state.layout.root())
+            .map(|(published, _)| published.elapsed()),
         // A poisoned lock is not a reason to publish; the busy path holds the
         // same lock and will report its own failure.
         Err(_) => return,
@@ -3173,25 +3170,34 @@ pub(crate) fn publish_footprint_standing_on_idle_tick(state: &DaemonState) {
     publish_footprint_standing(state, &call);
 }
 
+/// Publish this store's standing against its budget, on this store's cadence.
+///
+/// Called from every point that already took a pressure call, so the standing
+/// keeps up with the daemon's own work without a task of its own to schedule,
+/// idle-shutdown against, or leak. A level change publishes at once: the rung
+/// is the part a reader acts on, and delaying it by up to half a minute would
+/// be the one field worth having promptly. Both the interval and the rung are
+/// this store's own; see [`FOOTPRINT_LAST_PUBLISH`].
 pub(crate) fn publish_footprint_standing(state: &DaemonState, call: &PressureCall) {
     let Some(standing) = call.standing.as_ref() else {
         return;
     };
+    let root = state.layout.root();
     let cell = footprint_last_publish();
     let Ok(mut guard) = cell.lock() else {
         return;
     };
-    let (since_last, level_changed) = match guard.as_ref() {
+    let (since_last, level_changed) = match guard.get(root) {
         Some((published, level)) => (Some(published.elapsed()), *level != call.level),
         None => (None, false),
     };
     if !publish_is_owed(since_last, level_changed) {
         return;
     }
-    *guard = Some((Instant::now(), call.level));
+    guard.insert(root.to_path_buf(), (Instant::now(), call.level));
     drop(guard);
     kin_core::memory_pressure::DaemonFootprint::record(
-        state.layout.root(),
+        root,
         standing,
         call.level,
         std::process::id(),

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -8328,17 +8328,19 @@ mod tests {
     /// is that a record reaches disk. Breaking `stand_down_tick` by dropping its
     /// publish reds this and nothing else.
     ///
-    /// The idle publisher's cadence and tree sample are process-wide. A suite
-    /// that already published in the last thirty seconds, or that pinned
-    /// `KIN_MEMORY_PRESSURE` with no figures, makes the tick a no-op for this
-    /// store. Seed both so the arm grades the tick, not the neighbours.
+    /// The idle publisher's tree sample is process-wide, and a suite that
+    /// pinned `KIN_MEMORY_PRESSURE` with no figures makes the tick a no-op for
+    /// this store, so the sample is seeded and the arm grades the tick, not the
+    /// neighbours. The publish cadence is this store's own and this store is
+    /// new, so no neighbour's publish can silence it. That half used to be
+    /// process-wide, and it failed this test three runs in twenty, featureless
+    /// and threaded; the sibling below holds it deterministically.
     #[test]
     fn a_round_that_stands_down_publishes_the_footprint_standing() {
         let _budget = kin_core::test_env::EnvVarGuard::set(
             kin_core::memory_pressure::FOOTPRINT_BUDGET_ENV,
             (8u64 * 1024 * 1024 * 1024).to_string(),
         );
-        crate::daemon::reset_footprint_publish_clock_for_test();
         crate::daemon::seed_tree_footprint_for_test(kin_core::memory_pressure::TreeFootprint {
             own_bytes: 64 * 1024 * 1024,
             children_bytes: 0,
@@ -8368,6 +8370,86 @@ mod tests {
         assert!(
             published.budget_bytes > 0,
             "a standing with no budget states nothing about what the daemon is allowed to hold"
+        );
+    }
+
+    /// A store that has never published is owed its first standing, whatever
+    /// another store in the same process published a moment ago.
+    ///
+    /// The race the test above used to lose, made deterministic. The publish
+    /// cadence was one clock for the whole process, so a sibling's publish for
+    /// its own store told a store that had published nothing that it was not
+    /// owed a publish, and the round that stood down wrote no standing at all.
+    /// Measured before the fix on the featureless build: three failures in
+    /// twenty threaded runs of the target beside its publishers, and none in
+    /// twenty with one test thread. Here the other store lives in this same
+    /// test, so the interleaving happens on every run rather than one in seven.
+    ///
+    /// Both stores have never published, so both first rounds are the property.
+    /// Run alone, the first store publishes and the second is the one a shared
+    /// clock silences. Run in a crowd, another test's publish can silence the
+    /// first store instead, and a shared clock was seen doing exactly that when
+    /// this test was falsified, so the first assertion names the defect too
+    /// rather than blaming the harness.
+    ///
+    /// The control is the cadence itself. A second tick for the same store
+    /// inside its own interval must not publish again, or a build that passed
+    /// the first half by publishing on every tick would pass this too and put
+    /// a pressure read on the loop's poll cadence. The idle path returns on the
+    /// interval before it reads pressure at all, so the control does not
+    /// depend on which rung the machine sits at.
+    #[test]
+    fn a_store_that_never_published_is_not_silenced_by_another_stores_publish() {
+        let _budget = kin_core::test_env::EnvVarGuard::set(
+            kin_core::memory_pressure::FOOTPRINT_BUDGET_ENV,
+            (8u64 * 1024 * 1024 * 1024).to_string(),
+        );
+        crate::daemon::seed_tree_footprint_for_test(kin_core::memory_pressure::TreeFootprint {
+            own_bytes: 64 * 1024 * 1024,
+            children_bytes: 0,
+            child_count: 0,
+            kernel_capped: false,
+        });
+
+        let first_repo = tempfile::TempDir::new().unwrap();
+        let first = open_test_state(&first_repo);
+        let first_pass = first
+            .background_work
+            .pass(crate::background_work::PASS_RECONCILE);
+        stand_down_tick(&first, &first_pass);
+        assert!(
+            kin_core::memory_pressure::DaemonFootprint::read(first.layout.root()).is_some(),
+            "a store that had never published wrote no standing on its first round: either a \
+             publish for some other store in this process silenced it, which is the defect this \
+             test is about, or this tick publishes nothing at all"
+        );
+
+        let second_repo = tempfile::TempDir::new().unwrap();
+        let second = open_test_state(&second_repo);
+        let second_pass = second
+            .background_work
+            .pass(crate::background_work::PASS_RECONCILE);
+        assert!(
+            kin_core::memory_pressure::DaemonFootprint::read(second.layout.root()).is_none(),
+            "a store that has never published must start with no record"
+        );
+        stand_down_tick(&second, &second_pass);
+        assert!(
+            kin_core::memory_pressure::DaemonFootprint::read(second.layout.root()).is_some(),
+            "a store that had never published was silenced by another store's publish a \
+             moment earlier"
+        );
+
+        // The control: the cadence still holds for the store that just published.
+        std::fs::remove_file(kin_core::memory_pressure::footprint_record_path(
+            second.layout.root(),
+        ))
+        .expect("the record the second store just published is on disk");
+        stand_down_tick(&second, &second_pass);
+        assert!(
+            kin_core::memory_pressure::DaemonFootprint::read(second.layout.root()).is_none(),
+            "a store's second tick inside its own interval published again, so the cadence \
+             that keeps a pressure read off the poll loop is gone"
         );
     }
 


### PR DESCRIPTION
`a_round_that_stands_down_publishes_the_footprint_standing` has been failing main's featureless
permutation job on and off all day (00:34Z, 11:57Z, 15:26Z, 16:20Z, 17:55Z), and the permutation job
runs only on a push to main, so no pull request ever saw it. It is not flaky in the sense of noise.
It is a real cadence defect that only a process holding more than one store can show.

## What was measured, before any change

A local-only trace on the publish path (never committed) printed the test thread, the store root and
`since_last` for every publish and every cadence skip. On `919f7ede1`:

```
full featureless lib suite, threaded, 1 run   1662 passed; 0 failed (604.79 s)
  13 publishes, 15 cadence skips; two skips landed 263 ms and 455 ms after another store's publish

targeted loop (the target plus the tests that publish beside it, 36 tests a run), 20 runs each
  featureless, threaded          target failed 3/20   nothing else failed
  featureless, --test-threads=1  target failed 0/20   nothing else failed
  default features, threaded     target failed 0/20   nothing else failed
```

Every failure in the trace is the same interleaving:

```
FOOTPRINT-PUB  thread=loop_runner::tests::startup_diagnostic_watch_arms_before_marked_repair_is_live root=.tmp1TavDF
FOOTPRINT-SKIP thread=loop_runner::tests::a_round_that_stands_down_publishes_the_footprint_standing root=.tmpCFlx9q since_last=223.940333ms
thread 'loop_runner::tests::a_round_that_stands_down_publishes_the_footprint_standing' panicked at crates/kin-daemon/src/loop_runner.rs:8362:14:
a round that stood down must have published a standing
```

The other two failures carry the same publisher and the same panic, with the target skipped at
82.9 ms and 93.6 ms. The same bytes and the same 36 tests fail threaded and never with one test
thread. Default features reached 0/20, and I have no trace that says why, so I read it as timing,
not immunity. The clock code is compiled the same way under both feature sets.

## Cause

`FOOTPRINT_LAST_PUBLISH` was one `OnceLock<Mutex<Option<(Instant, PressureLevel)>>>` for the
whole process. The record it paces is per store: `DaemonFootprint::record` writes one store's
`footprint_record_path`. `interval_owes_publish(None)` is documented as "never published, which is
owed", and in a process holding more than one store that `None` meant "this process never
published", not "this store never published". So a sibling's publish for its own store told the
target's store, which had published nothing, that it was not owed a publish. The round stood down
and wrote no standing.

`reset_footprint_publish_clock_for_test` was the earlier attempt, and it could not close the window.
The target reset the clock and then ticked, and the race is a sibling's publish landing between the
two.

Production has never seen this, and the reason is worth writing down rather than assuming. A daemon
process opens exactly one `DaemonState`. The only production constructor is `create_state` in
`crates/kin-daemon/src/bin/kin-daemon.rs` (line 204), called once, at line 763. Its three branches
each return one state: local, and two backend modes. All 33 `DaemonState::open*` sites in `daemon.rs` sit
inside `#[cfg(test)]` modules. Hosted multi-repo mode keeps its other repositories as
`repo_graphs: RwLock<HashMap<String, Arc<HostedRepoCacheEntry>>>` inside that one state, and a
`HostedRepoCacheEntry` holds a graph, an authority envelope, a cursor and a default-ref tree, never
a `DaemonState`. So in local and hosted modes alike a daemon publishes footprints under one root.
Only this crate's own test binary holds many stores in one process.

## The change

**The clock is keyed by store root.** In `daemon.rs` the cell becomes
`OnceLock<Mutex<HashMap<PathBuf, (Instant, PressureLevel)>>>`. `publish_footprint_standing_on_idle_tick`
and `publish_footprint_standing` both look up and insert by `state.layout.root()`. "Never published"
now means what the doc comment always said it meant, and a level change is judged against this
store's own last rung. In production the map holds one entry and makes every decision the single
cell made. The pure `interval_owes_publish` and `publish_is_owed` are unchanged, and so is
`footprint_cadence_tests`. I read every test that uses the clock, and none relies on it being
process-wide.

**The reset helper is gone.** Its only caller was this test, and it could not help.

**The target test** drops the reset and the sentence that said the cadence is process-wide. The
tree-sample half of that comment is still true, so the seed stays.

**A deterministic sibling**, `a_store_that_never_published_is_not_silenced_by_another_stores_publish`.
Store A stands down and publishes. Store B then stands down inside A's interval and must publish its
own first record. On the old clock B is a cadence skip on every run, with no thread timing involved,
so a pull request sees the class in the default `cargo test -p kin-daemon` that the check job
runs. The permutation job that exposed it runs only on main. Its control: B's second tick inside
B's own interval must not publish again, so a build that passed the first half by dropping the
cadence is caught. The idle path returns on the interval before it reads pressure at all, so the
control does not depend on which rung the machine sits at.

Not touched: `state.rs`, `kin-core`, `handlers/`. I considered moving the clock onto `DaemonState`
as a field, the cleaner home, but it reaches into `state.rs` and every constructor for the same
per-store truth.

## Falsification

The fix's own tests pass under both feature sets. That's `a_store_that_never_published_is_not_silenced_by_another_stores_publish`,
the target and `footprint_cadence_tests`, 5 passed and 0 failed with default features and again
with `--no-default-features`.

Each arm breaks one link, runs those five tests, and restores the exact text. Arm X is the old
behaviour rebuilt inside the new code: every lookup and every insert keyed by one constant path,
which makes the clock a single cell again. Arm Y removes the cadence by making any elapsed interval
owed.

```
BASELINE (the fix)                     5 passed; 0 failed                        rc=0

ARM X  one process-wide cell again     3 passed; 2 failed                        rc=101
  loop_runner.rs:8437  a store that had never published was silenced by another store's publish a moment earlier
  loop_runner.rs:8364  a round that stood down must have published a standing

ARM Y  the cadence is gone             2 passed; 3 failed                        rc=101
  loop_runner.rs:8441  a store's second tick inside its own interval published again, so the cadence
                       that keeps a pressure read off the poll loop is gone
  daemon.rs:3702       one millisecond short of the interval is NOT owed
  daemon.rs:3732       and an unchanged level one second in still waits

ARM X  the new test alone               0 passed; 1 failed                        rc=101
  loop_runner.rs:8437  a store that had never published was silenced by another store's publish a moment earlier

RESTORED  default features              5 passed; 0 failed                        rc=0
RESTORED  featureless                   5 passed; 0 failed                        rc=0
```

Arm X is the strongest half. With one shared cell, the original target fails with the exact panic
main's permutation job has been showing, in a crowd of five tests. The only thing between that and
the green baseline is the per-store key.

Arm X also exposed a flaw in the first draft of the new test. In an earlier ordering, another
test's publish silenced the new test's first store. It went red on the first-store assertion,
whose message blamed the harness, so a reader would have gone looking in the wrong place. Both
stores have never published, so both first rounds are the property. That message now names the
defect as well as the harness case.

After the fix, on the loop the baseline was taken with (same 36 tests, same 20 threaded runs, the
traced fixed featureless binary):

```
before  featureless, threaded   target failed 3/20   nothing else failed
after   featureless, threaded   target failed 0/20   nothing else failed
```

The full featureless lib suite, three runs on that same fixed binary, finished after this pull
request merged:

```
== fullsuite-fixed: 0/3 runs failed the target, 0/3 failed elsewhere ==
run 1 rc=0 pass 1663 passed; 0 failed
run 2 rc=0 pass 1663 passed; 0 failed
run 3 rc=0 pass 1663 passed; 0 failed
```

One full run before the fix also passed, so the full suite on its own cannot tell a fixed build from
a lucky one. The targeted loop and the two-store test are the evidence; this count is the wide net
beside them.

The traced binaries predate one change: the reworded first-store assertion message in the new test.
That test is not in the targeted loop's filter set, so both counts grade the behaviour this commit
carries.

`bin/kin-precheck kin`:

```
kin-precheck: repo=kin tree=.../maingreen-kin sha=6f0c14fe1944f9a49a18ddfa8a5876ad474fd3b9 branch=chore/lane-maingreen-standdown-kin
kin-precheck: behind origin/main 8 commit(s); the gate list below is the one on THIS tree, not the one on main
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <allows>
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:check-quarantine.py            python3 scripts/check-quarantine.py
...      (18 more gates, all PASS)
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin 6f0c14fe1944f9a49a18ddfa8a5876ad474fd3b9
```
