### PR TITLE
Raise release alarms on kin-infra through an issues-only App token

### DIFF
--- a/.github/workflows/advisory-sweep.yml
+++ b/.github/workflows/advisory-sweep.yml
@@ -125,6 +125,23 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
+      # A second, narrower mint for the alarm alone. The bump-branch token above
+      # carries contents and pull-request authority on this repository; the
+      # unfixable-advisory issue lives on firelock-ai/kin-infra and needs
+      # issues: write there and here and nothing else, so it gets a token that
+      # holds exactly that. A mint that fails fails the sweep loudly.
+      - name: Mint the alarm token, issues only, this repository and kin-infra
+        id: alarm-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.KIN_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.KIN_RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ${{ github.event.repository.name }}
+            kin-infra
+          permission-issues: write
+
       - name: Install Rust toolchain
         uses: ./.github/actions/rust-toolchain
 
@@ -285,27 +302,58 @@ jobs:
       - name: Open or update the unfixable-advisory issue
         if: steps.plan.outputs.unfixable != '0'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.alarm-token.outputs.token }}
+          ALARM_REPO: firelock-ai/kin-infra
+          ALARM_LABEL: ${{ github.event.repository.name }}
           RUNNER_TEMP: ${{ runner.temp }}
         run: |
           set -euo pipefail
-          gh label create "advisory-sweep" --repo "$GITHUB_REPOSITORY" \
+          # Two labels: the kind of alarm, and the repository it is about, since
+          # kin-infra collects every repository's alarms. Both are created
+          # before the issue that carries them, idempotently, so a missing label
+          # can never fail the create.
+          gh label create "advisory-sweep" --repo "$ALARM_REPO" \
             --color "B60205" \
             --description "Advisories with no semver-compatible bump, found by the scheduled sweep" \
             --force
+          gh label create "$ALARM_LABEL" --repo "$ALARM_REPO" --force \
+            --color 5319E7 \
+            --description "Alarms raised by ${GITHUB_REPOSITORY}'s workflows"
           node scripts/advisory-sweep.mjs \
             --plan-in "$RUNNER_TEMP/plan.json" \
             --render issue-body > "$RUNNER_TEMP/issue-body.md"
           ids="$(jq -r '[.unfixable[].id] | unique | join(", ")' "$RUNNER_TEMP/plan.json")"
           title="Advisories with no semver-compatible bump: ${ids}"
-          issue="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
-            --label "advisory-sweep" --json number --jq '.[0].number // ""')"
+          issue="$(gh issue list --repo "$ALARM_REPO" --state open \
+            --label "advisory-sweep,${ALARM_LABEL}" --json number --jq '.[0].number // ""')"
           if [ -z "$issue" ]; then
-            gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" \
-              --label "advisory-sweep" --body-file "$RUNNER_TEMP/issue-body.md" > /dev/null
-          else
-            gh issue edit "$issue" --repo "$GITHUB_REPOSITORY" --title "$title" \
+            gh issue create --repo "$ALARM_REPO" --title "$title" \
+              --label "advisory-sweep" --label "$ALARM_LABEL" \
               --body-file "$RUNNER_TEMP/issue-body.md" > /dev/null
+          else
+            gh issue edit "$issue" --repo "$ALARM_REPO" --title "$title" \
+              --body-file "$RUNNER_TEMP/issue-body.md" > /dev/null
+          fi
+
+      # The close path this issue never had. A sweep that resolves every
+      # advisory, by bump or by a deny.toml ignore with a reason, is the green
+      # run of this workflow, and the issue it leaves open would otherwise sit
+      # on kin-infra until somebody noticed.
+      - name: Close the unfixable-advisory issue once the sweep finds none
+        if: steps.plan.outcome == 'success' && steps.plan.outputs.unfixable == '0'
+        env:
+          GH_TOKEN: ${{ steps.alarm-token.outputs.token }}
+          ALARM_REPO: firelock-ai/kin-infra
+          ALARM_LABEL: ${{ github.event.repository.name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          issue="$(gh issue list --repo "$ALARM_REPO" --state open \
+            --label "advisory-sweep,${ALARM_LABEL}" --json number --jq '.[0].number // ""')"
+          if [ -n "$issue" ]; then
+            gh issue close "$issue" --repo "$ALARM_REPO" \
+              --comment "This sweep found no advisory without a semver-compatible bump: ${RUN_URL}."
+            echo "closed unfixable-advisory issue #${issue}"
           fi
 
       - name: Summarize

--- a/.github/workflows/alarm-dry-run.yml
+++ b/.github/workflows/alarm-dry-run.yml
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+name: Alarm Dry Run
+
+# Proves the cross-repository alarm credential end to end. It mints the same
+# issues-only release App token every alarm job in this repository mints,
+# opens one clearly marked issue on firelock-ai/kin-infra carrying this
+# repository's label, reads it back, closes it, and reads that back too. No
+# alarm job can be made to do that without a real failure to report.
+#
+# `repository_dispatch` rather than a branch-selectable dispatch, for the reason
+# advisory-sweep.yml gives: this job reaches the release App key, and the
+# authority guard refuses that key beside a dispatch that lets a branch pick
+# the workflow file it runs. The `release-tag` Environment admits main alone,
+# so this runs from main or not at all. Trigger it with:
+#
+#   gh api repos/firelock-ai/kin/dispatches -f event_type=alarm-dry-run
+#
+# A mint that fails because kin-infra is not among the installation's selected
+# repositories fails this run at the first step, which is the answer the dry run
+# exists to give; nothing here falls back to the workflow token, which cannot
+# reach another repository at all.
+on:
+  repository_dispatch:
+    types: [alarm-dry-run]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: kin-alarm-dry-run
+  cancel-in-progress: false
+
+jobs:
+  dry-run:
+    name: Open and close one alarm on kin-infra
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: release-tag
+    steps:
+      - name: Mint the alarm token, issues only, this repository and kin-infra
+        id: alarm-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.KIN_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.KIN_RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ${{ github.event.repository.name }}
+            kin-infra
+          permission-issues: write
+
+      # Every assertion reads the issue back through the API rather than
+      # trusting the exit code of the write before it: a 200 from a create is
+      # not the same fact as an issue that is open and labelled.
+      - name: Open one alarm, read it back, close it, read that back
+        env:
+          GH_TOKEN: ${{ steps.alarm-token.outputs.token }}
+          ALARM_REPO: firelock-ai/kin-infra
+          ALARM_LABEL: ${{ github.event.repository.name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          gh label create "$ALARM_LABEL" --repo "$ALARM_REPO" --force \
+            --color 5319E7 \
+            --description "Alarms raised by ${GITHUB_REPOSITORY}'s workflows"
+          title="Alarm dry run from ${GITHUB_REPOSITORY}: safe to ignore"
+          body="This issue proves the cross-repository alarm credential from ${RUN_URL}. It closes itself in the same run."
+          url="$(gh issue create --repo "$ALARM_REPO" --title "$title" \
+            --label "$ALARM_LABEL" --body "$body")"
+          number="${url##*/}"
+          case "$number" in
+            ''|*[!0-9]*)
+              echo "::error::issue create returned no issue number: ${url}"
+              exit 1
+              ;;
+          esac
+          readback="$(gh issue view "$number" --repo "$ALARM_REPO" \
+            --json state,labels \
+            --jq '.state + " " + ([.labels[].name] | join(","))')"
+          echo "after create: ${ALARM_REPO}#${number} ${readback}"
+          if [ "${readback%% *}" != OPEN ]; then
+            echo "::error::${ALARM_REPO}#${number} is not OPEN after create: ${readback}"
+            exit 1
+          fi
+          case ",${readback#* }," in
+            *",${ALARM_LABEL},"*) ;;
+            *)
+              echo "::error::${ALARM_REPO}#${number} does not carry label ${ALARM_LABEL}: ${readback}"
+              exit 1
+              ;;
+          esac
+          gh issue close "$number" --repo "$ALARM_REPO" \
+            --comment "Dry run complete: this credential can open and close an alarm here."
+          closed="$(gh issue view "$number" --repo "$ALARM_REPO" --json state --jq .state)"
+          if [ "$closed" != CLOSED ]; then
+            echo "::error::${ALARM_REPO}#${number} is not CLOSED after close: ${closed}"
+            exit 1
+          fi
+          echo "dry run green: ${ALARM_REPO}#${number} opened with label ${ALARM_LABEL} and closed"

--- a/.github/workflows/base-image-pins.yml
+++ b/.github/workflows/base-image-pins.yml
@@ -53,15 +53,19 @@ name: Base Image Pins
 # unreachable pin opens or updates a tracking issue, which persists until
 # someone acts on it.
 #
-# A `workflow_dispatch` run still fails hard, because an operator asked a direct
-# question and deserves a direct answer. The residual is theirs to own:
-# dispatching against main during a release train can publish a failure
-# check-run on the candidate sha. Prefer the schedule unless you need the answer
-# now.
+# A dispatched run still fails hard, because an operator asked a direct question
+# and deserves a direct answer. The residual is theirs to own: dispatching
+# against main during a release train can publish a failure check-run on the
+# candidate sha. Prefer the schedule unless you need the answer now. The
+# dispatch is typed rather than branch-selectable because the alarm below
+# reaches the release App key to file on kin-infra, and the authority guard
+# refuses that key beside a dispatch that lets a branch pick the workflow file:
+#   gh api repos/firelock-ai/kin/dispatches -f event_type=base-image-pins
 on:
   schedule:
     - cron: "23 5 * * 1"
-  workflow_dispatch:
+  repository_dispatch:
+    types: [base-image-pins]
 
 permissions:
   contents: read
@@ -79,9 +83,15 @@ jobs:
     # about 7.5 minutes. Exceeding this concludes `cancelled`, so the budget is
     # sized so that finishing is never in question.
     timeout-minutes: 20
+    # The release App credentials resolve only inside this Environment, which
+    # admits main alone; both triggers on this file run from main.
+    environment: release-tag
     permissions:
       contents: read
-      # The tracking issue is the alarm. It is the only write this job performs.
+      # The tracking issue is the alarm. It is the only write this job performs,
+      # and it lands on firelock-ai/kin-infra through the App token minted
+      # below rather than through this token, which cannot reach another
+      # repository.
       issues: write
     steps:
       # A checkout that fails is a step failure, and a failed step fails the job
@@ -92,6 +102,25 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
+      # Tolerated, and this file is the one place that is. Everywhere else a
+      # mint that fails is the alarm's own loud failure, but a red step here
+      # publishes a failure check-run on a main sha, which is exactly what the
+      # header above exists to prevent. The alarm step below reports a missing
+      # token as an error annotation and files nothing; it never falls back to
+      # the workflow token, which could not reach kin-infra anyway.
+      - name: Mint the alarm token, issues only, this repository and kin-infra
+        id: alarm-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.KIN_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.KIN_RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ${{ github.event.repository.name }}
+            kin-infra
+          permission-issues: write
 
       # The shell is declared explicitly and carries no `-e`, because the
       # default (`bash -e {0}`) does, and the `set -o pipefail` below is exactly
@@ -145,11 +174,20 @@ jobs:
         if: ${{ always() && steps.verify.outputs.status == '1' }}
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.alarm-token.outputs.token }}
+          ALARM_REPO: firelock-ai/kin-infra
+          ALARM_LABEL: ${{ github.event.repository.name }}
           ALARM_TITLE: "Base image pin unreachable: the release build has lost a registry"
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::no alarm token was minted, so the tracking issue could not be filed on ${ALARM_REPO}; the unreachable pin above still stands"
+            exit 0
+          fi
+          gh label create "$ALARM_LABEL" --repo "$ALARM_REPO" --force \
+            --color 5319E7 \
+            --description "Alarms raised by ${GITHUB_REPOSITORY}'s workflows"
           {
             echo "A base image pinned by \`Dockerfile\` is no longer served at that digest by"
             echo "one of the two registries the release build resolves through, so the build"
@@ -166,29 +204,40 @@ jobs:
           } > /tmp/alarm-body.md
 
           # Match on the exact title rather than a search expression so the
-          # lookup cannot widen into an unrelated issue.
-          existing="$(gh issue list --state open --limit 100 --json number,title \
+          # lookup cannot widen into an unrelated issue, and on this
+          # repository's label, because kin-infra collects every repository's
+          # alarms.
+          existing="$(gh issue list --repo "$ALARM_REPO" --label "$ALARM_LABEL" \
+            --state open --limit 100 --json number,title \
             --jq '[.[] | select(.title == env.ALARM_TITLE)] | .[0].number // empty')"
           if [ -n "$existing" ]; then
-            gh issue comment "$existing" --body-file /tmp/alarm-body.md
+            gh issue comment "$existing" --repo "$ALARM_REPO" --body-file /tmp/alarm-body.md
             echo "updated tracking issue #${existing}"
           else
-            gh issue create --title "$ALARM_TITLE" --body-file /tmp/alarm-body.md
+            gh issue create --repo "$ALARM_REPO" --title "$ALARM_TITLE" \
+              --label "$ALARM_LABEL" --body-file /tmp/alarm-body.md
           fi
 
       - name: Close the tracking issue once the pins are healthy
         if: ${{ always() && steps.verify.outputs.status == '0' }}
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.alarm-token.outputs.token }}
+          ALARM_REPO: firelock-ai/kin-infra
+          ALARM_LABEL: ${{ github.event.repository.name }}
           ALARM_TITLE: "Base image pin unreachable: the release build has lost a registry"
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          existing="$(gh issue list --state open --limit 100 --json number,title \
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::no alarm token was minted, so an open tracking issue on ${ALARM_REPO} could not be closed this run"
+            exit 0
+          fi
+          existing="$(gh issue list --repo "$ALARM_REPO" --label "$ALARM_LABEL" \
+            --state open --limit 100 --json number,title \
             --jq '[.[] | select(.title == env.ALARM_TITLE)] | .[0].number // empty')"
           if [ -n "$existing" ]; then
-            gh issue close "$existing" \
+            gh issue close "$existing" --repo "$ALARM_REPO" \
               --comment "Every pin resolves from both registries again, verified by [this run](${RUN_URL})."
             echo "closed tracking issue #${existing}"
           fi
@@ -196,7 +245,7 @@ jobs:
       # Only a dispatched run may go red, and only after the alarm above has
       # already been raised, so the operator's answer never costs the alarm.
       - name: Report the failure to the operator who asked
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && steps.verify.outputs.status != '0' }}
+        if: ${{ always() && github.event_name == 'repository_dispatch' && steps.verify.outputs.status != '0' }}
         run: |
           echo "::error::base image pin verification exited ${{ steps.verify.outputs.status }}; see the log above"
           exit 1

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -31,8 +31,9 @@ on:
   schedule:
     - cron: "9,24,39,54 * * * *"
   # For a captain who has just published a record and does not want to wait a
-  # quarter of an hour. Typed rather than a workflow_dispatch: a dispatch takes
-  # a ref, and this job reaches a credential that can flip a release.
+  # quarter of an hour. Typed rather than branch-selectable, because a plain
+  # dispatch takes a ref, and this job reaches a credential that can flip a
+  # release and, since the alarm moved to kin-infra, the release App key.
   repository_dispatch:
     types: [release_promote]
 
@@ -67,13 +68,31 @@ jobs:
       # One release flip and one body edit.
       contents: write
       # The alarm, which is the only thing standing between a forgotten release
-      # and a rail that is quietly one version behind forever.
+      # and a rail that is quietly one version behind forever. It lands on
+      # firelock-ai/kin-infra through the App token minted below rather than
+      # through this token, which cannot reach another repository.
       issues: write
     steps:
       - name: Checkout release policy
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
+      # Minted before the plan, because the plan's open-issue lookup reads the
+      # alarm repository and a private repository read with the workflow token
+      # answers 404, which the sweep would take for "no alarm open" and open a
+      # fresh one every quarter hour. A mint that fails fails this run, loudly.
+      - name: Mint the alarm token, issues only, this repository and kin-infra
+        id: alarm-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.KIN_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.KIN_RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ${{ github.event.repository.name }}
+            kin-infra
+          permission-issues: write
 
       # Judge every held release, and write down what was decided before
       # anything is changed. The plan is a file rather than a set of step
@@ -88,6 +107,8 @@ jobs:
         id: plan
         env:
           GH_TOKEN: ${{ github.token }}
+          KIN_ALARM_REPO: firelock-ai/kin-infra
+          KIN_ALARM_TOKEN: ${{ steps.alarm-token.outputs.token }}
           KIN_PROMOTION_PLAN: ${{ runner.temp }}/promotion-plan.json
         run: |
           set -euo pipefail
@@ -190,7 +211,9 @@ jobs:
       - name: Report releases still waiting for first-contact proof
         if: ${{ always() && steps.plan.outcome == 'success' }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.alarm-token.outputs.token }}
+          ALARM_REPO: firelock-ai/kin-infra
+          ALARM_LABEL: ${{ github.event.repository.name }}
           KIN_PROMOTION_PLAN: ${{ runner.temp }}/promotion-plan.json
         run: |
           set -euo pipefail
@@ -199,24 +222,29 @@ jobs:
           IFS=$'\t' read -r action number title < "$RUNNER_TEMP/alarm-decision.txt"
           case "$action" in
             open)
-              # The label is how the next sweep finds this issue in a bounded
-              # read rather than paging every open issue, so it has to exist
+              # The labels are how the next sweep finds this issue in a bounded
+              # read rather than paging every open issue, so they have to exist
               # before the issue does. `--force` makes this idempotent; a
               # missing label would otherwise fail the create and leave the
               # alarm silent, which is the one outcome this job exists to
-              # prevent.
-              gh label create release-proof --repo "$GITHUB_REPOSITORY" --force \
+              # prevent. The second label names this repository, because
+              # kin-infra collects every repository's alarms.
+              gh label create release-proof --repo "$ALARM_REPO" --force \
                 --color B60205 \
                 --description "A published release is waiting for first-contact proof"
-              gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" \
-                --label release-proof --body-file "$RUNNER_TEMP/alarm-body.md"
+              gh label create "$ALARM_LABEL" --repo "$ALARM_REPO" --force \
+                --color 5319E7 \
+                --description "Alarms raised by ${GITHUB_REPOSITORY}'s workflows"
+              gh issue create --repo "$ALARM_REPO" --title "$title" \
+                --label release-proof --label "$ALARM_LABEL" \
+                --body-file "$RUNNER_TEMP/alarm-body.md"
               ;;
             update)
-              gh issue comment "$number" --repo "$GITHUB_REPOSITORY" \
+              gh issue comment "$number" --repo "$ALARM_REPO" \
                 --body-file "$RUNNER_TEMP/alarm-body.md"
               ;;
             close)
-              gh issue close "$number" --repo "$GITHUB_REPOSITORY" \
+              gh issue close "$number" --repo "$ALARM_REPO" \
                 --comment "Every published release now carries complete first-contact proof, or is already GitHub Latest."
               ;;
             none)

--- a/.github/workflows/release-recovery.yml
+++ b/.github/workflows/release-recovery.yml
@@ -39,6 +39,9 @@ jobs:
       )
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # The release App credentials resolve only inside this Environment, which
+    # admits main alone; both triggers on this file run from main.
+    environment: release-tag
     steps:
       - name: Resolve exact retry candidate
         id: resolve
@@ -381,6 +384,79 @@ jobs:
             >/dev/null
           echo "Requested bounded automatic retry for Release run ${RUN_ID}."
 
+      # The alert below lands on firelock-ai/kin-infra rather than on this
+      # repository's public issue tab, and the workflow token cannot write to
+      # another repository, so the two steps that touch the alarm mint their
+      # own App token carrying issues: write on this repository and kin-infra
+      # and nothing else. Placed after the retry on purpose: a mint that fails
+      # fails the run loudly, and it must cost the alarm surface alone, never
+      # the retry that is this controller's actual job.
+      - name: Mint the alarm token, issues only, this repository and kin-infra
+        id: alarm-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.KIN_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.KIN_RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ${{ github.event.repository.name }}
+            kin-infra
+          permission-issues: write
+
+      # The close path the alert never had. Its title names one tag, so the
+      # one fact that can close it truthfully is a Release run on that tag
+      # concluding success, which this reads off the same listing the resolve
+      # step reads, every tick. A tag abandoned instead never ships; the hand
+      # that records the abandonment closes its alarm.
+      - name: Close blocked-release alarms whose tag has since shipped
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ALARM_TOKEN: ${{ steps.alarm-token.outputs.token }}
+          ALARM_REPO: firelock-ai/kin-infra
+          ALARM_LABEL: ${{ github.event.repository.name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          prefix="Release blocked after automatic retries: "
+          open="$(GH_TOKEN="$ALARM_TOKEN" gh issue list \
+            --repo "$ALARM_REPO" \
+            --label "$ALARM_LABEL" \
+            --state open \
+            --limit 100 \
+            --json number,title \
+            --jq --arg p "$prefix" \
+              '.[] | select(.title | startswith($p)) | "\(.number)\t\(.title[($p | length):])"')"
+          if [ -z "$open" ]; then
+            echo "no blocked-release alarm is open"
+            exit 0
+          fi
+          runs="$(gh api "repos/${REPO}/actions/workflows/release.yml/runs?per_page=100")"
+          while IFS=$'\t' read -r number tag; do
+            [ -n "$number" ] || continue
+            if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "#${number} names no release tag (${tag}); left alone"
+              continue
+            fi
+            url="$(jq -r --arg tag "$tag" '
+              [
+                .workflow_runs[] |
+                select(
+                  .head_branch == $tag and
+                  .event == "push" and
+                  .status == "completed" and
+                  .conclusion == "success" and
+                  .path == ".github/workflows/release.yml"
+                )
+              ] | sort_by(.created_at) | last | .html_url // empty' <<< "$runs")"
+            if [ -z "$url" ]; then
+              echo "${tag} has no successful Release run yet; #${number} stays open"
+              continue
+            fi
+            GH_TOKEN="$ALARM_TOKEN" gh issue close "$number" --repo "$ALARM_REPO" \
+              --comment "${tag} shipped: its Release run concluded success at ${url}."
+            echo "closed alarm #${number} for ${tag}"
+          done <<< "$open"
+
       - name: Alert after automatic retries are exhausted
         if: >-
           steps.resolve.outputs.needed == 'true' &&
@@ -390,7 +466,12 @@ jobs:
           ) &&
           steps.record.outputs.abandoned != 'true'
         env:
+          # The workflow token reads this repository's release state below; only
+          # the issue calls, which touch the alarm repository, use the App token.
           GH_TOKEN: ${{ github.token }}
+          ALARM_TOKEN: ${{ steps.alarm-token.outputs.token }}
+          ALARM_REPO: firelock-ai/kin-infra
+          ALARM_LABEL: ${{ github.event.repository.name }}
           REPO: ${{ github.repository }}
           TAG: ${{ steps.resolve.outputs.tag }}
           SHA: ${{ steps.resolve.outputs.sha }}
@@ -482,8 +563,16 @@ jobs:
           fi
 
           title="Release blocked after automatic retries: ${TAG}"
-          existing="$(gh issue list \
-            --repo "$REPO" \
+          # The label names this repository on kin-infra, which collects every
+          # repository's alarms. Created before it is read, and --force keeps
+          # that idempotent, because an alarm that fails to file is the one
+          # outcome this step exists to prevent.
+          GH_TOKEN="$ALARM_TOKEN" gh label create "$ALARM_LABEL" --repo "$ALARM_REPO" --force \
+            --color 5319E7 \
+            --description "Alarms raised by ${REPO}'s workflows"
+          existing="$(GH_TOKEN="$ALARM_TOKEN" gh issue list \
+            --repo "$ALARM_REPO" \
+            --label "$ALARM_LABEL" \
             --state open \
             --search "\"${title}\" in:title" \
             --json number,title \
@@ -504,9 +593,10 @@ jobs:
               printf '\n%s\n\n' "$release_state"
               printf 'The tag and any immutable public artifacts remain in place.\n'
             } > "$body"
-            gh issue create \
-              --repo "$REPO" \
+            GH_TOKEN="$ALARM_TOKEN" gh issue create \
+              --repo "$ALARM_REPO" \
               --title "$title" \
+              --label "$ALARM_LABEL" \
               --body-file "$body" \
               >/dev/null
           fi

--- a/.github/workflows/release-sentinel.yml
+++ b/.github/workflows/release-sentinel.yml
@@ -64,13 +64,24 @@ on:
     # Offset from the train (7,22,37,52) and recovery (3,18,33,48) so the
     # sentinel reads a settled rail rather than one mid-reconcile.
     - cron: "11,41 * * * *"
-  workflow_dispatch:
+  # Typed rather than a branch-selectable dispatch, because the two alarm jobs
+  # below reach the release App key to file their alarms on kin-infra, and the
+  # authority guard refuses that key beside a dispatch that lets a branch pick
+  # the workflow file it runs. The `release-tag` Environment admits main alone,
+  # so a patrol runs from main or not at all. Start one by hand with:
+  #   gh api repos/firelock-ai/kin/dispatches -f event_type=release-sentinel
+  repository_dispatch:
+    types: [release-sentinel]
 
 # Read-only by default, so a job that says nothing can do nothing. `patrol`
 # escalates on its own job below and the credential check never does;
 # `credential-alarm` and `mechanical-patrol` each escalate only to what their
 # own alarm needs (issues: write, plus actions: read for the mechanical
-# patrol's run lookups).
+# patrol's run lookups). Their alarms live on firelock-ai/kin-infra rather
+# than on this repository's public issue tab, and this token cannot write to
+# another repository, so each of those jobs mints a release App token carrying
+# issues: write on this repository and kin-infra and nothing else. A mint that
+# fails is that job's own loud failure; neither falls back to this token.
 permissions:
   contents: read
 
@@ -119,6 +130,9 @@ jobs:
     # always success; only the meaning of a 'false' output changes here, from
     # quiet to loud).
     if: always()
+    # The release App credentials resolve only inside this Environment, which
+    # admits main alone; every trigger on this file runs from main.
+    environment: release-tag
     permissions:
       contents: read
       issues: write
@@ -133,14 +147,31 @@ jobs:
       - name: Prove the judge still grades its own fixtures
         run: python3 scripts/release-sentinel-credential-alarm.py --self-test
 
+      - name: Mint the alarm token, issues only, this repository and kin-infra
+        id: alarm-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.KIN_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.KIN_RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ${{ github.event.repository.name }}
+            kin-infra
+          permission-issues: write
+
       - name: Alarm or clear, based on whether the patrol has a credential
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.alarm-token.outputs.token }}
+          ALARM_REPO: firelock-ai/kin-infra
+          ALARM_LABEL: ${{ github.event.repository.name }}
+          ENABLED: ${{ needs.preflight.outputs.enabled }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           python3 scripts/release-sentinel-credential-alarm.py \
-            --repo "${{ github.repository }}" \
-            --enabled "${{ needs.preflight.outputs.enabled }}" \
-            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            --repo "$ALARM_REPO" \
+            --label "$ALARM_LABEL" \
+            --enabled "$ENABLED" \
+            --run-url "$RUN_URL"
 
   patrol:
     name: Patrol the release rail
@@ -356,6 +387,9 @@ jobs:
   # `needs:` on `preflight`, and never gates on its output.
   mechanical-patrol:
     name: Patrol the RC-Build-to-Release-Cut handoff mechanically
+    # The release App credentials resolve only inside this Environment, which
+    # admits main alone; every trigger on this file runs from main.
+    environment: release-tag
     permissions:
       contents: read
       issues: write
@@ -371,7 +405,30 @@ jobs:
       - name: Prove the judge still grades its own fixtures
         run: python3 scripts/release-rail-parked-alarm.py --self-test
 
+      - name: Mint the alarm token, issues only, this repository and kin-infra
+        id: alarm-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.KIN_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.KIN_RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ${{ github.event.repository.name }}
+            kin-infra
+          permission-issues: write
+
+      # The run lookups read this repository with the workflow token, and only
+      # the calls that touch the alarm repository swap in the App token, which
+      # the script does itself from KIN_ALARM_TOKEN.
       - name: Patrol RC Build for a parked rail
         env:
           GH_TOKEN: ${{ github.token }}
-        run: python3 scripts/release-rail-parked-alarm.py --repo "${{ github.repository }}"
+          KIN_ALARM_TOKEN: ${{ steps.alarm-token.outputs.token }}
+          SOURCE_REPO: ${{ github.repository }}
+          ALARM_REPO: firelock-ai/kin-infra
+          ALARM_LABEL: ${{ github.event.repository.name }}
+        run: |
+          python3 scripts/release-rail-parked-alarm.py \
+            --repo "$SOURCE_REPO" \
+            --alarm-repo "$ALARM_REPO" \
+            --label "$ALARM_LABEL"

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -878,9 +878,15 @@ jobs:
     # and hide the distinction. The alarm would have read as working and been
     # structurally unable to fire.
     if: always() && needs.reconcile.result != 'skipped'
+    # The release App credentials resolve only inside this Environment, which
+    # admits main alone; every trigger on this file runs from main.
+    environment: release-tag
     permissions:
       # Reading prior cycles' markers, and nothing else, needs actions:read.
-      # Nothing in this job writes to a branch, a tag, or a pull request.
+      # Nothing in this job writes to a branch, a tag, or a pull request. The
+      # alarm lands on firelock-ai/kin-infra through the App token minted
+      # below rather than through this token, which cannot reach another
+      # repository.
       actions: read
       contents: read
       issues: write
@@ -897,6 +903,20 @@ jobs:
         with:
           sparse-checkout: scripts
           persist-credentials: false
+
+      # issues: write on this repository and kin-infra and nothing else. A mint
+      # that fails fails this job loudly, which is the alarm's own shape.
+      - name: Mint the alarm token, issues only, this repository and kin-infra
+        id: alarm-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.KIN_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.KIN_RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ${{ github.event.repository.name }}
+            kin-infra
+          permission-issues: write
 
       - name: Gather this cycle and the cycles before it
         id: history
@@ -973,20 +993,30 @@ jobs:
 
       - name: Decide whether the rail is quietly held, and say so if it is
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.alarm-token.outputs.token }}
           REPO: ${{ github.repository }}
+          ALARM_REPO: firelock-ai/kin-infra
+          ALARM_LABEL: ${{ github.event.repository.name }}
           MARKERS: ${{ steps.history.outputs.markers }}
           THRESHOLD: "4"
         run: |
           set -euo pipefail
           work="$RUNNER_TEMP/release-hold-history"
 
+          # The label names this repository on kin-infra, which collects every
+          # repository's alarms. Created before it is read, and --force keeps
+          # that idempotent, so a missing label can never fail the create.
+          gh label create "$ALARM_LABEL" --repo "$ALARM_REPO" --force \
+            --color 5319E7 \
+            --description "Alarms raised by ${REPO}'s workflows"
+
           # The one title the alarm ever carries. GitHub's title search is fuzzy,
           # so the exact-title filter after it is what keeps this idempotent: a
           # fuzzy hit on a differently titled issue would edit the wrong one.
           title="Release rail is held with releasable drift"
           existing="$(gh issue list \
-            --repo "$REPO" \
+            --repo "$ALARM_REPO" \
+            --label "$ALARM_LABEL" \
             --state open \
             --search "\"$title\" in:title" \
             --json number,title \
@@ -1035,7 +1065,8 @@ jobs:
             open)
               body="$work/body.md"
               jq -er .body "$decision" > "$body"
-              gh issue create --repo "$REPO" --title "$title" --body-file "$body" >/dev/null
+              gh issue create --repo "$ALARM_REPO" --title "$title" \
+                --label "$ALARM_LABEL" --body-file "$body" >/dev/null
               echo "::error::Release rail requires attention (${reason}). Opened the tracking issue with the observed failure or hold and its recovery path."
               exit 1
               ;;
@@ -1043,7 +1074,7 @@ jobs:
               body="$work/body.md"
               jq -er .body "$decision" > "$body"
               number="$(jq -er .issue "$decision")"
-              gh issue edit "$number" --repo "$REPO" --body-file "$body" >/dev/null
+              gh issue edit "$number" --repo "$ALARM_REPO" --body-file "$body" >/dev/null
               echo "::error::Release rail still requires attention (${reason}); issue #${number} carries the current failure or hold."
               exit 1
               ;;
@@ -1051,8 +1082,8 @@ jobs:
               number="$(jq -er .issue "$decision")"
               comment="$work/comment.md"
               jq -er .comment "$decision" > "$comment"
-              gh issue comment "$number" --repo "$REPO" --body-file "$comment" >/dev/null
-              gh issue close "$number" --repo "$REPO" >/dev/null
+              gh issue comment "$number" --repo "$ALARM_REPO" --body-file "$comment" >/dev/null
+              gh issue close "$number" --repo "$ALARM_REPO" >/dev/null
               echo "Closed rail-hold issue #${number}: the train is minting again."
               ;;
             *)

--- a/docs/release-bot.md
+++ b/docs/release-bot.md
@@ -342,7 +342,13 @@ default-branch ancestry, absence of any successful attempt, and absence of an
 active release before requesting `rerun-failed-jobs`. The initial attempt plus
 two retries is the hard cap. Cancellation is treated as an operator stop and is
 never retried. If all three attempts fail, the controller opens one
-`Release blocked after automatic retries` issue and stops.
+`Release blocked after automatic retries` issue and stops. That issue, like
+every alarm the release workflows raise, lives on the private ops repository
+`firelock-ai/kin-infra` under a label carrying this repository's name, not on
+this repository's public issue tab; the controller reaches it with a release
+App token that holds `issues: write` on the two repositories and nothing else.
+On a later tick, once a Release run for that tag concludes success, the
+controller closes the issue with one line naming that run.
 
 The issue compares the complete failing job/step set across attempts. A repeated
 set is reported as a **repeated failure signature**, not as proof of a

--- a/scripts/release-hold-alarm.test.mjs
+++ b/scripts/release-hold-alarm.test.mjs
@@ -323,12 +323,26 @@ test('the workflow opens and updates crash alarms with a loud accurate diagnosti
       const result = spawnSync('bash', ['-c', script], { encoding: 'utf8', env: {
         ...process.env, work: root, decision: filename, action: decision.action, reason: decision.reason,
         REPO: 'firelock-ai/kin', title: ALARM_TITLE,
+        // The alarm lives on kin-infra under this repository's label, and the
+        // workflow reaches it through a token minted for that alone. The arm
+        // must file there, never back on REPO.
+        ALARM_REPO: 'firelock-ai/kin-infra', ALARM_LABEL: 'kin',
       } });
       assert.equal(result.status, 1, result.stdout + result.stderr);
       assert.equal(result.stderr, '');
       assert.match(result.stdout, /::error::Release rail.*reconcile_failed/);
       assert.doesNotMatch(result.stdout, /consecutive cycles|blocking tag|two ways out/);
-      assert.match(fs.readFileSync(path.join(root, 'gh-calls'), 'utf8'), issue ? /issue edit 4242/ : /issue create/);
+      const calls = fs.readFileSync(path.join(root, 'gh-calls'), 'utf8');
+      assert.match(
+        calls,
+        issue
+          ? /issue edit 4242 --repo firelock-ai\/kin-infra --body-file/
+          : /issue create --repo firelock-ai\/kin-infra --title .* --label kin --body-file/,
+      );
+      // A create or edit routed back to the source repository is the public
+      // alarm this change exists to end; kin-infra's name starts with kin's,
+      // so the boundary after the name is what tells the two apart.
+      assert.doesNotMatch(calls, /--repo firelock-ai\/kin(\s|$)/m);
     }
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });

--- a/scripts/release-promotion-plan.mjs
+++ b/scripts/release-promotion-plan.mjs
@@ -276,6 +276,12 @@ export async function buildPlan({
   api,
   judge,
   alarmTitle = ALARM_TITLE,
+  // The alarm issue lives on firelock-ai/kin-infra, not beside the releases it
+  // reports on, so the open-issue lookup goes through a client bound to that
+  // repository and its own token. Defaulting to `api` keeps a caller that
+  // passes one client reading the alarm where the releases are, which is what
+  // every fixture in the test file does.
+  alarmApi = api,
   now = Date.now(),
   log = () => {},
 }) {
@@ -314,7 +320,7 @@ export async function buildPlan({
     judgements.push(judgement);
   }
 
-  const issues = await api('/issues?state=open&per_page=100&labels=release-proof');
+  const issues = await alarmApi('/issues?state=open&per_page=100&labels=release-proof');
   const openIssue =
     (Array.isArray(issues) ? issues : []).find((issue) => issue?.title === alarmTitle) ?? null;
   const plan = planPromotion(judgements, { now, openIssue });
@@ -346,6 +352,12 @@ function githubApi(repository, token, fetchImpl = fetch) {
 export async function main({
   repository = process.env.GITHUB_REPOSITORY,
   token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN,
+  // Where the alarm issue lives and the credential that can read it there.
+  // Both or neither: an alarm repository read with the release token would
+  // 404 on a private repository and the sweep would open a duplicate alarm
+  // every tick, so half a configuration is refused rather than half-applied.
+  alarmRepository = process.env.KIN_ALARM_REPO,
+  alarmToken = process.env.KIN_ALARM_TOKEN,
   out = process.env.KIN_PROMOTION_PLAN,
   fetchImpl = fetch,
   log = (line) => process.stderr.write(`${line}\n`),
@@ -353,11 +365,16 @@ export async function main({
   if (!out) {
     throw new Error('no plan path given; set KIN_PROMOTION_PLAN');
   }
+  if (Boolean(alarmRepository) !== Boolean(alarmToken)) {
+    throw new Error('KIN_ALARM_REPO and KIN_ALARM_TOKEN must be set together or not at all');
+  }
   const api = githubApi(repository, token, fetchImpl);
+  const alarmApi = alarmRepository ? githubApi(alarmRepository, alarmToken, fetchImpl) : api;
   const { main: judgeCandidate } = await import('./check-release-proof-artifacts.mjs');
   const plan = await buildPlan({
     repository,
     api,
+    alarmApi,
     judge: (sha) =>
       judgeCandidate({
         sha,

--- a/scripts/release-promotion-plan.test.mjs
+++ b/scripts/release-promotion-plan.test.mjs
@@ -443,6 +443,99 @@ test('buildPlan finds the open alarm by its exact title and nothing else', async
   assert.equal(other.alarm, 'open');
 });
 
+// The alarm issue lives on firelock-ai/kin-infra, not beside the releases. The
+// open-issue lookup has to go through the client bound to that repository, or
+// the sweep reads the wrong repository's issues, finds nothing every tick, and
+// opens a fresh alarm each time. The release client here answers the issue
+// lookup with an exact-title match that must NOT be adopted; only the alarm
+// client's answer counts.
+test('buildPlan reads the open alarm through the alarm client, never the release client', async () => {
+  const releaseReads = [];
+  const alarmReads = [];
+  const record = (log, answers) => async (path) => {
+    log.push(path);
+    return stubApi(answers)(path);
+  };
+  const plan = await buildPlan({
+    repository: 'firelock-ai/kin',
+    api: record(releaseReads, {
+      ...listing({ published_at: ago(DEFAULT_ALARM_AFTER_MINUTES + 1) }),
+      '/issues?': [{ number: 99, title: ALARM_TITLE }],
+    }),
+    alarmApi: record(alarmReads, { '/issues?': [{ number: 12, title: ALARM_TITLE }] }),
+    judge: async () => {
+      throw new Error('pending');
+    },
+    now: NOW,
+  });
+  assert.equal(plan.openIssue, 12);
+  assert.equal(plan.alarm, 'update');
+  assert.ok(alarmReads.some((path) => path.startsWith('/issues?')), 'the alarm client was never asked');
+  assert.ok(
+    !releaseReads.some((path) => path.startsWith('/issues?')),
+    'the release client must not be asked for issues once an alarm client exists',
+  );
+});
+
+test('main refuses half an alarm configuration rather than half-applying it', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-promoter-'));
+  const out = path.join(dir, 'plan.json');
+  for (const half of [{ alarmRepository: 'firelock-ai/kin-infra' }, { alarmToken: 'app' }]) {
+    await assert.rejects(
+      main({ repository: 'firelock-ai/kin', token: 'x', out, log: () => {}, ...half }),
+      /KIN_ALARM_REPO and KIN_ALARM_TOKEN must be set together/,
+    );
+  }
+});
+
+// The wiring main() does with both halves set: the issue lookup goes to the
+// alarm repository with the alarm token as its bearer, and the release reads
+// keep the release token. Read off the URLs and headers the fetch actually
+// received, because that is the only place the two clients differ.
+test('main binds the alarm lookup to the alarm repository and token', async () => {
+  const previous = process.env.KIN_RELEASE_REQUIRE;
+  process.env.KIN_RELEASE_REQUIRE = 'preflight';
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-promoter-'));
+  const out = path.join(dir, 'plan.json');
+  const sha = 'a'.repeat(40);
+  const requests = [];
+  try {
+    await main({
+      repository: 'firelock-ai/kin',
+      token: 'release-token',
+      alarmRepository: 'firelock-ai/kin-infra',
+      alarmToken: 'alarm-token',
+      out,
+      log: () => {},
+      fetchImpl: async (url, init = {}) => {
+        requests.push({ url, authorization: init.headers?.authorization });
+        const answer = (body) => ({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: async () => body,
+          text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+        });
+        if (url.includes('/releases?')) return answer([release()]);
+        if (url.includes('/git/ref/tags/')) return answer({ object: { type: 'commit', sha } });
+        if (url.includes('/issues?')) return answer([]);
+        return { ok: false, status: 404, statusText: 'Not Found', text: async () => '' };
+      },
+    });
+  } finally {
+    if (previous === undefined) delete process.env.KIN_RELEASE_REQUIRE;
+    else process.env.KIN_RELEASE_REQUIRE = previous;
+  }
+  const issueReads = requests.filter((entry) => entry.url.includes('/issues?'));
+  assert.equal(issueReads.length, 1);
+  assert.match(issueReads[0].url, /^https:\/\/api\.github\.com\/repos\/firelock-ai\/kin-infra\/issues\?/);
+  assert.equal(issueReads[0].authorization, 'Bearer alarm-token');
+  const releaseReads = requests.filter((entry) => entry.url.includes('/releases?'));
+  assert.ok(releaseReads.length >= 1);
+  assert.match(releaseReads[0].url, /^https:\/\/api\.github\.com\/repos\/firelock-ai\/kin\/releases\?/);
+  assert.equal(releaseReads[0].authorization, 'Bearer release-token');
+});
+
 test('buildPlan refuses without a repository', async () => {
   await assert.rejects(
     buildPlan({ api: stubApi({}), judge: async () => ({}) }),

--- a/scripts/release-rail-parked-alarm.py
+++ b/scripts/release-rail-parked-alarm.py
@@ -82,21 +82,57 @@ RECOVERED = "RECOVERED"
 
 ALARM_TITLE = "Release rail is parked: RC Build has no follow-on Release Cut run"
 
+# The alarm lives on firelock-ai/kin-infra beside every other repository's alarms,
+# and the label passed as --label is how a reader tells whose each one is.
+LABEL_COLOR = "5319E7"
+
+# The run lookups above read THIS repository with the workflow token. The alarm
+# repository is another, private repository that token cannot reach, so the calls
+# that touch it swap in the issues-only App token the workflow minted, carried in
+# this variable. Absent, the alarm calls use whatever GH_TOKEN the run has, which is
+# right when the alarm repository is this one.
+ALARM_TOKEN_ENV = "KIN_ALARM_TOKEN"
+
 
 class Unreadable(Exception):
     """A `gh` call failed, or answered with a shape this script does not recognize."""
 
 
-def gh(args, capture=True):
+def gh(args, capture=True, env=None):
     """Run gh, refusing an empty answer rather than treating it as a zero (same idiom
     as acceptance_red_alarm.py and release-sentinel-credential-alarm.py: a gh call can
     go out unauthenticated and its 403 wears a quota costume)."""
-    proc = subprocess.run(["gh"] + args, capture_output=capture, text=True, check=False)
+    proc = subprocess.run(["gh"] + args, capture_output=capture, text=True, check=False, env=env)
     if proc.returncode != 0:
         raise Unreadable(
             "gh %s exited %d: %s" % (" ".join(args), proc.returncode, (proc.stderr or "").strip()[:400])
         )
     return proc.stdout
+
+
+def alarm_env(base=None):
+    """Pure. The environment for a gh call that touches the alarm repository: the
+    caller's environment with GH_TOKEN replaced by the alarm token when one is set."""
+    env = dict(os.environ if base is None else base)
+    token = env.get(ALARM_TOKEN_ENV)
+    if token:
+        env["GH_TOKEN"] = token
+    return env
+
+
+def gh_alarm(args, capture=True):
+    return gh(args, capture=capture, env=alarm_env())
+
+
+def ensure_label(repo, label, gh_fn=gh):
+    """Create the source-repository label on the alarm repository, idempotently.
+
+    Created before the issue rather than assumed, because a create against a missing
+    label fails, and an alarm that fails to file is the one outcome this script exists
+    to prevent. `--force` makes an existing label a no-op.
+    """
+    gh_fn(["label", "create", label, "--repo", repo, "--force", "--color", LABEL_COLOR,
+           "--description", "Alarms raised by the %s repository's workflows" % label])
 
 
 def gh_json(args, gh_fn):
@@ -248,10 +284,16 @@ def render_alarm_body(repo, rc_build, detail):
     return "\n".join(lines) + "\n"
 
 
-def run_alarm(repo, rc_build_runs, release_cut_runs, now, dry_run=False, gh_fn=gh):
+def run_alarm(repo, rc_build_runs, release_cut_runs, now, dry_run=False, gh_fn=gh,
+              alarm_repo=None, label=None, alarm_gh_fn=None):
+    """`repo` is the repository whose rail was read and is named in the body;
+    `alarm_repo` is where the issue lives (defaulting to `repo`), `label` names the
+    source repository on it, and `alarm_gh_fn` is the gh that can reach it."""
+    alarm_repo = alarm_repo or repo
+    alarm_gh_fn = alarm_gh_fn or gh_fn
     verdict, detail, rc_build = decide(rc_build_runs, release_cut_runs, now)
-    label = "RC Build %s" % rc_build.get("id") if rc_build else "no qualifying RC Build run"
-    print("VERDICT %s (%s): %s" % (verdict, label, detail))
+    subject = "RC Build %s" % rc_build.get("id") if rc_build else "no qualifying RC Build run"
+    print("VERDICT %s (%s): %s" % (verdict, subject, detail))
 
     if dry_run:
         if verdict == PARKED:
@@ -259,19 +301,23 @@ def run_alarm(repo, rc_build_runs, release_cut_runs, now, dry_run=False, gh_fn=g
             print(render_alarm_body(repo, rc_build, detail))
         return verdict
 
-    existing = find_issue(repo, gh_fn=gh_fn)
+    existing = find_issue(alarm_repo, gh_fn=alarm_gh_fn)
     if verdict == PARKED:
         body = render_alarm_body(repo, rc_build, detail)
         if existing:
-            gh_fn(["issue", "comment", str(existing), "--repo", repo, "--body", body])
+            alarm_gh_fn(["issue", "comment", str(existing), "--repo", alarm_repo, "--body", body])
             print("updated tracking issue #%s" % existing)
         else:
-            number = gh_fn(["issue", "create", "--repo", repo, "--title", ALARM_TITLE, "--body", body])
+            create = ["issue", "create", "--repo", alarm_repo, "--title", ALARM_TITLE, "--body", body]
+            if label:
+                ensure_label(alarm_repo, label, gh_fn=alarm_gh_fn)
+                create += ["--label", label]
+            number = alarm_gh_fn(create)
             print("opened tracking issue %s" % number.strip())
     else:
         if existing:
-            gh_fn(["issue", "close", str(existing), "--repo", repo, "--comment",
-                   "The rail is no longer parked: %s" % detail])
+            alarm_gh_fn(["issue", "close", str(existing), "--repo", alarm_repo, "--comment",
+                         "The rail is no longer parked: %s" % detail])
             print("closed tracking issue #%s" % existing)
         else:
             print("nothing open to close")
@@ -320,9 +366,13 @@ class _FakeGh:
         self.open_issue = existing_issue
         self.closed_issue = None
         self.comments = []
+        self.labels = []
 
     def __call__(self, args):
         self.calls.append(args)
+        if args[0] == "label" and args[1] == "create":
+            self.labels.append(args[2])
+            return ""
         if args[0] == "issue" and args[1] == "list":
             rows = [{"number": self.open_issue, "title": ALARM_TITLE}] if self.open_issue else []
             return json.dumps(rows)
@@ -442,6 +492,51 @@ def self_test():
     check("CLEAR with nothing open performs no mutation",
           [c for c in fake4.calls if c[1] in ("create", "comment", "close")] == [] and verdict == CLEAR)
 
+    # The alarm repository is not the repository whose rail was read. Every issue
+    # call goes to the alarm repository through the alarm gh, the run repository
+    # stays in the body, the label is created there before the issue that carries
+    # it, and the gh that read the runs never touches an issue.
+    runs_gh = _FakeGh(existing_issue=None)
+    alarm_gh = _FakeGh(existing_issue=None)
+    verdict = run_alarm("firelock-ai/kin", [REAL_RC_BUILD_V0_7_10], [], now_soon_after,
+                        gh_fn=runs_gh, alarm_repo="firelock-ai/kin-infra", label="kin",
+                        alarm_gh_fn=alarm_gh)
+    created = [c for c in alarm_gh.calls if c[:2] == ["issue", "create"]]
+    check("a routed PARKED creates exactly one issue through the alarm gh",
+          verdict == PARKED and len(created) == 1)
+    check("the routed create lands on the alarm repository",
+          created and created[0][2:4] == ["--repo", "firelock-ai/kin-infra"])
+    check("the routed create carries the source label",
+          created and "--label" in created[0] and created[0][created[0].index("--label") + 1] == "kin")
+    check("the label is created on the alarm repository before the issue",
+          alarm_gh.labels == ["kin"]
+          and alarm_gh.calls.index(["label", "create", "kin", "--repo", "firelock-ai/kin-infra",
+                                    "--force", "--color", LABEL_COLOR, "--description",
+                                    "Alarms raised by the kin repository's workflows"])
+          < alarm_gh.calls.index(created[0]))
+    check("the routed body still names the repository whose rail was read",
+          created and "repos/firelock-ai/kin/dispatches" in created[0][created[0].index("--body") + 1])
+    check("the gh that reads the runs never touches an issue", runs_gh.calls == [])
+
+    alarm_gh_repeat = _FakeGh(existing_issue=889)
+    run_alarm("firelock-ai/kin", [REAL_RC_BUILD_V0_7_10], [], now_soon_after,
+              gh_fn=runs_gh, alarm_repo="firelock-ai/kin-infra", label="kin",
+              alarm_gh_fn=alarm_gh_repeat)
+    check("a routed repeat PARKED comments on the alarm repository and never relabels",
+          alarm_gh_repeat.labels == [] and len(alarm_gh_repeat.comments) == 1
+          and [c for c in alarm_gh_repeat.calls if c[:2] == ["issue", "create"]] == []
+          and all(c[c.index("--repo") + 1] == "firelock-ai/kin-infra"
+                  for c in alarm_gh_repeat.calls if "--repo" in c))
+
+    # The token routing the workflow relies on: with the alarm token set, the alarm
+    # calls authenticate with it; without it, the environment passes through unchanged.
+    routed = alarm_env({"GH_TOKEN": "workflow", ALARM_TOKEN_ENV: "app"})
+    check("alarm_env swaps in the alarm token when one is set", routed["GH_TOKEN"] == "app")
+    check("alarm_env keeps the rest of the environment", routed[ALARM_TOKEN_ENV] == "app")
+    untouched = alarm_env({"GH_TOKEN": "workflow"})
+    check("alarm_env leaves GH_TOKEN alone when no alarm token is set",
+          untouched == {"GH_TOKEN": "workflow"})
+
     print("release-rail-parked-alarm: self-test %s"
           % ("PASSED" if not failures else "FAILED on %s" % ", ".join(failures)))
     return 1 if failures else 0
@@ -449,7 +544,14 @@ def self_test():
 
 def main(argv):
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", "firelock-ai/kin"))
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", "firelock-ai/kin"),
+                        help="the repository whose rail is read")
+    parser.add_argument("--alarm-repo", default=None,
+                        help="where the tracking issue lives; defaults to --repo. Its gh calls "
+                             "authenticate with $%s when set" % ALARM_TOKEN_ENV)
+    parser.add_argument("--label", default=None,
+                        help="the source-repository label to put on a newly opened alarm; "
+                             "created on the alarm repository first when given")
     parser.add_argument("--dry-run", action="store_true", help="judge and print, touch no issue")
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args(argv[1:])
@@ -461,7 +563,8 @@ def main(argv):
         rc_build_runs = fetch_rc_build_runs(args.repo, gh)
         release_cut_runs = fetch_release_cut_runs(args.repo, gh)
         verdict = run_alarm(args.repo, rc_build_runs, release_cut_runs,
-                             datetime.now(timezone.utc), dry_run=args.dry_run)
+                             datetime.now(timezone.utc), dry_run=args.dry_run,
+                             alarm_repo=args.alarm_repo, label=args.label, alarm_gh_fn=gh_alarm)
     except Unreadable as exc:
         print("VERDICT UNREADABLE %s" % exc)
         return 2

--- a/scripts/release-sentinel-credential-alarm.py
+++ b/scripts/release-sentinel-credential-alarm.py
@@ -50,6 +50,10 @@ CLEAR = "CLEAR"
 
 ALARM_TITLE = "Release Sentinel has no credential to patrol with"
 
+# The alarm lives on firelock-ai/kin-infra beside every other repository's alarms,
+# and the label passed as --label is how a reader tells whose each one is.
+LABEL_COLOR = "5319E7"
+
 
 class Unreadable(Exception):
     """A `gh` call failed or answered with nothing usable."""
@@ -85,6 +89,17 @@ def find_issue(repo, gh_fn=gh):
     return None
 
 
+def ensure_label(repo, label, gh_fn=gh):
+    """Create the source-repository label on the alarm repository, idempotently.
+
+    Created before the issue rather than assumed, because a create against a missing
+    label fails, and an alarm that fails to file is the one outcome this script exists
+    to prevent. `--force` makes an existing label a no-op.
+    """
+    gh_fn(["label", "create", label, "--repo", repo, "--force", "--color", LABEL_COLOR,
+           "--description", "Alarms raised by the %s repository's workflows" % label])
+
+
 def judge(enabled):
     """Pure. `enabled` is the exact string release-sentinel.yml's `preflight` job
     outputs: 'true' when the secret is present, anything else otherwise."""
@@ -116,7 +131,9 @@ def render_alarm_body(run_url):
     return "\n".join(lines) + "\n"
 
 
-def run_alarm(repo, enabled, run_url, dry_run=False, gh_fn=gh):
+def run_alarm(repo, enabled, run_url, dry_run=False, gh_fn=gh, label=None):
+    """`repo` is where the alarm issue lives (the alarm repository, not necessarily the
+    repository whose sentinel this is); `label` names the source repository on it."""
     verdict = judge(enabled)
     print("VERDICT %s (preflight enabled=%r)" % (verdict, enabled))
 
@@ -133,7 +150,11 @@ def run_alarm(repo, enabled, run_url, dry_run=False, gh_fn=gh):
             gh_fn(["issue", "comment", str(existing), "--repo", repo, "--body", body])
             print("updated tracking issue #%s" % existing)
         else:
-            number = gh_fn(["issue", "create", "--repo", repo, "--title", ALARM_TITLE, "--body", body])
+            create = ["issue", "create", "--repo", repo, "--title", ALARM_TITLE, "--body", body]
+            if label:
+                ensure_label(repo, label, gh_fn=gh_fn)
+                create += ["--label", label]
+            number = gh_fn(create)
             print("opened tracking issue %s" % number.strip())
     else:
         if existing:
@@ -164,10 +185,14 @@ class _FakeGh:
         self.open_issue = existing_issue  # None, or an int issue number
         self.closed_issue = None
         self.comments = []
+        self.labels = []
 
     def __call__(self, args):
         self.calls.append(args)
         cmd = args[0] if args else ""
+        if cmd == "label" and args[1] == "create":
+            self.labels.append(args[2])
+            return ""
         if cmd == "issue" and args[1] == "list":
             rows = [{"number": self.open_issue, "title": ALARM_TITLE}] if self.open_issue else []
             return json.dumps(rows)
@@ -206,6 +231,34 @@ def self_test():
     check("first ALARM creates an issue", fake.open_issue == fake.next_number)
     check("first ALARM never closes", fake.closed_issue is None)
     check("first ALARM posts no comment (nothing existed to comment on)", fake.comments == [])
+    check("an unlabelled ALARM touches no label", fake.labels == [])
+
+    # The alarm repository and the source label, as release-sentinel.yml passes them:
+    # every call lands on the repository given, the label is created before the issue
+    # that carries it, and the create is the only call that carries it.
+    fake_labelled = _FakeGh(existing_issue=None)
+    run_alarm("firelock-ai/kin-infra", "false", "https://example/runs/5",
+              gh_fn=fake_labelled, label="kin")
+    labelled_create = [c for c in fake_labelled.calls if c[:2] == ["issue", "create"]]
+    check("a labelled ALARM creates exactly one issue", len(labelled_create) == 1)
+    check("the labelled create lands on the alarm repository",
+          labelled_create and labelled_create[0][2:4] == ["--repo", "firelock-ai/kin-infra"])
+    check("the labelled create carries the source label",
+          labelled_create and "--label" in labelled_create[0]
+          and labelled_create[0][labelled_create[0].index("--label") + 1] == "kin")
+    check("the label is created on the alarm repository before the issue",
+          fake_labelled.labels == ["kin"]
+          and fake_labelled.calls.index(["label", "create", "kin", "--repo", "firelock-ai/kin-infra",
+                                         "--force", "--color", LABEL_COLOR, "--description",
+                                         "Alarms raised by the kin repository's workflows"])
+          < fake_labelled.calls.index(labelled_create[0]))
+
+    fake_labelled_repeat = _FakeGh(existing_issue=556)
+    run_alarm("firelock-ai/kin-infra", "false", "https://example/runs/6",
+              gh_fn=fake_labelled_repeat, label="kin")
+    check("a labelled repeat ALARM comments and never relabels or recreates",
+          fake_labelled_repeat.labels == [] and len(fake_labelled_repeat.comments) == 1
+          and [c for c in fake_labelled_repeat.calls if c[:2] == ["issue", "create"]] == [])
 
     # A second ALARM while one is already open: comments on it, creates no duplicate.
     fake2 = _FakeGh(existing_issue=555)
@@ -251,6 +304,9 @@ def main(argv):
                          help="the exact string release-sentinel.yml's preflight job output; "
                               "'true' means a credential is present")
     parser.add_argument("--run-url", default="")
+    parser.add_argument("--label", default=None,
+                        help="the source-repository label to put on a newly opened alarm; "
+                             "created on --repo first when given")
     parser.add_argument("--dry-run", action="store_true", help="judge and print, touch no issue")
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args(argv[1:])
@@ -261,7 +317,8 @@ def main(argv):
         parser.error("--enabled is required unless --self-test")
 
     try:
-        verdict = run_alarm(args.repo, args.enabled, args.run_url, dry_run=args.dry_run)
+        verdict = run_alarm(args.repo, args.enabled, args.run_url, dry_run=args.dry_run,
+                            label=args.label)
     except Unreadable as exc:
         print("VERDICT UNREADABLE %s" % exc)
         return 2

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -809,6 +809,13 @@ EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
     ".github/workflows/advisory-sweep.yml": {
         "sweep": "Sweep advisories",
     },
+    # The typed-dispatch proof that the alarm credential can open and close an
+    # issue on kin-infra. It publishes no required context and runs on no
+    # pull-request or merge-group event; registered so its job NAME cannot
+    # appear unreviewed.
+    ".github/workflows/alarm-dry-run.yml": {
+        "dry-run": "Open and close one alarm on kin-infra",
+    },
     ".github/workflows/approve-to-merge.yml": {
         "gate": None,
     },
@@ -8462,16 +8469,32 @@ def write_recovery_gh_stub(binaries: Path) -> None:
                       printf '%s\n' "$body"
                     fi
                     ;;
+                  label)
+                    # The alert creates its source-repository label on the
+                    # alarm repository before the issue that carries it.
+                    shift
+                    if [ "$1" = create ]; then
+                      printf '%s' "$2" > "$FIXTURE/label-created"
+                    fi
+                    exit 0
+                    ;;
                   issue)
                     shift
                     case "$1" in
                       list) exit 0 ;;
                       create)
                         shift
+                        # The token the create authenticated with is the one
+                        # fact that separates an alarm filed through the
+                        # release App from one that fell back to the workflow
+                        # token, so it is recorded beside the arguments.
+                        printf '%s' "${GH_TOKEN:-}" > "$FIXTURE/issue-token"
                         while [ $# -gt 0 ]; do
                           case "$1" in
                             --title) shift; printf '%s' "$1" > "$FIXTURE/issue-title" ;;
                             --body-file) shift; cp "$1" "$FIXTURE/issue-body" ;;
+                            --repo) shift; printf '%s' "$1" > "$FIXTURE/issue-repo" ;;
+                            --label) shift; printf '%s' "$1" > "$FIXTURE/issue-label" ;;
                           esac
                           shift
                         done
@@ -8555,6 +8578,13 @@ def execute_recovery_escalation(
                 "UNKNOWN": classifier_outputs.get("unknown", ""),
                 "REPEATED": classifier_outputs.get("repeated", ""),
                 "DISTINCT": classifier_outputs.get("distinct", ""),
+                # The alarm lives on kin-infra and is filed through the App
+                # token the job minted for it, never through the workflow
+                # token above. Distinct fixture values, so the recorded create
+                # can only match by using each for what it is for.
+                "ALARM_TOKEN": RECOVERY_ALARM_FIXTURE_TOKEN,
+                "ALARM_REPO": RECOVERY_ALARM_FIXTURE_REPO,
+                "ALARM_LABEL": RECOVERY_ALARM_FIXTURE_LABEL,
             }
         )
         completed = subprocess.run(
@@ -8567,7 +8597,41 @@ def execute_recovery_escalation(
         )
         body_path = root / "issue-body"
         body = body_path.read_text(encoding="utf-8") if body_path.exists() else ""
+        if body_path.exists():
+            assert_recovery_alert_filed_on_alarm_repository(root)
         return completed, body
+
+
+RECOVERY_ALARM_FIXTURE_TOKEN = "alarm-fixture-token"
+RECOVERY_ALARM_FIXTURE_REPO = "firelock-ai/kin-infra"
+RECOVERY_ALARM_FIXTURE_LABEL = "kin"
+
+
+def assert_recovery_alert_filed_on_alarm_repository(root: Path) -> None:
+    """Every alert the recovery controller files lands on kin-infra, labelled
+    with the source repository, through the alarm token and no other.
+
+    Read off what the stub recorded rather than off the workflow text, so a
+    create that quietly went back to `--repo "$REPO"` or to the workflow token
+    fails here even when every string the text checks pin is still present.
+    """
+
+    recorded = {
+        name: (root / name).read_text(encoding="utf-8") if (root / name).exists() else None
+        for name in ("issue-repo", "issue-label", "issue-token", "label-created")
+    }
+    expected = {
+        "issue-repo": RECOVERY_ALARM_FIXTURE_REPO,
+        "issue-label": RECOVERY_ALARM_FIXTURE_LABEL,
+        "issue-token": RECOVERY_ALARM_FIXTURE_TOKEN,
+        "label-created": RECOVERY_ALARM_FIXTURE_LABEL,
+    }
+    for name, want in expected.items():
+        if recorded[name] != want:
+            raise AssertionError(
+                "recovery alert was not filed on the alarm repository through the "
+                f"alarm token: {name} recorded {recorded[name]!r}, expected {want!r}"
+            )
 
 
 def assert_recovery_escalation_classifies(release_recovery: str) -> None:


### PR DESCRIPTION
## Summary

Every alarm issue this repository's release workflows raise now opens on `firelock-ai/kin-infra`, the private ops repository, under the `kin` label, instead of on this repository's public issue tab, where a stranger reads a row of `github-actions` alarms as churn. Each alarm job mints its own release App token scoped to this repository and kin-infra with `permission-issues: write` only; the workflow token cannot write to another repository and nothing here falls back to it. A mint that fails is that job's own loud failure. The one exception is `base-image-pins.yml`, whose header explains why it must never publish a failing check-run on a main sha: its mint is tolerated and a missing token is reported as an error annotation, still with no fallback.

Workflows: `advisory-sweep.yml` (narrow second mint beside the bump-branch token; the unfixable-advisory issue carries `advisory-sweep` plus `kin`; a close step, which it never had, closes it on the next sweep that finds nothing unfixable), `base-image-pins.yml` (typed `repository_dispatch` replaces `workflow_dispatch`, since the authority guard refuses a branch-selectable dispatch beside the App key), `release-promote.yml` (the plan's open-issue lookup reads kin-infra through a second API client; `KIN_ALARM_REPO` and `KIN_ALARM_TOKEN` are refused half-set), `release-recovery.yml` (mint placed after the retry so a credential failure never costs the retry; a new step closes any open blocked-release alarm whose tag has since had a successful Release run, the close path this alarm never had), `release-sentinel.yml` (typed dispatch; both alarm jobs mint and file on kin-infra; the parked-rail patrol keeps reading runs with the workflow token and swaps in the App token only for issue calls), `release-train.yml` (hold-alarm mints and files on kin-infra), and a new `alarm-dry-run.yml`.

Scripts: `release-sentinel-credential-alarm.py` gains `--label`; `release-rail-parked-alarm.py` gains `--alarm-repo`, `--label` and `KIN_ALARM_TOKEN` routing; `release-promotion-plan.mjs` gains an alarm client; the authority guard's recovery harness supplies the alarm environment and asserts the recorded create went to kin-infra, with the label, through the alarm token; the job census registers the dry run; `docs/release-bot.md` says where the alarm lives.

Untouched: `release.yml`, `rc-build.yml`, the acceptance workflow, crates, `scripts/acceptance`. The "Acceptance is red on main" alarm is not one of these workflows and stays where it is.

## Verification

Hosted CI runs the self-tests, the mjs suites and the authority guard. The claims below are the ones it does not make on its own.

Each new control goes red under a mutant and green on the restored file:

```
$ python3 scripts/release-sentinel-credential-alarm.py --self-test   # `create += ["--label", label]` deleted
CONTROL FAIL the labelled create carries the source label
release-sentinel-credential-alarm: self-test FAILED on the labelled create carries the source label
$ python3 scripts/release-rail-parked-alarm.py --self-test           # issue lookup routed back to the source repo
CONTROL FAIL the gh that reads the runs never touches an issue
CONTROL FAIL a routed repeat PARKED comments on the alarm repository and never relabels
$ node --test scripts/release-promotion-plan.test.mjs                # lookup uses the release client
not ok 28 - buildPlan reads the open alarm through the alarm client, never the release client
not ok 30 - main binds the alarm lookup to the alarm repository and token
$ python3 scripts/test-release-workflow-authority.py                 # recovery create back to --repo "$REPO"
AssertionError: recovery alert was not filed on the alarm repository through the alarm token: issue-repo recorded 'firelock-ai/kin', expected 'firelock-ai/kin-infra'
```

```
$ node --test scripts/release-hold-alarm.test.mjs                    # release-train create routed back to "$REPO"
ℹ pass 33
ℹ fail 1
```

Restored: both self-tests `PASSED`, `node --test` on the two promotion-plan files `# pass 44 # fail 0`, the authority guard ends on its usual summary line, `check-release-sentinel-shape.py` reports the shape holds, and the npm launcher job's own `node --test` list runs 217 for 217 locally.

The dry run cannot run before this lands: the App secrets live only in the `release-tag` Environment, whose branch policy admits `main` alone, and the guard forbids a branch-selectable dispatch beside them. Once it lands: `gh api repos/firelock-ai/kin/dispatches -f event_type=alarm-dry-run`, then read the run. Every alarm path here is inert until a real alarm condition fires, so nothing files anywhere between landing and that dispatch.

After landing, kin#1640 becomes an orphan: its successor alarm opens on kin-infra and nothing on kin closes the old one, so it needs a hand close when the founder's decision on it lands.

## Precheck

`bin/kin-precheck kin --repo-dir kin=<lane worktree>` through a builder slot, on the rebased head:

```
kin-precheck: repo=kin tree=.kin-coord/worktrees/issuehygiene-kin sha=3c521f49e1641c7c3d95d388b633ca2885d2e8d0 branch=chore/lane-issuehygiene-kin
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:test-release-workflow-authority.py python3 scripts/test-release-workflow-authority.py
PASS     node-test                            node --test <16 file(s) named by the check job>
PASS     guard:check-quarantine.py            python3 scripts/check-quarantine.py
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin 3c521f49e1641c7c3d95d388b633ca2885d2e8d0
```

(The 17 guard lines between those are all `PASS` too; the full log is `.kin-coord/reports/issuehygiene-precheck.log`.)

The kin-actions half of this change is landed (kin-actions#63) and its dry run from main is green, run 34665030156: the mint scoped to the caller and kin-infra with `permission-issues: write` succeeded, so the kin-release-bot installation already includes kin-infra, which is the fact every alarm here depends on.

## Landed, and the dry run

Landed as `be74b97a23ce98367d4254ef12b9fca8d1f022d4` (2026-09-12T01:51:46Z) off head `7360e4379`, whose check-run set read fully paged (49 of 49): 29 success, 18 skipped, 1 neutral, and `Analyze (rust)` (CodeQL) still pending at landing; no failures. Dry run dispatched from main with `gh api repos/firelock-ai/kin/dispatches -f event_type=alarm-dry-run`: run 34666084062, https://github.com/firelock-ai/kin/actions/runs/34666084062, conclusion `success`, both steps `success`: the mint scoped to `kin` and `kin-infra` with `permission-issues: write`, then the open, read-back, close, read-back on kin-infra under the `kin` label. Every alarm in this change now has a proven path to its home.
