### PR TITLE
Count a staged release hold as work in flight while the cut is switched on

### DIFF
--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -1001,10 +1001,29 @@ jobs:
           fi
 
           decision="$work/decision.json"
+          # Whether the workflow that owns a staged transition is switched on.
+          # A `tag_staged` hold is the cut proving a candidate, which takes far
+          # longer than four cycles, and cycles are workflow_run firings rather
+          # than clock ticks. It is a rail standing still only when the cut is
+          # off, which is the first thing the staged alarm body tells a reader
+          # to check; the decision now reads it rather than leaving it to a
+          # human after the issue is already open. Any answer but a known state,
+          # including a failed read, becomes `unreadable`, which the script
+          # counts exactly as it counted a staged hold before, so this can never
+          # quiet the alarm by failing.
+          cut_state="$(gh api "repos/${REPO}/actions/workflows/release-cut.yml" \
+            --jq .state 2>/dev/null | head -1 | tr -d '"[:space:]')" || true
+          case "$cut_state" in
+            active|disabled_manually|disabled_inactivity|disabled_fork) ;;
+            *) cut_state=unreadable ;;
+          esac
+          echo "release-cut.yml state: $cut_state"
+
           node scripts/release-hold-alarm.mjs \
             --markers "$MARKERS" \
             --issue "$issue_arg" \
-            --threshold "$THRESHOLD" > "$decision"
+            --threshold "$THRESHOLD" \
+            --cut-state "$cut_state" > "$decision"
           jq -c . "$decision"
 
           action="$(jq -er .action "$decision")"

--- a/scripts/release-hold-alarm.mjs
+++ b/scripts/release-hold-alarm.mjs
@@ -121,7 +121,7 @@ function describeFailedRelease(marker) {
 // cause was reachable in two API calls that nothing told them to make.
 export const STAGED_REASON = "tag_staged";
 
-export function buildBody(marker, consecutive, threshold) {
+export function buildBody(marker, consecutive, threshold, cutState) {
   const drift = marker.drift;
   const blocking = marker.blocking_tag || "an unresolved tag";
   const latest = marker.latest_tag || "an unread Latest";
@@ -184,12 +184,28 @@ export function buildBody(marker, consecutive, threshold) {
     );
     lines.push("```");
     lines.push("");
-    lines.push(
-      "`disabled_manually` is the whole answer: no candidate can exist until " +
-        "that workflow is enabled. Enabling it opens a window in which the " +
-        "cut proves whatever is newest and green, so it is a decision to take " +
-        "deliberately rather than an automatic repair.",
-    );
+    // This paragraph used to assert `disabled_manually` outright, which made
+    // the issue state a diagnosis nothing had measured: kin#1750 told a reader
+    // the cut was switched off while the API read it `active`. The job now
+    // reads that state before deciding, so the body reports what it read.
+    const readState = cutState || "unreadable";
+    if (readState === "disabled_manually" || readState === "disabled_inactivity") {
+      lines.push(
+        `This alarm read that workflow's state as \`${readState}\`, and that is ` +
+          "the whole answer: no candidate can exist until it is enabled. " +
+          "Enabling it opens a window in which the cut proves whatever is " +
+          "newest and green, so it is a decision to take deliberately rather " +
+          "than an automatic repair.",
+      );
+    } else {
+      lines.push(
+        `This alarm read that workflow's state as \`${readState}\`, so a switch ` +
+          "that is off is not the answer here, and the two commands above are " +
+          "where to start instead. A staged hold never reaches this body while " +
+          "that state reads `active`, so either the read failed or the cut " +
+          "changed state between the read and now.",
+      );
+    }
   } else {
     lines.push(describeFailedRelease(marker));
     lines.push("");
@@ -300,7 +316,7 @@ export function decide({ markers, issue, threshold = DEFAULT_THRESHOLD, cutState
     };
   }
 
-  const body = buildBody(newest, consecutive, threshold);
+  const body = buildBody(newest, consecutive, threshold, cutState);
   if (open) {
     return {
       action: "update",

--- a/scripts/release-hold-alarm.mjs
+++ b/scripts/release-hold-alarm.mjs
@@ -29,11 +29,16 @@ export const DEFAULT_THRESHOLD = 4;
 
 export const MARKER_SCHEMA = "kin.release-hold.v1";
 
+// The one workflow state in which a staged hold is work in flight rather than a
+// rail standing still. Read from the Actions API by the job that runs this
+// script, and passed in, so this file stays a pure function over its inputs.
+export const CUT_STATE_ACTIVE = "active";
+
 // A marker this reader cannot vouch for is not a quiet rail and it is not a
 // held one either. It breaks the streak and it never closes an open alarm,
 // because an unreadable observation and an observed all-clear are different
 // findings and only one of them is safe to act on.
-function classify(marker) {
+function classify(marker, cutState) {
   if (!marker || typeof marker !== "object") return "unreadable";
   if (marker.unreadable === true) return "unreadable";
   if (marker.schema !== MARKER_SCHEMA) return "unreadable";
@@ -41,13 +46,35 @@ function classify(marker) {
   if (marker.state === "clear") return "clear";
   if (marker.state !== "held") return "unreadable";
   if (!Number.isInteger(marker.drift) || marker.drift < 0) return "unreadable";
+  // A staged hold is the cut proving a candidate, not the train declining to
+  // mint, but only while the workflow that owns that transition is switched on.
+  // Measured on the v0.7.15 release: the bump merged at 21:32:11Z and four
+  // consecutive `tag_staged` markers arrived by 21:53:09Z, 9m33s apart end to
+  // end, because every one of those cycles was a `workflow_run` firing on a
+  // completed CI run somewhere in the fleet rather than the quarter-hourly
+  // cron. The cut had not even chosen a candidate yet: its own decision line
+  // still read "no complete green sha carries 0.7.15 yet; still being graded",
+  // and its candidate build alone takes about fifty minutes. So the threshold
+  // counts runs, whose rate is fleet traffic, and no count can be tuned to a
+  // release's latency.
+  //
+  // `cutState` is what keeps this from silencing the failure the body below
+  // documents. On 2026-09-07 a staged hold alarmed truthfully because
+  // release-cut.yml was switched off, so the staged tag was never going to be
+  // minted. That is the FIRST thing the staged body tells a reader to check,
+  // and this is that check promoted into the decision: staged is progress only
+  // while the cut is `active`, and a cut that is disabled, or whose state could
+  // not be read, counts exactly as it did before.
+  if (marker.reason === STAGED_REASON && cutState === CUT_STATE_ACTIVE) {
+    return "staged_in_progress";
+  }
   return marker.drift > 0 ? "held_with_drift" : "held_idle";
 }
 
-function leadingHeldWithDrift(markers) {
+function leadingHeldWithDrift(markers, cutState) {
   let count = 0;
   for (const marker of markers) {
-    if (classify(marker) !== "held_with_drift") break;
+    if (classify(marker, cutState) !== "held_with_drift") break;
     count += 1;
   }
   return count;
@@ -192,11 +219,11 @@ export function buildBody(marker, consecutive, threshold) {
   return lines.join("\n");
 }
 
-export function decide({ markers, issue, threshold = DEFAULT_THRESHOLD }) {
+export function decide({ markers, issue, threshold = DEFAULT_THRESHOLD, cutState = null }) {
   const list = Array.isArray(markers) ? markers : [];
   const open = issue && typeof issue === "object" && issue.number ? issue : null;
   const newest = list[0];
-  const state = classify(newest);
+  const state = classify(newest, cutState);
 
   if (state === "unreadable") {
     return {
@@ -237,6 +264,19 @@ export function decide({ markers, issue, threshold = DEFAULT_THRESHOLD }) {
     return { action: "quiet", reason: "rail_healthy", detail: "The train resolved drift and proceeded." };
   }
 
+  if (state === "staged_in_progress") {
+    // Quiet, and an open alarm is left exactly where it is. Only the train's own
+    // all-clear closes one, and a staged hold is not an all-clear.
+    return {
+      action: "quiet",
+      reason: "staged_in_progress",
+      detail:
+        "The next version is staged on main and the cut is switched on, so a " +
+        "workflow owns this transition and the rail is moving. A staged hold " +
+        "counts toward the alarm only while release-cut.yml is not active.",
+    };
+  }
+
   if (state === "held_idle") {
     return {
       action: "quiet",
@@ -247,7 +287,7 @@ export function decide({ markers, issue, threshold = DEFAULT_THRESHOLD }) {
     };
   }
 
-  const consecutive = leadingHeldWithDrift(list);
+  const consecutive = leadingHeldWithDrift(list, cutState);
   if (consecutive < threshold) {
     return {
       action: "quiet",
@@ -283,12 +323,16 @@ export function decide({ markers, issue, threshold = DEFAULT_THRESHOLD }) {
 }
 
 function parseArgs(argv) {
-  const args = { markers: null, issue: null, threshold: DEFAULT_THRESHOLD };
+  const args = { markers: null, issue: null, threshold: DEFAULT_THRESHOLD, cutState: null };
   for (let index = 0; index < argv.length; index += 1) {
     const flag = argv[index];
     if (flag === "--markers") args.markers = argv[++index];
     else if (flag === "--issue") args.issue = argv[++index];
     else if (flag === "--threshold") args.threshold = Number.parseInt(argv[++index], 10);
+    // Absent, or any value but "active", leaves a staged hold counting exactly
+    // as it did before, so a caller that cannot read the cut's state never
+    // quiets the alarm by omission.
+    else if (flag === "--cut-state") args.cutState = argv[++index] ?? null;
     else throw new Error(`unknown argument: ${flag}`);
   }
   if (!args.markers) throw new Error("--markers <path> is required");
@@ -309,7 +353,7 @@ function main(argv) {
   // which is a different statement from having never looked. An absent path
   // would be the second, so the caller has to spell the first.
   const issue = !args.issue || args.issue === "none" ? null : readJson(args.issue);
-  process.stdout.write(`${JSON.stringify(decide({ markers, issue, threshold: args.threshold }), null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify(decide({ markers, issue, threshold: args.threshold, cutState: args.cutState }), null, 2)}\n`);
 }
 
 if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {

--- a/scripts/release-hold-alarm.test.mjs
+++ b/scripts/release-hold-alarm.test.mjs
@@ -431,3 +431,16 @@ test('a staged hold leaves an open alarm exactly where it is', () => {
   assert.equal(decision.action, 'quiet');
   assert.equal(decision.reason, 'staged_in_progress');
 });
+
+test('the staged body reports the cut state that was read, not an assumed one', () => {
+  // kin#1750 told a reader the cut was disabled_manually while the API read it
+  // active. The body states what the job measured.
+  const off = decide({ markers: V0715_STAGED_SEQUENCE, issue: null, cutState: 'disabled_manually' });
+  assert.match(off.body, /read that workflow's state as `disabled_manually`, and that is/);
+  assert.match(off.body, /no candidate can exist until it is enabled/);
+
+  const unknown = decide({ markers: V0715_STAGED_SEQUENCE, issue: null, cutState: null });
+  assert.match(unknown.body, /read that workflow's state as `unreadable`/);
+  assert.match(unknown.body, /a switch that is off is not the answer here/);
+  assert.doesNotMatch(unknown.body, /`disabled_manually`, and that is the whole answer/);
+});

--- a/scripts/release-hold-alarm.test.mjs
+++ b/scripts/release-hold-alarm.test.mjs
@@ -358,3 +358,76 @@ test('the alarm job result overrides missing or stale markers after finalizer or
     }
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
+
+// The v0.7.15 release, replayed from the markers the train actually wrote.
+// Measured from each run's own `release-hold-marker` artifact: the bump merged
+// at 21:32:11Z and these four staged markers were observed between 21:43:36Z
+// and 21:53:09Z, 9m33s end to end, because every one of those cycles was a
+// `workflow_run` firing on a completed CI run somewhere in the fleet. The cut
+// had not chosen a candidate yet, and its candidate build alone takes about
+// fifty minutes. The fourth of them opened kin#1750.
+function stagedV0715({ drift, runId, observedAt, mainSha }) {
+  return {
+    ...staged({ drift, blocking: 'v0.7.15', latest: 'v0.7.13' }),
+    detail: 'v0.7.15 is already staged on main; tag reconciliation owns the next transition',
+    run_id: runId,
+    run_url: `https://github.com/firelock-ai/kin/actions/runs/${runId}`,
+    main_sha: mainSha,
+    observed_at: observedAt,
+  };
+}
+
+const V0715_STAGED_SEQUENCE = [
+  stagedV0715({ drift: 44, runId: '34651465000', observedAt: '2026-09-11T21:53:09Z', mainSha: '42f0a1e0e00000000000000000000000000000ab' }),
+  stagedV0715({ drift: 44, runId: '34651353446', observedAt: '2026-09-11T21:52:03Z', mainSha: '42f0a1e0e00000000000000000000000000000ab' }),
+  stagedV0715({ drift: 44, runId: '34651339407', observedAt: '2026-09-11T21:51:28Z', mainSha: '42f0a1e0e00000000000000000000000000000ab' }),
+  stagedV0715({ drift: 43, runId: '34650711251', observedAt: '2026-09-11T21:43:36Z', mainSha: '27a542c7600000000000000000000000000000ab' }),
+];
+
+test('the v0.7.15 staged wait stays quiet while the cut is switched on', () => {
+  const decision = decide({ markers: V0715_STAGED_SEQUENCE, issue: null, cutState: 'active' });
+  assert.equal(decision.action, 'quiet');
+  assert.equal(decision.reason, 'staged_in_progress');
+});
+
+test('the same sequence opened an issue before the cut state was consulted', () => {
+  // The falsification: today's counting, which is what an omitted cut state
+  // still reproduces exactly, reaches the threshold on this very sequence.
+  const decision = decide({ markers: V0715_STAGED_SEQUENCE, issue: null });
+  assert.equal(decision.action, 'open');
+  assert.equal(decision.reason, 'hold_established');
+  assert.equal(decision.consecutive, DEFAULT_THRESHOLD);
+});
+
+test('a staged hold still alarms when the cut is switched off', () => {
+  // 2026-09-07: the staged tag was never going to be minted because
+  // release-cut.yml was disabled, and the alarm was right to ring.
+  for (const cutState of ['disabled_manually', 'disabled_inactivity', 'unreadable', null]) {
+    const decision = decide({ markers: V0715_STAGED_SEQUENCE, issue: null, cutState });
+    assert.equal(decision.action, 'open', `cut state ${cutState} must still alarm`);
+    assert.equal(decision.reason, 'hold_established');
+  }
+});
+
+test('an active cut does not quiet a hold that is not staged', () => {
+  const markers = [held(), held(), held(), held()];
+  const decision = decide({ markers, issue: null, cutState: 'active' });
+  assert.equal(decision.action, 'open');
+  assert.equal(decision.reason, 'hold_established');
+  assert.equal(decision.consecutive, DEFAULT_THRESHOLD);
+});
+
+test('a staged cycle breaks a streak of declined mints rather than extending it', () => {
+  const markers = [V0715_STAGED_SEQUENCE[0], held(), held(), held(), held()];
+  const decision = decide({ markers, issue: null, cutState: 'active' });
+  assert.equal(decision.action, 'quiet');
+  assert.equal(decision.reason, 'staged_in_progress');
+});
+
+test('a staged hold leaves an open alarm exactly where it is', () => {
+  // Only the train's own all-clear closes one. A staged hold is not an
+  // all-clear, so it neither closes nor updates.
+  const decision = decide({ markers: V0715_STAGED_SEQUENCE, issue: OPEN_ISSUE, cutState: 'active' });
+  assert.equal(decision.action, 'quiet');
+  assert.equal(decision.reason, 'staged_in_progress');
+});


### PR DESCRIPTION
## What this fixes

The release-hold alarm counts the normal wait between a version bump landing and its tag being minted as the train declining to mint, so it opens an alarm on every release. It opened kin#1750 during the v0.7.15 release while the cut was still choosing a candidate.

This is workflow and policy only. No product code.

## The measurement, before the fix

Every non-skipped release-train run since 21:05Z on 2026-09-11, each read from its own `release-hold-marker` artifact:

| train run | observed | state | reason | drift |
|---|---|---|---|---|
| 34648792343 | 21:19:40Z | clear | (none) | 39 |
| 34650711251 | 21:43:36Z | held | `tag_staged` | 43 |
| 34651339407 | 21:51:28Z | held | `tag_staged` | 44 |
| 34651353446 | 21:52:03Z | held | `tag_staged` | 44 |
| 34651465000 | 21:53:09Z | held | `tag_staged` | 44 |
| 34651797245 | 21:57:36Z | held | `tag_staged` | 44 |

The bump merged at 21:32:11Z. Run 34651465000 is the one whose alarm opened kin#1750, with `consecutive: 4, threshold: 4`.

**The threshold counts runs, not time.** Those four markers span 9m33s, from 21:43:36Z to 21:53:09Z, because every one of them is a `workflow_run` firing: the train runs on each completed CI run in the fleet, not only on its quarter-hourly cron. So four "consecutive cycles" arrives in minutes on a busy evening. The alarm opened 21 minutes after the bump merged, while the cut's own decision line still read `stand-down (no complete green sha carries 0.7.15 yet; still being graded)`.

**So raising the threshold cannot work.** Any count is measured in runs whose rate is fleet traffic, not release latency. For scale, this release's cut armed at 22:26:09Z and its candidate build alone ran until 23:19:49Z.

## Why a staged hold is not unconditionally in progress

`buildBody`'s staged branch exists because a staged hold *can* be a real failure. Its own comment records 2026-09-07, when a staged hold alarmed truthfully: `release-cut.yml` was switched off, so the staged tag was never going to be minted. Classifying every `tag_staged` hold as in progress would silence exactly that.

So the condition is the one the alarm body already tells a reader to check first: **a staged hold counts as in progress only while `release-cut.yml` reads `active`.** A cut that is disabled, or whose state cannot be read, counts exactly as it did before. The deciding job holds `actions: read`, which is what reading a workflow's state needs, so this is one API call and one input.

The second commit follows from the first. The staged body asserted `disabled_manually` as fixed prose, which on kin#1750 told a reader the cut was switched off while the API read it `active`. Now that the job reads that state, the body reports what it read.

## What this does not cover

A cut that is enabled but never publishes preflight, because main never grades green or rc-build attempts exhaust, is quiet under this change. `scripts/release-rail-parked-alarm.py` does not cover it either: it watches for a Release Cut run failing to appear after an RC Build, and its own docstring records that a cut run which appears and skips every job "reads CLEAR here; that is a narrower, real gap in this specific check, left for a future patrol". Stated as a follow-up patrol, not as coverage.

A second, separate gap was measured on this very release and belongs to FIR-3599 rather than to this change. The candidate build for v0.7.15, RC Build 34654042143, concluded success at 23:19:49Z, and no Release Cut run of any kind followed it: the `workflow_run` trigger created nothing and the 23:33 cron did not fire. `release-rail-parked-alarm.py` sets `PARKED_RAIL_WINDOW_MINUTES` to 15, so the rail was parked by that alarm's own definition from about 23:34:49Z, and no parked-rail issue was open. The alarm that would have caught it runs inside `release-sentinel.yml`, which had not run since 22:30:56Z, before the build concluded. In that last sentinel run the mechanical patrol job concluded success, so the patrol itself is sound; what failed was "Alarm when the sentinel has no credential to patrol with", working as designed while no Claude token is wired, with the agent-driven patrol skipped for the same reason. The rail was restarted by hand with a `repository_dispatch` of type `release_cut`, the remedy that alarm's own docstring names.

A wall-clock bound cannot close it in this file: the deciding job hands the script four markers, this run's plus three prior, which span minutes on a busy fleet.

## Tests

`node --test scripts/release-hold-alarm.test.mjs`: 34 tests, 34 pass, 0 fail.

- **Replay.** This release's real marker sequence, with the cut active, stays quiet with reason `staged_in_progress`.
- **Falsification of the old behavior.** The same sequence, with no cut state supplied, still opens the issue at `consecutive: 4`, which is what today's counting does.
- **Positive control, the 2026-09-07 case.** The same sequence with `disabled_manually`, `disabled_inactivity`, `unreadable` and no state at all each still opens the alarm.
- **Positive control, a real hold.** A `tag_not_finalized` streak with the cut active still opens at the threshold, so an active cut quiets nothing but a staged hold.
- **Body.** A disabled cut keeps the "whole answer" wording; any other state says so instead and does not claim the switch is off.

Each new test was falsified by breaking what it guards. Neutering the staged-in-progress condition turns exactly the three staged tests red and leaves the other 31 passing. Forcing the body's read state back to a constant turns exactly the body test red.

The workflow's new shell was run against a stubbed `gh`: an active cut reads `active`, a `gh` that fails outright reads `unreadable`, a 404 error body printed on stdout reads `unreadable`, and a disabled cut reads `disabled_manually`. Every case exits 0, so a failed read can neither abort the step nor quiet the alarm. `actionlint` passes on the changed workflow.

## Local gates

`bin/kin-precheck kin --repo-dir kin=<this lane worktree>`, through the fleet's builder slot, against this PR's head sha:

```
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin b40427808158089cc34965166dfde491947d7cca
```

Refs #1750.
