### PR TITLE
Compare the kin-vfs-core the release builds with, wherever it comes from

### DIFF
--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -230,13 +230,25 @@ jobs:
               version: block.match(/^version = "([^"]+)"/m)?.[1],
               source: block.match(/^source = "([^"]+)"/m)?.[1] ?? null,
             }));
+          // Kin's side is the kin-vfs-core Kin BUILDS WITH, wherever it comes from. It
+          // used to come only from the registry; since the crate moved into
+          // crates/kin-vfs-core it has no `source` line at all, the shape a workspace
+          // member has in any lock. Both are accepted, and the question is unchanged:
+          // the shipped kin-vfs binaries are built from the pinned kin-vfs checkout, and
+          // if that checkout builds a different kin-vfs-core than Kin does, the release
+          // is wrong. The pinned side keeps the strict `source === null` rule, because
+          // that lock is the kin-vfs repository's own and its member entry is the one
+          // being compared. scripts/check-kin-vfs-compat.mjs is the pull-request
+          // counterpart and carries the same rule with its own tests.
           const kinVfsCore = lockPackages(path.join(process.cwd(), "Cargo.lock"))
-            .filter((pkg) => pkg.name === "kin-vfs-core" && pkg.source?.startsWith("sparse+"));
+            .filter((pkg) => pkg.name === "kin-vfs-core"
+              && (pkg.source === null || pkg.source.startsWith("sparse+")));
           const pinnedVfsCore = lockPackages(path.join(process.cwd(), "kin-vfs", "Cargo.lock"))
             .filter((pkg) => pkg.name === "kin-vfs-core" && pkg.source === null);
           if (kinVfsCore.length !== 1 || pinnedVfsCore.length !== 1) {
             throw new Error(
-              `expected one registry Kin kin-vfs-core and one pinned local kin-vfs-core; ` +
+              `expected one Kin kin-vfs-core, from the registry or from this workspace, ` +
+              `and one pinned local kin-vfs-core; ` +
               `found ${kinVfsCore.length} and ${pinnedVfsCore.length}`
             );
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -622,13 +622,25 @@ jobs:
               version: block.match(/^version = "([^"]+)"/m)?.[1],
               source: block.match(/^source = "([^"]+)"/m)?.[1] ?? null,
             }));
+          // Kin's side is the kin-vfs-core Kin BUILDS WITH, wherever it comes from. It
+          // used to come only from the registry; since the crate moved into
+          // crates/kin-vfs-core it has no `source` line at all, the shape a workspace
+          // member has in any lock. Both are accepted, and the question is unchanged:
+          // the shipped kin-vfs binaries are built from the pinned kin-vfs checkout, and
+          // if that checkout builds a different kin-vfs-core than Kin does, the release
+          // is wrong. The pinned side keeps the strict `source === null` rule, because
+          // that lock is the kin-vfs repository's own and its member entry is the one
+          // being compared. scripts/check-kin-vfs-compat.mjs is the pull-request
+          // counterpart and carries the same rule with its own tests.
           const kinVfsCore = lockPackages(path.join(process.cwd(), "Cargo.lock"))
-            .filter((pkg) => pkg.name === "kin-vfs-core" && pkg.source?.startsWith("sparse+"));
+            .filter((pkg) => pkg.name === "kin-vfs-core"
+              && (pkg.source === null || pkg.source.startsWith("sparse+")));
           const pinnedVfsCore = lockPackages(path.join(process.cwd(), "kin-vfs", "Cargo.lock"))
             .filter((pkg) => pkg.name === "kin-vfs-core" && pkg.source === null);
           if (kinVfsCore.length !== 1 || pinnedVfsCore.length !== 1) {
             throw new Error(
-              `expected one registry Kin kin-vfs-core and one pinned local kin-vfs-core; ` +
+              `expected one Kin kin-vfs-core, from the registry or from this workspace, ` +
+              `and one pinned local kin-vfs-core; ` +
               `found ${kinVfsCore.length} and ${pinnedVfsCore.length}`
             );
           }

--- a/scripts/check-kin-vfs-compat.test.mjs
+++ b/scripts/check-kin-vfs-compat.test.mjs
@@ -274,6 +274,37 @@ test('still catches the lock-moved-pin-did-not shape on a workspace member', () 
 // The transitional case this import creates and PR C ends: a registry copy
 // beside the workspace one is two packages with one name, and the gate must not
 // pick either and call it agreement.
+// release.yml and rc-build.yml carry their own copy of this comparison inline, in
+// the release build job, which runs AFTER the tag exists. When kin-vfs-core moved
+// into crates/ their filter stopped finding it, and nothing on a pull request would
+// have said so, because THIS gate was fixed first. So the rule is asserted against
+// the shipped workflow text rather than against a copy of it: the filter is read out
+// of the file and exercised on both lock shapes.
+for (const workflow of ['.github/workflows/release.yml', '.github/workflows/rc-build.yml']) {
+  test(`${workflow} accepts a workspace-sourced kin-vfs-core on Kin's side`, () => {
+    const text = fs.readFileSync(path.join(ROOT, workflow), 'utf8');
+    const match = text.match(
+      /const kinVfsCore = lockPackages\([^;]*?\)\s*\.filter\(\(pkg\) =>([\s\S]*?)\);/,
+    );
+    assert.ok(match, `${workflow} no longer carries a kinVfsCore filter this test can read`);
+    // eslint-disable-next-line no-new-func
+    const filter = new Function('pkg', `return (${match[1].trim()});`);
+    const workspaceMember = { name: VFS_CORE, version: '0.4.25', source: null };
+    const registryCopy = { name: VFS_CORE, version: '0.4.25', source: REGISTRY };
+    const notOurs = { name: 'lru', version: '0.18.2', source: REGISTRY };
+    assert.equal(filter(workspaceMember), true, 'a workspace member must be Kin\'s copy');
+    assert.equal(filter(registryCopy), true, 'a registry package must still be Kin\'s copy');
+    assert.equal(filter(notOurs), false, 'another package must not be');
+    // And the pinned side stays strict, so the kin-vfs checkout's own member entry is
+    // what it compares against rather than anything the registry happens to carry.
+    assert.match(
+      text,
+      /pinnedVfsCore = lockPackages\([\s\S]*?pkg\.source === null\);/,
+      `${workflow}'s pinned side must keep the strict source === null rule`,
+    );
+  });
+}
+
 test('refuses a Kin lock carrying both a workspace and a registry kin-vfs-core', () => {
   assert.throws(
     () =>

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -14140,9 +14140,15 @@ def main() -> None:
             f"release workflow; release={sorted(vfs_refs)}, "
             f"install-proof={sorted(install_proof_vfs_expected)}"
         )
+    # The Kin-side filter moved when kin-vfs-core became a workspace member: a
+    # member carries no `source` line, so a registry-only filter finds zero and the
+    # gate throws in the release build job, after the tag exists. What is pinned here
+    # is the pair of shapes Kin's side must accept, not the old spelling of it, and
+    # the pinned side's strict rule is pinned separately below so loosening it still
+    # has to be a deliberate edit to this list.
     for policy in (
         "Verified Kin/kin-vfs release compatibility at kin-vfs-core",
-        'pkg.name === "kin-vfs-core" && pkg.source?.startsWith("sparse+")',
+        'pkg.source === null || pkg.source.startsWith("sparse+")',
         'pkg.name === "kin-vfs-core" && pkg.source === null',
         "update the immutable kin-vfs pin",
     ):


### PR DESCRIPTION
`release.yml` refuses a release whose Kin lock resolves a different kin-vfs-core than the pinned
kin-vfs checkout builds, because the shipped kin-vfs binaries come from that checkout. It found
Kin's copy by looking for a lock entry with a `sparse+` source.

Since kin#1758 moved kin-vfs-core into `crates/kin-vfs-core` there is no such entry. A workspace
member carries no `source` line at all, so the filter finds zero and the next line throws:

```
expected one registry Kin kin-vfs-core and one pinned local kin-vfs-core; found 0 and 1
```

**That throw sits in the release BUILD job, which runs after the tag exists**, where no fix lands
without cutting another tag. And nothing on a pull request would have warned anyone, because the
pull-request counterpart, `scripts/check-kin-vfs-compat.mjs`, was taught to accept both shapes in
the same pull request that created the problem here.

## The change

Kin's side of both comparisons accepts either shape. Nothing else in either file moves.

```js
.filter((pkg) => pkg.name === "kin-vfs-core"
  && (pkg.source === null || pkg.source.startsWith("sparse+")));
```

The pinned side keeps the strict `source === null` rule, because that lock is the kin-vfs
repository's own and its member entry is the one being compared. The version comparison and the
exactly-one-each rule are untouched, so the gate still refuses the lock-moved-pin-did-not shape and
still refuses a lock carrying both copies. `rc-build.yml` gets the identical edit, which
`scripts/check-rc-build-drift.mjs` requires and which is why that check stays green.

## Asserted against the shipped text, not a copy of it

Two cases in `scripts/check-kin-vfs-compat.test.mjs` read the filter out of each workflow file and
exercise it on a workspace-sourced entry, a registry-sourced entry and an unrelated package, then
require the pinned side to still read `source === null`. That file is already in the
`npm launcher tests` policy step's `node --test` list, so this needs no new gate name.

Falsified, with the unpoisoned copy green so a red arm means something:

```
control: the copy as committed                             rc=0 # pass 25 # fail 0
revert release.yml to registry-only                        rc=1 RED on its own case
revert rc-build.yml to registry-only                       rc=1 RED on its own case
loosen release.yml's pinned side                           rc=1 RED
loosen rc-build.yml's pinned side                          rc=1 RED
```

## The release-authority census

`scripts/test-release-workflow-authority.py` pins four literal policy strings out of release.yml so
this comparison cannot be quietly removed, and one of them was the old spelling of the filter. It
now pins the PAIR OF SHAPES Kin's side must accept rather than that spelling, and the pinned side's
strict rule stays pinned separately, so loosening either is still a deliberate edit to that list.
Falsified in place, then restored byte identical:

```
control, the tree as committed:  rc=0
poisoned, release.yml reverted to the registry-only filter:  rc=1, AssertionError on the missing policy
restored: git diff against HEAD on release.yml is empty
```

## Verification

```
node scripts/check-rc-build-drift.mjs                          rc=0, "rc-build.yml mirrors release.yml's build job"
node --test check-kin-vfs-compat.test.mjs + check-rc-build-drift.test.mjs   rc=0, 42 tests, 0 failed
python3 scripts/test-release-workflow-authority.py             rc=0
actionlint on both workflows                                   rc=0
bin/kin-precheck kin --repo-dir kin=<worktree>                 22 gates enumerated, 22 ran, 22 passed, 0 failed
                                                               on kin fc19a79ced9020f7576262d4458c52e37b2387f2, this head
```

Precheck was named by absolute path with `--repo-dir`, so it could not resolve inside the worktree
and exit 126 having graded nothing, and the `N gates enumerated` line is what says it graded
anything at all.
