### PR TITLE
Take the loopback fixture's accepted socket out of non-blocking mode

### DIFF
--- a/crates/kin-remote/src/http_transport.rs
+++ b/crates/kin-remote/src/http_transport.rs
@@ -353,6 +353,13 @@ pub(crate) mod tests {
                     Err(error) => panic!("{error}"),
                 }
             };
+            // A socket accepted from a non-blocking listener inherits O_NONBLOCK on
+            // macOS and BSD, where on Linux it does not, and a read timeout does not
+            // apply to a non-blocking socket. Without this the read below returns
+            // WouldBlock the moment a client has not written its request yet, and
+            // this thread panics: measured on this fixture at twelve failures in two
+            // hundred runs, every one of them on WouldBlock.
+            stream.set_nonblocking(false).unwrap();
             stream
                 .set_read_timeout(Some(Duration::from_secs(2)))
                 .unwrap();
@@ -366,6 +373,40 @@ pub(crate) mod tests {
             String::from_utf8(request).unwrap()
         });
         (url, thread)
+    }
+
+    /// A client whose request lands after the server's first read is still served.
+    ///
+    /// The fixture binds a non-blocking listener so its accept loop can give up
+    /// rather than hang. On macOS and BSD the socket `accept` returns inherits that
+    /// flag and on Linux it does not, and `set_read_timeout` does nothing to a
+    /// non-blocking socket, so the server's first `read_exact` answered WouldBlock
+    /// whenever the client had not written yet and the fixture thread panicked. That
+    /// is the macOS shard's own failure on kin#1742's landing, and it measured here
+    /// at twelve failures in two hundred runs before the fix, all twelve on
+    /// WouldBlock.
+    ///
+    /// The delay is the subject rather than a wait for a race to settle: it puts the
+    /// client's bytes strictly after the server's first read, which is the ordering
+    /// the kernel failed on. On Linux this passes either way, so the macOS shards are
+    /// what grade it.
+    #[test]
+    fn a_client_whose_request_lands_after_the_first_read_is_still_served() {
+        use std::io::{Read, Write};
+        let (url, server) = serve_once(
+            "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".to_owned(),
+        );
+        let mut client = std::net::TcpStream::connect(url.trim_start_matches("http://")).unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+        client
+            .write_all(b"GET / HTTP/1.1\r\nHost: fixture\r\n\r\n")
+            .unwrap();
+        let mut response = Vec::new();
+        client.read_to_end(&mut response).unwrap();
+        let request = server
+            .join()
+            .expect("the fixture server must survive a client that writes after it reads");
+        assert!(request.starts_with("GET / HTTP/1.1"), "{request}");
     }
 
     #[test]


### PR DESCRIPTION
`http_transport::tests::sync_credentials_allow_literal_loopback_and_refuse_redirects` failed
`Check & Test macOS shard (1)` on main's CI run 34646864509, the #1742 landing. The fixture's
loopback server thread panicked at `http_transport.rs:362:46` on
`Os { code: 35, kind: WouldBlock }`, and the test then unwrapped the join at `:427:45`. Later runs
were green, so it is a fixture flake on macOS rather than a product red.

## Measured first

The one test, run two hundred times on `e86530eef` before any change, built with `--features http`:

```
== red4 baseline: 12/200 runs failed, 12 of them on WouldBlock, 13s ==
```

Twelve in two hundred, every one of them the class.

## Cause

`serve_once` calls `listener.set_nonblocking(true)` so its accept loop can give up rather than hang.
On macOS and BSD a socket returned by `accept` inherits `O_NONBLOCK` from the listener, where on
Linux it does not, and `set_read_timeout` does not apply to a non-blocking socket. So the server's
first `read_exact` returns WouldBlock the moment the client has connected but not yet written, which
is ordinary, and the fixture thread panics. Linux never sees it because the accepted socket is
blocking there.

## The change

One line after the accept loop, `stream.set_nonblocking(false)`, which makes the two-second read
timeout mean what it says.

`serve_once` is the only fixture in this crate that accepts and then reads. The other four
non-blocking listeners (`http_transport.rs:374` and `:407`, `repository_transfer_http.rs:474` and
`:498`) only assert that nothing connected, so they are not the class. It serves both callers
(`http_transport.rs:416` and `repository_transfer_http.rs:504`), so this covers
`repository_transfer_http.rs` without touching it.

## The guard a pull request can see

`a_client_whose_request_lands_after_the_first_read_is_still_served` connects, waits 50 ms, then
writes, putting the client's bytes strictly after the server's first read. That is the ordering the
kernel failed on, so it is deterministic rather than a wait for a race to settle. On Linux it passes
either way, which its doc comment says; the macOS shards are what grade it.

## Falsification

```
AFTER THE FIX   both tests ok; loop == red4 fixed: 0/200 runs failed, 0 on WouldBlock ==

ONE LINE REMOVED
  a_client_whose_request_lands_after_the_first_read_is_still_served ... FAILED
  panicked at crates/kin-remote/src/http_transport.rs:368:46:
    called `Result::unwrap()` on an `Err` value: Os { code: 35, kind: WouldBlock }
  panicked at crates/kin-remote/src/http_transport.rs:407:14   (the join, as on CI)
  sync_credentials_allow_literal_loopback_and_refuse_redirects ... ok   (it is the 1-in-16 flake)
  loop == red4 reverted: 2/200 runs failed, 2 of them on WouldBlock ==

RESTORED        both tests ok
```

The new test goes red on the removal every time; the old one passed that same run, which is exactly
why the loop count is here beside it.

`bin/kin-precheck kin`:

```
kin-precheck: repo=kin tree=.../maingreen-kin sha=50758099ab34963f45b9303469b97654fc819e28 branch=chore/lane-maingreen-loopback-kin
kin-precheck: behind origin/main 0 commit(s)
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <allows>
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:check-quarantine.py            python3 scripts/check-quarantine.py
...      (18 more gates, all PASS)
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin 50758099ab34963f45b9303469b97654fc819e28
```
