### PR TITLE
Read the query and command authority wrappers through the daemon's held open

### DIFF
--- a/crates/kin-cli/src/commands/ref_grammar.rs
+++ b/crates/kin-cli/src/commands/ref_grammar.rs
@@ -161,8 +161,14 @@ impl<'a> Authority<'a> {
             } => Ok((lease, workspace_id)),
             Self::Deferred { source, opened } => {
                 if opened.get().is_none() {
-                    let opens_before =
-                        super::repository_authority::repository_authority_opens_on_this_thread();
+                    // Counted on kin-core's funnel rather than on this crate's
+                    // own wrapper counter. Every path into KinDB's recovery
+                    // reaches that funnel, and a server resolving this authority
+                    // may open through another crate's wrapper, which this
+                    // crate's counter cannot see. Read from the wrapper counter,
+                    // the first read at a publication reported that nothing was
+                    // opened while a whole-store open had just been paid for it.
+                    let opens_before = kin_core::authority_opens();
                     let started = std::time::Instant::now();
                     let authority = source.open().map_err(|error| {
                         ref_error(
@@ -172,9 +178,7 @@ impl<'a> Authority<'a> {
                     })?;
                     let cost = AuthorityOpen {
                         waited: started.elapsed(),
-                        opened_here:
-                            super::repository_authority::repository_authority_opens_on_this_thread()
-                                > opens_before,
+                        opened_here: kin_core::authority_opens() > opens_before,
                         shared: source.is_shared(),
                     };
                     let lease = authority.manager().read_authority();

--- a/crates/kin-cli/src/commands/repository_authority.rs
+++ b/crates/kin-cli/src/commands/repository_authority.rs
@@ -19,7 +19,10 @@ use kin_model::{
 use serde::{Deserialize, Serialize};
 
 pub struct ActiveRepositoryAuthority {
-    manager: RepositoryAuthorityManager<LocalFileBackend>,
+    /// Shared rather than owned, so a server that has already paid for one open
+    /// reads through it here instead of opening the same publication a second
+    /// time. See [`ActiveRepositoryAuthority::from_shared`].
+    manager: std::sync::Arc<RepositoryAuthorityManager<LocalFileBackend>>,
     payload_stats: Option<AuthorityPayloadStats>,
     pub(crate) repository_id: RepositoryId,
     pub(crate) workspace_id: WorkspaceId,
@@ -379,15 +382,41 @@ impl ActiveRepositoryAuthority {
             .context("open repository-v6 authority through retained local binding")?;
 
         Ok(Self {
-            manager,
+            manager: std::sync::Arc::new(manager),
             payload_stats,
             repository_id,
             workspace_id,
         })
     }
 
+    /// Read through an authority a server already has open, without opening a
+    /// second one over the same durable bytes.
+    ///
+    /// Nothing is skipped: the manager handed in is the result of one full
+    /// validating open, and this type reads the same durable state through it.
+    /// The caller owns the freshness argument stated at
+    /// [`RequestRepositoryAuthority::shared`].
+    ///
+    /// The payload receipt travels with the manager because it describes the
+    /// open that produced it. A status report answered from a borrowed authority
+    /// therefore still names the payload it was read from, rather than dropping
+    /// the field because the reading came from someone else's open.
+    pub fn from_shared(
+        manager: std::sync::Arc<RepositoryAuthorityManager<LocalFileBackend>>,
+        payload_stats: Option<AuthorityPayloadStats>,
+        repository_id: RepositoryId,
+        workspace_id: WorkspaceId,
+    ) -> Self {
+        Self {
+            manager,
+            payload_stats,
+            repository_id,
+            workspace_id,
+        }
+    }
+
     pub(crate) fn manager(&self) -> &RepositoryAuthorityManager<LocalFileBackend> {
-        &self.manager
+        self.manager.as_ref()
     }
 
     /// Persist the current workspace base graph as an idempotent acceleration

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -63,10 +63,13 @@ fn exact_source_archive_exports() -> Arc<ExactSourceArchiveExportQueue> {
 ///
 /// The manager is shared rather than owned so a caller that has already paid
 /// for one open can hand the same coherent authority to another reader; see
-/// [`ProjectionAuthorityCache`].
+/// [`ProjectionAuthorityCache`]. The payload receipt that recovery returned
+/// travels with it, because it describes the open this manager came out of, and
+/// a reader that borrows the manager reports the payload it actually read from.
 #[derive(Clone)]
 struct ActiveApiRepositoryAuthority {
     manager: Arc<RepositoryAuthorityManager<LocalFileBackend>>,
+    payload_stats: Option<kin_db::AuthorityPayloadStats>,
     repository_id: RepositoryId,
     workspace_id: WorkspaceId,
 }
@@ -76,10 +79,13 @@ impl ActiveApiRepositoryAuthority {
         let binding = state
             .local_repository_authority_binding()
             .map_err(repository_authority_error)?;
-        let manager = binding.open_manager().map_err(repository_authority_error)?;
+        let (manager, payload_stats) = binding
+            .open_manager_with_payload_stats()
+            .map_err(repository_authority_error)?;
         state.projection_authority.record_load();
         Ok(Self {
             manager: Arc::new(manager),
+            payload_stats,
             repository_id: binding.repository_id().clone(),
             workspace_id: binding.workspace_id(),
         })
@@ -89,9 +95,12 @@ impl ActiveApiRepositoryAuthority {
     fn open_layout_for_test(layout: &kin_core::KinLayout) -> Result<Self, (StatusCode, String)> {
         let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(layout)
             .map_err(repository_authority_error)?;
-        let manager = binding.open_manager().map_err(repository_authority_error)?;
+        let (manager, payload_stats) = binding
+            .open_manager_with_payload_stats()
+            .map_err(repository_authority_error)?;
         Ok(Self {
             manager: Arc::new(manager),
+            payload_stats,
             repository_id: binding.repository_id().clone(),
             workspace_id: binding.workspace_id(),
         })
@@ -359,6 +368,7 @@ impl ProjectionAuthorityCache {
         &self,
         published: LocalPublicationIdentity,
         manager: Arc<RepositoryAuthorityManager<LocalFileBackend>>,
+        payload_stats: Option<kin_db::AuthorityPayloadStats>,
         repository_id: RepositoryId,
         workspace_id: WorkspaceId,
     ) {
@@ -366,6 +376,7 @@ impl ProjectionAuthorityCache {
             published,
             ActiveApiRepositoryAuthority {
                 manager,
+                payload_stats,
                 repository_id,
                 workspace_id,
             },
@@ -685,26 +696,30 @@ fn query_repository_authority(
         return Ok(authority);
     }
 
-    let _load = lock_recover(&state.projection_authority.load_gate);
-    // Re-read under the gate: the publication may have moved while this request
-    // waited, and the label installed below must be the one taken before the
-    // load it describes.
-    let published = read_local_publication_identity(&backend, &repository_id)?;
+    // The manager comes from the daemon's one held authority rather than from an
+    // open of this wrapper's own. `held_projection_authority` reads the
+    // publication record before the load it labels, serializes misses on the
+    // shared load gate, and returns the label that authority was loaded under,
+    // so this slot is keyed on the publication its bytes were verified at and
+    // never on a later reading.
+    let (published, held) = held_projection_authority(state)?;
+    // Whoever waited on that gate takes the wrapper the winner installed rather
+    // than building a second one over the same manager.
     if let Some(authority) = state.projection_authority.reuse_query(&published) {
         return Ok(authority);
     }
-    let authority = Arc::new(
-        kin_mcp::handlers::ActiveRepositoryAuthority::open(&binding)
-            .map_err(repository_authority_error)?,
-    );
-    state.projection_authority.record_load();
+    let authority = Arc::new(kin_mcp::handlers::ActiveRepositoryAuthority::from_shared(
+        Arc::clone(&held.manager),
+        repository_id.clone(),
+        held.workspace_id,
+    ));
     state
         .projection_authority
         .install_query(published, Arc::clone(&authority));
     tracing::debug!(
         repository = %repository_id,
         loads = state.projection_authority.loads(),
-        "query repository authority loaded"
+        "query repository authority bound to the held load"
     );
     Ok(authority)
 }
@@ -753,26 +768,28 @@ fn command_repository_authority(
         return Ok(authority);
     }
 
-    let _load = lock_recover(&state.projection_authority.load_gate);
-    // Re-read under the gate: the publication may have moved while this request
-    // waited, and the label installed below must be the one taken before the
-    // load it describes.
-    let published = read_local_publication_identity(&backend, &repository_id)?;
+    // The same borrow the query wrapper above takes, under the same label rule
+    // and the same gate. The receipt travels with the manager so a status report
+    // answered through this wrapper still names the payload it read.
+    let (published, held) = held_projection_authority(state)?;
     if let Some(authority) = state.projection_authority.reuse_command(&published) {
         return Ok(authority);
     }
     let authority = Arc::new(
-        kin_cli::commands::repository_authority::ActiveRepositoryAuthority::open(&binding)
-            .map_err(repository_authority_error)?,
+        kin_cli::commands::repository_authority::ActiveRepositoryAuthority::from_shared(
+            Arc::clone(&held.manager),
+            held.payload_stats,
+            repository_id.clone(),
+            held.workspace_id,
+        ),
     );
-    state.projection_authority.record_load();
     state
         .projection_authority
         .install_command(published, Arc::clone(&authority));
     tracing::debug!(
         repository = %repository_id,
         loads = state.projection_authority.loads(),
-        "command repository authority loaded"
+        "command repository authority bound to the held load"
     );
     Ok(authority)
 }
@@ -49000,6 +49017,137 @@ mod tests {
         );
     }
 
+    /// The MCP query tools and the kin-cli command helpers read through the
+    /// authority this daemon already holds, so one publication costs ONE
+    /// whole-store open for all three wrappers rather than one each.
+    ///
+    /// Three wrappers over one durable state is migration debt, and each of them
+    /// used to open for itself. One open ran 6.3 to 7.6 s on the 1.42 GB scratch
+    /// store this was measured on, so the first source read and the first
+    /// entity-source read after every publication each re-verified bytes this
+    /// daemon had already verified, and retained a second and a third copy of
+    /// them.
+    ///
+    /// Counted on `kin_core::authority_opens()`, the funnel every path into
+    /// KinDB's recovery reaches. Either wrapper's own counter is blind to an open
+    /// taken through another wrapper, which is why the funnel counter exists.
+    #[tokio::test]
+    async fn the_query_and_command_wrappers_borrow_the_held_authority() {
+        let state = test_state();
+        install_repository_file(&state, "src/lib.py", b"def handler():\n    return 1\n");
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        // The publication the fixture just made moved the record every slot is
+        // keyed on, so this pair is cold: one of the two must load, and before
+        // this change both did.
+        let cold = kin_core::authority_opens();
+        let query =
+            query_repository_authority(&state).expect("the fixture must resolve a query authority");
+        let command = command_repository_authority(&state)
+            .expect("the fixture must resolve a command authority");
+        assert_eq!(
+            kin_core::authority_opens() - cold,
+            1,
+            "the query and the command wrapper at one publication must share one whole-store \
+             open; one open each is two full re-verifications of the same durable bytes"
+        );
+
+        for call in 1..=8 {
+            let query_again = query_repository_authority(&state)
+                .unwrap_or_else(|(_, message)| panic!("query reuse call {call} failed: {message}"));
+            let command_again =
+                command_repository_authority(&state).unwrap_or_else(|(_, message)| {
+                    panic!("command reuse call {call} failed: {message}")
+                });
+            assert!(
+                Arc::ptr_eq(&query, &query_again) && Arc::ptr_eq(&command, &command_again),
+                "reuse call {call} rebuilt a wrapper at a publication that had not moved"
+            );
+        }
+        assert_eq!(
+            kin_core::authority_opens() - cold,
+            1,
+            "eight further reads at one publication must open the store no further times"
+        );
+
+        // A publication moves the record both slots are keyed on. Neither
+        // wrapper may keep answering from the manager it borrowed before it, and
+        // stopping must not cost one load each.
+        install_repository_file(&state, "src/next.py", b"def added():\n    return 2\n");
+        let moved = kin_core::authority_opens();
+        let query_after =
+            query_repository_authority(&state).expect("the read after a publication must resolve");
+        let command_after = command_repository_authority(&state)
+            .expect("the read after a publication must resolve");
+        assert!(
+            !Arc::ptr_eq(&query, &query_after) && !Arc::ptr_eq(&command, &command_after),
+            "a wrapper handed out after another publication is pinned to the authority it \
+             borrowed before it, which is worse than a slow read"
+        );
+        assert_eq!(
+            kin_core::authority_opens() - moved,
+            1,
+            "the publication must cost one fresh load, shared by both wrappers"
+        );
+    }
+
+    /// A status report answered through a borrowed authority still names the
+    /// payload it was read from.
+    ///
+    /// `/commands/status` renders the payload receipt KinDB's recovery returns,
+    /// and that receipt used to arrive because this route opened the store for
+    /// itself. Reading through the daemon's held authority instead is only the
+    /// same answer if the receipt travels with the manager; carrying the manager
+    /// alone would delete a field from the report and leave the route green.
+    #[tokio::test]
+    async fn a_status_report_from_the_borrowed_authority_still_names_its_payload() {
+        let state = test_state();
+        install_repository_file(&state, "src/lib.py", b"def handler():\n    return 1\n");
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        // Hold the authority first, so the route below is answered from a borrow
+        // rather than from an open of its own. Without this the report would
+        // carry a receipt either way and the test would prove nothing.
+        let held = kin_core::authority_opens();
+        crate::api::held_repository_authority(&state).expect("the fixture must hold an authority");
+
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/commands/status")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({ "json": false }).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 256 * 1024)
+            .await
+            .unwrap();
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "the status route must answer: {}",
+            String::from_utf8_lossy(&body)
+        );
+        assert_eq!(
+            kin_core::authority_opens() - held,
+            1,
+            "the status route must read through the authority this daemon already held, so the \
+             only open in this section is the one that produced it"
+        );
+        let report: kin_cli::commands::status::CommandStatusResponse =
+            serde_json::from_slice(&body).unwrap();
+        assert!(
+            report.report.authority_payload.is_some(),
+            "the report answered from a borrowed authority dropped its payload receipt: {}",
+            String::from_utf8_lossy(&body)
+        );
+    }
+
     /// A trace request must not be the only thing this daemon can be doing.
     ///
     /// The walk now runs on the blocking pool, so the runtime stays free to
@@ -50514,11 +50662,19 @@ mod tests {
     /// thread that built it, and on the daemon's load counter. The counter alone
     /// could not fail: a route handed the bare binding opens the store through
     /// the ref grammar and never touches this daemon's cache, so the counter
-    /// stays flat while every request pays for a whole-store open.
+    /// stays flat while every request pays for a whole-store open. The answer's
+    /// own witness is kin-core's funnel counter, so it names an open whichever
+    /// crate's wrapper performed it.
     #[tokio::test]
     async fn blame_and_history_answer_head_from_the_authority_the_daemon_holds() {
         let state =
             test_state_with_committed_sources(&[("src/lib.py", "def retained():\n    return 1\n")]);
+        // `DaemonState::open` holds the authority its own startup paid for, so
+        // this fixture already holds the publication it just imported and a read
+        // through it opens nothing at all. Invalidate first, which is the state a
+        // publication by another writer leaves, so the read below is the first at
+        // a publication this daemon does not hold.
+        state.projection_authority.invalidate();
         let loads_before = state.projection_authority.loads();
         let app = router(Arc::clone(&state));
 
@@ -59296,7 +59452,12 @@ mod tests {
         install_locate_page(&state, PAGE);
         let app = router(state);
 
-        let before = kin_mcp::handlers::common::repository_authority_opens_on_this_thread();
+        // Counted on `kin_core::authority_opens()`, the funnel every path into
+        // KinDB's recovery reaches. The query wrapper's own counter counts only
+        // the opens that wrapper performs, and this daemon's query slot reads
+        // through the authority it already holds, so a count taken there reads
+        // zero whether the page opened once or once per projected body.
+        let before = kin_core::authority_opens();
         let fused = call_semantic_locate(
             app,
             json!({
@@ -59307,7 +59468,7 @@ mod tests {
             }),
         )
         .await;
-        let opens = kin_mcp::handlers::common::repository_authority_opens_on_this_thread() - before;
+        let opens = kin_core::authority_opens() - before;
 
         // Non-vacuity first. A page that projected fewer than two bodies cannot
         // tell "one open per request" apart from "one open per body", so the

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -5335,7 +5335,7 @@ impl DaemonState {
         // of an unpersisted generation-zero authority. Use the receipt from
         // this same recovery to refuse an intact namespace whose authority
         // record disappeared without paying for a second load or lock.
-        let (authority, _authority_payload_stats) = phases
+        let (authority, authority_payload_stats) = phases
             .record("authority_open", || {
                 kin_core::open_persisted_local_repository_authority(
                     repository_id.clone(),
@@ -5761,6 +5761,11 @@ impl DaemonState {
             state.projection_authority.install_opened(
                 published,
                 Arc::new(authority),
+                // The receipt this same recovery returned. A reader that borrows
+                // the manager reports the payload it actually read from, so the
+                // status route's payload line survives the borrow instead of
+                // going missing because someone else paid for the open.
+                Some(authority_payload_stats),
                 repository_id,
                 workspace_id,
             );

--- a/crates/kin-mcp/src/handlers/repository_authority.rs
+++ b/crates/kin-mcp/src/handlers/repository_authority.rs
@@ -75,7 +75,10 @@ pub(crate) fn discover_for_process() -> Result<Option<RequestRepositoryAuthority
 pub const HOSTED_SEMANTIC_SOURCE_BLOB_MAX_BYTES: u64 = 8 * 1024 * 1024;
 
 enum ActiveRepositoryAuthorityManager {
-    Local(RepositoryAuthorityManager<LocalFileBackend>),
+    /// Shared rather than owned, so a server that has already paid for one open
+    /// reads through it here instead of opening the same publication a second
+    /// time. See [`ActiveRepositoryAuthority::from_shared`].
+    Local(Arc<RepositoryAuthorityManager<LocalFileBackend>>),
     Hosted {
         manager: RepositoryAuthorityManager<dyn StorageBackend>,
         backend: Arc<dyn StorageBackend>,
@@ -430,11 +433,39 @@ impl ActiveRepositoryAuthority {
             ))
         })?;
         Ok(Self {
-            manager: ActiveRepositoryAuthorityManager::Local(manager),
+            manager: ActiveRepositoryAuthorityManager::Local(Arc::new(manager)),
             repository_id: binding.repository_id().clone(),
             workspace_id: Some(binding.workspace_id()),
             hosted_head: None,
         })
+    }
+
+    /// Read through an authority a server already has open, without opening a
+    /// second one over the same durable bytes.
+    ///
+    /// Nothing is skipped here. The manager handed in is the result of one full
+    /// validating open, so every body read through it was verified by that open
+    /// exactly as it would have been by one of this type's own. What the caller
+    /// owns is the freshness argument, the same one
+    /// [`RequestRepositoryAuthority::shared`] states: the manager must have been
+    /// loaded at a durable publication whose record was read BEFORE that load,
+    /// and it may be handed here only while the record still reads the same.
+    ///
+    /// Deliberately not counted in [`REPOSITORY_AUTHORITY_OPEN_COUNT`] or in the
+    /// per-thread counter beside it. Those count whole-store opens, which is
+    /// what a reader pays for. A borrow pays for none, and counting one there
+    /// would make the number that names the cost climb while nothing was spent.
+    pub fn from_shared(
+        manager: Arc<RepositoryAuthorityManager<LocalFileBackend>>,
+        repository_id: RepositoryId,
+        workspace_id: WorkspaceId,
+    ) -> Self {
+        Self {
+            manager: ActiveRepositoryAuthorityManager::Local(manager),
+            repository_id,
+            workspace_id: Some(workspace_id),
+            hosted_head: None,
+        }
     }
 
     /// Bind an already-opened hosted authority to the exact default-ref tree


### PR DESCRIPTION
The MCP query tools and the kin-cli command helpers now read through the repository authority this
daemon already holds. One durable publication costs one whole-store open for all three of the
daemon's authority wrappers instead of three.

## Why

Opening a persisted authority re-verifies every body in the store against its content address, so it
costs whatever the whole store is worth rather than whatever the request asked for. This daemon
already holds one open authority per durable publication and hands it to its local readers. Two of
them could not take it: the MCP query tools read through kin-mcp's `ActiveRepositoryAuthority` and
`get_entity_source`, `get_entity_sources` and `trace_data_flow` read through kin-cli's, and both
owned their managers by value. Each paid a full open of its own after every publication and then kept
its own decoded copy of the store.

Measured on one scratch store, a kin-db clone at 488ca5e with 607 changes, a 1,418,328,932-byte
snapshot and 5,710 bodies: a whole-store open runs 6.3 to 7.6 s there, and the first read through
each of those two wrappers after a commit paid one.

## How

- Each wrapper's manager becomes an `Arc`, and each gains a `from_shared` constructor that takes a
  manager the caller already opened. Nothing an open proves is skipped: the manager handed in is the
  result of one full validating open, so every body read through it was verified by that open exactly
  as it would have been by one of the wrapper's own.
- The daemon's query and command resolvers borrow that held manager instead of opening. They keep the
  label rule they already had. The `authority.json` digest is read before the load it labels, each
  slot is keyed on that label, and a record another writer moved sends the next reader to a fresh
  load rather than to what this daemon held before it.
- kin-db's payload receipt travels with the manager, because it describes the open the manager came
  out of. A `/commands/status` report answered from a borrowed authority still names the payload it
  read instead of dropping the field.
- The answer line that names who paid for an open reads the same funnel counter
  (`kin-cli commands/ref_grammar.rs`). A blame or history read resolves its authority through the
  daemon's shared resolver, so the open happens inside another crate's wrapper. Reading kin-cli's own
  counter there reports no open on a read that has just paid for one, and
  `blame_and_history_answer_head_from_the_authority_the_daemon_holds` goes red without this.

The startup open now keeps the receipt its own recovery returned, which is where the borrowed
reports get theirs.

## Numbers

Same store (fresh APFS clones of one kin-db store at 488ca5e: 607 changes, a 1,418,328,932-byte
snapshot, 5,710 bodies), same driver and settings, one standalone daemon each. Before is run 6 on kin
#1745's bytes. After is run 7 on this change's bytes. Whole-store opens that started in each phase,
with their summed milliseconds, and the phase's wall time:

| phase | before opens (ms) | after opens (ms) | before wall s | after wall s |
|---|---|---|---|---|
| startup | 1 (8,170) | 1 (9,411) | 72.6 | 74.8 |
| refs_cold | 0 | 0 | 0.011 | 0.014 |
| refs_warm | 0 | 0 | 0.006 | 0.007 |
| source_cold | 1 (8,280) | 0 | 8.29 | 0.007 |
| pack_cold | 1 (7,652) | 0 | 11.40 | 3.11 |
| mcp_commit | 1 (11,657) | 1 (7,896) | 184.2 | 187.6 |
| refs_after | 0 | 0 | 0.020 | 0.012 |
| source_after | 1 (21,985) | 0 | 22.12 | 0.007 |
| pack_after | 1 (12,631) | 0 | 18.04 | 3.36 |
| flush_after | 0 | 0 | 60.4 | 62.3 |
| edit_flush | 2 (20,056) | 2 (18,745) | 153.5 | 148.4 |
| dirty_stop | 2 (15,037) | 2 (26,802) | 71.0 | 132.8 |
| whole run | 10 | 6 | | |

What changed is the two wrappers' reads, cold and after a publication. Each was one whole-store open
and is now none: the MCP query wrapper's source read at 8.29 s to 0.007 s, the kin-cli command
wrapper's context pack at 11.40 s to 3.11 s, and the same two after a commit at 22.12 s to 0.007 s
and 18.04 s to 3.36 s. Those post-commit rows come from this change and #1729 composing. That PR made the
commit's finalize reload resolve through the held authority, so the daemon already holds the
publication a commit just made and these reads borrow it instead of loading it again.

Footprint, read as `phys_footprint` beside RSS: 4.21 GiB to 2.99 GiB at the end of the cold pack read,
3.57 GiB to 3.18 GiB at the end of the pack read after the commit, and the run's peak through the
commit 5.75 GiB to 4.52 GiB. Neither wrapper keeps a decoded copy of the store any more.

Unmoved by design: startup, the commit itself, the flushes and the dirty stop. Those belong to the
classes already on main.

Read the counts rather than the clocks across these two runs. Run 6 began with swap at 2,100 MB. Run 7
began with swap at 13,938 MB and load 13.87, on a box where another lane held a 16 GB model resident,
so the dirty stop reads 132.8 s against 71.0 s with its open count identical at 2, and the commit
reads a little longer with one open in both. The rows this change owns move by a count, and that
count is read from each run's own `opens.json`.

## Tests

`the_query_and_command_wrappers_borrow_the_held_authority` in `crates/kin-daemon/src/api.rs` resolves
both wrappers at one publication and requires one whole-store open between them, counted on
`kin_core::authority_opens()`, the funnel every path into kin-db's recovery reaches. Eight further
reads at that publication must open nothing and must hand back the same two wrappers. After a second
publication both wrappers must be new ones, and the load behind them must be a single load. That arm
goes red if either slot stops being keyed on the publication.

`a_status_report_from_the_borrowed_authority_still_names_its_payload` holds the authority first, then
drives `POST /commands/status` and requires the report to name its payload receipt, with no further
open.

```text
$ cargo test -p kin-daemon --lib
test result: ok. 1715 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 460.14s
$ cargo test -p kin-mcp --lib
test result: ok. 1017 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 40.46s
$ cargo test -p kin-cli --lib
test result: ok. 2325 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 261.79s
```

## Falsification

Four arms, each applied to the committed fix and then restored from HEAD, and each run against both
new tests. Every arm must be caught by at least the test it targets, and some are caught by both:
the borrow test targets `query_opens`, `command_opens` and `label_ignored`, and the status test
targets `payload_dropped`. An `rc=0` row is a test staying green under a mutation it does not cover,
which is what a specific arm looks like rather than a mutant that survived.

```text
$ bash falsify-a6.sh
arm query_opens applied
arm query_opens test the_query_and_command_wrappers_borrow_the_held_authority rc=101
test api::tests::the_query_and_command_wrappers_borrow_the_held_authority ... FAILED
thread 'api::tests::the_query_and_command_wrappers_borrow_the_held_authority' (94059422) panicked at crates/kin-daemon/src/api.rs:49050:9:
  left: 2
 right: 1
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1718 filtered out; finished in 0.97s
arm query_opens test a_status_report_from_the_borrowed_authority_still_names_its_payload rc=0
test api::tests::a_status_report_from_the_borrowed_authority_still_names_its_payload ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1718 filtered out; finished in 1.31s
arm command_opens applied
arm command_opens test the_query_and_command_wrappers_borrow_the_held_authority rc=101
test api::tests::the_query_and_command_wrappers_borrow_the_held_authority ... FAILED
thread 'api::tests::the_query_and_command_wrappers_borrow_the_held_authority' (94177137) panicked at crates/kin-daemon/src/api.rs:49047:9:
  left: 2
 right: 1
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1718 filtered out; finished in 0.73s
arm command_opens test a_status_report_from_the_borrowed_authority_still_names_its_payload rc=101
test api::tests::a_status_report_from_the_borrowed_authority_still_names_its_payload ... FAILED
thread 'api::tests::a_status_report_from_the_borrowed_authority_still_names_its_payload' (94224886) panicked at crates/kin-daemon/src/api.rs:49133:9:
  left: 2
 right: 1
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1718 filtered out; finished in 0.98s
arm label_ignored applied
arm label_ignored test the_query_and_command_wrappers_borrow_the_held_authority rc=101
test api::tests::the_query_and_command_wrappers_borrow_the_held_authority ... FAILED
thread 'api::tests::the_query_and_command_wrappers_borrow_the_held_authority' (94285549) panicked at crates/kin-daemon/src/api.rs:49082:9:
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1718 filtered out; finished in 1.04s
arm label_ignored test a_status_report_from_the_borrowed_authority_still_names_its_payload rc=0
test api::tests::a_status_report_from_the_borrowed_authority_still_names_its_payload ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1718 filtered out; finished in 0.66s
arm payload_dropped applied
arm payload_dropped test the_query_and_command_wrappers_borrow_the_held_authority rc=0
test api::tests::the_query_and_command_wrappers_borrow_the_held_authority ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1718 filtered out; finished in 1.25s
arm payload_dropped test a_status_report_from_the_borrowed_authority_still_names_its_payload rc=101
test api::tests::a_status_report_from_the_borrowed_authority_still_names_its_payload ... FAILED
thread 'api::tests::a_status_report_from_the_borrowed_authority_still_names_its_payload' (94395800) panicked at crates/kin-daemon/src/api.rs:49144:9:
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1718 filtered out; finished in 0.65s
restored to 92430de43
chain done 23:42:38Z
```

## Local gates

```text
$ bin/kin-precheck kin --repo-dir kin=<this worktree>
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin 92430de43633e6797518b7c25ac814342558e602
```

kin's Product Acceptance job grades main after landing, not this pull request.

Tickets: FIR-2024, FIR-3496, FIR-3504.
