### PR TITLE
Name the namespace an entity lives in, one rule per language

### DIFF
--- a/crates/kin-model/src/lib.rs
+++ b/crates/kin-model/src/lib.rs
@@ -64,6 +64,7 @@ pub mod relation;
 pub mod repository;
 pub mod retrieval;
 pub mod review;
+pub mod scope;
 pub mod sealed_observation;
 pub mod session;
 pub mod spec;
@@ -154,6 +155,7 @@ pub use review::{
     ReviewDecisionState, ReviewDiscussion, ReviewDiscussionId, ReviewDiscussionState, ReviewFilter,
     ReviewId, ReviewNote, ReviewNoteId, RiskLevel, RiskSummary,
 };
+pub use scope::{EntityScope, ScopeAbsence, ScopePath, ScopePathError};
 pub use spec::Spec;
 pub use stats::GraphStats;
 pub use temporal::{is_active_at, ArtifactRevision, EntityRevision, RelationRevision};

--- a/crates/kin-model/src/scope.rs
+++ b/crates/kin-model/src/scope.rs
@@ -1,0 +1,353 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! The namespace an entity lives in.
+//!
+//! A file path is where an entity's bytes happen to sit. A namespace is what
+//! the language calls the region the entity belongs to, and it is what another
+//! entity writes when it names this one. `queue/models.py` is a path;
+//! `queue.models` is what an importer types. The two agree today only because
+//! nothing has moved yet.
+//!
+//! This is the type that lets a query group by region without grouping by path.
+
+use std::fmt;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// An entity's namespace, as the ordered segments that name it.
+///
+/// Segments, not a rendered string, because the separator is a language's
+/// spelling and not part of the identity: `queue.models`, `queue::models` and
+/// `queue\models` are one value here. Holding the string instead makes a prefix
+/// test textual, and a textual prefix answers `queue` with everything in
+/// `queue_internal`, which is a wrong answer that looks right.
+#[derive(
+    Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(try_from = "Vec<String>", into = "Vec<String>")]
+#[schemars(with = "Vec<String>")]
+pub struct ScopePath {
+    segments: Vec<String>,
+}
+
+/// Why a `Vec<String>` is not a scope path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScopePathError {
+    /// A scope with no segments names nothing, and would be a prefix of every
+    /// other scope, so every query would answer with the whole repository.
+    Empty,
+    /// A segment that is empty or blank comes from a separator run such as
+    /// `a..b`, and keeping it would make `a..b` and `a.b` different scopes for
+    /// the same region.
+    BlankSegment,
+}
+
+impl fmt::Display for ScopePathError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => write!(f, "a scope path needs at least one segment"),
+            Self::BlankSegment => write!(f, "a scope path segment cannot be blank"),
+        }
+    }
+}
+
+impl std::error::Error for ScopePathError {}
+
+impl ScopePath {
+    /// The scope naming these segments, or why they do not name one.
+    pub fn new<I, S>(segments: I) -> Result<Self, ScopePathError>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let segments: Vec<String> = segments.into_iter().map(Into::into).collect();
+        if segments.is_empty() {
+            return Err(ScopePathError::Empty);
+        }
+        if segments.iter().any(|segment| segment.trim().is_empty()) {
+            return Err(ScopePathError::BlankSegment);
+        }
+        Ok(Self { segments })
+    }
+
+    /// The scope a written path names, taking `.`, `::`, `/` and `\` as
+    /// separators and dropping empty runs between them.
+    ///
+    /// All four appear in the languages Kin reads: Python and Java write `.`,
+    /// Rust and C++ write `::`, PHP writes `\`, and a module specifier written
+    /// in an import writes `/`. They are spellings of one structure, so they
+    /// parse to one value, and a caller that has segments already should call
+    /// [`ScopePath::new`] rather than render and reparse them.
+    pub fn parse(text: &str) -> Result<Self, ScopePathError> {
+        let segments: Vec<String> = text
+            .replace("::", ".")
+            .split(['.', '/', '\\'])
+            .map(str::trim)
+            .filter(|segment| !segment.is_empty())
+            .map(str::to_string)
+            .collect();
+        Self::new(segments)
+    }
+
+    /// The ordered segments, outermost first.
+    pub fn segments(&self) -> &[String] {
+        &self.segments
+    }
+
+    /// How many segments deep this scope is. Never zero.
+    pub fn depth(&self) -> usize {
+        self.segments.len()
+    }
+
+    /// Whether this scope is `prefix` or lives inside it.
+    ///
+    /// Segment-wise, so `queue` holds `queue.models` and does not hold
+    /// `queue_internal.models`.
+    pub fn is_within(&self, prefix: &Self) -> bool {
+        self.segments.len() >= prefix.segments.len()
+            && self
+                .segments
+                .iter()
+                .zip(prefix.segments.iter())
+                .all(|(mine, theirs)| mine == theirs)
+    }
+
+    /// This scope with one more segment inside it.
+    pub fn child(&self, segment: impl Into<String>) -> Result<Self, ScopePathError> {
+        let mut segments = self.segments.clone();
+        segments.push(segment.into());
+        Self::new(segments)
+    }
+}
+
+impl TryFrom<Vec<String>> for ScopePath {
+    type Error = ScopePathError;
+
+    fn try_from(segments: Vec<String>) -> Result<Self, Self::Error> {
+        Self::new(segments)
+    }
+}
+
+impl From<ScopePath> for Vec<String> {
+    fn from(path: ScopePath) -> Self {
+        path.segments
+    }
+}
+
+/// Rendered with `.`, which is the spelling most of the languages use and the
+/// one every surface already prints. The value is the segments; this is display.
+impl fmt::Display for ScopePath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.segments.join("."))
+    }
+}
+
+/// Why an entity has no namespace, when it genuinely has none.
+///
+/// Separate from [`EntityScope::NotComputed`] on purpose. "This language has no
+/// namespaces" and "nobody has looked yet" are different facts, and a query that
+/// treats them alike either hides a gap or refuses forever.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ScopeAbsence {
+    /// The language has no namespace at this level. C, HCL and Swift: C has
+    /// none, HCL has blocks rather than namespaces, and a Swift module is a
+    /// build-target property that no source file declares.
+    LanguageHasNone,
+    /// The entity has no file origin, so no layout can name a region for it.
+    /// Graph-created entities before placement are the case.
+    NoFileOrigin,
+    /// The file's path carries no segment that names a module. A root-level
+    /// `index.ts` is the case: `require('.')` names the repository, not a module.
+    PathNamesNoModule,
+}
+
+impl fmt::Display for ScopeAbsence {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::LanguageHasNone => write!(f, "the language has no namespace at this level"),
+            Self::NoFileOrigin => write!(f, "the entity has no file origin"),
+            Self::PathNamesNoModule => write!(f, "the path names no module"),
+        }
+    }
+}
+
+/// The namespace an entity lives in, or the reason it has none, or the fact
+/// that nobody has computed one.
+///
+/// Three states rather than an `Option`, and the third is the one that matters.
+/// A store written before scopes existed holds entities with no scope, and an
+/// `Option` would report those as "no namespace", which is the same answer a C
+/// file gives. A query would then narrow silently on a store nobody has
+/// backfilled and report an empty region as an empty region. `NotComputed` makes
+/// that state nameable, so the query refuses instead and says how many entities
+/// it is waiting on.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum EntityScope {
+    /// The namespace this entity lives in.
+    Known(ScopePath),
+    /// The entity has no namespace, for the reason given.
+    None(ScopeAbsence),
+    /// Nobody has computed a scope for this entity yet.
+    NotComputed,
+}
+
+/// `NotComputed`, so a record written before this field existed reads as
+/// uncomputed rather than as scopeless.
+impl Default for EntityScope {
+    fn default() -> Self {
+        Self::NotComputed
+    }
+}
+
+impl EntityScope {
+    /// The scope path, when one is known.
+    pub fn path(&self) -> Option<&ScopePath> {
+        match self {
+            Self::Known(path) => Some(path),
+            Self::None(_) | Self::NotComputed => std::option::Option::None,
+        }
+    }
+
+    /// Whether a query may rely on this entity's scope being settled.
+    pub fn is_computed(&self) -> bool {
+        !matches!(self, Self::NotComputed)
+    }
+}
+
+impl fmt::Display for EntityScope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Known(path) => write!(f, "{path}"),
+            Self::None(reason) => write!(f, "none ({reason})"),
+            Self::NotComputed => write!(f, "not computed"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_prefix_match_is_segment_wise_and_not_textual() {
+        let queue = ScopePath::parse("queue").unwrap();
+        let models = ScopePath::parse("queue.models").unwrap();
+        let internal = ScopePath::parse("queue_internal.models").unwrap();
+
+        assert!(models.is_within(&queue), "queue.models lives in queue");
+        assert!(queue.is_within(&queue), "a scope is within itself");
+        assert!(
+            !internal.is_within(&queue),
+            "queue_internal is a different region, and a textual prefix would say otherwise"
+        );
+        assert!(
+            !queue.is_within(&models),
+            "a parent does not live inside its child"
+        );
+    }
+
+    #[test]
+    fn the_four_separators_parse_to_one_value() {
+        let expected = ScopePath::new(["queue", "models"]).unwrap();
+        for spelling in [
+            "queue.models",
+            "queue::models",
+            "queue/models",
+            "queue\\models",
+        ] {
+            assert_eq!(
+                ScopePath::parse(spelling).unwrap(),
+                expected,
+                "{spelling} names the same region"
+            );
+        }
+    }
+
+    #[test]
+    fn a_path_that_names_nothing_is_refused() {
+        assert_eq!(ScopePath::parse(""), Err(ScopePathError::Empty));
+        assert_eq!(ScopePath::parse("..."), Err(ScopePathError::Empty));
+        assert_eq!(
+            ScopePath::new(Vec::<String>::new()),
+            Err(ScopePathError::Empty)
+        );
+        assert_eq!(
+            ScopePath::new(["queue", " "]),
+            Err(ScopePathError::BlankSegment)
+        );
+    }
+
+    #[test]
+    fn a_separator_run_does_not_make_a_second_region() {
+        assert_eq!(
+            ScopePath::parse("queue..models").unwrap(),
+            ScopePath::parse("queue.models").unwrap()
+        );
+        assert_eq!(
+            ScopePath::parse("/queue/models/").unwrap(),
+            ScopePath::parse("queue.models").unwrap()
+        );
+    }
+
+    #[test]
+    fn display_renders_with_dots_whatever_it_was_parsed_from() {
+        assert_eq!(
+            ScopePath::parse("queue::models").unwrap().to_string(),
+            "queue.models"
+        );
+        assert_eq!(
+            ScopePath::parse("App\\Http").unwrap().to_string(),
+            "App.Http"
+        );
+    }
+
+    #[test]
+    fn an_unwritten_scope_reads_as_uncomputed_and_not_as_scopeless() {
+        let default = EntityScope::default();
+        assert_eq!(default, EntityScope::NotComputed);
+        assert!(!default.is_computed());
+        assert!(default.path().is_none());
+        assert!(
+            EntityScope::None(ScopeAbsence::LanguageHasNone).is_computed(),
+            "a language with no namespaces has a settled answer"
+        );
+    }
+
+    #[test]
+    fn a_scope_round_trips_through_its_persisted_shape() {
+        let scope = EntityScope::Known(ScopePath::parse("queue::models").unwrap());
+        let json = serde_json::to_string(&scope).unwrap();
+        assert_eq!(
+            serde_json::from_str::<EntityScope>(&json).unwrap(),
+            scope,
+            "the persisted shape is the segments, not the rendering"
+        );
+        assert!(
+            json.contains("[\"queue\",\"models\"]"),
+            "segments are persisted, got {json}"
+        );
+    }
+
+    #[test]
+    fn a_persisted_scope_with_a_blank_segment_is_refused_rather_than_loaded() {
+        let refused = serde_json::from_str::<ScopePath>("[\"queue\",\"\"]");
+        assert!(
+            refused.is_err(),
+            "a blank segment would make two spellings of one region"
+        );
+    }
+
+    #[test]
+    fn a_child_extends_the_region_it_was_built_from() {
+        let queue = ScopePath::parse("queue").unwrap();
+        let models = queue.child("models").unwrap();
+        assert_eq!(models.segments(), ["queue", "models"]);
+        assert_eq!(models.depth(), 2);
+        assert!(models.is_within(&queue));
+        assert_eq!(queue.child(" "), Err(ScopePathError::BlankSegment));
+    }
+}

--- a/crates/kin-parser/examples/scope_census.rs
+++ b/crates/kin-parser/examples/scope_census.rs
@@ -1,0 +1,286 @@
+// kin/crates/kin-parser/examples/scope_census.rs
+//
+// How many entities land in each scope state, per language, over a tree.
+//
+// Run before letting any query answer by scope, because the answer to "what is
+// in this namespace" is only as good as the fraction of entities that have one.
+// This walks a directory the way ingestion walks it, extracts with the same
+// adapters, and derives each entity's scope with the same rules, so the tally is
+// the one the product would produce rather than an estimate of it.
+//
+//   cargo run -p kin-parser --example scope_census -- <dir>
+//
+// It lives in `examples/` because it reads the filesystem. That is ingestion IO
+// here, not an answer path, and the zero-file-search checker excludes cargo's
+// examples directory for exactly this reason.
+
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use kin_model::{EntityScope, FilePathId, LanguageId, ScopeAbsence};
+use kin_parser::scope::{derive, Manifest, ManifestKind, ScopeInputs, ScopeLayout};
+use kin_parser::AdapterRegistry;
+
+/// Directories that hold no repository source, so walking them measures the
+/// toolchain rather than the tree.
+const SKIP_DIRS: &[&str] = &[
+    ".git",
+    "target",
+    "node_modules",
+    ".kin",
+    "dist",
+    "build",
+    "vendor",
+    ".venv",
+];
+
+/// The layout read off the disk, for a census taken before any store exists.
+///
+/// PR B's implementation answers these two questions from the graph's own
+/// `Package` entities. This one answers them from the tree being censused, which
+/// is the same tree ingestion would read.
+struct DiskLayout {
+    root: PathBuf,
+}
+
+impl DiskLayout {
+    fn manifest_name(&self, dir: &str, kind: ManifestKind) -> Option<String> {
+        let (file, key) = match kind {
+            ManifestKind::Cargo => ("Cargo.toml", "name"),
+            ManifestKind::Node => ("package.json", "\"name\""),
+        };
+        let text = fs::read_to_string(self.root.join(dir).join(file)).ok()?;
+        match kind {
+            // The first `name =` under `[package]`. A workspace-only manifest
+            // has no `[package]` section and so declares no crate, which is the
+            // right answer for a directory that is not a crate.
+            ManifestKind::Cargo => {
+                let after = text.split("[package]").nth(1)?;
+                after
+                    .lines()
+                    .take_while(|line| !line.trim_start().starts_with('['))
+                    .find_map(|line| toml_string_value(line, key))
+            }
+            ManifestKind::Node => text.lines().find_map(|line| json_string_value(line, key)),
+        }
+    }
+
+    fn has_manifest(&self, dir: &str, kind: ManifestKind) -> bool {
+        let file = match kind {
+            ManifestKind::Cargo => "Cargo.toml",
+            ManifestKind::Node => "package.json",
+        };
+        self.root.join(dir).join(file).is_file()
+    }
+}
+
+impl ScopeLayout for DiskLayout {
+    fn is_python_package(&self, dir: &str) -> bool {
+        self.root.join(dir).join("__init__.py").is_file()
+    }
+
+    fn manifest_at_or_above(&self, dir: &str, kind: ManifestKind) -> Option<Manifest> {
+        let mut current = dir;
+        loop {
+            if self.has_manifest(current, kind) {
+                return Some(Manifest {
+                    dir: current.to_string(),
+                    name: self.manifest_name(current, kind),
+                });
+            }
+            if current.is_empty() {
+                return None;
+            }
+            current = match current.rsplit_once('/') {
+                Some((head, _)) => head,
+                None => "",
+            };
+        }
+    }
+}
+
+fn toml_string_value(line: &str, key: &str) -> Option<String> {
+    let (name, rest) = line.split_once('=')?;
+    (name.trim() == key).then(|| rest.trim().trim_matches('"').to_string())
+}
+
+fn json_string_value(line: &str, key: &str) -> Option<String> {
+    let (name, rest) = line.split_once(':')?;
+    (name.trim() == key).then(|| {
+        rest.trim()
+            .trim_end_matches(',')
+            .trim_matches('"')
+            .to_string()
+    })
+}
+
+/// One row of the census: a language, and where its entities landed.
+#[derive(Default, Clone, Copy)]
+struct Row {
+    known: u64,
+    none_language: u64,
+    none_other: u64,
+    not_computed: u64,
+    /// Of the known ones, how many were rooted at the repository's own manifest
+    /// rather than at a nested package's.
+    rooted_at_repository: u64,
+    /// Of the known ones, how many had no manifest above them at all, so the
+    /// repository root was used with nothing declaring it a package.
+    rooted_with_no_manifest: u64,
+}
+
+impl Row {
+    fn total(&self) -> u64 {
+        self.known + self.none_language + self.none_other + self.not_computed
+    }
+}
+
+fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with('.') && name != "." {
+            continue;
+        }
+        if path.is_dir() {
+            if SKIP_DIRS.contains(&name.as_ref()) {
+                continue;
+            }
+            walk(&path, out);
+        } else if path.is_file() {
+            out.push(path);
+        }
+    }
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let root = PathBuf::from(args.get(1).cloned().unwrap_or_else(|| ".".to_string()));
+    let root = root.canonicalize().unwrap_or(root);
+
+    let registry = AdapterRegistry::new();
+    let layout = DiskLayout { root: root.clone() };
+    let mut files = Vec::new();
+    walk(&root, &mut files);
+    files.sort();
+
+    let mut rows: BTreeMap<String, Row> = BTreeMap::new();
+    let mut parsed_files = 0u64;
+    for path in &files {
+        let extension = path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .unwrap_or("")
+            .to_string();
+        let Ok(content) = fs::read(path) else {
+            continue;
+        };
+        let Some(adapter) = registry.get_by_extension_and_content(&extension, &content) else {
+            continue;
+        };
+        let Ok(tree) = adapter.parse(&content) else {
+            continue;
+        };
+        let relative = path
+            .strip_prefix(&root)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        let file_id = FilePathId::new(relative.clone());
+        let Ok(output) = adapter.extract(&tree, &content, &file_id) else {
+            continue;
+        };
+        parsed_files += 1;
+
+        let language = adapter.language_id();
+        let row = rows.entry(language.to_string()).or_default();
+        let ecmascript = matches!(language, LanguageId::TypeScript | LanguageId::JavaScript);
+        let nearest = ecmascript
+            .then(|| layout.manifest_at_or_above(parent_of(&relative), ManifestKind::Node))
+            .flatten();
+        let repository_rooted = ecmascript && nearest.as_ref().is_some_and(|m| m.dir.is_empty());
+        let unclaimed = ecmascript && nearest.is_none();
+
+        for _entity in &output.entities {
+            // Every extractor passes no declared namespace today, which is the
+            // measurement: the seven declared languages report NotComputed until
+            // their extractor reads the declaration.
+            let scope = derive(
+                ScopeInputs {
+                    language,
+                    file: Some(&file_id),
+                    declared: None,
+                },
+                &layout,
+            );
+            match scope {
+                EntityScope::Known(_) => {
+                    row.known += 1;
+                    if repository_rooted {
+                        row.rooted_at_repository += 1;
+                    }
+                    if unclaimed {
+                        row.rooted_with_no_manifest += 1;
+                    }
+                }
+                EntityScope::None(ScopeAbsence::LanguageHasNone) => row.none_language += 1,
+                EntityScope::None(_) => row.none_other += 1,
+                EntityScope::NotComputed => row.not_computed += 1,
+            }
+        }
+    }
+
+    println!("scope census over {}", root.display());
+    println!("{parsed_files} files parsed of {} walked", files.len());
+    println!();
+    println!(
+        "{:<12} {:>9} {:>9} {:>9} {:>9} {:>9}",
+        "language", "entities", "known", "none(lang)", "none(oth)", "uncomputed"
+    );
+    let mut totals = Row::default();
+    for (language, row) in &rows {
+        println!(
+            "{:<12} {:>9} {:>9} {:>9} {:>9} {:>9}",
+            language,
+            row.total(),
+            row.known,
+            row.none_language,
+            row.none_other,
+            row.not_computed
+        );
+        totals.known += row.known;
+        totals.none_language += row.none_language;
+        totals.none_other += row.none_other;
+        totals.not_computed += row.not_computed;
+        totals.rooted_at_repository += row.rooted_at_repository;
+        totals.rooted_with_no_manifest += row.rooted_with_no_manifest;
+    }
+    println!(
+        "{:<12} {:>9} {:>9} {:>9} {:>9} {:>9}",
+        "TOTAL",
+        totals.total(),
+        totals.known,
+        totals.none_language,
+        totals.none_other,
+        totals.not_computed
+    );
+    println!();
+    println!(
+        "of the known ECMAScript entities, {} are rooted at the repository's own package.json \
+         because no nested package claimed them, and {} had no package.json above them at all",
+        totals.rooted_at_repository, totals.rooted_with_no_manifest
+    );
+}
+
+fn parent_of(path: &str) -> &str {
+    match path.rsplit_once('/') {
+        Some((head, _)) => head,
+        None => "",
+    }
+}

--- a/crates/kin-parser/src/languages/javascript.rs
+++ b/crates/kin-parser/src/languages/javascript.rs
@@ -2918,7 +2918,7 @@ pub(super) const JS_SUFFIXES: &[&str] = &[".jsx", ".mjs", ".cjs", ".js"];
 /// `.d.ts` leads because it must: `foo.d.ts` stripped of `.ts` is `foo.d`, a
 /// name no source ever writes. The old `is_ts_index_file` never matched
 /// `index.d.ts` at all, which is the drift the shared helper exists to stop.
-pub(super) const TS_SUFFIXES: &[&str] = &[".d.ts", ".tsx", ".ts"];
+pub(crate) const TS_SUFFIXES: &[&str] = &[".d.ts", ".tsx", ".ts"];
 
 /// The module identity of a JavaScript or TypeScript source file: its name, and
 /// whether the file is a package index.
@@ -2942,7 +2942,7 @@ pub(super) const TS_SUFFIXES: &[&str] = &[".d.ts", ".tsx", ".ts"];
 /// once for the directory name. Python has no such blocklist and neither does
 /// this. `lib/index.js` is named `lib`, because `require('./lib')` is what the
 /// source calls it.
-pub(super) fn js_module_identity(path: &str, suffixes: &[&str]) -> (String, bool) {
+pub(crate) fn js_module_identity(path: &str, suffixes: &[&str]) -> (String, bool) {
     let basename = path.rsplit('/').next().unwrap_or(path);
     let Some(stem) = suffixes
         .iter()

--- a/crates/kin-parser/src/languages/mod.rs
+++ b/crates/kin-parser/src/languages/mod.rs
@@ -21,6 +21,9 @@ pub use go::{attach_go_command_effect_contract_metadata, GoAdapter};
 pub use hcl::HclAdapter;
 pub use java::JavaAdapter;
 pub use javascript::JavaScriptAdapter;
+// Crate-private: the module-identity rule these two spell is the one
+// `crate::scope` derives a module specifier from, so both surfaces stay one rule.
+pub(crate) use javascript::{js_module_identity, TS_SUFFIXES};
 pub use kotlin::KotlinAdapter;
 pub use php::PhpAdapter;
 pub use python::{is_python_builtin_name, PythonAdapter, PYTHON_BUILTIN_NAMES};

--- a/crates/kin-parser/src/lib.rs
+++ b/crates/kin-parser/src/lib.rs
@@ -35,6 +35,7 @@ pub mod adapter;
 pub mod error;
 pub mod extract;
 pub mod languages;
+pub mod scope;
 pub mod shallow;
 pub mod todos;
 

--- a/crates/kin-parser/src/scope.rs
+++ b/crates/kin-parser/src/scope.rs
@@ -1,0 +1,651 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! What namespace an entity lives in, one rule per language.
+//!
+//! Three classes, and which class a language is in decides where its answer
+//! comes from rather than how confident it is.
+//!
+//! **Declared.** Java, Kotlin, Go, PHP, C++, C# and Ruby write the namespace in
+//! the source. The extractor reads it and passes it in; nothing here guesses it.
+//! When the extractor did not read one, the answer is [`EntityScope::NotComputed`],
+//! never "no namespace", because those are different facts and a query that
+//! confuses them narrows silently.
+//!
+//! **Derived.** Python, Rust, TypeScript and JavaScript put the namespace in the
+//! layout: a directory tree plus a marker decides what an importer types. These
+//! rules read the layout, and they read it through [`ScopeLayout`] rather than
+//! off the disk, so the same rule answers from the graph at query time and from
+//! a fixture in a test.
+//!
+//! **None.** C, HCL and Swift have no namespace at this level. C has none at
+//! all, HCL has blocks rather than namespaces, and a Swift module is a
+//! build-target property no source file declares, so deriving one from layout
+//! would be an invention.
+//!
+//! Nothing here reads a file. Every input arrives as an argument.
+
+use kin_model::{EntityScope, FilePathId, LanguageId, ScopeAbsence, ScopePath};
+
+use crate::languages::{js_module_identity, TS_SUFFIXES};
+
+/// The JavaScript suffixes, beside TypeScript's, so a `.mjs` module names itself
+/// the way a `.ts` one does.
+pub const JS_SUFFIXES: &[&str] = &[".mjs", ".cjs", ".jsx", ".js"];
+
+/// Which manifest declares a package for a language.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ManifestKind {
+    /// `Cargo.toml`, whose `[package] name` is a Rust crate's root segment.
+    Cargo,
+    /// `package.json`, whose directory roots every module specifier under it.
+    Node,
+}
+
+/// A package manifest the layout found.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Manifest {
+    /// The manifest's directory, repository-relative, empty for the root.
+    pub dir: String,
+    /// The package name it declares, when it declares one.
+    pub name: Option<String>,
+}
+
+/// What the layout rules need to know, asked rather than read.
+///
+/// Every method answers about repository-relative directories. The
+/// implementation in the product answers from the graph, so a scope is derived
+/// from graph truth and the Zero File-Search Authority Rule holds; the
+/// implementation in these tests answers from a list.
+pub trait ScopeLayout {
+    /// Whether `dir` holds an `__init__.py`, which is what makes it importable
+    /// as a Python package and what ends the walk up.
+    fn is_python_package(&self, dir: &str) -> bool;
+
+    /// The nearest manifest of `kind` at or above `dir`.
+    fn manifest_at_or_above(&self, dir: &str, kind: ManifestKind) -> Option<Manifest>;
+}
+
+/// What the caller knows about one entity, beside the layout.
+#[derive(Debug, Clone, Copy)]
+pub struct ScopeInputs<'a> {
+    pub language: LanguageId,
+    /// Where the entity's bytes sit. `None` for a graph-created entity that
+    /// projection has not placed.
+    pub file: Option<&'a FilePathId>,
+    /// The namespace the source declares for this entity, when the language
+    /// declares one and the extractor read it. A Java `package a.b;`, a Go
+    /// `package queue`, the container chain of a C++ `namespace`.
+    pub declared: Option<&'a str>,
+}
+
+/// The namespace an entity lives in.
+pub fn derive<L: ScopeLayout>(inputs: ScopeInputs<'_>, layout: &L) -> EntityScope {
+    use LanguageId::*;
+
+    match inputs.language {
+        C | Hcl | Swift => EntityScope::None(ScopeAbsence::LanguageHasNone),
+        Java | Kotlin | Go | Php | Cpp | CSharp | Ruby => declared_scope(inputs.declared),
+        Python => match inputs.file {
+            Some(file) => python_scope(&file.0, layout),
+            None => EntityScope::None(ScopeAbsence::NoFileOrigin),
+        },
+        Rust => match inputs.file {
+            Some(file) => rust_scope(&file.0, inputs.declared, layout),
+            None => EntityScope::None(ScopeAbsence::NoFileOrigin),
+        },
+        TypeScript | JavaScript => match inputs.file {
+            Some(file) => ecmascript_scope(&file.0, inputs.language, layout),
+            None => EntityScope::None(ScopeAbsence::NoFileOrigin),
+        },
+    }
+}
+
+/// A declared namespace is read, never inferred, so an unread one is uncomputed.
+fn declared_scope(declared: Option<&str>) -> EntityScope {
+    match declared.map(ScopePath::parse) {
+        Some(Ok(path)) => EntityScope::Known(path),
+        // A declaration that parses to nothing is a declaration of the root
+        // namespace, which Java writes by omitting the clause and Go cannot
+        // write at all. The file is in the default namespace, which is a fact,
+        // not an absence of one.
+        Some(Err(_)) => EntityScope::None(ScopeAbsence::PathNamesNoModule),
+        None => EntityScope::NotComputed,
+    }
+}
+
+/// Python: the ancestor directories that are packages, then the module.
+///
+/// `queue/models.py` under a `queue/__init__.py` is `queue.models`, which is
+/// what an importer types, and what the extractor records today is `models`,
+/// which three other files in the tree also record.
+fn python_scope<L: ScopeLayout>(path: &str, layout: &L) -> EntityScope {
+    let (module, is_package) = python_module_identity(path);
+    let dir = parent_dir(path);
+    // A package's `__init__.py` is named after its own directory, so the walk
+    // for it starts one level higher or it would name itself twice.
+    let walk_from = if is_package { parent_dir(dir) } else { dir };
+    let mut segments = package_chain(walk_from, layout);
+    if !module.is_empty() {
+        segments.push(module);
+    }
+    known_or_absent(segments)
+}
+
+/// Rust: the crate, then the module path the layout spells, then inline modules.
+///
+/// `crates/kin-mcp/src/handlers/review.rs` in the crate `kin-mcp` is
+/// `kin_mcp::handlers::review`, and a `mod tests` inside it is
+/// `kin_mcp::handlers::review::tests`.
+fn rust_scope<L: ScopeLayout>(path: &str, declared: Option<&str>, layout: &L) -> EntityScope {
+    let Some(manifest) = layout.manifest_at_or_above(parent_dir(path), ManifestKind::Cargo) else {
+        // Without a crate there is no root segment to hang the module path on,
+        // and two crates' `queue::models` would collide in one repository.
+        return EntityScope::NotComputed;
+    };
+    let Some(crate_name) = manifest.name else {
+        return EntityScope::NotComputed;
+    };
+    let mut segments = vec![crate_name.replace('-', "_")];
+    segments.extend(rust_module_path(path, &manifest.dir));
+    if let Some(declared) = declared {
+        if let Ok(inline) = ScopePath::parse(declared) {
+            segments.extend(inline.segments().iter().cloned());
+        }
+    }
+    known_or_absent(segments)
+}
+
+/// The module path a Rust file's location spells, relative to its crate.
+///
+/// Both layouts of one module answer the same: `src/queue/models.rs` and
+/// `src/queue/models/mod.rs` are `queue::models`. A crate root, `src/lib.rs` or
+/// `src/main.rs`, adds nothing, because the crate segment already names it.
+fn rust_module_path(path: &str, crate_dir: &str) -> Vec<String> {
+    let relative = strip_dir_prefix(path, crate_dir);
+    let Some(under_src) = relative.strip_prefix("src/") else {
+        return Vec::new();
+    };
+    let Some(stem) = under_src.strip_suffix(".rs") else {
+        return Vec::new();
+    };
+    let mut segments: Vec<String> = stem.split('/').map(str::to_string).collect();
+    match segments.last().map(String::as_str) {
+        Some("lib") | Some("main") | Some("mod") => {
+            segments.pop();
+        }
+        _ => {}
+    }
+    segments
+}
+
+/// TypeScript and JavaScript: the path from the package root, then the module.
+///
+/// A module specifier is what code names in an import, and it is read relative
+/// to the package that owns the file, so `packages/repo-eval/src/score.ts` in
+/// the package rooted at `packages/repo-eval` is `src.score`. With no manifest
+/// above it the repository is the package, which is the single-package case
+/// rather than a fallback.
+fn ecmascript_scope<L: ScopeLayout>(path: &str, language: LanguageId, layout: &L) -> EntityScope {
+    let suffixes = if language == LanguageId::TypeScript {
+        TS_SUFFIXES
+    } else {
+        JS_SUFFIXES
+    };
+    let (module, is_index) = js_module_identity(path, suffixes);
+    let dir = parent_dir(path);
+    let root = layout
+        .manifest_at_or_above(dir, ManifestKind::Node)
+        .map(|manifest| manifest.dir)
+        .unwrap_or_default();
+    // An index file is named after its own directory, so the path to it stops
+    // one level higher, exactly as a Python package's `__init__.py` does.
+    let walk_from = if is_index { parent_dir(dir) } else { dir };
+    let mut segments: Vec<String> = strip_dir_prefix(walk_from, &root)
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .map(str::to_string)
+        .collect();
+    if !module.is_empty() {
+        segments.push(module);
+    }
+    known_or_absent(segments)
+}
+
+/// The Python module identity of a path: its name, and whether it is a package
+/// marker. The same rule `languages::python` names its Module entities by.
+fn python_module_identity(path: &str) -> (String, bool) {
+    let basename = path.rsplit('/').next().unwrap_or(path);
+    if basename == "__init__.py" {
+        let package = parent_dir(path)
+            .rsplit('/')
+            .next()
+            .unwrap_or("")
+            .to_string();
+        return (package, true);
+    }
+    (
+        basename.strip_suffix(".py").unwrap_or("").to_string(),
+        false,
+    )
+}
+
+/// The importable package directories at and above `dir`, outermost first.
+///
+/// The walk stops at the first directory that is not a package, which is what
+/// makes `a/b/c` with `__init__.py` in `b` and `c` but not `a` answer `b.c`.
+fn package_chain<L: ScopeLayout>(dir: &str, layout: &L) -> Vec<String> {
+    let mut chain: Vec<String> = Vec::new();
+    let mut current = dir;
+    while !current.is_empty() && layout.is_python_package(current) {
+        chain.push(current.rsplit('/').next().unwrap_or(current).to_string());
+        current = parent_dir(current);
+    }
+    chain.reverse();
+    chain
+}
+
+/// The directory holding `path`, empty at the repository root.
+fn parent_dir(path: &str) -> &str {
+    match path.rsplit_once('/') {
+        Some((head, _)) => head,
+        None => "",
+    }
+}
+
+/// `path` with `prefix` and its separator removed, when `prefix` is a directory
+/// above it. Segment-wise, so `src` does not strip from `srcgen/x`.
+fn strip_dir_prefix<'a>(path: &'a str, prefix: &str) -> &'a str {
+    if prefix.is_empty() {
+        return path;
+    }
+    path.strip_prefix(prefix)
+        .and_then(|rest| {
+            rest.strip_prefix('/')
+                .or(Some(""))
+                .filter(|_| rest.is_empty() || rest.starts_with('/'))
+        })
+        .unwrap_or(path)
+}
+
+/// Segments into a scope, or the reason they name no module.
+fn known_or_absent(segments: Vec<String>) -> EntityScope {
+    match ScopePath::new(segments) {
+        Ok(path) => EntityScope::Known(path),
+        Err(_) => EntityScope::None(ScopeAbsence::PathNamesNoModule),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A layout answered from two lists, so a rule is tested against a stated
+    /// tree rather than against whatever the disk happens to hold.
+    struct StaticLayout {
+        python_packages: Vec<&'static str>,
+        manifests: Vec<(&'static str, ManifestKind, Option<&'static str>)>,
+    }
+
+    impl ScopeLayout for StaticLayout {
+        fn is_python_package(&self, dir: &str) -> bool {
+            self.python_packages.contains(&dir)
+        }
+
+        fn manifest_at_or_above(&self, dir: &str, kind: ManifestKind) -> Option<Manifest> {
+            let mut current = dir;
+            loop {
+                if let Some((found, _, name)) = self
+                    .manifests
+                    .iter()
+                    .find(|(at, at_kind, _)| *at == current && *at_kind == kind)
+                {
+                    return Some(Manifest {
+                        dir: (*found).to_string(),
+                        name: name.map(str::to_string),
+                    });
+                }
+                if current.is_empty() {
+                    return None;
+                }
+                current = parent_dir(current);
+            }
+        }
+    }
+
+    fn empty_layout() -> StaticLayout {
+        StaticLayout {
+            python_packages: Vec::new(),
+            manifests: Vec::new(),
+        }
+    }
+
+    fn scope_of(language: LanguageId, path: &str, layout: &StaticLayout) -> EntityScope {
+        derive(
+            ScopeInputs {
+                language,
+                file: Some(&FilePathId(path.to_string())),
+                declared: None,
+            },
+            layout,
+        )
+    }
+
+    fn declared_of(language: LanguageId, declared: &str) -> EntityScope {
+        derive(
+            ScopeInputs {
+                language,
+                file: Some(&FilePathId("src/Thing.java".to_string())),
+                declared: Some(declared),
+            },
+            &empty_layout(),
+        )
+    }
+
+    fn known(scope: &EntityScope) -> String {
+        match scope {
+            EntityScope::Known(path) => path.to_string(),
+            other => panic!("expected a known scope, got {other}"),
+        }
+    }
+
+    #[test]
+    fn a_language_with_no_namespace_says_so_rather_than_going_uncomputed() {
+        for language in [LanguageId::C, LanguageId::Hcl, LanguageId::Swift] {
+            assert_eq!(
+                scope_of(language, "src/thing.c", &empty_layout()),
+                EntityScope::None(ScopeAbsence::LanguageHasNone),
+                "{language} has no namespace at this level, which is an answer"
+            );
+        }
+    }
+
+    #[test]
+    fn a_declared_namespace_is_read_and_an_unread_one_is_uncomputed() {
+        for language in [
+            LanguageId::Java,
+            LanguageId::Kotlin,
+            LanguageId::Go,
+            LanguageId::Php,
+            LanguageId::Cpp,
+            LanguageId::CSharp,
+            LanguageId::Ruby,
+        ] {
+            assert_eq!(
+                known(&declared_of(language, "com.example.queue")),
+                "com.example.queue",
+                "{language} declares its namespace and the rule reads it"
+            );
+            assert_eq!(
+                scope_of(language, "src/Thing.java", &empty_layout()),
+                EntityScope::NotComputed,
+                "{language} with no declaration read is uncomputed, not scopeless"
+            );
+        }
+    }
+
+    #[test]
+    fn a_declared_namespace_parses_from_every_spelling_its_language_writes() {
+        assert_eq!(
+            known(&declared_of(LanguageId::Php, "App\\Http")),
+            "App.Http"
+        );
+        assert_eq!(
+            known(&declared_of(LanguageId::Cpp, "outer::inner")),
+            "outer.inner"
+        );
+        assert_eq!(known(&declared_of(LanguageId::Go, "queue")), "queue");
+    }
+
+    #[test]
+    fn python_walks_the_package_chain_and_stops_where_it_ends() {
+        let layout = StaticLayout {
+            python_packages: vec!["a/queue", "a/queue/models"],
+            manifests: Vec::new(),
+        };
+        assert_eq!(
+            known(&scope_of(
+                LanguageId::Python,
+                "a/queue/models/user.py",
+                &layout
+            )),
+            "queue.models.user",
+            "the chain is the packages, and `a` is not one"
+        );
+        assert_eq!(
+            known(&scope_of(LanguageId::Python, "a/loose.py", &layout)),
+            "loose",
+            "a module outside every package is named by itself"
+        );
+    }
+
+    #[test]
+    fn a_python_package_marker_is_named_after_its_directory_once() {
+        let layout = StaticLayout {
+            python_packages: vec!["queue", "queue/models"],
+            manifests: Vec::new(),
+        };
+        assert_eq!(
+            known(&scope_of(
+                LanguageId::Python,
+                "queue/models/__init__.py",
+                &layout
+            )),
+            "queue.models",
+            "the marker names its own directory, and must not name it twice"
+        );
+    }
+
+    #[test]
+    fn rust_names_the_crate_then_the_module_path_in_both_layouts() {
+        let layout = StaticLayout {
+            python_packages: Vec::new(),
+            manifests: vec![("crates/kin-mcp", ManifestKind::Cargo, Some("kin-mcp"))],
+        };
+        assert_eq!(
+            known(&scope_of(
+                LanguageId::Rust,
+                "crates/kin-mcp/src/handlers/review.rs",
+                &layout
+            )),
+            "kin_mcp.handlers.review"
+        );
+        assert_eq!(
+            known(&scope_of(
+                LanguageId::Rust,
+                "crates/kin-mcp/src/handlers/mod.rs",
+                &layout
+            )),
+            "kin_mcp.handlers",
+            "the two spellings of one module answer alike"
+        );
+        assert_eq!(
+            known(&scope_of(
+                LanguageId::Rust,
+                "crates/kin-mcp/src/lib.rs",
+                &layout
+            )),
+            "kin_mcp",
+            "the crate root adds no segment because the crate segment names it"
+        );
+    }
+
+    #[test]
+    fn rust_without_a_crate_is_uncomputed_rather_than_rooted_at_the_repository() {
+        assert_eq!(
+            scope_of(LanguageId::Rust, "scripts/tool.rs", &empty_layout()),
+            EntityScope::NotComputed,
+            "two crates' queue::models would collide with no crate segment"
+        );
+    }
+
+    #[test]
+    fn rust_appends_the_inline_modules_the_extractor_read() {
+        let layout = StaticLayout {
+            python_packages: Vec::new(),
+            manifests: vec![("", ManifestKind::Cargo, Some("kin-model"))],
+        };
+        let scope = derive(
+            ScopeInputs {
+                language: LanguageId::Rust,
+                file: Some(&FilePathId("src/entity.rs".to_string())),
+                declared: Some("tests"),
+            },
+            &layout,
+        );
+        assert_eq!(known(&scope), "kin_model.entity.tests");
+    }
+
+    #[test]
+    fn a_module_specifier_is_read_from_the_package_that_owns_the_file() {
+        let layout = StaticLayout {
+            python_packages: Vec::new(),
+            manifests: vec![
+                ("", ManifestKind::Node, Some("kinlab")),
+                (
+                    "packages/repo-eval",
+                    ManifestKind::Node,
+                    Some("@kinlab/repo-eval"),
+                ),
+            ],
+        };
+        assert_eq!(
+            known(&scope_of(
+                LanguageId::TypeScript,
+                "packages/repo-eval/src/score.ts",
+                &layout
+            )),
+            "src.score",
+            "the nearest package roots the specifier, not the repository"
+        );
+        assert_eq!(
+            known(&scope_of(
+                LanguageId::TypeScript,
+                "services/gateway/main.ts",
+                &layout
+            )),
+            "services.gateway.main",
+            "a file under no nested package is rooted at the repository package"
+        );
+    }
+
+    #[test]
+    fn an_index_file_takes_the_directory_it_marks() {
+        let layout = StaticLayout {
+            python_packages: Vec::new(),
+            manifests: vec![("", ManifestKind::Node, Some("kinlab"))],
+        };
+        assert_eq!(
+            known(&scope_of(
+                LanguageId::TypeScript,
+                "packages/ui/index.ts",
+                &layout
+            )),
+            "packages.ui",
+            "require('./packages/ui') names the directory, not an `index` module"
+        );
+        assert_eq!(
+            known(&scope_of(LanguageId::JavaScript, "lib/index.js", &layout)),
+            "lib"
+        );
+    }
+
+    #[test]
+    fn a_declaration_file_scopes_like_the_module_it_declares() {
+        let layout = StaticLayout {
+            python_packages: Vec::new(),
+            manifests: vec![("", ManifestKind::Node, Some("kinlab"))],
+        };
+        assert_eq!(
+            known(&scope_of(
+                LanguageId::TypeScript,
+                "types/marked.d.ts",
+                &layout
+            )),
+            "types.marked",
+            "the `.d.ts` suffix is stripped whole, not down to `marked.d`"
+        );
+    }
+
+    #[test]
+    fn an_entity_with_no_file_cannot_be_placed_by_layout() {
+        for language in [
+            LanguageId::Python,
+            LanguageId::Rust,
+            LanguageId::TypeScript,
+            LanguageId::JavaScript,
+        ] {
+            assert_eq!(
+                derive(
+                    ScopeInputs {
+                        language,
+                        file: None,
+                        declared: None
+                    },
+                    &empty_layout()
+                ),
+                EntityScope::None(ScopeAbsence::NoFileOrigin),
+                "{language} derives from layout and there is no layout without a file"
+            );
+        }
+    }
+
+    #[test]
+    fn a_root_level_index_names_the_repository_and_so_names_no_module() {
+        let layout = StaticLayout {
+            python_packages: Vec::new(),
+            manifests: vec![("", ManifestKind::Node, Some("kinlab"))],
+        };
+        assert_eq!(
+            scope_of(LanguageId::JavaScript, "index.js", &layout),
+            EntityScope::None(ScopeAbsence::PathNamesNoModule),
+            "there is no module above the package root to name"
+        );
+    }
+
+    #[test]
+    fn a_prefix_that_is_not_a_directory_boundary_does_not_strip() {
+        assert_eq!(strip_dir_prefix("srcgen/x.ts", "src"), "srcgen/x.ts");
+        assert_eq!(strip_dir_prefix("src/x.ts", "src"), "x.ts");
+        assert_eq!(strip_dir_prefix("src", "src"), "");
+        assert_eq!(strip_dir_prefix("src/x.ts", ""), "src/x.ts");
+    }
+
+    /// The positive control. Every assertion above this one is satisfied by a
+    /// rule set that answers `NotComputed` for everything, so one arm has to
+    /// require real scopes for real paths across all three classes.
+    #[test]
+    fn the_rules_produce_real_scopes_across_all_three_classes() {
+        let layout = StaticLayout {
+            python_packages: vec!["queue"],
+            manifests: vec![
+                ("", ManifestKind::Cargo, Some("kin-model")),
+                ("", ManifestKind::Node, Some("kinlab")),
+            ],
+        };
+        let cases: Vec<(LanguageId, &str, Option<&str>, &str)> = vec![
+            (LanguageId::Python, "queue/models.py", None, "queue.models"),
+            (LanguageId::Rust, "src/entity.rs", None, "kin_model.entity"),
+            (LanguageId::TypeScript, "web/app.ts", None, "web.app"),
+            (LanguageId::JavaScript, "web/app.js", None, "web.app"),
+            (
+                LanguageId::Java,
+                "A.java",
+                Some("com.example"),
+                "com.example",
+            ),
+            (LanguageId::Go, "a.go", Some("queue"), "queue"),
+        ];
+        for (language, path, declared, expected) in cases {
+            let scope = derive(
+                ScopeInputs {
+                    language,
+                    file: Some(&FilePathId(path.to_string())),
+                    declared,
+                },
+                &layout,
+            );
+            assert_eq!(known(&scope), expected, "{language} at {path}");
+        }
+    }
+}


### PR DESCRIPTION
## What this adds

A file path is where an entity's bytes sit. A namespace is what the language calls the region it
belongs to, and it is what another entity writes when it names this one. Kin has only ever had the
first, so every question shaped "what is in this region" has had to be asked as "what is under this
directory". The two agree right up until something moves.

This is the vocabulary and the derivation rules. Nothing consumes them yet, on purpose: the walk,
the query and the containment edges are the next pull request, and this one is meant to be readable
on its own.

`ScopePath` holds ordered segments rather than a rendered string, because the separator is a
language's spelling and not part of the identity. `queue.models`, `queue::models`, `queue/models` and
`queue\models` are one value here. A textual prefix answers `queue` with everything in
`queue_internal`, which is a wrong answer that looks right, so containment is segment-wise.

`EntityScope` is three states rather than an `Option`, and the third carries the weight. A store
nobody has scoped would report every entity as having no namespace, which is the same answer a C file
gives, and a query would then narrow silently and report a region as empty. `NotComputed` makes that
state nameable so a query can refuse instead, and say how many entities it is waiting on.

## One rule per language, in three classes

Java, Kotlin, Go, PHP, C++, C# and Ruby **declare** their namespace in the source. The extractor
reads it and passes it in; nothing here guesses. A declaration nobody read is `NotComputed`, never
"no namespace".

Python, Rust, TypeScript and JavaScript **derive** it from layout. Those rules read the layout
through an injected `ScopeLayout` rather than off the disk, which is what lets the same rule answer
from the graph in the next pull request and from a fixture in the tests here. Rust names the crate
then the module path, so `crates/kin-mcp/src/handlers/review.rs` is `kin_mcp.handlers.review` and
`handlers/mod.rs` and `handlers.rs` answer alike. Python walks the `__init__.py` chain and stops
where it ends, so `queue/models.py` under a package is `queue.models` where the extractor records
`models` today and three other files record it too. TypeScript and JavaScript root the specifier at
the nearest `package.json`, so `packages/repo-eval/src/score.ts` is `src.score`, and an index file
takes the directory it marks because `require('./lib')` names the directory.

C, HCL and Swift have **none** at this level. C has no namespaces, HCL has blocks rather than
namespaces, and a Swift module is a build-target property that no source file declares, so deriving
one from layout would be an invention.

That is every variant of `LanguageId`, so no language falls through to a default.

## Nothing is stored on `Entity`, and that is load-bearing

`EntityDelta` embeds whole entities (`change.rs:81-85`) and a change id is a hash over their
canonical encoding taken straight out of `Serialize`, so one serialized field on `Entity` would move
every content-addressed id in every repository on disk. I built that version first to be sure: the
field added last, `#[serde(default)]`, `NotComputed` on every entity, exactly what the crate's
positional-wire rule asks for. It compiled, and three pinned identities moved. Arm P1 below is that
experiment kept as a falsification arm, so the constraint stays guarded rather than remembered.

## The census, before any query is allowed to answer

`examples/scope_census.rs` walks a tree the way ingestion walks it, extracts with the same adapters,
and derives each entity's scope with the same rules, so the tally is the one the product would
produce. It lives in `examples/` because it reads the filesystem, which is ingestion IO and not an
answer path; `verify-zero-file-search.py` excludes cargo's examples directory for that reason
(`:477-484`) and kin-parser already keeps `examples/dump_parsed.rs` there.

Run over this repository at `29c10ff04`, which is the main this branch was first cut from. Re-running it at a later head moves the counts by whatever landed in between, so the sha is named rather than left as "the base":

```
848 files parsed of 1102 walked

language      entities     known none(lang) none(oth) uncomputed
c                   61         0        61         0         0
cpp                 23         0         0         0        23
csharp               5         0         0         0         5
go                  31         0         0         0        31
hcl                  1         0         1         0         0
java                29         0         0         0        29
javascript         759       759         0         0         0
kotlin              15         0         0         0        15
php                  4         0         0         0         4
python            4022      4022         0         0         0
ruby                 5         0         0         0         5
rust             35699     35673         0         0        26
swift               14         0        14         0         0
typescript         177       177         0         0         0
TOTAL            40845     40631        76         0       138
```

40,631 of 40,845 land in a known scope, 99.5%. The other 214 split cleanly and neither half is a gap
in the rules.

76 are `None(LanguageHasNone)`: C, HCL and Swift. That is the answer those languages have.

112 are the seven declared languages waiting for their extractor to pass what it read, which is the
number that sizes the remaining parser work. C# and Ruby already qualify their names through
`qualify_container` and would resolve the moment the extractor passes it; Java, Go, Kotlin and PHP
read no package or namespace declaration at all today.

The remaining 26 are Rust and they are correct. They are the entities of
`tests/adapter-fixtures/rust/basic.rs` and `edge_cases.rs`, the only two `.rs` files here with no
crate above them, since the root `Cargo.toml` is workspace-only with no `[package]` section. Without
a crate segment two crates' `queue::models` would collide, so `NotComputed` beats a
repository-rooted guess.

Of 936 ECMAScript entities, 638 root at this repository's own `package.json` and zero have no
`package.json` above them, so the no-manifest arm is unexercised on this tree and says so rather than
being claimed as passing.

## Falsification

Eight arms, each mutating the behaviour one assertion guards, each restored by sha256 rather than by
`git checkout`, all eight ending `restored by hash, tree matches the committed head` and the run
ending `ALL ARMS RUN`.

```
E1  segment-wise containment becomes a textual prefix
    kin-model/src/scope.rs:238  queue_internal is a different region, and a textual prefix
                                would say otherwise
E2  Python stops looking for __init__.py and takes every ancestor
    kin-parser/src/scope.rs:406  the chain is the packages, and `a` is not one
                                 left "a.queue.models.user"  right "queue.models.user"
E3  mod.rs stops being the same module as its sibling spelling
    kin-parser/src/scope.rs:453  the two spellings of one module answer alike
                                 left "kin_mcp.handlers.mod"  right "kin_mcp.handlers"
E4  a Rust file with no crate gets a repository-rooted guess instead of a refusal
    kin-parser/src/scope.rs:473  two crates' queue::models would collide with no crate segment
                                 left None(PathNamesNoModule)  right NotComputed
E5  a module specifier stops being read from the package that owns the file
    kin-parser/src/scope.rs:511  the nearest package roots the specifier, not the repository
                                 left "packages.repo-eval.src.score"  right "src.score"
E6  an unread declaration starts reading as "this language has no namespace"
    kin-parser/src/scope.rs:377  java with no declaration read is uncomputed, not scopeless
                                 left None(LanguageHasNone)  right NotComputed
P1  a serialized field is added to Entity
    kin-model/src/identity.rs:1526  the tree walk this pin was measured from no longer produces
                                    it, so the pin anchors nothing
                                    left  4c41c36266e3ce754654d07a9fa22bba2bf186542ced8d44435133abbd7db105
                                    right 0c62d43eca6530d579900e459b2dcc2385cf483bcebea896cb02c0eb4c43085e
```

**E7 is the positive control, and it is the arm that matters most.** Every arm above is a negative,
and a rule set that answered `NotComputed` for everything would satisfy all of them. E7 makes the
derivation do exactly that, and then runs the whole scope suite:

```
the_rules_produce_real_scopes_across_all_three_classes ... FAILED
  expected a known scope, got not computed
```

Seven arms stayed green under it, including
`rust_without_a_crate_is_uncomputed_rather_than_rooted_at_the_repository` and
`a_declared_namespace_is_read_and_an_unread_one_is_uncomputed`, which is the demonstration that the
control is doing work no negative arm does. It requires real scopes for real paths in all three
classes at once: `queue.models` for Python, `kin_model.entity` for Rust, `web.app` for both
ECMAScript languages, `com.example` for Java and `queue` for Go.

## Local verification

```
at 0d7b15d2f
fmt rc=0
clippy rc=0
test rc=0
test result: ok. 349 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.81s
```

`test rc=0` is `cargo test -p kin-model -p kin-parser`, which runs both crates' lib suites and
their integration binaries; the line quoted is kin-model's lib, the largest single one, and every
other suite in that run was green too or the return code would not be zero.

clippy is the form `ci.yml` runs, `RUSTFLAGS="-D warnings" cargo clippy -p kin-model -p kin-parser
--all-targets --all-features` with the allows assembled out of `.github/clippy-allowed-lints.txt`,
and it reported zero.

`bin/kin-precheck kin --repo-dir` on the same head:

```
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin 0d7b15d2fe6e2834d3e7e4aaedb920e1f5be1066
```

## Notes for review

kin-model's version is untouched. The registry release flow manages it with `--version-mode manual`
and `--bump-own-version false`, and no PR-time gate in this repository requires a bump, so moving it
by hand from a lane would fight the train rather than help it. Say the word if that is wrong and I
will bump it.

Part of FIR-3578. The walk up `Contains`, the `Package` entities that root a module specifier from
the graph rather than from disk, and the query that refuses while any entity in range reads
`NotComputed`, are the next pull request.
