### PR TITLE
Fix database feature gating and concurrent model tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Firelock, LLC
 
+# Test scheduling and flake quarantine.
+#
+# nextest runs tests in separate processes. Tests that load the default model
+# share its HuggingFace cache, whose download lock times out before a cold
+# download can finish. Serialize those consumers without retrying failures.
+[test-groups.model-download]
+max-threads = 1
+
+[[profile.default.overrides]]
+filter = 'binary_id(=kin-db) & (test(=embed::tests::default_dimensions_match_default_model) | test(=engine::graph::tests::test_vector_index_dimension_mismatch_auto_recovery) | test(=engine::graph::tests::a_surviving_revision_key_does_not_resolve_a_retired_entity))'
+test-group = 'model-download'
+
+[[profile.default.overrides]]
+filter = 'binary_id(=kin-db::embed_oom_cpu_fallback) | binary_id(=kin-db::embedding_sanity) | binary_id(=kin-db::embed_hybrid_parity) | binary_id(=kin-db::embed_budget_profile) | binary_id(=kin-db::metal_seq_len_regression)'
+test-group = 'model-download'
+
 # Flake quarantine, and the two verdicts one execution produces.
 #
 # A job-level retry restarts the check clock, which is what a merge-queue
@@ -20,9 +36,9 @@
 # The last one decides the shape of this file. nextest IGNORES keys it does not
 # know, so quarantine bookkeeping cannot live in this table as extra fields: a
 # typo would be silently dropped and the row would still read complete. The
-# bookkeeping is therefore a comment line in a fixed format above each override,
-# and scripts/check-quarantine.py refuses the file unless every override carries
-# one and the comment and the filter name the same test.
+# bookkeeping is therefore a comment line in a fixed format above each retry
+# override. scripts/check-quarantine.py requires that comment and the filter to
+# name the same test. Scheduling-only overrides above do not grant retries.
 #
 # The blocking verdict is this profile: a quarantined test that passes on retry
 # does not fail the run, so it stops ejecting queue entries and stops reddening

--- a/crates/kin-db/src/embed/mod.rs
+++ b/crates/kin-db/src/embed/mod.rs
@@ -593,14 +593,16 @@ const DEFAULT_REVISION: &str = "main";
 /// Serializes `--lib` unit tests that build a real [`CodeEmbedder`] against
 /// the shared on-disk HuggingFace Hub cache
 /// (`default_dimensions_match_default_model` here and
-/// `test_vector_index_dimension_mismatch_auto_recovery` in `engine::graph`;
-/// both resolve `DEFAULT_MODEL_ID`/`DEFAULT_REVISION`). `cargo test` runs
+/// the vector-index tests in `engine::graph`; all resolve
+/// `DEFAULT_MODEL_ID`/`DEFAULT_REVISION`). `cargo test` runs
 /// unit tests from one binary concurrently by default, and two threads
 /// racing `hf_hub`'s first-time blob download for the same repo+revision
 /// can corrupt the shared cache directory. Holding this lock around
 /// embedder construction means the first test performs the real download
 /// and every later test observes an already-warm cache: no network race,
 /// and the model is fetched once per test run instead of once per test.
+/// nextest uses separate processes, coordinated by the `model-download` test
+/// group in `.config/nextest.toml`.
 #[cfg(all(test, feature = "embeddings"))]
 pub(crate) static EMBED_MODEL_DOWNLOAD_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
 

--- a/crates/kin-db/src/engine/graph.rs
+++ b/crates/kin-db/src/engine/graph.rs
@@ -4807,7 +4807,7 @@ impl InMemoryGraph {
     ///
     /// Downloads the model from HuggingFace on first call (~270 MB).
     /// Subsequent calls return the cached instance.
-    #[cfg(feature = "embeddings")]
+    #[cfg(all(feature = "embeddings", feature = "vector"))]
     fn get_embedder(&self) -> Result<Arc<CodeEmbedder>, KinDbError> {
         let mut guard = self.embedder.lock();
         if let Some(ref e) = *guard {

--- a/crates/kin-db/src/engine/graph.rs
+++ b/crates/kin-db/src/engine/graph.rs
@@ -12045,6 +12045,8 @@ mod tests {
     #[cfg(feature = "vector")]
     #[test]
     fn a_surviving_revision_key_does_not_resolve_a_retired_entity() {
+        #[cfg(feature = "embeddings")]
+        let _download_guard = crate::embed::EMBED_MODEL_DOWNLOAD_LOCK.lock();
         let graph = InMemoryGraph::new();
         let file = FilePathId::new("src/retired.rs");
         let entry = TreeEntry::blob(Hash256::from_bytes([0x21; 32]), false);

--- a/scripts/check-quarantine.py
+++ b/scripts/check-quarantine.py
@@ -101,7 +101,7 @@ QUARANTINE_MAX_DAYS = 14
 QUARANTINE_MAX_ROWS = 5
 QUARANTINE_PROMOTION_DAYS = 7
 
-# The bookkeeping comment that must sit above every override. Keys are matched
+# The bookkeeping comment above every quarantine override. Keys are matched
 # individually rather than as one line pattern, so a row missing exactly one of
 # them is refused by the arm that owns that key instead of by a shapeless
 # "malformed comment".
@@ -136,21 +136,31 @@ class Row:
 
 
 def parse_rows(text):
-    """Pair each `[[profile.default.overrides]]` with the comment above it.
+    """Pair quarantine overrides with their bookkeeping comments.
 
     Textual on purpose. tomllib discards comments, and the comment is where the
     bookkeeping lives, so a TOML-only read would report every row as having no
     ticket. tomllib still runs, in `load_config`, to prove the file is valid
-    TOML and to read the values; this pass only supplies what tomllib throws
-    away.
+    TOML. Scheduling-only overrides assign a declared test group without
+    retries; they do not belong to quarantine.
     """
 
+    config = tomllib.loads(text)
+    groups = config.get("test-groups", {})
+    profile = config.get("profile", {}).get("default", {})
+    if profile.get("retries", 0) != 0:
+        raise AssertionError(
+            "global-retries: default-profile retries apply to every test without "
+            "quarantine metadata; declare retries only on ticketed test overrides"
+        )
+    overrides = iter(profile.get("overrides", []))
     rows = []
     lines = text.splitlines()
     index = 0
     for number, line in enumerate(lines, start=1):
         if line.strip() != "[[profile.default.overrides]]":
             continue
+        override = next(overrides)
         meta = {}
         # Walk back over the contiguous comment block above the table header.
         for above in range(number - 2, -1, -1):
@@ -162,6 +172,13 @@ def parse_rows(text):
                 if found:
                     meta = found
                     break
+        if (
+            not meta
+            and set(override) == {"filter", "test-group"}
+            and isinstance(override["test-group"], str)
+            and override["test-group"] in groups
+        ):
+            continue
         filter_expr = None
         retries = None
         for below in range(number, len(lines)):
@@ -476,6 +493,38 @@ def run_controls():
                 f"{findings + warnings}, so every mutation below would be red "
                 "for the wrong reason"
             )
+
+        scheduling = """
+[test-groups.model-download]
+max-threads = 1
+[[profile.default.overrides]]
+filter = 'binary_id(=pkg::target) & test(=a_test_that_is_defined)'
+test-group = 'model-download'
+"""
+        findings, warnings = grade(scheduling + clean)
+        if findings or warnings or len(parse_rows(scheduling + clean)) != 1:
+            raise AssertionError(
+                "control failed: a scheduling-only group was treated as quarantine"
+            )
+        for untracked in (
+            scheduling + "retries = 2\n",
+            scheduling.replace("test-group = 'model-download'", "test-group = 'unknown'"),
+        ):
+            findings, _ = grade(untracked)
+            if not any(finding.startswith("no-ticket:") for finding in findings):
+                raise AssertionError(
+                    "control failed: a retry or unknown group bypassed quarantine validation"
+                )
+        for retries in ("2", '{ count = 2, backoff = "fixed", delay = "1s" }'):
+            try:
+                parse_rows(scheduling + f"\n[profile.default]\nretries = {retries}\n")
+            except AssertionError as error:
+                if not str(error).startswith("global-retries:"):
+                    raise
+            else:
+                raise AssertionError(
+                    "control failed: inherited global retries bypassed quarantine validation"
+                )
 
         mutations = {
             "no-ticket": clean.replace("ticket=FIR-1 ", ""),


### PR DESCRIPTION
The macOS featureless CLI build enables database embeddings through its target-specific Metal/Accelerate dependencies while leaving vector search disabled. That compiles `get_embedder` without any callers, and `-D warnings` fails CI, blocking the next release.

Compile the helper only when both embeddings and vector search are enabled, matching every caller. Keep the shared embedder field available under the embeddings feature.

The imported database tests also share the default model's HuggingFace cache. Their in-process mutex does not coordinate nextest's separate test processes, so concurrent cold-cache downloads can exceed hf-hub's five-second lock deadline. Assign those unit and integration tests to one native nextest group with a concurrency limit of one. Add the missing mutex to the retirement test for ordinary `cargo test` runs. Scheduling-only group assignments remain separate from retry quarantine, and undeclared retries still fail its guard.

Validation on macOS used the same featureless CLI test command as CI, with `RUSTFLAGS="-D warnings"`, `CARGO_INCREMENTAL=0`, and dev/test debug info disabled:

```text
cargo test -p kin-cli --no-default-features --lib --tests --locked
test result: ok. 2289 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 113.87s
[remaining binary and integration test suites passed]
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.82s
command exit rc=0
```

Across the 82 test result summaries, 3,273 tests passed, two were ignored and none failed. `cargo fmt --all -- --check` and `git diff --check` also passed. Full main CI and release artifact verification remain the release gates.

The concurrency correction passed focused verification:

```text
cargo nextest show-config test-groups -p kin-db --lib --test embed_oom_cpu_fallback --test embedding_sanity --test embed_hybrid_parity --test embed_budget_profile --test metal_seq_len_regression --locked --run-ignored all --groups model-download
group: model-download (max threads = 1)
[three unit tests and the compiled integration consumers listed in that group]
command exit rc=0

cargo nextest run -p kin-db --lib --test embed_oom_cpu_fallback --locked -E 'test(=embed::tests::default_dimensions_match_default_model) | test(=engine::graph::tests::test_vector_index_dimension_mismatch_auto_recovery) | test(=engine::graph::tests::a_surviving_revision_key_does_not_resolve_a_retired_entity) | test(=metal_oom_degrades_to_cpu_twin_and_returns_correct_vectors)'
Summary [23.366s] 4 tests run: 4 passed, 1131 skipped
command exit rc=0

python3 scripts/check-quarantine.py
0 quarantine row(s), every one ticketed, dated, inside 14 days, and naming a test that still exists
```

The new scheduling-only control failed before the guard correction and passed afterward. Controls also verify that a group carrying retries or naming an undeclared group cannot bypass quarantine validation. A separately falsified control rejects inherited global retries, including the backoff-table form. Model tests used the local provider with CPU inference and the existing model cache. Fresh-runner CI remains the cold-cache check; no retries were added.
