### PR TITLE
docs(claude): add plugin requirements

### DIFF
--- a/plugins/kin-claude/README.md
+++ b/plugins/kin-claude/README.md
@@ -36,6 +36,11 @@ Every response names the graph state that produced it, and an empty result says 
 absence can be trusted. A graph gap is reported as a gap rather than filled in from raw file
 search.
 
+## Requirements
+
+Node 20 or newer for `npx`, and network access on the first run to fetch the Kin release.
+macOS, Linux, and Windows x64 are supported. On Windows, WSL2 is the recommended path.
+
 ## Links
 
 - Repository: https://github.com/firelock-ai/kin


### PR DESCRIPTION
## Summary
- Add the missing `## Requirements` section to `plugins/kin-claude/README.md`.
- Match the Node, first-run network, and supported-platform wording already used by the Codex and Cursor plugin READMEs.

Closes #1733

## Test Plan
- PASS: `python3 - <<'PY' ... PY` verified the Claude, Codex, and Cursor plugin READMEs contain the same Requirements section text.
- PASS: `git diff --check`
- NOT RUN: full Rust workspace checks (`cargo test`, `cargo clippy`, `cargo fmt`) because this is a docs-only plugin README change.
