### PR TITLE
fix(cli): skip repository profile for help and version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Let top-level `kin --help` and `kin --version` skip repository profile discovery.
 - Show the `--continue` alias in `kin resolve --help`.
 
 ## [0.7.16] - 2026-09-12

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -2960,13 +2960,24 @@ fn run() -> Result<()> {
     // process, and mutating the environment is only safe while the process is
     // still single-threaded. An operator's explicit KIN_RESOURCE_PROFILE wins.
     kin_cli::resource_profile::apply_product_default();
+
+    let skip_repository_profile = {
+        let mut args = std::env::args_os();
+        let _program = args.next();
+        match (args.next(), args.next()) {
+            (Some(arg), None) => matches!(arg.to_str(), Some("--help" | "-h" | "--version" | "-V")),
+            _ => false,
+        }
+    };
     // ...then let the repository's recorded profile take over from that default,
     // exactly as kin-daemon does, so the two agree by construction. Without this
     // the daemon runs under the repository's profile and this process does not,
     // and every command in such a repository reports a behavior-env divergence
     // whose remedy cannot clear it.
-    if let Ok(cwd) = std::env::current_dir() {
-        kin_cli::resource_profile::apply_repository_profile_at(&cwd);
+    if !skip_repository_profile {
+        if let Ok(cwd) = std::env::current_dir() {
+            kin_cli::resource_profile::apply_repository_profile_at(&cwd);
+        }
     }
     // Put Kin's own tool directories on PATH while this process is still
     // single-threaded, so a language server Kin provisioned is reachable by the


### PR DESCRIPTION
## What

Skip repository profile discovery for bare top-level help and version invocations:

- `kin --help`
- `kin -h`
- `kin --version`
- `kin -V`

Normal commands continue to use repository profile discovery as before.

The changelog has also been updated to document the change.

## Why

When Kin is run inside a checkout nested under another Kin-admitted repository, repository discovery can emit a boundary warning before the requested help or version output.

Top-level help and version requests do not need repository context, so they should print only their requested output without triggering the repository-boundary warning.

Closes #1736

## How

Before applying the repository's recorded resource profile, the CLI checks whether the invocation contains exactly one argument and whether that argument is one of `--help`, `-h`, `--version`, or `-V`.

Repository profile discovery is skipped only for those bare top-level invocations. Other commands, including subcommand help such as `kin resolve --help`, retain the existing repository discovery behavior.

## Testing

- [x] Verified `kin --help` does not emit the repository-boundary warning
- [x] Verified `kin -h` does not emit the repository-boundary warning
- [x] Verified `kin --version` does not emit the repository-boundary warning
- [x] Verified `kin -V` does not emit the repository-boundary warning
- [x] Verified a normal command still follows the existing repository discovery behavior
- [x] `cargo fmt` applied
- [x] Commit carries the required `Signed-off-by` trailer
- [ ] `cargo test` — full workspace testing is blocked by unrelated existing workspace failures
- [ ] `cargo clippy --all-targets -- -D warnings` — blocked by unrelated existing workspace Clippy failures