### PR TITLE
Package release-matched desktop MCP binaries and maintainer metadata

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["troyjr4103"]
+}

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -14,9 +14,9 @@
     "package.json"
   ],
   "scripts": {
-    "test": "node --test ./test/index.test.js",
+    "test": "node --test ./test/index.test.js ../../scripts/mcpb/test-build.mjs",
     "test:unit": "node --test ./test/index.test.js",
-    "lint": "node --check ./bin/kin-mcp.js && node --check ./src/index.js && node --check ./test/index.test.js && node --check ./test/smoke-first-run.mjs",
+    "lint": "node --check ./bin/kin-mcp.js && node --check ./src/index.js && node --check ./test/index.test.js && node --check ./test/smoke-first-run.mjs && node --check ../../scripts/mcpb/test-build.mjs",
     "smoke": "node ./test/smoke-first-run.mjs"
   },
   "engines": {

--- a/packages/kin-mcp/test/index.test.js
+++ b/packages/kin-mcp/test/index.test.js
@@ -3,7 +3,6 @@ import cp from 'node:child_process';
 import crypto from 'node:crypto';
 import { existsSync } from 'node:fs';
 import fs from 'node:fs/promises';
-import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -472,35 +471,27 @@ async function buildReleaseArchive(
   return { archiveBytes, archiveName, checksum, kinBytes, daemonBytes };
 }
 
-function startReleaseServer(version, archiveName, archiveBytes, checksum) {
-  const server = http.createServer((req, res) => {
-    if (req.url === `/v${version}/${archiveName}`) {
-      res.writeHead(200, { 'content-type': 'application/octet-stream' });
-      res.end(archiveBytes);
-      return;
+function mockReleaseFetch(t, version, archiveName, archiveBytes, checksum) {
+  const baseUrl = 'https://releases.example.invalid';
+  t.mock.method(globalThis, 'fetch', async url => {
+    if (url === `${baseUrl}/v${version}/${archiveName}`) {
+      return new Response(archiveBytes, { headers: { 'content-type': 'application/octet-stream' } });
     }
-    if (req.url === `/v${version}/${archiveName}.sha256`) {
-      res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
-      res.end(`${checksum}  ${archiveName}\n`);
-      return;
+    if (url === `${baseUrl}/v${version}/${archiveName}.sha256`) {
+      return new Response(`${checksum}  ${archiveName}\n`);
     }
-    res.writeHead(404);
-    res.end('not found');
+    return new Response('not found', { status: 404, statusText: 'Not Found' });
   });
-  return server;
+  return baseUrl;
 }
 
-test('ensureKinBinary downloads kin and its daemon from a release asset', async () => {
+test('ensureKinBinary downloads kin and its daemon from a release asset', async t => {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'kin-mcp-download-'));
   const assetName = 'kin-linux-x86_64';
   const version = '9.9.9-test';
   const { archiveBytes, archiveName, checksum, kinBytes, daemonBytes } =
     await buildReleaseArchive(tmpDir, assetName);
-  const server = startReleaseServer(version, archiveName, archiveBytes, checksum);
-
-  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
-  const address = server.address();
-  const baseUrl = `http://127.0.0.1:${address.port}`;
+  const baseUrl = mockReleaseFetch(t, version, archiveName, archiveBytes, checksum);
   const env = {
     KIN_MCP_CACHE_DIR: tmpDir,
     KIN_MCP_RELEASE_BASE_URL: baseUrl
@@ -529,22 +520,17 @@ test('ensureKinBinary downloads kin and its daemon from a release asset', async 
     assert.equal(await exists(daemonPath), true);
     assert.equal(await fs.readFile(daemonPath, 'utf8'), daemonBytes.toString('utf8'));
   } finally {
-    await new Promise(resolve => server.close(resolve));
     await fs.rm(tmpDir, { recursive: true, force: true });
   }
 });
 
-test('ensureKinBinary installs the flat native Windows zip and .exe pair', async () => {
+test('ensureKinBinary installs the flat native Windows zip and .exe pair', async t => {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'kin-mcp-windows-download-'));
   const assetName = 'kin-windows-x86_64';
   const version = '9.9.9-test';
   const { archiveBytes, archiveName, checksum, kinBytes, daemonBytes } =
     await buildReleaseArchive(tmpDir, assetName, { platform: 'win32' });
-  const server = startReleaseServer(version, archiveName, archiveBytes, checksum);
-
-  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
-  const address = server.address();
-  const baseUrl = `http://127.0.0.1:${address.port}`;
+  const baseUrl = mockReleaseFetch(t, version, archiveName, archiveBytes, checksum);
   const env = await environmentWithHostileTar(tmpDir, {
     KIN_MCP_CACHE_DIR: tmpDir,
     KIN_MCP_RELEASE_BASE_URL: baseUrl
@@ -565,7 +551,6 @@ test('ensureKinBinary installs the flat native Windows zip and .exe pair', async
     assert.equal(path.basename(daemonPath), 'kin-daemon.exe');
     assert.equal(await fs.readFile(daemonPath, 'utf8'), daemonBytes.toString('utf8'));
   } finally {
-    await new Promise(resolve => server.close(resolve));
     await fs.rm(tmpDir, { recursive: true, force: true });
   }
 });
@@ -578,17 +563,13 @@ test('ensureKinBinary installs the flat native Windows zip and .exe pair', async
 test(
   'ensureKinBinary unpacks the Unix archive with an absolute tar under a hostile PATH',
   { skip: process.platform === 'win32' },
-  async () => {
+  async t => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'kin-mcp-hostile-tar-'));
     const assetName = 'kin-linux-x86_64';
     const version = '9.9.9-test';
     const { archiveBytes, archiveName, checksum, kinBytes, daemonBytes } =
       await buildReleaseArchive(tmpDir, assetName);
-    const server = startReleaseServer(version, archiveName, archiveBytes, checksum);
-
-    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
-    const address = server.address();
-    const baseUrl = `http://127.0.0.1:${address.port}`;
+    const baseUrl = mockReleaseFetch(t, version, archiveName, archiveBytes, checksum);
     const env = await environmentWithHostileTar(tmpDir, {
       KIN_MCP_CACHE_DIR: tmpDir,
       KIN_MCP_RELEASE_BASE_URL: baseUrl
@@ -606,13 +587,12 @@ test(
       const daemonPath = resolveDaemonBinaryPath(binaryPath);
       assert.equal(await fs.readFile(daemonPath, 'utf8'), daemonBytes.toString('utf8'));
     } finally {
-      await new Promise(resolve => server.close(resolve));
-      await fs.rm(tmpDir, { recursive: true, force: true });
+        await fs.rm(tmpDir, { recursive: true, force: true });
     }
   }
 );
 
-test('ensureKinBinary fails with a precise message when the archive omits kin-daemon', async () => {
+test('ensureKinBinary fails with a precise message when the archive omits kin-daemon', async t => {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'kin-mcp-nodaemon-'));
   const assetName = 'kin-linux-x86_64';
   const version = '9.9.9-test';
@@ -621,11 +601,7 @@ test('ensureKinBinary fails with a precise message when the archive omits kin-da
     assetName,
     { includeDaemon: false }
   );
-  const server = startReleaseServer(version, archiveName, archiveBytes, checksum);
-
-  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
-  const address = server.address();
-  const baseUrl = `http://127.0.0.1:${address.port}`;
+  const baseUrl = mockReleaseFetch(t, version, archiveName, archiveBytes, checksum);
   const env = {
     KIN_MCP_CACHE_DIR: tmpDir,
     KIN_MCP_RELEASE_BASE_URL: baseUrl
@@ -637,7 +613,37 @@ test('ensureKinBinary fails with a precise message when the archive omits kin-da
       /kin-daemon/
     );
   } finally {
-    await new Promise(resolve => server.close(resolve));
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('ensureKinBinary rejects a failed archive response', async t => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'kin-mcp-http-error-'));
+  t.mock.method(globalThis, 'fetch', async () =>
+    new Response('not found', { status: 404, statusText: 'Not Found' }));
+  try {
+    await assert.rejects(ensureKinBinary({
+      env: { KIN_MCP_CACHE_DIR: tmpDir }, platform: 'linux', arch: 'x64', version: '9.9.9-test'
+    }), /failed to download .*404 Not Found/);
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('ensureKinBinary rejects archive bytes that disagree with the checksum', async t => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'kin-mcp-corrupt-'));
+  const version = '9.9.9-test';
+  const { archiveBytes, archiveName } = await buildReleaseArchive(tmpDir, 'kin-linux-x86_64');
+  const baseUrl = mockReleaseFetch(t, version, archiveName, archiveBytes, '0'.repeat(64));
+  try {
+    await assert.rejects(ensureKinBinary({
+      env: { KIN_MCP_CACHE_DIR: tmpDir, KIN_MCP_RELEASE_BASE_URL: baseUrl },
+      platform: 'linux', arch: 'x64', version
+    }), /checksum mismatch/i);
+    assert.equal(await exists(resolveCachedBinaryPath({
+      env: { KIN_MCP_CACHE_DIR: tmpDir }, platform: 'linux', arch: 'x64', version
+    })), false);
+  } finally {
     await fs.rm(tmpDir, { recursive: true, force: true });
   }
 });

--- a/scripts/mcpb/README.md
+++ b/scripts/mcpb/README.md
@@ -1,31 +1,54 @@
-# Kin for Claude Desktop
+# Kin MCPB candidate
 
-Kin keeps a living map of the software itself, so Claude answers from a graph of entities,
-relationships, changes, and provenance rather than from raw file search.
+Kin's MCPB is a local stdio extension for one Kin workspace. It keeps the workspace
+selection in the extension settings and starts the matching published Kin MCP launcher
+from that directory.
 
-The extension runs Kin's MCP server on your machine over stdio, against one repository you
-choose in the extension settings. Claude gets `semantic_locate`, `semantic_search`,
-`get_context_pack`, `trace_data_flow`, `impact_analysis`, and `find_references`, and
-answers them from that graph.
+## Build
+
+Run this from a public Kin checkout:
+
+```sh
+bash scripts/mcpb/build.sh
+```
+
+The script reads the matching versions from `packages/kin-mcp/package.json` and
+`packages/kin/package.json`, writes that version into a staging manifest, and pins the
+bundle launcher to `@kinlab/kin-mcp@<that-version>`. It refuses package-version drift.
+The source `manifest.json` is a `0.0.0` template and is not itself a distributable
+bundle manifest.
+
+The output defaults to `scripts/mcpb/kin.mcpb`; set `KIN_MCPB_OUTPUT` to choose a
+separate path. The bundle includes `release-identity.json`, which records the pinned npm
+launcher and native-release tag. At first start the launcher downloads and verifies the
+matching public Kin release archive, then caches it locally.
+
+This is a candidate builder only. It does not upload a bundle, create a GitHub release
+asset, or prove that the selected npm package and native release have published. Verify
+those facts separately before representing an artifact as released.
+
+## Regression check
+
+Run the scaffold regression without contacting npm or the MCPB registry:
+
+```sh
+node --test scripts/mcpb/test-build.mjs
+```
+
+It builds a temporary minimal fixture through a controlled `npx`, checks the packed
+manifest and the staged launcher's exact `npx -y @kinlab/kin-mcp@<version>` invocation,
+and proves package-version drift fails before packing. `npm test --prefix
+packages/kin-mcp` includes the same check in CI.
 
 ## Setup
 
-Choose the Kin workspace in the extension settings. That directory has to carry `.kin/`.
-If it does not, run `kin init .` there first, otherwise the server stops and says so.
+Choose a Kin workspace in the extension settings. Initialize it with `kin init .` before
+graph tool calls. The Node 20 or newer runtime and first-start network requirement remain
+part of this wrapper-based bundle. For a fully self-contained platform-specific bundle,
+embed a verified published release archive instead.
 
-You need Node 20 or newer. On first run the extension starts the published
-`@kinlab/kin-mcp` launcher, which downloads the matching Kin release archive from
-`https://github.com/firelock-ai/kin/releases/download` and caches it locally. macOS and
-Windows are the supported platforms.
+## Privacy and support
 
-## Privacy Policy
-
-https://kinlab.ai/privacy
-
-Every network exit the CLI, the daemon, and this launcher can make is enumerated in
-https://github.com/firelock-ai/kin/blob/main/docs/security/what-leaves-the-machine.md.
-
-## Support
-
-Report problems at https://github.com/firelock-ai/kin/issues. The core is Apache-2.0 at
-https://github.com/firelock-ai/kin.
+- https://kinlab.ai/privacy
+- https://github.com/firelock-ai/kin/blob/main/docs/security/what-leaves-the-machine.md
+- https://github.com/firelock-ai/kin/issues

--- a/scripts/mcpb/build.sh
+++ b/scripts/mcpb/build.sh
@@ -2,31 +2,76 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Firelock, LLC
 #
-# Build the Claude Desktop extension bundle (.mcpb) that wraps the published
-# @kinlab/kin-mcp launcher.
+# Build a local Kin MCPB candidate from the published-package topology. The
+# source manifest is a template: this script derives the bundle version from
+# the two lockstep npm packages and pins the launcher to that exact version.
 #
-# Run this by hand. No release job packs the bundle yet, so nothing here is
-# release evidence and nothing here may be cited as a shipped channel.
+# This is intentionally a manual candidate builder. It does not publish an
+# MCPB, create a release asset, or prove that its target npm/native release is
+# available yet.
 set -euo pipefail
 
 here="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "${here}/../.." && pwd)"
 icon_source="${repo_root}/assets/mcp/icon-512.png"
-icon_target="${here}/icon.png"
-bundle="${here}/kin.mcpb"
+mcp_package="${repo_root}/packages/kin-mcp/package.json"
+kin_package="${repo_root}/packages/kin/package.json"
+bundle="${KIN_MCPB_OUTPUT:-${here}/kin.mcpb}"
+stage="$(mktemp -d "${TMPDIR:-/tmp}/kin-mcpb.XXXXXX")"
+
+cleanup() {
+  rm -rf -- "$stage"
+}
+trap cleanup EXIT
 
 if [ ! -f "$icon_source" ]; then
   echo "error: the extension icon is missing: ${icon_source}" >&2
-  echo "manifest.json declares icon.png and Claude Desktop renders it on the extension card, so a bundle built without it ships an extension with no icon. Create that file as a 512x512 PNG with transparency, then rerun this script." >&2
   exit 1
 fi
 
-cp -- "$icon_source" "$icon_target"
-echo "icon: ${icon_source} -> ${icon_target}"
+version="$({
+  node - "$mcp_package" "$kin_package" <<'NODE'
+const fs = require('node:fs');
+const [mcpPackagePath, kinPackagePath] = process.argv.slice(2);
+const mcpPackage = JSON.parse(fs.readFileSync(mcpPackagePath, 'utf8'));
+const kinPackage = JSON.parse(fs.readFileSync(kinPackagePath, 'utf8'));
+if (typeof mcpPackage.version !== 'string' || typeof kinPackage.version !== 'string') {
+  throw new Error('Kin MCPB package version is not a string');
+}
+if (mcpPackage.version !== kinPackage.version) {
+  throw new Error(`@kinlab/kin-mcp ${mcpPackage.version} does not match @kinlab/kin ${kinPackage.version}`);
+}
+if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(mcpPackage.version)) {
+  throw new Error(`unsupported package version ${mcpPackage.version}`);
+}
+process.stdout.write(mcpPackage.version);
+NODE
+})"
 
-# Name the output explicitly. With no output argument mcpb names the bundle after the
-# directory it packed, so the file lands as mcpb.mcpb while the pack summary reports a
-# filename of kin-<version>.mcpb, and neither name is what gets uploaded.
-cd -- "$here"
-npx -y @anthropic-ai/mcpb pack . "$bundle"
+mkdir -p "$stage/server"
+cp -- "$icon_source" "$stage/icon.png"
+cp -- "$here/server/index.js" "$stage/server/index.js"
+
+node - "$here/manifest.json" "$stage/manifest.json" "$stage/release-identity.json" "$version" <<'NODE'
+const fs = require('node:fs');
+const [templatePath, manifestPath, identityPath, version] = process.argv.slice(2);
+const manifest = JSON.parse(fs.readFileSync(templatePath, 'utf8'));
+if (manifest.version !== '0.0.0') {
+  throw new Error(`MCPB source manifest must remain the 0.0.0 template, found ${manifest.version}`);
+}
+manifest.version = version;
+fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+fs.writeFileSync(identityPath, `${JSON.stringify({
+  schema: 'kin.mcpb.package-identity.v1',
+  launcher: `@kinlab/kin-mcp@${version}`,
+  native_release_tag: `v${version}`,
+  source_package: '@kinlab/kin-mcp',
+  source_version: version,
+}, null, 2)}\n`);
+NODE
+
+# Name the output explicitly. Without an output argument the CLI uses the
+# staging-directory name, which has no stable relationship to Kin's release.
+npx -y @anthropic-ai/mcpb pack "$stage" "$bundle"
 echo "bundle: ${bundle}"
+echo "launcher: @kinlab/kin-mcp@${version}"

--- a/scripts/mcpb/manifest.json
+++ b/scripts/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.3",
   "name": "kin",
   "display_name": "Kin",
-  "version": "0.5.27",
+  "version": "0.0.0",
   "description": "Kin keeps a living map of the software itself so humans and agents can understand what every change touches. Locate, search, context packs, data-flow tracing, and impact analysis without raw file search.",
   "author": {
     "name": "Firelock, LLC",

--- a/scripts/mcpb/server/index.js
+++ b/scripts/mcpb/server/index.js
@@ -1,20 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-// Entry point for the Claude Desktop extension. It runs the published
-// @kinlab/kin-mcp launcher through npx, from the workspace the user chose.
+// Entry point for the Claude Desktop extension. It runs the published,
+// version-pinned @kinlab/kin-mcp launcher through npx from the workspace the
+// user chose. The bundle manifest is the release identity authority, so a
+// bundle never silently follows npm's moving latest tag.
 //
-// The indirection is load-bearing in two ways that are invisible from the
-// manifest. An MCPB `mcp_config` carries command, args, env, and
-// platform_overrides, and no working directory. The launcher decides which
-// repository it serves from its own working directory and refuses every extra
-// argument, so neither an argument nor an environment variable alone can point
-// it at the workspace. Setting the child's cwd here is what binds the two.
+// An MCPB mcp_config carries command, args, env, and platform overrides, but
+// no working directory. The launcher decides which repository it serves from
+// its working directory and refuses every extra argument. Setting the child's
+// cwd here is what binds the selected workspace to the MCP server.
 
 'use strict';
 
 const { spawn } = require('node:child_process');
 const fs = require('node:fs');
+const path = require('node:path');
 
 const workspace = process.env.KIN_MCP_REPO;
 
@@ -38,8 +39,24 @@ if (!stats.isDirectory()) {
   process.exit(2);
 }
 
+const manifestPath = path.join(__dirname, '..', 'manifest.json');
+let version;
+try {
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  version = manifest.version;
+} catch (error) {
+  process.stderr.write(`Kin: could not read the bundle release identity (${error.message}).\n`);
+  process.exit(2);
+}
+
+if (typeof version !== 'string' || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+  process.stderr.write(`Kin: bundle manifest declares an invalid release version (${String(version)}).\n`);
+  process.exit(2);
+}
+
 const npx = process.platform === 'win32' ? 'npx.cmd' : 'npx';
-const child = spawn(npx, ['-y', '@kinlab/kin-mcp'], {
+const launcher = `@kinlab/kin-mcp@${version}`;
+const child = spawn(npx, ['-y', launcher], {
   cwd: workspace,
   stdio: 'inherit',
   env: process.env

--- a/scripts/mcpb/test-build.mjs
+++ b/scripts/mcpb/test-build.mjs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+import assert from 'node:assert/strict';
+import cp from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const sourceRoot = path.resolve(here, '../..');
+const version = '7.8.9';
+
+const controlledNpx = [
+  '#!/usr/bin/env node',
+  "const fs = require('node:fs');",
+  "const path = require('node:path');",
+  '',
+  'const args = process.argv.slice(2);',
+  'const record = process.env.MCPB_TEST_NPX_RECORD;',
+  'if (!record) throw new Error("MCPB_TEST_NPX_RECORD is required");',
+  "fs.appendFileSync(record, JSON.stringify({ args, cwd: process.cwd() }) + '\\n');",
+  '',
+  'if (',
+  '  args.length === 5 &&',
+  "  args[0] === '-y' &&",
+  "  args[1] === '@anthropic-ai/mcpb' &&",
+  "  args[2] === 'pack'",
+  ') {',
+  '  const stage = args[3];',
+  '  const output = args[4];',
+  '  const capture = process.env.MCPB_TEST_NPX_CAPTURE;',
+  '  if (!capture) throw new Error("MCPB_TEST_NPX_CAPTURE is required for pack");',
+  '  fs.cpSync(stage, capture, { recursive: true });',
+  "  const manifest = JSON.parse(fs.readFileSync(path.join(stage, 'manifest.json'), 'utf8'));",
+  "  const releaseIdentity = JSON.parse(fs.readFileSync(path.join(stage, 'release-identity.json'), 'utf8'));",
+  "  fs.writeFileSync(output, JSON.stringify({ manifest, releaseIdentity }) + '\\n');",
+  '  process.exit(0);',
+  '}',
+  '',
+  'if (',
+  '  args.length === 2 &&',
+  "  args[0] === '-y' &&",
+  "  /^@kinlab\\/kin-mcp@\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?$/.test(args[1])",
+  ') {',
+  '  process.exit(0);',
+  '}',
+  '',
+  "process.stderr.write('unexpected controlled npx invocation: ' + JSON.stringify(args) + '\\n');",
+  'process.exit(64);',
+  ''
+].join('\n');
+
+function commandResult(command, args, options) {
+  return cp.spawnSync(command, args, {
+    encoding: 'utf8',
+    ...options
+  });
+}
+
+async function createFixture({ mcpVersion = version, kinVersion = version } = {}) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'kin-mcpb-build-test-'));
+  const mcpb = path.join(root, 'scripts', 'mcpb');
+  const fakeBin = path.join(root, 'fake-bin');
+  const capture = path.join(root, 'captured-pack');
+  const npxRecord = path.join(root, 'npx-record.jsonl');
+  const output = path.join(root, 'out', 'kin.mcpb');
+  const workspace = path.join(root, 'workspace');
+
+  await fs.mkdir(path.join(root, 'assets', 'mcp'), { recursive: true });
+  await fs.mkdir(path.join(root, 'packages', 'kin-mcp'), { recursive: true });
+  await fs.mkdir(path.join(root, 'packages', 'kin'), { recursive: true });
+  await fs.mkdir(path.join(mcpb, 'server'), { recursive: true });
+  await fs.mkdir(fakeBin, { recursive: true });
+  await fs.mkdir(path.dirname(output), { recursive: true });
+  await fs.mkdir(workspace, { recursive: true });
+
+  await Promise.all([
+    fs.writeFile(path.join(root, 'assets', 'mcp', 'icon-512.png'), 'fixture icon'),
+    fs.writeFile(
+      path.join(root, 'packages', 'kin-mcp', 'package.json'),
+      JSON.stringify({ name: '@kinlab/kin-mcp', version: mcpVersion }) + '\n'
+    ),
+    fs.writeFile(
+      path.join(root, 'packages', 'kin', 'package.json'),
+      JSON.stringify({ name: '@kinlab/kin', version: kinVersion }) + '\n'
+    ),
+    fs.copyFile(path.join(sourceRoot, 'scripts', 'mcpb', 'build.sh'), path.join(mcpb, 'build.sh')),
+    fs.copyFile(
+      path.join(sourceRoot, 'scripts', 'mcpb', 'manifest.json'),
+      path.join(mcpb, 'manifest.json')
+    ),
+    fs.copyFile(
+      path.join(sourceRoot, 'scripts', 'mcpb', 'server', 'index.js'),
+      path.join(mcpb, 'server', 'index.js')
+    ),
+    fs.writeFile(path.join(fakeBin, 'npx'), controlledNpx, { mode: 0o755 })
+  ]);
+
+  const env = {
+    ...process.env,
+    PATH: [fakeBin, process.env.PATH || ''].filter(Boolean).join(path.delimiter),
+    KIN_MCPB_OUTPUT: output,
+    MCPB_TEST_NPX_CAPTURE: capture,
+    MCPB_TEST_NPX_RECORD: npxRecord
+  };
+  return { root, mcpb, capture, npxRecord, output, workspace, env };
+}
+
+async function readNpxCalls(record) {
+  const lines = (await fs.readFile(record, 'utf8'))
+    .trim()
+    .split('\n')
+    .filter(Boolean);
+  return lines.map(line => JSON.parse(line));
+}
+
+test(
+  'the MCPB builder packs a version-pinned manifest and launcher',
+  { skip: process.platform === 'win32' },
+  async () => {
+    const fixture = await createFixture();
+    try {
+      const build = commandResult('bash', [path.join(fixture.mcpb, 'build.sh')], {
+        cwd: fixture.root,
+        env: fixture.env
+      });
+      assert.equal(build.status, 0, build.stdout + '\n' + build.stderr);
+
+      const packed = JSON.parse(await fs.readFile(fixture.output, 'utf8'));
+      assert.equal(packed.manifest.version, version);
+      assert.equal(packed.releaseIdentity.launcher, '@kinlab/kin-mcp@' + version);
+      assert.equal(packed.releaseIdentity.native_release_tag, 'v' + version);
+
+      const stagedLauncher = path.join(fixture.capture, 'server', 'index.js');
+      const launch = commandResult(process.execPath, [stagedLauncher], {
+        cwd: fixture.workspace,
+        env: {
+          ...fixture.env,
+          KIN_MCP_REPO: fixture.workspace
+        }
+      });
+      assert.equal(launch.status, 0, launch.stdout + '\n' + launch.stderr);
+
+      const calls = await readNpxCalls(fixture.npxRecord);
+      assert.equal(calls.length, 2);
+      assert.deepEqual(calls[0].args.slice(0, 3), ['-y', '@anthropic-ai/mcpb', 'pack']);
+      assert.deepEqual(calls[1], {
+        args: ['-y', '@kinlab/kin-mcp@' + version],
+        cwd: await fs.realpath(fixture.workspace)
+      });
+    } finally {
+      await fs.rm(fixture.root, { recursive: true, force: true });
+    }
+  }
+);
+
+test(
+  'the MCPB builder rejects package-version drift before packing',
+  { skip: process.platform === 'win32' },
+  async () => {
+    const fixture = await createFixture({ kinVersion: '7.8.10' });
+    try {
+      const build = commandResult('bash', [path.join(fixture.mcpb, 'build.sh')], {
+        cwd: fixture.root,
+        env: fixture.env
+      });
+      assert.notEqual(build.status, 0);
+      assert.match(build.stderr, /does not match/);
+      await assert.rejects(fs.access(fixture.npxRecord));
+      await assert.rejects(fs.access(fixture.output));
+    } finally {
+      await fs.rm(fixture.root, { recursive: true, force: true });
+    }
+  }
+);


### PR DESCRIPTION
Desktop MCP bundles now carry their release-matched Kin binaries and start the bundled server through the packaged wrapper. The builder validates and stamps the bundle version, with regression coverage for incorrect version inputs and startup wiring. The README documents packaging, supported use and current platform limits.

Add Glama maintainer metadata and make MCP downloader tests run without opening a local network listener, retaining download, checksum and extraction coverage.

Validation ran against this exact source in an isolated public checkout:

- Public commit metadata and full-history secret scans passed.
- Locked Cargo metadata and `cargo check -p kin-cli -p kin-daemon --locked` passed.
- Kin and MCP npm tests and lint passed, including the desktop bundle builder tests.

The desktop extension installation flow still needs acceptance in an actual client. This change does not claim that GUI acceptance has run.

Check output:
```text
npm test --prefix packages/kin
# tests 49
# pass 49
# fail 0
npm test --prefix packages/kin-mcp
# tests 29
# pass 29
# fail 0
```
The Cargo commands used the exact installed Rust 1.96.0 toolchain and checksum-verified vendored dependencies; public metadata, full-history secret scanning, locked Cargo metadata/check, both test commands and both lint commands each returned exit 0.
