### PR TITLE
fix(cli): skip profile for top-level display flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Show the `--continue` alias in `kin resolve --help`.
 
+### Fixed
+
+- Let top-level `kin --help`, `kin -h`, `kin --version`, and `kin -V` display without a nested-repository parent-store warning.
+
 ## [0.7.16] - 2026-09-12
 
 ### Changed

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -2930,6 +2930,17 @@ fn parse_cli_or_report_retired_command() -> Cli {
     }
 }
 
+fn is_top_level_display_flag() -> bool {
+    let mut args = std::env::args_os().skip(1);
+    let Some(flag) = args.next() else {
+        return false;
+    };
+    if args.next().is_some() {
+        return false;
+    }
+    matches!(flag.to_str(), Some("--help" | "-h" | "--version" | "-V"))
+}
+
 /// The process entry. The outcome of [`run`] becomes an exit status in one
 /// place, so a refusal is reported the same way whether or not anyone still
 /// reads stderr, and the `println!` and `eprintln!` this file imports from
@@ -2965,8 +2976,10 @@ fn run() -> Result<()> {
     // the daemon runs under the repository's profile and this process does not,
     // and every command in such a repository reports a behavior-env divergence
     // whose remedy cannot clear it.
-    if let Ok(cwd) = std::env::current_dir() {
-        kin_cli::resource_profile::apply_repository_profile_at(&cwd);
+    if !is_top_level_display_flag() {
+        if let Ok(cwd) = std::env::current_dir() {
+            kin_cli::resource_profile::apply_repository_profile_at(&cwd);
+        }
     }
     // Put Kin's own tool directories on PATH while this process is still
     // single-threaded, so a language server Kin provisioned is reachable by the

--- a/crates/kin-cli/tests/top_level_display_flags.rs
+++ b/crates/kin-cli/tests/top_level_display_flags.rs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+use std::path::PathBuf;
+
+use tempfile::TempDir;
+
+mod common;
+
+use common::Command;
+
+fn nested_repository_without_own_store() -> (TempDir, PathBuf) {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let parent = temp.path().join("parent");
+    let child = parent.join("child");
+    std::fs::create_dir_all(parent.join(".kin")).expect("create parent store marker");
+    std::fs::create_dir_all(&child).expect("create nested repository");
+
+    let output = Command::new("git")
+        .args(["init", "--initial-branch=main"])
+        .current_dir(&child)
+        .output()
+        .expect("initialize nested repository");
+    assert!(
+        output.status.success(),
+        "git init failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    (temp, child)
+}
+
+#[test]
+fn top_level_help_and_version_skip_parent_store_boundary_warning() {
+    let (_temp, child) = nested_repository_without_own_store();
+
+    for flag in ["--help", "-h", "--version", "-V"] {
+        let output = Command::new(env!("CARGO_BIN_EXE_kin"))
+            .arg(flag)
+            .current_dir(&child)
+            .output()
+            .expect("run kin display flag");
+        assert!(
+            output.status.success(),
+            "kin {flag} failed: stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            !output.stdout.is_empty(),
+            "kin {flag} should print its display output"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !stderr.contains("refusing to bind the parent store"),
+            "kin {flag} should not warn before display output: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn subcommand_help_still_runs_repository_boundary_check() {
+    let (_temp, child) = nested_repository_without_own_store();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kin"))
+        .args(["resolve", "--help"])
+        .current_dir(&child)
+        .output()
+        .expect("run kin subcommand help");
+    assert!(
+        output.status.success(),
+        "kin resolve --help failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("refusing to bind the parent store"),
+        "non-bare help should preserve the repository boundary warning: {stderr}"
+    );
+}


### PR DESCRIPTION
## What

Skip repository profile discovery for the bare top-level display flags `kin --help`, `kin -h`, `kin --version`, and `kin -V`, and add an integration regression for the nested-repository parent-store warning case.

## Why

Closes #1736. In a nested checkout under a parent `.kin/` store, those display-only commands could print the parent-store boundary warning before the help/version text even though the user only asked for display output.

## How

- Detect the exact one-argument top-level display flag case before `apply_repository_profile_at` runs.
- Leave subcommand help and all non-bare invocations on the existing repository-boundary path.
- Cover both sides with a nested git repository fixture: top-level display flags stay warning-free, while `kin resolve --help` still emits the boundary warning.
- Add an Unreleased changelog note for the user-facing CLI behavior.

## Testing

- [ ] `cargo test` passes
- [ ] `cargo clippy` produces no warnings
- [x] `cargo fmt` applied
- [x] Every commit carries a `Signed-off-by` trailer (`git commit -s`); the DCO
      check fails without it, and [CONTRIBUTING.md](https://github.com/firelock-ai/kin/blob/main/CONTRIBUTING.md#dco-sign-off)
      shows how to add it after the fact

Evidence run locally:

```text
export PATH=/root/.cargo/bin:$PATH
cargo fmt --check
# passed

cargo test -p kin-cli --test top_level_display_flags -- --nocapture
# passed: 11 passed; 0 failed; 0 ignored; finished in 0.96s

git diff --check
# passed
```

After adding the changelog note and rebasing onto current `main`, I re-ran:

```text
cargo fmt --check && git diff --check origin/main..HEAD
# passed
```

A fresh rebuild of the same targeted test after `cargo clean` was attempted, but this local runner timed out after 10 minutes while recompiling the Rust workspace from scratch; it had previously hit a local disk-full/linker bus-error condition before I cleaned `target/`. No generated files were changed.
