### PR TITLE
Mark the four file-path tool parameters deprecated and say so in the answer

### DIFF
--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -276,6 +276,53 @@ pub const ELISION_REASON_DEPENDENTS_CAP: &str = "dependents_cap";
 /// Where a payload publishes what its lists lost.
 pub const ELISIONS_KEY: &str = "elisions";
 
+/// Where a payload publishes the parameters it answered that are on their way
+/// out, beside `degradations` and `elisions`.
+///
+/// No `ResponseShape` names it, so the ladder never cuts it, and it is bounded
+/// by construction: one entry per deprecated parameter the call actually
+/// passed. It is measured with the rest of the payload, so it cannot push a
+/// response past its ceiling unseen.
+pub const DEPRECATIONS_KEY: &str = "deprecations";
+
+/// The last release that still answers a deprecated parameter. The parameter
+/// keeps working through it and is removed after it.
+pub const DEPRECATION_REMOVED_AFTER: &str = "0.7.16";
+
+/// Record that this response answered a deprecated parameter, naming what
+/// replaces it and the last release that still answers it. Recording the same
+/// tool and parameter twice keeps one entry. A payload that is not an object has
+/// no top level to carry the key, and is left as it is.
+pub fn record_deprecation(
+    payload: &mut Value,
+    tool: &str,
+    parameter: &str,
+    replacement: &str,
+    removed_after: &str,
+) {
+    let entry = json!({
+        "tool": tool,
+        "parameter": parameter,
+        "replacement": replacement,
+        "removed_after": removed_after,
+    });
+    let Some(map) = payload.as_object_mut() else {
+        return;
+    };
+    let list = map
+        .entry(DEPRECATIONS_KEY.to_string())
+        .or_insert_with(|| Value::Array(Vec::new()));
+    if let Some(entries) = list.as_array_mut() {
+        let already = entries.iter().any(|prior| {
+            prior.get("tool") == entry.get("tool")
+                && prior.get("parameter") == entry.get("parameter")
+        });
+        if !already {
+            entries.push(entry);
+        }
+    }
+}
+
 /// Per-row marker naming the budget that took this row's inline source.
 ///
 /// A row that simply loses its `body` key is byte-identical to a row from a
@@ -3271,6 +3318,40 @@ mod tests {
             "an unpaged tool must not be handed a cursor it never mints"
         );
         assert_eq!(unpaged["next_cursor"], Value::Null);
+    }
+
+    /// A deprecation rides beside the answer: one entry per tool and parameter,
+    /// never cut by the ladder, and still there after the ceiling has bitten.
+    #[test]
+    fn a_deprecation_is_recorded_once_and_survives_a_cut() {
+        let mut payload = file_entities_final_page(40, 200, 240, 600);
+        for _ in 0..2 {
+            record_deprecation(
+                &mut payload,
+                "impact_analysis",
+                "files",
+                "entity_ids",
+                DEPRECATION_REMOVED_AFTER,
+            );
+        }
+        let budget = ResponseBudget {
+            max_chars: 6_000,
+            ..ResponseBudget::default()
+        };
+        enforce(&mut payload, FILE_ENTITIES_TOOL, &budget).expect("budgeted");
+        assert!(
+            payload["entities"].as_array().expect("entities").len() < 40,
+            "the ceiling has to bite for this to test anything"
+        );
+        assert_eq!(
+            payload[DEPRECATIONS_KEY],
+            json!([{
+                "tool": "impact_analysis",
+                "parameter": "files",
+                "replacement": "entity_ids",
+                "removed_after": DEPRECATION_REMOVED_AFTER,
+            }])
+        );
     }
 
     fn cosine_locate_payload(hits: usize) -> Value {

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -7501,6 +7501,76 @@ mod tests {
     /// looking for one, which is the wrong-cause error class this workspace
     /// polices. Tracked paths with no parser-emitted entities are the ordinary
     /// way to hit it: a workflow file is a real artifact and resolves to nothing.
+    /// Each files-mode tool answers a `files` call with the deprecation beside
+    /// its answer, and an `entity_ids` call with none.
+    #[tokio::test]
+    async fn a_files_call_carries_its_deprecation_and_an_entity_call_does_not() {
+        let store = InMemoryGraph::new();
+        let present = impact_probe_entity("deprecation_probe_3578", Some(3));
+        let present_path = present
+            .file_origin
+            .as_ref()
+            .expect("the probe carries a file origin")
+            .to_string();
+        kin_model::graph::EntityStore::upsert_entity(&store, &present).unwrap();
+        let sessions = SessionRegistry::new();
+        let by_file = HashMap::from([
+            ("files".to_string(), serde_json::json!([present_path])),
+            ("include_traffic".to_string(), serde_json::json!(false)),
+        ]);
+        let by_id = HashMap::from([
+            (
+                "entity_ids".to_string(),
+                serde_json::json!([present.id.to_string()]),
+            ),
+            ("include_traffic".to_string(), serde_json::json!(false)),
+        ]);
+        let text_of = |result: &ToolCallResult| {
+            let crate::types::ContentBlock::Text { text } = &result.content[0];
+            text.clone()
+        };
+
+        let impact = tool_result_json(
+            review::handle_impact_analysis(&by_file, &store, &sessions)
+                .await
+                .expect("a resolvable file yields a report"),
+        );
+        assert_eq!(impact["deprecations"][0]["tool"], "impact_analysis");
+        assert_eq!(impact["deprecations"][0]["parameter"], "files");
+        let impact = tool_result_json(
+            review::handle_impact_analysis(&by_id, &store, &sessions)
+                .await
+                .expect("an entity id yields a report"),
+        );
+        assert!(impact.get("deprecations").is_none(), "{impact}");
+
+        for (tool, by_file_result, by_id_result) in [
+            (
+                "semantic_diff",
+                review::handle_semantic_diff(&by_file, &store).expect("diff by file"),
+                review::handle_semantic_diff(&by_id, &store).expect("diff by id"),
+            ),
+            (
+                "semantic_review",
+                review::handle_semantic_review(&by_file, &store, &sessions)
+                    .expect("review by file"),
+                review::handle_semantic_review(&by_id, &store, &sessions).expect("review by id"),
+            ),
+        ] {
+            let value: serde_json::Value = serde_json::from_str(&text_of(&by_file_result))
+                .unwrap_or_else(|_| panic!("{tool} by file must answer in JSON"));
+            assert_eq!(value["deprecations"][0]["tool"], tool, "{value}");
+            assert!(
+                value["message"].is_string(),
+                "{tool} keeps its text: {value}"
+            );
+            assert!(
+                !text_of(&by_id_result).contains("\"deprecations\""),
+                "{tool} by entity id must carry no deprecation"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn impact_analysis_files_mode_names_a_resolution_miss_not_a_diff_complaint() {
         let store = InMemoryGraph::new();

--- a/crates/kin-mcp/src/handlers/path.rs
+++ b/crates/kin-mcp/src/handlers/path.rs
@@ -1736,7 +1736,32 @@ pub fn handle_trace_path<G: GraphStore>(
     let request = request_from_args(args)?;
     match build_path_response(store, &request) {
         Ok(response) => {
-            let json = serde_json::to_string_pretty(&response).map_err(McpError::Json)?;
+            let mut value = serde_json::to_value(&response).map_err(McpError::Json)?;
+            // A pin named by file keeps working for one more release and says
+            // so. The entity id in `from` or `to` is the spelling that stays.
+            for (parameter, used, replacement) in [
+                (
+                    "from_file",
+                    request.from_file.is_some(),
+                    "the entity id in `from`",
+                ),
+                (
+                    "to_file",
+                    request.to_file.is_some(),
+                    "the entity id in `to`",
+                ),
+            ] {
+                if used {
+                    crate::budget::record_deprecation(
+                        &mut value,
+                        TOOL_NAME,
+                        parameter,
+                        replacement,
+                        crate::budget::DEPRECATION_REMOVED_AFTER,
+                    );
+                }
+            }
+            let json = serde_json::to_string_pretty(&value).map_err(McpError::Json)?;
             Ok(ToolCallResult::text(json))
         }
         Err(PathError::InvalidRequest(message)) => Err(McpError::InvalidParams(message)),
@@ -1849,6 +1874,44 @@ mod tests {
 
     fn names(route: &PathRoute) -> Vec<&str> {
         route.steps.iter().map(|step| step.name.as_str()).collect()
+    }
+
+    /// A pin named by file answers with its deprecation beside the route; the
+    /// same call without the pin carries none.
+    #[test]
+    fn a_file_pin_answers_with_its_deprecation_beside_the_route() {
+        let store = InMemoryGraph::new();
+        let a = function("edit", "src/editor.ts");
+        let b = function("apply", "src/view.ts");
+        seed(&store, &[&a, &b], &[call_at(&a, &b, 2)]);
+        let answer = |args: &HashMap<String, serde_json::Value>| -> serde_json::Value {
+            let result = handle_trace_path(args, &store).expect("the route resolves");
+            let crate::types::ContentBlock::Text { text } = &result.content[0];
+            serde_json::from_str(text).expect("trace_path answers in JSON")
+        };
+        let mut args = HashMap::from([
+            ("from".to_string(), serde_json::json!("edit")),
+            ("to".to_string(), serde_json::json!("apply")),
+        ]);
+
+        let plain = answer(&args);
+        assert!(
+            plain["routes"]
+                .as_array()
+                .is_some_and(|routes| !routes.is_empty()),
+            "positive control: the route itself answered: {plain}"
+        );
+        assert!(plain.get("deprecations").is_none(), "{plain}");
+
+        args.insert("from_file".to_string(), serde_json::json!("src/editor.ts"));
+        let pinned = answer(&args);
+        assert_eq!(pinned["deprecations"][0]["tool"], TOOL_NAME);
+        assert_eq!(pinned["deprecations"][0]["parameter"], "from_file");
+        assert_eq!(
+            pinned["deprecations"].as_array().map(Vec::len),
+            Some(1),
+            "only the pin that was passed: {pinned}"
+        );
     }
 
     /// A three-link chain answers with the chain, in order, with every hop

--- a/crates/kin-mcp/src/handlers/review.rs
+++ b/crates/kin-mcp/src/handlers/review.rs
@@ -31,7 +31,41 @@ pub fn handle_semantic_diff<G: GraphStore>(
 ) -> Result<ToolCallResult> {
     let diff = resolve_diff(args, store)?;
     let formatted = kin_review::format_diff(&diff);
-    Ok(ToolCallResult::text(formatted))
+    text_answer(formatted, args, "semantic_diff")
+}
+
+/// Whether the call named `files`, the file-path targeting these tools keep
+/// answering for one more release.
+fn names_files(args: &HashMap<String, serde_json::Value>) -> bool {
+    get_optional_string_array(args, "files").is_some_and(|files| !files.is_empty())
+}
+
+fn record_files_deprecation(payload: &mut serde_json::Value, tool: &str) {
+    crate::budget::record_deprecation(
+        payload,
+        tool,
+        "files",
+        "entity_ids",
+        crate::budget::DEPRECATION_REMOVED_AFTER,
+    );
+}
+
+/// A text answer, or, when the call named the deprecated `files` parameter, the
+/// object the envelope already wraps text in, `{ "message": <text> }`, with the
+/// deprecation beside the text. A text answer has no top level to carry a key,
+/// so this is the one shape in which a text caller sees the notice.
+fn text_answer(
+    text: String,
+    args: &HashMap<String, serde_json::Value>,
+    tool: &str,
+) -> Result<ToolCallResult> {
+    if !names_files(args) {
+        return Ok(ToolCallResult::text(text));
+    }
+    let mut result = serde_json::json!({ "message": text });
+    record_files_deprecation(&mut result, tool);
+    let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
+    Ok(ToolCallResult::text(json))
 }
 
 pub const IMPACT_ANALYSIS_DESC: &str = "\
@@ -161,6 +195,9 @@ pub async fn handle_impact_analysis<G: GraphStore>(
 
     let mut result = serde_json::to_value(&impact).map_err(McpError::Json)?;
     annotate_impact_presentation_lines(&mut result, &impact);
+    if names_files(args) {
+        record_files_deprecation(&mut result, "impact_analysis");
+    }
 
     if include_traffic {
         // Collect traffic for all changed entities.
@@ -315,27 +352,29 @@ pub fn handle_semantic_review<G: GraphStore>(
                 }
             }
         }
+        if names_files(args) {
+            record_files_deprecation(&mut result, "semantic_review");
+        }
         let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
         return Ok(ToolCallResult::text(json));
     }
 
-    if include_traffic {
+    let text = if include_traffic {
         // Collect traffic for all entities in the diff.
         let traffic_lines = collect_review_traffic_lines(&review, sessions);
-
         if traffic_lines.is_empty() {
-            Ok(ToolCallResult::text(formatted))
+            formatted
         } else {
-            let with_traffic = format!(
+            format!(
                 "{}\n\n--- Active Traffic ---\n{}",
                 formatted,
                 traffic_lines.join("\n")
-            );
-            Ok(ToolCallResult::text(with_traffic))
+            )
         }
     } else {
-        Ok(ToolCallResult::text(formatted))
-    }
+        formatted
+    };
+    text_answer(text, args, "semantic_review")
 }
 
 fn collect_review_traffic_lines(
@@ -1519,6 +1558,33 @@ mod tests {
             parse_review_create_scopes(&args).is_err(),
             "a misspelled scopes entry must refuse, not fall through to entity_ids"
         );
+    }
+
+    /// A text tool answers in text until the caller names the deprecated `files`,
+    /// and then in the object the envelope wraps text in, with the notice beside it.
+    #[test]
+    fn a_text_answer_carries_the_files_deprecation_only_when_files_was_named() {
+        fn text_of(result: &ToolCallResult) -> String {
+            let crate::types::ContentBlock::Text { text } = &result.content[0];
+            text.clone()
+        }
+
+        let by_id = HashMap::from([("entity_ids".to_string(), serde_json::json!(["x"]))]);
+        let answer = text_answer("the diff".to_string(), &by_id, "semantic_diff").unwrap();
+        assert_eq!(
+            text_of(&answer),
+            "the diff",
+            "no deprecated parameter, plain text"
+        );
+
+        let by_file = HashMap::from([("files".to_string(), serde_json::json!(["src/a.rs"]))]);
+        let answer = text_answer("the diff".to_string(), &by_file, "semantic_diff").unwrap();
+        let value: serde_json::Value =
+            serde_json::from_str(&text_of(&answer)).expect("a files call answers in JSON");
+        assert_eq!(value["message"], "the diff");
+        assert_eq!(value["deprecations"][0]["tool"], "semantic_diff");
+        assert_eq!(value["deprecations"][0]["parameter"], "files");
+        assert_eq!(value["deprecations"][0]["replacement"], "entity_ids");
     }
 
     #[test]

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -783,8 +783,8 @@ fn registered_tools() -> ToolsListResult {
                     "properties": {
                         "from": { "type": "string", "description": "Source end: entity UUID, exact name, or name@file to pin one of two same-named entities." },
                         "to": { "type": "string", "description": "Target end, in the same forms." },
-                        "from_file": { "type": "string", "description": "Pin `from` to the entity of that name in the file this path or path suffix names. Same request as the name@file spelling." },
-                        "to_file": { "type": "string", "description": "Pin `to` the same way." },
+                        "from_file": { "type": "string", "description": "Deprecated, answered through 0.7.16; pass the entity id in `from`. Pins `from` by file." },
+                        "to_file": { "type": "string", "description": "Deprecated, answered through 0.7.16; pass the entity id in `to`. Pins `to` by file." },
                         "max_depth": { "type": "integer", "description": "Hops walked between the two ends (default 6, ceiling 12). Containment hops joining a class to its members are not counted.", "default": 6, "minimum": 1, "maximum": crate::remediation::PATH_MAX_MAX_DEPTH },
                         "limit": { "type": "integer", "description": "Routes returned, shortest first (default 3, ceiling 25). `routes_total` says how many shortest routes exist.", "default": 3, "minimum": 1, "maximum": 25 },
                         "direction": {
@@ -865,7 +865,7 @@ fn registered_tools() -> ToolsListResult {
                         "base": { "type": "string", "description": "Base semantic change ID (hex)" },
                         "head": { "type": "string", "description": "Head semantic change ID (hex)" },
                         "entity_ids": { "type": "array", "items": { "type": "string" }, "description": "Entity UUIDs to analyze impact for" },
-                        "files": { "type": "array", "items": { "type": "string" }, "description": "File paths: resolves to entities, then analyzes impact" },
+                        "files": { "type": "array", "items": { "type": "string" }, "description": "Deprecated, answered through 0.7.16; use entity_ids. File paths resolved to entities." },
                         "change_ids": { "type": "array", "items": { "type": "string" }, "description": "Change ID hexes to combine and analyze impact" },
                         "include_traffic": { "type": "boolean", "description": "Include active traffic on impacted entities", "default": true }
                     }
@@ -881,7 +881,7 @@ fn registered_tools() -> ToolsListResult {
                         "base": { "type": "string", "description": "Base semantic change ID (hex)" },
                         "head": { "type": "string", "description": "Head semantic change ID (hex)" },
                         "entity_ids": { "type": "array", "items": { "type": "string" }, "description": "Entity UUIDs to diff (current state vs history)" },
-                        "files": { "type": "array", "items": { "type": "string" }, "description": "File paths: resolves to entities, then diffs" },
+                        "files": { "type": "array", "items": { "type": "string" }, "description": "Deprecated, answered through 0.7.16; use entity_ids. File paths resolved to entities." },
                         "change_ids": { "type": "array", "items": { "type": "string" }, "description": "Change ID hexes to combine into one diff" }
                     }
                 }),
@@ -896,7 +896,7 @@ fn registered_tools() -> ToolsListResult {
                         "base": { "type": "string", "description": "Base semantic change ID (hex)" },
                         "head": { "type": "string", "description": "Head semantic change ID (hex)" },
                         "entity_ids": { "type": "array", "items": { "type": "string" }, "description": "Entity UUIDs to review (current state vs history)" },
-                        "files": { "type": "array", "items": { "type": "string" }, "description": "File paths: resolves to entities, then reviews" },
+                        "files": { "type": "array", "items": { "type": "string" }, "description": "Deprecated, answered through 0.7.16; use entity_ids. File paths resolved to entities." },
                         "change_ids": { "type": "array", "items": { "type": "string" }, "description": "Change ID hexes to combine into one review" },
                         "format": { "type": "string", "enum": ["text", "json"], "description": "Response format. Use json for editor integrations.", "default": "text" },
                         "include_traffic": { "type": "boolean", "description": "Include active traffic on reviewed entities", "default": true }

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -305,7 +305,7 @@ reported rather than served as a confident answer.
 ## 3. Semantic Change, Impact & Review
 *Tools:* `impact_analysis`, `semantic_diff`, `semantic_review`, `shadow_gate_report`
 
-- **`semantic_diff`**: Compute an entity-level diff of which declarations were added, removed, or changed, rather than a line-by-line text diff. Target it by base/head change IDs, entity IDs, file paths, or a list of change IDs.
+- **`semantic_diff`**: Compute an entity-level diff of which declarations were added, removed, or changed, rather than a line-by-line text diff. Target it by base/head change IDs, entity IDs, or a list of change IDs (file paths still answer through 0.7.16 and are deprecated in favour of entity IDs).
 - **`impact_analysis`**: Walk the relation graph from what changed to find the downstream entities that could be affected ("if I change this, what else might break?").
 - **`semantic_review`**: Produce a complete review of a change in one call. It covers entity-level diff, downstream impact, and an overall risk assessment, in `text` or `json` form.
 - **`shadow_gate_report`**: Run the shadow-mode merge gate over a PR-shaped change (`base` ref to `head` ref) and return one report covering changed entities, graph-proven blast radius, the verdict the gate would have issued, the repair context needed to fix findings, explicit evidence gaps, and audit evidence. Shadow mode is report-only and never blocks. Refs accept branch names and semantic change IDs, and imported Git commit SHAs resolve once their history is in the graph. Where the graph cannot prove something, the report says so in `evidence_gaps` rather than passing silently.


### PR DESCRIPTION
Part of FIR-3578, the audit of kin's file-shaped MCP and CLI surface.

## What this does

Four MCP parameters address code by file path, and no caller outside kin's own tests passes any of
them: `files` on `impact_analysis`, `semantic_diff` and `semantic_review`, and `from_file` and
`to_file` on `trace_path`. They keep answering for one more release and now say they are
deprecated. The entity-keyed form already exists beside each one: `entity_ids` on the three review
tools, and the entity id in `from` or `to` on `trace_path`.

## The shape

A response that used a deprecated parameter carries a top-level `deprecations` array beside
`degradations`, with one entry per parameter the call passed:

```json
"deprecations": [
  { "tool": "impact_analysis", "parameter": "files", "replacement": "entity_ids", "removed_after": "0.7.16" }
]
```

`semantic_diff` always answers in text, and `semantic_review` does unless `format` is `json`. A text
answer has no top level to put a key on. The envelope already wraps text as
`{ "_kin": ..., "message": <text> }`, so when a deprecated parameter was used, those two answer with
`{ "message": <the same text>, "deprecations": [...] }` instead. That's the shape a text client
already receives, plus one array. `_kin` is untouched.

`DEPRECATIONS_KEY` and `record_deprecation` sit beside `ELISIONS_KEY` in `budget.rs`. No
`ResponseShape` names the key, so the ladder never cuts it. It's bounded by construction, at most
two entries, on `trace_path`, and it's measured with the rest of the payload. A test confirms that
an entry survives a response the ceiling has cut. The four schema descriptions and the
`semantic_diff` line in `docs/mcp-tools.md` say the same thing.

`packages/boundary-contracts/schemas/mcp-tool-input.schema.json` still declares `files` and is left
alone. The parameter keeps answering for this release, and changing the shared schema would pull
kinlab's typecheck into a kin-only change.

## removed_after

`removed_after` is `0.7.16`: the parameter answers through that release and is removed after it,
so a caller gets at least one full release with the notice in hand.

Read at 22:03:33Z: the workspace version on `origin/main` is `"0.7.15"` and the `v0.7.15` tag is not cut yet.
That makes `0.7.16` right either way and never early. If this lands before the v0.7.15 tag is cut,
the notice ships in 0.7.15 and callers get two releases; if it lands after, the notice first ships in
0.7.16 and they get one.

## Who this can break

Nobody on record, and every count below has a positive control that hits in its repo. kin's only
files-mode call sites are its own unit tests. kinlab's `impact_analysis` caller passes `entity_ids`.
kin-editor never passes `files`. No acceptance script passes any of the four. `from_file` and
`to_file` have no caller outside kin's own source.

## Verification

Run the way `ci.yml` runs them (`ci.yml:1203-1214`): the allow list joined unquoted under bash, and
`-D warnings` from `RUSTFLAGS`.

```
$ cargo fmt --all -- --check
fmt rc=0
$ RUSTFLAGS="-D warnings" cargo clippy -p kin-mcp --all-targets --all-features -- $allows
clippy rc=0
$ RUSTFLAGS="-D warnings" cargo test -p kin-mcp --lib
test result: ok. 1027 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 31.08s
```

The evidence below was produced on this exact diff, then the branch was rebased over one unrelated
commit that landed on main while it ran. The rebase was clean, no conflict and no file of this
change touched, and CI grades the merged result.

### Falsification

Each new test was falsified by restoring the behaviour it guards, one arm at a time, under plain
`cargo test`. Each arm was restored from saved bytes checked by sha256, and the tree was confirmed
identical to the committed head after every arm.

P1, `record_deprecation` stops deduping, so a parameter recorded twice lands twice:

```
thread 'budget::tests::a_deprecation_is_recorded_once_and_survives_a_cut' panicked at crates/kin-mcp/src/budget.rs:3344:9:
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1026 filtered out; finished in 0.01s
```

P2, `impact_analysis`'s hook is removed:

```
thread 'handlers::tests::a_files_call_carries_its_deprecation_and_an_entity_call_does_not' panicked at crates/kin-mcp/src/handlers/mod.rs:7538:9:
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1026 filtered out; finished in 0.01s
```

P3, `text_answer` ignores `files` and always answers in plain text:

```
thread 'handlers::review::tests::a_text_answer_carries_the_files_deprecation_only_when_files_was_named' panicked at crates/kin-mcp/src/handlers/review.rs:1581:53:
thread 'handlers::tests::a_files_call_carries_its_deprecation_and_an_entity_call_does_not' panicked at crates/kin-mcp/src/handlers/mod.rs:7561:37:
test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 1025 filtered out; finished in 0.01s
```

P4, `trace_path`'s hook is removed:

```
thread 'handlers::path::tests::a_file_pin_answers_with_its_deprecation_beside_the_route' panicked at crates/kin-mcp/src/handlers/path.rs:1900:9:
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1026 filtered out; finished in 0.01s
```

P5, `names_files` returns true whatever the call passed:

```
thread 'handlers::review::tests::a_text_answer_carries_the_files_deprecation_only_when_files_was_named' panicked at crates/kin-mcp/src/handlers/review.rs:1574:9:
thread 'handlers::tests::a_files_call_carries_its_deprecation_and_an_entity_call_does_not' panicked at crates/kin-mcp/src/handlers/mod.rs:7545:9:
test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 1025 filtered out; finished in 0.01s
```

Every arm printed "restored by hash, tree matches the committed head", and the run ended
`ALL ARMS RUN` with no mutator state left behind.

### Every PR 3 test, by name, on the committed head

```
test handlers::review::tests::a_text_answer_carries_the_files_deprecation_only_when_files_was_named ... ok
test handlers::tests::a_files_call_carries_its_deprecation_and_an_entity_call_does_not ... ok
test handlers::path::tests::a_file_pin_answers_with_its_deprecation_beside_the_route ... ok
test budget::tests::a_deprecation_is_recorded_once_and_survives_a_cut ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 1023 filtered out; finished in 0.01s
```
