### PR TITLE
Lead a release with what it is, and stop publishing a pending-proof sentence

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1635,6 +1635,42 @@ jobs:
             --input ./CHANGELOG.md \
             --output ./release-notes.md
 
+      # Two lines about the release itself, permanent and unquoted, above
+      # everything else a reader meets. The first is the category line from
+      # docs/brand/tokens/canon.json verbatim, which is the line that leads the
+      # developer surfaces and a release page is one. The second says what this
+      # release carries, counted from the changelog section the step above
+      # extracted, which is the changes since the previous tag. Neither line
+      # mentions proof state, and nothing here is a benchmark, a latency or a
+      # completeness figure, so the canon's numbers rule is untouched.
+      #
+      # These lines are NOT quoted, on purpose. stripPendingNotice cuts forward
+      # from the pending marker and stops at the first line that is neither a
+      # quote nor blank, so an unquoted summary above the marker survives a
+      # promotion while the marker below it is removed.
+      - name: Put the release's own two lines on top of the notes
+        run: |
+          set -euo pipefail
+          # `grep -c` prints 0 and exits 1 when nothing matches, so the fallback
+          # must add no second line of its own.
+          changes="$(grep -c '^- ' ./release-notes.md || :)"
+          case "$changes" in ''|*[!0-9]*) changes=0 ;; esac
+          if [ "$changes" -eq 0 ]; then
+            carries="The changes in this release are listed below."
+          elif [ "$changes" -eq 1 ]; then
+            carries="${GITHUB_REF_NAME} lands 1 change, listed below."
+          else
+            carries="${GITHUB_REF_NAME} lands ${changes} changes, listed below."
+          fi
+          {
+            echo "A graph-native code repository for people and AI agents."
+            echo "$carries"
+            echo
+            cat ./release-notes.md
+          } > "$RUNNER_TEMP/release-notes-summary.md"
+          mv "$RUNNER_TEMP/release-notes-summary.md" ./release-notes.md
+          head -3 ./release-notes.md
+
       - name: Aggregate per-artifact checksums
         run: |
           set -euo pipefail
@@ -2671,18 +2707,20 @@ jobs:
           # cannot drift into an idempotency check that never matches. There is
           # no other expansion in this text.
           #
-          # Two plain lines, and they stay a quoted block on purpose. The marker
-          # is an HTML comment, so a reader never sees it while every watcher
-          # still keys on it: release-promote.yml greps the body for it and
-          # scripts/release-promotion-plan.mjs exports it as PENDING_MARKER.
-          # stripPendingNotice removes the marker line and then every following
-          # line that is a quote or blank, so a summary written as anything but
-          # a quoted block would survive the strip and go on claiming a pending
-          # proof after the proof landed.
+          # The marker and nothing else. A reader is never told that a proof is
+          # pending, because that sentence said nothing they could act on and
+          # cost them five lines before the first word about the release. The
+          # state itself is unchanged and still machine-readable here, which is
+          # where every watcher already reads it: release-promote.yml greps the
+          # body for it, scripts/release-promotion-plan.mjs exports it as
+          # PENDING_MARKER, and the grep above keys on it for idempotency. It is
+          # an HTML comment, so it renders as nothing at all.
+          #
+          # stripPendingNotice cuts FORWARD from the marker, so the two-line
+          # summary written above the notes survives a promotion untouched,
+          # while this marker and any legacy quoted block below it are removed.
           cat > "$RUNNER_TEMP/release-body.md" <<NOTE
           ${marker}
-          > This release passed the automated preflight on the exact bytes it ships. The
-          > first-install checks that measure what a new user meets have not run for it yet.
 
           NOTE
           printf '%s\n' "$body" >> "$RUNNER_TEMP/release-body.md"

--- a/scripts/read-promotion-plan.test.mjs
+++ b/scripts/read-promotion-plan.test.mjs
@@ -21,8 +21,8 @@ import {
 const tmp = () => fs.mkdtempSync(path.join(os.tmpdir(), 'kin-promotion-'));
 
 const HELD_BODY = `${PENDING_MARKER}
-> This release passed the automated preflight on the exact bytes it ships. The
-> first-install checks that measure what a new user meets have not run for it yet.
+> **First-contact proof pending.** This release cleared the machine preflight on its
+> own bytes.
 
 ## What changed
 
@@ -64,7 +64,7 @@ test('renderAlarm writes the body and returns the decision with its title', () =
 
 test('stripPendingNotice removes the block this chain wrote and nothing else', () => {
   const stripped = stripPendingNotice(HELD_BODY);
-  assert.doesNotMatch(stripped, /automated preflight/);
+  assert.doesNotMatch(stripped, /First-contact proof pending/);
   assert.doesNotMatch(stripped, new RegExp(PENDING_MARKER.replace(/[-[\]{}()*+?.,\\^$|#]/g, '\\$&')));
   // The human's own notes survive. A strip that took the whole body would lose
   // the release notes, which is a worse failure than leaving the notice.
@@ -128,8 +128,15 @@ test('stripPendingNotice strips the notice release.yml actually writes', () => {
   // fixture that never built.
   assert.ok(body.length >= 2, `extracted ${body.length} notice line(s) from release.yml`);
   assert.ok(
-    body.some((line) => line.includes('automated preflight')),
-    `the extracted block is not the notice: ${JSON.stringify(body)}`,
+    body.some((line) => line.includes('${marker}')),
+    `the extracted block does not carry the marker: ${JSON.stringify(body)}`,
+  );
+  // The ruling this shape exists to hold: the writer emits the marker and no
+  // visible sentence at all, so a reader is never told a proof is pending.
+  assert.deepEqual(
+    body.filter((line) => line.trimStart().startsWith('>')),
+    [],
+    `release.yml still writes a visible proof notice: ${JSON.stringify(body)}`,
   );
 
   const notice = body.join('\n').replace('${marker}', PENDING_MARKER);
@@ -231,4 +238,22 @@ test('the promotions CLI emits the tab-separated lines the workflow reads', () =
     env: { ...process.env, KIN_PROMOTION_PLAN: plan },
   });
   assert.equal(out, 'v9.9.9\tlocal\n');
+});
+
+// The permanent summary is not about the proof, so a promotion must not take it
+// away. It is unquoted and sits above the marker, and stripPendingNotice cuts
+// forward from the marker, which is exactly what keeps it.
+test('the two-line summary above the marker survives the strip', () => {
+  const summary = 'A graph-native code repository for people and AI agents.\nv1.2.3 lands 4 changes, listed below.\n';
+  const notes = '## Notes\n\n- a real change\n';
+  // A modern body: summary, then the marker, then the notes.
+  const modern = `${summary}\n${PENDING_MARKER}\n\n${notes}`;
+  assert.equal(stripPendingNotice(modern), `${summary}\n${notes}`);
+
+  // And a legacy body, where the quoted notice below the marker still goes.
+  const legacy = `${summary}\n${PENDING_MARKER}\n> **First-contact proof pending.** old\n> wording\n\n${notes}`;
+  const strippedLegacy = stripPendingNotice(legacy);
+  assert.equal(strippedLegacy, `${summary}\n${notes}`);
+  assert.doesNotMatch(strippedLegacy, /First-contact proof pending/);
+  assert.match(strippedLegacy, /A graph-native code repository/);
 });


### PR DESCRIPTION
## Why this exists

Forward fix for #1760, which landed an earlier draft of this change.

**Root cause, in one line:** #1760's head was one commit older than the version its body described and than the sha its cited precheck graded, because the commit was amended after the branch was pushed and the pull request was opened without force-pushing the amend.

So what is live on `main` is the draft, not the reviewed design. No revert: this applies the corrected design on top of what is live.

## What is live on main right now

From `origin/main:.github/workflows/release.yml`, the release body still opens with a visible quoted proof notice:

```
<!-- kin-first-contact-proof -->
> This release passed the automated preflight on the exact bytes it ships. The
> first-install checks that measure what a new user meets have not run for it yet.

## [0.7.15] - 2026-09-11
```

Counted on main: `first-install checks` = 1, `A graph-native code repository` = 0, `Put the release's own two lines` = 0.

## What it becomes

```
<!-- kin-first-contact-proof -->

A graph-native code repository for people and AI agents.
v0.7.15 lands 5 changes, listed below.

## [0.7.15] - 2026-09-11
```

The marker is an HTML comment, so it renders as nothing and the two lines are the first thing a reader sees. No proof sentence is published at all.

Line 1 is the category line from `docs/brand/tokens/canon.json` verbatim, the line its own rule puts at the head of the developer surfaces, and a release page is one. Line 2 says what the release carries, counted from the changelog section the notes step already extracted, which is the changes since the previous tag. Nothing here is a benchmark, a latency or a completeness figure, so the canon's numbers rule is untouched, and nothing on its avoid list appears.

## Where the proof state lives

Unchanged. The `<!-- kin-first-contact-proof -->` marker is the whole state:

- `.github/workflows/release-promote.yml` greps the body for `kin-first-contact-proof`, to find releases to clear and to verify the clear worked.
- `scripts/release-promotion-plan.mjs` exports it as `PENDING_MARKER` and decides `held` from `body.includes(PENDING_MARKER)`.
- `.github/workflows/release.yml` greps it for its own idempotency.

No watcher changed.

## Why the summary is unquoted, and above the marker

`stripPendingNotice` finds the marker, removes it and every following line that is a quote or blank, stops at the first line that is neither, and keeps everything before it. So an unquoted summary above the marker survives a promotion, while the marker and any legacy quoted block below it are removed. A summary written as a quote, or a strip that cut backwards, would take the release's own description away the moment its proof landed. Legacy releases keep working: their quoted notice still strips.

## This reverts nothing

`release.yml` also changed under #1763 after this work's base. The corrected files were NOT checked out wholesale over main for that reason; the two changes were applied surgically on top of it. Verified: the diff against `origin/main` removes zero lines matching `kin-vfs-core`, and #1763's marker string is present in both main and this head.

## Tests

`node --test scripts/read-promotion-plan.test.mjs`: 13 tests, 13 pass, 0 fail.

The coupling test reads the real heredoc out of `release.yml`, substitutes the marker and asserts the strip returns the notes byte for byte. It also asserts that heredoc writes no quoted line at all, so a visible proof sentence cannot come back unnoticed. A further test holds the summary across a modern body and a legacy one.

Both falsified by breaking what they guard, on this head:

- Give the heredoc a `> First-contact proof pending.` line again: the coupling test goes red (12 pass, 1 fail).
- Make the strip drop everything above the marker: the summary-survives test goes red (12 pass, 1 fail).

Each restore returns 13 pass, 0 fail. `actionlint` passes on the changed workflow.

## Local gates

`bin/kin-precheck kin --repo-dir kin=<this lane worktree>`, through the fleet's builder slot, against this PR's head sha:

```
kin-precheck: 22 gates ran, 22 passed, 0 failed, on kin 65c28a903df1f5b985ea05bec12d08c050a31d9a
```

Not enqueued. The captain reads this diff against the founder's approved wording and lands it.
