### PR TITLE
Stop the witness search spending its budget on a class no build can mint (FIR-3541)

### DIFF
--- a/crates/kin-cli/src/commands/absence_qualifier.rs
+++ b/crates/kin-cli/src/commands/absence_qualifier.rs
@@ -102,9 +102,26 @@ pub fn qualify(
     // (FIR-2672), and a class the build could not produce reads `unproduced`
     // rather than `absent`, so the sentence below can say which it was.
     let decided = decided_by(tool, payload, envelope);
+    // `unproduced` carries two reasons and only one of them is about the
+    // linker, so they render as different sentences. A class this build mints
+    // for no language at all has no resolved site to blame, and saying the
+    // source carries sites the linker resolved would be a claim about code this
+    // observation never made.
+    let build_gap = |class: &str| -> bool {
+        observed
+            .and_then(|coverage| coverage.get("unproduced_evidence"))
+            .and_then(|evidence| evidence.get(class))
+            .and_then(|evidence| evidence.get("this_build_mints_no_entity_level_edge_for"))
+            .is_some()
+    };
+    let unminted: Vec<&'static str> = decided
+        .iter()
+        .filter(|class| state_of(class) == Some("unproduced") && build_gap(class))
+        .map(|class| edge_class_noun(class))
+        .collect();
     let unproduced: Vec<&'static str> = decided
         .iter()
-        .filter(|class| state_of(class) == Some("unproduced"))
+        .filter(|class| state_of(class) == Some("unproduced") && !build_gap(class))
         .map(|class| edge_class_noun(class))
         .collect();
     let missing: Vec<&'static str> = decided
@@ -123,7 +140,7 @@ pub fn qualify(
     // is whatever the verdict actually disclosed. This is also the whole of the
     // language-scoped path: `semantic_search` reads no edge class, so its
     // qualifier always renders from the disclosed signals.
-    if missing.is_empty() && unproduced.is_empty() {
+    if missing.is_empty() && unproduced.is_empty() && unminted.is_empty() {
         let subject = absence_subject(tool);
         let disclosed = negative
             .get("degraded_signals")
@@ -181,8 +198,27 @@ pub fn qualify(
             )
         }
     };
-    let short_all: Vec<&str> = unproduced.iter().chain(missing.iter()).copied().collect();
+    let short_all: Vec<&str> = unminted
+        .iter()
+        .chain(unproduced.iter())
+        .chain(missing.iter())
+        .copied()
+        .collect();
     let mut said = Vec::new();
+    if !unminted.is_empty() {
+        let tail = if unproduced.is_empty() && missing.is_empty() {
+            stand_in(&short_all)
+        } else {
+            String::new()
+        };
+        said.push(format!(
+            "{indent}{QUALIFIER_MARK} {subject}: this build mints no entity-level {} edge for \
+             {language} at all, and the graph therefore holds none to find, {}. The gap is in \
+             this build, not in the code.{tail}",
+            unminted.join(" or "),
+            absence_direction(tool)
+        ));
+    }
     if !unproduced.is_empty() {
         let tail = if missing.is_empty() {
             stand_in(&short_all)

--- a/crates/kin-cli/src/commands/impact.rs
+++ b/crates/kin-cli/src/commands/impact.rs
@@ -1221,15 +1221,27 @@ mod tests {
         .expect("impact response");
         let rendered = response.lines.join("\n");
 
+        let build_gap = rendered
+            .find("mints no entity-level import edge for Rust")
+            .unwrap_or_else(|| panic!("the class no build mints must be named: {rendered}"));
         let class_gap = rendered
-            .find("holds no cross-file import or reference edges")
+            .find("holds no cross-file reference edges")
             .unwrap_or_else(|| panic!("the short classes decide and must be named: {rendered}"));
         let worker = rendered.find("embed_worker_failed").unwrap_or_else(|| {
             panic!("the failed worker must stay named beside the class gap: {rendered}")
         });
         assert!(
-            class_gap < worker,
-            "the structural gap leads and the run degradation follows: {rendered}"
+            build_gap < class_gap && class_gap < worker,
+            "the structural gaps lead and the run degradation follows: {rendered}"
+        );
+        // `unproduced` carries two reasons and only one of them is about the
+        // source. This build mints no entity-level import edge for Rust at all,
+        // so there is no resolved site to blame, and rendering the linker's
+        // sentence over this class would be a claim about code the observation
+        // never made.
+        assert!(
+            !rendered.contains("although the source carries"),
+            "a class no build mints has no resolved import site to blame: {rendered}"
         );
     }
 

--- a/crates/kin-mcp/src/edge_coverage.rs
+++ b/crates/kin-mcp/src/edge_coverage.rs
@@ -118,9 +118,17 @@ enum ClassState {
     Absent,
     /// The scan stopped on its budget before it could observe one.
     Unknown,
-    /// The scan completed, observed no entity-rooted edge of this class at all,
-    /// and the language's parse side shows sites of the class that the linker
-    /// resolved into no entity-level edge.
+    /// The class exists in no form this build could have produced for the
+    /// language, for either of two reasons.
+    ///
+    /// One: the scan completed, observed no entity-rooted edge of this class at
+    /// all, and the language's parse side shows sites of the class that the
+    /// linker resolved into no entity-level edge.
+    ///
+    /// Two: this build cannot mint the class for the language at all, which
+    /// [`cannot_mint_entity_level`] reads from the linker. That case needs no
+    /// scan and is not weakened by one that stopped early, so it is decided
+    /// before the states are published rather than inferred from counts.
     ///
     /// Not `Absent`, because `Absent` reads as a completed observation about the
     /// code, and this is a completed observation about the build: the sites are
@@ -327,6 +335,35 @@ pub fn observe_cross_file_reference_coverage_for_languages_witnessed<S: EntitySt
                 *state = ClassState::Unproduced;
                 unproduced_evidence.insert(class_name(*kind).to_string(), evidence);
             }
+        }
+        // The other reason a class reads `unproduced`: this build mints no
+        // entity-level edge of it for one of the languages in scope, which is
+        // decided from the linker rather than from counts. Said in the payload,
+        // because "unproduced" carries two reasons now and a reader acting on
+        // one of them must be able to tell which they have.
+        for (kind, _) in merged
+            .iter()
+            .filter(|(kind, state)| {
+                *state == ClassState::Unproduced
+                    && observed_languages
+                        .iter()
+                        .any(|language| cannot_mint_entity_level(*language, *kind))
+            })
+            .map(|(kind, state)| (*kind, *state))
+            .collect::<Vec<_>>()
+        {
+            let languages: Vec<String> = observed_languages
+                .iter()
+                .filter(|language| cannot_mint_entity_level(**language, kind))
+                .map(|language| format!("{language:?}"))
+                .collect();
+            unproduced_evidence.insert(
+                class_name(kind).to_string(),
+                json!({
+                    "this_build_mints_no_entity_level_edge_for": languages,
+                    "entity_level_import_edges": 0,
+                }),
+            );
         }
     }
 
@@ -918,6 +955,46 @@ pub(crate) mod test_support {
     }
 }
 
+/// Whether this build demonstrably cannot mint an entity-rooted edge of `kind`
+/// for `language`, whatever any repository holds.
+///
+/// A fact about the build, read from the linker rather than assumed here, and
+/// deliberately one-sided: a language is named only where the source proves the
+/// edge impossible, so every language this list does not name is scanned for
+/// exactly as before.
+///
+/// An entity-level `Imports` edge needs two halves, and either can be missing.
+/// First the specifier has to resolve to a file this repository holds:
+/// `resolve_module_path` in `kin_index::linker` sends a Python source file to
+/// `resolve_python_module_import`, joins a `.`-prefixed specifier onto the
+/// importer's directory with extension and index probing, and otherwise tries a
+/// repo-local header, a monorepo package, a Java dotted package and a Go module
+/// path, in that order. Rust `use` paths take none of those branches, which is
+/// why a Rust store reports its import statements parsed and none resolved.
+/// Second, the importing file has to carry a module entity, which
+/// `make_entity_import_relations` uses as the edge's source and
+/// `module_entity_by_file` reads as the first `EntityKind::Module` entity in the
+/// file: the cpp, hcl, javascript, python, rust and typescript adapters emit
+/// one, and go, java, kotlin, php and swift do not, so those five cannot source
+/// the edge however well their specifiers resolve.
+///
+/// `Calls` and `References` are never named here. Calls are minted from call
+/// sites for every language that parses them, and whether a reference edge can
+/// exist is a fact about the language server that `reference_enrichment`
+/// already carries.
+fn cannot_mint_entity_level(language: LanguageId, kind: RelationKind) -> bool {
+    kind == RelationKind::Imports
+        && matches!(
+            language,
+            LanguageId::Rust
+                | LanguageId::Go
+                | LanguageId::Java
+                | LanguageId::Kotlin
+                | LanguageId::Swift
+                | LanguageId::Php
+        )
+}
+
 /// The reference classes among `kinds`, in the order given. Other relation kinds
 /// are dropped: containment and definition edges never cross a file boundary, so
 /// including them would let an intra-file fact stand in for a cross-file one.
@@ -1056,8 +1133,14 @@ fn observe_language<S: EntityStore>(
                     }
                 }
                 for entity in &candidates {
+                    // Only the classes this build could mint for the language
+                    // hold the search open. A class it cannot mint is already
+                    // decided, and waiting for a witness that cannot exist is
+                    // what spent the whole budget and then reported every other
+                    // class unknown.
                     if states
                         .iter()
+                        .filter(|(kind, _)| !cannot_mint_entity_level(language, *kind))
                         .all(|(_, state)| *state == ClassState::Present)
                     {
                         break;
@@ -1128,6 +1211,20 @@ fn observe_language<S: EntityStore>(
             // stays unknown rather than being reported absent from a scan that
             // never ran.
             Err(_) => budget_exhausted = true,
+        }
+    }
+
+    // Decided by the build, not by the scan, so it holds whether or not the
+    // walk above ran at all and whether or not it finished.
+    //
+    // A witness still wins. The table describes what this build's linker mints,
+    // and a graph that demonstrably holds such an edge is reporting what it
+    // holds; overriding an observed `present` here would be a claim about the
+    // graph that the graph itself refutes, which is the failure this module
+    // exists to prevent rather than commit.
+    for (kind, state) in states.iter_mut() {
+        if *state != ClassState::Present && cannot_mint_entity_level(language, *kind) {
+            *state = ClassState::Unproduced;
         }
     }
 
@@ -1251,6 +1348,110 @@ mod tests {
             import_source: None,
             evidence: Vec::new(),
         }
+    }
+
+    /// A class this build cannot mint for the language is decided by the build
+    /// rather than by the scan: it reads `unproduced` with the reason named, it
+    /// no longer holds the search open for a witness that cannot exist, and the
+    /// classes the build CAN mint are observed to the end.
+    ///
+    /// The shape this exists for was measured on a 5,088-entity Rust store: the
+    /// search spent all 4,096 entities of its budget looking for an entity-level
+    /// `Imports` edge the linker has no branch to mint for Rust, reported
+    /// `budget_exhausted`, and left every other class `unknown`, so a
+    /// default-kinds `find_references` was inconclusive on the budget whatever
+    /// the graph held.
+    ///
+    /// Breaking it: stop excluding the class from the search and it reads
+    /// `absent`, a statement about the code, for a class no repository could
+    /// have carried.
+    #[test]
+    fn a_class_this_build_cannot_mint_is_unproduced_and_spends_no_budget() {
+        let store = InMemoryGraph::new();
+        let caller = entity("open_store", "src/engine/open.rs", LanguageId::Rust);
+        let target = entity("read_header", "src/storage/header.rs", LanguageId::Rust);
+        store.upsert_entity(&caller).unwrap();
+        store.upsert_entity(&target).unwrap();
+        store
+            .upsert_relation(&relation(caller.id, target.id, RelationKind::Calls))
+            .unwrap();
+
+        let coverage = observe_cross_file_reference_coverage(
+            &store,
+            &target,
+            &[
+                RelationKind::Calls,
+                RelationKind::Imports,
+                RelationKind::References,
+            ],
+        );
+        assert_eq!(coverage["classes"]["imports"], json!("unproduced"));
+        assert_eq!(coverage["classes"]["calls"], json!("present"));
+        assert_eq!(coverage["budget_exhausted"], json!(false));
+        assert_eq!(
+            coverage["unproduced_evidence"]["imports"]["this_build_mints_no_entity_level_edge_for"],
+            json!(["Rust"]),
+            "the payload says which of the state's two reasons this is: {coverage}"
+        );
+    }
+
+    /// The table is one-sided on purpose. A language this build CAN mint the
+    /// class for is scanned exactly as it was, in both directions: a real
+    /// cross-file import edge still reads `present`, and a graph that merely
+    /// holds none still reads `absent` rather than the build's own gap.
+    ///
+    /// Both arms are here because only the second can catch the table. A
+    /// witness beats the table by design, so naming a language in the table
+    /// leaves the first arm green and proves nothing about it; where no witness
+    /// exists, the table alone decides the answer, and that is the input a
+    /// mutation of the table has to move.
+    #[test]
+    fn a_language_this_build_can_mint_for_is_scanned_as_before() {
+        let store = InMemoryGraph::new();
+        let importer = entity("save_note", "nk/storage.py", LanguageId::Python);
+        let target = entity("parse_note", "nk/parsing.py", LanguageId::Python);
+        store.upsert_entity(&importer).unwrap();
+        store.upsert_entity(&target).unwrap();
+        store
+            .upsert_relation(&relation(importer.id, target.id, RelationKind::Imports))
+            .unwrap();
+
+        let coverage = observe_cross_file_reference_coverage(
+            &store,
+            &target,
+            &[
+                RelationKind::Calls,
+                RelationKind::Imports,
+                RelationKind::References,
+            ],
+        );
+        assert_eq!(coverage["classes"]["imports"], json!("present"));
+        assert_eq!(coverage["unproduced_evidence"]["imports"], json!(null));
+
+        // The arm that can actually catch the table: no witness anywhere, so
+        // nothing beats it to the answer. `absent` is a statement about this
+        // graph, and a language the table does not name keeps it.
+        let bare = InMemoryGraph::new();
+        let caller = entity("save_note", "nk/storage.py", LanguageId::Python);
+        let lonely = entity("parse_note", "nk/parsing.py", LanguageId::Python);
+        let sibling = entity("helper", "nk/storage.py", LanguageId::Python);
+        bare.upsert_entity(&caller).unwrap();
+        bare.upsert_entity(&lonely).unwrap();
+        bare.upsert_entity(&sibling).unwrap();
+        bare.upsert_relation(&relation(caller.id, sibling.id, RelationKind::Calls))
+            .unwrap();
+
+        let coverage = observe_cross_file_reference_coverage(
+            &bare,
+            &lonely,
+            &[RelationKind::Calls, RelationKind::Imports],
+        );
+        assert_eq!(
+            coverage["classes"]["imports"],
+            json!("absent"),
+            "a language the table does not name keeps the graph's own answer: {coverage}"
+        );
+        assert_eq!(coverage["unproduced_evidence"], Value::Null, "{coverage}");
     }
 
     /// The FIR-2353 shape: entities and intra-file edges only. Every requested

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -9209,10 +9209,26 @@ mod tests {
         );
         assert_eq!(response["negative"]["trust"], "inconclusive");
         // And the edge gap LEADS, ahead of the ambient path's own cross-repo
-        // binding gap, because it is the factor that limited this answer.
+        // binding gap, because it is the factor that limited this answer. Of
+        // the two edge clauses the class this build mints for no Rust program
+        // comes first, and the classes the graph simply holds none of still
+        // follow it.
         assert!(
-            trust_reason(&response).starts_with("cross_file_edges_absent"),
+            trust_reason(&response).starts_with("cross_file_edges_unproduced"),
             "{}",
+            trust_reason(&response)
+        );
+        assert!(
+            trust_reason(&response).contains("cross_file_edges_absent"),
+            "the classes the graph holds none of are still named: {}",
+            trust_reason(&response)
+        );
+        // The half that makes the leading clause honest: no build mints that
+        // class here, so there is no resolved site to blame and the sentence
+        // must claim nothing about what the source contains.
+        assert!(
+            !trust_reason(&response).contains("the source carries"),
+            "a class no build mints has no resolved site to blame: {}",
             trust_reason(&response)
         );
     }

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -706,6 +706,35 @@ pub(crate) fn absence_coverage_clauses(tool: &str, payload: &Value) -> Vec<Strin
         let unknown = classes_in_state(&required, states, "unknown");
         let present = classes_in_state(&requested, states, "present");
 
+        // `unproduced` carries two reasons and only one of them is a statement
+        // about the source, so the two take different sentences. A class this
+        // build mints for no language at all has no resolved site to blame, and
+        // telling a reader the linker dropped sites it resolved sends them
+        // hunting a linker bug that is not there.
+        let build_gap = |class: &str| -> bool {
+            coverage
+                .get("unproduced_evidence")
+                .and_then(Value::as_object)
+                .and_then(|evidence| evidence.get(class))
+                .and_then(|evidence| evidence.get("this_build_mints_no_entity_level_edge_for"))
+                .is_some()
+        };
+        let (unminted, unproduced): (Vec<&str>, Vec<&str>) =
+            unproduced.into_iter().partition(|class| build_gap(class));
+
+        if !unminted.is_empty() {
+            // The build, and not this graph either. The class is one this build
+            // mints for none of the languages in scope, decided from the linker
+            // before any scanning, so the absence says nothing about what the
+            // source contains and the sentence must not pretend otherwise.
+            let missing = unminted.join(", ");
+            gaps.push(format!(
+                "cross_file_edges_unproduced: this build mints no entity-level {missing} edge \
+                 for {language} at all, so no graph it builds holds one and a use that reaches \
+                 the target through {missing} could not have been found whatever the source \
+                 contains, and the gap is in this build, not in the code"
+            ));
+        }
         if !unproduced.is_empty() {
             // The build, not the code. The scan completed, saw no entity-rooted
             // edge of the class at all, and the parse side shows sites the

--- a/crates/kin-mcp/src/verdict.rs
+++ b/crates/kin-mcp/src/verdict.rs
@@ -642,13 +642,41 @@ fn edge_coverage_reading(tool: &str, payload: &Value) -> Reading {
     };
     let unproduced = in_state("unproduced");
     if !unproduced.is_empty() {
-        let missing = unproduced.join(", ");
-        return Reading::Inconclusive(vec![format!(
-            "cross_file_edges_unproduced: this build produced no entity-level {missing} edge for \
-             {language} although the source carries {missing} sites the linker resolved, so a \
-             use that reaches the target through {missing} could not have been found, and the gap \
-             is in the linker, not in the code"
-        )]);
+        // `unproduced` carries two reasons and only one of them is a statement
+        // about the source, so they take different sentences here exactly as
+        // they do in the absence gate. A class this build mints for no language
+        // at all has no resolved site to blame, and the older sentence would
+        // send a reader hunting a linker bug that is not there.
+        let build_gap = |class: &str| -> bool {
+            coverage
+                .get("unproduced_evidence")
+                .and_then(Value::as_object)
+                .and_then(|evidence| evidence.get(class))
+                .and_then(|evidence| evidence.get("this_build_mints_no_entity_level_edge_for"))
+                .is_some()
+        };
+        let (unminted, unproduced): (Vec<&str>, Vec<&str>) =
+            unproduced.into_iter().partition(|class| build_gap(class));
+        let mut clauses = Vec::new();
+        if !unminted.is_empty() {
+            let missing = unminted.join(", ");
+            clauses.push(format!(
+                "cross_file_edges_unproduced: this build mints no entity-level {missing} edge \
+                 for {language} at all, so no graph it builds holds one and a use that reaches \
+                 the target through {missing} could not have been found whatever the source \
+                 contains, and the gap is in this build, not in the code"
+            ));
+        }
+        if !unproduced.is_empty() {
+            let missing = unproduced.join(", ");
+            clauses.push(format!(
+                "cross_file_edges_unproduced: this build produced no entity-level {missing} edge \
+                 for {language} although the source carries {missing} sites the linker resolved, \
+                 so a use that reaches the target through {missing} could not have been found, \
+                 and the gap is in the linker, not in the code"
+            ));
+        }
+        return Reading::Inconclusive(clauses);
     }
     let absent = in_state("absent");
     if !absent.is_empty() {
@@ -1918,6 +1946,62 @@ mod tests {
         assert!(
             seen > 0,
             "no clause was produced by any shape, so this asserted nothing"
+        );
+    }
+
+    /// `unproduced` carries two reasons, and this reading says which one it has.
+    ///
+    /// The state was minted for a linker that resolved import sites and emitted
+    /// no entity-level edge for any of them. A class this build mints for no
+    /// language at all arrives at the same state by a different road, and the
+    /// sentence written for the first is false for the second: there are no
+    /// resolved sites to blame, and a reader who believes there are goes hunting
+    /// a linker bug that is not there. Both arms run, because a split that only
+    /// ever renders one of its branches is not a split, and the payload's own
+    /// evidence is what decides which arm this is rather than the language name.
+    #[test]
+    fn the_reading_says_which_of_the_two_reasons_unproduced_carries() {
+        let mut payload = populated_reference_payload("unproduced");
+        payload["edge_coverage"]["language"] = json!("Rust");
+
+        let Reading::Inconclusive(linker) = edge_coverage_reading("find_references", &payload)
+        else {
+            panic!("an unproduced class bounds the answer: {payload}");
+        };
+        assert!(
+            linker
+                .iter()
+                .any(|clause| clause.contains("although the source carries")),
+            "with nothing saying the build mints none, the linker sentence stands: {linker:?}"
+        );
+
+        payload["edge_coverage"]["unproduced_evidence"] = json!({
+            "imports": {
+                "this_build_mints_no_entity_level_edge_for": ["Rust"],
+                "entity_level_import_edges": 0,
+            }
+        });
+        let Reading::Inconclusive(build) = edge_coverage_reading("find_references", &payload)
+        else {
+            panic!("the class still bounds the answer: {payload}");
+        };
+        assert!(
+            build
+                .iter()
+                .any(|clause| clause.contains("mints no entity-level imports edge for Rust at all")),
+            "the build gap gets its own words: {build:?}"
+        );
+        assert!(
+            !build
+                .iter()
+                .any(|clause| clause.contains("the source carries")),
+            "a class no build mints has no resolved site to blame: {build:?}"
+        );
+        assert!(
+            build
+                .iter()
+                .all(|clause| clause.starts_with("cross_file_edges_unproduced:")),
+            "the label is what a consumer keys on and it does not change: {build:?}"
         );
     }
 


### PR DESCRIPTION
The cross-file witness search no longer spends its budget looking for a class this build cannot mint for the
language, so it finishes, says which class that is and why, and observes the classes that can exist to the end.

## What was wrong

The search looks for one entity-rooted cross-file edge of every requested class and stops when it has found them
all or examined 4,096 entities (`WITNESS_BUDGET`). A class this build cannot mint for the language has no witness
to find, so the search ran to the budget, reported `budget_exhausted`, and left every other class `unknown`.

Measured on a 5,088-entity Rust store (72 files, 56,915 relations): `find_references` asked with its default kinds
returned the exact caller sets the graph holds and read `inconclusive`, limited by `edge_coverage_unknown` and
`edge_coverage_budget_exhausted`, while the same questions asked for calls only certified. The imports class it
was hunting cannot exist for Rust at all.

## What changes

The search change is `crates/kin-mcp/src/edge_coverage.rs`. Three more files carry the sentence the new case
needs: `crates/kin-mcp/src/negative.rs`, `crates/kin-mcp/src/verdict.rs` and
`crates/kin-cli/src/commands/absence_qualifier.rs`.

- `cannot_mint_entity_level(language, kind)` names, from the linker rather than from memory, the cases where this
  build mints no entity-rooted edge of a class for a language. An entity-level `Imports` edge needs two halves:
  the specifier must resolve to a file this repository holds, which `resolve_module_path` cannot do for Rust
  `use` paths, and the importing file must carry a module entity, which `make_entity_import_relations` uses as the
  edge's source and which the go, java, kotlin, php and swift adapters never emit. Those six languages are named
  for `Imports`, and nothing else is: the table is one-sided, so every language it does not name is scanned
  exactly as before. `Calls` and `References` are never named, because calls are minted wherever call sites parse
  and reference edges are a fact about the language server that `reference_enrichment` already carries.
- The scan's early exit ignores such a class, so it stops holding the search open for a witness that cannot exist.
- Such a class is set to `unproduced` after the walk, decided by the build rather than inferred from counts, which
  matters because the evidence path refuses that state whenever a scan stopped on its budget.
- The payload's `unproduced_evidence` says which of the state's two reasons applies and lists the languages, so a
  reader acting on "the gap is in the build" can tell a linker that emitted nothing for real sites from a build
  that mints the class for no language at all.
- The three places that render `unproduced` stop sharing one sentence, because the state now carries two reasons.
  The existing words say the source carries sites the linker resolved, which is true of a linker that dropped
  resolved sites and false of a class no build mints, and reusing them would send a reader hunting a linker bug
  that is not there. The absence gate, the CLI qualifier and the reading behind `limiting_factor` each branch on
  the evidence key beside the state and give the build-cannot-mint case its own words, which claim nothing about
  what the source contains. All three keep the `cross_file_edges_unproduced` label, so a consumer keying on the
  clause still works. The two fixtures that pinned the old wording keep every assertion they had and each gained
  one that the false sentence is gone, and the reading gains a test that drives it both ways off one payload,
  with the evidence and without it, because that branch had no test of its own and a split that only ever renders
  one of its branches is not a split.

## What this does not change

The verdict. `unproduced` already bounds an answer and `deciding_classes` is untouched, so a Rust default-kinds
`find_references` stays inconclusive; it now names the build gap instead of the budget. Whether a class no build
can mint should bound a default-kinds answer at all is a separate product question, raised with the captain and
carried to the founder rather than decided here. FIR-2672's rule that every requested class decides stands.

## Census of the sentence

The first two copies of the reused sentence were found by test panics, which is a search that stops as soon as a
fixture happens to cover a line. Grepping for the sentence itself found a third, in the reading that becomes
`limiting_factor`, plus a fixture in kin-daemon that pins the old wording and that a kin-mcp and kin-cli run does
not grade at all. That daemon fixture needs no change and is the control: its graph is Python
(`src/a.py`, `src/b.py`, `src/orphan.py`), the table names Python for nothing, so its imports class stays
`absent` and the line it pins still renders word for word. A change that altered it would have been a change
reaching a language the linker evidence never implicated. Three source copies, one fixture to update and one that
must stay green, found by the search rather than by whichever test happened to fail:

```
$ git grep -n "mints no entity-level" -- crates        # the new sentence, once per renderer
crates/kin-cli/src/commands/absence_qualifier.rs:215:            "{indent}{QUALIFIER_MARK} {subject}: this build mints no entity-level {} edge for \
crates/kin-mcp/src/negative.rs:732:                "cross_file_edges_unproduced: this build mints no entity-level {missing} edge \
crates/kin-mcp/src/verdict.rs:664:                "cross_file_edges_unproduced: this build mints no entity-level {missing} edge \

$ git grep -n "although the source carries" -- crates  # the old sentence, kept for the case it was written for
crates/kin-cli/src/commands/absence_qualifier.rs:230:             {language} although the source carries {} sites, {}. The gap is in the linker, \
crates/kin-mcp/src/negative.rs:746:                 for {language} although the source carries {missing} sites the linker \
crates/kin-mcp/src/verdict.rs:674:                 for {language} although the source carries {missing} sites the linker resolved, \

$ git grep -n "holds no cross-file import or reference edges" -- crates   # the control, untouched
crates/kin-daemon/src/api.rs:32972:            .find("holds no cross-file import or reference edges")
```

Three renderers, each now carrying both sentences and choosing between them on the payload's evidence rather than
on the state alone. The greps also match doc comments and the test assertions, both trimmed here for width; the
assertions are `impact.rs:1243`, `verdict.rs:1974` and `verdict.rs:1991`, which pin each sentence to its own case.

## Measurement

One store, two builds, same questions. The store is the 5,088-entity Rust clone (72 files, 56,915 relations).
Before is `bin-sc`, release bytes carrying the search exactly as it was; after is `bin-wb`, release bytes of this
tree. The sweep is off in both, so no read is taken while relations are installing, and no memory pressure is
forced. Ids 11 to 14 are `find_references` with its default kinds; 22 and 23 are the same questions asked for
calls only, as the control.

The verdict state does not move. All four default-kinds reads were `inconclusive` before and are `inconclusive`
after. What changes is which sentence a reader acts on:

```
before  limiting_factor=edge_coverage_unknown: whether the graph holds cross-file calls, imports, references
        edges for Rust could not be established, so an empty result may mean the query had no edges to answer
        from rather than that the target is unused; [...] edge_coverage_budget_exhausted: the coverage scan for
        Rust stopped before it could establish what the graph holds

after   limiting_factor=cross_file_edges_unproduced: this build mints no entity-level imports edge for Rust at
        all, so no graph it builds holds one and a use that reaches the target through imports could not have
        been found whatever the source contains, and the gap is in this build, not in the code; [...]
        substrate_partial: the coverage classes this answer depended on [...]
```

The budget clause is not reworded, it is gone: the scan no longer spends 4,096 entities hunting a witness that
cannot exist, so it never reports stopping early. The answer now names the build gap that was always the real
reason.

The control holds. Ids 22 and 23, asked for calls only, read `certified` before and `certified` after, so the
path that could always certify still does and this change did not buy its honesty by refusing more.

The release bytes above were built from this tree before its final test edit, which lives inside
`#[cfg(test)] mod tests` (the module opens at `edge_coverage.rs:1301`) and so cannot enter a release binary.
Every gate that reads source, formatting included, was re-run after that edit.

Both arms were taken at base `919f7ede1`, the same tree with and without this change, so the difference above is
this change and nothing else. The branch was then rebased onto `29c10ff04`, 398 commits later, with no conflicts,
and the full three-crate grade, the five arms and precheck were re-run green on the rebased head. The baseline was
not rebuilt at the new base on purpose: a second A/B there would isolate this change no better than the one above
and would cost the shared builders two full release builds.

## Tests and falsification

`cargo nextest run -p kin-mcp -p kin-cli -p kin-daemon`, through the fleet's builder slot on this tree:

```
     Summary [1161.924s] 6094 tests run: 6094 passed (60 slow, 5 leaky), 6 skipped
```

kin-daemon is graded rather than assumed, because the change reaches it: `verdict.rs` composes the factor the
daemon renders, and api.rs carries a fixture that pins the old wording.

That grade and the arms below ran with this change applied at base `29c10ff04`. Main moved 379 commits under it
in the next twenty minutes, so the branch was rebased again and precheck re-run on the final head; the diff is
byte for byte the same across both rebases, neither had a conflict, and the lint gate compiles the workspace and
its tests, so the final head is proven to build against current main. Behaviour over the whole workspace is
hosted CI's call, which is the gate of record for it.

New, in `edge_coverage`: `a_class_this_build_cannot_mint_is_unproduced_and_spends_no_budget` pins that the class
reads `unproduced`, that the scan spends no budget on it and that the evidence names the reason;
`a_language_this_build_can_mint_for_is_scanned_as_before` is the control over a graph that HOLDS the edge, so a
table that grew a language it should not have goes red.

New, in `verdict`: `the_reading_says_which_of_the_two_reasons_unproduced_carries` drives the reading twice off one
payload, once without `unproduced_evidence` and once with it, because the branch had no test and a split that only
ever renders one side is not a split.

Updated, each keeping every assertion it had and gaining one that the false sentence is gone:
`handlers::entities::find_references_on_an_intra_file_only_graph_refuses_to_certify_absence` and
`commands::impact::a_short_graph_on_a_degraded_daemon_renders_both_reasons`.

Untouched, and the control that the table is one-sided: `api::a_degraded_daemon_with_short_coverage_renders_both_reasons`
in kin-daemon pins the old wording over a Python graph. The table names Python for nothing, so that fixture has to
keep rendering the old sentence word for word, and it does.

Each arm swaps one exact string in one file, runs the tests that pin the behaviour it breaks, expects the named
ones to FAIL, restores the file and checks its sha256. The script is
`.kin-coord/measure/enrichverdict-20260911/falsify-witness.py`.

```
X1 RED (the table claims every language can mint every class)
     failed [a_class_this_build_cannot_mint_is_unproduced_and_spends_no_budget]
     at crates/kin-mcp/src/edge_coverage.rs:1388:9
X2 RED (the table names a language that demonstrably can mint the class)
     failed [a_language_this_build_can_mint_for_is_scanned_as_before]
     at crates/kin-mcp/src/edge_coverage.rs:1450:9
X3 RED (the verdict clause stops splitting the two reasons `unproduced` carries)
     failed [find_references_on_an_intra_file_only_graph_refuses_to_certify_absence]
     at crates/kin-mcp/src/handlers/entities.rs:9229:9
X4 RED (the CLI rendering stops splitting them and reads the linker sentence over both)
     failed [a_short_graph_on_a_degraded_daemon_renders_both_reasons]
     at crates/kin-cli/src/commands/impact.rs:1226:32
X5 RED (the reading behind limiting_factor stops splitting the two reasons)
     failed [the_reading_says_which_of_the_two_reasons_unproduced_carries]
     at crates/kin-mcp/src/verdict.rs:1988:9
```

X2 survived the first time it ran, and that is worth the paragraph. It names Python in the table and expected the
one-sidedness control to go red. It did not, because that control's Python graph HOLDS a cross-file import edge,
so the witness rule sets the class `present` before the table is ever consulted and naming a language changes
nothing on that input. The second defence was catching it one step earlier. The control's own doc comment claimed
that arm would break it, which was false and written before the witness rule existed. The answer was a new input
rather than a weakened guard: the control gained a second arm over a Python graph with NO cross-file import edge,
where the table alone decides the answer, and the comment now says which arm can catch what. Nothing was deleted
to make an arm go red.

The budget half is not falsifiable in a unit fixture, because a two-entity store never reaches a 4,096-entity
budget. It is evidenced by the before-and-after run on the 5,088-entity store above, where the
`edge_coverage_budget_exhausted` clause is present before and absent after.

## Local gates

`bin/kin-precheck kin`, which reads the gate list out of this repo's own ci.yml check job rather than a
remembered copy, on the head this PR carries:

```
kin-precheck: behind origin/main 0 commit(s)
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin dc06080fe886b909a5dfcc158ea2b817ed76b291
```

It refused twice before this, both times correctly, and both refusals are the reason the run above is worth
reading. Exit 2 means a gate could not run and prints no tally at all, which looks exactly like a pass to anything
counting failures; it said the tree was 398, then 379 commits behind main, so the gate list it would have read is
not the one this PR is judged against. That was not a formality: `ci.yml` really had changed over that range, by
150 lines from the first base and 18 from the second, adding a Windows library leg and raising a resolver's
minimum count. Raising the limit with `--max-behind` would have graded this PR against a check job that no longer
exists, so the branch was rebased instead, twice, and the tally above is from a head level with main.

Ticket: follow-up to FIR-3541.
