### PR TITLE
docs: explain C# and Ruby test detection gap

### DIFF
--- a/docs/language-support.md
+++ b/docs/language-support.md
@@ -42,6 +42,12 @@ cannot drift apart.
 | PHP | ✓ | calls, contains, extends, implements, references | ✓ (phpunit) | ✓ | ✗ |
 | HCL / Terraform | ✓ | imports, references | ✗ | ✓ | ✗ |
 
+C# and Ruby currently use dedicated semantic adapters for entities, relations,
+imports, and documentation, but those adapters do not yet implement
+test-framework detection. Their extracted parse output therefore leaves the
+test list empty. This differs from adapters such as Python and Swift, which
+include framework-aware detection for pytest and XCTest respectively.
+
 ## Shallow syntax support
 
 The shallow tier exists in the pipeline but currently routes no extensions.


### PR DESCRIPTION
## What

Document why C# and Ruby are marked as not supporting test detection in the language support table.

The new paragraph explains that their semantic adapters currently extract entities, relations, imports, and documentation, but do not yet implement test-framework detection, so their parse output leaves the test list empty.

## Why

The language support table showed `✗` for C# and Ruby test detection without explaining why.

This change makes the limitation explicit and distinguishes it from languages such as Python and Swift, which include framework-aware test detection.

Closes #1734

## How

Added a short explanatory paragraph below the full semantic support table in `docs/language-support.md`.

No runtime behavior or parser implementation was changed.

## Testing

- [x] Docs-only change
- [x] Verified the wording matches the current C# and Ruby adapter behavior
- [x] `git diff --check`
- [x] Commit carries the required `Signed-off-by` trailer