### PR TITLE
fix(cli): show continue alias in resolve help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Show the `--continue` alias in `kin resolve --help`.
+
 ## [0.7.16] - 2026-09-12
 
 ### Changed

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -781,7 +781,7 @@ enum Command {
         #[arg(long)]
         all_theirs: bool,
         /// Complete the merge after all conflicts are resolved
-        #[arg(long, alias = "continue")]
+        #[arg(long, visible_alias = "continue")]
         do_continue: bool,
         /// Abort the merge and discard conflict state
         #[arg(long)]

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -706,7 +706,7 @@ kin resolve [options]
 | `--file <path> <file>` |  | Resolve a conflicted repository path using the exact bytes in `<file>`, which is the form that takes a file you merged by hand. `<path>` is the conflicted repository path or artifact identity from `kin conflicts`. Repeatable; the bodies of one request total at most 8 MiB. |
 | `--all-ours` |  | Resolve all remaining conflicts keeping your version |
 | `--all-theirs` |  | Resolve all remaining conflicts keeping the incoming version |
-| `--do-continue`, `--continue` |  | Complete the merge after all conflicts are resolved. `--continue` is an accepted alias that the CLI parses but does not list in `--help`, so a reader coming from Git will find it works. |
+| `--do-continue`, `--continue` |  | Complete the merge after all conflicts are resolved. `--continue` is a visible alias for `--do-continue`. |
 | `--abort` |  | Abort the merge and discard conflict state |
 | `--expect <hash>` |  | Require the merge transaction to still be the one this identity names |
 | `--json` |  | Emit the machine-readable merge transaction record |


### PR DESCRIPTION
## What

Make the existing `--continue` alias visible in `kin resolve --help`.

Also update the CLI reference and changelog to reflect that `--continue` is now a visible alias for `--do-continue`.

## Why

`kin resolve --continue` was already accepted by the CLI, but the alias was hidden from `kin resolve --help`. This made the Git-style `--continue` spelling difficult to discover.

Closes #1732

## How

Changed the existing clap argument from:

`alias = "continue"`

to:

`visible_alias = "continue"`

This preserves the existing behavior while exposing the alias in help output. No merge-resolution behavior was changed.

## Testing

- [x] Verified `cargo run --bin kin -- resolve --help` displays `[alias: --continue]`
- [x] Verified `cargo run --bin kin -- resolve --continue` is accepted by clap and reaches normal repository validation
- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets -- -D warnings` — blocked by unrelated existing workspace Clippy failures, including `too_many_arguments` in `kin-daemon-spawn`
- [ ] `cargo test` — full workspace testing is blocked by unrelated existing workspace build/test issues
- [x] Commit includes the required DCO `Signed-off-by` trailer