### PR TITLE
Let the release-intent gate accept independently versioned crates

### DIFF
--- a/scripts/release-intent.mjs
+++ b/scripts/release-intent.mjs
@@ -88,6 +88,103 @@ function readManifestVersion(text) {
   throw new Error(`could not read [workspace.package]/[package] version from manifest`);
 }
 
+// Every path listed under the root manifest's `[workspace]` `members` array,
+// read from manifest TEXT. Pure, so it is reachable from a test without a
+// filesystem; only readLocalMemberVersions() below turns a member path into a
+// file read. The real root manifest opens the array with a comment line,
+// which contains no quotes and is skipped for free.
+export function readWorkspaceMembers(text) {
+  const members = [];
+  let section = '';
+  let inMembers = false;
+  for (const raw of text.split('\n')) {
+    const line = raw.trim();
+    if (line.startsWith('[') && line.endsWith(']') && !inMembers) {
+      section = line;
+      continue;
+    }
+    if (section !== '[workspace]') continue;
+    if (inMembers) {
+      const closeAt = line.indexOf(']');
+      const segment = closeAt === -1 ? line : line.slice(0, closeAt);
+      for (const m of segment.matchAll(/"([^"]+)"/g)) members.push(m[1]);
+      if (closeAt !== -1) inMembers = false;
+      continue;
+    }
+    const opening = line.match(/^members\s*=\s*\[(.*)$/);
+    if (!opening) continue;
+    inMembers = true;
+    const closeAt = opening[1].indexOf(']');
+    const segment = closeAt === -1 ? opening[1] : opening[1].slice(0, closeAt);
+    for (const m of segment.matchAll(/"([^"]+)"/g)) members.push(m[1]);
+    if (closeAt !== -1) inMembers = false;
+  }
+  return members;
+}
+
+// A member manifest's own package identity: its name, and its own version
+// ONLY when the member declares one explicitly (`version = "x"` under
+// `[package]`). A member that inherits `version.workspace = true`, or
+// declares neither, reports `explicitVersion: null` so the caller falls back
+// to the workspace version. Pure, same reason as readWorkspaceMembers.
+export function readPackageIdentity(text) {
+  let section = '';
+  let name = null;
+  let explicitVersion = null;
+  for (const raw of text.split('\n')) {
+    const line = raw.trim();
+    if (line.startsWith('[') && line.endsWith(']')) {
+      section = line;
+      continue;
+    }
+    if (section !== '[package]') continue;
+    const nameMatch = line.match(/^name\s*=\s*"([^"]+)"/);
+    if (nameMatch) {
+      name = nameMatch[1];
+      continue;
+    }
+    if (/^version\.workspace\s*=\s*true/.test(line)) continue;
+    const versionMatch = line.match(/^version\s*=\s*"([^"]+)"/);
+    if (versionMatch) explicitVersion = versionMatch[1];
+  }
+  return { name, explicitVersion };
+}
+
+// The version a local Cargo.lock entry must carry: its own manifest's version
+// when the workspace member that produced it declares one explicitly, the
+// workspace version otherwise. `memberVersions` is name -> explicit version,
+// built by walking the `[workspace]` members list rather than any list of
+// names kept here, because kin#1747 made kin-blobs, kin-model, kin-search and
+// kin-vector independently versioned by that rule alone, and every crate
+// after them (kin-infer, kin-lsp, kin-vfs-core, kin-db as of this writing)
+// must be covered without editing this file again.
+export function expectedLocalVersion(name, memberVersions, workspaceVersion) {
+  const explicit = memberVersions.get(name);
+  if (explicit != null) return { expected: explicit, independent: true };
+  return { expected: workspaceVersion, independent: false };
+}
+
+// Read every workspace member's own version declaration off disk, keyed by
+// package name. A member whose manifest cannot be read is silently absent
+// from the map rather than a failure here: expectedLocalVersion() then falls
+// back to the workspace version for it, which is the pre-kin#1747 behaviour
+// and keeps a member with no on-disk manifest (a minimal test fixture, a
+// member removed mid-history) from failing a check it was never the subject
+// of.
+async function readLocalMemberVersions(manifestPath, manifestText) {
+  const lastSlash = manifestPath.lastIndexOf('/');
+  const root = lastSlash === -1 ? '' : manifestPath.slice(0, lastSlash + 1);
+  const members = readWorkspaceMembers(manifestText);
+  const versions = new Map();
+  for (const member of members) {
+    const text = await readFileOrNull(`${root}${member}/Cargo.toml`);
+    if (text === null) continue;
+    const { name, explicitVersion } = readPackageIdentity(text);
+    if (name && explicitVersion != null) versions.set(name, explicitVersion);
+  }
+  return versions;
+}
+
 // Is a changed path something a release actually ships?
 //
 // This mirrors `classifyPath` in scripts/check-release-version.mjs and is a
@@ -282,6 +379,7 @@ async function main() {
   const version = readManifestVersion(manifestText);
   const tag = `v${version}`;
   const isPrerelease = version.includes('-');
+  const memberVersions = await readLocalMemberVersions(opts.manifest, manifestText);
 
   const failures = [];
   const warnings = [];
@@ -303,10 +401,14 @@ async function main() {
   }
   const npmVersion = npmVersions.map((n) => `${n.manifest.split('/').slice(-2, -1)[0] ?? n.manifest}@${n.version ?? '<missing>'}`).join(', ');
 
-  // 1b. Cargo's explicit internal path-version pin and every local Kin
-  // workspace entry in Cargo.lock must move with the workspace version. A
-  // global text replacement is forbidden: third-party packages such as
-  // async-stream can legitimately have the same numeric version.
+  // 1b. Cargo's explicit internal path-version pin always moves with the
+  // workspace version (kin-spine has no independent version of its own).
+  // Every local Kin workspace entry in Cargo.lock moves with EITHER the
+  // workspace version or its own manifest's version, decided by
+  // expectedLocalVersion() from what that member's own Cargo.toml declares,
+  // never by name or a remembered list. A global text replacement is
+  // forbidden: third-party packages such as async-stream can legitimately
+  // have the same numeric version.
   const cliManifestPath = 'crates/kin-cli/Cargo.toml';
   const cliManifest = await readFileOrNull(cliManifestPath);
   const spinePin = cliManifest?.match(
@@ -329,10 +431,13 @@ async function main() {
       const name = block.match(/^name = "([^"]+)"/m)?.[1] ?? null;
       const locked = block.match(/^version = "([^"]+)"/m)?.[1] ?? null;
       if (!name?.startsWith('kin-')) continue;
-      localLockVersions.push({ name, version: locked });
-      if (locked !== version) {
+      const { expected, independent } = expectedLocalVersion(name, memberVersions, version);
+      localLockVersions.push({ name, version: locked, independent });
+      if (locked !== expected) {
         failures.push(
-          `${cargoLockPath} local package ${name} is ${locked ?? '<missing>'}, workspace is ${version}`,
+          independent
+            ? `${cargoLockPath} local package ${name} is ${locked ?? '<missing>'}, its own manifest is ${expected}`
+            : `${cargoLockPath} local package ${name} is ${locked ?? '<missing>'}, workspace is ${expected}`,
         );
       }
     }
@@ -340,10 +445,15 @@ async function main() {
       failures.push(`${cargoLockPath} has no local Kin workspace packages`);
     }
   }
+  const independentLockCount = localLockVersions.filter((v) => v.independent).length;
+  const workspaceLockCount = localLockVersions.length - independentLockCount;
 
-  // 1c. The fuzz workspace resolves kin-parser by path, so its lockfile carries
-  // the workspace version as well. A stale entry only surfaces in the fuzz job's
-  // --locked resolution, which runs after the release commit already exists.
+  // 1c. The fuzz workspace resolves kin-parser by path, so its lockfile
+  // carries whatever version kin-parser's own manifest calls for, by the same
+  // rule as 1b (the workspace version today; kin-parser's own version the day
+  // it is published independently too). A stale entry only surfaces in the
+  // fuzz job's --locked resolution, which runs after the release commit
+  // already exists.
   const fuzzLockPath = 'fuzz/Cargo.lock';
   const fuzzLock = await readFileOrNull(fuzzLockPath);
   if (fuzzLock === null) {
@@ -356,9 +466,12 @@ async function main() {
       const locked = block.match(/^version = "([^"]+)"/m)?.[1] ?? null;
       if (name !== 'kin-parser') continue;
       fuzzLocal += 1;
-      if (locked !== version) {
+      const { expected, independent } = expectedLocalVersion(name, memberVersions, version);
+      if (locked !== expected) {
         failures.push(
-          `${fuzzLockPath} local package ${name} is ${locked ?? '<missing>'}, workspace is ${version}`,
+          independent
+            ? `${fuzzLockPath} local package ${name} is ${locked ?? '<missing>'}, its own manifest is ${expected}`
+            : `${fuzzLockPath} local package ${name} is ${locked ?? '<missing>'}, workspace is ${expected}`,
         );
       }
     }
@@ -407,7 +520,7 @@ async function main() {
     console.log(`  workspace version : ${version}`);
     console.log(`  npm packages      : ${npmVersion || '<missing>'}`);
     console.log(`  kin-spine pin     : ${spinePin ?? '<missing>'}`);
-    console.log(`  local lock entries: ${localLockVersions.length}`);
+    console.log(`  local lock entries: ${localLockVersions.length} (${workspaceLockCount} workspace-versioned, ${independentLockCount} independent)`);
     console.log(`  changelog section : ${hasChangelog ? 'present' : 'absent'}`);
     console.log(`  newest tag        : ${newest ?? '<none>'}`);
     console.log(`  tag ${tag}${' '.repeat(Math.max(0, 13 - tag.length))}: ${tagExists ? 'exists' : 'absent'}`);

--- a/scripts/release-intent.test.mjs
+++ b/scripts/release-intent.test.mjs
@@ -11,7 +11,13 @@ import './resolve-release-intent.test.mjs';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
-import { classifyPath as intentClassifyPath, decideReleaseIntent } from './release-intent.mjs';
+import {
+  classifyPath as intentClassifyPath,
+  decideReleaseIntent,
+  readWorkspaceMembers,
+  readPackageIdentity,
+  expectedLocalVersion,
+} from './release-intent.mjs';
 import { classifyPath as versionClassifyPath } from './check-release-version.mjs';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -86,6 +92,97 @@ test('a stranded release outranks an out-of-sync surface in the report', () => {
   });
   assert.equal(verdict.stranded, true);
   assert.equal(verdict.exitCode, 1);
+});
+
+// --------------------------------------------------------------------------
+// Independent-vs-workspace local package versions (kin#1747).
+//
+// kin-blobs, kin-model, kin-search and kin-vector became workspace members
+// with their OWN `version = "x"` instead of `version.workspace = true`, so a
+// Cargo.lock entry for one of them legitimately disagrees with the workspace
+// version. These three functions are the pure core of telling the two kinds
+// of local package apart; the fixture-backed tests further down exercise them
+// through the full CLI the way the mint actually invokes it.
+// --------------------------------------------------------------------------
+
+test('readWorkspaceMembers reads a multi-line array with a leading comment', () => {
+  const text = [
+    '[workspace]',
+    'resolver = "2"',
+    'members = [',
+    '    # Kin libraries, developed here and published as independent packages.',
+    '    "crates/kin-blobs",',
+    '    "crates/kin-model",',
+    '    "tests/integration",',
+    ']',
+    '',
+    '[workspace.package]',
+    'version = "0.7.16"',
+  ].join('\n');
+  assert.deepEqual(readWorkspaceMembers(text), [
+    'crates/kin-blobs',
+    'crates/kin-model',
+    'tests/integration',
+  ]);
+});
+
+test('readWorkspaceMembers reads a single-line array', () => {
+  const text = '[workspace]\nmembers = ["crates/a", "crates/b"]\n\n[workspace.package]\nversion = "1.0.0"\n';
+  assert.deepEqual(readWorkspaceMembers(text), ['crates/a', 'crates/b']);
+});
+
+test('readWorkspaceMembers returns nothing for a manifest with no [workspace] members', () => {
+  // The shape of the minimal fixtures below (`releasedRepository`): only
+  // `[workspace.package]`, no `[workspace]` at all. The gate must fall back
+  // to comparing every local package against the workspace version, exactly
+  // as it did before kin#1747, rather than treat an absent list as zero
+  // members and refuse to compare anything.
+  assert.deepEqual(readWorkspaceMembers('[workspace.package]\nversion = "1.2.3"\n'), []);
+});
+
+test('readPackageIdentity reports an explicit version', () => {
+  assert.deepEqual(
+    readPackageIdentity('[package]\nname = "kin-blobs"\nversion = "0.1.5"\nedition = "2021"\n'),
+    { name: 'kin-blobs', explicitVersion: '0.1.5' },
+  );
+});
+
+test('readPackageIdentity reports no explicit version for version.workspace = true', () => {
+  assert.deepEqual(
+    readPackageIdentity('[package]\nname = "kin-core"\nversion.workspace = true\n'),
+    { name: 'kin-core', explicitVersion: null },
+  );
+});
+
+test('readPackageIdentity ignores fields outside [package]', () => {
+  // A dependency section can carry its own inline `version = "x"` for an
+  // unrelated crate; only a version line inside this manifest's OWN
+  // [package] table describes this package's identity.
+  const text = [
+    '[package]',
+    'name = "kin-cli"',
+    'version.workspace = true',
+    '',
+    '[dependencies]',
+    'kin-spine = { path = "../kin-spine", version = "9.9.9" }',
+  ].join('\n');
+  assert.deepEqual(readPackageIdentity(text), { name: 'kin-cli', explicitVersion: null });
+});
+
+test('expectedLocalVersion prefers an independent member\'s own version', () => {
+  const members = new Map([['kin-blobs', '0.1.5']]);
+  assert.deepEqual(expectedLocalVersion('kin-blobs', members, '0.7.16'), {
+    expected: '0.1.5',
+    independent: true,
+  });
+});
+
+test('expectedLocalVersion falls back to the workspace version for an unlisted or workspace-versioned member', () => {
+  const members = new Map([['kin-blobs', '0.1.5']]);
+  assert.deepEqual(expectedLocalVersion('kin-core', members, '0.7.16'), {
+    expected: '0.7.16',
+    independent: false,
+  });
 });
 
 // --------------------------------------------------------------------------
@@ -306,5 +403,200 @@ test('the gate runs from a copy reached through a symlinked directory', () => {
     fs.readFileSync(outputs, 'utf8'),
     /should_tag=/,
     'the gate wrote no outputs, so the mint would read an empty tag',
+  );
+});
+
+// --------------------------------------------------------------------------
+// The gate against a workspace shaped like today's real one: a `[workspace]`
+// members list where some crates carry their own explicit version (kin-blobs,
+// as of kin#1747) and some inherit the workspace version (kin-core). This is
+// the shape `releasedRepository()` above predates, so it stays as a separate
+// fixture rather than a change to that one, and every test above keeps
+// passing against a manifest with no `[workspace]` members list at all.
+// --------------------------------------------------------------------------
+
+function workspaceCargoToml(version, members) {
+  const list = members.map((m) => `    "${m}",`).join('\n');
+  return `[workspace]\nmembers = [\n${list}\n]\n\n[workspace.package]\nversion = "${version}"\n`;
+}
+
+// Bump every release surface a real release commit touches EXCEPT Cargo.lock
+// and fuzz/Cargo.lock, which each test below writes itself since those two
+// are what is under test.
+function bumpCommonReleaseSurfaces(root, version, previousVersion) {
+  write(
+    root,
+    'crates/kin-cli/Cargo.toml',
+    `[dependencies]\nkin-spine = { path = "../kin-spine", version = "${version}" }\n`,
+  );
+  write(
+    root,
+    'CHANGELOG.md',
+    `## [${version}]\n\n- next\n\n## [${previousVersion}]\n\n- released\n`,
+  );
+  for (const pkg of ['kin-mcp', 'kin', 'boundary-contracts']) {
+    write(root, `packages/${pkg}/package.json`, JSON.stringify({ version }, null, 2));
+  }
+}
+
+function releasedWorkspaceRepository(version = '1.2.3') {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-intent-workspace-'));
+  git(root, ['init', '--quiet', '--initial-branch=main']);
+  git(root, ['config', 'user.name', 'Test']);
+  git(root, ['config', 'user.email', 'test@example.invalid']);
+  write(root, 'Cargo.toml', workspaceCargoToml(version, ['crates/kin-core', 'crates/kin-blobs']));
+  write(root, 'crates/kin-core/Cargo.toml', '[package]\nname = "kin-core"\nversion.workspace = true\n');
+  write(root, 'crates/kin-blobs/Cargo.toml', '[package]\nname = "kin-blobs"\nversion = "0.1.5"\n');
+  write(
+    root,
+    'Cargo.lock',
+    `[[package]]\nname = "kin-core"\nversion = "${version}"\n\n[[package]]\nname = "kin-blobs"\nversion = "0.1.5"\n`,
+  );
+  write(root, 'fuzz/Cargo.lock', `[[package]]\nname = "kin-parser"\nversion = "${version}"\n`);
+  write(
+    root,
+    'crates/kin-cli/Cargo.toml',
+    `[dependencies]\nkin-spine = { path = "../kin-spine", version = "${version}" }\n`,
+  );
+  write(root, 'CHANGELOG.md', `## [${version}]\n\n- released\n`);
+  for (const pkg of ['kin-mcp', 'kin', 'boundary-contracts']) {
+    write(root, `packages/${pkg}/package.json`, JSON.stringify({ version }, null, 2));
+  }
+  git(root, ['add', '-A']);
+  git(root, ['commit', '--quiet', '-m', `Release Kin v${version}`]);
+  git(root, ['tag', `v${version}`]);
+  return root;
+}
+
+test('the local lock entries summary counts workspace-versioned and independent members apart', () => {
+  const root = releasedWorkspaceRepository();
+  const run = runGateAsMintDoes(root);
+  assert.match(run.stdout, /local lock entries: 2 \(1 workspace-versioned, 1 independent\)/);
+});
+
+test('an independently versioned member keeps its own version through a workspace bump', () => {
+  // This is the exact kin#1750 failure: kin-blobs stays at 0.1.5 while the
+  // workspace moves to 1.2.4, and that must be accepted, not refused.
+  const root = releasedWorkspaceRepository();
+  write(root, 'Cargo.toml', workspaceCargoToml('1.2.4', ['crates/kin-core', 'crates/kin-blobs']));
+  write(
+    root,
+    'Cargo.lock',
+    '[[package]]\nname = "kin-core"\nversion = "1.2.4"\n\n[[package]]\nname = "kin-blobs"\nversion = "0.1.5"\n',
+  );
+  write(root, 'fuzz/Cargo.lock', '[[package]]\nname = "kin-parser"\nversion = "1.2.4"\n');
+  bumpCommonReleaseSurfaces(root, '1.2.4', '1.2.3');
+  git(root, ['add', '-A']);
+  git(root, ['commit', '--quiet', '-m', 'Release Kin v1.2.4']);
+
+  const run = runGateAsMintDoes(root);
+  assert.doesNotMatch(run.stdout, /FAIL:.*kin-blobs/);
+  assert.match(run.outputs, /should_tag=true/);
+  assert.match(run.outputs, /tag=v1\.2\.4/);
+});
+
+test('an independent member whose lock disagrees with its own manifest fails naming both versions', () => {
+  const root = releasedWorkspaceRepository();
+  write(root, 'Cargo.toml', workspaceCargoToml('1.2.4', ['crates/kin-core', 'crates/kin-blobs']));
+  // Neither kin-blobs' own manifest version (0.1.5) nor the workspace version
+  // (1.2.4): a genuine mismatch, not the independence the previous test proves.
+  write(
+    root,
+    'Cargo.lock',
+    '[[package]]\nname = "kin-core"\nversion = "1.2.4"\n\n[[package]]\nname = "kin-blobs"\nversion = "0.1.6"\n',
+  );
+  write(root, 'fuzz/Cargo.lock', '[[package]]\nname = "kin-parser"\nversion = "1.2.4"\n');
+  bumpCommonReleaseSurfaces(root, '1.2.4', '1.2.3');
+  git(root, ['add', '-A']);
+  git(root, ['commit', '--quiet', '-m', 'Release Kin v1.2.4']);
+
+  const failed = runGateExpectingFailure(root);
+  assert.ok(failed, 'the gate exited 0 on an independent member lock mismatch');
+  assert.match(
+    failed.stdout,
+    /Cargo\.lock local package kin-blobs is 0\.1\.6, its own manifest is 0\.1\.5/,
+  );
+  assert.doesNotMatch(failed.stdout, /kin-blobs is 0\.1\.6, workspace is/);
+});
+
+test('a workspace-versioned member at the wrong version still fails', () => {
+  // The independence rule must not mask an ordinary dropped bump: kin-blobs
+  // is correctly untouched, but kin-core's move to 1.2.4 never landed.
+  const root = releasedWorkspaceRepository();
+  write(root, 'Cargo.toml', workspaceCargoToml('1.2.4', ['crates/kin-core', 'crates/kin-blobs']));
+  write(
+    root,
+    'Cargo.lock',
+    '[[package]]\nname = "kin-core"\nversion = "1.2.3"\n\n[[package]]\nname = "kin-blobs"\nversion = "0.1.5"\n',
+  );
+  write(root, 'fuzz/Cargo.lock', '[[package]]\nname = "kin-parser"\nversion = "1.2.4"\n');
+  bumpCommonReleaseSurfaces(root, '1.2.4', '1.2.3');
+  git(root, ['add', '-A']);
+  git(root, ['commit', '--quiet', '-m', 'Release Kin v1.2.4']);
+
+  const failed = runGateExpectingFailure(root);
+  assert.ok(failed, 'the gate exited 0 on a dropped workspace-versioned bump');
+  assert.match(
+    failed.stdout,
+    /Cargo\.lock local package kin-core is 1\.2\.3, workspace is 1\.2\.4/,
+  );
+});
+
+test('the fuzz lock applies the same independent-vs-workspace rule as the main lock', () => {
+  // kin-parser is workspace-versioned in the real repo today, but the fuzz
+  // block must reach that conclusion through the same member lookup as the
+  // main lock, not by always comparing to the workspace version. Declaring it
+  // independent here proves the rule, not the name, decides the comparison.
+  const root = releasedWorkspaceRepository();
+  write(
+    root,
+    'Cargo.toml',
+    workspaceCargoToml('1.2.4', ['crates/kin-core', 'crates/kin-blobs', 'crates/kin-parser']),
+  );
+  write(root, 'crates/kin-parser/Cargo.toml', '[package]\nname = "kin-parser"\nversion = "0.9.0"\n');
+  write(
+    root,
+    'Cargo.lock',
+    '[[package]]\nname = "kin-core"\nversion = "1.2.4"\n\n' +
+      '[[package]]\nname = "kin-blobs"\nversion = "0.1.5"\n\n' +
+      '[[package]]\nname = "kin-parser"\nversion = "0.9.0"\n',
+  );
+  write(root, 'fuzz/Cargo.lock', '[[package]]\nname = "kin-parser"\nversion = "0.9.0"\n');
+  bumpCommonReleaseSurfaces(root, '1.2.4', '1.2.3');
+  git(root, ['add', '-A']);
+  git(root, ['commit', '--quiet', '-m', 'Release Kin v1.2.4']);
+
+  const run = runGateAsMintDoes(root);
+  assert.doesNotMatch(run.stdout, /fuzz\/Cargo\.lock local package kin-parser/);
+  assert.match(run.outputs, /should_tag=true/);
+});
+
+test('a fuzz lock entry that disagrees with an independent member\'s manifest fails naming both', () => {
+  const root = releasedWorkspaceRepository();
+  write(
+    root,
+    'Cargo.toml',
+    workspaceCargoToml('1.2.4', ['crates/kin-core', 'crates/kin-blobs', 'crates/kin-parser']),
+  );
+  write(root, 'crates/kin-parser/Cargo.toml', '[package]\nname = "kin-parser"\nversion = "0.9.0"\n');
+  write(
+    root,
+    'Cargo.lock',
+    '[[package]]\nname = "kin-core"\nversion = "1.2.4"\n\n' +
+      '[[package]]\nname = "kin-blobs"\nversion = "0.1.5"\n\n' +
+      '[[package]]\nname = "kin-parser"\nversion = "0.9.0"\n',
+  );
+  // Wrong on both counts: neither kin-parser's own 0.9.0 nor the 1.2.4
+  // workspace version.
+  write(root, 'fuzz/Cargo.lock', '[[package]]\nname = "kin-parser"\nversion = "0.8.0"\n');
+  bumpCommonReleaseSurfaces(root, '1.2.4', '1.2.3');
+  git(root, ['add', '-A']);
+  git(root, ['commit', '--quiet', '-m', 'Release Kin v1.2.4']);
+
+  const failed = runGateExpectingFailure(root);
+  assert.ok(failed, 'the gate exited 0 on a fuzz-lock mismatch against an independent manifest');
+  assert.match(
+    failed.stdout,
+    /fuzz\/Cargo\.lock local package kin-parser is 0\.8\.0, its own manifest is 0\.9\.0/,
   );
 });


### PR DESCRIPTION
Release Train run 34664162581 staged Kin 0.7.16 and the release-intent gate refused it:

```
FAIL: Cargo.lock local package kin-blobs is 0.1.5, workspace is 0.7.16
FAIL: Cargo.lock local package kin-model is 0.7.28, workspace is 0.7.16
FAIL: Cargo.lock local package kin-search is 0.1.9, workspace is 0.7.16
FAIL: Cargo.lock local package kin-vector is 0.2.1, workspace is 0.7.16
=> should_tag=false
```

kin#1747 made kin-blobs, kin-model, kin-search and kin-vector workspace members with their own
version, so they can be published independently. `scripts/release-intent.mjs` compared every local
Cargo.lock entry against the workspace version unconditionally, which was right while every local
crate inherited `version.workspace = true` and is wrong now. Related to #1750.

A local package whose own Cargo.toml sets an explicit `version = "x"` must match its own manifest in
Cargo.lock. A package that inherits `version.workspace = true` must still match the workspace
version. The gate reads which is which from the `[workspace]` members list on every run, never from
a name list, so a fifth or sixth independent crate needs no edit here. This applies to both the main
Cargo.lock check and the fuzz/Cargo.lock kin-parser check. The FAIL message now says which number it
compared against ("its own manifest is X" vs "workspace is X"), and the summary line reads
`local lock entries: N (W workspace-versioned, I independent)`.

Between reading this ticket and finishing the fix, kin#1758's PR B merged into main and added three
more independently versioned crates: kin-infer, kin-lsp and kin-vfs-core ("grade seven libraries not
four"). I rebased onto that and re-measured with no code changes needed.

Before, pre-fix code, current main, all seven independent crates:
```
FAIL: Cargo.lock local package kin-blobs is 0.1.5, workspace is 0.7.15
FAIL: Cargo.lock local package kin-infer is 0.2.44, workspace is 0.7.15
FAIL: Cargo.lock local package kin-lsp is 0.7.19, workspace is 0.7.15
FAIL: Cargo.lock local package kin-model is 0.7.28, workspace is 0.7.15
FAIL: Cargo.lock local package kin-search is 0.1.9, workspace is 0.7.15
FAIL: Cargo.lock local package kin-vector is 0.2.1, workspace is 0.7.15
FAIL: Cargo.lock local package kin-vfs-core is 0.4.25, workspace is 0.7.15
```

After, same tree with the fixed code, all seven FAIL lines are gone and the summary reads
`local lock entries: 31 (24 workspace-versioned, 7 independent)`.

Positive control: a scratch copy of the current tree, every workspace-versioned surface bumped to
0.7.16 the way prepare-release.mjs does, independent crates left at their own real versions.
```
local lock entries: 31 (24 workspace-versioned, 7 independent)
tag v0.7.16      : absent
=> should_tag=true
v0.7.16 is a coherent release. Ready to tag.
```

`scripts/check-release-version.mjs` and `scripts/resolve-release-intent.mjs` were left alone. I read
both in full and neither has this assumption. `check-release-version.mjs` compares only the single
workspace version between a base and head ref and never reads Cargo.lock or a per-crate manifest.
`resolve-release-intent.mjs` reads `Kin-Release-Intent` git trailers for the bump size and does no
per-crate comparison at all. Neither needed a change.

On the version bump question: `classifyPath` does not exempt `scripts/`, so this change technically
classifies as `release`. It does not matter here, because the `release-version` job in ci.yml only
runs on a PR whose head ref is `automation/release-next` or that carries the `release:automated`
label, and this PR is neither, so that job is skipped regardless.

Tests added: pure-function unit tests for the new `readWorkspaceMembers`, `readPackageIdentity` and
`expectedLocalVersion`, plus end-to-end tests against a new fixture shaped like today's real
workspace. They cover an independent crate at its own version passing (the literal defect), an
independent crate that disagrees with its own manifest still failing and naming both numbers, a
workspace-versioned crate at the wrong version still failing (independence does not mask an ordinary
dropped bump), the counts line, and the same two cases for the fuzz lock. Every new test ran against
the pre-fix script and failed there for the right reason, except the workspace-versioned regression
guard, which correctly passes under both since that protection already existed. 29 pre-existing
tests plus 14 new ones, 43 of 43 green.

Gates run: `node --check` on all three scripts; `node --test` on `release-intent.test.mjs` (43/43)
and `check-release-version.test.mjs` (13/13, unmodified, confirming no collateral change); and
`bin/kin-precheck kin --repo-dir kin=<worktree>` through `heavy-slot.sh`:

```
kin-precheck: 22 gates enumerated from the check job of .github/workflows/ci.yml
PASS     fmt                                  cargo fmt -- --check
PASS     clippy                               cargo clippy --all-targets --all-features -- <45 allows from .github/clippy-allowed-lints.txt>
PASS     guard:check_private_repo_coupling.sh bash scripts/check_private_repo_coupling.sh
PASS     guard:check_runtime_boundaries.sh    bash scripts/check_runtime_boundaries.sh
PASS     guard:test-release-policy-gate.sh    bash scripts/test-release-policy-gate.sh
PASS     guard:test-windows-authority-legs.sh bash scripts/test-windows-authority-legs.sh
PASS     guard:zero_file_search_guard.sh      bash scripts/zero_file_search_guard.sh
PASS     guard:check-kin-vfs-compat.mjs       node scripts/check-kin-vfs-compat.mjs
PASS     guard:check-rc-build-drift.mjs       node scripts/check-rc-build-drift.mjs
PASS     guard:check-required-contexts.py     python3 scripts/check-required-contexts.py
PASS     guard:test-assertion-reachability.py python3 scripts/test-assertion-reachability.py
PASS     guard:test-guard-duplicate-release-run.py python3 scripts/test-guard-duplicate-release-run.py
PASS     guard:test-homebrew-release-gate.py  python3 scripts/test-homebrew-release-gate.py
PASS     guard:test-install-checksum.py       python3 scripts/test-install-checksum.py
PASS     guard:test-private-repo-coupling.py  python3 scripts/test-private-repo-coupling.py
PASS     guard:test-release-tag-evaluate-dispatch.py python3 scripts/test-release-tag-evaluate-dispatch.py
PASS     guard:test-release-workflow-authority.py python3 scripts/test-release-workflow-authority.py
PASS     guard:test-select-release-candidate.py python3 scripts/test-select-release-candidate.py
PASS     guard:verify-hydration-semantics.py  python3 scripts/verify-hydration-semantics.py
PASS     guard:verify-zero-file-search.py     python3 scripts/verify-zero-file-search.py
PASS     node-test                            node --test <16 file(s) named by the check job>
PASS     guard:check-quarantine.py            python3 scripts/check-quarantine.py
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin 66ce12177133ef15d0b12b6727ad5ddce89d7168 DIRTY
```

This PR is ready but held for PR D (lane `monorepob`, `chore/lane-monorepob-kin-d`), which fixes a
separate release.yml failure on a workspace-sourced kin-vfs-core, itself a kin#1758 consequence.
Landing this one first would let the next Release Train cycle stage and mint v0.7.16 into that still
broken workflow. Enqueue is held until the captain confirms PR D is on main.
